### PR TITLE
fix: truncate long terminal title in sidebar single-tab mode

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -477,13 +477,27 @@
 .monaco-action-bar .action-item .single-terminal-tab {
 	display: flex !important;
 	align-items: center;
+	min-width: 0;
+	overflow: hidden;
+}
+
+.monaco-action-bar .action-item .single-terminal-tab .single-terminal-tab-label {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.monaco-action-bar .action-item .single-terminal-tab .codicon {
+	flex-shrink: 0;
 }
 
 .monaco-action-bar .action-item .single-terminal-tab .codicon:first-child {
 	margin-right: 4px;
 }
 
-.monaco-action-bar .action-item .single-terminal-tab .codicon:nth-child(2) {
+.monaco-action-bar .action-item .single-terminal-tab .codicon:last-child {
 	margin-left: 4px;
 	color: inherit;
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -30,7 +30,7 @@ import { ISelectOptionItem, SeparatorSelectOption } from '../../../../base/brows
 import { IActionViewItem } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { TerminalTabbedView } from './terminalTabbedView.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { getColorForSeverity } from './terminalStatusList.js';
 import { getFlatContextMenuActions, MenuEntryActionViewItem } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { DropdownWithPrimaryActionViewItem } from '../../../../platform/actions/browser/dropdownWithPrimaryActionViewItem.js';
@@ -515,7 +515,7 @@ class SingleTerminalTabActionViewItem extends MenuEntryActionViewItem {
 				}
 			}
 			label.style.color = colorStyle;
-			dom.reset(label, ...renderLabelWithIcons(this._instantiationService.invokeFunction(getSingleTabLabel, instance, this._terminaConfigurationService.config.tabs.separator, ThemeIcon.isThemeIcon(this._commandAction.item.icon) ? this._commandAction.item.icon : undefined)));
+			dom.reset(label, ...this._instantiationService.invokeFunction(getSingleTabLabel, instance, this._terminaConfigurationService.config.tabs.separator, ThemeIcon.isThemeIcon(this._commandAction.item.icon) ? this._commandAction.item.icon : undefined));
 
 			if (this._altCommand) {
 				label.classList.remove(this._altCommand);
@@ -564,23 +564,24 @@ class SingleTerminalTabActionViewItem extends MenuEntryActionViewItem {
 	}
 }
 
-function getSingleTabLabel(accessor: ServicesAccessor, instance: ITerminalInstance | undefined, separator: string, icon?: ThemeIcon) {
+export function getSingleTabLabel(accessor: ServicesAccessor, instance: ITerminalInstance | undefined, separator: string, icon?: ThemeIcon): Array<Node> {
 	// Don't even show the icon if there is no title as the icon would shift around when the title
 	// is added
 	if (!instance || !instance.title) {
-		return '';
+		return [];
 	}
 	const iconId = ThemeIcon.isThemeIcon(instance.icon) ? instance.icon.id : accessor.get(ITerminalProfileResolverService).getDefaultIcon().id;
-	const label = `$(${icon?.id || iconId}) ${getSingleTabTitle(instance, separator)}`;
+	const title = dom.$('span.single-terminal-tab-label', {}, getSingleTabTitle(instance, separator));
+	const nodes: Node[] = [renderIcon(icon ? { id: icon.id } : { id: iconId }), title];
 
 	const primaryStatus = instance.statusList.primary;
-	if (!primaryStatus?.icon) {
-		return label;
+	if (primaryStatus?.icon) {
+		nodes.push(renderIcon(primaryStatus.icon));
 	}
-	return `${label} $(${primaryStatus.icon.id})`;
+	return nodes;
 }
 
-function getSingleTabTitle(instance: ITerminalInstance | undefined, separator: string): string {
+export function getSingleTabTitle(instance: ITerminalInstance | undefined, separator: string): string {
 	if (!instance) {
 		return '';
 	}

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalView.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalView.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { deepStrictEqual, strictEqual } from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import Severity from '../../../../../base/common/severity.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { getSingleTabLabel, getSingleTabTitle } from '../../browser/terminalView.js';
+import { ITerminalStatus } from '../../common/terminal.js';
+import { ITerminalInstance } from '../../browser/terminal.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import type { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+
+function createInstance(opts: { title?: string; description?: string; icon?: ThemeIcon; primaryStatus?: ITerminalStatus }): ITerminalInstance {
+	return {
+		title: opts.title,
+		description: opts.description,
+		icon: opts.icon,
+		statusList: { primary: opts.primaryStatus },
+	} as unknown as ITerminalInstance;
+}
+
+suite('Workbench - TerminalView single tab', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	let accessor: ServicesAccessor;
+
+	setup(() => {
+		accessor = workbenchInstantiationService(undefined, store);
+	});
+
+	test('getSingleTabTitle returns empty for undefined instance', () => {
+		strictEqual(getSingleTabTitle(undefined, '—'), '');
+	});
+
+	test('getSingleTabTitle returns title when no description', () => {
+		const instance = createInstance({ title: 'zsh' });
+		strictEqual(getSingleTabTitle(instance, '—'), 'zsh');
+	});
+
+	test('getSingleTabTitle joins title, separator and description', () => {
+		const instance = createInstance({ title: 'node', description: '/home/cham/project' });
+		strictEqual(getSingleTabTitle(instance, '—'), 'node — /home/cham/project');
+	});
+
+	test('getSingleTabLabel returns no nodes when title is missing', () => {
+		deepStrictEqual(getSingleTabLabel(accessor, undefined, '—'), []);
+		deepStrictEqual(getSingleTabLabel(accessor, createInstance({ title: '' }), '—'), []);
+	});
+
+	test('getSingleTabLabel wraps title in a single-terminal-tab-label span', () => {
+		const instance = createInstance({ title: 'zsh' });
+		const nodes = getSingleTabLabel(accessor, instance, '—');
+		strictEqual(nodes.length, 2);
+		strictEqual((nodes[0] as HTMLElement).tagName, 'SPAN');
+		strictEqual((nodes[0] as HTMLElement).classList.contains('codicon'), true);
+		const label = nodes[1] as HTMLElement;
+		strictEqual(label.tagName, 'SPAN');
+		strictEqual(label.classList.contains('single-terminal-tab-label'), true);
+		strictEqual(label.textContent, 'zsh');
+	});
+
+	test('getSingleTabLabel renders the long title inside the label span', () => {
+		const long = 'A very long terminal title that should definitely truncate with ellipsis';
+		const instance = createInstance({ title: long });
+		const nodes = getSingleTabLabel(accessor, instance, '—');
+		const label = nodes[1] as HTMLElement;
+		strictEqual(label.textContent, long);
+	});
+
+	test('getSingleTabLabel appends a status icon when the instance has a primary status', () => {
+		const instance = createInstance({
+			title: 'zsh',
+			primaryStatus: { id: 'disconnected', severity: Severity.Error, icon: Codicon.debugDisconnect },
+		});
+		const nodes = getSingleTabLabel(accessor, instance, '—');
+		strictEqual(nodes.length, 3);
+		strictEqual((nodes[2] as HTMLElement).classList.contains('codicon'), true);
+	});
+
+	test('getSingleTabLabel uses the explicit icon when provided', () => {
+		const instance = createInstance({ title: 'zsh', icon: Codicon.terminal });
+		const nodes = getSingleTabLabel(accessor, instance, '—', Codicon.zap);
+		const icon = nodes[0] as HTMLElement;
+		strictEqual(icon.classList.contains('codicon-zap'), true);
+	});
+});


### PR DESCRIPTION
Fixes #324910

When the terminal panel is docked to the side and tabs are collapsed to single-tab mode, a long terminal title rendered into `.single-terminal-tab` overlapped the split/kill control buttons on the right.

Root cause: the title was a raw string returned by `getSingleTabLabel` and fed to `renderLabelWithIcons`, becoming an anonymous flex text node. Such nodes default to `min-width: auto` and expand infinitely, and `text-overflow: ellipsis` cannot apply to anonymous flex text.

Wrap the title in a real `<span class="single-terminal-tab-label">` element and constrain it (and the parent `.single-terminal-tab`) with `min-width: 0; overflow: hidden; text-overflow: ellipsis`, mirroring the pattern already used by `.monaco-icon-label` (tabs-list path) and the `.switch-terminal` select container.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
