### PR TITLE
sessions: single source of truth for single-pane layout enablement

### DIFF
--- a/src/vs/sessions/SINGLE_PANE_SCENARIOS.md
+++ b/src/vs/sessions/SINGLE_PANE_SCENARIOS.md
@@ -6,6 +6,11 @@ bar spanning the editor content and a docked detail panel).
 
 - The whole feature is gated behind the experimental setting **`sessions.layout.singlePaneDetailPanel`**
   (const `DOCK_DETAIL_PANEL_SETTING`), read **once at startup** — a window reload applies a change.
+  The setting is read only by `createSessionsWorkbench` (which selects the workbench/parts); the
+  resulting choice is published as `IAgentWorkbenchLayoutService.isSinglePaneLayoutEnabled` (read by
+  imperative code) and the `SinglePaneLayoutEnabledContext` context key (read only by declarative
+  `when` clauses). Features must gate on those — never read the setting or the context key directly
+  in imperative code.
 - When the setting is **OFF** (default), the Agents window renders exactly as before (auxiliary bar as
   its own grid column with its composite tab strip; the standard multi-diff Changes editor). Nothing in
   this document applies.

--- a/src/vs/sessions/browser/layoutActions.ts
+++ b/src/vs/sessions/browser/layoutActions.ts
@@ -16,8 +16,7 @@ import { KeybindingWeight } from '../../platform/keybinding/common/keybindingsRe
 import { registerIcon } from '../../platform/theme/common/iconRegistry.js';
 import { AuxiliaryBarVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext, IsWindowAlwaysOnTopContext, SideBarVisibleContext } from '../../workbench/common/contextkeys.js';
 import { IWorkbenchLayoutService, Parts } from '../../workbench/services/layout/browser/layoutService.js';
-import { SessionsWelcomeVisibleContext } from '../common/contextkeys.js';
-import { DOCK_DETAIL_PANEL_SETTING } from '../common/sessionConfig.js';
+import { SessionsWelcomeVisibleContext, SinglePaneLayoutEnabledContext } from '../common/contextkeys.js';
 
 // Register Icons
 const panelCloseIcon = registerIcon('agent-panel-close', Codicon.close, localize('agentPanelCloseIcon', "Icon to close the panel."));
@@ -82,7 +81,7 @@ const editorTitleAuxiliaryBarWhen = ContextKeyExpr.and(
 	IsSessionsWindowContext,
 	IsAuxiliaryWindowContext.toNegated(),
 	IsTopRightEditorGroupContext);
-const isSinglePaneDetailPanelDisabled = ContextKeyExpr.equals(`config.${DOCK_DETAIL_PANEL_SETTING}`, true).negate();
+const isSinglePaneDetailPanelDisabled = SinglePaneLayoutEnabledContext.negate();
 
 MenuRegistry.appendMenuItem(MenuId.EditorTitleLayout, {
 	command: {

--- a/src/vs/sessions/browser/paneCompositePartService.ts
+++ b/src/vs/sessions/browser/paneCompositePartService.ts
@@ -23,9 +23,9 @@ import { MobileAuxiliaryBarPart } from './parts/mobile/mobileAuxiliaryBarPart.js
 import { getClientArea } from '../../base/browser/dom.js';
 import { mainWindow } from '../../base/browser/window.js';
 import { InstantiationType, registerSingleton } from '../../platform/instantiation/common/extensions.js';
-import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { IEditorGroupsService } from '../../workbench/services/editor/common/editorGroupsService.js';
-import { shouldUseSinglePaneLayout, SinglePaneMainEditorPart } from './parts/singlePaneEditorPart.js';
+import { IAgentWorkbenchLayoutService } from './workbench.js';
+import { SinglePaneMainEditorPart } from './parts/singlePaneEditorPart.js';
 
 export class AgenticPaneCompositePartService extends Disposable implements IPaneCompositePartService {
 
@@ -41,7 +41,7 @@ export class AgenticPaneCompositePartService extends Disposable implements IPane
 
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IConfigurationService configurationService: IConfigurationService,
+		@IAgentWorkbenchLayoutService layoutService: IAgentWorkbenchLayoutService,
 		@IEditorGroupsService editorGroupsService: IEditorGroupsService,
 	) {
 		super();
@@ -54,7 +54,7 @@ export class AgenticPaneCompositePartService extends Disposable implements IPane
 
 		// In the single-pane layout the auxiliary bar is owned by (docked inside)
 		// the editor part; share that instance instead of creating a separate one.
-		const auxiliaryBarPart = shouldUseSinglePaneLayout(configurationService)
+		const auxiliaryBarPart = layoutService.isSinglePaneLayoutEnabled
 			? (editorGroupsService.mainPart as SinglePaneMainEditorPart).auxiliaryBar
 			: instantiationService.createInstance(isPhoneLayout ? MobileAuxiliaryBarPart : AuxiliaryBarPart);
 		this.registerPart(ViewContainerLocation.AuxiliaryBar, auxiliaryBarPart);

--- a/src/vs/sessions/browser/parts/editorParts.ts
+++ b/src/vs/sessions/browser/parts/editorParts.ts
@@ -4,17 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/editorPart.css';
-import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { InstantiationType, registerSingleton } from '../../../platform/instantiation/common/extensions.js';
 import { EditorParts as EditorPartsBase } from '../../../workbench/browser/parts/editor/editorParts.js';
 import { IEditorGroupsService } from '../../../workbench/services/editor/common/editorGroupsService.js';
+import { IAgentWorkbenchLayoutService } from '../workbench.js';
 import { MainEditorPart } from './editorPart.js';
-import { shouldUseSinglePaneLayout, SinglePaneMainEditorPart } from './singlePaneEditorPart.js';
+import { SinglePaneMainEditorPart } from './singlePaneEditorPart.js';
 
 export class EditorParts extends EditorPartsBase {
 	protected override createMainEditorPart(): MainEditorPart {
-		const configurationService = this.instantiationService.invokeFunction(accessor => accessor.get(IConfigurationService));
-		if (shouldUseSinglePaneLayout(configurationService)) {
+		const layoutService = this.instantiationService.invokeFunction(accessor => accessor.get(IAgentWorkbenchLayoutService));
+		if (layoutService.isSinglePaneLayoutEnabled) {
 			return this.instantiationService.createInstance(SinglePaneMainEditorPart, this);
 		}
 		return this.instantiationService.createInstance(MainEditorPart, this);

--- a/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
+++ b/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getClientArea } from '../../../base/browser/dom.js';
 import { DisposableMap } from '../../../base/common/lifecycle.js';
 import { mainWindow } from '../../../base/browser/window.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
@@ -15,25 +14,11 @@ import { IEditorGroupViewOptions, IEditorPartCreationOptions, IEditorPartsView }
 import { EditorGroupView } from '../../../workbench/browser/parts/editor/editorGroupView.js';
 import { IWorkbenchLayoutService, Parts } from '../../../workbench/services/layout/browser/layoutService.js';
 import { IHostService } from '../../../workbench/services/host/browser/host.js';
-import { DOCK_DETAIL_PANEL_SETTING } from '../../common/sessionConfig.js';
 import { DockedAuxiliaryBarController } from '../dockedAuxiliaryBarController.js';
 import { Menus } from '../menus.js';
 import { IAgentWorkbenchLayoutService } from '../workbench.js';
 import { MainEditorPart } from './editorPart.js';
 import { SinglePaneAuxiliaryBarPart } from './singlePaneAuxiliaryBarPart.js';
-
-/**
- * Whether the Agents window should use the single-pane detail-panel layout, where
- * the auxiliary bar is owned by (docked inside) the editor part. True only when the
- * setting is enabled on a non-phone viewport — the classic and mobile layouts keep
- * the auxiliary bar as a standalone part. This is the single source of truth for
- * selecting the single-pane workbench, editor part, and auxiliary bar together.
- */
-export function shouldUseSinglePaneLayout(configurationService: IConfigurationService): boolean {
-	const { width } = getClientArea(mainWindow.document.body);
-	const isPhoneLayout = width < 640;
-	return !isPhoneLayout && configurationService.getValue<boolean>(DOCK_DETAIL_PANEL_SETTING) === true;
-}
 
 /**
  * Single-pane editor part: owns the docked auxiliary bar so "tab bar + editor

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -64,7 +64,7 @@ import { EditorMarkdownCodeBlockRenderer } from '../../editor/browser/widget/mar
 import { SyncDescriptor } from '../../platform/instantiation/common/descriptors.js';
 import { TitleService } from './parts/titlebarPart.js';
 import { IContextKeyService } from '../../platform/contextkey/common/contextkey.js';
-import { EditorMaximizedContext, IsPhoneLayoutContext } from '../common/contextkeys.js';
+import { EditorMaximizedContext, IsPhoneLayoutContext, SinglePaneLayoutEnabledContext } from '../common/contextkeys.js';
 import {
 	NotificationsPosition,
 	NotificationsSettings,
@@ -140,8 +140,10 @@ export interface IAgentWorkbenchLayoutService extends IWorkbenchLayoutService, I
 	/**
 	 * Whether the Agents window is using the single-pane (docked detail panel)
 	 * layout. Fixed at construction by the workbench subclass — `false` for the
-	 * classic/mobile workbench, `true` for {@link SinglePaneWorkbench}. Features
-	 * gate single-pane behaviour on this instead of reading the setting directly.
+	 * classic/mobile workbench, `true` for {@link SinglePaneWorkbench}. Imperative
+	 * features gate single-pane behaviour on this (and declarative `when` clauses on
+	 * the `SinglePaneLayoutEnabledContext` context key it publishes) instead of
+	 * reading the setting directly.
 	 */
 	readonly isSinglePaneLayoutEnabled: boolean;
 
@@ -531,6 +533,12 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 				this._register(autorun(reader => {
 					isPhoneLayoutCtx.set(this.layoutPolicy.viewportClass.read(reader) === 'phone');
 				}));
+
+				// Single-Pane Layout Context Key: mirrors `isSinglePaneLayoutEnabled` so
+				// declarative `when` clauses can gate on the single-pane layout. Fixed at
+				// construction (a reload applies a setting change). Imperative code reads
+				// `isSinglePaneLayoutEnabled` off the layout service instead.
+				SinglePaneLayoutEnabledContext.bindTo(contextKeyService).set(this.isSinglePaneLayoutEnabled);
 
 				// Virtual keyboard tracking (visualViewport): publishes the
 				// keyboard height as an observable, mirrors it onto the

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -139,11 +139,8 @@ export interface IAgentWorkbenchLayoutService extends IWorkbenchLayoutService, I
 
 	/**
 	 * Whether the Agents window is using the single-pane (docked detail panel)
-	 * layout. Fixed at construction by the workbench subclass — `false` for the
-	 * classic/mobile workbench, `true` for {@link SinglePaneWorkbench}. Imperative
-	 * features gate single-pane behaviour on this (and declarative `when` clauses on
-	 * the `SinglePaneLayoutEnabledContext` context key it publishes) instead of
-	 * reading the setting directly.
+	 * layout. Fixed at construction — `false` for the classic/mobile workbench,
+	 * `true` for {@link SinglePaneWorkbench}.
 	 */
 	readonly isSinglePaneLayoutEnabled: boolean;
 
@@ -534,10 +531,6 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 					isPhoneLayoutCtx.set(this.layoutPolicy.viewportClass.read(reader) === 'phone');
 				}));
 
-				// Single-Pane Layout Context Key: mirrors `isSinglePaneLayoutEnabled` so
-				// declarative `when` clauses can gate on the single-pane layout. Fixed at
-				// construction (a reload applies a setting change). Imperative code reads
-				// `isSinglePaneLayoutEnabled` off the layout service instead.
 				SinglePaneLayoutEnabledContext.bindTo(contextKeyService).set(this.isSinglePaneLayoutEnabled);
 
 				// Virtual keyboard tracking (visualViewport): publishes the

--- a/src/vs/sessions/browser/workbenchFactory.ts
+++ b/src/vs/sessions/browser/workbenchFactory.ts
@@ -3,23 +3,31 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { getClientArea } from '../../base/browser/dom.js';
+import { mainWindow } from '../../base/browser/window.js';
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { SyncDescriptor } from '../../platform/instantiation/common/descriptors.js';
 import { ServiceCollection } from '../../platform/instantiation/common/serviceCollection.js';
 import { ILogService } from '../../platform/log/common/log.js';
-import { shouldUseSinglePaneLayout } from './parts/singlePaneEditorPart.js';
+import { DOCK_DETAIL_PANEL_SETTING } from '../common/sessionConfig.js';
 import { SinglePaneWorkbench } from './singlePaneWorkbench.js';
 import { IWorkbenchOptions, Workbench } from './workbench.js';
 
 /**
  * Creates the Agents window workbench, choosing the single-pane (docked
- * detail-panel) variant when the setting is enabled. The layout mode is fixed at
- * construction — toggling the setting requires a window reload.
+ * detail-panel) variant when the setting is enabled on a non-phone viewport. This
+ * is the **only** place the `sessions.layout.singlePaneDetailPanel` setting is read:
+ * the chosen variant fixes {@link Workbench.isSinglePaneLayoutEnabled} (read by
+ * imperative code) and the `SinglePaneLayoutEnabledContext` context key it publishes
+ * (read by declarative `when` clauses). The layout mode is fixed at construction —
+ * toggling the setting requires a window reload.
  */
 export function createSessionsWorkbench(parent: HTMLElement, options: IWorkbenchOptions | undefined, serviceCollection: ServiceCollection, logService: ILogService): Workbench {
 	const configurationService = serviceCollection.get(IConfigurationService);
+	const isPhoneLayout = getClientArea(mainWindow.document.body).width < 640;
 	const singlePane = !(configurationService instanceof SyncDescriptor)
-		&& shouldUseSinglePaneLayout(configurationService);
+		&& !isPhoneLayout
+		&& configurationService.getValue<boolean>(DOCK_DETAIL_PANEL_SETTING) === true;
 	return singlePane
 		? new SinglePaneWorkbench(parent, options, serviceCollection, logService)
 		: new Workbench(parent, options, serviceCollection, logService);

--- a/src/vs/sessions/browser/workbenchFactory.ts
+++ b/src/vs/sessions/browser/workbenchFactory.ts
@@ -14,12 +14,8 @@ import { SinglePaneWorkbench } from './singlePaneWorkbench.js';
 import { IWorkbenchOptions, Workbench } from './workbench.js';
 
 /**
- * Creates the Agents window workbench, choosing the single-pane (docked
- * detail-panel) variant when the setting is enabled on a non-phone viewport. This
- * is the **only** place the `sessions.layout.singlePaneDetailPanel` setting is read:
- * the chosen variant fixes {@link Workbench.isSinglePaneLayoutEnabled} (read by
- * imperative code) and the `SinglePaneLayoutEnabledContext` context key it publishes
- * (read by declarative `when` clauses). The layout mode is fixed at construction —
+ * Creates the Agents window workbench, choosing the single-pane variant when the
+ * detail-panel setting is enabled on a non-phone viewport. Fixed at construction —
  * toggling the setting requires a window reload.
  */
 export function createSessionsWorkbench(parent: HTMLElement, options: IWorkbenchOptions | undefined, serviceCollection: ServiceCollection, logService: ILogService): Workbench {

--- a/src/vs/sessions/common/contextkeys.ts
+++ b/src/vs/sessions/common/contextkeys.ts
@@ -108,6 +108,7 @@ export const CanGoForwardContext = new RawContextKey<boolean>('sessionsCanGoForw
 //#region < --- Editor --- >
 
 export const EditorMaximizedContext = new RawContextKey<boolean>('editorMaximized', false, localize('editorMaximized', "Whether the editor area is maximized"));
+export const SinglePaneLayoutEnabledContext = new RawContextKey<boolean>('agentSessionsSinglePaneLayoutEnabled', false, localize('agentSessionsSinglePaneLayoutEnabled', "Whether the Agents window is using the single-pane (docked detail panel) layout. Single source of truth for gating single-pane behaviour — set once by the workbench from the layout it was constructed with; features must read this instead of the underlying setting"));
 export const SinglePaneDetailChangesOrFilesActiveContext = new RawContextKey<boolean>('agentSessionsSinglePaneDetailChangesOrFiles', false, localize('agentSessionsSinglePaneDetailChangesOrFiles', "Whether the single-pane detail panel's active editor maps to the Changes or Files detail target"));
 export const SinglePaneChangesTabMissingContext = new RawContextKey<boolean>('agentSessionsSinglePaneChangesTabMissing', false, localize('agentSessionsSinglePaneChangesTabMissing', "Whether the single-pane session supports a Changes editor but its tab is not currently open"));
 export const SinglePaneFilesTabMissingContext = new RawContextKey<boolean>('agentSessionsSinglePaneFilesTabMissing', false, localize('agentSessionsSinglePaneFilesTabMissing', "Whether the single-pane session supports a Files tab but its tab is not currently open"));

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -21,11 +21,10 @@ import { URI } from '../../../../base/common/uri.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { IChangesViewService } from '../common/changesViewService.js';
-import { DOCK_DETAIL_PANEL_SETTING } from '../../../common/sessionConfig.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionChangesEditor } from './sessionChangesEditor.js';
 import { CHANGES_HEADER_ACTIONS_ID } from './changesView.js';
-import { SessionHasChangesContext } from '../../../common/contextkeys.js';
+import { SessionHasChangesContext, SinglePaneLayoutEnabledContext } from '../../../common/contextkeys.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { logChangesViewViewModeChange } from '../../../common/sessionsTelemetry.js';
@@ -124,7 +123,7 @@ registerAction2(OpenPullRequestAction);
 const singlePaneChangesEditorActive = ContextKeyExpr.and(
 	IsSessionsWindowContext,
 	ActiveEditorContext.isEqualTo(SessionChangesEditor.ID),
-	ContextKeyExpr.equals(`config.${DOCK_DETAIL_PANEL_SETTING}`, true)
+	SinglePaneLayoutEnabledContext
 );
 
 // Title-bar (tab-row) gate that does NOT require the editor content area to be
@@ -160,7 +159,7 @@ class ChangesHeaderActionsAction extends Action2 {
 				when: ContextKeyExpr.and(
 					IsSessionsWindowContext,
 					IsAuxiliaryWindowContext.toNegated(),
-					ContextKeyExpr.equals(`config.${DOCK_DETAIL_PANEL_SETTING}`, true),
+					SinglePaneLayoutEnabledContext,
 					SessionHasChangesContext
 				)
 			},

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
@@ -31,7 +31,7 @@ import { IMultiDiffEditorOptions } from '../../../../editor/browser/widget/multi
 import { IDiffEditorOptions } from '../../../../editor/common/config/editorOptions.js';
 import { IResourceLabel, IWorkbenchUIElementFactory } from '../../../../editor/browser/widget/multiDiffEditor/workbenchUIElementFactory.js';
 import { Menus } from '../../../browser/menus.js';
-import { shouldUseSinglePaneLayout } from '../../../browser/parts/singlePaneEditorPart.js';
+import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { ActiveSessionContextKeys } from '../common/changes.js';
 import { IChangesViewService } from '../common/changesViewService.js';
 import { ChangesActionsBar } from './changesView.js';
@@ -99,6 +99,7 @@ export class SessionChangesEditor extends EditorPane {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IChangesViewService private readonly changesViewService: IChangesViewService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IAgentWorkbenchLayoutService private readonly layoutService: IAgentWorkbenchLayoutService,
 	) {
 		super(SessionChangesEditor.ID, group, telemetryService, themeService, storageService);
 	}
@@ -118,7 +119,7 @@ export class SessionChangesEditor extends EditorPane {
 		// In single-pane, the header (Branch Changes dropdown, diff stats and primary
 		// actions) is hosted by the editor part's full-width header instead of inside
 		// this editor, so it spans the editor content and the docked detail panel.
-		this._singlePane = shouldUseSinglePaneLayout(this.configurationService);
+		this._singlePane = this.layoutService.isSinglePaneLayoutEnabled;
 		if (!this._singlePane) {
 			const header = append(root, $('.session-changes-editor-header'));
 			const left = append(header, $('.session-changes-editor-header-left'));

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesService.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesService.ts
@@ -93,10 +93,6 @@ export class SessionChangesService implements ISessionChangesService {
 	async openChangesEditor(sessionResource: URI, options?: IMultiDiffEditorOptions, group?: PreferredGroup): Promise<IEditorGroup | undefined> {
 		const multiDiffSource = this.getChangesEditorResource(sessionResource);
 
-		// The layout service is the single source of truth for the single-pane
-		// decision. In minimal environments — component fixtures / tests — a plain
-		// workbench layout service is registered whose `isSinglePaneLayoutEnabled`
-		// is undefined (falsy), matching the classic layout.
 		if (this.layoutService.isSinglePaneLayoutEnabled) {
 			const input = this.instantiationService.createInstance(SessionChangesEditorInput, multiDiffSource);
 			const pane = await this.editorService.openEditor(input, { ...options, pinned: true }, group);

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesService.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesService.ts
@@ -6,11 +6,10 @@
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { createDecorator, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IMultiDiffEditorOptions } from '../../../../editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.js';
 import { IEditorService, PreferredGroup } from '../../../../workbench/services/editor/common/editorService.js';
 import { IEditorGroup } from '../../../../workbench/services/editor/common/editorGroupsService.js';
-import { DOCK_DETAIL_PANEL_SETTING } from '../../../common/sessionConfig.js';
+import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { SessionChangesEditorInput } from './sessionChangesEditorInput.js';
 
 export const ISessionChangesService = createDecorator<ISessionChangesService>('sessionChangesService');
@@ -62,7 +61,7 @@ export class SessionChangesService implements ISessionChangesService {
 	constructor(
 		@IEditorService private readonly editorService: IEditorService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IAgentWorkbenchLayoutService private readonly layoutService: IAgentWorkbenchLayoutService,
 	) { }
 
 	getChangesEditorResource(sessionResource: URI): URI {
@@ -94,11 +93,11 @@ export class SessionChangesService implements ISessionChangesService {
 	async openChangesEditor(sessionResource: URI, options?: IMultiDiffEditorOptions, group?: PreferredGroup): Promise<IEditorGroup | undefined> {
 		const multiDiffSource = this.getChangesEditorResource(sessionResource);
 
-		// Read the setting directly (rather than via IAgentWorkbenchLayoutService) so this
-		// singleton also resolves in minimal environments — component fixtures / tests — that
-		// don't register the Agents-window layout service. The layout service remains the
-		// single source of truth for contributions that run only in the real window.
-		if (this.configurationService.getValue<boolean>(DOCK_DETAIL_PANEL_SETTING) === true) {
+		// The layout service is the single source of truth for the single-pane
+		// decision. In minimal environments — component fixtures / tests — a plain
+		// workbench layout service is registered whose `isSinglePaneLayoutEnabled`
+		// is undefined (falsy), matching the classic layout.
+		if (this.layoutService.isSinglePaneLayoutEnabled) {
 			const input = this.instantiationService.createInstance(SessionChangesEditorInput, multiDiffSource);
 			const pane = await this.editorService.openEditor(input, { ...options, pinned: true }, group);
 			return pane?.group;

--- a/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
+++ b/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
@@ -12,9 +12,8 @@ import { isICommandActionToggleInfo } from '../../../../../platform/action/commo
 import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
 import { ActiveEditorContext, AuxiliaryBarVisibleContext, IsSessionsWindowContext, MainEditorAreaVisibleContext } from '../../../../../workbench/common/contextkeys.js';
 import { Menus } from '../../../../browser/menus.js';
-import { DOCK_DETAIL_PANEL_SETTING } from '../../../../common/sessionConfig.js';
 import { ChangesContextKeys } from '../../common/changes.js';
-import { SessionHasChangesContext } from '../../../../common/contextkeys.js';
+import { SessionHasChangesContext, SinglePaneLayoutEnabledContext } from '../../../../common/contextkeys.js';
 import { SessionChangesEditor } from '../../browser/sessionChangesEditor.js';
 import { CHANGES_HEADER_ACTIONS_ID } from '../../browser/changesView.js';
 import '../../browser/changesViewActions.js';
@@ -35,7 +34,7 @@ suite('Changes View Actions', () => {
 			icon: ThemeIcon.isThemeIcon(item.command.icon) ? item.command.icon.id : undefined,
 			hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
 			hasActiveEditorGate: when.includes(ActiveEditorContext.key) && when.includes(SessionChangesEditor.ID),
-			hasSinglePaneConfigGate: when.includes(`config.${DOCK_DETAIL_PANEL_SETTING}`),
+			hasSinglePaneConfigGate: when.includes(SinglePaneLayoutEnabledContext.key),
 			hasEditorAreaVisibleGate: when.includes(MainEditorAreaVisibleContext.key),
 		}, {
 			group: '1_diff',
@@ -61,7 +60,7 @@ suite('Changes View Actions', () => {
 			icon: ThemeIcon.isThemeIcon(item.command.icon) ? item.command.icon.id : undefined,
 			hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
 			hasActiveEditorGate: when.includes(ActiveEditorContext.key) && when.includes(SessionChangesEditor.ID),
-			hasSinglePaneConfigGate: when.includes(`config.${DOCK_DETAIL_PANEL_SETTING}`),
+			hasSinglePaneConfigGate: when.includes(SinglePaneLayoutEnabledContext.key),
 			hasEditorAreaVisibleGate: when.includes(MainEditorAreaVisibleContext.key),
 			hasAllCollapsedGate: when.includes(EditorContextKeys.multiDiffEditorAllCollapsed.key),
 		}, {
@@ -95,7 +94,7 @@ suite('Changes View Actions', () => {
 			toggledOnSideBySide: toggledInfo?.condition.serialize() === EditorContextKeys.multiDiffEditorRenderSideBySide.serialize(),
 			hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
 			hasActiveEditorGate: when.includes(ActiveEditorContext.key) && when.includes(SessionChangesEditor.ID),
-			hasSinglePaneConfigGate: when.includes(`config.${DOCK_DETAIL_PANEL_SETTING}`),
+			hasSinglePaneConfigGate: when.includes(SinglePaneLayoutEnabledContext.key),
 			hasEditorAreaVisibleGate: when.includes(MainEditorAreaVisibleContext.key),
 		}, {
 			id: 'workbench.action.agentSessions.toggleInlineView',
@@ -125,7 +124,7 @@ suite('Changes View Actions', () => {
 			category: item.command.category && typeof item.command.category !== 'string' ? item.command.category.value : item.command.category,
 			hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
 			hasActiveEditorGate: when.includes(ActiveEditorContext.key) && when.includes(SessionChangesEditor.ID),
-			hasSinglePaneConfigGate: when.includes(`config.${DOCK_DETAIL_PANEL_SETTING}`),
+			hasSinglePaneConfigGate: when.includes(SinglePaneLayoutEnabledContext.key),
 			hasEditorAreaVisibleGate: when.includes(MainEditorAreaVisibleContext.key),
 		}, {
 			id: 'workbench.action.agentSessions.toggleInlineView',
@@ -154,7 +153,7 @@ suite('Changes View Actions', () => {
 				icon: ThemeIcon.isThemeIcon(item.command.icon) ? item.command.icon.id : undefined,
 				hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
 				hasActiveEditorGate: when.includes(ActiveEditorContext.key) && when.includes(SessionChangesEditor.ID),
-				hasSinglePaneConfigGate: when.includes(`config.${DOCK_DETAIL_PANEL_SETTING}`),
+				hasSinglePaneConfigGate: when.includes(SinglePaneLayoutEnabledContext.key),
 				hasAuxBarVisibleGate: when.includes(AuxiliaryBarVisibleContext.key),
 				hasViewModeGate: when.includes(ChangesContextKeys.ViewMode.key),
 			};
@@ -196,7 +195,7 @@ suite('Changes View Actions', () => {
 			group: item.group,
 			order: item.order,
 			hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
-			hasSinglePaneConfigGate: when.includes(`config.${DOCK_DETAIL_PANEL_SETTING}`),
+			hasSinglePaneConfigGate: when.includes(SinglePaneLayoutEnabledContext.key),
 			hasChangesGate: when.includes(SessionHasChangesContext.key),
 		}, {
 			group: 'navigation',

--- a/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
+++ b/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
@@ -11,7 +11,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { ActiveEditorContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext } from '../../../../workbench/common/contextkeys.js';
-import { IsPhoneLayoutContext, SessionWorkspaceIsVirtualContext, SessionProviderIdContext } from '../../../common/contextkeys.js';
+import { IsPhoneLayoutContext, SessionWorkspaceIsVirtualContext, SessionProviderIdContext, SinglePaneLayoutEnabledContext } from '../../../common/contextkeys.js';
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { CHAT_CATEGORY } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
@@ -20,14 +20,13 @@ import { CodeReviewService, ICodeReviewService } from './codeReviewService.js';
 import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../common/agentHostSessionsProvider.js';
 import { Menus } from '../../../browser/menus.js';
-import { DOCK_DETAIL_PANEL_SETTING } from '../../../common/sessionConfig.js';
 import { SessionChangesEditorInput } from '../../changes/browser/sessionChangesEditorInput.js';
 
 registerSingleton(ICodeReviewService, CodeReviewService, InstantiationType.Delayed);
 
 const CODE_REVIEW_QUERY = '/code-review';
 
-const singlePaneDetailPanel = ContextKeyExpr.equals(`config.${DOCK_DETAIL_PANEL_SETTING}`, true);
+const singlePaneDetailPanel = SinglePaneLayoutEnabledContext;
 
 // Code review is shown in the single-pane Changes editor header (to the right),
 // so it is only contributed to the classic changes button bar when single-pane is off.

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -19,7 +19,7 @@ import { ActiveEditorContext, AuxiliaryBarVisibleContext, EditorPartModalContext
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { Menus } from '../../../browser/menus.js';
 import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
-import { EditorMaximizedContext, SinglePaneDetailChangesOrFilesActiveContext } from '../../../common/contextkeys.js';
+import { EditorMaximizedContext, SinglePaneDetailChangesOrFilesActiveContext, SinglePaneLayoutEnabledContext } from '../../../common/contextkeys.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorGroupsService } from '../../../../workbench/services/editor/common/editorGroupsService.js';
@@ -38,14 +38,13 @@ import { TEXT_FILE_EDITOR_ID } from '../../../../workbench/contrib/files/common/
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { ISessionsPartService } from '../../../services/sessions/browser/sessionsPartService.js';
 import { SessionsCategories } from '../../../common/categories.js';
-import { DOCK_DETAIL_PANEL_SETTING } from '../../../common/sessionConfig.js';
 import { IChangesViewService } from '../../changes/common/changesViewService.js';
 
 const terminalPanelHiddenForMaximizedEditor = new WeakSet<IAgentWorkbenchLayoutService>();
 
 // The pop-out-to-modal and close-editor-area buttons do not apply to the single-pane
-// redesign, so they are hidden when the setting is enabled (original layout keeps them).
-const singlePaneDetailPanel = ContextKeyExpr.equals(`config.${DOCK_DETAIL_PANEL_SETTING}`, true);
+// redesign, so they are hidden when single-pane is enabled (original layout keeps them).
+const singlePaneDetailPanel = SinglePaneLayoutEnabledContext;
 const notSinglePaneDetailPanel = singlePaneDetailPanel.negate();
 
 const editorTitleActionsWhen = ContextKeyExpr.and(

--- a/src/vs/sessions/contrib/layout/browser/sessions.layout.contribution.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessions.layout.contribution.ts
@@ -27,13 +27,13 @@ class SessionsLayoutContribution extends Disposable implements IWorkbenchContrib
 	) {
 		super();
 
-		if (isWeb && isMobile) {
-			this._register(instantiationService.createInstance(MobileLayoutController));
+		if (layoutService.isSinglePaneLayoutEnabled) {
+			this._register(instantiationService.createInstance(SinglePaneLayoutController));
 			return;
 		}
 
-		if (layoutService.isSinglePaneLayoutEnabled) {
-			this._register(instantiationService.createInstance(SinglePaneLayoutController));
+		if (isWeb && isMobile) {
+			this._register(instantiationService.createInstance(MobileLayoutController));
 			return;
 		}
 

--- a/src/vs/sessions/contrib/layout/browser/sessions.layout.contribution.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessions.layout.contribution.ts
@@ -6,7 +6,6 @@
 import { isMobile, isWeb } from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import product from '../../../../platform/product/common/product.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
@@ -15,6 +14,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { LayoutController, RESPONSIVE_SIDEBAR_SETTING } from './desktopSessionLayoutController.js';
 import { MobileLayoutController } from './mobileSessionLayoutController.js';
 import { DOCK_DETAIL_PANEL_SETTING } from '../../../common/sessionConfig.js';
+import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { SinglePaneLayoutController } from './singlePaneLayoutController.js';
 
 class SessionsLayoutContribution extends Disposable implements IWorkbenchContribution {
@@ -23,7 +23,7 @@ class SessionsLayoutContribution extends Disposable implements IWorkbenchContrib
 
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IConfigurationService configurationService: IConfigurationService,
+		@IAgentWorkbenchLayoutService layoutService: IAgentWorkbenchLayoutService,
 	) {
 		super();
 
@@ -32,7 +32,7 @@ class SessionsLayoutContribution extends Disposable implements IWorkbenchContrib
 			return;
 		}
 
-		if (configurationService.getValue<boolean>(DOCK_DETAIL_PANEL_SETTING)) {
+		if (layoutService.isSinglePaneLayoutEnabled) {
 			this._register(instantiationService.createInstance(SinglePaneLayoutController));
 			return;
 		}

--- a/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneResponsiveSidebarStrategy.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneResponsiveSidebarStrategy.ts
@@ -18,8 +18,7 @@ import { FileEditorInput } from '../../../../../workbench/contrib/files/browser/
 import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
 import { Parts } from '../../../../../workbench/services/layout/browser/layoutService.js';
 import { IAgentWorkbenchLayoutService } from '../../../../browser/workbench.js';
-import { SinglePaneDetailChangesOrFilesActiveContext } from '../../../../common/contextkeys.js';
-import { DOCK_DETAIL_PANEL_SETTING } from '../../../../common/sessionConfig.js';
+import { SinglePaneDetailChangesOrFilesActiveContext, SinglePaneLayoutEnabledContext } from '../../../../common/contextkeys.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { ISinglePaneLayoutContext, SinglePaneLayoutStrategy } from './singlePaneLayoutStrategy.js';
 
@@ -160,7 +159,7 @@ export class SinglePaneResponsiveSidebarStrategy extends SinglePaneLayoutStrateg
 						when: ContextKeyExpr.and(
 							IsSessionsWindowContext,
 							IsAuxiliaryWindowContext.toNegated(),
-							ContextKeyExpr.equals(`config.${DOCK_DETAIL_PANEL_SETTING}`, true))
+							SinglePaneLayoutEnabledContext)
 					},
 					menu: {
 						id: MenuId.EditorTitleLayout,
@@ -172,7 +171,7 @@ export class SinglePaneResponsiveSidebarStrategy extends SinglePaneLayoutStrateg
 							IsSessionsWindowContext,
 							IsAuxiliaryWindowContext.toNegated(),
 							IsTopRightEditorGroupContext,
-							ContextKeyExpr.equals(`config.${DOCK_DETAIL_PANEL_SETTING}`, true),
+							SinglePaneLayoutEnabledContext,
 							MainEditorAreaVisibleContext,
 							SinglePaneDetailChangesOrFilesActiveContext)
 					}

--- a/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
@@ -28,6 +28,7 @@ import { EditorInput } from '../../../../../workbench/common/editor/editorInput.
 import { IEditorWillOpenEvent, IUntypedEditorInput, isResourceEditorInput } from '../../../../../workbench/common/editor.js';
 import { IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import { IAgentWorkbenchLayoutService } from '../../../../browser/workbench.js';
 import { ChatInteractivity, IChat, ISession, ISessionFileChange, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { ISessionChangesService, SessionChangesService } from '../../../changes/browser/sessionChangesService.js';
 import { CHANGES_VIEW_CONTAINER_ID } from '../../../changes/common/changes.js';
@@ -285,7 +286,9 @@ export function createTestHarness(store: DisposableStore, options: ICreateOption
 		editorGroupsHaveContent: true,
 		applyWorkingSetCalls: [],
 		saveWorkingSetCalls: [],
-		sessionChangesService: new SessionChangesService(new class extends mock<IEditorService>() { }, instaService, configService),
+		sessionChangesService: new SessionChangesService(new class extends mock<IEditorService>() { }, instaService, new class extends mock<IAgentWorkbenchLayoutService>() {
+			override get isSinglePaneLayoutEnabled(): boolean { return options.singlePaneLayoutEnabled ?? false; }
+		}),
 		contextKeyService,
 	};
 


### PR DESCRIPTION
## What

Establishes a **single source of truth** for whether the Agents window uses the single-pane (docked detail panel) layout. Previously the experimental setting `sessions.layout.singlePaneDetailPanel` (`DOCK_DETAIL_PANEL_SETTING`) was read directly in many places — both as `config.…` context-key expressions in `when` clauses and as imperative `configurationService.getValue(...)`/`shouldUseSinglePaneLayout(...)` calls at several construction sites.

## Changes

- **Setting is read exactly once** — in `createSessionsWorkbench`, which picks the `Workbench` vs `SinglePaneWorkbench` variant. The redundant `shouldUseSinglePaneLayout` helper was inlined here and removed, so the setting + viewport-width check is no longer re-evaluated at multiple part-construction sites.
- The chosen variant is published two ways:
  - `IAgentWorkbenchLayoutService.isSinglePaneLayoutEnabled` — read by **imperative** code.
  - New `SinglePaneLayoutEnabledContext` context key (set once by the workbench) — read **only** by declarative `when` clauses.
- **Declarative consumers** (`layoutActions`, `editor`/`codeReview`/`changes` contributions, responsive sidebar) now gate on the context key instead of `config.${DOCK_DETAIL_PANEL_SETTING}`.
- **Imperative consumers** (`editorParts`, `paneCompositePartService`, `sessionChangesService`, `sessionChangesEditor`, layout contribution) now read `isSinglePaneLayoutEnabled` off the layout service — never the context key or the setting directly.

## Notes for reviewers

- Context keys are read **only** in `when` clauses; imperative code uses the layout service. This addressed review feedback.
- Minimal environments (component fixtures / tests) register a plain workbench layout service whose `isSinglePaneLayoutEnabled` is falsy, which correctly maps to the classic layout.
- Verified with `typecheck-client`, `valid-layers-check`, ESLint, and the pre-commit hygiene hook. Test harness updated to inject a mock layout service.
