### PR TITLE
Style overrides: Adjust scrollbar corner rounding for diff editor when overview ruler is shown

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -148,7 +148,7 @@
  * `modified-in-monaco-diff-editor` class lives on the `.monaco-editor` root, so
  * target the slider as a descendant.
  */
-.style-override .monaco-diff-editor:has(> .diffOverview) .modified-in-monaco-diff-editor .monaco-scrollable-element > .scrollbar > .slider {
+.style-override .monaco-diff-editor:has(> .diffOverview) .modified-in-monaco-diff-editor .monaco-scrollable-element > .scrollbar.vertical > .slider {
 	border-radius: var(--vscode-cornerRadius-small) 0 0 var(--vscode-cornerRadius-small) !important;
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -133,6 +133,25 @@
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
+/*
+ * Diff editor "fake united slider": when the overview ruler is shown, the diff
+ * editor draws its own combined viewport slider (`.diffViewport`, spanning both
+ * overview rulers). The modified editor's real scrollbar slider sits over the
+ * right edge of that band. Rounding all four corners floats the right corners
+ * clear of the joined viewport and breaks the combined widget, so round only
+ * the left corners (facing the editor) and keep the right side flat/flush.
+ *
+ * Gate on `:has(> .diffOverview)` so this only applies when the combined slider
+ * is actually present: with `diffEditor.renderOverviewRuler` off there is no
+ * `.diffViewport`, so the real slider is the sole scrollbar and should stay
+ * rounded on all corners like every other scrollbar. The
+ * `modified-in-monaco-diff-editor` class lives on the `.monaco-editor` root, so
+ * target the slider as a descendant.
+ */
+.style-override .monaco-diff-editor:has(> .diffOverview) .modified-in-monaco-diff-editor .monaco-scrollable-element > .scrollbar > .slider {
+	border-radius: var(--vscode-cornerRadius-small) 0 0 var(--vscode-cornerRadius-small) !important;
+}
+
 /* Terminal uses xterm.js' own scrollbar (.xterm-scrollable-element) */
 .style-override .xterm .xterm-scrollable-element > .xterm-scrollbar > .xterm-slider {
 	border-radius: var(--vscode-cornerRadius-small) !important;


### PR DESCRIPTION
Modify scrollbar corner rounding in the diff editor to ensure proper appearance when the overview ruler is displayed. This change prevents visual issues by rounding only the left corners of the scrollbar slider while keeping the right side flat. Test by enabling the overview ruler in the diff editor and observing the scrollbar's appearance.

<img width="111" height="288" alt="image" src="https://github.com/user-attachments/assets/562ccf65-0e59-46aa-b827-787818101769" />

Resolves https://github.com/microsoft/vscode/issues/324213