### PR TITLE
Codex agent host: forking, subagent rendering, single approvals chip, auto-review denial surfacing

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -701,6 +701,9 @@ export type AgentProvider = string;
 /** Well-known agent provider id for the Claude agent-host backend. */
 export const CLAUDE_AGENT_PROVIDER_ID = 'claude' as const;
 
+/** Well-known agent provider id for the Codex agent-host backend. */
+export const CODEX_AGENT_PROVIDER_ID = 'codex' as const;
+
 /**
  * Static capability facts an agent backend advertises about itself. Each flag
  * is opt-in (absent means unsupported) so single-chat agents (e.g. Codex) can omit

--- a/src/vs/platform/agentHost/common/codexSessionConfigKeys.ts
+++ b/src/vs/platform/agentHost/common/codexSessionConfigKeys.ts
@@ -91,3 +91,24 @@ export function resolveCodexPermissionsPreset(preset: CodexPermissionsPreset): I
 			return { approvalPolicy: 'on-request', sandboxMode: 'workspace-write', approvalsReviewer: 'user' };
 	}
 }
+
+/**
+ * Inverse of {@link resolveCodexPermissionsPreset}: find the preset whose
+ * expanded axes exactly match the given resolved permissions, or `undefined`
+ * when no preset can represent them (e.g. a `read-only` sandbox, which no
+ * preset expands to).
+ *
+ * Used when restoring a legacy session that persisted the individual security
+ * axes but no preset: if the axes map cleanly onto a preset we can migrate them
+ * to the modern single-preset representation; otherwise the raw axes must be
+ * preserved so they are not silently escalated.
+ */
+export function presetForResolvedPermissions(resolved: ICodexResolvedPermissions): CodexPermissionsPreset | undefined {
+	for (const preset of CODEX_PERMISSIONS_PRESETS) {
+		const axes = resolveCodexPermissionsPreset(preset);
+		if (axes.approvalPolicy === resolved.approvalPolicy && axes.sandboxMode === resolved.sandboxMode && axes.approvalsReviewer === resolved.approvalsReviewer) {
+			return preset;
+		}
+	}
+	return undefined;
+}

--- a/src/vs/platform/agentHost/common/codexSessionConfigKeys.ts
+++ b/src/vs/platform/agentHost/common/codexSessionConfigKeys.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Well-known session-config keys advertised by the agent-host Codex provider
+ * in its `resolveSessionConfig` schema.
+ *
+ * This file is intentionally protocol-free (no imports from the generated
+ * `node/protocol` types) so it can be shared with the browser pickers, which
+ * cannot import from the `node` layer. The string-literal unions below are
+ * declared to match — and are structurally assignable to — the corresponding
+ * generated Codex app-server types (`AskForApproval`, `SandboxMode`,
+ * `ApprovalsReviewer`). Protocol-typed narrowing helpers live alongside the
+ * node agent in `node/codex/codexSessionConfigKeys.ts`.
+ */
+export const enum CodexSessionConfigKey {
+	PermissionsPreset = 'codex.permissionsPreset',
+	ApprovalPolicy = 'codex.approvalPolicy',
+	SandboxMode = 'codex.sandboxMode',
+	AdditionalDirectories = 'codex.additionalDirectories',
+	NetworkAccessEnabled = 'codex.networkAccessEnabled',
+	WebSearchMode = 'codex.webSearchMode',
+	ModelReasoningEffort = 'codex.modelReasoningEffort',
+	Personality = 'codex.personality',
+	ReasoningSummary = 'codex.reasoningSummary',
+}
+
+/** Subset of the generated `AskForApproval` union that VS Code exposes. */
+export type CodexApprovalPolicy = 'never' | 'on-request' | 'on-failure' | 'untrusted';
+
+/** Mirrors the generated `SandboxMode` union. */
+export type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
+
+/** Mirrors the generated `ApprovalsReviewer` union. */
+export type CodexApprovalsReviewer = 'user' | 'auto_review' | 'guardian_subagent';
+
+/**
+ * Codex collapses its three security axes (sandbox × approval policy ×
+ * approvals reviewer) into a single user-facing "permissions" preset, matching
+ * the selector in the Codex app and IDE extension.
+ *
+ * @see https://developers.openai.com/codex/concepts/sandboxing#how-you-control-it
+ */
+export type CodexPermissionsPreset = 'default' | 'auto-review' | 'full-access';
+
+/** Ordered preset list advertised in the Codex session-config schema. */
+export const CODEX_PERMISSIONS_PRESETS: readonly CodexPermissionsPreset[] = ['default', 'auto-review', 'full-access'];
+
+/** Default preset applied to new Codex sessions. */
+export const CODEX_DEFAULT_PERMISSIONS_PRESET: CodexPermissionsPreset = 'default';
+
+/**
+ * Single source of truth for narrowing an arbitrary runtime value to the
+ * closed {@link CodexPermissionsPreset} union. Returns `undefined` for
+ * non-strings or unmatched strings; callers apply their own fallback.
+ */
+export function narrowCodexPermissionsPreset(raw: unknown): CodexPermissionsPreset | undefined {
+	switch (raw) {
+		case 'default':
+		case 'auto-review':
+		case 'full-access':
+			return raw;
+		default:
+			return undefined;
+	}
+}
+
+export interface ICodexResolvedPermissions {
+	readonly approvalPolicy: CodexApprovalPolicy;
+	readonly sandboxMode: CodexSandboxMode;
+	readonly approvalsReviewer: CodexApprovalsReviewer;
+}
+
+/**
+ * Expand a {@link CodexPermissionsPreset} into the three underlying Codex
+ * security axes sent to the app-server (`approvalPolicy`, `sandbox`,
+ * `approvalsReviewer`).
+ */
+export function resolveCodexPermissionsPreset(preset: CodexPermissionsPreset): ICodexResolvedPermissions {
+	switch (preset) {
+		case 'auto-review':
+			// Same workspace-write sandbox as `default`, but on-request approvals
+			// are routed through the auto-reviewer instead of a UI prompt.
+			return { approvalPolicy: 'on-request', sandboxMode: 'workspace-write', approvalsReviewer: 'auto_review' };
+		case 'full-access':
+			return { approvalPolicy: 'never', sandboxMode: 'danger-full-access', approvalsReviewer: 'user' };
+		case 'default':
+		default:
+			return { approvalPolicy: 'on-request', sandboxMode: 'workspace-write', approvalsReviewer: 'user' };
+	}
+}

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -49,7 +49,7 @@ import { resolveCodexInput } from './codexPromptResolver.js';
 import { buildUserInputRequest, emptyUserInputResponse, userInputResponseFromAnswers } from './codexUserInputMapper.js';
 import { replayThreadToTurns } from './codexReplayMapper.js';
 import { CodexSessionMetadataStore } from './codexSessionMetadataStore.js';
-import { CodexSessionConfigKey, CODEX_DEFAULT_PERMISSIONS_PRESET, CODEX_PERMISSIONS_PRESETS, collaborationModeKind, narrowAdditionalDirectories, narrowBoolean, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowWebSearchMode, resolveCodexPermissions, type CodexApprovalPolicy, type CodexPermissionsPreset, type ICodexResolvedPermissions } from './codexSessionConfigKeys.js';
+import { CodexSessionConfigKey, CODEX_DEFAULT_PERMISSIONS_PRESET, CODEX_PERMISSIONS_PRESETS, collaborationModeKind, migrateCodexPermissionValues, narrowAdditionalDirectories, narrowBoolean, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowWebSearchMode, resolveCodexPermissions, type CodexApprovalPolicy, type CodexPermissionsPreset, type ICodexResolvedPermissions } from './codexSessionConfigKeys.js';
 import type { ReasoningEffort } from './protocol/generated/ReasoningEffort.js';
 import type { ReasoningSummary } from './protocol/generated/ReasoningSummary.js';
 import type { Personality } from './protocol/generated/Personality.js';
@@ -3156,10 +3156,29 @@ export class CodexAgent extends Disposable implements IAgent {
 	resolveSessionConfig(params: IAgentResolveSessionConfigParams): Promise<ResolveSessionConfigResult> {
 		const values = codexSessionConfigSchema.validateOrDefault(params.config, codexSessionConfigDefaults);
 		const schema = codexVisibleSessionConfigSchema.toProtocol();
+		// Preserve every value the caller previously persisted. This return
+		// REPLACES the stored session config on restore (see
+		// `AgentService._resolveCreatedSessionConfig`), so cherry-picking only
+		// the visible keys here would reset all the others (reasoning effort,
+		// personality, sandbox axes, …) back to their defaults on resume.
 		const resolvedValues: Record<string, unknown> = {
+			...params.config,
 			[SessionConfigKey.Mode]: values[SessionConfigKey.Mode],
-			[CodexSessionConfigKey.PermissionsPreset]: values[CodexSessionConfigKey.PermissionsPreset],
 		};
+		// Migrate the permission axes off the raw config. `validateOrDefault`
+		// always materializes `permissionsPreset='default'`, but blindly storing
+		// that would silently escalate a legacy session that persisted only the
+		// individual `sandboxMode`/`approvalPolicy` axes (e.g. `read-only`) —
+		// `resolveCodexPermissions` checks the preset first. Drop all three
+		// permission keys, then re-apply only the ones the migration decides are
+		// safe (an explicit or exactly-equivalent preset, else the raw axes).
+		delete resolvedValues[CodexSessionConfigKey.PermissionsPreset];
+		delete resolvedValues[CodexSessionConfigKey.ApprovalPolicy];
+		delete resolvedValues[CodexSessionConfigKey.SandboxMode];
+		Object.assign(resolvedValues, migrateCodexPermissionValues(params.config, {
+			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
+			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
+		}));
 		return Promise.resolve({ values: resolvedValues, schema });
 	}
 

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -44,11 +44,12 @@ import { CodexAppServerClient, JsonRpcError, transportFromChildProcess, type ICo
 import { ICodexProxyService, type ICodexProxyHandle } from './codexProxyService.js';
 import { createCodexSessionMapState, extractUserInputText, mapAgentMessageDelta, mapCommandExecutionOutputDelta, mapFileChangeOutputDelta, mapFileChangePatchUpdated, mapItemCompleted, mapItemStarted, mapMcpToolCallProgress, mapReasoningSummaryPartAdded, mapReasoningSummaryTextDelta, mapReasoningTextDelta, mapTokenUsageUpdated, mapTurnCompleted, mapTurnStarted, resetCodexTurnMapState, type ICodexSessionMapState } from './codexMapAppServerEvents.js';
 import { unwrapShellInvocation } from './codexShellCommand.js';
+import { planForkedTurnIdMap, resolveForkBoundary } from './codexForkPlan.js';
 import { resolveCodexInput } from './codexPromptResolver.js';
 import { buildUserInputRequest, emptyUserInputResponse, userInputResponseFromAnswers } from './codexUserInputMapper.js';
 import { replayThreadToTurns } from './codexReplayMapper.js';
 import { CodexSessionMetadataStore } from './codexSessionMetadataStore.js';
-import { CodexSessionConfigKey, CODEX_DEFAULT_PERMISSIONS_PRESET, CODEX_PERMISSIONS_PRESETS, collaborationModeKind, narrowAdditionalDirectories, narrowBoolean, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowWebSearchMode, resolveCodexPermissions, type CodexApprovalPolicy, type CodexPermissionsPreset } from './codexSessionConfigKeys.js';
+import { CodexSessionConfigKey, CODEX_DEFAULT_PERMISSIONS_PRESET, CODEX_PERMISSIONS_PRESETS, collaborationModeKind, narrowAdditionalDirectories, narrowBoolean, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowWebSearchMode, resolveCodexPermissions, type CodexApprovalPolicy, type CodexPermissionsPreset, type ICodexResolvedPermissions } from './codexSessionConfigKeys.js';
 import type { ReasoningEffort } from './protocol/generated/ReasoningEffort.js';
 import type { ReasoningSummary } from './protocol/generated/ReasoningSummary.js';
 import type { Personality } from './protocol/generated/Personality.js';
@@ -778,6 +779,27 @@ export class CodexAgent extends Disposable implements IAgent {
 		);
 	}
 
+	/**
+	 * Resolve the Codex security axes (approval policy, sandbox, reviewer) for a
+	 * live or restored session from its RAW persisted config values.
+	 *
+	 * Reading the raw values (rather than {@link _readSessionConfig}, which runs
+	 * `validateOrDefault`) is important: `validateOrDefault` always materializes
+	 * the default {@link CodexSessionConfigKey.PermissionsPreset}, which would
+	 * shadow a legacy session that persisted only the individual `sandboxMode` /
+	 * `approvalPolicy` axes — silently escalating e.g. a `read-only` session back
+	 * to `workspace-write` on resume. Using the raw values lets
+	 * {@link resolveCodexPermissions} honor those legacy axes when no explicit
+	 * preset was ever chosen.
+	 */
+	private _resolveSessionPermissions(session: ICodexSession): ICodexResolvedPermissions {
+		const rawValues = this._configurationService.getSessionConfigValues(session.sessionUri.toString());
+		return resolveCodexPermissions(rawValues, {
+			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
+			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
+		});
+	}
+
 	private _sandboxPolicy(session: ICodexSession, config: ReturnType<typeof codexSessionConfigSchema.validateOrDefault>, mode: SandboxMode): SandboxPolicy {
 		if (mode === 'danger-full-access') {
 			return { type: 'dangerFullAccess' };
@@ -801,10 +823,7 @@ export class CodexAgent extends Disposable implements IAgent {
 
 	private _turnStartOptions(session: ICodexSession, modelId: string): Pick<TurnStartParams, 'approvalPolicy' | 'sandboxPolicy' | 'approvalsReviewer' | 'effort' | 'runtimeWorkspaceRoots' | 'personality' | 'summary' | 'collaborationMode'> {
 		const config = this._readSessionConfig(session);
-		const { approvalPolicy, sandboxMode, approvalsReviewer } = resolveCodexPermissions(config, {
-			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
-			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
-		});
+		const { approvalPolicy, sandboxMode, approvalsReviewer } = this._resolveSessionPermissions(session);
 		const sandboxPolicy = this._sandboxPolicy(session, config, sandboxMode);
 		const runtimeWorkspaceRoots = sandboxPolicy.type === 'workspaceWrite' ? sandboxPolicy.writableRoots : undefined;
 		const effort = this._getReasoningEffort(session);
@@ -2038,20 +2057,30 @@ export class CodexAgent extends Disposable implements IAgent {
 		// caller-supplied `turnIndex` when the id can't be resolved.
 		const sourceSession = this._sessions.get(AgentSession.id(fork.session));
 		const codexTurnId = sourceSession?.codexTurnIdByHostTurnId.get(fork.turnId) ?? fork.turnId;
-		let keepThroughIndex = sourceTurns.findIndex(t => t.id === codexTurnId);
-		if (keepThroughIndex === -1) {
-			keepThroughIndex = fork.turnIndex;
+		// Reject an unresolvable fork boundary rather than silently keeping the
+		// full history: if neither the mapped codex turn id nor the caller's
+		// `turnIndex` lands inside the source turns, a `numTurnsToDrop` of 0 would
+		// branch from the wrong point (the tip instead of the requested turn).
+		const boundary = resolveForkBoundary(sourceTurns.map(t => t.id), codexTurnId, fork.turnIndex);
+		if (!boundary.resolved) {
+			throw new Error(`Cannot fork codex session ${sourceThreadId}: unable to resolve fork boundary for turn ${fork.turnId} (turnIndex=${fork.turnIndex}, turns=${sourceTurns.length})`);
 		}
-		const numTurnsToDrop = sourceTurns.length > 0 && keepThroughIndex >= 0
-			? Math.max(0, sourceTurns.length - (keepThroughIndex + 1))
-			: 0;
+		const { keepThroughIndex, numTurnsToDrop } = boundary;
 
 		const conn = await this._ensureConnection();
 		const model = this._supportedModelOrUndefined(config.model);
-		const { approvalPolicy, sandboxMode, approvalsReviewer } = resolveCodexPermissions(config.config, {
-			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
-			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
-		});
+		// Inherit the source session's effective permissions so forking an
+		// auto-review / full-access / read-only session doesn't silently reset the
+		// fork back to the Default preset. Fork callers typically pass an empty
+		// `config.config`; any explicit override there still wins.
+		const sourceConfigValues = this._configurationService.getSessionConfigValues(fork.session.toString());
+		const { approvalPolicy, sandboxMode, approvalsReviewer } = resolveCodexPermissions(
+			{ ...sourceConfigValues, ...config.config },
+			{
+				approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
+				sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
+			},
+		);
 		const forkResult = await conn.client.request<'thread/fork', ThreadForkResponse>('thread/fork', {
 			threadId: sourceThreadId,
 			...(model ? { model: model.id } : {}),
@@ -2098,6 +2127,32 @@ export class CodexAgent extends Disposable implements IAgent {
 			this._serverToolHost.advertise(session.sessionUri.toString());
 		}
 		this._persistMaterializedSession(session);
+
+		// Seed the host→codex turn-id map for the copied turns so a later
+		// edit/truncate of an inherited turn can resolve its app-server turn id.
+		// Without this, `truncateSession` can't map the host id and skips the
+		// rollback. `thread/fork` may regenerate turn ids, so read the forked
+		// thread's authoritative kept turns and pair them, in order, with the new
+		// host turn ids from `fork.turnIdMapping`. Best-effort: a failed read just
+		// leaves the map unseeded (same as before), never blocking the fork.
+		if (fork.turnIdMapping && fork.turnIdMapping.size > 0) {
+			try {
+				const forkedRead = await this._readSession(newSessionUri);
+				const forkedTurns = forkedRead?.thread.turns ?? [];
+				const entries = planForkedTurnIdMap(
+					sourceTurns.map(t => t.id),
+					forkedTurns.map(t => t.id),
+					keepThroughIndex,
+					sourceSession?.hostTurnIdByAppTurnId,
+					fork.turnIdMapping,
+				);
+				for (const [hostTurnId, forkedCodexTurnId] of entries) {
+					session.codexTurnIdByHostTurnId.set(hostTurnId, forkedCodexTurnId);
+				}
+			} catch (err) {
+				this._logService.warn(`[Codex:${newThreadId}] failed to seed forked turn-id map: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
 
 		this._logService.info(`[Codex] forked session ${sourceThreadId} → ${newThreadId} (kept ${sourceTurns.length - numTurnsToDrop}/${sourceTurns.length} turns)`);
 		return {
@@ -2155,10 +2210,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		const conn = await this._ensureConnection();
 		const config = this._readSessionConfig(session);
 		const model = await this._resolveModel(session);
-		const { approvalPolicy, sandboxMode, approvalsReviewer } = resolveCodexPermissions(config, {
-			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
-			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
-		});
+		const { approvalPolicy, sandboxMode, approvalsReviewer } = this._resolveSessionPermissions(session);
 		const startResult = await conn.client.request<'thread/start', { thread: { id: string } }>('thread/start', {
 			cwd: session.workingDirectory.fsPath,
 			model: model.id,

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -80,6 +80,7 @@ import type { ThreadForkResponse } from './protocol/generated/v2/ThreadForkRespo
 import type { TurnCompletedNotification } from './protocol/generated/v2/TurnCompletedNotification.js';
 import type { TurnStartedNotification } from './protocol/generated/v2/TurnStartedNotification.js';
 import type { ItemStartedNotification } from './protocol/generated/v2/ItemStartedNotification.js';
+import type { ItemCompletedNotification } from './protocol/generated/v2/ItemCompletedNotification.js';
 import type { TurnStartParams } from './protocol/generated/v2/TurnStartParams.js';
 import type { UserInput } from './protocol/generated/v2/UserInput.js';
 import type { ListMcpServerStatusResponse } from './protocol/generated/v2/ListMcpServerStatusResponse.js';
@@ -484,6 +485,31 @@ interface ICodexSession {
 }
 
 /**
+ * A live Codex collab-agent (subagent) child thread. Codex runs each spawned
+ * subagent as its OWN app-server thread that emits a full item/turn event
+ * stream (`turn/started`, `item/*`, `turn/completed`) under the child thread
+ * id — it is NOT flattened onto the parent thread. We render that stream in a
+ * read-only peer chat (the "agent team" pattern, mirroring Copilot/Claude) by
+ * routing the child thread's notifications through the shared mappers with an
+ * isolated {@link ICodexSession} and firing each resulting action tagged with
+ * the parent `spawnAgent` tool call as its `parentToolCallId`, so the shared
+ * orchestrator ({@link AgentSideEffects}) lands them in the subagent chat.
+ */
+interface ICodexSubagent {
+	/** Caller-facing sessionId of the parent session that spawned this subagent. */
+	readonly parentSessionId: string;
+	/** Host-side toolCallId of the parent `spawnAgent` collab tool call (routing key). */
+	readonly toolCallId: string;
+	/**
+	 * Isolated session used to run the shared event mappers for the child
+	 * thread. Shares the parent's `sessionUri` and `acceptedForSession` memo so
+	 * side effects target the parent's working tree and the accept-for-session
+	 * decision spans parent + subagents, but keeps its own map/turn state.
+	 */
+	readonly session: ICodexSession;
+}
+
+/**
  * Connection state machine. The codex process is spawned lazily on first
  * need (Decision 6) and stays alive for the agent's lifetime.
  */
@@ -627,6 +653,14 @@ export class CodexAgent extends Disposable implements IAgent {
 	private readonly _sessions = new Map<string, ICodexSession>();
 	/** Inverse map: codex threadId → caller-facing sessionId, for routing codex notifications back to sessions. */
 	private readonly _sessionIdByThreadId = new Map<string, string>();
+	/**
+	 * Live subagent (collab-agent) child threads, keyed by the child codex
+	 * thread id. Populated when a parent session's `spawnAgent` collab tool
+	 * call completes (carrying the child `receiverThreadIds`); the child's
+	 * subsequent `turn/*` and `item/*` notifications route here instead of
+	 * {@link _sessionIdByThreadId}. Removed on the child's `turn/completed`.
+	 */
+	private readonly _subagentsByThreadId = new Map<string, ICodexSubagent>();
 	/**
 	 * Connection-global MCP server inventory reported by the codex
 	 * app-server (`mcpServerStatus/list` + `mcpServer/startupStatus/updated`).
@@ -783,21 +817,25 @@ export class CodexAgent extends Disposable implements IAgent {
 	 * Resolve the Codex security axes (approval policy, sandbox, reviewer) for a
 	 * live or restored session from its RAW persisted config values.
 	 *
-	 * Reading the raw values (rather than {@link _readSessionConfig}, which runs
-	 * `validateOrDefault`) is important: `validateOrDefault` always materializes
-	 * the default {@link CodexSessionConfigKey.PermissionsPreset}, which would
-	 * shadow a legacy session that persisted only the individual `sandboxMode` /
-	 * `approvalPolicy` axes — silently escalating e.g. a `read-only` session back
-	 * to `workspace-write` on resume. Using the raw values lets
-	 * {@link resolveCodexPermissions} honor those legacy axes when no explicit
-	 * preset was ever chosen.
+	 * The raw values are normalized through {@link migrateCodexPermissionValues}
+	 * (the same migration the restore path applies) before resolving, so the
+	 * axes we send to the app-server always match the preset the "Approvals" chip
+	 * displays. This matters for two legacy shapes:
+	 * - a session that persisted only `sandboxMode = 'read-only'` is preserved
+	 *   verbatim, so it is NOT silently escalated back to `workspace-write` on
+	 *   resume (the chip over-promises, but the session stays more locked down);
+	 * - a session that persisted `approvalPolicy = 'never'` + `workspace-write`
+	 *   (which the chip renders as "Default Permissions") is snapped onto the
+	 *   `default` preset's `on-request` policy so it actually prompts, instead of
+	 *   running commands unprompted while the chip claims it would ask.
 	 */
 	private _resolveSessionPermissions(session: ICodexSession): ICodexResolvedPermissions {
 		const rawValues = this._configurationService.getSessionConfigValues(session.sessionUri.toString());
-		return resolveCodexPermissions(rawValues, {
+		const defaults = {
 			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
 			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
-		});
+		};
+		return resolveCodexPermissions(migrateCodexPermissionValues(rawValues, defaults), defaults);
 	}
 
 	private _sandboxPolicy(session: ICodexSession, config: ReturnType<typeof codexSessionConfigSchema.validateOrDefault>, mode: SandboxMode): SandboxPolicy {
@@ -1086,8 +1124,8 @@ export class CodexAgent extends Disposable implements IAgent {
 		this._register(client.onNotification('item/reasoning/summaryTextDelta', params => this._dispatchByThread(params.threadId, s => mapReasoningSummaryTextDelta(s.mapState, this._withHostTurnId(s, params)))));
 		this._register(client.onNotification('item/reasoning/textDelta', params => this._dispatchByThread(params.threadId, s => mapReasoningTextDelta(s.mapState, this._withHostTurnId(s, params)))));
 		this._register(client.onNotification('thread/tokenUsage/updated', params => this._dispatchByThread(params.threadId, s => mapTokenUsageUpdated(this._withHostTurnId(s, params)))));
-		this._register(client.onNotification('item/completed', params => this._dispatchByThread(params.threadId, s => mapItemCompleted(s.mapState, this._withHostTurnId(s, params)))));
-		this._register(client.onNotification('turn/completed', params => this._dispatchByThread(params.threadId, s => this._handleTurnCompletedNotification(s, params))));
+		this._register(client.onNotification('item/completed', params => this._dispatchItemCompleted(params)));
+		this._register(client.onNotification('turn/completed', params => this._dispatchTurnCompleted(params)));
 		// Auto-review (guardian) surfacing. The guardian warning is shown as a
 		// system notification; a completed *denied* review is turned into a
 		// retroactive "Approve anyway" tool-call card. The review lifecycle is
@@ -1514,6 +1552,18 @@ export class CodexAgent extends Disposable implements IAgent {
 	}
 
 	private _dispatchByThread(threadId: string, mapFn: (s: ICodexSession) => ReturnType<typeof mapTurnStarted>): void {
+		// Collab-agent (subagent) child threads emit their own full event
+		// stream; route them to the isolated subagent session and fire each
+		// action tagged with the parent `spawnAgent` tool call so the shared
+		// orchestrator lands them in the read-only peer chat.
+		const subagent = this._subagentsByThreadId.get(threadId);
+		if (subagent) {
+			const actions = mapFn(subagent.session);
+			for (const action of actions) {
+				this._fireSubagent(subagent, action);
+			}
+			return;
+		}
 		const sessionId = this._sessionIdByThreadId.get(threadId);
 		const session = sessionId ? this._sessions.get(sessionId) : undefined;
 		if (!session) {
@@ -1525,6 +1575,170 @@ export class CodexAgent extends Disposable implements IAgent {
 		for (const action of actions) {
 			this._fire(session.sessionUri, action);
 		}
+	}
+
+	/**
+	 * `item/completed` dispatch. In addition to the normal per-thread mapping,
+	 * a parent session's completed `spawnAgent` collab tool call now carries
+	 * the child `receiverThreadIds`, so we register each spawned subagent and
+	 * emit a `subagent_started` signal (before mapping the completion, so the
+	 * shared orchestrator has attached the subagent-chat block to the parent
+	 * tool call by the time it completes).
+	 */
+	private _dispatchItemCompleted(params: ItemCompletedNotification): void {
+		const subagent = this._subagentsByThreadId.get(params.threadId);
+		if (subagent) {
+			const actions = mapItemCompleted(subagent.session.mapState, this._withHostTurnId(subagent.session, params));
+			for (const action of actions) {
+				this._fireSubagent(subagent, action);
+			}
+			return;
+		}
+		const sessionId = this._sessionIdByThreadId.get(params.threadId);
+		const session = sessionId ? this._sessions.get(sessionId) : undefined;
+		if (!session) {
+			this._logService.trace(`[Codex] Ignoring item/completed for untracked threadId=${params.threadId}; likely unclaimed prewarm`);
+			return;
+		}
+		// Detect subagent spawns BEFORE mapping the completion: the host
+		// toolCallId lives in the parent's itemToToolCall map (which the mapper
+		// may clear), and firing `subagent_started` first lets the orchestrator
+		// attach the read-only-chat block to the still-open parent tool call.
+		this._maybeRegisterSubagents(session, params);
+		const actions = mapItemCompleted(session.mapState, this._withHostTurnId(session, params));
+		for (const action of actions) {
+			this._fire(session.sessionUri, action);
+		}
+	}
+
+	/**
+	 * `turn/completed` dispatch. For a subagent child thread, route the turn's
+	 * flush/orphan actions to the peer chat but suppress its `ChatTurnComplete`
+	 * — the child chat's turn is closed cleanly (without the parent's
+	 * checkpoint/changeset/title side effects) by the `subagent_completed`
+	 * signal, which also tears down the child-thread tracking.
+	 */
+	private _dispatchTurnCompleted(params: TurnCompletedNotification): void {
+		const subagent = this._subagentsByThreadId.get(params.threadId);
+		if (subagent) {
+			const actions = this._handleTurnCompletedNotification(subagent.session, params);
+			for (const action of actions) {
+				if (action.type === ActionType.ChatTurnComplete) {
+					continue;
+				}
+				this._fireSubagent(subagent, action);
+			}
+			this._subagentsByThreadId.delete(params.threadId);
+			subagent.session.pendingCommandApprovals.denyAll('decline');
+			this._onDidSessionProgress.fire({
+				kind: 'subagent_completed',
+				chat: URI.parse(buildDefaultChatUri(subagent.session.sessionUri)),
+				toolCallId: subagent.toolCallId,
+			});
+			return;
+		}
+		this._dispatchByThread(params.threadId, s => this._handleTurnCompletedNotification(s, params));
+	}
+
+	/**
+	 * When a parent session's `spawnAgent` collab tool call completes it
+	 * carries the child thread id(s) in `receiverThreadIds`. Register an
+	 * isolated subagent session for each new child thread and emit a
+	 * `subagent_started` signal so the shared orchestrator opens the read-only
+	 * peer chat and attaches its discovery block to the parent tool call.
+	 */
+	private _maybeRegisterSubagents(session: ICodexSession, params: ItemCompletedNotification): void {
+		const item = params.item;
+		if (item.type !== 'collabAgentToolCall' || item.tool !== 'spawnAgent') {
+			return;
+		}
+		const entry = session.mapState.itemToToolCall.get(item.id);
+		if (!entry) {
+			return;
+		}
+		const parentChat = URI.parse(buildDefaultChatUri(session.sessionUri));
+		const model = item.model || undefined;
+		const taskDescription = item.prompt || undefined;
+		for (const childThreadId of item.receiverThreadIds) {
+			if (this._subagentsByThreadId.has(childThreadId)) {
+				continue;
+			}
+			const subSession = this._createSubagentSession(session, childThreadId);
+			this._subagentsByThreadId.set(childThreadId, {
+				parentSessionId: session.sessionId,
+				toolCallId: entry.toolCallId,
+				session: subSession,
+			});
+			this._onDidSessionProgress.fire({
+				kind: 'subagent_started',
+				chat: parentChat,
+				toolCallId: entry.toolCallId,
+				agentName: model ?? 'codex',
+				agentDisplayName: model ?? 'Subagent',
+				taskDescription,
+			});
+			this._logService.trace(`[Codex:${session.sessionId}] subagent spawned thread=${childThreadId} toolCall=${entry.toolCallId} model=${model ?? '(default)'}`);
+		}
+	}
+
+	/**
+	 * Build an isolated {@link ICodexSession} used to run the shared event
+	 * mappers for a subagent child thread. It shares the parent's `sessionUri`
+	 * (so side effects target the parent's working tree and the fired actions
+	 * resolve to the parent chat channel) and `acceptedForSession` memo (so the
+	 * accept-for-session decision spans parent + subagents), but has its own
+	 * fresh map/turn state and approval registry so the child's events don't
+	 * collide with the parent's.
+	 */
+	private _createSubagentSession(parent: ICodexSession, childThreadId: string): ICodexSession {
+		const clientToolSet = new ActiveClientToolSet();
+		return {
+			sessionId: parent.sessionId,
+			threadId: childThreadId,
+			sessionUri: parent.sessionUri,
+			workingDirectory: parent.workingDirectory,
+			managedWorkingDirectory: undefined,
+			mapState: createCodexSessionMapState(new Set(this._serverToolHost?.toolNames ?? []), clientToolSet),
+			pendingCommandApprovals: new PendingRequestRegistry<CommandExecutionApprovalDecision>(),
+			acceptedForSession: parent.acceptedForSession,
+			handledGuardianReviews: new Set<string>(),
+			pendingGuardianReviewCards: new Set<string>(),
+			pendingSteeringFlips: new Map<string, PendingMessage>(),
+			clientToolSet,
+			pendingClientToolCalls: new PendingRequestRegistry<ToolCallResult>(),
+			pendingUserInputs: new PendingRequestRegistry<ICodexUserInputResult>(),
+			materializedToolsSig: undefined,
+			firstTurnSent: true,
+			model: parent.model,
+			currentTurnId: undefined,
+			currentAppTurnId: undefined,
+			hostTurnIdByAppTurnId: new Map<string, string>(),
+			codexTurnIdByHostTurnId: new Map<string, string>(),
+			needsResume: false,
+			lastPromptText: '',
+			disposed: false,
+			materializePromise: undefined,
+			materializedEventFired: true,
+			prewarmTimer: undefined,
+			prewarmClaimed: true,
+			serverToolsAdvertised: true,
+			mcpController: undefined,
+		};
+	}
+
+	/**
+	 * Fire a subagent action tagged with the parent `spawnAgent` tool call.
+	 * The `resource` is the PARENT chat channel (the key the subagent chat is
+	 * registered under in the orchestrator); `parentToolCallId` routes the
+	 * action into the child's read-only peer chat.
+	 */
+	private _fireSubagent(subagent: ICodexSubagent, action: SessionAction | ChatAction): void {
+		this._onDidSessionProgress.fire({
+			kind: 'action',
+			resource: URI.parse(buildDefaultChatUri(subagent.session.sessionUri)),
+			action,
+			parentToolCallId: subagent.toolCallId,
+		});
 	}
 
 	/**
@@ -1549,15 +1763,15 @@ export class CodexAgent extends Disposable implements IAgent {
 		readonly command?: string | null;
 		readonly reason?: string | null;
 	}): Promise<CommandExecutionApprovalDecision> {
-		const sessionId = this._sessionIdByThreadId.get(params.threadId);
-		const session = sessionId ? this._sessions.get(sessionId) : undefined;
-		if (!session) {
+		const target = this._resolveApprovalTarget(params.threadId);
+		if (!target) {
 			this._logService.warn(`[Codex] commandExecution/requestApproval for unknown threadId=${params.threadId}; declining`);
 			return 'decline';
 		}
+		const session = target.session;
 		const entry = session.mapState.itemToToolCall.get(params.itemId);
 		if (!entry) {
-			this._logService.warn(`[Codex:${sessionId}] commandExecution/requestApproval for unknown itemId=${params.itemId}; declining`);
+			this._logService.warn(`[Codex:${session.sessionId}] commandExecution/requestApproval for unknown itemId=${params.itemId}; declining`);
 			return 'decline';
 		}
 		const command = params.command ?? '';
@@ -1576,7 +1790,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		// PendingConfirmation signal so a synchronous responder can't
 		// miss the registration.
 		const decision = await session.pendingCommandApprovals.registerAndFire(entry.toolCallId, () => {
-			this._fire(session.sessionUri, {
+			this._fireApproval(target, {
 				type: ActionType.ChatToolCallReady,
 				turnId: entry.turnId,
 				toolCallId: entry.toolCallId,
@@ -1619,19 +1833,19 @@ export class CodexAgent extends Disposable implements IAgent {
 	 * if the session or item is unknown.
 	 */
 	private async _requestItemApproval(threadId: string, itemId: string, confirmationTitle: string): Promise<CommandExecutionApprovalDecision> {
-		const sessionId = this._sessionIdByThreadId.get(threadId);
-		const session = sessionId ? this._sessions.get(sessionId) : undefined;
-		if (!session) {
+		const target = this._resolveApprovalTarget(threadId);
+		if (!target) {
 			this._logService.warn(`[Codex] approval request for unknown threadId=${threadId}; declining`);
 			return 'decline';
 		}
+		const session = target.session;
 		const entry = session.mapState.itemToToolCall.get(itemId);
 		if (!entry) {
-			this._logService.warn(`[Codex:${sessionId}] approval request for unknown itemId=${itemId}; declining`);
+			this._logService.warn(`[Codex:${session.sessionId}] approval request for unknown itemId=${itemId}; declining`);
 			return 'decline';
 		}
 		return session.pendingCommandApprovals.registerAndFire(entry.toolCallId, () => {
-			this._fire(session.sessionUri, {
+			this._fireApproval(target, {
 				type: ActionType.ChatToolCallReady,
 				turnId: entry.turnId,
 				toolCallId: entry.toolCallId,
@@ -1640,6 +1854,34 @@ export class CodexAgent extends Disposable implements IAgent {
 				confirmationTitle,
 			});
 		});
+	}
+
+	/**
+	 * Resolve the {@link ICodexSession} that owns a codex thread for an
+	 * approval request, plus the subagent wrapper when the thread is a
+	 * collab-agent child. A subagent tool call's pending-confirmation
+	 * `ChatToolCallReady` must be fired with the parent `spawnAgent` tool call
+	 * as its `parentToolCallId` (via {@link _fireApproval}) so it lands in the
+	 * child's read-only peer chat — where the matching `ChatToolCallStart`
+	 * lives — instead of on the parent session.
+	 */
+	private _resolveApprovalTarget(threadId: string): { readonly session: ICodexSession; readonly subagent?: ICodexSubagent } | undefined {
+		const subagent = this._subagentsByThreadId.get(threadId);
+		if (subagent) {
+			return { session: subagent.session, subagent };
+		}
+		const sessionId = this._sessionIdByThreadId.get(threadId);
+		const session = sessionId ? this._sessions.get(sessionId) : undefined;
+		return session ? { session } : undefined;
+	}
+
+	/** Fire an approval action to the parent session or the subagent peer chat. */
+	private _fireApproval(target: { readonly session: ICodexSession; readonly subagent?: ICodexSubagent }, action: SessionAction | ChatAction): void {
+		if (target.subagent) {
+			this._fireSubagent(target.subagent, action);
+		} else {
+			this._fire(target.session.sessionUri, action);
+		}
 	}
 
 	private _handleGuardianWarning(session: ICodexSession, params: GuardianWarningNotification): ChatAction[] {
@@ -2074,12 +2316,13 @@ export class CodexAgent extends Disposable implements IAgent {
 		// fork back to the Default preset. Fork callers typically pass an empty
 		// `config.config`; any explicit override there still wins.
 		const sourceConfigValues = this._configurationService.getSessionConfigValues(fork.session.toString());
+		const forkDefaults = {
+			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
+			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
+		};
 		const { approvalPolicy, sandboxMode, approvalsReviewer } = resolveCodexPermissions(
-			{ ...sourceConfigValues, ...config.config },
-			{
-				approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
-				sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
-			},
+			migrateCodexPermissionValues({ ...sourceConfigValues, ...config.config }, forkDefaults),
+			forkDefaults,
 		);
 		const forkResult = await conn.client.request<'thread/fork', ThreadForkResponse>('thread/fork', {
 			threadId: sourceThreadId,
@@ -2617,6 +2860,15 @@ export class CodexAgent extends Disposable implements IAgent {
 		session.pendingUserInputs.rejectAll(new CancellationError());
 		// Clear any buffered steering so its pending bubble doesn't leak.
 		this._drainPendingSteering(session);
+		// Tear down any live subagent child threads spawned by this session so
+		// their parked approvals unwind and their tracking doesn't leak. The
+		// orchestrator closes the peer chats as part of session teardown.
+		for (const [childThreadId, subagent] of this._subagentsByThreadId) {
+			if (subagent.parentSessionId === sessionId) {
+				subagent.session.pendingCommandApprovals.denyAll('decline');
+				this._subagentsByThreadId.delete(childThreadId);
+			}
+		}
 		const conn = this._connection;
 		if (conn.kind === 'ready' && session.threadId !== undefined) {
 			const threadId = session.threadId;
@@ -2712,9 +2964,14 @@ export class CodexAgent extends Disposable implements IAgent {
 	}
 
 	respondToPermissionRequest(requestId: string, approved: boolean): void {
-		// `requestId` is the host-side toolCallId; iterate sessions and
-		// resolve the first match. Mirrors the Claude/Copilot agents.
-		for (const session of this._sessions.values()) {
+		// `requestId` is the host-side toolCallId; iterate sessions (including
+		// live subagent child sessions, whose command approvals live on their
+		// own registry) and resolve the first match. Mirrors Claude/Copilot.
+		const sessions = [
+			...this._sessions.values(),
+			...[...this._subagentsByThreadId.values()].map(s => s.session),
+		];
+		for (const session of sessions) {
 			if (session.pendingCommandApprovals.respond(requestId, approved ? 'accept' : 'decline')) {
 				if (!approved) {
 					// Remember the decline so the tool's `item/completed` (which
@@ -3230,6 +3487,10 @@ export class CodexAgent extends Disposable implements IAgent {
 			s.pendingUserInputs.rejectAll(new CancellationError());
 			s.mcpController?.dispose();
 		}
+		for (const subagent of this._subagentsByThreadId.values()) {
+			subagent.session.pendingCommandApprovals.denyAll('decline');
+		}
+		this._subagentsByThreadId.clear();
 		this._sessions.clear();
 		this._sessionIdByThreadId.clear();
 		this._mcpInventory.clear();

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -17,16 +17,16 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
-import { createSchema, platformSessionSchema, schemaProperty, type SessionMode } from '../../common/agentHostSchema.js';
+import { createSchema, platformSessionSchema, schemaProperty, type ISchemaProperty, type SessionMode } from '../../common/agentHostSchema.js';
 import { createPricingMetaFromBilling, normalizeCAPIBilling } from '../../common/agentModelPricing.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
-import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, IActiveClient, IAgent, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatResult, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IMcpNotification, type AgentProvider } from '../../common/agentService.js';
+import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, CODEX_AGENT_PROVIDER_ID, IActiveClient, IAgent, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatResult, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IMcpNotification, type AgentProvider } from '../../common/agentService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { ActionType, isChatAction, type SessionAction, type ChatAction } from '../../common/state/sessionActions.js';
 import type { ConfigSchema, ModelSelection, ProtectedResourceMetadata, ToolDefinition, AgentSelection } from '../../common/state/protocol/state.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
-import { buildDefaultChatUri, parseChatUri, type ClientPluginCustomization, type MessageAttachment, type PendingMessage, type ChatInputAnswer, ChatInputResponseKind, type PolicyState, type ToolCallResult, ToolResultContentType, type Turn } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, parseChatUri, type ClientPluginCustomization, type MessageAttachment, type PendingMessage, type ChatInputAnswer, ChatInputResponseKind, type PolicyState, type ToolCallResult, ToolResultContentType, type Turn, ResponsePartKind } from '../../common/state/sessionState.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { McpCustomizationController } from '../shared/mcpCustomizationController.js';
@@ -43,11 +43,12 @@ import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { CodexAppServerClient, JsonRpcError, transportFromChildProcess, type ICodexAppServerClient, type ServerRequestHandlerResult } from './codexAppServerClient.js';
 import { ICodexProxyService, type ICodexProxyHandle } from './codexProxyService.js';
 import { createCodexSessionMapState, extractUserInputText, mapAgentMessageDelta, mapCommandExecutionOutputDelta, mapFileChangeOutputDelta, mapFileChangePatchUpdated, mapItemCompleted, mapItemStarted, mapMcpToolCallProgress, mapReasoningSummaryPartAdded, mapReasoningSummaryTextDelta, mapReasoningTextDelta, mapTokenUsageUpdated, mapTurnCompleted, mapTurnStarted, resetCodexTurnMapState, type ICodexSessionMapState } from './codexMapAppServerEvents.js';
+import { unwrapShellInvocation } from './codexShellCommand.js';
 import { resolveCodexInput } from './codexPromptResolver.js';
 import { buildUserInputRequest, emptyUserInputResponse, userInputResponseFromAnswers } from './codexUserInputMapper.js';
 import { replayThreadToTurns } from './codexReplayMapper.js';
 import { CodexSessionMetadataStore } from './codexSessionMetadataStore.js';
-import { CodexSessionConfigKey, collaborationModeKind, narrowAdditionalDirectories, narrowApprovalPolicy, narrowBoolean, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowSandboxMode, narrowWebSearchMode, type CodexApprovalPolicy } from './codexSessionConfigKeys.js';
+import { CodexSessionConfigKey, CODEX_DEFAULT_PERMISSIONS_PRESET, CODEX_PERMISSIONS_PRESETS, collaborationModeKind, narrowAdditionalDirectories, narrowBoolean, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowWebSearchMode, resolveCodexPermissions, type CodexApprovalPolicy, type CodexPermissionsPreset } from './codexSessionConfigKeys.js';
 import type { ReasoningEffort } from './protocol/generated/ReasoningEffort.js';
 import type { ReasoningSummary } from './protocol/generated/ReasoningSummary.js';
 import type { Personality } from './protocol/generated/Personality.js';
@@ -74,6 +75,7 @@ import type { GetAccountResponse } from './protocol/generated/v2/GetAccountRespo
 import type { Thread } from './protocol/generated/v2/Thread.js';
 import type { ThreadListResponse } from './protocol/generated/v2/ThreadListResponse.js';
 import type { ThreadReadResponse } from './protocol/generated/v2/ThreadReadResponse.js';
+import type { ThreadForkResponse } from './protocol/generated/v2/ThreadForkResponse.js';
 import type { TurnCompletedNotification } from './protocol/generated/v2/TurnCompletedNotification.js';
 import type { TurnStartedNotification } from './protocol/generated/v2/TurnStartedNotification.js';
 import type { ItemStartedNotification } from './protocol/generated/v2/ItemStartedNotification.js';
@@ -85,6 +87,10 @@ import type { McpResourceReadResponse } from './protocol/generated/v2/McpResourc
 import type { McpServerStartupState } from './protocol/generated/v2/McpServerStartupState.js';
 import type { McpServerElicitationRequestParams } from './protocol/generated/v2/McpServerElicitationRequestParams.js';
 import type { McpServerElicitationRequestResponse } from './protocol/generated/v2/McpServerElicitationRequestResponse.js';
+import type { ItemGuardianApprovalReviewCompletedNotification } from './protocol/generated/v2/ItemGuardianApprovalReviewCompletedNotification.js';
+import type { GuardianWarningNotification } from './protocol/generated/v2/GuardianWarningNotification.js';
+import type { ThreadApproveGuardianDeniedActionResponse } from './protocol/generated/v2/ThreadApproveGuardianDeniedActionResponse.js';
+import { formatGuardianDenialNotification, summarizeGuardianReviewAction, toGuardianAssessmentEventJson } from './codexGuardianReview.js';
 
 const CLIENT_INFO = {
 	name: 'vscode_agent_host',
@@ -146,7 +152,44 @@ const MCP_TOOL_APPROVAL_ANSWER_DECLINE = '__codex_mcp_decline__';
  */
 const CODEX_RESPONSES_ENDPOINT = '/responses';
 
+/**
+ * Codex's Agent Mode schema, derived from the platform-generic Mode schema but
+ * with "Autopilot" removed. Codex has only two native collaboration modes —
+ * `plan` and `default` (see {@link ModeKind}) — so "Autopilot" would map to
+ * `default`, identical to "Interactive", and offering it in the picker would be
+ * a no-op duplicate. Labels and descriptions are sliced by index so they stay
+ * in sync with the platform schema.
+ */
+function createCodexModeSchema(): ISchemaProperty<SessionMode> {
+	const base = platformSessionSchema.definition[SessionConfigKey.Mode].protocol;
+	const kept = (base.enum ?? []).flatMap((value, index) => value === 'autopilot' ? [] : [index]);
+	return schemaProperty<SessionMode>({
+		...base,
+		enum: kept.map(index => base.enum![index]),
+		enumLabels: base.enumLabels && kept.map(index => base.enumLabels![index]),
+		enumDescriptions: base.enumDescriptions && kept.map(index => base.enumDescriptions![index]),
+	});
+}
+
 const codexSessionConfigSchema = createSchema({
+	[CodexSessionConfigKey.PermissionsPreset]: schemaProperty<CodexPermissionsPreset>({
+		type: 'string',
+		title: localize('codex.sessionConfig.permissionsPreset', "Approvals"),
+		description: localize('codex.sessionConfig.permissionsPresetDescription', "How much Codex can do on its own before asking for approval."),
+		enum: [...CODEX_PERMISSIONS_PRESETS],
+		enumLabels: [
+			localize('codex.sessionConfig.permissionsPreset.default', "Default Permissions"),
+			localize('codex.sessionConfig.permissionsPreset.autoReview', "Auto-Review"),
+			localize('codex.sessionConfig.permissionsPreset.fullAccess', "Full Access"),
+		],
+		enumDescriptions: [
+			localize('codex.sessionConfig.permissionsPreset.defaultDescription', "Codex can read and edit files in the workspace and run routine local commands. It asks before using the internet or going beyond the workspace."),
+			localize('codex.sessionConfig.permissionsPreset.autoReviewDescription', "Same workspace access as Default, but approval requests are routed through the auto-reviewer instead of prompting you."),
+			localize('codex.sessionConfig.permissionsPreset.fullAccessDescription', "Codex can edit files outside the workspace and use the internet without asking. Use only when you want full machine access."),
+		],
+		default: CODEX_DEFAULT_PERMISSIONS_PRESET,
+		sessionMutable: true,
+	}),
 	[CodexSessionConfigKey.ApprovalPolicy]: schemaProperty<CodexApprovalPolicy>({
 		type: 'string',
 		title: localize('codex.sessionConfig.approvalPolicy', "Approvals"),
@@ -208,7 +251,7 @@ const codexSessionConfigSchema = createSchema({
 		default: 'medium',
 		sessionMutable: true,
 	}),
-	[SessionConfigKey.Mode]: platformSessionSchema.definition[SessionConfigKey.Mode],
+	[SessionConfigKey.Mode]: createCodexModeSchema(),
 	[CodexSessionConfigKey.Personality]: schemaProperty<Personality>({
 		type: 'string',
 		title: localize('codex.sessionConfig.personality', "Personality"),
@@ -262,20 +305,12 @@ const codexSessionConfigSchema = createSchema({
 
 const codexVisibleSessionConfigSchema = createSchema({
 	[SessionConfigKey.Mode]: codexSessionConfigSchema.definition[SessionConfigKey.Mode],
-	[CodexSessionConfigKey.ApprovalPolicy]: codexSessionConfigSchema.definition[CodexSessionConfigKey.ApprovalPolicy],
-	[CodexSessionConfigKey.SandboxMode]: codexSessionConfigSchema.definition[CodexSessionConfigKey.SandboxMode],
-	[CodexSessionConfigKey.WebSearchMode]: codexSessionConfigSchema.definition[CodexSessionConfigKey.WebSearchMode],
-	[CodexSessionConfigKey.Personality]: codexSessionConfigSchema.definition[CodexSessionConfigKey.Personality],
-	[CodexSessionConfigKey.ReasoningSummary]: codexSessionConfigSchema.definition[CodexSessionConfigKey.ReasoningSummary],
+	[CodexSessionConfigKey.PermissionsPreset]: codexSessionConfigSchema.definition[CodexSessionConfigKey.PermissionsPreset],
 	[SessionConfigKey.Permissions]: platformSessionSchema.definition[SessionConfigKey.Permissions],
 });
 
-const codexWorkspaceWriteSessionConfigSchema = createSchema({
-	...codexVisibleSessionConfigSchema.definition,
-	[CodexSessionConfigKey.NetworkAccessEnabled]: codexSessionConfigSchema.definition[CodexSessionConfigKey.NetworkAccessEnabled],
-});
-
 interface ICodexSessionConfigDefaults {
+	readonly [CodexSessionConfigKey.PermissionsPreset]: CodexPermissionsPreset;
 	readonly [CodexSessionConfigKey.ApprovalPolicy]: CodexApprovalPolicy;
 	readonly [CodexSessionConfigKey.SandboxMode]: SandboxMode;
 	readonly [CodexSessionConfigKey.WebSearchMode]: WebSearchMode;
@@ -288,6 +323,7 @@ interface ICodexSessionConfigDefaults {
 }
 
 const codexSessionConfigDefaults: ICodexSessionConfigDefaults = {
+	[CodexSessionConfigKey.PermissionsPreset]: CODEX_DEFAULT_PERMISSIONS_PRESET,
 	[CodexSessionConfigKey.ApprovalPolicy]: 'on-request',
 	[CodexSessionConfigKey.SandboxMode]: 'workspace-write',
 	[CodexSessionConfigKey.WebSearchMode]: 'disabled',
@@ -353,6 +389,23 @@ interface ICodexSession {
 	 * approval requests on the same session resolve automatically.
 	 */
 	readonly acceptedForSession: Set<string>;
+	/**
+	 * Guardian (auto-review) `reviewId`s that have already been surfaced to
+	 * the user as a denied-action approval card. Guards against acting twice
+	 * on the same review if the completed notification is redelivered.
+	 */
+	readonly handledGuardianReviews: Set<string>;
+	/**
+	 * Host-side toolCallIds of the synthetic "Approve anyway" cards created for
+	 * guardian (auto-review) denials that are still awaiting a user decision.
+	 * Unlike codex's blocking command approvals, these cards live inside the
+	 * active turn but codex does *not* wait on them — so when the turn ends
+	 * (often via the auto-review circuit-breaker interrupt) the reducer cancels
+	 * the card. We use this set to unwind the parked deferred on turn end so the
+	 * suspended {@link CodexAgent._handleGuardianReviewCompleted} frame doesn't
+	 * leak.
+	 */
+	readonly pendingGuardianReviewCards: Set<string>;
 	/**
 	 * Steering messages handed to codex via `turn/steer` that are awaiting
 	 * the matching `userMessage` item echo, which promotes them into their
@@ -555,7 +608,7 @@ function narrowFileChangeDecision(decision: CommandExecutionApprovalDecision): F
 
 export class CodexAgent extends Disposable implements IAgent {
 
-	readonly id: AgentProvider = 'codex';
+	readonly id: AgentProvider = CODEX_AGENT_PROVIDER_ID;
 
 	private readonly _onDidSessionProgress = this._register(new Emitter<AgentSignal>());
 	readonly onDidSessionProgress = this._onDidSessionProgress.event;
@@ -725,8 +778,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		);
 	}
 
-	private _sandboxPolicy(session: ICodexSession, config: ReturnType<typeof codexSessionConfigSchema.validateOrDefault>): SandboxPolicy {
-		const mode = narrowSandboxMode(config[CodexSessionConfigKey.SandboxMode]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode];
+	private _sandboxPolicy(session: ICodexSession, config: ReturnType<typeof codexSessionConfigSchema.validateOrDefault>, mode: SandboxMode): SandboxPolicy {
 		if (mode === 'danger-full-access') {
 			return { type: 'dangerFullAccess' };
 		}
@@ -747,10 +799,13 @@ export class CodexAgent extends Disposable implements IAgent {
 		};
 	}
 
-	private _turnStartOptions(session: ICodexSession, modelId: string): Pick<TurnStartParams, 'approvalPolicy' | 'sandboxPolicy' | 'effort' | 'runtimeWorkspaceRoots' | 'personality' | 'summary' | 'collaborationMode'> {
+	private _turnStartOptions(session: ICodexSession, modelId: string): Pick<TurnStartParams, 'approvalPolicy' | 'sandboxPolicy' | 'approvalsReviewer' | 'effort' | 'runtimeWorkspaceRoots' | 'personality' | 'summary' | 'collaborationMode'> {
 		const config = this._readSessionConfig(session);
-		const approvalPolicy = narrowApprovalPolicy(config[CodexSessionConfigKey.ApprovalPolicy]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy];
-		const sandboxPolicy = this._sandboxPolicy(session, config);
+		const { approvalPolicy, sandboxMode, approvalsReviewer } = resolveCodexPermissions(config, {
+			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
+			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
+		});
+		const sandboxPolicy = this._sandboxPolicy(session, config, sandboxMode);
 		const runtimeWorkspaceRoots = sandboxPolicy.type === 'workspaceWrite' ? sandboxPolicy.writableRoots : undefined;
 		const effort = this._getReasoningEffort(session);
 		const personality = narrowPersonality(config[CodexSessionConfigKey.Personality]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.Personality];
@@ -768,6 +823,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		return {
 			approvalPolicy,
 			sandboxPolicy,
+			approvalsReviewer,
 			effort,
 			personality,
 			summary,
@@ -1013,6 +1069,13 @@ export class CodexAgent extends Disposable implements IAgent {
 		this._register(client.onNotification('thread/tokenUsage/updated', params => this._dispatchByThread(params.threadId, s => mapTokenUsageUpdated(this._withHostTurnId(s, params)))));
 		this._register(client.onNotification('item/completed', params => this._dispatchByThread(params.threadId, s => mapItemCompleted(s.mapState, this._withHostTurnId(s, params)))));
 		this._register(client.onNotification('turn/completed', params => this._dispatchByThread(params.threadId, s => this._handleTurnCompletedNotification(s, params))));
+		// Auto-review (guardian) surfacing. The guardian warning is shown as a
+		// system notification; a completed *denied* review is turned into a
+		// retroactive "Approve anyway" tool-call card. The review lifecycle is
+		// non-blocking (codex does not wait on us), so the completed handler is
+		// async and resolves its session directly rather than via _dispatchByThread.
+		this._register(client.onNotification('guardianWarning', params => this._dispatchByThread(params.threadId, s => this._handleGuardianWarning(s, params))));
+		this._register(client.onNotification('item/autoApprovalReview/completed', params => { void this._handleGuardianReviewCompleted(client, params); }));
 
 		// MCP server lifecycle. Codex owns MCP servers at the process level
 		// (shared across threads); surface them to AHP clients as per-session
@@ -1292,6 +1355,17 @@ export class CodexAgent extends Disposable implements IAgent {
 		// Any steering still buffered was never echoed as a `userMessage`
 		// item; clear the pending bubble now that the turn is over.
 		this._drainPendingSteering(session);
+		// Unwind any still-pending "Approve anyway" guardian cards. codex does not
+		// block on them, so the reducer cancels the card when the turn ends; here
+		// we resolve the parked deferred (`cancel`) so the suspended
+		// {@link _handleGuardianReviewCompleted} frame unwinds instead of leaking
+		// until session dispose. The durable denial notification already emitted
+		// remains in the transcript.
+		if (session.pendingGuardianReviewCards.size > 0) {
+			for (const guardianToolCallId of [...session.pendingGuardianReviewCards]) {
+				session.pendingCommandApprovals.respond(guardianToolCallId, 'cancel');
+			}
+		}
 		return out;
 	}
 
@@ -1402,6 +1476,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			'account/rateLimits/updated', // Rate-limit UI/state is not implemented yet.
 			'remoteControl/status/changed', // Remote-control state is not part of the VS Code integration.
 			'serverRequest/resolved', // We resolve requests through JSON-RPC responses, so this echo is informational.
+			'item/autoApprovalReview/started', // Informational; the completed notification drives the denied-action card.
 		] as const;
 		for (const method of ignored) {
 			this._register(client.onNotification(method, () => { /* intentionally ignored */ }));
@@ -1467,6 +1542,11 @@ export class CodexAgent extends Disposable implements IAgent {
 			return 'decline';
 		}
 		const command = params.command ?? '';
+		// Peel the OS shell wrapper (`/bin/zsh -lc '…'`) off for display so the
+		// approval card matches the terminal pill, but keep the raw command as
+		// the accept-for-session memo key so it stays byte-identical to what
+		// Codex re-sends on the next request for the same command.
+		const displayCommand = unwrapShellInvocation(command);
 		// Accept-for-session memo: if the user previously accepted this
 		// exact command for the session, auto-accept without prompting.
 		if (command && session.acceptedForSession.has(command)) {
@@ -1481,8 +1561,8 @@ export class CodexAgent extends Disposable implements IAgent {
 				type: ActionType.ChatToolCallReady,
 				turnId: entry.turnId,
 				toolCallId: entry.toolCallId,
-				invocationMessage: command,
-				toolInput: command,
+				invocationMessage: displayCommand,
+				toolInput: displayCommand,
 				confirmationTitle,
 			});
 		});
@@ -1541,6 +1621,164 @@ export class CodexAgent extends Disposable implements IAgent {
 				confirmationTitle,
 			});
 		});
+	}
+
+	private _handleGuardianWarning(session: ICodexSession, params: GuardianWarningNotification): ChatAction[] {
+		const turnId = session.currentTurnId;
+		if (turnId === undefined) {
+			this._logService.trace(`[Codex:${session.sessionId}] guardianWarning without active turn; ignoring`);
+			return [];
+		}
+		return [{
+			type: ActionType.ChatResponsePart,
+			turnId,
+			part: {
+				kind: ResponsePartKind.SystemNotification,
+				content: params.message,
+			},
+		}];
+	}
+
+	private async _handleGuardianReviewCompleted(client: ICodexAppServerClient, params: ItemGuardianApprovalReviewCompletedNotification): Promise<void> {
+		const sessionId = this._sessionIdByThreadId.get(params.threadId);
+		const session = sessionId ? this._sessions.get(sessionId) : undefined;
+		if (!session) {
+			this._logService.trace(`[Codex] autoApprovalReview/completed for unknown threadId=${params.threadId}; ignoring`);
+			return;
+		}
+		if (params.review.status !== 'denied') {
+			return;
+		}
+		if (session.handledGuardianReviews.has(params.reviewId)) {
+			return;
+		}
+		// Bind the denial surfacing to the review's OWN turn (mapped app→host),
+		// not whatever turn happens to be current. An `autoApprovalReview/completed`
+		// that arrives out of order — after its turn ended, or once a later turn is
+		// active — must not mis-attribute the notice/card to a different turn, nor
+		// apply this review's stale action against it. When the review's turn is no
+		// longer the active turn there is nothing left to approve within it, so ignore.
+		const turnId = this._hostTurnId(session, params.turnId);
+		if (session.currentTurnId !== turnId) {
+			this._logService.trace(`[Codex:${sessionId}] autoApprovalReview/completed for non-current turn ${turnId} (current=${session.currentTurnId ?? '(none)'}); ignoring reviewId=${params.reviewId}`);
+			return;
+		}
+
+		session.handledGuardianReviews.add(params.reviewId);
+
+		const summary = summarizeGuardianReviewAction(params.action);
+
+		// Durable record: a Markdown response part survives turn completion AND is
+		// rendered by the live streaming path (unlike a system-notification part,
+		// which the workbench maps to a transient progress message and never emits
+		// mid-turn). The auto-review circuit-breaker interrupts the turn after
+		// repeated denials — cancelling the tool-call card below — so without this
+		// the user could be left with no feedback at all. Surfacing the reviewer
+		// rationale here mirrors the manual-approval feedback the Default
+		// permissions preset provides.
+		this._fire(session.sessionUri, {
+			type: ActionType.ChatResponsePart,
+			turnId,
+			part: {
+				kind: ResponsePartKind.Markdown,
+				id: generateUuid(),
+				content: formatGuardianDenialNotification(summary, params.review.rationale),
+			},
+		});
+
+		// Best-effort in-turn override: while the turn is still running (before the
+		// circuit-breaker interrupt) the model keeps trying safer paths, so
+		// approving here lets codex retry the exact denied action. codex does not
+		// block on this card, so if the turn ends first the reducer cancels it and
+		// {@link _handleTurnCompletedNotification} unwinds the parked deferred.
+		const toolCallId = generateUuid();
+		const invocationMessage = summary.detail || summary.title;
+		const confirmationTitle = 'Approve anyway';
+		// Deliberately render this as a PLAIN confirmation card, NOT a terminal
+		// pill: the denied action already appears as its real commandExecution
+		// terminal box (streamed by the app-server) and again in the denial
+		// blockquote above. Tagging the card with a terminal `toolKind` + a
+		// `toolInput` would make the adapter draw a *second* terminal box for the
+		// same command (see stateToProgressAdapter `shouldRenderAsTerminal`),
+		// which is the duplicate the user reported. Omitting both keeps the card
+		// to just its title/message + "Approve anyway" button. The button still
+		// works because the reducer keys PendingConfirmation off confirmationTitle
+		// (with `confirmed` unset), independent of toolInput/meta.
+		session.pendingGuardianReviewCards.add(toolCallId);
+		let decision: CommandExecutionApprovalDecision;
+		try {
+			decision = await session.pendingCommandApprovals.registerAndFire(toolCallId, () => {
+				this._fire(session.sessionUri, {
+					type: ActionType.ChatToolCallStart,
+					turnId,
+					toolCallId,
+					toolName: 'auto_review_denied',
+					displayName: summary.title,
+					intention: invocationMessage,
+				});
+				this._fire(session.sessionUri, {
+					type: ActionType.ChatToolCallReady,
+					turnId,
+					toolCallId,
+					invocationMessage,
+					confirmationTitle,
+				});
+			});
+		} catch (err) {
+			// The parked approval was rejected (session dispose / cancellation);
+			// there is no card lifecycle left to finalize.
+			this._logService.trace(`[Codex:${sessionId}] guardian approval cancelled for reviewId=${params.reviewId}: ${err instanceof Error ? err.message : String(err)}`);
+			return;
+		} finally {
+			session.pendingGuardianReviewCards.delete(toolCallId);
+		}
+
+		if (decision !== 'accept' && decision !== 'acceptForSession') {
+			// Declined, cancelled, or unwound by turn completion: the action stays
+			// blocked by codex. When the user declined, the UI already transitioned
+			// the card off the ChatToolCallConfirmed it dispatched; when the turn
+			// ended, the reducer cancelled it. Either way there is nothing to send.
+			return;
+		}
+
+		// If the turn ended between the user's approval and here, the card was
+		// already cancelled by the reducer and codex is no longer waiting on this
+		// action within the turn — skip the round-trip.
+		if (session.currentTurnId !== turnId) {
+			this._logService.trace(`[Codex:${sessionId}] turn ended before guardian approval could be applied for reviewId=${params.reviewId}`);
+			return;
+		}
+
+		try {
+			await client.request<'thread/approveGuardianDeniedAction', ThreadApproveGuardianDeniedActionResponse>('thread/approveGuardianDeniedAction', {
+				threadId: params.threadId,
+				event: toGuardianAssessmentEventJson(params),
+			});
+			this._fire(session.sessionUri, {
+				type: ActionType.ChatToolCallComplete,
+				turnId,
+				toolCallId,
+				result: {
+					success: true,
+					pastTenseMessage: 'Approved anyway',
+				},
+			});
+		} catch (err) {
+			// The user approved but the app-server rejected the round-trip; finalize
+			// the card as failed so it does not hang in the running state forever.
+			const message = err instanceof Error ? err.message : String(err);
+			this._logService.warn(`[Codex:${sessionId}] approveGuardianDeniedAction failed for reviewId=${params.reviewId}: ${message}`);
+			this._fire(session.sessionUri, {
+				type: ActionType.ChatToolCallComplete,
+				turnId,
+				toolCallId,
+				result: {
+					success: false,
+					pastTenseMessage: 'Approval failed',
+					error: { message },
+				},
+			});
+		}
 	}
 
 	private _handleConnectionLost(): void {
@@ -1658,7 +1896,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		this._logService.info(`[Codex DEBUG] createSession session=${config.session?.toString() ?? '(none)'} model=${config.model?.id ?? '(none)'} cwd=${config.workingDirectory?.toString() ?? '(none)'}`);
 		this._ensureAuthenticated();
 		if (config.fork) {
-			throw new Error('Codex agent does not support session forking');
+			return this._forkSession(config, config.fork);
 		}
 		// Codex requires a working directory to start a thread, but the client
 		// may not have one to give (e.g. an editor window with no workspace
@@ -1699,6 +1937,8 @@ export class CodexAgent extends Disposable implements IAgent {
 			mapState: createCodexSessionMapState(new Set(this._serverToolHost?.toolNames ?? []), clientToolSet),
 			pendingCommandApprovals: new PendingRequestRegistry<CommandExecutionApprovalDecision>(),
 			acceptedForSession: new Set<string>(),
+			handledGuardianReviews: new Set<string>(),
+			pendingGuardianReviewCards: new Set<string>(),
 			pendingSteeringFlips: new Map<string, PendingMessage>(),
 			clientToolSet,
 			pendingClientToolCalls: new PendingRequestRegistry<ToolCallResult>(),
@@ -1726,6 +1966,144 @@ export class CodexAgent extends Disposable implements IAgent {
 			session: sessionUri,
 			workingDirectory: config.workingDirectory,
 			provisional: true,
+		};
+	}
+
+	/**
+	 * Build an {@link ICodexSession} entry for a thread that already exists on
+	 * the app-server (a restored session or a freshly forked one). Such a
+	 * session skips materialization — its first {@link _sendMessage} issues a
+	 * `thread/resume` (`needsResume: true`) — so the prewarm/first-turn flags
+	 * are pre-set to their post-materialization values.
+	 */
+	private _createResumedSessionEntry(sessionId: string, threadId: string, sessionUri: URI, workingDirectory: URI | undefined, model: ModelSelection | undefined): ICodexSession {
+		const clientToolSet = new ActiveClientToolSet();
+		return {
+			sessionId,
+			threadId,
+			sessionUri,
+			workingDirectory,
+			managedWorkingDirectory: undefined,
+			mapState: createCodexSessionMapState(new Set(this._serverToolHost?.toolNames ?? []), clientToolSet),
+			pendingCommandApprovals: new PendingRequestRegistry<CommandExecutionApprovalDecision>(),
+			acceptedForSession: new Set<string>(),
+			handledGuardianReviews: new Set<string>(),
+			pendingGuardianReviewCards: new Set<string>(),
+			pendingSteeringFlips: new Map<string, PendingMessage>(),
+			clientToolSet,
+			pendingClientToolCalls: new PendingRequestRegistry<ToolCallResult>(),
+			pendingUserInputs: new PendingRequestRegistry<ICodexUserInputResult>(),
+			materializedToolsSig: undefined,
+			firstTurnSent: true,
+			model,
+			currentTurnId: undefined,
+			currentAppTurnId: undefined,
+			hostTurnIdByAppTurnId: new Map<string, string>(),
+			codexTurnIdByHostTurnId: new Map<string, string>(),
+			needsResume: true,
+			lastPromptText: '',
+			disposed: false,
+			materializePromise: undefined,
+			materializedEventFired: true,
+			prewarmTimer: undefined,
+			prewarmClaimed: true,
+			serverToolsAdvertised: false,
+			mcpController: undefined,
+		};
+	}
+
+	/**
+	 * Fork an existing codex session at a turn into a brand-new session.
+	 *
+	 * Codex is single-chat, so the workbench routes the "fork conversation"
+	 * gesture here (via {@link AgentHostSessionHandler}) instead of minting a
+	 * peer chat. We `thread/fork` the source thread — which copies its full
+	 * history — then `thread/rollback` the trailing turns so the fork retains
+	 * only the turns up to and including `fork.turnId`. The forked thread is
+	 * registered as a resumable session (its first send issues a
+	 * `thread/resume`) keyed by its new thread id, preserving the Codex
+	 * convention that a session id equals its thread id.
+	 */
+	private async _forkSession(config: IAgentCreateSessionConfig, fork: NonNullable<IAgentCreateSessionConfig['fork']>): Promise<IAgentCreateSessionResult> {
+		const sourceRead = await this._readSession(fork.session);
+		if (!sourceRead) {
+			throw new Error(`Cannot fork codex session ${fork.session.toString()}: source thread could not be read`);
+		}
+		const sourceThreadId = sourceRead.thread.id;
+		const sourceTurns = sourceRead.thread.turns ?? [];
+
+		// Resolve how many trailing turns to drop so the fork keeps turns up to
+		// and including `fork.turnId`. A live source maps host turn ids to codex
+		// turn ids; a restored source already uses codex ids. Fall back to the
+		// caller-supplied `turnIndex` when the id can't be resolved.
+		const sourceSession = this._sessions.get(AgentSession.id(fork.session));
+		const codexTurnId = sourceSession?.codexTurnIdByHostTurnId.get(fork.turnId) ?? fork.turnId;
+		let keepThroughIndex = sourceTurns.findIndex(t => t.id === codexTurnId);
+		if (keepThroughIndex === -1) {
+			keepThroughIndex = fork.turnIndex;
+		}
+		const numTurnsToDrop = sourceTurns.length > 0 && keepThroughIndex >= 0
+			? Math.max(0, sourceTurns.length - (keepThroughIndex + 1))
+			: 0;
+
+		const conn = await this._ensureConnection();
+		const model = this._supportedModelOrUndefined(config.model);
+		const { approvalPolicy, sandboxMode, approvalsReviewer } = resolveCodexPermissions(config.config, {
+			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
+			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
+		});
+		const forkResult = await conn.client.request<'thread/fork', ThreadForkResponse>('thread/fork', {
+			threadId: sourceThreadId,
+			...(model ? { model: model.id } : {}),
+			approvalPolicy,
+			sandbox: sandboxMode,
+			approvalsReviewer,
+		});
+		const newThreadId = forkResult.thread.id;
+
+		// The fork copies the full source history; drop the trailing turns so
+		// the new thread ends at the requested fork point. A failed rollback
+		// would leave the fork carrying the very turns the user asked to branch
+		// away from, so treat it as a hard failure: archive the orphaned fork
+		// and reject rather than returning a session with the wrong history.
+		if (numTurnsToDrop > 0) {
+			try {
+				await conn.client.request<'thread/rollback'>('thread/rollback', { threadId: newThreadId, numTurns: numTurnsToDrop });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				this._logService.warn(`[Codex:${newThreadId}] fork rollback failed (numTurns=${numTurnsToDrop}); discarding fork: ${message}`);
+				try {
+					await conn.client.request<'thread/archive'>('thread/archive', { threadId: newThreadId });
+				} catch (archiveErr) {
+					this._logService.warn(`[Codex:${newThreadId}] failed to archive orphaned fork after rollback failure: ${archiveErr instanceof Error ? archiveErr.message : String(archiveErr)}`);
+				}
+				throw new Error(`Failed to fork codex session ${sourceThreadId}: could not roll back forked thread ${newThreadId} to the requested turn (${message})`);
+			}
+		}
+
+		// Codex convention (Decision 7): session id == thread id, so a restore
+		// round-trips through `getSessionMetadata`.
+		const newSessionUri = AgentSession.uri(this.id, newThreadId);
+		const workingDirectory = forkResult.cwd
+			? URI.file(forkResult.cwd)
+			: (sourceRead.thread.cwd ? URI.file(sourceRead.thread.cwd) : config.workingDirectory);
+
+		const session = this._createResumedSessionEntry(newThreadId, newThreadId, newSessionUri, workingDirectory, model);
+		this._sessions.set(newThreadId, session);
+		this._sessionIdByThreadId.set(newThreadId, newThreadId);
+		// Forked threads skip materialization (the thread already exists), so
+		// advertise the server tools here for client-side parity.
+		if (!session.serverToolsAdvertised && this._serverToolHost) {
+			session.serverToolsAdvertised = true;
+			this._serverToolHost.advertise(session.sessionUri.toString());
+		}
+		this._persistMaterializedSession(session);
+
+		this._logService.info(`[Codex] forked session ${sourceThreadId} → ${newThreadId} (kept ${sourceTurns.length - numTurnsToDrop}/${sourceTurns.length} turns)`);
+		return {
+			session: newSessionUri,
+			workingDirectory,
+			provisional: false,
 		};
 	}
 
@@ -1777,11 +2155,16 @@ export class CodexAgent extends Disposable implements IAgent {
 		const conn = await this._ensureConnection();
 		const config = this._readSessionConfig(session);
 		const model = await this._resolveModel(session);
+		const { approvalPolicy, sandboxMode, approvalsReviewer } = resolveCodexPermissions(config, {
+			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
+			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
+		});
 		const startResult = await conn.client.request<'thread/start', { thread: { id: string } }>('thread/start', {
 			cwd: session.workingDirectory.fsPath,
 			model: model.id,
-			approvalPolicy: narrowApprovalPolicy(config[CodexSessionConfigKey.ApprovalPolicy]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
-			sandbox: narrowSandboxMode(config[CodexSessionConfigKey.SandboxMode]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
+			approvalPolicy,
+			sandbox: sandboxMode,
+			approvalsReviewer,
 			config: {
 				web_search: narrowWebSearchMode(config[CodexSessionConfigKey.WebSearchMode]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.WebSearchMode],
 			},
@@ -2320,37 +2703,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		if (!this._sessions.has(sessionId)) {
 			const workingDirectory = read.thread.cwd ? URI.file(read.thread.cwd) : undefined;
 			const threadId = read.thread.id;
-			const clientToolSet = new ActiveClientToolSet();
-			this._sessions.set(sessionId, {
-				sessionId,
-				threadId,
-				sessionUri: session,
-				workingDirectory,
-				managedWorkingDirectory: undefined,
-				mapState: createCodexSessionMapState(new Set(this._serverToolHost?.toolNames ?? []), clientToolSet),
-				pendingCommandApprovals: new PendingRequestRegistry<CommandExecutionApprovalDecision>(),
-				acceptedForSession: new Set<string>(),
-				pendingSteeringFlips: new Map<string, PendingMessage>(),
-				clientToolSet,
-				pendingClientToolCalls: new PendingRequestRegistry<ToolCallResult>(),
-				pendingUserInputs: new PendingRequestRegistry<ICodexUserInputResult>(),
-				materializedToolsSig: undefined,
-				firstTurnSent: true,
-				model: undefined,
-				currentTurnId: undefined,
-				currentAppTurnId: undefined,
-				hostTurnIdByAppTurnId: new Map<string, string>(),
-				codexTurnIdByHostTurnId: new Map<string, string>(),
-				needsResume: true,
-				lastPromptText: '',
-				disposed: false,
-				materializePromise: undefined,
-				materializedEventFired: true,
-				prewarmTimer: undefined,
-				prewarmClaimed: true,
-				serverToolsAdvertised: false,
-				mcpController: undefined,
-			});
+			this._sessions.set(sessionId, this._createResumedSessionEntry(sessionId, threadId, session, workingDirectory, undefined));
 			this._sessionIdByThreadId.set(threadId, sessionId);
 			// Restored threads skip materialization (the thread already exists),
 			// so advertise the server tools here for client-side parity.
@@ -2750,21 +3103,11 @@ export class CodexAgent extends Disposable implements IAgent {
 
 	resolveSessionConfig(params: IAgentResolveSessionConfigParams): Promise<ResolveSessionConfigResult> {
 		const values = codexSessionConfigSchema.validateOrDefault(params.config, codexSessionConfigDefaults);
-		const isWorkspaceWrite = values[CodexSessionConfigKey.SandboxMode] === 'workspace-write';
-		const schema = isWorkspaceWrite
-			? codexWorkspaceWriteSessionConfigSchema.toProtocol()
-			: codexVisibleSessionConfigSchema.toProtocol();
+		const schema = codexVisibleSessionConfigSchema.toProtocol();
 		const resolvedValues: Record<string, unknown> = {
 			[SessionConfigKey.Mode]: values[SessionConfigKey.Mode],
-			[CodexSessionConfigKey.ApprovalPolicy]: values[CodexSessionConfigKey.ApprovalPolicy],
-			[CodexSessionConfigKey.SandboxMode]: values[CodexSessionConfigKey.SandboxMode],
-			[CodexSessionConfigKey.WebSearchMode]: values[CodexSessionConfigKey.WebSearchMode],
-			[CodexSessionConfigKey.Personality]: values[CodexSessionConfigKey.Personality],
-			[CodexSessionConfigKey.ReasoningSummary]: values[CodexSessionConfigKey.ReasoningSummary],
+			[CodexSessionConfigKey.PermissionsPreset]: values[CodexSessionConfigKey.PermissionsPreset],
 		};
-		if (isWorkspaceWrite) {
-			resolvedValues[CodexSessionConfigKey.NetworkAccessEnabled] = values[CodexSessionConfigKey.NetworkAccessEnabled];
-		}
 		return Promise.resolve({ values: resolvedValues, schema });
 	}
 

--- a/src/vs/platform/agentHost/node/codex/codexForkPlan.ts
+++ b/src/vs/platform/agentHost/node/codex/codexForkPlan.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Pure decision helpers for the Codex `thread/fork` path, extracted so they can
+ * be unit-tested without standing up the whole {@link CodexAgent} (mirrors the
+ * `codexShellCommand.ts` extraction). No protocol or service imports.
+ */
+
+/**
+ * Outcome of locating where a fork should branch within the source thread.
+ * `resolved: false` means neither the mapped codex turn id nor the caller's
+ * fallback index identified a turn, and the caller must reject the fork instead
+ * of silently branching from the tip.
+ */
+export type ForkBoundaryResolution =
+	| { readonly resolved: true; readonly keepThroughIndex: number; readonly numTurnsToDrop: number }
+	| { readonly resolved: false };
+
+/**
+ * Resolve the fork boundary from the source thread's ordered turn ids.
+ *
+ * `thread/fork` copies the full source history; the returned `numTurnsToDrop`
+ * is how many trailing turns must be rolled back so the fork ends at (and
+ * includes) the requested turn.
+ *
+ * @param sourceTurnIds Codex turn ids of the source thread, in order.
+ * @param codexTurnId The resolved codex turn id of the requested fork point.
+ * @param fallbackTurnIndex Zero-based index used when `codexTurnId` isn't found.
+ */
+export function resolveForkBoundary(sourceTurnIds: readonly string[], codexTurnId: string, fallbackTurnIndex: number): ForkBoundaryResolution {
+	const total = sourceTurnIds.length;
+	let keepThroughIndex = sourceTurnIds.findIndex(id => id === codexTurnId);
+	if (keepThroughIndex === -1) {
+		keepThroughIndex = fallbackTurnIndex;
+	}
+	// An empty source thread is a valid (empty) fork; otherwise the boundary
+	// must land inside the source turns.
+	if (total > 0 && (keepThroughIndex < 0 || keepThroughIndex >= total)) {
+		return { resolved: false };
+	}
+	const numTurnsToDrop = total > 0 ? Math.max(0, total - (keepThroughIndex + 1)) : 0;
+	return { resolved: true, keepThroughIndex, numTurnsToDrop };
+}
+
+/** A `[hostTurnId, codexTurnId]` pair to seed into a forked session's map. */
+export type ForkedTurnIdMapEntry = readonly [hostTurnId: string, codexTurnId: string];
+
+/**
+ * Plan the `codexTurnIdByHostTurnId` seeding for a freshly forked session.
+ *
+ * A later edit/truncate of a copied turn needs to map the workbench's (new)
+ * host turn id back to the forked thread's app-server turn id. The kept turns
+ * line up by index between the source and the forked thread (the fork copies
+ * them in order, then trailing turns are rolled back), so for each kept turn we
+ * derive its new host id via `turnIdMapping` and pair it with the forked
+ * thread's authoritative codex id (which `thread/fork` may have regenerated).
+ *
+ * @param sourceTurnIds Codex turn ids of the source thread, in order.
+ * @param forkedTurnIds Codex turn ids of the forked thread (post-rollback), in order.
+ * @param keepThroughIndex Index of the last kept turn (inclusive).
+ * @param hostTurnIdBySourceCodexId Source session's codex→host turn id map (live sessions only).
+ * @param turnIdMapping Old→new host turn id remapping supplied by the fork caller.
+ */
+export function planForkedTurnIdMap(
+	sourceTurnIds: readonly string[],
+	forkedTurnIds: readonly string[],
+	keepThroughIndex: number,
+	hostTurnIdBySourceCodexId: ReadonlyMap<string, string> | undefined,
+	turnIdMapping: ReadonlyMap<string, string> | undefined,
+): ForkedTurnIdMapEntry[] {
+	if (!turnIdMapping || turnIdMapping.size === 0) {
+		return [];
+	}
+	const keptCount = Math.min(keepThroughIndex + 1, sourceTurnIds.length, forkedTurnIds.length);
+	const entries: ForkedTurnIdMapEntry[] = [];
+	for (let i = 0; i < keptCount; i++) {
+		const sourceCodexId = sourceTurnIds[i];
+		const oldHostId = hostTurnIdBySourceCodexId?.get(sourceCodexId) ?? sourceCodexId;
+		const newHostId = turnIdMapping.get(oldHostId) ?? oldHostId;
+		entries.push([newHostId, forkedTurnIds[i]]);
+	}
+	return entries;
+}

--- a/src/vs/platform/agentHost/node/codex/codexGuardianReview.ts
+++ b/src/vs/platform/agentHost/node/codex/codexGuardianReview.ts
@@ -1,0 +1,201 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { GuardianApprovalReviewAction } from './protocol/generated/v2/GuardianApprovalReviewAction.js';
+import type { ItemGuardianApprovalReviewCompletedNotification } from './protocol/generated/v2/ItemGuardianApprovalReviewCompletedNotification.js';
+import type { RequestPermissionProfile } from './protocol/generated/v2/RequestPermissionProfile.js';
+import type { JsonValue } from './protocol/generated/serde_json/JsonValue.js';
+import { unwrapShellInvocation } from './codexShellCommand.js';
+
+/**
+ * Auto-review (guardian) notifications are emitted by the app-server with
+ * `ts-rs`-generated camelCase field names. The `thread/approveGuardianDeniedAction`
+ * request, however, echoes back a `codex_protocol::protocol::GuardianAssessmentEvent`
+ * that is (de)serialized with plain `serde` — which uses **snake_case** for enum
+ * variants, enum values, and the tagged-union `type` discriminant. The two shapes
+ * therefore diverge (`inProgress` vs `in_progress`, `networkAccess` vs
+ * `network_access`, `unifiedExec` vs `unified_exec`, `toolName` vs `tool_name`, …),
+ * so we cannot round-trip the notification payload verbatim.
+ *
+ * These helpers translate the camelCase completed-review notification into the
+ * snake_case `GuardianAssessmentEvent` JSON that the app-server can deserialize,
+ * and summarise a review action for display on the approval card.
+ */
+
+/** camelCase {@link GuardianApprovalReviewStatus} value -> snake_case `GuardianAssessmentStatus`. */
+function guardianStatusToEvent(status: string): string {
+	switch (status) {
+		case 'inProgress': return 'in_progress';
+		case 'timedOut': return 'timed_out';
+		// `approved`, `denied`, `aborted` are identical in both casings.
+		default: return status;
+	}
+}
+
+/** camelCase {@link GuardianCommandSource} value -> snake_case. */
+function commandSourceToEvent(source: string): string {
+	return source === 'unifiedExec' ? 'unified_exec' : source;
+}
+
+/** camelCase {@link NetworkApprovalProtocol} value -> snake_case. */
+function networkProtocolToEvent(protocol: string): string {
+	switch (protocol) {
+		case 'socks5Tcp': return 'socks5_tcp';
+		case 'socks5Udp': return 'socks5_udp';
+		// `http`, `https` are identical in both casings.
+		default: return protocol;
+	}
+}
+
+/**
+ * camelCase {@link RequestPermissionProfile} -> snake_case. The `network`
+ * profile (`{ enabled }`) is identical in both casings, but the file-system
+ * profile renames `fileSystem` -> `file_system` and `globScanMaxDepth` ->
+ * `glob_scan_max_depth`. Its `read`/`write`/`entries` members (and the entry
+ * `path`/`access` fields) are already snake_case in the notification, so they
+ * round-trip verbatim.
+ */
+function requestPermissionProfileToEvent(profile: RequestPermissionProfile): JsonValue {
+	const fs = profile.fileSystem;
+	let fileSystem: JsonValue = null;
+	if (fs) {
+		const mapped: Record<string, JsonValue> = { read: fs.read, write: fs.write };
+		if (fs.globScanMaxDepth !== undefined) {
+			mapped.glob_scan_max_depth = fs.globScanMaxDepth;
+		}
+		if (fs.entries !== undefined) {
+			mapped.entries = fs.entries as JsonValue;
+		}
+		fileSystem = mapped;
+	}
+	return { network: profile.network as JsonValue, file_system: fileSystem };
+}
+
+/**
+ * Translate the camelCase notification action into the snake_case
+ * `GuardianAssessmentAction` (`#[serde(tag = "type", rename_all = "snake_case")]`)
+ * that `thread/approveGuardianDeniedAction` deserializes.
+ */
+export function guardianReviewActionToEventAction(action: GuardianApprovalReviewAction): JsonValue {
+	switch (action.type) {
+		case 'command':
+			return { type: 'command', source: commandSourceToEvent(action.source), command: action.command, cwd: action.cwd };
+		case 'execve':
+			return { type: 'execve', source: commandSourceToEvent(action.source), program: action.program, argv: action.argv, cwd: action.cwd };
+		case 'applyPatch':
+			return { type: 'apply_patch', cwd: action.cwd, files: action.files };
+		case 'networkAccess':
+			return { type: 'network_access', target: action.target, host: action.host, protocol: networkProtocolToEvent(action.protocol), port: action.port };
+		case 'mcpToolCall':
+			return { type: 'mcp_tool_call', server: action.server, tool_name: action.toolName, connector_id: action.connectorId, connector_name: action.connectorName, tool_title: action.toolTitle };
+		case 'requestPermissions':
+			return { type: 'request_permissions', reason: action.reason, permissions: requestPermissionProfileToEvent(action.permissions) };
+	}
+}
+
+/**
+ * Build the snake_case `GuardianAssessmentEvent` JSON expected by
+ * `thread/approveGuardianDeniedAction` from a completed-review notification.
+ * Optional fields are omitted when absent (the Rust struct defaults them).
+ */
+export function toGuardianAssessmentEventJson(notification: ItemGuardianApprovalReviewCompletedNotification): JsonValue {
+	const event: Record<string, JsonValue> = {
+		id: notification.reviewId,
+		turn_id: notification.turnId,
+		started_at_ms: notification.startedAtMs,
+		status: guardianStatusToEvent(notification.review.status),
+		action: guardianReviewActionToEventAction(notification.action),
+	};
+	if (notification.targetItemId !== null) {
+		event.target_item_id = notification.targetItemId;
+	}
+	if (notification.completedAtMs !== null && notification.completedAtMs !== undefined) {
+		event.completed_at_ms = notification.completedAtMs;
+	}
+	if (notification.review.riskLevel !== null) {
+		event.risk_level = notification.review.riskLevel;
+	}
+	if (notification.review.userAuthorization !== null) {
+		event.user_authorization = notification.review.userAuthorization;
+	}
+	if (notification.review.rationale !== null) {
+		event.rationale = notification.review.rationale;
+	}
+	if (notification.decisionSource !== null && notification.decisionSource !== undefined) {
+		event.decision_source = notification.decisionSource;
+	}
+	return event;
+}
+
+/** A human-readable summary of a reviewed action for the approval card. */
+export interface IGuardianActionSummary {
+	/** Short title (e.g. `"Network access"`). */
+	readonly title: string;
+	/** Detail line describing the specific action (e.g. the command or host). */
+	readonly detail: string;
+	/** Closest matching tool kind for iconography, when one applies. */
+	readonly toolKind?: 'terminal' | 'search';
+}
+
+/** Summarise a review action for display on the denied-action approval card. */
+export function summarizeGuardianReviewAction(action: GuardianApprovalReviewAction): IGuardianActionSummary {
+	switch (action.type) {
+		case 'command':
+			// Display-only: unwrap the OS shell wrapper (`/bin/zsh -lc '…'`) so the
+			// denial notice and "Approve anyway" card show the same clean command
+			// as the terminal pill. The raw action is still round-tripped verbatim
+			// to the app-server via toGuardianAssessmentEventJson on approval.
+			return { title: 'Run command', detail: unwrapShellInvocation(action.command), toolKind: 'terminal' };
+		case 'execve':
+			return { title: 'Run program', detail: unwrapShellInvocation([action.program, ...action.argv].join(' ')), toolKind: 'terminal' };
+		case 'applyPatch':
+			return { title: 'Apply file changes', detail: action.files.join(', ') };
+		case 'networkAccess':
+			return { title: 'Network access', detail: action.target || `${action.protocol}://${action.host}:${action.port}`, toolKind: 'search' };
+		case 'mcpToolCall':
+			return { title: 'MCP tool call', detail: `${action.server}/${action.toolName}` };
+		case 'requestPermissions':
+			return { title: 'Elevated permissions', detail: action.reason ?? 'Requested additional permissions' };
+	}
+}
+
+/** Escape the inline-code span so an embedded backtick can't break out of it. */
+function inlineCode(text: string): string {
+	// Use a fence long enough to contain any run of backticks in the text, per
+	// CommonMark's variable-length code-span rule, and pad with spaces when the
+	// content itself starts/ends with a backtick.
+	const longestRun = (text.match(/`+/g) ?? []).reduce((max, run) => Math.max(max, run.length), 0);
+	const fence = '`'.repeat(longestRun + 1);
+	const padding = text.startsWith('`') || text.endsWith('`') ? ' ' : '';
+	return `${fence}${padding}${text}${padding}${fence}`;
+}
+
+/**
+ * Compose the durable denial notice for an auto-review denial, rendered as a
+ * Markdown response part (which survives turn completion and, unlike a transient
+ * progress/system-notification message, is not dropped by the live streaming
+ * path) so the user always learns *why* an action was blocked — including the
+ * reviewer rationale — even when the turn ends before the best-effort "Approve
+ * anyway" card can be acted on. The notice is emitted as a blockquote so it
+ * stays visually distinct from the model's own prose even when adjacent
+ * Markdown parts are concatenated into one rendered block.
+ */
+export function formatGuardianDenialNotification(summary: IGuardianActionSummary, rationale: string | null): string {
+	const detail = summary.detail?.trim();
+	const header = '**Auto-review denied**';
+	const lines: string[] = [
+		detail
+			? `⚠️ ${header} — ${summary.title}: ${inlineCode(detail)}`
+			: `⚠️ ${header} — ${summary.title}`,
+	];
+	const reason = rationale?.trim();
+	if (reason) {
+		lines.push('', ...reason.split('\n'));
+	}
+	const quoted = lines.map(line => (line ? `> ${line}` : '>')).join('\n');
+	// Leading blank line separates the blockquote from any preceding Markdown
+	// part; trailing newline keeps subsequent model output on its own block.
+	return `\n\n${quoted}\n`;
+}

--- a/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
@@ -83,6 +83,34 @@ export interface ICodexSessionMapState {
 	 * result instead. Drained on completion and cleared per turn.
 	 */
 	readonly declinedToolCalls: Set<string>;
+	/**
+	 * A `commandExecution` that completed successfully with NO output is
+	 * potentially a sandbox pre-flight. When Codex runs a network (or otherwise
+	 * escalated) command under `on-request` + `workspace-write` it first attempts
+	 * it inside the sandbox — which completes instantly with no output because
+	 * the sandbox blocked it — then re-runs the SAME command as a separate
+	 * `commandExecution` item guarded by an approval request. Rendering both
+	 * items draws the command box twice. To coalesce them we defer the
+	 * pre-flight's completion here: if the next `commandExecution` in the turn
+	 * re-runs the same command it reuses this (still-open) tool call for a single
+	 * box; otherwise the deferred completion is flushed (on the next item or at
+	 * turn end) so a genuinely output-less command still finalizes.
+	 */
+	pendingPreflight: ICodexPendingPreflight | undefined;
+}
+
+/**
+ * A deferred `commandExecution` completion held back to coalesce a sandbox
+ * pre-flight with its approval-guarded re-run. See
+ * {@link ICodexSessionMapState.pendingPreflight}.
+ */
+interface ICodexPendingPreflight {
+	readonly toolCallId: string;
+	readonly turnId: string;
+	/** Unwrapped command text, used to match the re-run. */
+	readonly command: string;
+	/** The `ChatToolCallComplete` action to emit if the pre-flight is not reused. */
+	readonly completion: (SessionAction | ChatAction)[];
 }
 
 export interface ICodexToolCallEntry {
@@ -102,6 +130,7 @@ export function createCodexSessionMapState(serverToolNames: ReadonlySet<string> 
 		serverToolNames,
 		mcpCustomizationIds: new Map(),
 		declinedToolCalls: new Set(),
+		pendingPreflight: undefined,
 	};
 }
 
@@ -117,6 +146,21 @@ export function resetCodexTurnMapState(state: ICodexSessionMapState): void {
 	state.itemToToolCall.clear();
 	state.itemToReasoningPartId.clear();
 	state.declinedToolCalls.clear();
+	state.pendingPreflight = undefined;
+}
+
+/**
+ * Emit and clear any deferred sandbox pre-flight completion (see
+ * {@link ICodexSessionMapState.pendingPreflight}). Returns `[]` when nothing is
+ * pending, so callers can unconditionally prepend the result.
+ */
+function flushPendingPreflight(state: ICodexSessionMapState): (SessionAction | ChatAction)[] {
+	const pending = state.pendingPreflight;
+	if (!pending) {
+		return [];
+	}
+	state.pendingPreflight = undefined;
+	return pending.completion;
 }
 
 /**
@@ -156,7 +200,7 @@ function ensureReasoningPart(state: ICodexSessionMapState, turnId: string, key: 
 	};
 }
 
-function describeWebSearch(query: string, action: WebSearchAction | null): string {
+export function describeWebSearch(query: string, action: WebSearchAction | null): string {
 	if (action?.type === 'search') {
 		return action.queries?.join(', ') ?? action.query ?? query;
 	}
@@ -169,7 +213,7 @@ function describeWebSearch(query: string, action: WebSearchAction | null): strin
 	return query;
 }
 
-function describeFileChange(changes: readonly FileUpdateChange[]): string {
+export function describeFileChange(changes: readonly FileUpdateChange[]): string {
 	return changes.map(change => {
 		const kind = change.kind.type === 'update' && change.kind.move_path
 			? `rename from ${change.kind.move_path}`
@@ -178,7 +222,7 @@ function describeFileChange(changes: readonly FileUpdateChange[]): string {
 	}).join('\n');
 }
 
-function fileChangeOutput(changes: readonly FileUpdateChange[]): string {
+export function fileChangeOutput(changes: readonly FileUpdateChange[]): string {
 	return changes.map(change => `${describeFileChange([change])}\n${change.diff}`.trim()).join('\n\n');
 }
 
@@ -209,9 +253,12 @@ function mcpToolOutput(result: McpToolCallResult | null, errorMessage?: string):
 /**
  * Human labels for a Codex collab-agent (subagent) tool call, mirroring the
  * reference client's phrasing. Codex surfaces subagent orchestration as
- * `collabAgentToolCall` items on the parent thread — there is no separate
- * child-thread event stream — so each collab tool call renders as a tool
- * call in the parent chat.
+ * `collabAgentToolCall` items on the parent thread, but each spawned agent
+ * ALSO runs as its own child thread that emits a full `turn/*` + `item/*`
+ * event stream. The host ({@link CodexAgent}) renders that child stream in a
+ * read-only peer chat and attaches a discovery block to the parent
+ * `spawnAgent` tool call; the lifecycle collab tools (`wait`, `closeAgent`,
+ * `sendInput`, …) render as plain tool calls in the parent chat.
  */
 function collabAgentToolLabels(tool: CollabAgentTool): { readonly displayName: string; readonly present: string; readonly past: string } {
 	switch (tool) {
@@ -368,6 +415,36 @@ export function mapTokenUsageUpdated(params: ThreadTokenUsageUpdatedNotification
  * Phase 6's tool-call mapper.
  */
 export function mapItemStarted(
+	state: ICodexSessionMapState,
+	params: ItemStartedNotification,
+): (SessionAction | ChatAction)[] {
+	// Coalesce a sandbox pre-flight with its approval-guarded re-run: if the
+	// immediately-preceding commandExecution in this turn ran the same command
+	// and completed with no output (deferred as a pending pre-flight), reuse its
+	// still-open tool call instead of opening a second box. The escalation's
+	// `requestApproval` / `item/completed` then drive that box to its final
+	// state, so nothing new is emitted here.
+	if (params.item.type === 'commandExecution') {
+		const pending = state.pendingPreflight;
+		if (pending && pending.turnId === params.turnId && pending.command === unwrapShellInvocation(params.item.command ?? '')) {
+			state.pendingPreflight = undefined;
+			state.itemToToolCall.set(params.item.id, {
+				toolCallId: pending.toolCallId,
+				turnId: params.turnId,
+				toolName: 'shell',
+				output: '',
+			});
+			return [];
+		}
+	}
+	// Any other item supersedes a deferred pre-flight: finalize it first so a
+	// genuinely output-less command still renders promptly as a single box.
+	const flushed = flushPendingPreflight(state);
+	const body = mapItemStartedBody(state, params);
+	return flushed.length === 0 ? body : [...flushed, ...body];
+}
+
+function mapItemStartedBody(
 	state: ICodexSessionMapState,
 	params: ItemStartedNotification,
 ): (SessionAction | ChatAction)[] {
@@ -587,6 +664,37 @@ export function mapItemStarted(
 		const toolCallId = generateUuid();
 		const labels = collabAgentToolLabels(params.item.tool);
 		const toolName = `codex.${params.item.tool}`;
+		state.itemToToolCall.set(params.item.id, {
+			toolCallId,
+			turnId: params.turnId,
+			toolName,
+			output: '',
+		});
+		// `spawnAgent` opens a read-only peer chat for the child thread (the
+		// host attaches the subagent-discovery block to THIS tool call on
+		// `subagent_started`), so we deliberately do NOT dump the raw prompt
+		// into the tool box — it would duplicate the child chat's first user
+		// message and blow out the tool-call width. The other collab tools
+		// (`sendInput`, `wait`, `closeAgent`, …) are lifecycle ops with no peer
+		// chat, so they keep a compact prompt/model summary.
+		if (params.item.tool === 'spawnAgent') {
+			return [
+				{
+					type: ActionType.ChatToolCallStart,
+					turnId: params.turnId,
+					toolCallId,
+					toolName,
+					displayName: labels.displayName,
+				},
+				{
+					type: ActionType.ChatToolCallReady,
+					turnId: params.turnId,
+					toolCallId,
+					invocationMessage: labels.present,
+					confirmed: ToolCallConfirmationReason.NotNeeded,
+				},
+			];
+		}
 		const inputParts: string[] = [];
 		if (params.item.prompt) {
 			inputParts.push(params.item.prompt);
@@ -595,12 +703,6 @@ export function mapItemStarted(
 			inputParts.push(`Model: ${params.item.model}`);
 		}
 		const toolInput = inputParts.join('\n\n');
-		state.itemToToolCall.set(params.item.id, {
-			toolCallId,
-			turnId: params.turnId,
-			toolName,
-			output: '',
-		});
 		return [
 			{
 				type: ActionType.ChatToolCallStart,
@@ -761,7 +863,7 @@ export function mapItemCompleted(
 			: exit !== null
 				? `Ran \`${command}\` (exit ${exit})`
 				: `Ran \`${command}\` (failed)`;
-		return [
+		const completion: (SessionAction | ChatAction)[] = [
 			{
 				type: ActionType.ChatToolCallComplete,
 				turnId: entry.turnId,
@@ -779,6 +881,17 @@ export function mapItemCompleted(
 				},
 			},
 		];
+		// A successful command that produced NO output may be a sandbox
+		// pre-flight that Codex will immediately re-run under an approval prompt
+		// (same command, new item). Defer its completion so the re-run can reuse
+		// this box; if no re-run arrives, it is flushed on the next item or at
+		// turn end (see mapItemStarted / mapTurnCompleted).
+		if (success && !output && !declined) {
+			const flushed = flushPendingPreflight(state);
+			state.pendingPreflight = { toolCallId: entry.toolCallId, turnId: entry.turnId, command, completion };
+			return flushed;
+		}
+		return [...flushPendingPreflight(state), ...completion];
 	}
 	if (params.item.type === 'webSearch') {
 		const query = describeWebSearch(params.item.query, params.item.action);
@@ -874,6 +987,10 @@ export function mapTurnCompleted(
 	state.currentTurnId = undefined;
 	state.itemToPartId.clear();
 	state.itemToReasoningPartId.clear();
+	// Finalize any command whose completion was deferred to coalesce a possible
+	// sandbox pre-flight (see ICodexSessionMapState.pendingPreflight) — it was
+	// never reused, so it is a genuine output-less command and must complete.
+	const preflightFlush = flushPendingPreflight(state);
 	const orphanedToolCalls = [...state.itemToToolCall.values()];
 	state.itemToToolCall.clear();
 	const turnId = params.turn.id;
@@ -892,6 +1009,7 @@ export function mapTurnCompleted(
 	if (status === 'failed' && params.turn.error) {
 		const errMessage = params.turn.error.message ?? 'Codex turn failed';
 		return [
+			...preflightFlush,
 			...orphanedToolCallActions,
 			{
 				type: ActionType.ChatError,
@@ -908,9 +1026,9 @@ export function mapTurnCompleted(
 		];
 	}
 	if (status === 'interrupted') {
-		return [...orphanedToolCallActions, { type: ActionType.ChatTurnCancelled, turnId }];
+		return [...preflightFlush, ...orphanedToolCallActions, { type: ActionType.ChatTurnCancelled, turnId }];
 	}
-	return [...orphanedToolCallActions, { type: ActionType.ChatTurnComplete, turnId }];
+	return [...preflightFlush, ...orphanedToolCallActions, { type: ActionType.ChatTurnComplete, turnId }];
 }
 
 /**

--- a/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
@@ -10,6 +10,7 @@ import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallCont
 import { extractForwardedErrorInfo } from '../shared/forwardedChatError.js';
 import { getServerToolDisplay } from '../shared/serverToolGroups.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
+import { unwrapShellInvocation } from './codexShellCommand.js';
 import type { AgentMessageDeltaNotification } from './protocol/generated/v2/AgentMessageDeltaNotification.js';
 import type { CommandExecutionOutputDeltaNotification } from './protocol/generated/v2/CommandExecutionOutputDeltaNotification.js';
 import type { FileChangeOutputDeltaNotification } from './protocol/generated/v2/FileChangeOutputDeltaNotification.js';
@@ -29,6 +30,8 @@ import type { UserInput } from './protocol/generated/v2/UserInput.js';
 import type { WebSearchAction } from './protocol/generated/v2/WebSearchAction.js';
 import type { DynamicToolCallOutputContentItem } from './protocol/generated/v2/DynamicToolCallOutputContentItem.js';
 import type { JsonValue } from './protocol/generated/serde_json/JsonValue.js';
+import type { CollabAgentTool } from './protocol/generated/v2/CollabAgentTool.js';
+import type { CollabAgentState } from './protocol/generated/v2/CollabAgentState.js';
 
 /**
  * Per-session mutable state held by the mapper. Carries the bookkeeping
@@ -204,6 +207,71 @@ function mcpToolOutput(result: McpToolCallResult | null, errorMessage?: string):
 }
 
 /**
+ * Human labels for a Codex collab-agent (subagent) tool call, mirroring the
+ * reference client's phrasing. Codex surfaces subagent orchestration as
+ * `collabAgentToolCall` items on the parent thread — there is no separate
+ * child-thread event stream — so each collab tool call renders as a tool
+ * call in the parent chat.
+ */
+function collabAgentToolLabels(tool: CollabAgentTool): { readonly displayName: string; readonly present: string; readonly past: string } {
+	switch (tool) {
+		case 'spawnAgent': return { displayName: 'Spawn agent', present: 'Spawning agent', past: 'Spawned agent' };
+		case 'sendInput': return { displayName: 'Send input to agent', present: 'Sending input to agent', past: 'Sent input to agent' };
+		case 'resumeAgent': return { displayName: 'Resume agent', present: 'Resuming agent', past: 'Resumed agent' };
+		case 'wait': return { displayName: 'Wait for agents', present: 'Waiting for agents', past: 'Finished waiting' };
+		case 'closeAgent': return { displayName: 'Close agent', present: 'Closing agent', past: 'Closed agent' };
+		default: return { displayName: tool, present: tool, past: tool };
+	}
+}
+
+/** One-line summary of a spawned agent's state — the subagent's result. */
+function collabAgentStateSummary(state: CollabAgentState): string {
+	switch (state.status) {
+		case 'completed': return state.message ? `Completed — ${state.message}` : 'Completed';
+		case 'errored': return state.message ? `Errored — ${state.message}` : 'Errored';
+		case 'running': return state.message ? `Running — ${state.message}` : 'Running';
+		case 'interrupted': return state.message ? `Interrupted — ${state.message}` : 'Interrupted';
+		case 'pendingInit': return 'Pending init';
+		case 'shutdown': return 'Shutdown';
+		case 'notFound': return 'Not found';
+		default: return state.status;
+	}
+}
+
+/**
+ * Render the per-agent result block for a completed collab tool call. Prefers
+ * the receiver order, then appends any other agents present in `agentsStates`.
+ * The completed message carries the subagent's actual output.
+ */
+function collabAgentResultOutput(receiverThreadIds: readonly string[], agentsStates: { readonly [key: string]: CollabAgentState | undefined }): string {
+	const seen = new Set<string>();
+	const states: CollabAgentState[] = [];
+	for (const id of receiverThreadIds) {
+		const state = agentsStates[id];
+		if (state) {
+			states.push(state);
+			seen.add(id);
+		}
+	}
+	for (const id of Object.keys(agentsStates).sort()) {
+		if (seen.has(id)) {
+			continue;
+		}
+		const state = agentsStates[id];
+		if (state) {
+			states.push(state);
+		}
+	}
+	if (states.length === 0) {
+		return '';
+	}
+	if (states.length === 1) {
+		return collabAgentStateSummary(states[0]);
+	}
+	return states.map((state, index) => `Agent ${index + 1}: ${collabAgentStateSummary(state)}`).join('\n');
+}
+
+/**
  * Translate `turn/started` into a `ChatTurnStarted` action.
  *
  * Codex's `turn/started.turn.items[0]` SHOULD be the userMessage that
@@ -329,7 +397,7 @@ export function mapItemStarted(
 			toolName: 'shell',
 			output: '',
 		});
-		const command = params.item.command ?? '';
+		const command = unwrapShellInvocation(params.item.command ?? '');
 		return [
 			{
 				type: ActionType.ChatToolCallStart,
@@ -515,6 +583,48 @@ export function mapItemStarted(
 			} satisfies SessionAction | ChatAction] : []),
 		];
 	}
+	if (params.item.type === 'collabAgentToolCall') {
+		const toolCallId = generateUuid();
+		const labels = collabAgentToolLabels(params.item.tool);
+		const toolName = `codex.${params.item.tool}`;
+		const inputParts: string[] = [];
+		if (params.item.prompt) {
+			inputParts.push(params.item.prompt);
+		}
+		if (params.item.model) {
+			inputParts.push(`Model: ${params.item.model}`);
+		}
+		const toolInput = inputParts.join('\n\n');
+		state.itemToToolCall.set(params.item.id, {
+			toolCallId,
+			turnId: params.turnId,
+			toolName,
+			output: '',
+		});
+		return [
+			{
+				type: ActionType.ChatToolCallStart,
+				turnId: params.turnId,
+				toolCallId,
+				toolName,
+				displayName: labels.displayName,
+			},
+			...(toolInput ? [{
+				type: ActionType.ChatToolCallDelta,
+				turnId: params.turnId,
+				toolCallId,
+				content: toolInput,
+			} satisfies SessionAction | ChatAction] : []),
+			{
+				type: ActionType.ChatToolCallReady,
+				turnId: params.turnId,
+				toolCallId,
+				invocationMessage: labels.present,
+				toolInput,
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			},
+		];
+	}
 	return [];
 }
 
@@ -644,7 +754,7 @@ export function mapItemCompleted(
 	if (params.item.type === 'commandExecution') {
 		const success = params.item.status === 'completed' && (params.item.exitCode === 0 || params.item.exitCode === null);
 		const output = params.item.aggregatedOutput ?? entry.output;
-		const command = params.item.command ?? '';
+		const command = unwrapShellInvocation(params.item.command ?? '');
 		const exit = params.item.exitCode;
 		const pastTense = success
 			? `Ran \`${command}\``
@@ -729,6 +839,23 @@ export function mapItemCompleted(
 				pastTenseMessage: serverPastTense ?? (success ? `Called ${entry.toolName}` : `Failed to call ${entry.toolName}`),
 				content,
 				...(success ? {} : { error: { message: `Dynamic tool ${params.item.status}`, ...(declined ? { code: 'denied' } : {}) } }),
+			},
+		}];
+	}
+	if (params.item.type === 'collabAgentToolCall') {
+		const labels = collabAgentToolLabels(params.item.tool);
+		const success = params.item.status === 'completed';
+		const output = collabAgentResultOutput(params.item.receiverThreadIds, params.item.agentsStates) || entry.output;
+		const content = output ? [{ type: ToolResultContentType.Text as const, text: output }] : undefined;
+		return [{
+			type: ActionType.ChatToolCallComplete,
+			turnId: entry.turnId,
+			toolCallId: entry.toolCallId,
+			result: {
+				success,
+				pastTenseMessage: success ? labels.past : `${labels.displayName} failed`,
+				content,
+				...(success ? {} : { error: { message: `Collab agent ${params.item.status}`, ...(declined ? { code: 'denied' } : {}) } }),
 			},
 		}];
 	}

--- a/src/vs/platform/agentHost/node/codex/codexPromptResolver.ts
+++ b/src/vs/platform/agentHost/node/codex/codexPromptResolver.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { join } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
-import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/sessionState.js';
+import { MessageAttachmentKind, type MessageAttachment, type MessageEmbeddedResourceAttachment } from '../../common/state/sessionState.js';
 import type { UserInput } from './protocol/generated/v2/UserInput.js';
 import type { TextElement } from './protocol/generated/v2/TextElement.js';
 
@@ -26,6 +26,13 @@ import type { TextElement } from './protocol/generated/v2/TextElement.js';
  *    written to a temp file and surfaced as `{ type: 'localImage' }`. The
  *    returned files are tracked in `cleanupPaths` so the caller can unlink
  *    them after the turn completes.
+ *  - `EmbeddedResource` attachments carrying textual content (e.g. the live
+ *    text of an unsaved / dirty editor or a code selection, which the client
+ *    inlines as a `text/plain` embedded resource) are base64-decoded and
+ *    inlined into the prompt as a labelled fenced block so codex sees the
+ *    exact in-memory content — a path mention would read the stale on-disk
+ *    file (or nothing at all for untitled buffers). Non-textual, non-image
+ *    embedded resources (e.g. `application/pdf`) are still dropped.
  *
  * Skill / app mentions are deferred to a later phase.
  */
@@ -77,8 +84,23 @@ export function resolveCodexInput(
 							// attachment silently — better to send the prompt
 							// without the image than to fail the whole turn.
 						}
+						break;
 					}
-					// Non-image embedded resources are not yet supported.
+					if (isTextualContentType(att.contentType)) {
+						// The client inlines the live text of an unsaved / dirty
+						// editor (or a selection within one) as a `text/plain`
+						// embedded resource. Decode it and inline it into the
+						// prompt so codex sees the exact in-memory content — a
+						// `@<path>` mention would read the stale on-disk file (or
+						// nothing at all for an untitled buffer).
+						const inlined = renderTextualEmbeddedResource(att);
+						if (inlined) {
+							textChunks.push(inlined);
+						}
+						break;
+					}
+					// Non-textual, non-image embedded resources (e.g.
+					// application/pdf) are not supported and are dropped.
 					break;
 				}
 				case MessageAttachmentKind.Simple: {
@@ -117,4 +139,51 @@ function guessImageExtension(contentType: string): string {
 		default:
 			return '';
 	}
+}
+
+/**
+ * Whether an embedded resource's content type carries UTF-8 text that can be
+ * inlined into the prompt. Covers `text/*` plus a small allow-list of textual
+ * `application/*` types. Anything else (e.g. `application/pdf`,
+ * `application/octet-stream`) is treated as binary and dropped.
+ */
+function isTextualContentType(contentType: string): boolean {
+	const type = contentType.toLowerCase().split(';', 1)[0].trim();
+	if (type.startsWith('text/')) {
+		return true;
+	}
+	// Structured-text application subtypes and the `+json` / `+xml` suffixes.
+	return type === 'application/json'
+		|| type === 'application/xml'
+		|| type === 'application/javascript'
+		|| type === 'application/typescript'
+		|| type.endsWith('+json')
+		|| type.endsWith('+xml');
+}
+
+/**
+ * Decode a textual {@link MessageEmbeddedResourceAttachment} (e.g. the live
+ * text of an unsaved / dirty editor or a selection within one) and render it
+ * as a labelled fenced block for inlining into the prompt. Returns `undefined`
+ * when the payload decodes to empty text so the caller can skip it.
+ */
+function renderTextualEmbeddedResource(att: MessageEmbeddedResourceAttachment): string | undefined {
+	let content: string;
+	try {
+		content = Buffer.from(att.data, 'base64').toString('utf8');
+	} catch {
+		return undefined;
+	}
+	if (content.length === 0) {
+		return undefined;
+	}
+	const label = att.label || 'attachment';
+	const range = att.selection?.range;
+	// Positions on the wire are zero-based; render them one-based for humans.
+	const suffix = range
+		? ` (lines ${range.start.line + 1}-${range.end.line + 1})`
+		: '';
+	// A fenced block keeps the inlined text visually distinct from the prompt
+	// and prevents backtick-free content from bleeding into surrounding markup.
+	return `${label}${suffix}:\n\`\`\`\n${content}\n\`\`\``;
 }

--- a/src/vs/platform/agentHost/node/codex/codexProxyService.ts
+++ b/src/vs/platform/agentHost/node/codex/codexProxyService.ts
@@ -66,7 +66,40 @@ export const ICodexProxyService = createDecorator<ICodexProxyService>('codexProx
 interface ICodexProxyState {
 	/** Token cell — read fresh on each outbound request. */
 	githubToken: string;
+	/**
+	 * Most recent *primary* (non-reviewer) model id forwarded on this bind,
+	 * observed from normal turn requests. Used to remap the unsupported
+	 * auto-review reviewer model (see {@link CODEX_AUTO_REVIEW_MODEL}) onto a
+	 * model that is known to be supported by the Copilot CAPI. `undefined`
+	 * until the first primary request is seen.
+	 *
+	 * Bind-global, not per-session: the proxy is a single refcounted bind
+	 * shared by every concurrent Codex session and reviewer requests carry no
+	 * session identity, so this tracks the last primary model seen across all
+	 * sessions. Under the documented single-tenant assumption (one active model
+	 * at a time) that is correct; with two concurrent sessions on *different*
+	 * models where one uses Auto-review, the reviewer may run on the other
+	 * session's model. That only affects reviewer model choice, never
+	 * correctness of the primary turns (which are forwarded verbatim).
+	 */
+	lastPrimaryModel: string | undefined;
 }
+
+/**
+ * Model id the Codex app-server uses for its built-in auto-review reviewer
+ * (the "Auto-review" permissions preset routes eligible approvals through it).
+ *
+ * This is a specialized OpenAI model that is **not** part of the GitHub
+ * Copilot CAPI catalog, so forwarding it verbatim yields a 400
+ * `model_not_supported`. The app-server treats that as the review having
+ * *failed* and rejects the action inline ("Automatic approval review failed")
+ * without ever emitting an `item/autoApprovalReview/completed` notification —
+ * which breaks the entire Auto-review preset. We transparently remap it onto
+ * the session's primary model (see {@link ICodexProxyState.lastPrimaryModel})
+ * so the reviewer runs on a supported model; only the underlying model
+ * differs, the app-server's review instructions are unchanged.
+ */
+const CODEX_AUTO_REVIEW_MODEL = 'codex-auto-review';
 
 type ICodexProxyRuntime = ILoopbackProxyRuntime<ICodexProxyState>;
 
@@ -136,7 +169,7 @@ export class CodexProxyService extends LoopbackProxyServer<ICodexProxyState, str
 	}
 
 	protected createState(githubToken: string): ICodexProxyState {
-		return { githubToken };
+		return { githubToken, lastPrimaryModel: undefined };
 	}
 
 	async start(githubToken: string): Promise<ICodexProxyHandle> {
@@ -214,6 +247,17 @@ export class CodexProxyService extends LoopbackProxyServer<ICodexProxyState, str
 			writeJsonError(res, 400, 'invalid_request_error', `Failed to read request body: ${err instanceof Error ? err.message : String(err)}`);
 			return;
 		}
+
+		// Remap the unsupported auto-review reviewer model onto the session's
+		// primary model before forwarding, so the "Auto-review" preset works
+		// against the Copilot CAPI (which does not expose `codex-auto-review`).
+		// All downstream handling (dump, logging, forward) uses the outbound
+		// body so logs reflect exactly what is sent upstream.
+		const remap = remapCodexReviewerModel(body, runtime.state);
+		if (remap.remappedFrom) {
+			this._logService.info(`[${PROXY_USER_FACING_NAME}] remapped unsupported reviewer model '${remap.remappedFrom}' -> '${remap.remappedTo}'`);
+		}
+		body = remap.body;
 
 		const dumpDir = getDumpDir();
 		const dumpSeq = dumpDir ? nextDumpSeq() : undefined;
@@ -358,11 +402,47 @@ export class CodexProxyService extends LoopbackProxyServer<ICodexProxyState, str
 }
 
 /**
- * Build the headers forwarded to {@link ICopilotApiService.responses} from the
- * inbound codex request. Currently forwards `user-agent` (transformed via
- * {@link transformUserAgent}); the remaining outbound headers are supplied by
- * the API service itself.
+ * Compute the outbound `/v1/responses` body, transparently remapping the
+ * unsupported Codex auto-review reviewer model (see
+ * {@link CODEX_AUTO_REVIEW_MODEL}) onto the last-seen primary model. Records
+ * the primary model on `state` as a side effect so a later reviewer request
+ * can be remapped.
+ *
+ * Returns the original body untouched — and forwards verbatim, exactly as
+ * before — when it is unparseable, carries no `model`, already uses a primary
+ * model, or when no primary model has been observed yet (graceful
+ * degradation: the reviewer request still 400s, i.e. no worse than not
+ * remapping at all).
  */
+export function remapCodexReviewerModel(
+	body: string,
+	state: { lastPrimaryModel: string | undefined },
+): { readonly body: string; readonly remappedFrom?: string; readonly remappedTo?: string } {
+	let parsed: { model?: unknown };
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		return { body };
+	}
+	const model = typeof parsed.model === 'string' ? parsed.model : undefined;
+	if (!model) {
+		return { body };
+	}
+	if (model !== CODEX_AUTO_REVIEW_MODEL) {
+		// A normal turn request — remember its model so we can substitute it
+		// for a subsequent reviewer request.
+		state.lastPrimaryModel = model;
+		return { body };
+	}
+	const target = state.lastPrimaryModel;
+	if (!target) {
+		return { body };
+	}
+	(parsed as { model: string }).model = target;
+	return { body: JSON.stringify(parsed), remappedFrom: model, remappedTo: target };
+}
+
+
 function buildOutboundHeaders(inbound: http.IncomingHttpHeaders): Record<string, string> {
 	const out: Record<string, string> = {};
 	const userAgent = inbound['user-agent'];

--- a/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
@@ -4,11 +4,28 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { generateUuid } from '../../../../base/common/uuid.js';
-import { MessageKind, ResponsePartKind, type Turn, type ResponsePart } from '../../common/state/sessionState.js';
+import { toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
+import {
+	MessageKind,
+	ResponsePartKind,
+	ToolCallConfirmationReason,
+	ToolCallStatus,
+	ToolResultContentType,
+	type ResponsePart,
+	type ToolCallResponsePart,
+	type ToolResultContent,
+	type Turn,
+} from '../../common/state/sessionState.js';
+import {
+	describeFileChange,
+	describeWebSearch,
+	fileChangeOutput,
+	turnStateFromStatus,
+} from './codexMapAppServerEvents.js';
+import { unwrapShellInvocation } from './codexShellCommand.js';
 import type { Thread } from './protocol/generated/v2/Thread.js';
 import type { ThreadItem } from './protocol/generated/v2/ThreadItem.js';
 import type { Turn as CodexTurn } from './protocol/generated/v2/Turn.js';
-import { turnStateFromStatus } from './codexMapAppServerEvents.js';
 
 /**
  * Reconstruct protocol {@link Turn}s from codex's `thread/read` response.
@@ -18,13 +35,17 @@ import { turnStateFromStatus } from './codexMapAppServerEvents.js';
  * host's turn shape: each user message opens a turn; subsequent assistant
  * items become response parts on that turn until `turn/completed` closes it.
  *
- * Phase 3 produces:
- *  - `userMessage` → opens a `Turn` with `userMessage: { text }`
- *  - `agentMessage` → `MarkdownResponsePart` with the full text
- *  - everything else → currently dropped (Phase 6 will add tool/reasoning)
+ * Produces:
+ *  - `userMessage`      → opens a `Turn` with `userMessage: { text }`
+ *  - `agentMessage`     → `MarkdownResponsePart` with the full text
+ *  - `commandExecution` → completed terminal `ToolCallResponsePart`
+ *  - `webSearch`        → completed web-search `ToolCallResponsePart`
+ *  - `fileChange`       → completed file-edit `ToolCallResponsePart`
+ *  - everything else    → currently dropped (reasoning/plan/mcp/collab)
  *
- * Mirrors the live mapper's translation kernel so restored sessions render
- * identically to active ones.
+ * Mirrors the live mapper's translation kernel — including the sandbox
+ * pre-flight coalescing (see {@link codexMapAppServerEvents}) — so restored
+ * sessions render identically to active ones.
  */
 export function replayThreadToTurns(thread: Thread): Turn[] {
 	const turns: Turn[] = [];
@@ -37,10 +58,50 @@ export function replayThreadToTurns(thread: Thread): Turn[] {
 	return turns;
 }
 
+/** A completed `commandExecution` item narrowed to its terminal fields. */
+type CommandExecutionItem = Extract<ThreadItem, { type: 'commandExecution' }>;
+
 function replayTurnToTurn(codexTurn: CodexTurn): Turn | undefined {
 	let userText = '';
 	const parts: ResponsePart[] = [];
+	// A successful command that produced no output may be a sandbox pre-flight
+	// that codex immediately re-ran under an approval prompt (same command, new
+	// item). Defer emitting it so the re-run can coalesce into a single box —
+	// mirroring the live mapper's `pendingPreflight` state machine.
+	let pendingPreflight: { command: string; item: CommandExecutionItem } | undefined;
+	const flushPreflight = () => {
+		if (pendingPreflight) {
+			parts.push(shellToolCallPart(pendingPreflight.item, pendingPreflight.command));
+			pendingPreflight = undefined;
+		}
+	};
+
 	for (const item of codexTurn.items ?? []) {
+		if (item.type === 'commandExecution') {
+			const command = unwrapShellInvocation(item.command ?? '');
+			if (pendingPreflight && pendingPreflight.command === command) {
+				// Escalated re-run of the deferred pre-flight: render only this
+				// item (it carries the real output/approval), dropping the
+				// output-less pre-flight box.
+				pendingPreflight = undefined;
+				parts.push(shellToolCallPart(item, command));
+				continue;
+			}
+			flushPreflight();
+			const success = item.status === 'completed' && (item.exitCode === 0 || item.exitCode === null);
+			const output = item.aggregatedOutput ?? '';
+			if (success && !output) {
+				pendingPreflight = { command, item };
+				continue;
+			}
+			parts.push(shellToolCallPart(item, command));
+			continue;
+		}
+
+		// Any other item supersedes a deferred pre-flight: finalize it first so
+		// a genuinely output-less command still renders as a single box.
+		flushPreflight();
+
 		if (item.type === 'userMessage') {
 			const collected: string[] = [];
 			for (const c of item.content) {
@@ -59,10 +120,16 @@ function replayTurnToTurn(codexTurn: CodexTurn): Turn | undefined {
 					content: item.text,
 				});
 			}
+		} else if (item.type === 'webSearch') {
+			parts.push(webSearchToolCallPart(item));
+		} else if (item.type === 'fileChange') {
+			parts.push(fileChangeToolCallPart(item));
 		}
-		// Other item types (plan/reasoning/commandExecution/fileChange/…)
-		// are deferred to Phase 6.
+		// Other item types (plan/reasoning/mcpToolCall/collabAgentToolCall/…)
+		// are not yet reconstructed in replay.
 	}
+	flushPreflight();
+
 	// If we got nothing recognizable, drop the turn — there's nothing for
 	// the UI to render.
 	if (!userText && parts.length === 0) {
@@ -74,5 +141,77 @@ function replayTurnToTurn(codexTurn: CodexTurn): Turn | undefined {
 		responseParts: parts,
 		usage: undefined,
 		state: turnStateFromStatus(codexTurn.status),
+	};
+}
+
+function textContent(output: string): ToolResultContent[] | undefined {
+	return output ? [{ type: ToolResultContentType.Text, text: output }] : undefined;
+}
+
+function shellToolCallPart(item: CommandExecutionItem, command: string): ToolCallResponsePart {
+	const success = item.status === 'completed' && (item.exitCode === 0 || item.exitCode === null);
+	const output = item.aggregatedOutput ?? '';
+	const exit = item.exitCode;
+	const pastTense = success
+		? `Ran \`${command}\``
+		: exit !== null
+			? `Ran \`${command}\` (exit ${exit})`
+			: `Ran \`${command}\` (failed)`;
+	return {
+		kind: ResponsePartKind.ToolCall,
+		toolCall: {
+			status: ToolCallStatus.Completed,
+			toolCallId: generateUuid(),
+			toolName: 'shell',
+			displayName: 'Run shell command',
+			_meta: toToolCallMeta({ toolKind: 'terminal' }),
+			invocationMessage: command,
+			toolInput: command,
+			confirmed: ToolCallConfirmationReason.NotNeeded,
+			success,
+			pastTenseMessage: pastTense,
+			content: textContent(output),
+			error: success ? undefined : { message: exit !== null ? `Exit code ${exit}` : 'Command failed' },
+		},
+	};
+}
+
+function webSearchToolCallPart(item: Extract<ThreadItem, { type: 'webSearch' }>): ToolCallResponsePart {
+	const query = describeWebSearch(item.query, item.action);
+	return {
+		kind: ResponsePartKind.ToolCall,
+		toolCall: {
+			status: ToolCallStatus.Completed,
+			toolCallId: generateUuid(),
+			toolName: 'web_search',
+			displayName: 'Web search',
+			_meta: toToolCallMeta({ toolKind: 'search' }),
+			invocationMessage: query,
+			toolInput: query,
+			confirmed: ToolCallConfirmationReason.NotNeeded,
+			success: true,
+			pastTenseMessage: `Searched ${query}`,
+		},
+	};
+}
+
+function fileChangeToolCallPart(item: Extract<ThreadItem, { type: 'fileChange' }>): ToolCallResponsePart {
+	const success = item.status === 'completed';
+	const summary = describeFileChange(item.changes) || 'Apply file changes';
+	const output = fileChangeOutput(item.changes);
+	return {
+		kind: ResponsePartKind.ToolCall,
+		toolCall: {
+			status: ToolCallStatus.Completed,
+			toolCallId: generateUuid(),
+			toolName: 'file_edit',
+			displayName: 'Apply file changes',
+			invocationMessage: summary,
+			confirmed: ToolCallConfirmationReason.NotNeeded,
+			success,
+			pastTenseMessage: success ? 'Applied file changes' : 'Failed to apply file changes',
+			content: textContent(output),
+			error: success ? undefined : { message: `Patch ${item.status}` },
+		},
 	};
 }

--- a/src/vs/platform/agentHost/node/codex/codexSessionConfigKeys.ts
+++ b/src/vs/platform/agentHost/node/codex/codexSessionConfigKeys.ts
@@ -9,7 +9,7 @@ import type { Personality } from './protocol/generated/Personality.js';
 import type { WebSearchMode } from './protocol/generated/WebSearchMode.js';
 import type { ModeKind } from './protocol/generated/ModeKind.js';
 import type { SandboxMode } from './protocol/generated/v2/SandboxMode.js';
-import { CodexSessionConfigKey, narrowCodexPermissionsPreset, presetForResolvedPermissions, resolveCodexPermissionsPreset, type CodexApprovalPolicy, type ICodexResolvedPermissions } from '../../common/codexSessionConfigKeys.js';
+import { CodexSessionConfigKey, CODEX_DEFAULT_PERMISSIONS_PRESET, narrowCodexPermissionsPreset, presetForResolvedPermissions, resolveCodexPermissionsPreset, type CodexApprovalPolicy, type ICodexResolvedPermissions } from '../../common/codexSessionConfigKeys.js';
 
 // Re-export the shared, protocol-free config-key surface so node callers can
 // keep importing everything from this module.
@@ -82,8 +82,19 @@ export function resolveCodexPermissions(
  * - an explicitly chosen preset is kept as-is;
  * - legacy axes that map exactly onto a preset are migrated to that preset
  *   (single source of truth) and the raw axes dropped;
- * - legacy axes with no equivalent preset (e.g. `read-only`) are preserved
- *   verbatim and no preset is surfaced, so the legacy fallback keeps applying.
+ * - legacy axes with a `workspace-write` or `danger-full-access` sandbox that
+ *   do NOT map exactly onto a preset are snapped to the preset whose sandbox
+ *   matches (`default` / `full-access`). This keeps the resolved axes in sync
+ *   with the preset the "Approvals" chip displays, so a legacy
+ *   `approvalPolicy = 'never'` + `workspace-write` session resolves to the
+ *   `default` preset's `on-request` policy (and actually prompts) instead of
+ *   silently running without approval while the chip claims "Default
+ *   Permissions". Snapping never grants more sandbox access than the legacy
+ *   value already had;
+ * - legacy axes with a `read-only` sandbox (which no preset expands to, and
+ *   which is more locked-down than any preset) are preserved verbatim and no
+ *   preset is surfaced, so restore never silently escalates them to
+ *   `workspace-write`.
  */
 export function migrateCodexPermissionValues(
 	config: Record<string, unknown> | undefined,
@@ -98,9 +109,22 @@ export function migrateCodexPermissionValues(
 	if (equivalentPreset) {
 		return { [CodexSessionConfigKey.PermissionsPreset]: equivalentPreset };
 	}
+	// `read-only` is more locked-down than any preset's sandbox and cannot be
+	// represented by one, so preserve the raw axes — surfacing a preset here
+	// would silently escalate the session to `workspace-write` on restore.
+	if (resolved.sandboxMode === 'read-only') {
+		return {
+			[CodexSessionConfigKey.ApprovalPolicy]: resolved.approvalPolicy,
+			[CodexSessionConfigKey.SandboxMode]: resolved.sandboxMode,
+		};
+	}
+	// Otherwise snap onto the preset whose sandbox matches so the displayed chip
+	// and the resolved axes stay consistent (`danger-full-access` → Full Access,
+	// any other non-exact `workspace-write` combo → Default Permissions).
 	return {
-		[CodexSessionConfigKey.ApprovalPolicy]: resolved.approvalPolicy,
-		[CodexSessionConfigKey.SandboxMode]: resolved.sandboxMode,
+		[CodexSessionConfigKey.PermissionsPreset]: resolved.sandboxMode === 'danger-full-access'
+			? 'full-access'
+			: CODEX_DEFAULT_PERMISSIONS_PRESET,
 	};
 }
 

--- a/src/vs/platform/agentHost/node/codex/codexSessionConfigKeys.ts
+++ b/src/vs/platform/agentHost/node/codex/codexSessionConfigKeys.ts
@@ -7,22 +7,14 @@ import type { ReasoningEffort } from './protocol/generated/ReasoningEffort.js';
 import type { ReasoningSummary } from './protocol/generated/ReasoningSummary.js';
 import type { Personality } from './protocol/generated/Personality.js';
 import type { WebSearchMode } from './protocol/generated/WebSearchMode.js';
-import type { AskForApproval } from './protocol/generated/v2/AskForApproval.js';
 import type { ModeKind } from './protocol/generated/ModeKind.js';
 import type { SandboxMode } from './protocol/generated/v2/SandboxMode.js';
+import { CodexSessionConfigKey, narrowCodexPermissionsPreset, resolveCodexPermissionsPreset, type CodexApprovalPolicy, type ICodexResolvedPermissions } from '../../common/codexSessionConfigKeys.js';
 
-export const enum CodexSessionConfigKey {
-	ApprovalPolicy = 'codex.approvalPolicy',
-	SandboxMode = 'codex.sandboxMode',
-	AdditionalDirectories = 'codex.additionalDirectories',
-	NetworkAccessEnabled = 'codex.networkAccessEnabled',
-	WebSearchMode = 'codex.webSearchMode',
-	ModelReasoningEffort = 'codex.modelReasoningEffort',
-	Personality = 'codex.personality',
-	ReasoningSummary = 'codex.reasoningSummary',
-}
-
-export type CodexApprovalPolicy = Extract<AskForApproval, 'never' | 'on-request' | 'on-failure' | 'untrusted'>;
+// Re-export the shared, protocol-free config-key surface so node callers can
+// keep importing everything from this module.
+export { CodexSessionConfigKey, resolveCodexPermissionsPreset, narrowCodexPermissionsPreset, CODEX_PERMISSIONS_PRESETS, CODEX_DEFAULT_PERMISSIONS_PRESET } from '../../common/codexSessionConfigKeys.js';
+export type { CodexApprovalPolicy, CodexPermissionsPreset, CodexSandboxMode, CodexApprovalsReviewer, ICodexResolvedPermissions } from '../../common/codexSessionConfigKeys.js';
 
 export function narrowApprovalPolicy(value: unknown): CodexApprovalPolicy | undefined {
 	switch (value) {
@@ -45,6 +37,31 @@ export function narrowSandboxMode(value: unknown): SandboxMode | undefined {
 		default:
 			return undefined;
 	}
+}
+
+/**
+ * Resolve the Codex security axes (approval policy, sandbox, approvals
+ * reviewer) for a session's stored config values.
+ *
+ * The user-facing {@link CodexSessionConfigKey.PermissionsPreset} is the source
+ * of truth; when present it expands into all three axes. For backward
+ * compatibility (older sessions / programmatic config) we fall back to the
+ * individual {@link CodexSessionConfigKey.ApprovalPolicy} /
+ * {@link CodexSessionConfigKey.SandboxMode} keys with a `user` reviewer.
+ */
+export function resolveCodexPermissions(
+	values: Record<string, unknown> | undefined,
+	defaults: { approvalPolicy: CodexApprovalPolicy; sandboxMode: SandboxMode },
+): ICodexResolvedPermissions {
+	const preset = narrowCodexPermissionsPreset(values?.[CodexSessionConfigKey.PermissionsPreset]);
+	if (preset) {
+		return resolveCodexPermissionsPreset(preset);
+	}
+	return {
+		approvalPolicy: narrowApprovalPolicy(values?.[CodexSessionConfigKey.ApprovalPolicy]) ?? defaults.approvalPolicy,
+		sandboxMode: narrowSandboxMode(values?.[CodexSessionConfigKey.SandboxMode]) ?? defaults.sandboxMode,
+		approvalsReviewer: 'user',
+	};
 }
 
 export function narrowAdditionalDirectories(value: unknown): readonly string[] | undefined {

--- a/src/vs/platform/agentHost/node/codex/codexSessionConfigKeys.ts
+++ b/src/vs/platform/agentHost/node/codex/codexSessionConfigKeys.ts
@@ -9,11 +9,11 @@ import type { Personality } from './protocol/generated/Personality.js';
 import type { WebSearchMode } from './protocol/generated/WebSearchMode.js';
 import type { ModeKind } from './protocol/generated/ModeKind.js';
 import type { SandboxMode } from './protocol/generated/v2/SandboxMode.js';
-import { CodexSessionConfigKey, narrowCodexPermissionsPreset, resolveCodexPermissionsPreset, type CodexApprovalPolicy, type ICodexResolvedPermissions } from '../../common/codexSessionConfigKeys.js';
+import { CodexSessionConfigKey, narrowCodexPermissionsPreset, presetForResolvedPermissions, resolveCodexPermissionsPreset, type CodexApprovalPolicy, type ICodexResolvedPermissions } from '../../common/codexSessionConfigKeys.js';
 
 // Re-export the shared, protocol-free config-key surface so node callers can
 // keep importing everything from this module.
-export { CodexSessionConfigKey, resolveCodexPermissionsPreset, narrowCodexPermissionsPreset, CODEX_PERMISSIONS_PRESETS, CODEX_DEFAULT_PERMISSIONS_PRESET } from '../../common/codexSessionConfigKeys.js';
+export { CodexSessionConfigKey, resolveCodexPermissionsPreset, presetForResolvedPermissions, narrowCodexPermissionsPreset, CODEX_PERMISSIONS_PRESETS, CODEX_DEFAULT_PERMISSIONS_PRESET } from '../../common/codexSessionConfigKeys.js';
 export type { CodexApprovalPolicy, CodexPermissionsPreset, CodexSandboxMode, CodexApprovalsReviewer, ICodexResolvedPermissions } from '../../common/codexSessionConfigKeys.js';
 
 export function narrowApprovalPolicy(value: unknown): CodexApprovalPolicy | undefined {
@@ -61,6 +61,46 @@ export function resolveCodexPermissions(
 		approvalPolicy: narrowApprovalPolicy(values?.[CodexSessionConfigKey.ApprovalPolicy]) ?? defaults.approvalPolicy,
 		sandboxMode: narrowSandboxMode(values?.[CodexSessionConfigKey.SandboxMode]) ?? defaults.sandboxMode,
 		approvalsReviewer: 'user',
+	};
+}
+
+/**
+ * Decide how a restored session's three permission keys (`permissionsPreset`,
+ * `approvalPolicy`, `sandboxMode`) should be represented, given its raw
+ * persisted config values.
+ *
+ * This exists to prevent a silent privilege escalation on restore: a legacy
+ * session that persisted only the individual axes (for example
+ * `sandboxMode = 'read-only'`) and never chose a preset must not have a
+ * materialized `permissionsPreset = 'default'` inserted on top of it, because
+ * {@link resolveCodexPermissions} checks the preset first and would resume the
+ * session as `workspace-write`.
+ *
+ * The returned object contains ONLY the permission keys that should be present
+ * afterwards, so callers should drop all three permission keys before applying
+ * it:
+ * - an explicitly chosen preset is kept as-is;
+ * - legacy axes that map exactly onto a preset are migrated to that preset
+ *   (single source of truth) and the raw axes dropped;
+ * - legacy axes with no equivalent preset (e.g. `read-only`) are preserved
+ *   verbatim and no preset is surfaced, so the legacy fallback keeps applying.
+ */
+export function migrateCodexPermissionValues(
+	config: Record<string, unknown> | undefined,
+	defaults: { approvalPolicy: CodexApprovalPolicy; sandboxMode: SandboxMode },
+): Record<string, string> {
+	const explicitPreset = narrowCodexPermissionsPreset(config?.[CodexSessionConfigKey.PermissionsPreset]);
+	if (explicitPreset) {
+		return { [CodexSessionConfigKey.PermissionsPreset]: explicitPreset };
+	}
+	const resolved = resolveCodexPermissions(config, defaults);
+	const equivalentPreset = presetForResolvedPermissions(resolved);
+	if (equivalentPreset) {
+		return { [CodexSessionConfigKey.PermissionsPreset]: equivalentPreset };
+	}
+	return {
+		[CodexSessionConfigKey.ApprovalPolicy]: resolved.approvalPolicy,
+		[CodexSessionConfigKey.SandboxMode]: resolved.sandboxMode,
 	};
 }
 

--- a/src/vs/platform/agentHost/node/codex/codexShellCommand.ts
+++ b/src/vs/platform/agentHost/node/codex/codexShellCommand.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Codex reports a shell command as the exact invocation it hands to the OS —
+ * the user's login shell wrapping the actual script, e.g.
+ * `/bin/zsh -lc 'touch ~/foo'`. That wrapper is noise in the chat UI and makes
+ * Codex's terminal pills (and its approval / denial cards) look different from
+ * Claude's (which surface the bare `touch ~/foo`). Peel off a leading
+ * `<shell> -[l]c <script>` wrapper and return the inner script so both agents
+ * render identically. Falls back to the raw command when it doesn't match the
+ * wrapper shape.
+ *
+ * This is a display-only transform: callers must keep the raw command for any
+ * identity/round-trip purpose (accept-for-session memo keys, re-sending the
+ * exact action to the app-server, etc.).
+ */
+export function unwrapShellInvocation(command: string): string {
+	const match = /^\s*\S*sh(?:\.exe)?\s+-[a-z]*c\s+([\s\S]+)$/i.exec(command);
+	if (!match) {
+		return command;
+	}
+	return unquoteShellArg(match[1].trim());
+}
+
+/**
+ * Strips the surrounding quotes the shell wrapper added around a script
+ * argument and undoes the corresponding escaping (POSIX `'\''` for single
+ * quotes; backslash escapes for double quotes). Returns the argument unchanged
+ * when it is not quoted.
+ */
+function unquoteShellArg(arg: string): string {
+	if (arg.length >= 2 && arg[0] === '\'' && arg[arg.length - 1] === '\'') {
+		return arg.slice(1, -1).replace(/'\\''/g, '\'');
+	}
+	if (arg.length >= 2 && arg[0] === '"' && arg[arg.length - 1] === '"') {
+		return arg.slice(1, -1).replace(/\\(["\\$`])/g, '$1');
+	}
+	return arg;
+}

--- a/src/vs/platform/agentHost/test/node/codex/codexForkPlan.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexForkPlan.test.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { planForkedTurnIdMap, resolveForkBoundary } from '../../../node/codex/codexForkPlan.js';
+
+suite('codexForkPlan', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('resolveForkBoundary', () => {
+
+		test('locates the boundary by codex turn id (first / middle / last)', () => {
+			const ids = ['t0', 't1', 't2'];
+			assert.deepStrictEqual({
+				first: resolveForkBoundary(ids, 't0', -1),
+				middle: resolveForkBoundary(ids, 't1', -1),
+				last: resolveForkBoundary(ids, 't2', -1),
+			}, {
+				// Fork at t0 keeps 1 turn, drops the 2 trailing turns.
+				first: { resolved: true, keepThroughIndex: 0, numTurnsToDrop: 2 },
+				middle: { resolved: true, keepThroughIndex: 1, numTurnsToDrop: 1 },
+				// Fork at the tip keeps everything, drops nothing.
+				last: { resolved: true, keepThroughIndex: 2, numTurnsToDrop: 0 },
+			});
+		});
+
+		test('falls back to turnIndex when the id is not found', () => {
+			const ids = ['t0', 't1', 't2'];
+			assert.deepStrictEqual(
+				resolveForkBoundary(ids, 'missing', 1),
+				{ resolved: true, keepThroughIndex: 1, numTurnsToDrop: 1 },
+			);
+		});
+
+		test('rejects an unresolvable boundary instead of keeping full history', () => {
+			const ids = ['t0', 't1', 't2'];
+			assert.deepStrictEqual({
+				// id missing AND fallback index out of range → unresolved
+				negativeFallback: resolveForkBoundary(ids, 'missing', -1),
+				tooLargeFallback: resolveForkBoundary(ids, 'missing', 5),
+			}, {
+				negativeFallback: { resolved: false },
+				tooLargeFallback: { resolved: false },
+			});
+		});
+
+		test('treats an empty source thread as a valid empty fork', () => {
+			assert.deepStrictEqual(
+				resolveForkBoundary([], 'anything', -1),
+				{ resolved: true, keepThroughIndex: -1, numTurnsToDrop: 0 },
+			);
+		});
+	});
+
+	suite('planForkedTurnIdMap', () => {
+
+		test('maps new host ids to the forked thread\'s (regenerated) codex ids for a live source', () => {
+			// Live source: source session tracks codex→host ids; the fork remaps
+			// old host ids to new ones and regenerates the codex turn ids.
+			const sourceTurnIds = ['c0', 'c1', 'c2'];
+			const forkedTurnIds = ['f0', 'f1']; // t2 was rolled back
+			const hostBySourceCodex = new Map([['c0', 'h0'], ['c1', 'h1'], ['c2', 'h2']]);
+			const turnIdMapping = new Map([['h0', 'n0'], ['h1', 'n1'], ['h2', 'n2']]);
+
+			assert.deepStrictEqual(
+				planForkedTurnIdMap(sourceTurnIds, forkedTurnIds, /*keepThroughIndex*/ 1, hostBySourceCodex, turnIdMapping),
+				[['n0', 'f0'], ['n1', 'f1']],
+			);
+		});
+
+		test('uses the source codex id as the host id for a restored source (no host map)', () => {
+			// Restored source: no live host map, so old host id == source codex id.
+			const sourceTurnIds = ['c0', 'c1'];
+			const forkedTurnIds = ['c0', 'c1'];
+			const turnIdMapping = new Map([['c0', 'n0'], ['c1', 'n1']]);
+
+			assert.deepStrictEqual(
+				planForkedTurnIdMap(sourceTurnIds, forkedTurnIds, /*keepThroughIndex*/ 1, undefined, turnIdMapping),
+				[['n0', 'c0'], ['n1', 'c1']],
+			);
+		});
+
+		test('returns nothing when there is no turn-id mapping to apply', () => {
+			assert.deepStrictEqual({
+				undefinedMapping: planForkedTurnIdMap(['c0'], ['c0'], 0, undefined, undefined),
+				emptyMapping: planForkedTurnIdMap(['c0'], ['c0'], 0, undefined, new Map()),
+			}, {
+				undefinedMapping: [],
+				emptyMapping: [],
+			});
+		});
+
+		test('clamps to the number of forked turns actually present', () => {
+			// keepThroughIndex claims 3 kept turns but the forked read only
+			// returned 2 → only pair the turns we can resolve.
+			const turnIdMapping = new Map([['c0', 'n0'], ['c1', 'n1'], ['c2', 'n2']]);
+			assert.deepStrictEqual(
+				planForkedTurnIdMap(['c0', 'c1', 'c2'], ['c0', 'c1'], /*keepThroughIndex*/ 2, undefined, turnIdMapping),
+				[['n0', 'c0'], ['n1', 'c1']],
+			);
+		});
+
+		test('falls back to the old host id when the mapping lacks an entry', () => {
+			const turnIdMapping = new Map([['c0', 'n0']]);
+			assert.deepStrictEqual(
+				planForkedTurnIdMap(['c0', 'c1'], ['c0', 'c1'], /*keepThroughIndex*/ 1, undefined, turnIdMapping),
+				[['n0', 'c0'], ['c1', 'c1']],
+			);
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/codex/codexGuardianReview.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexGuardianReview.test.ts
@@ -1,0 +1,148 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { formatGuardianDenialNotification, summarizeGuardianReviewAction, toGuardianAssessmentEventJson } from '../../../node/codex/codexGuardianReview.js';
+import type { ItemGuardianApprovalReviewCompletedNotification } from '../../../node/codex/protocol/generated/v2/ItemGuardianApprovalReviewCompletedNotification.js';
+
+suite('codexGuardianReview', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const deniedNetworkReview: ItemGuardianApprovalReviewCompletedNotification = {
+		threadId: 'thread-1',
+		turnId: 'turn-1',
+		startedAtMs: 1234,
+		completedAtMs: 2345,
+		reviewId: 'review-1',
+		targetItemId: null,
+		decisionSource: 'agent',
+		review: {
+			status: 'denied',
+			riskLevel: 'critical',
+			userAuthorization: 'unknown',
+			rationale: 'Network access is not allowed for this prompt.',
+		},
+		action: {
+			type: 'networkAccess',
+			target: 'https://developers.openai.com/codex/app-server',
+			host: 'developers.openai.com',
+			protocol: 'https',
+			port: 443,
+		},
+	};
+
+	test('toGuardianAssessmentEventJson converts network review payloads to snake_case', () => {
+		assert.deepStrictEqual(toGuardianAssessmentEventJson(deniedNetworkReview), {
+			id: 'review-1',
+			turn_id: 'turn-1',
+			started_at_ms: 1234,
+			completed_at_ms: 2345,
+			status: 'denied',
+			risk_level: 'critical',
+			user_authorization: 'unknown',
+			rationale: 'Network access is not allowed for this prompt.',
+			decision_source: 'agent',
+			action: {
+				type: 'network_access',
+				target: 'https://developers.openai.com/codex/app-server',
+				host: 'developers.openai.com',
+				protocol: 'https',
+				port: 443,
+			},
+		});
+	});
+
+	test('summarizeGuardianReviewAction labels denied network access clearly', () => {
+		assert.deepStrictEqual(summarizeGuardianReviewAction(deniedNetworkReview.action), {
+			title: 'Network access',
+			detail: 'https://developers.openai.com/codex/app-server',
+			toolKind: 'search',
+		});
+	});
+
+	test('summarizeGuardianReviewAction unwraps the OS shell wrapper so the card matches the terminal pill', () => {
+		assert.deepStrictEqual({
+			command: summarizeGuardianReviewAction({
+				type: 'command', source: 'shell',
+				command: '/bin/zsh -lc \'rm -rf ~/secret\'', cwd: '/tmp',
+			} as never),
+			execve: summarizeGuardianReviewAction({
+				type: 'execve', source: 'shell',
+				program: '/bin/bash', argv: ['-lc', 'echo hi'], cwd: '/tmp',
+			} as never),
+		}, {
+			command: { title: 'Run command', detail: 'rm -rf ~/secret', toolKind: 'terminal' },
+			execve: { title: 'Run program', detail: 'echo hi', toolKind: 'terminal' },
+		});
+	});
+
+	const deniedPermissionsReview: ItemGuardianApprovalReviewCompletedNotification = {
+		threadId: 'thread-2',
+		turnId: 'turn-2',
+		startedAtMs: 10,
+		completedAtMs: 20,
+		reviewId: 'review-2',
+		targetItemId: null,
+		decisionSource: 'agent',
+		review: {
+			status: 'denied',
+			riskLevel: null,
+			userAuthorization: null,
+			rationale: null,
+		},
+		action: {
+			type: 'requestPermissions',
+			reason: 'Needs to read outside the workspace',
+			permissions: {
+				network: { enabled: true },
+				fileSystem: {
+					read: ['/etc/hosts'],
+					write: null,
+					globScanMaxDepth: 3,
+					entries: [{ path: { type: 'path', path: '/tmp/x' }, access: 'read' }],
+				},
+			},
+		},
+	};
+
+	test('toGuardianAssessmentEventJson snake_cases the requestPermissions profile', () => {
+		assert.deepStrictEqual(toGuardianAssessmentEventJson(deniedPermissionsReview), {
+			id: 'review-2',
+			turn_id: 'turn-2',
+			started_at_ms: 10,
+			completed_at_ms: 20,
+			status: 'denied',
+			decision_source: 'agent',
+			action: {
+				type: 'request_permissions',
+				reason: 'Needs to read outside the workspace',
+				permissions: {
+					network: { enabled: true },
+					file_system: {
+						read: ['/etc/hosts'],
+						write: null,
+						glob_scan_max_depth: 3,
+						entries: [{ path: { type: 'path', path: '/tmp/x' }, access: 'read' }],
+					},
+				},
+			},
+		});
+	});
+
+	test('formatGuardianDenialNotification renders the action summary and rationale as a distinct blockquote', () => {
+		assert.deepStrictEqual(
+			[
+				formatGuardianDenialNotification({ title: 'Network access', detail: 'https://example.com' }, 'Blocked for safety.'),
+				formatGuardianDenialNotification({ title: 'Elevated permissions', detail: '' }, null),
+			],
+			[
+				'\n\n> ⚠️ **Auto-review denied** — Network access: `https://example.com`\n>\n> Blocked for safety.\n',
+				'\n\n> ⚠️ **Auto-review denied** — Elevated permissions\n',
+			]
+		);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
@@ -220,6 +220,44 @@ suite('codexMapAppServerEvents', () => {
 		assert.deepStrictEqual((start as { _meta?: Record<string, unknown> })._meta, { toolKind: 'terminal' });
 	});
 
+	test('commandExecution unwraps the OS shell wrapper for display (start + completed)', () => {
+		const state = createCodexSessionMapState();
+		const started = mapItemStarted(state, {
+			item: {
+				type: 'commandExecution', id: 'cmd_wrap',
+				command: '/bin/zsh -lc \'touch ~/foo\'', cwd: '/tmp', processId: null,
+				source: 'agent' as never, status: 'inProgress' as never,
+				commandActions: [], aggregatedOutput: null,
+				exitCode: null, durationMs: null,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const delta = started[1] as { content: string };
+		const ready = started[2] as { invocationMessage: string; toolInput: string };
+		const completed = mapItemCompleted(state, {
+			item: {
+				type: 'commandExecution', id: 'cmd_wrap',
+				command: '/bin/zsh -lc \'touch ~/foo\'', cwd: '/tmp', processId: null,
+				source: 'agent' as never, status: 'completed' as never,
+				commandActions: [], aggregatedOutput: '',
+				exitCode: 0, durationMs: 4,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
+		});
+		const complete = completed[0] as { result: { pastTenseMessage: string } };
+		assert.deepStrictEqual({
+			delta: delta.content,
+			invocationMessage: ready.invocationMessage,
+			toolInput: ready.toolInput,
+			pastTenseMessage: complete.result.pastTenseMessage,
+		}, {
+			delta: 'touch ~/foo',
+			invocationMessage: 'touch ~/foo',
+			toolInput: 'touch ~/foo',
+			pastTenseMessage: 'Ran `touch ~/foo`',
+		});
+	});
+
 	test('item/commandExecution/outputDelta streams running tool content', () => {
 		const state = createCodexSessionMapState();
 		mapItemStarted(state, {
@@ -501,6 +539,130 @@ suite('codexMapAppServerEvents', () => {
 		}
 		assert.strictEqual(complete.result.success, false);
 		assert.strictEqual(complete.result.error?.code, 'denied');
+	});
+
+	test('collabAgentToolCall spawnAgent start emits tool-call lifecycle carrying the prompt and model', () => {
+		const state = createCodexSessionMapState();
+		const startActions = mapItemStarted(state, {
+			item: {
+				type: 'collabAgentToolCall', id: 'collab_1', tool: 'spawnAgent',
+				status: 'inProgress', senderThreadId: 'thr_1', receiverThreadIds: [],
+				prompt: 'Investigate the failing test', model: 'gpt-5.5',
+				reasoningEffort: null, agentsStates: {},
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const toolCallId = state.itemToToolCall.get('collab_1')!.toolCallId;
+		assert.deepStrictEqual({
+			actions: startActions,
+			entryToolName: state.itemToToolCall.get('collab_1')!.toolName,
+		}, {
+			actions: [
+				{ type: ActionType.ChatToolCallStart, turnId: 'turn_a', toolCallId, toolName: 'codex.spawnAgent', displayName: 'Spawn agent' },
+				{ type: ActionType.ChatToolCallDelta, turnId: 'turn_a', toolCallId, content: 'Investigate the failing test\n\nModel: gpt-5.5' },
+				{ type: ActionType.ChatToolCallReady, turnId: 'turn_a', toolCallId, invocationMessage: 'Spawning agent', toolInput: 'Investigate the failing test\n\nModel: gpt-5.5', confirmed: ToolCallConfirmationReason.NotNeeded },
+			],
+			entryToolName: 'codex.spawnAgent',
+		});
+	});
+
+	test('collabAgentToolCall spawnAgent completed renders the subagent result as tool output', () => {
+		const state = createCodexSessionMapState();
+		mapItemStarted(state, {
+			item: {
+				type: 'collabAgentToolCall', id: 'collab_2', tool: 'spawnAgent',
+				status: 'inProgress', senderThreadId: 'thr_1', receiverThreadIds: ['sub_1'],
+				prompt: 'Investigate the failing test', model: 'gpt-5.5',
+				reasoningEffort: null, agentsStates: {},
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const toolCallId = state.itemToToolCall.get('collab_2')!.toolCallId;
+		const actions = mapItemCompleted(state, {
+			item: {
+				type: 'collabAgentToolCall', id: 'collab_2', tool: 'spawnAgent',
+				status: 'completed', senderThreadId: 'thr_1', receiverThreadIds: ['sub_1'],
+				prompt: 'Investigate the failing test', model: 'gpt-5.5',
+				reasoningEffort: null,
+				agentsStates: { sub_1: { status: 'completed', message: 'Found the bug in foo.ts' } },
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
+		});
+		assert.deepStrictEqual({ actions, remainingToolCalls: state.itemToToolCall.size }, {
+			actions: [{
+				type: ActionType.ChatToolCallComplete, turnId: 'turn_a', toolCallId,
+				result: {
+					success: true,
+					pastTenseMessage: 'Spawned agent',
+					content: [{ type: ToolResultContentType.Text, text: 'Completed — Found the bug in foo.ts' }],
+				},
+			}],
+			remainingToolCalls: 0,
+		});
+	});
+
+	test('collabAgentToolCall wait aggregates results from multiple subagents', () => {
+		const state = createCodexSessionMapState();
+		mapItemStarted(state, {
+			item: {
+				type: 'collabAgentToolCall', id: 'collab_wait', tool: 'wait',
+				status: 'inProgress', senderThreadId: 'thr_1', receiverThreadIds: ['sub_1', 'sub_2'],
+				prompt: null, model: null, reasoningEffort: null, agentsStates: {},
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const toolCallId = state.itemToToolCall.get('collab_wait')!.toolCallId;
+		const actions = mapItemCompleted(state, {
+			item: {
+				type: 'collabAgentToolCall', id: 'collab_wait', tool: 'wait',
+				status: 'completed', senderThreadId: 'thr_1', receiverThreadIds: ['sub_1', 'sub_2'],
+				prompt: null, model: null, reasoningEffort: null,
+				agentsStates: {
+					sub_1: { status: 'completed', message: 'Migration finished' },
+					sub_2: { status: 'running', message: 'Still analysing' },
+				},
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
+		});
+		assert.deepStrictEqual(actions, [{
+			type: ActionType.ChatToolCallComplete, turnId: 'turn_a', toolCallId,
+			result: {
+				success: true,
+				pastTenseMessage: 'Finished waiting',
+				content: [{ type: ToolResultContentType.Text, text: 'Agent 1: Completed — Migration finished\nAgent 2: Running — Still analysing' }],
+			},
+		}]);
+	});
+
+	test('collabAgentToolCall failure reports the errored subagent state', () => {
+		const state = createCodexSessionMapState();
+		mapItemStarted(state, {
+			item: {
+				type: 'collabAgentToolCall', id: 'collab_fail', tool: 'spawnAgent',
+				status: 'inProgress', senderThreadId: 'thr_1', receiverThreadIds: ['sub_1'],
+				prompt: 'Refactor the parser', model: 'gpt-5.5', reasoningEffort: null, agentsStates: {},
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const toolCallId = state.itemToToolCall.get('collab_fail')!.toolCallId;
+		const actions = mapItemCompleted(state, {
+			item: {
+				type: 'collabAgentToolCall', id: 'collab_fail', tool: 'spawnAgent',
+				status: 'failed', senderThreadId: 'thr_1', receiverThreadIds: ['sub_1'],
+				prompt: 'Refactor the parser', model: 'gpt-5.5', reasoningEffort: null,
+				agentsStates: { sub_1: { status: 'errored', message: 'Model unavailable' } },
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
+		});
+		assert.deepStrictEqual(actions, [{
+			type: ActionType.ChatToolCallComplete, turnId: 'turn_a', toolCallId,
+			result: {
+				success: false,
+				pastTenseMessage: 'Spawn agent failed',
+				content: [{ type: ToolResultContentType.Text, text: 'Errored — Model unavailable' }],
+				error: { message: 'Collab agent failed' },
+			},
+		}]);
 	});
 
 	test('dynamicToolCall item carries a Client contributor when a client owns the tool', () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
@@ -234,7 +234,9 @@ suite('codexMapAppServerEvents', () => {
 		});
 		const delta = started[1] as { content: string };
 		const ready = started[2] as { invocationMessage: string; toolInput: string };
-		const completed = mapItemCompleted(state, {
+		// A successful no-output command is deferred to coalesce a possible
+		// sandbox pre-flight re-run; with no re-run it flushes at turn end.
+		const deferred = mapItemCompleted(state, {
 			item: {
 				type: 'commandExecution', id: 'cmd_wrap',
 				command: '/bin/zsh -lc \'touch ~/foo\'', cwd: '/tmp', processId: null,
@@ -244,17 +246,97 @@ suite('codexMapAppServerEvents', () => {
 			} as never,
 			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
 		});
-		const complete = completed[0] as { result: { pastTenseMessage: string } };
+		const flushed = mapTurnCompleted(state, {
+			threadId: 'thr_1',
+			turn: {
+				id: 'turn_a',
+				items: [], itemsView: { type: 'full' } as never,
+				status: 'completed' as never,
+				error: null, startedAt: null, completedAt: null, durationMs: null,
+			},
+		} as never);
+		const complete = flushed[0] as { result: { pastTenseMessage: string } };
 		assert.deepStrictEqual({
+			deferred,
 			delta: delta.content,
 			invocationMessage: ready.invocationMessage,
 			toolInput: ready.toolInput,
 			pastTenseMessage: complete.result.pastTenseMessage,
 		}, {
+			deferred: [],
 			delta: 'touch ~/foo',
 			invocationMessage: 'touch ~/foo',
 			toolInput: 'touch ~/foo',
 			pastTenseMessage: 'Ran `touch ~/foo`',
+		});
+	});
+
+	test('commandExecution coalesces a sandbox pre-flight with its approved re-run into one box', () => {
+		const state = createCodexSessionMapState();
+		// Pre-flight: codex runs the command in the sandbox first; it produces
+		// no output and completes successfully.
+		const preStarted = mapItemStarted(state, {
+			item: {
+				type: 'commandExecution', id: 'cmd_preflight',
+				command: 'curl -s https://example.com', cwd: '/tmp', processId: null,
+				source: 'agent' as never, status: 'inProgress' as never,
+				commandActions: [], aggregatedOutput: null, exitCode: null, durationMs: null,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const toolCallId = state.itemToToolCall.get('cmd_preflight')!.toolCallId;
+		const preCompleted = mapItemCompleted(state, {
+			item: {
+				type: 'commandExecution', id: 'cmd_preflight',
+				command: 'curl -s https://example.com', cwd: '/tmp', processId: null,
+				source: 'agent' as never, status: 'completed' as never,
+				commandActions: [], aggregatedOutput: '', exitCode: 0, durationMs: 4,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
+		});
+		// Escalation: same command re-run under an approval prompt, new item id.
+		const escStarted = mapItemStarted(state, {
+			item: {
+				type: 'commandExecution', id: 'cmd_escalated',
+				command: 'curl -s https://example.com', cwd: '/tmp', processId: null,
+				source: 'agent' as never, status: 'inProgress' as never,
+				commandActions: [], aggregatedOutput: null, exitCode: null, durationMs: null,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const escCompleted = mapItemCompleted(state, {
+			item: {
+				type: 'commandExecution', id: 'cmd_escalated',
+				command: 'curl -s https://example.com', cwd: '/tmp', processId: null,
+				source: 'agent' as never, status: 'completed' as never,
+				commandActions: [], aggregatedOutput: 'Example Domain', exitCode: 0, durationMs: 40,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
+		});
+		const startCount = (actions: readonly unknown[]) => actions.filter(a => (a as { type: ActionType }).type === ActionType.ChatToolCallStart).length;
+		assert.deepStrictEqual({
+			// exactly one box opened (pre-flight's), escalation reuses it
+			starts: startCount(preStarted) + startCount(escStarted),
+			// pre-flight completion deferred, escalation start emits nothing
+			preCompleted,
+			escStarted,
+			// single completion carries the escalation's real output
+			escComplete: escCompleted[0],
+		}, {
+			starts: 1,
+			preCompleted: [],
+			escStarted: [],
+			escComplete: {
+				type: ActionType.ChatToolCallComplete,
+				turnId: 'turn_a',
+				toolCallId,
+				result: {
+					success: true,
+					pastTenseMessage: 'Ran `curl -s https://example.com`',
+					content: [{ type: ToolResultContentType.Text, text: 'Example Domain' }],
+					error: undefined,
+				},
+			},
 		});
 	});
 
@@ -541,7 +623,7 @@ suite('codexMapAppServerEvents', () => {
 		assert.strictEqual(complete.result.error?.code, 'denied');
 	});
 
-	test('collabAgentToolCall spawnAgent start emits tool-call lifecycle carrying the prompt and model', () => {
+	test('collabAgentToolCall spawnAgent start renders compactly (no prompt dump — the peer chat shows it)', () => {
 		const state = createCodexSessionMapState();
 		const startActions = mapItemStarted(state, {
 			item: {
@@ -553,17 +635,38 @@ suite('codexMapAppServerEvents', () => {
 			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
 		});
 		const toolCallId = state.itemToToolCall.get('collab_1')!.toolCallId;
+		// spawnAgent opens a read-only peer chat (the host attaches the
+		// subagent-discovery block to this tool call), so the raw prompt is
+		// deliberately NOT dumped into the tool box.
 		assert.deepStrictEqual({
 			actions: startActions,
 			entryToolName: state.itemToToolCall.get('collab_1')!.toolName,
 		}, {
 			actions: [
 				{ type: ActionType.ChatToolCallStart, turnId: 'turn_a', toolCallId, toolName: 'codex.spawnAgent', displayName: 'Spawn agent' },
-				{ type: ActionType.ChatToolCallDelta, turnId: 'turn_a', toolCallId, content: 'Investigate the failing test\n\nModel: gpt-5.5' },
-				{ type: ActionType.ChatToolCallReady, turnId: 'turn_a', toolCallId, invocationMessage: 'Spawning agent', toolInput: 'Investigate the failing test\n\nModel: gpt-5.5', confirmed: ToolCallConfirmationReason.NotNeeded },
+				{ type: ActionType.ChatToolCallReady, turnId: 'turn_a', toolCallId, invocationMessage: 'Spawning agent', confirmed: ToolCallConfirmationReason.NotNeeded },
 			],
 			entryToolName: 'codex.spawnAgent',
 		});
+	});
+
+	test('collabAgentToolCall sendInput start still carries the prompt (only spawnAgent is compacted)', () => {
+		const state = createCodexSessionMapState();
+		const startActions = mapItemStarted(state, {
+			item: {
+				type: 'collabAgentToolCall', id: 'collab_si', tool: 'sendInput',
+				status: 'inProgress', senderThreadId: 'thr_1', receiverThreadIds: ['sub_1'],
+				prompt: 'Also check the CHANGELOG', model: null,
+				reasoningEffort: null, agentsStates: {},
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const toolCallId = state.itemToToolCall.get('collab_si')!.toolCallId;
+		assert.deepStrictEqual(startActions, [
+			{ type: ActionType.ChatToolCallStart, turnId: 'turn_a', toolCallId, toolName: 'codex.sendInput', displayName: 'Send input to agent' },
+			{ type: ActionType.ChatToolCallDelta, turnId: 'turn_a', toolCallId, content: 'Also check the CHANGELOG' },
+			{ type: ActionType.ChatToolCallReady, turnId: 'turn_a', toolCallId, invocationMessage: 'Sending input to agent', toolInput: 'Also check the CHANGELOG', confirmed: ToolCallConfirmationReason.NotNeeded },
+		]);
 	});
 
 	test('collabAgentToolCall spawnAgent completed renders the subagent result as tool output', () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexPromptResolver.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPromptResolver.test.ts
@@ -76,4 +76,38 @@ suite('codexPromptResolver', () => {
 		assert.strictEqual(input.length, 1);
 		assert.strictEqual(input[0].type, 'text');
 	});
+
+	test('textual EmbeddedResource (unsaved document) is inlined with label', () => {
+		const body = 'console.log("draft")';
+		const att: MessageAttachment = {
+			type: MessageAttachmentKind.EmbeddedResource,
+			label: 'Untitled-1',
+			displayKind: 'document',
+			data: Buffer.from(body).toString('base64'),
+			contentType: 'text/plain',
+		} as MessageAttachment;
+		const { input, cleanupPaths } = resolveCodexInput('review this', [att]);
+		assert.strictEqual(cleanupPaths.length, 0);
+		assert.strictEqual(input.length, 1);
+		const text = (input[0] as { text: string }).text;
+		assert.ok(text.includes('review this'), `text: ${text}`);
+		assert.ok(text.includes('Untitled-1'), `text: ${text}`);
+		assert.ok(text.includes(body), `text: ${text}`);
+	});
+
+	test('textual EmbeddedResource selection annotates a one-based line range', () => {
+		const body = 'second line\nthird line';
+		const att: MessageAttachment = {
+			type: MessageAttachmentKind.EmbeddedResource,
+			label: 'foo.ts',
+			displayKind: 'selection',
+			data: Buffer.from(body).toString('base64'),
+			contentType: 'text/plain',
+			selection: { range: { start: { line: 1, character: 0 }, end: { line: 2, character: 9 } } },
+		} as MessageAttachment;
+		const { input } = resolveCodexInput('explain', [att]);
+		const text = (input[0] as { text: string }).text;
+		assert.ok(text.includes('foo.ts (lines 2-3)'), `text: ${text}`);
+		assert.ok(text.includes(body), `text: ${text}`);
+	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexProxyService.test.ts
@@ -11,7 +11,7 @@ import {
 	type ICopilotApiService,
 	type ICopilotApiServiceRequestOptions,
 } from '../../../node/shared/copilotApiService.js';
-import { CodexProxyService } from '../../../node/codex/codexProxyService.js';
+import { CodexProxyService, remapCodexReviewerModel } from '../../../node/codex/codexProxyService.js';
 
 // #region Test fakes
 
@@ -139,6 +139,70 @@ suite('CodexProxyService', () => {
 				body: JSON.stringify({ model: 'gpt-5', stream: true, input: [] }),
 			});
 			assert.strictEqual(fake.responsesCalls.at(-1)?.options?.headers?.['User-Agent'], undefined);
+		});
+	});
+
+	test('remaps the unsupported auto-review reviewer model onto the last primary model', async () => {
+		await withProxy(async (handle, fake) => {
+			const headers = { 'Authorization': `Bearer ${handle.nonce}`, 'User-Agent': 'codex/1.0' };
+			// A normal turn establishes the session's primary model...
+			await postResponses(`${handle.baseUrl}/v1/responses`, {
+				headers,
+				body: JSON.stringify({ model: 'gpt-5.5', stream: true, input: [] }),
+			});
+			// ...then the auto-review reviewer fires with the unsupported model.
+			await postResponses(`${handle.baseUrl}/v1/responses`, {
+				headers,
+				body: JSON.stringify({ model: 'codex-auto-review', stream: true, input: [] }),
+			});
+			assert.deepStrictEqual(fake.responsesCalls.map(call => JSON.parse(call.body).model), ['gpt-5.5', 'gpt-5.5']);
+		});
+	});
+
+	test('forwards the auto-review reviewer model unchanged when no primary model has been seen', async () => {
+		await withProxy(async (handle, fake) => {
+			await postResponses(`${handle.baseUrl}/v1/responses`, {
+				headers: { 'Authorization': `Bearer ${handle.nonce}`, 'User-Agent': 'codex/1.0' },
+				body: JSON.stringify({ model: 'codex-auto-review', stream: true, input: [] }),
+			});
+			// Graceful degradation: nothing to remap onto, so the request is
+			// forwarded verbatim (and 400s upstream, exactly as before).
+			assert.strictEqual(JSON.parse(fake.responsesCalls.at(-1)!.body).model, 'codex-auto-review');
+		});
+	});
+
+	test('remaps the reviewer model onto the most recent primary model', async () => {
+		await withProxy(async (handle, fake) => {
+			const headers = { 'Authorization': `Bearer ${handle.nonce}`, 'User-Agent': 'codex/1.0' };
+			await postResponses(`${handle.baseUrl}/v1/responses`, { headers, body: JSON.stringify({ model: 'gpt-5.5', input: [] }) });
+			await postResponses(`${handle.baseUrl}/v1/responses`, { headers, body: JSON.stringify({ model: 'gpt-5-codex', input: [] }) });
+			await postResponses(`${handle.baseUrl}/v1/responses`, { headers, body: JSON.stringify({ model: 'codex-auto-review', input: [] }) });
+			assert.strictEqual(JSON.parse(fake.responsesCalls.at(-1)!.body).model, 'gpt-5-codex');
+		});
+	});
+
+	suite('remapCodexReviewerModel', () => {
+		test('records the primary model and leaves the body untouched', () => {
+			const state = { lastPrimaryModel: undefined as string | undefined };
+			const result = remapCodexReviewerModel(JSON.stringify({ model: 'gpt-5.5', input: [] }), state);
+			assert.deepStrictEqual({ remappedFrom: result.remappedFrom, lastPrimaryModel: state.lastPrimaryModel, model: JSON.parse(result.body).model }, { remappedFrom: undefined, lastPrimaryModel: 'gpt-5.5', model: 'gpt-5.5' });
+		});
+
+		test('remaps the reviewer model and reports the substitution', () => {
+			const state = { lastPrimaryModel: 'gpt-5.5' as string | undefined };
+			const result = remapCodexReviewerModel(JSON.stringify({ model: 'codex-auto-review', input: [] }), state);
+			assert.deepStrictEqual({ remappedFrom: result.remappedFrom, remappedTo: result.remappedTo, model: JSON.parse(result.body).model }, { remappedFrom: 'codex-auto-review', remappedTo: 'gpt-5.5', model: 'gpt-5.5' });
+		});
+
+		test('returns the original body for unparseable or model-less payloads', () => {
+			const state = { lastPrimaryModel: 'gpt-5.5' as string | undefined };
+			assert.deepStrictEqual({
+				unparseable: remapCodexReviewerModel('not json', state).body,
+				modelless: remapCodexReviewerModel(JSON.stringify({ input: [] }), state).body,
+			}, {
+				unparseable: 'not json',
+				modelless: JSON.stringify({ input: [] }),
+			});
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexReplayMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexReplayMapper.test.ts
@@ -105,4 +105,77 @@ suite('codexReplayMapper', () => {
 		} as never);
 		assert.deepStrictEqual(turns.map(t => t.id), ['t1', 't2']);
 	});
+
+	test('commandExecution renders a completed terminal tool call', () => {
+		const turns = replayThreadToTurns({
+			id: 'thr',
+			turns: [{
+				id: 'turn_a',
+				items: [
+					{ type: 'userMessage', id: 'u', content: [{ type: 'text', text: 'run it', text_elements: [] }] },
+					{
+						type: 'commandExecution', id: 'c1',
+						command: '/bin/zsh -lc \'ls -la\'', cwd: '/tmp', processId: null,
+						source: 'agent', status: 'completed',
+						commandActions: [], aggregatedOutput: 'total 0', exitCode: 0, durationMs: 5,
+					},
+				],
+				itemsView: { type: 'full' } as never,
+				status: 'completed' as never,
+				error: null, startedAt: null, completedAt: null, durationMs: null,
+			}],
+		} as never);
+		assert.strictEqual(turns.length, 1);
+		assert.strictEqual(turns[0].responseParts.length, 1);
+		const part = turns[0].responseParts[0] as { kind: ResponsePartKind; toolCall: { toolName: string; invocationMessage: string; pastTenseMessage: string; success: boolean; content?: { text: string }[] } };
+		assert.deepStrictEqual({
+			kind: part.kind,
+			toolName: part.toolCall.toolName,
+			invocationMessage: part.toolCall.invocationMessage,
+			pastTenseMessage: part.toolCall.pastTenseMessage,
+			success: part.toolCall.success,
+			output: part.toolCall.content?.[0].text,
+		}, {
+			kind: ResponsePartKind.ToolCall,
+			toolName: 'shell',
+			invocationMessage: 'ls -la',
+			pastTenseMessage: 'Ran `ls -la`',
+			success: true,
+			output: 'total 0',
+		});
+	});
+
+	test('commandExecution coalesces a sandbox pre-flight with its re-run into one box', () => {
+		const turns = replayThreadToTurns({
+			id: 'thr',
+			turns: [{
+				id: 'turn_a',
+				items: [
+					{ type: 'userMessage', id: 'u', content: [{ type: 'text', text: 'curl it', text_elements: [] }] },
+					// Pre-flight: same command, no output, success → deferred.
+					{
+						type: 'commandExecution', id: 'pre',
+						command: 'curl -s https://example.com', cwd: '/tmp', processId: null,
+						source: 'agent', status: 'completed',
+						commandActions: [], aggregatedOutput: '', exitCode: 0, durationMs: 3,
+					},
+					// Escalated re-run: same command, real output.
+					{
+						type: 'commandExecution', id: 'esc',
+						command: 'curl -s https://example.com', cwd: '/tmp', processId: null,
+						source: 'agent', status: 'completed',
+						commandActions: [], aggregatedOutput: 'Example Domain', exitCode: 0, durationMs: 30,
+					},
+				],
+				itemsView: { type: 'full' } as never,
+				status: 'completed' as never,
+				error: null, startedAt: null, completedAt: null, durationMs: null,
+			}],
+		} as never);
+		assert.strictEqual(turns.length, 1);
+		// Exactly one box — the pre-flight is coalesced away.
+		assert.strictEqual(turns[0].responseParts.length, 1);
+		const part = turns[0].responseParts[0] as { toolCall: { content?: { text: string }[] } };
+		assert.strictEqual(part.toolCall.content?.[0].text, 'Example Domain');
+	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import type { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { CodexSessionConfigKey, collaborationModeKind, narrowAdditionalDirectories, narrowApprovalPolicy, narrowBoolean, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowSandboxMode, narrowWebSearchMode } from '../../../node/codex/codexSessionConfigKeys.js';
+import { CodexSessionConfigKey, collaborationModeKind, narrowAdditionalDirectories, narrowApprovalPolicy, narrowBoolean, narrowCodexPermissionsPreset, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowSandboxMode, narrowWebSearchMode, resolveCodexPermissions, resolveCodexPermissionsPreset } from '../../../node/codex/codexSessionConfigKeys.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
@@ -38,6 +38,7 @@ suite('codexSessionConfigKeys', () => {
 		assert.deepStrictEqual({
 			approvalPolicy: [narrowApprovalPolicy('never'), narrowApprovalPolicy('on-request'), narrowApprovalPolicy('nope')],
 			sandboxMode: [narrowSandboxMode('read-only'), narrowSandboxMode('workspace-write'), narrowSandboxMode('folder')],
+			permissionsPreset: [narrowCodexPermissionsPreset('default'), narrowCodexPermissionsPreset('full-access'), narrowCodexPermissionsPreset('yolo')],
 			additionalDirectories: [narrowAdditionalDirectories(['/tmp/a', '', 1, '/tmp/b']), narrowAdditionalDirectories('nope')],
 			boolean: [narrowBoolean(true), narrowBoolean(false), narrowBoolean('true')],
 			webSearchMode: [narrowWebSearchMode('disabled'), narrowWebSearchMode('cached'), narrowWebSearchMode('online')],
@@ -48,6 +49,7 @@ suite('codexSessionConfigKeys', () => {
 		}, {
 			approvalPolicy: ['never', 'on-request', undefined],
 			sandboxMode: ['read-only', 'workspace-write', undefined],
+			permissionsPreset: ['default', 'full-access', undefined],
 			additionalDirectories: [['/tmp/a', '/tmp/b'], undefined],
 			boolean: [true, false, undefined],
 			webSearchMode: ['disabled', 'cached', undefined],
@@ -58,55 +60,55 @@ suite('codexSessionConfigKeys', () => {
 		});
 	});
 
-	test('resolveSessionConfig scopes Codex-specific config properties', async () => {
+	test('expands permissions presets and falls back to legacy axes', () => {
+		const legacyDefaults = { approvalPolicy: 'on-request' as const, sandboxMode: 'workspace-write' as const };
+		assert.deepStrictEqual({
+			presets: {
+				default: resolveCodexPermissionsPreset('default'),
+				autoReview: resolveCodexPermissionsPreset('auto-review'),
+				fullAccess: resolveCodexPermissionsPreset('full-access'),
+			},
+			// A stored preset is the source of truth and expands to all three axes.
+			fromPreset: resolveCodexPermissions({ [CodexSessionConfigKey.PermissionsPreset]: 'full-access' }, legacyDefaults),
+			// Without a preset, legacy per-axis keys are honored with a `user` reviewer.
+			fromLegacyKeys: resolveCodexPermissions({ [CodexSessionConfigKey.SandboxMode]: 'read-only', [CodexSessionConfigKey.ApprovalPolicy]: 'never' }, legacyDefaults),
+			// Empty config falls back entirely to the provided defaults.
+			fromDefaults: resolveCodexPermissions(undefined, legacyDefaults),
+		}, {
+			presets: {
+				default: { approvalPolicy: 'on-request', sandboxMode: 'workspace-write', approvalsReviewer: 'user' },
+				autoReview: { approvalPolicy: 'on-request', sandboxMode: 'workspace-write', approvalsReviewer: 'auto_review' },
+				fullAccess: { approvalPolicy: 'never', sandboxMode: 'danger-full-access', approvalsReviewer: 'user' },
+			},
+			fromPreset: { approvalPolicy: 'never', sandboxMode: 'danger-full-access', approvalsReviewer: 'user' },
+			fromLegacyKeys: { approvalPolicy: 'never', sandboxMode: 'read-only', approvalsReviewer: 'user' },
+			fromDefaults: { approvalPolicy: 'on-request', sandboxMode: 'workspace-write', approvalsReviewer: 'user' },
+		});
+	});
+
+	test('resolveSessionConfig exposes a single permissions-preset chip', async () => {
 		const agent = createAgent(disposables);
 
-		const readOnly = await agent.resolveSessionConfig({ config: { [CodexSessionConfigKey.SandboxMode]: 'read-only' } });
-		const workspaceWrite = await agent.resolveSessionConfig({ config: { [CodexSessionConfigKey.SandboxMode]: 'workspace-write' } });
+		const defaulted = await agent.resolveSessionConfig({ config: {} });
+		const fullAccess = await agent.resolveSessionConfig({ config: { [CodexSessionConfigKey.PermissionsPreset]: 'full-access' } });
 
 		assert.deepStrictEqual({
-			readOnlyProperties: Object.keys(readOnly.schema.properties).filter(key => key.startsWith('codex.')).sort(),
-			readOnlyMode: readOnly.values[SessionConfigKey.Mode],
-			readOnlyValues: {
-				[CodexSessionConfigKey.ApprovalPolicy]: readOnly.values[CodexSessionConfigKey.ApprovalPolicy],
-				[CodexSessionConfigKey.SandboxMode]: readOnly.values[CodexSessionConfigKey.SandboxMode],
-				[CodexSessionConfigKey.WebSearchMode]: readOnly.values[CodexSessionConfigKey.WebSearchMode],
-				[CodexSessionConfigKey.Personality]: readOnly.values[CodexSessionConfigKey.Personality],
-				[CodexSessionConfigKey.ReasoningSummary]: readOnly.values[CodexSessionConfigKey.ReasoningSummary],
+			// The visible schema is reduced to Mode + one permissions preset + Permissions.
+			schemaProperties: Object.keys(defaulted.schema.properties).sort(),
+			// Codex drops "Autopilot" (no native equivalent — it would duplicate
+			// "Interactive"), so the Mode picker offers only interactive + plan.
+			modeEnum: defaulted.schema.properties[SessionConfigKey.Mode].enum,
+			defaultedValues: {
+				mode: defaulted.values[SessionConfigKey.Mode],
+				preset: defaulted.values[CodexSessionConfigKey.PermissionsPreset],
 			},
-			workspaceWriteProperties: Object.keys(workspaceWrite.schema.properties).filter(key => key.startsWith('codex.')).sort(),
-			workspaceWriteValues: {
-				additionalDirectories: workspaceWrite.values[CodexSessionConfigKey.AdditionalDirectories],
-				networkAccessEnabled: workspaceWrite.values[CodexSessionConfigKey.NetworkAccessEnabled],
-			},
+			// The preset is session-mutable and echoed back unchanged.
+			fullAccessPreset: fullAccess.values[CodexSessionConfigKey.PermissionsPreset],
 		}, {
-			readOnlyProperties: [
-				CodexSessionConfigKey.ApprovalPolicy,
-				CodexSessionConfigKey.SandboxMode,
-				CodexSessionConfigKey.WebSearchMode,
-				CodexSessionConfigKey.Personality,
-				CodexSessionConfigKey.ReasoningSummary,
-			].sort(),
-			readOnlyMode: 'interactive',
-			readOnlyValues: {
-				[CodexSessionConfigKey.ApprovalPolicy]: 'on-request',
-				[CodexSessionConfigKey.SandboxMode]: 'read-only',
-				[CodexSessionConfigKey.WebSearchMode]: 'disabled',
-				[CodexSessionConfigKey.Personality]: 'none',
-				[CodexSessionConfigKey.ReasoningSummary]: 'auto',
-			},
-			workspaceWriteProperties: [
-				CodexSessionConfigKey.ApprovalPolicy,
-				CodexSessionConfigKey.NetworkAccessEnabled,
-				CodexSessionConfigKey.SandboxMode,
-				CodexSessionConfigKey.WebSearchMode,
-				CodexSessionConfigKey.Personality,
-				CodexSessionConfigKey.ReasoningSummary,
-			].sort(),
-			workspaceWriteValues: {
-				additionalDirectories: undefined,
-				networkAccessEnabled: false,
-			},
+			schemaProperties: [SessionConfigKey.Mode, CodexSessionConfigKey.PermissionsPreset, SessionConfigKey.Permissions].sort(),
+			modeEnum: ['interactive', 'plan'],
+			defaultedValues: { mode: 'interactive', preset: 'default' },
+			fullAccessPreset: 'full-access',
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import type { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { CodexSessionConfigKey, collaborationModeKind, narrowAdditionalDirectories, narrowApprovalPolicy, narrowBoolean, narrowCodexPermissionsPreset, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowSandboxMode, narrowWebSearchMode, resolveCodexPermissions, resolveCodexPermissionsPreset } from '../../../node/codex/codexSessionConfigKeys.js';
+import { CodexSessionConfigKey, collaborationModeKind, migrateCodexPermissionValues, narrowAdditionalDirectories, narrowApprovalPolicy, narrowBoolean, narrowCodexPermissionsPreset, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowSandboxMode, narrowWebSearchMode, presetForResolvedPermissions, resolveCodexPermissions, resolveCodexPermissionsPreset } from '../../../node/codex/codexSessionConfigKeys.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
@@ -109,6 +109,78 @@ suite('codexSessionConfigKeys', () => {
 			modeEnum: ['interactive', 'plan'],
 			defaultedValues: { mode: 'interactive', preset: 'default' },
 			fullAccessPreset: 'full-access',
+		});
+	});
+
+	test('inverts presets and migrates legacy axes without escalating', () => {
+		const defaults = { approvalPolicy: 'on-request' as const, sandboxMode: 'workspace-write' as const };
+		assert.deepStrictEqual({
+			// Every preset round-trips through expand → invert; a `read-only`
+			// sandbox is not representable by any preset.
+			invert: {
+				default: presetForResolvedPermissions(resolveCodexPermissionsPreset('default')),
+				autoReview: presetForResolvedPermissions(resolveCodexPermissionsPreset('auto-review')),
+				fullAccess: presetForResolvedPermissions(resolveCodexPermissionsPreset('full-access')),
+				readOnly: presetForResolvedPermissions({ approvalPolicy: 'on-request', sandboxMode: 'read-only', approvalsReviewer: 'user' }),
+			},
+			// An explicit preset is kept verbatim.
+			explicit: migrateCodexPermissionValues({ [CodexSessionConfigKey.PermissionsPreset]: 'auto-review' }, defaults),
+			// Legacy axes equal to a preset are migrated to it (raw axes dropped).
+			migrated: migrateCodexPermissionValues({ [CodexSessionConfigKey.SandboxMode]: 'workspace-write', [CodexSessionConfigKey.ApprovalPolicy]: 'on-request' }, defaults),
+			// Legacy `read-only` axes are preserved verbatim with NO preset — the
+			// escalation the reviewer flagged.
+			preserved: migrateCodexPermissionValues({ [CodexSessionConfigKey.SandboxMode]: 'read-only' }, defaults),
+			// Empty config resolves to the default preset.
+			empty: migrateCodexPermissionValues(undefined, defaults),
+		}, {
+			invert: { default: 'default', autoReview: 'auto-review', fullAccess: 'full-access', readOnly: undefined },
+			explicit: { [CodexSessionConfigKey.PermissionsPreset]: 'auto-review' },
+			migrated: { [CodexSessionConfigKey.PermissionsPreset]: 'default' },
+			preserved: { [CodexSessionConfigKey.ApprovalPolicy]: 'on-request', [CodexSessionConfigKey.SandboxMode]: 'read-only' },
+			empty: { [CodexSessionConfigKey.PermissionsPreset]: 'default' },
+		});
+	});
+
+	test('resolveSessionConfig preserves legacy read-only permissions on restore', async () => {
+		const agent = createAgent(disposables);
+		const legacyDefaults = { approvalPolicy: 'on-request' as const, sandboxMode: 'workspace-write' as const };
+
+		// A pre-preset session persisted only the individual axes (read-only)
+		// plus an unrelated non-permission setting.
+		const legacy = await agent.resolveSessionConfig({
+			config: {
+				[CodexSessionConfigKey.SandboxMode]: 'read-only',
+				[CodexSessionConfigKey.ApprovalPolicy]: 'on-request',
+				[CodexSessionConfigKey.ModelReasoningEffort]: 'high',
+			},
+		});
+		// A legacy session whose axes map exactly onto a preset is migrated to it.
+		const migratable = await agent.resolveSessionConfig({
+			config: {
+				[CodexSessionConfigKey.SandboxMode]: 'danger-full-access',
+				[CodexSessionConfigKey.ApprovalPolicy]: 'never',
+			},
+		});
+
+		assert.deepStrictEqual({
+			// read-only has no equivalent preset: axes preserved, NO preset
+			// inserted, and the effective permissions stay read-only.
+			legacyPreset: legacy.values[CodexSessionConfigKey.PermissionsPreset],
+			legacySandbox: legacy.values[CodexSessionConfigKey.SandboxMode],
+			legacyEffective: resolveCodexPermissions(legacy.values, legacyDefaults),
+			// Non-permission settings survive the restore round-trip.
+			legacyEffort: legacy.values[CodexSessionConfigKey.ModelReasoningEffort],
+			// danger-full-access + never == the full-access preset: migrated, raw
+			// axes dropped.
+			migratablePreset: migratable.values[CodexSessionConfigKey.PermissionsPreset],
+			migratableSandbox: migratable.values[CodexSessionConfigKey.SandboxMode],
+		}, {
+			legacyPreset: undefined,
+			legacySandbox: 'read-only',
+			legacyEffective: { approvalPolicy: 'on-request', sandboxMode: 'read-only', approvalsReviewer: 'user' },
+			legacyEffort: 'high',
+			migratablePreset: 'full-access',
+			migratableSandbox: undefined,
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
@@ -127,6 +127,13 @@ suite('codexSessionConfigKeys', () => {
 			explicit: migrateCodexPermissionValues({ [CodexSessionConfigKey.PermissionsPreset]: 'auto-review' }, defaults),
 			// Legacy axes equal to a preset are migrated to it (raw axes dropped).
 			migrated: migrateCodexPermissionValues({ [CodexSessionConfigKey.SandboxMode]: 'workspace-write', [CodexSessionConfigKey.ApprovalPolicy]: 'on-request' }, defaults),
+			// A legacy `never` + `workspace-write` combo has no exact preset but is
+			// snapped onto `default` so the chip and the resolved (on-request) axes
+			// stay in sync instead of running without ever prompting.
+			snappedDefault: migrateCodexPermissionValues({ [CodexSessionConfigKey.SandboxMode]: 'workspace-write', [CodexSessionConfigKey.ApprovalPolicy]: 'never' }, defaults),
+			// A legacy off-preset `danger-full-access` combo is snapped onto
+			// `full-access` so the chip honestly reflects the full machine access.
+			snappedFullAccess: migrateCodexPermissionValues({ [CodexSessionConfigKey.SandboxMode]: 'danger-full-access', [CodexSessionConfigKey.ApprovalPolicy]: 'on-request' }, defaults),
 			// Legacy `read-only` axes are preserved verbatim with NO preset — the
 			// escalation the reviewer flagged.
 			preserved: migrateCodexPermissionValues({ [CodexSessionConfigKey.SandboxMode]: 'read-only' }, defaults),
@@ -136,6 +143,8 @@ suite('codexSessionConfigKeys', () => {
 			invert: { default: 'default', autoReview: 'auto-review', fullAccess: 'full-access', readOnly: undefined },
 			explicit: { [CodexSessionConfigKey.PermissionsPreset]: 'auto-review' },
 			migrated: { [CodexSessionConfigKey.PermissionsPreset]: 'default' },
+			snappedDefault: { [CodexSessionConfigKey.PermissionsPreset]: 'default' },
+			snappedFullAccess: { [CodexSessionConfigKey.PermissionsPreset]: 'full-access' },
 			preserved: { [CodexSessionConfigKey.ApprovalPolicy]: 'on-request', [CodexSessionConfigKey.SandboxMode]: 'read-only' },
 			empty: { [CodexSessionConfigKey.PermissionsPreset]: 'default' },
 		});

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -177,6 +177,9 @@ export class ChatView extends AbstractChatView {
 				rendererOptions: {
 					referencesExpandedWhenEmptyResponse: false,
 					progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask,
+					// Wrap long lines in response code blocks so command/tool output pasted
+					// by the agent stays compact instead of overflowing horizontally.
+					codeBlockRenderOptions: { editorOptions: { wordWrap: 'on' } },
 				},
 				enableImplicitContext: true,
 				enableWorkingSet: 'implicit',

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -179,7 +179,12 @@ export class ChatView extends AbstractChatView {
 					progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask,
 					// Wrap long lines in response code blocks so command/tool output pasted
 					// by the agent stays compact instead of overflowing horizontally.
-					codeBlockRenderOptions: { editorOptions: { wordWrap: 'on' } },
+					// `wrappingIndent: 'none'` makes wrapped continuations start at column 1
+					// instead of inheriting the source line's indentation. Without it, monaco's
+					// default (`'same'`) injects the leading indent as real whitespace at every
+					// wrap boundary, which corrupts the rendered text's DOM `textContent`
+					// (splitting tokens mid-word) and breaks smoke tests that read it.
+					codeBlockRenderOptions: { editorOptions: { wordWrap: 'on', wrappingIndent: 'none' } },
 				},
 				enableImplicitContext: true,
 				enableWorkingSet: 'implicit',

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostCodexApprovalsPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostCodexApprovalsPicker.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { IObservable } from '../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { ActionListItemKind, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
+import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { CodexSessionConfigKey } from '../../../../../platform/agentHost/common/codexSessionConfigKeys.js';
+import { SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
+import { AgentHostSessionEnumPicker, IAgentHostSessionEnumPickerItem } from './agentHostModePicker.js';
+import { isWellKnownCodexApprovalsSchema } from './agentHostPermissionPickerDelegate.js';
+
+const CODEX_APPROVALS_LEARN_MORE_URL = 'https://developers.openai.com/codex/concepts/sandboxing#how-you-control-it';
+const LEARN_MORE_VALUE = '__agentHostCodexApprovalsPicker.learnMore__';
+
+function getCodexApprovalsIcon(value: string | undefined): ThemeIcon | undefined {
+	switch (value) {
+		case 'default': return Codicon.shield;
+		case 'auto-review': return Codicon.sparkle;
+		case 'full-access': return Codicon.warning;
+		default: return undefined;
+	}
+}
+
+/**
+ * Picker widget for the Codex `codex.permissionsPreset` session-config
+ * property. Codex collapses its three security axes (sandbox × approval policy
+ * × approvals reviewer) into a single user-facing preset, so this presents one
+ * "Approvals" chip whose options mirror the Codex app's permissions selector.
+ */
+export class AgentHostCodexApprovalsPicker extends AgentHostSessionEnumPicker {
+
+	protected readonly _property = CodexSessionConfigKey.PermissionsPreset;
+	protected readonly _pickerId = 'agentHostCodexApprovalsPicker';
+	protected readonly _telemetryId = 'NewChatAgentHostCodexApprovalsPicker';
+
+	constructor(
+		session: IObservable<IActiveSession | undefined>,
+		@IActionWidgetService actionWidgetService: IActionWidgetService,
+		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IHoverService hoverService: IHoverService,
+		@IOpenerService private readonly _openerService: IOpenerService,
+	) {
+		super(session, actionWidgetService, sessionsProvidersService, telemetryService, hoverService);
+	}
+
+	protected _isWellKnownSchema(schema: SessionConfigPropertySchema): boolean {
+		return isWellKnownCodexApprovalsSchema(schema);
+	}
+
+	protected _getTriggerIcon(value: string | undefined): ThemeIcon | undefined {
+		return getCodexApprovalsIcon(value);
+	}
+
+	protected _getActionItemIcon(item: IAgentHostSessionEnumPickerItem): ThemeIcon | undefined {
+		return getCodexApprovalsIcon(item.value);
+	}
+
+	protected _getTriggerAriaLabel(label: string): string {
+		return localize('agentHostCodexApprovalsPicker.triggerAriaLabel', "Pick Approvals, {0}", label);
+	}
+
+	protected _getWidgetAriaLabel(): string {
+		return localize('agentHostCodexApprovalsPicker.ariaLabel', "Approvals Picker");
+	}
+
+	protected override _getFooterActionItems(): readonly IActionListItem<IAgentHostSessionEnumPickerItem>[] {
+		const learnMoreLabel = localize('codexApprovals.learnMore', "Learn more about permissions");
+		return [
+			{
+				kind: ActionListItemKind.Separator,
+				label: '',
+			},
+			{
+				kind: ActionListItemKind.Action,
+				label: learnMoreLabel,
+				group: { title: '', icon: Codicon.blank },
+				item: {
+					value: LEARN_MORE_VALUE,
+					label: learnMoreLabel,
+				},
+			},
+		];
+	}
+
+	protected override _handleFooterActionItem(item: IAgentHostSessionEnumPickerItem): boolean {
+		if (item.value !== LEARN_MORE_VALUE) {
+			return false;
+		}
+		void this._openerService.open(URI.parse(CODEX_APPROVALS_LEARN_MORE_URL));
+		return true;
+	}
+}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerDelegate.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerDelegate.ts
@@ -8,6 +8,7 @@ import { derived, IObservable, IReader, observableSignal } from '../../../../../
 import { localize } from '../../../../../nls.js';
 import { KNOWN_AUTO_APPROVE_VALUES, SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { narrowClaudePermissionMode } from '../../../../../platform/agentHost/common/claudeSessionConfigKeys.js';
+import { narrowCodexPermissionsPreset } from '../../../../../platform/agentHost/common/codexSessionConfigKeys.js';
 import { SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { ChatConfiguration, ChatPermissionLevel, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { IPermissionLevelMeta, IPermissionPickerDelegate } from '../../copilotChatSessions/browser/permissionPicker.js';
@@ -19,6 +20,7 @@ import { IActiveSession } from '../../../../services/sessions/common/sessionsMan
 const REQUIRED_AUTO_APPROVE_VALUE = 'default';
 const REQUIRED_MODE_VALUE = 'interactive';
 const REQUIRED_PERMISSION_MODE_VALUE = 'default';
+const REQUIRED_CODEX_APPROVALS_VALUE = 'default';
 
 /**
  * Returns `true` when an `autoApprove` session-config property uses the
@@ -208,4 +210,23 @@ export function isWellKnownClaudePermissionModeSchema(schema: SessionConfigPrope
 		return false;
 	}
 	return schema.enum.every(value => narrowClaudePermissionMode(value) !== undefined);
+}
+
+/**
+ * Returns `true` when a `codex.permissionsPreset` session-config property uses
+ * the Codex permissions-preset value set and includes `default`.
+ *
+ * Codex collapses its three security axes (sandbox × approval policy ×
+ * approvals reviewer) into a single user-facing preset; this guard lets the
+ * dedicated {@link AgentHostCodexApprovalsPicker} claim the property while the
+ * generic per-property picker stands down.
+ */
+export function isWellKnownCodexApprovalsSchema(schema: SessionConfigPropertySchema): boolean {
+	if (schema.type !== 'string' || !Array.isArray(schema.enum) || schema.enum.length === 0) {
+		return false;
+	}
+	if (!schema.enum.includes(REQUIRED_CODEX_APPROVALS_VALUE)) {
+		return false;
+	}
+	return schema.enum.every(value => narrowCodexPermissionsPreset(value) !== undefined);
 }

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -51,10 +51,12 @@ import { showMobilePickerSheet, IMobilePickerSheetItem, IMobilePickerSheetSearch
 import { AgentHostModePicker } from './agentHostModePicker.js';
 import { MobileAgentHostModePicker } from './mobile/mobileAgentHostModePicker.js';
 import { AgentHostPermissionPickerActionItem } from './agentHostPermissionPickerActionItem.js';
-import { AgentHostPermissionPickerDelegate, isWellKnownAutoApproveSchema, isWellKnownClaudePermissionModeSchema, isWellKnownModeSchema } from './agentHostPermissionPickerDelegate.js';
+import { AgentHostPermissionPickerDelegate, isWellKnownAutoApproveSchema, isWellKnownClaudePermissionModeSchema, isWellKnownCodexApprovalsSchema, isWellKnownModeSchema } from './agentHostPermissionPickerDelegate.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { AgentHostClaudePermissionModePicker } from './agentHostClaudePermissionModePicker.js';
 import { ClaudeSessionConfigKey } from '../../../../../platform/agentHost/common/claudeSessionConfigKeys.js';
+import { AgentHostCodexApprovalsPicker } from './agentHostCodexApprovalsPicker.js';
+import { CodexSessionConfigKey } from '../../../../../platform/agentHost/common/codexSessionConfigKeys.js';
 
 const IsActiveSessionRemoteAgentHost = ContextKeyExpr.regex(SessionProviderIdContext.key, REMOTE_AGENT_HOST_PROVIDER_RE);
 const IsActiveSessionLocalAgentHost = ContextKeyExpr.equals(SessionProviderIdContext.key, LOCAL_AGENT_HOST_PROVIDER_ID);
@@ -324,6 +326,12 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			// Claude's permissionMode has a dedicated Claude-native picker so
 			// it doesn't render as a generic enum chip.
 			if (property === ClaudeSessionConfigKey.PermissionMode && isWellKnownClaudePermissionModeSchema(schema)) {
+				continue;
+			}
+			// Codex's permissions preset has a dedicated Codex-native picker
+			// (a single "Approvals" chip) so it doesn't render as a generic
+			// enum chip.
+			if (property === CodexSessionConfigKey.PermissionsPreset && isWellKnownCodexApprovalsSchema(schema)) {
 				continue;
 			}
 			const value = resolvedConfig.values[property] ?? schema.default;
@@ -890,6 +898,14 @@ class AgentHostSessionConfigPickerContribution extends Disposable implements IWo
 			},
 		));
 		this._register(actionViewItemService.register(
+			Menus.NewSessionControl,
+			NEW_SESSION_CODEX_APPROVALS_PICKER_ID,
+			(_action, _options, scopedInstantiationService) => {
+				const { session } = scopedInstantiationService.invokeFunction(accessor => accessor.get(ISessionContext));
+				return new PickerActionViewItem(scopedInstantiationService.createInstance(AgentHostCodexApprovalsPicker, session));
+			},
+		));
+		this._register(actionViewItemService.register(
 			MenuId.ChatInputSecondary,
 			RUNNING_SESSION_CONFIG_PICKER_ID,
 			this._createRunningSessionPermissionPickerFactory(),
@@ -900,6 +916,14 @@ class AgentHostSessionConfigPickerContribution extends Disposable implements IWo
 			(_action, _options, scopedInstantiationService) => {
 				const { session } = scopedInstantiationService.invokeFunction(accessor => accessor.get(ISessionContext));
 				return new PickerActionViewItem(scopedInstantiationService.createInstance(AgentHostClaudePermissionModePicker, session));
+			},
+		));
+		this._register(actionViewItemService.register(
+			MenuId.ChatInputSecondary,
+			RUNNING_SESSION_CODEX_APPROVALS_PICKER_ID,
+			(_action, _options, scopedInstantiationService) => {
+				const { session } = scopedInstantiationService.invokeFunction(accessor => accessor.get(ISessionContext));
+				return new PickerActionViewItem(scopedInstantiationService.createInstance(AgentHostCodexApprovalsPicker, session));
 			},
 		));
 	}
@@ -983,6 +1007,32 @@ registerAction2(class extends Action2 {
 	override async run(): Promise<void> { }
 });
 
+// ---- New session Codex approvals picker (NewSessionControl) ----
+// Codex-specific "Approvals" chip. Shares the NewSessionControl navigation
+// group with the Claude permission-mode picker (order 2); the two are
+// mutually exclusive because each hides itself when the active session's
+// schema doesn't expose its backing property.
+
+const NEW_SESSION_CODEX_APPROVALS_PICKER_ID = 'sessions.agentHost.newSessionCodexApprovalsPicker';
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: NEW_SESSION_CODEX_APPROVALS_PICKER_ID,
+			title: localize2('agentHostNewSessionCodexApprovalsPicker', "Approvals"),
+			f1: false,
+			menu: [{
+				id: Menus.NewSessionControl,
+				group: 'navigation',
+				order: 3,
+				when: ContextKeyExpr.or(IsActiveSessionLocalAgentHost, IsActiveSessionRemoteAgentHost),
+			}],
+		});
+	}
+
+	override async run(): Promise<void> { }
+});
+
 // ---- New session mode picker (NewSessionControl) ----
 
 const NEW_SESSION_MODE_PICKER_ID = 'sessions.agentHost.newSessionModePicker';
@@ -1046,6 +1096,31 @@ registerAction2(class extends Action2 {
 				id: MenuId.ChatInputSecondary,
 				group: 'navigation',
 				order: 11,
+				when: ChatContextKeyExprs.isAgentHostSession,
+			}],
+		});
+	}
+
+	override async run(): Promise<void> { }
+});
+
+// ---- Running session Codex approvals picker (ChatInputSecondary) ----
+// Codex-specific "Approvals" chip for a running session. Mutually exclusive
+// with the Claude permission-mode picker (order 11) — each hides when its
+// backing property is absent from the active session's schema.
+
+const RUNNING_SESSION_CODEX_APPROVALS_PICKER_ID = 'sessions.agentHost.runningSessionCodexApprovalsPicker';
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: RUNNING_SESSION_CODEX_APPROVALS_PICKER_ID,
+			title: localize2('agentHostRunningSessionCodexApprovalsPicker', "Approvals"),
+			f1: false,
+			menu: [{
+				id: MenuId.ChatInputSecondary,
+				group: 'navigation',
+				order: 12,
 				when: ChatContextKeyExprs.isAgentHostSession,
 			}],
 		});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
@@ -18,6 +18,7 @@ import { localize } from '../../../../../../nls.js';
 import { IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
 import { KNOWN_AUTO_APPROVE_VALUES, SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { ClaudeSessionConfigKey } from '../../../../../../platform/agentHost/common/claudeSessionConfigKeys.js';
+import { CodexSessionConfigKey } from '../../../../../../platform/agentHost/common/codexSessionConfigKeys.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import type { ResolveSessionConfigResult, SessionConfigPropertySchema, SessionConfigValueItem } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
 import type { SessionState } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
@@ -81,6 +82,13 @@ function getConfigIcon(property: string, value: unknown | undefined): ThemeIcon 
 			case 'bypassPermissions': return Codicon.warning;
 		}
 	}
+	if (property === CodexSessionConfigKey.PermissionsPreset && typeof value === 'string') {
+		switch (value) {
+			case 'default': return Codicon.shield;
+			case 'auto-review': return Codicon.sparkle;
+			case 'full-access': return Codicon.warning;
+		}
+	}
 	return undefined;
 }
 
@@ -128,6 +136,9 @@ function getEnumValueDescription(schema: SessionConfigPropertySchema, value: unk
 }
 
 export function getConfigPickerTriggerHover(property: string, schema: SessionConfigPropertySchema, value: unknown | undefined, isReadOnly: boolean): string {
+	if (property === CodexSessionConfigKey.PermissionsPreset) {
+		return getEnumValueDescription(schema, value) ?? schema.description ?? schema.title;
+	}
 	if (property !== SessionConfigKey.AutoApprove) {
 		return schema.description ?? schema.title;
 	}
@@ -216,6 +227,7 @@ export const WELL_KNOWN_PICKER_PROPERTIES: ReadonlySet<string> = new Set<string>
 	SessionConfigKey.WorktreeBranchPrefix,
 	SessionConfigKey.WorktreeIncludeFiles,
 	ClaudeSessionConfigKey.PermissionMode,
+	CodexSessionConfigKey.PermissionsPreset,
 ]);
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -26,7 +26,7 @@ import { isLocation, type Location } from '../../../../../../editor/common/langu
 import type { ITextModel } from '../../../../../../editor/common/model.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { localize } from '../../../../../../nls.js';
-import { AgentProvider, AgentSession, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentProvider, AgentSession, CODEX_AGENT_PROVIDER_ID, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
 import { agentHostAuthority } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
 import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
@@ -4004,8 +4004,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				existingKeys.add(key);
 			}
 		}
-		// Non-Copilot-CLI backends can't read an untitled buffer, so don't forward it as a broken path.
-		const skipUntitled = this._config.provider !== SessionType.CopilotCLI;
+		// Backends that read files from disk can't see an untitled buffer, so don't forward it as a
+		// broken path unless we inline its live text below.
+		const skipUntitled = !this._backendInlinesUnsavedEditors();
 		for (const entry of implicitContext.values) {
 			if (entry.value === undefined) {
 				continue;
@@ -4054,6 +4055,16 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}
 		const { start, end } = selection.range;
 		return `${uri}#${start.line}:${start.character}-${end.line}:${end.character}`;
+	}
+
+	/**
+	 * Whether this backend reads referenced files from disk (rather than seeing the editor's
+	 * in-memory buffer) and therefore needs the live text of an unsaved / dirty editor inlined as
+	 * an embedded resource. Copilot CLI and Codex both run as separate processes with only disk
+	 * access, so a `@path` mention (or an `untitled:` URI) would give them stale or missing content.
+	 */
+	private _backendInlinesUnsavedEditors(): boolean {
+		return this._config.provider === SessionType.CopilotCLI || this._config.provider === CODEX_AGENT_PROVIDER_ID;
 	}
 
 	/** A resource is unsaved when it's untitled or a saved file with in-memory (dirty) changes. */
@@ -4143,8 +4154,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 	private _convertVariableToAttachment(v: IChatRequestVariableEntry, sessionResource: URI, messageText?: string): MessageAttachment | MessageAttachment[] | undefined {
 		const referenceRange = this._toAttachmentReferenceRange(messageText, v.range);
-		// Copilot CLI can't read unsaved content from disk, so inline the live buffer; drop unreadable schemes.
-		if ((v.kind === 'file' || v.kind === 'implicit') && this._config.provider === SessionType.CopilotCLI) {
+		// Copilot CLI and Codex can't read unsaved content from disk, so inline the live buffer; drop unreadable schemes.
+		if ((v.kind === 'file' || v.kind === 'implicit') && this._backendInlinesUnsavedEditors()) {
 			const uri = isLocation(v.value) ? v.value.uri : (v.value instanceof URI ? v.value : undefined);
 			if (uri && this._isUnsavedResource(uri)) {
 				const embedded = this._buildUnsavedEditorAttachment(uri, v, referenceRange);

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -27,7 +27,7 @@ import { ChatAttachmentModel } from './attachments/chatAttachmentModel.js';
 import { IChatEditorOptions } from './widgetHosts/editor/chatEditor.js';
 import { ChatInputPart } from './widget/input/chatInputPart.js';
 import { ChatWidget, IChatWidgetContrib } from './widget/chatWidget.js';
-import { ICodeBlockActionContext } from './widget/chatContentParts/codeBlockPart.js';
+import { ICodeBlockActionContext, ICodeBlockRenderOptions } from './widget/chatContentParts/codeBlockPart.js';
 import { AgentSessionTarget } from './agentSessions/agentSessions.js';
 
 /**
@@ -262,6 +262,11 @@ export interface IChatListItemRendererOptions {
 	readonly referencesExpandedWhenEmptyResponse?: boolean | ((mode: ChatModeKind) => boolean);
 	readonly progressMessageAtBottomOfResponse?: boolean | ((mode: ChatModeKind) => boolean);
 	readonly contentHorizontalPadding?: number;
+	/**
+	 * Render options applied to code blocks in response markdown (e.g. force word-wrap
+	 * so command/tool output pasted by the model wraps instead of overflowing).
+	 */
+	readonly codeBlockRenderOptions?: ICodeBlockRenderOptions;
 }
 
 export interface IChatWidgetViewOptions {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1009,7 +1009,13 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 	private async _toggleOutput(expanded: boolean): Promise<boolean> {
 		const didChange = await this._outputView.toggle(expanded);
 		const isExpanded = this._outputView.isExpanded;
-		this._titleElement.classList.toggle('chat-terminal-content-title-no-bottom-radius', isExpanded);
+		// Only drop the title's bottom border/radius when the output section is
+		// actually rendered below the title to visually close the box. Display-only
+		// invocations (e.g. a denied command with no terminal session or output) never
+		// append the output section (see constructor), so removing the title's bottom
+		// border here would leave an open-bottomed box.
+		const hasOutputSection = !!this._outputView.domNode.parentElement;
+		this._titleElement.classList.toggle('chat-terminal-content-title-no-bottom-radius', isExpanded && hasOutputSection);
 		this._toolbarOutputExpanded = isExpanded;
 		this._updateToolbarActions();
 		if (didChange) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -3473,7 +3473,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 		const fillInIncompleteTokens = isResponseVM(element) && (!element.isComplete || element.isCanceled || element.errorDetails?.responseIsFiltered || element.errorDetails?.responseIsIncomplete || !!element.renderData);
 		const codeBlockStartIndex = context.codeBlockStartIndex;
-		const markdownPart = templateData.instantiationService.createInstance(ChatMarkdownContentPart, markdown, context, this._editorPool, fillInIncompleteTokens, codeBlockStartIndex, this.chatContentMarkdownRenderer, undefined, this._currentLayoutWidth.get(), {});
+		const markdownPart = templateData.instantiationService.createInstance(ChatMarkdownContentPart, markdown, context, this._editorPool, fillInIncompleteTokens, codeBlockStartIndex, this.chatContentMarkdownRenderer, undefined, this._currentLayoutWidth.get(), { codeBlockRenderOptions: this.rendererOptions.codeBlockRenderOptions });
 		markdownPart.addDisposable(markdownPart.onDidChangeHeight(() => this.fireItemHeightChange(templateData)));
 		if (isRequestVM(element)) {
 			markdownPart.domNode.tabIndex = 0;


### PR DESCRIPTION
> **Stacked PR — 2 of 2 (top).** Based on #325262 (the @openai/codex 0.142.0 protocol regeneration). Review/merge #325262 first; this PR's diff excludes the generated client. GitHub will retarget this PR to `main` automatically once #325262 merges.

The hand-written half of the Codex agent-host work. The large generated protocol client is in #325262 and is excluded from this diff, so what remains here is the actual logic.

### Highlights
- **Forking** — a Codex session can be forked from a prior turn (create-chat fork source wired through the agent).
- **Subagent rendering** — subagent results render properly in the chat transcript of a Codex session.
- **Single approvals chip** — replaces the sprawl of per-axis pickers with one permission chip mapping to the documented Codex presets (**Default permissions** / **Auto-review** / **Full access**) across the sandbox + approval-policy + reviewer axes.
- **Auto-review denial surfacing** — guardian denials become a durable, reload-safe notice plus an "Approve anyway" card, attributed to the correct turn, with the OS shell wrapper unwrapped so the command matches the terminal pill.
- **0.142.0 consumer adaptations** — discriminated `DynamicToolSpec`, the new `openai/form` elicitation mode, required `userMessage.clientId` / `McpServerStatus.serverInfo`.
- **Misc** — inline unsaved/dirty editor content as textual embedded resources; drop the no-op Autopilot mode; terminal tool-call rendering cleanup; AHP protocol state bump for the new session-config keys.

### Validation
- `npm run typecheck-client` clean; full node unit suite green (Codex guardian/proxy/prompt/config suites included).
- Live-verified in an Agents window: forking, subagent rendering, the approvals chip presets, and real auto-review denial surfacing (via a deny-all reviewer policy).
