### PR TITLE
Fix custom-endpoint model settings colliding across providers (#325069)

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -1427,24 +1427,28 @@ export class LanguageModelsService implements ILanguageModelsService {
 		const allGroups = this._languageModelsConfigurationService.getLanguageModelsProviderGroups();
 		let group: ILanguageModelsProviderGroup | undefined;
 
-		// First try to find a group that already has config for this model.
-		group = allGroups.find(g => g.vendor === metadata.vendor && g.settings?.[metadata.id] !== undefined);
-
-		// Otherwise find the group that actually *defines* this model. Several
-		// groups can share the same `vendor` (e.g. multiple `customendpoint`
-		// providers like DeepSeek and MyCustom), so matching by vendor alone would
-		// write the config to the first group of that vendor — not the one the
-		// model belongs to. Resolve via the model→group map instead. See #322872.
-		if (!group) {
-			const vendorGroups = this._modelsGroups.get(metadata.vendor);
-			const containingGroup = vendorGroups?.find(vg => vg.modelIdentifiers.includes(modelId) && vg.group)?.group;
-			if (containingGroup) {
-				group = allGroups.find(g => g.vendor === containingGroup.vendor && g.name === containingGroup.name) ?? containingGroup;
-			}
+		// First find the group that actually *defines* this model via the
+		// model→group map. Several groups can share the same `vendor` (e.g.
+		// multiple `customendpoint` providers), and they can even declare models
+		// with the same bare `id` (e.g. two providers both exposing `gpt-5.5`).
+		// Resolving by the full model identifier — instead of the bare
+		// `metadata.id` — ensures the config is written to the group the model
+		// actually belongs to, rather than whichever group of that vendor happens
+		// to list that `id` first. See #322872 and #325069.
+		const vendorGroups = this._modelsGroups.get(metadata.vendor);
+		const containingGroup = vendorGroups?.find(vg => vg.modelIdentifiers.includes(modelId) && vg.group)?.group;
+		if (containingGroup) {
+			group = allGroups.find(g => g.vendor === containingGroup.vendor && g.name === containingGroup.name) ?? containingGroup;
 		}
 
-		// As a last resort (model not yet resolved into any group), fall back to
-		// any group for this vendor.
+		// Legacy fallback: the model was not resolved into any group (e.g. config
+		// present but the provider has not resolved its models yet). Match by
+		// vendor + existing settings for the bare id.
+		if (!group) {
+			group = allGroups.find(g => g.vendor === metadata.vendor && g.settings?.[metadata.id] !== undefined);
+		}
+
+		// As a last resort, fall back to any group for this vendor.
 		if (!group) {
 			group = allGroups.find(g => g.vendor === metadata.vendor);
 		}

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -1427,14 +1427,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 		const allGroups = this._languageModelsConfigurationService.getLanguageModelsProviderGroups();
 		let group: ILanguageModelsProviderGroup | undefined;
 
-		// First find the group that actually *defines* this model via the
-		// model→group map. Several groups can share the same `vendor` (e.g.
-		// multiple `customendpoint` providers), and they can even declare models
-		// with the same bare `id` (e.g. two providers both exposing `gpt-5.5`).
-		// Resolving by the full model identifier — instead of the bare
-		// `metadata.id` — ensures the config is written to the group the model
-		// actually belongs to, rather than whichever group of that vendor happens
-		// to list that `id` first. See #322872 and #325069.
+		// Resolve the owning provider group via the full model identifier to avoid collisions across same-vendor groups (#322872/#325069).
 		const vendorGroups = this._modelsGroups.get(metadata.vendor);
 		const containingGroup = vendorGroups?.find(vg => vg.modelIdentifiers.includes(modelId) && vg.group)?.group;
 		if (containingGroup) {

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -1275,6 +1275,122 @@ suite('LanguageModels - Per-Model Configuration with multiple same-vendor groups
 	});
 });
 
+suite('LanguageModels - Per-Model Configuration with same model id across groups (#325069)', function () {
+
+	let languageModelsService: LanguageModelsService;
+	let providerGroups: ILanguageModelsProviderGroup[];
+	const disposables = new DisposableStore();
+
+	function makeModel(group: string, id: string): { metadata: ILanguageModelChatMetadata; identifier: string } {
+		return {
+			metadata: {
+				extension: nullExtensionDescription.identifier,
+				name: id,
+				vendor: 'customendpoint',
+				family: id,
+				version: '1.0',
+				id,
+				maxInputTokens: 100,
+				maxOutputTokens: 100,
+				isDefaultForLocation: {},
+				configurationSchema: {
+					type: 'object',
+					properties: {
+						reasoningEffort: { type: 'string', default: 'medium' }
+					}
+				}
+			} satisfies ILanguageModelChatMetadata,
+			identifier: `customendpoint/${group}/${id}`
+		};
+	}
+
+	setup(async function () {
+		// Two groups sharing the same `vendor` AND the same bare model `id`.
+		providerGroups = [
+			{ vendor: 'customendpoint', name: 'ProviderA' },
+			{ vendor: 'customendpoint', name: 'ProviderB' }
+		];
+
+		languageModelsService = new LanguageModelsService(
+			new class extends mock<IExtensionService>() {
+				override activateByEvent() {
+					return Promise.resolve();
+				}
+			},
+			new NullLogService(),
+			new TestStorageService(),
+			new MockContextKeyService(),
+			new class extends mock<ILanguageModelsConfigurationService>() {
+				override onDidChangeLanguageModelGroups = Event.None;
+				override getLanguageModelsProviderGroups() {
+					return providerGroups;
+				}
+				override async updateLanguageModelsProviderGroup(from: ILanguageModelsProviderGroup, to: ILanguageModelsProviderGroup): Promise<ILanguageModelsProviderGroup> {
+					providerGroups = providerGroups.map(group => group === from ? to : group);
+					return to;
+				}
+				override async addLanguageModelsProviderGroup(group: ILanguageModelsProviderGroup): Promise<ILanguageModelsProviderGroup> {
+					providerGroups = [...providerGroups, group];
+					return group;
+				}
+			},
+			new class extends mock<IQuickInputService>() { },
+			new TestSecretStorageService(),
+			new class extends mock<IProductService>() { override readonly version = '1.100.0'; },
+			new class extends mock<IRequestService>() { },
+			new TestNotificationService(),
+			NullOpenerService,
+			NullTelemetryService,
+		);
+
+		languageModelsService.deltaLanguageModelChatProviderDescriptors([
+			{
+				vendor: 'customendpoint',
+				displayName: 'Custom Endpoint',
+				configuration: { type: 'object', properties: {} } as unknown as undefined,
+				managementCommand: undefined,
+				when: undefined
+			}
+		], []);
+
+		disposables.add(languageModelsService.registerLanguageModelProvider('customendpoint', {
+			onDidChange: Event.None,
+			provideLanguageModelChatInfo: async (options) => {
+				if (options.group === 'ProviderA' || options.group === 'ProviderB') {
+					return [makeModel(options.group, 'gpt-5.5')];
+				}
+				return [];
+			},
+			sendChatRequest: async () => { throw new Error(); },
+			provideTokenCount: async () => { throw new Error(); }
+		}));
+
+		await languageModelsService.selectLanguageModels({});
+	});
+
+	teardown(function () {
+		languageModelsService.dispose();
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('configuring one group does not contaminate another group that exposes the same model id', async function () {
+		await languageModelsService.setModelConfiguration('customendpoint/ProviderA/gpt-5.5', { reasoningEffort: 'high' });
+		await languageModelsService.setModelConfiguration('customendpoint/ProviderB/gpt-5.5', { reasoningEffort: 'low' });
+
+		const providerA = providerGroups.find(g => g.name === 'ProviderA');
+		const providerB = providerGroups.find(g => g.name === 'ProviderB');
+		assert.deepStrictEqual(
+			{ providerA: providerA?.settings, providerB: providerB?.settings },
+			{
+				providerA: { 'gpt-5.5': { reasoningEffort: 'high' } },
+				providerB: { 'gpt-5.5': { reasoningEffort: 'low' } }
+			}
+		);
+	});
+});
+
 suite('LanguageModels - Provider Group Management', function () {
 
 	class TestInputBox extends mock<IInputBox>() {


### PR DESCRIPTION
Per-model settings (thinking effort, context size, …) were keyed only by the bare model `id`, so two `customendpoint` provider groups both declaring e.g. `"id": "gpt-5.5"` would overwrite each other's settings.

**Fix**

`setModelConfiguration` now resolves the owning provider group via the full model identifier (`<vendor>/<group>/<id>`) first, falling back to the legacy `vendor + id` match only when the model isn't mapped to a group. Same-`id` models in different groups now keep independent settings — no config change or migration needed.

**Tests**

- Two same-vendor groups sharing a model `id` retain independent settings.

Fixes #325069