### PR TITLE
Prompt for MCP server auth once per conversation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -82,6 +82,7 @@ import { ILanguageModelToolsService, IToolInvocation, IToolResult, ToolInvocatio
 import { IChatWidgetService } from '../../chat.js';
 import { getAgentSessionProviderIcon } from '../agentSessions.js';
 import { IAgentHostActiveClientService } from './agentHostActiveClientService.js';
+import { IAgentHostCustomizationService } from './agentHostCustomizationService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
 import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
 import { AgentHostSnapshotController } from './agentHostSnapshotController.js';
@@ -610,6 +611,14 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	private readonly _serverTurnWatchers = this._register(new DisposableResourceMap());
 	/** Historical turns with file edits, pending hydration into the editing session. */
 	private readonly _pendingHistoryTurns = new ResourceMap<readonly Turn[]>();
+	/**
+	 * Per-session set of MCP server ids that already had an authentication
+	 * prompt surfaced in the current conversation. A server is removed from the
+	 * set once it reaches the running state ({@link McpServerStatus.Ready}), so
+	 * that a later auth requirement for the same server prompts again instead of
+	 * the prompt repeating on every message.
+	 */
+	private readonly _surfacedMcpAuthServers = new ResourceMap<Set<string>>();
 	/** Turn IDs dispatched by this client, used to distinguish server-originated turns. */
 	private readonly _clientDispatchedTurnIds = new Set<string>();
 	private readonly _config: IAgentHostSessionHandlerConfig;
@@ -670,9 +679,15 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		@IChatResponseFileChangesService private readonly _chatResponseFileChangesService: IChatResponseFileChangesService,
 		@IPathService private readonly _pathService: IPathService,
 		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
+		@IAgentHostCustomizationService private readonly _customizationService: IAgentHostCustomizationService,
 	) {
 		super();
 		this._config = config;
+
+		// Drop MCP servers from the per-session surfaced set once they reach the
+		// running state so a later auth requirement for the same server prompts
+		// again.
+		this._register(this._customizationService.onDidChangeCustomizations(() => this._reconcileSurfacedMcpAuthServers()));
 
 		this._register(autorun(reader => {
 			const defs = this._activeClientService.getClientTools(this._config.sessionType).read(reader);
@@ -996,6 +1011,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				this._draftSyncSubscriptions.deleteAndDispose(sessionResource);
 				this._serverTurnWatchers.deleteAndDispose(sessionResource);
 				this._pendingHistoryTurns.delete(sessionResource);
+				this._surfacedMcpAuthServers.delete(sessionResource);
 				const chatURI = this._chatURIsBySessionResource.get(sessionResource);
 				this._chatURIsBySessionResource.delete(sessionResource);
 				if (chatURI) {
@@ -1878,35 +1894,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// own view, not the parent.
 		if (opts.subAgentInvocationId === undefined) {
 			let lastUsage: ReturnType<typeof usageInfoToChatUsage>;
-			let mcpAuthPart: IChatMcpAuthenticationRequired & { servers: ISettableObservable<IChatMcpAuthenticationRequiredServer[]> } | undefined;
-			let mcpAuthRunId = 0;
 
-			store.add(autorun(reader => {
-				const pendingAuth = mcpAuthRequired$.read(reader);
-				const runId = ++mcpAuthRunId;
-				this._filterAutoGrantedMcpAuthentication(opts.sessionResource, pendingAuth).then(servers => {
-					// Ignore stale completions: a newer run has superseded this one
-					// (guards against out-of-order resolution of the async filter).
-					if (runId !== mcpAuthRunId) {
-						return;
-					}
-					// Don't emit an empty prompt: only surface the part once there is
-					// something to authenticate, or to update/hide a live prompt.
-					if (!servers.length && (!mcpAuthPart || mcpAuthPart.isUsed)) {
-						return;
-					}
-					if (!mcpAuthPart || mcpAuthPart.isUsed) {
-						mcpAuthPart = {
-							kind: 'mcpAuthenticationRequired',
-							sessionResource: opts.sessionResource.toJSON(),
-							isUsed: false,
-							servers: observableValue('mcpAuthNeededServers', []),
-						};
-						opts.sink([mcpAuthPart]);
-					}
-					mcpAuthPart.servers.set(servers.slice(), undefined);
-				});
-			}));
+			this._setupMcpAuthPrompt(mcpAuthRequired$, store, opts);
 
 			// Surface a "Starting MCP servers …" progress hint when servers
 			// remain in the `Starting` state past a short grace period after the
@@ -2131,6 +2120,100 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}));
 
 		return store;
+	}
+
+	/**
+	 * Surfaces the "MCP server … requires authentication" prompt for a turn.
+	 *
+	 * Each server is prompted at most once per conversation: {@link mcpAuthRequired$}
+	 * is session-wide, so without this guard the prompt would repeat on every
+	 * message. The per-session {@link _surfacedMcpAuthServers surfaced set} tracks
+	 * which servers were already prompted; it is pruned by
+	 * {@link _reconcileSurfacedMcpAuthServers} once a server reaches the running
+	 * state, so a server that is re-required after being authenticated (e.g.
+	 * after a restart) prompts again.
+	 *
+	 * The emitted part lists only the servers it introduced and shrinks as they
+	 * authenticate.
+	 */
+	private _setupMcpAuthPrompt(
+		mcpAuthRequired$: IObservable<readonly IChatMcpAuthenticationRequiredServer[]>,
+		store: DisposableStore,
+		opts: IObserveTurnOptions,
+	): void {
+		let part: IChatMcpAuthenticationRequired & { servers: ISettableObservable<IChatMcpAuthenticationRequiredServer[]> } | undefined;
+		let ownedIds = new Set<string>();
+		let runId = 0;
+
+		store.add(autorun(reader => {
+			const pendingAuth = mcpAuthRequired$.read(reader);
+			const currentRunId = ++runId;
+			this._filterAutoGrantedMcpAuthentication(opts.sessionResource, pendingAuth).then(servers => {
+				// Ignore stale completions: a newer run has superseded this one
+				// (guards against out-of-order resolution of the async filter).
+				if (currentRunId !== runId) {
+					return;
+				}
+				const surfaced = this._getSurfacedMcpAuthServers(opts.sessionResource);
+				const newServers = servers.filter(server => !surfaced.has(server.id));
+				// Nothing new to prompt and no live prompt to update/hide.
+				if (!newServers.length && (!part || part.isUsed)) {
+					return;
+				}
+				if (!part || part.isUsed) {
+					ownedIds = new Set();
+					part = {
+						kind: 'mcpAuthenticationRequired',
+						sessionResource: opts.sessionResource.toJSON(),
+						isUsed: false,
+						servers: observableValue('mcpAuthNeededServers', []),
+					};
+					opts.sink([part]);
+				}
+				for (const server of newServers) {
+					surfaced.add(server.id);
+					ownedIds.add(server.id);
+				}
+				part.servers.set(servers.filter(server => ownedIds.has(server.id)), undefined);
+			});
+		}));
+	}
+
+	/**
+	 * Returns the mutable set of MCP server ids already surfaced for
+	 * authentication in the given session, creating it on first use.
+	 */
+	private _getSurfacedMcpAuthServers(sessionResource: URI): Set<string> {
+		let surfaced = this._surfacedMcpAuthServers.get(sessionResource);
+		if (!surfaced) {
+			surfaced = new Set<string>();
+			this._surfacedMcpAuthServers.set(sessionResource, surfaced);
+		}
+		return surfaced;
+	}
+
+	/**
+	 * Prunes servers that reached the running ({@link McpServerStatus.Ready})
+	 * state from every session's {@link _surfacedMcpAuthServers surfaced set} so
+	 * a subsequent auth requirement surfaces a fresh prompt instead of being
+	 * suppressed. Only the running state counts as actioned — a server that
+	 * merely left {@link McpServerStatus.AuthRequired} for an error/stopped
+	 * state was not authenticated and stays suppressed.
+	 */
+	private _reconcileSurfacedMcpAuthServers(): void {
+		for (const [sessionResource, surfaced] of this._surfacedMcpAuthServers) {
+			if (surfaced.size === 0) {
+				continue;
+			}
+			const ready = new Set(this._customizationService.getMcpServers(sessionResource)
+				.filter(server => server.status === McpServerStatus.Ready)
+				.map(server => server.id));
+			for (const id of surfaced) {
+				if (ready.has(id)) {
+					surfaced.delete(id);
+				}
+			}
+		}
 	}
 
 	private async _filterAutoGrantedMcpAuthentication(sessionResource: URI, servers: readonly IChatMcpAuthenticationRequiredServer[]): Promise<readonly IChatMcpAuthenticationRequiredServer[]> {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -26,7 +26,7 @@ import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey 
 import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
 import { ActionType, isSessionAction, isChatAction, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type ChatAction, type TerminalAction, type INotification, type IToolCallConfirmedAction, type ITurnStartedAction, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import type { IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
-import { CustomizationType, type ClientPluginCustomization, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { CustomizationType, McpAuthRequiredReason, McpServerStatus, type ClientPluginCustomization, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallContributorKind, createSessionState, createChatState, createDefaultChatSummary, buildChatUri, buildDefaultChatUri, parseDefaultChatUri, isAhpChatChannel, createActiveTurn, isAhpRootChannel, PolicyState, ResponsePartKind, ROOT_STATE_URI, StateComponents, buildSubagentChatUri, ToolResultContentType, MessageAttachmentKind, MessageKind, type SessionState, type SessionSummary, type ChatState, type ISessionWithDefaultChat, RootState, type ToolCallState, type AgentInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { CompletionItemKind as AhpCompletionItemKind, type CompletionsParams, type CompletionsResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { sessionReducer, chatReducer } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
@@ -36,7 +36,7 @@ import { IAuthenticationService } from '../../../../../services/authentication/c
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatAgentData, IChatAgentImplementation, IChatAgentRequest, IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../../common/constants.js';
-import { ChatRequestQueueKind, ElicitationState, IChatService, IChatMarkdownContent, IChatProgress, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, IChatUsage, ToolConfirmKind } from '../../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, ElicitationState, IChatService, IChatMarkdownContent, IChatMcpAuthenticationRequired, IChatProgress, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, IChatUsage, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { IChatDebugService } from '../../../common/chatDebugService.js';
 import { IChatEditingService } from '../../../common/editing/chatEditingService.js';
 import { IChatResponseFileChangesService } from '../../../browser/chatResponseFileChangesService.js';
@@ -80,6 +80,7 @@ import { type ContextKeyValue } from '../../../../../../platform/contextkey/comm
 import { IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { SyncedCustomizationBundler } from '../../../browser/agentSessions/agentHost/syncedCustomizationBundler.js';
 import { IAgentHostCustomizationService, NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
+import { IAgentHostMcpServer } from '../../../../../../sessions/common/agentHostSessionsProvider.js';
 import { ILanguageModelToolsService, ToolDataSource } from '../../../common/tools/languageModelToolsService.js';
 import { IPromptsService } from '../../../common/promptSyntax/service/promptsService.js';
 import { IChatWidgetService } from '../../../browser/chat.js';
@@ -593,7 +594,7 @@ class MockWorkingCopyService extends mock<IWorkingCopyService>() {
 
 // ---- Helpers ----------------------------------------------------------------
 
-function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }, authServiceOverride?: Partial<IAuthenticationService>, languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>, provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>, isSessionsWindow = false, languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>, configOverrides?: Record<string, unknown>, chatSessionsServiceOverride?: Partial<IChatSessionsService>, chatDebugServiceOverride?: Partial<IChatDebugService>, remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService>) {
+function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }, authServiceOverride?: Partial<IAuthenticationService>, languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>, provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>, isSessionsWindow = false, languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>, configOverrides?: Record<string, unknown>, chatSessionsServiceOverride?: Partial<IChatSessionsService>, chatDebugServiceOverride?: Partial<IChatDebugService>, remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService>, customizationServiceOverride?: IAgentHostCustomizationService) {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	const agentHostService = new MockAgentHostService();
@@ -773,7 +774,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		isNewSession: sessionResource => workingDirectoryResolver?.isNewSession?.(sessionResource) ?? sessionResource.path.substring(1).startsWith('new-'),
 	});
 	instantiationService.stub(IWorkbenchEnvironmentService, { isSessionsWindow } as Partial<IWorkbenchEnvironmentService>);
-	instantiationService.stub(IAgentHostCustomizationService, new NullAgentHostCustomizationService());
+	instantiationService.stub(IAgentHostCustomizationService, customizationServiceOverride ?? new NullAgentHostCustomizationService());
 	instantiationService.stub(IAgentHostUntitledProvisionalSessionService, {
 		onDidChange: Event.None,
 		get: () => undefined,
@@ -843,8 +844,8 @@ function createSessionListController(disposables: DisposableStore, instantiation
 	return disposables.add(instantiationService.createInstance(AgentHostSessionListController, sessionType, provider, sessionListStore, description, 'local'));
 }
 
-function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }; languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>; provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>; languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>; configOverrides?: Record<string, unknown>; provider?: string; chatSessionsServiceOverride?: Partial<IChatSessionsService>; chatDebugServiceOverride?: Partial<IChatDebugService>; remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService> }) {
-	const { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, trustController, modelService, workingCopyService } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride, opts?.languageModels, opts?.provisionalServiceOverride, false, opts?.languageModelToolsServiceOverride, opts?.configOverrides, opts?.chatSessionsServiceOverride, opts?.chatDebugServiceOverride, opts?.remoteAgentHostServiceOverride);
+function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }; languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>; provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>; languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>; configOverrides?: Record<string, unknown>; provider?: string; chatSessionsServiceOverride?: Partial<IChatSessionsService>; chatDebugServiceOverride?: Partial<IChatDebugService>; remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService>; customizationServiceOverride?: IAgentHostCustomizationService }) {
+	const { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, trustController, modelService, workingCopyService } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride, opts?.languageModels, opts?.provisionalServiceOverride, false, opts?.languageModelToolsServiceOverride, opts?.configOverrides, opts?.chatSessionsServiceOverride, opts?.chatDebugServiceOverride, opts?.remoteAgentHostServiceOverride, opts?.customizationServiceOverride);
 
 	const listController = createSessionListController(disposables, instantiationService, agentHostService);
 	const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
@@ -862,10 +863,10 @@ function createContribution(disposables: DisposableStore, opts?: { authServiceOv
 	return { contribution, listController, sessionHandler, agentHostService, chatAgentService, chatWidgetService, chatService, instantiationService, openerService, trustController, modelService, workingCopyService };
 }
 
-function makeRequest(overrides: Partial<{ message: string; sessionResource: URI; variables: IChatAgentRequest['variables']; userSelectedModelId: string; modelConfiguration: Record<string, unknown>; agentHostSessionConfig: Record<string, string>; agentId: string }> = {}): IChatAgentRequest {
+function makeRequest(overrides: Partial<{ message: string; sessionResource: URI; variables: IChatAgentRequest['variables']; userSelectedModelId: string; modelConfiguration: Record<string, unknown>; agentHostSessionConfig: Record<string, string>; agentId: string; requestId: string }> = {}): IChatAgentRequest {
 	return upcastPartial<IChatAgentRequest>({
 		sessionResource: overrides.sessionResource ?? URI.from({ scheme: 'untitled', path: '/chat-1' }),
-		requestId: 'req-1',
+		requestId: overrides.requestId ?? 'req-1',
 		agentId: overrides.agentId ?? 'agent-host-copilot',
 		message: overrides.message ?? 'Hello',
 		variables: overrides.variables ?? { variables: [] },
@@ -7892,6 +7893,145 @@ suite('AgentHostChatContribution', () => {
 
 			assert.deepStrictEqual(agentHostService.authenticateCalls, []);
 		});
+	});
+
+	// ---- MCP auth prompt dedupe (per conversation) ----------------------
+
+	suite('mcp auth prompt', () => {
+
+		// A customization service whose MCP server statuses and change events the
+		// test drives directly, so the handler's reconcile pass — which prunes a
+		// server from the per-conversation surfaced set once it reaches Ready —
+		// can be exercised deterministically.
+		class TestMcpCustomizationService extends NullAgentHostCustomizationService {
+			private readonly _onDidChange = new Emitter<void>();
+			override readonly onDidChangeCustomizations = this._onDidChange.event;
+			mcpServers: readonly IAgentHostMcpServer[] = [];
+			override getMcpServers(): readonly IAgentHostMcpServer[] {
+				return this.mcpServers;
+			}
+			fireChange(): void {
+				this._onDidChange.fire();
+			}
+			dispose(): void {
+				this._onDidChange.dispose();
+			}
+		}
+
+		// An MCP server customization stuck in the auth-required state. Empty
+		// `authorization_servers` keeps the auto-grant probe off the network so it
+		// resolves to "not authenticated" and the server stays pending.
+		const authRequiredCustomization = () => ({
+			type: CustomizationType.McpServer,
+			id: 'mcp-1',
+			name: 'GitHub MCP',
+			enabled: true,
+			uri: URI.parse('https://example.com/mcp'),
+			state: {
+				kind: McpServerStatus.AuthRequired,
+				reason: McpAuthRequiredReason.Required,
+				resource: { resource: 'https://example.com/mcp', authorization_servers: [] },
+				requiredScopes: ['read:user'],
+			},
+		});
+
+		// Runs one turn on `resource` to completion, optionally pushing session
+		// customizations mid-turn, and returns the auth-prompt parts emitted.
+		async function runTurn(
+			sessionHandler: AgentHostSessionHandler,
+			agentHostService: MockAgentHostService,
+			chatAgentService: MockChatAgentService,
+			resource: URI,
+			seq: { v: number },
+			opts?: { customizations?: unknown[] },
+		): Promise<IChatMcpAuthenticationRequired[]> {
+			const chatSession = await sessionHandler.provideChatSessionContent(resource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+			agentHostService.dispatchedActions.length = 0;
+
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+			const collected: IChatProgress[][] = [];
+			const turnPromise = registered.impl.invoke(
+				makeRequest({ message: 'Hello', sessionResource: resource, requestId: `turn-${seq.v}` }),
+				parts => collected.push(parts),
+				[],
+				CancellationToken.None,
+			);
+			await timeout(10);
+
+			const dispatch = agentHostService.turnActions[agentHostService.turnActions.length - 1];
+			const turnId = (dispatch.action as ITurnStartedAction).turnId;
+			// Echo turnStarted to clear the pending write-ahead entry.
+			agentHostService.fireAction({ channel: dispatch.channel.toString(), action: dispatch.action, serverSeq: seq.v++, origin: { clientId: agentHostService.clientId, clientSeq: dispatch.clientSeq } });
+
+			if (opts?.customizations) {
+				const sessionChannel = parseDefaultChatUri(dispatch.channel.toString())!;
+				agentHostService.fireAction({
+					channel: sessionChannel,
+					action: { type: ActionType.SessionCustomizationsChanged, customizations: opts.customizations } as unknown as SessionAction,
+					serverSeq: seq.v++,
+					origin: undefined,
+				});
+			}
+			// Let the async auto-grant filter resolve and the prompt part emit.
+			await timeout(50);
+
+			const promptParts = collected.flat().filter((p): p is IChatMcpAuthenticationRequired => p.kind === 'mcpAuthenticationRequired');
+
+			agentHostService.fireAction({ channel: dispatch.channel.toString(), action: { type: 'chat/turnComplete', turnId } as ChatAction, serverSeq: seq.v++, origin: undefined });
+			await turnPromise;
+			return promptParts;
+		}
+
+		test('surfaces an unauthenticated server once, then suppresses it on the next turn', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+			const resource = URI.from({ scheme: 'agent-host-copilot', path: '/mcp-auth-1' });
+			const seq = { v: 1 };
+
+			// Turn 1: server needs auth → the prompt surfaces it.
+			const turn1 = await runTurn(sessionHandler, agentHostService, chatAgentService, resource, seq, { customizations: [authRequiredCustomization()] });
+			assert.deepStrictEqual(turn1.flatMap(p => p.servers.get().map(s => s.name)), ['GitHub MCP']);
+
+			// Turn 2: still needs auth, but was already prompted → no new prompt.
+			const turn2 = await runTurn(sessionHandler, agentHostService, chatAgentService, resource, seq);
+			assert.deepStrictEqual(turn2.flatMap(p => p.servers.get()), []);
+		}));
+
+		test('re-surfaces a server that reaches Ready and then needs auth again', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const customizationService = disposables.add(new TestMcpCustomizationService());
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, { customizationServiceOverride: customizationService });
+			const resource = URI.from({ scheme: 'agent-host-copilot', path: '/mcp-auth-2' });
+			const seq = { v: 1 };
+
+			const turn1 = await runTurn(sessionHandler, agentHostService, chatAgentService, resource, seq, { customizations: [authRequiredCustomization()] });
+			const serverId = turn1[0].servers.get()[0].id;
+
+			// Server authenticates and reaches Ready → reconcile clears suppression.
+			customizationService.mcpServers = [upcastPartial<IAgentHostMcpServer>({ id: serverId, status: McpServerStatus.Ready })];
+			customizationService.fireChange();
+
+			// Turn 2: auth is required again → the prompt surfaces once more.
+			const turn2 = await runTurn(sessionHandler, agentHostService, chatAgentService, resource, seq);
+			assert.deepStrictEqual(turn2.flatMap(p => p.servers.get().map(s => s.name)), ['GitHub MCP']);
+		}));
+
+		test('keeps a server suppressed when it leaves auth-required without reaching Ready', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const customizationService = disposables.add(new TestMcpCustomizationService());
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, { customizationServiceOverride: customizationService });
+			const resource = URI.from({ scheme: 'agent-host-copilot', path: '/mcp-auth-3' });
+			const seq = { v: 1 };
+
+			const turn1 = await runTurn(sessionHandler, agentHostService, chatAgentService, resource, seq, { customizations: [authRequiredCustomization()] });
+			const serverId = turn1[0].servers.get()[0].id;
+
+			// Server transitions to a non-ready state (error) → it was not actioned,
+			// so it stays suppressed.
+			customizationService.mcpServers = [upcastPartial<IAgentHostMcpServer>({ id: serverId, status: McpServerStatus.Error })];
+			customizationService.fireChange();
+
+			const turn2 = await runTurn(sessionHandler, agentHostService, chatAgentService, resource, seq);
+			assert.deepStrictEqual(turn2.flatMap(p => p.servers.get()), []);
+		}));
 	});
 
 	// ---- Chat input completions delegation -----------------------------

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -33,6 +33,7 @@ import { TestInstantiationService } from '../../../../../../platform/instantiati
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { AgentHostSessionHandler, toolDataToDefinition, toolResultToProtocol } from '../../../browser/agentSessions/agentHost/agentHostSessionHandler.js';
 import { AgentHostActiveClientService, IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
+import { IAgentHostCustomizationService, NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
 import { IAgentHostToolSetEnablementService, IToolEnablementState } from '../../../browser/agentSessions/agentHost/agentHostToolSetEnablementService.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { TestFileService } from '../../../../../test/common/workbenchTestServices.js';
@@ -489,6 +490,7 @@ suite('AgentHostClientTools', () => {
 				registerAuthority: () => toDisposable(() => { }),
 				ensureSyncedCustomizationProvider: () => { },
 			});
+			instantiationService.stub(IAgentHostCustomizationService, new NullAgentHostCustomizationService());
 			instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
 			instantiationService.stub(IAgentHostImportConversationStore, {
 				set: () => { },


### PR DESCRIPTION
### Problem

The "The MCP server … requires authentication" prompt shown for agent host sessions reappeared on **every** chat message. The auth-required state is derived from session-wide customization state, but the prompt is emitted from the per-turn observable graph in `_observeTurn`, so each turn independently re-surfaced it.

### Fix

Track, per session, which MCP servers have already had an auth prompt surfaced in the current conversation, and only surface not-yet-prompted servers:

- `_surfacedMcpAuthServers`: per-session set of server ids already prompted.
- `_setupMcpAuthPrompt`: extracted from `_observeTurn` (matching the sibling `_setupMarkdownPart` / `_setupReasoningPart` helpers). Surfaces only new servers and lists just the servers the prompt introduced, shrinking as they authenticate.
- `_reconcileSurfacedMcpAuthServers`: on `onDidChangeCustomizations`, prunes a server from the set once it reaches the running state (`McpServerStatus.Ready`). This runs independently of active turns so authentication performed while idle is still observed, and a server that later needs auth again (e.g. after a restart) re-prompts. A server that merely left `AuthRequired` for an error/stopped state stays suppressed.

### Result

Each MCP server prompts **once per conversation** if it is never authenticated, but re-prompts if it was authenticated and later needs auth again.