### PR TITLE
Fix inline suggestion false negatives via canonical cursor-edit rebasing

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/test/vscode-node/isInlineSuggestion.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/vscode-node/isInlineSuggestion.spec.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { assert, suite, test } from 'vitest';
-import { Position, Range, Uri } from 'vscode';
+import { Position, Range, type TextDocument, Uri } from 'vscode';
 import { createTextDocumentData } from '../../../../util/common/test/shims/textDocument';
-import { toInlineSuggestion } from '../../vscode-node/isInlineSuggestion';
+import { isSubword, toInlineSuggestion } from '../../vscode-node/isInlineSuggestion';
 
 suite('toInlineSuggestion', () => {
 
@@ -20,6 +20,42 @@ suite('toInlineSuggestion', () => {
 		const completionInsertionPoint = new Position(1, 12);
 		const replaceText = 'This is line 2,';
 		return { document, completionInsertionPoint, replaceRange, replaceText };
+	}
+
+	function applyEdit(document: TextDocument, range: Range, newText: string): string {
+		const documentText = document.getText();
+		return documentText.substring(0, document.offsetAt(range.start)) + newText + documentText.substring(document.offsetAt(range.end));
+	}
+
+	function canRepresentAsInlineSuggestion(document: TextDocument, cursorPosition: Position, range: Range, newText: string): boolean {
+		const documentText = document.getText();
+		const editedText = applyEdit(document, range, newText);
+		const lineLength = document.lineAt(cursorPosition.line).text.length;
+
+		for (let startCharacter = 0; startCharacter <= cursorPosition.character; startCharacter++) {
+			for (let endCharacter = cursorPosition.character; endCharacter <= lineLength; endCharacter++) {
+				const candidateRange = new Range(cursorPosition.line, startCharacter, cursorPosition.line, endCharacter);
+				const prefix = documentText.substring(0, document.offsetAt(candidateRange.start));
+				const suffix = documentText.substring(document.offsetAt(candidateRange.end));
+				const candidateNewTextEnd = editedText.length - suffix.length;
+				if (candidateNewTextEnd < prefix.length || !editedText.startsWith(prefix) || !editedText.endsWith(suffix)) {
+					continue;
+				}
+
+				const candidateNewText = editedText.substring(prefix.length, candidateNewTextEnd);
+				const replacedText = document.getText(candidateRange);
+				const cursorOffset = cursorPosition.character - startCharacter;
+				if (
+					applyEdit(document, candidateRange, candidateNewText) === editedText
+					&& replacedText.substring(0, cursorOffset) === candidateNewText.substring(0, cursorOffset)
+					&& isSubword(replacedText, candidateNewText)
+				) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	test('line before completion', () => {
@@ -129,16 +165,16 @@ suite('toInlineSuggestion', () => {
 	// Tests probing the behavior change: multi-line next-line insertions
 	// where newText does not end with '\n'
 
-	test('multi-line insertion on next empty line without trailing newline', () => {
+	test('multi-line insertion on next empty line without trailing newline is not an inline suggestion', () => {
 		const document = createMockDocument(['function foo(', '', 'other']);
 		const cursorPosition = new Position(0, 13); // end of "function foo("
 		const replaceRange = new Range(1, 0, 1, 0); // empty line
 		const replaceText = '  a: string,\n  b: number\n)';
 
-		const result = toInlineSuggestion(cursorPosition, document, replaceRange, replaceText);
-		assert.isDefined(result);
-		assert.deepStrictEqual(result!.range, new Range(0, 13, 0, 13));
-		assert.strictEqual(result!.newText, '\n' + replaceText);
+		// newText does not end with '\n'. The original line terminator after the
+		// cursor cannot be consumed by ghost text, so pulling the insertion up to
+		// the cursor would leave a spurious blank line — not representable.
+		assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText));
 	});
 
 	test('multi-line insertion on next non-empty line with trailing newline', () => {
@@ -174,7 +210,7 @@ suite('toInlineSuggestion', () => {
 		assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText));
 	});
 
-	test('render ghost text for next line suggestion with massaged range', () => {
+	test('next-line suggestion onto empty last line without trailing newline is not an inline suggestion', () => {
 
 		const document = createMockDocument([`import * as vscode from 'vscode';
 import { NodeTypesIndex } from './nodeTypesIndex';
@@ -247,24 +283,25 @@ function createDocumentSymbol(
 	);
 }`;
 
-		const result = toInlineSuggestion(cursorPosition, document, replaceRange, replaceText);
-		assert.isDefined(result);
-		// Range is an empty range at cursor position
-		assert.deepStrictEqual(result!.range, new Range(45, 30, 45, 30));
-		// Text is prepended with newline
-		assert.strictEqual(result!.newText, '\n' + replaceText);
+		// The replacement lands on the empty last line and does not end with '\n',
+		// so it cannot be rendered as ghost text without a spurious trailing blank line.
+		assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText));
 	});
 
 	// --- Branch 1 regression: next-line insertion edge cases ---
 
-	test('next-line: cursor mid-line rejects even with valid next-line edit', () => {
+	test('next-line: cursor mid-line extends through the unchanged line suffix', () => {
 		const document = createMockDocument(['function foo(bar', '', 'other']);
 		const cursorPosition = new Position(0, 8); // middle of "function foo(bar"
 		const replaceRange = new Range(1, 0, 1, 0);
 		const replaceText = '  param1,\n  param2\n';
 
-		// Cursor not at end of line → rejected
-		assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText));
+		const result = toInlineSuggestion(cursorPosition, document, replaceRange, replaceText);
+		assert.deepStrictEqual(result, {
+			range: new Range(0, 8, 0, 16),
+			newText: ' foo(bar\n  param1,\n  param2',
+		});
+		assert.strictEqual(applyEdit(document, result!.range, result!.newText), applyEdit(document, replaceRange, replaceText));
 	});
 
 	test('next-line: non-empty range on next line falls through and is rejected', () => {
@@ -347,16 +384,144 @@ function createDocumentSymbol(
 		assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText));
 	});
 
+	suite('equivalent edit rebasing', () => {
+
+		test('rebases a next-line replacement preserving the closing line', () => {
+			const document = createMockDocument([
+				'\tprivate gatherNeighborSnippets(',
+				'\t\tactiveDocument: StatelessNextEditDocument,',
+				'\t) {',
+				'\t\treturn undefined;',
+			]);
+			const cursorPosition = document.lineAt(1).range.end;
+			const replaceRange = new Range(2, 0, 2, 4);
+			const replaceText = [
+				'\t\tcurrentDocument: StatelessNextEditDocument,',
+				'\t\tpromptOptions: ModelConfig,',
+				'\t\tdelaySession: DelaySession,',
+				'\t\ttracer: RequestTracingContext,',
+				'\t\tcancellationToken: CancellationToken,',
+				'\t) {',
+			].join('\n');
+
+			const result = toInlineSuggestion(cursorPosition, document, replaceRange, replaceText);
+
+			assert.deepStrictEqual(result, {
+				range: new Range(cursorPosition, cursorPosition),
+				newText: [
+					'',
+					'\t\tcurrentDocument: StatelessNextEditDocument,',
+					'\t\tpromptOptions: ModelConfig,',
+					'\t\tdelaySession: DelaySession,',
+					'\t\ttracer: RequestTracingContext,',
+					'\t\tcancellationToken: CancellationToken,',
+				].join('\n'),
+			});
+			assert.strictEqual(applyEdit(document, result!.range, result!.newText), applyEdit(document, replaceRange, replaceText));
+		});
+
+		test('rebases a replacement starting after indentation on the next line', () => {
+			const document = createMockDocument(['function foo(', '  close', 'other']);
+			const cursorPosition = new Position(0, 13);
+			const replaceRange = new Range(1, 2, 1, 7);
+			const replaceText = 'item\n  close';
+
+			const result = toInlineSuggestion(cursorPosition, document, replaceRange, replaceText);
+
+			assert.deepStrictEqual(result, {
+				range: new Range(cursorPosition, cursorPosition),
+				newText: '\n  item',
+			});
+			assert.strictEqual(applyEdit(document, result!.range, result!.newText), applyEdit(document, replaceRange, replaceText));
+		});
+
+		test('does not rebase when the replacement changes the closing line', () => {
+			const document = createMockDocument(['function foo(', '  close', 'other']);
+			const cursorPosition = new Position(0, 13);
+			const replaceRange = new Range(1, 2, 1, 7);
+			const replaceText = 'item\n  changed';
+
+			assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText));
+		});
+
+		test('collapses a multi-line edit around the cursor using unchanged prefix and suffix', () => {
+			const document = createMockDocument(['header', 'abc', 'close']);
+			const cursorPosition = new Position(1, 1);
+			const replaceRange = new Range(0, 0, 2, 5);
+			const replaceText = 'header\naXbc\nclose';
+
+			const result = toInlineSuggestion(cursorPosition, document, replaceRange, replaceText);
+
+			assert.deepStrictEqual(result, {
+				range: new Range(1, 1, 1, 3),
+				newText: 'Xbc',
+			});
+			assert.strictEqual(applyEdit(document, result!.range, result!.newText), applyEdit(document, replaceRange, replaceText));
+		});
+
+		test('matches the representability oracle over a finite exhaustive corpus', () => {
+			const documents: readonly { text: string; eol: '\n' | '\r\n' }[] = [
+				{ text: '', eol: '\n' },
+				{ text: 'a', eol: '\n' },
+				{ text: 'ab', eol: '\n' },
+				{ text: 'a\n', eol: '\n' },
+				{ text: 'a\nb', eol: '\n' },
+				{ text: 'ab\nc', eol: '\n' },
+				{ text: 'a\nb\nc', eol: '\n' },
+				{ text: 'a\r\nb', eol: '\r\n' },
+				{ text: 'ab\r\nc', eol: '\r\n' },
+			];
+			const newTexts = ['', 'a', 'b', 'ab', '\n', '\r\n', 'a\n', 'a\r\n', '\nb', '\r\nb', 'a\nb', 'a\r\nb', 'b\na', 'a\nb\nc'];
+
+			for (const { text: documentText, eol } of documents) {
+				const document = createTextDocumentData(Uri.from({ scheme: 'test', path: '/test/file.ts' }), documentText, 'typescript', eol).document;
+				const positions: Position[] = [];
+				for (let line = 0; line < document.lineCount; line++) {
+					for (let character = 0; character <= document.lineAt(line).text.length; character++) {
+						positions.push(new Position(line, character));
+					}
+				}
+
+				for (const cursorPosition of positions) {
+					for (let startIndex = 0; startIndex < positions.length; startIndex++) {
+						for (let endIndex = startIndex; endIndex < positions.length; endIndex++) {
+							const range = new Range(positions[startIndex], positions[endIndex]);
+							for (const newText of newTexts) {
+								const representable = canRepresentAsInlineSuggestion(document, cursorPosition, range, newText);
+								const result = toInlineSuggestion(cursorPosition, document, range, newText);
+								const scenario = JSON.stringify({ documentText, cursorPosition, range, newText });
+
+								// Completeness: every representable edit is offered as a suggestion.
+								if (representable) {
+									assert.isDefined(result, scenario);
+								}
+								// Soundness: any offered suggestion must reproduce the edit
+								// exactly. This catches spurious-newline acceptances that the
+								// oracle classifies as non-representable.
+								if (result !== undefined) {
+									assert.strictEqual(applyEdit(document, result.range, result.newText), applyEdit(document, range, newText), scenario);
+								}
+							}
+						}
+					}
+				}
+			}
+		});
+	});
+
 	// --- Branch 2 regression: same-line edit edge cases ---
 
-	test('same-line: cursor before range start rejects', () => {
+	test('same-line: edit after cursor is extended back to cursor', () => {
 		const document = createMockDocument(['abcdef']);
 		const cursorPosition = new Position(0, 1);
 		const replaceRange = new Range(0, 3, 0, 6); // replaces "def"
 		const replaceText = 'defgh';
 
-		// cursorOffsetInReplacedText < 0
-		assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText));
+		const result = toInlineSuggestion(cursorPosition, document, replaceRange, replaceText);
+		assert.deepStrictEqual(result, {
+			range: new Range(0, 1, 0, 6),
+			newText: 'bcdefgh',
+		});
 	});
 
 	test('same-line: text before cursor differs rejects', () => {
@@ -642,6 +807,20 @@ const fieldLabels: Record<keyof FormData, string> = {
 			assert.deepStrictEqual(result!.range, new Range(0, 6, 0, 6));
 			// Only the prepended CRLF between cursor and original range remains.
 			assert.strictEqual(result!.newText, '\r\n');
+		});
+
+		test('next-line insertion: bare LF newText in a CRLF document is not an inline suggestion', () => {
+			// The edit inserts a lone '\n' on the next line, producing a bare-LF
+			// blank line in a CRLF document. A cursor pull-up would re-use the
+			// document's '\r\n', which is a different edit, so this must be rejected.
+			const document = createCRLFDocument(['a', 'b']);
+			const cursorPosition = new Position(0, 1); // end of "a"
+			const replaceRange = new Range(1, 0, 1, 0);
+			const replaceText = '\n';
+
+			assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText));
+			// Also exercise the ungated fallback (advanced disabled).
+			assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText, false));
 		});
 	});
 

--- a/extensions/copilot/src/extension/inlineEdits/test/vscode-node/isInlineSuggestion.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/vscode-node/isInlineSuggestion.spec.ts
@@ -418,6 +418,10 @@ function createDocumentSymbol(
 				].join('\n'),
 			});
 			assert.strictEqual(applyEdit(document, result!.range, result!.newText), applyEdit(document, replaceRange, replaceText));
+
+			// With rebasing disabled the non-empty next-line range cannot be pulled
+			// up by the ungated fallback, so the edit must not be rebased.
+			assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText, false));
 		});
 
 		test('rebases a replacement starting after indentation on the next line', () => {
@@ -821,6 +825,22 @@ const fieldLabels: Record<keyof FormData, string> = {
 			assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText));
 			// Also exercise the ungated fallback (advanced disabled).
 			assert.isUndefined(toInlineSuggestion(cursorPosition, document, replaceRange, replaceText, false));
+		});
+
+		test('next-line insertion: ungated fallback pulls up a CRLF-terminated insertion (advanced disabled)', () => {
+			// With rebasing disabled, tryAdjustNextLineInsertion must still pull an
+			// empty-range next-line insertion up to the cursor when newText ends with
+			// the document's CRLF, dropping exactly that trailing break.
+			const document = createCRLFDocument(['function foo(', '', 'other']);
+			const cursorPosition = new Position(0, 13); // end of "function foo("
+			const replaceRange = new Range(1, 0, 1, 0);
+			const replaceText = '  a: string,\r\n  b: number\r\n';
+
+			const result = toInlineSuggestion(cursorPosition, document, replaceRange, replaceText, false);
+			assert.isDefined(result);
+			assert.deepStrictEqual(result!.range, new Range(0, 13, 0, 13));
+			assert.strictEqual(result!.newText, '\r\n  a: string,\r\n  b: number');
+			assert.strictEqual(applyEdit(document, result!.range, result!.newText), applyEdit(document, replaceRange, replaceText));
 		});
 	});
 

--- a/extensions/copilot/src/extension/inlineEdits/vscode-node/isInlineSuggestion.ts
+++ b/extensions/copilot/src/extension/inlineEdits/vscode-node/isInlineSuggestion.ts
@@ -16,35 +16,77 @@ export interface InlineSuggestionEdit {
  * which is required for VS Code to render ghost text.
  */
 export function toInlineSuggestion(cursorPos: Position, doc: TextDocument, range: Range, newText: string, advanced: boolean = true): InlineSuggestionEdit | undefined {
-	// Special case: a multi-line insertion that starts on the line *after* the cursor
-	// can be re-expressed as a pure insertion at the cursor.
+	if (range.start.line === range.end.line && range.start.line === cursorPos.line) {
+		const sameLineEdit = validateSameLineGhostText(cursorPos, doc, range, newText);
+		if (sameLineEdit) {
+			return sameLineEdit;
+		}
+	}
+
+	if (advanced) {
+		const cursorEdit = tryRebaseAsCursorEdit(cursorPos, doc, range, newText);
+		if (cursorEdit) {
+			return cursorEdit;
+		}
+	}
+
+	// Preserve the established behavior for insertions into an empty next line.
 	const nextLineInsertion = tryAdjustNextLineInsertion(cursorPos, doc, range, newText);
 	if (nextLineInsertion) {
 		return nextLineInsertion;
 	}
 
-	// If the range spans multiple lines, try to collapse it to a single line by
-	// trimming a shared prefix up to a newline boundary.
-	if (advanced && range.start.line !== range.end.line) {
-		({ range, newText } = stripCommonLinePrefix(doc, range, newText));
-	}
+	return undefined;
+}
 
-	// Ghost text requires the edit to be on the cursor's line.
-	if (range.start.line !== range.end.line || range.start.line !== cursorPos.line) {
+/**
+ * Re-express an edit as an equivalent edit from the cursor to the end of its
+ * line. If any equivalent inline suggestion exists, one exists in this form.
+ */
+function tryRebaseAsCursorEdit(cursorPos: Position, doc: TextDocument, range: Range, newText: string): InlineSuggestionEdit | undefined {
+	const cursorOffset = doc.offsetAt(cursorPos);
+	const lineEnd = doc.lineAt(cursorPos.line).range.end;
+	const lineEndOffset = doc.offsetAt(lineEnd);
+	const rangeStartOffset = doc.offsetAt(range.start);
+	const rangeEndOffset = doc.offsetAt(range.end);
+	const affectedStart = doc.positionAt(Math.min(cursorOffset, rangeStartOffset));
+	const affectedEnd = doc.positionAt(Math.max(lineEndOffset, rangeEndOffset));
+
+	const editedText = doc.getText(new Range(affectedStart, range.start)) + newText + doc.getText(new Range(range.end, affectedEnd));
+	const unchangedPrefix = doc.getText(new Range(affectedStart, cursorPos));
+	const unchangedSuffix = doc.getText(new Range(lineEnd, affectedEnd));
+	const cursorEditTextEnd = editedText.length - unchangedSuffix.length;
+	if (
+		cursorEditTextEnd < unchangedPrefix.length
+		|| !editedText.startsWith(unchangedPrefix)
+		|| !editedText.endsWith(unchangedSuffix)
+	) {
 		return undefined;
 	}
 
-	return validateSameLineGhostText(cursorPos, doc, range, newText);
+	const cursorEdit = {
+		range: new Range(cursorPos, lineEnd),
+		newText: editedText.substring(unchangedPrefix.length, cursorEditTextEnd),
+	};
+	return validateSameLineGhostText(cursorPos, doc, cursorEdit.range, cursorEdit.newText);
 }
 
 /**
  * If the cursor is at the end of a line and the edit is an empty-range insertion
  * at column 0 of the next line, rewrite it as a pure insertion at the cursor
- * position. This is allowed when either:
- *  - `newText` ends with a newline (any existing content on the target line is
- *    pushed onto the following line), or
- *  - `newText` contains a newline and the target line is fully consumed by the
- *    insertion (no leftover content after the insertion).
+ * position.
+ *
+ * This is the ungated fallback for when `advanced` rebasing is disabled; when it
+ * is enabled, {@link tryRebaseAsCursorEdit} already subsumes this case.
+ *
+ * The line terminator between the cursor and `range.start` (`lineBreak`) lives in
+ * the document, not in the edit, so a cursor insertion always leaves it *after*
+ * the inserted text. Inserting `N` at the start of the next line therefore equals
+ * inserting `lineBreak + N'` at the cursor iff `N === N' + lineBreak` — i.e. `N`
+ * must end with the document's own line break (then `N'` is `N` with that break
+ * dropped). Requiring the document break (not merely '\n') keeps this exact for
+ * CRLF documents. Otherwise a pure cursor insertion cannot reproduce the edit
+ * without a spurious blank line, so we bail and let it render as an inline edit.
  */
 function tryAdjustNextLineInsertion(cursorPos: Position, doc: TextDocument, range: Range, newText: string): InlineSuggestionEdit | undefined {
 	if (!range.isEmpty) {
@@ -57,45 +99,17 @@ function tryAdjustNextLineInsertion(cursorPos: Position, doc: TextDocument, rang
 		return undefined; // cursor is not at the end of the line
 	}
 
-	const targetLineFullyConsumed = doc.lineAt(range.end.line).text.length === range.end.character;
-	const noLeftoverAfterInsertion = newText.endsWith('\n') || (newText.includes('\n') && targetLineFullyConsumed);
-	if (!noLeftoverAfterInsertion) {
+	// Use an empty range at the cursor so the suggestion is a pure insertion.
+	// `lineBreak` is the document's own terminator between the cursor and the next
+	// line; the pull-up is exact only when `newText` ends with exactly that break,
+	// which we drop and re-prepend at the cursor. Matching the document break (not
+	// just '\n') keeps CRLF documents exact and never leaks a dangling '\r'.
+	const lineBreak = doc.getText(new Range(cursorPos, range.start));
+	if (!newText.endsWith(lineBreak)) {
 		return undefined;
 	}
-
-	// Use an empty range at the cursor so the suggestion is a pure insertion.
-	// The original line terminator between the cursor and `range.start` is preserved
-	// in the document, so:
-	//  - prepend that terminator to `newText` (it lives in the doc, not in the edit), and
-	//  - drop a single trailing line ending from `newText` to avoid an extra blank line.
-	// CRLF-safe so we don't leak a dangling '\r' into the suggestion.
-	const lineBreak = doc.getText(new Range(cursorPos, range.start));
-	const trimmedNewText = newText.replace(/\r?\n$/, '');
+	const trimmedNewText = newText.substring(0, newText.length - lineBreak.length);
 	return { range: new Range(cursorPos, cursorPos), newText: lineBreak + trimmedNewText };
-}
-
-/**
- * Strip the longest shared prefix that ends on a newline boundary from both sides
- * of a multi-line edit. This often shrinks the range so it fits on a single line,
- * which is required for ghost text rendering.
- */
-function stripCommonLinePrefix(doc: TextDocument, range: Range, newText: string): { range: Range; newText: string } {
-	const replacedText = doc.getText(range);
-	const maxLen = Math.min(replacedText.length, newText.length);
-	let commonLen = 0;
-	while (commonLen < maxLen && replacedText[commonLen] === newText[commonLen]) {
-		commonLen++;
-	}
-	if (commonLen === 0) {
-		return { range, newText };
-	}
-	const lastNewline = replacedText.lastIndexOf('\n', commonLen - 1);
-	if (lastNewline < 0) {
-		return { range, newText };
-	}
-	const strippedLen = lastNewline + 1;
-	const newStart = doc.positionAt(doc.offsetAt(range.start) + strippedLen);
-	return { range: new Range(newStart, range.end), newText: newText.substring(strippedLen) };
 }
 
 /**
@@ -133,4 +147,3 @@ export function isSubword(a: string, b: string): boolean {
 	}
 	return true;
 }
-

--- a/extensions/copilot/src/extension/inlineEdits/vscode-node/isInlineSuggestion.ts
+++ b/extensions/copilot/src/extension/inlineEdits/vscode-node/isInlineSuggestion.ts
@@ -30,7 +30,8 @@ export function toInlineSuggestion(cursorPos: Position, doc: TextDocument, range
 		}
 	}
 
-	// Preserve the established behavior for insertions into an empty next line.
+	// Preserve the established behavior for empty-range insertions at the start of
+	// the next line (the target line itself may be non-empty, e.g. `\t) {`).
 	const nextLineInsertion = tryAdjustNextLineInsertion(cursorPos, doc, range, newText);
 	if (nextLineInsertion) {
 		return nextLineInsertion;


### PR DESCRIPTION
## Why

`toInlineSuggestion` decides whether a next-edit suggestion (NES) renders as ghost text at the cursor (an inline suggestion) or as a NES box (an inline edit). It had frequent false negatives: edits that *could* be shown as ghost text were misclassified as inline edits, so ghost text was suppressed. The motivating real-world case was replacing the next `) {` line with new parameters plus the same `) {` re-appended, which is really an insertion at the cursor but was not detected as one.

## Approach

Instead of a growing pile of prefix/suffix trimming special cases, re-express any edit as the single equivalent edit spanning `cursor -> end-of-line` and validate that one canonical form (`tryRebaseAsCursorEdit`). This form is maximal: if any equivalent inline suggestion exists, one exists here. That subsumes the previous special cases and closes the false-negative family in one place.

`tryAdjustNextLineInsertion` is kept as the fallback used when advanced detection is disabled, but its pull-up is now provably exact: it only accepts when `newText` ends with the document's own line break, then drops that break and re-prepends it at the cursor.

## Notable fixes and trade-offs

- **Spurious blank line**: inserting a block that does not end in `\n` onto an empty next line used to be accepted and produced an extra blank line. It is now correctly rejected (rendered as an inline edit instead).
- **CRLF soundness bug** (latent before this PR): inserting a bare `\n` into a CRLF document produced `a\r\n\r\nb` instead of the true `a\r\n\nb`. Requiring the document's actual line break (not merely `\n`) fixes it. This was surfaced by the strengthened test harness below.
- The rebase is gated behind the existing advanced-detection setting; when it is off, the exact next-line fallback still applies.

## Tests

Added an independent representability oracle plus an exhaustive soundness + completeness harness over both LF and CRLF corpora (every document/cursor/range/newText combination). The harness asserts both that every representable edit is offered and that any offered suggestion reproduces the edit exactly. The soundness direction is what caught the CRLF bug. Also added a named CRLF regression test. Full suite passes (51 tests) and the extension type-checks cleanly.