### PR TITLE
Fix lopsided padding in chat pickers with no icons

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/media/agentHostChatInputPicker.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/media/agentHostChatInputPicker.css
@@ -136,5 +136,8 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.agent-host-chat-input-picker-slot .action-label .codicon + .agent-host-chat-input-picker-label {
 	margin-left: 6px;
 }

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/media/chatSessionPickerActionItem.css
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/media/chatSessionPickerActionItem.css
@@ -26,6 +26,9 @@
 	.chat-session-option-label {
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	.codicon + .chat-session-option-label {
 		margin-left: 6px;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1706,7 +1706,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 				text-overflow: ellipsis;
 			}
 
-			span + .chat-input-picker-label {
+			.codicon + .chat-input-picker-label {
 				margin-left: 6px;
 			}
 
@@ -1813,7 +1813,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 				}
 			}
 
-			span + .chat-input-picker-label {
+			.codicon + .chat-input-picker-label {
 				margin-left: 2px;
 			}
 
@@ -1904,7 +1904,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	font-size: 12px;
 }
 
-.chat-input-picker-item .action-label.model-picker-split .model-picker-section span + .chat-input-picker-label {
+.chat-input-picker-item .action-label.model-picker-split .model-picker-section .codicon + .chat-input-picker-label {
 	margin-left: 2px;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/325164

Removes extra padding from chat input pickers when no icon is shown. Currently hover states have a lopsided look to them.

Before:

<img width="482" height="228" alt="Image" src="https://github.com/user-attachments/assets/5fef51a3-9064-4c97-82a0-6f360fa333f5" />

After:

<img width="537" height="222" alt="Screenshot 2026-07-09 at 3 31 53 PM" src="https://github.com/user-attachments/assets/b2057e76-adb3-44f2-afe7-da4bef350ecd" />
