### PR TITLE
Style overrides: Add color to dialog message detail in notifications

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
@@ -43,6 +43,10 @@
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 }
 
+.style-override .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message-detail {
+	color: var(--vscode-descriptionForeground);
+}
+
 .style-override .monaco-dialog-box .dialog-toolbar-row {
 	position: absolute;
 	top: 8px;


### PR DESCRIPTION
Enhance the visibility of dialog message details in notifications by applying a color style. This change improves the user experience by making important information more distinguishable.

![image.png](https://github.com/user-attachments/assets/958ced7b-8539-4a9a-9115-eca2e280d389)
