### PR TITLE
Cleanup for network isolation on pipelines

### DIFF
--- a/build/azure-pipelines/alpine/product-build-alpine-cli.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine-cli.yml
@@ -47,21 +47,7 @@ jobs:
       condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
       displayName: Setup NPM Registry
 
-    - script: |
-        set -e
-        # Set the private NPM registry to the global npmrc file
-        # so that authentication works for subfolders like build/, remote/, extensions/ etc
-        # which does not have their own .npmrc file
-        npm config set registry "$NPM_REGISTRY"
-        echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-      condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-      displayName: Setup NPM
-
-    - task: npmAuthenticate@0
-      inputs:
-        workingFile: $(NPMRC_PATH)
-      condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-      displayName: Setup NPM Authentication
+    - template: ../common/setup-npm.yml@self
 
     - script: |
         set -e

--- a/build/azure-pipelines/alpine/product-build-alpine-cli.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine-cli.yml
@@ -43,9 +43,37 @@ jobs:
 
     - template: ../cli/cli-apply-patches.yml@self
 
+    - script: node build/setup-npm-registry.ts $NPM_REGISTRY build
+      condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+      displayName: Setup NPM Registry
+
     - script: |
         set -e
-        npm ci
+        # Set the private NPM registry to the global npmrc file
+        # so that authentication works for subfolders like build/, remote/, extensions/ etc
+        # which does not have their own .npmrc file
+        npm config set registry "$NPM_REGISTRY"
+        echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
+      condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+      displayName: Setup NPM
+
+    - task: npmAuthenticate@0
+      inputs:
+        workingFile: $(NPMRC_PATH)
+      condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+      displayName: Setup NPM Authentication
+
+    - script: |
+        set -e
+
+        for i in {1..5}; do # try 5 times
+          npm ci && break
+          if [ $i -eq 5 ]; then
+            echo "Npm install failed too many times" >&2
+            exit 1
+          fi
+          echo "Npm install failed $i, trying again..."
+        done
       workingDirectory: build
       env:
         GITHUB_TOKEN: "$(github-token-code-oss)"

--- a/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
@@ -45,21 +45,7 @@ jobs:
           cacheHitVar: NODE_MODULES_RESTORED
         displayName: Restore node_modules cache
 
-      - script: |
-          set -e
-          # Set the private NPM registry to the global npmrc file
-          # so that authentication works for subfolders like build/, remote/, extensions/ etc
-          # which does not have their own .npmrc file
-          npm config set registry "$NPM_REGISTRY"
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ../common/setup-npm.yml@self
 
       - task: Docker@1
         inputs:
@@ -90,10 +76,12 @@ jobs:
           mkdir -p .build/nodejs-musl
           NODE_VERSION=$(grep '^target=' remote/.npmrc | cut -d '"' -f 2)
           BUILD_ID=$(grep '^ms_build_id=' remote/.npmrc | cut -d '"' -f 2)
-          # The azure-devops extension is preinstalled on the 1ES image. Under
-          # network isolation the --upgrade attempt cannot reach PyPI, so keep it
-          # non-fatal and fall back to the preinstalled version.
-          az extension add --name azure-devops --upgrade --only-show-errors || echo "azure-devops extension upgrade unavailable (network isolation), using preinstalled version"
+          # The azure-devops extension is preinstalled on the 1ES image. Under network
+          # isolation the --upgrade attempt cannot reach PyPI, so tolerate that failure —
+          # but verify the extension is actually available and fail fast otherwise, so a
+          # genuinely missing extension does not surface later as a confusing az artifacts error.
+          az extension add --name azure-devops --upgrade --only-show-errors || echo "azure-devops extension upgrade skipped (network isolation); using preinstalled version"
+          az extension show --name azure-devops --only-show-errors > /dev/null 2>&1 || { echo "azure-devops CLI extension is not available" >&2; exit 1; }
           az artifacts universal download \
             --organization "https://dev.azure.com/monacotools" \
             --project "Monaco" \

--- a/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
@@ -52,13 +52,13 @@ jobs:
           # which does not have their own .npmrc file
           npm config set registry "$NPM_REGISTRY"
           echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM
 
       - task: npmAuthenticate@0
         inputs:
           workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Authentication
 
       - task: Docker@1
@@ -90,7 +90,10 @@ jobs:
           mkdir -p .build/nodejs-musl
           NODE_VERSION=$(grep '^target=' remote/.npmrc | cut -d '"' -f 2)
           BUILD_ID=$(grep '^ms_build_id=' remote/.npmrc | cut -d '"' -f 2)
-          az extension add --name azure-devops --upgrade --only-show-errors
+          # The azure-devops extension is preinstalled on the 1ES image. Under
+          # network isolation the --upgrade attempt cannot reach PyPI, so keep it
+          # non-fatal and fall back to the preinstalled version.
+          az extension add --name azure-devops --upgrade --only-show-errors || echo "azure-devops extension upgrade unavailable (network isolation), using preinstalled version"
           az artifacts universal download \
             --organization "https://dev.azure.com/monacotools" \
             --project "Monaco" \

--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -96,13 +96,13 @@ jobs:
           # which does not have their own .npmrc file
           npm config set registry "$NPM_REGISTRY"
           echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM
 
       - task: npmAuthenticate@0
         inputs:
           workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Authentication
 
       - task: Docker@1
@@ -134,7 +134,10 @@ jobs:
           mkdir -p .build/nodejs-musl
           NODE_VERSION=$(grep '^target=' remote/.npmrc | cut -d '"' -f 2)
           BUILD_ID=$(grep '^ms_build_id=' remote/.npmrc | cut -d '"' -f 2)
-          az extension add --name azure-devops --upgrade --only-show-errors
+          # The azure-devops extension is preinstalled on the 1ES image. Under
+          # network isolation the --upgrade attempt cannot reach PyPI, so keep it
+          # non-fatal and fall back to the preinstalled version.
+          az extension add --name azure-devops --upgrade --only-show-errors || echo "azure-devops extension upgrade unavailable (network isolation), using preinstalled version"
           az artifacts universal download \
             --organization "https://dev.azure.com/monacotools" \
             --project "Monaco" \

--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -89,21 +89,7 @@ jobs:
         condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Extract node_modules cache
 
-      - script: |
-          set -e
-          # Set the private NPM registry to the global npmrc file
-          # so that authentication works for subfolders like build/, remote/, extensions/ etc
-          # which does not have their own .npmrc file
-          npm config set registry "$NPM_REGISTRY"
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ../common/setup-npm.yml@self
 
       - task: Docker@1
         inputs:
@@ -134,10 +120,12 @@ jobs:
           mkdir -p .build/nodejs-musl
           NODE_VERSION=$(grep '^target=' remote/.npmrc | cut -d '"' -f 2)
           BUILD_ID=$(grep '^ms_build_id=' remote/.npmrc | cut -d '"' -f 2)
-          # The azure-devops extension is preinstalled on the 1ES image. Under
-          # network isolation the --upgrade attempt cannot reach PyPI, so keep it
-          # non-fatal and fall back to the preinstalled version.
-          az extension add --name azure-devops --upgrade --only-show-errors || echo "azure-devops extension upgrade unavailable (network isolation), using preinstalled version"
+          # The azure-devops extension is preinstalled on the 1ES image. Under network
+          # isolation the --upgrade attempt cannot reach PyPI, so tolerate that failure —
+          # but verify the extension is actually available and fail fast otherwise, so a
+          # genuinely missing extension does not surface later as a confusing az artifacts error.
+          az extension add --name azure-devops --upgrade --only-show-errors || echo "azure-devops extension upgrade skipped (network isolation); using preinstalled version"
+          az extension show --name azure-devops --only-show-errors > /dev/null 2>&1 || { echo "azure-devops CLI extension is not available" >&2; exit 1; }
           az artifacts universal download \
             --organization "https://dev.azure.com/monacotools" \
             --project "Monaco" \

--- a/build/azure-pipelines/common/checkout.yml
+++ b/build/azure-pipelines/common/checkout.yml
@@ -3,9 +3,13 @@ steps:
   # checkout (e.g. the distro repository in download-distro.yml) does not relocate
   # self into a repo-named subfolder, which would break every script that assumes
   # self lives at $(Build.SourcesDirectory).
+  # persistCredentials keeps the repo auth header in .git/config after checkout so
+  # that the later standalone `git lfs pull` (see distro/download-distro.yml) can
+  # authenticate to the Git LFS endpoint; the checkout otherwise clears it.
   - checkout: self
     path: s
     fetchDepth: 1
     fetchTags: false
+    persistCredentials: true
     retryCountOnTaskFailure: 3
     displayName: Checkout microsoft/vscode

--- a/build/azure-pipelines/common/mixin-vscode-capi.yml
+++ b/build/azure-pipelines/common/mixin-vscode-capi.yml
@@ -1,3 +1,17 @@
+parameters:
+  # The npm script to run inside the vscode-capi checkout to apply the mixin.
+  # Product builds mix capi into the vscode product ('mixin_vscode'); the Copilot
+  # build mixes it into the copilot extension ('mixin').
+  - name: mixinScript
+    type: string
+    default: mixin_vscode
+  # The directory the mixin script targets, exported as BUILD_SOURCESDIRECTORY.
+  # Defaults to the vscode product root; the Copilot build overrides this to the
+  # copilot extension folder.
+  - name: buildSourcesDirectory
+    type: string
+    default: $(Build.SourcesDirectory)
+
 steps:
   # Check out the private microsoft/vscode-capi repository using the agent's
   # GitHub App (Monaco) credentials instead of cloning it with a PAT. The
@@ -7,6 +21,31 @@ steps:
     fetchDepth: 1
     retryCountOnTaskFailure: 3
     displayName: Checkout microsoft/vscode-capi
+
+  # Redirect vscode-capi's package-lock.json to the internal npm feed so the
+  # `npm ci` below works under network isolation. The capi checkout's lockfile
+  # otherwise resolves to the public registry (registry.npmjs.org), which is
+  # blocked on the isolated ADO build agents. Uses pwsh so it runs on every
+  # platform this shared template targets (Linux, macOS, Windows, Alpine).
+  - pwsh: node build/setup-npm-registry.ts $env:NPM_REGISTRY (Join-Path '$(Build.SourcesDirectory)' '.build/vscode-capi')
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Setup NPM Registry (vscode-capi)
+
+  # Authenticate the capi checkout against the internal feed. The calling stage's
+  # global npm authentication is conditional on a node_modules cache miss, so on a
+  # cache hit there is no token for the capi `npm ci` (which now targets the
+  # authenticated internal feed rather than the public registry). Write a project
+  # .npmrc in the capi checkout and authenticate it directly so the mixin is
+  # self-sufficient regardless of the caller's cache state.
+  - pwsh: Set-Content -Path (Join-Path '$(Build.SourcesDirectory)' '.build/vscode-capi/.npmrc') -Value "registry=$env:NPM_REGISTRY"
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Write vscode-capi .npmrc
+
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: $(Build.SourcesDirectory)/.build/vscode-capi/.npmrc
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Authenticate vscode-capi NPM feed
 
   - pwsh: |
       $ErrorActionPreference = 'Stop'
@@ -24,8 +63,8 @@ steps:
 
       try {
         Invoke-CheckedCommand { npm ci }
-        $env:BUILD_SOURCESDIRECTORY = '$(Build.SourcesDirectory)'
-        Invoke-CheckedCommand { npm run mixin_vscode }
+        $env:BUILD_SOURCESDIRECTORY = '${{ parameters.buildSourcesDirectory }}'
+        Invoke-CheckedCommand { npm run ${{ parameters.mixinScript }} }
       } finally {
         Pop-Location
       }

--- a/build/azure-pipelines/common/setup-npm.yml
+++ b/build/azure-pipelines/common/setup-npm.yml
@@ -1,0 +1,28 @@
+# Point npm at the internal Azure Artifacts feed and authenticate to it.
+#
+# Sets the registry in the user-level npmrc so it applies to subfolders like
+# build/, remote/, extensions/ that have no .npmrc of their own, then runs
+# npmAuthenticate against that npmrc. Emits Windows (pwsh) and non-Windows (bash)
+# variants so the same template can be included from every platform job. No-op
+# when NPM_REGISTRY is 'none'.
+steps:
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      npm config set registry "$env:NPM_REGISTRY"
+      $NpmrcPath = (npm config get userconfig)
+      Write-Host "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'), contains(variables['Agent.OS'], 'windows'))
+    displayName: Setup NPM
+
+  - script: |
+      set -e
+      npm config set registry "$NPM_REGISTRY"
+      echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'), not(contains(variables['Agent.OS'], 'windows')))
+    displayName: Setup NPM
+
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: $(NPMRC_PATH)
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Setup NPM Authentication

--- a/build/azure-pipelines/copilot/build-steps.yml
+++ b/build/azure-pipelines/copilot/build-steps.yml
@@ -1,19 +1,11 @@
 steps:
-  # Check out the private microsoft/vscode-capi repository using the agent's
-  # GitHub App (Monaco) credentials instead of cloning it with a PAT. The
-  # repository resource is declared in the top-level pipeline (resources.repositories).
-  - checkout: capi
-    path: s/.build/vscode-capi
-    fetchDepth: 1
-    retryCountOnTaskFailure: 3
-    displayName: Checkout microsoft/vscode-capi
-
-  - script: |
-      set -e
-      cd $(Build.SourcesDirectory)/.build/vscode-capi
-      npm ci
-      BUILD_SOURCESDIRECTORY=$(Build.SourcesDirectory)/extensions/copilot npm run mixin
-    displayName: Mixin vscode-capi
+  # Mix the private vscode-capi repo into the copilot extension. Uses the shared
+  # capi-mixin template with copilot-specific parameters (the 'mixin' script and
+  # the copilot extension as the target directory).
+  - template: ../common/mixin-vscode-capi.yml@self
+    parameters:
+      mixinScript: mixin
+      buildSourcesDirectory: $(Build.SourcesDirectory)/extensions/copilot
 
   - script: npm run build
     workingDirectory: $(Build.SourcesDirectory)/extensions/copilot

--- a/build/azure-pipelines/copilot/setup-steps.yml
+++ b/build/azure-pipelines/copilot/setup-steps.yml
@@ -27,32 +27,7 @@ steps:
     condition: and(succeeded(), eq(variables.BUILD_CACHE_RESTORED, 'true'))
     displayName: Extract node_modules cache
 
-  - pwsh: |
-      $ErrorActionPreference = 'Stop'
-      # Set the private NPM registry to the global npmrc file
-      # so that authentication works for subfolders like build/, remote/, extensions/ etc
-      # which does not have their own .npmrc file
-      npm config set registry "$env:NPM_REGISTRY"
-      $NpmrcPath = (npm config get userconfig)
-      Write-Host "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'), contains(variables['Agent.OS'], 'windows'))
-    displayName: Setup NPM (Windows)
-
-  - script: |
-      set -e
-      # Set the private NPM registry to the global npmrc file
-      # so that authentication works for subfolders like build/, remote/, extensions/ etc
-      # which does not have their own .npmrc file
-      npm config set registry "$NPM_REGISTRY"
-      echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'), not(contains(variables['Agent.OS'], 'windows')))
-    displayName: Setup NPM (non-Windows)
-
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM Authentication
+  - template: ../common/setup-npm.yml@self
 
   - script: npm ci
     workingDirectory: build

--- a/build/azure-pipelines/copilot/setup-steps.yml
+++ b/build/azure-pipelines/copilot/setup-steps.yml
@@ -35,7 +35,7 @@ steps:
       npm config set registry "$env:NPM_REGISTRY"
       $NpmrcPath = (npm config get userconfig)
       Write-Host "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
-    condition: and(succeeded(), ne(variables.BUILD_CACHE_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'), contains(variables['Agent.OS'], 'windows'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'), contains(variables['Agent.OS'], 'windows'))
     displayName: Setup NPM (Windows)
 
   - script: |
@@ -45,13 +45,13 @@ steps:
       # which does not have their own .npmrc file
       npm config set registry "$NPM_REGISTRY"
       echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-    condition: and(succeeded(), ne(variables.BUILD_CACHE_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'), not(contains(variables['Agent.OS'], 'windows')))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'), not(contains(variables['Agent.OS'], 'windows')))
     displayName: Setup NPM (non-Windows)
 
   - task: npmAuthenticate@0
     inputs:
       workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables.BUILD_CACHE_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
   - script: npm ci

--- a/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
@@ -53,21 +53,7 @@ jobs:
           cacheHitVar: NODE_MODULES_RESTORED
         displayName: Restore node_modules cache
 
-      - script: |
-          set -e
-          # Set the private NPM registry to the global npmrc file
-          # so that authentication works for subfolders like build/, remote/, extensions/ etc
-          # which does not have their own .npmrc file
-          npm config set registry "$NPM_REGISTRY"
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ../common/setup-npm.yml@self
 
       - script: |
           set -e

--- a/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
@@ -60,13 +60,13 @@ jobs:
           # which does not have their own .npmrc file
           npm config set registry "$NPM_REGISTRY"
           echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM
 
       - task: npmAuthenticate@0
         inputs:
           workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Authentication
 
       - script: |

--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -49,21 +49,7 @@ jobs:
         condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Registry
 
-      - script: |
-          set -e
-          # Set the private NPM registry to the global npmrc file
-          # so that authentication works for subfolders like build/, remote/, extensions/ etc
-          # which does not have their own .npmrc file
-          npm config set registry "$NPM_REGISTRY"
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ../common/setup-npm.yml@self
 
       - script: |
           set -e

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -57,21 +57,7 @@ steps:
     condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Extract node_modules cache
 
-  - script: |
-      set -e
-      # Set the private NPM registry to the global npmrc file
-      # so that authentication works for subfolders like build/, remote/, extensions/ etc
-      # which does not have their own .npmrc file
-      npm config set registry "$NPM_REGISTRY"
-      echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM
-
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM Authentication
+  - template: ../../common/setup-npm.yml@self
 
   - script: |
       set -e

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -64,13 +64,13 @@ steps:
       # which does not have their own .npmrc file
       npm config set registry "$NPM_REGISTRY"
       echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM
 
   - task: npmAuthenticate@0
     inputs:
       workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
   - script: |

--- a/build/azure-pipelines/linux/product-build-linux-cli.yml
+++ b/build/azure-pipelines/linux/product-build-linux-cli.yml
@@ -62,21 +62,7 @@ jobs:
         condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Registry
 
-      - script: |
-          set -e
-          # Set the private NPM registry to the global npmrc file
-          # so that authentication works for subfolders like build/, remote/, extensions/ etc
-          # which does not have their own .npmrc file
-          npm config set registry "$NPM_REGISTRY"
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ../common/setup-npm.yml@self
 
       - script: |
           set -e

--- a/build/azure-pipelines/linux/product-build-linux-node-modules.yml
+++ b/build/azure-pipelines/linux/product-build-linux-node-modules.yml
@@ -66,21 +66,7 @@ jobs:
           cacheHitVar: NODE_MODULES_RESTORED
         displayName: Restore node_modules cache
 
-      - script: |
-          set -e
-          # Set the private NPM registry to the global npmrc file
-          # so that authentication works for subfolders like build/, remote/, extensions/ etc
-          # which does not have their own .npmrc file
-          npm config set registry "$NPM_REGISTRY"
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ../common/setup-npm.yml@self
 
       - script: |
           set -e

--- a/build/azure-pipelines/linux/product-build-linux-node-modules.yml
+++ b/build/azure-pipelines/linux/product-build-linux-node-modules.yml
@@ -73,13 +73,13 @@ jobs:
           # which does not have their own .npmrc file
           npm config set registry "$NPM_REGISTRY"
           echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM
 
       - task: npmAuthenticate@0
         inputs:
           workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Authentication
 
       - script: |

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -84,13 +84,13 @@ steps:
       # which does not have their own .npmrc file
       npm config set registry "$NPM_REGISTRY"
       echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM
 
   - task: npmAuthenticate@0
     inputs:
       workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
   - script: |

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -77,21 +77,7 @@ steps:
     condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Extract node_modules cache
 
-  - script: |
-      set -e
-      # Set the private NPM registry to the global npmrc file
-      # so that authentication works for subfolders like build/, remote/, extensions/ etc
-      # which does not have their own .npmrc file
-      npm config set registry "$NPM_REGISTRY"
-      echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM
-
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM Authentication
+  - template: ../../common/setup-npm.yml@self
 
   - script: |
       set -e

--- a/build/azure-pipelines/product-publish.yml
+++ b/build/azure-pipelines/product-publish.yml
@@ -58,18 +58,7 @@ jobs:
         condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Registry
 
-      - pwsh: |
-          npm config set registry "$env:NPM_REGISTRY"
-          $NpmrcPath = (npm config get userconfig)
-          Write-Host "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ./common/setup-npm.yml@self
 
       - pwsh: |
           npm ci

--- a/build/azure-pipelines/product-publish.yml
+++ b/build/azure-pipelines/product-publish.yml
@@ -54,6 +54,23 @@ jobs:
       - pwsh: Write-Host "##vso[build.addbuildtag]🚀"
         displayName: Add build tag
 
+      - pwsh: node build/setup-npm-registry.ts $env:NPM_REGISTRY build
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+        displayName: Setup NPM Registry
+
+      - pwsh: |
+          npm config set registry "$env:NPM_REGISTRY"
+          $NpmrcPath = (npm config get userconfig)
+          Write-Host "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+        displayName: Setup NPM
+
+      - task: npmAuthenticate@0
+        inputs:
+          workingFile: $(NPMRC_PATH)
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+        displayName: Setup NPM Authentication
+
       - pwsh: |
           npm ci
         workingDirectory: build

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -42,18 +42,7 @@ jobs:
         condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Extract node_modules cache
 
-      - script: |
-          set -e
-          npm config set registry "$NPM_REGISTRY"
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ./common/setup-npm.yml@self
 
       - script: |
           set -e

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -46,13 +46,13 @@ jobs:
           set -e
           npm config set registry "$NPM_REGISTRY"
           echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM
 
       - task: npmAuthenticate@0
         inputs:
           workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Authentication
 
       - script: |

--- a/build/azure-pipelines/product-release.yml
+++ b/build/azure-pipelines/product-release.yml
@@ -27,6 +27,22 @@ steps:
         Write-Host "##vso[task.setvariable variable=AZURE_CLIENT_ID]$env:servicePrincipalId"
         Write-Host "##vso[task.setvariable variable=AZURE_ID_TOKEN;issecret=true]$env:idToken"
 
+  - script: node build/setup-npm-registry.ts $NPM_REGISTRY build
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Setup NPM Registry
+
+  - script: |
+      npm config set registry "$NPM_REGISTRY"
+      echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Setup NPM
+
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: $(NPMRC_PATH)
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Setup NPM Authentication
+
   - script: npm ci
     workingDirectory: build
     displayName: Install build dependencies

--- a/build/azure-pipelines/product-release.yml
+++ b/build/azure-pipelines/product-release.yml
@@ -31,17 +31,7 @@ steps:
     condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Registry
 
-  - script: |
-      npm config set registry "$NPM_REGISTRY"
-      echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM
-
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM Authentication
+  - template: ./common/setup-npm.yml@self
 
   - script: npm ci
     workingDirectory: build

--- a/build/azure-pipelines/web/product-build-web-node-modules.yml
+++ b/build/azure-pipelines/web/product-build-web-node-modules.yml
@@ -38,21 +38,7 @@ jobs:
           cacheHitVar: NODE_MODULES_RESTORED
         displayName: Restore node_modules cache
 
-      - script: |
-          set -e
-          # Set the private NPM registry to the global npmrc file
-          # so that authentication works for subfolders like build/, remote/, extensions/ etc
-          # which does not have their own .npmrc file
-          npm config set registry "$NPM_REGISTRY"
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ../common/setup-npm.yml@self
 
       - script: |
           set -e

--- a/build/azure-pipelines/web/product-build-web-node-modules.yml
+++ b/build/azure-pipelines/web/product-build-web-node-modules.yml
@@ -45,13 +45,13 @@ jobs:
           # which does not have their own .npmrc file
           npm config set registry "$NPM_REGISTRY"
           echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM
 
       - task: npmAuthenticate@0
         inputs:
           workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Authentication
 
       - script: |

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -52,21 +52,7 @@ jobs:
         condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Extract node_modules cache
 
-      - script: |
-          set -e
-          # Set the private NPM registry to the global npmrc file
-          # so that authentication works for subfolders like build/, remote/, extensions/ etc
-          # which does not have their own .npmrc file
-          npm config set registry "$NPM_REGISTRY"
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ../common/setup-npm.yml@self
 
       - script: |
           set -e

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -59,13 +59,13 @@ jobs:
           # which does not have their own .npmrc file
           npm config set registry "$NPM_REGISTRY"
           echo "##vso[task.setvariable variable=NPMRC_PATH]$(npm config get userconfig)"
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM
 
       - task: npmAuthenticate@0
         inputs:
           workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Authentication
 
       - script: |

--- a/build/azure-pipelines/win32/product-build-win32-node-modules.yml
+++ b/build/azure-pipelines/win32/product-build-win32-node-modules.yml
@@ -53,23 +53,7 @@ jobs:
           cacheHitVar: NODE_MODULES_RESTORED
         displayName: Restore node_modules cache
 
-      - powershell: |
-          . build/azure-pipelines/win32/exec.ps1
-          $ErrorActionPreference = "Stop"
-          # Set the private NPM registry to the global npmrc file
-          # so that authentication works for subfolders like build/, remote/, extensions/ etc
-          # which does not have their own .npmrc file
-          exec { npm config set registry "$env:NPM_REGISTRY" }
-          $NpmrcPath = (npm config get userconfig)
-          echo "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM
-
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-        displayName: Setup NPM Authentication
+      - template: ../common/setup-npm.yml@self
 
       - powershell: |
           . build/azure-pipelines/win32/exec.ps1

--- a/build/azure-pipelines/win32/product-build-win32-node-modules.yml
+++ b/build/azure-pipelines/win32/product-build-win32-node-modules.yml
@@ -62,13 +62,13 @@ jobs:
           exec { npm config set registry "$env:NPM_REGISTRY" }
           $NpmrcPath = (npm config get userconfig)
           echo "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM
 
       - task: npmAuthenticate@0
         inputs:
           workingFile: $(NPMRC_PATH)
-        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
         displayName: Setup NPM Authentication
 
       - powershell: |

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -30,23 +30,7 @@ steps:
     condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Registry
 
-  - powershell: |
-      . build/azure-pipelines/win32/exec.ps1
-      $ErrorActionPreference = "Stop"
-      # Set the private NPM registry to the global npmrc file
-      # so that authentication works for subfolders like build/, remote/, extensions/ etc
-      # which does not have their own .npmrc file
-      exec { npm config set registry "$env:NPM_REGISTRY" }
-      $NpmrcPath = (npm config get userconfig)
-      echo "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM
-
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM Authentication
+  - template: ../common/setup-npm.yml@self
 
   - pwsh: |
       $includes = @'

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -70,13 +70,13 @@ steps:
       exec { npm config set registry "$env:NPM_REGISTRY" }
       $NpmrcPath = (npm config get userconfig)
       echo "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM
 
   - task: npmAuthenticate@0
     inputs:
       workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
   - powershell: |

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -61,23 +61,7 @@ steps:
     condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Extract node_modules cache
 
-  - powershell: |
-      . build/azure-pipelines/win32/exec.ps1
-      $ErrorActionPreference = "Stop"
-      # Set the private NPM registry to the global npmrc file
-      # so that authentication works for subfolders like build/, remote/, extensions/ etc
-      # which does not have their own .npmrc file
-      exec { npm config set registry "$env:NPM_REGISTRY" }
-      $NpmrcPath = (npm config get userconfig)
-      echo "##vso[task.setvariable variable=NPMRC_PATH]$NpmrcPath"
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM
-
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: $(NPMRC_PATH)
-    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-    displayName: Setup NPM Authentication
+  - template: ../../common/setup-npm.yml@self
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1


### PR DESCRIPTION
Route npm through the internal feed and keep registry auth always-on so installs work on cache-restored runs.