### PR TITLE
sessions: use Worktree checkbox for isolation instead of dropdown

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -344,6 +344,24 @@
 	display: none;
 }
 
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .action-label {
+	cursor: pointer;
+}
+
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .monaco-checkbox {
+	margin-right: 6px;
+}
+
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .sessions-chat-dropdown-label {
+	margin-left: 0;
+	cursor: pointer;
+}
+
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox.disabled .action-label,
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox.disabled .sessions-chat-dropdown-label {
+	cursor: default;
+}
+
 .sessions-chat-picker-slot .action-label:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 	color: var(--vscode-foreground);

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -344,24 +344,6 @@
 	display: none;
 }
 
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .action-label {
-	cursor: pointer;
-}
-
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .monaco-checkbox {
-	margin-right: 6px;
-}
-
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .sessions-chat-dropdown-label {
-	margin-left: 0;
-	cursor: pointer;
-}
-
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox.disabled .action-label,
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox.disabled .sessions-chat-dropdown-label {
-	cursor: default;
-}
-
 .sessions-chat-picker-slot .action-label:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 	color: var(--vscode-foreground);

--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -177,7 +177,7 @@ The provider ships a rich set of session-scoped UI in `browser/`:
 
 | File | Responsibility |
 |------|----------------|
-| `agentHostSessionConfigPicker.ts` | The per-session config picker (isolation, branch, and host-declared dynamic properties) backed by the dynamic-session-config API; includes `media/agentHostSessionConfigPicker.css`. |
+| `agentHostSessionConfigPicker.ts` | The per-session config picker (isolation, branch, and host-declared dynamic properties) backed by the dynamic-session-config API; includes `media/agentHostSessionConfigPicker.css`. On desktop the `isolation` property renders as a "Worktree" checkbox (checked = worktree, unchecked = folder) instead of a dropdown; the phone layout keeps the chip so it can route to the unified repo sheet. |
 | `agentHostAgentPicker.ts` | Custom-agent picker for a session. |
 | `agentHostModePicker.ts` | Agent mode enum picker (extends a shared `AgentHostSessionEnumPicker`), rendered immediately before approvals in the secondary toolbar for new and active sessions. |
 | `agentHostModelPicker.ts` | `getAgentHostModels` — filters language models by the session resource scheme. |

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -10,6 +10,7 @@ import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { BaseActionViewItem } from '../../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { Checkbox } from '../../../../../base/browser/ui/toggle/toggle.js';
 import { Delayer } from '../../../../../base/common/async.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
@@ -25,6 +26,7 @@ import { IInstantiationService, ServicesAccessor } from '../../../../../platform
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { defaultCheckboxStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import type { SessionConfigPropertySchema, SessionConfigValueItem } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { ChatConfiguration, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { maybeConfirmElevatedPermissionLevel } from '../../../../../workbench/contrib/chat/common/chatPermissionWarnings.js';
@@ -321,6 +323,11 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			if (property === SessionConfigKey.Isolation) {
 				this._renderDisposables.add(markOnboardingTarget(slot, 'sessions.newSession.isolation'));
 			}
+			// Isolation renders as a Worktree checkbox on desktop; the phone layout keeps the chip for the unified repo sheet.
+			if (property === SessionConfigKey.Isolation && this._shouldRenderIsolationAsCheckbox(schema)) {
+				this._renderIsolationCheckbox(slot, provider, session.sessionId, schema, value, isReadOnly, !isReadOnly && isLoading);
+				continue;
+			}
 			// `renderPickerTrigger`'s `disabled` flag means "read-only"
 			// (renders a `<span>` with `aria-readonly`). The resolving
 			// state is transient and uses `.disabled` on the slot (see
@@ -409,6 +416,62 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			? localize('agentHostSessionConfig.triggerAriaReadOnly', "{0}: {1}, Read-Only", schema.title, label)
 			: localize('agentHostSessionConfig.triggerAria', "{0}: {1}", schema.title, label));
 		applyAutoApproveTriggerStyles(trigger, property, value);
+	}
+
+	/**
+	 * Whether the isolation property should render as a checkbox
+	 * (Worktree on/off) rather than a dropdown. Only on non-phone
+	 * layouts and only when the schema offers both folder and worktree.
+	 */
+	protected _shouldRenderIsolationAsCheckbox(schema: SessionConfigPropertySchema): boolean {
+		return !isPhoneLayout(this._layoutService)
+			&& Array.isArray(schema.enum)
+			&& schema.enum.includes('worktree')
+			&& schema.enum.includes('folder');
+	}
+
+	private _renderIsolationCheckbox(slot: HTMLElement, provider: IAgentHostSessionsProvider, sessionId: string, schema: SessionConfigPropertySchema, value: unknown | undefined, isReadOnly: boolean, isLoading: boolean): void {
+		const disabled = isReadOnly || isLoading;
+		const label = localize('agentHostSessionConfig.isolation.worktree', "Worktree");
+		slot.classList.add('sessions-chat-isolation-checkbox');
+		slot.classList.toggle('disabled', disabled);
+
+		const row = dom.append(slot, dom.$('.action-label'));
+		const checkbox = this._renderDisposables.add(new Checkbox(label, value === 'worktree', { ...defaultCheckboxStyles, size: 14 }));
+		if (disabled) {
+			checkbox.disable();
+		}
+		dom.append(row, checkbox.domNode);
+		const labelSpan = dom.append(row, dom.$('span.sessions-chat-dropdown-label'));
+		labelSpan.textContent = label;
+
+		const tooltip = schema.description ?? schema.title;
+		if (tooltip) {
+			this._renderDisposables.add(this._hoverService.setupDelayedHover(row, { content: tooltip }));
+		}
+
+		const applyValue = (checked: boolean) => {
+			const before = provider.getSessionConfig(sessionId)?.values[SessionConfigKey.Isolation];
+			const nextValue = checked ? 'worktree' : 'folder';
+			reportNewChatPickerClosed(this._telemetryService, {
+				id: 'NewChatAgentHostSessionConfigPicker',
+				name: `NewChatAgentHostSessionConfigPicker.${SessionConfigKey.Isolation}`,
+				optionIdBefore: typeof before === 'string' ? before : undefined,
+				optionIdAfter: nextValue,
+				optionLabelBefore: undefined,
+				optionLabelAfter: nextValue,
+				isPII: false,
+			});
+			provider.setSessionConfigValue(sessionId, SessionConfigKey.Isolation, nextValue).catch(() => { /* best-effort */ });
+		};
+
+		this._renderDisposables.add(checkbox.onChange(() => applyValue(checkbox.checked)));
+		if (!disabled) {
+			this._renderDisposables.add(dom.addDisposableListener(labelSpan, dom.EventType.CLICK, () => {
+				checkbox.checked = !checkbox.checked;
+				applyValue(checkbox.checked);
+			}));
+		}
 	}
 
 	protected async _showPicker(provider: IAgentHostSessionsProvider, sessionId: string, property: string, schema: SessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -244,6 +244,15 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			this._renderConfigPickers();
 		}));
 		this._watchProviders(this._sessionsProvidersService.getProviders());
+
+		// Re-render when the layout crosses the phone breakpoint so the
+		// isolation control swaps between the desktop checkbox and the
+		// phone chip (which routes to the unified repository sheet).
+		this._register(this._contextKeyService.onDidChangeContext(e => {
+			if (e.affectsSome(new Set([IsPhoneLayoutContext.key]))) {
+				this._renderConfigPickers();
+			}
+		}));
 	}
 
 	private _watchProviders(providers: readonly ISessionsProvider[]): void {
@@ -451,15 +460,15 @@ export class AgentHostSessionConfigPicker extends Disposable {
 		}
 
 		const applyValue = (checked: boolean) => {
-			const before = provider.getSessionConfig(sessionId)?.values[SessionConfigKey.Isolation];
+			const before = provider.getSessionConfig(sessionId)?.values[SessionConfigKey.Isolation] ?? schema.default;
 			const nextValue = checked ? 'worktree' : 'folder';
 			reportNewChatPickerClosed(this._telemetryService, {
 				id: 'NewChatAgentHostSessionConfigPicker',
 				name: `NewChatAgentHostSessionConfigPicker.${SessionConfigKey.Isolation}`,
 				optionIdBefore: typeof before === 'string' ? before : undefined,
 				optionIdAfter: nextValue,
-				optionLabelBefore: undefined,
-				optionLabelAfter: nextValue,
+				optionLabelBefore: typeof before === 'string' ? this._getLabel(schema, before) : undefined,
+				optionLabelAfter: this._getLabel(schema, nextValue),
 				isPII: false,
 			});
 			provider.setSessionConfigValue(sessionId, SessionConfigKey.Isolation, nextValue).catch(() => { /* best-effort */ });
@@ -467,10 +476,17 @@ export class AgentHostSessionConfigPicker extends Disposable {
 
 		this._renderDisposables.add(checkbox.onChange(() => applyValue(checkbox.checked)));
 		if (!disabled) {
-			this._renderDisposables.add(dom.addDisposableListener(labelSpan, dom.EventType.CLICK, () => {
-				checkbox.checked = !checkbox.checked;
-				applyValue(checkbox.checked);
-			}));
+			// Toggle from anywhere on the row so the visible hit target
+			// (padding + checkbox/label gap) matches the interactive one.
+			// The checkbox stops its own click from bubbling here.
+			this._renderDisposables.add(Gesture.addTarget(row));
+			for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
+				this._renderDisposables.add(dom.addDisposableListener(row, eventType, e => {
+					dom.EventHelper.stop(e, true);
+					checkbox.checked = !checkbox.checked;
+					applyValue(checkbox.checked);
+				}));
+			}
 		}
 	}
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/media/agentHostSessionConfigPicker.css
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/media/agentHostSessionConfigPicker.css
@@ -16,3 +16,21 @@
 .sessions-chat-agent-host-config a.action-label {
 	touch-action: manipulation;
 }
+
+.sessions-chat-agent-host-config .sessions-chat-isolation-checkbox .action-label {
+	cursor: pointer;
+}
+
+.sessions-chat-agent-host-config .sessions-chat-isolation-checkbox .monaco-checkbox {
+	margin-right: 6px;
+}
+
+.sessions-chat-agent-host-config .sessions-chat-isolation-checkbox .sessions-chat-dropdown-label {
+	margin-left: 0;
+	cursor: pointer;
+}
+
+.sessions-chat-agent-host-config .sessions-chat-isolation-checkbox.disabled .action-label,
+.sessions-chat-agent-host-config .sessions-chat-isolation-checkbox.disabled .sessions-chat-dropdown-label {
+	cursor: default;
+}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../base/browser/dom.js';
+import './media/isolationPicker.css';
 import { Disposable, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun, IObservable } from '../../../../../base/common/observable.js';
 import { Checkbox } from '../../../../../base/browser/ui/toggle/toggle.js';

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
@@ -4,17 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../base/browser/dom.js';
-import { Gesture, EventType as TouchEventType } from '../../../../../base/browser/touch.js';
-import { Codicon } from '../../../../../base/common/codicons.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun, IObservable } from '../../../../../base/common/observable.js';
-import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { Checkbox } from '../../../../../base/browser/ui/toggle/toggle.js';
 import { localize } from '../../../../../nls.js';
-import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
-import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { defaultCheckboxStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { reportNewChatPickerClosed } from '../../../chat/browser/newChatPickerTelemetry.js';
 import { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
@@ -24,22 +21,15 @@ import { SessionIsolationPickerVisibleContext } from '../../../../common/context
 
 export type IsolationMode = 'worktree' | 'workspace';
 
-interface IIsolationPickerItem {
-	readonly mode: IsolationMode;
-	readonly checked?: boolean;
-}
-
 /**
  * A self-contained widget for selecting the isolation mode.
  *
- * Options:
- * - **Worktree** (`worktree`) — run in a git worktree
- * - **Folder** (`workspace`) — run directly in the folder
+ * Rendered as a "Worktree" checkbox: checked runs the session in a git
+ * worktree (`worktree`), unchecked runs it directly in the folder
+ * (`workspace`).
  *
  * Only visible when isolation option is enabled, project has a git repo,
  * and the target is CLI.
- *
- * Emits `onDidChange` with the selected `IsolationMode` when the user picks an option.
  */
 export class IsolationPicker extends Disposable {
 
@@ -47,6 +37,7 @@ export class IsolationPicker extends Disposable {
 	private _isolationOptionEnabled: boolean;
 
 	private readonly _renderDisposables = this._register(new DisposableStore());
+	private readonly _triggerContent = this._register(new DisposableStore());
 	private _slotElement: HTMLElement | undefined;
 	private _triggerElement: HTMLElement | undefined;
 
@@ -60,7 +51,6 @@ export class IsolationPicker extends Disposable {
 
 	constructor(
 		private readonly _session: IObservable<IActiveSession | undefined>,
-		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
@@ -77,7 +67,7 @@ export class IsolationPicker extends Disposable {
 				if (!this._isolationOptionEnabled) {
 					this._setModeOnSession('worktree');
 				}
-				this._updateTriggerLabel();
+				this._updateTrigger();
 			}
 		}));
 
@@ -97,7 +87,7 @@ export class IsolationPicker extends Disposable {
 			} else {
 				this._hasGitRepo = false;
 			}
-			this._updateTriggerLabel();
+			this._updateTrigger();
 		}));
 	}
 
@@ -111,91 +101,15 @@ export class IsolationPicker extends Disposable {
 	render(container: HTMLElement): void {
 		this._renderDisposables.clear();
 
-		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot'));
+		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot.sessions-chat-isolation-checkbox'));
 		this._renderDisposables.add({ dispose: () => slot.remove() });
 		this._slotElement = slot;
 		// Onboarding spotlight target — id is referenced by the "new session" tour
 		// in vs/sessions/contrib/onboardingTours.
 		this._renderDisposables.add(markOnboardingTarget(slot, 'sessions.newSession.isolation'));
 
-		const trigger = dom.append(slot, dom.$('a.action-label'));
-		trigger.tabIndex = 0;
-		trigger.role = 'button';
-		this._triggerElement = trigger;
-		this._updateTriggerLabel();
-
-		this._renderDisposables.add(Gesture.addTarget(trigger));
-		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
-			this._renderDisposables.add(dom.addDisposableListener(trigger, eventType, (e) => {
-				dom.EventHelper.stop(e, true);
-				this._showPicker();
-			}));
-		}
-
-		this._renderDisposables.add(dom.addDisposableListener(trigger, dom.EventType.KEY_DOWN, (e) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				dom.EventHelper.stop(e, true);
-				this._showPicker();
-			}
-		}));
-	}
-
-	private _showPicker(): void {
-		if (!this._triggerElement || this.actionWidgetService.isVisible) {
-			return;
-		}
-
-		if (!this._hasGitRepo || !this._isolationOptionEnabled) {
-			return;
-		}
-
-		const currentIsolationMode = this._getSessionIsolationMode();
-		const items: IActionListItem<IIsolationPickerItem>[] = [
-			{
-				kind: ActionListItemKind.Action,
-				label: localize('isolationMode.worktree', "Worktree"),
-				group: { title: '', icon: Codicon.worktree },
-				item: { mode: 'worktree', checked: currentIsolationMode === 'worktree' || undefined },
-			},
-			{
-				kind: ActionListItemKind.Action,
-				label: localize('isolationMode.folder', "Folder"),
-				group: { title: '', icon: Codicon.folder },
-				item: { mode: 'workspace', checked: currentIsolationMode === 'workspace' || undefined },
-			},
-		];
-
-		const triggerElement = this._triggerElement;
-		const delegate: IActionListDelegate<IIsolationPickerItem> = {
-			onSelect: ({ mode }) => {
-				this.actionWidgetService.hide();
-				reportNewChatPickerClosed(this.telemetryService, {
-					id: 'NewChatIsolationPicker',
-					name: 'NewChatIsolationPicker',
-					optionIdBefore: currentIsolationMode,
-					optionIdAfter: mode,
-					optionLabelBefore: undefined,
-					optionLabelAfter: undefined,
-					isPII: false,
-				});
-				this._setModeOnSession(mode);
-			},
-			onHide: () => { triggerElement.focus(); },
-		};
-
-		this.actionWidgetService.show<IIsolationPickerItem>(
-			'isolationPicker',
-			false,
-			items,
-			delegate,
-			this._triggerElement,
-			undefined,
-			[],
-			{
-				getAriaLabel: (item) => item.label ?? '',
-				getWidgetAriaLabel: () => localize('isolationPicker.ariaLabel', "Isolation Mode"),
-			},
-		);
+		this._triggerElement = dom.append(slot, dom.$('.action-label'));
+		this._updateTrigger();
 	}
 
 	private _setModeOnSession(mode: IsolationMode): void {
@@ -205,41 +119,52 @@ export class IsolationPicker extends Disposable {
 		providerSession?.setIsolationMode(mode);
 	}
 
-	private _updateTriggerLabel(): void {
+	private _updateTrigger(): void {
 		if (!this._triggerElement) {
 			this._visibleKey.set(false);
 			return;
 		}
 
+		this._triggerContent.clear();
 		dom.clearNode(this._triggerElement);
 
-		const isolationMode = this._getSessionIsolationMode();
-		let modeIcon;
-		let modeLabel: string;
+		const isDisabled = !this._hasGitRepo;
+		const isChecked = this._getSessionIsolationMode() === 'worktree';
+		const label = localize('isolationMode.worktree', "Worktree");
 
-		switch (isolationMode) {
-			case 'workspace':
-				modeIcon = Codicon.folder;
-				modeLabel = localize('isolationMode.folder', "Folder");
-				break;
-			case 'worktree':
-			default:
-				modeIcon = Codicon.worktree;
-				modeLabel = localize('isolationMode.worktree', "Worktree");
-				break;
+		const checkbox = this._triggerContent.add(new Checkbox(label, isChecked, { ...defaultCheckboxStyles, size: 14 }));
+		if (isDisabled) {
+			checkbox.disable();
+		}
+		dom.append(this._triggerElement, checkbox.domNode);
+		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
+		labelSpan.textContent = label;
+
+		const applyChecked = (checked: boolean) => {
+			const before: IsolationMode = this._getSessionIsolationMode();
+			const mode: IsolationMode = checked ? 'worktree' : 'workspace';
+			reportNewChatPickerClosed(this.telemetryService, {
+				id: 'NewChatIsolationPicker',
+				name: 'NewChatIsolationPicker',
+				optionIdBefore: before,
+				optionIdAfter: mode,
+				optionLabelBefore: undefined,
+				optionLabelAfter: undefined,
+				isPII: false,
+			});
+			this._setModeOnSession(mode);
+		};
+
+		this._triggerContent.add(checkbox.onChange(() => applyChecked(checkbox.checked)));
+		if (!isDisabled) {
+			this._triggerContent.add(dom.addDisposableListener(labelSpan, dom.EventType.CLICK, () => {
+				checkbox.checked = !checkbox.checked;
+				applyChecked(checkbox.checked);
+			}));
 		}
 
-		dom.append(this._triggerElement, renderIcon(modeIcon));
-		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
-		labelSpan.textContent = modeLabel;
-		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
-
-		this._triggerElement.ariaLabel = localize('isolationPicker.triggerAriaLabel', "Pick Isolation Mode, {0}", modeLabel);
-
-		const isDisabled = !this._hasGitRepo;
+		this._triggerElement.setAttribute('aria-label', localize('isolationPicker.checkboxAriaLabel', "Worktree isolation"));
 		this._slotElement?.classList.toggle('disabled', isDisabled);
-		this._triggerElement.setAttribute('aria-disabled', String(isDisabled));
-		this._triggerElement.tabIndex = isDisabled ? -1 : 0;
 		this._visibleKey.set(this._hasGitRepo && this._isolationOptionEnabled);
 	}
 }

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
@@ -5,6 +5,7 @@
 
 import * as dom from '../../../../../base/browser/dom.js';
 import './media/isolationPicker.css';
+import { Gesture, EventType as TouchEventType } from '../../../../../base/browser/touch.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun, IObservable } from '../../../../../base/common/observable.js';
 import { Checkbox } from '../../../../../base/browser/ui/toggle/toggle.js';
@@ -38,9 +39,9 @@ export class IsolationPicker extends Disposable {
 	private _isolationOptionEnabled: boolean;
 
 	private readonly _renderDisposables = this._register(new DisposableStore());
-	private readonly _triggerContent = this._register(new DisposableStore());
 	private _slotElement: HTMLElement | undefined;
 	private _triggerElement: HTMLElement | undefined;
+	private _checkbox: Checkbox | undefined;
 
 	/**
 	 * Tracks whether the isolation picker is currently visible — i.e. the
@@ -109,7 +110,37 @@ export class IsolationPicker extends Disposable {
 		// in vs/sessions/contrib/onboardingTours.
 		this._renderDisposables.add(markOnboardingTarget(slot, 'sessions.newSession.isolation'));
 
-		this._triggerElement = dom.append(slot, dom.$('.action-label'));
+		const label = localize('isolationMode.worktree', "Worktree");
+		const row = dom.append(slot, dom.$('.action-label'));
+		this._triggerElement = row;
+		row.setAttribute('aria-label', localize('isolationPicker.checkboxAriaLabel', "Worktree isolation"));
+
+		// The checkbox instance is kept stable across state updates so that
+		// toggling it (which re-enters `_updateTrigger` via the isolation
+		// observable) doesn't recreate the DOM and drop keyboard focus.
+		const checkbox = this._renderDisposables.add(new Checkbox(label, this._getSessionIsolationMode() === 'worktree', { ...defaultCheckboxStyles, size: 14 }));
+		this._checkbox = checkbox;
+		dom.append(row, checkbox.domNode);
+		const labelSpan = dom.append(row, dom.$('span.sessions-chat-dropdown-label'));
+		labelSpan.textContent = label;
+
+		this._renderDisposables.add(checkbox.onChange(() => this._applyChecked(checkbox.checked)));
+		// Toggle from anywhere on the row so the visible hit target
+		// (padding + checkbox/label gap) matches the interactive one. The
+		// checkbox stops its own click from bubbling here. `Gesture` +
+		// tap keeps this custom non-button target reliable on iOS.
+		this._renderDisposables.add(Gesture.addTarget(row));
+		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
+			this._renderDisposables.add(dom.addDisposableListener(row, eventType, e => {
+				if (!checkbox.enabled) {
+					return;
+				}
+				dom.EventHelper.stop(e, true);
+				checkbox.checked = !checkbox.checked;
+				this._applyChecked(checkbox.checked);
+			}));
+		}
+
 		this._updateTrigger();
 	}
 
@@ -120,51 +151,34 @@ export class IsolationPicker extends Disposable {
 		providerSession?.setIsolationMode(mode);
 	}
 
+	private _applyChecked(checked: boolean): void {
+		const before: IsolationMode = this._getSessionIsolationMode();
+		const mode: IsolationMode = checked ? 'worktree' : 'workspace';
+		reportNewChatPickerClosed(this.telemetryService, {
+			id: 'NewChatIsolationPicker',
+			name: 'NewChatIsolationPicker',
+			optionIdBefore: before,
+			optionIdAfter: mode,
+			optionLabelBefore: undefined,
+			optionLabelAfter: undefined,
+			isPII: false,
+		});
+		this._setModeOnSession(mode);
+	}
+
 	private _updateTrigger(): void {
-		if (!this._triggerElement) {
+		if (!this._triggerElement || !this._checkbox) {
 			this._visibleKey.set(false);
 			return;
 		}
 
-		this._triggerContent.clear();
-		dom.clearNode(this._triggerElement);
-
 		const isDisabled = !this._hasGitRepo;
-		const isChecked = this._getSessionIsolationMode() === 'worktree';
-		const label = localize('isolationMode.worktree', "Worktree");
-
-		const checkbox = this._triggerContent.add(new Checkbox(label, isChecked, { ...defaultCheckboxStyles, size: 14 }));
+		this._checkbox.checked = this._getSessionIsolationMode() === 'worktree';
 		if (isDisabled) {
-			checkbox.disable();
+			this._checkbox.disable();
+		} else {
+			this._checkbox.enable();
 		}
-		dom.append(this._triggerElement, checkbox.domNode);
-		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
-		labelSpan.textContent = label;
-
-		const applyChecked = (checked: boolean) => {
-			const before: IsolationMode = this._getSessionIsolationMode();
-			const mode: IsolationMode = checked ? 'worktree' : 'workspace';
-			reportNewChatPickerClosed(this.telemetryService, {
-				id: 'NewChatIsolationPicker',
-				name: 'NewChatIsolationPicker',
-				optionIdBefore: before,
-				optionIdAfter: mode,
-				optionLabelBefore: undefined,
-				optionLabelAfter: undefined,
-				isPII: false,
-			});
-			this._setModeOnSession(mode);
-		};
-
-		this._triggerContent.add(checkbox.onChange(() => applyChecked(checkbox.checked)));
-		if (!isDisabled) {
-			this._triggerContent.add(dom.addDisposableListener(labelSpan, dom.EventType.CLICK, () => {
-				checkbox.checked = !checkbox.checked;
-				applyChecked(checkbox.checked);
-			}));
-		}
-
-		this._triggerElement.setAttribute('aria-label', localize('isolationPicker.checkboxAriaLabel', "Worktree isolation"));
 		this._slotElement?.classList.toggle('disabled', isDisabled);
 		this._visibleKey.set(this._hasGitRepo && this._isolationOptionEnabled);
 	}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/media/isolationPicker.css
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/media/isolationPicker.css
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .action-label {
+	cursor: pointer;
+}
+
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .monaco-checkbox {
+	margin-right: 6px;
+}
+
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .sessions-chat-dropdown-label {
+	margin-left: 0;
+	cursor: pointer;
+}
+
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox.disabled .action-label,
+.sessions-chat-picker-slot.sessions-chat-isolation-checkbox.disabled .sessions-chat-dropdown-label {
+	cursor: default;
+}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/isolationPicker.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/isolationPicker.test.ts
@@ -8,8 +8,6 @@ import { Event } from '../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
-import { IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
@@ -23,21 +21,16 @@ import { IActiveSession, ISessionsManagementService } from '../../../../../servi
 import { CopilotChatSessionsProvider } from '../../browser/copilotChatSessionsProvider.js';
 import { IsolationMode, IsolationPicker } from '../../browser/isolationPicker.js';
 
-interface IIsolationActionItem {
-	readonly mode: IsolationMode;
-	readonly checked?: boolean;
-}
-
-function showPicker(container: HTMLElement): void {
-	const trigger = container.querySelector<HTMLElement>('a.action-label');
-	assert.ok(trigger);
-	trigger.click();
+function getCheckbox(container: HTMLElement): HTMLElement {
+	const checkbox = container.querySelector<HTMLElement>('.monaco-checkbox');
+	assert.ok(checkbox, 'expected a worktree checkbox to be rendered');
+	return checkbox;
 }
 
 function createPicker(
 	disposables: DisposableStore,
 	mode: IsolationMode,
-	actionWidgetItems: IActionListItem<IIsolationActionItem>[],
+	setModeCalls: IsolationMode[],
 ): IsolationPicker {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	const activeSession = {
@@ -58,16 +51,13 @@ function createPicker(
 		getSession: () => ({
 			gitRepository: { state: gitState },
 			isolationMode,
+			setIsolationMode: (next: IsolationMode) => {
+				setModeCalls.push(next);
+				isolationMode.set(next, undefined);
+			},
 		}),
 	});
 
-	instantiationService.stub(IActionWidgetService, {
-		isVisible: false,
-		hide: () => { },
-		show: <T>(_id: string, _supportsPreview: boolean, items: IActionListItem<T>[]) => {
-			actionWidgetItems.splice(0, actionWidgetItems.length, ...(items as IActionListItem<IIsolationActionItem>[]));
-		},
-	});
 	instantiationService.stub(IConfigurationService, new TestConfigurationService());
 	const sessionObs = observableValue<IActiveSession | undefined>('activeSession', activeSession);
 	instantiationService.stub(ISessionsManagementService, {
@@ -93,35 +83,31 @@ suite('IsolationPicker', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('marks folder as checked when workspace isolation is selected', () => {
-		const actionWidgetItems: IActionListItem<IIsolationActionItem>[] = [];
-		const picker = createPicker(disposables, 'workspace', actionWidgetItems);
+	test('checkbox unchecked when workspace isolation is selected', () => {
+		const picker = createPicker(disposables, 'workspace', []);
 		const container = document.createElement('div');
 		picker.render(container);
-		showPicker(container);
 
-		assert.deepStrictEqual(
-			actionWidgetItems.map(item => ({ label: item.label, checked: item.item?.checked })),
-			[
-				{ label: 'Worktree', checked: undefined },
-				{ label: 'Folder', checked: true },
-			],
-		);
+		assert.strictEqual(getCheckbox(container).getAttribute('aria-checked'), 'false');
 	});
 
-	test('marks worktree as checked when worktree isolation is selected', () => {
-		const actionWidgetItems: IActionListItem<IIsolationActionItem>[] = [];
-		const picker = createPicker(disposables, 'worktree', actionWidgetItems);
+	test('checkbox checked when worktree isolation is selected', () => {
+		const picker = createPicker(disposables, 'worktree', []);
 		const container = document.createElement('div');
 		picker.render(container);
-		showPicker(container);
 
-		assert.deepStrictEqual(
-			actionWidgetItems.map(item => ({ label: item.label, checked: item.item?.checked })),
-			[
-				{ label: 'Worktree', checked: true },
-				{ label: 'Folder', checked: undefined },
-			],
-		);
+		assert.strictEqual(getCheckbox(container).getAttribute('aria-checked'), 'true');
+	});
+
+	test('toggling the checkbox updates the session isolation mode', () => {
+		const setModeCalls: IsolationMode[] = [];
+		const picker = createPicker(disposables, 'worktree', setModeCalls);
+		const container = document.createElement('div');
+		picker.render(container);
+
+		getCheckbox(container).click();
+
+		assert.deepStrictEqual(setModeCalls, ['workspace']);
+		assert.strictEqual(getCheckbox(container).getAttribute('aria-checked'), 'false');
 	});
 });

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/isolationPicker.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/isolationPicker.test.ts
@@ -110,4 +110,15 @@ suite('IsolationPicker', () => {
 		assert.deepStrictEqual(setModeCalls, ['workspace']);
 		assert.strictEqual(getCheckbox(container).getAttribute('aria-checked'), 'false');
 	});
+
+	test('keeps the same checkbox element across toggles', () => {
+		const picker = createPicker(disposables, 'worktree', []);
+		const container = document.createElement('div');
+		picker.render(container);
+
+		const before = getCheckbox(container);
+		before.click();
+
+		assert.strictEqual(getCheckbox(container), before, 'checkbox element should be reused so focus is preserved');
+	});
 });


### PR DESCRIPTION
## What

Replaces the folder/worktree **isolation dropdown** in the Agents window with a **"Worktree" checkbox** (checked = worktree isolation, unchecked = folder isolation).

This applies to both providers that expose an isolation control:
- **Agent host** session config picker (`agentHostSessionConfigPicker.ts`) — isolation now renders as a Worktree checkbox on desktop. The phone layout keeps the chip so it can still route to the unified repo bottom sheet (isolation + branch).
- **Copilot chat sessions** provider (`isolationPicker.ts`) — the dropdown/action-widget popup is replaced by the Worktree checkbox.

## Why

A single checkbox is a lighter, clearer affordance for a binary worktree/folder choice than a two-item dropdown.

## Notes for reviewers

- The shared checkbox chip styling lives in `chatWidget.css` (scoped to `.sessions-chat-picker-slot.sessions-chat-isolation-checkbox`) so both providers reuse it; the duplicated rules were removed from `agentHostSessionConfigPicker.css`.
- Checkbox is sized to 14px with a 6px gap to the label.
- `IsolationPicker` dropped its now-unused `IActionWidgetService`/gesture/icon dependencies.
- Toggling writes through the existing `setSessionConfigValue` / `setIsolationMode` paths and keeps existing telemetry and disabled (read-only / no-git-repo / loading) behavior.
- Updated the `IsolationPicker` unit tests to assert checkbox state and toggle behavior (3 passing). Typecheck and layers checks pass.