### PR TITLE
Style overrides: Fix notification row height for style overrides

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -34,9 +34,23 @@ import type { IManagedHover } from '../../../../base/browser/ui/hover/hover.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
+/** Default height (px) of a single notification row. */
+export const DEFAULT_NOTIFICATION_ROW_HEIGHT = 42;
+
+/** Current height (px) of a single notification row; overridable via {@link setNotificationRowHeight}. */
+let notificationRowHeight = DEFAULT_NOTIFICATION_ROW_HEIGHT;
+
+/**
+ * Overrides the height (px) of a single notification row. Used by the Modern UI
+ * style-override experiment to shrink the collapsed notification card.
+ */
+export function setNotificationRowHeight(height: number): void {
+	notificationRowHeight = height;
+}
+
 export class NotificationsListDelegate implements IListVirtualDelegate<INotificationViewItem> {
 
-	private static readonly ROW_HEIGHT = 42;
+	private static get ROW_HEIGHT(): number { return notificationRowHeight; }
 	private static readonly LINE_HEIGHT = 22;
 
 	private offsetHelper: HTMLElement;

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -10,9 +10,13 @@ import { IWorkbenchLayoutService, LayoutSettings } from '../../../services/layou
 import { Extensions as WorkbenchExtensions, IWorkbenchContribution, IWorkbenchContributionsRegistry } from '../../../common/contributions.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { DEFAULT_SCROLLBAR_SIZE, setGlobalDefaultScrollbarSize } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
+import { DEFAULT_NOTIFICATION_ROW_HEIGHT, setNotificationRowHeight } from '../../../browser/parts/notifications/notificationsViewer.js';
 
 /** Reduced scrollbar size (px) applied when the style-override experiment is on. */
 const SCROLLBAR_OVERRIDE_SIZE = 8;
+
+/** Reduced collapsed notification row height (px) applied when the style-override experiment is on. */
+const NOTIFICATION_ROW_HEIGHT_OVERRIDE = 36;
 
 // Bundle the CSS for every style-override module. Every file gates all of its
 // rules behind the single `.style-override` ancestor class, so the styles are
@@ -145,6 +149,7 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 			this.applyTo(container, enabled);
 		}
 		this.applyScrollbarSize(enabled);
+		this.applyNotificationRowHeight(enabled);
 	}
 
 	private applyTo(container: HTMLElement, enabled: boolean): void {
@@ -155,12 +160,17 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 		setGlobalDefaultScrollbarSize(enabled ? SCROLLBAR_OVERRIDE_SIZE : DEFAULT_SCROLLBAR_SIZE);
 	}
 
+	private applyNotificationRowHeight(enabled: boolean): void {
+		setNotificationRowHeight(enabled ? NOTIFICATION_ROW_HEIGHT_OVERRIDE : DEFAULT_NOTIFICATION_ROW_HEIGHT);
+	}
+
 	override dispose(): void {
 		// Remove the class this contribution added so it leaves no DOM state behind.
 		for (const container of this.layoutService.containers) {
 			container.classList.remove(STYLE_OVERRIDE_CLASS);
 		}
 		setGlobalDefaultScrollbarSize(DEFAULT_SCROLLBAR_SIZE);
+		setNotificationRowHeight(DEFAULT_NOTIFICATION_ROW_HEIGHT);
 		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -16,7 +16,7 @@ import { DEFAULT_NOTIFICATION_ROW_HEIGHT, setNotificationRowHeight } from '../..
 const SCROLLBAR_OVERRIDE_SIZE = 8;
 
 /** Reduced collapsed notification row height (px) applied when the style-override experiment is on. */
-const NOTIFICATION_ROW_HEIGHT_OVERRIDE = 36;
+const NOTIFICATION_ROW_OVERRIDE_HEIGHT = 34;
 
 // Bundle the CSS for every style-override module. Every file gates all of its
 // rules behind the single `.style-override` ancestor class, so the styles are
@@ -161,7 +161,7 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 	}
 
 	private applyNotificationRowHeight(enabled: boolean): void {
-		setNotificationRowHeight(enabled ? NOTIFICATION_ROW_HEIGHT_OVERRIDE : DEFAULT_NOTIFICATION_ROW_HEIGHT);
+		setNotificationRowHeight(enabled ? NOTIFICATION_ROW_OVERRIDE_HEIGHT : DEFAULT_NOTIFICATION_ROW_HEIGHT);
 	}
 
 	override dispose(): void {


### PR DESCRIPTION
This pull request introduces a mechanism to allow dynamic adjustment of the notification row height in the notifications viewer, primarily to support style overrides for experiments such as the Modern UI. The changes make the notification row height configurable and ensure that it is reset appropriately when style overrides are toggled or disposed.

<img width="475" height="75" alt="image" src="https://github.com/user-attachments/assets/312e46a4-fea9-4a01-8e9a-5e8378648c87" />

**Notification Row Height Customization:**

* Added `DEFAULT_NOTIFICATION_ROW_HEIGHT` and a mutable `notificationRowHeight` variable, along with a `setNotificationRowHeight` function, to make the notification row height configurable in `notificationsViewer.ts`. The `NotificationsListDelegate` now uses this dynamic value instead of a hardcoded constant.

* In `styleOverrides.contribution.ts`, defined a reduced notification row height (`NOTIFICATION_ROW_OVERRIDE_HEIGHT`) for use when the style-override experiment is enabled, and imported the new notification row height utilities.

* Updated the `StyleOverridesContribution` class to apply the notification row height override when the style-override is toggled, and to reset it to the default when the override is disabled or disposed. [[1]](diffhunk://#diff-a865927f9a8f20356e381f95544db109d49d6ae661c7a60a1a50a37e329aadc2R152) [[2]](diffhunk://#diff-a865927f9a8f20356e381f95544db109d49d6ae661c7a60a1a50a37e329aadc2R163-R173)