### PR TITLE
Show real Mermaid error instead of "[object Object]"

### DIFF
--- a/extensions/mermaid-markdown-features/preview-src/shared/index.ts
+++ b/extensions/mermaid-markdown-features/preview-src/shared/index.ts
@@ -14,11 +14,35 @@ import { vsCodeMermaidTheme, VsCodeMermaidThemeTracker } from './vsCodeTheme';
  * Creates the `<pre class="mermaid-error">` node shown when a diagram fails to render.
  */
 export function createMermaidErrorElement(error: unknown): HTMLElement {
-	const message = error instanceof Error ? error.message : String(error);
 	const errorMessageNode = document.createElement('pre');
 	errorMessageNode.className = 'mermaid-error';
-	errorMessageNode.innerText = message;
+	errorMessageNode.innerText = getErrorMessage(error);
 	return errorMessageNode;
+}
+
+/**
+ * Extracts a human readable message from a thrown value.
+ *
+ * Mermaid rejects parse/render failures with a plain object of the shape
+ * `{ str, message, hash, error }` rather than a real `Error` instance, so a naive
+ * `String(error)` renders the unhelpful `[object Object]` instead of the actual
+ * syntax error. Prefer a `message` (or Mermaid's `str`) property when present
+ * before falling back.
+ */
+function getErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	if (error && typeof error === 'object') {
+		const candidate = error as { message?: unknown; str?: unknown };
+		if (typeof candidate.message === 'string' && candidate.message) {
+			return candidate.message;
+		}
+		if (typeof candidate.str === 'string' && candidate.str) {
+			return candidate.str;
+		}
+	}
+	return String(error);
 }
 
 /**


### PR DESCRIPTION
Fixes #325144

When a Mermaid diagram fails to render in chat, the error box showed `[object Object]` instead of the real error, hiding why the diagram didn't render.

### Cause

The Mermaid chat webview catches render failures from `mermaid.run()` and calls `createMermaidErrorElement`. Mermaid rejects those failures with a **plain object** of shape `{ str, message, hash, error }` — not an `Error` instance. The old code:

```ts
const message = error instanceof Error ? error.message : String(error);
```

fell to `String(error)` → `[object Object]`, discarding the object's usable `.message`.

### Fix

Extract the message from non-`Error` throwables (prefer `.message`, then Mermaid's `.str`) before falling back to `String(error)`. Now the box shows the actual message, e.g.:

```
Parse error on line 1:
...A -->|create_session(workspace, prompt)|
-----------------------^
Expecting 'PIPE', 'TEXT', ... got 'PS'
```

The other call site (`renderMermaidElement`, markdown preview) uses `mermaid.parse()`, which throws a real `Error`, so it was already fine and is unchanged.

### Verification

- Reproduced the `[object Object]` throwable with mermaid 11.15.0 via `mermaid.run()`.
- Confirmed the helper returns the real message for the mermaid object, real `Error`s, plain strings, empty-`message` (falls back to `str`), and `null`.
- `tsc -p preview-src/tsconfig.json --noEmit` passes; hygiene passes.
