### PR TITLE
Propagate MCP App metadata eagerly for Copilot tool calls

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2924,12 +2924,9 @@ export class CopilotAgentSession extends Disposable {
 			if (e.data.mcpToolName) {
 				meta.mcpToolName = e.data.mcpToolName;
 			}
-			// TODO(sdk-gap): the Copilot SDK doesn't yet surface MCP App
-			// `_meta.ui.resourceUri` on `tool.execution_start`; we attach
-			// it on `tool.execution_complete` below so the App webview
-			// mounts on completion. Drop-in once the SDK exposes it here:
-			//   const resourceUri = e.data.toolDescription?._meta?.ui?.resourceUri;
-			//   if (resourceUri) { meta.ui = { resourceUri }; }
+			// eslint-disable-next-line local/code-no-untyped-meta-access -- Copilot SDK's own typed `_meta`, not the AHP protocol bag.
+			const resourceUri = e.data.toolDescription?._meta?.ui?.resourceUri;
+			this._setToolCallUiMeta(meta, resourceUri, e.data.mcpServerName);
 
 			// Stash the start-time meta on the tracked tool call so the
 			// `tool.execution_complete` emission below can merge any
@@ -3091,23 +3088,6 @@ export class CopilotAgentSession extends Disposable {
 				}
 			}
 
-			// eslint-disable-next-line local/code-no-untyped-meta-access -- Copilot SDK's own typed `_meta`, not the AHP protocol bag.
-			const resourceUri = e.data.toolDescription?._meta?.ui?.resourceUri;
-			let completeMeta: IToolCallMeta | undefined = tracked.meta;
-			if (resourceUri) {
-				const ui: Mutable<IToolCallUiMeta> = { resourceUri };
-				if (tracked.mcpServerName) {
-					const channel = this._mcpCustomizations.channelForServer(tracked.mcpServerName);
-					if (channel !== undefined) {
-						ui.channel = channel;
-					}
-				}
-				// Merge the `ui` namespace on top of whatever meta we
-				// emitted at start time (`toolKind`, `subagentDescription`,
-				// `toolArguments`, …). Reducers replace the whole `_meta`
-				// blob, so we must do the merge here.
-				completeMeta = { ...(tracked.meta ?? {}), ui };
-			}
 			this._emitAction({
 				type: ActionType.ChatToolCallComplete,
 				turnId: this._turnId,
@@ -3118,7 +3098,7 @@ export class CopilotAgentSession extends Disposable {
 					content: content.length > 0 ? content : undefined,
 					error: e.data.error,
 				},
-				_meta: completeMeta ? toToolCallMeta(completeMeta) : undefined,
+				_meta: tracked.meta ? toToolCallMeta(tracked.meta) : undefined,
 			}, parentToolCallId);
 		}));
 
@@ -3476,6 +3456,20 @@ export class CopilotAgentSession extends Disposable {
 		const sdkServers = servers
 			.map(s => this._toSdkMcpServer(s.name, s.status, s.error));
 		this._mcpCustomizations.applyAll(sdkServers);
+	}
+
+	private _setToolCallUiMeta(meta: Mutable<IToolCallMeta>, resourceUri: string | undefined, mcpServerName: string | undefined): void {
+		if (!resourceUri) {
+			return;
+		}
+		const ui: Mutable<IToolCallUiMeta> = { resourceUri };
+		if (mcpServerName) {
+			const channel = this._mcpCustomizations.channelForServer(mcpServerName);
+			if (channel !== undefined) {
+				ui.channel = channel;
+			}
+		}
+		meta.ui = ui;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -2393,6 +2393,81 @@ suite('CopilotAgentSession', () => {
 			}
 		});
 
+		test('tool_start carries MCP App UI metadata from the SDK', async () => {
+			const { mockSession, signals } = await createAgentSession(disposables);
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-app',
+				toolName: 'mcp_tool',
+				mcpServerName: 'docs',
+				toolDescription: {
+					name: 'mcp_tool',
+					_meta: {
+						ui: { resourceUri: 'ui://docs' },
+					},
+				},
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			const toolStart = signals.find(s => isAction(s, ActionType.ChatToolCallStart));
+			assert.ok(toolStart && isAction(toolStart, ActionType.ChatToolCallStart));
+			if (toolStart && isAction(toolStart, ActionType.ChatToolCallStart)) {
+				const action = toolStart.action as ChatToolCallStartAction;
+				assert.deepStrictEqual(action._meta, {
+					mcpServerName: 'docs',
+					ui: { resourceUri: 'ui://docs' },
+				});
+			}
+		});
+
+		test('tool_start carries the MCP App channel when the server is already ready', async () => {
+			// A tool call cannot begin until its MCP server is Ready, so the
+			// AHP `mcp://` channel is always available at `tool.execution_start`
+			// and is published as part of the initial `_meta.ui` payload.
+			const { mockSession, signals } = await createAgentSession(disposables, {
+				configureMockSession: m => {
+					m.mcpListResult = { servers: [{ name: 'docs', status: 'connected' }] };
+				},
+			});
+			mockSession.fire('session.mcp_server_status_changed', {
+				serverName: 'docs',
+				status: 'connected',
+			} as SessionEventPayload<'session.mcp_server_status_changed'>['data']);
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-app-channel',
+				toolName: 'mcp_tool',
+				mcpServerName: 'docs',
+				arguments: { topic: 'metadata' },
+				toolDescription: {
+					name: 'mcp_tool',
+					_meta: {
+						ui: { resourceUri: 'ui://docs' },
+					},
+				},
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			const toolStart = signals.find(s => isAction(s, ActionType.ChatToolCallStart));
+			assert.ok(toolStart && isAction(toolStart, ActionType.ChatToolCallStart));
+			if (toolStart && isAction(toolStart, ActionType.ChatToolCallStart)) {
+				const action = toolStart.action as ChatToolCallStartAction;
+				assert.deepStrictEqual({
+					contributor: action.contributor,
+					meta: action._meta,
+				}, {
+					contributor: {
+						kind: ToolCallContributorKind.MCP,
+						customizationId: 'mcp-top-level:copilot:test-session-1:docs',
+					},
+					meta: {
+						mcpServerName: 'docs',
+						toolArguments: '{"topic":"metadata"}',
+						ui: {
+							resourceUri: 'ui://docs',
+							channel: 'mcp://copilot/test-session-1/docs',
+						},
+					},
+				});
+			}
+		});
+
 		test('tool_start derives intention from a shell tool description argument', async () => {
 			const { session, mockSession, signals } = await createAgentSession(disposables);
 			session.resetTurnState('turn-intent');

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -1832,7 +1832,7 @@ export function toolCallStateToInvocation(tc: ToolCallState, subAgentInvocationI
 		};
 	} else if (getToolKind(tc) === 'search') {
 		invocation.toolSpecificData = { kind: 'search' };
-	} else {
+	} else if (tc.status !== ToolCallStatus.Streaming) {
 		invocation.toolSpecificData = buildMcpAppToolInputData(tc, sessionResource);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -130,6 +130,39 @@ function getMcpAppData(tc: ToolCallState, _sessionResource: URI): ChatMcpAppData
 	};
 }
 
+function getToolRawInput(tc: ToolCallState): unknown {
+	try {
+		return tc.status === ToolCallStatus.Streaming || !tc.toolInput ? {} : JSON.parse(tc.toolInput);
+	} catch {
+		return { input: tc.status === ToolCallStatus.Streaming ? undefined : tc.toolInput };
+	}
+}
+
+function buildMcpAppToolInputData(tc: ToolCallState, sessionResource: URI, existingRawInput?: unknown): IChatToolInputInvocationData | undefined {
+	const mcpAppData = getMcpAppData(tc, sessionResource);
+	if (!mcpAppData) {
+		return undefined;
+	}
+	return {
+		kind: 'input',
+		rawInput: existingRawInput ?? getToolRawInput(tc),
+		mcpAppData,
+	};
+}
+
+function isSameMcpAppData(a: ChatMcpAppData | undefined, b: ChatMcpAppData | undefined): boolean {
+	if (a?.kind !== b?.kind || a?.resourceUri !== b?.resourceUri) {
+		return false;
+	}
+	if (a?.kind === 'agentHost' && b?.kind === 'agentHost') {
+		return a.serverId === b.serverId && a.channel === b.channel;
+	}
+	if (a?.kind === 'local' && b?.kind === 'local') {
+		return a.serverDefinitionId === b.serverDefinitionId && a.collectionId === b.collectionId;
+	}
+	return a === b;
+}
+
 /**
  * Known tool names that spawn subagent sessions. Used as a client-side
  * fallback when the server hasn't set `_meta.toolKind` (e.g. sessions
@@ -1225,12 +1258,7 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 	} else {
 		toolSpecificData = buildSessionCreatedToolData(tc);
 		if (!toolSpecificData) {
-			const mcpAppData = getMcpAppData(tc, sessionResource);
-			if (mcpAppData) {
-				let rawInput: unknown;
-				try { rawInput = tc.toolInput ? JSON.parse(tc.toolInput) : {}; } catch { rawInput = { input: tc.toolInput }; }
-				toolSpecificData = { kind: 'input', rawInput, mcpAppData };
-			}
+			toolSpecificData = buildMcpAppToolInputData(tc, sessionResource);
 		}
 	}
 
@@ -1804,6 +1832,8 @@ export function toolCallStateToInvocation(tc: ToolCallState, subAgentInvocationI
 		};
 	} else if (getToolKind(tc) === 'search') {
 		invocation.toolSpecificData = { kind: 'search' };
+	} else {
+		invocation.toolSpecificData = buildMcpAppToolInputData(tc, sessionResource);
 	}
 
 	return invocation;
@@ -1850,6 +1880,23 @@ export function updateRunningToolSpecificData(existing: ChatToolInvocation, tc: 
 		const agentName = getSubagentAgentName(tc) ?? existing.toolSpecificData.agentName;
 		if (description !== existing.toolSpecificData.description || agentName !== existing.toolSpecificData.agentName) {
 			existing.toolSpecificData = { kind: 'subagent', isActive: existing.toolSpecificData.isActive, description, agentName, credits: existing.toolSpecificData.credits, modelName: existing.toolSpecificData.modelName, chatResource: existing.toolSpecificData.chatResource };
+			existing.notifyToolSpecificDataChanged();
+		}
+		return;
+	}
+
+	// Mount the MCP App once the tool starts running. The channel is present
+	// in `_meta.ui` from the first tool state (a tool cannot start until its
+	// MCP server is Ready), but confirmation-gated tools are created without
+	// `mcpAppData` (see `toolCallStateToInvocation`), so this is where the App
+	// first appears for them. `buildMcpAppToolInputData` returns `undefined`
+	// for non-MCP tools (search, terminal, …), so those fall through to the
+	// handling below.
+	const existingInput = existing.toolSpecificData?.kind === 'input' ? existing.toolSpecificData : undefined;
+	const nextInput = buildMcpAppToolInputData(tc, sessionResource, existingInput?.rawInput);
+	if (nextInput) {
+		if (!existingInput || !isSameMcpAppData(existingInput.mcpAppData, nextInput.mcpAppData)) {
+			existing.toolSpecificData = nextInput;
 			existing.notifyToolSpecificDataChanged();
 		}
 		return;
@@ -1978,15 +2025,17 @@ export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: ToolC
 	}
 
 	if (isCompleted) {
-		const mcpAppData = getMcpAppData(tc, backendSession);
-		if (mcpAppData) {
+		const mcpAppInput = buildMcpAppToolInputData(
+			tc,
+			backendSession,
+			invocation.toolSpecificData?.kind === 'input' ? invocation.toolSpecificData.rawInput : undefined,
+		);
+		if (mcpAppInput) {
 			const existingInput = invocation.toolSpecificData?.kind === 'input' ? invocation.toolSpecificData : undefined;
-			let rawInput: unknown = existingInput?.rawInput;
-			if (rawInput === undefined) {
-				try { rawInput = tc.toolInput ? JSON.parse(tc.toolInput) : {}; } catch { rawInput = { input: tc.toolInput }; }
+			invocation.toolSpecificData = mcpAppInput;
+			if (!existingInput || !isSameMcpAppData(existingInput.mcpAppData, mcpAppInput.mcpAppData)) {
+				invocation.notifyToolSpecificDataChanged();
 			}
-			invocation.toolSpecificData = { kind: 'input', rawInput, mcpAppData };
-			invocation.notifyToolSpecificDataChanged();
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -6,7 +6,7 @@
 import * as dom from '../../../../../../../base/browser/dom.js';
 import { Emitter } from '../../../../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../../../base/common/lifecycle.js';
-import { autorun, constObservable, IObservable } from '../../../../../../../base/common/observable.js';
+import { autorun, constObservable, derivedOpts, IObservable } from '../../../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
 import { IMarkdownRenderer } from '../../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, isLegacyChatTerminalToolInvocationData, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
@@ -34,6 +34,32 @@ import { ChatToolOutputSubPart } from './chatToolOutputPart.js';
 import { ChatToolPostExecuteConfirmationPart } from './chatToolPostExecuteConfirmationPart.js';
 import { ChatToolProgressSubPart } from './chatToolProgressPart.js';
 import { ChatToolStreamingSubPart } from './chatToolStreamingSubPart.js';
+
+/**
+ * Value equality for {@link IMcpAppRenderData}, used so the App's derived
+ * render data stays stable across state ticks that don't actually change what
+ * the webview renders — otherwise re-reading `state` (to react to in-place
+ * `toolSpecificData` mutations) would recreate the webview on every progress
+ * update.
+ */
+function mcpAppRenderDataEquals(a: IMcpAppRenderData | undefined, b: IMcpAppRenderData | undefined): boolean {
+	if (a === b) {
+		return true;
+	}
+	if (!a || !b) {
+		return false;
+	}
+	if (a.kind !== b.kind || a.resourceUri !== b.resourceUri || a.input !== b.input || a.sessionResource.toString() !== b.sessionResource.toString()) {
+		return false;
+	}
+	if (a.kind === 'agentHost' && b.kind === 'agentHost') {
+		return a.serverId === b.serverId && a.channel === b.channel;
+	}
+	if (a.kind === 'local' && b.kind === 'local') {
+		return a.serverDefinitionId === b.serverDefinitionId && a.collectionId === b.collectionId;
+	}
+	return false;
+}
 
 export class ChatToolInvocationPart extends Disposable implements IChatContentPart {
 	public readonly domNode: HTMLElement;
@@ -105,16 +131,27 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 				}
 			}));
 
-			appData = toolInvocation.toolSpecificDataKind
-				.map(() => this.getMcpAppRenderData())
-				.map((data, reader) => {
-					if (!data) {
-						return undefined;
-					}
+			appData = derivedOpts<IMcpAppRenderData | undefined>({
+				owner: this,
+				equalsFn: mcpAppRenderDataEquals,
+			}, reader => {
+				// Read `state` alongside `toolSpecificDataKind` so the App
+				// re-derives when `toolSpecificData` is mutated in place — e.g.
+				// `mcpAppData` attached on the confirmation -> running
+				// transition, which bumps `state` via
+				// `notifyToolSpecificDataChanged()` but leaves the kind (`input`)
+				// unchanged. `equalsFn` keeps the webview stable across state
+				// ticks that don't change the render data.
+				reader.readObservable(toolInvocation.state);
+				reader.readObservable(toolInvocation.toolSpecificDataKind);
+				const data = this.getMcpAppRenderData();
+				if (!data) {
+					return undefined;
+				}
 
-					const outcome = IChatToolInvocation.executionConfirmedOrDenied(toolInvocation, reader);
-					return !!outcome && outcome.type !== ToolConfirmKind.Denied && outcome.type !== ToolConfirmKind.Skipped ? data : undefined;
-				});
+				const outcome = IChatToolInvocation.executionConfirmedOrDenied(toolInvocation, reader);
+				return !!outcome && outcome.type !== ToolConfirmKind.Denied && outcome.type !== ToolConfirmKind.Skipped ? data : undefined;
+			});
 		}
 
 		// This part is a bit different, since IChatToolInvocation is not an immutable model object. So this part is able to rerender itself.

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -864,6 +864,27 @@ suite('stateToProgressAdapter', () => {
 			});
 		});
 
+		test('does not set MCP App toolSpecificData for a streaming MCP tool call', () => {
+			// A `Streaming` call is created in the UI's `Executing` state before
+			// it may transition to confirmation, so the App must not mount yet.
+			const invocation = toolCallStateToInvocation({
+				toolCallId: 'tc-1',
+				toolName: 'test_tool',
+				displayName: 'Test Tool',
+				invocationMessage: 'Running test tool...',
+				status: ToolCallStatus.Streaming,
+				contributor: { kind: ToolCallContributorKind.MCP, customizationId: 'docs-customization' },
+				_meta: {
+					ui: {
+						resourceUri: 'ui://docs/app',
+						channel: 'mcp://copilot/test-session-1/docs',
+					},
+				},
+			});
+
+			assert.strictEqual(invocation.toolSpecificData, undefined);
+		});
+
 		test('synthesizes subagent chatResource from the tool call id when no discovery content block is present', () => {
 			// A background subagent's `subagent_started` can arrive after its
 			// spawning tool call has already completed, so the running-only

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -10,7 +10,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import type { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { fromAgentHostUri, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
-import { buildSubagentChatUri, MessageKind, ToolCallStatus, ToolCallConfirmationReason, ToolResultContentType, TurnState, ResponsePartKind, type ActiveTurn, type ICompletedToolCall, type ToolCallRunningState, type Turn, type ToolCallResponsePart, ToolCallCancellationReason, type Message } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { buildSubagentChatUri, MessageKind, ToolCallContributorKind, ToolCallStatus, ToolCallConfirmationReason, ToolResultContentType, TurnState, ResponsePartKind, type ActiveTurn, type ICompletedToolCall, type ToolCallRunningState, type Turn, type ToolCallResponsePart, ToolCallCancellationReason, type Message } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, type IChatMarkdownContent, type IChatTerminalToolInvocationData, type IChatThinkingPart, type IChatUsage } from '../../../common/chatService/chatService.js';
 import { isToolResultInputOutputDetails, type IToolResultInputOutputDetails, ToolDataSource, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
 import { turnsToHistory as rawTurnsToHistory, activeTurnToProgress as rawActiveTurnToProgress, toolCallStateToInvocation as rawToolCallStateToInvocation, finalizeToolInvocation as rawFinalizeToolInvocation, updateRunningToolSpecificData as rawUpdateRunningToolSpecificData, usageInfoToQuotas, formatTurnResponseDetails, rewriteAgentHostLinkTarget, rewriteMarkdownLinks } from '../../../browser/agentSessions/agentHost/stateToProgressAdapter.js';
@@ -838,6 +838,30 @@ suite('stateToProgressAdapter', () => {
 				assert.strictEqual(invocation.toolSpecificData.description, 'Review code');
 				assert.strictEqual(invocation.toolSpecificData.agentName, 'code-reviewer');
 			}
+		});
+
+		test('sets MCP App toolSpecificData for running MCP tool calls', () => {
+			const invocation = toolCallStateToInvocation(createToolCallState({
+				toolInput: '{"topic":"metadata"}',
+				contributor: { kind: ToolCallContributorKind.MCP, customizationId: 'docs-customization' },
+				_meta: {
+					ui: {
+						resourceUri: 'ui://docs/app',
+						channel: 'mcp://copilot/test-session-1/docs',
+					},
+				},
+			}));
+
+			assert.deepStrictEqual(invocation.toolSpecificData, {
+				kind: 'input',
+				rawInput: { topic: 'metadata' },
+				mcpAppData: {
+					kind: 'agentHost',
+					resourceUri: 'ui://docs/app',
+					serverId: 'docs-customization',
+					channel: 'mcp://copilot/test-session-1/docs',
+				},
+			});
 		});
 
 		test('synthesizes subagent chatResource from the tool call id when no discovery content block is present', () => {
@@ -1830,6 +1854,57 @@ suite('stateToProgressAdapter', () => {
 			if (invocation.toolSpecificData?.kind === 'subagent') {
 				assert.strictEqual(invocation.toolSpecificData.modelName, 'Claude Sonnet 4', 'model name should survive a toolSpecificData refresh');
 			}
+		});
+
+		test('mounts MCP App toolSpecificData when a confirmed MCP tool starts running', () => {
+			// The MCP App channel is present in `_meta.ui` from the first tool
+			// state (a tool cannot start until its server is Ready), but the App
+			// is only mounted once the tool leaves confirmation and starts
+			// running.
+			const meta = {
+				ui: {
+					resourceUri: 'ui://docs/app',
+					channel: 'mcp://copilot/test-session-1/docs',
+				},
+			};
+			const invocation = toolCallStateToInvocation({
+				toolCallId: 'tc-1',
+				toolName: 'test_tool',
+				displayName: 'Test Tool',
+				invocationMessage: 'Running test tool...',
+				status: ToolCallStatus.PendingConfirmation,
+				toolInput: '{"topic":"metadata"}',
+				contributor: { kind: ToolCallContributorKind.MCP, customizationId: 'docs-customization' },
+				_meta: meta,
+			});
+			// Confirmation state carries the raw input but does not mount the App.
+			assert.deepStrictEqual(invocation.toolSpecificData, { kind: 'input', rawInput: { topic: 'metadata' } });
+
+			let stateChanged = false;
+			const disposable = autorun(r => {
+				invocation.state.read(r);
+				stateChanged = true;
+			});
+			stateChanged = false;
+
+			updateRunningToolSpecificData(invocation, createToolCallState({
+				toolInput: '{"topic":"metadata"}',
+				contributor: { kind: ToolCallContributorKind.MCP, customizationId: 'docs-customization' },
+				_meta: meta,
+			}));
+
+			assert.strictEqual(stateChanged, true, 'state observers should be notified');
+			assert.deepStrictEqual(invocation.toolSpecificData, {
+				kind: 'input',
+				rawInput: { topic: 'metadata' },
+				mcpAppData: {
+					kind: 'agentHost',
+					resourceUri: 'ui://docs/app',
+					serverId: 'docs-customization',
+					channel: 'mcp://copilot/test-session-1/docs',
+				},
+			});
+			disposable.dispose();
 		});
 
 		test('does not notify when no subagent content is present', () => {


### PR DESCRIPTION
## Why

For MCP-App tools running through the Copilot agent host, the MCP App surface previously only mounted **on tool completion**. That was a workaround: the Copilot SDK didn't surface MCP App `_meta.ui.resourceUri` on `tool.execution_start`, so the host recovered it at `tool.execution_complete`.

The recent SDK version fixes this and surfaces the metadata at tool start. Combined with the invariant that **a tool call cannot begin until its MCP server is `Ready`**, the AHP `mcp://` channel is also available at start — so we can publish the complete `_meta.ui` payload (resourceUri **+** channel) once, at `ChatToolCallStart`, and mount the App eagerly for a running tool.

## What

**Host — `copilotAgentSession.ts`**
- Build `_meta.ui = { resourceUri, channel }` at `tool.execution_start` (the SDK now provides `resourceUri`; the channel is available because the server is already `Ready`).
- Simplify the completion path to just re-emit the tracked meta (the reducer preserves `_meta` when an action passes `undefined`, via `meta ?? tc._meta`).
- Remove `_refreshActiveMcpToolCallUiMeta` and the running-state meta re-emission that only existed to handle "server becomes `Ready` after the tool started" — impossible under the readiness invariant.

**UI — `stateToProgressAdapter.ts`**
- Mount MCP App `toolSpecificData` eagerly for running tool calls in `toolCallStateToInvocation`, rather than only at completion.
- Confirmation-gated tools (created without `mcpAppData`) mount the App on the `PendingConfirmation → Running` transition; the channel is present in `_meta.ui` throughout. This branch leans on `getMcpAppData`'s MCP-contributor check so non-MCP tools fall through to their own handling.

## Tests
- Host: `tool_start` carries MCP App UI metadata; the channel is included in the start meta when the server is already `Ready`.
- UI: MCP App `toolSpecificData` is set for running MCP tool calls; the App mounts when a confirmed MCP tool starts running.

Full `CopilotAgentSession` (180) and `stateToProgressAdapter` (91) suites, `typecheck-client`, and hygiene all pass.

<sub>Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;</sub>