### PR TITLE
sessions: align chat tab strip action button height with tabs

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -277,8 +277,10 @@
 }
 
 .chat-composite-bar-new-chat .action-item .action-label {
-	width: 22px;
-	height: 22px;
+	box-sizing: border-box;
+	width: 26px;
+	height: 26px;
+	padding: 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -305,8 +307,10 @@
 }
 
 .chat-composite-bar-action-menu .action-item .action-label {
-	width: 22px;
-	height: 22px;
+	box-sizing: border-box;
+	width: 26px;
+	height: 26px;
+	padding: 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
## What

In the Agents window chats tab strip, the **New Chat** (`+`) button and the conversations action-menu button did not have the same height as the chat tab pills.

## Why

Both action buttons had their `.action-label` sized to a fixed `22px`, but the default action bar rule (`.monaco-action-bar .action-label`) applies `padding: 3px` with the default `content-box` sizing. That padding was added on top of the fixed size, so the rendered box was `22 + 6 = 28px` instead of matching the `26px` tab pill — a visible height mismatch next to the tabs.

## Change

- Set `box-sizing: border-box` and `padding: 0` on the New Chat and conversations action-menu `.action-label`, and size them to `26px` so their box exactly matches the tab pill height.

CSS-only change scoped to `src/vs/sessions/browser/parts/media/chatCompositeBar.css`. Hygiene passes.