### PR TITLE
sessions: align chat tab strip under session title/meta

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -19,9 +19,12 @@
 }
 
 /* Tabs host: the chat tab strip, shown only when the session has multiple chats.
-	It lives in the same centered session-view content host as the header. */
+	It lives in the same centered session-view content host as the header.
+	The left padding adds the header's status-icon column (icon + gap) on top of
+	the shared 10px so the first tab aligns under the title/meta main column
+	rather than under the status icon. */
 .chat-composite-bar.session-chat-tabs-bar {
-	padding: 0 10px;
+	padding: 0 10px 0 calc(10px + var(--vscode-codiconFontSize, 16px) + 6px);
 	box-sizing: border-box;
 	container-type: inline-size;
 


### PR DESCRIPTION
## What

Fixes the horizontal misalignment between the session header and the chat tab strip in the Agents window session view.

## Why

The session header lays out its title and meta pills (e.g. `vscode`, `7 files`, `#324935`) in a *main column* that sits to the right of the status-icon column (icon + `6px` gap). The chat tab strip below (`.session-chat-tabs-bar`) only had the shared `10px` horizontal padding and no matching offset, so the first tab pill started ~22px further left than the title/meta above it.

## How

Add the status-icon column width plus the header's gap to the tab strip's left padding:

```css
padding: 0 10px 0 calc(10px + var(--vscode-codiconFontSize, 16px) + 6px);
```

This reuses the same `--vscode-codiconFontSize` variable the header's status icon uses for sizing, so the first tab lines up precisely under the title/meta regardless of codicon size.

## Notes for reviewers

- CSS-only change scoped to `src/vs/sessions/`.
- The `chatCompositeBar` component-fixture screenshot baselines will now reflect the added left indent and should be regenerated on the next CI screenshot run.