### PR TITLE
Fix disabled and enabled extension disable button dropdown (#244138)

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1781,6 +1781,7 @@ export class DisableGloballyAction extends ExtensionAction {
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
 				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& !this.extensionEnablementService.isDisabledGlobally(this.extension.local)
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
Fixes #244138

**Bug:** When an extension is disabled globally and then enabled for a workspace, the "Disable" button shows a dropdown with both "Disable" and "Disable (Workspace)", even though the global disable action is no longer valid.

**Fix:** Updated `DisableGloballyAction.update()` to verify the extension is not already globally disabled before enabling the global disable action. This correctly hides the global disable action from the dropdown, leaving only the "Disable (Workspace)" button.
