### PR TITLE
Style overrides: Enhance agent sessions viewer and chat viewpane styling

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -185,19 +185,15 @@
 	.agent-session-section {
 		text-transform: none;
 	}
+
+	.agent-session-item .agent-session-details-row {
+		font-size: var(--vscode-agents-fontSize-label2);
+	}
 }
 
 .style-override.monaco-workbench .chat-viewpane.has-sessions-control {
 	.agent-session-section {
 		padding-left: 12px;
-	}
-}
-
-.style-override.monaco-workbench .agent-sessions-viewer {
-	& .agent-session-item {
-		& .agent-session-details-row {
-			font-size: var(--vscode-agents-fontSize-label2);
-		}
 	}
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -180,3 +180,29 @@
 .style-override.monaco-workbench .monaco-count-badge {
 	font-weight: var(--vscode-fontWeight-semiBold);
 }
+
+.style-override.monaco-workbench .agent-sessions-viewer {
+	.agent-session-section {
+		text-transform: none;
+	}
+}
+
+.style-override.monaco-workbench .chat-viewpane.has-sessions-control {
+	.agent-session-section {
+		padding-left: 12px;
+	}
+}
+
+.style-override.monaco-workbench .agent-sessions-viewer {
+	& .agent-session-item {
+		& .agent-session-details-row {
+			font-size: var(--vscode-agents-fontSize-label2);
+		}
+	}
+}
+
+.style-override.monaco-workbench .monaco-icon-label::after,
+.style-override.monaco-workbench .explorer-folders-view .explorer-item::after {
+	margin-right: 8px;
+	font-size: var(--vscode-fontSize-label2);
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -212,3 +212,12 @@
 .style-override.monaco-workbench .part.panel .pane-body.integrated-terminal .xterm {
 	padding-bottom: var(--vscode-spacing-size80, 8px);
 }
+
+.style-override.monaco-workbench .scm-view .monaco-list-row .resource-group .actions-container,
+.style-override.monaco-workbench .scm-view .monaco-list-row .resource .actions-container {
+	gap: 2px;
+}
+
+.style-override.monaco-workbench .scm-view .monaco-list-row .resource > .name > .monaco-icon-label::after {
+	margin-right: 4px;
+}


### PR DESCRIPTION
This pull request introduces several style improvements and refinements to the UI components in the workbench. The main focus is on enhancing the appearance and spacing of elements in the agent sessions viewer, chat viewpane, and SCM view for better readability and consistency.

<img width="406" height="112" alt="image" src="https://github.com/user-attachments/assets/109f45dc-259f-4b22-8ad0-f94030aacd2e" />

<img width="386" height="485" alt="image" src="https://github.com/user-attachments/assets/5f5b1108-8d47-43e7-b583-d95c79d16669" />


**Agent Sessions and Chat UI enhancements:**
- Added styles to `.agent-sessions-viewer` and `.chat-viewpane` to remove text transformation from `.agent-session-section`, adjust padding, and set font sizes for `.agent-session-details-row` for improved readability.

**Icon and label styling:**
- Updated the appearance of `.monaco-icon-label::after` and `.explorer-item::after` by increasing right margin and font size for better visual alignment.

**SCM view spacing improvements:**
- Introduced a 2px gap between action buttons in the SCM view’s `.actions-container` and adjusted the right margin for `.monaco-icon-label::after` within resource names for more consistent spacing.