### PR TITLE
Add open/close motion to other chat input pickers

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -633,6 +633,11 @@ export interface IActionListOptions {
 	 * before the context view is hidden.
 	 */
 	readonly closeAnimation?: IActionListCloseAnimation;
+
+	/**
+	 * Optional fixed side of the anchor where the action list should render.
+	 */
+	readonly anchorPosition?: AnchorPosition;
 }
 
 /**
@@ -2007,6 +2012,7 @@ export class ActionList<T> extends Disposable {
 	private _cachedMaxWidth: number | undefined;
 	private _hasLaidOut = false;
 	private _showAbove: boolean | undefined;
+	private readonly _preferredAnchorPosition: AnchorPosition | undefined;
 
 	get domNode(): HTMLElement {
 		return this._widget.domNode;
@@ -2037,6 +2043,9 @@ export class ActionList<T> extends Disposable {
 	 * Used by the context view delegate to lock the dropdown direction.
 	 */
 	get anchorPosition(): AnchorPosition | undefined {
+		if (this._preferredAnchorPosition !== undefined) {
+			return this._preferredAnchorPosition;
+		}
 		if (this._showAbove === undefined) {
 			return undefined;
 		}
@@ -2057,6 +2066,7 @@ export class ActionList<T> extends Disposable {
 	) {
 		super();
 		this._anchor = anchor;
+		this._preferredAnchorPosition = options?.anchorPosition;
 
 		this._widget = this._register(instantiationService.createInstance(
 			ActionListWidget<T>,
@@ -2148,7 +2158,7 @@ export class ActionList<T> extends Disposable {
 		const targetWindow = dom.getWindow(this.domNode);
 		let availableHeight;
 
-		if (this.hasDynamicHeight()) {
+		if (this.hasDynamicHeight() || this._preferredAnchorPosition !== undefined) {
 			const viewportHeight = targetWindow.innerHeight;
 			const anchorRect = getAnchorRect(this._anchor);
 			const anchorTopInViewport = anchorRect.top - targetWindow.pageYOffset;
@@ -2160,8 +2170,9 @@ export class ActionList<T> extends Disposable {
 			// unconstrained list fits below. Once decided, the dropdown stays
 			// in the same position even when the visible item count changes.
 			if (this._showAbove === undefined) {
-				const fullHeight = chromeHeight + this._widget.computeFullHeight();
-				this._showAbove = fullHeight > spaceBelow && spaceAbove > spaceBelow;
+				this._showAbove = this._preferredAnchorPosition !== undefined
+					? this._preferredAnchorPosition === AnchorPosition.ABOVE
+					: (chromeHeight + this._widget.computeFullHeight() > spaceBelow && spaceAbove > spaceBelow);
 			}
 			availableHeight = Math.max(0, (this._showAbove ? spaceAbove : spaceBelow) - this.computeActionWidgetVerticalChromeHeight());
 		} else {
@@ -2173,6 +2184,11 @@ export class ActionList<T> extends Disposable {
 
 		const viewportMaxHeight = Math.floor(targetWindow.innerHeight * 0.6);
 		const actionLineHeight = this._widget.lineHeight;
+		if (this._preferredAnchorPosition !== undefined) {
+			const maxHeight = Math.min(availableHeight, viewportMaxHeight);
+			const height = Math.min(listHeight + chromeHeight, Math.max(0, maxHeight));
+			return Math.max(0, height - chromeHeight);
+		}
 		const maxHeight = Math.min(Math.max(availableHeight, actionLineHeight * 3 + chromeHeight), viewportMaxHeight);
 		const height = Math.min(listHeight + chromeHeight, maxHeight);
 		return height - chromeHeight;

--- a/src/vs/platform/actionWidget/test/browser/actionList.test.ts
+++ b/src/vs/platform/actionWidget/test/browser/actionList.test.ts
@@ -21,6 +21,7 @@ import { IOpenerService } from '../../../opener/common/opener.js';
 import { NullOpenerService } from '../../../opener/test/common/nullOpenerService.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ActionList, ActionListItemKind, ActionListWidget, IActionListItem, IActionListOptions } from '../../browser/actionList.js';
+import { AnchorPosition } from '../../../../base/common/layout.js';
 
 interface ITestActionItem {
 	readonly id: string;
@@ -108,7 +109,10 @@ function withWindowInnerHeight<T>(height: number, callback: () => T): T {
 	}
 }
 
-function createActionList(disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>, items: readonly IActionListItem<ITestActionItem>[]): ActionList<ITestActionItem> {
+function createActionList(disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>, items: readonly IActionListItem<ITestActionItem>[], options?: {
+	readonly listOptions?: Partial<IActionListOptions>;
+	readonly anchor?: { x: number; y: number; width: number; height: number };
+}): ActionList<ITestActionItem> {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	instantiationService.set(IKeybindingService, new MockKeybindingService());
 	instantiationService.set(IHoverService, NullHoverService);
@@ -139,8 +143,8 @@ function createActionList(disposables: ReturnType<typeof ensureNoDisposablesAreL
 			onSelect: () => { },
 		},
 		undefined,
-		{ showFilter: true },
-		{ x: 10, y: 150, width: 20, height: 20 },
+		{ showFilter: true, ...options?.listOptions },
+		options?.anchor ?? { x: 10, y: 150, width: 20, height: 20 },
 	));
 
 	const widget = document.createElement('div');
@@ -243,6 +247,20 @@ suite('ActionListWidget', () => {
 		const availableSpaceAboveAnchor = 150;
 		const listHeight = parseFloat(list.domNode.style.height);
 		assert.ok(listHeight + filterHeight + actionWidgetVerticalChromeHeight <= availableSpaceAboveAnchor);
+	}));
+
+	test('forced above anchor position can clamp dynamic height without the default minimum floor', () => withWindowInnerHeight(300, () => {
+		const list = createActionList(disposables, Array.from({ length: 50 }, (_, i) => action(`item-${i}`)), {
+			listOptions: { anchorPosition: AnchorPosition.ABOVE },
+			anchor: { x: 10, y: 20, width: 20, height: 20 },
+		});
+
+		list.layout(200);
+
+		assert.deepStrictEqual(
+			{ anchorPosition: list.anchorPosition, listHeight: parseFloat(list.domNode.style.height) },
+			{ anchorPosition: AnchorPosition.ABOVE, listHeight: 0 },
+		);
 	}));
 
 	test('header dismiss removes the banner and requests a re-layout', () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
@@ -36,6 +36,7 @@ import type { IChatWidget } from '../../chat.js';
 import { ChatConfiguration, ChatPermissionLevel, isChatPermissionLevel } from '../../../common/constants.js';
 import { maybeConfirmElevatedPermissionLevel } from '../../../common/chatPermissionWarnings.js';
 import { isUntitledChatSession } from '../../../common/model/chatUri.js';
+import { withChatInputPickerMotion } from '../../widget/input/chatInputPickerActionItem.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
 import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
@@ -594,8 +595,8 @@ export class AgentHostChatInputPicker extends Disposable {
 				getWidgetAriaLabel: () => localize('agentHostChatInputPicker.ariaLabel', "{0} Picker", ctx.schema.title),
 			},
 			actionItems.length > FILTER_THRESHOLD || ctx.schema.enumDynamic
-				? { showFilter: true, filterPlaceholder: localize('agentHostChatInputPicker.filter', "Filter...") }
-				: undefined,
+				? withChatInputPickerMotion({ showFilter: true, filterPlaceholder: localize('agentHostChatInputPicker.filter', "Filter...") })
+				: withChatInputPickerMotion(undefined),
 		);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionPickerActionItem.ts
@@ -21,7 +21,7 @@ import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { localize } from '../../../../../nls.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { IChatInputPickerOptions } from '../widget/input/chatInputPickerActionItem.js';
+import { IChatInputPickerOptions, withChatInputPickerMotion } from '../widget/input/chatInputPickerActionItem.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { IActionListItemHover } from '../../../../../platform/actionWidget/browser/actionList.js';
@@ -73,6 +73,7 @@ export class ChatSessionPickerActionItem extends ActionWidgetDropdownActionViewI
 			actionBarActionProvider: undefined,
 			reporter: { id: group.id, name: `ChatSession:${group.name}`, includeOptions: false },
 			getAnchor: () => this._getAnchorElement(),
+			listOptions: withChatInputPickerMotion(undefined),
 		};
 
 		super(actionWithLabel, sessionPickerActionWidgetOptions, actionWidgetService, keybindingService, contextKeyService, telemetryService);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.ts
@@ -5,6 +5,7 @@
 
 import { getActiveWindow } from '../../../../../../base/browser/dom.js';
 import { IAction } from '../../../../../../base/common/actions.js';
+import { AnchorPosition } from '../../../../../../base/common/layout.js';
 import { autorun, IObservable } from '../../../../../../base/common/observable.js';
 import { ActionWidgetDropdownActionViewItem } from '../../../../../../platform/actions/browser/actionWidgetDropdownActionViewItem.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
@@ -32,10 +33,11 @@ export const CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS = 'chat-input-picker-dropd
 export const CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION = 150;
 export const CHAT_INPUT_PICKER_MOTION_ANCESTOR_CLASSES = ['style-override', 'monaco-enable-motion'];
 
-function withChatInputPickerMotion(listOptions: IActionListOptions | undefined): IActionListOptions {
+export function withChatInputPickerMotion(listOptions: IActionListOptions | undefined): IActionListOptions {
 	return {
 		...listOptions,
 		className: [listOptions?.className, CHAT_INPUT_PICKER_DROPDOWN_CLASS].filter(Boolean).join(' '),
+		anchorPosition: AnchorPosition.ABOVE,
 		closeAnimation: listOptions?.closeAnimation ?? {
 			className: CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS,
 			duration: CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -45,7 +45,7 @@ import { IUriIdentityService } from '../../../../../../platform/uriIdentity/comm
 import { GitHubPaths, IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IUpdateService, StateType } from '../../../../../../platform/update/common/update.js';
 import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
-import { CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION, CHAT_INPUT_PICKER_DROPDOWN_CLASS, CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS, CHAT_INPUT_PICKER_MOTION_ANCESTOR_CLASSES } from './chatInputPickerActionItem.js';
+import { withChatInputPickerMotion } from './chatInputPickerActionItem.js';
 
 function isVersionAtLeast(current: string, required: string): boolean {
 	const currentSemver = semver.coerce(current);
@@ -1419,7 +1419,7 @@ export class ModelPickerWidget extends Disposable {
 		// heading).
 		const unavailable = this.isRestrictedMode() || this.isSetupRequired();
 		const showCacheBreakHint = this.shouldShowCacheBreakHint(/* excludeAutoModel */ true);
-		const listOptions = {
+		const listOptions = withChatInputPickerMotion({
 			headerText: showCacheBreakHint ? localize('chat.modelPicker.cacheBreakHint', "Switching models mid-session resets the prompt cache and may increase cost.") : undefined,
 			headerIcon: showCacheBreakHint ? Codicon.info : undefined,
 			headerLink: showCacheBreakHint ? this.getCacheBreakLearnMoreLink() : undefined,
@@ -1442,13 +1442,7 @@ export class ModelPickerWidget extends Disposable {
 				void this._openerService.open(uri, { allowCommands: true });
 			},
 			minWidth: 200,
-			className: CHAT_INPUT_PICKER_DROPDOWN_CLASS,
-			closeAnimation: {
-				className: CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS,
-				duration: CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION,
-				requiredAncestorClasses: CHAT_INPUT_PICKER_MOTION_ANCESTOR_CLASSES,
-			},
-		};
+		});
 		const previouslyFocusedElement = dom.getActiveElement();
 
 		const delegate = {
@@ -1785,18 +1779,12 @@ export class ModelPickerWidget extends Disposable {
 				getRole: (element: IActionListItem<IActionWidgetDropdownAction>) => element.kind === ActionListItemKind.Action ? 'menuitemradio' as const : 'separator' as const,
 				getWidgetRole: () => 'menu' as const,
 			},
-			{
+			withChatInputPickerMotion({
 				headerText: showCacheBreakHint ? localize('chat.config.cacheBreakHint', "Changing these options mid-session resets the prompt cache and may increase cost.") : undefined,
 				headerIcon: showCacheBreakHint ? Codicon.info : undefined,
 				headerLink: showCacheBreakHint ? this.getCacheBreakLearnMoreLink() : undefined,
 				headerDismiss: showCacheBreakHint ? () => this.dismissCacheBreakHint() : undefined,
-				className: CHAT_INPUT_PICKER_DROPDOWN_CLASS,
-				closeAnimation: {
-					className: CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS,
-					duration: CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION,
-					requiredAncestorClasses: CHAT_INPUT_PICKER_MOTION_ANCESTOR_CLASSES,
-				},
-			}
+			})
 		);
 
 		// Focus the requested section's first option (e.g. when opened from a


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Related to https://github.com/microsoft/vscode/issues/325020

Following up from https://github.com/microsoft/vscode/pull/325023, I realized I missed a few picker menus that appear when different agent harnesses are selected.

This also fixes inconsistent picker positioning by making chat input picker menus consistently open above their picker button.

Changes made:

- Added open/close motion to agent-host configuration pickers, including mode and approval-related pickers.
- Added open/close motion to Cloud harness option pickers, including custom agent and model pickers.
- Reused the shared chat input picker motion behavior for model and model configuration pickers.
- Added support for forcing action-widget picker menus to render above their anchor.
- Updated chat input pickers to use the forced-above positioning for consistent menu placement.