### PR TITLE
Emit restricted skillContentRead telemetry from the agent host

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -5,6 +5,7 @@
 
 import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEvent } from '../../telemetry/common/languageModelToolTelemetry.js';
 import type { ITelemetryService } from '../../telemetry/common/telemetry.js';
+import { hash } from '../../../base/common/hash.js';
 import { AgentSession } from '../common/agentService.js';
 import type { MessageAttachment, SessionInputRequestKind, ToolDefinition } from '../common/state/protocol/state.js';
 import { isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
@@ -96,6 +97,21 @@ export interface IAgentHostToolCallDetailsReport {
 	totalToolCalls: number;
 	parallelToolCallRounds: number;
 	parallelToolCallsTotal: number;
+}
+
+export interface IAgentHostSkillContentReadReport {
+	/** The skill name. */
+	name: string;
+	/** Path to the SKILL.md file. */
+	path: string;
+	/** Full skill content; hashed (never sent raw), matching the extension. */
+	content: string;
+	/** Where the skill was discovered (project, personal-copilot, plugin, builtin, …). */
+	source: string | undefined;
+	/** Name of the plugin the skill came from, when applicable (AH-native analog of the extension's skill extension id). */
+	pluginName: string | undefined;
+	/** Version of the plugin the skill came from, when applicable. */
+	pluginVersion: string | undefined;
 }
 
 export interface IAgentHostToolCallStalledEvent {
@@ -316,6 +332,45 @@ export class AgentHostTelemetryReporter {
 		};
 		restricted.sendEnhancedGHTelemetryEvent('toolCallDetailsExternal', properties, measurements);
 		restricted.sendInternalMSFTTelemetryEvent('toolCallDetailsInternal', properties, measurements);
+	}
+
+	/**
+	 * Mirrors the Copilot extension's restricted `skillContentRead` event (`skillTelemetry.ts` ->
+	 * `sendSkillContentReadTelemetry`) — records which skill file was loaded into the conversation.
+	 * The extension emits it from the skill/readFile tools; the agent host observes the equivalent
+	 * boundary at the SDK `skill.invoked` event, whose payload already carries the content (hashed
+	 * here, never sent raw), the discovery `source`, and the plugin identity. The extension's
+	 * `skillExtensionId` / `skillExtensionVersion` encode the contributing *VS Code extension*, which
+	 * does not exist in the agent host; the AH-native provenance is the plugin, so `pluginName` /
+	 * `pluginVersion` fill those columns. No-ops when the skill name is empty.
+	 *
+	 * @param report The invoked skill's metadata (from the SDK `skill.invoked` payload).
+	 */
+	skillContentRead(report: IAgentHostSkillContentReadReport): void {
+		const restricted = this._restricted;
+		if (!restricted || !report.name) {
+			return;
+		}
+		const contentHash = report.content ? String(hash(report.content)) : '';
+		const skillStorage = report.source ?? '';
+		const skillExtensionVersion = report.pluginVersion ?? '';
+		const plaintextProps = {
+			skillName: report.name,
+			skillPath: report.path,
+			skillExtensionId: report.pluginName ?? '',
+			skillExtensionVersion,
+			skillStorage,
+			skillContentHash: contentHash,
+		};
+		restricted.sendGHTelemetryEvent('skillContentRead', {
+			skillNameHash: String(hash(report.name)),
+			skillExtensionIdHash: report.pluginName ? String(hash(report.pluginName)) : '',
+			skillExtensionVersion,
+			skillStorage,
+			skillContentHash: contentHash,
+		});
+		restricted.sendEnhancedGHTelemetryEvent('skillContentRead', plaintextProps);
+		restricted.sendInternalMSFTTelemetryEvent('skillContentRead', plaintextProps);
 	}
 
 	turnCompleted(report: IAgentHostTurnCompletedReport): void {

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -353,7 +353,9 @@ export class AgentHostTelemetryReporter {
 		}
 		const contentHash = report.content ? String(hash(report.content)) : '';
 		const skillStorage = report.source ?? '';
-		const skillExtensionVersion = report.pluginVersion ?? '';
+		// Match the extension: the version is only reported when the (plugin) id is known, so we
+		// never emit a `skillExtensionVersion` without a corresponding `skillExtensionId`.
+		const skillExtensionVersion = report.pluginName ? (report.pluginVersion ?? '') : '';
 		const plaintextProps = {
 			skillName: report.name,
 			skillPath: report.path,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3172,6 +3172,19 @@ export class CopilotAgentSession extends Disposable {
 			if (this._shouldDropUnmappedSubagentEvent(e, 'skill.invoked')) {
 				return;
 			}
+			// Restricted `skillContentRead`: which skill file was loaded into context. Main-agent only,
+			// consistent with the other restricted events; the SDK `skill.invoked` payload already
+			// carries the content (hashed by the reporter), the discovery source, and the plugin identity.
+			if (!e.agentId) {
+				this._telemetryReporter.skillContentRead({
+					name: e.data.name,
+					path: e.data.path,
+					content: e.data.content,
+					source: e.data.source,
+					pluginName: e.data.pluginName,
+					pluginVersion: e.data.pluginVersion,
+				});
+			}
 			const parentToolCallId = this._parentToolCallIdForSubagentEvent(e);
 			const synth = synthesizeSkillToolCall(e.data, e.id);
 			this._emitAction({

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3172,9 +3172,7 @@ export class CopilotAgentSession extends Disposable {
 			if (this._shouldDropUnmappedSubagentEvent(e, 'skill.invoked')) {
 				return;
 			}
-			// Restricted `skillContentRead`: which skill file was loaded into context. Main-agent only,
-			// consistent with the other restricted events; the SDK `skill.invoked` payload already
-			// carries the content (hashed by the reporter), the discovery source, and the plugin identity.
+			// Restricted `skillContentRead`: which skill file was loaded. Main-agent only, like the other restricted events.
 			if (!e.agentId) {
 				this._telemetryReporter.skillContentRead({
 					name: e.data.name,

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { hash } from '../../../../base/common/hash.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { AgentSession } from '../../common/agentService.js';
 import type { ToolDefinition } from '../../common/state/protocol/state.js';
@@ -160,5 +161,30 @@ suite('AgentHostTelemetryReporter', () => {
 		assert.strictEqual(service.internalEvents.length, 2);
 		assert.strictEqual(service.internalEvents[0].eventName, 'toolCallDetailsInternal');
 		assert.strictEqual(service.internalEvents[1].eventName, 'toolCallDetailsInternal');
+	});
+
+	test('skillContentRead emits plaintext skill metadata to enhanced + internal, maps plugin identity + hashes content, and no-ops without a name', () => {
+		const service = new TestRestrictedTelemetryService();
+		const reporter = new AgentHostTelemetryReporter(service);
+
+		reporter.skillContentRead({ name: '', path: '/skills/x/SKILL.md', content: 'body', source: 'project', pluginName: undefined, pluginVersion: undefined }); // dropped: no name
+		reporter.skillContentRead({
+			name: 'pdf', path: '/plugins/pdf/SKILL.md', content: 'skill body',
+			source: 'plugin', pluginName: 'pdf-plugin', pluginVersion: '1.2.3',
+		}); // emitted
+
+		const expected: IRestrictedCall = {
+			eventName: 'skillContentRead',
+			properties: {
+				skillName: 'pdf',
+				skillPath: '/plugins/pdf/SKILL.md',
+				skillExtensionId: 'pdf-plugin',
+				skillExtensionVersion: '1.2.3',
+				skillStorage: 'plugin',
+				skillContentHash: String(hash('skill body')),
+			},
+		};
+		assert.deepStrictEqual(service.enhancedEvents, [expected]);
+		assert.deepStrictEqual(service.internalEvents, [expected]);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -187,4 +187,16 @@ suite('AgentHostTelemetryReporter', () => {
 		assert.deepStrictEqual(service.enhancedEvents, [expected]);
 		assert.deepStrictEqual(service.internalEvents, [expected]);
 	});
+
+	test('skillContentRead drops the version when no plugin name is known, matching the extension', () => {
+		const service = new TestRestrictedTelemetryService();
+		const reporter = new AgentHostTelemetryReporter(service);
+
+		reporter.skillContentRead({ name: 'local', path: '/skills/local/SKILL.md', content: 'c', source: 'project', pluginName: undefined, pluginVersion: '9.9.9' });
+
+		assert.strictEqual(service.enhancedEvents.length, 1);
+		assert.strictEqual(service.enhancedEvents[0].properties?.skillExtensionId, '');
+		assert.strictEqual(service.enhancedEvents[0].properties?.skillExtensionVersion, '');
+	});
 });
+


### PR DESCRIPTION
Emits the restricted `skillContentRead` event from the agent host when a skill is loaded into a conversation, mirroring the Copilot Chat extension so the same signal is available whether chat runs in the extension or the agent host.

### What
- The agent host observes the SDK `skill.invoked` event and reports `skillContentRead` (standard GH hashed + enhanced/internal plaintext), matching the extension's `sendSkillContentReadTelemetry`.
- The SDK payload already carries everything needed — the skill content (hashed here, never sent raw), the discovery `source`, and the plugin identity — so **no SDK change is required**.
- The extension's `skillExtensionId` / `skillExtensionVersion` encode the contributing *VS Code extension*, which does not exist in the agent host; the AH-native provenance is the plugin, so `pluginName` / `pluginVersion` populate those fields.
- Fires for the main agent only, consistent with the other restricted agent-host events.

### How to test
1. Configure a skill reachable by an Agents-window session (e.g. `.github/skills/<name>/SKILL.md` in the working directory, `~/.copilot/skills/…`, or a plugin-provided skill).
2. Run a turn that invokes the skill; confirm the skill runs (synthesized skill tool-call appears).
3. A new unit test covers the reporter (`skillContentRead` emit + no-op) — `npm run test-node --grep AgentHostTelemetryReporter`.

### Known limitations & parity notes
- **Load path.** The extension emits `skillContentRead` from two paths: the skill tool *and* the read_file tool when it reads a `SKILL.md` (`isSkillMdFile`). This change covers the canonical agent-host skill-load signal (SDK `skill.invoked`) only, so a skill pulled in by directly reading its `SKILL.md` via the read tool is not captured here. A read-path hook can be added as a follow-up if the difference proves material.
- **`skill_storage` vocabulary.** The value comes straight from the SDK `source` (`project` / `inherited` / `personal-copilot` / `personal-agents` / `custom` / `plugin` / `builtin` / `remote`), which is richer than the extension's (`extension` / `internal` / `personal` / `workspace`). Same column, different value set — downstream queries should expect both.
- **`skill_path`.** Emitted as the SDK file path (vs the extension's `uri.toString()` / `file://…`); both identify the same file.
- **Scope.** Main-agent only (subagent skill loads are not reported), consistent with the other restricted agent-host events.

Part of the agent-host telemetry migration — microsoft/vscode-internalbacklog#8247
