### PR TITLE
sessions: move conversations pill next to the add chat action

### DIFF
--- a/src/vs/sessions/browser/parts/chatCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/chatCompositeBar.ts
@@ -115,10 +115,22 @@ export class ChatCompositeBar extends Disposable {
 		}));
 		this._tabsRow.appendChild(this._tabsScrollbar.getDomNode());
 
-		// "New Chat" button pinned at the end of the tab strip (after the last
-		// tab). Starting a new chat is offered here while the tabs are shown; when
-		// the session has a single chat the session header toolbar offers it
-		// instead.
+		// Chat tab bar action menu (e.g. the Conversations dropdown) grouped with
+		// the New Chat button at the end of the strip; items are contributed into
+		// Menus.SessionChatTabBar.
+		const actionMenuContainer = $('.chat-composite-bar-action-menu');
+		this._tabsRow.appendChild(actionMenuContainer);
+		this._actionMenuToolbar = this._register(this._instantiationService.createInstance(MenuWorkbenchToolBar, actionMenuContainer, Menus.SessionChatTabBar, {
+			hiddenItemStrategy: HiddenItemStrategy.Ignore,
+			menuOptions: { shouldForwardArgs: true },
+			highlightToggledItems: true,
+			toolbarOptions: { primaryGroup: () => true, useSeparatorsInPrimaryActions: true },
+		}));
+
+		// "New Chat" button pinned at the end of the tab strip, next to the
+		// Conversations menu. Starting a new chat is offered here while the tabs
+		// are shown; when the session has a single chat the session header toolbar
+		// offers it instead.
 		const newChatAction = this._newChatAction = this._register(new Action(
 			'chatCompositeBar.addChat',
 			localize('chatCompositeBar.addChat', "New Chat"),
@@ -136,17 +148,6 @@ export class ChatCompositeBar extends Disposable {
 		newChatActionBar.push(newChatAction, { icon: true, label: false });
 		this._newChatContainer = newChatActionBar.getContainer();
 		this._newChatContainer.classList.add('chat-composite-bar-new-chat');
-
-		// Chat tab bar action menu (e.g. the Conversations dropdown) right-aligned
-		// at the end of the strip; items are contributed into Menus.SessionChatTabBar.
-		const actionMenuContainer = $('.chat-composite-bar-action-menu');
-		this._tabsRow.appendChild(actionMenuContainer);
-		this._actionMenuToolbar = this._register(this._instantiationService.createInstance(MenuWorkbenchToolBar, actionMenuContainer, Menus.SessionChatTabBar, {
-			hiddenItemStrategy: HiddenItemStrategy.Ignore,
-			menuOptions: { shouldForwardArgs: true },
-			highlightToggledItems: true,
-			toolbarOptions: { primaryGroup: () => true, useSeparatorsInPrimaryActions: true },
-		}));
 
 		// Keep the visual scrollbar in sync with native scrolling inside the tabs container
 		this._register(addDisposableListener(this._tabsContainer, EventType.SCROLL, () => {

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -264,7 +264,7 @@
 	gap: 4px;
 }
 
-/* "New Chat" button pinned after the tab strip. */
+/* "New Chat" button pinned at the end of the tab strip, after the Conversations menu. */
 .chat-composite-bar-tabs-row > .chat-composite-bar-new-chat {
 	flex-shrink: 0;
 	display: flex;
@@ -296,12 +296,13 @@
 	outline-offset: -1px;
 }
 
-/* Chat tab bar action menu (e.g. the Conversations dropdown) right-aligned at the end of the strip. */
+/* Chat tab bar action menu (e.g. the Conversations dropdown) grouped with the
+	New Chat button right after the tab strip. */
 .chat-composite-bar-tabs-row > .chat-composite-bar-action-menu {
 	flex-shrink: 0;
 	display: flex;
 	align-items: center;
-	margin-left: auto;
+	margin-left: 4px;
 }
 
 .chat-composite-bar-action-menu .action-item .action-label {


### PR DESCRIPTION
## What

In the Agents window chat composite bar, moves the **Conversations** action menu so it sits directly after the chat tab strip, immediately before the **New Chat (+)** button — instead of being right-aligned to the far edge of the strip.

The row now reads: `[tabs] [conversations] [+]`, all grouped together next to the tabs, matching the intended design.

## Why

Previously the Conversations pill was pushed to the far right of the tab strip (via `margin-left: auto`) while the New Chat button sat next to the tabs, splitting the two related controls apart. Grouping them together next to the tabs is more discoverable and consistent.

## Changes

- [`chatCompositeBar.ts`](https://github.com/microsoft/vscode/blob/sandy081/agents/move-conversations-pill-next-to-add-chat/src/vs/sessions/browser/parts/chatCompositeBar.ts): reorder DOM construction so the Conversations action menu is appended before the New Chat button.
- [`chatCompositeBar.css`](https://github.com/microsoft/vscode/blob/sandy081/agents/move-conversations-pill-next-to-add-chat/src/vs/sessions/browser/parts/media/chatCompositeBar.css): drop the `margin-left: auto` on the action menu so the group stays left, adjacent to the tabs.

## Notes for reviewers

Pure layout/DOM-order change — no behavioral change to the actions themselves.