### PR TITLE
Stop session/customizationsChanged log spam in agent host

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -37,7 +37,6 @@ import {
 	SessionLifecycle,
 	ToolCallStatus,
 	ToolResultContentType,
-	type Customization,
 	type ErrorInfo,
 	type ISessionWithDefaultChat,
 	type Message,
@@ -114,7 +113,6 @@ export class AgentSideEffects extends Disposable {
 	/** Maps tool call IDs to the agent that owns them, for routing confirmations. */
 	private readonly _toolCallAgents = new Map<string, string>();
 	private _lastAgentInfos: readonly AgentInfo[] = [];
-	private readonly _lastSessionCustomizations = new Map<ProtocolURI, readonly Customization[]>();
 
 	private readonly _permissionManager: SessionPermissionManager;
 
@@ -241,18 +239,23 @@ export class AgentSideEffects extends Disposable {
 
 		const customizations = await agent.getSessionCustomizations(URI.parse(session));
 
-		// Skip the dispatch when the resolved customizations are unchanged since
-		// the last publish for this session. A single edit under a shared
-		// `~/.claude` tree fans out to every open session (and, via the
-		// agent-level `onDidCustomizationsChange`, is republished once per
-		// session), so without this guard a single change emitted O(N^2)
-		// identical `SessionCustomizationsChanged` envelopes. Mirrors the
-		// `_publishAgentInfos` dedup.
-		const previous = this._lastSessionCustomizations.get(session);
-		if (previous && equals(previous, customizations)) {
+		// Skip the dispatch when the resolved customizations match what the
+		// session state already holds. A single edit under a shared `~/.claude`
+		// tree fans out to every open session (and, via the agent-level
+		// `onDidCustomizationsChange`, is republished once per session), so
+		// without this guard a single change emitted O(N^2) identical
+		// `SessionCustomizationsChanged` envelopes. Comparing against the
+		// authoritative session state (rather than a side cache) keeps this
+		// correct across idle-eviction + restore: a restored session's state
+		// starts without customizations, so the first successful refresh always
+		// dispatches even if the resolved set matches the prior incarnation.
+		// It also needs no cleanup on session teardown. `undefined` (never
+		// published) never equals a resolved array, so the initial publish
+		// always goes through.
+		const current = this._stateManager.getSessionState(session)?.customizations;
+		if (current && equals(current, customizations)) {
 			return;
 		}
-		this._lastSessionCustomizations.set(session, customizations);
 
 		this._stateManager.dispatchServerAction(session, {
 			type: ActionType.SessionCustomizationsChanged,
@@ -272,7 +275,6 @@ export class AgentSideEffects extends Disposable {
 				this._publishSessionCustomizationsSoon(agent, session);
 			}
 		}
-		this._pruneSessionCustomizationsCache();
 	}
 
 	private _publishAllSessionCustomizations(): void {
@@ -280,27 +282,6 @@ export class AgentSideEffects extends Disposable {
 			const agent = this._options.getAgent(session);
 			if (agent) {
 				this._publishSessionCustomizationsSoon(agent, session);
-			}
-		}
-		this._pruneSessionCustomizationsCache();
-	}
-
-	/**
-	 * Drops dedup-cache entries for sessions that no longer exist. Session
-	 * teardown (both permanent `deleteSession` and eviction via `removeSession`)
-	 * emits no signal we subscribe to here, so instead of listening for removal
-	 * we reconcile against the live session set on every customization publish
-	 * cycle. That keeps {@link _lastSessionCustomizations} bounded by the live
-	 * session count rather than growing over the host's lifetime.
-	 */
-	private _pruneSessionCustomizationsCache(): void {
-		if (this._lastSessionCustomizations.size === 0) {
-			return;
-		}
-		const live = new Set<ProtocolURI>(this._stateManager.getSessionUris());
-		for (const session of this._lastSessionCustomizations.keys()) {
-			if (!live.has(session)) {
-				this._lastSessionCustomizations.delete(session);
 			}
 		}
 	}

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -37,6 +37,7 @@ import {
 	SessionLifecycle,
 	ToolCallStatus,
 	ToolResultContentType,
+	type Customization,
 	type ErrorInfo,
 	type ISessionWithDefaultChat,
 	type Message,
@@ -113,6 +114,7 @@ export class AgentSideEffects extends Disposable {
 	/** Maps tool call IDs to the agent that owns them, for routing confirmations. */
 	private readonly _toolCallAgents = new Map<string, string>();
 	private _lastAgentInfos: readonly AgentInfo[] = [];
+	private readonly _lastSessionCustomizations = new Map<ProtocolURI, readonly Customization[]>();
 
 	private readonly _permissionManager: SessionPermissionManager;
 
@@ -238,6 +240,20 @@ export class AgentSideEffects extends Disposable {
 		}
 
 		const customizations = await agent.getSessionCustomizations(URI.parse(session));
+
+		// Skip the dispatch when the resolved customizations are unchanged since
+		// the last publish for this session. A single edit under a shared
+		// `~/.claude` tree fans out to every open session (and, via the
+		// agent-level `onDidCustomizationsChange`, is republished once per
+		// session), so without this guard a single change emitted O(N^2)
+		// identical `SessionCustomizationsChanged` envelopes. Mirrors the
+		// `_publishAgentInfos` dedup.
+		const previous = this._lastSessionCustomizations.get(session);
+		if (previous && equals(previous, customizations)) {
+			return;
+		}
+		this._lastSessionCustomizations.set(session, customizations);
+
 		this._stateManager.dispatchServerAction(session, {
 			type: ActionType.SessionCustomizationsChanged,
 			customizations: [...customizations],
@@ -256,6 +272,7 @@ export class AgentSideEffects extends Disposable {
 				this._publishSessionCustomizationsSoon(agent, session);
 			}
 		}
+		this._pruneSessionCustomizationsCache();
 	}
 
 	private _publishAllSessionCustomizations(): void {
@@ -263,6 +280,27 @@ export class AgentSideEffects extends Disposable {
 			const agent = this._options.getAgent(session);
 			if (agent) {
 				this._publishSessionCustomizationsSoon(agent, session);
+			}
+		}
+		this._pruneSessionCustomizationsCache();
+	}
+
+	/**
+	 * Drops dedup-cache entries for sessions that no longer exist. Session
+	 * teardown (both permanent `deleteSession` and eviction via `removeSession`)
+	 * emits no signal we subscribe to here, so instead of listening for removal
+	 * we reconcile against the live session set on every customization publish
+	 * cycle. That keeps {@link _lastSessionCustomizations} bounded by the live
+	 * session count rather than growing over the host's lifetime.
+	 */
+	private _pruneSessionCustomizationsCache(): void {
+		if (this._lastSessionCustomizations.size === 0) {
+			return;
+		}
+		const live = new Set<ProtocolURI>(this._stateManager.getSessionUris());
+		for (const session of this._lastSessionCustomizations.keys()) {
+			if (!live.has(session)) {
+				this._lastSessionCustomizations.delete(session);
 			}
 		}
 	}

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
@@ -420,6 +420,27 @@ export function buildDiscoveredCustomizations(
 }
 
 /**
+ * The customization-source subpaths under a `.claude` directory. Only edits
+ * to these should force a re-scan. Everything else under `.claude` is Claude
+ * SDK runtime churn — `history.jsonl`, `projects/` (per-message transcripts),
+ * `tasks/`, `file-history/`, `sessions/`, `shell-snapshots/`, `backups/`,
+ * `session-env/`, `statsig`, and assorted `*-cache.json` files — all of which
+ * the SDK rewrites constantly during a turn. Triggering on those produced a
+ * storm of `SessionCustomizationsChanged` envelopes (thousands per session),
+ * so the watcher deliberately triggers on this allowlist only.
+ */
+const CLAUDE_CUSTOMIZATION_SUBPATHS: readonly string[] = Object.freeze([
+	'agents',
+	'skills',
+	'commands',
+	'rules',
+	'plugins',
+	'CLAUDE.md',
+	'settings.json',
+	'settings.local.json',
+]);
+
+/**
  * Watches a session's on-disk Claude customization sources and fires
  * {@link onDidChange} (debounced) whenever any of them is created, edited,
  * or removed, so the workbench re-fetches `getSessionCustomizations`.
@@ -429,9 +450,13 @@ export function buildDiscoveredCustomizations(
  *    agents / skills / commands trees, the `.claude/rules` + `.claude/CLAUDE.md`
  *    instruction sources, plus the inline `settings.json` MCP config.
  *  - `<cwd>` (non-recursive) — watched to catch the sibling `.mcp.json` and
- *    the root `CLAUDE.md` / `CLAUDE.local.md` memory files; the triggers are
- *    narrowed to those files so unrelated edits in the workspace root don't
- *    force a re-scan.
+ *    the root `CLAUDE.md` / `CLAUDE.local.md` memory files.
+ *
+ * The recursive `.claude` watches keep OS-level watcher count low, but the
+ * change *triggers* are narrowed to {@link CLAUDE_CUSTOMIZATION_SUBPATHS} (and
+ * the specific memory / `.mcp.json` files) so the SDK's high-frequency runtime
+ * writes elsewhere under `.claude` (and unrelated edits in the workspace root)
+ * don't force a re-scan.
  */
 export class ClaudeCustomizationWatcher extends Disposable {
 
@@ -458,16 +483,25 @@ export class ClaudeCustomizationWatcher extends Disposable {
 			}
 		};
 
+		// Trigger only on the customization sources under a `.claude` root, not
+		// on the root itself — that would fire on every SDK runtime write (see
+		// CLAUDE_CUSTOMIZATION_SUBPATHS).
+		const addClaudeTriggers = (base: URI) => {
+			for (const sub of CLAUDE_CUSTOMIZATION_SUBPATHS) {
+				triggers.push(URI.joinPath(base, sub));
+			}
+		};
+
 		if (workingDirectory) {
 			const projectClaude = URI.joinPath(workingDirectory, '.claude');
 			watch(projectClaude, true);
-			triggers.push(projectClaude);
+			addClaudeTriggers(projectClaude);
 			watch(workingDirectory, false);
 			triggers.push(URI.joinPath(workingDirectory, '.mcp.json'));
 		}
 		const userClaude = URI.joinPath(userHome, '.claude');
 		watch(userClaude, true);
-		triggers.push(userClaude);
+		addClaudeTriggers(userClaude);
 
 		// Memory files (CLAUDE.md / CLAUDE.local.md) — reuse the scanner's
 		// canonical list so the watcher never drifts from what it actually

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1066,11 +1066,15 @@ suite('AgentSideEffects', () => {
 		test('customizations change publishes once, then dedupes identical re-fetches', async () => {
 			setupSession();
 
-			const customizations: Customization[] = [
+			// Return a freshly-built array of freshly-built objects on every
+			// fetch (matching real providers, which re-scan disk each time) so
+			// the dedup is proven to rely on structural equality, not reference
+			// identity.
+			const makeCustomizations = (): Customization[] => [
 				{ type: CustomizationType.Plugin, id: customizationId('file:///plugin-a'), uri: 'file:///plugin-a', name: 'Plugin A', enabled: true, load: { kind: CustomizationLoadStatus.Loaded } },
 			];
 			let fetchCalls = 0;
-			agent.getSessionCustomizations = async () => { fetchCalls++; return customizations; };
+			agent.getSessionCustomizations = async () => { fetchCalls++; return makeCustomizations(); };
 
 			const changed: ActionEnvelope[] = [];
 			disposables.add(stateManager.onDidEmitEnvelope(e => {
@@ -1085,8 +1089,9 @@ suite('AgentSideEffects', () => {
 			await waitForState(stateManager, () => changed.length >= 1 || undefined);
 			assert.strictEqual(changed.length, 1);
 
-			// Subsequent changes that resolve to the same customizations (e.g. the
-			// O(N^2) fan-out from a shared `~/.claude` edit) must not re-publish.
+			// Subsequent changes that resolve to structurally-equal customizations
+			// (e.g. the O(N^2) fan-out from a shared `~/.claude` edit) must not
+			// re-publish, even though each fetch returns a brand-new array.
 			agent.fireCustomizationsChange();
 			agent.fireCustomizationsChange();
 			const deadline = Date.now() + 5000;
@@ -1095,6 +1100,40 @@ suite('AgentSideEffects', () => {
 			}
 			assert.strictEqual(changed.length, 1, 'identical customizations must not re-publish');
 			assert.ok(fetchCalls >= 3, 'each change still re-fetches to compare');
+		});
+
+		test('re-publishes after session eviction + restore even when customizations are unchanged', async () => {
+			setupSession();
+
+			const makeCustomizations = (): Customization[] => [
+				{ type: CustomizationType.Plugin, id: customizationId('file:///plugin-a'), uri: 'file:///plugin-a', name: 'Plugin A', enabled: true, load: { kind: CustomizationLoadStatus.Loaded } },
+			];
+			agent.getSessionCustomizations = async () => makeCustomizations();
+
+			const changed: ActionEnvelope[] = [];
+			disposables.add(stateManager.onDidEmitEnvelope(e => {
+				if (e.action.type === ActionType.SessionCustomizationsChanged) {
+					changed.push(e);
+				}
+			}));
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			// Initial publish populates the session state's customizations.
+			agent.fireCustomizationsChange();
+			await waitForState(stateManager, () => changed.length >= 1 || undefined);
+			assert.strictEqual(changed.length, 1);
+
+			// Idle-evict then restore the same session URI: the restored state
+			// starts without customizations. Because dedup compares against the
+			// authoritative session state (not a stale side cache), the next
+			// refresh must publish again even though the resolved set is
+			// structurally identical to the prior incarnation's.
+			stateManager.removeSession(sessionUri.toString());
+			setupSession();
+
+			agent.fireCustomizationsChange();
+			await waitForState(stateManager, () => changed.length >= 2 || undefined);
+			assert.strictEqual(changed.length, 2, 'restored session must receive its customizations');
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { VSBuffer } from '../../../../base/common/buffer.js';
+import { timeout } from '../../../../base/common/async.js';
 import { Event } from '../../../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
@@ -1060,6 +1061,40 @@ suite('AgentSideEffects', () => {
 				action: { type: ActionType.ChatResponsePart, turnId: 'turn-1', part: { kind: ResponsePartKind.Markdown, id: 'msg-2', content: 'after' } },
 			});
 			assert.strictEqual(envelopes.filter(e => e.action.type === ActionType.ChatResponsePart).length, 1);
+		});
+
+		test('customizations change publishes once, then dedupes identical re-fetches', async () => {
+			setupSession();
+
+			const customizations: Customization[] = [
+				{ type: CustomizationType.Plugin, id: customizationId('file:///plugin-a'), uri: 'file:///plugin-a', name: 'Plugin A', enabled: true, load: { kind: CustomizationLoadStatus.Loaded } },
+			];
+			let fetchCalls = 0;
+			agent.getSessionCustomizations = async () => { fetchCalls++; return customizations; };
+
+			const changed: ActionEnvelope[] = [];
+			disposables.add(stateManager.onDidEmitEnvelope(e => {
+				if (e.action.type === ActionType.SessionCustomizationsChanged) {
+					changed.push(e);
+				}
+			}));
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			// First change: fetch + publish.
+			agent.fireCustomizationsChange();
+			await waitForState(stateManager, () => changed.length >= 1 || undefined);
+			assert.strictEqual(changed.length, 1);
+
+			// Subsequent changes that resolve to the same customizations (e.g. the
+			// O(N^2) fan-out from a shared `~/.claude` edit) must not re-publish.
+			agent.fireCustomizationsChange();
+			agent.fireCustomizationsChange();
+			const deadline = Date.now() + 5000;
+			while (fetchCalls < 3 && Date.now() < deadline) {
+				await timeout(5);
+			}
+			assert.strictEqual(changed.length, 1, 'identical customizations must not re-publish');
+			assert.ok(fetchCalls >= 3, 'each change still re-fetches to compare');
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
@@ -371,6 +371,27 @@ suite('claudeSessionCustomizationDiscovery', () => {
 			await settle();
 			assert.strictEqual(fires, 1);
 		});
+
+		test('ignores SDK runtime churn under `.claude` (transcripts, history, tasks, ...)', async () => {
+			const watcher = disposables.add(new ClaudeCustomizationWatcher(workspace, userHome, fileService, new NullLogService(), debounceMs));
+			let fires = 0;
+			disposables.add(watcher.onDidChange(() => { fires++; }));
+
+			// The Claude SDK constantly rewrites these under `~/.claude` during a
+			// turn. None of them are customization sources, so they must not
+			// trigger a re-scan (previously each write fanned out to an O(N^2)
+			// storm of `SessionCustomizationsChanged` envelopes).
+			await Promise.all([
+				seed('/home/.claude/history.jsonl', '{}'),
+				seed('/home/.claude/projects/-Users-me-repo/session.jsonl', '{}'),
+				seed('/home/.claude/tasks/abc/state.json', '{}'),
+				seed('/home/.claude/file-history/abc/edit.json', '{}'),
+				seed('/home/.claude/shell-snapshots/snap.sh', '#'),
+				seed('/home/.claude/stats-cache.json', '{}'),
+			]);
+			await settle();
+			assert.strictEqual(fires, 0);
+		});
 	});
 
 	suite('resolveClaudeAgentName', () => {


### PR DESCRIPTION
## Problem

The agent host was emitting **thousands** of `session/customizationsChanged` envelopes — bursts of ~100+/second during active Claude turns. In a captured log, a single session accumulated ~1,084 of these (7,317 total across 10 sessions).

Two compounding causes:

1. **`ClaudeCustomizationWatcher` triggered on SDK runtime churn.** It recursively watches `~/.claude` and treated *any* change under it as a customization change. But the Claude SDK constantly rewrites runtime data there — `history.jsonl`, `projects/` transcripts (appended on every message/tool call), `tasks/`, `file-history/`, `shell-snapshots/`, `sessions/`, `backups/`, caches — none of which are customization sources.

2. **`_publishSessionCustomizations` dispatched unconditionally.** A single edit under the shared `~/.claude` tree fans out to every open session, and the agent-level `onDidCustomizationsChange` republishes once per session, so one change emitted **O(N²)** identical envelopes.

## Fix

1. **Narrow the watcher trigger scope** (`claudeSessionCustomizationDiscovery.ts`). The recursive watch on `.claude` is unchanged (keeps OS watcher count low), but the change *triggers* are now an allowlist of the actual customization sources — `agents`, `skills`, `commands`, `rules`, `plugins`, `CLAUDE.md`, `settings.json`, `settings.local.json` — plus the existing `.mcp.json` and memory-file triggers.

2. **Add a per-session dedup guard** (`agentSideEffects.ts`). `_publishSessionCustomizations` now skips the dispatch when the resolved customizations are unchanged since the last publish for that session (mirroring the existing `_publishAgentInfos` dedup). The dedup cache is pruned against the live session set on each publish cycle (covers both `deleteSession` and eviction, neither of which emits a signal we subscribe to).

## Verification

Covered by new unit tests **and** verified live in the Agents window against real Claude sessions:

| Scenario | `customizationsChanged` | Before |
|---|---|---|
| One full Claude turn | **1** (correct initial publish) | ~1,084/session |
| 20 rounds runtime churn under `~/.claude` (1 session) | **0** | ~20 × N |
| 30 rounds runtime churn, **3 active sessions** | **0** | hundreds (N² fanout) |
| Add / rename / delete a real customization | **fires** ✅ | — |
| Identical re-touch | **deduped** ✅ | — |

Body-only edits to a rule/agent don't re-emit, which is correct: the event payload carries only the descriptor (`id`/`uri`/`name`/`description`/`model`/`enabled`), never file content, and the workbench consumer uses it solely to refresh the agent picker + customizations tree.

## Notes

- Separate, pre-existing issue not addressed here: repeated `snapshotResolvedCustomizations failed — Subprocess initialization did not complete within 60000ms` warnings (Claude SDK subprocess/auth timeout).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
