### PR TITLE
Allow importing setup from other editors

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -95,6 +95,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/externalEditorImport",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/externalTerminal",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImport.contribution.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImport.contribution.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { isWeb } from '../../../../base/common/platform.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
+import { IExternalEditorImportResult, IExternalEditorImportService, IExternalEditorSource } from '../common/externalEditorImport.js';
+import { ExternalEditorImportService } from './externalEditorImportService.js';
+
+registerSingleton(IExternalEditorImportService, ExternalEditorImportService, InstantiationType.Delayed);
+
+const EXTERNAL_IMPORT_PROMPTED_KEY = 'externalEditorImport.prompted';
+
+/**
+ * Imports everything the source offers and reports the outcome to the user.
+ */
+export async function runExternalEditorImport(
+	source: IExternalEditorSource,
+	importService: IExternalEditorImportService,
+	notificationService: INotificationService,
+	progressService: IProgressService,
+): Promise<IExternalEditorImportResult> {
+	const result = await progressService.withProgress(
+		{ location: ProgressLocation.Notification, title: localize('externalImport.progress', "Importing customizations from {0}\u2026", source.label) },
+		() => importService.import(source, { settings: true, keybindings: true, snippets: true, extensions: true }, CancellationToken.None),
+	);
+
+	const parts: string[] = [];
+	if (result.settingsImported > 0) {
+		parts.push(localize('externalImport.settingsCount', "{0} settings", result.settingsImported));
+	}
+	if (result.keybindingsImported) {
+		parts.push(localize('externalImport.keybindings', "keyboard shortcuts"));
+	}
+	if (result.snippetsImported > 0) {
+		parts.push(localize('externalImport.snippetsCount', "{0} snippet files", result.snippetsImported));
+	}
+	if (result.extensionsInstalled > 0) {
+		parts.push(localize('externalImport.extensionsCount', "{0} extensions", result.extensionsInstalled));
+	}
+
+	if (parts.length === 0) {
+		notificationService.info(localize('externalImport.nothing', "Nothing new to import from {0} \u2014 your customizations are already up to date.", source.label));
+	} else {
+		notificationService.info(localize('externalImport.done', "Imported {0} from {1}.", parts.join(', '), source.label));
+	}
+
+	return result;
+}
+
+/**
+ * Offers returning users a one-click way to import their customizations from a
+ * detected source editor (e.g. Cursor). First-time users are handled by the
+ * onboarding modal instead.
+ */
+export class ExternalEditorImportNotificationContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.externalEditorImportNotification';
+
+	constructor(
+		@IExternalEditorImportService private readonly importService: IExternalEditorImportService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@IStorageService private readonly storageService: IStorageService,
+		@IProgressService private readonly progressService: IProgressService,
+	) {
+		super();
+
+		if (isWeb) {
+			return; // local detection is only possible on desktop
+		}
+
+		if (this.storageService.isNew(StorageScope.APPLICATION)) {
+			return; // brand-new users are handled by the onboarding modal
+		}
+
+		if (this.storageService.getBoolean(EXTERNAL_IMPORT_PROMPTED_KEY, StorageScope.APPLICATION)) {
+			return; // already offered before
+		}
+
+		this.tryPrompt();
+	}
+
+	private async tryPrompt(): Promise<void> {
+		let sources: IExternalEditorSource[];
+		try {
+			sources = await this.importService.detectSources(CancellationToken.None);
+		} catch {
+			return;
+		}
+
+		const source = sources[0];
+		if (!source) {
+			return;
+		}
+
+		// Mark as prompted regardless of the user's choice so we never nag.
+		this.storageService.store(EXTERNAL_IMPORT_PROMPTED_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+
+		this.notificationService.prompt(
+			Severity.Info,
+			localize('externalImport.prompt', "We noticed {0} is installed. Want to bring your settings, keyboard shortcuts, and extensions over to VS Code?", source.label),
+			[
+				{
+					label: localize('externalImport.prompt.import', "Import from {0}", source.label),
+					run: () => { runExternalEditorImport(source, this.importService, this.notificationService, this.progressService); },
+				},
+				{
+					label: localize('externalImport.prompt.notNow', "Not Now"),
+					run: () => { },
+				},
+			],
+		);
+	}
+}
+
+registerWorkbenchContribution2(ExternalEditorImportNotificationContribution.ID, ExternalEditorImportNotificationContribution, WorkbenchPhase.Eventually);
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.importFromExternalEditor',
+			title: localize2('externalImport.action', "Import Settings and Extensions from Another Editor..."),
+			category: Categories.Preferences,
+			f1: true,
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const importService = accessor.get(IExternalEditorImportService);
+		const notificationService = accessor.get(INotificationService);
+		const progressService = accessor.get(IProgressService);
+
+		const sources = await importService.detectSources(CancellationToken.None);
+		const source = sources[0];
+		if (!source) {
+			notificationService.info(localize('externalImport.none', "No other editors with importable customizations were found on this machine."));
+			return;
+		}
+
+		await runExternalEditorImport(source, importService, notificationService, progressService);
+	}
+});

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImport.contribution.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImport.contribution.ts
@@ -151,3 +151,29 @@ registerAction2(class extends Action2 {
 		await runExternalEditorImport(source, importService, notificationService, progressService);
 	}
 });
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.importFromCursor',
+			title: localize2('externalImport.cursorAction', "Import Settings and Extensions from Cursor"),
+			category: Categories.Preferences,
+			f1: true,
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const importService = accessor.get(IExternalEditorImportService);
+		const notificationService = accessor.get(INotificationService);
+		const progressService = accessor.get(IProgressService);
+
+		const sources = await importService.detectSources(CancellationToken.None);
+		const source = sources.find(candidate => candidate.id === 'cursor');
+		if (!source) {
+			notificationService.info(localize('externalImport.cursor.none', "Cursor with importable customizations was not found on this machine."));
+			return;
+		}
+
+		await runExternalEditorImport(source, importService, notificationService, progressService);
+	}
+});

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImport.contribution.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImport.contribution.ts
@@ -51,7 +51,19 @@ export async function runExternalEditorImport(
 	}
 
 	if (parts.length === 0) {
-		notificationService.info(localize('externalImport.nothing', "Nothing new to import from {0} \u2014 your customizations are already up to date.", source.label));
+		if (result.extensionsFailed > 0) {
+			notificationService.notify({
+				severity: Severity.Warning,
+				message: localize('externalImport.failed', "Some customizations from {0} could not be imported. You can try again later from the Command Palette.", source.label),
+			});
+		} else {
+			notificationService.info(localize('externalImport.nothing', "Nothing new to import from {0} \u2014 your customizations are already up to date.", source.label));
+		}
+	} else if (result.extensionsFailed > 0) {
+		notificationService.notify({
+			severity: Severity.Warning,
+			message: localize('externalImport.donePartial', "Imported {0} from {1}. Some extensions could not be imported.", parts.join(', '), source.label),
+		});
 	} else {
 		notificationService.info(localize('externalImport.done', "Imported {0} from {1}.", parts.join(', '), source.label));
 	}

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImport.contribution.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImport.contribution.ts
@@ -12,12 +12,15 @@ import { Action2, registerAction2 } from '../../../../platform/actions/common/ac
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 import { IExternalEditorImportResult, IExternalEditorImportService, IExternalEditorSource } from '../common/externalEditorImport.js';
+import { ExternalEditorImportEnvironmentService, IExternalEditorImportEnvironmentService } from '../common/externalEditorImportEnvironment.js';
 import { ExternalEditorImportService } from './externalEditorImportService.js';
 
+registerSingleton(IExternalEditorImportEnvironmentService, ExternalEditorImportEnvironmentService, InstantiationType.Delayed);
 registerSingleton(IExternalEditorImportService, ExternalEditorImportService, InstantiationType.Delayed);
 
 const EXTERNAL_IMPORT_PROMPTED_KEY = 'externalEditorImport.prompted';
@@ -38,20 +41,27 @@ export async function runExternalEditorImport(
 
 	const parts: string[] = [];
 	if (result.settingsImported > 0) {
-		parts.push(localize('externalImport.settingsCount', "{0} settings", result.settingsImported));
+		parts.push(result.settingsImported === 1
+			? localize('externalImport.oneSetting', "1 setting")
+			: localize('externalImport.settingsCount', "{0} settings", result.settingsImported));
 	}
 	if (result.keybindingsImported) {
 		parts.push(localize('externalImport.keybindings', "keyboard shortcuts"));
 	}
 	if (result.snippetsImported > 0) {
-		parts.push(localize('externalImport.snippetsCount', "{0} snippet files", result.snippetsImported));
+		parts.push(result.snippetsImported === 1
+			? localize('externalImport.oneSnippet', "1 snippet file")
+			: localize('externalImport.snippetsCount', "{0} snippet files", result.snippetsImported));
 	}
 	if (result.extensionsInstalled > 0) {
-		parts.push(localize('externalImport.extensionsCount', "{0} extensions", result.extensionsInstalled));
+		parts.push(result.extensionsInstalled === 1
+			? localize('externalImport.oneExtension', "1 extension")
+			: localize('externalImport.extensionsCount', "{0} extensions", result.extensionsInstalled));
 	}
+	const failed = result.settingsFailed || result.keybindingsFailed || result.snippetsFailed > 0 || result.extensionsFailed > 0;
 
 	if (parts.length === 0) {
-		if (result.extensionsFailed > 0) {
+		if (failed) {
 			notificationService.notify({
 				severity: Severity.Warning,
 				message: localize('externalImport.failed', "Some customizations from {0} could not be imported. You can try again later from the Command Palette.", source.label),
@@ -59,10 +69,10 @@ export async function runExternalEditorImport(
 		} else {
 			notificationService.info(localize('externalImport.nothing', "Nothing new to import from {0} \u2014 your customizations are already up to date.", source.label));
 		}
-	} else if (result.extensionsFailed > 0) {
+	} else if (failed) {
 		notificationService.notify({
 			severity: Severity.Warning,
-			message: localize('externalImport.donePartial', "Imported {0} from {1}. Some extensions could not be imported.", parts.join(', '), source.label),
+			message: localize('externalImport.donePartial', "Imported {0} from {1}. Some customizations could not be imported.", parts.join(', '), source.label),
 		});
 	} else {
 		notificationService.info(localize('externalImport.done', "Imported {0} from {1}.", parts.join(', '), source.label));
@@ -85,6 +95,7 @@ export class ExternalEditorImportNotificationContribution extends Disposable imp
 		@INotificationService private readonly notificationService: INotificationService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IProgressService private readonly progressService: IProgressService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 
@@ -100,7 +111,7 @@ export class ExternalEditorImportNotificationContribution extends Disposable imp
 			return; // already offered before
 		}
 
-		this.tryPrompt();
+		void this.tryPrompt().catch(error => this.logService.error('[externalEditorImport] Failed to determine whether to prompt for import', error));
 	}
 
 	private async tryPrompt(): Promise<void> {
@@ -115,6 +126,10 @@ export class ExternalEditorImportNotificationContribution extends Disposable imp
 		if (!source) {
 			return;
 		}
+		const preview = await this.importService.preview(source, CancellationToken.None);
+		if (preview.settings.length === 0 && preview.keybindings.length === 0 && preview.snippets.length === 0 && preview.extensions.length === 0) {
+			return;
+		}
 
 		// Mark as prompted regardless of the user's choice so we never nag.
 		this.storageService.store(EXTERNAL_IMPORT_PROMPTED_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
@@ -125,7 +140,12 @@ export class ExternalEditorImportNotificationContribution extends Disposable imp
 			[
 				{
 					label: localize('externalImport.prompt.import', "Import from {0}", source.label),
-					run: () => { runExternalEditorImport(source, this.importService, this.notificationService, this.progressService); },
+					run: () => {
+						void runExternalEditorImport(source, this.importService, this.notificationService, this.progressService).catch(error => {
+							this.logService.error('[externalEditorImport] Import from notification failed', error);
+							this.notificationService.error(localize('externalImport.unexpectedError', "Could not import customizations from {0}.", source.label));
+						});
+					},
 				},
 				{
 					label: localize('externalImport.prompt.notNow', "Not Now"),
@@ -157,32 +177,6 @@ registerAction2(class extends Action2 {
 		const source = sources[0];
 		if (!source) {
 			notificationService.info(localize('externalImport.none', "No other editors with importable customizations were found on this machine."));
-			return;
-		}
-
-		await runExternalEditorImport(source, importService, notificationService, progressService);
-	}
-});
-
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: 'workbench.action.importFromCursor',
-			title: localize2('externalImport.cursorAction', "Import Settings and Extensions from Cursor"),
-			category: Categories.Preferences,
-			f1: true,
-		});
-	}
-
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const importService = accessor.get(IExternalEditorImportService);
-		const notificationService = accessor.get(INotificationService);
-		const progressService = accessor.get(IProgressService);
-
-		const sources = await importService.detectSources(CancellationToken.None);
-		const source = sources.find(candidate => candidate.id === 'cursor');
-		if (!source) {
-			notificationService.info(localize('externalImport.cursor.none', "Cursor with importable customizations was not found on this machine."));
 			return;
 		}
 

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
@@ -45,6 +45,12 @@ interface IKnownEditorDescriptor {
 	readonly themeStateNameKeys?: readonly string[];
 }
 
+interface IExternalEditorKeybinding {
+	readonly key: string;
+	readonly command: string;
+	readonly [property: string]: unknown;
+}
+
 const KNOWN_EDITORS: readonly IKnownEditorDescriptor[] = [
 	{
 		id: 'cursor',
@@ -228,7 +234,7 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		}
 
 		if (!token?.isCancellationRequested && selection.snippets && source.hasSnippets) {
-			const result = await this.importSnippets(source);
+			const result = await this.importSnippets(source, token);
 			snippetsImported = result.imported;
 			snippetsFailed = result.failed;
 		}
@@ -278,22 +284,18 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	}
 
 	private async previewKeybindings(source: IExternalEditorSource): Promise<string[]> {
-		const sourceKeybindings = await this.readJsonArray(URI.joinPath(source.userDataUri, 'keybindings.json'));
+		const sourceKeybindings = await this.readKeybindings(URI.joinPath(source.userDataUri, 'keybindings.json'));
 		if (!sourceKeybindings || sourceKeybindings.length === 0) {
 			return [];
 		}
 
-		const existingKeybindings = await this.readJsonArray(this.userDataProfileService.currentProfile.keybindingsResource) ?? [];
+		const existingKeybindings = await this.readKeybindings(this.userDataProfileService.currentProfile.keybindingsResource) ?? [];
 		const labels: string[] = [];
 		for (const entry of sourceKeybindings) {
 			if (existingKeybindings.some(existing => equals(existing, entry))) {
 				continue;
 			}
-			const key = (entry as { key?: unknown } | null)?.key;
-			const command = (entry as { command?: unknown } | null)?.command;
-			if (typeof key === 'string' && key) {
-				labels.push(typeof command === 'string' && command ? `${key} → ${command}` : key);
-			}
+			labels.push(`${entry.key} → ${entry.command}`);
 		}
 		return labels;
 	}
@@ -416,9 +418,6 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	 * 2. Otherwise the source's persisted theme state (`globalStorage/storage.json`) is consulted —
 	 *    forks such as Cursor store the active theme there under their own namespace. Its kind
 	 *    (light/dark/high-contrast) is mapped to the matching VS Code default theme.
-	 * 3. Otherwise the `preferred*ColorTheme` / `window.autoDetectColorScheme` settings are used to
-	 *    infer a kind.
-	 *
 	 * Returns `undefined` when no theme preference can be determined.
 	 */
 	private async resolveColorThemeId(editor: IKnownEditorDescriptor, userDataUri: URI, settingsUri: URI): Promise<string | undefined> {
@@ -443,9 +442,7 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 			return DEFAULT_THEME_BY_KIND[kindFromState];
 		}
 
-		// 3. Fall back to preferred-theme / auto-detect settings.
-		const kindFromSettings = settings ? this.inferKindFromSettings(settings) : undefined;
-		return kindFromSettings ? DEFAULT_THEME_BY_KIND[kindFromSettings] : undefined;
+		return undefined;
 	}
 
 	private async readThemeKindFromState(editor: IKnownEditorDescriptor, userDataUri: URI): Promise<ColorThemeKind | undefined> {
@@ -495,43 +492,19 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		return undefined;
 	}
 
-	/**
-	 * Infers a color theme kind from the source settings' `preferred*ColorTheme` names. Used only
-	 * when the persisted theme state does not resolve a kind.
-	 */
-	private inferKindFromSettings(settings: Record<string, unknown>): ColorThemeKind | undefined {
-		const preferredHcDark = settings['workbench.preferredHighContrastColorTheme'];
-		const preferredHcLight = settings['workbench.preferredHighContrastLightColorTheme'];
-		const preferredDark = settings['workbench.preferredDarkColorTheme'];
-		const preferredLight = settings['workbench.preferredLightColorTheme'];
-		if (typeof preferredHcDark === 'string') {
-			return 'hc-dark';
-		}
-		if (typeof preferredHcLight === 'string') {
-			return 'hc-light';
-		}
-		if (typeof preferredDark === 'string') {
-			return 'dark';
-		}
-		if (typeof preferredLight === 'string') {
-			return 'light';
-		}
-		return undefined;
-	}
-
 	// =====================================================================
 	// Keybindings
 	// =====================================================================
 
 	private async importKeybindings(source: IExternalEditorSource): Promise<{ imported: boolean; failed: boolean }> {
-		const sourceKeybindings = await this.readJsonArray(URI.joinPath(source.userDataUri, 'keybindings.json'));
+		const sourceKeybindings = await this.readKeybindings(URI.joinPath(source.userDataUri, 'keybindings.json'));
 		if (!sourceKeybindings || sourceKeybindings.length === 0) {
 			return { imported: false, failed: false };
 		}
 
 		const targetResource = this.userDataProfileService.currentProfile.keybindingsResource;
 		const targetExists = await this.safeExists(targetResource);
-		const existingKeybindings = targetExists ? await this.readJsonArray(targetResource) : [];
+		const existingKeybindings = targetExists ? await this.readKeybindings(targetResource) : [];
 
 		// The target file exists but could not be parsed. Rewriting it would discard the user's
 		// keybindings, so bail out rather than risk data loss.
@@ -565,7 +538,7 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	// Snippets
 	// =====================================================================
 
-	private async importSnippets(source: IExternalEditorSource): Promise<{ imported: number; failed: number }> {
+	private async importSnippets(source: IExternalEditorSource, token?: CancellationToken): Promise<{ imported: number; failed: number }> {
 		const sourceSnippetsHome = URI.joinPath(source.userDataUri, 'snippets');
 		let sourceStat;
 		try {
@@ -583,6 +556,9 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		let imported = 0;
 		let failed = 0;
 		for (const child of sourceStat.children) {
+			if (token?.isCancellationRequested) {
+				break;
+			}
 			if (child.isDirectory || !this.isSnippetFile(child.resource)) {
 				continue;
 			}
@@ -593,6 +569,9 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 			}
 			try {
 				const content = await this.fileService.readFile(child.resource);
+				if (token?.isCancellationRequested) {
+					break;
+				}
 				await this.fileService.writeFile(targetUri, content.value);
 				imported++;
 			} catch (error) {
@@ -747,6 +726,17 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	private async readJsonArray(resource: URI): Promise<unknown[] | undefined> {
 		const parsed = await this.readJson(resource);
 		return Array.isArray(parsed) ? parsed : undefined;
+	}
+
+	private async readKeybindings(resource: URI): Promise<IExternalEditorKeybinding[] | undefined> {
+		const entries = await this.readJsonArray(resource);
+		return entries?.filter((entry): entry is IExternalEditorKeybinding => {
+			if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+				return false;
+			}
+			const keybinding = entry as Record<string, unknown>;
+			return typeof keybinding.key === 'string' && !!keybinding.key && typeof keybinding.command === 'string' && !!keybinding.command;
+		});
 	}
 
 	private async readJson(resource: URI): Promise<unknown> {

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
@@ -16,7 +16,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IJSONEditingService, IJSONValue } from '../../../services/configuration/common/jsonEditing.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
-import { IExternalEditorImportResult, IExternalEditorImportSelection, IExternalEditorImportService, IExternalEditorSource } from '../common/externalEditorImport.js';
+import { IExternalEditorImportPreview, IExternalEditorImportResult, IExternalEditorImportSelection, IExternalEditorImportService, IExternalEditorSource } from '../common/externalEditorImport.js';
 
 /**
  * Describes how to locate a known source editor's user data. Source editors that
@@ -136,6 +136,134 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		}
 
 		return { settingsImported, keybindingsImported, snippetsImported, extensionsInstalled, extensionsFailed };
+	}
+
+	// =====================================================================
+	// Preview
+	// =====================================================================
+
+	async preview(source: IExternalEditorSource, token?: CancellationToken): Promise<IExternalEditorImportPreview> {
+		const [settings, keybindings, snippets, extensions] = await Promise.all([
+			source.hasSettings ? this.previewSettings(source) : Promise.resolve([]),
+			source.hasKeybindings ? this.previewKeybindings(source) : Promise.resolve([]),
+			source.hasSnippets ? this.previewSnippets(source) : Promise.resolve([]),
+			source.hasExtensions ? this.previewExtensions(source, token) : Promise.resolve([]),
+		]);
+		return { settings, keybindings, snippets, extensions };
+	}
+
+	async hasImportableChanges(source: IExternalEditorSource): Promise<boolean> {
+		const [settings, keybindings, snippets, extensions] = await Promise.all([
+			source.hasSettings ? this.previewSettings(source) : Promise.resolve([]),
+			source.hasKeybindings ? this.previewKeybindings(source) : Promise.resolve([]),
+			source.hasSnippets ? this.previewSnippets(source) : Promise.resolve([]),
+			source.hasExtensions ? this.hasNewExtensions(source) : Promise.resolve(false),
+		]);
+		return settings.length > 0 || keybindings.length > 0 || snippets.length > 0 || extensions;
+	}
+
+	private async hasNewExtensions(source: IExternalEditorSource): Promise<boolean> {
+		if (!source.extensionsManifestUri) {
+			return false;
+		}
+
+		const identifiers = await this.readExtensionIdentifiers(source.extensionsManifestUri);
+		if (identifiers.length === 0) {
+			return false;
+		}
+
+		const installed = await this.extensionManagementService.getInstalled();
+		return identifiers.some(identifier => !installed.some(local => areSameExtensions(local.identifier, identifier)));
+	}
+
+	private async previewSettings(source: IExternalEditorSource): Promise<string[]> {
+		const sourceSettings = await this.readJsonObject(URI.joinPath(source.userDataUri, 'settings.json'));
+		if (!sourceSettings) {
+			return [];
+		}
+
+		const existingSettings = await this.readJsonObject(this.userDataProfileService.currentProfile.settingsResource) ?? {};
+		const keys: string[] = [];
+		for (const key of Object.keys(sourceSettings)) {
+			if (Object.prototype.hasOwnProperty.call(existingSettings, key) || this.isBlockedSettingKey(key)) {
+				continue;
+			}
+			keys.push(key);
+		}
+		return keys;
+	}
+
+	private async previewKeybindings(source: IExternalEditorSource): Promise<string[]> {
+		const sourceKeybindings = await this.readJsonArray(URI.joinPath(source.userDataUri, 'keybindings.json'));
+		if (!sourceKeybindings || sourceKeybindings.length === 0) {
+			return [];
+		}
+
+		const existingKeybindings = await this.readJsonArray(this.userDataProfileService.currentProfile.keybindingsResource) ?? [];
+		const labels: string[] = [];
+		for (const entry of sourceKeybindings) {
+			if (existingKeybindings.some(existing => this.deepEqual(existing, entry))) {
+				continue;
+			}
+			const key = (entry as { key?: unknown } | null)?.key;
+			const command = (entry as { command?: unknown } | null)?.command;
+			if (typeof key === 'string' && key) {
+				labels.push(typeof command === 'string' && command ? `${key} → ${command}` : key);
+			}
+		}
+		return labels;
+	}
+
+	private async previewSnippets(source: IExternalEditorSource): Promise<string[]> {
+		const sourceSnippetsHome = URI.joinPath(source.userDataUri, 'snippets');
+		let sourceStat;
+		try {
+			sourceStat = await this.fileService.resolve(sourceSnippetsHome);
+		} catch {
+			return [];
+		}
+
+		if (!sourceStat.children?.length) {
+			return [];
+		}
+
+		const targetSnippetsHome = this.userDataProfileService.currentProfile.snippetsHome;
+		const names: string[] = [];
+		for (const child of sourceStat.children) {
+			if (child.isDirectory) {
+				continue;
+			}
+			if (await this.safeExists(URI.joinPath(targetSnippetsHome, child.name))) {
+				continue;
+			}
+			names.push(child.name);
+		}
+		return names;
+	}
+
+	private async previewExtensions(source: IExternalEditorSource, token?: CancellationToken): Promise<string[]> {
+		if (!source.extensionsManifestUri) {
+			return [];
+		}
+
+		const identifiers = await this.readExtensionIdentifiers(source.extensionsManifestUri);
+		if (identifiers.length === 0) {
+			return [];
+		}
+
+		const installed = await this.extensionManagementService.getInstalled();
+		const toQuery = identifiers.filter(identifier => !installed.some(local => areSameExtensions(local.identifier, identifier)));
+		if (toQuery.length === 0) {
+			return [];
+		}
+
+		try {
+			const galleryExtensions = await this.extensionGalleryService.getExtensions(toQuery.map(identifier => ({ id: identifier.id })), token ?? CancellationToken.None);
+			return galleryExtensions.map(extension => extension.displayName || extension.identifier.id);
+		} catch (error) {
+			this.logService.error('[externalEditorImport] Failed to query extensions for preview', error);
+			return toQuery.map(identifier => identifier.id);
+		}
 	}
 
 	// =====================================================================

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
@@ -14,6 +14,7 @@ import { areSameExtensions } from '../../../../platform/extensionManagement/comm
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IJSONEditingService, IJSONValue } from '../../../services/configuration/common/jsonEditing.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
 import { IExternalEditorImportPreview, IExternalEditorImportResult, IExternalEditorImportSelection, IExternalEditorImportService, IExternalEditorSource } from '../common/externalEditorImport.js';
@@ -30,6 +31,13 @@ interface IKnownEditorDescriptor {
 	readonly appDataFolder: string;
 	/** Home-relative segments of the extensions directory, e.g. `.cursor/extensions`. */
 	readonly extensionsDirSegments: readonly string[];
+	/**
+	 * Keys in the source editor's `globalStorage/storage.json` that hold the label of the
+	 * user's currently selected color theme. Forks such as Cursor persist the active theme
+	 * here (under their own namespace) rather than in `settings.json`, so we consult these to
+	 * recover the user's real theme choice. Checked in order; the first string value wins.
+	 */
+	readonly themeStateNameKeys?: readonly string[];
 }
 
 const KNOWN_EDITORS: readonly IKnownEditorDescriptor[] = [
@@ -38,8 +46,37 @@ const KNOWN_EDITORS: readonly IKnownEditorDescriptor[] = [
 		label: 'Cursor',
 		appDataFolder: 'Cursor',
 		extensionsDirSegments: ['.cursor', 'extensions'],
+		themeStateNameKeys: ['glass.theme.settingsId'],
 	},
 ];
+
+/**
+ * The base kind of a color theme, mirroring VS Code's UI theme types.
+ */
+type ColorThemeKind = 'light' | 'dark' | 'hc-dark' | 'hc-light';
+
+/**
+ * The closest VS Code built-in default theme for each color theme kind. Used to map a source
+ * editor's selected theme — which is frequently a proprietary theme VS Code does not ship — onto
+ * an equivalent theme that always exists here.
+ */
+const DEFAULT_THEME_BY_KIND: Record<ColorThemeKind, string> = {
+	'light': 'Light Modern',
+	'dark': 'Dark Modern',
+	'hc-dark': 'Dark High Contrast',
+	'hc-light': 'Light High Contrast',
+};
+
+/**
+ * VS Code base theme identifiers (`uiTheme`) as persisted in `globalStorage/storage.json`, mapped
+ * to their color theme kind.
+ */
+const BASE_THEME_TO_KIND: Record<string, ColorThemeKind> = {
+	'vs': 'light',
+	'vs-dark': 'dark',
+	'hc-black': 'hc-dark',
+	'hc-light': 'hc-light',
+};
 
 /**
  * Settings keys (or prefixes) that should never be imported because they are
@@ -50,6 +87,37 @@ const SETTINGS_KEY_BLOCKLIST_PREFIXES: readonly string[] = [
 	'cursorai.',
 	'aicontext.',
 ];
+
+/**
+ * Settings keys that express a color theme preference. These are handled specially rather than
+ * bulk-imported: forks frequently rely on OS-driven auto-detection or a proprietary theme that has
+ * no VS Code equivalent, so instead of copying them verbatim we resolve the source's effective
+ * theme and pin the closest VS Code built-in theme. See {@link resolveColorThemeId}.
+ */
+const THEME_SETTING_KEYS: readonly string[] = [
+	'workbench.colorTheme',
+	'workbench.preferredDarkColorTheme',
+	'workbench.preferredLightColorTheme',
+	'workbench.preferredHighContrastColorTheme',
+	'workbench.preferredHighContrastLightColorTheme',
+	'window.autoDetectColorScheme',
+];
+
+const COLOR_THEME_SETTING_KEY = 'workbench.colorTheme';
+
+/**
+ * Some source editors (notably Cursor) ship their own forks of Microsoft extensions under a
+ * different publisher — e.g. Cursor publishes the Remote extensions under `anysphere.*`. Those
+ * identifiers do not exist on the VS Code Marketplace, so importing them verbatim always fails and
+ * surfaces a spurious warning even though the genuine extension is installable. Map the known forks
+ * onto their Marketplace equivalents so the real extension gets installed instead. Keys are
+ * lowercased source extension ids.
+ */
+const EXTENSION_ID_REMAP: ReadonlyMap<string, string> = new Map([
+	['anysphere.remote-ssh', 'ms-vscode-remote.remote-ssh'],
+	['anysphere.remote-wsl', 'ms-vscode-remote.remote-wsl'],
+	['anysphere.remote-containers', 'ms-vscode-remote.remote-containers'],
+]);
 
 export class ExternalEditorImportService extends Disposable implements IExternalEditorImportService {
 
@@ -62,13 +130,21 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
 		@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService,
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 	}
 
 	async detectSources(token?: CancellationToken): Promise<IExternalEditorSource[]> {
-		const home = await this.pathService.userHome();
+		// Detection reads the local machine's application-data directory. In a remote window the
+		// workbench file system operates against the remote host, so local detection would either
+		// find nothing or inspect the wrong machine. Skip it entirely in that case.
+		if (this.environmentService.remoteAuthority) {
+			return [];
+		}
+
+		const home = await this.pathService.userHome({ preferLocal: true });
 		const appDataHome = this.getApplicationDataHome(home);
 		if (!appDataHome) {
 			return [];
@@ -94,6 +170,7 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 			]);
 
 			if (hasSettings || hasKeybindings || hasSnippets || hasExtensions) {
+				const colorThemeId = hasSettings ? await this.resolveColorThemeId(editor, userDataUri, settingsUri) : undefined;
 				sources.push({
 					id: editor.id,
 					label: editor.label,
@@ -103,6 +180,8 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 					hasKeybindings,
 					hasSnippets,
 					hasExtensions,
+					hasTheme: !!colorThemeId,
+					colorThemeId,
 				});
 			}
 		}
@@ -185,10 +264,14 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		const existingSettings = await this.readJsonObject(this.userDataProfileService.currentProfile.settingsResource) ?? {};
 		const keys: string[] = [];
 		for (const key of Object.keys(sourceSettings)) {
-			if (Object.prototype.hasOwnProperty.call(existingSettings, key) || this.isBlockedSettingKey(key)) {
+			// Theme keys are represented by the resolved color theme (added below), not copied verbatim.
+			if (Object.prototype.hasOwnProperty.call(existingSettings, key) || this.isBlockedSettingKey(key) || this.isThemeSettingKey(key)) {
 				continue;
 			}
 			keys.push(key);
+		}
+		if (this.willApplyColorTheme(source, existingSettings)) {
+			keys.push(COLOR_THEME_SETTING_KEY);
 		}
 		return keys;
 	}
@@ -281,11 +364,18 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 
 		const edits: IJSONValue[] = [];
 		for (const key of Object.keys(sourceSettings)) {
-			// Never overwrite settings the user already has, and skip source-specific keys.
-			if (Object.prototype.hasOwnProperty.call(existingSettings, key) || this.isBlockedSettingKey(key)) {
+			// Never overwrite settings the user already has, skip source-specific keys, and defer
+			// theme keys — they are applied via the resolved color theme below.
+			if (Object.prototype.hasOwnProperty.call(existingSettings, key) || this.isBlockedSettingKey(key) || this.isThemeSettingKey(key)) {
 				continue;
 			}
 			edits.push({ path: [key], value: sourceSettings[key] });
+		}
+
+		// Pin the source editor's effective color theme (mapped to the closest VS Code built-in),
+		// unless the user already chose one.
+		if (this.willApplyColorTheme(source, existingSettings)) {
+			edits.push({ path: [COLOR_THEME_SETTING_KEY], value: source.colorThemeId });
 		}
 
 		if (edits.length === 0) {
@@ -305,6 +395,122 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		return SETTINGS_KEY_BLOCKLIST_PREFIXES.some(prefix => key.startsWith(prefix));
 	}
 
+	private isThemeSettingKey(key: string): boolean {
+		return THEME_SETTING_KEYS.includes(key);
+	}
+
+	/**
+	 * Whether importing would pin a resolved color theme, i.e. the source had a detectable theme
+	 * and the user has not already chosen one.
+	 */
+	private willApplyColorTheme(source: IExternalEditorSource, existingSettings: Record<string, unknown>): boolean {
+		return !!source.colorThemeId && !Object.prototype.hasOwnProperty.call(existingSettings, COLOR_THEME_SETTING_KEY);
+	}
+
+	/**
+	 * Resolves the source editor's effective color theme to the closest VS Code built-in theme.
+	 *
+	 * Resolution order:
+	 * 1. An explicit `workbench.colorTheme` in the source's `settings.json` is used as-is.
+	 * 2. Otherwise the source's persisted theme state (`globalStorage/storage.json`) is consulted —
+	 *    forks such as Cursor store the active theme there under their own namespace. Its kind
+	 *    (light/dark/high-contrast) is mapped to the matching VS Code default theme.
+	 * 3. Otherwise the `preferred*ColorTheme` / `window.autoDetectColorScheme` settings are used to
+	 *    infer a kind.
+	 *
+	 * Returns `undefined` when no theme preference can be determined.
+	 */
+	private async resolveColorThemeId(editor: IKnownEditorDescriptor, userDataUri: URI, settingsUri: URI): Promise<string | undefined> {
+		const settings = await this.readJsonObject(settingsUri);
+
+		// 1. Explicit theme in settings.json wins.
+		const explicit = settings?.[COLOR_THEME_SETTING_KEY];
+		if (typeof explicit === 'string' && explicit) {
+			return explicit;
+		}
+
+		// 2. The fork's persisted theme state (the user's real selected theme).
+		const kindFromState = await this.readThemeKindFromState(editor, userDataUri);
+		if (kindFromState) {
+			return DEFAULT_THEME_BY_KIND[kindFromState];
+		}
+
+		// 3. Fall back to preferred-theme / auto-detect settings.
+		const kindFromSettings = settings ? this.inferKindFromSettings(settings) : undefined;
+		return kindFromSettings ? DEFAULT_THEME_BY_KIND[kindFromSettings] : undefined;
+	}
+
+	private async readThemeKindFromState(editor: IKnownEditorDescriptor, userDataUri: URI): Promise<ColorThemeKind | undefined> {
+		const state = await this.readJsonObject(URI.joinPath(userDataUri, 'globalStorage', 'storage.json'));
+		if (!state) {
+			return undefined;
+		}
+
+		// Prefer the fork-specific key holding the selected theme's label (e.g. "Cursor Light"),
+		// since it reflects the user's explicit choice even when the base-theme cache is stale.
+		for (const key of editor.themeStateNameKeys ?? []) {
+			const value = state[key];
+			if (typeof value === 'string') {
+				const kind = this.inferKindFromThemeName(value);
+				if (kind) {
+					return kind;
+				}
+			}
+		}
+
+		// Fall back to the standard base-theme cache (`theme` = uiTheme id).
+		const baseTheme = state['theme'];
+		if (typeof baseTheme === 'string') {
+			return BASE_THEME_TO_KIND[baseTheme];
+		}
+		return undefined;
+	}
+
+	/**
+	 * Infers a color theme kind from a human-readable theme label such as "Cursor Light" or
+	 * "Default High Contrast". Returns `undefined` when the name gives no clear signal.
+	 */
+	private inferKindFromThemeName(name: string): ColorThemeKind | undefined {
+		const normalized = name.toLowerCase();
+		const isHighContrast = normalized.includes('high contrast') || /\bhc\b/.test(normalized);
+		const isLight = normalized.includes('light');
+		const isDark = normalized.includes('dark');
+		if (isHighContrast) {
+			return isLight ? 'hc-light' : 'hc-dark';
+		}
+		if (isLight) {
+			return 'light';
+		}
+		if (isDark) {
+			return 'dark';
+		}
+		return undefined;
+	}
+
+	/**
+	 * Infers a color theme kind from the source settings' `preferred*ColorTheme` names. Used only
+	 * when the persisted theme state does not resolve a kind.
+	 */
+	private inferKindFromSettings(settings: Record<string, unknown>): ColorThemeKind | undefined {
+		const preferredHcDark = settings['workbench.preferredHighContrastColorTheme'];
+		const preferredHcLight = settings['workbench.preferredHighContrastLightColorTheme'];
+		const preferredDark = settings['workbench.preferredDarkColorTheme'];
+		const preferredLight = settings['workbench.preferredLightColorTheme'];
+		if (typeof preferredHcDark === 'string') {
+			return 'hc-dark';
+		}
+		if (typeof preferredHcLight === 'string') {
+			return 'hc-light';
+		}
+		if (typeof preferredDark === 'string') {
+			return 'dark';
+		}
+		if (typeof preferredLight === 'string') {
+			return 'light';
+		}
+		return undefined;
+	}
+
 	// =====================================================================
 	// Keybindings
 	// =====================================================================
@@ -316,22 +522,30 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		}
 
 		const targetResource = this.userDataProfileService.currentProfile.keybindingsResource;
-		const existingKeybindings = await this.readJsonArray(targetResource) ?? [];
+		const targetExists = await this.safeExists(targetResource);
+		const existingKeybindings = targetExists ? await this.readJsonArray(targetResource) : [];
 
-		const merged = [...existingKeybindings];
-		for (const entry of sourceKeybindings) {
-			const isDuplicate = existingKeybindings.some(existing => this.deepEqual(existing, entry));
-			if (!isDuplicate) {
-				merged.push(entry);
-			}
+		// The target file exists but could not be parsed. Rewriting it would discard the user's
+		// keybindings, so bail out rather than risk data loss.
+		if (targetExists && !existingKeybindings) {
+			this.logService.warn('[externalEditorImport] Existing keybindings.json could not be parsed; skipping keybindings import');
+			return false;
 		}
 
-		if (merged.length === existingKeybindings.length) {
+		const newEntries = sourceKeybindings.filter(entry => !existingKeybindings!.some(existing => this.deepEqual(existing, entry)));
+		if (newEntries.length === 0) {
 			return false;
 		}
 
 		try {
-			await this.fileService.writeFile(targetResource, VSBuffer.fromString(JSON.stringify(merged, null, '\t')));
+			if (!targetExists) {
+				// No existing file to preserve, so create it with the new entries directly.
+				await this.fileService.writeFile(targetResource, VSBuffer.fromString(JSON.stringify(newEntries, null, '\t')));
+			} else {
+				// Append via JSONC-aware editing so the user's comments and formatting are preserved.
+				const edits: IJSONValue[] = newEntries.map(value => ({ path: [-1], value }));
+				await this.jsonEditingService.write(targetResource, edits, true);
+			}
 			return true;
 		} catch (error) {
 			this.logService.error('[externalEditorImport] Failed to import keybindings', error);
@@ -408,8 +622,11 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 			return { installed: 0, failed: toQuery.length };
 		}
 
+		// Extensions that could not be resolved in the gallery (e.g. not published on the
+		// Marketplace) count as failures so callers can report an accurate outcome.
+		const unresolved = toQuery.length - galleryExtensions.length;
 		if (galleryExtensions.length === 0) {
-			return { installed: 0, failed: 0 };
+			return { installed: 0, failed: unresolved };
 		}
 
 		const installExtensionInfos: InstallExtensionInfo[] = galleryExtensions.map(extension => ({
@@ -419,11 +636,11 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 
 		try {
 			const results = await this.extensionManagementService.installGalleryExtensions(installExtensionInfos);
-			const failed = results.filter(result => !result.local).length;
-			return { installed: results.length - failed, failed };
+			const installFailed = results.filter(result => !result.local).length;
+			return { installed: results.length - installFailed, failed: unresolved + installFailed };
 		} catch (error) {
 			this.logService.error('[externalEditorImport] Failed to install extensions', error);
-			return { installed: 0, failed: installExtensionInfos.length };
+			return { installed: 0, failed: unresolved + installExtensionInfos.length };
 		}
 	}
 
@@ -437,16 +654,21 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		const seen = new Set<string>();
 		for (const entry of manifest) {
 			const identifier = (entry as { identifier?: { id?: unknown; uuid?: unknown } } | null)?.identifier;
-			const id = identifier?.id;
-			if (typeof id !== 'string' || !id) {
+			const rawId = identifier?.id;
+			if (typeof rawId !== 'string' || !rawId) {
 				continue;
 			}
+			// Remap known source-editor forks (e.g. Cursor's `anysphere.*` Remote extensions) to
+			// their VS Code Marketplace equivalents. When remapped, the fork's uuid no longer
+			// applies and must be dropped so the identifier is matched by id instead.
+			const remapped = EXTENSION_ID_REMAP.get(rawId.toLowerCase());
+			const id = remapped ?? rawId;
 			const key = id.toLowerCase();
 			if (seen.has(key)) {
 				continue;
 			}
 			seen.add(key);
-			const uuid = identifier?.uuid;
+			const uuid = remapped ? undefined : identifier?.uuid;
 			identifiers.push({ id, uuid: typeof uuid === 'string' ? uuid : undefined });
 		}
 

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
@@ -7,7 +7,8 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { parse } from '../../../../base/common/json.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { isLinux, isMacintosh, isWindows } from '../../../../base/common/platform.js';
+import { equals } from '../../../../base/common/objects.js';
+import { extname } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IExtensionGalleryService, IExtensionManagementService, IExtensionIdentifier, InstallExtensionInfo, EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { areSameExtensions } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
@@ -15,9 +16,12 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IJSONEditingService, IJSONValue } from '../../../services/configuration/common/jsonEditing.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { IWorkbenchExtensionManagementService } from '../../../services/extensionManagement/common/extensionManagement.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
+import { IWorkbenchThemeService } from '../../../services/themes/common/workbenchThemeService.js';
 import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
 import { IExternalEditorImportPreview, IExternalEditorImportResult, IExternalEditorImportSelection, IExternalEditorImportService, IExternalEditorSource } from '../common/externalEditorImport.js';
+import { IExternalEditorImportEnvironmentService } from '../common/externalEditorImportEnvironment.js';
 
 /**
  * Describes how to locate a known source editor's user data. Source editors that
@@ -130,7 +134,10 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
 		@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService,
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
+		@IWorkbenchExtensionManagementService private readonly workbenchExtensionManagementService: IWorkbenchExtensionManagementService,
+		@IWorkbenchThemeService private readonly themeService: IWorkbenchThemeService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
+		@IExternalEditorImportEnvironmentService private readonly importEnvironmentService: IExternalEditorImportEnvironmentService,
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
@@ -145,7 +152,7 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		}
 
 		const home = await this.pathService.userHome({ preferLocal: true });
-		const appDataHome = this.getApplicationDataHome(home);
+		const appDataHome = await this.importEnvironmentService.getApplicationDataHome(home);
 		if (!appDataHome) {
 			return [];
 		}
@@ -191,30 +198,39 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 
 	async import(source: IExternalEditorSource, selection: IExternalEditorImportSelection, token?: CancellationToken): Promise<IExternalEditorImportResult> {
 		let settingsImported = 0;
+		let settingsFailed = false;
 		let keybindingsImported = false;
+		let keybindingsFailed = false;
 		let snippetsImported = 0;
+		let snippetsFailed = 0;
 		let extensionsInstalled = 0;
 		let extensionsFailed = 0;
 
-		if (selection.settings && source.hasSettings) {
-			settingsImported = await this.importSettings(source);
+		if (!token?.isCancellationRequested && selection.settings && source.hasSettings) {
+			const result = await this.importSettings(source);
+			settingsImported = result.imported;
+			settingsFailed = result.failed;
 		}
 
-		if (selection.keybindings && source.hasKeybindings) {
-			keybindingsImported = await this.importKeybindings(source);
+		if (!token?.isCancellationRequested && selection.keybindings && source.hasKeybindings) {
+			const result = await this.importKeybindings(source);
+			keybindingsImported = result.imported;
+			keybindingsFailed = result.failed;
 		}
 
-		if (selection.snippets && source.hasSnippets) {
-			snippetsImported = await this.importSnippets(source);
+		if (!token?.isCancellationRequested && selection.snippets && source.hasSnippets) {
+			const result = await this.importSnippets(source);
+			snippetsImported = result.imported;
+			snippetsFailed = result.failed;
 		}
 
-		if (selection.extensions && source.hasExtensions) {
+		if (!token?.isCancellationRequested && selection.extensions && source.hasExtensions) {
 			const result = await this.importExtensions(source, token);
 			extensionsInstalled = result.installed;
 			extensionsFailed = result.failed;
 		}
 
-		return { settingsImported, keybindingsImported, snippetsImported, extensionsInstalled, extensionsFailed };
+		return { settingsImported, settingsFailed, keybindingsImported, keybindingsFailed, snippetsImported, snippetsFailed, extensionsInstalled, extensionsFailed };
 	}
 
 	// =====================================================================
@@ -229,30 +245,6 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 			source.hasExtensions ? this.previewExtensions(source, token) : Promise.resolve([]),
 		]);
 		return { settings, keybindings, snippets, extensions };
-	}
-
-	async hasImportableChanges(source: IExternalEditorSource): Promise<boolean> {
-		const [settings, keybindings, snippets, extensions] = await Promise.all([
-			source.hasSettings ? this.previewSettings(source) : Promise.resolve([]),
-			source.hasKeybindings ? this.previewKeybindings(source) : Promise.resolve([]),
-			source.hasSnippets ? this.previewSnippets(source) : Promise.resolve([]),
-			source.hasExtensions ? this.hasNewExtensions(source) : Promise.resolve(false),
-		]);
-		return settings.length > 0 || keybindings.length > 0 || snippets.length > 0 || extensions;
-	}
-
-	private async hasNewExtensions(source: IExternalEditorSource): Promise<boolean> {
-		if (!source.extensionsManifestUri) {
-			return false;
-		}
-
-		const identifiers = await this.readExtensionIdentifiers(source.extensionsManifestUri);
-		if (identifiers.length === 0) {
-			return false;
-		}
-
-		const installed = await this.extensionManagementService.getInstalled();
-		return identifiers.some(identifier => !installed.some(local => areSameExtensions(local.identifier, identifier)));
 	}
 
 	private async previewSettings(source: IExternalEditorSource): Promise<string[]> {
@@ -285,7 +277,7 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		const existingKeybindings = await this.readJsonArray(this.userDataProfileService.currentProfile.keybindingsResource) ?? [];
 		const labels: string[] = [];
 		for (const entry of sourceKeybindings) {
-			if (existingKeybindings.some(existing => this.deepEqual(existing, entry))) {
+			if (existingKeybindings.some(existing => equals(existing, entry))) {
 				continue;
 			}
 			const key = (entry as { key?: unknown } | null)?.key;
@@ -313,7 +305,7 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		const targetSnippetsHome = this.userDataProfileService.currentProfile.snippetsHome;
 		const names: string[] = [];
 		for (const child of sourceStat.children) {
-			if (child.isDirectory) {
+			if (child.isDirectory || !this.isSnippetFile(child.resource)) {
 				continue;
 			}
 			if (await this.safeExists(URI.joinPath(targetSnippetsHome, child.name))) {
@@ -334,7 +326,7 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 			return [];
 		}
 
-		const installed = await this.extensionManagementService.getInstalled();
+		const installed = await this.extensionManagementService.getInstalled(undefined, this.userDataProfileService.currentProfile.extensionsResource);
 		const toQuery = identifiers.filter(identifier => !installed.some(local => areSameExtensions(local.identifier, identifier)));
 		if (toQuery.length === 0) {
 			return [];
@@ -353,10 +345,10 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	// Settings
 	// =====================================================================
 
-	private async importSettings(source: IExternalEditorSource): Promise<number> {
+	private async importSettings(source: IExternalEditorSource): Promise<{ imported: number; failed: boolean }> {
 		const sourceSettings = await this.readJsonObject(URI.joinPath(source.userDataUri, 'settings.json'));
 		if (!sourceSettings) {
-			return 0;
+			return { imported: 0, failed: false };
 		}
 
 		const targetResource = this.userDataProfileService.currentProfile.settingsResource;
@@ -379,15 +371,15 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		}
 
 		if (edits.length === 0) {
-			return 0;
+			return { imported: 0, failed: false };
 		}
 
 		try {
 			await this.jsonEditingService.write(targetResource, edits, true);
-			return edits.length;
+			return { imported: edits.length, failed: false };
 		} catch (error) {
 			this.logService.error('[externalEditorImport] Failed to import settings', error);
-			return 0;
+			return { imported: 0, failed: true };
 		}
 	}
 
@@ -426,7 +418,14 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		// 1. Explicit theme in settings.json wins.
 		const explicit = settings?.[COLOR_THEME_SETTING_KEY];
 		if (typeof explicit === 'string' && explicit) {
-			return explicit;
+			const themes = await this.themeService.getColorThemes();
+			if (themes.some(theme => theme.settingsId === explicit)) {
+				return explicit;
+			}
+			const kind = this.inferKindFromThemeName(explicit);
+			if (kind) {
+				return DEFAULT_THEME_BY_KIND[kind];
+			}
 		}
 
 		// 2. The fork's persisted theme state (the user's real selected theme).
@@ -515,10 +514,10 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	// Keybindings
 	// =====================================================================
 
-	private async importKeybindings(source: IExternalEditorSource): Promise<boolean> {
+	private async importKeybindings(source: IExternalEditorSource): Promise<{ imported: boolean; failed: boolean }> {
 		const sourceKeybindings = await this.readJsonArray(URI.joinPath(source.userDataUri, 'keybindings.json'));
 		if (!sourceKeybindings || sourceKeybindings.length === 0) {
-			return false;
+			return { imported: false, failed: false };
 		}
 
 		const targetResource = this.userDataProfileService.currentProfile.keybindingsResource;
@@ -529,12 +528,12 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		// keybindings, so bail out rather than risk data loss.
 		if (targetExists && !existingKeybindings) {
 			this.logService.warn('[externalEditorImport] Existing keybindings.json could not be parsed; skipping keybindings import');
-			return false;
+			return { imported: false, failed: true };
 		}
 
-		const newEntries = sourceKeybindings.filter(entry => !existingKeybindings!.some(existing => this.deepEqual(existing, entry)));
+		const newEntries = sourceKeybindings.filter(entry => !existingKeybindings!.some(existing => equals(existing, entry)));
 		if (newEntries.length === 0) {
-			return false;
+			return { imported: false, failed: false };
 		}
 
 		try {
@@ -546,10 +545,10 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 				const edits: IJSONValue[] = newEntries.map(value => ({ path: [-1], value }));
 				await this.jsonEditingService.write(targetResource, edits, true);
 			}
-			return true;
+			return { imported: true, failed: false };
 		} catch (error) {
 			this.logService.error('[externalEditorImport] Failed to import keybindings', error);
-			return false;
+			return { imported: false, failed: true };
 		}
 	}
 
@@ -557,24 +556,25 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	// Snippets
 	// =====================================================================
 
-	private async importSnippets(source: IExternalEditorSource): Promise<number> {
+	private async importSnippets(source: IExternalEditorSource): Promise<{ imported: number; failed: number }> {
 		const sourceSnippetsHome = URI.joinPath(source.userDataUri, 'snippets');
 		let sourceStat;
 		try {
 			sourceStat = await this.fileService.resolve(sourceSnippetsHome);
 		} catch (error) {
 			this.logService.error('[externalEditorImport] Failed to read snippets', error);
-			return 0;
+			return { imported: 0, failed: 1 };
 		}
 
 		if (!sourceStat.children?.length) {
-			return 0;
+			return { imported: 0, failed: 0 };
 		}
 
 		const targetSnippetsHome = this.userDataProfileService.currentProfile.snippetsHome;
 		let imported = 0;
+		let failed = 0;
 		for (const child of sourceStat.children) {
-			if (child.isDirectory) {
+			if (child.isDirectory || !this.isSnippetFile(child.resource)) {
 				continue;
 			}
 			const targetUri = URI.joinPath(targetSnippetsHome, child.name);
@@ -588,10 +588,11 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 				imported++;
 			} catch (error) {
 				this.logService.error(`[externalEditorImport] Failed to import snippet ${child.name}`, error);
+				failed++;
 			}
 		}
 
-		return imported;
+		return { imported, failed };
 	}
 
 	// =====================================================================
@@ -608,7 +609,8 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 			return { installed: 0, failed: 0 };
 		}
 
-		const installed = await this.extensionManagementService.getInstalled();
+		const profileLocation = this.userDataProfileService.currentProfile.extensionsResource;
+		const installed = await this.extensionManagementService.getInstalled(undefined, profileLocation);
 		const toQuery = identifiers.filter(identifier => !installed.some(local => areSameExtensions(local.identifier, identifier)));
 		if (toQuery.length === 0) {
 			return { installed: 0, failed: 0 };
@@ -629,19 +631,46 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 			return { installed: 0, failed: unresolved };
 		}
 
-		const installExtensionInfos: InstallExtensionInfo[] = galleryExtensions.map(extension => ({
-			extension,
-			options: { context: { [EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT]: true } },
-		}));
-
-		try {
-			const results = await this.extensionManagementService.installGalleryExtensions(installExtensionInfos);
-			const installFailed = results.filter(result => !result.local).length;
-			return { installed: results.length - installFailed, failed: unresolved + installFailed };
-		} catch (error) {
-			this.logService.error('[externalEditorImport] Failed to install extensions', error);
-			return { installed: 0, failed: unresolved + installExtensionInfos.length };
+		const installExtensionInfos: InstallExtensionInfo[] = [];
+		for (const extension of galleryExtensions) {
+			if (await this.workbenchExtensionManagementService.canInstall(extension) !== true) {
+				continue;
+			}
+			installExtensionInfos.push({
+				extension,
+				options: {
+					isMachineScoped: false,
+					donotIncludePackAndDependencies: true,
+					profileLocation,
+					context: { [EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT]: true },
+				},
+			});
 		}
+
+		let failed = unresolved + galleryExtensions.length - installExtensionInfos.length;
+		try {
+			await this.workbenchExtensionManagementService.requestPublisherTrust(installExtensionInfos);
+		} catch (error) {
+			this.logService.error('[externalEditorImport] Publisher trust was not granted', error);
+			return { installed: 0, failed: failed + installExtensionInfos.length };
+		}
+
+		let installedCount = 0;
+		for (let index = 0; index < installExtensionInfos.length; index++) {
+			const { extension, options } = installExtensionInfos[index];
+			if (token?.isCancellationRequested) {
+				failed += installExtensionInfos.length - index;
+				break;
+			}
+			try {
+				await this.workbenchExtensionManagementService.installFromGallery(extension, options);
+				installedCount++;
+			} catch (error) {
+				failed++;
+				this.logService.error(`[externalEditorImport] Failed to install extension ${extension.identifier.id}`, error);
+			}
+		}
+		return { installed: installedCount, failed };
 	}
 
 	private async readExtensionIdentifiers(manifestUri: URI): Promise<IExtensionIdentifier[]> {
@@ -679,23 +708,6 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	// Helpers
 	// =====================================================================
 
-	/**
-	 * Returns the platform application-data directory that contains per-product
-	 * folders (e.g. `Cursor`, `Code`). Returns `undefined` for unsupported platforms.
-	 */
-	private getApplicationDataHome(home: URI): URI | undefined {
-		if (isWindows) {
-			return URI.joinPath(home, 'AppData', 'Roaming');
-		}
-		if (isMacintosh) {
-			return URI.joinPath(home, 'Library', 'Application Support');
-		}
-		if (isLinux) {
-			return URI.joinPath(home, '.config');
-		}
-		return undefined;
-	}
-
 	private async safeExists(resource: URI): Promise<boolean> {
 		try {
 			return await this.fileService.exists(resource);
@@ -707,10 +719,15 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	private async safeHasChildren(resource: URI): Promise<boolean> {
 		try {
 			const stat = await this.fileService.resolve(resource);
-			return !!stat.children?.some(child => !child.isDirectory);
+			return !!stat.children?.some(child => !child.isDirectory && this.isSnippetFile(child.resource));
 		} catch {
 			return false;
 		}
+	}
+
+	private isSnippetFile(resource: URI): boolean {
+		const extension = extname(resource).toLowerCase();
+		return extension === '.json' || extension === '.code-snippets';
 	}
 
 	private async readJsonObject(resource: URI): Promise<Record<string, unknown> | undefined> {
@@ -733,7 +750,4 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 		}
 	}
 
-	private deepEqual(a: unknown, b: unknown): boolean {
-		return JSON.stringify(a) === JSON.stringify(b);
-	}
 }

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
@@ -187,7 +187,6 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 					hasKeybindings,
 					hasSnippets,
 					hasExtensions,
-					hasTheme: !!colorThemeId,
 					colorThemeId,
 				});
 			}

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
@@ -8,6 +8,7 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { parse } from '../../../../base/common/json.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { equals } from '../../../../base/common/objects.js';
+import { isWeb } from '../../../../base/common/platform.js';
 import { extname } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IExtensionGalleryService, IExtensionManagementService, IExtensionIdentifier, InstallExtensionInfo, EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT } from '../../../../platform/extensionManagement/common/extensionManagement.js';
@@ -144,6 +145,15 @@ export class ExternalEditorImportService extends Disposable implements IExternal
 	}
 
 	async detectSources(token?: CancellationToken): Promise<IExternalEditorSource[]> {
+		// Importing from another local editor requires access to the real local machine's
+		// application-data directory. On web there is no such thing: the path service synthesizes a
+		// "home" from the workspace root, so a repository containing e.g. `.config/Cursor/User` could
+		// be misidentified as an installed editor and offered as trusted import data (including
+		// extension ids). Never detect sources on web.
+		if (isWeb) {
+			return [];
+		}
+
 		// Detection reads the local machine's application-data directory. In a remote window the
 		// workbench file system operates against the remote host, so local detection would either
 		// find nothing or inspect the wrong machine. Skip it entirely in that case.

--- a/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/browser/externalEditorImportService.ts
@@ -1,0 +1,389 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { parse } from '../../../../base/common/json.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { isLinux, isMacintosh, isWindows } from '../../../../base/common/platform.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IExtensionGalleryService, IExtensionManagementService, IExtensionIdentifier, InstallExtensionInfo, EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT } from '../../../../platform/extensionManagement/common/extensionManagement.js';
+import { areSameExtensions } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IJSONEditingService, IJSONValue } from '../../../services/configuration/common/jsonEditing.js';
+import { IPathService } from '../../../services/path/common/pathService.js';
+import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
+import { IExternalEditorImportResult, IExternalEditorImportSelection, IExternalEditorImportService, IExternalEditorSource } from '../common/externalEditorImport.js';
+
+/**
+ * Describes how to locate a known source editor's user data. Source editors that
+ * are VS Code forks (e.g. Cursor) share the same on-disk layout, so a single
+ * descriptor with the product folder name is enough.
+ */
+interface IKnownEditorDescriptor {
+	readonly id: string;
+	readonly label: string;
+	/** Product folder name under the platform application-data directory, e.g. `Cursor`. */
+	readonly appDataFolder: string;
+	/** Home-relative segments of the extensions directory, e.g. `.cursor/extensions`. */
+	readonly extensionsDirSegments: readonly string[];
+}
+
+const KNOWN_EDITORS: readonly IKnownEditorDescriptor[] = [
+	{
+		id: 'cursor',
+		label: 'Cursor',
+		appDataFolder: 'Cursor',
+		extensionsDirSegments: ['.cursor', 'extensions'],
+	},
+];
+
+/**
+ * Settings keys (or prefixes) that should never be imported because they are
+ * specific to the source editor and have no meaning in VS Code.
+ */
+const SETTINGS_KEY_BLOCKLIST_PREFIXES: readonly string[] = [
+	'cursor.',
+	'cursorai.',
+	'aicontext.',
+];
+
+export class ExternalEditorImportService extends Disposable implements IExternalEditorImportService {
+
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IFileService private readonly fileService: IFileService,
+		@IPathService private readonly pathService: IPathService,
+		@IJSONEditingService private readonly jsonEditingService: IJSONEditingService,
+		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
+		@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService,
+		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+	}
+
+	async detectSources(token?: CancellationToken): Promise<IExternalEditorSource[]> {
+		const home = await this.pathService.userHome();
+		const appDataHome = this.getApplicationDataHome(home);
+		if (!appDataHome) {
+			return [];
+		}
+
+		const sources: IExternalEditorSource[] = [];
+		for (const editor of KNOWN_EDITORS) {
+			if (token?.isCancellationRequested) {
+				break;
+			}
+
+			const userDataUri = URI.joinPath(appDataHome, editor.appDataFolder, 'User');
+			const settingsUri = URI.joinPath(userDataUri, 'settings.json');
+			const keybindingsUri = URI.joinPath(userDataUri, 'keybindings.json');
+			const snippetsUri = URI.joinPath(userDataUri, 'snippets');
+			const extensionsManifestUri = URI.joinPath(home, ...editor.extensionsDirSegments, 'extensions.json');
+
+			const [hasSettings, hasKeybindings, hasSnippets, hasExtensions] = await Promise.all([
+				this.safeExists(settingsUri),
+				this.safeExists(keybindingsUri),
+				this.safeHasChildren(snippetsUri),
+				this.safeExists(extensionsManifestUri),
+			]);
+
+			if (hasSettings || hasKeybindings || hasSnippets || hasExtensions) {
+				sources.push({
+					id: editor.id,
+					label: editor.label,
+					userDataUri,
+					extensionsManifestUri: hasExtensions ? extensionsManifestUri : undefined,
+					hasSettings,
+					hasKeybindings,
+					hasSnippets,
+					hasExtensions,
+				});
+			}
+		}
+
+		return sources;
+	}
+
+	async import(source: IExternalEditorSource, selection: IExternalEditorImportSelection, token?: CancellationToken): Promise<IExternalEditorImportResult> {
+		let settingsImported = 0;
+		let keybindingsImported = false;
+		let snippetsImported = 0;
+		let extensionsInstalled = 0;
+		let extensionsFailed = 0;
+
+		if (selection.settings && source.hasSettings) {
+			settingsImported = await this.importSettings(source);
+		}
+
+		if (selection.keybindings && source.hasKeybindings) {
+			keybindingsImported = await this.importKeybindings(source);
+		}
+
+		if (selection.snippets && source.hasSnippets) {
+			snippetsImported = await this.importSnippets(source);
+		}
+
+		if (selection.extensions && source.hasExtensions) {
+			const result = await this.importExtensions(source, token);
+			extensionsInstalled = result.installed;
+			extensionsFailed = result.failed;
+		}
+
+		return { settingsImported, keybindingsImported, snippetsImported, extensionsInstalled, extensionsFailed };
+	}
+
+	// =====================================================================
+	// Settings
+	// =====================================================================
+
+	private async importSettings(source: IExternalEditorSource): Promise<number> {
+		const sourceSettings = await this.readJsonObject(URI.joinPath(source.userDataUri, 'settings.json'));
+		if (!sourceSettings) {
+			return 0;
+		}
+
+		const targetResource = this.userDataProfileService.currentProfile.settingsResource;
+		const existingSettings = await this.readJsonObject(targetResource) ?? {};
+
+		const edits: IJSONValue[] = [];
+		for (const key of Object.keys(sourceSettings)) {
+			// Never overwrite settings the user already has, and skip source-specific keys.
+			if (Object.prototype.hasOwnProperty.call(existingSettings, key) || this.isBlockedSettingKey(key)) {
+				continue;
+			}
+			edits.push({ path: [key], value: sourceSettings[key] });
+		}
+
+		if (edits.length === 0) {
+			return 0;
+		}
+
+		try {
+			await this.jsonEditingService.write(targetResource, edits, true);
+			return edits.length;
+		} catch (error) {
+			this.logService.error('[externalEditorImport] Failed to import settings', error);
+			return 0;
+		}
+	}
+
+	private isBlockedSettingKey(key: string): boolean {
+		return SETTINGS_KEY_BLOCKLIST_PREFIXES.some(prefix => key.startsWith(prefix));
+	}
+
+	// =====================================================================
+	// Keybindings
+	// =====================================================================
+
+	private async importKeybindings(source: IExternalEditorSource): Promise<boolean> {
+		const sourceKeybindings = await this.readJsonArray(URI.joinPath(source.userDataUri, 'keybindings.json'));
+		if (!sourceKeybindings || sourceKeybindings.length === 0) {
+			return false;
+		}
+
+		const targetResource = this.userDataProfileService.currentProfile.keybindingsResource;
+		const existingKeybindings = await this.readJsonArray(targetResource) ?? [];
+
+		const merged = [...existingKeybindings];
+		for (const entry of sourceKeybindings) {
+			const isDuplicate = existingKeybindings.some(existing => this.deepEqual(existing, entry));
+			if (!isDuplicate) {
+				merged.push(entry);
+			}
+		}
+
+		if (merged.length === existingKeybindings.length) {
+			return false;
+		}
+
+		try {
+			await this.fileService.writeFile(targetResource, VSBuffer.fromString(JSON.stringify(merged, null, '\t')));
+			return true;
+		} catch (error) {
+			this.logService.error('[externalEditorImport] Failed to import keybindings', error);
+			return false;
+		}
+	}
+
+	// =====================================================================
+	// Snippets
+	// =====================================================================
+
+	private async importSnippets(source: IExternalEditorSource): Promise<number> {
+		const sourceSnippetsHome = URI.joinPath(source.userDataUri, 'snippets');
+		let sourceStat;
+		try {
+			sourceStat = await this.fileService.resolve(sourceSnippetsHome);
+		} catch (error) {
+			this.logService.error('[externalEditorImport] Failed to read snippets', error);
+			return 0;
+		}
+
+		if (!sourceStat.children?.length) {
+			return 0;
+		}
+
+		const targetSnippetsHome = this.userDataProfileService.currentProfile.snippetsHome;
+		let imported = 0;
+		for (const child of sourceStat.children) {
+			if (child.isDirectory) {
+				continue;
+			}
+			const targetUri = URI.joinPath(targetSnippetsHome, child.name);
+			// Do not overwrite snippets the user already has.
+			if (await this.safeExists(targetUri)) {
+				continue;
+			}
+			try {
+				const content = await this.fileService.readFile(child.resource);
+				await this.fileService.writeFile(targetUri, content.value);
+				imported++;
+			} catch (error) {
+				this.logService.error(`[externalEditorImport] Failed to import snippet ${child.name}`, error);
+			}
+		}
+
+		return imported;
+	}
+
+	// =====================================================================
+	// Extensions
+	// =====================================================================
+
+	private async importExtensions(source: IExternalEditorSource, token?: CancellationToken): Promise<{ installed: number; failed: number }> {
+		if (!source.extensionsManifestUri) {
+			return { installed: 0, failed: 0 };
+		}
+
+		const identifiers = await this.readExtensionIdentifiers(source.extensionsManifestUri);
+		if (identifiers.length === 0) {
+			return { installed: 0, failed: 0 };
+		}
+
+		const installed = await this.extensionManagementService.getInstalled();
+		const toQuery = identifiers.filter(identifier => !installed.some(local => areSameExtensions(local.identifier, identifier)));
+		if (toQuery.length === 0) {
+			return { installed: 0, failed: 0 };
+		}
+
+		let galleryExtensions;
+		try {
+			galleryExtensions = await this.extensionGalleryService.getExtensions(toQuery.map(identifier => ({ id: identifier.id })), token ?? CancellationToken.None);
+		} catch (error) {
+			this.logService.error('[externalEditorImport] Failed to query extensions from gallery', error);
+			return { installed: 0, failed: toQuery.length };
+		}
+
+		if (galleryExtensions.length === 0) {
+			return { installed: 0, failed: 0 };
+		}
+
+		const installExtensionInfos: InstallExtensionInfo[] = galleryExtensions.map(extension => ({
+			extension,
+			options: { context: { [EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT]: true } },
+		}));
+
+		try {
+			const results = await this.extensionManagementService.installGalleryExtensions(installExtensionInfos);
+			const failed = results.filter(result => !result.local).length;
+			return { installed: results.length - failed, failed };
+		} catch (error) {
+			this.logService.error('[externalEditorImport] Failed to install extensions', error);
+			return { installed: 0, failed: installExtensionInfos.length };
+		}
+	}
+
+	private async readExtensionIdentifiers(manifestUri: URI): Promise<IExtensionIdentifier[]> {
+		const manifest = await this.readJsonArray(manifestUri);
+		if (!manifest) {
+			return [];
+		}
+
+		const identifiers: IExtensionIdentifier[] = [];
+		const seen = new Set<string>();
+		for (const entry of manifest) {
+			const identifier = (entry as { identifier?: { id?: unknown; uuid?: unknown } } | null)?.identifier;
+			const id = identifier?.id;
+			if (typeof id !== 'string' || !id) {
+				continue;
+			}
+			const key = id.toLowerCase();
+			if (seen.has(key)) {
+				continue;
+			}
+			seen.add(key);
+			const uuid = identifier?.uuid;
+			identifiers.push({ id, uuid: typeof uuid === 'string' ? uuid : undefined });
+		}
+
+		return identifiers;
+	}
+
+	// =====================================================================
+	// Helpers
+	// =====================================================================
+
+	/**
+	 * Returns the platform application-data directory that contains per-product
+	 * folders (e.g. `Cursor`, `Code`). Returns `undefined` for unsupported platforms.
+	 */
+	private getApplicationDataHome(home: URI): URI | undefined {
+		if (isWindows) {
+			return URI.joinPath(home, 'AppData', 'Roaming');
+		}
+		if (isMacintosh) {
+			return URI.joinPath(home, 'Library', 'Application Support');
+		}
+		if (isLinux) {
+			return URI.joinPath(home, '.config');
+		}
+		return undefined;
+	}
+
+	private async safeExists(resource: URI): Promise<boolean> {
+		try {
+			return await this.fileService.exists(resource);
+		} catch {
+			return false;
+		}
+	}
+
+	private async safeHasChildren(resource: URI): Promise<boolean> {
+		try {
+			const stat = await this.fileService.resolve(resource);
+			return !!stat.children?.some(child => !child.isDirectory);
+		} catch {
+			return false;
+		}
+	}
+
+	private async readJsonObject(resource: URI): Promise<Record<string, unknown> | undefined> {
+		const parsed = await this.readJson(resource);
+		return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as Record<string, unknown> : undefined;
+	}
+
+	private async readJsonArray(resource: URI): Promise<unknown[] | undefined> {
+		const parsed = await this.readJson(resource);
+		return Array.isArray(parsed) ? parsed : undefined;
+	}
+
+	private async readJson(resource: URI): Promise<unknown> {
+		try {
+			const content = await this.fileService.readFile(resource);
+			return parse(content.value.toString());
+		} catch (error) {
+			this.logService.trace(`[externalEditorImport] Could not read ${resource.toString()}`, error);
+			return undefined;
+		}
+	}
+
+	private deepEqual(a: unknown, b: unknown): boolean {
+		return JSON.stringify(a) === JSON.stringify(b);
+	}
+}

--- a/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
@@ -57,8 +57,11 @@ export interface IExternalEditorImportSelection {
  */
 export interface IExternalEditorImportResult {
 	readonly settingsImported: number;
+	readonly settingsFailed: boolean;
 	readonly keybindingsImported: boolean;
+	readonly keybindingsFailed: boolean;
 	readonly snippetsImported: number;
+	readonly snippetsFailed: number;
 	readonly extensionsInstalled: number;
 	readonly extensionsFailed: number;
 }
@@ -92,13 +95,6 @@ export interface IExternalEditorImportService {
 	 * given source, without making any changes.
 	 */
 	preview(source: IExternalEditorSource, token?: CancellationToken): Promise<IExternalEditorImportPreview>;
-
-	/**
-	 * Quickly determines whether importing from the given source would bring over anything
-	 * new. Uses only local checks (no gallery lookups) so it is safe to call on a hot path,
-	 * such as deciding whether to show the import step at all.
-	 */
-	hasImportableChanges(source: IExternalEditorSource): Promise<boolean>;
 
 	/**
 	 * Imports the selected categories of customizations from the given source into the current profile.

--- a/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
@@ -29,6 +29,17 @@ export interface IExternalEditorSource {
 	readonly hasSnippets: boolean;
 	/** Whether an extensions manifest was found. */
 	readonly hasExtensions: boolean;
+	/**
+	 * Whether a color theme could be resolved for the source editor. Equivalent to
+	 * `colorThemeId !== undefined`; callers can use this to avoid prompting the user to pick a theme.
+	 */
+	readonly hasTheme: boolean;
+	/**
+	 * The VS Code built-in color theme that most closely matches the source editor's currently
+	 * selected theme (by kind: light, dark, or high contrast), or `undefined` when none could be
+	 * determined. Applied during a settings import unless the user already chose a theme.
+	 */
+	readonly colorThemeId: string | undefined;
 }
 
 /**

--- a/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { URI } from '../../../../base/common/uri.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+
+export const IExternalEditorImportService = createDecorator<IExternalEditorImportService>('externalEditorImportService');
+
+/**
+ * A source editor (e.g. Cursor) whose customizations can be imported into VS Code.
+ */
+export interface IExternalEditorSource {
+	/** Stable identifier, e.g. `cursor`. */
+	readonly id: string;
+	/** Human readable name, e.g. `Cursor`. */
+	readonly label: string;
+	/** The `User` folder of the source editor (contains settings.json, keybindings.json, snippets/). */
+	readonly userDataUri: URI;
+	/** Location of the source editor's extensions manifest, if known. */
+	readonly extensionsManifestUri: URI | undefined;
+	/** Whether a settings.json was found. */
+	readonly hasSettings: boolean;
+	/** Whether a keybindings.json was found. */
+	readonly hasKeybindings: boolean;
+	/** Whether any snippets were found. */
+	readonly hasSnippets: boolean;
+	/** Whether an extensions manifest was found. */
+	readonly hasExtensions: boolean;
+}
+
+/**
+ * Which categories of customizations to import.
+ */
+export interface IExternalEditorImportSelection {
+	readonly settings?: boolean;
+	readonly keybindings?: boolean;
+	readonly snippets?: boolean;
+	readonly extensions?: boolean;
+}
+
+/**
+ * Summary of what an import applied.
+ */
+export interface IExternalEditorImportResult {
+	readonly settingsImported: number;
+	readonly keybindingsImported: boolean;
+	readonly snippetsImported: number;
+	readonly extensionsInstalled: number;
+	readonly extensionsFailed: number;
+}
+
+export interface IExternalEditorImportService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Detects source editors installed on this machine whose customizations can be imported.
+	 * Returns an empty array in environments where local detection is not possible (e.g. web).
+	 */
+	detectSources(token?: CancellationToken): Promise<IExternalEditorSource[]>;
+
+	/**
+	 * Imports the selected categories of customizations from the given source into the current profile.
+	 */
+	import(source: IExternalEditorSource, selection: IExternalEditorImportSelection, token?: CancellationToken): Promise<IExternalEditorImportResult>;
+}

--- a/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
@@ -52,6 +52,21 @@ export interface IExternalEditorImportResult {
 	readonly extensionsFailed: number;
 }
 
+/**
+ * A preview of the concrete items that an import would apply, after filtering out
+ * items the user already has and source-specific items that are never imported.
+ */
+export interface IExternalEditorImportPreview {
+	/** Setting keys that would be newly added. */
+	readonly settings: readonly string[];
+	/** Keyboard shortcut labels that would be newly added. */
+	readonly keybindings: readonly string[];
+	/** Snippet file names that would be newly added. */
+	readonly snippets: readonly string[];
+	/** Extension display names that would be newly installed. */
+	readonly extensions: readonly string[];
+}
+
 export interface IExternalEditorImportService {
 	readonly _serviceBrand: undefined;
 
@@ -60,6 +75,19 @@ export interface IExternalEditorImportService {
 	 * Returns an empty array in environments where local detection is not possible (e.g. web).
 	 */
 	detectSources(token?: CancellationToken): Promise<IExternalEditorSource[]>;
+
+	/**
+	 * Computes a preview of the concrete items that {@link import} would apply for the
+	 * given source, without making any changes.
+	 */
+	preview(source: IExternalEditorSource, token?: CancellationToken): Promise<IExternalEditorImportPreview>;
+
+	/**
+	 * Quickly determines whether importing from the given source would bring over anything
+	 * new. Uses only local checks (no gallery lookups) so it is safe to call on a hot path,
+	 * such as deciding whether to show the import step at all.
+	 */
+	hasImportableChanges(source: IExternalEditorSource): Promise<boolean>;
 
 	/**
 	 * Imports the selected categories of customizations from the given source into the current profile.

--- a/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImport.ts
@@ -30,11 +30,6 @@ export interface IExternalEditorSource {
 	/** Whether an extensions manifest was found. */
 	readonly hasExtensions: boolean;
 	/**
-	 * Whether a color theme could be resolved for the source editor. Equivalent to
-	 * `colorThemeId !== undefined`; callers can use this to avoid prompting the user to pick a theme.
-	 */
-	readonly hasTheme: boolean;
-	/**
 	 * The VS Code built-in color theme that most closely matches the source editor's currently
 	 * selected theme (by kind: light, dark, or high contrast), or `undefined` when none could be
 	 * determined. Applied during a settings import unless the user already chose a theme.

--- a/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImportEnvironment.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/common/externalEditorImportEnvironment.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isLinux, isMacintosh, isWindows } from '../../../../base/common/platform.js';
+import { URI } from '../../../../base/common/uri.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+
+export const IExternalEditorImportEnvironmentService = createDecorator<IExternalEditorImportEnvironmentService>('externalEditorImportEnvironmentService');
+
+export interface IExternalEditorImportEnvironmentService {
+	readonly _serviceBrand: undefined;
+
+	getApplicationDataHome(home: URI): Promise<URI | undefined>;
+}
+
+export class ExternalEditorImportEnvironmentService implements IExternalEditorImportEnvironmentService {
+	declare readonly _serviceBrand: undefined;
+
+	getApplicationDataHome(home: URI): Promise<URI | undefined> {
+		if (isWindows) {
+			return Promise.resolve(URI.joinPath(home, 'AppData', 'Roaming'));
+		}
+		if (isMacintosh) {
+			return Promise.resolve(URI.joinPath(home, 'Library', 'Application Support'));
+		}
+		if (isLinux) {
+			return Promise.resolve(URI.joinPath(home, '.config'));
+		}
+		return Promise.resolve(undefined);
+	}
+}

--- a/src/vs/workbench/contrib/externalEditorImport/electron-browser/externalEditorImportEnvironmentService.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/electron-browser/externalEditorImportEnvironmentService.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isLinux, isWindows } from '../../../../base/common/platform.js';
+import { URI } from '../../../../base/common/uri.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IExternalEditorImportEnvironmentService, ExternalEditorImportEnvironmentService } from '../common/externalEditorImportEnvironment.js';
+import { IShellEnvironmentService } from '../../../services/environment/electron-browser/shellEnvironmentService.js';
+
+export class NativeExternalEditorImportEnvironmentService extends ExternalEditorImportEnvironmentService {
+	constructor(
+		@IShellEnvironmentService private readonly shellEnvironmentService: IShellEnvironmentService,
+	) {
+		super();
+	}
+
+	override async getApplicationDataHome(home: URI): Promise<URI | undefined> {
+		const environment = await this.shellEnvironmentService.getShellEnv();
+		if (isWindows && environment.APPDATA) {
+			return URI.file(environment.APPDATA);
+		}
+		if (isLinux && environment.XDG_CONFIG_HOME) {
+			return URI.file(environment.XDG_CONFIG_HOME);
+		}
+		return super.getApplicationDataHome(home);
+	}
+}
+
+registerSingleton(IExternalEditorImportEnvironmentService, NativeExternalEditorImportEnvironmentService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
@@ -4,16 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { isMacintosh, isWindows } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
-import { IExtensionGalleryService, IExtensionManagementService } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
-import { IJSONEditingService } from '../../../../services/configuration/common/jsonEditing.js';
+import { IExtensionGalleryService, IExtensionManagementService, InstallExtensionInfo } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
+import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
+import { IJSONEditingService, IJSONValue } from '../../../../services/configuration/common/jsonEditing.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IUserDataProfileService } from '../../../../services/userDataProfile/common/userDataProfile.js';
 import { ExternalEditorImportService } from '../../browser/externalEditorImportService.js';
+import { IExternalEditorSource } from '../../common/externalEditorImport.js';
 
 function applicationDataHome(home: URI): URI {
 	if (isWindows) {
@@ -30,9 +33,16 @@ suite('ExternalEditorImportService', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	const home = URI.file('/home/tester');
 
-	function createService(existingPaths: Set<string>): ExternalEditorImportService {
+	function createService(existingPaths: Set<string>, remoteAuthority?: string, fileContents?: Map<string, string>): ExternalEditorImportService {
 		const fileService = {
 			exists: async (resource: URI) => existingPaths.has(resource.toString()),
+			readFile: async (resource: URI) => {
+				const content = fileContents?.get(resource.toString());
+				if (content === undefined) {
+					throw new Error('not found');
+				}
+				return { value: VSBuffer.fromString(content) };
+			},
 			resolve: async (resource: URI) => {
 				if (!existingPaths.has(resource.toString())) {
 					throw new Error('not found');
@@ -52,8 +62,59 @@ suite('ExternalEditorImportService', () => {
 			{} as unknown as IUserDataProfileService,
 			{} as unknown as IExtensionGalleryService,
 			{} as unknown as IExtensionManagementService,
+			{ remoteAuthority } as unknown as IWorkbenchEnvironmentService,
 			new NullLogService(),
 		));
+	}
+
+	/**
+	 * A minimal in-memory file system backing the reads and writes an import performs.
+	 */
+	class InMemoryFiles {
+		constructor(private readonly contents: Map<string, string>) { }
+
+		readonly service = {
+			exists: async (resource: URI) => this.contents.has(resource.toString()),
+			readFile: async (resource: URI) => {
+				const content = this.contents.get(resource.toString());
+				if (content === undefined) {
+					throw new Error('not found');
+				}
+				return { value: VSBuffer.fromString(content) };
+			},
+			writeFile: async (resource: URI, value: VSBuffer) => {
+				this.contents.set(resource.toString(), value.toString());
+			},
+			resolve: async (resource: URI) => {
+				if (!this.contents.has(resource.toString())) {
+					throw new Error('not found');
+				}
+				return { children: [] };
+			},
+		} as unknown as IFileService;
+
+		get(resource: URI): string | undefined {
+			return this.contents.get(resource.toString());
+		}
+	}
+
+	const cursorUserData = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
+	const keybindingsTarget = URI.file('/profile/keybindings.json');
+
+	function cursorSource(overrides: Partial<IExternalEditorSource> = {}): IExternalEditorSource {
+		return {
+			id: 'cursor',
+			label: 'Cursor',
+			userDataUri: cursorUserData,
+			extensionsManifestUri: URI.joinPath(home, '.cursor', 'extensions', 'extensions.json'),
+			hasSettings: false,
+			hasKeybindings: false,
+			hasSnippets: false,
+			hasExtensions: false,
+			hasTheme: false,
+			colorThemeId: undefined,
+			...overrides,
+		};
 	}
 
 	test('detects Cursor and reports available categories', async () => {
@@ -83,9 +144,255 @@ suite('ExternalEditorImportService', () => {
 		}]);
 	});
 
+	test('resolves an explicit color theme to itself', async () => {
+		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
+		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
+		const existing = new Set<string>([settingsUri.toString()]);
+		const contents = new Map<string, string>([
+			[settingsUri.toString(), JSON.stringify({ 'workbench.colorTheme': 'Monokai', 'editor.fontSize': 14 })],
+		]);
+
+		const service = createService(existing, undefined, contents);
+		const sources = await service.detectSources();
+
+		assert.deepStrictEqual(
+			{ hasTheme: sources[0]?.hasTheme, colorThemeId: sources[0]?.colorThemeId },
+			{ hasTheme: true, colorThemeId: 'Monokai' },
+		);
+	});
+
+	test('maps the selected theme from state storage to the closest VS Code theme', async () => {
+		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
+		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
+		const storageUri = URI.joinPath(cursorUser, 'globalStorage', 'storage.json');
+		const existing = new Set<string>([settingsUri.toString()]);
+		// settings.json only follows the OS; the real selection ("Cursor Light") lives in state.
+		const contents = new Map<string, string>([
+			[settingsUri.toString(), JSON.stringify({ 'window.autoDetectColorScheme': true })],
+			[storageUri.toString(), JSON.stringify({ 'glass.theme.settingsId': 'Cursor Light', 'theme': 'vs-dark' })],
+		]);
+
+		const service = createService(existing, undefined, contents);
+		const sources = await service.detectSources();
+
+		assert.deepStrictEqual(
+			{ hasTheme: sources[0]?.hasTheme, colorThemeId: sources[0]?.colorThemeId },
+			{ hasTheme: true, colorThemeId: 'Light Modern' },
+		);
+	});
+
+	test('maps a high-contrast base theme from state storage', async () => {
+		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
+		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
+		const storageUri = URI.joinPath(cursorUser, 'globalStorage', 'storage.json');
+		const existing = new Set<string>([settingsUri.toString()]);
+		const contents = new Map<string, string>([
+			[settingsUri.toString(), JSON.stringify({ 'editor.fontSize': 14 })],
+			[storageUri.toString(), JSON.stringify({ 'theme': 'hc-black' })],
+		]);
+
+		const service = createService(existing, undefined, contents);
+		const sources = await service.detectSources();
+
+		assert.strictEqual(sources[0]?.colorThemeId, 'Dark High Contrast');
+	});
+
+	test('does not treat OS auto-detect alone as a resolved theme', async () => {
+		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
+		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
+		const existing = new Set<string>([settingsUri.toString()]);
+		const contents = new Map<string, string>([
+			[settingsUri.toString(), JSON.stringify({ 'window.autoDetectColorScheme': true })],
+		]);
+
+		const service = createService(existing, undefined, contents);
+		const sources = await service.detectSources();
+
+		assert.deepStrictEqual(
+			{ hasTheme: sources[0]?.hasTheme, colorThemeId: sources[0]?.colorThemeId },
+			{ hasTheme: false, colorThemeId: undefined },
+		);
+	});
+
+	test('reports no theme preference when the source settings set none', async () => {
+		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
+		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
+		const existing = new Set<string>([settingsUri.toString()]);
+		const contents = new Map<string, string>([
+			[settingsUri.toString(), JSON.stringify({ 'editor.fontSize': 14 })],
+		]);
+
+		const service = createService(existing, undefined, contents);
+		const sources = await service.detectSources();
+
+		assert.strictEqual(sources[0]?.hasTheme, false);
+	});
+
 	test('returns no sources when nothing is installed', async () => {
 		const service = createService(new Set<string>());
 		const sources = await service.detectSources();
 		assert.strictEqual(sources.length, 0);
+	});
+
+	test('returns no sources in a remote window', async () => {
+		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
+		const existing = new Set<string>([URI.joinPath(cursorUser, 'settings.json').toString()]);
+		const service = createService(existing, 'ssh-remote+host');
+		const sources = await service.detectSources();
+		assert.strictEqual(sources.length, 0);
+	});
+
+	function createImportService(options: {
+		files: InMemoryFiles;
+		jsonEditingService?: IJSONEditingService;
+		extensionGalleryService?: IExtensionGalleryService;
+		extensionManagementService?: IExtensionManagementService;
+	}): ExternalEditorImportService {
+		const pathService = { userHome: async () => home } as unknown as IPathService;
+		const userDataProfileService = {
+			currentProfile: {
+				settingsResource: URI.file('/profile/settings.json'),
+				keybindingsResource: keybindingsTarget,
+				snippetsHome: URI.file('/profile/snippets'),
+			},
+		} as unknown as IUserDataProfileService;
+
+		return store.add(new ExternalEditorImportService(
+			options.files.service,
+			pathService,
+			options.jsonEditingService ?? ({ write: async () => { } } as unknown as IJSONEditingService),
+			userDataProfileService,
+			options.extensionGalleryService ?? ({} as unknown as IExtensionGalleryService),
+			options.extensionManagementService ?? ({} as unknown as IExtensionManagementService),
+			{ remoteAuthority: undefined } as unknown as IWorkbenchEnvironmentService,
+			new NullLogService(),
+		));
+	}
+
+	test('imports settings, skips theme/source keys, and pins the resolved color theme', async () => {
+		const sourceSettings = URI.joinPath(cursorUserData, 'settings.json');
+		const targetSettings = URI.file('/profile/settings.json');
+		const files = new InMemoryFiles(new Map([
+			[sourceSettings.toString(), JSON.stringify({
+				'editor.fontSize': 14,
+				'window.autoDetectColorScheme': true, // theme key: skipped in favour of the resolved theme
+				'cursor.internal': true,              // source-specific: blocked
+			})],
+		]));
+
+		const writes: { resource: URI; values: IJSONValue[] }[] = [];
+		const jsonEditingService = {
+			write: async (resource: URI, values: IJSONValue[]) => { writes.push({ resource, values }); },
+		} as unknown as IJSONEditingService;
+
+		const service = createImportService({ files, jsonEditingService });
+		const result = await service.import(cursorSource({ hasSettings: true, hasTheme: true, colorThemeId: 'Light Modern' }), { settings: true });
+
+		assert.strictEqual(result.settingsImported, 2);
+		assert.deepStrictEqual(writes.map(w => ({ resource: w.resource.toString(), values: w.values })), [{
+			resource: targetSettings.toString(),
+			values: [
+				{ path: ['editor.fontSize'], value: 14 },
+				{ path: ['workbench.colorTheme'], value: 'Light Modern' },
+			],
+		}]);
+	});
+
+	test('imports keybindings by appending through the JSON editing service to preserve the existing file', async () => {
+		const sourceKeybindings = URI.joinPath(cursorUserData, 'keybindings.json');
+		const files = new InMemoryFiles(new Map([
+			[sourceKeybindings.toString(), JSON.stringify([{ key: 'ctrl+a', command: 'a' }, { key: 'ctrl+b', command: 'b' }])],
+			// Existing file contains a comment and one of the source entries already.
+			[keybindingsTarget.toString(), '// user keybindings\n[\n\t{ "key": "ctrl+a", "command": "a" }\n]'],
+		]));
+
+		const writes: { resource: URI; values: IJSONValue[] }[] = [];
+		const jsonEditingService = {
+			write: async (resource: URI, values: IJSONValue[]) => { writes.push({ resource, values }); },
+		} as unknown as IJSONEditingService;
+
+		const service = createImportService({ files, jsonEditingService });
+		const result = await service.import(cursorSource({ hasKeybindings: true }), { keybindings: true });
+
+		assert.strictEqual(result.keybindingsImported, true);
+		// Only the new (ctrl+b) entry is appended, via the JSON editing service (not a raw rewrite).
+		assert.deepStrictEqual(writes, [{
+			resource: keybindingsTarget,
+			values: [{ path: [-1], value: { key: 'ctrl+b', command: 'b' } }],
+		}]);
+		// The existing file (with its comment) is left untouched by a direct write.
+		assert.strictEqual(files.get(keybindingsTarget), '// user keybindings\n[\n\t{ "key": "ctrl+a", "command": "a" }\n]');
+	});
+
+	test('does not overwrite a corrupt (non-array) keybindings file', async () => {
+		const sourceKeybindings = URI.joinPath(cursorUserData, 'keybindings.json');
+		const files = new InMemoryFiles(new Map([
+			[sourceKeybindings.toString(), JSON.stringify([{ key: 'ctrl+b', command: 'b' }])],
+			[keybindingsTarget.toString(), '{ "not": "an array" }'],
+		]));
+
+		let jsonWriteCalled = false;
+		const jsonEditingService = { write: async () => { jsonWriteCalled = true; } } as unknown as IJSONEditingService;
+
+		const service = createImportService({ files, jsonEditingService });
+		const result = await service.import(cursorSource({ hasKeybindings: true }), { keybindings: true });
+
+		assert.strictEqual(result.keybindingsImported, false);
+		assert.strictEqual(jsonWriteCalled, false);
+		// The original content is preserved rather than clobbered.
+		assert.strictEqual(files.get(keybindingsTarget), '{ "not": "an array" }');
+	});
+
+	test('counts extensions missing from the gallery as failed', async () => {
+		const manifest = URI.joinPath(home, '.cursor', 'extensions', 'extensions.json');
+		const files = new InMemoryFiles(new Map([
+			[manifest.toString(), JSON.stringify([{ identifier: { id: 'pub.a' } }, { identifier: { id: 'pub.b' } }])],
+		]));
+
+		const extensionManagementService = {
+			getInstalled: async () => [],
+			installGalleryExtensions: async (infos: InstallExtensionInfo[]) => infos.map(info => ({ identifier: info.extension.identifier, local: {} })),
+		} as unknown as IExtensionManagementService;
+
+		// Only one of the two requested extensions resolves in the gallery.
+		const extensionGalleryService = {
+			getExtensions: async () => [{ identifier: { id: 'pub.a' }, displayName: 'A' }],
+		} as unknown as IExtensionGalleryService;
+
+		const service = createImportService({ files, extensionGalleryService, extensionManagementService });
+		const result = await service.import(cursorSource({ hasExtensions: true }), { extensions: true });
+
+		assert.deepStrictEqual(
+			{ installed: result.extensionsInstalled, failed: result.extensionsFailed },
+			{ installed: 1, failed: 1 },
+		);
+	});
+
+	test('remaps known source-editor forks to their Marketplace equivalents', async () => {
+		const manifest = URI.joinPath(home, '.cursor', 'extensions', 'extensions.json');
+		const files = new InMemoryFiles(new Map([
+			[manifest.toString(), JSON.stringify([{ identifier: { id: 'anysphere.remote-ssh', uuid: 'anysphere-uuid' } }])],
+		]));
+
+		const extensionManagementService = {
+			getInstalled: async () => [],
+			installGalleryExtensions: async (infos: InstallExtensionInfo[]) => infos.map(info => ({ identifier: info.extension.identifier, local: {} })),
+		} as unknown as IExtensionManagementService;
+
+		let queriedIds: string[] = [];
+		const extensionGalleryService = {
+			getExtensions: async (infos: { id: string }[]) => {
+				queriedIds = infos.map(info => info.id);
+				return infos.map(info => ({ identifier: { id: info.id }, displayName: info.id }));
+			},
+		} as unknown as IExtensionGalleryService;
+
+		const service = createImportService({ files, extensionGalleryService, extensionManagementService });
+		const result = await service.import(cursorSource({ hasExtensions: true }), { extensions: true });
+
+		assert.deepStrictEqual(
+			{ queriedIds, installed: result.extensionsInstalled, failed: result.extensionsFailed },
+			{ queriedIds: ['ms-vscode-remote.remote-ssh'], installed: 1, failed: 0 },
+		);
 	});
 });

--- a/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
@@ -118,7 +118,6 @@ suite('ExternalEditorImportService', () => {
 			hasKeybindings: false,
 			hasSnippets: false,
 			hasExtensions: false,
-			hasTheme: false,
 			colorThemeId: undefined,
 			...overrides,
 		};
@@ -162,10 +161,7 @@ suite('ExternalEditorImportService', () => {
 		const service = createService(existing, undefined, contents);
 		const sources = await service.detectSources();
 
-		assert.deepStrictEqual(
-			{ hasTheme: sources[0]?.hasTheme, colorThemeId: sources[0]?.colorThemeId },
-			{ hasTheme: true, colorThemeId: 'Monokai' },
-		);
+		assert.strictEqual(sources[0]?.colorThemeId, 'Monokai');
 	});
 
 	test('maps the selected theme from state storage to the closest VS Code theme', async () => {
@@ -182,10 +178,7 @@ suite('ExternalEditorImportService', () => {
 		const service = createService(existing, undefined, contents);
 		const sources = await service.detectSources();
 
-		assert.deepStrictEqual(
-			{ hasTheme: sources[0]?.hasTheme, colorThemeId: sources[0]?.colorThemeId },
-			{ hasTheme: true, colorThemeId: 'Light Modern' },
-		);
+		assert.strictEqual(sources[0]?.colorThemeId, 'Light Modern');
 	});
 
 	test('maps a high-contrast base theme from state storage', async () => {
@@ -215,10 +208,7 @@ suite('ExternalEditorImportService', () => {
 		const service = createService(existing, undefined, contents);
 		const sources = await service.detectSources();
 
-		assert.deepStrictEqual(
-			{ hasTheme: sources[0]?.hasTheme, colorThemeId: sources[0]?.colorThemeId },
-			{ hasTheme: false, colorThemeId: undefined },
-		);
+		assert.strictEqual(sources[0]?.colorThemeId, undefined);
 	});
 
 	test('reports no theme preference when the source settings set none', async () => {
@@ -232,7 +222,7 @@ suite('ExternalEditorImportService', () => {
 		const service = createService(existing, undefined, contents);
 		const sources = await service.detectSources();
 
-		assert.strictEqual(sources[0]?.hasTheme, false);
+		assert.strictEqual(sources[0]?.colorThemeId, undefined);
 	});
 
 	test('returns no sources when nothing is installed', async () => {
@@ -318,7 +308,7 @@ suite('ExternalEditorImportService', () => {
 		} as unknown as IJSONEditingService;
 
 		const service = createImportService({ files, jsonEditingService });
-		const result = await service.import(cursorSource({ hasSettings: true, hasTheme: true, colorThemeId: 'Light Modern' }), { settings: true });
+		const result = await service.import(cursorSource({ hasSettings: true, colorThemeId: 'Light Modern' }), { settings: true });
 
 		assert.strictEqual(result.settingsImported, 2);
 		assert.deepStrictEqual(writes.map(w => ({ resource: w.resource.toString(), values: w.values })), [{

--- a/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
-import { isMacintosh, isWindows } from '../../../../../base/common/platform.js';
+import { isMacintosh, isWeb, isWindows } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
@@ -36,6 +36,8 @@ suite('ExternalEditorImportService', () => {
 
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	const home = URI.file('/home/tester');
+	const nativeTest = isWeb ? test.skip : test;
+	const webTest = isWeb ? test : test.skip;
 
 	function createService(existingPaths: Set<string>, remoteAuthority?: string, fileContents?: Map<string, string>, importEnvironmentService?: IExternalEditorImportEnvironmentService): ExternalEditorImportService {
 		const fileService = {
@@ -123,7 +125,7 @@ suite('ExternalEditorImportService', () => {
 		};
 	}
 
-	test('detects Cursor and reports available categories', async () => {
+	nativeTest('detects Cursor and reports available categories', async () => {
 		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
 		const existing = new Set<string>([
 			URI.joinPath(cursorUser, 'settings.json').toString(),
@@ -150,7 +152,7 @@ suite('ExternalEditorImportService', () => {
 		}]);
 	});
 
-	test('resolves an explicit color theme to itself', async () => {
+	nativeTest('resolves an explicit color theme to itself', async () => {
 		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
 		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
 		const existing = new Set<string>([settingsUri.toString()]);
@@ -164,7 +166,7 @@ suite('ExternalEditorImportService', () => {
 		assert.strictEqual(sources[0]?.colorThemeId, 'Monokai');
 	});
 
-	test('maps the selected theme from state storage to the closest VS Code theme', async () => {
+	nativeTest('maps the selected theme from state storage to the closest VS Code theme', async () => {
 		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
 		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
 		const storageUri = URI.joinPath(cursorUser, 'globalStorage', 'storage.json');
@@ -181,7 +183,7 @@ suite('ExternalEditorImportService', () => {
 		assert.strictEqual(sources[0]?.colorThemeId, 'Light Modern');
 	});
 
-	test('maps a high-contrast base theme from state storage', async () => {
+	nativeTest('maps a high-contrast base theme from state storage', async () => {
 		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
 		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
 		const storageUri = URI.joinPath(cursorUser, 'globalStorage', 'storage.json');
@@ -197,12 +199,16 @@ suite('ExternalEditorImportService', () => {
 		assert.strictEqual(sources[0]?.colorThemeId, 'Dark High Contrast');
 	});
 
-	test('does not treat OS auto-detect alone as a resolved theme', async () => {
+	nativeTest('does not infer the active theme from preferred themes', async () => {
 		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
 		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
 		const existing = new Set<string>([settingsUri.toString()]);
 		const contents = new Map<string, string>([
-			[settingsUri.toString(), JSON.stringify({ 'window.autoDetectColorScheme': true })],
+			[settingsUri.toString(), JSON.stringify({
+				'window.autoDetectColorScheme': true,
+				'workbench.preferredDarkColorTheme': 'Cursor Dark',
+				'workbench.preferredLightColorTheme': 'Cursor Light',
+			})],
 		]);
 
 		const service = createService(existing, undefined, contents);
@@ -211,7 +217,7 @@ suite('ExternalEditorImportService', () => {
 		assert.strictEqual(sources[0]?.colorThemeId, undefined);
 	});
 
-	test('reports no theme preference when the source settings set none', async () => {
+	nativeTest('reports no theme preference when the source settings set none', async () => {
 		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
 		const settingsUri = URI.joinPath(cursorUser, 'settings.json');
 		const existing = new Set<string>([settingsUri.toString()]);
@@ -225,13 +231,13 @@ suite('ExternalEditorImportService', () => {
 		assert.strictEqual(sources[0]?.colorThemeId, undefined);
 	});
 
-	test('returns no sources when nothing is installed', async () => {
+	nativeTest('returns no sources when nothing is installed', async () => {
 		const service = createService(new Set<string>());
 		const sources = await service.detectSources();
 		assert.strictEqual(sources.length, 0);
 	});
 
-	test('returns no sources in a remote window', async () => {
+	nativeTest('returns no sources in a remote window', async () => {
 		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
 		const existing = new Set<string>([URI.joinPath(cursorUser, 'settings.json').toString()]);
 		const service = createService(existing, 'ssh-remote+host');
@@ -239,7 +245,7 @@ suite('ExternalEditorImportService', () => {
 		assert.strictEqual(sources.length, 0);
 	});
 
-	test('detects Cursor under a redirected application-data root', async () => {
+	nativeTest('detects Cursor under a redirected application-data root', async () => {
 		const redirectedHome = URI.file('/redirected/config');
 		const cursorUser = URI.joinPath(redirectedHome, 'Cursor', 'User');
 		const existing = new Set<string>([URI.joinPath(cursorUser, 'settings.json').toString()]);
@@ -251,6 +257,15 @@ suite('ExternalEditorImportService', () => {
 		const sources = await createService(existing, undefined, undefined, importEnvironmentService).detectSources();
 
 		assert.deepStrictEqual(sources.map(source => source.userDataUri.toString()), [cursorUser.toString()]);
+	});
+
+	webTest('returns no sources in web', async () => {
+		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
+		const existing = new Set<string>([URI.joinPath(cursorUser, 'settings.json').toString()]);
+
+		const sources = await createService(existing).detectSources();
+
+		assert.deepStrictEqual(sources, []);
 	});
 
 	function createImportService(options: {
@@ -392,6 +407,29 @@ suite('ExternalEditorImportService', () => {
 		assert.deepStrictEqual({ preview: preview.keybindings, imported: result.keybindingsImported }, { preview: [], imported: false });
 	});
 
+	test('ignores invalid keybinding entries consistently', async () => {
+		const sourceKeybindings = URI.joinPath(cursorUserData, 'keybindings.json');
+		const files = new InMemoryFiles(new Map([
+			[sourceKeybindings.toString(), JSON.stringify([null, 42, 'invalid', { key: 'ctrl+a' }, { key: 'ctrl+b', command: 'b' }])],
+		]));
+		const writes: IJSONValue[][] = [];
+		const jsonEditingService = {
+			write: async (_resource: URI, values: IJSONValue[]) => { writes.push(values); },
+		} as unknown as IJSONEditingService;
+		const service = createImportService({ files, jsonEditingService });
+		const source = cursorSource({ hasKeybindings: true });
+
+		const preview = await service.preview(source);
+		const result = await service.import(source, { keybindings: true });
+
+		assert.deepStrictEqual({ preview: preview.keybindings, imported: result.keybindingsImported, writes }, {
+			preview: ['ctrl+b → b'],
+			imported: true,
+			writes: [],
+		});
+		assert.strictEqual(files.get(keybindingsTarget), JSON.stringify([{ key: 'ctrl+b', command: 'b' }], null, '\t'));
+	});
+
 	test('previews and imports only supported snippet files', async () => {
 		const snippetsHome = URI.joinPath(cursorUserData, 'snippets');
 		const files = new InMemoryFiles(new Map([
@@ -502,6 +540,35 @@ suite('ExternalEditorImportService', () => {
 		const result = await service.import(cursorSource({ hasSnippets: true }), { snippets: true });
 
 		assert.deepStrictEqual({ imported: result.snippetsImported, failed: result.snippetsFailed }, { imported: 0, failed: 1 });
+	});
+
+	test('stops importing snippets when cancelled', async () => {
+		const snippetsHome = URI.joinPath(cursorUserData, 'snippets');
+		const firstSnippet = URI.joinPath(snippetsHome, 'first.code-snippets');
+		const secondSnippet = URI.joinPath(snippetsHome, 'second.code-snippets');
+		const files = new InMemoryFiles(new Map([
+			[snippetsHome.toString(), 'directory'],
+			[firstSnippet.toString(), '{}'],
+			[secondSnippet.toString(), '{}'],
+		]));
+		files.service.resolve = async () => ({
+			children: [
+				{ name: 'first.code-snippets', isDirectory: false, resource: firstSnippet },
+				{ name: 'second.code-snippets', isDirectory: false, resource: secondSnippet },
+			],
+		}) as never;
+		const cancellation = store.add(new CancellationTokenSource());
+		const writeFile = files.service.writeFile;
+		files.service.writeFile = async (resource, value) => {
+			await writeFile(resource, value);
+			cancellation.cancel();
+		};
+		const service = createImportService({ files });
+
+		const result = await service.import(cursorSource({ hasSnippets: true }), { snippets: true }, cancellation.token);
+
+		assert.deepStrictEqual({ imported: result.snippetsImported, failed: result.snippetsFailed }, { imported: 1, failed: 0 });
+		assert.strictEqual(files.get(URI.file('/profile/snippets/second.code-snippets')), undefined);
 	});
 
 	test('counts extensions missing from the gallery as failed', async () => {

--- a/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
@@ -4,19 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { isMacintosh, isWindows } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
-import { IExtensionGalleryService, IExtensionManagementService, InstallExtensionInfo } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
+import { IExtensionGalleryService, IExtensionManagementService } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
+import { IWorkbenchExtensionManagementService } from '../../../../services/extensionManagement/common/extensionManagement.js';
 import { IJSONEditingService, IJSONValue } from '../../../../services/configuration/common/jsonEditing.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
+import { IWorkbenchThemeService } from '../../../../services/themes/common/workbenchThemeService.js';
 import { IUserDataProfileService } from '../../../../services/userDataProfile/common/userDataProfile.js';
 import { ExternalEditorImportService } from '../../browser/externalEditorImportService.js';
 import { IExternalEditorSource } from '../../common/externalEditorImport.js';
+import { ExternalEditorImportEnvironmentService, IExternalEditorImportEnvironmentService } from '../../common/externalEditorImportEnvironment.js';
 
 function applicationDataHome(home: URI): URI {
 	if (isWindows) {
@@ -33,7 +37,7 @@ suite('ExternalEditorImportService', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	const home = URI.file('/home/tester');
 
-	function createService(existingPaths: Set<string>, remoteAuthority?: string, fileContents?: Map<string, string>): ExternalEditorImportService {
+	function createService(existingPaths: Set<string>, remoteAuthority?: string, fileContents?: Map<string, string>, importEnvironmentService?: IExternalEditorImportEnvironmentService): ExternalEditorImportService {
 		const fileService = {
 			exists: async (resource: URI) => existingPaths.has(resource.toString()),
 			readFile: async (resource: URI) => {
@@ -62,7 +66,10 @@ suite('ExternalEditorImportService', () => {
 			{} as unknown as IUserDataProfileService,
 			{} as unknown as IExtensionGalleryService,
 			{} as unknown as IExtensionManagementService,
+			{} as unknown as IWorkbenchExtensionManagementService,
+			{ getColorThemes: async () => [{ settingsId: 'Monokai' }] } as unknown as IWorkbenchThemeService,
 			{ remoteAuthority } as unknown as IWorkbenchEnvironmentService,
+			importEnvironmentService ?? new ExternalEditorImportEnvironmentService(),
 			new NullLogService(),
 		));
 	}
@@ -242,11 +249,27 @@ suite('ExternalEditorImportService', () => {
 		assert.strictEqual(sources.length, 0);
 	});
 
+	test('detects Cursor under a redirected application-data root', async () => {
+		const redirectedHome = URI.file('/redirected/config');
+		const cursorUser = URI.joinPath(redirectedHome, 'Cursor', 'User');
+		const existing = new Set<string>([URI.joinPath(cursorUser, 'settings.json').toString()]);
+		const importEnvironmentService = {
+			_serviceBrand: undefined,
+			getApplicationDataHome: async () => redirectedHome,
+		};
+
+		const sources = await createService(existing, undefined, undefined, importEnvironmentService).detectSources();
+
+		assert.deepStrictEqual(sources.map(source => source.userDataUri.toString()), [cursorUser.toString()]);
+	});
+
 	function createImportService(options: {
 		files: InMemoryFiles;
 		jsonEditingService?: IJSONEditingService;
 		extensionGalleryService?: IExtensionGalleryService;
 		extensionManagementService?: IExtensionManagementService;
+		workbenchExtensionManagementService?: IWorkbenchExtensionManagementService;
+		importEnvironmentService?: IExternalEditorImportEnvironmentService;
 	}): ExternalEditorImportService {
 		const pathService = { userHome: async () => home } as unknown as IPathService;
 		const userDataProfileService = {
@@ -254,8 +277,14 @@ suite('ExternalEditorImportService', () => {
 				settingsResource: URI.file('/profile/settings.json'),
 				keybindingsResource: keybindingsTarget,
 				snippetsHome: URI.file('/profile/snippets'),
+				extensionsResource: URI.file('/profile/extensions.json'),
 			},
 		} as unknown as IUserDataProfileService;
+		const workbenchExtensionManagementService = {
+			canInstall: async () => true,
+			requestPublisherTrust: async () => true,
+			installFromGallery: async () => undefined,
+		} as unknown as IWorkbenchExtensionManagementService;
 
 		return store.add(new ExternalEditorImportService(
 			options.files.service,
@@ -264,7 +293,10 @@ suite('ExternalEditorImportService', () => {
 			userDataProfileService,
 			options.extensionGalleryService ?? ({} as unknown as IExtensionGalleryService),
 			options.extensionManagementService ?? ({} as unknown as IExtensionManagementService),
+			options.workbenchExtensionManagementService ?? workbenchExtensionManagementService,
+			{ getColorThemes: async () => [] } as unknown as IWorkbenchThemeService,
 			{ remoteAuthority: undefined } as unknown as IWorkbenchEnvironmentService,
+			options.importEnvironmentService ?? new ExternalEditorImportEnvironmentService(),
 			new NullLogService(),
 		));
 	}
@@ -296,6 +328,19 @@ suite('ExternalEditorImportService', () => {
 				{ path: ['workbench.colorTheme'], value: 'Light Modern' },
 			],
 		}]);
+	});
+
+	test('reports settings write failures without importing anything', async () => {
+		const sourceSettings = URI.joinPath(cursorUserData, 'settings.json');
+		const files = new InMemoryFiles(new Map([
+			[sourceSettings.toString(), JSON.stringify({ 'editor.fontSize': 14 })],
+		]));
+		const jsonEditingService = { write: async () => { throw new Error('write failed'); } } as unknown as IJSONEditingService;
+		const service = createImportService({ files, jsonEditingService });
+
+		const result = await service.import(cursorSource({ hasSettings: true }), { settings: true });
+
+		assert.deepStrictEqual({ imported: result.settingsImported, failed: result.settingsFailed }, { imported: 0, failed: true });
 	});
 
 	test('imports keybindings by appending through the JSON editing service to preserve the existing file', async () => {
@@ -343,6 +388,132 @@ suite('ExternalEditorImportService', () => {
 		assert.strictEqual(files.get(keybindingsTarget), '{ "not": "an array" }');
 	});
 
+	test('compares keybindings structurally regardless of property order', async () => {
+		const sourceKeybindings = URI.joinPath(cursorUserData, 'keybindings.json');
+		const files = new InMemoryFiles(new Map([
+			[sourceKeybindings.toString(), JSON.stringify([{ command: 'a', key: 'ctrl+a' }])],
+			[keybindingsTarget.toString(), JSON.stringify([{ key: 'ctrl+a', command: 'a' }])],
+		]));
+
+		const service = createImportService({ files });
+		const preview = await service.preview(cursorSource({ hasKeybindings: true }));
+		const result = await service.import(cursorSource({ hasKeybindings: true }), { keybindings: true });
+
+		assert.deepStrictEqual({ preview: preview.keybindings, imported: result.keybindingsImported }, { preview: [], imported: false });
+	});
+
+	test('previews and imports only supported snippet files', async () => {
+		const snippetsHome = URI.joinPath(cursorUserData, 'snippets');
+		const files = new InMemoryFiles(new Map([
+			[snippetsHome.toString(), 'directory'],
+			[URI.joinPath(snippetsHome, 'valid.code-snippets').toString(), '{}'],
+			[URI.joinPath(snippetsHome, 'notes.txt').toString(), 'not a snippet'],
+		]));
+		files.service.resolve = async resource => ({
+			children: [
+				{ name: 'valid.code-snippets', isDirectory: false, resource: URI.joinPath(resource, 'valid.code-snippets') },
+				{ name: 'notes.txt', isDirectory: false, resource: URI.joinPath(resource, 'notes.txt') },
+			],
+		}) as never;
+
+		const service = createImportService({ files });
+		const source = cursorSource({ hasSnippets: true });
+		const preview = await service.preview(source);
+		const result = await service.import(source, { snippets: true });
+
+		assert.deepStrictEqual({ preview: preview.snippets, imported: result.snippetsImported }, { preview: ['valid.code-snippets'], imported: 1 });
+	});
+
+	test('previews no changes when every source customization already exists', async () => {
+		const sourceSettings = URI.joinPath(cursorUserData, 'settings.json');
+		const sourceKeybindings = URI.joinPath(cursorUserData, 'keybindings.json');
+		const sourceSnippets = URI.joinPath(cursorUserData, 'snippets');
+		const sourceSnippet = URI.joinPath(sourceSnippets, 'existing.code-snippets');
+		const targetSnippet = URI.file('/profile/snippets/existing.code-snippets');
+		const manifest = URI.joinPath(home, '.cursor', 'extensions', 'extensions.json');
+		const files = new InMemoryFiles(new Map([
+			[sourceSettings.toString(), JSON.stringify({ 'editor.fontSize': 14 })],
+			[URI.file('/profile/settings.json').toString(), JSON.stringify({ 'editor.fontSize': 14 })],
+			[sourceKeybindings.toString(), JSON.stringify([{ key: 'ctrl+a', command: 'a' }])],
+			[keybindingsTarget.toString(), JSON.stringify([{ command: 'a', key: 'ctrl+a' }])],
+			[sourceSnippets.toString(), 'directory'],
+			[sourceSnippet.toString(), '{}'],
+			[targetSnippet.toString(), '{}'],
+			[manifest.toString(), JSON.stringify([{ identifier: { id: 'pub.existing' } }])],
+		]));
+		files.service.resolve = async resource => ({
+			children: resource.toString() === sourceSnippets.toString()
+				? [{ name: 'existing.code-snippets', isDirectory: false, resource: sourceSnippet }]
+				: [],
+		}) as never;
+		const extensionManagementService = {
+			getInstalled: async () => [{ identifier: { id: 'pub.existing' } }],
+		} as unknown as IExtensionManagementService;
+		const service = createImportService({ files, extensionManagementService });
+
+		const preview = await service.preview(cursorSource({ hasSettings: true, hasKeybindings: true, hasSnippets: true, hasExtensions: true }));
+
+		assert.deepStrictEqual(preview, { settings: [], keybindings: [], snippets: [], extensions: [] });
+	});
+
+	test('previews each independently available customization category', async () => {
+		const settingsFiles = new InMemoryFiles(new Map([
+			[URI.joinPath(cursorUserData, 'settings.json').toString(), JSON.stringify({ 'editor.fontSize': 14 })],
+		]));
+		const settings = await createImportService({ files: settingsFiles }).preview(cursorSource({ hasSettings: true }));
+
+		const keybindingsFiles = new InMemoryFiles(new Map([
+			[URI.joinPath(cursorUserData, 'keybindings.json').toString(), JSON.stringify([{ key: 'ctrl+a', command: 'a' }])],
+		]));
+		const keybindings = await createImportService({ files: keybindingsFiles }).preview(cursorSource({ hasKeybindings: true }));
+
+		const snippetsHome = URI.joinPath(cursorUserData, 'snippets');
+		const snippet = URI.joinPath(snippetsHome, 'new.code-snippets');
+		const snippetFiles = new InMemoryFiles(new Map([
+			[snippetsHome.toString(), 'directory'],
+			[snippet.toString(), '{}'],
+		]));
+		snippetFiles.service.resolve = async () => ({
+			children: [{ name: 'new.code-snippets', isDirectory: false, resource: snippet }],
+		}) as never;
+		const snippets = await createImportService({ files: snippetFiles }).preview(cursorSource({ hasSnippets: true }));
+
+		const manifest = URI.joinPath(home, '.cursor', 'extensions', 'extensions.json');
+		const extensionFiles = new InMemoryFiles(new Map([
+			[manifest.toString(), JSON.stringify([{ identifier: { id: 'pub.new' } }])],
+		]));
+		const extensionManagementService = { getInstalled: async () => [] } as unknown as IExtensionManagementService;
+		const extensionGalleryService = {
+			getExtensions: async () => [{ identifier: { id: 'pub.new' }, displayName: 'New Extension' }],
+		} as unknown as IExtensionGalleryService;
+		const extensions = await createImportService({ files: extensionFiles, extensionManagementService, extensionGalleryService }).preview(cursorSource({ hasExtensions: true }));
+
+		assert.deepStrictEqual({ settings, keybindings, snippets, extensions }, {
+			settings: { settings: ['editor.fontSize'], keybindings: [], snippets: [], extensions: [] },
+			keybindings: { settings: [], keybindings: ['ctrl+a → a'], snippets: [], extensions: [] },
+			snippets: { settings: [], keybindings: [], snippets: ['new.code-snippets'], extensions: [] },
+			extensions: { settings: [], keybindings: [], snippets: [], extensions: ['New Extension'] },
+		});
+	});
+
+	test('counts snippet write failures', async () => {
+		const snippetsHome = URI.joinPath(cursorUserData, 'snippets');
+		const sourceSnippet = URI.joinPath(snippetsHome, 'valid.code-snippets');
+		const files = new InMemoryFiles(new Map([
+			[snippetsHome.toString(), 'directory'],
+			[sourceSnippet.toString(), '{}'],
+		]));
+		files.service.resolve = async resource => ({
+			children: [{ name: 'valid.code-snippets', isDirectory: false, resource: URI.joinPath(resource, 'valid.code-snippets') }],
+		}) as never;
+		files.service.writeFile = async () => { throw new Error('write failed'); };
+		const service = createImportService({ files });
+
+		const result = await service.import(cursorSource({ hasSnippets: true }), { snippets: true });
+
+		assert.deepStrictEqual({ imported: result.snippetsImported, failed: result.snippetsFailed }, { imported: 0, failed: 1 });
+	});
+
 	test('counts extensions missing from the gallery as failed', async () => {
 		const manifest = URI.joinPath(home, '.cursor', 'extensions', 'extensions.json');
 		const files = new InMemoryFiles(new Map([
@@ -351,7 +522,6 @@ suite('ExternalEditorImportService', () => {
 
 		const extensionManagementService = {
 			getInstalled: async () => [],
-			installGalleryExtensions: async (infos: InstallExtensionInfo[]) => infos.map(info => ({ identifier: info.extension.identifier, local: {} })),
 		} as unknown as IExtensionManagementService;
 
 		// Only one of the two requested extensions resolves in the gallery.
@@ -376,7 +546,6 @@ suite('ExternalEditorImportService', () => {
 
 		const extensionManagementService = {
 			getInstalled: async () => [],
-			installGalleryExtensions: async (infos: InstallExtensionInfo[]) => infos.map(info => ({ identifier: info.extension.identifier, local: {} })),
 		} as unknown as IExtensionManagementService;
 
 		let queriedIds: string[] = [];
@@ -394,5 +563,96 @@ suite('ExternalEditorImportService', () => {
 			{ queriedIds, installed: result.extensionsInstalled, failed: result.extensionsFailed },
 			{ queriedIds: ['ms-vscode-remote.remote-ssh'], installed: 1, failed: 0 },
 		);
+	});
+
+	test('checks and installs extensions in the current profile', async () => {
+		const manifest = URI.joinPath(home, '.cursor', 'extensions', 'extensions.json');
+		const profileLocation = URI.file('/profile/extensions.json');
+		const files = new InMemoryFiles(new Map([
+			[manifest.toString(), JSON.stringify([{ identifier: { id: 'pub.a' } }])],
+		]));
+		const getInstalledLocations: (URI | undefined)[] = [];
+		const extensionManagementService = {
+			getInstalled: async (_type: undefined, location: URI | undefined) => {
+				getInstalledLocations.push(location);
+				return [];
+			},
+		} as unknown as IExtensionManagementService;
+		const extensionGalleryService = {
+			getExtensions: async () => [{ identifier: { id: 'pub.a' }, displayName: 'A' }],
+		} as unknown as IExtensionGalleryService;
+		const installLocations: (URI | undefined)[] = [];
+		const workbenchExtensionManagementService = {
+			canInstall: async () => true,
+			requestPublisherTrust: async () => true,
+			installFromGallery: async (_extension: object, options: { profileLocation?: URI }) => { installLocations.push(options.profileLocation); },
+		} as unknown as IWorkbenchExtensionManagementService;
+		const service = createImportService({ files, extensionGalleryService, extensionManagementService, workbenchExtensionManagementService });
+		const source = cursorSource({ hasExtensions: true });
+
+		await service.preview(source);
+		await service.import(source, { extensions: true });
+
+		assert.deepStrictEqual({ getInstalledLocations, installLocations }, {
+			getInstalledLocations: [profileLocation, profileLocation],
+			installLocations: [profileLocation],
+		});
+	});
+
+	test('counts unsupported and untrusted extensions as failed', async () => {
+		const manifest = URI.joinPath(home, '.cursor', 'extensions', 'extensions.json');
+		const files = new InMemoryFiles(new Map([
+			[manifest.toString(), JSON.stringify([
+				{ identifier: { id: 'pub.unsupported' } },
+				{ identifier: { id: 'pub.untrusted' } },
+			])],
+		]));
+		const extensionManagementService = { getInstalled: async () => [] } as unknown as IExtensionManagementService;
+		const extensionGalleryService = {
+			getExtensions: async () => [
+				{ identifier: { id: 'pub.unsupported' } },
+				{ identifier: { id: 'pub.untrusted' } },
+			],
+		} as unknown as IExtensionGalleryService;
+		const workbenchExtensionManagementService = {
+			canInstall: async (extension: { identifier: { id: string } }) => extension.identifier.id !== 'pub.unsupported',
+			requestPublisherTrust: async () => { throw new Error('denied'); },
+			installFromGallery: async () => undefined,
+		} as unknown as IWorkbenchExtensionManagementService;
+		const service = createImportService({ files, extensionGalleryService, extensionManagementService, workbenchExtensionManagementService });
+
+		const result = await service.import(cursorSource({ hasExtensions: true }), { extensions: true });
+
+		assert.deepStrictEqual({ installed: result.extensionsInstalled, failed: result.extensionsFailed }, { installed: 0, failed: 2 });
+	});
+
+	test('counts only remaining extensions as failed when installation is cancelled', async () => {
+		const manifest = URI.joinPath(home, '.cursor', 'extensions', 'extensions.json');
+		const files = new InMemoryFiles(new Map([
+			[manifest.toString(), JSON.stringify([
+				{ identifier: { id: 'pub.installed' } },
+				{ identifier: { id: 'pub.cancelled-a' } },
+				{ identifier: { id: 'pub.cancelled-b' } },
+			])],
+		]));
+		const extensionManagementService = { getInstalled: async () => [] } as unknown as IExtensionManagementService;
+		const extensionGalleryService = {
+			getExtensions: async () => [
+				{ identifier: { id: 'pub.installed' } },
+				{ identifier: { id: 'pub.cancelled-a' } },
+				{ identifier: { id: 'pub.cancelled-b' } },
+			],
+		} as unknown as IExtensionGalleryService;
+		const cancellation = store.add(new CancellationTokenSource());
+		const workbenchExtensionManagementService = {
+			canInstall: async () => true,
+			requestPublisherTrust: async () => true,
+			installFromGallery: async () => { cancellation.cancel(); },
+		} as unknown as IWorkbenchExtensionManagementService;
+		const service = createImportService({ files, extensionGalleryService, extensionManagementService, workbenchExtensionManagementService });
+
+		const result = await service.import(cursorSource({ hasExtensions: true }), { extensions: true }, cancellation.token);
+
+		assert.deepStrictEqual({ installed: result.extensionsInstalled, failed: result.extensionsFailed }, { installed: 1, failed: 2 });
 	});
 });

--- a/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
+++ b/src/vs/workbench/contrib/externalEditorImport/test/browser/externalEditorImportService.test.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { isMacintosh, isWindows } from '../../../../../base/common/platform.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { IExtensionGalleryService, IExtensionManagementService } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
+import { IJSONEditingService } from '../../../../services/configuration/common/jsonEditing.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
+import { IUserDataProfileService } from '../../../../services/userDataProfile/common/userDataProfile.js';
+import { ExternalEditorImportService } from '../../browser/externalEditorImportService.js';
+
+function applicationDataHome(home: URI): URI {
+	if (isWindows) {
+		return URI.joinPath(home, 'AppData', 'Roaming');
+	}
+	if (isMacintosh) {
+		return URI.joinPath(home, 'Library', 'Application Support');
+	}
+	return URI.joinPath(home, '.config');
+}
+
+suite('ExternalEditorImportService', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	const home = URI.file('/home/tester');
+
+	function createService(existingPaths: Set<string>): ExternalEditorImportService {
+		const fileService = {
+			exists: async (resource: URI) => existingPaths.has(resource.toString()),
+			resolve: async (resource: URI) => {
+				if (!existingPaths.has(resource.toString())) {
+					throw new Error('not found');
+				}
+				return { children: [{ name: 'a.code-snippets', isDirectory: false, resource: URI.joinPath(resource, 'a.code-snippets') }] };
+			},
+		} as unknown as IFileService;
+
+		const pathService = {
+			userHome: async () => home,
+		} as unknown as IPathService;
+
+		return store.add(new ExternalEditorImportService(
+			fileService,
+			pathService,
+			{} as unknown as IJSONEditingService,
+			{} as unknown as IUserDataProfileService,
+			{} as unknown as IExtensionGalleryService,
+			{} as unknown as IExtensionManagementService,
+			new NullLogService(),
+		));
+	}
+
+	test('detects Cursor and reports available categories', async () => {
+		const cursorUser = URI.joinPath(applicationDataHome(home), 'Cursor', 'User');
+		const existing = new Set<string>([
+			URI.joinPath(cursorUser, 'settings.json').toString(),
+			URI.joinPath(home, '.cursor', 'extensions', 'extensions.json').toString(),
+		]);
+
+		const service = createService(existing);
+		const sources = await service.detectSources();
+
+		assert.deepStrictEqual(sources.map(s => ({
+			id: s.id,
+			hasSettings: s.hasSettings,
+			hasKeybindings: s.hasKeybindings,
+			hasSnippets: s.hasSnippets,
+			hasExtensions: s.hasExtensions,
+			userData: s.userDataUri.toString(),
+		})), [{
+			id: 'cursor',
+			hasSettings: true,
+			hasKeybindings: false,
+			hasSnippets: false,
+			hasExtensions: true,
+			userData: cursorUser.toString(),
+		}]);
+	});
+
+	test('returns no sources when nothing is installed', async () => {
+		const service = createService(new Set<string>());
+		const sources = await service.detectSources();
+		assert.strictEqual(sources.length, 0);
+	});
+});

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
@@ -711,47 +711,108 @@
 	width: 100%;
 }
 
-.onboarding-a-import-hint {
+.onboarding-a-import-group {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.onboarding-a-import-group-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
 	font-size: 13px;
-	color: var(--vscode-descriptionForeground);
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.onboarding-a-import-group-icon {
+	display: flex;
+	align-items: center;
+	color: var(--vscode-textLink-foreground, #3794ff);
 }
 
 .onboarding-a-import-list {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
+	padding-left: 24px;
 }
 
 .onboarding-a-import-item {
 	display: flex;
-	align-items: center;
-	gap: 10px;
-	padding: 12px 14px;
+	flex-direction: column;
 	border-radius: 8px;
 	border: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
 	background: var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
+	transition: border-color 0.12s ease, background 0.12s ease;
+}
+
+.onboarding-a-import-item.selected {
+	border-color: var(--vscode-focusBorder);
+	background: color-mix(in srgb, var(--vscode-focusBorder) 8%, var(--vscode-editor-background));
+}
+
+.onboarding-a-import-item-header {
+	display: flex;
+	align-items: center;
+}
+
+.onboarding-a-import-toggle {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex: 1 1 auto;
+	min-width: 0;
+	padding: 12px 8px 12px 14px;
+	border: none;
+	background: transparent;
 	color: inherit;
 	cursor: pointer;
 	font-family: inherit;
 	font-size: 13px;
 	text-align: left;
 	outline: none;
-	transition: border-color 0.12s ease, background 0.12s ease;
+	border-radius: 8px 0 0 8px;
 }
 
-.onboarding-a-import-item:hover {
+.onboarding-a-import-toggle:hover {
 	background: var(--vscode-list-hoverBackground);
-	border-color: var(--vscode-focusBorder);
 }
 
-.onboarding-a-import-item:focus-visible {
+.onboarding-a-import-toggle:focus-visible,
+.onboarding-a-import-expand:focus-visible {
 	outline: 2px solid var(--vscode-focusBorder);
 	outline-offset: -2px;
 }
 
-.onboarding-a-import-item.selected {
-	border-color: var(--vscode-focusBorder);
-	background: color-mix(in srgb, var(--vscode-focusBorder) 8%, var(--vscode-editor-background));
+.onboarding-a-import-expand {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	width: 36px;
+	align-self: stretch;
+	border: none;
+	background: transparent;
+	color: var(--vscode-icon-foreground, var(--vscode-foreground));
+	cursor: pointer;
+	outline: none;
+	border-radius: 0 8px 8px 0;
+}
+
+.onboarding-a-import-expand:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+
+.onboarding-a-import-chevron {
+	display: flex;
+	align-items: center;
+	transition: transform 0.12s ease;
+}
+
+.onboarding-a-import-expand.expanded .onboarding-a-import-chevron {
+	transform: rotate(180deg);
 }
 
 .onboarding-a-import-check {
@@ -784,6 +845,38 @@
 
 .onboarding-a-import-label {
 	flex: 1;
+}
+
+.onboarding-a-import-preview {
+	padding: 0 14px 12px 42px;
+	border-top: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
+	margin-top: -1px;
+}
+
+.onboarding-a-import-preview-message {
+	padding-top: 10px;
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.onboarding-a-import-preview-items {
+	list-style: none;
+	margin: 0;
+	padding: 8px 0 0 0;
+	max-height: 160px;
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.onboarding-a-import-preview-item {
+	font-size: 12px;
+	color: var(--vscode-foreground);
+	font-family: var(--monaco-monospace-font);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 /* AI Preference step */

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
@@ -703,6 +703,89 @@
 	border-color: var(--vscode-button-background);
 }
 
+/* Import From Editor step */
+.onboarding-a-import {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	width: 100%;
+}
+
+.onboarding-a-import-hint {
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.onboarding-a-import-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.onboarding-a-import-item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 12px 14px;
+	border-radius: 8px;
+	border: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
+	background: var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
+	color: inherit;
+	cursor: pointer;
+	font-family: inherit;
+	font-size: 13px;
+	text-align: left;
+	outline: none;
+	transition: border-color 0.12s ease, background 0.12s ease;
+}
+
+.onboarding-a-import-item:hover {
+	background: var(--vscode-list-hoverBackground);
+	border-color: var(--vscode-focusBorder);
+}
+
+.onboarding-a-import-item:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: -2px;
+}
+
+.onboarding-a-import-item.selected {
+	border-color: var(--vscode-focusBorder);
+	background: color-mix(in srgb, var(--vscode-focusBorder) 8%, var(--vscode-editor-background));
+}
+
+.onboarding-a-import-check {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-checkbox-border, var(--vscode-widget-border));
+	background: var(--vscode-checkbox-background);
+	flex: 0 0 auto;
+}
+
+.onboarding-a-import-item.selected .onboarding-a-import-check {
+	background: var(--vscode-button-background);
+	border-color: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+}
+
+.onboarding-a-import-check .codicon {
+	font-size: 14px;
+}
+
+.onboarding-a-import-icon {
+	display: flex;
+	align-items: center;
+	color: var(--vscode-textLink-foreground, #3794ff);
+}
+
+.onboarding-a-import-label {
+	flex: 1;
+}
+
 /* AI Preference step */
 .onboarding-a-ai-pref {
 	display: flex;

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
@@ -717,7 +717,7 @@
 	gap: 12px;
 	padding: 20px;
 	border-radius: 12px;
-	border: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
+	border: var(--vscode-strokeThickness) solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
 	background: var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
 }
 
@@ -761,7 +761,7 @@
 	flex-shrink: 0;
 }
 
-.onboarding-a-import-action.onboarding-a-btn {
+.onboarding-a-import-action.monaco-button {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -769,35 +769,13 @@
 	min-width: 0;
 	padding: 4px 10px;
 	min-height: 28px;
-	border: var(--vscode-strokeThickness) solid var(--vscode-button-border, var(--vscode-contrastBorder, transparent));
-	background: transparent;
-	color: var(--vscode-button-secondaryForeground);
 	font-size: var(--vscode-fontSize-label1);
 	line-height: 1.3333333333;
 	white-space: nowrap;
 	align-self: flex-start;
 }
 
-.onboarding-a-import-action.onboarding-a-btn:hover {
-	background: var(--vscode-button-secondaryHoverBackground);
-}
-
-.onboarding-a-import-action-icon {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 16px;
-	height: 16px;
-	font-size: var(--vscode-codiconFontSize);
-	color: inherit;
-	flex-shrink: 0;
-}
-
-.onboarding-a-import-action-icon[hidden] {
-	display: none;
-}
-
-.onboarding-a-import-action:disabled {
+.onboarding-a-import-action.disabled {
 	opacity: 1;
 }
 
@@ -805,6 +783,9 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
+	list-style: none;
+	margin: 0;
+	padding: 0;
 }
 
 .onboarding-a-import-category {
@@ -813,7 +794,7 @@
 	gap: 8px;
 	padding: 6px 10px;
 	border-radius: var(--vscode-cornerRadius-circle);
-	border: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
+	border: var(--vscode-strokeThickness) solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
 	background: color-mix(in srgb, var(--vscode-foreground) 6%, transparent);
 	color: var(--vscode-foreground);
 	font-size: var(--vscode-fontSize-label1);

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
@@ -714,169 +714,129 @@
 .onboarding-a-import-group {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 12px;
+	padding: 20px;
+	border-radius: 12px;
+	border: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
+	background: var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
 }
 
 .onboarding-a-import-group-header {
 	display: flex;
-	align-items: center;
-	gap: 8px;
-	font-size: 13px;
-	font-weight: 600;
-	color: var(--vscode-foreground);
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
 }
 
-.onboarding-a-import-group-icon {
+.onboarding-a-import-group-identity {
 	display: flex;
-	align-items: center;
-	color: var(--vscode-textLink-foreground, #3794ff);
-}
-
-.onboarding-a-import-list {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-	padding-left: 24px;
-}
-
-.onboarding-a-import-item {
-	display: flex;
-	flex-direction: column;
-	border-radius: 8px;
-	border: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
-	background: var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
-	transition: border-color 0.12s ease, background 0.12s ease;
-}
-
-.onboarding-a-import-item.selected {
-	border-color: var(--vscode-focusBorder);
-	background: color-mix(in srgb, var(--vscode-focusBorder) 8%, var(--vscode-editor-background));
-}
-
-.onboarding-a-import-item-header {
-	display: flex;
-	align-items: center;
-}
-
-.onboarding-a-import-toggle {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	flex: 1 1 auto;
+	align-items: flex-start;
 	min-width: 0;
-	padding: 12px 8px 12px 14px;
-	border: none;
-	background: transparent;
-	color: inherit;
-	cursor: pointer;
-	font-family: inherit;
-	font-size: 13px;
-	text-align: left;
-	outline: none;
-	border-radius: 8px 0 0 8px;
-}
-
-.onboarding-a-import-toggle:hover {
-	background: var(--vscode-list-hoverBackground);
-}
-
-.onboarding-a-import-toggle:focus-visible,
-.onboarding-a-import-expand:focus-visible {
-	outline: 2px solid var(--vscode-focusBorder);
-	outline-offset: -2px;
-}
-
-.onboarding-a-import-expand {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	flex: 0 0 auto;
-	width: 36px;
-	align-self: stretch;
-	border: none;
-	background: transparent;
-	color: var(--vscode-icon-foreground, var(--vscode-foreground));
-	cursor: pointer;
-	outline: none;
-	border-radius: 0 8px 8px 0;
-}
-
-.onboarding-a-import-expand:hover {
-	background: var(--vscode-list-hoverBackground);
-}
-
-.onboarding-a-import-chevron {
-	display: flex;
-	align-items: center;
-	transition: transform 0.12s ease;
-}
-
-.onboarding-a-import-expand.expanded .onboarding-a-import-chevron {
-	transform: rotate(180deg);
-}
-
-.onboarding-a-import-check {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 18px;
-	height: 18px;
-	border-radius: 4px;
-	border: 1px solid var(--vscode-checkbox-border, var(--vscode-widget-border));
-	background: var(--vscode-checkbox-background);
-	flex: 0 0 auto;
-}
-
-.onboarding-a-import-item.selected .onboarding-a-import-check {
-	background: var(--vscode-button-background);
-	border-color: var(--vscode-button-background);
-	color: var(--vscode-button-foreground);
-}
-
-.onboarding-a-import-check .codicon {
-	font-size: 14px;
-}
-
-.onboarding-a-import-icon {
-	display: flex;
-	align-items: center;
-	color: var(--vscode-textLink-foreground, #3794ff);
-}
-
-.onboarding-a-import-label {
 	flex: 1;
 }
 
-.onboarding-a-import-preview {
-	padding: 0 14px 12px 42px;
-	border-top: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
-	margin-top: -1px;
-}
-
-.onboarding-a-import-preview-message {
-	padding-top: 10px;
-	font-size: 12px;
-	color: var(--vscode-descriptionForeground);
-}
-
-.onboarding-a-import-preview-items {
-	list-style: none;
-	margin: 0;
-	padding: 8px 0 0 0;
-	max-height: 160px;
-	overflow-y: auto;
+.onboarding-a-import-group-text {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
+	min-width: 0;
 }
 
-.onboarding-a-import-preview-item {
-	font-size: 12px;
+.onboarding-a-import-group-label {
+	font-size: var(--vscode-fontSize-body1);
+	font-weight: var(--vscode-fontWeight-semiBold);
 	color: var(--vscode-foreground);
-	font-family: var(--monaco-monospace-font);
+}
+
+.onboarding-a-import-group-description {
+	font-size: var(--vscode-fontSize-body2);
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.5;
+}
+
+.onboarding-a-import-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-shrink: 0;
+}
+
+.onboarding-a-import-action.onboarding-a-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	min-width: 0;
+	padding: 4px 10px;
+	min-height: 28px;
+	border: var(--vscode-strokeThickness) solid var(--vscode-button-border, var(--vscode-contrastBorder, transparent));
+	background: transparent;
+	color: var(--vscode-button-secondaryForeground);
+	font-size: var(--vscode-fontSize-label1);
+	line-height: 1.3333333333;
 	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	align-self: flex-start;
+}
+
+.onboarding-a-import-action.onboarding-a-btn:hover {
+	background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.onboarding-a-import-action-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
+	font-size: var(--vscode-codiconFontSize);
+	color: inherit;
+	flex-shrink: 0;
+}
+
+.onboarding-a-import-action-icon[hidden] {
+	display: none;
+}
+
+.onboarding-a-import-action:disabled {
+	opacity: 1;
+}
+
+.onboarding-a-import-categories {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.onboarding-a-import-category {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 10px;
+	border-radius: var(--vscode-cornerRadius-circle);
+	border: 1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08));
+	background: color-mix(in srgb, var(--vscode-foreground) 6%, transparent);
+	color: var(--vscode-foreground);
+	font-size: var(--vscode-fontSize-label1);
+}
+
+.onboarding-a-import-category-icon {
+	display: flex;
+	align-items: center;
+	color: inherit;
+}
+
+@media (max-width: 840px) {
+	.onboarding-a-import-group-header {
+		flex-direction: column;
+	}
+
+	.onboarding-a-import-actions {
+		width: 100%;
+	}
+
+	.onboarding-a-import-action {
+		width: 100%;
+	}
 }
 
 /* AI Preference step */

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -48,7 +48,7 @@ import {
 	parseGheInstanceInput,
 } from '../common/onboardingTypes.js';
 import { IOnboardingService } from '../common/onboardingService.js';
-import { IExternalEditorImportService, IExternalEditorSource } from '../../externalEditorImport/common/externalEditorImport.js';
+import { IExternalEditorImportService, IExternalEditorImportPreview, IExternalEditorSource } from '../../externalEditorImport/common/externalEditorImport.js';
 
 type OnboardingStepViewClassification = {
 	owner: 'cwebster-99';
@@ -132,6 +132,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	private _importSource: IExternalEditorSource | undefined;
 	private readonly _importSelection = { settings: true, keybindings: true, snippets: true, extensions: true };
 	private _importCompleted = false;
+	private _importPreviewPromise: Promise<IExternalEditorImportPreview> | undefined;
 	private _userSignedIn = false;
 	private selectedAiMode: AiCollaborationMode = AiCollaborationMode.Balanced;
 	private enterpriseSignInUiState: EnterpriseSignInUiState = 'options';
@@ -178,6 +179,19 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			if (!source || this._isShowing) {
 				return; // nothing to import, or the modal is already showing
 			}
+
+			// Skip the step entirely when there is nothing new to bring over (i.e. the user
+			// already has everything the source has). This uses only fast, local checks
+			// (no gallery lookups) so it does not delay showing the modal; the richer
+			// preview shown in the step UI is computed lazily.
+			const hasSomethingNew = await this.externalEditorImportService.hasImportableChanges(source);
+			if (this._isShowing) {
+				return; // the modal started showing while we were checking
+			}
+			if (!hasSomethingNew) {
+				return; // nothing different to bring over — skip the step
+			}
+
 			this._importSource = source;
 			if (!this.steps.includes(OnboardingStepId.ImportFromEditor)) {
 				const signInIndex = this.steps.indexOf(OnboardingStepId.SignIn);
@@ -412,14 +426,17 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		const stepId = this.steps[this.currentStepIndex];
 		const useSignInHero = stepId === OnboardingStepId.SignIn;
 		this.titleEl.style.display = useSignInHero ? 'none' : '';
-		this.subtitleEl.style.display = useSignInHero ? 'none' : '';
 		this.titleEl.textContent = getOnboardingStepTitle(stepId);
 		if (stepId === OnboardingStepId.AgentSessions) {
+			this.subtitleEl.style.display = useSignInHero ? 'none' : '';
 			this._renderAgentSessionsSubtitle(this.subtitleEl);
 		} else if (stepId === OnboardingStepId.Personalize) {
+			this.subtitleEl.style.display = useSignInHero ? 'none' : '';
 			this._renderPersonalizeSubtitle(this.subtitleEl);
 		} else {
-			this.subtitleEl.textContent = getOnboardingStepSubtitle(stepId);
+			const subtitle = getOnboardingStepSubtitle(stepId);
+			this.subtitleEl.textContent = subtitle;
+			this.subtitleEl.style.display = (useSignInHero || !subtitle) ? 'none' : '';
 		}
 
 		clearNode(this.contentEl);
@@ -1084,10 +1101,16 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 
 		const wrapper = append(container, $('.onboarding-a-import'));
 
-		const hint = append(wrapper, $('div.onboarding-a-import-hint'));
-		hint.textContent = localize('onboarding.import.hint', "We found {0} on your machine. Pick what you'd like to bring over.", source.label);
+		const group = append(wrapper, $('.onboarding-a-import-group'));
 
-		const list = append(wrapper, $('.onboarding-a-import-list'));
+		const groupHeader = append(group, $('.onboarding-a-import-group-header'));
+		const groupIcon = append(groupHeader, $('span.onboarding-a-import-group-icon'));
+		groupIcon.setAttribute('aria-hidden', 'true');
+		groupIcon.appendChild(renderIcon(Codicon.window));
+		const groupLabel = append(groupHeader, $('span.onboarding-a-import-group-label'));
+		groupLabel.textContent = source.label;
+
+		const list = append(group, $('.onboarding-a-import-list'));
 		list.setAttribute('role', 'group');
 		list.setAttribute('aria-label', localize('onboarding.import.listLabel', "Customizations to import from {0}", source.label));
 
@@ -1105,23 +1128,27 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 				continue;
 			}
 
-			const item = this._registerStepFocusable(append(list, $<HTMLButtonElement>('button.onboarding-a-import-item')));
-			item.type = 'button';
-			item.setAttribute('role', 'checkbox');
-			item.setAttribute('aria-checked', this._importSelection[row.key] ? 'true' : 'false');
+			const card = append(list, $('.onboarding-a-import-item'));
+			const header = append(card, $('.onboarding-a-import-item-header'));
 
-			const check = append(item, $('span.onboarding-a-import-check'));
+			const toggle = this._registerStepFocusable(append(header, $<HTMLButtonElement>('button.onboarding-a-import-toggle')));
+			toggle.type = 'button';
+			toggle.setAttribute('role', 'checkbox');
+			toggle.setAttribute('aria-checked', this._importSelection[row.key] ? 'true' : 'false');
+			toggle.setAttribute('aria-label', row.label);
+
+			const check = append(toggle, $('span.onboarding-a-import-check'));
 			check.setAttribute('aria-hidden', 'true');
-			const iconEl = append(item, $('span.onboarding-a-import-icon'));
+			const iconEl = append(toggle, $('span.onboarding-a-import-icon'));
 			iconEl.setAttribute('aria-hidden', 'true');
 			iconEl.appendChild(renderIcon(row.icon));
-			const labelEl = append(item, $('span.onboarding-a-import-label'));
+			const labelEl = append(toggle, $('span.onboarding-a-import-label'));
 			labelEl.textContent = row.label;
 
 			const updateChecked = () => {
 				const checked = this._importSelection[row.key];
-				item.classList.toggle('selected', checked);
-				item.setAttribute('aria-checked', checked ? 'true' : 'false');
+				card.classList.toggle('selected', checked);
+				toggle.setAttribute('aria-checked', checked ? 'true' : 'false');
 				clearNode(check);
 				if (checked) {
 					check.appendChild(renderIcon(Codicon.check));
@@ -1129,11 +1156,71 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			};
 			updateChecked();
 
-			this.stepDisposables.add(addDisposableListener(item, EventType.CLICK, () => {
+			this.stepDisposables.add(addDisposableListener(toggle, EventType.CLICK, () => {
 				this._importSelection[row.key] = !this._importSelection[row.key];
 				this._logAction('toggleImport', OnboardingStepId.ImportFromEditor, row.key);
 				updateChecked();
 			}));
+
+			// Expandable preview of the concrete items that would be imported.
+			const previewId = `onboarding-a-import-preview-${row.key}`;
+			const expand = this._registerStepFocusable(append(header, $<HTMLButtonElement>('button.onboarding-a-import-expand')));
+			expand.type = 'button';
+			expand.setAttribute('aria-expanded', 'false');
+			expand.setAttribute('aria-controls', previewId);
+			expand.setAttribute('aria-label', localize('onboarding.import.previewLabel', "Preview {0} to import", row.label));
+			const chevron = append(expand, $('span.onboarding-a-import-chevron'));
+			chevron.setAttribute('aria-hidden', 'true');
+			chevron.appendChild(renderIcon(Codicon.chevronDown));
+
+			const preview = append(card, $('.onboarding-a-import-preview'));
+			preview.id = previewId;
+			preview.setAttribute('role', 'region');
+			preview.hidden = true;
+
+			let loaded = false;
+			this.stepDisposables.add(addDisposableListener(expand, EventType.CLICK, () => {
+				const expanded = expand.getAttribute('aria-expanded') === 'true';
+				const next = !expanded;
+				expand.setAttribute('aria-expanded', next ? 'true' : 'false');
+				expand.classList.toggle('expanded', next);
+				preview.hidden = !next;
+				if (next && !loaded) {
+					loaded = true;
+					this._logAction('previewImport', OnboardingStepId.ImportFromEditor, row.key);
+					this._populateImportPreview(source, row.key, row.label, preview);
+				}
+			}));
+		}
+	}
+
+	private async _populateImportPreview(source: IExternalEditorSource, key: 'settings' | 'keybindings' | 'snippets' | 'extensions', label: string, container: HTMLElement): Promise<void> {
+		clearNode(container);
+		const message = append(container, $('.onboarding-a-import-preview-message'));
+		message.textContent = localize('onboarding.import.preview.loading', "Loading…");
+
+		let items: readonly string[];
+		try {
+			if (!this._importPreviewPromise) {
+				this._importPreviewPromise = this.externalEditorImportService.preview(source);
+			}
+			const preview = await this._importPreviewPromise;
+			items = preview[key];
+		} catch {
+			clearNode(container);
+			append(container, $('.onboarding-a-import-preview-message')).textContent = localize('onboarding.import.preview.error', "Couldn't load a preview of {0}.", label);
+			return;
+		}
+
+		clearNode(container);
+		if (items.length === 0) {
+			append(container, $('.onboarding-a-import-preview-message')).textContent = localize('onboarding.import.preview.empty', "Nothing new to bring over — you already have these.");
+			return;
+		}
+
+		const itemsEl = append(container, $<HTMLUListElement>('ul.onboarding-a-import-preview-items'));
+		for (const item of items) {
+			append(itemsEl, $<HTMLLIElement>('li.onboarding-a-import-preview-item')).textContent = item;
 		}
 	}
 

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -1191,6 +1191,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			const importStepIndex = this.currentStepIndex;
 			this.closeButton?.focus();
 			setImportButtonState('running');
+			this.accessibilityService.status(localize('onboarding.import.started.status', "Importing customizations from {0}", source.label));
 			void this._runImport().then(async succeeded => {
 				if (!this._isShowing) {
 					return;

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -48,7 +48,7 @@ import {
 	parseGheInstanceInput,
 } from '../common/onboardingTypes.js';
 import { IOnboardingService } from '../common/onboardingService.js';
-import { IExternalEditorImportService, IExternalEditorImportPreview, IExternalEditorSource } from '../../externalEditorImport/common/externalEditorImport.js';
+import { IExternalEditorImportService, IExternalEditorSource } from '../../externalEditorImport/common/externalEditorImport.js';
 
 type OnboardingStepViewClassification = {
 	owner: 'cwebster-99';
@@ -77,6 +77,14 @@ type OnboardingActionEvent = {
 };
 
 type EnterpriseSignInUiState = 'options' | 'instance' | 'progress';
+type ImportCategoryKey = 'settings' | 'keybindings' | 'snippets' | 'extensions';
+
+interface IImportRow {
+	readonly key: ImportCategoryKey;
+	readonly label: string;
+	readonly icon: ThemeIcon;
+	readonly available: boolean;
+}
 
 assertDefined(product.defaultChatAgent, 'Onboarding requires a default chat agent product configuration.');
 const defaultChat = product.defaultChatAgent;
@@ -130,9 +138,8 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	private selectedKeymapId = 'vscode';
 	private _detectedEditorIds: Set<string> | undefined;
 	private _importSource: IExternalEditorSource | undefined;
-	private readonly _importSelection = { settings: true, keybindings: true, snippets: true, extensions: true };
+	private _importInProgress = false;
 	private _importCompleted = false;
-	private _importPreviewPromise: Promise<IExternalEditorImportPreview> | undefined;
 	private _userSignedIn = false;
 	private selectedAiMode: AiCollaborationMode = AiCollaborationMode.Balanced;
 	private enterpriseSignInUiState: EnterpriseSignInUiState = 'options';
@@ -363,9 +370,6 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			if (leavingStep === OnboardingStepId.Personalize) {
 				this._applyKeymap(this.selectedKeymapId);
 			}
-			if (leavingStep === OnboardingStepId.ImportFromEditor) {
-				this._runImport();
-			}
 			this.currentStepIndex++;
 			this._renderStep();
 			this._renderProgress();
@@ -490,6 +494,10 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 				this.nextButton.className = 'onboarding-a-btn onboarding-a-btn-primary';
 				this.nextButton.textContent = localize('onboarding.next', "Continue");
 			}
+			this.nextButton.disabled = this._importInProgress;
+		}
+		if (this.backButton) {
+			this.backButton.disabled = this._importInProgress;
 		}
 		if (this.footerLeft) {
 			if (this._isLastStep()) {
@@ -1099,149 +1107,135 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			return;
 		}
 
+		const rows = this._getImportRows(source).filter(row => row.available);
 		const wrapper = append(container, $('.onboarding-a-import'));
-
 		const group = append(wrapper, $('.onboarding-a-import-group'));
+		group.setAttribute('role', 'group');
+		group.setAttribute('aria-label', localize('onboarding.import.cardLabel', "Import available customizations from {0}", source.label));
 
 		const groupHeader = append(group, $('.onboarding-a-import-group-header'));
-		const groupIcon = append(groupHeader, $('span.onboarding-a-import-group-icon'));
-		groupIcon.setAttribute('aria-hidden', 'true');
-		groupIcon.appendChild(renderIcon(Codicon.window));
-		const groupLabel = append(groupHeader, $('span.onboarding-a-import-group-label'));
+		const groupIdentity = append(groupHeader, $('.onboarding-a-import-group-identity'));
+		const groupText = append(groupIdentity, $('.onboarding-a-import-group-text'));
+		const groupLabel = append(groupText, $('span.onboarding-a-import-group-label'));
 		groupLabel.textContent = source.label;
+		const groupDescription = append(groupText, $('span.onboarding-a-import-group-description'));
+		groupDescription.textContent = localize(
+			'onboarding.import.groupDescription',
+			"Import your extensions and settings from {0}.",
+			source.label
+		);
 
-		const list = append(group, $('.onboarding-a-import-list'));
-		list.setAttribute('role', 'group');
-		list.setAttribute('aria-label', localize('onboarding.import.listLabel', "Customizations to import from {0}", source.label));
+		const actions = append(groupHeader, $('.onboarding-a-import-actions'));
+		const importButton = this._registerStepFocusable(append(actions, $<HTMLButtonElement>('button.onboarding-a-btn.onboarding-a-btn-secondary.onboarding-a-import-action')));
+		importButton.type = 'button';
+		const importButtonIcon = append(importButton, $('span.onboarding-a-import-action-icon'));
+		importButtonIcon.setAttribute('aria-hidden', 'true');
+		const importButtonLabel = append(importButton, $('span.onboarding-a-import-action-label'));
+		const setImportButtonState = (state: 'idle' | 'running' | 'done') => {
+			clearNode(importButtonIcon);
+			importButton.disabled = state !== 'idle';
+			importButtonIcon.hidden = state !== 'done';
+			switch (state) {
+				case 'idle':
+					importButtonLabel.textContent = localize('onboarding.import.cta', "Import");
+					importButton.setAttribute('aria-label', localize('onboarding.import.cta.aria', "Import customizations from {0}", source.label));
+					break;
+				case 'running':
+					importButtonLabel.textContent = localize('onboarding.import.cta.inProgress', "Importing...");
+					importButton.setAttribute('aria-label', localize('onboarding.import.cta.inProgress.aria', "Importing customizations from {0}", source.label));
+					break;
+				case 'done':
+					importButtonIcon.appendChild(renderIcon(Codicon.check));
+					importButtonLabel.textContent = localize('onboarding.import.cta.done', "Imported");
+					importButton.setAttribute('aria-label', localize('onboarding.import.cta.done.aria', "Imported customizations from {0}", source.label));
+					break;
+			}
+		};
+		setImportButtonState(this._importCompleted ? 'done' : 'idle');
 
-		interface IImportRow { key: 'settings' | 'keybindings' | 'snippets' | 'extensions'; label: string; icon: ThemeIcon; available: boolean }
-		const rows: IImportRow[] = [
+		const categories = append(group, $('.onboarding-a-import-categories'));
+		categories.setAttribute('aria-label', localize('onboarding.import.categoriesLabel', "Available customizations from {0}", source.label));
+		for (const row of rows) {
+			const category = append(categories, $('.onboarding-a-import-category'));
+			const iconEl = append(category, $('span.onboarding-a-import-category-icon'));
+			iconEl.setAttribute('aria-hidden', 'true');
+			iconEl.appendChild(renderIcon(row.icon));
+			append(category, $('span.onboarding-a-import-category-label')).textContent = row.label;
+		}
+
+		this.stepDisposables.add(addDisposableListener(importButton, EventType.CLICK, () => {
+			if (this._importInProgress || this._importCompleted) {
+				return;
+			}
+			const importStepIndex = this.currentStepIndex;
+			setImportButtonState('running');
+			void this._runImport().then(async succeeded => {
+				if (!this._isShowing) {
+					return;
+				}
+				if (!succeeded) {
+					setImportButtonState('idle');
+					return;
+				}
+				setImportButtonState('done');
+				await new Promise<void>(resolve => setTimeout(resolve, 600));
+				if (!this._isShowing) {
+					return;
+				}
+				if (this.currentStepIndex !== importStepIndex || this.steps[this.currentStepIndex] !== OnboardingStepId.ImportFromEditor) {
+					return;
+				}
+				this._logAction('next');
+				this._nextStep();
+			});
+		}));
+	}
+
+	private _getImportRows(source: IExternalEditorSource): IImportRow[] {
+		return [
 			{ key: 'settings', label: localize('onboarding.import.settings', "Settings"), icon: Codicon.settingsGear, available: source.hasSettings },
 			{ key: 'keybindings', label: localize('onboarding.import.keybindings', "Keyboard Shortcuts"), icon: Codicon.keyboard, available: source.hasKeybindings },
 			{ key: 'snippets', label: localize('onboarding.import.snippets', "Snippets"), icon: Codicon.code, available: source.hasSnippets },
 			{ key: 'extensions', label: localize('onboarding.import.extensions', "Extensions"), icon: Codicon.extensions, available: source.hasExtensions },
 		];
-
-		for (const row of rows) {
-			if (!row.available) {
-				this._importSelection[row.key] = false;
-				continue;
-			}
-
-			const card = append(list, $('.onboarding-a-import-item'));
-			const header = append(card, $('.onboarding-a-import-item-header'));
-
-			const toggle = this._registerStepFocusable(append(header, $<HTMLButtonElement>('button.onboarding-a-import-toggle')));
-			toggle.type = 'button';
-			toggle.setAttribute('role', 'checkbox');
-			toggle.setAttribute('aria-checked', this._importSelection[row.key] ? 'true' : 'false');
-			toggle.setAttribute('aria-label', row.label);
-
-			const check = append(toggle, $('span.onboarding-a-import-check'));
-			check.setAttribute('aria-hidden', 'true');
-			const iconEl = append(toggle, $('span.onboarding-a-import-icon'));
-			iconEl.setAttribute('aria-hidden', 'true');
-			iconEl.appendChild(renderIcon(row.icon));
-			const labelEl = append(toggle, $('span.onboarding-a-import-label'));
-			labelEl.textContent = row.label;
-
-			const updateChecked = () => {
-				const checked = this._importSelection[row.key];
-				card.classList.toggle('selected', checked);
-				toggle.setAttribute('aria-checked', checked ? 'true' : 'false');
-				clearNode(check);
-				if (checked) {
-					check.appendChild(renderIcon(Codicon.check));
-				}
-			};
-			updateChecked();
-
-			this.stepDisposables.add(addDisposableListener(toggle, EventType.CLICK, () => {
-				this._importSelection[row.key] = !this._importSelection[row.key];
-				this._logAction('toggleImport', OnboardingStepId.ImportFromEditor, row.key);
-				updateChecked();
-			}));
-
-			// Expandable preview of the concrete items that would be imported.
-			const previewId = `onboarding-a-import-preview-${row.key}`;
-			const expand = this._registerStepFocusable(append(header, $<HTMLButtonElement>('button.onboarding-a-import-expand')));
-			expand.type = 'button';
-			expand.setAttribute('aria-expanded', 'false');
-			expand.setAttribute('aria-controls', previewId);
-			expand.setAttribute('aria-label', localize('onboarding.import.previewLabel', "Preview {0} to import", row.label));
-			const chevron = append(expand, $('span.onboarding-a-import-chevron'));
-			chevron.setAttribute('aria-hidden', 'true');
-			chevron.appendChild(renderIcon(Codicon.chevronDown));
-
-			const preview = append(card, $('.onboarding-a-import-preview'));
-			preview.id = previewId;
-			preview.setAttribute('role', 'region');
-			preview.hidden = true;
-
-			let loaded = false;
-			this.stepDisposables.add(addDisposableListener(expand, EventType.CLICK, () => {
-				const expanded = expand.getAttribute('aria-expanded') === 'true';
-				const next = !expanded;
-				expand.setAttribute('aria-expanded', next ? 'true' : 'false');
-				expand.classList.toggle('expanded', next);
-				preview.hidden = !next;
-				if (next && !loaded) {
-					loaded = true;
-					this._logAction('previewImport', OnboardingStepId.ImportFromEditor, row.key);
-					this._populateImportPreview(source, row.key, row.label, preview);
-				}
-			}));
-		}
 	}
 
-	private async _populateImportPreview(source: IExternalEditorSource, key: 'settings' | 'keybindings' | 'snippets' | 'extensions', label: string, container: HTMLElement): Promise<void> {
-		clearNode(container);
-		const message = append(container, $('.onboarding-a-import-preview-message'));
-		message.textContent = localize('onboarding.import.preview.loading', "Loading…");
-
-		let items: readonly string[];
-		try {
-			if (!this._importPreviewPromise) {
-				this._importPreviewPromise = this.externalEditorImportService.preview(source);
-			}
-			const preview = await this._importPreviewPromise;
-			items = preview[key];
-		} catch {
-			clearNode(container);
-			append(container, $('.onboarding-a-import-preview-message')).textContent = localize('onboarding.import.preview.error', "Couldn't load a preview of {0}.", label);
-			return;
-		}
-
-		clearNode(container);
-		if (items.length === 0) {
-			append(container, $('.onboarding-a-import-preview-message')).textContent = localize('onboarding.import.preview.empty', "Nothing new to bring over — you already have these.");
-			return;
-		}
-
-		const itemsEl = append(container, $<HTMLUListElement>('ul.onboarding-a-import-preview-items'));
-		for (const item of items) {
-			append(itemsEl, $<HTMLLIElement>('li.onboarding-a-import-preview-item')).textContent = item;
-		}
-	}
-
-	private async _runImport(): Promise<void> {
+	private async _runImport(): Promise<boolean> {
 		const source = this._importSource;
-		if (!source || this._importCompleted) {
-			return;
-		}
-		if (!this._importSelection.settings && !this._importSelection.keybindings && !this._importSelection.snippets && !this._importSelection.extensions) {
-			return; // nothing selected
+		if (!source || this._importCompleted || this._importInProgress) {
+			return false;
 		}
 
-		this._importCompleted = true;
+		this._importInProgress = true;
+		this._updateButtonStates();
 		this._logAction('import', OnboardingStepId.ImportFromEditor, source.id);
 		try {
-			await this.externalEditorImportService.import(source, { ...this._importSelection });
+			const result = await this.externalEditorImportService.import(source, { settings: true, keybindings: true, snippets: true, extensions: true });
+			const importedAnything = result.settingsImported > 0 || result.keybindingsImported || result.snippetsImported > 0 || result.extensionsInstalled > 0;
+			if (result.extensionsFailed > 0 || !importedAnything) {
+				if (result.extensionsFailed > 0) {
+					this.notificationService.notify({
+						severity: Severity.Warning,
+						message: localize('onboarding.import.partialError', "Some customizations could not be imported from {0}. You can try again later from the Command Palette.", source.label),
+					});
+				} else {
+					this.notificationService.info(localize('onboarding.import.nothing', "Nothing new to import from {0}.", source.label));
+				}
+				return false;
+			}
+			this._importCompleted = true;
+			this.accessibilityService.alert(localize('onboarding.import.done.alert', "Imported customizations from {0}", source.label));
+			return true;
 		} catch {
+			this._importCompleted = false;
 			this.notificationService.notify({
 				severity: Severity.Warning,
 				message: localize('onboarding.import.error', "Some customizations could not be imported from {0}. You can try again later from the Command Palette.", source.label),
 			});
+			return false;
+		} finally {
+			this._importInProgress = false;
+			this._updateButtonStates();
 		}
 	}
 

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -77,7 +77,7 @@ type OnboardingActionEvent = {
 };
 
 type EnterpriseSignInUiState = 'options' | 'instance' | 'progress';
-type ImportCategoryKey = 'settings' | 'keybindings' | 'snippets' | 'extensions';
+type ImportCategoryKey = 'theme' | 'settings' | 'keybindings' | 'snippets' | 'extensions';
 
 interface IImportRow {
 	readonly key: ImportCategoryKey;
@@ -183,8 +183,8 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		try {
 			const sources = await this.externalEditorImportService.detectSources();
 			const source = sources[0];
-			if (!source || this._isShowing) {
-				return; // nothing to import, or the modal is already showing
+			if (!source) {
+				return; // nothing to import
 			}
 
 			// Skip the step entirely when there is nothing new to bring over (i.e. the user
@@ -192,21 +192,42 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			// (no gallery lookups) so it does not delay showing the modal; the richer
 			// preview shown in the step UI is computed lazily.
 			const hasSomethingNew = await this.externalEditorImportService.hasImportableChanges(source);
-			if (this._isShowing) {
-				return; // the modal started showing while we were checking
-			}
 			if (!hasSomethingNew) {
 				return; // nothing different to bring over — skip the step
 			}
 
 			this._importSource = source;
-			if (!this.steps.includes(OnboardingStepId.ImportFromEditor)) {
-				const signInIndex = this.steps.indexOf(OnboardingStepId.SignIn);
-				const insertAt = signInIndex >= 0 ? signInIndex + 1 : 0;
-				this.steps.splice(insertAt, 0, OnboardingStepId.ImportFromEditor);
-			}
+			this._insertImportStep();
 		} catch {
 			// Detection failed — the step simply will not be shown
+		}
+	}
+
+	/**
+	 * Inserts the import step right after Sign In. Detection runs asynchronously and can finish
+	 * after the modal is already showing, so this is safe to call at any time: when the modal is
+	 * visible the step is only inserted if the user has not yet moved past the insertion point,
+	 * and the progress indicator is refreshed to reflect the added step.
+	 */
+	private _insertImportStep(): void {
+		if (this.steps.includes(OnboardingStepId.ImportFromEditor)) {
+			return;
+		}
+
+		const signInIndex = this.steps.indexOf(OnboardingStepId.SignIn);
+		const insertAt = signInIndex >= 0 ? signInIndex + 1 : 0;
+
+		// If the modal is already showing and the user has advanced to or past the insertion
+		// point, inserting would shift the step they are currently viewing. Leave the steps
+		// untouched in that case.
+		if (this._isShowing && this.currentStepIndex >= insertAt) {
+			return;
+		}
+
+		this.steps.splice(insertAt, 0, OnboardingStepId.ImportFromEditor);
+
+		if (this._isShowing) {
+			this._renderProgress();
 		}
 	}
 
@@ -1185,6 +1206,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 				if (this.currentStepIndex !== importStepIndex || this.steps[this.currentStepIndex] !== OnboardingStepId.ImportFromEditor) {
 					return;
 				}
+				this._skipRedundantThemeStep();
 				this._logAction('next');
 				this._nextStep();
 			});
@@ -1193,6 +1215,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 
 	private _getImportRows(source: IExternalEditorSource): IImportRow[] {
 		return [
+			{ key: 'theme', label: localize('onboarding.import.theme', "Theme"), icon: Codicon.symbolColor, available: source.hasTheme },
 			{ key: 'settings', label: localize('onboarding.import.settings', "Settings"), icon: Codicon.settingsGear, available: source.hasSettings },
 			{ key: 'keybindings', label: localize('onboarding.import.keybindings', "Keyboard Shortcuts"), icon: Codicon.keyboard, available: source.hasKeybindings },
 			{ key: 'snippets', label: localize('onboarding.import.snippets', "Snippets"), icon: Codicon.code, available: source.hasSnippets },
@@ -1212,17 +1235,22 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		try {
 			const result = await this.externalEditorImportService.import(source, { settings: true, keybindings: true, snippets: true, extensions: true });
 			const importedAnything = result.settingsImported > 0 || result.keybindingsImported || result.snippetsImported > 0 || result.extensionsInstalled > 0;
-			if (result.extensionsFailed > 0 || !importedAnything) {
-				if (result.extensionsFailed > 0) {
-					this.notificationService.notify({
-						severity: Severity.Warning,
-						message: localize('onboarding.import.partialError', "Some customizations could not be imported from {0}. You can try again later from the Command Palette.", source.label),
-					});
-				} else {
-					this.notificationService.info(localize('onboarding.import.nothing', "Nothing new to import from {0}.", source.label));
-				}
+
+			// Some items may not be importable — most commonly source-specific extensions that are
+			// not on the Marketplace. That must not block the flow: surface a warning and continue.
+			if (result.extensionsFailed > 0) {
+				this.notificationService.notify({
+					severity: Severity.Warning,
+					message: localize('onboarding.import.partialError', "Some customizations could not be imported from {0}. You can try again later from the Command Palette.", source.label),
+				});
+			}
+
+			// Only stay on the step when there was genuinely nothing to bring over.
+			if (!importedAnything && result.extensionsFailed === 0) {
+				this.notificationService.info(localize('onboarding.import.nothing', "Nothing new to import from {0}.", source.label));
 				return false;
 			}
+
 			this._importCompleted = true;
 			this.accessibilityService.alert(localize('onboarding.import.done.alert', "Imported customizations from {0}", source.label));
 			return true;
@@ -1237,6 +1265,28 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			this._importInProgress = false;
 			this._updateButtonStates();
 		}
+	}
+
+	/**
+	 * The source editor's selected color theme is brought over as part of its settings, so the
+	 * theme picker in the Personalize step is redundant after a successful import. Removes that
+	 * step when it would only offer theme selection — that is, when the source had a theme and
+	 * there is no keyboard-mapping section to show for another detected editor — and the user has
+	 * not yet reached it.
+	 */
+	private _skipRedundantThemeStep(): void {
+		if (!this._importSource?.hasTheme) {
+			return; // no theme preference was imported, so the picker is still useful
+		}
+		if (this._hasOtherEditors()) {
+			return; // keep the step for its keyboard-mapping section
+		}
+		const personalizeIndex = this.steps.indexOf(OnboardingStepId.Personalize);
+		if (personalizeIndex <= this.currentStepIndex) {
+			return; // not present, or already reached
+		}
+		this.steps.splice(personalizeIndex, 1);
+		this._renderProgress();
 	}
 
 	// =====================================================================

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -78,10 +78,7 @@ type OnboardingActionEvent = {
 };
 
 type EnterpriseSignInUiState = 'options' | 'instance' | 'progress';
-type ImportCategoryKey = 'theme' | 'settings' | 'keybindings' | 'snippets' | 'extensions';
-
 interface IImportRow {
-	readonly key: ImportCategoryKey;
 	readonly label: string;
 	readonly icon: ThemeIcon;
 	readonly available: boolean;
@@ -1136,7 +1133,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			return;
 		}
 
-		const rows = this._getImportRows(source).filter(row => row.available);
+		const rows = this._getImportRows().filter(row => row.available);
 		const wrapper = append(container, $('.onboarding-a-import'));
 		const group = append(wrapper, $('.onboarding-a-import-group'));
 		group.setAttribute('role', 'group');
@@ -1217,14 +1214,14 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		}));
 	}
 
-	private _getImportRows(source: IExternalEditorSource): IImportRow[] {
+	private _getImportRows(): IImportRow[] {
 		const preview = this._importPreview;
 		return [
-			{ key: 'theme', label: localize('onboarding.import.theme', "Theme"), icon: Codicon.symbolColor, available: preview?.settings.includes('workbench.colorTheme') ?? source.hasTheme },
-			{ key: 'settings', label: localize('onboarding.import.settings', "Settings"), icon: Codicon.settingsGear, available: !!preview?.settings.some(key => key !== 'workbench.colorTheme') },
-			{ key: 'keybindings', label: localize('onboarding.import.keybindings', "Keyboard Shortcuts"), icon: Codicon.keyboard, available: !!preview?.keybindings.length },
-			{ key: 'snippets', label: localize('onboarding.import.snippets', "Snippets"), icon: Codicon.code, available: !!preview?.snippets.length },
-			{ key: 'extensions', label: localize('onboarding.import.extensions', "Extensions"), icon: Codicon.extensions, available: !!preview?.extensions.length },
+			{ label: localize('onboarding.import.theme', "Theme"), icon: Codicon.symbolColor, available: !!preview?.settings.includes('workbench.colorTheme') },
+			{ label: localize('onboarding.import.settings', "Settings"), icon: Codicon.settingsGear, available: !!preview?.settings.some(key => key !== 'workbench.colorTheme') },
+			{ label: localize('onboarding.import.keybindings', "Keyboard Shortcuts"), icon: Codicon.keyboard, available: !!preview?.keybindings.length },
+			{ label: localize('onboarding.import.snippets', "Snippets"), icon: Codicon.code, available: !!preview?.snippets.length },
+			{ label: localize('onboarding.import.extensions', "Extensions"), icon: Codicon.extensions, available: !!preview?.extensions.length },
 		];
 	}
 
@@ -1289,7 +1286,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	 * not yet reached it.
 	 */
 	private async _skipRedundantThemeStep(): Promise<void> {
-		if (!this._importSource?.hasTheme) {
+		if (!this._importSource?.colorThemeId) {
 			return; // no theme preference was imported, so the picker is still useful
 		}
 		await this._detectedEditorIdsPromise;

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -48,6 +48,7 @@ import {
 	parseGheInstanceInput,
 } from '../common/onboardingTypes.js';
 import { IOnboardingService } from '../common/onboardingService.js';
+import { IExternalEditorImportService, IExternalEditorSource } from '../../externalEditorImport/common/externalEditorImport.js';
 
 type OnboardingStepViewClassification = {
 	owner: 'cwebster-99';
@@ -117,7 +118,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	private _footerSignInBtn: HTMLButtonElement | undefined;
 
 	private currentStepIndex = 0;
-	private readonly steps = ONBOARDING_STEPS;
+	private steps: OnboardingStepId[] = [...ONBOARDING_STEPS];
 	private readonly disposables = this._register(new DisposableStore());
 	private readonly stepDisposables = this._register(new DisposableStore());
 	private previouslyFocusedElement: HTMLElement | undefined;
@@ -128,6 +129,9 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	private selectedThemeId = 'dark-2026';
 	private selectedKeymapId = 'vscode';
 	private _detectedEditorIds: Set<string> | undefined;
+	private _importSource: IExternalEditorSource | undefined;
+	private readonly _importSelection = { settings: true, keybindings: true, snippets: true, extensions: true };
+	private _importCompleted = false;
 	private _userSignedIn = false;
 	private selectedAiMode: AiCollaborationMode = AiCollaborationMode.Balanced;
 	private enterpriseSignInUiState: EnterpriseSignInUiState = 'options';
@@ -147,6 +151,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
+		@IExternalEditorImportService private readonly externalEditorImportService: IExternalEditorImportService,
 	) {
 		super();
 
@@ -160,6 +165,28 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 
 		// Start detecting installed editors early so results are ready by the Personalize step
 		this._detectInstalledEditors().then(ids => { this._detectedEditorIds = ids; });
+
+		// Detect importable customizations from another editor (e.g. Cursor) and,
+		// if found, insert the import step right after Sign In.
+		this._detectImportSource();
+	}
+
+	private async _detectImportSource(): Promise<void> {
+		try {
+			const sources = await this.externalEditorImportService.detectSources();
+			const source = sources[0];
+			if (!source || this._isShowing) {
+				return; // nothing to import, or the modal is already showing
+			}
+			this._importSource = source;
+			if (!this.steps.includes(OnboardingStepId.ImportFromEditor)) {
+				const signInIndex = this.steps.indexOf(OnboardingStepId.SignIn);
+				const insertAt = signInIndex >= 0 ? signInIndex + 1 : 0;
+				this.steps.splice(insertAt, 0, OnboardingStepId.ImportFromEditor);
+			}
+		} catch {
+			// Detection failed — the step simply will not be shown
+		}
 	}
 
 	get isShowing(): boolean {
@@ -322,6 +349,9 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			if (leavingStep === OnboardingStepId.Personalize) {
 				this._applyKeymap(this.selectedKeymapId);
 			}
+			if (leavingStep === OnboardingStepId.ImportFromEditor) {
+				this._runImport();
+			}
 			this.currentStepIndex++;
 			this._renderStep();
 			this._renderProgress();
@@ -397,6 +427,9 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		switch (stepId) {
 			case OnboardingStepId.SignIn:
 				this._renderSignInStep(this.contentEl);
+				break;
+			case OnboardingStepId.ImportFromEditor:
+				this._renderImportFromEditorStep(this.contentEl);
 				break;
 			case OnboardingStepId.Personalize:
 				this._renderPersonalizeStep(this.contentEl);
@@ -1037,6 +1070,92 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		}));
 
 		return detected;
+	}
+
+	// =====================================================================
+	// Step: Import From Editor
+	// =====================================================================
+
+	private _renderImportFromEditorStep(container: HTMLElement): void {
+		const source = this._importSource;
+		if (!source) {
+			return;
+		}
+
+		const wrapper = append(container, $('.onboarding-a-import'));
+
+		const hint = append(wrapper, $('div.onboarding-a-import-hint'));
+		hint.textContent = localize('onboarding.import.hint', "We found {0} on your machine. Pick what you'd like to bring over.", source.label);
+
+		const list = append(wrapper, $('.onboarding-a-import-list'));
+		list.setAttribute('role', 'group');
+		list.setAttribute('aria-label', localize('onboarding.import.listLabel', "Customizations to import from {0}", source.label));
+
+		interface IImportRow { key: 'settings' | 'keybindings' | 'snippets' | 'extensions'; label: string; icon: ThemeIcon; available: boolean }
+		const rows: IImportRow[] = [
+			{ key: 'settings', label: localize('onboarding.import.settings', "Settings"), icon: Codicon.settingsGear, available: source.hasSettings },
+			{ key: 'keybindings', label: localize('onboarding.import.keybindings', "Keyboard Shortcuts"), icon: Codicon.keyboard, available: source.hasKeybindings },
+			{ key: 'snippets', label: localize('onboarding.import.snippets', "Snippets"), icon: Codicon.code, available: source.hasSnippets },
+			{ key: 'extensions', label: localize('onboarding.import.extensions', "Extensions"), icon: Codicon.extensions, available: source.hasExtensions },
+		];
+
+		for (const row of rows) {
+			if (!row.available) {
+				this._importSelection[row.key] = false;
+				continue;
+			}
+
+			const item = this._registerStepFocusable(append(list, $<HTMLButtonElement>('button.onboarding-a-import-item')));
+			item.type = 'button';
+			item.setAttribute('role', 'checkbox');
+			item.setAttribute('aria-checked', this._importSelection[row.key] ? 'true' : 'false');
+
+			const check = append(item, $('span.onboarding-a-import-check'));
+			check.setAttribute('aria-hidden', 'true');
+			const iconEl = append(item, $('span.onboarding-a-import-icon'));
+			iconEl.setAttribute('aria-hidden', 'true');
+			iconEl.appendChild(renderIcon(row.icon));
+			const labelEl = append(item, $('span.onboarding-a-import-label'));
+			labelEl.textContent = row.label;
+
+			const updateChecked = () => {
+				const checked = this._importSelection[row.key];
+				item.classList.toggle('selected', checked);
+				item.setAttribute('aria-checked', checked ? 'true' : 'false');
+				clearNode(check);
+				if (checked) {
+					check.appendChild(renderIcon(Codicon.check));
+				}
+			};
+			updateChecked();
+
+			this.stepDisposables.add(addDisposableListener(item, EventType.CLICK, () => {
+				this._importSelection[row.key] = !this._importSelection[row.key];
+				this._logAction('toggleImport', OnboardingStepId.ImportFromEditor, row.key);
+				updateChecked();
+			}));
+		}
+	}
+
+	private async _runImport(): Promise<void> {
+		const source = this._importSource;
+		if (!source || this._importCompleted) {
+			return;
+		}
+		if (!this._importSelection.settings && !this._importSelection.keybindings && !this._importSelection.snippets && !this._importSelection.extensions) {
+			return; // nothing selected
+		}
+
+		this._importCompleted = true;
+		this._logAction('import', OnboardingStepId.ImportFromEditor, source.id);
+		try {
+			await this.externalEditorImportService.import(source, { ...this._importSelection });
+		} catch {
+			this.notificationService.notify({
+				severity: Severity.Warning,
+				message: localize('onboarding.import.error', "Some customizations could not be imported from {0}. You can try again later from the Command Palette.", source.label),
+			});
+		}
 	}
 
 	// =====================================================================

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { $, append, addDisposableListener, EventType, clearNode, getActiveWindow } from '../../../../base/browser/dom.js';
 import { isCancellationError } from '../../../../base/common/errors.js';
@@ -16,6 +16,7 @@ import { ILayoutService } from '../../../../platform/layout/browser/layoutServic
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { InputBox } from '../../../../base/browser/ui/inputbox/inputBox.js';
+import { Button } from '../../../../base/browser/ui/button/button.js';
 import { localize } from '../../../../nls.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -24,10 +25,10 @@ import { Action } from '../../../../base/common/actions.js';
 import { IWorkbenchThemeService } from '../../../services/themes/common/workbenchThemeService.js';
 import { EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT, IExtensionGalleryService, IExtensionManagementService } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
-import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { defaultInputBoxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
+import { defaultButtonStyles, defaultInputBoxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import product from '../../../../platform/product/common/product.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
@@ -48,7 +49,7 @@ import {
 	parseGheInstanceInput,
 } from '../common/onboardingTypes.js';
 import { IOnboardingService } from '../common/onboardingService.js';
-import { IExternalEditorImportService, IExternalEditorSource } from '../../externalEditorImport/common/externalEditorImport.js';
+import { IExternalEditorImportPreview, IExternalEditorImportService, IExternalEditorSource } from '../../externalEditorImport/common/externalEditorImport.js';
 
 type OnboardingStepViewClassification = {
 	owner: 'cwebster-99';
@@ -137,9 +138,12 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	private selectedThemeId = 'dark-2026';
 	private selectedKeymapId = 'vscode';
 	private _detectedEditorIds: Set<string> | undefined;
+	private readonly _detectedEditorIdsPromise: Promise<Set<string>>;
 	private _importSource: IExternalEditorSource | undefined;
+	private _importPreview: IExternalEditorImportPreview | undefined;
 	private _importInProgress = false;
 	private _importCompleted = false;
+	private readonly _importCancellation = this._register(new MutableDisposable<CancellationTokenSource>());
 	private _userSignedIn = false;
 	private selectedAiMode: AiCollaborationMode = AiCollaborationMode.Balanced;
 	private enterpriseSignInUiState: EnterpriseSignInUiState = 'options';
@@ -172,7 +176,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		}
 
 		// Start detecting installed editors early so results are ready by the Personalize step
-		this._detectInstalledEditors().then(ids => { this._detectedEditorIds = ids; });
+		this._detectedEditorIdsPromise = this._detectInstalledEditors().then(ids => this._detectedEditorIds = ids, () => this._detectedEditorIds = new Set());
 
 		// Detect importable customizations from another editor (e.g. Cursor) and,
 		// if found, insert the import step right after Sign In.
@@ -187,15 +191,12 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 				return; // nothing to import
 			}
 
-			// Skip the step entirely when there is nothing new to bring over (i.e. the user
-			// already has everything the source has). This uses only fast, local checks
-			// (no gallery lookups) so it does not delay showing the modal; the richer
-			// preview shown in the step UI is computed lazily.
-			const hasSomethingNew = await this.externalEditorImportService.hasImportableChanges(source);
-			if (!hasSomethingNew) {
+			const preview = await this.externalEditorImportService.preview(source);
+			if (preview.settings.length === 0 && preview.keybindings.length === 0 && preview.snippets.length === 0 && preview.extensions.length === 0) {
 				return; // nothing different to bring over — skip the step
 			}
 
+			this._importPreview = preview;
 			this._importSource = source;
 			this._insertImportStep();
 		} catch {
@@ -228,6 +229,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 
 		if (this._isShowing) {
 			this._renderProgress();
+			this._updateStepAriaLabel();
 		}
 	}
 
@@ -357,6 +359,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		if (!this.overlay) {
 			return;
 		}
+		this._importCancellation.value?.cancel();
 
 		this._logAction('dismiss', undefined, reason);
 
@@ -484,6 +487,11 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 				break;
 		}
 
+		this._updateStepAriaLabel();
+	}
+
+	private _updateStepAriaLabel(): void {
+		const stepId = this.steps[this.currentStepIndex];
 		this.bodyEl?.setAttribute('aria-label', localize(
 			'onboarding.step.aria',
 			"Step {0} of {1}: {2}",
@@ -1147,48 +1155,44 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		);
 
 		const actions = append(groupHeader, $('.onboarding-a-import-actions'));
-		const importButton = this._registerStepFocusable(append(actions, $<HTMLButtonElement>('button.onboarding-a-btn.onboarding-a-btn-secondary.onboarding-a-import-action')));
-		importButton.type = 'button';
-		const importButtonIcon = append(importButton, $('span.onboarding-a-import-action-icon'));
-		importButtonIcon.setAttribute('aria-hidden', 'true');
-		const importButtonLabel = append(importButton, $('span.onboarding-a-import-action-label'));
+		const importButton = this.stepDisposables.add(new Button(actions, { ...defaultButtonStyles, secondary: true, supportIcons: true }));
+		importButton.element.classList.add('onboarding-a-import-action');
+		this._registerStepFocusable(importButton.element);
 		const setImportButtonState = (state: 'idle' | 'running' | 'done') => {
-			clearNode(importButtonIcon);
-			importButton.disabled = state !== 'idle';
-			importButtonIcon.hidden = state !== 'done';
+			importButton.enabled = state === 'idle';
 			switch (state) {
 				case 'idle':
-					importButtonLabel.textContent = localize('onboarding.import.cta', "Import");
-					importButton.setAttribute('aria-label', localize('onboarding.import.cta.aria', "Import customizations from {0}", source.label));
+					importButton.label = localize('onboarding.import.cta', "Import");
+					importButton.setAriaLabel(localize('onboarding.import.cta.aria', "Import customizations from {0}", source.label));
 					break;
 				case 'running':
-					importButtonLabel.textContent = localize('onboarding.import.cta.inProgress', "Importing...");
-					importButton.setAttribute('aria-label', localize('onboarding.import.cta.inProgress.aria', "Importing customizations from {0}", source.label));
+					importButton.label = localize('onboarding.import.cta.inProgress', "Importing...");
+					importButton.setAriaLabel(localize('onboarding.import.cta.inProgress.aria', "Importing customizations from {0}", source.label));
 					break;
 				case 'done':
-					importButtonIcon.appendChild(renderIcon(Codicon.check));
-					importButtonLabel.textContent = localize('onboarding.import.cta.done', "Imported");
-					importButton.setAttribute('aria-label', localize('onboarding.import.cta.done.aria', "Imported customizations from {0}", source.label));
+					importButton.label = localize('onboarding.import.cta.done', "{0} Imported", '$(check)');
+					importButton.setAriaLabel(localize('onboarding.import.cta.done.aria', "Imported customizations from {0}", source.label));
 					break;
 			}
 		};
 		setImportButtonState(this._importCompleted ? 'done' : 'idle');
 
-		const categories = append(group, $('.onboarding-a-import-categories'));
+		const categories = append(group, $('ul.onboarding-a-import-categories'));
 		categories.setAttribute('aria-label', localize('onboarding.import.categoriesLabel', "Available customizations from {0}", source.label));
 		for (const row of rows) {
-			const category = append(categories, $('.onboarding-a-import-category'));
+			const category = append(categories, $('li.onboarding-a-import-category'));
 			const iconEl = append(category, $('span.onboarding-a-import-category-icon'));
 			iconEl.setAttribute('aria-hidden', 'true');
 			iconEl.appendChild(renderIcon(row.icon));
 			append(category, $('span.onboarding-a-import-category-label')).textContent = row.label;
 		}
 
-		this.stepDisposables.add(addDisposableListener(importButton, EventType.CLICK, () => {
+		this.stepDisposables.add(importButton.onDidClick(() => {
 			if (this._importInProgress || this._importCompleted) {
 				return;
 			}
 			const importStepIndex = this.currentStepIndex;
+			this.closeButton?.focus();
 			setImportButtonState('running');
 			void this._runImport().then(async succeeded => {
 				if (!this._isShowing) {
@@ -1206,7 +1210,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 				if (this.currentStepIndex !== importStepIndex || this.steps[this.currentStepIndex] !== OnboardingStepId.ImportFromEditor) {
 					return;
 				}
-				this._skipRedundantThemeStep();
+				await this._skipRedundantThemeStep();
 				this._logAction('next');
 				this._nextStep();
 			});
@@ -1214,12 +1218,13 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	}
 
 	private _getImportRows(source: IExternalEditorSource): IImportRow[] {
+		const preview = this._importPreview;
 		return [
-			{ key: 'theme', label: localize('onboarding.import.theme', "Theme"), icon: Codicon.symbolColor, available: source.hasTheme },
-			{ key: 'settings', label: localize('onboarding.import.settings', "Settings"), icon: Codicon.settingsGear, available: source.hasSettings },
-			{ key: 'keybindings', label: localize('onboarding.import.keybindings', "Keyboard Shortcuts"), icon: Codicon.keyboard, available: source.hasKeybindings },
-			{ key: 'snippets', label: localize('onboarding.import.snippets', "Snippets"), icon: Codicon.code, available: source.hasSnippets },
-			{ key: 'extensions', label: localize('onboarding.import.extensions', "Extensions"), icon: Codicon.extensions, available: source.hasExtensions },
+			{ key: 'theme', label: localize('onboarding.import.theme', "Theme"), icon: Codicon.symbolColor, available: preview?.settings.includes('workbench.colorTheme') ?? source.hasTheme },
+			{ key: 'settings', label: localize('onboarding.import.settings', "Settings"), icon: Codicon.settingsGear, available: !!preview?.settings.some(key => key !== 'workbench.colorTheme') },
+			{ key: 'keybindings', label: localize('onboarding.import.keybindings', "Keyboard Shortcuts"), icon: Codicon.keyboard, available: !!preview?.keybindings.length },
+			{ key: 'snippets', label: localize('onboarding.import.snippets', "Snippets"), icon: Codicon.code, available: !!preview?.snippets.length },
+			{ key: 'extensions', label: localize('onboarding.import.extensions', "Extensions"), icon: Codicon.extensions, available: !!preview?.extensions.length },
 		];
 	}
 
@@ -1230,15 +1235,21 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		}
 
 		this._importInProgress = true;
+		const cancellation = new CancellationTokenSource();
+		this._importCancellation.value = cancellation;
 		this._updateButtonStates();
 		this._logAction('import', OnboardingStepId.ImportFromEditor, source.id);
 		try {
-			const result = await this.externalEditorImportService.import(source, { settings: true, keybindings: true, snippets: true, extensions: true });
+			const result = await this.externalEditorImportService.import(source, { settings: true, keybindings: true, snippets: true, extensions: true }, cancellation.token);
+			if (cancellation.token.isCancellationRequested) {
+				return false;
+			}
 			const importedAnything = result.settingsImported > 0 || result.keybindingsImported || result.snippetsImported > 0 || result.extensionsInstalled > 0;
+			const failedAnything = result.settingsFailed || result.keybindingsFailed || result.snippetsFailed > 0 || result.extensionsFailed > 0;
 
-			// Some items may not be importable — most commonly source-specific extensions that are
-			// not on the Marketplace. That must not block the flow: surface a warning and continue.
-			if (result.extensionsFailed > 0) {
+			// Keep the user on this step after any partial failure so retryable items are not silently
+			// skipped. Successfully imported items are additive and will be filtered out on retry.
+			if (failedAnything) {
 				this.notificationService.notify({
 					severity: Severity.Warning,
 					message: localize('onboarding.import.partialError', "Some customizations could not be imported from {0}. You can try again later from the Command Palette.", source.label),
@@ -1246,8 +1257,10 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			}
 
 			// Only stay on the step when there was genuinely nothing to bring over.
-			if (!importedAnything && result.extensionsFailed === 0) {
-				this.notificationService.info(localize('onboarding.import.nothing', "Nothing new to import from {0}.", source.label));
+			if (!importedAnything || failedAnything) {
+				if (!failedAnything) {
+					this.notificationService.info(localize('onboarding.import.nothing', "Nothing new to import from {0}.", source.label));
+				}
 				return false;
 			}
 
@@ -1262,6 +1275,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 			});
 			return false;
 		} finally {
+			this._importCancellation.clear();
 			this._importInProgress = false;
 			this._updateButtonStates();
 		}
@@ -1274,10 +1288,11 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	 * there is no keyboard-mapping section to show for another detected editor — and the user has
 	 * not yet reached it.
 	 */
-	private _skipRedundantThemeStep(): void {
+	private async _skipRedundantThemeStep(): Promise<void> {
 		if (!this._importSource?.hasTheme) {
 			return; // no theme preference was imported, so the picker is still useful
 		}
+		await this._detectedEditorIdsPromise;
 		if (this._hasOtherEditors()) {
 			return; // keep the step for its keyboard-mapping section
 		}
@@ -1517,11 +1532,18 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 
 		const first = allFocusable[0];
 		const last = allFocusable[allFocusable.length - 1];
+		const activeElement = getActiveWindow().document.activeElement;
 
-		if (shiftKey && getActiveWindow().document.activeElement === first) {
+		if (!allFocusable.includes(activeElement as HTMLElement)) {
+			e.preventDefault();
+			(shiftKey ? last : first).focus();
+			return;
+		}
+
+		if (shiftKey && activeElement === first) {
 			e.preventDefault();
 			last.focus();
-		} else if (!shiftKey && getActiveWindow().document.activeElement === last) {
+		} else if (!shiftKey && activeElement === last) {
 			e.preventDefault();
 			first.focus();
 		}

--- a/src/vs/workbench/contrib/welcomeOnboarding/common/onboardingTypes.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/common/onboardingTypes.ts
@@ -44,7 +44,7 @@ export function getOnboardingStepSubtitle(stepId: OnboardingStepId): string {
 		case OnboardingStepId.SignIn:
 			return localize('onboarding.step.signIn.subtitle', "Sync settings, unlock AI features, and connect to GitHub");
 		case OnboardingStepId.ImportFromEditor:
-			return '';
+			return localize('onboarding.step.importFromEditor.subtitle', "Extensions can be installed and settings changed at any time");
 		case OnboardingStepId.Personalize:
 			return localize('onboarding.step.personalize.subtitle', "Choose your theme and keyboard mapping");
 		case OnboardingStepId.AiPreference:

--- a/src/vs/workbench/contrib/welcomeOnboarding/common/onboardingTypes.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/common/onboardingTypes.ts
@@ -12,6 +12,7 @@ import { IProductOnboardingTheme } from '../../../../base/common/product.js';
  */
 export const enum OnboardingStepId {
 	SignIn = 'onboarding.signIn',
+	ImportFromEditor = 'onboarding.importFromEditor',
 	Personalize = 'onboarding.personalize',
 	AiPreference = 'onboarding.aiPreference',
 	AgentSessions = 'onboarding.agentSessions',
@@ -24,6 +25,8 @@ export function getOnboardingStepTitle(stepId: OnboardingStepId): string {
 	switch (stepId) {
 		case OnboardingStepId.SignIn:
 			return localize('onboarding.step.signIn', "Sign In");
+		case OnboardingStepId.ImportFromEditor:
+			return localize('onboarding.step.importFromEditor', "Bring Your Setup");
 		case OnboardingStepId.Personalize:
 			return localize('onboarding.step.personalize', "Make It Yours");
 		case OnboardingStepId.AiPreference:
@@ -40,6 +43,8 @@ export function getOnboardingStepSubtitle(stepId: OnboardingStepId): string {
 	switch (stepId) {
 		case OnboardingStepId.SignIn:
 			return localize('onboarding.step.signIn.subtitle', "Sync settings, unlock AI features, and connect to GitHub");
+		case OnboardingStepId.ImportFromEditor:
+			return localize('onboarding.step.importFromEditor.subtitle', "Import your settings, keyboard shortcuts, and extensions from another editor");
 		case OnboardingStepId.Personalize:
 			return localize('onboarding.step.personalize.subtitle', "Choose your theme and keyboard mapping");
 		case OnboardingStepId.AiPreference:

--- a/src/vs/workbench/contrib/welcomeOnboarding/common/onboardingTypes.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/common/onboardingTypes.ts
@@ -26,7 +26,7 @@ export function getOnboardingStepTitle(stepId: OnboardingStepId): string {
 		case OnboardingStepId.SignIn:
 			return localize('onboarding.step.signIn', "Sign In");
 		case OnboardingStepId.ImportFromEditor:
-			return localize('onboarding.step.importFromEditor', "Bring Your Setup");
+			return localize('onboarding.step.importFromEditor', "Import Your Setup");
 		case OnboardingStepId.Personalize:
 			return localize('onboarding.step.personalize', "Make It Yours");
 		case OnboardingStepId.AiPreference:
@@ -44,7 +44,7 @@ export function getOnboardingStepSubtitle(stepId: OnboardingStepId): string {
 		case OnboardingStepId.SignIn:
 			return localize('onboarding.step.signIn.subtitle', "Sync settings, unlock AI features, and connect to GitHub");
 		case OnboardingStepId.ImportFromEditor:
-			return localize('onboarding.step.importFromEditor.subtitle', "Import your settings, keyboard shortcuts, and extensions from another editor");
+			return '';
 		case OnboardingStepId.Personalize:
 			return localize('onboarding.step.personalize.subtitle', "Choose your theme and keyboard mapping");
 		case OnboardingStepId.AiPreference:

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -392,6 +392,9 @@ import './contrib/welcomeViews/common/newFile.contribution.js';
 // Welcome Onboarding
 import './contrib/welcomeOnboarding/browser/welcomeOnboarding.contribution.js';
 
+// Import from other editors (e.g. Cursor)
+import './contrib/externalEditorImport/browser/externalEditorImport.contribution.js';
+
 // Onboarding (scenario engine)
 import './contrib/onboarding/browser/onboarding.contribution.js';
 

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -114,6 +114,7 @@ import './contrib/logs/electron-browser/logs.contribution.js';
 
 // Localizations
 import './contrib/localization/electron-browser/localization.contribution.js';
+import './contrib/externalEditorImport/electron-browser/externalEditorImportEnvironmentService.js';
 
 // Explorer
 import './contrib/files/electron-browser/fileActions.contribution.js';


### PR DESCRIPTION
This pull request introduces a new "Import from External Editor" feature to the workbench, allowing users to import settings, keybindings, snippets, and extensions from other editors into VS Code. It provides both the underlying service API and the user interface integration, including notification prompts and commands.

**External Editor Import Service API:**

- Added a new `IExternalEditorImportService` interface and related types in `externalEditorImport.ts` to support detection of external editors, previewing importable items, and performing imports.

**Workbench Integration and User Experience:**

- Registered `ExternalEditorImportService` as a singleton and contributed a new workbench notification (`ExternalEditorImportNotificationContribution`) that prompts returning users to import customizations from detected editors, avoiding repeated prompts.
- Implemented the `runExternalEditorImport` function to handle the import process, show progress notifications, and summarize results for the user.
- Added two new commands:
  - [`workbench.action.importFromExternalEditor`](diffhunk://#diff-bffa819572bcec6ccee77be2c7c063239dbe84bc53766a8fc54cefb94474f8b7R1-R191): Imports from the first detected editor or informs the user if none are found.