### PR TITLE
feat: Support modifier-click opening files and folders in a new window

### DIFF
--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -586,6 +586,21 @@ export class Menubar extends Disposable {
 		return !!(event && ((!isMacintosh && (event.ctrlKey || event.shiftKey)) || (isMacintosh && (event.metaKey || event.altKey))));
 	}
 
+	private getCommandIdForClick(commandId: string, event: KeyboardEvent): string {
+		if (!this.isOptionClick(event)) {
+			return commandId;
+		}
+
+		switch (commandId) {
+			case 'workbench.action.files.openFileFolder':
+				return 'workbench.action.files.openFileFolderInNewWindow';
+			case 'workbench.action.files.openFolder':
+				return 'workbench.action.files.openFolderInNewWindow';
+			default:
+				return commandId;
+		}
+	}
+
 	private isKeyboardEvent(event: KeyboardEvent): boolean {
 		return !!(event.triggeredByAccelerator || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey);
 	}
@@ -689,7 +704,7 @@ export class Menubar extends Disposable {
 			if (userSettingsLabel && event.triggeredByAccelerator) {
 				this.runActionInRenderer({ type: 'keybinding', userSettingsLabel });
 			} else {
-				this.runActionInRenderer({ type: 'commandId', commandId });
+				this.runActionInRenderer({ type: 'commandId', commandId: this.getCommandIdForClick(commandId, event) });
 			}
 		};
 		const enabled = typeof enabledOpt === 'boolean' ? enabledOpt : this.windowsMainService.getWindowCount() > 0;

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -9,7 +9,7 @@ import { IMenuService, MenuId, IMenu, SubmenuItemAction, registerAction2, Action
 import { MenuBarVisibility, IWindowOpenable, getMenuBarVisibility, MenuSettings, hasNativeMenu } from '../../../../platform/window/common/window.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IAction, Action, SubmenuAction, Separator, IActionRunner, ActionRunner, WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification, toAction } from '../../../../base/common/actions.js';
-import { addDisposableListener, Dimension, EventType } from '../../../../base/browser/dom.js';
+import { addDisposableListener, Dimension, EventType, isMouseEvent } from '../../../../base/browser/dom.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { isMacintosh, isWeb, isIOS, isNative } from '../../../../base/common/platform.js';
 import { IConfigurationService, IConfigurationChangeEvent } from '../../../../platform/configuration/common/configuration.js';
@@ -377,6 +377,29 @@ export class CustomMenubarControl extends MenubarControl {
 		}
 	}
 
+	private isOptionClick(event: unknown): boolean {
+		if (!isMouseEvent(event)) {
+			return false;
+		}
+
+		return (!isMacintosh && (event.ctrlKey || event.shiftKey)) || (isMacintosh && (event.metaKey || event.altKey));
+	}
+
+	private getCommandIdForClick(commandId: string, event: unknown): string {
+		if (!this.isOptionClick(event)) {
+			return commandId;
+		}
+
+		switch (commandId) {
+			case 'workbench.action.files.openFileFolder':
+				return 'workbench.action.files.openFileFolderInNewWindow';
+			case 'workbench.action.files.openFolder':
+				return 'workbench.action.files.openFolderInNewWindow';
+			default:
+				return commandId;
+		}
+	}
+
 	private getUpdateAction(): IAction | null {
 		const state = this.updateService.state;
 
@@ -578,7 +601,7 @@ export class CustomMenubarControl extends MenubarControl {
 							title = menuItem.item.toggled.mnemonicTitle ?? menuItem.item.toggled.title ?? title;
 						}
 
-						const newAction = store.add(new Action(menuItem.id, mnemonicMenuLabel(title), menuItem.class, menuItem.enabled, () => this.commandService.executeCommand(menuItem.id)));
+						const newAction = store.add(new Action(menuItem.id, mnemonicMenuLabel(title), menuItem.class, menuItem.enabled, event => this.commandService.executeCommand(this.getCommandIdForClick(menuItem.id, event))));
 						newAction.tooltip = menuItem.tooltip;
 						newAction.checked = menuItem.checked;
 						target.push(newAction);


### PR DESCRIPTION
Fixes #325225

This adds modifier-click support for File menu open actions so users can open files and folders in a new window without adding new visible menu items.

The implementation reuses the existing `*InNewWindow` commands:

- `workbench.action.files.openFileFolderInNewWindow`
- `workbench.action.files.openFolderInNewWindow`

It handles both menu paths:

- native menubar / fallback menu handling
- custom renderer menubar

How to test:

1. Open VS Code with the custom menubar enabled.
2. Hold `Ctrl` or `Shift` on Windows/Linux.
3. Click `File > Open Folder...`.
4. Select a folder.
5. Verify the folder opens in a new window.
6. Verify normal clicking `File > Open Folder...` still opens with the existing behavior.

On macOS, use `Cmd` or `Option` instead.

Validation:

- `npm run typecheck-client`
- `npm run precommit`