### PR TITLE
Semantic colorization customization applied even if `editor.semanticTokenColorCustomizations.ena [sweeper experiment]

### DIFF
--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -449,15 +449,15 @@ export class ColorThemeData implements IWorkbenchColorTheme {
 
 		if (semanticTokenColors) {
 			this.customSemanticHighlighting = semanticTokenColors.enabled;
-			if (semanticTokenColors.rules) {
-				this.readSemanticTokenRules(semanticTokenColors.rules);
-			}
 			const themeSpecificColors = this.getThemeSpecificColors(semanticTokenColors) as ISemanticTokenColorCustomizations;
-			if (types.isObject(themeSpecificColors)) {
-				if (themeSpecificColors.enabled !== undefined) {
-					this.customSemanticHighlighting = themeSpecificColors.enabled;
+			if (types.isObject(themeSpecificColors) && themeSpecificColors.enabled !== undefined) {
+				this.customSemanticHighlighting = themeSpecificColors.enabled;
+			}
+			if (this.customSemanticHighlighting !== false) {
+				if (semanticTokenColors.rules) {
+					this.readSemanticTokenRules(semanticTokenColors.rules);
 				}
-				if (themeSpecificColors.rules) {
+				if (types.isObject(themeSpecificColors) && themeSpecificColors.rules) {
 					this.readSemanticTokenRules(themeSpecificColors.rules);
 				}
 			}

--- a/src/vs/workbench/services/themes/test/node/tokenStyleResolving.test.ts
+++ b/src/vs/workbench/services/themes/test/node/tokenStyleResolving.test.ts
@@ -356,4 +356,22 @@ suite('Themes - TokenStyleResolving', () => {
 			assert.strictEqual(registry.getTokenStylingDefaultRules().length, numberOfDefaultRules);
 		}
 	});
+
+	test('enabled false suppresses custom semantic token rules', async () => {
+		const themeData = ColorThemeData.createLoadedEmptyTheme('test', 'test');
+		themeData.setCustomColors({ 'editor.foreground': '#000000' });
+		themeData.setCustomSemanticTokenColors({
+			enabled: false,
+			rules: {
+				'type': '#ff0000',
+				'namespace': '#00ff00'
+			}
+		});
+
+		const tokenStyleMetaData = themeData.getTokenStyleMetadata('namespace', [], 'typescript');
+		assert.strictEqual(tokenStyleMetaData === undefined || tokenStyleMetaData.foreground === undefined, true, 'namespace token should not have custom foreground color when enabled is false');
+
+		const typeStyleMetaData = themeData.getTokenStyleMetadata('type', [], 'typescript');
+		assert.strictEqual(typeStyleMetaData === undefined || typeStyleMetaData.foreground === undefined, true, 'type token should not have custom foreground color when enabled is false');
+	});
 });


### PR DESCRIPTION
> 🧹 **Experimental — generated by VS Code Sweeper.** This draft PR was produced by an AI
> engine from a reviewed issue, as part of an experiment in AI-assisted issue management.
> A maintainer invoked it and will decide whether it proceeds — it is not ready for review
> until they mark it so. Feedback welcome; feel free to close.

Fixes #204043

## Change summary

Custom semantic token color rules in `editor.semanticTokenColorCustomizations.rules` are applied even when `enabled` is explicitly set to `false` in the same setting block.

## Review spec

In `colorThemeData.ts#setCustomSemanticTokenColors`, gate the `readSemanticTokenRules` calls on `semanticTokenColors.enabled !== false` so that setting `enabled: false` suppresses both semantic highlighting and the custom rules.

## Validation

Add a test in src/vs/workbench/services/themes/test/common/colorThemeData.test.ts asserting that after calling setCustomSemanticTokenColors({ enabled: false, rules: { namespace: '#ff0000' } }), the theme's customSemanticTokenRules array is empty and getTokenStyleMetadata for a 'namespace' token does not return the custom color.

---
Head `egamma:vscodesweeper/implement-204043` · one AI cross-review comment follows; nothing is auto-addressed.