### PR TITLE
Track automation runs until sessions complete

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -554,6 +554,15 @@ Providers may fire `onDidReplaceSession` when a temporary (untitled) session is 
 
 Provider add notifications are authoritative upserts. A provisional `listSessions()` entry may already be cached when the backend publishes its materialized project and working directory, so providers update the existing session adapter in place and report it as changed rather than replacing its identity.
 
+### Automation Run Lifecycle
+
+`AutomationRunner` records the committed session resource on the run row as soon
+as `createAndSendNewChatRequest` returns, then observes `ISession.status` until it
+reaches a terminal state. `InProgress`, `Untitled`, and `NeedsInput` all keep the
+automation run `running`; `Completed` completes the run and `Error` fails it.
+Scheduler cancellation also stops the observation and fails the run, so a timed
+out or disposed scheduler does not leave a live observable subscription behind.
+
 ---
 
 ## Adding a New Provider

--- a/src/vs/sessions/contrib/automations/browser/automationRunner.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationRunner.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { waitForState } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
@@ -12,6 +13,7 @@ import { AutomationRunTrigger, IAutomation } from '../../../../workbench/contrib
 import { IAutomationRunner } from '../../../../workbench/contrib/chat/common/automations/automationRunner.js';
 import { IAutomationService } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { publishAutomationRun, publishAutomationRunError } from '../../../../workbench/contrib/chat/common/automations/automationTelemetry.js';
+import { SessionStatus } from '../../../services/sessions/common/session.js';
 import { ICreateNewSessionOptions, ISendRequestOptions, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 
 /** Sessions-layer runner. Never throws; failures are recorded on the run row. */
@@ -91,19 +93,45 @@ export class AutomationRunner implements IAutomationRunner {
 
 			const session = await this.sessionsManagementService.createAndSendNewChatRequest(automation.folderUri, options, createOptions);
 
-			// Re-check cancellation post-send so mid-flight timeouts surface as `failed`.
+			if (session) {
+				await this.automationService.updateRun(runId, {
+					sessionResource: session.resource.toString(),
+				});
+			}
+
 			if (token.isCancellationRequested) {
 				await this._markCancelled(runId, trigger, automation, startTimeMs);
 				return;
 			}
 
+			const terminalStatus = session
+				? await waitForState(
+					session.status,
+					status => status === SessionStatus.Completed || status === SessionStatus.Error,
+					undefined,
+					token,
+				)
+				: SessionStatus.Completed;
+
+			if (token.isCancellationRequested) {
+				await this._markCancelled(runId, trigger, automation, startTimeMs);
+				return;
+			}
+
+			if (terminalStatus === SessionStatus.Error) {
+				throw new Error(localize('automationRunner.sessionFailed', "Agent session failed."));
+			}
+
 			await this.automationService.updateRun(runId, {
 				status: 'completed',
 				completedAt: new Date().toISOString(),
-				...(session ? { sessionResource: session.resource.toString() } : {}),
 			});
 			publishAutomationRun(this.telemetryService, { trigger, automation, success: true, durationMs: Date.now() - startTimeMs });
 		} catch (err) {
+			if (runId && token.isCancellationRequested) {
+				await this._markCancelled(runId, trigger, automation, startTimeMs);
+				return;
+			}
 			this.logService.error(`[AutomationRunner] run for ${automation.id} failed`, err);
 			try {
 				const errorMessage = err instanceof Error ? err.message : String(err);
@@ -125,11 +153,13 @@ export class AutomationRunner implements IAutomationRunner {
 
 	private async _markCancelled(runId: string, trigger: AutomationRunTrigger, automation: IAutomation, startTimeMs: number): Promise<void> {
 		try {
-			await this.automationService.updateRun(runId, {
-				status: 'failed',
-				completedAt: new Date().toISOString(),
-				errorMessage: localize('automationRunner.cancelled', "Cancelled"),
-			});
+			if (this.automationService.getActiveRunFor(automation.id)?.id === runId) {
+				await this.automationService.updateRun(runId, {
+					status: 'failed',
+					completedAt: new Date().toISOString(),
+					errorMessage: localize('automationRunner.cancelled', "Cancelled"),
+				});
+			}
 			publishAutomationRun(this.telemetryService, { trigger, automation, success: false, durationMs: Date.now() - startTimeMs });
 		} catch (err) {
 			this.logService.error(`[AutomationRunner] error recording cancellation for ${automation.id}`, err);

--- a/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
@@ -159,8 +159,7 @@ export class AutomationSchedulerCore extends Disposable {
 				timeoutMs,
 				() => {
 					timedOut = true;
-					this.logService.warn(`[AutomationScheduler] runOnce for automation ${automation.id} timed out after ${timeoutMs}ms; cancelling.`);
-					perRunCts.cancel();
+					this.logService.warn(`[AutomationScheduler] runOnce for automation ${automation.id} timed out after ${timeoutMs}ms.`);
 				},
 			);
 
@@ -181,6 +180,7 @@ export class AutomationSchedulerCore extends Disposable {
 			} catch (err) {
 				this.logService.warn('[AutomationScheduler] failed to mark timed-out run as failed', err);
 			}
+			perRunCts.cancel();
 		} finally {
 			perRunCts.dispose();
 		}
@@ -252,4 +252,3 @@ function isDue(automation: IAutomation, now: Date): boolean {
 	}
 	return next <= now.getTime();
 }
-

--- a/src/vs/sessions/contrib/automations/test/browser/automationRunner.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationRunner.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
+import { observableValue, waitForState } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -14,7 +15,7 @@ import { InMemoryStorageService } from '../../../../../platform/storage/common/s
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { AutomationService } from '../../browser/automationService.js';
 import { IAutomationSchedule } from '../../../../../workbench/contrib/chat/common/automations/automation.js';
-import { ISession } from '../../../../services/sessions/common/session.js';
+import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { ICreateNewSessionOptions, ISendRequestOptions, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { AutomationRunner } from '../../browser/automationRunner.js';
 
@@ -57,8 +58,12 @@ class FakeSessionsManagementService extends mock<ISessionsManagementService>() {
 	}
 }
 
-function fakeSession(id: string): ISession {
-	return upcastPartial<ISession>({ sessionId: id, resource: URI.from({ scheme: 'vscode-chat-session', authority: 'test', path: `/${id}` }) });
+function fakeSession(id: string, status = observableValue(`status-${id}`, SessionStatus.Completed)): ISession {
+	return upcastPartial<ISession>({
+		sessionId: id,
+		resource: URI.from({ scheme: 'vscode-chat-session', authority: 'test', path: `/${id}` }),
+		status,
+	});
 }
 
 suite('AutomationRunner', () => {
@@ -92,6 +97,69 @@ suite('AutomationRunner', () => {
 		assert.strictEqual(runs[0].sessionResource, 'vscode-chat-session://test/s1');
 		assert.strictEqual(runs[0].trigger, 'schedule');
 		assert.strictEqual(runs[0].leaderWindowId, 99);
+	});
+
+	test('keeps the run active through NeedsInput and records the session before completion', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		const status = observableValue('status-s1', SessionStatus.InProgress);
+		sessionsMgmt.nextSession = fakeSession('s1', status);
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'do the thing', schedule: hourly(), folderUri: FOLDER_A });
+		let settled = false;
+		const runPromise = runner.runOnce(a, 'schedule', 99).finally(() => settled = true);
+
+		await waitForState(service.runs, runs => runs[0]?.sessionResource !== undefined);
+		assert.deepStrictEqual(service.runs.get().map(run => ({
+			status: run.status,
+			sessionResource: run.sessionResource,
+			completedAt: run.completedAt,
+		})), [{
+			status: 'running',
+			sessionResource: 'vscode-chat-session://test/s1',
+			completedAt: undefined,
+		}]);
+
+		status.set(SessionStatus.NeedsInput, undefined);
+		await Promise.resolve();
+		assert.deepStrictEqual({
+			settled,
+			status: service.runs.get()[0].status,
+			completedAt: service.runs.get()[0].completedAt,
+		}, {
+			settled: false,
+			status: 'running',
+			completedAt: undefined,
+		});
+
+		status.set(SessionStatus.Completed, undefined);
+		await runPromise;
+		assert.strictEqual(service.runs.get()[0].status, 'completed');
+	});
+
+	test('marks the run failed when the session reports an error', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		const status = observableValue('status-s1', SessionStatus.InProgress);
+		sessionsMgmt.nextSession = fakeSession('s1', status);
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		const runPromise = runner.runOnce(a, 'schedule', 1);
+		await waitForState(service.runs, runs => runs[0]?.sessionResource !== undefined);
+
+		status.set(SessionStatus.Error, undefined);
+		await runPromise;
+
+		const run = service.runs.get()[0];
+		assert.deepStrictEqual({
+			status: run.status,
+			sessionResource: run.sessionResource,
+			errorMessage: run.errorMessage,
+			hasCompletedAt: run.completedAt !== undefined,
+		}, {
+			status: 'failed',
+			sessionResource: 'vscode-chat-session://test/s1',
+			errorMessage: 'Agent session failed.',
+			hasCompletedAt: true,
+		});
 	});
 
 	test('always uses the automation folder regardless of the current workspace', async () => {
@@ -162,9 +230,6 @@ suite('AutomationRunner', () => {
 	});
 
 	test('marks the run cancelled when the token is cancelled mid-flight', async () => {
-		// Regression: previously the runner only checked the token before
-		// `createAndSendNewChatRequest`, so a cancellation that landed during
-		// the in-flight send would still stamp the run as `completed`.
 		const { service, sessionsMgmt, runner } = setup();
 		const cts = new CancellationTokenSource();
 		sessionsMgmt.nextSession = fakeSession('s-mid');
@@ -180,9 +245,61 @@ suite('AutomationRunner', () => {
 		assert.strictEqual(runs.length, 1);
 		assert.strictEqual(runs[0].status, 'failed');
 		assert.strictEqual(runs[0].errorMessage, 'Cancelled');
-		// Even though the service returned a session, the cancellation
-		// outcome wins and the session id is not stamped onto the run.
-		assert.strictEqual(runs[0].sessionResource, undefined);
+		assert.strictEqual(runs[0].sessionResource, 'vscode-chat-session://test/s-mid');
+		cts.dispose();
+	});
+
+	test('cancels while waiting for the session to finish', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		const cts = new CancellationTokenSource();
+		const status = observableValue('status-s-waiting', SessionStatus.InProgress);
+		sessionsMgmt.nextSession = fakeSession('s-waiting', status);
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		const runPromise = runner.runOnce(a, 'schedule', 1, cts.token);
+		await waitForState(service.runs, runs => runs[0]?.sessionResource !== undefined);
+
+		cts.cancel();
+		await runPromise;
+
+		const run = service.runs.get()[0];
+		assert.deepStrictEqual({
+			status: run.status,
+			sessionResource: run.sessionResource,
+			errorMessage: run.errorMessage,
+		}, {
+			status: 'failed',
+			sessionResource: 'vscode-chat-session://test/s-waiting',
+			errorMessage: 'Cancelled',
+		});
+		cts.dispose();
+	});
+
+	test('does not overwrite a terminal failure when cancelled', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		const cts = new CancellationTokenSource();
+		const status = observableValue('status-s-timeout', SessionStatus.InProgress);
+		sessionsMgmt.nextSession = fakeSession('s-timeout', status);
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		const runPromise = runner.runOnce(a, 'schedule', 1, cts.token);
+		const run = await waitForState(service.runs.map(runs => runs[0]), run => run?.sessionResource !== undefined);
+		await service.updateRun(run.id, {
+			status: 'failed',
+			completedAt: new Date().toISOString(),
+			errorMessage: 'Timed out',
+		});
+
+		cts.cancel();
+		await runPromise;
+
+		assert.deepStrictEqual({
+			status: service.runs.get()[0].status,
+			errorMessage: service.runs.get()[0].errorMessage,
+		}, {
+			status: 'failed',
+			errorMessage: 'Timed out',
+		});
 		cts.dispose();
 	});
 

--- a/src/vs/sessions/contrib/automations/test/browser/automationScheduler.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationScheduler.test.ts
@@ -280,11 +280,8 @@ suite('AutomationSchedulerCore', () => {
 		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
 		const b = await service.createAutomation({ name: 'B', prompt: 'q', schedule: hourly(), folderUri: FOLDER });
 
-		// A runner whose first invocation hangs until we release it,
-		// AND that creates a run row (mimicking the real runner) so
-		// the timeout path has something to mark as failed. Dispatch
-		// order is not guaranteed to match creation order, so the
-		// runner records which automation it hung on.
+		// The first run hangs until cancellation and tries to record `Cancelled`,
+		// matching the real runner's timeout behavior.
 		let hungAutomationId: string | undefined;
 		class HangingRunner implements IAutomationRunner {
 			declare readonly _serviceBrand: undefined;
@@ -296,7 +293,17 @@ suite('AutomationSchedulerCore', () => {
 				if (this.calls === 1) {
 					hungAutomationId = automation.id;
 					await service.recordRunStart(automation.id, trigger, leaderWindowId);
-					const listener = token?.onCancellationRequested(() => { this.cancelObserved = true; });
+					const listener = token?.onCancellationRequested(() => {
+						this.cancelObserved = true;
+						const active = service.getActiveRunFor(automation.id);
+						if (active) {
+							void service.updateRun(active.id, {
+								status: 'failed',
+								errorMessage: 'Cancelled',
+							});
+						}
+						this.hung.complete();
+					});
 					try {
 						await this.hung.p;
 					} finally {
@@ -337,9 +344,5 @@ suite('AutomationSchedulerCore', () => {
 		// by the timeout path.
 		const otherRun = service.runs.get().find(r => r.automationId === otherId);
 		assert.notStrictEqual(otherRun?.status, 'failed');
-
-		// Cleanup: release the hung promise so the runner can exit.
-		runner.hung.complete();
-		await core.waitForPendingRuns();
 	});
 });

--- a/src/vs/workbench/contrib/chat/common/automations/automation.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automation.ts
@@ -80,6 +80,10 @@ export interface IAutomation {
 	readonly nextRunAt?: string;
 }
 
+/**
+ * Lifecycle of an automation run. A run stays `running` while its agent session
+ * is active or needs input, and becomes terminal only when that session completes or fails.
+ */
 export type AutomationRunStatus = 'pending' | 'running' | 'completed' | 'failed';
 
 /**
@@ -94,7 +98,7 @@ export interface IAutomationRun {
 	readonly status: AutomationRunStatus;
 	readonly trigger: AutomationRunTrigger;
 
-	/** Session resource URI (stringified) assigned by ISessionsManagementService, if any. */
+	/** Session resource URI (stringified), recorded as soon as the committed session is available. */
 	readonly sessionResource?: string;
 
 	readonly startedAt: string;


### PR DESCRIPTION
## Summary

- persist the committed session resource on the run as soon as dispatch succeeds
- keep automation history in Running while the session is active or needs input
- derive Completed/Failed from the session terminal state while preserving cancellation and timeout outcomes

Fixes #325088

## Validation

- `npm run typecheck-client -- --pretty false`
- `npm run valid-layers-check`
- `npm run transpile-client`
- focused AutomationRunner and AutomationScheduler tests (27 passing)
- hygiene, pre-commit, and diff checks

merging; can revert if we don't like the fix

cc @benvillalobos