### PR TITLE
ci: fix universal build

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -28,6 +28,10 @@ fsevents/test/**
 @vscode/deviceid/*.yml
 !@vscode/deviceid/build/Release/*.node
 
+@vscode/fs-copyfile/binding.gyp
+@vscode/fs-copyfile/build/**
+@vscode/fs-copyfile/src/**
+!@vscode/fs-copyfile/build/Release/*.node
 
 @vscode/sqlite3/binding.gyp
 @vscode/sqlite3/benchmark/**


### PR DESCRIPTION
Refs https://dev.azure.com/monacotools/Monaco/_build/results?buildId=454754&view=logs&j=fdf13662-433c-5ba9-9c13-a848a9d221fa&t=e93b1be8-756e-54fd-5ecb-4ffbf10163de&s=d26761af-f5e8-5e3e-3ed3-ef1ee2069094

Followup to https://github.com/microsoft/vscode/pull/325118

cc @lszomoru 