### PR TITLE
Possible fix for test flake

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -26,7 +26,7 @@ import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostHeadlessTerminal } from './agentHostHeadlessTerminal.js';
 import { isZsh } from './agentHostShellUtils.js';
 import type { AgentHostStateManager } from './agentHostStateManager.js';
-import { Osc633Event, Osc633EventType, Osc633Parser } from './osc633Parser.js';
+import { Osc633Event, Osc633EventType, Osc633ParseSegment, Osc633Parser } from './osc633Parser.js';
 
 const WAIT_FOR_PROMPT_TIMEOUT = 10_000;
 const HEADLESS_TERMINAL_SCROLLBACK = 0;
@@ -591,38 +591,44 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 	/** Process raw PTY output: parse OSC 633 sequences, dispatch actions, track content. */
 	private _handlePtyData(managed: IManagedTerminal, rawData: string): void {
 		const tracker = managed.commandTracker;
-		let cleanedData: string;
 
-		if (tracker) {
-			const parseResult = tracker.parser.parse(rawData);
-			cleanedData = parseResult.cleanedData;
+		// Without command detection there are no OSC 633 sequences to
+		// interleave — the whole chunk is command output. With a tracker,
+		// process cleaned-data and events in stream order so that output which
+		// arrives before a CommandFinished marker (commonly in the same PTY
+		// read for fast commands) is appended to the command's output BEFORE the
+		// finished event snapshots it. Handling all events first would emit
+		// CommandFinished with the not-yet-appended output missing.
+		const segments: Osc633ParseSegment[] = tracker
+			? tracker.parser.parseSegments(rawData)
+			: (rawData.length > 0 ? [{ kind: 'data', data: rawData }] : []);
 
-			for (const event of parseResult.events) {
-				this._handleOsc633Event(managed, tracker, event);
+		let cleanedForClient = '';
+		for (const segment of segments) {
+			if (segment.kind === 'event') {
+				this._handleOsc633Event(managed, tracker!, segment.event);
+				continue;
 			}
-		} else {
-			cleanedData = rawData;
-		}
 
-		// Agent Host's server-side headless terminal answers CPR so terminals
-		// work without an attached client. Hide those queries from client xterms
-		// to avoid a second CPR response flowing back through AgentHostPty.input.
-		cleanedData = removeServerHandledTerminalQueries(cleanedData, managed.terminalQueryFilterState);
-
-		// Append to structured content
-		if (cleanedData.length > 0) {
-			this._appendToContent(managed, cleanedData);
+			// Agent Host's server-side headless terminal answers CPR so terminals
+			// work without an attached client. Hide those queries from client xterms
+			// to avoid a second CPR response flowing back through AgentHostPty.input.
+			const cleanedData = removeServerHandledTerminalQueries(segment.data, managed.terminalQueryFilterState);
+			if (cleanedData.length > 0) {
+				this._appendToContent(managed, cleanedData);
+				cleanedForClient += cleanedData;
+			}
 		}
 
 		// Trim content if too large
 		this._trimContent(managed);
 
 		// Fire data event and dispatch to protocol (cleaned, without OSC 633)
-		if (cleanedData.length > 0) {
-			managed.onDataEmitter.fire(cleanedData);
+		if (cleanedForClient.length > 0) {
+			managed.onDataEmitter.fire(cleanedForClient);
 			this._stateManager.dispatchServerAction(managed.uri, {
 				type: ActionType.TerminalData,
-				data: cleanedData,
+				data: cleanedForClient,
 			});
 		}
 	}

--- a/src/vs/platform/agentHost/node/osc633Parser.ts
+++ b/src/vs/platform/agentHost/node/osc633Parser.ts
@@ -73,6 +73,16 @@ export interface IOsc633ParseResult {
 }
 
 /**
+ * A single segment of parsed PTY data: either a run of cleaned output data or
+ * an OSC 633 event. Segments are emitted in stream order so that output which
+ * arrives before an event (e.g. a `CommandFinished` marker) can be attributed
+ * to the command before the event is handled — see {@link Osc633Parser.parseSegments}.
+ */
+export type Osc633ParseSegment =
+	| { readonly kind: 'data'; readonly data: string }
+	| { readonly kind: 'event'; readonly event: Osc633Event };
+
+/**
  * Decode escaped values in OSC 633 messages.
  * Handles `\\` -> `\` and `\xAB` -> character with code 0xAB.
  */
@@ -154,14 +164,59 @@ export class Osc633Parser {
 	/**
 	 * Parse a chunk of PTY data.
 	 * Returns cleaned data (all OSC 633 sequences removed) and extracted events.
+	 *
+	 * This is a convenience view over {@link parseSegments} that concatenates the
+	 * cleaned-data segments and collects the events. Callers that need to know
+	 * whether a run of output arrived before or after an event (for correct
+	 * command-output attribution) should use {@link parseSegments} instead.
 	 */
 	parse(data: string): IOsc633ParseResult {
 		const events: Osc633Event[] = [];
+		let cleanedData = '';
+		for (const segment of this.parseSegments(data)) {
+			if (segment.kind === 'data') {
+				cleanedData += segment.data;
+			} else {
+				events.push(segment.event);
+			}
+		}
+		return { cleanedData, events };
+	}
+
+	/**
+	 * Parse a chunk of PTY data into an ordered list of segments, preserving the
+	 * relative order of cleaned output data and OSC 633 events as they appear in
+	 * the stream. Handles partial sequences that span multiple chunks.
+	 *
+	 * Preserving order matters because a single PTY read frequently contains a
+	 * command's output immediately followed by its `CommandFinished` marker;
+	 * consumers must append that output to the command before handling the
+	 * finished event, otherwise the output is lost from the command result.
+	 */
+	parseSegments(data: string): Osc633ParseSegment[] {
+		const segments: Osc633ParseSegment[] = [];
+		let pending = '';
+
+		const appendData = (value: string): void => {
+			pending += value;
+		};
+		const flushData = (): void => {
+			if (pending.length > 0) {
+				segments.push({ kind: 'data', data: pending });
+				pending = '';
+			}
+		};
+		const emitEvent = (event: Osc633Event): void => {
+			flushData();
+			segments.push({ kind: 'event', event });
+		};
+
 		if (!this._inOsc && data.indexOf(OSC_START) === -1) {
-			return { cleanedData: data, events };
+			appendData(data);
+			flushData();
+			return segments;
 		}
 
-		let cleaned = '';
 		let i = 0;
 
 		while (i < data.length) {
@@ -175,14 +230,14 @@ export class Osc633Parser {
 						this._inOsc = false;
 						const payload = this._pendingOsc;
 						this._pendingOsc = '';
-						this._handleOscPayload(payload, events, { value: cleaned, append(s: string) { cleaned = s; } }, ST);
+						this._handleOscPayload(payload, emitEvent, appendData, ST);
 						continue;
 					}
 					// ESC was not followed by \, malformed: complete the OSC anyway.
 					this._inOsc = false;
 					const payload = this._pendingOsc;
 					this._pendingOsc = '';
-					this._handleOscPayload(payload, events, { value: cleaned, append(s: string) { cleaned = s; } });
+					this._handleOscPayload(payload, emitEvent, appendData);
 					continue;
 				}
 
@@ -193,7 +248,7 @@ export class Osc633Parser {
 					this._inOsc = false;
 					const payload = this._pendingOsc;
 					this._pendingOsc = '';
-					this._handleOscPayload(payload, events, { value: cleaned, append(s: string) { cleaned = s; } }, result.terminator);
+					this._handleOscPayload(payload, emitEvent, appendData, result.terminator);
 				} else if (result.pendingEsc) {
 					this._pendingEscInOsc = true;
 				}
@@ -204,13 +259,13 @@ export class Osc633Parser {
 			// Look for the next ESC ] which starts an OSC sequence
 			const escIdx = data.indexOf(OSC_START, i);
 			if (escIdx === -1) {
-				cleaned += data.substring(i);
+				appendData(data.substring(i));
 				i = data.length;
 				continue;
 			}
 
 			// Copy everything before the OSC start to cleaned output.
-			cleaned += data.substring(i, escIdx);
+			appendData(data.substring(i, escIdx));
 
 			// Start of OSC: check if it's 633.
 			i = escIdx + 2; // skip past ESC ]
@@ -225,14 +280,15 @@ export class Osc633Parser {
 				const payload = this._pendingOsc;
 				this._pendingOsc = '';
 				// If it's a 633 sequence, extract event; otherwise put it back in cleaned.
-				this._handleOscPayload(payload, events, { value: cleaned, append(s: string) { cleaned = s; } }, result.terminator);
+				this._handleOscPayload(payload, emitEvent, appendData, result.terminator);
 			} else if (result.pendingEsc) {
 				this._pendingEscInOsc = true;
 			}
 			// If not complete, we're at end of data and _pendingOsc is buffered.
 		}
 
-		return { cleanedData: cleaned, events };
+		flushData();
+		return segments;
 	}
 
 	/**
@@ -268,27 +324,25 @@ export class Osc633Parser {
 
 	/**
 	 * Process a complete OSC payload. If it's a 633; sequence, extract the
-	 * event. Otherwise, reconstruct the original bytes and pass them through
-	 * to cleaned output.
+	 * event via {@link emitEvent}. Otherwise, reconstruct the original bytes and
+	 * pass them through to the cleaned output via {@link appendData}.
 	 */
 	private _handleOscPayload(
 		payload: string,
-		events: Osc633Event[],
-		cleanedRef: { value: string; append(s: string): void } | undefined,
+		emitEvent: (event: Osc633Event) => void,
+		appendData: (data: string) => void,
 		terminator = BEL,
 	): void {
 		if (payload.startsWith('633;')) {
 			const oscContent = payload.substring(4); // strip "633;"
 			const event = parseOsc633Payload(oscContent);
 			if (event) {
-				events.push(event);
+				emitEvent(event);
 			}
 			// 633 sequences are always stripped from output
 		} else {
 			// Non-633 OSC: put back the original bytes.
-			if (cleanedRef) {
-				cleanedRef.append(cleanedRef.value + OSC_START + payload + terminator);
-			}
+			appendData(OSC_START + payload + terminator);
 		}
 	}
 }

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -47,13 +47,6 @@ class TestTerminalDataHandler {
 	readonly dispatched: StateAction[] = [];
 	content: TerminalContentPart[] = [];
 	cwd = '/home/user';
-	/**
-	 * Output captured for each completed command at the moment its
-	 * CommandFinished event is handled — mirrors the `output` field of
-	 * AgentHostTerminalManager's onCommandFinished event, which is what the
-	 * shell tools surface to the model.
-	 */
-	readonly finishedOutputs: string[] = [];
 	private readonly _terminalQueryFilterState: ITerminalQueryFilterState = { pendingData: '' };
 
 	constructor(
@@ -138,7 +131,6 @@ class TestTerminalDataHandler {
 						part.isComplete = true;
 						part.exitCode = event.exitCode;
 						part.durationMs = durationMs;
-						this.finishedOutputs.push(part.output);
 						break;
 					}
 				}
@@ -723,24 +715,41 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		assert.strictEqual(cmdParts[0].type === 'command' && cmdParts[0].output, 'line1\r\nline2\r\nline3\r\n');
 	});
 
-	test('output and CommandFinished arriving in one PTY read are attributed to the command', () => {
+	test('output and CommandFinished arriving in one PTY read are attributed to the command', async () => {
 		// A fast command (e.g. `echo`) frequently emits its output and the
 		// CommandExecuted/CommandFinished markers in a single PTY read. The
 		// output that precedes the CommandFinished marker must be attributed to
 		// the command before the finished event snapshots it, otherwise it is
 		// lost from the command result (regression for the flaky agent-host
 		// sandbox smoke test, where the shell tool returned an empty output).
-		const handler = createHandler();
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
+		const pty = new TestPty();
+		const manager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, pty));
+		const uri = 'agenthost-terminal://test/coalesced-command-finished';
 
-		handler.handlePtyData(
-			`${osc633('E;echo\\x20hi;test-nonce')}${osc633('C')}hi\r\n${osc633('D;0')}`
-		);
+		const createTerminal = manager.createTerminal({
+			channel: uri,
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/bash' });
 
-		const cmdParts = handler.content.filter(p => p.type === 'command');
-		assert.strictEqual(cmdParts.length, 1);
-		assert.strictEqual(cmdParts[0].type === 'command' && cmdParts[0].output, 'hi\r\n');
-		// The output captured at CommandFinished time must include the stdout,
-		// mirroring the onCommandFinished event surfaced to the shell tools.
-		assert.deepStrictEqual(handler.finishedOutputs, ['hi\r\n']);
+		await pty.dataListenerRegistered.p;
+		pty.fireData(osc633('A'));
+		await createTerminal;
+
+		const completions: { readonly exitCode: number | undefined; readonly output: string }[] = [];
+		disposables.add(manager.onCommandFinished(uri, event => completions.push({
+			exitCode: event.exitCode,
+			output: event.output,
+		})));
+
+		pty.fireData(`${osc633('C')}hi\r\n${osc633('D;0')}`);
+
+		assert.deepStrictEqual(completions, [{ exitCode: 0, output: 'hi\r\n' }]);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -736,7 +736,7 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 			cwd: process.cwd(),
 			cols: 80,
 			rows: 24,
-		}, { shell: '/bin/bash' });
+		}, { shell: process.platform === 'win32' ? 'pwsh.exe' : '/bin/bash' });
 
 		await pty.dataListenerRegistered.p;
 		pty.fireData(osc633('A'));

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -47,6 +47,13 @@ class TestTerminalDataHandler {
 	readonly dispatched: StateAction[] = [];
 	content: TerminalContentPart[] = [];
 	cwd = '/home/user';
+	/**
+	 * Output captured for each completed command at the moment its
+	 * CommandFinished event is handled — mirrors the `output` field of
+	 * AgentHostTerminalManager's onCommandFinished event, which is what the
+	 * shell tools surface to the model.
+	 */
+	readonly finishedOutputs: string[] = [];
 	private readonly _terminalQueryFilterState: ITerminalQueryFilterState = { pendingData: '' };
 
 	constructor(
@@ -56,18 +63,25 @@ class TestTerminalDataHandler {
 
 	/** Simulates AgentHostTerminalManager._handlePtyData */
 	handlePtyData(rawData: string): string {
-		const parseResult = this.tracker.parser.parse(rawData);
-		const cleanedData = removeServerHandledTerminalQueries(parseResult.cleanedData, this._terminalQueryFilterState);
+		let cleanedForClient = '';
 
-		for (const event of parseResult.events) {
-			this._handleOsc633Event(event);
+		// Process cleaned-data and events in stream order so that output which
+		// arrives before a CommandFinished marker is appended to the command
+		// before the finished event snapshots it — see _handlePtyData.
+		for (const segment of this.tracker.parser.parseSegments(rawData)) {
+			if (segment.kind === 'event') {
+				this._handleOsc633Event(segment.event);
+				continue;
+			}
+
+			const cleanedData = removeServerHandledTerminalQueries(segment.data, this._terminalQueryFilterState);
+			if (cleanedData.length > 0) {
+				this._appendToContent(cleanedData);
+				cleanedForClient += cleanedData;
+			}
 		}
 
-		if (cleanedData.length > 0) {
-			this._appendToContent(cleanedData);
-		}
-
-		return cleanedData;
+		return cleanedForClient;
 	}
 
 	private _handleOsc633Event(event: Osc633Event): void {
@@ -124,6 +138,7 @@ class TestTerminalDataHandler {
 						part.isComplete = true;
 						part.exitCode = event.exitCode;
 						part.durationMs = durationMs;
+						this.finishedOutputs.push(part.output);
 						break;
 					}
 				}
@@ -706,5 +721,26 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		const cmdParts = handler.content.filter(p => p.type === 'command');
 		assert.strictEqual(cmdParts.length, 1);
 		assert.strictEqual(cmdParts[0].type === 'command' && cmdParts[0].output, 'line1\r\nline2\r\nline3\r\n');
+	});
+
+	test('output and CommandFinished arriving in one PTY read are attributed to the command', () => {
+		// A fast command (e.g. `echo`) frequently emits its output and the
+		// CommandExecuted/CommandFinished markers in a single PTY read. The
+		// output that precedes the CommandFinished marker must be attributed to
+		// the command before the finished event snapshots it, otherwise it is
+		// lost from the command result (regression for the flaky agent-host
+		// sandbox smoke test, where the shell tool returned an empty output).
+		const handler = createHandler();
+
+		handler.handlePtyData(
+			`${osc633('E;echo\\x20hi;test-nonce')}${osc633('C')}hi\r\n${osc633('D;0')}`
+		);
+
+		const cmdParts = handler.content.filter(p => p.type === 'command');
+		assert.strictEqual(cmdParts.length, 1);
+		assert.strictEqual(cmdParts[0].type === 'command' && cmdParts[0].output, 'hi\r\n');
+		// The output captured at CommandFinished time must include the stdout,
+		// mirroring the onCommandFinished event surfaced to the shell tools.
+		assert.deepStrictEqual(handler.finishedOutputs, ['hi\r\n']);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/osc633Parser.test.ts
+++ b/src/vs/platform/agentHost/test/node/osc633Parser.test.ts
@@ -295,4 +295,34 @@ suite('Osc633Parser', () => {
 			}],
 		});
 	});
+
+	// -- Ordered segments -------------------------------------------------
+
+	test('parseSegments preserves the order of output before a CommandFinished marker', () => {
+		// Output that precedes the D marker in the same chunk must be emitted as
+		// a data segment BEFORE the CommandFinished event, so consumers can
+		// attribute it to the command before handling the finished event.
+		const segments = parser.parseSegments(`${osc633('C')}hi\r\n${osc633('D;0')}`);
+		assert.deepStrictEqual(segments, [
+			{ kind: 'event', event: { type: Osc633EventType.CommandExecuted } },
+			{ kind: 'data', data: 'hi\r\n' },
+			{ kind: 'event', event: { type: Osc633EventType.CommandFinished, exitCode: 0 } },
+		]);
+	});
+
+	test('parseSegments interleaves data and events across a full command chunk', () => {
+		const segments = parser.parseSegments(
+			`prompt${osc633('A')}$ ${osc633('E;ls;nonce1')}${osc633('C')}file1\nfile2\n${osc633('D;0')}done`
+		);
+		assert.deepStrictEqual(segments, [
+			{ kind: 'data', data: 'prompt' },
+			{ kind: 'event', event: { type: Osc633EventType.PromptStart } },
+			{ kind: 'data', data: '$ ' },
+			{ kind: 'event', event: { type: Osc633EventType.CommandLine, commandLine: 'ls', nonce: 'nonce1' } },
+			{ kind: 'event', event: { type: Osc633EventType.CommandExecuted } },
+			{ kind: 'data', data: 'file1\nfile2\n' },
+			{ kind: 'event', event: { type: Osc633EventType.CommandFinished, exitCode: 0 } },
+			{ kind: 'data', data: 'done' },
+		]);
+	});
 });


### PR DESCRIPTION
We saw the flake here: https://github.com/microsoft/vscode/actions/runs/28904390309/job/85748173328

Agent thinks that it can happen when the CI system is under load, which is why we almost never see it.