### PR TITLE
SessionTypePicker: Add optional folder source support

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -6,7 +6,7 @@
 import * as dom from '../../../../base/browser/dom.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
@@ -92,6 +92,15 @@ export class SessionTypePicker extends Disposable {
 	/** Session types the active session's folder can be served by, across all providers. */
 	protected _folderSessionTypes: IProviderSessionType[] = [];
 
+	/**
+	 * Optional folder that drives the available session types instead of the
+	 * active session. Set via {@link setFolderSource}; `undefined` keeps the
+	 * default session-driven behavior. When set, the picker lists the folder's
+	 * session types and defaults independently of any session.
+	 */
+	private _folderSource: IObservable<URI | undefined> | undefined;
+	private readonly _folderSourceWatch = this._register(new MutableDisposable());
+
 	private readonly _renderDisposables = this._register(new DisposableStore());
 	protected _triggerElement: HTMLElement | undefined;
 
@@ -123,31 +132,93 @@ export class SessionTypePicker extends Disposable {
 		// Restore the previously selected session type from storage
 		this._picked = this._readStoredPick();
 
-		const refresh = (session: ISession | undefined) => {
-			if (session) {
-				this._folderSessionTypes = this._sessionTypesForSession(session);
-				// Reflect the active session's type in the trigger label, but do
-				// not persist it: the stored preference must only change when the
-				// user explicitly picks a type via the picker.
-				this._picked = { providerId: session.providerId, sessionTypeId: session.sessionType };
-			} else {
-				this._folderSessionTypes = [];
-				// Preserve the stored pick when no active session exists,
-				// so it can be used as the default for the next new session.
-				this._picked = this._readStoredPick();
-			}
-			this._updateTriggerLabel();
-		};
-
 		this._register(autorun(reader => {
-			const session = this._session.read(reader);
-			refresh(session);
+			this._session.read(reader);
+			this._recompute();
 		}));
 		// Re-read when a provider advertises/removes session types at runtime
 		// (e.g. a remote agent host discovers a new agent).
-		this._register(this.sessionsManagementService.onDidChangeSessionTypes(() => {
-			refresh(this._session.get());
-		}));
+		this._register(this.sessionsManagementService.onDidChangeSessionTypes(() => this._recompute()));
+	}
+
+	/**
+	 * Recompute the available session types and the displayed pick from the
+	 * current source (session or folder), then refresh the trigger label.
+	 * Invoked reactively when the session, folder, or advertised types change.
+	 */
+	protected _recompute(): void {
+		this._folderSessionTypes = this._resolveFolderSessionTypes();
+		this._picked = this._computeCurrentPick();
+		this._updateTriggerLabel();
+	}
+
+	/**
+	 * The session types to offer, sourced from the folder when a folder source
+	 * is set (see {@link setFolderSource}), otherwise from the active session.
+	 */
+	protected _resolveFolderSessionTypes(): IProviderSessionType[] {
+		if (this._folderSource) {
+			const folderUri = this._folderSource.get();
+			return folderUri ? this.sessionsManagementService.getSessionTypesForFolder(folderUri) : [];
+		}
+		const session = this._session.get();
+		return session ? this._sessionTypesForSession(session) : [];
+	}
+
+	/**
+	 * The pick to display for the current source. Session-driven pickers
+	 * reflect the active session's type (or the stored preference when there
+	 * is no session). Folder-driven pickers keep the current pick while it is
+	 * served by the folder, otherwise fall back to the stored preference and
+	 * finally the folder's preferred (first) type.
+	 */
+	protected _computeCurrentPick(): IPreferredSessionType | undefined {
+		const session = this._session.get();
+		if (session) {
+			// Reflect the active session's type in the trigger label, but do not
+			// persist it: the stored preference must only change when the user
+			// explicitly picks a type via the picker.
+			return { providerId: session.providerId, sessionTypeId: session.sessionType };
+		}
+		if (!this._folderSource) {
+			// Session-driven picker with no active session: preserve the stored
+			// pick so it can seed the next new session.
+			return this._readStoredPick();
+		}
+		const candidate = this._picked ?? this._readStoredPick();
+		if (this._pickServedByFolder(candidate)) {
+			return candidate;
+		}
+		const stored = this._readStoredPick();
+		if (this._pickServedByFolder(stored)) {
+			return stored;
+		}
+		const preferred = this._folderSessionTypes[0];
+		return preferred ? { providerId: preferred.providerId, sessionTypeId: preferred.sessionType.id } : undefined;
+	}
+
+	private _pickServedByFolder(pick: IPreferredSessionType | undefined): boolean {
+		return !!pick && this._folderSessionTypes.some(t =>
+			t.sessionType.id === pick.sessionTypeId &&
+			(pick.providerId === undefined || t.providerId === pick.providerId));
+	}
+
+	/**
+	 * Drive the picker from a folder instead of the active session. The picker
+	 * then lists the folder's session types and defaults independently of any
+	 * session. Optionally seeds the initially displayed pick (e.g. a value
+	 * restored from a saved record); the user's own picks and the stored
+	 * preference take over from there.
+	 */
+	setFolderSource(source: IObservable<URI | undefined>, options?: { readonly initialPick?: IPreferredSessionType }): void {
+		this._folderSource = source;
+		if (options?.initialPick) {
+			this._picked = options.initialPick;
+		}
+		this._folderSourceWatch.value = autorun(reader => {
+			source.read(reader);
+			this._recompute();
+		});
 	}
 
 	get selectedPick(): IPreferredSessionType | undefined {
@@ -236,16 +307,11 @@ export class SessionTypePicker extends Disposable {
 			return;
 		}
 
-		const session = this._session.get();
-		if (!session) {
-			return;
-		}
-
 		// Recompute types fresh at open time so a late-registering provider
 		// (e.g. Local Agent Host whose session types are populated only after
 		// agent discovery) shows up without waiting for the refresh event to
 		// land before the user clicks.
-		const folderTypes = this._sessionTypesForSession(session);
+		const folderTypes = this._resolveFolderSessionTypes();
 		this._folderSessionTypes = folderTypes;
 
 		if (folderTypes.length <= 1) {
@@ -385,6 +451,11 @@ export class SessionTypePicker extends Disposable {
 		} else {
 			this._writeStoredPick(pick);
 		}
+		// Reflect the new pick in the trigger immediately. Session-driven
+		// callers previously got this for free when the pick changed the active
+		// session (re-running the refresh autorun), but folder-driven callers
+		// have no such trigger, so update the label directly here.
+		this._updateTriggerLabel();
 		// Only notify (and trigger draft recreation) when the visible pick
 		// actually changed, to avoid unnecessary work.
 		if (visiblePickChanged) {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -174,7 +174,7 @@ export class SessionTypePicker extends Disposable {
 	 */
 	protected _computeCurrentPick(): IPreferredSessionType | undefined {
 		const session = this._session.get();
-		if (session) {
+		if (!this._folderSource && session) {
 			// Reflect the active session's type in the trigger label, but do not
 			// persist it: the stored preference must only change when the user
 			// explicitly picks a type via the picker.
@@ -212,9 +212,7 @@ export class SessionTypePicker extends Disposable {
 	 */
 	setFolderSource(source: IObservable<URI | undefined>, options?: { readonly initialPick?: IPreferredSessionType }): void {
 		this._folderSource = source;
-		if (options?.initialPick) {
-			this._picked = options.initialPick;
-		}
+		this._picked = options?.initialPick ?? this._readStoredPick();
 		this._folderSourceWatch.value = autorun(reader => {
 			source.read(reader);
 			this._recompute();

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -92,12 +92,7 @@ export class SessionTypePicker extends Disposable {
 	/** Session types the active session's folder can be served by, across all providers. */
 	protected _folderSessionTypes: IProviderSessionType[] = [];
 
-	/**
-	 * Optional folder that drives the available session types instead of the
-	 * active session. Set via {@link setFolderSource}; `undefined` keeps the
-	 * default session-driven behavior. When set, the picker lists the folder's
-	 * session types and defaults independently of any session.
-	 */
+	/** Folder that drives the available session types when set via {@link setFolderSource}; `undefined` keeps session-driven behavior. */
 	private _folderSource: IObservable<URI | undefined> | undefined;
 	private readonly _folderSourceWatch = this._register(new MutableDisposable());
 
@@ -165,24 +160,15 @@ export class SessionTypePicker extends Disposable {
 		return session ? this._sessionTypesForSession(session) : [];
 	}
 
-	/**
-	 * The pick to display for the current source. Session-driven pickers
-	 * reflect the active session's type (or the stored preference when there
-	 * is no session). Folder-driven pickers keep the current pick while it is
-	 * served by the folder, otherwise fall back to the stored preference and
-	 * finally the folder's preferred (first) type.
-	 */
+	/** The pick to display for the current source: the active session's type, otherwise the folder or stored default. */
 	protected _computeCurrentPick(): IPreferredSessionType | undefined {
 		const session = this._session.get();
 		if (!this._folderSource && session) {
-			// Reflect the active session's type in the trigger label, but do not
-			// persist it: the stored preference must only change when the user
-			// explicitly picks a type via the picker.
+			// Reflect the session's type without persisting it; storage changes only on an explicit user pick.
 			return { providerId: session.providerId, sessionTypeId: session.sessionType };
 		}
 		if (!this._folderSource) {
-			// Session-driven picker with no active session: preserve the stored
-			// pick so it can seed the next new session.
+			// No active session: keep the stored pick to seed the next new session.
 			return this._readStoredPick();
 		}
 		const candidate = this._picked ?? this._readStoredPick();
@@ -203,13 +189,7 @@ export class SessionTypePicker extends Disposable {
 			(pick.providerId === undefined || t.providerId === pick.providerId));
 	}
 
-	/**
-	 * Drive the picker from a folder instead of the active session. The picker
-	 * then lists the folder's session types and defaults independently of any
-	 * session. Optionally seeds the initially displayed pick (e.g. a value
-	 * restored from a saved record); the user's own picks and the stored
-	 * preference take over from there.
-	 */
+	/** Drive the picker from a folder instead of the active session, optionally seeding the initial pick. */
 	setFolderSource(source: IObservable<URI | undefined>, options?: { readonly initialPick?: IPreferredSessionType }): void {
 		this._folderSource = source;
 		this._picked = options?.initialPick ?? this._readStoredPick();
@@ -449,10 +429,7 @@ export class SessionTypePicker extends Disposable {
 		} else {
 			this._writeStoredPick(pick);
 		}
-		// Reflect the new pick in the trigger immediately. Session-driven
-		// callers previously got this for free when the pick changed the active
-		// session (re-running the refresh autorun), but folder-driven callers
-		// have no such trigger, so update the label directly here.
+		// Folder-driven callers have no session change to re-run the refresh autorun, so refresh the label here.
 		this._updateTriggerLabel();
 		// Only notify (and trigger draft recreation) when the visible pick
 		// actually changed, to avoid unnecessary work.

--- a/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
@@ -36,9 +36,15 @@ class MockSessionsManagementService extends Disposable {
 
 	private _types: IProviderSessionType[] = [];
 	private _quickChatTypes: IProviderSessionType[] = [];
+	private readonly _typesByFolder = new Map<string, IProviderSessionType[]>();
 
 	setSessionTypes(types: IProviderSessionType[]): void {
 		this._types = types;
+		this._onDidChangeSessionTypes.fire();
+	}
+
+	setSessionTypesForFolder(folderUri: URI, types: IProviderSessionType[]): void {
+		this._typesByFolder.set(folderUri.toString(), types);
 		this._onDidChangeSessionTypes.fire();
 	}
 
@@ -47,8 +53,8 @@ class MockSessionsManagementService extends Disposable {
 		this._onDidChangeSessionTypes.fire();
 	}
 
-	getSessionTypesForFolder(_folderUri: URI): IProviderSessionType[] {
-		return this._types;
+	getSessionTypesForFolder(folderUri: URI): IProviderSessionType[] {
+		return this._typesByFolder.get(folderUri.toString()) ?? this._types;
 	}
 
 	getQuickChatSessionTypes(): IProviderSessionType[] {
@@ -266,5 +272,147 @@ suite('SessionTypePicker', () => {
 		// Picking a non-first quick-chat type is stored.
 		picker.pick({ providerId: 'copilot', sessionTypeId: 'copilot-cli' });
 		assert.deepStrictEqual(picker.getUserPickedSessionType(), { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+	});
+
+	test('folder-driven mode ignores the active session and defaults to the folder preferred type', () => {
+		const folderA = URI.file('/a');
+		management.setSessionTypesForFolder(folderA, [
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+
+		// An active session of a specific type is present...
+		session.set(createFakeSession('copilot', 'copilot-cli', folderA), undefined);
+
+		// ...but switching to folder-driven mode makes the folder authoritative,
+		// so the display defaults to the folder's preferred (first) type.
+		picker.setFolderSource(observableValue<URI | undefined>('folder', folderA));
+
+		assert.deepStrictEqual(picker.selectedPick, { providerId: 'local-1', sessionTypeId: 'local' });
+	});
+
+	test('folder-driven mode seeds the provided initial pick', () => {
+		const folderA = URI.file('/a');
+		management.setSessionTypesForFolder(folderA, [
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+
+		picker.setFolderSource(observableValue<URI | undefined>('folder', folderA), {
+			initialPick: { providerId: 'copilot', sessionTypeId: 'copilot-cli' },
+		});
+
+		assert.deepStrictEqual(picker.selectedPick, { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+	});
+
+	test('folder-driven mode re-defaults when a folder change no longer serves the pick', () => {
+		const folderA = URI.file('/a');
+		const folderB = URI.file('/b');
+		management.setSessionTypesForFolder(folderA, [
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+			sessionType('local-1', 'local', 'Local'),
+		]);
+		management.setSessionTypesForFolder(folderB, [
+			sessionType('local-1', 'local', 'Local'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+		const folderObs = observableValue<URI | undefined>('folder', folderA);
+		picker.setFolderSource(folderObs, { initialPick: { providerId: 'copilot', sessionTypeId: 'copilot-cli' } });
+
+		// Folder B does not serve copilot-cli, so the pick re-defaults to B's preferred type.
+		folderObs.set(folderB, undefined);
+
+		assert.deepStrictEqual(picker.selectedPick, { providerId: 'local-1', sessionTypeId: 'local' });
+	});
+
+	test('folder-driven mode falls back to the stored user pick when served by the folder', () => {
+		const folderA = URI.file('/a');
+		management.setSessionTypesForFolder(folderA, [
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+
+		// Store a non-default user preference.
+		const seeding = createPicker(disposables, session, management, storage);
+		seeding.pick({ providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+
+		// A fresh folder-driven picker with no initial pick restores that stored preference.
+		const picker = createPicker(disposables, observableValue<ISession | undefined>('session2', undefined), management, storage);
+		picker.setFolderSource(observableValue<URI | undefined>('folder', folderA));
+
+		assert.deepStrictEqual(picker.selectedPick, { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+	});
+
+	test('folder-driven mode persists an explicit pick, clears on default, and fires the change event', () => {
+		const folderA = URI.file('/a');
+		management.setSessionTypesForFolder(folderA, [
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+		picker.setFolderSource(observableValue<URI | undefined>('folder', folderA));
+
+		const fired: (IPickedSessionType | undefined)[] = [];
+		disposables.add(picker.onDidSelectSessionType(e => fired.push(e)));
+
+		// A non-default type is stored; the folder's default (first) type clears it.
+		picker.pick({ providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+		picker.pick({ providerId: 'local-1', sessionTypeId: 'local' });
+
+		assert.deepStrictEqual({
+			stored: picker.getUserPickedSessionType(),
+			selected: picker.selectedPick,
+			fired,
+		}, {
+			stored: undefined,
+			selected: { providerId: 'local-1', sessionTypeId: 'local' },
+			fired: [
+				{ providerId: 'copilot', sessionTypeId: 'copilot-cli' },
+				{ providerId: 'local-1', sessionTypeId: 'local' },
+			],
+		});
+	});
+
+	test('folder-driven mode has no selection until the folder resolves types', () => {
+		const folderA = URI.file('/a');
+		management.setSessionTypesForFolder(folderA, [
+			sessionType('local-1', 'local', 'Local'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+		const folderObs = observableValue<URI | undefined>('folder', undefined);
+		picker.setFolderSource(folderObs);
+
+		// No folder -> no types -> no selection; selecting a folder resolves the default.
+		const before = picker.selectedPick;
+		folderObs.set(folderA, undefined);
+		const after = picker.selectedPick;
+
+		assert.deepStrictEqual({ before, after }, {
+			before: undefined,
+			after: { providerId: 'local-1', sessionTypeId: 'local' },
+		});
+	});
+
+	test('folder-driven mode prefers the stored pick over the folder default when the initial pick is unavailable', () => {
+		const folderA = URI.file('/a');
+		management.setSessionTypesForFolder(folderA, [
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+
+		// Store copilot-cli (a non-default, folder-served preference).
+		const seeding = createPicker(disposables, session, management, storage);
+		seeding.pick({ providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+
+		// The initial pick is a type the folder does not serve, so it is dropped in
+		// favor of the stored pick rather than the folder's preferred (first) type.
+		const picker = createPicker(disposables, observableValue<ISession | undefined>('session2', undefined), management, storage);
+		picker.setFolderSource(observableValue<URI | undefined>('folder', folderA), {
+			initialPick: { providerId: 'claude', sessionTypeId: 'claude-code' },
+		});
+
+		assert.deepStrictEqual(picker.selectedPick, { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
 	});
 });


### PR DESCRIPTION
### Context
Updates `SessionTypePicker` to allow consumers to use `setFolderSource` to discover session types (Copilot, Claude, etc.) via folder source rather than explicitly requiring an existing session.

Required for the Automations dialog to display session types, because the automation dialog does not create a session itself.

Does not affect existing consumers (prove me wrong copilot), new code paths gated on a consumer setting the new `_folderSource` via `setFolderSource`

cc @sandy081 