### PR TITLE
Allow custom endpoints to specify a wire `modelId` distinct from `id`

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2062,7 +2062,11 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "description": "Unique identifier for the model"
+                    "markdownDescription": "Unique identifier for the model within this provider group. Used to identify the model in the model picker and to key its per-model settings, so it must be unique among the models in this group. When several entries should target the same underlying model on the server, keep their `id` values distinct and set the shared model name via `modelId`."
+                  },
+                  "modelId": {
+                    "type": "string",
+                    "markdownDescription": "The model name sent to the endpoint (the `model` field in the request body). Optional; defaults to `id`. Set this when multiple models must share the same underlying model name on the server while keeping distinct, unique `id` values so their settings don't collide."
                   },
                   "name": {
                     "type": "string",

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -90,6 +90,14 @@ interface _CustomEndpointModelConfig {
 	name: string;
 	url: string;
 	apiType?: CustomEndpointApiType;
+	/**
+	 * Optional model name sent on the wire (the `model` field in the request body).
+	 * When unset the model's {@link CustomEndpointModelConfig.id} is used. Specify
+	 * this when several models must share the same underlying model name while
+	 * keeping distinct, unique `id`s (e.g. two entries pointing at the same
+	 * `gpt-5.5` model but with different settings).
+	 */
+	modelId?: string;
 	/** Optional when {@link contextWindow} is set; then derived as `contextWindow - maxOutputTokens`. */
 	maxInputTokens?: number;
 	maxOutputTokens: number;
@@ -169,7 +177,13 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 			supportsReasoningEffort: modelConfiguration?.supportsReasoningEffort,
 			reasoningEffortFormat: modelConfiguration?.reasoningEffortFormat
 		};
-		const modelInfo = resolveModelInfo(model.id, this._name, undefined, modelCapabilities);
+		// The registered model identity (unique `id`) is what other components see
+		// (model picker, per-model settings). Only the request to the endpoint needs
+		// the actual wire model name, so resolve it here when a distinct `modelId`
+		// is configured; otherwise the unique `id` doubles as the wire name. This
+		// keeps the wire name contained to the custom endpoint. See #325069.
+		const wireModelId = modelConfiguration?.modelId ?? model.id;
+		const modelInfo = resolveModelInfo(wireModelId, this._name, undefined, modelCapabilities);
 		const supportedEndpoints = apiTypeToSupportedEndpoints(apiType);
 		if (supportedEndpoints) {
 			modelInfo.supported_endpoints = supportedEndpoints;

--- a/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
@@ -14,7 +14,9 @@ import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
-import { CustomEndpointOAIEndpoint, hasExplicitApiPath, resolveCustomEndpointUrl } from '../customEndpointProvider';
+import { OpenAICompatibleLanguageModelChatInformation } from '../abstractLanguageModelChatProvider';
+import { CustomEndpointBYOKModelProvider, CustomEndpointModelConfig, CustomEndpointModelProviderConfig, CustomEndpointOAIEndpoint, hasExplicitApiPath, resolveCustomEndpointUrl } from '../customEndpointProvider';
+import { IBYOKStorageService } from '../byokStorageService';
 
 describe('CustomEndpointBYOKModelProvider', () => {
 	const disposables = new DisposableStore();
@@ -577,6 +579,61 @@ describe('CustomEndpointBYOKModelProvider', () => {
 			expect(messages[0].reasoning_content).toBe('I should read the README before answering.');
 			expect(messages[0].reasoning).toBe('I should read the README before answering.');
 			expect(messages[0].cot_summary).toBe('I should read the README before answering.');
+		});
+	});
+
+	describe('createOpenAIEndPoint', () => {
+		class TestCustomEndpointProvider extends CustomEndpointBYOKModelProvider {
+			public createEndpointForTest(model: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>) {
+				return this.createOpenAIEndPoint(model);
+			}
+		}
+
+		const storageStub: IBYOKStorageService = {
+			getAPIKey: async () => undefined,
+			storeAPIKey: async () => { },
+			deleteAPIKey: async () => { },
+			getStoredModelConfigs: async () => ({}),
+			saveModelConfig: async () => { },
+			removeModelConfig: async () => { },
+		};
+
+		function makeProviderModel(id: string, models: CustomEndpointModelConfig[]): OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig> {
+			const cfg = models.find(m => m.id === id)!;
+			return {
+				id,
+				name: cfg.name,
+				family: id,
+				version: '1.0',
+				maxInputTokens: 100,
+				maxOutputTokens: cfg.maxOutputTokens,
+				capabilities: { toolCalling: cfg.toolCalling, imageInput: cfg.vision },
+				url: cfg.url,
+				configuration: { apiKey: 'test-api-key', models },
+			};
+		}
+
+		// Regression for https://github.com/microsoft/vscode/issues/325069
+		// A custom model can target a wire model name distinct from its unique `id`,
+		// so several entries with unique `id`s can share the same underlying model.
+		// The wire name stays contained to the endpoint request; only the unique
+		// `id` is exposed to the rest of the system.
+		it('issue #325069: sends modelId as the wire model when set, and the unique id otherwise', async () => {
+			const models: CustomEndpointModelConfig[] = [
+				{ id: 'gpt-5.5-a', modelId: 'gpt-5.5', name: 'A', url: 'https://api.example.com/v1/chat/completions', toolCalling: true, vision: false, maxOutputTokens: 100 },
+				{ id: 'gpt-5.5-b', name: 'B', url: 'https://api.example.com/v1/chat/completions', toolCalling: true, vision: false, maxOutputTokens: 100 },
+			];
+			const provider = instaService.createInstance(TestCustomEndpointProvider, storageStub);
+			const withOverride = await provider.createEndpointForTest(makeProviderModel('gpt-5.5-a', models));
+			const withoutOverride = await provider.createEndpointForTest(makeProviderModel('gpt-5.5-b', models));
+
+			expect({
+				overrideModel: withOverride.model,
+				fallbackModel: withoutOverride.model,
+			}).toEqual({
+				overrideModel: 'gpt-5.5',
+				fallbackModel: 'gpt-5.5-b',
+			});
 		});
 	});
 });


### PR DESCRIPTION
Adds an optional `modelId` field to `customendpoint` model configs. It lets several entries with distinct, unique `id`s target the same underlying wire model name.

**Change**

- New `modelId` (optional) on custom-endpoint models. Resolved inside `createOpenAIEndPoint` and used only for the request's wire `model` — it does not leak into shared model metadata. Defaults to `id` when omitted.
- `id` stays the unique identity used for the model picker and per-model settings.

**Tests**

- `modelId` is sent as the wire model when set, and the unique `id` otherwise.