### PR TITLE
Fix padding issues in tabs when close button is hidden

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -29,21 +29,31 @@
 
 .style-override .part.editor .tabs-container > .tab {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 5%, transparent) !important;
-	border-right: none !important;
+	background-clip: padding-box;
+	border-right: var(--vscode-spacing-size40) solid transparent !important;
 	border-radius: var(--vscode-cornerRadius-small);
+	border-top-right-radius: calc(var(--vscode-cornerRadius-small) + var(--vscode-spacing-size40));
+	border-bottom-right-radius: calc(var(--vscode-cornerRadius-small) + var(--vscode-spacing-size40));
 	font-size: 12px !important;
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	box-shadow: none !important;
 	padding: 0 0 0 4px !important;
-	margin-right: 4px !important;
 	--tab-border-top-color: transparent !important;
+}
+
+.style-override .part.editor .tabs-container > .tab.sticky-compact {
+	padding: 0 !important;
 }
 
 .style-override .part.editor .tabs-container > .tab.tab-actions-left:not(.sticky-compact) {
 	padding: 0 10px 0 0 !important;
 }
 
-.style-override .part.editor .tabs-container > .tab.sizing-fit {
+.style-override .part.editor .tabs-container > .tab.close-action-off:not(.dirty):not(.sticky-compact) {
+	padding: 0 8px 0 4px !important;
+}
+
+.style-override .part.editor .tabs-container > .tab.sizing-fit:not(.sticky-compact) {
 	width: auto !important;
 	min-width: 0 !important;
 	flex: 0 0 auto !important;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/325157

Adds extra padding to tabs when the close button is hidden.
