### PR TITLE
Fix opening automation history sessions

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -71,6 +71,8 @@ The first sidebar entry is a static `Overview` navigation item. It is styled lik
 
 The Tools section can browse the Marketplace in the core workbench, where extension gallery browsing and installation are available. The Sessions window hides Tools Marketplace browsing and only shows the tool enablement list.
 
+Automation run history stores the created session as a serialized URI. Its Open Session action uses the shared resource-first session opener, allowing the Agents window to route the URI through `ISessionsService` before the core workbench falls back to resolving an `IAgentSession`.
+
 ### IAICustomizationWorkspaceService
 
 The `IAICustomizationWorkspaceService` interface controls per-window behavior:

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -67,6 +67,8 @@ The **view** counterpart, **`SessionsService`** (services, `services/sessions/br
 ```
 open existing:  view.openSession(uri, { preserveFocus })
                   → view arranges visible slot (activeSession = active slot) + focuses    // focus skipped when preserveFocus
+external link:   workbench openSessionByResource(uri)
+                  → Agents-window opener participant → view.openSession(uri)
 new session:    composer → view.openNewSession({ folderUri, ... })  // view: management.createNewSession() (model draft) + activates it
                   → view observes activeSession == draft → shows draft slot
 delegate:       command → management.createNewSession({ providerId, sessionTypeId })

--- a/src/vs/sessions/contrib/chat/browser/sessionsOpenerParticipant.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsOpenerParticipant.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { IAgentSession } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
@@ -11,24 +12,22 @@ import { ISessionOpenerParticipant, ISessionOpenOptions, sessionOpenerRegistry }
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 
-/**
- * Routes session open requests in the Agents window through the
- * {@link ISessionsManagementService} so that the active session/chat state is
- * properly updated. Without this, the default opener tries to load the chat
- * directly into the `ChatViewId` view, which is hidden behind a `when` clause
- * tied to the new-chat context keys and may simply do nothing.
- */
+/** Routes session open requests through the Agents window session services. */
 class SessionsOpenerParticipant implements ISessionOpenerParticipant {
 
 	async handleOpenSession(accessor: ServicesAccessor, session: IAgentSession, openOptions?: ISessionOpenOptions): Promise<boolean> {
+		return this.handleOpenSessionResource(accessor, session.resource, openOptions);
+	}
+
+	async handleOpenSessionResource(accessor: ServicesAccessor, resource: URI, openOptions?: ISessionOpenOptions): Promise<boolean> {
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const sessionsService = accessor.get(ISessionsService);
-		const target = sessionsManagementService.getSession(session.resource);
+		const target = sessionsManagementService.getSession(resource);
 		if (!target) {
 			return false;
 		}
 
-		await sessionsService.openSession(session.resource, { preserveFocus: openOptions?.editorOptions?.preserveFocus });
+		await sessionsService.openSession(resource, { preserveFocus: openOptions?.editorOptions?.preserveFocus });
 		return true;
 	}
 }

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsOpenerParticipant.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsOpenerParticipant.test.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { openSessionByResource } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsOpener.js';
+import { SessionsOpenerParticipantContribution } from '../../browser/sessionsOpenerParticipant.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import { ISession } from '../../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+
+suite('SessionsOpenerParticipant', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('opens a sessions-layer resource without a legacy agent session', async () => {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(ILogService, new NullLogService());
+		const resource = URI.parse('agent-host-copilotcli://provider/session');
+		const session = upcastPartial<ISession>({ resource });
+		instantiationService.stub(ISessionsManagementService, upcastPartial<ISessionsManagementService>({
+			getSession: () => session,
+		}));
+		let opened: { resource: URI; preserveFocus: boolean | undefined } | undefined;
+		instantiationService.stub(ISessionsService, upcastPartial<ISessionsService>({
+			openSession: async (candidate, options) => {
+				opened = { resource: candidate, preserveFocus: options?.preserveFocus };
+			},
+		}));
+		const contribution = new SessionsOpenerParticipantContribution();
+
+		try {
+			await instantiationService.invokeFunction(openSessionByResource, resource, { editorOptions: { preserveFocus: true } });
+		} finally {
+			contribution.dispose();
+		}
+
+		assert.deepStrictEqual(opened, { resource, preserveFocus: true });
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsOpener.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsOpener.ts
@@ -18,11 +18,14 @@ import { INotificationService } from '../../../../../platform/notification/commo
 import { localize } from '../../../../../nls.js';
 import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IAgentSessionsService } from './agentSessionsService.js';
 
 //#region Session Opener Registry
 
 export interface ISessionOpenerParticipant {
 	handleOpenSession(accessor: ServicesAccessor, session: IAgentSession, openOptions?: ISessionOpenOptions): Promise<boolean>;
+	handleOpenSessionResource?(accessor: ServicesAccessor, resource: URI, openOptions?: ISessionOpenOptions): Promise<boolean>;
 }
 
 export interface ISessionOpenOptions {
@@ -52,6 +55,33 @@ class SessionOpenerRegistry {
 export const sessionOpenerRegistry = new SessionOpenerRegistry();
 
 //#endregion
+
+export async function openSessionByResource(accessor: ServicesAccessor, resource: URI, openOptions?: ISessionOpenOptions): Promise<IChatWidget | undefined> {
+	const instantiationService = accessor.get(IInstantiationService);
+	const logService = accessor.get(ILogService);
+
+	for (const participant of sessionOpenerRegistry.getParticipants()) {
+		if (!participant.handleOpenSessionResource) {
+			continue;
+		}
+
+		try {
+			const handled = await instantiationService.invokeFunction(accessor => participant.handleOpenSessionResource?.(accessor, resource, openOptions));
+			if (handled) {
+				return undefined;
+			}
+		} catch (error) {
+			logService.error(error);
+		}
+	}
+
+	const session = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService).getSession(resource));
+	if (!session) {
+		throw new Error(`Chat session not found: ${resource.toString()}`);
+	}
+
+	return instantiationService.invokeFunction(openSession, session, openOptions);
+}
 
 export async function openSession(accessor: ServicesAccessor, session: IAgentSession, openOptions?: ISessionOpenOptions): Promise<IChatWidget | undefined> {
 	const instantiationService = accessor.get(IInstantiationService);

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/automationsListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/automationsListWidget.ts
@@ -34,8 +34,7 @@ import { IAutomationService } from '../../common/automations/automationService.j
 import { IAutomationDialogService } from '../../common/automations/automationDialogService.js';
 import { CHAT_AUTOMATIONS_ENABLED_SETTING } from '../../common/automations/automationsEnabled.js';
 import { DAYS_OF_WEEK } from '../../common/automations/schedule.js';
-import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
-import { openSession as openSessionFromOpener } from '../agentSessions/agentSessionsOpener.js';
+import { openSessionByResource } from '../agentSessions/agentSessionsOpener.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 
@@ -116,7 +115,6 @@ class AutomationItemRenderer implements IListRenderer<IAutomationItemEntry, IAut
 		private readonly editorService: IEditorService,
 		private readonly editorGroupsService: IEditorGroupsService,
 		private readonly logService: ILogService,
-		private readonly agentSessionsService: IAgentSessionsService,
 		private readonly instantiationService: IInstantiationService,
 	) { }
 
@@ -310,13 +308,7 @@ class AutomationItemRenderer implements IListRenderer<IAutomationItemEntry, IAut
 				this.logService.debug(`[AutomationsListWidget] Opening session: ${sessionResource.toString()}`);
 				const activeEditor = this.editorService.activeEditor;
 				const activeGroupId = this.editorGroupsService.activeGroup.id;
-				const agentSession = this.agentSessionsService.getSession(sessionResource);
-				if (!agentSession) {
-					this.logService.warn(`[AutomationsListWidget] Session not found for ${sessionResource.toString()}`);
-					this.notificationService.error(localize('openRunSessionFailed', "Failed to open automation session"));
-					return;
-				}
-				this.instantiationService.invokeFunction(openSessionFromOpener, agentSession).then(() => {
+				this.instantiationService.invokeFunction(openSessionByResource, sessionResource).then(() => {
 					if (activeEditor) {
 						this.editorService.closeEditor({ editor: activeEditor, groupId: activeGroupId });
 					}
@@ -394,7 +386,6 @@ export class AutomationsListWidget extends Disposable {
 		@INotificationService private readonly notificationService: INotificationService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
-		@IAgentSessionsService private readonly agentSessionsService: IAgentSessionsService,
 	) {
 		super();
 
@@ -431,7 +422,7 @@ export class AutomationsListWidget extends Disposable {
 
 	private createList(): void {
 		const delegate = new AutomationItemDelegate();
-		const renderer = new AutomationItemRenderer(this, this.hoverService, this.notificationService, this.editorService, this.editorGroupsService, this.logService, this.agentSessionsService, this.instantiationService);
+		const renderer = new AutomationItemRenderer(this, this.hoverService, this.notificationService, this.editorService, this.editorGroupsService, this.logService, this.instantiationService);
 
 		this.list = this._register(this.instantiationService.createInstance(
 			WorkbenchList<IAutomationListEntry>,

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsOpener.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsOpener.test.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { IAgentSession } from '../../../browser/agentSessions/agentSessionsModel.js';
+import { openSessionByResource, ISessionOpenerParticipant, sessionOpenerRegistry } from '../../../browser/agentSessions/agentSessionsOpener.js';
+import { IAgentSessionsService } from '../../../browser/agentSessions/agentSessionsService.js';
+
+suite('AgentSessionsOpener', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('lets a participant handle a resource before legacy session lookup', async () => {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(ILogService, new NullLogService());
+		const resource = URI.parse('test-session://provider/session');
+		let handledResource: URI | undefined;
+		const participant: ISessionOpenerParticipant = {
+			handleOpenSession: async () => false,
+			handleOpenSessionResource: async (_accessor, candidate) => {
+				handledResource = candidate;
+				return true;
+			},
+		};
+		const registration = sessionOpenerRegistry.registerParticipant(participant);
+
+		try {
+			await instantiationService.invokeFunction(openSessionByResource, resource);
+		} finally {
+			registration.dispose();
+		}
+
+		assert.strictEqual(handledResource, resource);
+	});
+
+	test('falls back to the legacy session opener when no participant handles the resource', async () => {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(ILogService, new NullLogService());
+		const resource = URI.parse('test-session://provider/session');
+		const session = upcastPartial<IAgentSession>({ resource });
+		let resolvedResource: URI | undefined;
+		instantiationService.stub(IAgentSessionsService, upcastPartial<IAgentSessionsService>({
+			getSession: candidate => {
+				resolvedResource = candidate;
+				return session;
+			},
+		}));
+		let handledSession: IAgentSession | undefined;
+		const participant: ISessionOpenerParticipant = {
+			handleOpenSession: async (_accessor, candidate) => {
+				handledSession = candidate;
+				return true;
+			},
+		};
+		const registration = sessionOpenerRegistry.registerParticipant(participant);
+
+		try {
+			await instantiationService.invokeFunction(openSessionByResource, resource);
+		} finally {
+			registration.dispose();
+		}
+
+		assert.deepStrictEqual({ resolvedResource, handledSession }, { resolvedResource: resource, handledSession: session });
+	});
+});


### PR DESCRIPTION
## Summary

- route persisted session URIs through opener participants before legacy session lookup
- let the Agents window open the provider-agnostic session directly
- preserve the existing workbench session-opening fallback

Fixes #325089

merging; can revert if we don't like the fix

cc @benvillalobos