### PR TITLE
git: honor git.detectWorktrees when opening linked worktrees

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -1132,9 +1132,20 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 		// The repository path may be a worktree (usually stored outside the workspace) so we have
 		// to check the repository path against all the worktree paths of the repositories that have
 		// already been opened.
-		const worktreePaths = this.repositories.map(r => r.worktrees.map(w => w.path)).flat();
-		if (worktreePaths.some(p => pathEquals(p, repositoryPath))) {
-			return false;
+		//
+		// Only treat a linked worktree as being inside the workspace when worktree detection is
+		// enabled (`git.detectWorktrees`). Otherwise a worktree that the user did not explicitly
+		// open (e.g. discovered via an open editor, the file system watcher, or the extension API)
+		// should follow the same rules as any other repository outside the workspace
+		// (`git.openRepositoryInParentFolders`), instead of being opened unconditionally.
+		const detectWorktrees = workspace
+			.getConfiguration('git', Uri.file(repositoryPath))
+			.get<boolean>('detectWorktrees', false);
+		if (detectWorktrees) {
+			const worktreePaths = this.repositories.map(r => r.worktrees.map(w => w.path)).flat();
+			if (worktreePaths.some(p => pathEquals(p, repositoryPath))) {
+				return false;
+			}
 		}
 
 		// The repository path may be a canonical path or it may contain a symbolic link so we have


### PR DESCRIPTION
 ### Bug
 
 Linked worktrees of an open repository are opened as separate repositories in the Source Control view **even when the user has opted out** via `git.detectWorktrees` (default `false`) and/or `git.openRepositoryInParentFolders: "never"`.
 
 They come back immediately after being closed, because they are re-discovered through several paths that never consult `git.detectWorktrees`:
 
 - `onDidChangeVisibleTextEditors` (a file open from a worktree),
 - the global `**` file-system watcher (`onPossibleGitRepositoryChange`, fires on any `/.git` change),
 - the `vscode.git` extension API `openRepository(uri)` (used by other extensions),
 
 For users with many worktrees (e.g. one per PR under review) this floods Source Control with dozens of repositories that cannot be permanently dismissed.
 
 ### Root cause
 
 `Model.isRepositoryOutsideWorkspace()` **unconditionally** treats any path that matches a worktree of an already-open repository as being *inside* the workspace:
 
 ```ts
 const worktreePaths = this.repositories.map(r => r.worktrees.map(w => w.path)).flat();
 if (worktreePaths.some(p => pathEquals(p, repositoryPath))) {
     return false;
 }
 ```
 
 Because it returns `false`, the `git.openRepositoryInParentFolders` guard in `openRepository()` never applies to worktrees, and `git.detectWorktrees` — which is supposed to control worktree discovery — is ignored on every path except the explicit `checkForWorktrees()` enumeration.
 
 ### Fix
 
 Gate that in-workspace treatment on `git.detectWorktrees`. When detection is disabled, a worktree the user did not explicitly open is treated like any other repository outside the workspace and follows `git.openRepositoryInParentFolders`.
 When detection is enabled, behavior is unchanged.
 
 ### Behavior
 
 - `git.detectWorktrees: true` → unchanged (worktrees open automatically).
 - `git.detectWorktrees: false` (default) → worktrees now obey `git.openRepositoryInParentFolders` (`never` hides them; `prompt` asks; `always` opens them), instead of always appearing.
 
 This aligns all discovery paths with the setting that already exists to control them, and makes the default (`false`) actually mean "do not auto-open worktrees".
 
 ### Verification
 
 Open a workspace whose folder is inside a repo that has linked worktrees, with `git.detectWorktrees: false` and `git.openRepositoryInParentFolders: "never"`.
 Open a file from one of the worktrees. Before: the worktree is added as a repository. After: only the workspace's repository is shown.