### PR TITLE
Improve Copilot Cloud Sessions error handling and messaging

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionContentBuilder.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionContentBuilder.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as pathLib from 'path';
-import { AgentTaskGetResponse, AgentTaskSession, AgentTaskSessionEvent } from '@vscode/copilot-api';
+import { AgentTaskGetResponse, AgentTaskSession, AgentTaskSessionEvent, AgentTaskState } from '@vscode/copilot-api';
 import type { SessionEvent } from '@github/copilot/sdk';
 import * as vscode from 'vscode';
 import { ChatRequestTurn, ChatRequestTurn2, ChatResponseMarkdownPart, ChatResponseMultiDiffPart, ChatResponseProgressPart, ChatResponseThinkingProgressPart, ChatResponseTurn2, ChatResult, ChatToolInvocationPart, MarkdownString, Uri } from 'vscode';
@@ -14,7 +14,7 @@ import { ILogService } from '../../../platform/log/common/logService';
 import { findLast } from '../../../util/vs/base/common/arraysFind';
 import { appendResponsePartsForEvent, createResponseEventRenderContext, flushPendingAssistantMessage, ResponseEventRenderContext } from '../common/sessionEventRenderer';
 import { CLI_TOOL_EVENT_HANDLERS } from '../copilotcli/common/copilotCLITools';
-import { getAuthorDisplayName } from '../vscode/copilotCodingAgentUtils';
+import { getAuthorDisplayName, isFailedTaskState } from '../vscode/copilotCodingAgentUtils';
 
 export interface SessionResponseLogChunk {
 	choices: Array<{
@@ -99,6 +99,57 @@ export interface ParsedToolCallDetails {
 	pastTenseMessage?: string;
 	originMessage?: string;
 	toolSpecificData?: StrReplaceEditorToolData | BashToolData;
+}
+
+/**
+ * Best-effort human-readable error detail for a terminally-failed task (v2). Prefers the last
+ * non-dismissed `session.error` event (`(errorType) message`), falling back to a `session.shutdown`
+ * event's `errorReason`. Returns undefined when no detail is available — e.g. an agent that failed
+ * to launch before emitting any error event, where the failure is only reflected in the task state.
+ * Scans the full event list because a `session.error` emitted during bootstrap (before the first
+ * user message) is suppressed from the rendered turn history.
+ */
+export function extractTaskErrorDetail(events: readonly AgentTaskSessionEvent[]): string | undefined {
+	const errorEvent = findLast(events, e => e.type === 'session.error' && !e.dismissed);
+	if (errorEvent) {
+		const data = errorEvent.data as { errorType?: string; message?: string };
+		const message = data.message?.trim();
+		if (message) {
+			return data.errorType ? `(${data.errorType}) ${message}` : message;
+		}
+	}
+	const shutdownEvent = findLast(events, e => e.type === 'session.shutdown' && !e.dismissed);
+	if (shutdownEvent) {
+		const data = shutdownEvent.data as { shutdownType?: string; errorReason?: string };
+		const reason = data.errorReason?.trim();
+		if (data.shutdownType === 'error' && reason) {
+			return reason;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * The notice shown for a terminally-stopped task (v2): `Copilot stopped: <reason>`. The reason is
+ * the concrete error detail when one is available (`session.error`/`session.shutdown`), otherwise a
+ * word derived from the terminal task state — "cancelled" for a user/agent cancellation and "timed
+ * out" for a timeout, neither of which emits an error event. Failed tasks with no detail fall back
+ * to a generic "an error occurred".
+ */
+export function formatTaskStoppedMessage(state: AgentTaskState, detail: string | undefined): string {
+	const reason = detail ?? defaultStopReasonForState(state);
+	return vscode.l10n.t('Copilot stopped: {0}', reason);
+}
+
+function defaultStopReasonForState(state: AgentTaskState): string {
+	switch (state) {
+		case 'cancelled':
+			return vscode.l10n.t('cancelled');
+		case 'timed_out':
+			return vscode.l10n.t('timed out');
+		default:
+			return vscode.l10n.t('an error occurred');
+	}
 }
 
 export class ChatSessionContentBuilder {
@@ -240,9 +291,26 @@ export class ChatSessionContentBuilder {
 					history.push(new vscode.ChatResponseTurn2([card], {}, this.type));
 				}
 
-				// Only the latest turn can still be in-progress.
-				const state = index === turns.length - 1 ? latestSession?.state : undefined;
-				history.push(...this.buildTaskResponseTurn(turn.events, state));
+				// Only the latest turn can still be in-progress. When the task itself terminally
+				// failed, surface a failure notice (with any available error detail) instead of a
+				// stuck progress spinner — the latest session state can still read as active (e.g.
+				// "Failed to launch agent"). Detail is extracted from the full event list because a
+				// bootstrap `session.error` is suppressed from the rendered turns above.
+				// Only the latest turn can still be in-progress. When the task terminally stopped,
+				// surface a "Copilot stopped: <reason>" notice instead of a stuck progress spinner —
+				// the latest session state can still read as active (e.g. "Failed to launch agent"
+				// or a cancelled turn). Detail is extracted from the full event list because a
+				// bootstrap `session.error` is suppressed from the rendered turns above; a cancelled
+				// or timed-out task emits no error event, so the reason falls back to the task state.
+				const isLatestTurn = index === turns.length - 1;
+				const state = isLatestTurn ? latestSession?.state : undefined;
+				let failureMessage: string | undefined;
+				if (isLatestTurn && isFailedTaskState(task.state)) {
+					const detail = extractTaskErrorDetail(events);
+					this._logService.trace(`[ChatSessionContentBuilder] task ${task.id} stopped (state=${task.state}); errorDetail=${detail ?? 'none'}`);
+					failureMessage = formatTaskStoppedMessage(task.state, detail);
+				}
+				history.push(...this.buildTaskResponseTurn(turn.events, state, failureMessage));
 			});
 
 			return history;
@@ -262,7 +330,7 @@ export class ChatSessionContentBuilder {
 	 *    with content, no `parentToolCallId`, no `toolRequests`); intermediate
 	 *    messages carry narration that would clutter the view.
 	 */
-	private buildTaskResponseTurn(events: readonly AgentTaskSessionEvent[], state: AgentTaskSession['state'] | undefined): ChatResponseTurn2[] {
+	private buildTaskResponseTurn(events: readonly AgentTaskSessionEvent[], state: AgentTaskSession['state'] | undefined, failureMessage?: string): ChatResponseTurn2[] {
 		const lastFinalMessage = findLast(events, e =>
 			!e.dismissed
 			&& e.type === 'assistant.message'
@@ -308,9 +376,15 @@ export class ChatSessionContentBuilder {
 		flushPendingAssistantMessage(ctx);
 
 		const parts = [...ctx.currentResponseParts];
-		if (parts.length === 0 && (state === 'in_progress' || state === 'queued')) {
-			// TODO: Handle in-progress sessions correctly
-			parts.push(new ChatResponseProgressPart(vscode.l10n.t('Session is in progress...')));
+		if (parts.length === 0) {
+			if (failureMessage !== undefined) {
+				// The task ended in an unsuccessful terminal state (e.g. "Failed to launch agent")
+				// without emitting any renderable events. Surface the failure instead of a spinner.
+				parts.push(new ChatResponseMarkdownPart(failureMessage));
+			} else if (state === 'in_progress' || state === 'queued') {
+				// TODO: Handle in-progress sessions correctly
+				parts.push(new ChatResponseProgressPart(vscode.l10n.t('Session is in progress...')));
+			}
 		}
 		return [new ChatResponseTurn2(parts, {}, this.type)];
 	}

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -34,7 +34,7 @@ import { IInstantiationService } from '../../../util/vs/platform/instantiation/c
 import { SingleSlotTtlCache, TtlCache } from '../common/ttlCache';
 import { isUntitledSessionId } from '../common/utils';
 import { IChatDelegationSummaryService } from '../copilotcli/common/delegationSummaryService';
-import { CONTINUE_TRUNCATION, extractTitle, getAuthorDisplayName, getRepoId, SessionIdForPr, SessionIdForTask, toOpenPullRequestWebviewUri, truncatePrompt } from '../vscode/copilotCodingAgentUtils';
+import { CONTINUE_TRUNCATION, extractTitle, getAuthorDisplayName, getRepoId, isActiveTaskState, SessionIdForPr, SessionIdForTask, toOpenPullRequestWebviewUri, truncatePrompt } from '../vscode/copilotCodingAgentUtils';
 import { CloudAgentBackend, PullArtifactRef, TaskCloudAgentBackend, TaskContent } from '../vscode/cloudAgentBackend';
 import { CopilotCloudGitOperationsManager } from './copilotCloudGitOperationsManager';
 import { ChatSessionContentBuilder, SessionResponseLogChunk } from './copilotCloudSessionContentBuilder';
@@ -1594,7 +1594,12 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		// updatePullRequestToolbarContext (active-response settle, follow-up, PR creation).
 		this._activeToolbarTaskId = taskId;
 		this.setPullRequestToolbarContext(taskContent);
-		const activeResponseCallback = latestTurn && (latestTurn.state === 'in_progress' || latestTurn.state === 'queued')
+		// Only stream a live response when the task itself is still running. A terminally-failed
+		// task (e.g. "Failed to launch agent") can leave its latest turn's session state stuck at
+		// `in_progress`/`queued`; without the task-level guard the streamer would poll forever and
+		// the view would show a perpetual "Session is in progress…" spinner.
+		const activeResponseCallback = isActiveTaskState(taskContent.task.state)
+			&& latestTurn && (latestTurn.state === 'in_progress' || latestTurn.state === 'queued')
 			? this._createTaskStreamCallback(taskId, { mode: 'current', seedEventIds: new Set(events.map(e => e.id)) })
 			: undefined;
 

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/taskTurnStreamer.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/taskTurnStreamer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AgentTaskGetResponse, AgentTaskSessionEvent, AgentTaskState } from '@vscode/copilot-api';
+import type { AgentTaskGetResponse, AgentTaskSessionEvent } from '@vscode/copilot-api';
 import * as vscode from 'vscode';
 import { ILogService } from '../../../platform/log/common/logService';
 import { CLI_TOOL_EVENT_HANDLERS } from '../copilotcli/common/copilotCLITools';
@@ -13,15 +13,17 @@ import {
 	ResponseEventRenderContext,
 } from '../common/sessionEventRenderer';
 import { TaskCloudAgentBackend } from '../vscode/cloudAgentBackend';
-import { ChatSessionContentBuilder } from './copilotCloudSessionContentBuilder';
+import { isActiveTaskState, isFailedTaskState } from '../vscode/copilotCodingAgentUtils';
+import { ChatSessionContentBuilder, extractTaskErrorDetail, formatTaskStoppedMessage } from './copilotCloudSessionContentBuilder';
 
 /**
  * Phase of a single Task turn. The Task API uses `queued | in_progress | idle |
  * waiting_for_user` to mean "the agent still owns the turn"; the rest are terminal.
+ * Shared with the detail view and the `activeResponseCallback` gate via
+ * {@link isActiveTaskState}.
  */
-const ACTIVE_STATES = new Set<AgentTaskState>(['queued', 'in_progress', 'idle', 'waiting_for_user']);
-function isActiveState(state: AgentTaskState | undefined): boolean {
-	return state !== undefined && ACTIVE_STATES.has(state);
+function isActiveState(state: AgentTaskGetResponse['state'] | undefined): boolean {
+	return state !== undefined && isActiveTaskState(state);
 }
 
 /**
@@ -106,6 +108,7 @@ export class TaskTurnStreamer {
 			currentIntent: null,
 			assistantMessageContent: new Map<string, string>(),
 			activeMessageId: null,
+			renderedError: false,
 		};
 		let lastProgressLabel: string | undefined;
 
@@ -149,6 +152,22 @@ export class TaskTurnStreamer {
 
 				const sessions = task?.sessions;
 				const latestTurn = sessions?.[sessions.length - 1];
+				// Settle when the task itself reached a terminal state, even if its latest turn's
+				// session state is still active. A task that failed to launch (e.g. "Failed to
+				// launch agent") never advances the turn out of `queued`/`in_progress`, so the
+				// per-turn check below would otherwise poll forever.
+				if (task !== undefined && !isActiveState(task.state)) {
+					if (isFailedTaskState(task.state)) {
+						// Surface the stop in-stream too, so it shows even after partial content
+						// streamed. Skip the concrete detail if a `session.error` already rendered it.
+						sink.flush();
+						const detail = state.renderedError ? undefined : extractTaskErrorDetail(events);
+						this._logService.trace(`[TaskTurnStreamer] task ${taskId} settled stopped (state=${task.state}); renderedError=${state.renderedError}; errorDetail=${detail ?? 'none'}`);
+						stream.markdown(formatTaskStoppedMessage(task.state, detail));
+					}
+					state.isWorking = false;
+					return;
+				}
 				if (latestTurn && !isActiveState(latestTurn.state)) {
 					state.isWorking = false;
 					return;
@@ -236,6 +255,12 @@ export class TaskTurnStreamer {
 
 		if (event.dismissed) {
 			return;
+		}
+
+		if (event.type === 'session.error') {
+			// A `session.error` renders inline via the default path below; remember it so the
+			// terminal-failure notice on settle doesn't repeat the same detail.
+			state.renderedError = true;
 		}
 
 		// Skip `tool.execution_complete` for tool calls we already rendered eagerly
@@ -385,6 +410,9 @@ interface IngestState {
 	assistantMessageContent: Map<string, string>;
 	/** The messageId currently accumulating chunks in the render context, for flushing on boundaries. */
 	activeMessageId: string | null;
+	/** Whether a non-dismissed `session.error` was already rendered into the stream, so the terminal
+	 * failure notice doesn't repeat the same error detail. */
+	renderedError: boolean;
 }
 
 interface ToolRequest {

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCloudSessionsProvider.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCloudSessionsProvider.spec.ts
@@ -12,7 +12,7 @@ import { TestLogService } from '../../../../platform/testing/common/testLogServi
 import { mock } from '../../../../util/common/test/simpleMock';
 import { ChatRequestTurn2, ChatResponseMarkdownPart, ChatResponseTurn2, ChatToolInvocationPart } from '../../../../vscodeTypes';
 import { ITaskApiClient, ListTaskEventsOptions, ListTasksOptions } from '../../common/taskApiTypes';
-import { ChatSessionContentBuilder } from '../copilotCloudSessionContentBuilder';
+import { ChatSessionContentBuilder, extractTaskErrorDetail, formatTaskStoppedMessage } from '../copilotCloudSessionContentBuilder';
 import { normalizeInitialSessionOptions, parseSessionLogChunksSafely, taskStateToChatSessionStatus } from '../copilotCloudSessionsProvider';
 import { TaskApiBackend, parseRepoFromTaskUrl, isCloudCodingAgentTask } from '../taskApiBackend';
 import { NullCloudBackendInstrumentation } from '../cloudBackendTelemetry';
@@ -187,10 +187,10 @@ function userMessage(content: string): AgentTaskSessionEvent {
 	return evt('user.message', { content, transformedContent: `${content}\n\n<context>...</context>` });
 }
 
-function makeTask(sessions: Array<{ state: string; prompt?: string }> = []): AgentTaskGetResponse {
+function makeTask(sessions: Array<{ state: string; prompt?: string }> = [], taskState: string = 'completed'): AgentTaskGetResponse {
 	return {
 		id: 'task-1',
-		state: 'completed',
+		state: taskState,
 		created_at: '2026-03-27T00:00:00Z',
 		sessions: sessions.map((s, i) => ({
 			id: `s-${i}`,
@@ -317,6 +317,104 @@ describe('ChatSessionContentBuilder Task API history', () => {
 		expect(history[0]).toBeInstanceOf(ChatRequestTurn2);
 		const req = history[0] as ChatRequestTurn2;
 		expect(req.prompt).toBe('Original prompt from creation');
+	});
+
+	it('renders a stopped notice (not a progress spinner) when the task terminally failed but its latest session state is still active', async () => {
+		// "Failed to launch agent": the task ends in `failed` while its only session's state is
+		// stuck at `in_progress` and no renderable events were ever emitted. Keying off the task
+		// state must surface the stop instead of a perpetual "Session is in progress…" spinner.
+		const events: AgentTaskSessionEvent[] = [
+			evt('session.requested', {}),
+			evt('session.start', {}),
+		];
+		const task = makeTask([{ state: 'in_progress', prompt: 'Do the thing' }], 'failed');
+
+		const history = await newBuilder().buildTaskHistory(task, events, undefined, Promise.resolve([]));
+
+		expect(summarise(history)).toEqual([
+			{ kind: 'request', prompt: 'Do the thing' },
+			{ kind: 'response', parts: [{ type: 'markdown', value: 'Copilot stopped: an error occurred' }] },
+		]);
+	});
+
+	it('renders a cancellation reason (not an error) when the task was cancelled with no error event', async () => {
+		// A cancelled task emits no session.error/session.shutdown; the reason comes from the state.
+		const events: AgentTaskSessionEvent[] = [
+			evt('session.requested', {}),
+			evt('session.start', {}),
+			userMessage('one more'),
+		];
+		const task = makeTask([{ state: 'cancelled', prompt: 'Do the thing' }], 'cancelled');
+
+		const history = await newBuilder().buildTaskHistory(task, events, undefined, Promise.resolve([]));
+
+		expect(summarise(history)).toEqual([
+			{ kind: 'request', prompt: 'one more' },
+			{ kind: 'response', parts: [{ type: 'markdown', value: 'Copilot stopped: cancelled' }] },
+		]);
+	});
+
+	it('includes the concrete error detail from a bootstrap session.error in the stopped notice', async () => {
+		// A `session.error` emitted during bootstrap (before any user.message) is suppressed from
+		// the rendered turn, but its detail is still surfaced in the terminal-stopped notice.
+		const events: AgentTaskSessionEvent[] = [
+			evt('session.requested', {}),
+			evt('session.start', {}),
+			evt('session.error', { errorType: 'launch_failed', message: 'Failed to launch agent' }),
+		];
+		const task = makeTask([{ state: 'in_progress', prompt: 'Do the thing' }], 'failed');
+
+		const history = await newBuilder().buildTaskHistory(task, events, undefined, Promise.resolve([]));
+
+		expect(summarise(history)).toEqual([
+			{ kind: 'request', prompt: 'Do the thing' },
+			{ kind: 'response', parts: [{ type: 'markdown', value: 'Copilot stopped: (launch_failed) Failed to launch agent' }] },
+		]);
+	});
+
+	it('still shows the in-progress spinner when the task is active with no renderable events yet', async () => {
+		const events: AgentTaskSessionEvent[] = [
+			evt('session.requested', {}),
+			evt('session.start', {}),
+		];
+		const task = makeTask([{ state: 'in_progress', prompt: 'Do the thing' }], 'in_progress');
+
+		const history = await newBuilder().buildTaskHistory(task, events, undefined, Promise.resolve([]));
+
+		expect(summarise(history)).toEqual([
+			{ kind: 'request', prompt: 'Do the thing' },
+			{ kind: 'response', parts: [{ type: 'ChatResponseProgressPart' }] },
+		]);
+	});
+});
+
+describe('extractTaskErrorDetail / formatTaskStoppedMessage', () => {
+	it('prefers the last session.error message, falls back to session.shutdown errorReason, else undefined', () => {
+		expect(extractTaskErrorDetail([
+			evt('session.error', { errorType: 'launch_failed', message: 'Failed to launch agent' }),
+		])).toBe('(launch_failed) Failed to launch agent');
+
+		expect(extractTaskErrorDetail([
+			evt('session.error', { message: 'boom' }),
+		])).toBe('boom');
+
+		expect(extractTaskErrorDetail([
+			evt('session.error', { errorType: 'x', message: 'first' }, { dismissed: true }),
+			evt('session.shutdown', { shutdownType: 'error', errorReason: 'agent crashed' }),
+		])).toBe('agent crashed');
+
+		expect(extractTaskErrorDetail([
+			evt('session.shutdown', { shutdownType: 'routine' }),
+			evt('session.start', {}),
+		])).toBeUndefined();
+	});
+
+	it('uses the detail when present, else a state-derived reason', () => {
+		expect(formatTaskStoppedMessage('failed', '(launch_failed) Failed to launch agent'))
+			.toBe('Copilot stopped: (launch_failed) Failed to launch agent');
+		expect(formatTaskStoppedMessage('cancelled', undefined)).toBe('Copilot stopped: cancelled');
+		expect(formatTaskStoppedMessage('timed_out', undefined)).toBe('Copilot stopped: timed out');
+		expect(formatTaskStoppedMessage('failed', undefined)).toBe('Copilot stopped: an error occurred');
 	});
 });
 

--- a/extensions/copilot/src/extension/chatSessions/vscode/copilotCodingAgentUtils.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode/copilotCodingAgentUtils.ts
@@ -3,10 +3,43 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { AgentTaskState } from '@vscode/copilot-api';
 import * as vscode from 'vscode';
 import { getGithubRepoIdFromFetchUrl, GithubRepoId, IGitService } from '../../../platform/git/common/gitService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { UriHandlerPaths, UriHandlers } from './chatSessionsUriHandler';
+
+/**
+ * Task (v2) lifecycle states in which the cloud agent still owns the turn (or is about to):
+ * the session must render as active and any live stream keep polling. Terminal states
+ * (`completed`/`failed`/`timed_out`/`cancelled`) return false. This is the single source of
+ * truth for "is the task still running" so the detail view, the `activeResponseCallback`
+ * gate, and the {@link TaskTurnStreamer} settle check all agree.
+ */
+export function isActiveTaskState(state: AgentTaskState): boolean {
+	switch (state) {
+		case 'queued':
+		case 'in_progress':
+		case 'idle':
+		case 'waiting_for_user':
+			return true;
+		case 'completed':
+		case 'failed':
+		case 'timed_out':
+		case 'cancelled':
+			return false;
+	}
+}
+
+/**
+ * Task (v2) lifecycle states that represent an unsuccessful terminal outcome. Used to render a
+ * failure notice in the detail view when the task ended without emitting any events (e.g.
+ * "Failed to launch agent"), which otherwise leaves the latest turn's session state stuck at
+ * `in_progress`/`queued` and shows a perpetual "Session is in progress…" spinner.
+ */
+export function isFailedTaskState(state: AgentTaskState): boolean {
+	return state === 'failed' || state === 'timed_out' || state === 'cancelled';
+}
 
 export const MAX_PROBLEM_STATEMENT_LENGTH = 30_000 - 50; // 50 character buffer
 export const CONTINUE_TRUNCATION = vscode.l10n.t('Continue with truncation');


### PR DESCRIPTION
This pull request enhances the error handling and messaging for the Copilot Cloud Sessions feature, specifically addressing how task states are communicated to users.

### Changes Made:
- Unified the error message format to `Copilot stopped: <reason>`, where `<reason>` is derived from the task state (e.g., "cancelled", "timed out", or specific error details).
- Updated the `formatTaskStoppedMessage` function to reflect the new messaging format.
- Cleaned up verbose diagnostic logging in the `extractTaskErrorDetail` function, removing unnecessary parameters and logs.
- Restored assertions in the test for synthesizing a single turn that were accidentally removed in a previous edit.
- Updated tests to match the new message format and ensure all scenarios are covered.

### Rationale:
These changes improve user experience by providing clearer and more accurate feedback regarding task states, particularly distinguishing between cancellation and failure. The logging cleanup also enhances maintainability by reducing noise in the logs. All tests have been updated and pass successfully, ensuring the reliability of the new implementation.