### PR TITLE
Voice: keep hands-free listening when switching sessions without dictation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -580,10 +580,19 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 					listeningSession = targetSession ?? currentSession;
 					ownerSession = listeningSession;
 				} else if (!targetSession && currentSession && !isEqual(currentSession, listeningSession)) {
-					// User switched to a different session mid-dictation — stop
-					// transcription so it isn't sent to the newly focused session.
-					this.voiceSessionController.stopListening();
-					listeningSession = undefined;
+					// User switched to a different session while listening. Only
+					// stop when there's dictation in progress, so it isn't
+					// misrouted to the newly focused session. If nothing has been
+					// recorded yet (e.g. clicking "New Chat" while idly listening
+					// hands-free), keep listening and just follow the new session.
+					const activelyDictating = turns.some(t => t.speaker === 'user' && t.isPartial && t.text.trim().length > 0);
+					if (activelyDictating) {
+						this.voiceSessionController.stopListening();
+						listeningSession = undefined;
+					} else {
+						listeningSession = currentSession;
+						ownerSession = currentSession;
+					}
 				}
 			} else {
 				// Allow the next dictation to re-capture the owning session.


### PR DESCRIPTION
### Bug

In voice hands-free mode, if the mic was idly listening (nothing dictated yet) and the user clicked **New Chat** (or otherwise switched the visible session), the listening indicator was immediately dropped.

### Root cause

The chat view's transcript autorun (`chatViewPane.ts`) called `stopListening()` whenever `_currentSessionResource` changed while `voiceState === 'listening'`. This guard exists to avoid misrouting an **in-progress dictation** to the newly focused session, but it fired unconditionally — even when nothing had been recorded yet — so switching sessions killed an otherwise-idle listening turn.

### Fix

Only stop listening when there is actual in-progress dictation (a partial user turn with non-empty text). Otherwise keep listening and re-anchor `listeningSession`/`ownerSession` to the newly focused session so hands-free listening follows the user into the new chat.

### Testing

Verified against the running dev build: run a voice command in a session → wait for listening → click New Chat → listening now persists instead of dropping to idle.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
