### PR TITLE
Fix workspace matching in session tooling to align with UI behavior

### DIFF
--- a/src/vs/platform/agentHost/node/shared/sessionServerTools.ts
+++ b/src/vs/platform/agentHost/node/shared/sessionServerTools.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../base/common/uri.js';
+import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
 import type { Mutable } from '../../../../base/common/types.js';
 import { localize } from '../../../../nls.js';
 import type { IAgentCreateSessionConfig, IAgentModelInfo, IAgentSessionMetadata } from '../../common/agentService.js';
@@ -441,7 +442,13 @@ function sessionMatchesWorkspace(session: IAgentSessionMetadata, workspace: stri
 		return true;
 	}
 	const parsed = parseWorkspaceUri(workspace);
-	return !!parsed && parsed.toString() === dir.toString();
+	if (!parsed) {
+		return false;
+	}
+	// Use parent-child matching so sessions whose working directory is a
+	// subdirectory of the workspace (e.g. a git worktree created under
+	// `.copilot/worktrees/`) are still associated with that workspace.
+	return extUriBiasedIgnorePathCase.isEqualOrParent(dir, parsed);
 }
 
 /** Applies the {@link IListSessionsArgs} filters to a set of sessions. */

--- a/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
@@ -6,14 +6,17 @@
 import assert from 'assert';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
 import type { IAgentCreateSessionConfig, IAgentModelInfo, IAgentSessionMetadata } from '../../common/agentService.js';
+import { ActionType } from '../../common/state/sessionActions.js';
 import { SessionStatus } from '../../common/state/protocol/channels-session/state.js';
-import { buildChatUri, buildDefaultChatUri, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, TurnState, withSessionGitState, withSessionGitHubState, type ResponsePart, type ToolCallState, type Turn } from '../../common/state/sessionState.js';
+import { buildChatUri, buildDefaultChatUri, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, TurnState, withSessionGitState, withSessionGitHubState, type ResponsePart, type SessionSummary, type ToolCallState, type Turn } from '../../common/state/sessionState.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import {
 	applyCreateChatTool,
+	applyCreateSessionTool,
 	applyDeleteSessionTool,
 	applySendMessageTool,
 	createChatToolName,
@@ -438,5 +441,91 @@ suite('SessionServerTools', () => {
 		const text = await applyDeleteSessionTool(accessor, { session: 'copilot:/s2' }, URI.parse('copilot:/s1'));
 		assert.strictEqual(deleted?.toString(), 'copilot:/s2');
 		assert.ok(text.includes('copilot:/s2'));
+	});
+
+	test('a session created via create_session appears immediately in list_sessions', async () => {
+		// Simulate the AgentService.listSessions() pipeline:
+		// 1. Provider returns existing sessions (NOT including the provisional one)
+		// 2. State manager overlay fills in sessions known to state but not provider
+		const store = new DisposableStore();
+		const stateManager = store.add(new AgentHostStateManager(new NullLogService()));
+		const existingSession = sessionMeta('existing', SessionStatus.Idle, workspace);
+		const newSessionUri = URI.parse('copilot:/new');
+
+		// Build an accessor that mirrors the real AgentService behavior:
+		// - createSession seeds the state manager (provisional, no notification)
+		// - startPrompt dispatches ChatTurnStarted
+		// - listSessions composes provider results + state manager overlay
+		const accessor = createAccessor({
+			createSession: async (config) => {
+				const now = new Date().toISOString();
+				const summary: SessionSummary = {
+					resource: newSessionUri.toString(),
+					provider: 'copilot',
+					title: '',
+					status: SessionStatus.Idle,
+					createdAt: now,
+					modifiedAt: now,
+					workingDirectory: config.workingDirectory?.toString(),
+				};
+				stateManager.createSession(summary, { emitNotification: false });
+				return newSessionUri;
+			},
+			startPrompt: async (_session, chat, prompt) => {
+				const message = { text: prompt, origin: { kind: MessageKind.User } };
+				const action = { type: ActionType.ChatTurnStarted as const, turnId: generateUuid(), message };
+				stateManager.dispatchServerAction(chat.toString(), action);
+			},
+			listSessions: async () => {
+				// Simulates AgentService.listSessions():
+				// Provider returns only the existing session (provisional not in SDK/DB).
+				const providerResults = [existingSession];
+				// State manager overlay adds sessions known to state but not provider.
+				const known = new Set(providerResults.map(s => s.session.toString()));
+				const additions: IAgentSessionMetadata[] = [];
+				for (const summary of stateManager.getOverlaySessionSummaries()) {
+					if (known.has(summary.resource)) {
+						continue;
+					}
+					additions.push({
+						session: URI.parse(summary.resource),
+						startTime: Date.parse(summary.createdAt),
+						modifiedTime: Date.parse(summary.modifiedAt),
+						summary: summary.title,
+						status: summary.status,
+						activity: summary.activity,
+						workingDirectory: typeof summary.workingDirectory === 'string' ? URI.parse(summary.workingDirectory) : undefined,
+					});
+				}
+				return [...providerResults, ...additions];
+			},
+		});
+
+		// Step 1: create_session
+		await applyCreateSessionTool(accessor, { workspace: workspace.toString(), prompt: 'do it' });
+
+		// Step 2: list_sessions — the new session must appear
+		const allSessions = await accessor.listSessions();
+		const allIds = allSessions.map(s => s.session.toString());
+		assert.ok(allIds.includes('copilot:/new'), `Expected new session in list, got: ${JSON.stringify(allIds)}`);
+
+		// Step 3: list_sessions with workspace filter — the new session must still appear
+		const filtered = filterSessions(allSessions, getListSessionsArgs({ workspace: workspace.toString() }));
+		const filteredIds = filtered.map(s => s.session.toString());
+		assert.ok(filteredIds.includes('copilot:/new'), `Expected new session in workspace-filtered list, got: ${JSON.stringify(filteredIds)}`);
+
+		store.dispose();
+	});
+
+	test('sessionMatchesWorkspace accepts child paths (worktree within workspace)', () => {
+		// After materialization with worktree isolation, the session's working
+		// directory changes to a subdirectory of the original workspace.
+		const worktreePath = URI.parse('file:///workspace/app/.copilot/worktrees/agents/feature-branch');
+		const worktreeSession = sessionMeta('wt', SessionStatus.Idle, worktreePath);
+
+		// The tool's workspace filter uses exact matching, which should also
+		// accept child paths (worktrees are children of the workspace).
+		const filtered = filterSessions([worktreeSession], getListSessionsArgs({ workspace: workspace.toString() }));
+		assert.strictEqual(filtered.length, 1, `Expected worktree session to match workspace filter, got ${filtered.length} results`);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
@@ -523,8 +523,10 @@ suite('SessionServerTools', () => {
 		const worktreePath = URI.parse('file:///workspace/app/.copilot/worktrees/agents/feature-branch');
 		const worktreeSession = sessionMeta('wt', SessionStatus.Idle, worktreePath);
 
-		// The tool's workspace filter uses exact matching, which should also
-		// accept child paths (worktrees are children of the workspace).
+		// The tool's workspace filter uses parent-child matching (via
+		// extUriBiasedIgnorePathCase.isEqualOrParent), so a session whose
+		// working directory is a subdirectory of the workspace (a worktree)
+		// is still attributed to that workspace.
 		const filtered = filterSessions([worktreeSession], getListSessionsArgs({ workspace: workspace.toString() }));
 		assert.strictEqual(filtered.length, 1, `Expected worktree session to match workspace filter, got ${filtered.length} results`);
 	});


### PR DESCRIPTION
This pull request addresses a bug in the VS Code agent-host session tooling where sessions created via the `create_session` tool do not appear in the results of `list_sessions`, despite being visible in the VS Code UI. 

### Changes Made:
- **Root Cause Identified**: The issue stemmed from the `sessionMatchesWorkspace` function using exact URI string comparison, while the UI utilized parent-child matching via `isEqualOrParent`. This discrepancy caused sessions to be filtered out incorrectly after materialization.
  
- **Fix Implemented**: 
  - Updated the comparison in `sessionMatchesWorkspace` to use `extUriBiasedIgnorePathCase.isEqualOrParent(dir, parsed)`, aligning the behavior with the UI's session filtering logic.
  
- **Tests Added**: 
  - Two new tests were added to ensure that a session created is immediately visible in `list_sessions` and that worktree child paths correctly match the workspace filter.

All tests pass successfully, and the changes have been verified to maintain the expected functionality without introducing regressions. 

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8369