### PR TITLE
editor: fix Wrap Tabs underflow by driving add-tab (+) via menu id

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -100,11 +100,6 @@ export class MenuId {
 	static readonly EmptyEditorGroupContext = new MenuId('EmptyEditorGroupContext');
 	static readonly EditorGroupWatermarkToolbar = new MenuId('EditorGroupWatermarkToolbar');
 	static readonly EditorTabsBarContext = new MenuId('EditorTabsBarContext');
-	/**
-	 * Menu whose actions populate the editor tab bar's "+" (Add Tab) dropdown.
-	 * The button is rendered by core and is shown only when this menu has actions.
-	 */
-	static readonly EditorTabsBarAddTab = new MenuId('EditorTabsBarAddTab');
 	static readonly EditorTabsBarShowTabsSubmenu = new MenuId('EditorTabsBarShowTabsSubmenu');
 	static readonly EditorTabsBarShowTabsZenModeSubmenu = new MenuId('EditorTabsBarShowTabsZenModeSubmenu');
 	static readonly EditorActionsPositionSubmenu = new MenuId('EditorActionsPositionSubmenu');

--- a/src/vs/sessions/browser/menus.ts
+++ b/src/vs/sessions/browser/menus.ts
@@ -44,6 +44,7 @@ export const Menus = {
 	SessionsEditorHeaderSecondary: new MenuId('SessionsEditorHeaderSecondary'),
 	SessionsEditorTitle: new MenuId('SessionsEditorTitle'),
 	SessionsEditorTabsBarContext: new MenuId('SessionsEditorTabsBarContext'),
+	SessionsEditorTabsBarAddTab: new MenuId('SessionsEditorTabsBarAddTab'),
 	SessionHeaderMeta: new MenuId('SessionsSessionHeaderMeta'),
 	SessionHeaderContext: MenuId.SessionHeaderContext,
 } as const;

--- a/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
+++ b/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
@@ -59,7 +59,8 @@ export class SinglePaneMainEditorPart extends MainEditorPart {
 				headerPrimary: Menus.SessionsEditorHeaderPrimary,
 				headerSecondary: Menus.SessionsEditorHeaderSecondary,
 				editorActions: Menus.SessionsEditorTitle,
-				tabsBarContext: Menus.SessionsEditorTabsBarContext
+				tabsBarContext: Menus.SessionsEditorTabsBarContext,
+				tabsBarAddTab: Menus.SessionsEditorTabsBarAddTab
 			}
 		};
 	}

--- a/src/vs/sessions/contrib/editor/browser/addTabActions.ts
+++ b/src/vs/sessions/contrib/editor/browser/addTabActions.ts
@@ -8,7 +8,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { localize2 } from '../../../../nls.js';
-import { Action2, MenuId } from '../../../../platform/actions/common/actions.js';
+import { Action2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
@@ -22,6 +22,7 @@ import { SessionsCategories } from '../../../common/categories.js';
 import { ISessionChangesService } from '../../changes/browser/sessionChangesService.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { EmptyFileEditorInput } from './emptyFileEditorInput.js';
+import { Menus } from '../../../browser/menus.js';
 
 export const NEW_FILE_TAB_COMMAND_ID = 'workbench.action.agentSessions.newFileTab';
 export const NEW_BROWSER_TAB_COMMAND_ID = 'workbench.action.agentSessions.newBrowserTab';
@@ -55,7 +56,7 @@ export class NewFileTabAction extends Action2 {
 				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyB),
 			},
 			menu: {
-				id: MenuId.EditorTabsBarAddTab,
+				id: Menus.SessionsEditorTabsBarAddTab,
 				group: 'navigation',
 				order: 1,
 				// Only offer when the Files tab is not already shown.
@@ -90,7 +91,7 @@ export class NewBrowserTabAction extends Action2 {
 				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyK, KeyCode.KeyB),
 			},
 			menu: {
-				id: MenuId.EditorTabsBarAddTab,
+				id: Menus.SessionsEditorTabsBarAddTab,
 				group: 'navigation',
 				order: 2,
 				when: addTabLayoutWhen
@@ -123,7 +124,7 @@ export class NewSearchTabAction extends Action2 {
 				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyS),
 			},
 			menu: {
-				id: MenuId.EditorTabsBarAddTab,
+				id: Menus.SessionsEditorTabsBarAddTab,
 				group: 'navigation',
 				order: 3,
 				when: addTabLayoutWhen
@@ -148,7 +149,7 @@ export class NewChangesTabAction extends Action2 {
 			f1: false,
 			precondition: addTabActionWhen,
 			menu: {
-				id: MenuId.EditorTabsBarAddTab,
+				id: Menus.SessionsEditorTabsBarAddTab,
 				group: 'navigation',
 				order: 0,
 				// Only offer when the session has a Changes editor but its tab is closed.

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -277,6 +277,8 @@ export interface IEditorGroupMenuIds {
 	readonly editorActions?: MenuId;
 	/** Menu shown when right-clicking the empty tab-bar area. */
 	readonly tabsBarContext?: MenuId;
+	/** Menu whose actions populate the add-tab (`+`) control in the tab bar. */
+	readonly tabsBarAddTab?: MenuId;
 }
 
 /**

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -198,8 +198,13 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		// Tabs Container listeners
 		this.registerTabsContainerListeners(this.tabsContainer, this.tabsScrollbar);
 
-		// Create add tab control
-		this.createAddTabControl();
+		// Create add tab control (only when a menu id is configured, e.g. in
+		// the single-pane Agents window layout). When unset, no add-tab control
+		// is created and the last tab remains the last child of the tabs
+		// container, which tab layout logic relies on (see #324902).
+		if (this.menuIds?.tabsBarAddTab) {
+			this.createAddTabControl(this.menuIds.tabsBarAddTab);
+		}
 
 		// Create Editor Toolbar
 		this.createEditorActionsToolBar(this.tabsAndActionsContainer, ['editor-actions']);
@@ -210,13 +215,13 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		return this.tabsAndActionsContainer;
 	}
 
-	private createAddTabControl(): void {
+	private createAddTabControl(menuId: MenuId): void {
 		const tabsContainer = assertReturnsDefined(this.tabsContainer);
 		const container = $('.tabs-bar-add-tab');
 		tabsContainer.appendChild(container);
 		this.addTabContainer = container;
 
-		const menu = this._register(this.menuService.createMenu(MenuId.EditorTabsBarAddTab, this.contextKeyService));
+		const menu = this._register(this.menuService.createMenu(menuId, this.contextKeyService));
 		const getActions = () => getFlatActionBarActions(menu.getActions({ shouldForwardArgs: true }));
 
 		const addTabAction = toAction({


### PR DESCRIPTION
## What & why

`Wrap Tabs` underflowed: with `workbench.editor.wrapTabs: true`, after opening enough tabs, the last tab on the final row stretched to fill the entire row (#324902).

### Root cause
PR #324257 added an "Add Tab" (`+`) control that is created unconditionally in `MultiEditorTabsControl` and appended as a child of `.tabs-container`, so it permanently occupies the `:last-child` slot. The wrap-tabs CSS grows the last tab of every row for a homogeneous look but deliberately excludes the overall last tab via `:not(:last-child)`:

```css
.tabs-and-actions-container.wrapping .tabs-container > .tab.sizing-fit.last-in-row:not(:last-child) {
    flex-grow: 1; /* grow the last tab in a row ... except for last row (#113801) */
}
```

Because the add-tab element (not the last real tab) became `:last-child`, the real last tab matched the rule and got `flex-grow: 1`, spanning the row. The same broken assumption affected `--last-tab-margin-right` and the "no right border for last-in-row" rule.

### Fix
Drive the add-tab control through the group menu-id configuration instead of hardcoding it in core:

- Removed `MenuId.EditorTabsBarAddTab` from core `platform/actions`.
- Added `SessionsEditorTabsBarAddTab` to the sessions menu registry.
- Added `tabsBarAddTab?: MenuId` to `IEditorGroupMenuIds` and pass it from `SinglePaneMainEditorPart.getGroupViewOptions()`, exactly like `editorActions` / `tabsBarContext`.
- `MultiEditorTabsControl` now creates the add-tab control **only when `menuIds?.tabsBarAddTab` is configured**.
- `addTabActions.ts` (sessions) now contributes to the sessions menu id.

In the regular workbench no menu id is configured, so no add-tab element is created and the real last tab is once again `:last-child` — restoring the pre-regression wrap-tabs behavior. The add-tab control keeps working in the single-pane Agents window where it is intended.

Fixes #324902

## Notes for reviewers
- No core → sessions dependency is introduced; the menu id flows through the existing `IEditorGroupMenuIds` mechanism.
- Validated: `typecheck-client`, `eslint` on touched files, `valid-layers-check`, and `gulp hygiene` all pass.
