### PR TITLE
Style override: Update padding for agent sessions title container in chat viewpane

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -126,8 +126,7 @@
 
 .style-override.monaco-workbench .chat-viewpane.has-sessions-control .agent-sessions-container {
 	.agent-sessions-title-container {
-		padding-left: 12px;
-		padding-right: 0;
+		padding: 0 0 4px 12px;
 	}
 }
 


### PR DESCRIPTION
Adjust the padding for the agent sessions title container in the chat viewpane to improve layout and visual consistency.

![image.png](https://github.com/user-attachments/assets/d7376a73-c26f-4224-a9f8-6d2e5cbcc250)
