### PR TITLE
Bring voice mode to the Agents (Sessions) window

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -961,6 +961,7 @@
 		"--prompt-timeline-scrollbar-gutter",
 		"--chat-editing-last-edit-shift",
 		"--chat-voice-icon-glow-color",
+		"--sessions-voice-icon-glow-color",
 		"--chat-current-response-min-height",
 		"--chat-smooth-delay",
 		"--chat-smooth-duration",

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -3,14 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './media/voiceChatView.css';
+import * as dom from '../../../../base/browser/dom.js';
+import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { MutableDisposable } from '../../../../base/common/lifecycle.js';
-import { autorun } from '../../../../base/common/observable.js';
+import { autorun, observableValue } from '../../../../base/common/observable.js';
+import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IMicCaptureService } from '../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
+import { ITtsPlaybackService } from '../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
+import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 import { EDITOR_DRAG_AND_DROP_BACKGROUND } from '../../../../workbench/common/theme.js';
 import { ChatWidget } from '../../../../workbench/contrib/chat/browser/widget/chatWidget.js';
@@ -127,6 +136,8 @@ export class ChatView extends AbstractChatView {
 
 	/** Whether this view currently represents the active session. */
 	private _isActive = true;
+	/** Observable mirror of {@link _isActive} so the voice overlay can react. */
+	private readonly _isActiveObs = observableValue<boolean>(this, true);
 
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -134,7 +145,11 @@ export class ChatView extends AbstractChatView {
 		@IChatService private readonly chatService: IChatService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@ILogService private readonly logService: ILogService
+		@ILogService private readonly logService: ILogService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
+		@IMicCaptureService private readonly micCaptureService: IMicCaptureService,
+		@ITtsPlaybackService private readonly ttsPlaybackService: ITtsPlaybackService,
 	) {
 		super();
 
@@ -184,6 +199,9 @@ export class ChatView extends AbstractChatView {
 				this._applyHistoryKey();
 			}
 		}));
+
+		// Voice mode transcript overlay + audio-reactive glow on the chat input.
+		this._setupVoiceOverlay();
 	}
 
 	override dispose(): void {
@@ -332,6 +350,187 @@ export class ChatView extends AbstractChatView {
 		}
 	}
 
+	//#region Voice overlay
+
+	/**
+	 * Sets up the voice mode transcript overlay and audio-reactive glow on this
+	 * view's chat input, mirroring the main-window `ChatViewPane`. The overlay is
+	 * only shown while voice mode is connected and this view is the active
+	 * session; the transcript is hidden when the voice backend is targeting a
+	 * different session so it is never misrouted.
+	 */
+	private _setupVoiceOverlay(): void {
+		const inputContainerEl = this._widget.inputPart.inputContainerElement;
+		if (!inputContainerEl) {
+			return;
+		}
+		inputContainerEl.style.position = 'relative';
+
+		const transcriptOverlay = dom.$('.voice-transcript-overlay');
+		const transcriptScrollable = this._register(new DomScrollableElement(transcriptOverlay, {
+			horizontal: ScrollbarVisibility.Hidden,
+			vertical: ScrollbarVisibility.Auto,
+		}));
+		const transcriptOverlayNode = transcriptScrollable.getDomNode();
+		transcriptOverlayNode.classList.add('voice-transcript-overlay-scrollable');
+		transcriptOverlayNode.style.display = 'none';
+		inputContainerEl.append(transcriptOverlayNode);
+
+		// --- Audio-reactive glow (matches main-window behavior) ---
+		const win = dom.getWindow(inputContainerEl);
+		let animFrameId: number | undefined;
+		let glowDataArray: Uint8Array | undefined;
+		const startGlowAnimation = () => {
+			if (animFrameId !== undefined) {
+				return;
+			}
+			const animate = () => {
+				animFrameId = win.requestAnimationFrame(animate);
+				const voiceState = this.voiceSessionController.voiceState.get();
+
+				const analyser = this.ttsPlaybackService.analyserNode
+					?? (voiceState === 'listening' ? this.micCaptureService.analyserNode : null)
+					?? null;
+				let intensity: number;
+				if (!analyser) {
+					intensity = 0.3;
+				} else {
+					if (!glowDataArray || glowDataArray.length !== analyser.frequencyBinCount) {
+						glowDataArray = new Uint8Array(analyser.frequencyBinCount);
+					}
+					analyser.getByteFrequencyData(glowDataArray as Uint8Array<ArrayBuffer>);
+					let sum = 0;
+					for (let i = 0; i < glowDataArray.length; i++) {
+						sum += glowDataArray[i];
+					}
+					intensity = Math.min(1, (sum / glowDataArray.length) / 80);
+				}
+
+				// Blue when listening, purple when speaking.
+				const rgb = voiceState === 'speaking' ? '163,113,247' : '88,166,255';
+				const transcriptHidden = this.configurationService.getValue<boolean>('agents.voice.showTranscript') === false;
+				let borderAlpha: number;
+				let shadowSpread: number;
+				let shadowAlpha: number;
+				if (voiceState === 'listening' && transcriptHidden) {
+					borderAlpha = 0.6 + intensity * 0.4;
+					shadowSpread = 6 + intensity * 20;
+					shadowAlpha = 0.25 + intensity * 0.55;
+				} else {
+					borderAlpha = 0.4 + intensity * 0.5;
+					shadowSpread = 4 + intensity * 12;
+					shadowAlpha = 0.15 + intensity * 0.35;
+				}
+				inputContainerEl.style.borderColor = `rgba(${rgb},${borderAlpha})`;
+				if (voiceState === 'listening' && transcriptHidden) {
+					inputContainerEl.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), 0 0 ${shadowSpread * 2}px rgba(${rgb},${shadowAlpha * 0.3}), inset 0 0 ${shadowSpread * 0.5}px rgba(${rgb},${shadowAlpha * 0.4})`;
+				} else {
+					inputContainerEl.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), inset 0 0 ${shadowSpread * 0.4}px rgba(${rgb},${shadowAlpha * 0.3})`;
+				}
+				inputContainerEl.classList.add('voice-active');
+				inputContainerEl.classList.toggle('voice-listening', voiceState === 'listening');
+			};
+			animFrameId = win.requestAnimationFrame(animate);
+		};
+		const stopGlowAnimation = () => {
+			if (animFrameId !== undefined) {
+				win.cancelAnimationFrame(animFrameId);
+				animFrameId = undefined;
+			}
+			inputContainerEl.style.borderColor = '';
+			inputContainerEl.style.boxShadow = '';
+			inputContainerEl.classList.remove('voice-active', 'voice-listening');
+		};
+
+		this._register(autorun(reader => {
+			const connected = this.voiceSessionController.isConnected.read(reader);
+			const voiceState = this.voiceSessionController.voiceState.read(reader);
+			const active = this._isActiveObs.read(reader);
+			if (connected && active && (voiceState === 'listening' || voiceState === 'speaking')) {
+				startGlowAnimation();
+			} else {
+				stopGlowAnimation();
+			}
+		}));
+		this._register({ dispose: () => stopGlowAnimation() });
+
+		// --- Transcript rendering ---
+		this._register(autorun(reader => {
+			const turns = this.voiceSessionController.transcriptTurns.read(reader);
+			const connected = this.voiceSessionController.isConnected.read(reader);
+			const voiceState = this.voiceSessionController.voiceState.read(reader);
+			const targetSession = this.voiceSessionController.targetSession.read(reader);
+			const active = this._isActiveObs.read(reader);
+			const showTranscript = this.configurationService.getValue<boolean>('agents.voice.showTranscript') !== false;
+			const current = this._currentChatResource;
+			const visible = turns.filter(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
+
+			// Only the active session view renders the transcript, and never a
+			// transcript the backend is targeting at a different session.
+			const targetedElsewhere = !!targetSession && !!current && !isEqual(targetSession, current);
+			if (!connected || !active || targetedElsewhere) {
+				transcriptOverlayNode.style.display = 'none';
+				transcriptOverlayNode.classList.remove('has-transcript');
+				return;
+			}
+
+			if (visible.length === 0 || !showTranscript) {
+				const handsFree = this.configurationService.getValue<boolean>('agents.voice.handsFree') !== false;
+				if (voiceState === 'idle' && visible.length === 0 && showTranscript && !handsFree) {
+					transcriptOverlayNode.style.display = '';
+					transcriptOverlayNode.classList.remove('has-transcript');
+					transcriptOverlay.replaceChildren();
+					const hint = dom.$('span.partial');
+					const kb = this.keybindingService.lookupKeybinding('agentsVoice.pushToTalk');
+					const kbLabel = kb?.getLabel();
+					hint.textContent = kbLabel
+						? localize('voiceMode.pttHint', "Press {0} to talk", kbLabel)
+						: localize('voiceMode.clickMicHint', "Click voice mode to talk");
+					transcriptOverlay.append(hint);
+					transcriptScrollable.scanDomNode();
+				} else {
+					transcriptOverlayNode.style.display = 'none';
+					transcriptOverlayNode.classList.remove('has-transcript');
+				}
+				return;
+			}
+
+			transcriptOverlayNode.style.display = '';
+			transcriptOverlayNode.classList.add('has-transcript');
+			// Show only the latest visible turn.
+			const lastTurn = visible[visible.length - 1];
+			const contentElements: HTMLElement[] = [];
+			if (lastTurn.speaker === 'user') {
+				const span = dom.$('span');
+				if (lastTurn.isPartial) {
+					const committedPart = lastTurn.committed || '';
+					const unsurePart = lastTurn.text.slice(committedPart.length);
+					if (committedPart) {
+						const c = dom.$('span.committed');
+						c.textContent = committedPart;
+						span.append(c);
+					}
+					const u = dom.$('span.partial');
+					u.textContent = unsurePart + '\u2589';
+					span.append(u);
+				} else {
+					span.className = 'committed';
+					span.textContent = lastTurn.text;
+				}
+				contentElements.push(span);
+			} else {
+				const div = dom.$('div.assistant-text');
+				div.textContent = lastTurn.text;
+				contentElements.push(div);
+			}
+			transcriptOverlay.replaceChildren(...contentElements);
+			transcriptScrollable.scanDomNode();
+			transcriptScrollable.setScrollPosition({ scrollTop: 0 });
+		}));
+	}
+
+	//#endregion
+
 	override focus(): void {
 		this._widget.focusInput();
 	}
@@ -347,6 +546,7 @@ export class ChatView extends AbstractChatView {
 			return;
 		}
 		this._isActive = active;
+		this._isActiveObs.set(active, undefined);
 		this._banners.setActive(active);
 		this._widget.setStyles(this._buildStyles(active));
 	}

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -446,7 +446,11 @@ export class ChatView extends AbstractChatView {
 			const connected = this.voiceSessionController.isConnected.read(reader);
 			const voiceState = this.voiceSessionController.voiceState.read(reader);
 			const active = this._isActiveObs.read(reader);
-			if (connected && active && (voiceState === 'listening' || voiceState === 'speaking')) {
+			const targetSession = this.voiceSessionController.targetSession.read(reader);
+			// The Sessions window renders multiple session slots at once; only glow
+			// the active slot, and never a slot the backend is targeting elsewhere.
+			const targetedElsewhere = !!targetSession && !!this._currentChatResource && !isEqual(targetSession, this._currentChatResource);
+			if (connected && active && !targetedElsewhere && (voiceState === 'listening' || voiceState === 'speaking')) {
 				startGlowAnimation();
 			} else {
 				stopGlowAnimation();

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -9,7 +9,7 @@ import { MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -136,6 +136,16 @@ export class ChatView extends AbstractChatView {
 	/** Observable mirror of {@link _isActive} so the voice overlay can react. */
 	private readonly _isActiveObs = observableValue<boolean>(this, true);
 
+	/**
+	 * Per-view mirror of `agentsVoice.contribution`'s `agentsVoiceInitiatedHere`
+	 * key. Bound on this view's own scoped context service (parent of the chat
+	 * widget's), driven solely by whether this view is the active slot while voice
+	 * is connected/connecting. This keeps the post-connect voice controls (Stop,
+	 * Disconnect, Settings) anchored to the session the user is viewing, without
+	 * the multi-widget thrash of a global recompute across every chat widget.
+	 */
+	private readonly _voiceInitiatedHereKey: IContextKey<boolean>;
+
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -156,6 +166,9 @@ export class ChatView extends AbstractChatView {
 		const scopedInstantiationService = this._register(instantiationService.createChild(
 			new ServiceCollection([IContextKeyService, scopedContextKeyService])
 		));
+
+		// Matches `AGENTS_VOICE_INITIATED_HERE` in agentsVoice.contribution.ts.
+		this._voiceInitiatedHereKey = scopedContextKeyService.createKey<boolean>('agentsVoiceInitiatedHere', false);
 
 		this._widget = this._register(scopedInstantiationService.createInstance(
 			ChatWidget,
@@ -199,6 +212,15 @@ export class ChatView extends AbstractChatView {
 
 		// Voice mode transcript overlay + audio-reactive glow on the chat input.
 		this._setupVoiceOverlay();
+
+		// Anchor the post-connect voice controls to this view only while it is the
+		// active slot and voice is connected/connecting.
+		this._register(autorun(reader => {
+			const active = this._isActiveObs.read(reader);
+			const voiceActive = this.voiceSessionController.isConnected.read(reader)
+				|| this.voiceSessionController.isConnecting.read(reader);
+			this._voiceInitiatedHereKey.set(active && voiceActive);
+		}));
 	}
 
 	override dispose(): void {

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -137,12 +137,8 @@ export class ChatView extends AbstractChatView {
 	private readonly _isActiveObs = observableValue<boolean>(this, true);
 
 	/**
-	 * Per-view mirror of `agentsVoice.contribution`'s `agentsVoiceInitiatedHere`
-	 * key. Bound on this view's own scoped context service (parent of the chat
-	 * widget's), driven solely by whether this view is the active slot while voice
-	 * is connected/connecting. This keeps the post-connect voice controls (Stop,
-	 * Disconnect, Settings) anchored to the session the user is viewing, without
-	 * the multi-widget thrash of a global recompute across every chat widget.
+	 * Per-view mirror of `agentsVoiceInitiatedHere`, scoped above the chat widget.
+	 * Keeps post-connect voice controls anchored to the active session view.
 	 */
 	private readonly _voiceInitiatedHereKey: IContextKey<boolean>;
 
@@ -210,11 +206,10 @@ export class ChatView extends AbstractChatView {
 			}
 		}));
 
-		// Voice mode transcript overlay + audio-reactive glow on the chat input.
+		// Voice transcript overlay + input glow.
 		this._setupVoiceOverlay();
 
-		// Anchor the post-connect voice controls to this view only while it is the
-		// active slot and voice is connected/connecting.
+		// Anchor post-connect voice controls to this active voice view.
 		this._register(autorun(reader => {
 			const active = this._isActiveObs.read(reader);
 			const voiceActive = this.voiceSessionController.isConnected.read(reader)
@@ -372,11 +367,8 @@ export class ChatView extends AbstractChatView {
 	//#region Voice overlay
 
 	/**
-	 * Sets up the voice mode transcript overlay and audio-reactive glow on this
-	 * view's chat input, mirroring the main-window `ChatViewPane`. The overlay is
-	 * only shown while voice mode is connected and this view is the active
-	 * session; the transcript is hidden when the voice backend is targeting a
-	 * different session so it is never misrouted.
+	 * Sets up this view's transcript overlay and input glow, mirroring `ChatViewPane`.
+	 * Shows only while voice is connected and targeting this active session.
 	 */
 	private _setupVoiceOverlay(): void {
 		const inputContainerEl = this._widget.inputPart.inputContainerElement;

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -4,14 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/voiceChatView.css';
-import * as dom from '../../../../base/browser/dom.js';
-import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, observableValue } from '../../../../base/common/observable.js';
-import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { URI } from '../../../../base/common/uri.js';
-import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -38,6 +34,7 @@ import { SessionChatInputToolbar } from './sessionChatInputToolbar.js';
 import { AGENT_SESSIONS_SCOPED_INPUT_HISTORY_SETTING } from './sessionsChatHistory.js';
 import { activeSessionViewBackground, activeSessionViewForeground, agentsPanelBackground, inactiveSessionViewBackground, inactiveSessionViewForeground } from '../../../common/theme.js';
 import { isEqual } from '../../../../base/common/resources.js';
+import { setupVoiceInputDecorations } from './voiceInputDecorations.js';
 
 /**
  * A session view that hosts a {@link NewChatWidget} — the "new session" UI
@@ -364,172 +361,17 @@ export class ChatView extends AbstractChatView {
 		if (!inputContainerEl) {
 			return;
 		}
-		inputContainerEl.style.position = 'relative';
 
-		const transcriptOverlay = dom.$('.voice-transcript-overlay');
-		const transcriptScrollable = this._register(new DomScrollableElement(transcriptOverlay, {
-			horizontal: ScrollbarVisibility.Hidden,
-			vertical: ScrollbarVisibility.Auto,
-		}));
-		const transcriptOverlayNode = transcriptScrollable.getDomNode();
-		transcriptOverlayNode.classList.add('voice-transcript-overlay-scrollable');
-		transcriptOverlayNode.style.display = 'none';
-		inputContainerEl.append(transcriptOverlayNode);
-
-		// --- Audio-reactive glow (matches main-window behavior) ---
-		const win = dom.getWindow(inputContainerEl);
-		let animFrameId: number | undefined;
-		let glowDataArray: Uint8Array | undefined;
-		const startGlowAnimation = () => {
-			if (animFrameId !== undefined) {
-				return;
-			}
-			const animate = () => {
-				animFrameId = win.requestAnimationFrame(animate);
-				const voiceState = this.voiceSessionController.voiceState.get();
-
-				const analyser = this.ttsPlaybackService.analyserNode
-					?? (voiceState === 'listening' ? this.micCaptureService.analyserNode : null)
-					?? null;
-				let intensity: number;
-				if (!analyser) {
-					intensity = 0.3;
-				} else {
-					if (!glowDataArray || glowDataArray.length !== analyser.frequencyBinCount) {
-						glowDataArray = new Uint8Array(analyser.frequencyBinCount);
-					}
-					analyser.getByteFrequencyData(glowDataArray as Uint8Array<ArrayBuffer>);
-					let sum = 0;
-					for (let i = 0; i < glowDataArray.length; i++) {
-						sum += glowDataArray[i];
-					}
-					intensity = Math.min(1, (sum / glowDataArray.length) / 80);
-				}
-
-				// Blue when listening, purple when speaking.
-				const rgb = voiceState === 'speaking' ? '163,113,247' : '88,166,255';
-				const transcriptHidden = this.configurationService.getValue<boolean>('agents.voice.showTranscript') === false;
-				let borderAlpha: number;
-				let shadowSpread: number;
-				let shadowAlpha: number;
-				if (voiceState === 'listening' && transcriptHidden) {
-					borderAlpha = 0.6 + intensity * 0.4;
-					shadowSpread = 6 + intensity * 20;
-					shadowAlpha = 0.25 + intensity * 0.55;
-				} else {
-					borderAlpha = 0.4 + intensity * 0.5;
-					shadowSpread = 4 + intensity * 12;
-					shadowAlpha = 0.15 + intensity * 0.35;
-				}
-				inputContainerEl.style.borderColor = `rgba(${rgb},${borderAlpha})`;
-				if (voiceState === 'listening' && transcriptHidden) {
-					inputContainerEl.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), 0 0 ${shadowSpread * 2}px rgba(${rgb},${shadowAlpha * 0.3}), inset 0 0 ${shadowSpread * 0.5}px rgba(${rgb},${shadowAlpha * 0.4})`;
-				} else {
-					inputContainerEl.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), inset 0 0 ${shadowSpread * 0.4}px rgba(${rgb},${shadowAlpha * 0.3})`;
-				}
-				inputContainerEl.classList.add('voice-active');
-				inputContainerEl.classList.toggle('voice-listening', voiceState === 'listening');
-			};
-			animFrameId = win.requestAnimationFrame(animate);
-		};
-		const stopGlowAnimation = () => {
-			if (animFrameId !== undefined) {
-				win.cancelAnimationFrame(animFrameId);
-				animFrameId = undefined;
-			}
-			inputContainerEl.style.borderColor = '';
-			inputContainerEl.style.boxShadow = '';
-			inputContainerEl.classList.remove('voice-active', 'voice-listening');
-		};
-
-		this._register(autorun(reader => {
-			const connected = this.voiceSessionController.isConnected.read(reader);
-			const voiceState = this.voiceSessionController.voiceState.read(reader);
-			const active = this._isActiveObs.read(reader);
-			const targetSession = this.voiceSessionController.targetSession.read(reader);
-			// The Sessions window renders multiple session slots at once; only glow
-			// the active slot, and never a slot the backend is targeting elsewhere.
-			const targetedElsewhere = !!targetSession && !!this._currentChatResource && !isEqual(targetSession, this._currentChatResource);
-			if (connected && active && !targetedElsewhere && (voiceState === 'listening' || voiceState === 'speaking')) {
-				startGlowAnimation();
-			} else {
-				stopGlowAnimation();
-			}
-		}));
-		this._register({ dispose: () => stopGlowAnimation() });
-
-		// --- Transcript rendering ---
-		this._register(autorun(reader => {
-			const turns = this.voiceSessionController.transcriptTurns.read(reader);
-			const connected = this.voiceSessionController.isConnected.read(reader);
-			const voiceState = this.voiceSessionController.voiceState.read(reader);
-			const targetSession = this.voiceSessionController.targetSession.read(reader);
-			const active = this._isActiveObs.read(reader);
-			const showTranscript = this.configurationService.getValue<boolean>('agents.voice.showTranscript') !== false;
-			const current = this._currentChatResource;
-			const visible = turns.filter(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
-
-			// Only the active session view renders the transcript, and never a
-			// transcript the backend is targeting at a different session.
-			const targetedElsewhere = !!targetSession && !!current && !isEqual(targetSession, current);
-			if (!connected || !active || targetedElsewhere) {
-				transcriptOverlayNode.style.display = 'none';
-				transcriptOverlayNode.classList.remove('has-transcript');
-				return;
-			}
-
-			if (visible.length === 0 || !showTranscript) {
-				const handsFree = this.configurationService.getValue<boolean>('agents.voice.handsFree') !== false;
-				if (voiceState === 'idle' && visible.length === 0 && showTranscript && !handsFree) {
-					transcriptOverlayNode.style.display = '';
-					transcriptOverlayNode.classList.remove('has-transcript');
-					transcriptOverlay.replaceChildren();
-					const hint = dom.$('span.partial');
-					const kb = this.keybindingService.lookupKeybinding('agentsVoice.pushToTalk');
-					const kbLabel = kb?.getLabel();
-					hint.textContent = kbLabel
-						? localize('voiceMode.pttHint', "Press {0} to talk", kbLabel)
-						: localize('voiceMode.clickMicHint', "Click voice mode to talk");
-					transcriptOverlay.append(hint);
-					transcriptScrollable.scanDomNode();
-				} else {
-					transcriptOverlayNode.style.display = 'none';
-					transcriptOverlayNode.classList.remove('has-transcript');
-				}
-				return;
-			}
-
-			transcriptOverlayNode.style.display = '';
-			transcriptOverlayNode.classList.add('has-transcript');
-			// Show only the latest visible turn.
-			const lastTurn = visible[visible.length - 1];
-			const contentElements: HTMLElement[] = [];
-			if (lastTurn.speaker === 'user') {
-				const span = dom.$('span');
-				if (lastTurn.isPartial) {
-					const committedPart = lastTurn.committed || '';
-					const unsurePart = lastTurn.text.slice(committedPart.length);
-					if (committedPart) {
-						const c = dom.$('span.committed');
-						c.textContent = committedPart;
-						span.append(c);
-					}
-					const u = dom.$('span.partial');
-					u.textContent = unsurePart + '\u2589';
-					span.append(u);
-				} else {
-					span.className = 'committed';
-					span.textContent = lastTurn.text;
-				}
-				contentElements.push(span);
-			} else {
-				const div = dom.$('div.assistant-text');
-				div.textContent = lastTurn.text;
-				contentElements.push(div);
-			}
-			transcriptOverlay.replaceChildren(...contentElements);
-			transcriptScrollable.scanDomNode();
-			transcriptScrollable.setScrollPosition({ scrollTop: 0 });
+		this._register(setupVoiceInputDecorations({
+			voiceSessionController: this.voiceSessionController,
+			ttsPlaybackService: this.ttsPlaybackService,
+			micCaptureService: this.micCaptureService,
+			configurationService: this.configurationService,
+			keybindingService: this.keybindingService,
+		}, {
+			inputContainer: inputContainerEl,
+			isActive: this._isActiveObs,
+			getCurrentResource: () => this._currentChatResource,
 		}));
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -135,6 +135,16 @@
 	flex: 1;
 }
 
+/* Voice mode controls (mic / stop / settings / disconnect) */
+.sessions-chat-voice-toolbar {
+	display: flex;
+	align-items: center;
+}
+
+.sessions-chat-voice-toolbar .monaco-toolbar {
+	position: relative;
+}
+
 /* Model picker - uses workbench ModelPickerActionItem */
 /* Session config toolbar (model picker via MenuWorkbenchToolBar) */
 .sessions-chat-config-toolbar {

--- a/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
+++ b/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/* Voice transcript overlay shown inside the chat input container while voice mode is active. Mirrors the main-window overlay in chatViewPane.css. */
+/* Voice transcript overlay inside the chat input, mirroring chatViewPane.css. */
 
 @keyframes sessionsVoiceTextPulse {
 	0%,
@@ -23,7 +23,7 @@
 	right: 0;
 	bottom: 36px;
 	z-index: 10;
-	/* Let clicks pass through to the input editor unless there is scrollable transcript content */
+	/* Let clicks pass through to the input editor unless transcript is scrollable */
 	pointer-events: none;
 	background: var(--vscode-input-background, transparent);
 	border-radius: inherit;
@@ -62,11 +62,10 @@
 	white-space: pre-wrap;
 }
 
-/* Voice mode icon glow on the new-session composer toolbar. The shared chat.css
-rules only match the chat widget's `.chat-input-container`; the composer uses
-its own `.new-chat-input-area`, so mirror the blue-listening / purple-speaking
-glow here. `voice-active` / `voice-listening` are toggled on the input
-container by setupVoiceInputDecorations. */
+/* Voice icon glow on the new-session composer toolbar. chat.css only targets the
+chat widget's `.chat-input-container`; the composer uses `.new-chat-input-area`,
+so mirror the blue-listening / purple-speaking glow here. `voice-active` /
+`voice-listening` are toggled by setupVoiceInputDecorations. */
 @keyframes sessionsVoiceIconGlow {
 	0%,
 	100% {

--- a/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
+++ b/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
@@ -61,3 +61,41 @@
 	color: var(--vscode-descriptionForeground);
 	white-space: pre-wrap;
 }
+
+/* Voice mode icon glow on the new-session composer toolbar. The shared chat.css
+rules only match the chat widget's `.chat-input-container`; the composer uses
+its own `.new-chat-input-area`, so mirror the blue-listening / purple-speaking
+glow here. `voice-active` / `voice-listening` are toggled on the input
+container by setupVoiceInputDecorations. */
+@keyframes sessionsVoiceIconGlow {
+	0%,
+	100% {
+		box-shadow: 0 0 4px var(--sessions-voice-icon-glow-color);
+	}
+
+	50% {
+		box-shadow: 0 0 9px var(--sessions-voice-icon-glow-color);
+	}
+}
+
+/* Blue when listening */
+.new-chat-input-area.voice-active.voice-listening .action-label.codicon-voice-mode {
+	--sessions-voice-icon-glow-color: rgba(88, 166, 255, 0.65);
+	color: var(--vscode-charts-blue, #58a6ff) !important;
+	border-radius: 50%;
+}
+
+.monaco-workbench.monaco-enable-motion .new-chat-input-area.voice-active.voice-listening .action-label.codicon-voice-mode {
+	animation: sessionsVoiceIconGlow 1.4s ease-in-out infinite;
+}
+
+/* Purple when speaking */
+.new-chat-input-area.voice-active:not(.voice-listening) .action-label.codicon-voice-mode {
+	--sessions-voice-icon-glow-color: rgba(163, 113, 247, 0.65);
+	color: var(--vscode-charts-purple, #a371f7) !important;
+	border-radius: 50%;
+}
+
+.monaco-workbench.monaco-enable-motion .new-chat-input-area.voice-active:not(.voice-listening) .action-label.codicon-voice-mode {
+	animation: sessionsVoiceIconGlow 1.4s ease-in-out infinite;
+}

--- a/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
+++ b/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Voice transcript overlay shown inside the chat input container while voice mode is active. Mirrors the main-window overlay in chatViewPane.css. */
+
+@keyframes sessionsVoiceTextPulse {
+	0%,
+	100% {
+		opacity: 0.9;
+	}
+
+	50% {
+		opacity: 0.4;
+	}
+}
+
+.voice-transcript-overlay-scrollable {
+	position: absolute !important;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 36px;
+	z-index: 10;
+	/* Let clicks pass through to the input editor unless there is scrollable transcript content */
+	pointer-events: none;
+	background: var(--vscode-input-background, transparent);
+	border-radius: inherit;
+	border-bottom-left-radius: 0;
+	border-bottom-right-radius: 0;
+}
+
+.voice-transcript-overlay-scrollable.has-transcript {
+	pointer-events: auto;
+}
+
+.voice-transcript-overlay {
+	height: 100%;
+	box-sizing: border-box;
+	padding: var(--vscode-spacing-size80) var(--vscode-spacing-size120);
+	font-size: var(--vscode-fontSize-body1);
+	line-height: 1.4;
+	word-break: break-word;
+	overflow: hidden;
+	overscroll-behavior: contain;
+}
+
+.voice-transcript-overlay .committed {
+	color: var(--vscode-foreground);
+}
+
+.voice-transcript-overlay .partial {
+	color: var(--vscode-foreground);
+	opacity: 0.6;
+	font-style: italic;
+	animation: sessionsVoiceTextPulse 1.5s ease-in-out infinite;
+}
+
+.voice-transcript-overlay .assistant-text {
+	color: var(--vscode-descriptionForeground);
+	white-space: pre-wrap;
+}

--- a/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
@@ -84,6 +84,7 @@ export class NewChatInSessionWidget extends Disposable {
 			minEditorHeight: 64,
 			placeholder: localize('newChatInSessionPlaceholder', 'Ask a follow-up question or start a new topic within this session...'),
 			supportsBackground: true,
+			voiceRoutesWhileSessionActive: true,
 		}));
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -291,6 +291,13 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			placeholder?: string;
 			renderSessionTypePickerInControls?: boolean;
 			supportsBackground?: boolean;
+			/**
+			 * Keep this composer a valid voice target even while a created session
+			 * is active. Used by the in-session "new chat" composer so dictation
+			 * creates a parallel chat instead of routing to the parent session's
+			 * chat widget. The welcome composer leaves this unset.
+			 */
+			voiceRoutesWhileSessionActive?: boolean;
 		},
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IModelService private readonly modelService: IModelService,
@@ -634,9 +641,8 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 
 		dom.append(toolbar, dom.$('.sessions-chat-toolbar-spacer'));
 
-		// Voice mode controls (mic / stop / settings / disconnect). The composer
-		// uses a hand-built toolbar, so these are surfaced via a dedicated menu
-		// rather than the shared `MenuId.ChatExecute` used by the chat widget.
+		// Voice controls (mic/stop/settings/disconnect). The hand-built toolbar
+		// can't use the shared `MenuId.ChatExecute`, so a dedicated menu is used.
 		const voiceContainer = dom.append(toolbar, dom.$('.sessions-chat-voice-toolbar'));
 		this._register(this.instantiationService.createInstance(NewChatVoiceController, {
 			toolbarContainer: voiceContainer,
@@ -831,6 +837,11 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		this._editor?.focus();
 	}
 
+	/** See {@link INewChatVoiceComposer.routesWhileSessionActive}. */
+	get routesWhileSessionActive(): boolean {
+		return this.options.voiceRoutesWhileSessionActive === true;
+	}
+
 	prefillInput(text: string): void {
 		const editor = this._editor;
 		const model = editor?.getModel();
@@ -844,9 +855,8 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 	}
 
 	sendQuery(text: string): void {
-		// A submit is already in flight (e.g. a rapid second voice transcript
-		// arriving before the session is created); don't clobber the in-flight
-		// text or double-submit.
+		// A submit is already in flight (e.g. a rapid second transcript before the
+		// session is created); don't clobber the in-flight text or double-submit.
 		if (this._sending) {
 			return;
 		}

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -40,6 +40,7 @@ import * as aria from '../../../../base/browser/ui/aria/aria.js';
 import { ContextMenuController } from '../../../../editor/contrib/contextmenu/browser/contextmenu.js';
 import { getSimpleEditorOptions } from '../../../../workbench/contrib/codeEditor/browser/simpleEditorOptions.js';
 import { NewChatContextAttachments } from './newChatContextAttachments.js';
+import { NewChatVoiceController } from './newChatVoice.js';
 import { SessionTypePicker } from './sessionTypePicker.js';
 import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
 import { MobileSessionTypePicker } from './mobile/mobileSessionTypePicker.js';
@@ -633,6 +634,16 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 
 		dom.append(toolbar, dom.$('.sessions-chat-toolbar-spacer'));
 
+		// Voice mode controls (mic / stop / settings / disconnect). The composer
+		// uses a hand-built toolbar, so these are surfaced via a dedicated menu
+		// rather than the shared `MenuId.ChatExecute` used by the chat widget.
+		const voiceContainer = dom.append(toolbar, dom.$('.sessions-chat-voice-toolbar'));
+		this._register(this.instantiationService.createInstance(NewChatVoiceController, {
+			toolbarContainer: voiceContainer,
+			inputContainer: container,
+			composer: this,
+		}));
+
 		this._loadingSpinner = dom.append(toolbar, dom.$('.sessions-chat-loading-spinner'));
 		const loadingIcon = dom.append(this._loadingSpinner, renderIcon(ThemeIcon.modify(Codicon.loading, 'spin')));
 		loadingIcon.setAttribute('aria-hidden', 'true');
@@ -833,6 +844,12 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 	}
 
 	sendQuery(text: string): void {
+		// A submit is already in flight (e.g. a rapid second voice transcript
+		// arriving before the session is created); don't clobber the in-flight
+		// text or double-submit.
+		if (this._sending) {
+			return;
+		}
 		const model = this._editor?.getModel();
 		if (model) {
 			model.setValue(text);

--- a/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
@@ -1,0 +1,221 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Event } from '../../../../base/common/event.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { IObservable, autorun, derived, observableValue } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
+import { MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
+import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IInstantiationService, createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { IMicCaptureService } from '../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
+import { ITtsPlaybackService } from '../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
+import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { setupVoiceInputDecorations } from './voiceInputDecorations.js';
+
+/**
+ * Stable resource that identifies the new-session composer as the voice backend's
+ * target while no session exists yet. `_chat.voice.getCurrentSession` returns this
+ * so the controller routes transcribed input through the composer (creating the
+ * session) instead of falling back to a bare, unconfigured chat session.
+ */
+export const NEW_CHAT_VOICE_SENTINEL = URI.from({ scheme: 'sessions-voice', authority: 'new-chat', path: '/composer' });
+
+/** The subset of the new-session composer that voice mode drives. */
+export interface INewChatVoiceComposer {
+	/** Fires when the composer input gains focus, so it becomes the active voice target. */
+	readonly onDidFocus: Event<void>;
+	/** Set the input to `text` and submit it, creating the session. */
+	sendQuery(text: string): void;
+	/** Set the input to `text` without submitting. */
+	prefillInput(text: string): void;
+	/** Focus the composer input. */
+	focus(): void;
+}
+
+export const INewChatVoiceTargetService = createDecorator<INewChatVoiceTargetService>('newChatVoiceTargetService');
+
+/**
+ * Tracks the currently active new-session composer so the voice command bridge
+ * can route transcribed input to it while no session exists yet.
+ */
+export interface INewChatVoiceTargetService {
+	readonly _serviceBrand: undefined;
+	/** The most recently focused/registered composer, if any is mounted. */
+	readonly activeComposer: IObservable<INewChatVoiceComposer | undefined>;
+	/** Register a composer as a potential voice target; disposing removes it. */
+	registerComposer(composer: INewChatVoiceComposer): IDisposable;
+	/** Promote `composer` to the active voice target (e.g. on focus). */
+	setActive(composer: INewChatVoiceComposer): void;
+}
+
+export class NewChatVoiceTargetService extends Disposable implements INewChatVoiceTargetService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _composers = new Set<INewChatVoiceComposer>();
+	private readonly _activeComposer = observableValue<INewChatVoiceComposer | undefined>(this, undefined);
+	readonly activeComposer: IObservable<INewChatVoiceComposer | undefined> = this._activeComposer;
+
+	registerComposer(composer: INewChatVoiceComposer): IDisposable {
+		this._composers.add(composer);
+		this._activeComposer.set(composer, undefined);
+		return toDisposable(() => {
+			this._composers.delete(composer);
+			if (this._activeComposer.get() === composer) {
+				// Fall back to any remaining composer (last inserted), else none.
+				const remaining = [...this._composers];
+				this._activeComposer.set(remaining.length ? remaining[remaining.length - 1] : undefined, undefined);
+			}
+		});
+	}
+
+	setActive(composer: INewChatVoiceComposer): void {
+		if (this._composers.has(composer)) {
+			this._activeComposer.set(composer, undefined);
+		}
+	}
+}
+
+registerSingleton(INewChatVoiceTargetService, NewChatVoiceTargetService, InstantiationType.Delayed);
+
+// --- Voice toolbar menu for the new-session composer ---
+// The composer uses a hand-built toolbar (not the standard ChatWidget), so the
+// shared voice actions registered against `MenuId.ChatExecute` never appear here.
+// Re-surface the same commands in a dedicated menu whose visibility is driven by
+// the global voice state keys plus the composer-scoped `agentsVoiceInitiatedHere`.
+
+export const SessionsNewChatVoiceMenu = new MenuId('SessionsNewChatVoiceMenu');
+
+const WHEN_VOICE_ENABLED = ContextKeyExpr.equals('config.agents.voice.enabled', true);
+const WHEN_CONNECTING = ContextKeyExpr.equals('agentsVoiceConnecting', true);
+const WHEN_LISTENING = ContextKeyExpr.equals('agentsVoiceListening', true);
+const WHEN_CONNECTED = ContextKeyExpr.equals('agentsVoiceConnected', true);
+const WHEN_INITIATED_HERE = ContextKeyExpr.equals('agentsVoiceInitiatedHere', true);
+const WHEN_VOICE_SURFACE = ContextKeyExpr.equals('newChatVoiceSurface', true);
+
+MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
+	command: { id: 'agentsVoice.connecting', title: localize('agentsVoice.connecting', "Connecting..."), icon: Codicon.loading },
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_CONNECTING, WHEN_INITIATED_HERE),
+	group: 'navigation',
+	order: -10,
+});
+
+MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
+	command: { id: 'agentsVoice.startVoiceInChat', title: localize('agentsVoice.startVoiceInChat', "Voice Mode"), icon: Codicon.voiceMode },
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_VOICE_SURFACE, WHEN_LISTENING.negate(), WHEN_CONNECTING.negate()),
+	group: 'navigation',
+	order: -10,
+});
+
+MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
+	command: { id: 'agentsVoice.pttStopInChat', title: localize('agentsVoice.pttStopInChat', "Voice Mode: Stop Recording"), icon: Codicon.voiceMode },
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_LISTENING, WHEN_INITIATED_HERE),
+	group: 'navigation',
+	order: -10,
+});
+
+MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
+	command: { id: 'agentsVoice.openSettings', title: localize('agentsVoice.openSettings', "Voice Mode Settings"), icon: Codicon.settingsGear },
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_CONNECTED, WHEN_INITIATED_HERE),
+	group: 'navigation',
+	order: -9.5,
+});
+
+MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
+	command: { id: 'agentsVoice.disconnect', title: localize('agentsVoice.disconnect', "Disconnect Voice Mode"), icon: Codicon.debugDisconnect },
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_CONNECTED, WHEN_INITIATED_HERE),
+	group: 'navigation',
+	order: -9,
+});
+
+export interface INewChatVoiceControllerOptions {
+	/** Container the voice toolbar (mic/stop/settings/disconnect) is appended to. */
+	readonly toolbarContainer: HTMLElement;
+	/** Input container that receives the audio-reactive glow + transcript overlay. */
+	readonly inputContainer: HTMLElement;
+	/** The composer voice drives. */
+	readonly composer: INewChatVoiceComposer;
+}
+
+/**
+ * Wires voice mode into a new-session composer: renders the voice toolbar,
+ * binds the composer-scoped `agentsVoiceInitiatedHere` key while the composer is
+ * the voice target, sets up the input glow/transcript, and registers the
+ * composer with {@link INewChatVoiceTargetService} for command-bridge routing.
+ */
+export class NewChatVoiceController extends Disposable {
+
+	constructor(
+		options: INewChatVoiceControllerOptions,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@INewChatVoiceTargetService targetService: INewChatVoiceTargetService,
+		@IVoiceSessionController voiceSessionController: IVoiceSessionController,
+		@ISessionsService sessionsService: ISessionsService,
+		@ITtsPlaybackService ttsPlaybackService: ITtsPlaybackService,
+		@IMicCaptureService micCaptureService: IMicCaptureService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IKeybindingService keybindingService: IKeybindingService,
+	) {
+		super();
+
+		this._register(targetService.registerComposer(options.composer));
+		this._register(options.composer.onDidFocus(() => targetService.setActive(options.composer)));
+
+		// Scoped context so the voice toolbar's gating is local to this composer
+		// and does not leak to other surfaces.
+		const scopedContextKeyService = this._register(contextKeyService.createScoped(options.toolbarContainer));
+		// True while this composer is a valid voice surface (mounted, focused, and
+		// no real session created yet). Drives whether the mic button appears.
+		const voiceSurfaceKey = scopedContextKeyService.createKey<boolean>('newChatVoiceSurface', false);
+		// True while voice is active *and* this composer is the surface — gates the
+		// post-connect Stop/Disconnect/Settings controls, mirroring the chat widget.
+		const initiatedHereKey = scopedContextKeyService.createKey<boolean>('agentsVoiceInitiatedHere', false);
+		const scopedInstantiationService = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, scopedContextKeyService])));
+
+		this._register(scopedInstantiationService.createInstance(MenuWorkbenchToolBar, options.toolbarContainer, SessionsNewChatVoiceMenu, {
+			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+		}));
+
+		// This composer is the voice surface while it is the active composer and no
+		// session has been created yet (the welcome/new-session screen). A draft
+		// new-session still surfaces as `activeSession` with an `activeChat`, so we
+		// must gate on `isCreated`, not merely on the presence of an active chat.
+		const isVoiceSurface = derived(reader => {
+			const active = sessionsService.activeSession.read(reader);
+			const hasCreatedSession = !!active && active.isCreated.read(reader);
+			const isActiveComposer = targetService.activeComposer.read(reader) === options.composer;
+			return !hasCreatedSession && isActiveComposer;
+		});
+		const isVoiceTarget = derived(reader => {
+			const voiceActive = voiceSessionController.isConnected.read(reader) || voiceSessionController.isConnecting.read(reader);
+			return voiceActive && isVoiceSurface.read(reader);
+		});
+		this._register(autorun(reader => {
+			voiceSurfaceKey.set(isVoiceSurface.read(reader));
+			initiatedHereKey.set(isVoiceTarget.read(reader));
+		}));
+
+		this._register(setupVoiceInputDecorations({
+			voiceSessionController,
+			ttsPlaybackService,
+			micCaptureService,
+			configurationService,
+			keybindingService,
+		}, {
+			inputContainer: options.inputContainer,
+			isActive: isVoiceTarget,
+			getCurrentResource: () => NEW_CHAT_VOICE_SENTINEL,
+		}));
+	}
+}

--- a/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
@@ -24,20 +24,23 @@ import { ISessionsService } from '../../../services/sessions/browser/sessionsSer
 import { setupVoiceInputDecorations } from './voiceInputDecorations.js';
 
 /**
- * Stable resource that identifies the new-session composer as the voice backend's
- * target while no session exists yet. `_chat.voice.getCurrentSession` returns this
- * so the controller routes transcribed input through the composer (creating the
- * session) instead of falling back to a bare, unconfigured chat session.
+ * Stable resource for targeting the new-session composer before a session exists.
+ * This keeps dictation on the composer so it creates a configured session.
  */
 export const NEW_CHAT_VOICE_SENTINEL = URI.from({ scheme: 'sessions-voice', authority: 'new-chat', path: '/composer' });
 
-/** The subset of the new-session composer that voice mode drives. */
+/** New-session composer APIs used by voice mode. */
 export interface INewChatVoiceComposer {
-	/** Fires when the composer input gains focus, so it becomes the active voice target. */
+	/** Fires when the composer input gains focus. */
 	readonly onDidFocus: Event<void>;
-	/** Set the input to `text` and submit it, creating the session. */
+	/**
+	 * When true, this remains a voice target even with an active session.
+	 * Otherwise, it targets only before any session exists.
+	 */
+	readonly routesWhileSessionActive?: boolean;
+	/** Set `text` and submit, creating the session. */
 	sendQuery(text: string): void;
-	/** Set the input to `text` without submitting. */
+	/** Set `text` without submitting. */
 	prefillInput(text: string): void;
 	/** Focus the composer input. */
 	focus(): void;
@@ -46,16 +49,15 @@ export interface INewChatVoiceComposer {
 export const INewChatVoiceTargetService = createDecorator<INewChatVoiceTargetService>('newChatVoiceTargetService');
 
 /**
- * Tracks the currently active new-session composer so the voice command bridge
- * can route transcribed input to it while no session exists yet.
+ * Tracks the active new-session composer for voice command routing.
  */
 export interface INewChatVoiceTargetService {
 	readonly _serviceBrand: undefined;
-	/** The most recently focused/registered composer, if any is mounted. */
+	/** The most recent focused/registered mounted composer. */
 	readonly activeComposer: IObservable<INewChatVoiceComposer | undefined>;
-	/** Register a composer as a potential voice target; disposing removes it. */
+	/** Register a composer as a voice target; dispose to remove it. */
 	registerComposer(composer: INewChatVoiceComposer): IDisposable;
-	/** Promote `composer` to the active voice target (e.g. on focus). */
+	/** Promote `composer` to the active voice target. */
 	setActive(composer: INewChatVoiceComposer): void;
 }
 
@@ -72,7 +74,7 @@ export class NewChatVoiceTargetService extends Disposable implements INewChatVoi
 		return toDisposable(() => {
 			this._composers.delete(composer);
 			if (this._activeComposer.get() === composer) {
-				// Fall back to any remaining composer (last inserted), else none.
+				// Fall back to the last remaining composer.
 				const remaining = [...this._composers];
 				this._activeComposer.set(remaining.length ? remaining[remaining.length - 1] : undefined, undefined);
 			}
@@ -89,10 +91,8 @@ export class NewChatVoiceTargetService extends Disposable implements INewChatVoi
 registerSingleton(INewChatVoiceTargetService, NewChatVoiceTargetService, InstantiationType.Delayed);
 
 // --- Voice toolbar menu for the new-session composer ---
-// The composer uses a hand-built toolbar (not the standard ChatWidget), so the
-// shared voice actions registered against `MenuId.ChatExecute` never appear here.
-// Re-surface the same commands in a dedicated menu whose visibility is driven by
-// the global voice state keys plus the composer-scoped `agentsVoiceInitiatedHere`.
+// The composer has a custom toolbar, so `MenuId.ChatExecute` voice actions do
+// not appear here. Re-surface them with composer-scoped visibility.
 
 export const SessionsNewChatVoiceMenu = new MenuId('SessionsNewChatVoiceMenu');
 
@@ -139,19 +139,17 @@ MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 });
 
 export interface INewChatVoiceControllerOptions {
-	/** Container the voice toolbar (mic/stop/settings/disconnect) is appended to. */
+	/** Container for the voice toolbar. */
 	readonly toolbarContainer: HTMLElement;
-	/** Input container that receives the audio-reactive glow + transcript overlay. */
+	/** Input container for glow and transcript overlay. */
 	readonly inputContainer: HTMLElement;
-	/** The composer voice drives. */
+	/** Composer driven by voice. */
 	readonly composer: INewChatVoiceComposer;
 }
 
 /**
- * Wires voice mode into a new-session composer: renders the voice toolbar,
- * binds the composer-scoped `agentsVoiceInitiatedHere` key while the composer is
- * the voice target, sets up the input glow/transcript, and registers the
- * composer with {@link INewChatVoiceTargetService} for command-bridge routing.
+ * Wires voice mode into a new-session composer: toolbar, scoped keys,
+ * glow/transcript, and {@link INewChatVoiceTargetService} routing.
  */
 export class NewChatVoiceController extends Disposable {
 
@@ -172,14 +170,11 @@ export class NewChatVoiceController extends Disposable {
 		this._register(targetService.registerComposer(options.composer));
 		this._register(options.composer.onDidFocus(() => targetService.setActive(options.composer)));
 
-		// Scoped context so the voice toolbar's gating is local to this composer
-		// and does not leak to other surfaces.
+		// Keep voice toolbar gating scoped to this composer.
 		const scopedContextKeyService = this._register(contextKeyService.createScoped(options.toolbarContainer));
-		// True while this composer is a valid voice surface (mounted, focused, and
-		// no real session created yet). Drives whether the mic button appears.
+		// True when this composer can show the mic button.
 		const voiceSurfaceKey = scopedContextKeyService.createKey<boolean>('newChatVoiceSurface', false);
-		// True while voice is active *and* this composer is the surface — gates the
-		// post-connect Stop/Disconnect/Settings controls, mirroring the chat widget.
+		// True when voice is active on this composer.
 		const initiatedHereKey = scopedContextKeyService.createKey<boolean>('agentsVoiceInitiatedHere', false);
 		const scopedInstantiationService = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, scopedContextKeyService])));
 
@@ -187,15 +182,13 @@ export class NewChatVoiceController extends Disposable {
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 		}));
 
-		// This composer is the voice surface while it is the active composer and no
-		// session has been created yet (the welcome/new-session screen). A draft
-		// new-session still surfaces as `activeSession` with an `activeChat`, so we
-		// must gate on `isCreated`, not merely on the presence of an active chat.
+		// Target the active composer before a session exists, or when it opts in
+		// while a session is active. Gate on `isCreated` to exclude drafts.
 		const isVoiceSurface = derived(reader => {
 			const active = sessionsService.activeSession.read(reader);
 			const hasCreatedSession = !!active && active.isCreated.read(reader);
 			const isActiveComposer = targetService.activeComposer.read(reader) === options.composer;
-			return !hasCreatedSession && isActiveComposer;
+			return (options.composer.routesWhileSessionActive || !hasCreatedSession) && isActiveComposer;
 		});
 		const isVoiceTarget = derived(reader => {
 			const voiceActive = voiceSessionController.isConnected.read(reader) || voiceSessionController.isConnecting.read(reader);

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -181,6 +181,41 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 registerWorkbenchContribution2(SessionsVoiceBridgeContribution.ID, SessionsVoiceBridgeContribution, WorkbenchPhase.AfterRestored);
 
 /**
+ * Authoritatively tells the shared voice controller which session is active in
+ * the Agents window, so voice audio routing (`is_active`, response deferral, and
+ * flushing a buffered response when a session is revealed) follows the session
+ * the user is actually viewing.
+ *
+ * The controller normally infers the active session from chat-widget focus, but
+ * the Agents window renders multiple chat widgets at once and DOM focus stays on
+ * the sessions list, so that heuristic thrashes. Here we forward the single
+ * authoritative {@link ISessionsService.activeSession} instead. A draft
+ * new-session (welcome composer) is not a created session, so it reports
+ * `undefined` (no active real session) rather than a stale prior one.
+ */
+class SessionsVoiceActiveSessionContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.voiceActiveSession';
+
+	constructor(
+		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
+		@ISessionsService private readonly sessionsService: ISessionsService,
+	) {
+		super();
+
+		this._register(autorun(reader => {
+			const active = this.sessionsService.activeSession.read(reader);
+			const resource = active?.isCreated.read(reader)
+				? active.activeChat.read(reader)?.resource
+				: undefined;
+			this.voiceSessionController.setActiveSessionShown(resource);
+		}));
+	}
+}
+
+registerWorkbenchContribution2(SessionsVoiceActiveSessionContribution.ID, SessionsVoiceActiveSessionContribution, WorkbenchPhase.AfterRestored);
+
+/**
  * Keeps hands-free voice listening anchored to the session the user is dictating
  * into. When the active session changes while the microphone is listening, the
  * turn is only stopped if dictation is actually in progress (so it isn't

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -14,6 +14,7 @@ import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/c
 import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { INewChatVoiceTargetService, NEW_CHAT_VOICE_SENTINEL } from './newChatVoice.js';
 
 /**
  * Bridges the shared {@link IVoiceSessionController} to the Agents (Sessions)
@@ -39,6 +40,7 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
+		@INewChatVoiceTargetService private readonly newChatVoiceTargetService: INewChatVoiceTargetService,
 	) {
 		super();
 
@@ -63,8 +65,20 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 		// frequently stale; prefer the active session's widget and only fall back
 		// to the focused widget when there is no active session.
 		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.acceptInput', (_accessor, text: string) => {
+			if (!text) {
+				return;
+			}
+			// If a new-session composer is the voice target (no session exists yet),
+			// submit through it so the transcribed request creates the session.
+			// This takes priority over `lastFocusedWidget`, which can still point at
+			// a previously-opened session's chat widget on the welcome screen.
+			const composer = this._activeComposerTarget();
+			if (composer) {
+				composer.sendQuery(text);
+				return;
+			}
 			const widget = this._activeSessionWidget() ?? this.chatWidgetService.lastFocusedWidget;
-			if (text && widget?.viewModel) {
+			if (widget?.viewModel) {
 				if (widget.viewModel.editing) {
 					// When editing an old message, populate the active input editor
 					// so the user can review before submitting.
@@ -77,11 +91,17 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 
 		// Report the currently shown session's chat resource. Mirrors the main
 		// window's use of its single pane's shown session (not DOM focus): in the
-		// Agents window the shown session is the active session.
+		// Agents window the shown session is the active session. When no session
+		// exists yet but a new-session composer is mounted, report the composer
+		// sentinel so the controller routes input to it instead of spinning up a
+		// bare, unconfigured chat session.
 		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.getCurrentSession', (): string | undefined => {
-			const activeChat = this.sessionsService.activeSession.get()?.activeChat.get()?.resource;
+			const activeChat = this._createdActiveChatResource();
 			if (activeChat) {
 				return activeChat.toString();
+			}
+			if (this._activeComposerTarget()) {
+				return NEW_CHAT_VOICE_SENTINEL.toString();
 			}
 			return this.chatWidgetService.lastFocusedWidget?.viewModel?.sessionResource?.toString();
 		}));
@@ -91,6 +111,12 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.switchToSession', async (_accessor, resourceStr: string): Promise<boolean> => {
 			if (!resourceStr) {
 				return false;
+			}
+			// The composer sentinel has no session to open; just focus the composer.
+			if (resourceStr === NEW_CHAT_VOICE_SENTINEL.toString()) {
+				const composer = this._activeComposerTarget();
+				composer?.focus();
+				return !!composer;
 			}
 			let resource: URI;
 			try {
@@ -125,10 +151,30 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 		}));
 	}
 
-	/** The chat widget backing the currently active session, if any. */
+	/**
+	 * The active session's chat resource, but only once the session has actually
+	 * been created. A draft new-session (welcome composer) also surfaces as the
+	 * active session with an `activeChat`, so gating on {@link IActiveSession.isCreated}
+	 * is what distinguishes a real session from the composer.
+	 */
+	private _createdActiveChatResource(): URI | undefined {
+		const active = this.sessionsService.activeSession.get();
+		return active?.isCreated.get() ? active.activeChat.get()?.resource : undefined;
+	}
+
+	/** The chat widget backing the currently active (created) session, if any. */
 	private _activeSessionWidget() {
-		const resource = this.sessionsService.activeSession.get()?.activeChat.get()?.resource;
+		const resource = this._createdActiveChatResource();
 		return resource ? this.chatWidgetService.getWidgetBySessionResource(resource) : undefined;
+	}
+
+	/**
+	 * The new-session composer to route voice input through, but only while no
+	 * session has been created yet — once a real session exists, voice targets
+	 * its chat widget instead.
+	 */
+	private _activeComposerTarget() {
+		return this._createdActiveChatResource() ? undefined : this.newChatVoiceTargetService.activeComposer.get();
 	}
 }
 
@@ -162,7 +208,9 @@ class SessionsVoiceInitiatedContribution extends Disposable implements IWorkbenc
 		this._register(autorun(reader => {
 			this.voiceSessionController.isConnected.read(reader);
 			this.voiceSessionController.isConnecting.read(reader);
-			this.sessionsService.activeSession.read(reader)?.activeChat.read(reader);
+			const active = this.sessionsService.activeSession.read(reader);
+			active?.isCreated.read(reader);
+			active?.activeChat.read(reader);
 			this._apply();
 		}));
 		// Widgets can be created after voice connects (opening a session slot).
@@ -171,7 +219,10 @@ class SessionsVoiceInitiatedContribution extends Disposable implements IWorkbenc
 
 	private _apply(): void {
 		const voiceActive = this.voiceSessionController.isConnected.get() || this.voiceSessionController.isConnecting.get();
-		const activeResource = this.sessionsService.activeSession.get()?.activeChat.get()?.resource;
+		// Only a created session has a chat widget; a draft new-session (welcome
+		// composer) manages its own `agentsVoiceInitiatedHere` key instead.
+		const active = this.sessionsService.activeSession.get();
+		const activeResource = active?.isCreated.get() ? active.activeChat.get()?.resource : undefined;
 		for (const widget of this.chatWidgetService.getAllWidgets()) {
 			const widgetResource = widget.viewModel?.sessionResource;
 			const isActiveWidget = voiceActive && !!activeResource && !!widgetResource && isEqual(widgetResource, activeResource);

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -17,14 +17,11 @@ import { ISessionsManagementService } from '../../../services/sessions/common/se
 import { INewChatVoiceTargetService, NEW_CHAT_VOICE_SENTINEL } from './newChatVoice.js';
 
 /**
- * Bridges the shared {@link IVoiceSessionController} to the Agents (Sessions)
- * window chat surfaces. The controller drives the chat exclusively through the
- * `_chat.voice.*` commands; in the main VS Code window these are registered by
- * `ChatViewPane`. The Agents window hosts chats through {@link ISessionsService}
- * instead, so it registers its own bridge here.
+ * Bridges {@link IVoiceSessionController} to Agents window chat surfaces.
+ * The shared controller uses `_chat.voice.*` commands; Agents hosts chats
+ * through {@link ISessionsService}, so it registers them here.
  *
- * The commands are only registered while `agents.voice.enabled` is set, matching
- * the main-window behavior, and are wired to the sessions model:
+ * Commands are registered only while `agents.voice.enabled` is set:
  * - `_chat.voice.acceptInput` injects transcribed text into the focused chat widget.
  * - `_chat.voice.getCurrentSession` reports the active session's chat resource.
  * - `_chat.voice.switchToSession` activates the session that owns a chat resource.
@@ -59,19 +56,14 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 			return;
 		}
 
-		// Inject transcribed text into the active session's chat widget. Unlike
-		// the main window (a single chat pane), the Agents window keeps DOM focus
-		// on the sessions list while showing a chat, so `lastFocusedWidget` is
-		// frequently stale; prefer the active session's widget and only fall back
-		// to the focused widget when there is no active session.
+		// Prefer the active session widget; Agents often leaves DOM focus on the
+		// sessions list, making `lastFocusedWidget` stale.
 		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.acceptInput', (_accessor, text: string) => {
 			if (!text) {
 				return;
 			}
-			// If a new-session composer is the voice target (no session exists yet),
-			// submit through it so the transcribed request creates the session.
-			// This takes priority over `lastFocusedWidget`, which can still point at
-			// a previously-opened session's chat widget on the welcome screen.
+			// Route through the new-session composer so dictation creates the
+			// session instead of using a stale `lastFocusedWidget`.
 			const composer = this._activeComposerTarget();
 			if (composer) {
 				composer.sendQuery(text);
@@ -80,8 +72,7 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 			const widget = this._activeSessionWidget() ?? this.chatWidgetService.lastFocusedWidget;
 			if (widget?.viewModel) {
 				if (widget.viewModel.editing) {
-					// When editing an old message, populate the active input editor
-					// so the user can review before submitting.
+					// Let the user review edited input before submitting.
 					widget.input.setValue(text, false);
 				} else {
 					widget.acceptInput(text, { preserveFocus: true });
@@ -89,30 +80,26 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 			}
 		}));
 
-		// Report the currently shown session's chat resource. Mirrors the main
-		// window's use of its single pane's shown session (not DOM focus): in the
-		// Agents window the shown session is the active session. When no session
-		// exists yet but a new-session composer is mounted, report the composer
-		// sentinel so the controller routes input to it instead of spinning up a
-		// bare, unconfigured chat session.
+		// Report the shown session (the active Agents session), not DOM focus.
+		// Before a session exists, report the composer sentinel so dictation uses it.
 		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.getCurrentSession', (): string | undefined => {
+			// Composer targets take priority over the parent session chat widget.
+			if (this._activeComposerTarget()) {
+				return NEW_CHAT_VOICE_SENTINEL.toString();
+			}
 			const activeChat = this._createdActiveChatResource();
 			if (activeChat) {
 				return activeChat.toString();
 			}
-			if (this._activeComposerTarget()) {
-				return NEW_CHAT_VOICE_SENTINEL.toString();
-			}
 			return this.chatWidgetService.lastFocusedWidget?.viewModel?.sessionResource?.toString();
 		}));
 
-		// Activate the session that owns the given chat resource so its response
-		// becomes visible to the user.
+		// Reveal the session that owns the given chat resource.
 		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.switchToSession', async (_accessor, resourceStr: string): Promise<boolean> => {
 			if (!resourceStr) {
 				return false;
 			}
-			// The composer sentinel has no session to open; just focus the composer.
+			// The composer sentinel has no session; focus the composer.
 			if (resourceStr === NEW_CHAT_VOICE_SENTINEL.toString()) {
 				const composer = this._activeComposerTarget();
 				composer?.focus();
@@ -125,7 +112,7 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 				return false;
 			}
 
-			// A chat resource maps to its owning session (and specific chat).
+			// Chat resources map to their owning session and chat.
 			const owner = this.sessionsManagementService.getSessionForChatResource(resource);
 			if (owner) {
 				await this.sessionsService.openSession(owner.session.resource, { preserveFocus: true });
@@ -135,7 +122,7 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 				return true;
 			}
 
-			// Otherwise treat the resource as a session resource.
+			// Otherwise, treat it as a session resource.
 			const session = this.sessionsManagementService.getSession(resource);
 			if (session) {
 				await this.sessionsService.openSession(session.resource, { preserveFocus: true });
@@ -152,10 +139,8 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 	}
 
 	/**
-	 * The active session's chat resource, but only once the session has actually
-	 * been created. A draft new-session (welcome composer) also surfaces as the
-	 * active session with an `activeChat`, so gating on {@link IActiveSession.isCreated}
-	 * is what distinguishes a real session from the composer.
+	 * The active chat resource, only after its session exists.
+	 * {@link IActiveSession.isCreated} distinguishes it from the welcome composer.
 	 */
 	private _createdActiveChatResource(): URI | undefined {
 		const active = this.sessionsService.activeSession.get();
@@ -169,29 +154,31 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 	}
 
 	/**
-	 * The new-session composer to route voice input through, but only while no
-	 * session has been created yet — once a real session exists, voice targets
-	 * its chat widget instead.
+	 * The new-session composer voice should target.
+	 * Welcome composers stop targeting once a session exists; in-session composers
+	 * can opt in via {@link INewChatVoiceComposer.routesWhileSessionActive}.
 	 */
 	private _activeComposerTarget() {
-		return this._createdActiveChatResource() ? undefined : this.newChatVoiceTargetService.activeComposer.get();
+		const composer = this.newChatVoiceTargetService.activeComposer.get();
+		if (!composer) {
+			return undefined;
+		}
+		if (composer.routesWhileSessionActive || !this._createdActiveChatResource()) {
+			return composer;
+		}
+		return undefined;
 	}
 }
 
 registerWorkbenchContribution2(SessionsVoiceBridgeContribution.ID, SessionsVoiceBridgeContribution, WorkbenchPhase.AfterRestored);
 
 /**
- * Authoritatively tells the shared voice controller which session is active in
- * the Agents window, so voice audio routing (`is_active`, response deferral, and
- * flushing a buffered response when a session is revealed) follows the session
- * the user is actually viewing.
+ * Tells the shared voice controller which Agents session is active, so routing,
+ * response deferral, and buffered playback follow the visible session.
  *
- * The controller normally infers the active session from chat-widget focus, but
- * the Agents window renders multiple chat widgets at once and DOM focus stays on
- * the sessions list, so that heuristic thrashes. Here we forward the single
- * authoritative {@link ISessionsService.activeSession} instead. A draft
- * new-session (welcome composer) is not a created session, so it reports
- * `undefined` (no active real session) rather than a stale prior one.
+ * Agents can render multiple chat widgets while DOM focus stays on the sessions
+ * list, so forward {@link ISessionsService.activeSession}. Draft composers report
+ * `undefined` to avoid reusing a stale session.
  */
 class SessionsVoiceActiveSessionContribution extends Disposable implements IWorkbenchContribution {
 
@@ -216,13 +203,9 @@ class SessionsVoiceActiveSessionContribution extends Disposable implements IWork
 registerWorkbenchContribution2(SessionsVoiceActiveSessionContribution.ID, SessionsVoiceActiveSessionContribution, WorkbenchPhase.AfterRestored);
 
 /**
- * Keeps hands-free voice listening anchored to the session the user is dictating
- * into. When the active session changes while the microphone is listening, the
- * turn is only stopped if dictation is actually in progress (so it isn't
- * misrouted to the newly focused session); otherwise listening follows the user
- * into the new session. This mirrors the main-window `ChatViewPane` behavior
- * (see microsoft/vscode#325134), adapted to the Agents window's active-session
- * model.
+ * Keeps hands-free listening anchored to the dictation session.
+ * If the active session changes mid-dictation, stop to avoid misrouting;
+ * otherwise follow the new session, mirroring `ChatViewPane`.
  */
 class SessionsVoiceListeningContribution extends Disposable implements IWorkbenchContribution {
 
@@ -249,7 +232,7 @@ class SessionsVoiceListeningContribution extends Disposable implements IWorkbenc
 			}
 
 			if (voiceState !== 'listening') {
-				// Allow the next dictation to re-capture the owning session.
+				// Let the next dictation capture its session.
 				listeningSession = undefined;
 				return;
 			}
@@ -257,10 +240,7 @@ class SessionsVoiceListeningContribution extends Disposable implements IWorkbenc
 			if (!listeningSession) {
 				listeningSession = targetSession ?? currentSession;
 			} else if (!targetSession && currentSession && !isEqual(currentSession, listeningSession)) {
-				// User switched to a different session while listening. Only stop
-				// when there's dictation in progress, so it isn't misrouted to the
-				// newly focused session. If nothing has been recorded yet, keep
-				// listening and follow the new session.
+				// Stop only mid-dictation; otherwise follow the new session.
 				const activelyDictating = turns.some(t => t.speaker === 'user' && t.isPartial && t.text.trim().length > 0);
 				if (activelyDictating) {
 					voiceSessionController.stopListening();

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -57,9 +57,13 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 			return;
 		}
 
-		// Inject transcribed text into the focused chat widget.
+		// Inject transcribed text into the active session's chat widget. Unlike
+		// the main window (a single chat pane), the Agents window keeps DOM focus
+		// on the sessions list while showing a chat, so `lastFocusedWidget` is
+		// frequently stale; prefer the active session's widget and only fall back
+		// to the focused widget when there is no active session.
 		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.acceptInput', (_accessor, text: string) => {
-			const widget = this.chatWidgetService.lastFocusedWidget ?? this._activeSessionWidget();
+			const widget = this._activeSessionWidget() ?? this.chatWidgetService.lastFocusedWidget;
 			if (text && widget?.viewModel) {
 				if (widget.viewModel.editing) {
 					// When editing an old message, populate the active input editor
@@ -71,13 +75,15 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 			}
 		}));
 
-		// Report the currently active chat's session resource.
+		// Report the currently shown session's chat resource. Mirrors the main
+		// window's use of its single pane's shown session (not DOM focus): in the
+		// Agents window the shown session is the active session.
 		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.getCurrentSession', (): string | undefined => {
-			const focused = this.chatWidgetService.lastFocusedWidget?.viewModel?.sessionResource;
-			if (focused) {
-				return focused.toString();
+			const activeChat = this.sessionsService.activeSession.get()?.activeChat.get()?.resource;
+			if (activeChat) {
+				return activeChat.toString();
 			}
-			return this.sessionsService.activeSession.get()?.activeChat.get()?.resource.toString();
+			return this.chatWidgetService.lastFocusedWidget?.viewModel?.sessionResource?.toString();
 		}));
 
 		// Activate the session that owns the given chat resource so its response
@@ -127,6 +133,54 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 }
 
 registerWorkbenchContribution2(SessionsVoiceBridgeContribution.ID, SessionsVoiceBridgeContribution, WorkbenchPhase.AfterRestored);
+
+/**
+ * Context key mirror of `agentsVoice.contribution`'s per-widget
+ * `agentsVoiceInitiatedHere` key. The shared voice actions (Stop, Disconnect,
+ * Settings, Connecting) only appear in the chat widget whose scoped context has
+ * this key set, and it is normally set by `startVoiceInChat` on
+ * `IChatWidgetService.lastFocusedWidget`. In the Agents window DOM focus stays
+ * on the sessions list, so `lastFocusedWidget` is unreliable and the post-connect
+ * voice controls fail to appear. This contribution deterministically binds the
+ * key to the active session's chat widget while voice is connected/connecting,
+ * so the controls follow the session the user is viewing.
+ */
+class SessionsVoiceInitiatedContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.voiceInitiated';
+
+	/** Matches `AGENTS_VOICE_INITIATED_HERE` in agentsVoice.contribution.ts. */
+	private static readonly _INITIATED_HERE_KEY = 'agentsVoiceInitiatedHere';
+
+	constructor(
+		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
+		@ISessionsService private readonly sessionsService: ISessionsService,
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+	) {
+		super();
+
+		this._register(autorun(reader => {
+			this.voiceSessionController.isConnected.read(reader);
+			this.voiceSessionController.isConnecting.read(reader);
+			this.sessionsService.activeSession.read(reader)?.activeChat.read(reader);
+			this._apply();
+		}));
+		// Widgets can be created after voice connects (opening a session slot).
+		this._register(this.chatWidgetService.onDidAddWidget(() => this._apply()));
+	}
+
+	private _apply(): void {
+		const voiceActive = this.voiceSessionController.isConnected.get() || this.voiceSessionController.isConnecting.get();
+		const activeResource = this.sessionsService.activeSession.get()?.activeChat.get()?.resource;
+		for (const widget of this.chatWidgetService.getAllWidgets()) {
+			const widgetResource = widget.viewModel?.sessionResource;
+			const isActiveWidget = voiceActive && !!activeResource && !!widgetResource && isEqual(widgetResource, activeResource);
+			widget.scopedContextKeyService.createKey(SessionsVoiceInitiatedContribution._INITIATED_HERE_KEY, isActiveWidget);
+		}
+	}
+}
+
+registerWorkbenchContribution2(SessionsVoiceInitiatedContribution.ID, SessionsVoiceInitiatedContribution, WorkbenchPhase.AfterRestored);
 
 /**
  * Keeps hands-free voice listening anchored to the session the user is dictating

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -1,0 +1,189 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { isEqual } from '../../../../base/common/resources.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+
+/**
+ * Bridges the shared {@link IVoiceSessionController} to the Agents (Sessions)
+ * window chat surfaces. The controller drives the chat exclusively through the
+ * `_chat.voice.*` commands; in the main VS Code window these are registered by
+ * `ChatViewPane`. The Agents window hosts chats through {@link ISessionsService}
+ * instead, so it registers its own bridge here.
+ *
+ * The commands are only registered while `agents.voice.enabled` is set, matching
+ * the main-window behavior, and are wired to the sessions model:
+ * - `_chat.voice.acceptInput` injects transcribed text into the focused chat widget.
+ * - `_chat.voice.getCurrentSession` reports the active session's chat resource.
+ * - `_chat.voice.switchToSession` activates the session that owns a chat resource.
+ */
+class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.voiceBridge';
+
+	private readonly _commandDisposables = this._register(new DisposableStore());
+
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+		@ISessionsService private readonly sessionsService: ISessionsService,
+		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
+	) {
+		super();
+
+		this._updateCommands();
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('agents.voice.enabled')) {
+				this._updateCommands();
+			}
+		}));
+	}
+
+	private _updateCommands(): void {
+		this._commandDisposables.clear();
+
+		if (this.configurationService.getValue<boolean>('agents.voice.enabled') !== true) {
+			return;
+		}
+
+		// Inject transcribed text into the focused chat widget.
+		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.acceptInput', (_accessor, text: string) => {
+			const widget = this.chatWidgetService.lastFocusedWidget ?? this._activeSessionWidget();
+			if (text && widget?.viewModel) {
+				if (widget.viewModel.editing) {
+					// When editing an old message, populate the active input editor
+					// so the user can review before submitting.
+					widget.input.setValue(text, false);
+				} else {
+					widget.acceptInput(text, { preserveFocus: true });
+				}
+			}
+		}));
+
+		// Report the currently active chat's session resource.
+		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.getCurrentSession', (): string | undefined => {
+			const focused = this.chatWidgetService.lastFocusedWidget?.viewModel?.sessionResource;
+			if (focused) {
+				return focused.toString();
+			}
+			return this.sessionsService.activeSession.get()?.activeChat.get()?.resource.toString();
+		}));
+
+		// Activate the session that owns the given chat resource so its response
+		// becomes visible to the user.
+		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.switchToSession', async (_accessor, resourceStr: string): Promise<boolean> => {
+			if (!resourceStr) {
+				return false;
+			}
+			let resource: URI;
+			try {
+				resource = URI.parse(resourceStr);
+			} catch {
+				return false;
+			}
+
+			// A chat resource maps to its owning session (and specific chat).
+			const owner = this.sessionsManagementService.getSessionForChatResource(resource);
+			if (owner) {
+				await this.sessionsService.openSession(owner.session.resource, { preserveFocus: true });
+				if (!isEqual(owner.chat.resource, owner.session.resource)) {
+					await this.sessionsService.openChat(owner.session, owner.chat.resource);
+				}
+				return true;
+			}
+
+			// Otherwise treat the resource as a session resource.
+			const session = this.sessionsManagementService.getSession(resource);
+			if (session) {
+				await this.sessionsService.openSession(session.resource, { preserveFocus: true });
+				return true;
+			}
+
+			try {
+				await this.sessionsService.openSession(resource, { preserveFocus: true });
+				return true;
+			} catch {
+				return false;
+			}
+		}));
+	}
+
+	/** The chat widget backing the currently active session, if any. */
+	private _activeSessionWidget() {
+		const resource = this.sessionsService.activeSession.get()?.activeChat.get()?.resource;
+		return resource ? this.chatWidgetService.getWidgetBySessionResource(resource) : undefined;
+	}
+}
+
+registerWorkbenchContribution2(SessionsVoiceBridgeContribution.ID, SessionsVoiceBridgeContribution, WorkbenchPhase.AfterRestored);
+
+/**
+ * Keeps hands-free voice listening anchored to the session the user is dictating
+ * into. When the active session changes while the microphone is listening, the
+ * turn is only stopped if dictation is actually in progress (so it isn't
+ * misrouted to the newly focused session); otherwise listening follows the user
+ * into the new session. This mirrors the main-window `ChatViewPane` behavior
+ * (see microsoft/vscode#325134), adapted to the Agents window's active-session
+ * model.
+ */
+class SessionsVoiceListeningContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.voiceListening';
+
+	constructor(
+		@IVoiceSessionController voiceSessionController: IVoiceSessionController,
+		@ISessionsService sessionsService: ISessionsService,
+	) {
+		super();
+
+		let listeningSession: URI | undefined;
+		this._register(autorun(reader => {
+			const turns = voiceSessionController.transcriptTurns.read(reader);
+			const connected = voiceSessionController.isConnected.read(reader);
+			const voiceState = voiceSessionController.voiceState.read(reader);
+			const targetSession = voiceSessionController.targetSession.read(reader);
+			const activeSession = sessionsService.activeSession.read(reader);
+			const currentSession = activeSession?.activeChat.read(reader)?.resource;
+
+			if (!connected) {
+				listeningSession = undefined;
+				return;
+			}
+
+			if (voiceState !== 'listening') {
+				// Allow the next dictation to re-capture the owning session.
+				listeningSession = undefined;
+				return;
+			}
+
+			if (!listeningSession) {
+				listeningSession = targetSession ?? currentSession;
+			} else if (!targetSession && currentSession && !isEqual(currentSession, listeningSession)) {
+				// User switched to a different session while listening. Only stop
+				// when there's dictation in progress, so it isn't misrouted to the
+				// newly focused session. If nothing has been recorded yet, keep
+				// listening and follow the new session.
+				const activelyDictating = turns.some(t => t.speaker === 'user' && t.isPartial && t.text.trim().length > 0);
+				if (activelyDictating) {
+					voiceSessionController.stopListening();
+					listeningSession = undefined;
+				} else {
+					listeningSession = currentSession;
+				}
+			}
+		}));
+	}
+}
+
+registerWorkbenchContribution2(SessionsVoiceListeningContribution.ID, SessionsVoiceListeningContribution, WorkbenchPhase.Eventually);

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -181,59 +181,6 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 registerWorkbenchContribution2(SessionsVoiceBridgeContribution.ID, SessionsVoiceBridgeContribution, WorkbenchPhase.AfterRestored);
 
 /**
- * Context key mirror of `agentsVoice.contribution`'s per-widget
- * `agentsVoiceInitiatedHere` key. The shared voice actions (Stop, Disconnect,
- * Settings, Connecting) only appear in the chat widget whose scoped context has
- * this key set, and it is normally set by `startVoiceInChat` on
- * `IChatWidgetService.lastFocusedWidget`. In the Agents window DOM focus stays
- * on the sessions list, so `lastFocusedWidget` is unreliable and the post-connect
- * voice controls fail to appear. This contribution deterministically binds the
- * key to the active session's chat widget while voice is connected/connecting,
- * so the controls follow the session the user is viewing.
- */
-class SessionsVoiceInitiatedContribution extends Disposable implements IWorkbenchContribution {
-
-	static readonly ID = 'sessions.voiceInitiated';
-
-	/** Matches `AGENTS_VOICE_INITIATED_HERE` in agentsVoice.contribution.ts. */
-	private static readonly _INITIATED_HERE_KEY = 'agentsVoiceInitiatedHere';
-
-	constructor(
-		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
-		@ISessionsService private readonly sessionsService: ISessionsService,
-		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
-	) {
-		super();
-
-		this._register(autorun(reader => {
-			this.voiceSessionController.isConnected.read(reader);
-			this.voiceSessionController.isConnecting.read(reader);
-			const active = this.sessionsService.activeSession.read(reader);
-			active?.isCreated.read(reader);
-			active?.activeChat.read(reader);
-			this._apply();
-		}));
-		// Widgets can be created after voice connects (opening a session slot).
-		this._register(this.chatWidgetService.onDidAddWidget(() => this._apply()));
-	}
-
-	private _apply(): void {
-		const voiceActive = this.voiceSessionController.isConnected.get() || this.voiceSessionController.isConnecting.get();
-		// Only a created session has a chat widget; a draft new-session (welcome
-		// composer) manages its own `agentsVoiceInitiatedHere` key instead.
-		const active = this.sessionsService.activeSession.get();
-		const activeResource = active?.isCreated.get() ? active.activeChat.get()?.resource : undefined;
-		for (const widget of this.chatWidgetService.getAllWidgets()) {
-			const widgetResource = widget.viewModel?.sessionResource;
-			const isActiveWidget = voiceActive && !!activeResource && !!widgetResource && isEqual(widgetResource, activeResource);
-			widget.scopedContextKeyService.createKey(SessionsVoiceInitiatedContribution._INITIATED_HERE_KEY, isActiveWidget);
-		}
-	}
-}
-
-registerWorkbenchContribution2(SessionsVoiceInitiatedContribution.ID, SessionsVoiceInitiatedContribution, WorkbenchPhase.AfterRestored);
-
-/**
  * Keeps hands-free voice listening anchored to the session the user is dictating
  * into. When the active session changes while the microphone is listening, the
  * turn is only stopped if dictation is actually in progress (so it isn't

--- a/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
@@ -28,22 +28,19 @@ export interface IVoiceInputDecorationsServices {
 }
 
 export interface IVoiceInputDecorationsOptions {
-	/** The input container that receives the audio-reactive glow and hosts the transcript overlay. */
+	/** Input container for glow and transcript overlay. */
 	readonly inputContainer: HTMLElement;
-	/** Whether this surface is the active/visible one; decorations only render when active. */
+	/** Whether this surface is active/visible. */
 	readonly isActive: IObservable<boolean>;
-	/** Resource identifying this surface, compared against the voice backend's target to avoid misrouting. */
+	/** Surface resource, compared with the voice target to avoid misrouting. */
 	readonly getCurrentResource: () => URI | undefined;
 }
 
 /**
- * Sets up the voice mode transcript overlay and audio-reactive glow on a chat
- * input container. Shared by the Agents window's active-session `ChatView` and
- * the new-session composer so both surfaces render identical voice decorations.
+ * Adds the voice transcript overlay and audio-reactive glow to a chat input.
+ * Shared by the active-session `ChatView` and new-session composer.
  *
- * The overlay/glow are only shown while voice mode is connected and this surface
- * is active; they are suppressed when the voice backend is targeting a different
- * session so the transcript is never misrouted.
+ * Decorations show only while this surface is active and voice targets it.
  */
 export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServices, options: IVoiceInputDecorationsOptions): IDisposable {
 	const { voiceSessionController, ttsPlaybackService, micCaptureService, configurationService, keybindingService } = services;
@@ -63,7 +60,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 	transcriptOverlayNode.style.display = 'none';
 	inputContainerEl.append(transcriptOverlayNode);
 
-	// --- Audio-reactive glow (matches main-window behavior) ---
+	// --- Audio-reactive glow ---
 	const win = dom.getWindow(inputContainerEl);
 	let animFrameId: number | undefined;
 	const glowDataArrayRef: { value: Uint8Array | undefined } = { value: undefined };
@@ -105,8 +102,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 		const active = isActive.read(reader);
 		const targetSession = voiceSessionController.targetSession.read(reader);
 		const current = getCurrentResource();
-		// The Sessions window renders multiple session slots at once; only glow
-		// the active slot, and never a slot the backend is targeting elsewhere.
+		// Glow only the active slot targeted by the backend.
 		const targetedElsewhere = !!targetSession && !!current && !isEqual(targetSession, current);
 		if (connected && active && !targetedElsewhere && (voiceState === 'listening' || voiceState === 'speaking')) {
 			startGlowAnimation();
@@ -127,8 +123,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 		const current = getCurrentResource();
 		const visible = turns.filter(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
 
-		// Only the active surface renders the transcript, and never a transcript
-		// the backend is targeting at a different session.
+		// Render transcripts only on the active backend target.
 		const targetedElsewhere = !!targetSession && !!current && !isEqual(targetSession, current);
 		if (!connected || !active || targetedElsewhere) {
 			transcriptOverlayNode.style.display = 'none';

--- a/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
@@ -1,0 +1,223 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import './media/voiceChatView.css';
+import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
+import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { IObservable, autorun } from '../../../../base/common/observable.js';
+import { isEqual } from '../../../../base/common/resources.js';
+import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { IMicCaptureService } from '../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
+import { ITtsPlaybackService } from '../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
+import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
+
+export interface IVoiceInputDecorationsServices {
+	readonly voiceSessionController: IVoiceSessionController;
+	readonly ttsPlaybackService: ITtsPlaybackService;
+	readonly micCaptureService: IMicCaptureService;
+	readonly configurationService: IConfigurationService;
+	readonly keybindingService: IKeybindingService;
+}
+
+export interface IVoiceInputDecorationsOptions {
+	/** The input container that receives the audio-reactive glow and hosts the transcript overlay. */
+	readonly inputContainer: HTMLElement;
+	/** Whether this surface is the active/visible one; decorations only render when active. */
+	readonly isActive: IObservable<boolean>;
+	/** Resource identifying this surface, compared against the voice backend's target to avoid misrouting. */
+	readonly getCurrentResource: () => URI | undefined;
+}
+
+/**
+ * Sets up the voice mode transcript overlay and audio-reactive glow on a chat
+ * input container. Shared by the Agents window's active-session `ChatView` and
+ * the new-session composer so both surfaces render identical voice decorations.
+ *
+ * The overlay/glow are only shown while voice mode is connected and this surface
+ * is active; they are suppressed when the voice backend is targeting a different
+ * session so the transcript is never misrouted.
+ */
+export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServices, options: IVoiceInputDecorationsOptions): IDisposable {
+	const { voiceSessionController, ttsPlaybackService, micCaptureService, configurationService, keybindingService } = services;
+	const { inputContainer: inputContainerEl, isActive, getCurrentResource } = options;
+
+	const store = new DisposableStore();
+
+	inputContainerEl.style.position = 'relative';
+
+	const transcriptOverlay = dom.$('.voice-transcript-overlay');
+	const transcriptScrollable = store.add(new DomScrollableElement(transcriptOverlay, {
+		horizontal: ScrollbarVisibility.Hidden,
+		vertical: ScrollbarVisibility.Auto,
+	}));
+	const transcriptOverlayNode = transcriptScrollable.getDomNode();
+	transcriptOverlayNode.classList.add('voice-transcript-overlay-scrollable');
+	transcriptOverlayNode.style.display = 'none';
+	inputContainerEl.append(transcriptOverlayNode);
+
+	// --- Audio-reactive glow (matches main-window behavior) ---
+	const win = dom.getWindow(inputContainerEl);
+	let animFrameId: number | undefined;
+	let glowDataArray: Uint8Array | undefined;
+	const startGlowAnimation = () => {
+		if (animFrameId !== undefined) {
+			return;
+		}
+		const animate = () => {
+			animFrameId = win.requestAnimationFrame(animate);
+			const voiceState = voiceSessionController.voiceState.get();
+
+			const analyser = ttsPlaybackService.analyserNode
+				?? (voiceState === 'listening' ? micCaptureService.analyserNode : null)
+				?? null;
+			let intensity: number;
+			if (!analyser) {
+				intensity = 0.3;
+			} else {
+				if (!glowDataArray || glowDataArray.length !== analyser.frequencyBinCount) {
+					glowDataArray = new Uint8Array(analyser.frequencyBinCount);
+				}
+				analyser.getByteFrequencyData(glowDataArray as Uint8Array<ArrayBuffer>);
+				let sum = 0;
+				for (let i = 0; i < glowDataArray.length; i++) {
+					sum += glowDataArray[i];
+				}
+				intensity = Math.min(1, (sum / glowDataArray.length) / 80);
+			}
+
+			// Blue when listening, purple when speaking.
+			const rgb = voiceState === 'speaking' ? '163,113,247' : '88,166,255';
+			const transcriptHidden = configurationService.getValue<boolean>('agents.voice.showTranscript') === false;
+			let borderAlpha: number;
+			let shadowSpread: number;
+			let shadowAlpha: number;
+			if (voiceState === 'listening' && transcriptHidden) {
+				borderAlpha = 0.6 + intensity * 0.4;
+				shadowSpread = 6 + intensity * 20;
+				shadowAlpha = 0.25 + intensity * 0.55;
+			} else {
+				borderAlpha = 0.4 + intensity * 0.5;
+				shadowSpread = 4 + intensity * 12;
+				shadowAlpha = 0.15 + intensity * 0.35;
+			}
+			inputContainerEl.style.borderColor = `rgba(${rgb},${borderAlpha})`;
+			if (voiceState === 'listening' && transcriptHidden) {
+				inputContainerEl.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), 0 0 ${shadowSpread * 2}px rgba(${rgb},${shadowAlpha * 0.3}), inset 0 0 ${shadowSpread * 0.5}px rgba(${rgb},${shadowAlpha * 0.4})`;
+			} else {
+				inputContainerEl.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), inset 0 0 ${shadowSpread * 0.4}px rgba(${rgb},${shadowAlpha * 0.3})`;
+			}
+			inputContainerEl.classList.add('voice-active');
+			inputContainerEl.classList.toggle('voice-listening', voiceState === 'listening');
+		};
+		animFrameId = win.requestAnimationFrame(animate);
+	};
+	const stopGlowAnimation = () => {
+		if (animFrameId !== undefined) {
+			win.cancelAnimationFrame(animFrameId);
+			animFrameId = undefined;
+		}
+		inputContainerEl.style.borderColor = '';
+		inputContainerEl.style.boxShadow = '';
+		inputContainerEl.classList.remove('voice-active', 'voice-listening');
+	};
+
+	store.add(autorun(reader => {
+		const connected = voiceSessionController.isConnected.read(reader);
+		const voiceState = voiceSessionController.voiceState.read(reader);
+		const active = isActive.read(reader);
+		const targetSession = voiceSessionController.targetSession.read(reader);
+		const current = getCurrentResource();
+		// The Sessions window renders multiple session slots at once; only glow
+		// the active slot, and never a slot the backend is targeting elsewhere.
+		const targetedElsewhere = !!targetSession && !!current && !isEqual(targetSession, current);
+		if (connected && active && !targetedElsewhere && (voiceState === 'listening' || voiceState === 'speaking')) {
+			startGlowAnimation();
+		} else {
+			stopGlowAnimation();
+		}
+	}));
+	store.add({ dispose: () => stopGlowAnimation() });
+
+	// --- Transcript rendering ---
+	store.add(autorun(reader => {
+		const turns = voiceSessionController.transcriptTurns.read(reader);
+		const connected = voiceSessionController.isConnected.read(reader);
+		const voiceState = voiceSessionController.voiceState.read(reader);
+		const targetSession = voiceSessionController.targetSession.read(reader);
+		const active = isActive.read(reader);
+		const showTranscript = configurationService.getValue<boolean>('agents.voice.showTranscript') !== false;
+		const current = getCurrentResource();
+		const visible = turns.filter(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
+
+		// Only the active surface renders the transcript, and never a transcript
+		// the backend is targeting at a different session.
+		const targetedElsewhere = !!targetSession && !!current && !isEqual(targetSession, current);
+		if (!connected || !active || targetedElsewhere) {
+			transcriptOverlayNode.style.display = 'none';
+			transcriptOverlayNode.classList.remove('has-transcript');
+			return;
+		}
+
+		if (visible.length === 0 || !showTranscript) {
+			const handsFree = configurationService.getValue<boolean>('agents.voice.handsFree') !== false;
+			if (voiceState === 'idle' && visible.length === 0 && showTranscript && !handsFree) {
+				transcriptOverlayNode.style.display = '';
+				transcriptOverlayNode.classList.remove('has-transcript');
+				transcriptOverlay.replaceChildren();
+				const hint = dom.$('span.partial');
+				const kb = keybindingService.lookupKeybinding('agentsVoice.pushToTalk');
+				const kbLabel = kb?.getLabel();
+				hint.textContent = kbLabel
+					? localize('voiceMode.pttHint', "Press {0} to talk", kbLabel)
+					: localize('voiceMode.clickMicHint', "Click voice mode to talk");
+				transcriptOverlay.append(hint);
+				transcriptScrollable.scanDomNode();
+			} else {
+				transcriptOverlayNode.style.display = 'none';
+				transcriptOverlayNode.classList.remove('has-transcript');
+			}
+			return;
+		}
+
+		transcriptOverlayNode.style.display = '';
+		transcriptOverlayNode.classList.add('has-transcript');
+		// Show only the latest visible turn.
+		const lastTurn = visible[visible.length - 1];
+		const contentElements: HTMLElement[] = [];
+		if (lastTurn.speaker === 'user') {
+			const span = dom.$('span');
+			if (lastTurn.isPartial) {
+				const committedPart = lastTurn.committed || '';
+				const unsurePart = lastTurn.text.slice(committedPart.length);
+				if (committedPart) {
+					const c = dom.$('span.committed');
+					c.textContent = committedPart;
+					span.append(c);
+				}
+				const u = dom.$('span.partial');
+				u.textContent = unsurePart + '\u2589';
+				span.append(u);
+			} else {
+				span.className = 'committed';
+				span.textContent = lastTurn.text;
+			}
+			contentElements.push(span);
+		} else {
+			const div = dom.$('div.assistant-text');
+			div.textContent = lastTurn.text;
+			contentElements.push(div);
+		}
+		transcriptOverlay.replaceChildren(...contentElements);
+		transcriptScrollable.scanDomNode();
+		transcriptScrollable.setScrollPosition({ scrollTop: 0 });
+	}));
+
+	return store;
+}

--- a/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
@@ -17,6 +17,7 @@ import { IKeybindingService } from '../../../../platform/keybinding/common/keybi
 import { IMicCaptureService } from '../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
 import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
+import { computeVoiceGlowStyle, readVoiceGlowIntensity } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceGlow.js';
 
 export interface IVoiceInputDecorationsServices {
 	readonly voiceSessionController: IVoiceSessionController;
@@ -65,7 +66,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 	// --- Audio-reactive glow (matches main-window behavior) ---
 	const win = dom.getWindow(inputContainerEl);
 	let animFrameId: number | undefined;
-	let glowDataArray: Uint8Array | undefined;
+	const glowDataArrayRef: { value: Uint8Array | undefined } = { value: undefined };
 	const startGlowAnimation = () => {
 		if (animFrameId !== undefined) {
 			return;
@@ -77,42 +78,12 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 			const analyser = ttsPlaybackService.analyserNode
 				?? (voiceState === 'listening' ? micCaptureService.analyserNode : null)
 				?? null;
-			let intensity: number;
-			if (!analyser) {
-				intensity = 0.3;
-			} else {
-				if (!glowDataArray || glowDataArray.length !== analyser.frequencyBinCount) {
-					glowDataArray = new Uint8Array(analyser.frequencyBinCount);
-				}
-				analyser.getByteFrequencyData(glowDataArray as Uint8Array<ArrayBuffer>);
-				let sum = 0;
-				for (let i = 0; i < glowDataArray.length; i++) {
-					sum += glowDataArray[i];
-				}
-				intensity = Math.min(1, (sum / glowDataArray.length) / 80);
-			}
+			const intensity = readVoiceGlowIntensity(analyser, glowDataArrayRef);
 
-			// Blue when listening, purple when speaking.
-			const rgb = voiceState === 'speaking' ? '163,113,247' : '88,166,255';
 			const transcriptHidden = configurationService.getValue<boolean>('agents.voice.showTranscript') === false;
-			let borderAlpha: number;
-			let shadowSpread: number;
-			let shadowAlpha: number;
-			if (voiceState === 'listening' && transcriptHidden) {
-				borderAlpha = 0.6 + intensity * 0.4;
-				shadowSpread = 6 + intensity * 20;
-				shadowAlpha = 0.25 + intensity * 0.55;
-			} else {
-				borderAlpha = 0.4 + intensity * 0.5;
-				shadowSpread = 4 + intensity * 12;
-				shadowAlpha = 0.15 + intensity * 0.35;
-			}
-			inputContainerEl.style.borderColor = `rgba(${rgb},${borderAlpha})`;
-			if (voiceState === 'listening' && transcriptHidden) {
-				inputContainerEl.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), 0 0 ${shadowSpread * 2}px rgba(${rgb},${shadowAlpha * 0.3}), inset 0 0 ${shadowSpread * 0.5}px rgba(${rgb},${shadowAlpha * 0.4})`;
-			} else {
-				inputContainerEl.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), inset 0 0 ${shadowSpread * 0.4}px rgba(${rgb},${shadowAlpha * 0.3})`;
-			}
+			const { borderColor, boxShadow } = computeVoiceGlowStyle(voiceState, intensity, transcriptHidden);
+			inputContainerEl.style.borderColor = borderColor;
+			inputContainerEl.style.boxShadow = boxShadow;
 			inputContainerEl.classList.add('voice-active');
 			inputContainerEl.classList.toggle('voice-listening', voiceState === 'listening');
 		};

--- a/src/vs/sessions/contrib/chat/test/browser/newChatInput.fixture.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/newChatInput.fixture.ts
@@ -18,6 +18,11 @@ import { IActiveSession, ISessionsManagementService } from '../../../../services
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { NewChatInputWidget } from '../../browser/newChatInput.js';
+import { INewChatVoiceTargetService, NewChatVoiceTargetService } from '../../browser/newChatVoice.js';
+import { IVoiceSessionController } from '../../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
+import { ITtsPlaybackService } from '../../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
+import { IMicCaptureService } from '../../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
+import { URI } from '../../../../../base/common/uri.js';
 
 // The new-session input box styling lives in these stylesheets; `style.css`
 // provides the `--vscode-agentsChatInput-*` theme variables and the
@@ -69,6 +74,20 @@ async function renderNewChatInput(context: ComponentFixtureContext, fixtureOptio
 			}());
 			reg.defineInstance(IPromptsService, new class extends mock<IPromptsService>() {
 				override readonly onDidChangeSlashCommands = Event.None;
+			}());
+			reg.defineInstance(INewChatVoiceTargetService, disposableStore.add(new NewChatVoiceTargetService()));
+			reg.defineInstance(IVoiceSessionController, new class extends mock<IVoiceSessionController>() {
+				override readonly isConnected = observableValue<boolean>('isConnected', false);
+				override readonly isConnecting = observableValue<boolean>('isConnecting', false);
+				override readonly voiceState = observableValue<'idle' | 'listening' | 'processing' | 'speaking' | 'error'>('voiceState', 'idle');
+				override readonly targetSession = observableValue<URI | undefined>('targetSession', undefined);
+				override readonly transcriptTurns = observableValue<never[]>('transcriptTurns', []);
+			}());
+			reg.defineInstance(ITtsPlaybackService, new class extends mock<ITtsPlaybackService>() {
+				override readonly analyserNode = undefined;
+			}());
+			reg.defineInstance(IMicCaptureService, new class extends mock<IMicCaptureService>() {
+				override readonly analyserNode = undefined;
 			}());
 		},
 	});

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -69,6 +69,20 @@
 		}
 	}
 
+	.monaco-list-row .session-pending-voice-indicator {
+		display: none;
+		height: 16px;
+		align-items: center;
+		margin-left: 4px;
+		color: var(--vscode-charts-blue);
+		font-size: 12px;
+		pointer-events: none;
+
+		&.visible {
+			display: flex;
+		}
+	}
+
 	.monaco-list-row:hover,
 	.monaco-list-row.focused:not(.selected) {
 		.session-title-toolbar {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -39,6 +39,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../../pla
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { AgentSessionApprovalModel, agentSessionApprovalId, IAgentSessionApprovalInfo } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { IVoicePlaybackService } from '../../../../../workbench/contrib/chat/common/voicePlaybackService.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
 import { Action, ActionRunner, IAction, Separator, SubmenuAction } from '../../../../../base/common/actions.js';
@@ -280,6 +281,7 @@ interface ISessionItemTemplate {
 	readonly title: HighlightedLabel;
 	readonly titleContainer: HTMLElement;
 	readonly titleToolbar: MenuWorkbenchToolBar | undefined;
+	readonly pendingVoiceIndicator: HTMLElement;
 	readonly detailsRow: HTMLElement;
 	readonly approvalRow: HTMLElement;
 	readonly approvalLabel: HTMLElement;
@@ -328,7 +330,11 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		private readonly sessionsProvidersService: ISessionsProvidersService,
 		// TEMPORARY — see the note on the `IAgentSessionsService` import above (#320480).
 		private readonly agentSessionsService: IAgentSessionsService,
-	) { }
+	) {
+		this._voicePlaybackService = this.instantiationService.invokeFunction(accessor => accessor.get(IVoicePlaybackService));
+	}
+
+	private readonly _voicePlaybackService: IVoicePlaybackService;
 
 	renderTemplate(container: HTMLElement): ISessionItemTemplate {
 		const disposables = new DisposableStore();
@@ -354,6 +360,9 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			}
 		}));
 		const titleToolbarContainer = DOM.append(titleRow, $('.session-title-toolbar'));
+		// Shown when a voice response arrived while this session wasn't focused and
+		// is being held until it is (mirrors the main window's sessions viewer).
+		const pendingVoiceIndicator = DOM.append(titleRow, $('.session-pending-voice-indicator'));
 		// The list opens a session on click and on Gesture `tap` (touch).
 		// DOM event propagation stops only cover mouse/pointer events; the
 		// list's tap handler reads from `Gesture` directly, bypassing
@@ -384,7 +393,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			}));
 		}
 
-		return { container, statusIcon, title, titleContainer, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
+		return { container, statusIcon, title, titleContainer, titleToolbar, pendingVoiceIndicator, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionItemTemplate): void {
@@ -414,6 +423,16 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 				persistence: { hideOnHover: false },
 			}), { groupId: 'sessions-list' }));
 		}
+
+		// Pending voice response indicator - shown when a voice response arrived
+		// while this session wasn't focused and is being held until it is.
+		const pendingVoiceResource = element.resource;
+		template.pendingVoiceIndicator.className = 'session-pending-voice-indicator ' + ThemeIcon.asClassName(Codicon.unmute);
+		template.pendingVoiceIndicator.title = localize('pendingVoiceResponse', "Voice response ready");
+		template.elementDisposables.add(autorun(reader => {
+			this._voicePlaybackService.pendingResponseVersion.read(reader);
+			template.pendingVoiceIndicator.classList.toggle('visible', this._voicePlaybackService.hasPendingResponse(pendingVoiceResource));
+		}));
 
 		// Toolbar context
 		if (template.titleToolbar) {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -46,6 +46,7 @@ import { Action, ActionRunner, IAction, Separator, SubmenuAction } from '../../.
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { HoverStyle } from '../../../../../base/browser/ui/hover/hover.js';
 import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
+import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { ISessionsManagementService, IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { ISessionsListModelService, SessionSortMode } from '../../../../services/sessions/browser/sessionsListModelService.js';
@@ -330,11 +331,9 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		private readonly sessionsProvidersService: ISessionsProvidersService,
 		// TEMPORARY — see the note on the `IAgentSessionsService` import above (#320480).
 		private readonly agentSessionsService: IAgentSessionsService,
+		private readonly _voicePlaybackService: IVoicePlaybackService,
 	) {
-		this._voicePlaybackService = this.instantiationService.invokeFunction(accessor => accessor.get(IVoicePlaybackService));
 	}
-
-	private readonly _voicePlaybackService: IVoicePlaybackService;
 
 	renderTemplate(container: HTMLElement): ISessionItemTemplate {
 		const disposables = new DisposableStore();
@@ -428,7 +427,11 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		// while this session wasn't focused and is being held until it is.
 		const pendingVoiceResource = element.resource;
 		template.pendingVoiceIndicator.className = 'session-pending-voice-indicator ' + ThemeIcon.asClassName(Codicon.unmute);
-		template.pendingVoiceIndicator.title = localize('pendingVoiceResponse', "Voice response ready");
+		template.elementDisposables.add(this.hoverService.setupManagedHover(
+			getDefaultHoverDelegate('mouse'),
+			template.pendingVoiceIndicator,
+			localize('pendingVoiceResponse', "Voice response ready"),
+		));
 		template.elementDisposables.add(autorun(reader => {
 			this._voicePlaybackService.pendingResponseVersion.read(reader);
 			template.pendingVoiceIndicator.classList.toggle('visible', this._voicePlaybackService.hasPendingResponse(pendingVoiceResource));
@@ -1649,6 +1652,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		}));
 		// TEMPORARY (#320480): see the note on the `IAgentSessionsService` import.
 		const agentSessionsService = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
+		const voicePlaybackService = instantiationService.invokeFunction(accessor => accessor.get(IVoicePlaybackService));
 		const sessionRenderer = new SessionItemRenderer(
 			{ grouping: this.options.grouping, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions, getMultiSelectedSessions: s => this.getMultiSelectedSessions(s), isInChatsSection: s => this._chatsSectionSessionIds.has(s.resource.toString()), showHover: true, approvalRowMaxLines: DEFAULT_APPROVAL_ROW_MAX_LINES, toolbarActions: true },
 			approvalModel,
@@ -1658,6 +1662,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			hoverService,
 			sessionsProvidersService,
 			agentSessionsService,
+			voicePlaybackService,
 		);
 
 		const showMoreRenderer = new SessionShowMoreRenderer();
@@ -3301,6 +3306,7 @@ export class SessionsFlatList extends Disposable {
 		@IMarkdownRendererService markdownRendererService: IMarkdownRendererService,
 		@IHoverService hoverService: IHoverService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@IVoicePlaybackService voicePlaybackService: IVoicePlaybackService,
 	) {
 		super();
 
@@ -3334,6 +3340,7 @@ export class SessionsFlatList extends Disposable {
 			hoverService,
 			sessionsProvidersService,
 			agentSessionsService,
+			voicePlaybackService,
 		);
 
 		this._delegate = new SessionsTreeDelegate(approvalModel, () => false, this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -359,8 +359,8 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			}
 		}));
 		const titleToolbarContainer = DOM.append(titleRow, $('.session-title-toolbar'));
-		// Shown when a voice response arrived while this session wasn't focused and
-		// is being held until it is (mirrors the main window's sessions viewer).
+		// Shown when a voice response arrived while this session was unfocused and
+		// is held until it is (mirrors the main window's sessions viewer).
 		const pendingVoiceIndicator = DOM.append(titleRow, $('.session-pending-voice-indicator'));
 		// The list opens a session on click and on Gesture `tap` (touch).
 		// DOM event propagation stops only cover mouse/pointer events; the
@@ -423,8 +423,8 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			}), { groupId: 'sessions-list' }));
 		}
 
-		// Pending voice response indicator - shown when a voice response arrived
-		// while this session wasn't focused and is being held until it is.
+		// Pending voice response indicator: a response arrived while this session
+		// was unfocused and is held until it is.
 		const pendingVoiceResource = element.resource;
 		template.pendingVoiceIndicator.className = 'session-pending-voice-indicator ' + ThemeIcon.asClassName(Codicon.unmute);
 		template.elementDisposables.add(this.hoverService.setupManagedHover(

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -227,6 +227,10 @@ import '../workbench/contrib/chat/browser/chatSessions/chatSessions.contribution
 import '../workbench/contrib/chat/browser/contextContrib/chatContext.contribution.js';
 import '../workbench/contrib/imageCarousel/browser/imageCarousel.contribution.js';
 
+// Voice Mode (voice UI actions, settings and context keys)
+import '../workbench/contrib/agentsVoice/browser/agentsVoice.contribution.js';
+import './contrib/chat/browser/voiceBridge.contribution.js';
+
 // Interactive
 import '../workbench/contrib/interactive/browser/interactive.contribution.js';
 

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -43,7 +43,6 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { ChatAgentLocation } from '../../chat/common/constants.js';
-import { IChatWidgetService } from '../../chat/browser/chat.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 // --- Context Keys ---
@@ -52,8 +51,6 @@ export const AGENTS_VOICE_WIDGET_FOCUSED = new RawContextKey<boolean>('agentsVoi
 const AGENTS_VOICE_CONNECTED = new RawContextKey<boolean>('agentsVoiceConnected', false);
 const AGENTS_VOICE_CONNECTING = new RawContextKey<boolean>('agentsVoiceConnecting', false);
 const AGENTS_VOICE_LISTENING = new RawContextKey<boolean>('agentsVoiceListening', false);
-/** Set on the specific widget where voice was initiated — used to scope connecting/connected UI to that widget only. */
-const AGENTS_VOICE_INITIATED_HERE = new RawContextKey<boolean>('agentsVoiceInitiatedHere', false);
 
 // --- Context Key Binding ---
 
@@ -66,28 +63,16 @@ class AgentsVoiceConnectedKeyContribution extends Disposable implements IWorkben
 	constructor(
 		@IVoiceSessionController voiceSessionController: IVoiceSessionController,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@IChatWidgetService chatWidgetService: IChatWidgetService,
 	) {
 		super();
 
 		const connectedKey = AGENTS_VOICE_CONNECTED.bindTo(contextKeyService);
 		const connectingKey = AGENTS_VOICE_CONNECTING.bindTo(contextKeyService);
 		const listeningKey = AGENTS_VOICE_LISTENING.bindTo(contextKeyService);
-		let wasConnected = false;
 		this._register(autorun(reader => {
-			const connected = voiceSessionController.isConnected.read(reader);
-			connectedKey.set(connected);
+			connectedKey.set(voiceSessionController.isConnected.read(reader));
 			connectingKey.set(voiceSessionController.isConnecting.read(reader));
-			const state = voiceSessionController.voiceState.read(reader);
-			listeningKey.set(state === 'listening');
-
-			// Clear per-widget "initiated here" key when voice disconnects
-			if (wasConnected && !connected) {
-				for (const widget of chatWidgetService.getAllWidgets()) {
-					AGENTS_VOICE_INITIATED_HERE.bindTo(widget.scopedContextKeyService).set(false);
-				}
-			}
-			wasConnected = connected;
+			listeningKey.set(voiceSessionController.voiceState.read(reader) === 'listening');
 		}));
 	}
 }
@@ -148,7 +133,6 @@ registerAction2(class extends Action2 {
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					AGENTS_VOICE_CONNECTING.isEqualTo(true),
-					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
 				),
 				group: 'navigation',
 				order: -10
@@ -192,12 +176,6 @@ registerAction2(class extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const voiceController = accessor.get(IVoiceSessionController);
 		if (!voiceController.isConnected.get()) {
-			// Mark this widget as the one where voice was initiated
-			const chatWidgetService = accessor.get(IChatWidgetService);
-			const widget = chatWidgetService.lastFocusedWidget;
-			if (widget) {
-				AGENTS_VOICE_INITIATED_HERE.bindTo(widget.scopedContextKeyService).set(true);
-			}
 			await voiceController.connect(mainWindow);
 		} else {
 			voiceController.pttDown();
@@ -223,7 +201,6 @@ registerAction2(class extends Action2 {
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					ChatContextKeys.currentlyEditing.negate(),
 					AGENTS_VOICE_LISTENING.isEqualTo(true),
-					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
 				),
 				group: 'navigation',
 				order: -10
@@ -268,7 +245,6 @@ registerAction2(class extends Action2 {
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					ChatContextKeys.currentlyEditing.negate(),
 					AGENTS_VOICE_CONNECTED.isEqualTo(true),
-					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
 				),
 				group: 'navigation',
 				order: -9
@@ -313,7 +289,6 @@ registerAction2(class extends Action2 {
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					ChatContextKeys.currentlyEditing.negate(),
 					AGENTS_VOICE_CONNECTED.isEqualTo(true),
-					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
 				),
 				group: 'navigation',
 				// Just before the Disconnect button (order -9) and after the mic/stop button (order -10).

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -514,26 +514,26 @@ configurationRegistry.registerConfiguration({
 		},
 		'agents.voice.handsFree': {
 			type: 'boolean',
-			description: nls.localize('agents.voice.handsFree', "When enabled, voice mode automatically re-enters listening after the assistant finishes speaking, so you can hold a hands-free back-and-forth conversation. When disabled, you start each turn manually. This controls only the auto-listen loop; how a turn ends is controlled by `agents.voice.turn.autoEndMode`."),
+			markdownDescription: nls.localize('agents.voice.handsFree', "When enabled, voice mode automatically re-enters listening after the assistant finishes speaking, so you can hold a hands-free back-and-forth conversation. When disabled, you start each turn manually. This controls only the auto-listen loop; how a turn ends is controlled by `agents.voice.turn.autoEndMode`."),
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
 		},
 		'agents.voice.turn.autoEndMode': {
 			type: 'string',
 			enum: ['off', 'vad', 'phrase', 'both'],
-			enumDescriptions: [
+			markdownEnumDescriptions: [
 				nls.localize('agents.voice.turn.autoEndMode.off', "Never end the turn automatically; it ends only when you release (or, in toggle mode, tap again) push-to-talk."),
 				nls.localize('agents.voice.turn.autoEndMode.vad', "End the turn automatically after a period of trailing silence (see `agents.voice.turn.silenceMs`)."),
 				nls.localize('agents.voice.turn.autoEndMode.phrase', "End the turn automatically when a stop phrase is spoken (see `agents.voice.turn.stopPhrases`)."),
 				nls.localize('agents.voice.turn.autoEndMode.both', "End the turn automatically on either trailing silence or a spoken stop phrase."),
 			],
-			description: nls.localize('agents.voice.turn.autoEndMode', "Controls whether and how the voice backend ends a held turn on its own. The backend is the single source of truth for turn-ending: `vad` ends on trailing silence (`agents.voice.turn.silenceMs`), `phrase` ends on a spoken stop phrase (`agents.voice.turn.stopPhrases`), `both` enables either, and `off` requires you to end the turn manually."),
+			markdownDescription: nls.localize('agents.voice.turn.autoEndMode', "Controls whether and how the voice backend ends a held turn on its own. The backend is the single source of truth for turn-ending: `vad` ends on trailing silence (`agents.voice.turn.silenceMs`), `phrase` ends on a spoken stop phrase (`agents.voice.turn.stopPhrases`), `both` enables either, and `off` requires you to end the turn manually."),
 			default: 'vad',
 			scope: ConfigurationScope.APPLICATION,
 		},
 		'agents.voice.turn.silenceMs': {
 			type: 'number',
-			description: nls.localize('agents.voice.turn.silenceMs', "Trailing silence in milliseconds before the backend ends the turn. Applies only when `agents.voice.turn.autoEndMode` is `vad` or `both`; ignored otherwise. The backend clamps this to its supported range (currently 200-5000 ms) and is the source of truth."),
+			markdownDescription: nls.localize('agents.voice.turn.silenceMs', "Trailing silence in milliseconds before the backend ends the turn. Applies only when `agents.voice.turn.autoEndMode` is `vad` or `both`; ignored otherwise. The backend clamps this to its supported range (currently 200-5000 ms) and is the source of truth."),
 			default: 800,
 			minimum: 200,
 			maximum: 5000,
@@ -542,7 +542,7 @@ configurationRegistry.registerConfiguration({
 		'agents.voice.turn.stopPhrases': {
 			type: 'array',
 			items: { type: 'string' },
-			description: nls.localize('agents.voice.turn.stopPhrases', "Phrases that end the turn when spoken at the end of an utterance. Applies only when `agents.voice.turn.autoEndMode` is `phrase` or `both`; ignored otherwise. The backend strips the matched phrase from the transcript before it reaches the agent."),
+			markdownDescription: nls.localize('agents.voice.turn.stopPhrases', "Phrases that end the turn when spoken at the end of an utterance. Applies only when `agents.voice.turn.autoEndMode` is `phrase` or `both`; ignored otherwise. The backend strips the matched phrase from the transcript before it reaches the agent."),
 			default: ['send it'],
 			scope: ConfigurationScope.APPLICATION,
 		},

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
@@ -4,21 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Shared audio-reactive glow math for the voice-mode input decorations. Both the
- * main window's `ChatViewPane` and the Agents (Sessions) window surfaces render an
- * identical glow on the chat input container while voice mode is active; this
- * module is the single source of truth for the (tricky, easy-to-drift) intensity
- * and box-shadow computation so the two callers cannot diverge. Callers still own
- * their own animation loop, target selection, and gating.
+ * Shared audio-reactive glow math for voice-mode input decorations. The main
+ * window's `ChatViewPane` and the Agents window surfaces render an identical
+ * glow; this is the single source of truth for the easy-to-drift intensity and
+ * box-shadow math. Callers own their own animation loop, target, and gating.
  */
 
 export type VoiceGlowState = 'idle' | 'listening' | 'processing' | 'speaking' | 'error';
 
 /**
- * Reduce an analyser's frequency data to a normalized [0, 1] intensity. When no
- * analyser is available (e.g. before capture/playback starts) a small resting
- * intensity keeps the glow gently visible. `dataArray` is reused across frames;
- * pass a ref-cell so it can be lazily (re)allocated to match the bin count.
+ * Reduce an analyser's frequency data to a normalized [0, 1] intensity. Returns
+ * a small resting value when no analyser is available (before capture/playback).
+ * `dataArray` is a ref-cell reused across frames, lazily sized to the bin count.
  */
 export function readVoiceGlowIntensity(analyser: AnalyserNode | null, dataArray: { value: Uint8Array | undefined }): number {
 	if (!analyser) {
@@ -41,10 +38,8 @@ export interface IVoiceGlowStyle {
 }
 
 /**
- * Compute the border color and box-shadow for the voice glow. Blue while
- * listening (more flashy/audio-reactive when the transcript is hidden), purple
- * while speaking (subtle). Identical to the previous inline computation shared by
- * both windows.
+ * Compute the glow border color and box-shadow. Blue while listening (flashier
+ * when the transcript is hidden), purple while speaking.
  */
 export function computeVoiceGlowStyle(voiceState: VoiceGlowState, intensity: number, transcriptHidden: boolean): IVoiceGlowStyle {
 	// Blue when listening, purple when speaking.
@@ -54,7 +49,7 @@ export function computeVoiceGlowStyle(voiceState: VoiceGlowState, intensity: num
 	let shadowSpread: number;
 	let shadowAlpha: number;
 	if (flashy) {
-		// Flashy, audio-reactive glow while the user is speaking (no transcript visible).
+		// Flashy audio-reactive glow while speaking with no transcript visible.
 		borderAlpha = 0.6 + intensity * 0.4;
 		shadowSpread = 6 + intensity * 20;
 		shadowAlpha = 0.25 + intensity * 0.55;

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Shared audio-reactive glow math for the voice-mode input decorations. Both the
+ * main window's `ChatViewPane` and the Agents (Sessions) window surfaces render an
+ * identical glow on the chat input container while voice mode is active; this
+ * module is the single source of truth for the (tricky, easy-to-drift) intensity
+ * and box-shadow computation so the two callers cannot diverge. Callers still own
+ * their own animation loop, target selection, and gating.
+ */
+
+export type VoiceGlowState = 'idle' | 'listening' | 'processing' | 'speaking' | 'error';
+
+/**
+ * Reduce an analyser's frequency data to a normalized [0, 1] intensity. When no
+ * analyser is available (e.g. before capture/playback starts) a small resting
+ * intensity keeps the glow gently visible. `dataArray` is reused across frames;
+ * pass a ref-cell so it can be lazily (re)allocated to match the bin count.
+ */
+export function readVoiceGlowIntensity(analyser: AnalyserNode | null, dataArray: { value: Uint8Array | undefined }): number {
+	if (!analyser) {
+		return 0.3;
+	}
+	if (!dataArray.value || dataArray.value.length !== analyser.frequencyBinCount) {
+		dataArray.value = new Uint8Array(analyser.frequencyBinCount);
+	}
+	analyser.getByteFrequencyData(dataArray.value as Uint8Array<ArrayBuffer>);
+	let sum = 0;
+	for (let i = 0; i < dataArray.value.length; i++) {
+		sum += dataArray.value[i];
+	}
+	return Math.min(1, (sum / dataArray.value.length) / 80);
+}
+
+export interface IVoiceGlowStyle {
+	readonly borderColor: string;
+	readonly boxShadow: string;
+}
+
+/**
+ * Compute the border color and box-shadow for the voice glow. Blue while
+ * listening (more flashy/audio-reactive when the transcript is hidden), purple
+ * while speaking (subtle). Identical to the previous inline computation shared by
+ * both windows.
+ */
+export function computeVoiceGlowStyle(voiceState: VoiceGlowState, intensity: number, transcriptHidden: boolean): IVoiceGlowStyle {
+	// Blue when listening, purple when speaking.
+	const rgb = voiceState === 'speaking' ? '163,113,247' : '88,166,255';
+	const flashy = voiceState === 'listening' && transcriptHidden;
+	let borderAlpha: number;
+	let shadowSpread: number;
+	let shadowAlpha: number;
+	if (flashy) {
+		// Flashy, audio-reactive glow while the user is speaking (no transcript visible).
+		borderAlpha = 0.6 + intensity * 0.4;
+		shadowSpread = 6 + intensity * 20;
+		shadowAlpha = 0.25 + intensity * 0.55;
+	} else {
+		// Standard glow (transcript visible or TTS playback).
+		borderAlpha = 0.4 + intensity * 0.5;
+		shadowSpread = 4 + intensity * 12;
+		shadowAlpha = 0.15 + intensity * 0.35;
+	}
+	const borderColor = `rgba(${rgb},${borderAlpha})`;
+	const boxShadow = flashy
+		// Double-layer glow for extra presence when listening without transcript.
+		? `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), 0 0 ${shadowSpread * 2}px rgba(${rgb},${shadowAlpha * 0.3}), inset 0 0 ${shadowSpread * 0.5}px rgba(${rgb},${shadowAlpha * 0.4})`
+		: `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), inset 0 0 ${shadowSpread * 0.4}px rgba(${rgb},${shadowAlpha * 0.3})`;
+	return { borderColor, boxShadow };
+}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -114,17 +114,8 @@ export interface IVoiceSessionController {
 	newSessionAsTarget(): void;
 
 	/**
-	 * Authoritatively declare the session currently shown/active in the UI, for
-	 * audio routing purposes (`is_active`, response deferral, and flushing a
-	 * buffered response when a session is revealed).
-	 *
-	 * The main window infers the active session from chat-widget focus, but the
-	 * Agents (sessions) window renders multiple chat widgets simultaneously, so
-	 * DOM focus and per-widget view-model swaps can't reliably identify which
-	 * session the user is actually viewing. The sessions window calls this when
-	 * its active session changes so routing follows that session rather than a
-	 * stale focused widget or a thrashing last-shown heuristic. Passing
-	 * `undefined` clears the override and restores focus-based detection.
+	 * Declares the UI's active session for audio routing (`is_active`, deferral,
+	 * and buffered flushes). `undefined` restores focus-based detection.
 	 */
 	setActiveSessionShown(resource: URI | undefined): void;
 
@@ -204,10 +195,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Set after send_to_chat; blocks auto-listen until the reply TTS starts. */
 	private _awaitingReplyAudio = false;
 	/**
-	 * The session the user's currently-awaited reply belongs to (the active
-	 * session when they last spoke). A backend narration tagged to a DIFFERENT
-	 * session is therefore unsolicited even while `_awaitingReplyAudio` is true,
-	 * so it can be recognized as a stale on-focus re-narration and dropped.
+	 * Session awaiting the user's reply. Other-session narration is unsolicited
+	 * even while `_awaitingReplyAudio` is true, so stale on-focus re-reads drop.
 	 */
 	private _awaitingReplyForSession: string | undefined;
 	private _awaitingReplyWatchdog: ReturnType<typeof setTimeout> | undefined;
@@ -246,18 +235,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * session across all widgets closes that gap. */
 	private _lastShownSessionId: string | undefined;
 	/**
-	 * Authoritative override of the active/shown session, set by the Agents
-	 * (sessions) window (see `setActiveSessionShown`). Takes precedence over the
-	 * `_lastShownSessionId` / focused-widget heuristics that are unreliable when
-	 * multiple chat widgets are rendered at once. `undefined` in the main window.
+	 * Agents-window active-session override. Beats focus/last-shown heuristics,
+	 * which are unreliable with multiple rendered chat widgets.
 	 */
 	private _activeSessionShown: string | undefined;
 	/**
-	 * True once an embedder has driven the active session via
-	 * `setActiveSessionShown` (the Agents window). In this mode the focused-widget
-	 * / last-shown heuristics are disabled because they are unreliable when many
-	 * chat widgets render simultaneously; the embedder's override is the sole
-	 * source of truth for the active/shown session.
+	 * True once an embedder drives the active session via `setActiveSessionShown`.
+	 * Focus/last-shown heuristics are then disabled.
 	 */
 	private _externalActiveSessionMode = false;
 	/** Buffered audio for responses that arrived while their session was not
@@ -291,23 +275,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private static readonly RENARRATION_DEDUPE_WINDOW_MS = 6000;
 
 	/**
-	 * Per-session record of the last reply transcript the user actually HEARD
-	 * (played live or flushed from the deferred buffer). Used to guard against
-	 * the backend re-narrating a session's already-heard reply when that session
-	 * becomes active again on focus: on activation we arm `_recentlyFlushedResponse`
-	 * with this transcript so a matching backend re-read is dropped rather than
-	 * replaying stale content. A genuinely new reply (different text) still plays.
+	 * Last reply transcript heard per session. On activation it arms
+	 * `_recentlyFlushedResponse` so matching backend re-reads drop as stale.
 	 */
 	private readonly _lastHeardTranscriptById = new Map<string, string>();
 
 	/**
-	 * One-shot per-session override: while a session id is in this set,
-	 * `_buildSessionContext` reports it as `thinking` (its pre-confirmation state)
-	 * instead of its real state. Used by `_activateShownSession` to ship an
-	 * `is_active` flip in a delta of its own BEFORE the `agent_state` transition:
-	 * the backend does NOT narrate a `waiting_for_confirmation` transition that
-	 * arrives in the SAME delta patch as an `is_active` flip, so we must deliver
-	 * the two in separate deltas (is_active first, then the state transition).
+	 * One-shot override: report sessions as `thinking` so `is_active` ships before
+	 * `waiting_for_confirmation`, which the backend only narrates in a later delta.
 	 */
 	private readonly _forceThinkingOnce = new Set<string>();
 
@@ -336,10 +311,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private static readonly _CONFIRMATION_FLUSH_DELAY_MS = 1500;
 
 	/**
-	 * Pending phase-2 send of a confirmation activation (see
-	 * `_activateShownSession`). The `agent_state` transition is delayed slightly
-	 * after the `is_active` flip so the backend settles the flip first; a
-	 * transition arriving in the same instant as the flip is not narrated.
+	 * Pending confirmation phase 2 (see `_activateShownSession`): send
+	 * `agent_state` after `is_active` has settled so it narrates.
 	 */
 	private _confirmationActivateTimer: ReturnType<typeof setTimeout> | undefined;
 	private static readonly _CONFIRMATION_ACTIVATE_DELAY_MS = 250;
@@ -1177,9 +1150,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				// buffer on focus. Drop it so the user never hears it twice.
 				this.logService.info(`[voice] dropping duplicate re-narration for session=${e.codingSessionId} isFirstChunk=${e.isFirstChunk} isFinal=${e.isFinal}`);
 			} else if (this._isStaleRenarration(e.codingSessionId, e.isFirstChunk, e.isFinal)) {
-				// Unsolicited backend re-narration of an already-idle session's
-				// old reply, triggered by switching to it. Drop it so the user
-				// doesn't hear stale content replayed on focus.
+				// Drop unsolicited on-focus re-narration of an idle session's old reply.
 				this.logService.info(`[voice] dropping stale re-narration for now-active idle session=${e.codingSessionId} isFirstChunk=${e.isFirstChunk} isFinal=${e.isFinal}`);
 			} else {
 				// A fresh reply that plays live supersedes any older buffered
@@ -1192,9 +1163,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				this._enqueueAudio(e.codingSessionId, e.audio, e.isFirstChunk, e.isFinal, e.transcript);
 				if (e.isFinal) {
 					this._liveReplyKey = undefined;
-					// Remember what the user just heard for this session so a later
-					// backend re-narration on focus (switching back to it) is
-					// recognized as stale and dropped rather than replayed.
+					// Remember this heard reply so later on-focus re-reads drop as stale.
 					if (e.codingSessionId && e.transcript) {
 						const heard = this._normalizeTranscript(e.transcript);
 						if (heard) {
@@ -2176,10 +2145,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	private _onFocusedSessionChanged(): void {
-		// When an embedder (the Agents window) authoritatively drives the active
-		// session via `setActiveSessionShown`, chat-widget focus is not a reliable
-		// signal there (multiple widgets render at once and DOM focus stays on the
-		// sessions list), so ignore focus-based activation entirely.
+		// In embedder-driven mode, focus is unreliable; ignore focus activation.
 		if (this._externalActiveSessionMode) {
 			return;
 		}
@@ -2219,11 +2185,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * had downgraded while the session was unfocused.
 	 */
 	private _onSessionShown(resource: URI | undefined): void {
-		// See `_onFocusedSessionChanged`: when the active session is driven
-		// externally, per-widget view-model swaps are not the source of truth. In
-		// the Agents window multiple chat widgets (including background/preview
-		// slots) render at once, so reacting here would flush a deferred response
-		// for a session that isn't actually focused and thrash the active session.
+		// In embedder-driven mode, widget swaps are not authoritative and can
+		// flush the wrong session or thrash the active one.
 		if (this._externalActiveSessionMode) {
 			return;
 		}
@@ -2255,19 +2218,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (this._confirmationDetailPending(resource)) {
 			this._ensureModelLoaded(resource);
 		}
-		// Guard against the backend re-narrating this session's already-heard
-		// reply now that it becomes active on focus. Unless we just flushed a
-		// fresh buffered reply (which arms its own dedupe with the NEW text),
-		// arm the re-narration dedupe with the last reply the user heard for this
-		// session so a matching backend re-read is dropped instead of replaying
-		// stale content. A genuinely new reply (different text) still plays, and
-		// a pending confirmation (different text) still narrates.
-		//
-		// The dedupe-arming and the two-phase confirmation send below are gated
-		// to `_externalActiveSessionMode` (i.e. the sessions/agents window, which
-		// drives activation explicitly via `setActiveSessionShown`). The main
-		// window relies on focus/last-shown heuristics and already narrates
-		// confirmations reliably on focus, so we leave its behavior untouched.
+		// In embedder-driven mode, arm dedupe with the last heard reply so matching
+		// on-focus re-reads drop; new replies and confirmations still narrate.
 		if (this._externalActiveSessionMode) {
 			if (!this._recentlyFlushedResponse.has(key)) {
 				const heard = this._lastHeardTranscriptById.get(key);
@@ -2275,17 +2227,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					this._recentlyFlushedResponse.set(key, { transcript: heard, at: Date.now() });
 				}
 			}
-			// The backend does NOT narrate a `waiting_for_confirmation` transition
-			// that arrives in the same delta patch as the `is_active` flip (it only
-			// narrates the transition when is_active is already true). When we
-			// switch to a session that is ALREADY awaiting confirmation with its
-			// model resident, both would ship together, so the confirmation is
-			// never read. Split the send: first flip is_active while holding the
-			// session as `thinking`, then send the real `waiting_for_confirmation`
-			// transition so the backend narrates it. (The model-not-resident case
-			// already achieves this naturally: the initial send flips is_active,
-			// and the post-load re-send in `_ensureModelLoaded` delivers the
-			// transition separately.)
+			// Split resident confirmations across deltas: flip `is_active` while
+			// holding `thinking`, then send `waiting_for_confirmation` so it narrates.
 			const model = this.chatService.getSession(resource);
 			const currentState = model ? this._getAgentStateInfo(model).state : undefined;
 			const awaitingConfirmation = currentState === 'waiting_for_confirmation';
@@ -2294,21 +2237,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				this._forceThinkingOnce.add(key);
 				this._sendContext();
 				this.voiceClientService.flushSessionContext();
-				// Phase 2 (delayed): send the real `waiting_for_confirmation`
-				// transition. The backend does not narrate a transition that
-				// lands in the same instant as the is_active flip, so we wait a
-				// beat for it to settle the flip as the session's prior state.
+				// Phase 2: after `is_active` settles, send `waiting_for_confirmation`.
 				if (this._confirmationActivateTimer) {
 					clearTimeout(this._confirmationActivateTimer);
 				}
 				this._confirmationActivateTimer = setTimeout(() => {
 					this._confirmationActivateTimer = undefined;
-					// Clear the whole one-shot set, not just this key: a rapid
-					// switch between two resident confirmation sessions preempts
-					// (clearTimeout) the earlier timer, so its own delete never
-					// runs. Since the set is populated only here and the timer is
-					// one-shot, clearing it wholesale avoids a stuck key that would
-					// otherwise be forced to report `thinking` indefinitely.
+					// Clear all one-shot keys; rapid switches can preempt older timers,
+					// so per-key cleanup could leave a session stuck as `thinking`.
 					this._forceThinkingOnce.clear();
 					// Only ship the transition if this session is still active.
 					if (this._getActiveSessionId() === key) {
@@ -2353,10 +2289,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 */
 	private _getActiveSessionId(): string | undefined {
 		if (this._externalActiveSessionMode) {
-			// The embedder is authoritative: use only an explicit transcription
-			// target or the externally-declared active session. Never fall back to
-			// the focused/last-shown heuristics, which are polluted by the other
-			// (background/preview) chat widgets rendered at the same time.
+			// Embedder is authoritative; ignore polluted focus/last-shown heuristics.
 			return this._targetSession.get()?.toString() ?? this._activeSessionShown;
 		}
 		return this._targetSession.get()?.toString() ?? this._activeSessionShown ?? this._lastShownSessionId ?? this._getFocusedSessionId();
@@ -2371,9 +2304,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this.logService.info(`[voice] setActiveSessionShown=${key ?? '<none>'} (was ${this._activeSessionShown ?? '<none>'})`);
 		this._activeSessionShown = key;
 		if (resource) {
-			// Route audio to this session immediately: flush any buffered
-			// response, clear its pending indicator, and re-send context so the
-			// backend's `is_active` tracks it now rather than on the next poll.
+			// Route audio here now: flush buffers, clear pending, and re-send context.
 			this._activateShownSession(resource);
 		} else {
 			this._sendContext();
@@ -2569,23 +2500,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	/**
-	 * True when an incoming first-chunk narration tagged to the CURRENTLY-FOCUSED
-	 * session is a stale on-focus narration that should be dropped rather than
-	 * played. The backend re-emits a session's prior output (a completed reply, a
-	 * command that was aborted when the user switched away, etc.) when the session
-	 * becomes active on focus; the user does not want to hear that replayed.
-	 *
-	 * Deterministic (no time-window). Only applies in the sessions/agents window
-	 * (`_externalActiveSessionMode`), and never to the main window. A narration is
-	 * NOT stale (i.e. plays) when either:
-	 *   - it is SOLICITED — the user just spoke to THIS session and is awaiting its
-	 *     reply (`_awaitingReplyForSession === sessionId`), or
-	 *   - the session is currently `waiting_for_confirmation` — the one on-focus
-	 *     narration the user does want, so they can approve by voice.
-	 * Otherwise it is an unsolicited on-focus narration → drop it (and its
-	 * continuation chunks). Replies produced while the session was NOT focused are
-	 * handled separately by the defer/buffer path and are replayed on focus, so
-	 * they are never dropped here.
+	 * Drops stale on-focus replays in the sessions window. Solicited replies,
+	 * pending confirmations, and buffered background replies still play.
 	 */
 	private _isStaleRenarration(sessionId: string | undefined, isFirstChunk: boolean, isFinal: boolean): boolean {
 		if (!this._externalActiveSessionMode || !sessionId) {
@@ -2601,22 +2517,20 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 			return false;
 		}
-		// Only the focused session's own narration can be a stale on-focus replay.
-		// (A different session's narration is deferred/buffered elsewhere.)
+		// Only the focused session's own narration can be a stale replay.
 		if (this._getActiveSessionId() !== sessionId) {
 			return false;
 		}
-		// Solicited: the user spoke to THIS session and is awaiting its reply.
+		// Solicited reply: let it play.
 		if (this._awaitingReplyAudio && this._awaitingReplyForSession === sessionId) {
 			return false;
 		}
-		// A pending confirmation is the one on-focus narration we DO want.
+		// Pending confirmations should narrate on focus.
 		const model = this.chatService.getSession(URI.parse(sessionId));
 		if (model && this._getAgentStateInfo(model).state === 'waiting_for_confirmation') {
 			return false;
 		}
-		// Unsolicited on-focus narration of prior output → drop it and its
-		// continuation chunks until the final chunk.
+		// Drop unsolicited prior output and its continuation chunks.
 		if (this._liveReplyKey === sessionId) {
 			this._liveReplyKey = undefined;
 		}
@@ -3121,9 +3035,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// `thinking` for the same reason as the no-model case above: narrate
 			// exactly once, with the detail, rather than a detail-less one first.
 			const detailPending = stateInfo.state === 'waiting_for_confirmation' && !stateInfo.detail;
-			// One-shot: hold this session as `thinking` so a preceding `is_active`
-			// flip ships in its own delta; the follow-up send delivers the real
-			// state transition (see `_forceThinkingOnce` / `_activateShownSession`).
+			// One-shot: hold as `thinking` so `is_active` ships before the real state.
 			const forceThinking = this._forceThinkingOnce.has(s.resource.toString());
 			const scoped = (detailPending || forceThinking)
 				? { state: 'thinking', hideConfirmationDetail: true }
@@ -3209,13 +3121,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					}
 				} else {
 					this._eagerModelRefs.set(key, ref);
-					// The model is now resident, so its confirmation state and
-					// detail are finally readable. If nothing else re-evaluates
-					// state, the pending `waiting_for_confirmation` would only
-					// ship to the backend on the next unrelated context send
-					// (potentially minutes later), delaying its narration when
-					// the user switches to the session. Re-check and flush now so
-					// the confirmation narrates immediately.
+					// Model state/detail are now readable; flush so confirmation narrates
+					// immediately instead of waiting for the next context send.
 					this._checkSessionStateChanges();
 					this._sendContext();
 					this.voiceClientService.flushSessionContext();

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -283,6 +283,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private readonly _droppingRenarration = new Set<string>();
 	private static readonly RENARRATION_DEDUPE_WINDOW_MS = 6000;
 
+	/**
+	 * Per-session record of the last reply transcript the user actually HEARD
+	 * (played live or flushed from the deferred buffer). Used to guard against
+	 * the backend re-narrating a session's already-heard reply when that session
+	 * becomes active again on focus: on activation we arm `_recentlyFlushedResponse`
+	 * with this transcript so a matching backend re-read is dropped rather than
+	 * replaying stale content. A genuinely new reply (different text) still plays.
+	 */
+	private readonly _lastHeardTranscriptById = new Map<string, string>();
+
 
 	// --- Session audio cache for replay ---
 	private readonly _sessionAudioCache = new Map<string, Float32Array>();
@@ -1151,6 +1161,15 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				this._enqueueAudio(e.codingSessionId, e.audio, e.isFirstChunk, e.isFinal, e.transcript);
 				if (e.isFinal) {
 					this._liveReplyKey = undefined;
+					// Remember what the user just heard for this session so a later
+					// backend re-narration on focus (switching back to it) is
+					// recognized as stale and dropped rather than replayed.
+					if (e.codingSessionId && e.transcript) {
+						const heard = this._normalizeTranscript(e.transcript);
+						if (heard) {
+							this._lastHeardTranscriptById.set(e.codingSessionId, heard);
+						}
+					}
 				}
 			}
 			// On the final chunk we have the complete assistant transcript to persist.
@@ -1291,6 +1310,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._lastShownSessionId = undefined;
 		this._recentlyFlushedResponse.clear();
 		this._droppingRenarration.clear();
+		this._lastHeardTranscriptById.clear();
 		this._prevSessionStates.clear();
 		for (const t of this._userCancelledSessions.values()) { clearTimeout(t); }
 		this._userCancelledSessions.clear();
@@ -2195,6 +2215,19 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (this._confirmationDetailPending(resource)) {
 			this._ensureModelLoaded(resource);
 		}
+		// Guard against the backend re-narrating this session's already-heard
+		// reply now that it becomes active on focus. Unless we just flushed a
+		// fresh buffered reply (which arms its own dedupe with the NEW text),
+		// arm the re-narration dedupe with the last reply the user heard for this
+		// session so a matching backend re-read is dropped instead of replaying
+		// stale content. A genuinely new reply (different text) still plays, and
+		// a pending confirmation (different text) still narrates.
+		if (!this._recentlyFlushedResponse.has(key)) {
+			const heard = this._lastHeardTranscriptById.get(key);
+			if (heard) {
+				this._recentlyFlushedResponse.set(key, { transcript: heard, at: Date.now() });
+			}
+		}
 		this._sendContext();
 		this.voiceClientService.flushSessionContext();
 	}
@@ -2244,6 +2277,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (key === this._activeSessionShown) {
 			return;
 		}
+		this.logService.info(`[voice] setActiveSessionShown=${key ?? '<none>'} (was ${this._activeSessionShown ?? '<none>'})`);
 		this._activeSessionShown = key;
 		if (resource) {
 			// Route audio to this session immediately: flush any buffered
@@ -2359,6 +2393,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		);
 		if (flushedTranscript) {
 			this._recentlyFlushedResponse.set(key, { transcript: flushedTranscript, at: Date.now() });
+			this._lastHeardTranscriptById.set(key, flushedTranscript);
 		}
 
 		// Exit any active listening / auto-listen so playback can take over.
@@ -3021,6 +3056,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					}
 				} else {
 					this._eagerModelRefs.set(key, ref);
+					// The model is now resident, so its confirmation state and
+					// detail are finally readable. If nothing else re-evaluates
+					// state, the pending `waiting_for_confirmation` would only
+					// ship to the backend on the next unrelated context send
+					// (potentially minutes later), delaying its narration when
+					// the user switches to the session. Re-check and flush now so
+					// the confirmation narrates immediately.
+					this._checkSessionStateChanges();
+					this._sendContext();
+					this.voiceClientService.flushSessionContext();
 				}
 			} else {
 				// Load failed; stop suppressing the coarse idle for this session.

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -114,6 +114,21 @@ export interface IVoiceSessionController {
 	newSessionAsTarget(): void;
 
 	/**
+	 * Authoritatively declare the session currently shown/active in the UI, for
+	 * audio routing purposes (`is_active`, response deferral, and flushing a
+	 * buffered response when a session is revealed).
+	 *
+	 * The main window infers the active session from chat-widget focus, but the
+	 * Agents (sessions) window renders multiple chat widgets simultaneously, so
+	 * DOM focus and per-widget view-model swaps can't reliably identify which
+	 * session the user is actually viewing. The sessions window calls this when
+	 * its active session changes so routing follows that session rather than a
+	 * stale focused widget or a thrashing last-shown heuristic. Passing
+	 * `undefined` clears the override and restores focus-based detection.
+	 */
+	setActiveSessionShown(resource: URI | undefined): void;
+
+	/**
 	 * Submit user feedback along with full diagnostic data (transcript history,
 	 * client state, environment info). Returns success/failure.
 	 */
@@ -223,6 +238,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * second click, once the widget finally takes focus). Tracking the last-shown
 	 * session across all widgets closes that gap. */
 	private _lastShownSessionId: string | undefined;
+	/**
+	 * Authoritative override of the active/shown session, set by the Agents
+	 * (sessions) window (see `setActiveSessionShown`). Takes precedence over the
+	 * `_lastShownSessionId` / focused-widget heuristics that are unreliable when
+	 * multiple chat widgets are rendered at once. `undefined` in the main window.
+	 */
+	private _activeSessionShown: string | undefined;
 	/** Buffered audio for responses that arrived while their session was not
 	 *  focused. Flushed to playback when the session becomes focused. */
 	private readonly _deferredResponses = new Map<string, { audio: string; isFirstChunk: boolean; isFinal: boolean; transcript: string | undefined }[]>();
@@ -2183,7 +2205,24 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * session is "active" and everything else is a background narration.
 	 */
 	private _getActiveSessionId(): string | undefined {
-		return this._targetSession.get()?.toString() ?? this._lastShownSessionId ?? this._getFocusedSessionId();
+		return this._targetSession.get()?.toString() ?? this._activeSessionShown ?? this._lastShownSessionId ?? this._getFocusedSessionId();
+	}
+
+	setActiveSessionShown(resource: URI | undefined): void {
+		const key = resource?.toString();
+		if (key === this._activeSessionShown) {
+			return;
+		}
+		this._activeSessionShown = key;
+		if (resource) {
+			// Route audio to this session immediately: flush any buffered
+			// response, clear its pending indicator, and re-send context so the
+			// backend's `is_active` tracks it now rather than on the next poll.
+			this._activateShownSession(resource);
+		} else {
+			this._sendContext();
+			this.voiceClientService.flushSessionContext();
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2303,7 +2303,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				}
 				this._confirmationActivateTimer = setTimeout(() => {
 					this._confirmationActivateTimer = undefined;
-					this._forceThinkingOnce.delete(key);
+					// Clear the whole one-shot set, not just this key: a rapid
+					// switch between two resident confirmation sessions preempts
+					// (clearTimeout) the earlier timer, so its own delete never
+					// runs. Since the set is populated only here and the timer is
+					// one-shot, clearing it wholesale avoids a stuck key that would
+					// otherwise be forced to report `thinking` indefinitely.
+					this._forceThinkingOnce.clear();
 					// Only ship the transition if this session is still active.
 					if (this._getActiveSessionId() === key) {
 						this._sendContext();

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -245,6 +245,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * multiple chat widgets are rendered at once. `undefined` in the main window.
 	 */
 	private _activeSessionShown: string | undefined;
+	/**
+	 * True once an embedder has driven the active session via
+	 * `setActiveSessionShown` (the Agents window). In this mode the focused-widget
+	 * / last-shown heuristics are disabled because they are unreliable when many
+	 * chat widgets render simultaneously; the embedder's override is the sole
+	 * source of truth for the active/shown session.
+	 */
+	private _externalActiveSessionMode = false;
 	/** Buffered audio for responses that arrived while their session was not
 	 *  focused. Flushed to playback when the session becomes focused. */
 	private readonly _deferredResponses = new Map<string, { audio: string; isFirstChunk: boolean; isFinal: boolean; transcript: string | undefined }[]>();
@@ -2108,6 +2116,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	private _onFocusedSessionChanged(): void {
+		// When an embedder (the Agents window) authoritatively drives the active
+		// session via `setActiveSessionShown`, chat-widget focus is not a reliable
+		// signal there (multiple widgets render at once and DOM focus stays on the
+		// sessions list), so ignore focus-based activation entirely.
+		if (this._externalActiveSessionMode) {
+			return;
+		}
 		const focused = this._getFocusedSessionId();
 		this._focusedSessionId = focused;
 		if (focused) {
@@ -2144,6 +2159,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * had downgraded while the session was unfocused.
 	 */
 	private _onSessionShown(resource: URI | undefined): void {
+		// See `_onFocusedSessionChanged`: when the active session is driven
+		// externally, per-widget view-model swaps are not the source of truth. In
+		// the Agents window multiple chat widgets (including background/preview
+		// slots) render at once, so reacting here would flush a deferred response
+		// for a session that isn't actually focused and thrash the active session.
+		if (this._externalActiveSessionMode) {
+			return;
+		}
 		const key = resource?.toString();
 		if (!key || key === this._lastShownSessionId) {
 			return;
@@ -2205,10 +2228,18 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * session is "active" and everything else is a background narration.
 	 */
 	private _getActiveSessionId(): string | undefined {
+		if (this._externalActiveSessionMode) {
+			// The embedder is authoritative: use only an explicit transcription
+			// target or the externally-declared active session. Never fall back to
+			// the focused/last-shown heuristics, which are polluted by the other
+			// (background/preview) chat widgets rendered at the same time.
+			return this._targetSession.get()?.toString() ?? this._activeSessionShown;
+		}
 		return this._targetSession.get()?.toString() ?? this._activeSessionShown ?? this._lastShownSessionId ?? this._getFocusedSessionId();
 	}
 
 	setActiveSessionShown(resource: URI | undefined): void {
+		this._externalActiveSessionMode = true;
 		const key = resource?.toString();
 		if (key === this._activeSessionShown) {
 			return;

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -203,6 +203,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _replyPlayedSinceSend = false;
 	/** Set after send_to_chat; blocks auto-listen until the reply TTS starts. */
 	private _awaitingReplyAudio = false;
+	/**
+	 * The session the user's currently-awaited reply belongs to (the active
+	 * session when they last spoke). A backend narration tagged to a DIFFERENT
+	 * session is therefore unsolicited even while `_awaitingReplyAudio` is true,
+	 * so it can be recognized as a stale on-focus re-narration and dropped.
+	 */
+	private _awaitingReplyForSession: string | undefined;
 	private _awaitingReplyWatchdog: ReturnType<typeof setTimeout> | undefined;
 	/** Tracks whether the initial listen cue has been played after connecting. */
 	private _hasPlayedInitialListenCue = false;
@@ -293,6 +300,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 */
 	private readonly _lastHeardTranscriptById = new Map<string, string>();
 
+	/**
+	 * One-shot per-session override: while a session id is in this set,
+	 * `_buildSessionContext` reports it as `thinking` (its pre-confirmation state)
+	 * instead of its real state. Used by `_activateShownSession` to ship an
+	 * `is_active` flip in a delta of its own BEFORE the `agent_state` transition:
+	 * the backend does NOT narrate a `waiting_for_confirmation` transition that
+	 * arrives in the SAME delta patch as an `is_active` flip, so we must deliver
+	 * the two in separate deltas (is_active first, then the state transition).
+	 */
+	private readonly _forceThinkingOnce = new Set<string>();
 
 	// --- Session audio cache for replay ---
 	private readonly _sessionAudioCache = new Map<string, Float32Array>();
@@ -317,6 +334,15 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	// are no-ops on the BE because the merge-patch detects no field changes.
 	private readonly _confirmationFlushWatchdogs = new Map<string, ReturnType<typeof setTimeout>>();
 	private static readonly _CONFIRMATION_FLUSH_DELAY_MS = 1500;
+
+	/**
+	 * Pending phase-2 send of a confirmation activation (see
+	 * `_activateShownSession`). The `agent_state` transition is delayed slightly
+	 * after the `is_active` flip so the backend settles the flip first; a
+	 * transition arriving in the same instant as the flip is not narrated.
+	 */
+	private _confirmationActivateTimer: ReturnType<typeof setTimeout> | undefined;
+	private static readonly _CONFIRMATION_ACTIVATE_DELAY_MS = 250;
 
 	/** Model refs eagerly loaded for sessions awaiting input (no UI focus needed). */
 	private readonly _eagerModelRefs = new Map<string, IChatModelReference>();
@@ -1150,6 +1176,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				// Backend re-narrated a reply we just replayed from the deferred
 				// buffer on focus. Drop it so the user never hears it twice.
 				this.logService.info(`[voice] dropping duplicate re-narration for session=${e.codingSessionId} isFirstChunk=${e.isFirstChunk} isFinal=${e.isFinal}`);
+			} else if (this._isStaleRenarration(e.codingSessionId, e.isFirstChunk, e.isFinal)) {
+				// Unsolicited backend re-narration of an already-idle session's
+				// old reply, triggered by switching to it. Drop it so the user
+				// doesn't hear stale content replayed on focus.
+				this.logService.info(`[voice] dropping stale re-narration for now-active idle session=${e.codingSessionId} isFirstChunk=${e.isFirstChunk} isFinal=${e.isFinal}`);
 			} else {
 				// A fresh reply that plays live supersedes any older buffered
 				// response for the same session; drop the stale buffer and its
@@ -1311,6 +1342,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._recentlyFlushedResponse.clear();
 		this._droppingRenarration.clear();
 		this._lastHeardTranscriptById.clear();
+		this._forceThinkingOnce.clear();
+		this._awaitingReplyForSession = undefined;
+		if (this._confirmationActivateTimer) {
+			clearTimeout(this._confirmationActivateTimer);
+			this._confirmationActivateTimer = undefined;
+		}
 		this._prevSessionStates.clear();
 		for (const t of this._userCancelledSessions.values()) { clearTimeout(t); }
 		this._userCancelledSessions.clear();
@@ -1648,6 +1685,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Block auto-listen until reply audio arrives (with 30s watchdog). */
 	private _setAwaitingReply(): void {
 		this._awaitingReplyAudio = true;
+		this._awaitingReplyForSession = this._getActiveSessionId();
 		this._clearAutoListenTimer();
 		if (this._awaitingReplyWatchdog) {
 			clearTimeout(this._awaitingReplyWatchdog);
@@ -1655,6 +1693,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._awaitingReplyWatchdog = setTimeout(() => {
 			this._awaitingReplyWatchdog = undefined;
 			this._awaitingReplyAudio = false;
+			this._awaitingReplyForSession = undefined;
 			// No reply came — re-enter listening if eligible.
 			if (this._isHandsFreeEnabled() && !this._pttHeld) {
 				this._enterAutoListen();
@@ -1664,6 +1703,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 	private _clearAwaitingReply(): void {
 		this._awaitingReplyAudio = false;
+		this._awaitingReplyForSession = undefined;
 		if (this._awaitingReplyWatchdog) {
 			clearTimeout(this._awaitingReplyWatchdog);
 			this._awaitingReplyWatchdog = undefined;
@@ -2222,10 +2262,55 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// session so a matching backend re-read is dropped instead of replaying
 		// stale content. A genuinely new reply (different text) still plays, and
 		// a pending confirmation (different text) still narrates.
-		if (!this._recentlyFlushedResponse.has(key)) {
-			const heard = this._lastHeardTranscriptById.get(key);
-			if (heard) {
-				this._recentlyFlushedResponse.set(key, { transcript: heard, at: Date.now() });
+		//
+		// The dedupe-arming and the two-phase confirmation send below are gated
+		// to `_externalActiveSessionMode` (i.e. the sessions/agents window, which
+		// drives activation explicitly via `setActiveSessionShown`). The main
+		// window relies on focus/last-shown heuristics and already narrates
+		// confirmations reliably on focus, so we leave its behavior untouched.
+		if (this._externalActiveSessionMode) {
+			if (!this._recentlyFlushedResponse.has(key)) {
+				const heard = this._lastHeardTranscriptById.get(key);
+				if (heard) {
+					this._recentlyFlushedResponse.set(key, { transcript: heard, at: Date.now() });
+				}
+			}
+			// The backend does NOT narrate a `waiting_for_confirmation` transition
+			// that arrives in the same delta patch as the `is_active` flip (it only
+			// narrates the transition when is_active is already true). When we
+			// switch to a session that is ALREADY awaiting confirmation with its
+			// model resident, both would ship together, so the confirmation is
+			// never read. Split the send: first flip is_active while holding the
+			// session as `thinking`, then send the real `waiting_for_confirmation`
+			// transition so the backend narrates it. (The model-not-resident case
+			// already achieves this naturally: the initial send flips is_active,
+			// and the post-load re-send in `_ensureModelLoaded` delivers the
+			// transition separately.)
+			const model = this.chatService.getSession(resource);
+			const currentState = model ? this._getAgentStateInfo(model).state : undefined;
+			const awaitingConfirmation = currentState === 'waiting_for_confirmation';
+			if (awaitingConfirmation) {
+				// Phase 1: flip is_active while holding the session as `thinking`.
+				this._forceThinkingOnce.add(key);
+				this._sendContext();
+				this.voiceClientService.flushSessionContext();
+				// Phase 2 (delayed): send the real `waiting_for_confirmation`
+				// transition. The backend does not narrate a transition that
+				// lands in the same instant as the is_active flip, so we wait a
+				// beat for it to settle the flip as the session's prior state.
+				if (this._confirmationActivateTimer) {
+					clearTimeout(this._confirmationActivateTimer);
+				}
+				this._confirmationActivateTimer = setTimeout(() => {
+					this._confirmationActivateTimer = undefined;
+					this._forceThinkingOnce.delete(key);
+					// Only ship the transition if this session is still active.
+					if (this._getActiveSessionId() === key) {
+						this._sendContext();
+						this.voiceClientService.flushSessionContext();
+					}
+				}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS);
+				return;
 			}
 		}
 		this._sendContext();
@@ -2468,6 +2553,64 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// This first chunk is the duplicate re-narration. Consume the marker
 		// (one-shot) and, for a multi-chunk re-narration, keep dropping until final.
 		this._recentlyFlushedResponse.delete(sessionId);
+		if (this._liveReplyKey === sessionId) {
+			this._liveReplyKey = undefined;
+		}
+		if (!isFinal) {
+			this._droppingRenarration.add(sessionId);
+		}
+		return true;
+	}
+
+	/**
+	 * True when an incoming first-chunk narration tagged to the CURRENTLY-FOCUSED
+	 * session is a stale on-focus narration that should be dropped rather than
+	 * played. The backend re-emits a session's prior output (a completed reply, a
+	 * command that was aborted when the user switched away, etc.) when the session
+	 * becomes active on focus; the user does not want to hear that replayed.
+	 *
+	 * Deterministic (no time-window). Only applies in the sessions/agents window
+	 * (`_externalActiveSessionMode`), and never to the main window. A narration is
+	 * NOT stale (i.e. plays) when either:
+	 *   - it is SOLICITED — the user just spoke to THIS session and is awaiting its
+	 *     reply (`_awaitingReplyForSession === sessionId`), or
+	 *   - the session is currently `waiting_for_confirmation` — the one on-focus
+	 *     narration the user does want, so they can approve by voice.
+	 * Otherwise it is an unsolicited on-focus narration → drop it (and its
+	 * continuation chunks). Replies produced while the session was NOT focused are
+	 * handled separately by the defer/buffer path and are replayed on focus, so
+	 * they are never dropped here.
+	 */
+	private _isStaleRenarration(sessionId: string | undefined, isFirstChunk: boolean, isFinal: boolean): boolean {
+		if (!this._externalActiveSessionMode || !sessionId) {
+			return false;
+		}
+		// Continuation of a stale narration we're already dropping.
+		if (!isFirstChunk) {
+			if (this._droppingRenarration.has(sessionId)) {
+				if (isFinal) {
+					this._droppingRenarration.delete(sessionId);
+				}
+				return true;
+			}
+			return false;
+		}
+		// Only the focused session's own narration can be a stale on-focus replay.
+		// (A different session's narration is deferred/buffered elsewhere.)
+		if (this._getActiveSessionId() !== sessionId) {
+			return false;
+		}
+		// Solicited: the user spoke to THIS session and is awaiting its reply.
+		if (this._awaitingReplyAudio && this._awaitingReplyForSession === sessionId) {
+			return false;
+		}
+		// A pending confirmation is the one on-focus narration we DO want.
+		const model = this.chatService.getSession(URI.parse(sessionId));
+		if (model && this._getAgentStateInfo(model).state === 'waiting_for_confirmation') {
+			return false;
+		}
+		// Unsolicited on-focus narration of prior output → drop it and its
+		// continuation chunks until the final chunk.
 		if (this._liveReplyKey === sessionId) {
 			this._liveReplyKey = undefined;
 		}
@@ -2972,7 +3115,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// `thinking` for the same reason as the no-model case above: narrate
 			// exactly once, with the detail, rather than a detail-less one first.
 			const detailPending = stateInfo.state === 'waiting_for_confirmation' && !stateInfo.detail;
-			const scoped = detailPending
+			// One-shot: hold this session as `thinking` so a preceding `is_active`
+			// flip ships in its own delta; the follow-up send delivers the real
+			// state transition (see `_forceThinkingOnce` / `_activateShownSession`).
+			const forceThinking = this._forceThinkingOnce.has(s.resource.toString());
+			const scoped = (detailPending || forceThinking)
 				? { state: 'thinking', hideConfirmationDetail: true }
 				: this._reportedAgentState(stateInfo.state, isActive);
 			return {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -313,8 +313,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/**
 	 * Pending confirmation phase 2 (see `_activateShownSession`): send
 	 * `agent_state` after `is_active` has settled so it narrates.
+	 *
+	 * Keyed per session so activating one confirmation session never cancels
+	 * another's pending phase-2 (which would leave it stuck reporting `thinking`
+	 * and only narrate on a second focus).
 	 */
-	private _confirmationActivateTimer: ReturnType<typeof setTimeout> | undefined;
+	private readonly _confirmationActivateTimers = new Map<string, ReturnType<typeof setTimeout>>();
 	private static readonly _CONFIRMATION_ACTIVATE_DELAY_MS = 250;
 
 	/** Model refs eagerly loaded for sessions awaiting input (no UI focus needed). */
@@ -1313,10 +1317,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._lastHeardTranscriptById.clear();
 		this._forceThinkingOnce.clear();
 		this._awaitingReplyForSession = undefined;
-		if (this._confirmationActivateTimer) {
-			clearTimeout(this._confirmationActivateTimer);
-			this._confirmationActivateTimer = undefined;
-		}
+		for (const t of this._confirmationActivateTimers.values()) { clearTimeout(t); }
+		this._confirmationActivateTimers.clear();
 		this._prevSessionStates.clear();
 		for (const t of this._userCancelledSessions.values()) { clearTimeout(t); }
 		this._userCancelledSessions.clear();
@@ -2239,20 +2241,22 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._sendContext();
 			this.voiceClientService.flushSessionContext();
 			// Phase 2: after `is_active` settles, send `waiting_for_confirmation`.
-			if (this._confirmationActivateTimer) {
-				clearTimeout(this._confirmationActivateTimer);
+			// Timers are keyed per session so activating another confirmation
+			// session can't cancel this one's phase-2 (which would strand it as
+			// `thinking` and narrate only on a second focus).
+			const existing = this._confirmationActivateTimers.get(key);
+			if (existing) {
+				clearTimeout(existing);
 			}
-			this._confirmationActivateTimer = setTimeout(() => {
-				this._confirmationActivateTimer = undefined;
-				// Clear all one-shot keys; rapid switches can preempt older timers,
-				// so per-key cleanup could leave a session stuck as `thinking`.
-				this._forceThinkingOnce.clear();
+			this._confirmationActivateTimers.set(key, setTimeout(() => {
+				this._confirmationActivateTimers.delete(key);
+				this._forceThinkingOnce.delete(key);
 				// Only ship the transition if this session is still active.
 				if (this._getActiveSessionId() === key) {
 					this._sendContext();
 					this.voiceClientService.flushSessionContext();
 				}
-			}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS);
+			}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS));
 			return;
 		}
 		this._sendContext();

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2567,11 +2567,15 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * confirmation as audio.
 	 */
 	private _reconcileConfirmationIndicators(waitingSessionIds: Set<string>): void {
-		// Suppress the indicator for the session the user is actively viewing.
-		// Use the embedder-aware active id (falls back to focus in the main
-		// window) so the agents window suppresses the shown session rather than
-		// the raw chat-widget focus, which can point at a different session.
-		const activeId = this._getActiveSessionId();
+		// Suppress the indicator only for the session the user is currently
+		// viewing. In the agents window use the embedder-provided shown session
+		// (raw chat-widget focus is unreliable there); in the main window use
+		// the focused session. Deliberately avoid the _getActiveSessionId()
+		// fallback chain (_targetSession / _lastShownSessionId), which can point
+		// at a not-currently-visible session and wrongly hide its indicator.
+		const activeId = this._externalActiveSessionMode
+			? this._activeSessionShown
+			: this._getFocusedSessionId();
 		// Show the indicator for every non-active waiting session.
 		for (const sessionId of waitingSessionIds) {
 			if (sessionId === activeId) {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2567,10 +2567,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * confirmation as audio.
 	 */
 	private _reconcileConfirmationIndicators(waitingSessionIds: Set<string>): void {
-		const focusedId = this._getFocusedSessionId();
-		// Show the indicator for every unfocused waiting session.
+		// Suppress the indicator for the session the user is actively viewing.
+		// Use the embedder-aware active id (falls back to focus in the main
+		// window) so the agents window suppresses the shown session rather than
+		// the raw chat-widget focus, which can point at a different session.
+		const activeId = this._getActiveSessionId();
+		// Show the indicator for every non-active waiting session.
 		for (const sessionId of waitingSessionIds) {
-			if (sessionId === focusedId) {
+			if (sessionId === activeId) {
 				continue;
 			}
 			if (!this._confirmationPendingSessions.has(sessionId)) {
@@ -2578,9 +2582,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				this._markPendingResponse(sessionId, true);
 			}
 		}
-		// Clear it for sessions that are now focused or no longer waiting.
+		// Clear it for sessions that are now active or no longer waiting.
 		for (const sessionId of [...this._confirmationPendingSessions]) {
-			if (waitingSessionIds.has(sessionId) && sessionId !== focusedId) {
+			if (waitingSessionIds.has(sessionId) && sessionId !== activeId) {
 				continue;
 			}
 			this._clearConfirmationIndicator(sessionId);

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2220,40 +2220,40 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		}
 		// In embedder-driven mode, arm dedupe with the last heard reply so matching
 		// on-focus re-reads drop; new replies and confirmations still narrate.
-		if (this._externalActiveSessionMode) {
-			if (!this._recentlyFlushedResponse.has(key)) {
-				const heard = this._lastHeardTranscriptById.get(key);
-				if (heard) {
-					this._recentlyFlushedResponse.set(key, { transcript: heard, at: Date.now() });
-				}
+		if (this._externalActiveSessionMode && !this._recentlyFlushedResponse.has(key)) {
+			const heard = this._lastHeardTranscriptById.get(key);
+			if (heard) {
+				this._recentlyFlushedResponse.set(key, { transcript: heard, at: Date.now() });
 			}
-			// Split resident confirmations across deltas: flip `is_active` while
-			// holding `thinking`, then send `waiting_for_confirmation` so it narrates.
-			const model = this.chatService.getSession(resource);
-			const currentState = model ? this._getAgentStateInfo(model).state : undefined;
-			const awaitingConfirmation = currentState === 'waiting_for_confirmation';
-			if (awaitingConfirmation) {
-				// Phase 1: flip is_active while holding the session as `thinking`.
-				this._forceThinkingOnce.add(key);
-				this._sendContext();
-				this.voiceClientService.flushSessionContext();
-				// Phase 2: after `is_active` settles, send `waiting_for_confirmation`.
-				if (this._confirmationActivateTimer) {
-					clearTimeout(this._confirmationActivateTimer);
-				}
-				this._confirmationActivateTimer = setTimeout(() => {
-					this._confirmationActivateTimer = undefined;
-					// Clear all one-shot keys; rapid switches can preempt older timers,
-					// so per-key cleanup could leave a session stuck as `thinking`.
-					this._forceThinkingOnce.clear();
-					// Only ship the transition if this session is still active.
-					if (this._getActiveSessionId() === key) {
-						this._sendContext();
-						this.voiceClientService.flushSessionContext();
-					}
-				}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS);
-				return;
+		}
+		// Split resident confirmations across deltas: flip `is_active` while
+		// holding `thinking`, then send `waiting_for_confirmation` so it narrates.
+		// Without this, focusing an unfocused session awaiting confirmation ships
+		// the confirmation and `is_active` together and the backend narrates only
+		// on the next activation — so it's read on the second focus, not the first.
+		const model = this.chatService.getSession(resource);
+		const awaitingConfirmation = model ? this._getAgentStateInfo(model).state === 'waiting_for_confirmation' : false;
+		if (awaitingConfirmation) {
+			// Phase 1: flip is_active while holding the session as `thinking`.
+			this._forceThinkingOnce.add(key);
+			this._sendContext();
+			this.voiceClientService.flushSessionContext();
+			// Phase 2: after `is_active` settles, send `waiting_for_confirmation`.
+			if (this._confirmationActivateTimer) {
+				clearTimeout(this._confirmationActivateTimer);
 			}
+			this._confirmationActivateTimer = setTimeout(() => {
+				this._confirmationActivateTimer = undefined;
+				// Clear all one-shot keys; rapid switches can preempt older timers,
+				// so per-key cleanup could leave a session stuck as `thinking`.
+				this._forceThinkingOnce.clear();
+				// Only ship the transition if this session is still active.
+				if (this._getActiveSessionId() === key) {
+					this._sendContext();
+					this.voiceClientService.flushSessionContext();
+				}
+			}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS);
+			return;
 		}
 		this._sendContext();
 		this.voiceClientService.flushSessionContext();

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -72,6 +72,7 @@ import { IHostService } from '../../../../../services/host/browser/host.js';
 import { IMicCaptureService } from '../../voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../voiceClient/ttsPlaybackService.js';
 import { IVoiceSessionController } from '../../voiceClient/voiceSessionController.js';
+import { computeVoiceGlowStyle, readVoiceGlowIntensity } from '../../voiceClient/voiceGlow.js';
 import { IAgentTitleBarStatusService } from '../../agentSessions/experiments/agentTitleBarStatusService.js';
 import { IVoicePlaybackService } from '../../../common/voicePlaybackService.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
@@ -431,7 +432,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 		// Dynamic audio-reactive glow animation (matches aux window behavior)
 		let animFrameId: number | undefined;
-		let glowDataArray: Uint8Array | undefined;
+		const glowDataArrayRef: { value: Uint8Array | undefined } = { value: undefined };
 		const win = getWindow(inputContainerEl);
 		let lastGlowTarget: HTMLElement | undefined;
 		// Lock the glow target to whichever widget was focused when voice connected.
@@ -472,45 +473,12 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				const analyser = this.ttsPlaybackService.analyserNode
 					?? (voiceState === 'listening' ? this.micCaptureService.analyserNode : null)
 					?? null;
-				let intensity: number;
-				if (!analyser) {
-					intensity = 0.3;
-				} else {
-					if (!glowDataArray || glowDataArray.length !== analyser.frequencyBinCount) {
-						glowDataArray = new Uint8Array(analyser.frequencyBinCount);
-					}
-					analyser.getByteFrequencyData(glowDataArray as Uint8Array<ArrayBuffer>);
-					let sum = 0;
-					for (let i = 0; i < glowDataArray.length; i++) {
-						sum += glowDataArray[i];
-					}
-					intensity = Math.min(1, (sum / glowDataArray.length) / 80);
-				}
+				const intensity = readVoiceGlowIntensity(analyser, glowDataArrayRef);
 
-				// Blue when listening (more active/flashy when transcript hidden), purple when speaking (subtle)
-				const rgb = voiceState === 'speaking' ? '163,113,247' : '88,166,255';
 				const transcriptHidden = this.configurationService.getValue<boolean>('agents.voice.showTranscript') === false;
-				let borderAlpha: number;
-				let shadowSpread: number;
-				let shadowAlpha: number;
-				if (voiceState === 'listening' && transcriptHidden) {
-					// Flashy, audio-reactive glow while user is speaking (no transcript visible)
-					borderAlpha = 0.6 + intensity * 0.4;
-					shadowSpread = 6 + intensity * 20;
-					shadowAlpha = 0.25 + intensity * 0.55;
-				} else {
-					// Standard glow (transcript visible or TTS playback)
-					borderAlpha = 0.4 + intensity * 0.5;
-					shadowSpread = 4 + intensity * 12;
-					shadowAlpha = 0.15 + intensity * 0.35;
-				}
-				target.style.borderColor = `rgba(${rgb},${borderAlpha})`;
-				if (voiceState === 'listening' && transcriptHidden) {
-					// Double-layer glow for extra presence when listening without transcript
-					target.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), 0 0 ${shadowSpread * 2}px rgba(${rgb},${shadowAlpha * 0.3}), inset 0 0 ${shadowSpread * 0.5}px rgba(${rgb},${shadowAlpha * 0.4})`;
-				} else {
-					target.style.boxShadow = `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), inset 0 0 ${shadowSpread * 0.4}px rgba(${rgb},${shadowAlpha * 0.3})`;
-				}
+				const { borderColor, boxShadow } = computeVoiceGlowStyle(voiceState, intensity, transcriptHidden);
+				target.style.borderColor = borderColor;
+				target.style.boxShadow = boxShadow;
 				target.classList.add('voice-active');
 				target.classList.toggle('voice-listening', voiceState === 'listening');
 			};

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
@@ -27,6 +27,7 @@ import { ISessionsListModelService } from '../../../../../sessions/services/sess
 import { ISessionsProvidersService } from '../../../../../sessions/services/sessions/browser/sessionsProvidersService.js';
 // eslint-disable-next-line local/code-import-patterns
 import { BlockedSessionsList } from '../../../../../sessions/contrib/sessions/browser/blockedSessionsList.js';
+import { IVoicePlaybackService } from '../../../../contrib/chat/common/voicePlaybackService.js';
 import { IChatService } from '../../../../contrib/chat/common/chatService/chatService.js';
 import { IChatModel } from '../../../../contrib/chat/common/model/chatModel.js';
 import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSessions/agentSessionsService.js';
@@ -225,6 +226,12 @@ function renderBlockedList(ctx: ComponentFixtureContext, sessions: readonly ISes
 				override readonly onDidChangeProviders = Event.None;
 				override getProviders() { return []; }
 				override getProvider() { return undefined; }
+			}());
+			// `SessionsFlatList`/`SessionItemRenderer` read the voice pending-response
+			// indicator state; stub it as always-empty for the fixture.
+			reg.defineInstance(IVoicePlaybackService, new class extends mock<IVoicePlaybackService>() {
+				override readonly pendingResponseVersion: IObservable<number> = constObservable(0);
+				override hasPendingResponse() { return false; }
 			}());
 		},
 	});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8040

## Summary

Brings the **voice mode** feature — previously wired up only for the main VS Code window — to the **Agents (Sessions) window**.

The shared `VoiceSessionController` drives the chat exclusively through `_chat.voice.*` commands. In the main window these are registered by `ChatViewPane`. The Sessions window is a separate renderer with its own registries, so without per-window bridges voice would connect but transcribed text would go nowhere.

## Changes

- **`sessions.common.main.ts`** — imports `agentsVoice.contribution` (voice UI/actions/config/context keys + the mic button in `MenuId.ChatExecute`) and a new `voiceBridge.contribution`.
- **`voiceBridge.contribution.ts`** (new) — registers the `_chat.voice.acceptInput` / `getCurrentSession` / `switchToSession` command bridges (gated on `agents.voice.enabled`), wired to `ISessionsService` / `ISessionsManagementService` / `IChatWidgetService`. Also adds a listening-follow contribution that keeps hands-free listening anchored to the dictated session on switch — mirroring #325134.
- **`chatView.ts`** — renders the transcript overlay + audio-reactive glow for the active session, mirroring the main window's `ChatViewPane`.
- **`media/voiceChatView.css`** (new) — transcript overlay styles.