### PR TITLE
NES: Correct line numbering for prompt context

### DIFF
--- a/extensions/copilot/src/extension/xtab/common/promptCrafting.ts
+++ b/extensions/copilot/src/extension/xtab/common/promptCrafting.ts
@@ -286,7 +286,7 @@ export function runGlobalBudgetCascade(
 			}
 			case 'languageContext': {
 				if (langCtx) {
-					tokensConsumed = appendLanguageContextSnippets(langCtx, langCtxSnippets, budget, computeTokens, opts.recentlyViewedDocuments.includeLineNumbers);
+					tokensConsumed = appendLanguageContextSnippets(langCtx, langCtxSnippets, budget, computeTokens);
 				}
 				break;
 			}

--- a/extensions/copilot/src/extension/xtab/common/recentFilesForPrompt.ts
+++ b/extensions/copilot/src/extension/xtab/common/recentFilesForPrompt.ts
@@ -55,7 +55,7 @@ export function getRecentCodeSnippets(
 
 	const langCtxSnippets: string[] = [];
 	if (langCtx) {
-		appendLanguageContextSnippets(langCtx, langCtxSnippets, opts.languageContext.maxTokens, computeTokens, opts.recentlyViewedDocuments.includeLineNumbers);
+		appendLanguageContextSnippets(langCtx, langCtxSnippets, opts.languageContext.maxTokens, computeTokens);
 	}
 
 	const neighborOutSnippets: string[] = [];
@@ -344,6 +344,7 @@ export function historyEntriesToCodeSnippet(entries: IXtabHistoryEntry[]): Recen
 
 /**
  * Append language context snippets to the snippets array, respecting the token budget.
+ * Language context snippets omit line numbers because providers do not report source ranges.
  *
  * @returns the number of tokens consumed (matches the same per-snippet accounting
  * the function uses internally for budget decisions).
@@ -353,7 +354,6 @@ export function appendLanguageContextSnippets(
 	snippets: string[],
 	tokenBudget: number,
 	computeTokens: (code: string) => number,
-	includeLineNumbers: xtabPromptOptions.IncludeLineNumbersOption,
 ): number {
 	const initialBudget = tokenBudget;
 	for (const langCtxEntry of langCtx.items) {
@@ -373,7 +373,11 @@ export function appendLanguageContextSnippets(
 				break;
 			}
 			const documentId = DocumentId.create(ctx.uri.toString());
-			snippets.push(formatCodeSnippet(documentId, langCtxSnippet.split(/\r?\n/), { truncated: false, includeLineNumbers, startLineOffset: 0 }));
+			snippets.push(formatCodeSnippet(documentId, langCtxSnippet.split(/\r?\n/), {
+				truncated: false,
+				includeLineNumbers: xtabPromptOptions.IncludeLineNumbersOption.None,
+				startLineOffset: 0,
+			}));
 			tokenBudget = potentialBudget;
 		}
 	}
@@ -752,4 +756,3 @@ function buildCodeSnippetsWithProportionalBudget(
 	// of the entire pool, so consumed = totalBudget - finalUnspentBudget.
 	return { snippets: result.snippets.reverse(), docsInPrompt: result.docsInPrompt, tokensConsumed: totalBudget - unspentBudget };
 }
-

--- a/extensions/copilot/src/extension/xtab/test/common/recentFilesForPrompt.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/common/recentFilesForPrompt.spec.ts
@@ -835,7 +835,7 @@ suite('appendNeighborFileSnippets', () => {
 		return { uri, relativePath: uri, snippet, lineRange: new LineRange0Based(startLine, startLine + lineCount), score };
 	}
 
-	test('appends snippets formatted like recent files', () => {
+	test('uses the original source line range when adding line numbers', () => {
 		const snippets: string[] = [];
 		const docsInPrompt = new Set<DocumentId>();
 		appendNeighborFileSnippets(
@@ -856,6 +856,27 @@ suite('appendNeighborFileSnippets', () => {
 			]
 		`);
 		expect(docsInPrompt.has(DocumentId.create('file:///src/n1.ts'))).toBe(true);
+	});
+
+	test('uses the original source line range without spacing after line numbers', () => {
+		const snippets: string[] = [];
+		appendNeighborFileSnippets(
+			[makeNeighbor('file:///src/n1.ts', 'a\nb', 12)],
+			snippets,
+			new Set<DocumentId>(),
+			/*tokenBudget*/ 100,
+			computeTokens,
+			IncludeLineNumbersOption.WithoutSpace,
+		);
+		expect(snippets).toMatchInlineSnapshot(`
+			[
+			  "<|recently_viewed_code_snippet|>
+			code_snippet_file_path: /src/n1.ts
+			12|a
+			13|b
+			<|/recently_viewed_code_snippet|>",
+			]
+		`);
 	});
 
 	test('skips oversize snippets but keeps trying smaller ones', () => {

--- a/extensions/copilot/src/extension/xtab/test/common/recentFilesForPrompt.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/common/recentFilesForPrompt.spec.ts
@@ -6,14 +6,17 @@
 import { expect, suite, test } from 'vitest';
 import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
 import { RootedEdit } from '../../../../platform/inlineEdits/common/dataTypes/edit';
+import { LanguageContextResponse } from '../../../../platform/inlineEdits/common/dataTypes/languageContext';
 import { DEFAULT_OPTIONS, IncludeLineNumbersOption, PromptOptions, RecentFileClippingStrategy } from '../../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { IXtabHistoryEditEntry, IXtabHistoryVisibleRangesEntry } from '../../../../platform/inlineEdits/common/workspaceEditTracker/nesXtabHistoryTracker';
+import { ContextKind } from '../../../../platform/languageServer/common/languageContextService';
 import { splitLines } from '../../../../util/vs/base/common/strings';
 import { StringEdit } from '../../../../util/vs/editor/common/core/edits/stringEdit';
 import { OffsetRange } from '../../../../util/vs/editor/common/core/ranges/offsetRange';
 import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
+import { Uri } from '../../../../vscodeTypes';
 import { LineRange0Based } from '../../common/lineRange';
-import { appendNeighborFileSnippets, buildCodeSnippetsUsingPagedClipping, computeFocalPageCost, historyEntriesToCodeSnippet, selectFocalRangesWithinSpanCap } from '../../common/recentFilesForPrompt';
+import { appendLanguageContextSnippets, appendNeighborFileSnippets, buildCodeSnippetsUsingPagedClipping, computeFocalPageCost, historyEntriesToCodeSnippet, selectFocalRangesWithinSpanCap } from '../../common/recentFilesForPrompt';
 import { INeighborFileSnippet } from '../../common/similarFilesContextService';
 
 function nLines(n: number): StringText {
@@ -825,6 +828,39 @@ suite('historyEntriesToCodeSnippet', () => {
 			new OffsetRange(0, 2),  // newerEntry's "XX"
 			new OffsetRange(2, 2),  // olderEntry's deletion point, shifted
 		]);
+	});
+});
+
+suite('appendLanguageContextSnippets', () => {
+
+	test('does not add line numbers without a source range', () => {
+		const languageContext: LanguageContextResponse = {
+			start: 0,
+			end: 0,
+			items: [{
+				context: {
+					kind: ContextKind.Snippet,
+					priority: 1,
+					uri: Uri.parse('file:///src/context.ts'),
+					value: 'first line\nsecond line',
+				},
+				timeStamp: 0,
+				onTimeout: false,
+			}],
+		};
+		const snippets: string[] = [];
+
+		appendLanguageContextSnippets(languageContext, snippets, 100, computeTokens);
+
+		expect(snippets).toMatchInlineSnapshot(`
+			[
+			  "<|recently_viewed_code_snippet|>
+			code_snippet_file_path: /src/context.ts
+			first line
+			second line
+			<|/recently_viewed_code_snippet|>",
+			]
+		`);
 	});
 });
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Language-context snippets do not expose source ranges, so assigning synthetic line numbers can misrepresent their actual locations.

This change keeps neighbor-file numbering anchored to each snippet's 0-based source range and omits line numbers from language-context snippets in both prompt assembly paths. It also adds regression coverage for spaced and unspaced neighbor numbering and unnumbered language context.

## Testing

- `cd extensions/copilot && npm run typecheck --silent`
- `cd extensions/copilot && npm run test:unit --silent -- src/extension/xtab/test/common/recentFilesForPrompt.spec.ts src/extension/xtab/test/common/promptCrafting.spec.ts`