### PR TITLE
sessions: align add-tab keybindings with workbench view shortcuts

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/media/sessionChangesEditor.css
+++ b/src/vs/sessions/contrib/changes/browser/media/sessionChangesEditor.css
@@ -96,7 +96,6 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	font-size: var(--vscode-agents-fontSize-label1);
-	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	padding: 0 var(--vscode-spacing-size40);
 	border-radius: var(--vscode-cornerRadius-small);
 	cursor: default;

--- a/src/vs/sessions/contrib/editor/browser/addTabActions.ts
+++ b/src/vs/sessions/contrib/editor/browser/addTabActions.ts
@@ -6,7 +6,7 @@
 import './emptyFileEditor.contribution.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
-import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { localize2 } from '../../../../nls.js';
 import { Action2, MenuId } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
@@ -52,7 +52,7 @@ export class NewFileTabAction extends Action2 {
 			keybinding: {
 				weight: KeybindingWeight.SessionsContrib,
 				when: addTabActionWhen,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyB),
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyE,
 			},
 			menu: {
 				id: MenuId.EditorTabsBarAddTab,
@@ -87,7 +87,7 @@ export class NewBrowserTabAction extends Action2 {
 			keybinding: {
 				weight: KeybindingWeight.SessionsContrib,
 				when: addTabActionWhen,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyK, KeyCode.KeyB),
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyB,
 			},
 			menu: {
 				id: MenuId.EditorTabsBarAddTab,
@@ -120,7 +120,7 @@ export class NewSearchTabAction extends Action2 {
 			keybinding: {
 				weight: KeybindingWeight.SessionsContrib,
 				when: addTabActionWhen,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyS),
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyF,
 			},
 			menu: {
 				id: MenuId.EditorTabsBarAddTab,
@@ -147,6 +147,12 @@ export class NewChangesTabAction extends Action2 {
 			icon: Codicon.gitCompare,
 			f1: false,
 			precondition: addTabActionWhen,
+			keybinding: {
+				weight: KeybindingWeight.SessionsContrib,
+				when: addTabActionWhen,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG,
+				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KeyG },
+			},
 			menu: {
 				id: MenuId.EditorTabsBarAddTab,
 				group: 'navigation',

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -227,7 +227,8 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		});
 
 		const dropdown = this._register(new DropdownMenuActionViewItem(addTabAction, { getActions }, this.contextMenuService, {
-			classNames: ThemeIcon.asClassNameArray(Codicon.add)
+			classNames: ThemeIcon.asClassNameArray(Codicon.add),
+			keybindingProvider: action => this.getKeybinding(action)
 		}));
 		dropdown.render(container);
 


### PR DESCRIPTION
## What

Aligns the Agents window add-tab (`+`) actions with the keybindings of their equivalent workbench views, and shows those keybindings in the `+` dropdown menu.

| Tab | Keybinding | Matches workbench view |
|------|------------|------------------------|
| Files (empty file editor) | `Cmd/Ctrl+Shift+E` | Explorer |
| Search | `Cmd/Ctrl+Shift+F` | Search |
| Changes | `Cmd/Ctrl+Shift+G` (mac `Ctrl+Shift+G`) | Source Control |
| Browser | `Cmd+Shift+B` | (no workbench equivalent) |

## Why

- The **Browser** action previously used the chord `Cmd+Shift+K B`. Because it starts with `Cmd+Shift+K`, it swallowed the **Delete Line** shortcut in the Agents window (VS Code waited for the second chord key). It now uses a single `Cmd+Shift+B` binding.
- The other add-tab actions used ad-hoc chords (`Cmd+K B` for Files, `Cmd+K S` for Search) that were inconsistent with the rest of the workbench. They now mirror the corresponding view shortcuts so the bindings are predictable.
- The **Changes** action previously had no keybinding; it now reuses the Source Control binding.

## Notes for reviewers

- All bindings are scoped to the Agents window via `addTabActionWhen` (`IsSessionsWindowContext && !IsAuxiliaryWindowContext`), so they don't collide in the normal editor window.
- The `+` dropdown now passes a `keybindingProvider` so each menu item renders its shortcut.
- Removed the now-unused `KeyChord` import from `addTabActions.ts`.
- Also includes a minor style fix in `sessionChangesEditor.css` (drops a redundant `font-weight: semiBold`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
