### PR TITLE
sessions: add get_session_context tool + list_sessions single-session lookup

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -29,7 +29,7 @@ import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } f
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, ResourceChangeType, ResourceType, ResourceWriteMode, type CreateResourceWatchParams, type CreateResourceWatchResult, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWatchState, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { ChangesSummary, ChatInteractivity, ChatOriginKind, MessageAttachmentKind, type Message, type MessageAttachment, type MessageResourceAttachment } from '../common/state/protocol/state.js';
 import type { ChatPendingMessageSetAction, ChatTurnStartedAction } from '../common/state/protocol/actions.js';
-import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isSubagentSession, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, readSessionWorkspaceless, withSessionGitHubState, withSessionGitState, withSessionWorkspaceless, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
+import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, buildChatUri, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isSubagentSession, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, readSessionWorkspaceless, withSessionGitHubState, withSessionGitState, withSessionWorkspaceless, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
 import { IProductService } from '../../product/common/productService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostTerminalManager, IAgentHostTerminalManager } from './agentHostTerminalManager.js';
@@ -41,7 +41,7 @@ import { AgentSideEffects } from './agentSideEffects.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentServerToolHost } from './shared/agentServerToolHost.js';
 import { buildServerToolGroups } from './shared/serverToolGroups.js';
-import { type ISessionServerToolAccessor } from './shared/sessionServerTools.js';
+import { type IChatContextSnapshot, type ISessionServerToolAccessor } from './shared/sessionServerTools.js';
 import { AgentHostChangesetService } from './agentHostChangesetService.js';
 import { AgentHostFileMonitorService, IAgentHostFileMonitorService } from './agentHostFileMonitorService.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../common/agentHostCheckpointService.js';
@@ -559,6 +559,7 @@ export class AgentService extends Disposable implements IAgentService {
 				? { ...(options.title !== undefined ? { title: options.title } : {}), ...(options.model !== undefined ? { model: { id: options.model.id } } : {}) }
 				: undefined),
 			deleteSession: session => this.disposeSession(session),
+			getChatContext: (session, chatId) => this._getChatContext(session, chatId),
 			// Reads the `create_session` spawn depth from a session's `_meta` (0 when absent).
 			getSessionSpawnDepth: session => readSessionSpawnDepth(this._stateManager.getSessionSummary(session.toString())?._meta),
 			// Stamps a session's `create_session` spawn depth into its `_meta` (merging existing keys).
@@ -579,6 +580,26 @@ export class AgentService extends Disposable implements IAgentService {
 		const action = { type: ActionType.ChatTurnStarted, turnId: generateUuid(), message } as const;
 		this._stateManager.dispatchServerAction(chat.toString(), action);
 		this._sideEffects.handleAction(chat.toString(), action);
+	}
+
+	/**
+	 * Reads a point-in-time snapshot of a session's chat conversation for the
+	 * `get_session_context` server tool. Targets the session's default chat, or a
+	 * specific peer chat when `chatId` is provided. Returns `undefined` when no
+	 * live conversation state exists (e.g. a cold/unsubscribed session).
+	 */
+	private _getChatContext(session: URI, chatId?: string): IChatContextSnapshot | undefined {
+		const chatState = chatId
+			? this._stateManager.getChatState(buildChatUri(session.toString(), chatId))
+			: this._stateManager.getDefaultChatState(session.toString());
+		if (!chatState) {
+			return undefined;
+		}
+		return {
+			turns: chatState.turns,
+			...(chatState.activeTurn ? { activeTurn: { message: chatState.activeTurn.message, responseParts: chatState.activeTurn.responseParts } } : {}),
+			hasMoreHistory: !!chatState.turnsNextCursor,
+		};
 	}
 
 	async listSessions(): Promise<IAgentSessionMetadata[]> {

--- a/src/vs/platform/agentHost/node/shared/sessionServerTools.ts
+++ b/src/vs/platform/agentHost/node/shared/sessionServerTools.ts
@@ -8,7 +8,7 @@ import type { Mutable } from '../../../../base/common/types.js';
 import { localize } from '../../../../nls.js';
 import type { IAgentCreateSessionConfig, IAgentModelInfo, IAgentSessionMetadata } from '../../common/agentService.js';
 import { SessionStatus } from '../../common/state/protocol/channels-session/state.js';
-import { buildChatUri, buildDefaultChatUri, parseChatUri, readSessionGitState, readSessionGitHubState, type ToolDefinition, type StringOrMarkdown, type URI as ProtocolURI } from '../../common/state/sessionState.js';
+import { buildChatUri, buildDefaultChatUri, parseChatUri, readSessionGitState, readSessionGitHubState, ResponsePartKind, ToolCallStatus, TurnState, type Message, type ResponsePart, type ToolCallState, type ToolDefinition, type StringOrMarkdown, type Turn, type URI as ProtocolURI } from '../../common/state/sessionState.js';
 import { buildOpenSessionLinkUri, CREATE_CHAT_TOOL_NAME, CREATE_SESSION_TOOL_NAME, parseOpenSessionLinkChatId, parseOpenSessionLinkUri, SEND_MESSAGE_TOOL_NAME } from '../../common/openSessionLink.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import type { AgentHostStateManager } from '../agentHostStateManager.js';
@@ -19,6 +19,7 @@ export const getCurrentSessionToolName = 'get_current_session';
 export const createSessionToolName = CREATE_SESSION_TOOL_NAME;
 export const createChatToolName = CREATE_CHAT_TOOL_NAME;
 export const sendMessageToolName = SEND_MESSAGE_TOOL_NAME;
+export const getSessionContextToolName = 'get_session_context';
 export const deleteSessionToolName = 'delete_session';
 
 /**
@@ -49,6 +50,7 @@ const listSessionsStatusValues = ['idle', 'inProgress', 'inputNeeded', 'error', 
 const listSessionsInputSchema: ToolDefinition['inputSchema'] = {
 	type: 'object',
 	properties: {
+		session: { type: 'string', description: 'Return only the session with this URI or `agent-host-session://` link (a direct lookup that ignores the other filters). Use this to fetch one known session\'s metadata.' },
 		status: {
 			type: 'array',
 			items: { type: 'string', enum: [...listSessionsStatusValues] },
@@ -107,12 +109,28 @@ const sendMessageInputSchema: ToolDefinition['inputSchema'] = {
 	required: ['session', 'message'],
 };
 
+const sessionContextDetailValues = ['summary', 'digest', 'full'] as const;
+
+const getSessionContextInputSchema: ToolDefinition['inputSchema'] = {
+	type: 'object',
+	properties: {
+		session: { type: 'string', description: 'The session or chat to read: a session URI from `list_sessions`, or an `agent-host-session://` link (a `create_chat` link targets that specific chat).' },
+		detail: {
+			type: 'string',
+			enum: [...sessionContextDetailValues],
+			description: 'How much conversation detail to return. `summary` (default): status and a short per-turn gist (the message plus a compact snippet of the reply). `digest`: adds the full assistant reply text and tool-call names. `full`: adds tool-call inputs. Higher levels return more tokens.',
+		},
+		transcriptLimit: { type: 'number', description: 'Maximum number of most-recent turns to include. Defaults to 10; capped at 50.' },
+	},
+	required: ['session'],
+};
+
 /** Protocol tool definitions for the session-management server tools. */
 export const sessionServerToolDefinitions: ToolDefinition[] = [
 	{
 		name: listSessionsToolName,
 		title: 'List Sessions',
-		description: 'List sessions and their compact metadata (status, activity, working directory, project, worktree changes, git/GitHub info, timestamps). By default archived sessions are omitted. Optionally filter by `status`, `workspace`, `withChanges`, `unread`, `withPullRequest`, `includeArchived`, `createdAfter`, or `createdBefore`.',
+		description: 'List sessions and their compact metadata (status, activity, working directory, project, worktree changes, git/GitHub info, timestamps). Pass `session` to fetch a single known session by URI. By default archived sessions are omitted. Optionally filter by `status`, `workspace`, `withChanges`, `unread`, `withPullRequest`, `includeArchived`, `createdAfter`, or `createdBefore`.',
 		inputSchema: listSessionsInputSchema,
 		annotations: { readOnlyHint: true },
 	},
@@ -143,6 +161,13 @@ export const sessionServerToolDefinitions: ToolDefinition[] = [
 		description: 'Send a message to an existing session or chat, starting a new turn there. Provide a session URI from `list_sessions` or an `agent-host-session://` link (a `create_chat` link targets that specific chat). The message is delivered asynchronously — this tool does not wait for or return the reply. The UI shows a confirmation with a button to open the target, so reply with a single short sentence and do NOT print the URL or tell the user to click a button.',
 		inputSchema: sendMessageInputSchema,
 		annotations: { readOnlyHint: false },
+	},
+	{
+		name: getSessionContextToolName,
+		title: 'Get Session Context',
+		description: 'Read the recent conversation of an existing session or chat: a compacted transcript of its turns (messages, replies, and tool calls). Use this to see what a session you created is doing, or to gather context before sending it a message. Returns a compacted summary by default (`detail: "summary"`); request `digest` or `full` for more detail. For session metadata (status, working directory, changes, …) use `list_sessions` with the `session` argument.',
+		inputSchema: getSessionContextInputSchema,
+		annotations: { readOnlyHint: true },
 	},
 	{
 		name: deleteSessionToolName,
@@ -179,10 +204,22 @@ export interface ISessionServerToolAccessor {
 	readonly startPrompt: (session: URI, chat: URI, prompt: string) => Promise<void>;
 	readonly createChat: (session: URI, chat: URI, options?: { title?: string; model?: IAgentModelInfo }) => Promise<void>;
 	readonly deleteSession: (session: URI) => Promise<void>;
+	/** Reads a point-in-time snapshot of a session's chat conversation (default chat, or a specific chat by id). */
+	readonly getChatContext: (session: URI, chatId?: string) => IChatContextSnapshot | undefined;
 	/** The spawn depth of a session (0 for a user/top-level session, N for one created N levels deep by `create_session`). */
 	readonly getSessionSpawnDepth: (session: URI) => number;
 	/** Records the spawn depth of a freshly-created session so its own `create_session` calls can enforce the recursion limit. */
 	readonly setSessionSpawnDepth: (session: URI, depth: number) => void;
+}
+
+/** Point-in-time snapshot of a chat's conversation, read from the host state. */
+export interface IChatContextSnapshot {
+	/** Completed turns, oldest first. */
+	readonly turns: readonly Turn[];
+	/** The in-progress turn, if the chat is mid-response. */
+	readonly activeTurn?: Pick<Turn, 'message' | 'responseParts'>;
+	/** `true` when older completed turns exist beyond the in-memory window. */
+	readonly hasMoreHistory: boolean;
 }
 
 interface ISerializedGitState {
@@ -316,6 +353,8 @@ function describeSessionStatus(status: SessionStatus): string {
 
 /** Filters accepted by `list_sessions` to narrow the returned set. */
 export interface IListSessionsArgs {
+	/** Direct lookup: return only the session with this URI / open link, ignoring all other filters. */
+	readonly session?: string;
 	readonly status?: ReadonlySet<string>;
 	readonly workspace?: string;
 	readonly withChanges?: boolean;
@@ -354,7 +393,7 @@ function getOptionalTimestamp(value: unknown, field: string, toolName: string): 
 
 /** Validates and normalizes the optional `list_sessions` filter arguments. */
 export function getListSessionsArgs(rawArgs: unknown): IListSessionsArgs {
-	const args = (rawArgs ?? {}) as { status?: unknown; workspace?: unknown; withChanges?: unknown; unread?: unknown; withPullRequest?: unknown; includeArchived?: unknown; createdAfter?: unknown; createdBefore?: unknown };
+	const args = (rawArgs ?? {}) as { session?: unknown; status?: unknown; workspace?: unknown; withChanges?: unknown; unread?: unknown; withPullRequest?: unknown; includeArchived?: unknown; createdAfter?: unknown; createdBefore?: unknown };
 
 	let status: Set<string> | undefined;
 	if (args.status !== undefined) {
@@ -369,6 +408,7 @@ export function getListSessionsArgs(rawArgs: unknown): IListSessionsArgs {
 	}
 
 	return {
+		session: getOptionalString(args.session, 'session', listSessionsToolName),
 		status,
 		workspace: getOptionalString(args.workspace, 'workspace', listSessionsToolName),
 		withChanges: getOptionalBoolean(args.withChanges, 'withChanges', listSessionsToolName),
@@ -406,6 +446,12 @@ function sessionMatchesWorkspace(session: IAgentSessionMetadata, workspace: stri
 
 /** Applies the {@link IListSessionsArgs} filters to a set of sessions. */
 export function filterSessions(sessions: readonly IAgentSessionMetadata[], args: IListSessionsArgs): readonly IAgentSessionMetadata[] {
+	// A direct `session` lookup returns just that session, bypassing the other
+	// filters (including the default archived exclusion).
+	if (args.session !== undefined) {
+		const target = parseOpenSessionLinkUri(args.session)?.toString() ?? args.session;
+		return sessions.filter(session => session.session.toString() === target);
+	}
 	return sessions.filter(session => {
 		if (args.status) {
 			const names = session.status !== undefined ? describeSessionStatus(session.status).split(',') : [];
@@ -664,6 +710,192 @@ export function formatSendMessageResult(openLink: string): string {
 	return `Message sent (${openLink}). Reply with one short sentence confirming the message was sent; do not print the URL or mention a button.`;
 }
 
+// --- get_session_context -----------------------------------------------------
+
+type SessionContextDetail = (typeof sessionContextDetailValues)[number];
+
+const defaultTranscriptLimit = 10;
+const maxTranscriptLimit = 50;
+
+/** Per-detail truncation caps (characters); a value of 0 omits the field. */
+const contextCaps: Record<SessionContextDetail, { user: number; assistant: number; toolInput: number }> = {
+	// `summary` still carries a short assistant gist per turn so the reader sees
+	// what each turn actually did, not just what was asked.
+	summary: { user: 160, assistant: 140, toolInput: 0 },
+	digest: { user: 300, assistant: 800, toolInput: 0 },
+	full: { user: 1000, assistant: 2000, toolInput: 200 },
+};
+
+interface ISessionContextArgs {
+	readonly session?: unknown;
+	readonly detail?: unknown;
+	readonly transcriptLimit?: unknown;
+}
+
+export interface IResolvedSessionContextArgs {
+	readonly session: URI;
+	readonly chatId?: string;
+	readonly detail: SessionContextDetail;
+	readonly transcriptLimit: number;
+}
+
+/** Validates and resolves get-session-context arguments against the known sessions. */
+export function getSessionContextArgs(rawArgs: unknown, sessions: readonly IAgentSessionMetadata[]): IResolvedSessionContextArgs {
+	const args = (rawArgs ?? {}) as ISessionContextArgs;
+	const sessionInput = getRequiredString(args.session, 'session', getSessionContextToolName);
+	const session = resolveKnownSession(sessionInput, sessions);
+	if (!session) {
+		throw new Error(`Invalid ${getSessionContextToolName} input: session must match the URI of a known session (see list_sessions).`);
+	}
+	let detail: SessionContextDetail = 'summary';
+	if (args.detail !== undefined) {
+		if (typeof args.detail !== 'string' || !(sessionContextDetailValues as readonly string[]).includes(args.detail)) {
+			throw new Error(`Invalid ${getSessionContextToolName} input: detail must be one of ${sessionContextDetailValues.join(', ')}.`);
+		}
+		detail = args.detail as SessionContextDetail;
+	}
+	let transcriptLimit = defaultTranscriptLimit;
+	if (args.transcriptLimit !== undefined) {
+		if (typeof args.transcriptLimit !== 'number' || !Number.isFinite(args.transcriptLimit) || args.transcriptLimit < 1) {
+			throw new Error(`Invalid ${getSessionContextToolName} input: transcriptLimit must be a positive number.`);
+		}
+		transcriptLimit = Math.min(Math.floor(args.transcriptLimit), maxTranscriptLimit);
+	}
+	const chatId = parseOpenSessionLinkChatId(sessionInput);
+	return { session, detail, transcriptLimit, ...(chatId !== undefined ? { chatId } : {}) };
+}
+
+/** Truncates {@link text} to {@link max} characters, appending an ellipsis when cut. */
+function truncateText(text: string, max: number): { text: string; truncated: boolean } {
+	const trimmed = text.trim();
+	if (trimmed.length <= max) {
+		return { text: trimmed, truncated: false };
+	}
+	return { text: `${trimmed.slice(0, Math.max(0, max - 1))}…`, truncated: true };
+}
+
+/** Reads the tool-call parts of a turn, newest-emitted last. */
+function toolCallsOf(parts: readonly ResponsePart[]): ToolCallState[] {
+	return parts.filter((p): p is Extract<ResponsePart, { kind: ResponsePartKind.ToolCall }> => p.kind === ResponsePartKind.ToolCall).map(p => p.toolCall);
+}
+
+/** Concatenated markdown text of a turn's response, in stream order. */
+function assistantTextOf(parts: readonly ResponsePart[]): string {
+	return parts.filter((p): p is Extract<ResponsePart, { kind: ResponsePartKind.Markdown }> => p.kind === ResponsePartKind.Markdown).map(p => p.content).join('').trim();
+}
+
+/** Reads a tool call's JSON input string, which is absent while still streaming. */
+function readToolInput(tc: ToolCallState): string | undefined {
+	return tc.status === ToolCallStatus.Streaming ? undefined : tc.toolInput;
+}
+
+interface ISerializedContextTurn {
+	readonly turn: number;
+	readonly state: string;
+	readonly user?: string;
+	readonly assistant?: string;
+	readonly toolCalls?: readonly (string | { readonly name: string; readonly input?: string })[];
+}
+
+/** Maps a {@link TurnState} (or the in-progress active turn) to a display string. */
+function describeTurnState(state: TurnState | 'inProgress'): string {
+	switch (state) {
+		case TurnState.Complete: return 'complete';
+		case TurnState.Cancelled: return 'cancelled';
+		case TurnState.Error: return 'error';
+		default: return 'inProgress';
+	}
+}
+
+interface ISerializedSessionContext {
+	readonly session: string;
+	readonly openLink: string;
+	readonly detail: SessionContextDetail;
+	readonly transcript: readonly ISerializedContextTurn[];
+	readonly hasMoreHistory: boolean;
+	/** `true` when turns were dropped from the window or any field was shortened. */
+	readonly truncated: boolean;
+}
+
+/** Builds the compacted, model-facing session-context payload from a snapshot. */
+export function serializeSessionContext(session: URI, chatId: string | undefined, snapshot: IChatContextSnapshot, detail: SessionContextDetail, transcriptLimit: number): string {
+	const caps = contextCaps[detail];
+	let truncated = false;
+	const trunc = (text: string, max: number): string | undefined => {
+		if (max <= 0 || !text) {
+			return undefined;
+		}
+		const result = truncateText(text, max);
+		truncated = truncated || result.truncated;
+		return result.text || undefined;
+	};
+
+	const entries: { message: Message; parts: readonly ResponsePart[]; state: TurnState | 'inProgress' }[] =
+		snapshot.turns.map(t => ({ message: t.message, parts: t.responseParts, state: t.state }));
+	if (snapshot.activeTurn) {
+		entries.push({ message: snapshot.activeTurn.message, parts: snapshot.activeTurn.responseParts, state: 'inProgress' });
+	}
+	if (entries.length > transcriptLimit) {
+		truncated = true;
+	}
+	const windowStart = Math.max(0, entries.length - transcriptLimit);
+	const windowed = entries.slice(windowStart);
+
+	const transcript: ISerializedContextTurn[] = windowed.map((entry, index): ISerializedContextTurn => {
+		const user = trunc(entry.message.text, caps.user);
+		const assistant = trunc(assistantTextOf(entry.parts), caps.assistant);
+		const toolCalls = toolCallsOf(entry.parts);
+		let serializedToolCalls: (string | { name: string; input?: string })[] | undefined;
+		if (detail !== 'summary' && toolCalls.length > 0) {
+			serializedToolCalls = toolCalls.map(tc => {
+				if (caps.toolInput > 0) {
+					const input = trunc(readToolInput(tc) ?? '', caps.toolInput);
+					return input !== undefined ? { name: tc.toolName, input } : { name: tc.toolName };
+				}
+				return tc.toolName;
+			});
+		}
+		return {
+			turn: windowStart + index + 1,
+			state: describeTurnState(entry.state),
+			...(user !== undefined ? { user } : {}),
+			...(assistant !== undefined ? { assistant } : {}),
+			...(serializedToolCalls ? { toolCalls: serializedToolCalls } : {}),
+		};
+	});
+
+	const payload: ISerializedSessionContext = {
+		session: session.toString(),
+		openLink: buildOpenSessionLinkUri(session, chatId),
+		detail,
+		transcript,
+		hasMoreHistory: snapshot.hasMoreHistory,
+		truncated,
+	};
+	return JSON.stringify(payload);
+}
+
+/** Reads and serializes the context of an existing session/chat. */
+export async function applyGetSessionContextTool(accessor: ISessionServerToolAccessor, rawArgs: unknown): Promise<string> {
+	const sessions = await accessor.listSessions();
+	const { session, chatId, detail, transcriptLimit } = getSessionContextArgs(rawArgs, sessions);
+	const snapshot = accessor.getChatContext(session, chatId);
+	if (!snapshot) {
+		// No live conversation state (e.g. a cold/unsubscribed session): return the
+		// identity + an empty transcript. Metadata is available via list_sessions.
+		return JSON.stringify({
+			session: session.toString(),
+			openLink: buildOpenSessionLinkUri(session, chatId),
+			detail,
+			transcript: [],
+			hasMoreHistory: false,
+			truncated: false,
+		} satisfies ISerializedSessionContext);
+	}
+	return serializeSessionContext(session, chatId, snapshot, detail, transcriptLimit);
+}
+
+
 /** Serializes the current session's metadata + open link as the `get_current_session` result. */
 export function serializeCurrentSession(currentSession: URI, sessions: readonly IAgentSessionMetadata[]): string {
 	const meta = sessions.find(s => s.session.toString() === currentSession.toString());
@@ -752,6 +984,12 @@ function getSessionToolDisplay(toolName: string, _args: unknown, result?: IServe
 				invocationMessage: localize('toolInvoke.sendMessage', "Sending message"),
 				pastTenseMessage: localize('toolComplete.sendMessage', "Sent message"),
 			};
+		case getSessionContextToolName:
+			return {
+				displayName: localize('toolName.getSessionContext', "Get Session Context"),
+				invocationMessage: localize('toolInvoke.getSessionContext', "Reading session context"),
+				pastTenseMessage: localize('toolComplete.getSessionContext', "Read session context"),
+			};
 		case getCurrentSessionToolName:
 			return {
 				displayName: localize('toolName.getCurrentSession', "Get Current Session"),
@@ -823,6 +1061,8 @@ export function createSessionServerToolGroup(accessor?: ISessionServerToolAccess
 					sentMessageCount++;
 					return result;
 				}
+				case getSessionContextToolName:
+					return applyGetSessionContextTool(accessor, rawArgs);
 				case deleteSessionToolName:
 					return applyDeleteSessionTool(accessor, rawArgs, currentSessionUri(sessionUri));
 				default:

--- a/src/vs/platform/agentHost/test/node/serverToolGroups.test.ts
+++ b/src/vs/platform/agentHost/test/node/serverToolGroups.test.ts
@@ -50,6 +50,7 @@ suite('serverToolGroups display', () => {
 			create: display('create_session'),
 			chat: display('create_chat'),
 			send: display('send_message'),
+			context: display('get_session_context'),
 			del: display('delete_session'),
 		}, {
 			list: { displayName: 'List Sessions', invocation: 'Checking sessions' },
@@ -57,6 +58,7 @@ suite('serverToolGroups display', () => {
 			create: { displayName: 'Create Session', invocation: 'Creating session' },
 			chat: { displayName: 'Create Chat', invocation: 'Creating chat' },
 			send: { displayName: 'Send Message', invocation: 'Sending message' },
+			context: { displayName: 'Get Session Context', invocation: 'Reading session context' },
 			del: { displayName: 'Delete Session', invocation: 'Deleting session' },
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
@@ -10,7 +10,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { NullLogService } from '../../../log/common/log.js';
 import type { IAgentCreateSessionConfig, IAgentModelInfo, IAgentSessionMetadata } from '../../common/agentService.js';
 import { SessionStatus } from '../../common/state/protocol/channels-session/state.js';
-import { buildChatUri, buildDefaultChatUri, withSessionGitState, withSessionGitHubState } from '../../common/state/sessionState.js';
+import { buildChatUri, buildDefaultChatUri, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, TurnState, withSessionGitState, withSessionGitHubState, type ResponsePart, type ToolCallState, type Turn } from '../../common/state/sessionState.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import {
 	applyCreateChatTool,
@@ -25,6 +25,9 @@ import {
 	getCurrentSessionToolName,
 	getDeleteSessionArgs,
 	getSendMessageArgs,
+	getSessionContextArgs,
+	serializeSessionContext,
+	getSessionContextToolName,
 	filterSessions,
 	getListSessionsArgs,
 	listSessionsToolName,
@@ -32,6 +35,7 @@ import {
 	sessionServerToolDefinitions,
 	sessionToolRequiresConfirmation,
 	serializeSessions,
+	type IChatContextSnapshot,
 	type ISessionServerToolAccessor,
 } from '../../node/shared/sessionServerTools.js';
 
@@ -55,19 +59,21 @@ suite('SessionServerTools', () => {
 			startPrompt: overrides?.startPrompt ?? (async (session, chat, prompt) => { overrides?.onPrompt?.(session, chat, prompt); }),
 			createChat: overrides?.createChat ?? (async (session, chat, options) => { overrides?.onCreateChat?.(session, chat, options); }),
 			deleteSession: overrides?.deleteSession ?? (async session => { overrides?.onDelete?.(session); }),
+			getChatContext: overrides?.getChatContext ?? (() => undefined),
 			getSessionSpawnDepth: overrides?.getSessionSpawnDepth ?? (session => depths.get(session.toString()) ?? 0),
 			setSessionSpawnDepth: overrides?.setSessionSpawnDepth ?? ((session, depth) => { depths.set(session.toString(), depth); }),
 		};
 	}
 
 	test('definitions and confirmation', () => {
-		assert.deepStrictEqual(sessionServerToolDefinitions.map(d => d.name), [listSessionsToolName, getCurrentSessionToolName, createSessionToolName, createChatToolName, sendMessageToolName, deleteSessionToolName]);
+		assert.deepStrictEqual(sessionServerToolDefinitions.map(d => d.name), [listSessionsToolName, getCurrentSessionToolName, createSessionToolName, createChatToolName, sendMessageToolName, getSessionContextToolName, deleteSessionToolName]);
 		assert.strictEqual(sessionToolRequiresConfirmation(createSessionToolName), true);
 		assert.strictEqual(sessionToolRequiresConfirmation(createChatToolName), true);
 		assert.strictEqual(sessionToolRequiresConfirmation(sendMessageToolName), true);
 		assert.strictEqual(sessionToolRequiresConfirmation(deleteSessionToolName), true);
 		assert.strictEqual(sessionToolRequiresConfirmation(listSessionsToolName), false);
 		assert.strictEqual(sessionToolRequiresConfirmation(getCurrentSessionToolName), false);
+		assert.strictEqual(sessionToolRequiresConfirmation(getSessionContextToolName), false);
 	});
 
 	test('serializeSessions produces compact metadata', () => {
@@ -206,12 +212,30 @@ suite('SessionServerTools', () => {
 	});
 
 	test('getListSessionsArgs validates filter input', () => {
-		assert.deepStrictEqual(getListSessionsArgs({}), { status: undefined, workspace: undefined, withChanges: undefined, unread: undefined, withPullRequest: undefined, includeArchived: undefined, createdAfter: undefined, createdBefore: undefined });
+		assert.deepStrictEqual(getListSessionsArgs({}), { session: undefined, status: undefined, workspace: undefined, withChanges: undefined, unread: undefined, withPullRequest: undefined, includeArchived: undefined, createdAfter: undefined, createdBefore: undefined });
 		assert.throws(() => getListSessionsArgs({ status: ['bogus'] }), /status/);
 		assert.throws(() => getListSessionsArgs({ withChanges: 'yes' }), /withChanges/);
 		assert.throws(() => getListSessionsArgs({ includeArchived: 'no' }), /includeArchived/);
 		assert.throws(() => getListSessionsArgs({ createdAfter: 'not-a-date' }), /createdAfter/);
 		assert.strictEqual(filterSessions([sessionMeta('s1', SessionStatus.Idle, workspace)], getListSessionsArgs({})).length, 1);
+	});
+
+	test('list_sessions fetches a single session by URI or open link, bypassing other filters', () => {
+		const archived = { ...sessionMeta('archived', SessionStatus.Idle, workspace), isArchived: true };
+		const sessions = [sessionMeta('s1', SessionStatus.Idle, workspace), archived];
+		const ids = (args: object) => filterSessions(sessions, getListSessionsArgs(args)).map(s => s.session.toString());
+		assert.deepStrictEqual({
+			byUri: ids({ session: 'copilot:/s1' }),
+			byLink: ids({ session: 'agent-host-session://copilot/s1' }),
+			// A direct lookup returns an archived session even though archived are hidden by default.
+			archivedByUri: ids({ session: 'copilot:/archived' }),
+			unknown: ids({ session: 'copilot:/nope' }),
+		}, {
+			byUri: ['copilot:/s1'],
+			byLink: ['copilot:/s1'],
+			archivedByUri: ['copilot:/archived'],
+			unknown: [],
+		});
 	});
 
 	test('create_session stamps spawn depth and enforces the recursion depth limit', async () => {
@@ -306,6 +330,79 @@ suite('SessionServerTools', () => {
 		await assert.rejects(() => applySendMessageTool(accessor, { session: 'copilot:/nope', message: 'x' }, currentChannel), /known session/);
 		assert.throws(() => getSendMessageArgs({ message: 'x' }, []), /session/);
 		assert.throws(() => getSendMessageArgs({ session: 'copilot:/s2' }, []), /message/);
+	});
+
+	suite('get_session_context', () => {
+		const toolCall = (toolName: string, input: object): ToolCallState => ({
+			toolCallId: 't', toolName, displayName: toolName,
+			invocationMessage: '', toolInput: JSON.stringify(input),
+			status: ToolCallStatus.Completed, confirmed: ToolCallConfirmationReason.NotNeeded,
+			success: true, pastTenseMessage: '',
+		});
+		const md = (content: string): ResponsePart => ({ kind: ResponsePartKind.Markdown, id: 'm', content });
+		const toolPart = (tc: ToolCallState): ResponsePart => ({ kind: ResponsePartKind.ToolCall, toolCall: tc });
+		const turn = (id: string, user: string, parts: ResponsePart[], state = TurnState.Complete): Turn =>
+			({ id, message: { text: user, origin: { kind: MessageKind.User } }, responseParts: parts, usage: undefined, state });
+
+		const snapshot: IChatContextSnapshot = {
+			turns: [
+				turn('t1', 'do the thing', [toolPart(toolCall('read_file', { path: 'a.ts' })), md('Working on it.')]),
+				turn('t2', 'now finish it', [toolPart(toolCall('apply_patch', { patch: '@@' })), md('Here is the result.')]),
+			],
+			hasMoreHistory: true,
+		};
+
+		test('summary returns per-turn gists (message + reply snippet), no tool calls', () => {
+			assert.deepStrictEqual(JSON.parse(serializeSessionContext(URI.parse('copilot:/s1'), undefined, snapshot, 'summary', 10)), {
+				session: 'copilot:/s1',
+				openLink: 'agent-host-session://copilot/s1',
+				detail: 'summary',
+				transcript: [
+					{ turn: 1, state: 'complete', user: 'do the thing', assistant: 'Working on it.' },
+					{ turn: 2, state: 'complete', user: 'now finish it', assistant: 'Here is the result.' },
+				],
+				hasMoreHistory: true,
+				truncated: false,
+			});
+		});
+
+		test('digest adds assistant text and tool-call names', () => {
+			const digest = JSON.parse(serializeSessionContext(URI.parse('copilot:/s1'), undefined, snapshot, 'digest', 10));
+			assert.deepStrictEqual(digest.transcript[0], { turn: 1, state: 'complete', user: 'do the thing', assistant: 'Working on it.', toolCalls: ['read_file'] });
+		});
+
+		test('detail=full targeting a specific chat carries the chat link and tool inputs', () => {
+			const full = JSON.parse(serializeSessionContext(URI.parse('copilot:/s1'), 'c9', snapshot, 'full', 10));
+			assert.strictEqual(full.openLink, 'agent-host-session://copilot/s1?chat=c9');
+			assert.deepStrictEqual(full.transcript[1].toolCalls, [{ name: 'apply_patch', input: '{"patch":"@@"}' }]);
+		});
+
+		test('transcriptLimit drops older turns and flags truncated', () => {
+			const limited = JSON.parse(serializeSessionContext(URI.parse('copilot:/s1'), undefined, snapshot, 'summary', 1));
+			assert.deepStrictEqual({ turns: limited.transcript.map((t: { turn: number }) => t.turn), truncated: limited.truncated }, { turns: [2], truncated: true });
+		});
+
+		test('execute reads from the accessor; cold session returns identity + empty transcript', async () => {
+			const store = new DisposableStore();
+			const stateManager = store.add(new AgentHostStateManager(new NullLogService()));
+			const sessions = [sessionMeta('s1', SessionStatus.Idle, workspace)];
+			const withCtx = createSessionServerToolGroup(createAccessor({ listSessions: async () => sessions, getChatContext: () => snapshot }));
+			const live = JSON.parse(await withCtx.execute(stateManager, 'copilot:/caller', getSessionContextToolName, { session: 'copilot:/s1' }));
+			assert.strictEqual(live.transcript.length, 2);
+
+			const cold = createSessionServerToolGroup(createAccessor({ listSessions: async () => sessions, getChatContext: () => undefined }));
+			assert.deepStrictEqual(JSON.parse(await cold.execute(stateManager, 'copilot:/caller', getSessionContextToolName, { session: 'copilot:/s1' })), {
+				session: 'copilot:/s1', openLink: 'agent-host-session://copilot/s1', detail: 'summary', transcript: [], hasMoreHistory: false, truncated: false,
+			});
+			store.dispose();
+		});
+
+		test('getSessionContextArgs validates input', () => {
+			assert.throws(() => getSessionContextArgs({}, []), /session/);
+			assert.throws(() => getSessionContextArgs({ session: 'copilot:/nope' }, [sessionMeta('s1', SessionStatus.Idle, workspace)]), /known session/);
+			assert.throws(() => getSessionContextArgs({ session: 'copilot:/s1', detail: 'huge' }, [sessionMeta('s1', SessionStatus.Idle, workspace)]), /detail/);
+			assert.strictEqual(getSessionContextArgs({ session: 'copilot:/s1', transcriptLimit: 999 }, [sessionMeta('s1', SessionStatus.Idle, workspace)]).transcriptLimit, 50);
+		});
 	});
 
 	test('get_current_session returns the current session link + metadata', async () => {


### PR DESCRIPTION
## Overview

Follow-up in the session-management tool series (after #325051 and #325139). Adds a read-only **`get_session_context`** tool so an agent can inspect an *existing* session/chat's recent conversation — e.g. to see what a session it created is doing, or to gather context before `send_message`. Also extends **`list_sessions`** with a single-session lookup so the two tools stay cleanly separated.

> **Stacked on #325139** (`send_message`) — `get_session_context` reuses that tool's link helpers. GitHub will retarget this PR's base to `main` once #325139 merges.

## `get_session_context`

Reads a compacted transcript **directly from live chat state** (`ChatState.turns` + the in-progress turn). **Deterministic only** — no plan/todo heuristics.

**Input:** `session` (a `list_sessions` URI or `agent-host-session://` link; a `create_chat` link targets that specific peer chat), `detail`, `transcriptLimit`.

**`detail` levels** (per-turn fidelity; compaction is structural, no model call, tool *outputs* never included):
- `summary` (default): per-turn `user` message + short `assistant` reply gist + `state`.
- `digest`: full assistant reply text + tool-call **names**.
- `full`: + tool-call **inputs** (truncated).

**Output:** `session`, `openLink`, `detail`, `transcript[]`, `hasMoreHistory` (from `turnsNextCursor`), `truncated`. Bounded by `transcriptLimit` (default 10, max 50). Cold/unsubscribed sessions return identity + empty transcript. Read-only, no confirmation.

## `list_sessions` single-session lookup

Adds an optional **`session`** argument: a direct lookup returning just that one session's metadata by URI / open link, **bypassing the other filters** (including the default archived exclusion).

## Clean separation
- **`list_sessions`** → session **metadata** (breadth, or one session by URI).
- **`get_session_context`** → one session's **conversation** (depth).

No overlapping surface; flow is `list_sessions` → `get_session_context` → `send_message`.

## Notes for reviewers
- `get_session_context` reads via a new `IChatContextSnapshot` accessor (`agentService._getChatContext` → `getChatState`/`getDefaultChatState`); all compaction is pure/testable in `sessionServerTools.ts`.
- Plan/todo surfacing was intentionally dropped (heuristic/unreliable); a future authoritative option would be Copilot's `rpc.plan.read()`.
- Tests: `sessionServerTools.test.ts` (25) + `serverToolGroups.test.ts` (6). `typecheck-client` + `valid-layers-check` clean.
