### PR TITLE
Tests for custom agent/model selection restoration in chat and agents window sessions

### DIFF
--- a/scripts/chat-simulation/common/mock-llm-server.ts
+++ b/scripts/chat-simulation/common/mock-llm-server.ts
@@ -471,6 +471,28 @@ const ALL_MODELS: MockModel[] = [
 	...EXTRA_MODELS,
 ];
 
+/**
+ * Ids of models that are currently HIDDEN from the advertised model list.
+ *
+ * Tests use this to simulate a model becoming temporarily unavailable — e.g. a
+ * model the user picked in the model picker that is no longer advertised after a
+ * window reload — and later becoming available again. Mutated in-process via the
+ * handle's {@link MockLlmServerHandle.setHiddenModelIds}, or over the wire via
+ * `POST /_control/models` (so a value set before a window reload still applies
+ * when the reloaded client re-fetches `/models`). Reset to empty each time a
+ * server starts (see {@link _startServer}).
+ */
+let hiddenModelIds = new Set<string>();
+
+/**
+ * The advertised model list with any {@link hiddenModelIds} filtered out. All
+ * model-list endpoints (`GET /models`, `GET /models/{id}`, `POST /models/session`)
+ * go through this so the "available models" the client sees stay consistent.
+ */
+function getVisibleModels(): MockModel[] {
+	return hiddenModelIds.size === 0 ? ALL_MODELS : ALL_MODELS.filter(m => !hiddenModelIds.has(m.id));
+}
+
 function makeChunk(content: string, index: number, finish: boolean) {
 	return {
 		id: 'chatcmpl-perf-benchmark',
@@ -665,6 +687,24 @@ function handleRequest(req: import('http').IncomingMessage, res: import('http').
 	// -- Health -------------------------------------------------------
 	if (path === '/health') { res.writeHead(200); res.end('ok'); return; }
 
+	// -- Test control: mutate the advertised model list ---------------
+	// POST /_control/models  { hidden: string[] }  → hide (or re-show) models so
+	// tests can simulate a model becoming temporarily unavailable across a window
+	// reload and later available again. The value persists in-process, so a client
+	// that reloads and re-fetches `/models` sees the updated set.
+	if (path === '/_control/models' && req.method === 'POST') {
+		readBody().then(body => {
+			try {
+				const parsed = body ? JSON.parse(body) : {};
+				hiddenModelIds = new Set(Array.isArray(parsed.hidden) ? parsed.hidden : []);
+				json(200, { hidden: [...hiddenModelIds] });
+			} catch (e) {
+				json(400, { error: String(e) });
+			}
+		});
+		return;
+	}
+
 	// -- Token endpoints (DomainService.tokenURL / tokenNoAuthURL) ----
 	// /copilot_internal/v2/token, /copilot_internal/v2/nltoken
 	if (path.startsWith('/copilot_internal/')) {
@@ -705,7 +745,7 @@ function handleRequest(req: import('http').IncomingMessage, res: import('http').
 	if (path === '/models/session' && req.method === 'POST') {
 		readBody().then(() => {
 			json(200, {
-				available_models: [MODEL, 'gpt-4o-mini', ...EXTRA_MODELS.map(m => m.id)],
+				available_models: getVisibleModels().map(m => m.id),
 				selected_model: 'gpt-5.3-codex',
 				session_token: 'perf-session-token-' + Date.now(),
 				expires_at: Math.floor(Date.now() / 1000) + 3600,
@@ -717,7 +757,7 @@ function handleRequest(req: import('http').IncomingMessage, res: import('http').
 
 	// -- Models (DomainService.capiModelsURL = /models) --------------
 	if (path === '/models' && req.method === 'GET') {
-		json(200, { data: ALL_MODELS });
+		json(200, { data: getVisibleModels() });
 		return;
 	}
 
@@ -728,7 +768,7 @@ function handleRequest(req: import('http').IncomingMessage, res: import('http').
 			json(200, { state: 'accepted', terms: '' });
 			return;
 		}
-		const knownModel = ALL_MODELS.find(m => m.id === modelId);
+		const knownModel = getVisibleModels().find(m => m.id === modelId);
 		// TODO: give a 404 for unknown models instead of a fallback response. This requires
 		const result = knownModel || {
 			id: modelId || MODEL,
@@ -1837,6 +1877,15 @@ interface MockLlmServerHandle {
 	 * default so perf/mem-leak harnesses don't retain request bodies.
 	 */
 	getRequests(): CapturedRequest[];
+	/**
+	 * Hide the given model ids from the advertised model list so tests can
+	 * simulate a model becoming temporarily unavailable (e.g. after a window
+	 * reload). Pass an empty array to re-show all models. Equivalent to the
+	 * `POST /_control/models` endpoint but callable in-process on the handle.
+	 */
+	setHiddenModelIds(ids: string[]): void;
+	/** Return the currently hidden model ids (see {@link setHiddenModelIds}). */
+	getHiddenModelIds(): string[];
 }
 
 /**
@@ -1875,6 +1924,10 @@ function _startServer(port = 0, options?: StartServerOptions): Promise<MockLlmSe
 	return new Promise((resolve, reject) => {
 		let reqCount = 0;
 		let completions = 0;
+		// Start each server with a clean (fully-visible) model list. `hiddenModelIds`
+		// is module-level state shared by the request handlers, so reset it here so a
+		// prior suite's hidden set can't leak into a freshly started server.
+		hiddenModelIds = new Set<string>();
 		let requestWaiters: Array<() => boolean> = [];
 		let completionWaiters: Array<() => boolean> = [];
 
@@ -1941,6 +1994,8 @@ function _startServer(port = 0, options?: StartServerOptions): Promise<MockLlmSe
 					});
 				}),
 				getRequests: () => capturedRequests.slice(),
+				setHiddenModelIds: (ids: string[]) => { hiddenModelIds = new Set(ids); },
+				getHiddenModelIds: () => [...hiddenModelIds],
 			});
 		});
 		server.on('error', reject);

--- a/scripts/chat-simulation/common/mock-llm-server.ts
+++ b/scripts/chat-simulation/common/mock-llm-server.ts
@@ -472,23 +472,14 @@ const ALL_MODELS: MockModel[] = [
 ];
 
 /**
- * Ids of models that are currently HIDDEN from the advertised model list.
- *
- * Tests use this to simulate a model becoming temporarily unavailable — e.g. a
- * model the user picked in the model picker that is no longer advertised after a
- * window reload — and later becoming available again. Mutated in-process via the
- * handle's {@link MockLlmServerHandle.setHiddenModelIds}, or over the wire via
- * `POST /_control/models` (so a value set before a window reload still applies
- * when the reloaded client re-fetches `/models`). Reset to empty each time a
- * server starts (see {@link _startServer}).
+ * Ids of models currently HIDDEN from the advertised model list, so a test can
+ * simulate a model becoming temporarily unavailable (e.g. after a window
+ * reload) and later available again. Mutated over the wire via
+ * `POST /_control/models`; reset to empty each time a server starts.
  */
 let hiddenModelIds = new Set<string>();
 
-/**
- * The advertised model list with any {@link hiddenModelIds} filtered out. All
- * model-list endpoints (`GET /models`, `GET /models/{id}`, `POST /models/session`)
- * go through this so the "available models" the client sees stay consistent.
- */
+/** The advertised model list with any {@link hiddenModelIds} filtered out. */
 function getVisibleModels(): MockModel[] {
 	return hiddenModelIds.size === 0 ? ALL_MODELS : ALL_MODELS.filter(m => !hiddenModelIds.has(m.id));
 }
@@ -688,8 +679,8 @@ function handleRequest(req: import('http').IncomingMessage, res: import('http').
 	if (path === '/health') { res.writeHead(200); res.end('ok'); return; }
 
 	// -- Test control: mutate the advertised model list ---------------
-	// POST /_control/models  { hidden: string[] }  → hide (or re-show) models so
-	// tests can simulate a model becoming temporarily unavailable across a window
+	// POST /_control/models  { hidden: string[] }  → hide (or re-show) models so a
+	// test can simulate a model becoming temporarily unavailable across a window
 	// reload and later available again. The value persists in-process, so a client
 	// that reloads and re-fetches `/models` sees the updated set.
 	if (path === '/_control/models' && req.method === 'POST') {
@@ -1877,15 +1868,6 @@ interface MockLlmServerHandle {
 	 * default so perf/mem-leak harnesses don't retain request bodies.
 	 */
 	getRequests(): CapturedRequest[];
-	/**
-	 * Hide the given model ids from the advertised model list so tests can
-	 * simulate a model becoming temporarily unavailable (e.g. after a window
-	 * reload). Pass an empty array to re-show all models. Equivalent to the
-	 * `POST /_control/models` endpoint but callable in-process on the handle.
-	 */
-	setHiddenModelIds(ids: string[]): void;
-	/** Return the currently hidden model ids (see {@link setHiddenModelIds}). */
-	getHiddenModelIds(): string[];
 }
 
 /**
@@ -1924,9 +1906,8 @@ function _startServer(port = 0, options?: StartServerOptions): Promise<MockLlmSe
 	return new Promise((resolve, reject) => {
 		let reqCount = 0;
 		let completions = 0;
-		// Start each server with a clean (fully-visible) model list. `hiddenModelIds`
-		// is module-level state shared by the request handlers, so reset it here so a
-		// prior suite's hidden set can't leak into a freshly started server.
+		// Start each server with a clean (fully-visible) model list; `hiddenModelIds`
+		// is module-level state so reset it so a prior suite's set can't leak in.
 		hiddenModelIds = new Set<string>();
 		let requestWaiters: Array<() => boolean> = [];
 		let completionWaiters: Array<() => boolean> = [];
@@ -1994,8 +1975,6 @@ function _startServer(port = 0, options?: StartServerOptions): Promise<MockLlmSe
 					});
 				}),
 				getRequests: () => capturedRequests.slice(),
-				setHiddenModelIds: (ids: string[]) => { hiddenModelIds = new Set(ids); },
-				getHiddenModelIds: () => [...hiddenModelIds],
 			});
 		});
 		server.on('error', reject);

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostAgentPicker.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostAgentPicker.test.ts
@@ -7,9 +7,10 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { CustomizationType, type AgentCustomization } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { agentHostAgentPickerStorageKey, resolveAgentHostAgent } from '../../../../../../platform/agentHost/common/customAgents.js';
+import { InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 
 suite('agentHostAgentPicker', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	const alpha: AgentCustomization = { type: CustomizationType.Agent, id: 'agent://a', uri: 'agent://a', name: 'alpha' };
 	const beta: AgentCustomization = { type: CustomizationType.Agent, id: 'agent://b', uri: 'agent://b', name: 'beta', description: 'b desc' };
@@ -52,6 +53,79 @@ suite('agentHostAgentPicker', () => {
 		test('returns undefined for an empty agent list', () => {
 			assert.strictEqual(resolveAgentHostAgent([], 'agent://a', 'agent://a'), undefined);
 			assert.strictEqual(resolveAgentHostAgent([], undefined, undefined), undefined);
+		});
+	});
+
+	// Round-trip coverage for "restore the last selected Custom Agent": a user
+	// selects a custom agent in a Copilot Agent Host session, opens a NEW
+	// (untitled) session, and the new session pre-selects that same agent. This
+	// mirrors AgentHostAgentPickerContribution's write rule (`_setAgent`, which
+	// persists the pick per session-resource scheme) and its new-session seed
+	// (`_initAgent`, which for an untitled session with no session-level
+	// selection resolves the stored URI against the session's available agents),
+	// using a real in-memory storage service as the ledger.
+	suite('restore last selected custom agent on a new session (round-trip)', () => {
+		// `agent-host-copilotcli` is the Copilot Agent Host session-resource scheme.
+		const SCHEME = 'agent-host-copilotcli';
+
+		function createStorage(): InMemoryStorageService {
+			return store.add(new InMemoryStorageService());
+		}
+
+		// Mirrors `_setAgent`: persist the user's pick per scheme, or clear it when
+		// the default "Agent" (no custom agent) is chosen.
+		function selectAgent(storage: InMemoryStorageService, scheme: string, agent: AgentCustomization | undefined): void {
+			const key = agentHostAgentPickerStorageKey(scheme);
+			if (agent) {
+				storage.store(key, agent.uri, StorageScope.PROFILE, StorageTarget.MACHINE);
+			} else {
+				storage.remove(key, StorageScope.PROFILE);
+			}
+		}
+
+		// Mirrors `_initAgent` for a NEW untitled session (no session-level
+		// selection): the seeded agent is resolved from the stored URI against the
+		// session's available agents.
+		function seedNewUntitledSession(storage: InMemoryStorageService, scheme: string, sessionAgents: readonly AgentCustomization[]): AgentCustomization | undefined {
+			const storedUri = storage.get(agentHostAgentPickerStorageKey(scheme), StorageScope.PROFILE);
+			return resolveAgentHostAgent(sessionAgents, undefined, storedUri);
+		}
+
+		test('a new Copilot Agent Host session restores the last selected custom agent', () => {
+			const storage = createStorage();
+			selectAgent(storage, SCHEME, beta);
+			assert.deepStrictEqual(seedNewUntitledSession(storage, SCHEME, agents), beta);
+		});
+
+		test('selecting the default Agent clears the stored custom agent', () => {
+			const storage = createStorage();
+			selectAgent(storage, SCHEME, beta);
+			selectAgent(storage, SCHEME, undefined);
+			assert.strictEqual(seedNewUntitledSession(storage, SCHEME, agents), undefined);
+		});
+
+		test('an established (non-untitled) session is not seeded from the stored agent', () => {
+			const storage = createStorage();
+			selectAgent(storage, SCHEME, beta);
+			// `_initAgent` only reads the stored URI for untitled sessions; an
+			// established session passes `storedUri: undefined`, so it keeps its own
+			// persisted agent rather than inheriting the shared seed.
+			assert.strictEqual(resolveAgentHostAgent(agents, undefined, undefined), undefined);
+		});
+
+		test('a stored agent that is no longer available is ignored', () => {
+			const storage = createStorage();
+			selectAgent(storage, SCHEME, beta);
+			// `beta` was removed from the workspace; only `alpha` remains, so the new
+			// session falls back to the default "Agent" rather than a stale pick.
+			assert.strictEqual(seedNewUntitledSession(storage, SCHEME, [alpha]), undefined);
+		});
+
+		test('the stored custom agent is scoped per session-resource scheme', () => {
+			const storage = createStorage();
+			selectAgent(storage, SCHEME, beta);
+			// A different agent-host provider (e.g. Claude) does not inherit the pick.
+			assert.strictEqual(seedNewUntitledSession(storage, 'agent-host-claude', agents), undefined);
 		});
 	});
 });

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostAgentPicker.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostAgentPicker.test.ts
@@ -91,6 +91,14 @@ suite('agentHostAgentPicker', () => {
 			return resolveAgentHostAgent(sessionAgents, undefined, storedUri);
 		}
 
+		// Mirrors `_initAgent` for an ESTABLISHED (non-untitled) session: the
+		// per-scheme stored seed is deliberately NOT consulted (`storedUri`
+		// undefined), so the session keeps its own persisted agent rather than
+		// inheriting the shared new-session default.
+		function seedEstablishedSession(sessionAgents: readonly AgentCustomization[], sessionAgentUri: string | undefined): AgentCustomization | undefined {
+			return resolveAgentHostAgent(sessionAgents, sessionAgentUri, undefined);
+		}
+
 		test('a new Copilot Agent Host session restores the last selected custom agent', () => {
 			const storage = createStorage();
 			selectAgent(storage, SCHEME, beta);
@@ -107,10 +115,11 @@ suite('agentHostAgentPicker', () => {
 		test('an established (non-untitled) session is not seeded from the stored agent', () => {
 			const storage = createStorage();
 			selectAgent(storage, SCHEME, beta);
-			// `_initAgent` only reads the stored URI for untitled sessions; an
-			// established session passes `storedUri: undefined`, so it keeps its own
-			// persisted agent rather than inheriting the shared seed.
-			assert.strictEqual(resolveAgentHostAgent(agents, undefined, undefined), undefined);
+			// The stored seed exists and WOULD apply to a new untitled session...
+			assert.deepStrictEqual(seedNewUntitledSession(storage, SCHEME, agents), beta);
+			// ...but an established session ignores it and keeps its own agent
+			// (here: the default Agent, i.e. no session-level selection).
+			assert.strictEqual(seedEstablishedSession(agents, undefined), undefined);
 		});
 
 		test('a stored agent that is no longer available is ignored', () => {

--- a/test/automation/src/agentsWindow.ts
+++ b/test/automation/src/agentsWindow.ts
@@ -632,6 +632,85 @@ export class AgentsWindow {
 	}
 
 	/**
+	 * Selects the first non-default (non-"Auto") model offered by the active
+	 * session's model picker and returns its display name. Use when the exact set
+	 * of models a session type advertises is not known ahead of time (e.g. the
+	 * Local Agent Host / Copilot CLI pool is populated at runtime by the backend),
+	 * so a test cannot hard-code a model name.
+	 *
+	 * Robust against the `context-view-pointerBlock` overlay a prior picker (e.g.
+	 * the session-type dropdown) can leave animating over the model picker: it
+	 * dismisses lingering overlays before opening and force-clicks past the block,
+	 * retrying until a model commits or `timeoutMs` elapses.
+	 */
+	async selectFirstNonDefaultModel(timeoutMs: number = 60_000): Promise<string> {
+		const page = this.code.driver.currentPage;
+		const nameButton = page.locator(`${ACTIVE_SESSION_MODEL_PICKER_NAME}:visible`).first();
+		const deadline = Date.now() + timeoutMs;
+		let lastError: unknown;
+
+		while (Date.now() < deadline) {
+			try {
+				// Dismiss any lingering action-widget / context-view overlay (e.g. from
+				// the session-type picker) whose pointer-block would otherwise intercept
+				// the open click for the full click timeout.
+				await this.dismissContextView();
+				await nameButton.click({ force: true });
+				await this.code.waitForElement(ACTION_WIDGET);
+
+				const rows = page.locator(`${ACTION_WIDGET_ROW}:visible`);
+				const count = await rows.count();
+				let chosenRow: ReturnType<typeof rows.nth> | undefined;
+				for (let i = 0; i < count; i++) {
+					const row = rows.nth(i);
+					const text = ((await row.textContent()) ?? '').replace(/\s+/g, ' ').trim();
+					// Skip the synthetic "Auto" model and empty rows; pick the first real model.
+					if (text && !/^auto\b/i.test(text)) {
+						chosenRow = row;
+						break;
+					}
+				}
+				if (!chosenRow) {
+					throw new Error('no non-default model row found in the model picker');
+				}
+				// `force` bypasses the transient `context-view-pointerBlock` overlay.
+				await chosenRow.click({ force: true });
+
+				// Confirm the selection committed: the picker name button must move off
+				// "Auto" to the chosen model.
+				const commitDeadline = Date.now() + 10_000;
+				while (Date.now() < commitDeadline) {
+					const name = await this.getSelectedModelName();
+					if (name && !/^auto\b/i.test(name)) {
+						return name;
+					}
+					await new Promise(r => setTimeout(r, 250));
+				}
+				throw new Error('model selection did not commit (picker still shows Auto)');
+			} catch (error) {
+				lastError = error;
+				try { await page.keyboard.press('Escape'); } catch { /* dropdown already gone */ }
+				await new Promise(r => setTimeout(r, 500));
+			}
+		}
+		throw new Error(`Timed out selecting a non-default model in the active session picker. Last error: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+	}
+
+	/**
+	 * Dismiss any open action-widget / context-view popup and wait for its
+	 * animating `context-view-pointerBlock` overlay to detach, so a subsequent
+	 * click is not intercepted. Best-effort: never throws.
+	 */
+	private async dismissContextView(): Promise<void> {
+		const page = this.code.driver.currentPage;
+		await page.keyboard.press('Escape').catch(() => { /* nothing open */ });
+		await page.mouse.move(0, 0).catch(() => { /* no page */ });
+		await page.locator('.context-view-pointerBlock').first()
+			.waitFor({ state: 'detached', timeout: 3_000 })
+			.catch(() => { /* already gone or never present */ });
+	}
+
+	/**
 	 * Open the combined model configuration dropdown (Thinking Effort / Context
 	 * Size) by clicking the active session model picker's configuration button.
 	 * The button is only visible when the selected model advertises configurable

--- a/test/automation/src/agentsWindow.ts
+++ b/test/automation/src/agentsWindow.ts
@@ -632,23 +632,6 @@ export class AgentsWindow {
 	}
 
 	/**
-	 * Returns the session type (agent) currently preselected in the new-session
-	 * homepage picker, e.g. "Copilot", "Claude", "Local". Reads the picker
-	 * trigger's visible text, falling back to its aria-label. Use to assert the
-	 * last user-selected session type is restored when a new session is opened.
-	 */
-	async getSelectedSessionType(timeoutMs: number = 30_000): Promise<string> {
-		await this.code.waitForElement(SESSION_TYPE_PICKER_VISIBLE, undefined, Math.ceil(timeoutMs / 100));
-		const page = this.code.driver.currentPage;
-		const trigger = page.locator(SESSION_TYPE_PICKER_VISIBLE).first();
-		const text = ((await trigger.textContent()) ?? '').trim();
-		if (text) {
-			return text;
-		}
-		return ((await trigger.getAttribute('aria-label')) ?? '').trim();
-	}
-
-	/**
 	 * Open the combined model configuration dropdown (Thinking Effort / Context
 	 * Size) by clicking the active session model picker's configuration button.
 	 * The button is only visible when the selected model advertises configurable

--- a/test/automation/src/agentsWindow.ts
+++ b/test/automation/src/agentsWindow.ts
@@ -605,6 +605,50 @@ export class AgentsWindow {
 	}
 
 	/**
+	 * Returns the model currently selected in the active session's model picker.
+	 * Reads the picker name button's accessible name (aria-label, e.g.
+	 * "Models, <modelName>") because at a narrow width the button collapses to an
+	 * icon-only layout with no visible model name. The leading "Models," group
+	 * label is stripped so the caller gets just the model name.
+	 */
+	async getSelectedModelName(timeoutMs: number = 30_000): Promise<string> {
+		const page = this.code.driver.currentPage;
+		const nameButton = page.locator(`${ACTIVE_SESSION_MODEL_PICKER_NAME}:visible`).first();
+		await nameButton.waitFor({ state: 'visible', timeout: timeoutMs });
+		const label = (await nameButton.getAttribute('aria-label')) ?? '';
+		return label.replace(/^\s*Models,\s*/i, '').trim();
+	}
+
+	/**
+	 * Waits until the active session's model picker reflects a selected model
+	 * whose name contains `modelName` (matched against the picker name button's
+	 * aria-label). Use to assert a model was restored after switching into a
+	 * session, which happens asynchronously as the model list loads.
+	 */
+	async waitForSelectedModel(modelName: string, timeoutMs: number = 30_000): Promise<void> {
+		const page = this.code.driver.currentPage;
+		await page.locator(`${ACTIVE_SESSION_MODEL_PICKER_NAME}[aria-label*="${modelName}"]:visible`).first()
+			.waitFor({ state: 'visible', timeout: timeoutMs });
+	}
+
+	/**
+	 * Returns the session type (agent) currently preselected in the new-session
+	 * homepage picker, e.g. "Copilot", "Claude", "Local". Reads the picker
+	 * trigger's visible text, falling back to its aria-label. Use to assert the
+	 * last user-selected session type is restored when a new session is opened.
+	 */
+	async getSelectedSessionType(timeoutMs: number = 30_000): Promise<string> {
+		await this.code.waitForElement(SESSION_TYPE_PICKER_VISIBLE, undefined, Math.ceil(timeoutMs / 100));
+		const page = this.code.driver.currentPage;
+		const trigger = page.locator(SESSION_TYPE_PICKER_VISIBLE).first();
+		const text = ((await trigger.textContent()) ?? '').trim();
+		if (text) {
+			return text;
+		}
+		return ((await trigger.getAttribute('aria-label')) ?? '').trim();
+	}
+
+	/**
 	 * Open the combined model configuration dropdown (Thinking Effort / Context
 	 * Size) by clicking the active session model picker's configuration button.
 	 * The button is only visible when the selected model advertises configurable

--- a/test/automation/src/chat.ts
+++ b/test/automation/src/chat.ts
@@ -297,6 +297,35 @@ export class Chat {
 	}
 
 	/**
+	 * Returns the model currently selected in the panel chat model picker.
+	 *
+	 * Reads the picker name button's accessible name (aria-label, e.g.
+	 * "Models, <modelName>") rather than its visible text, because at a narrow
+	 * input width the picker collapses to an icon-only layout with no visible
+	 * model name. The leading "Models," group label is stripped so the caller
+	 * gets just the model name (e.g. "Auto", "Mock Config Model").
+	 */
+	async getSelectedModelName(timeoutMs: number = 30_000): Promise<string> {
+		const page = this.code.driver.currentPage;
+		const nameButton = page.locator(`${CHAT_MODEL_PICKER_NAME}:visible`).first();
+		await nameButton.waitFor({ state: 'visible', timeout: timeoutMs });
+		const label = (await nameButton.getAttribute('aria-label')) ?? '';
+		return label.replace(/^\s*Models,\s*/i, '').trim();
+	}
+
+	/**
+	 * Waits until the panel chat model picker reflects a selected model whose
+	 * name contains `modelName` (matched against the picker name button's
+	 * aria-label). Use to assert a model was restored after a window reload or a
+	 * new chat, which happens asynchronously as the model list loads.
+	 */
+	async waitForSelectedModel(modelName: string, timeoutMs: number = 30_000): Promise<void> {
+		const page = this.code.driver.currentPage;
+		await page.locator(`${CHAT_MODEL_PICKER_NAME}[aria-label*="${modelName}"]:visible`).first()
+			.waitFor({ state: 'visible', timeout: timeoutMs });
+	}
+
+	/**
 	 * Widens the panel chat (its host auxiliary bar) until the model picker leaves
 	 * its width-driven compact layout, i.e. until the inline model-config button
 	 * renders. At the auxiliary bar's default width the picker collapses to an

--- a/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
+++ b/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
@@ -772,12 +772,13 @@ export function setup(logger: Logger) {
 	describe('Agents Window (model restore)', () => {
 		// Uses the Local Agent Host (Copilot Agent running in the Agent Host)
 		// rather than the plain copilot-chat "Local" session, because agent-host
-		// session types own their own model pool — the exact surface the
-		// per-type model restore fix targets (shouldRestorePerTypeModelOnSessionSwitch /
+		// session types own their own model pool — the exact surface the per-type
+		// model restore fix targets (shouldRestorePerTypeModelOnSessionSwitch /
 		// shouldSuppressModelPersistenceOnSessionSwitch / shouldWaitForSessionModel).
-
-		// A non-default, picker-enabled model advertised by the mock server.
-		const RESTORE_MODEL_NAME = MODEL_CONFIG_MODEL_NAME;
+		//
+		// The model is DISCOVERED at runtime (first non-"Auto" row) rather than
+		// hard-coded: the CLI decides which models its pool advertises, so a fixed
+		// name (e.g. "Mock Config Model") is not guaranteed to appear here.
 		const RESTORE_1_ID = 'smoke-agents-model-restore-1';
 		const RESTORE_1_REPLY = 'MOCKED_AGENTS_MODEL_RESTORE_1';
 		const RESTORE_2_ID = 'smoke-agents-model-restore-2';
@@ -799,11 +800,10 @@ export function setup(logger: Logger) {
 			const aw = app.workbench.agentsWindow;
 
 			try {
-				// Prime the Local Agent Host CLI model list and leave a fresh
-				// new-session view with 'Local Agent Host' selected.
+				// Session 1: prime the Local Agent Host CLI model list, create the
+				// active session, then pick a non-default model (discovered at runtime).
 				await warmUpAgentHostModel(app, logger, 'Agents Window (model restore)');
 
-				// Session 1: create the active session, then pick a non-default model.
 				const requestsBefore = agentHost.mockServer.requestCount();
 				await aw.submitNewSessionPrompt(`hello world [scenario:${RESTORE_1_ID}]`);
 				await aw.waitForAssistantText(RESTORE_1_REPLY, 120_000);
@@ -812,8 +812,9 @@ export function setup(logger: Logger) {
 					'expected the mock LLM server to have received a request from the Local Agent Host session'
 				);
 
-				await aw.selectModel(RESTORE_MODEL_NAME);
-				await aw.waitForSelectedModel(RESTORE_MODEL_NAME);
+				const selectedModel = await aw.selectFirstNonDefaultModel();
+				await aw.waitForSelectedModel(selectedModel);
+				logger.log(`[Agents Window/model-restore] selected model: '${selectedModel}'`);
 
 				// Session 2: open a brand-new Local Agent Host session. The agent-host
 				// session type owns its own model pool, so the per-type persisted model
@@ -826,11 +827,11 @@ export function setup(logger: Logger) {
 				await aw.submitNewSessionPrompt(`hello world [scenario:${RESTORE_2_ID}]`);
 				await aw.waitForAssistantText(RESTORE_2_REPLY, 120_000);
 
-				await aw.waitForSelectedModel(RESTORE_MODEL_NAME);
+				await aw.waitForSelectedModel(selectedModel);
 				const restored = await aw.getSelectedModelName();
 				assert.ok(
-					restored.includes(RESTORE_MODEL_NAME),
-					`Expected the new Local Agent Host session to restore the selected model '${RESTORE_MODEL_NAME}', got '${restored}'.`
+					restored.includes(selectedModel),
+					`Expected the new Local Agent Host session to restore the selected model '${selectedModel}', got '${restored}'.`
 				);
 			} catch (error) {
 				logger.log(`[Agents Window/model-restore] FAILURE: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);

--- a/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
+++ b/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
@@ -769,6 +769,77 @@ export function setup(logger: Logger) {
 		});
 	});
 
+	describe('Agents Window (model restore)', () => {
+		// Uses the Local Agent Host (Copilot Agent running in the Agent Host)
+		// rather than the plain copilot-chat "Local" session, because agent-host
+		// session types own their own model pool — the exact surface the
+		// per-type model restore fix targets (shouldRestorePerTypeModelOnSessionSwitch /
+		// shouldSuppressModelPersistenceOnSessionSwitch / shouldWaitForSessionModel).
+
+		// A non-default, picker-enabled model advertised by the mock server.
+		const RESTORE_MODEL_NAME = MODEL_CONFIG_MODEL_NAME;
+		const RESTORE_1_ID = 'smoke-agents-model-restore-1';
+		const RESTORE_1_REPLY = 'MOCKED_AGENTS_MODEL_RESTORE_1';
+		const RESTORE_2_ID = 'smoke-agents-model-restore-2';
+		const RESTORE_2_REPLY = 'MOCKED_AGENTS_MODEL_RESTORE_2';
+
+		const agentHost = setupAgentHostSuite(logger, {
+			serverLabel: 'AgentHost model restore',
+			registerScenarios: ({ ScenarioBuilder, registerScenario }) => {
+				registerScenario(RESTORE_1_ID, new ScenarioBuilder().emit(RESTORE_1_REPLY).build());
+				registerScenario(RESTORE_2_ID, new ScenarioBuilder().emit(RESTORE_2_REPLY).build());
+			},
+			settings: {},
+		});
+
+		it('restores the selected model when a new Local Agent Host session is opened', async function () {
+			this.timeout(5 * 60 * 1000);
+
+			const app = this.app as Application;
+			const aw = app.workbench.agentsWindow;
+
+			try {
+				// Prime the Local Agent Host CLI model list and leave a fresh
+				// new-session view with 'Local Agent Host' selected.
+				await warmUpAgentHostModel(app, logger, 'Agents Window (model restore)');
+
+				// Session 1: create the active session, then pick a non-default model.
+				const requestsBefore = agentHost.mockServer.requestCount();
+				await aw.submitNewSessionPrompt(`hello world [scenario:${RESTORE_1_ID}]`);
+				await aw.waitForAssistantText(RESTORE_1_REPLY, 120_000);
+				assert.ok(
+					agentHost.mockServer.requestCount() > requestsBefore,
+					'expected the mock LLM server to have received a request from the Local Agent Host session'
+				);
+
+				await aw.selectModel(RESTORE_MODEL_NAME);
+				await aw.waitForSelectedModel(RESTORE_MODEL_NAME);
+
+				// Session 2: open a brand-new Local Agent Host session. The agent-host
+				// session type owns its own model pool, so the per-type persisted model
+				// must be restored into the new session's picker (this is the "open a
+				// new chat session restores the last selected model" half of the fix —
+				// a regression here previously reset it to Auto/default).
+				await aw.startNewSession();
+				await aw.waitForNewSessionView();
+				await aw.selectSessionType('Local Agent Host');
+				await aw.submitNewSessionPrompt(`hello world [scenario:${RESTORE_2_ID}]`);
+				await aw.waitForAssistantText(RESTORE_2_REPLY, 120_000);
+
+				await aw.waitForSelectedModel(RESTORE_MODEL_NAME);
+				const restored = await aw.getSelectedModelName();
+				assert.ok(
+					restored.includes(RESTORE_MODEL_NAME),
+					`Expected the new Local Agent Host session to restore the selected model '${RESTORE_MODEL_NAME}', got '${restored}'.`
+				);
+			} catch (error) {
+				logger.log(`[Agents Window/model-restore] FAILURE: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+				await dumpFailureDiagnostics(app, logger, 'Agents Window (model restore)', { sendButtonSelector: AGENTS_SEND_BUTTON_SELECTOR });
+				throw error;
+			}
+		});
+	});
+
 	describe('Agents Window (local AgentHost)', () => {
 
 		const agentHost = setupAgentHostSuite(logger, {

--- a/test/smoke/src/areas/chat/chatModelRestore.test.ts
+++ b/test/smoke/src/areas/chat/chatModelRestore.test.ts
@@ -1,0 +1,188 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Application, Chat, Logger } from '../../../../automation';
+import { getCopilotSmokeTestEnv, getMockLlmServerPath, installAllHandlers, MockLlmServer, preseedChatExtensionEnablement } from '../../utils';
+
+/**
+ * The mock LLM server handle plus the model-availability control the restore/
+ * fallback tests need. `setHiddenModelIds` removes a model from the advertised
+ * `/models` list so we can simulate it becoming temporarily unavailable across a
+ * window reload (see `scripts/chat-simulation/common/mock-llm-server.ts`).
+ */
+interface MockServerWithModelControl extends MockLlmServer {
+	setHiddenModelIds(ids: string[]): void;
+	getHiddenModelIds(): string[];
+}
+
+/**
+ * A non-default, picker-enabled mock model. Reused from the `Chat Model
+ * Configuration` suite because it is already proven selectable in the panel
+ * chat, and it is NOT the chat default — so a successful restore assertion
+ * cannot be a coincidence of the default happening to match.
+ */
+const MODEL_NAME = 'Mock Config Model';
+const MODEL_ID = 'mock-config-model';
+
+const WARMUP_SCENARIO_ID = 'smoke-model-restore-warmup';
+const WARMUP_REPLY = 'MOCKED_MODEL_RESTORE_WARMUP';
+
+/**
+ * Sends the warm-up message and waits for the model's reply, retrying until the
+ * panel is actually usable. In a from-source build the panel's first send can
+ * route to the (failing) chat-setup install path until the anonymous
+ * entitlement resolves, so a single send is not reliable — each retry gives the
+ * entitlement service more time to settle. Mirrors `chatModelConfig.test.ts`.
+ */
+async function sendWarmUpUntilReady(chat: Chat, logger: Logger): Promise<void> {
+	const tag = `[scenario:${WARMUP_SCENARIO_ID}]`;
+	const deadline = Date.now() + 180_000;
+	let attempt = 0;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		attempt++;
+		try {
+			await chat.sendMessage(`warm up ${tag}`);
+			await chat.waitForResponseText(WARMUP_REPLY, 25_000);
+			logger.log(`[Chat Model Restore] warm-up succeeded on attempt ${attempt}`);
+			return;
+		} catch (error) {
+			lastError = error;
+			logger.log(`[Chat Model Restore] warm-up attempt ${attempt} not ready yet; retrying`);
+		}
+	}
+	throw new Error(`Chat did not become ready for warm-up within timeout. Last error: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+}
+
+/**
+ * Open the panel chat and warm it up so the Copilot extension is active and the
+ * model list is populated (which makes the model picker usable). Safe to call
+ * again after a window reload.
+ */
+async function openAndWarmUpChat(app: Application, logger: Logger): Promise<Chat> {
+	await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
+	const chat = app.workbench.chat;
+	await chat.waitForChatView();
+	await sendWarmUpUntilReady(chat, logger);
+	return chat;
+}
+
+export function setup(logger: Logger) {
+
+	describe('Chat Model Restore', function () {
+		this.timeout(6 * 60 * 1000);
+		this.retries(0);
+
+		let mockServer: MockServerWithModelControl;
+
+		before(async function () {
+			const { startServer, ScenarioBuilder, registerScenario } = require(getMockLlmServerPath());
+
+			// Fallback for ancillary requests (title generation etc.) with no tag.
+			registerScenario('text-only', new ScenarioBuilder().emit('OK').build());
+			registerScenario(WARMUP_SCENARIO_ID, new ScenarioBuilder().emit(WARMUP_REPLY).build());
+
+			mockServer = await startServer(0, { logger: (msg: string) => logger.log(`[mock-llm] ${msg}`) });
+			logger.log(`[Chat Model Restore] mock LLM server started at ${mockServer.url}`);
+		});
+
+		installAllHandlers(logger, opts => {
+			const copilotEnv = getCopilotSmokeTestEnv(mockServer);
+			return {
+				...opts,
+				extraArgs: [...(opts.extraArgs ?? []), '--log=trace'],
+				extraEnv: {
+					...(opts.extraEnv ?? {}),
+					...copilotEnv,
+				},
+			};
+		}, app => {
+			// Keep the from-source built-in copilot-chat enabled on the fresh
+			// per-run profile (see `chatModelConfig.test.ts`).
+			preseedChatExtensionEnablement(app.userDataPath);
+		});
+
+		before(async function () {
+			const app = this.app as Application;
+			await app.workbench.settingsEditor.addUserSettings([
+				['github.copilot.advanced.debug.overrideProxyUrl', JSON.stringify(mockServer.url)],
+				['github.copilot.advanced.debug.overrideCapiUrl', JSON.stringify(mockServer.url)],
+				['github.copilot.advanced.debug.overrideAuthType', '"token"'],
+				['chat.allowAnonymousAccess', 'true'],
+				['github.copilot.chat.githubMcpServer.enabled', 'false'],
+				['chat.mcp.discovery.enabled', 'false'],
+				['chat.mcp.enabled', 'false'],
+				['chat.disableAIFeatures', 'false'],
+			]);
+			logger.log(`[Chat Model Restore] user settings written (mock URL=${mockServer.url})`);
+		});
+
+		after(async function () {
+			// Always re-show every model so a hidden set can't leak into a later suite.
+			mockServer?.setHiddenModelIds([]);
+			await mockServer?.close();
+		});
+
+		it('restores the last selected model after a window reload', async function () {
+			const app = this.app as Application;
+
+			// Select a non-default model, then confirm the picker committed to it.
+			let chat = await openAndWarmUpChat(app, logger);
+			await chat.selectModel(MODEL_NAME);
+			await chat.waitForSelectedModel(MODEL_NAME);
+
+			// Full window relaunch (reuses the same user-data dir, so the persisted
+			// model selection survives — this is the scenario the "all windows
+			// switched to Auto" regression broke).
+			await app.restart();
+
+			chat = await openAndWarmUpChat(app, logger);
+			await chat.waitForSelectedModel(MODEL_NAME);
+			const restored = await chat.getSelectedModelName();
+			assert.ok(
+				restored.includes(MODEL_NAME),
+				`Expected the model picker to restore '${MODEL_NAME}' after reload, got '${restored}'.`
+			);
+		});
+
+		it('keeps the picked model when it is temporarily unavailable and restores it when it returns', async function () {
+			const app = this.app as Application;
+
+			// Pick the model — this persists it as the user's explicit choice.
+			let chat = await openAndWarmUpChat(app, logger);
+			await chat.selectModel(MODEL_NAME);
+			await chat.waitForSelectedModel(MODEL_NAME);
+
+			// The model disappears from the advertised list (as if it were removed
+			// server-side or gated off after an update). After reload the client must
+			// fall back to another model WITHOUT overwriting the stored preference.
+			mockServer.setHiddenModelIds([MODEL_ID]);
+			await app.restart();
+
+			chat = await openAndWarmUpChat(app, logger);
+			const fallback = await chat.getSelectedModelName();
+			assert.ok(
+				!fallback.includes(MODEL_NAME),
+				`Expected the picker to fall back to another model while '${MODEL_NAME}' is unavailable, but it still shows '${fallback}'.`
+			);
+
+			// The model becomes available again. Because the fallback was never
+			// stored as the user's choice, the persisted preference still points at
+			// the picked model, so after reload the picker flips back to it.
+			mockServer.setHiddenModelIds([]);
+			await app.restart();
+
+			chat = await openAndWarmUpChat(app, logger);
+			await chat.waitForSelectedModel(MODEL_NAME);
+			const restored = await chat.getSelectedModelName();
+			assert.ok(
+				restored.includes(MODEL_NAME),
+				`Expected the picker to flip back to '${MODEL_NAME}' once it is available again, got '${restored}'. ` +
+				`This means the transient fallback was wrongly persisted as the user's choice.`
+			);
+		});
+	});
+}

--- a/test/smoke/src/areas/chat/chatModelRestore.test.ts
+++ b/test/smoke/src/areas/chat/chatModelRestore.test.ts
@@ -4,19 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { Application, Chat, Logger } from '../../../../automation';
+import fetch from 'node-fetch';
+import { Application, ApplicationOptions, Chat, Logger } from '../../../../automation';
 import { getCopilotSmokeTestEnv, getMockLlmServerPath, installAllHandlers, MockLlmServer, preseedChatExtensionEnablement } from '../../utils';
-
-/**
- * The mock LLM server handle plus the model-availability control the restore/
- * fallback tests need. `setHiddenModelIds` removes a model from the advertised
- * `/models` list so we can simulate it becoming temporarily unavailable across a
- * window reload (see `scripts/chat-simulation/common/mock-llm-server.ts`).
- */
-interface MockServerWithModelControl extends MockLlmServer {
-	setHiddenModelIds(ids: string[]): void;
-	getHiddenModelIds(): string[];
-}
 
 /**
  * A non-default, picker-enabled mock model. Reused from the `Chat Model
@@ -29,6 +19,22 @@ const MODEL_ID = 'mock-config-model';
 
 const WARMUP_SCENARIO_ID = 'smoke-model-restore-warmup';
 const WARMUP_REPLY = 'MOCKED_MODEL_RESTORE_WARMUP';
+
+/**
+ * Hide (or, with an empty array, re-show) the given models on the mock server so
+ * a reloaded client re-fetching `/models` sees the updated set. Uses the mock's
+ * `POST /_control/models` test endpoint (see `mock-llm-server.ts`).
+ */
+async function setHiddenModels(mockUrl: string, ids: string[]): Promise<void> {
+	const res = await fetch(`${mockUrl}/_control/models`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ hidden: ids }),
+	});
+	if (!res.ok) {
+		throw new Error(`Failed to set hidden models (HTTP ${res.status})`);
+	}
+}
 
 /**
  * Sends the warm-up message and waits for the model's reply, retrying until the
@@ -70,61 +76,66 @@ async function openAndWarmUpChat(app: Application, logger: Logger): Promise<Chat
 	return chat;
 }
 
+/**
+ * Register the mock LLM server, app env, and Copilot user settings for a panel
+ * chat model-restore suite. Each suite gets its OWN app instance (its own
+ * `installAllHandlers`) so a reload/restart in one test can't leave state that
+ * corrupts another test's warm-up. Returns an accessor for the started mock URL.
+ */
+function installPanelChatSuite(logger: Logger): { readonly url: string } {
+	let mockServer: MockLlmServer;
+
+	before(async function () {
+		const { startServer, ScenarioBuilder, registerScenario } = require(getMockLlmServerPath());
+		// Fallback for ancillary requests (title generation etc.) with no tag.
+		registerScenario('text-only', new ScenarioBuilder().emit('OK').build());
+		registerScenario(WARMUP_SCENARIO_ID, new ScenarioBuilder().emit(WARMUP_REPLY).build());
+		mockServer = await startServer(0, { logger: (msg: string) => logger.log(`[mock-llm] ${msg}`) });
+		logger.log(`[Chat Model Restore] mock LLM server started at ${mockServer.url}`);
+	});
+
+	installAllHandlers(logger, (opts: ApplicationOptions) => {
+		const copilotEnv = getCopilotSmokeTestEnv(mockServer);
+		return {
+			...opts,
+			extraArgs: [...(opts.extraArgs ?? []), '--log=trace'],
+			extraEnv: { ...(opts.extraEnv ?? {}), ...copilotEnv },
+		};
+	}, app => {
+		// Keep the from-source built-in copilot-chat enabled on the fresh
+		// per-run profile (see `chatModelConfig.test.ts`).
+		preseedChatExtensionEnablement(app.userDataPath);
+	});
+
+	before(async function () {
+		const app = this.app as Application;
+		await app.workbench.settingsEditor.addUserSettings([
+			['github.copilot.advanced.debug.overrideProxyUrl', JSON.stringify(mockServer.url)],
+			['github.copilot.advanced.debug.overrideCapiUrl', JSON.stringify(mockServer.url)],
+			['github.copilot.advanced.debug.overrideAuthType', '"token"'],
+			['chat.allowAnonymousAccess', 'true'],
+			['github.copilot.chat.githubMcpServer.enabled', 'false'],
+			['chat.mcp.discovery.enabled', 'false'],
+			['chat.mcp.enabled', 'false'],
+			['chat.disableAIFeatures', 'false'],
+		]);
+		logger.log(`[Chat Model Restore] user settings written (mock URL=${mockServer.url})`);
+	});
+
+	after(async function () {
+		await mockServer?.close();
+	});
+
+	return { get url() { return mockServer.url; } };
+}
+
 export function setup(logger: Logger) {
 
 	describe('Chat Model Restore', function () {
 		this.timeout(6 * 60 * 1000);
 		this.retries(0);
 
-		let mockServer: MockServerWithModelControl;
-
-		before(async function () {
-			const { startServer, ScenarioBuilder, registerScenario } = require(getMockLlmServerPath());
-
-			// Fallback for ancillary requests (title generation etc.) with no tag.
-			registerScenario('text-only', new ScenarioBuilder().emit('OK').build());
-			registerScenario(WARMUP_SCENARIO_ID, new ScenarioBuilder().emit(WARMUP_REPLY).build());
-
-			mockServer = await startServer(0, { logger: (msg: string) => logger.log(`[mock-llm] ${msg}`) });
-			logger.log(`[Chat Model Restore] mock LLM server started at ${mockServer.url}`);
-		});
-
-		installAllHandlers(logger, opts => {
-			const copilotEnv = getCopilotSmokeTestEnv(mockServer);
-			return {
-				...opts,
-				extraArgs: [...(opts.extraArgs ?? []), '--log=trace'],
-				extraEnv: {
-					...(opts.extraEnv ?? {}),
-					...copilotEnv,
-				},
-			};
-		}, app => {
-			// Keep the from-source built-in copilot-chat enabled on the fresh
-			// per-run profile (see `chatModelConfig.test.ts`).
-			preseedChatExtensionEnablement(app.userDataPath);
-		});
-
-		before(async function () {
-			const app = this.app as Application;
-			await app.workbench.settingsEditor.addUserSettings([
-				['github.copilot.advanced.debug.overrideProxyUrl', JSON.stringify(mockServer.url)],
-				['github.copilot.advanced.debug.overrideCapiUrl', JSON.stringify(mockServer.url)],
-				['github.copilot.advanced.debug.overrideAuthType', '"token"'],
-				['chat.allowAnonymousAccess', 'true'],
-				['github.copilot.chat.githubMcpServer.enabled', 'false'],
-				['chat.mcp.discovery.enabled', 'false'],
-				['chat.mcp.enabled', 'false'],
-				['chat.disableAIFeatures', 'false'],
-			]);
-			logger.log(`[Chat Model Restore] user settings written (mock URL=${mockServer.url})`);
-		});
-
-		after(async function () {
-			// Always re-show every model so a hidden set can't leak into a later suite.
-			mockServer?.setHiddenModelIds([]);
-			await mockServer?.close();
-		});
+		installPanelChatSuite(logger);
 
 		it('restores the last selected model after a window reload', async function () {
 			const app = this.app as Application;
@@ -147,6 +158,20 @@ export function setup(logger: Logger) {
 				`Expected the model picker to restore '${MODEL_NAME}' after reload, got '${restored}'.`
 			);
 		});
+	});
+
+	// Isolated in its own suite (own app) so the multi-restart flow can't
+	// contaminate — or be contaminated by — the reload test above.
+	describe('Chat Model Restore (fallback)', function () {
+		this.timeout(8 * 60 * 1000);
+		this.retries(0);
+
+		const mock = installPanelChatSuite(logger);
+
+		after(async function () {
+			// Re-show all models so a hidden set can't leak into a later suite.
+			try { await setHiddenModels(mock.url, []); } catch { /* server may be closing */ }
+		});
 
 		it('keeps the picked model when it is temporarily unavailable and restores it when it returns', async function () {
 			const app = this.app as Application;
@@ -156,10 +181,10 @@ export function setup(logger: Logger) {
 			await chat.selectModel(MODEL_NAME);
 			await chat.waitForSelectedModel(MODEL_NAME);
 
-			// The model disappears from the advertised list (as if it were removed
-			// server-side or gated off after an update). After reload the client must
-			// fall back to another model WITHOUT overwriting the stored preference.
-			mockServer.setHiddenModelIds([MODEL_ID]);
+			// The model disappears from the advertised list (as if removed
+			// server-side or gated off after an update). After reload the client
+			// must fall back to another model WITHOUT overwriting the stored pick.
+			await setHiddenModels(mock.url, [MODEL_ID]);
 			await app.restart();
 
 			chat = await openAndWarmUpChat(app, logger);
@@ -172,7 +197,7 @@ export function setup(logger: Logger) {
 			// The model becomes available again. Because the fallback was never
 			// stored as the user's choice, the persisted preference still points at
 			// the picked model, so after reload the picker flips back to it.
-			mockServer.setHiddenModelIds([]);
+			await setHiddenModels(mock.url, []);
 			await app.restart();
 
 			chat = await openAndWarmUpChat(app, logger);

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -32,6 +32,7 @@ import { setup as setupCopilotCliTests } from './areas/chat/copilotCli.test';
 import { setup as setupChatSandboxTests } from './areas/chat/chatSandbox.test';
 import { setup as setupChatSessionsTests } from './areas/chat/chatSessions.test';
 import { setup as setupChatModelConfigTests } from './areas/chat/chatModelConfig.test';
+import { setup as setupChatModelRestoreTests } from './areas/chat/chatModelRestore.test';
 import { setup as setupAccessibilityTests } from './areas/accessibility/accessibility.test';
 import { setup as setupAgentsWindowTests } from './areas/agentsWindow/agentsWindow.test';
 
@@ -439,6 +440,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (!opts.web) { setupChatSandboxTests(logger); }
 	if (!opts.web && !opts.remote) { setupChatSessionsTests(logger); }
 	if (!opts.web && !opts.remote) { setupChatModelConfigTests(logger); }
+	if (!opts.web && !opts.remote) { setupChatModelRestoreTests(logger); }
 	if (!opts.web && !opts.remote) { setupAgentsWindowTests(logger); }
 	setupAccessibilityTests(logger, opts, quality);
 });


### PR DESCRIPTION
- Add functionality to restore the last selected model in the chat model picker after a window reload.
- Ensure the selected model persists across new sessions in the agents window.
- Introduce tests to verify model restoration behavior in various scenarios, including temporary unavailability of models.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
