### PR TITLE
sessions: add Open Pull Request to session context menu

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -164,7 +164,7 @@ The sessions list defines menu IDs that contributions can target to add actions.
 | Menu | Constant | Where it appears | Use for |
 |------|----------|------------------|---------|
 | `SessionItemToolbar` | `SessionItemToolbarMenuId` | Inline toolbar on each session row (hover on desktop, always on mobile) | Primary actions like pin, archive. Group `navigation` for icons, other groups for overflow. |
-| `SessionItemContextMenu` | `SessionItemContextMenuId` | Right-click context menu on session rows | Secondary actions like rename, mark read/unread. Groups: `0_pin`, `0_read`, `1_edit`. |
+| `SessionItemContextMenu` | `SessionItemContextMenuId` | Right-click context menu on session rows | Secondary actions like rename, mark read/unread, and "Open Pull Request" (in the `navigation`/open group, gated on `sessionHasPullRequest`). Groups: `navigation`, `0_pin`, `0_read`, `1_edit`. |
 
 ### Section Header Menu
 
@@ -224,6 +224,7 @@ Context keys available for `when` clauses when contributing to session list menu
 | `sessionItem.hasBranchName` | boolean | Whether the session has a git branch name |
 | `sessionType` | string | Session type ID (use to scope actions to specific providers) |
 | `sessionProviderId` | string | Provider ID |
+| `sessionHasPullRequest` | boolean | Whether the session is associated with a GitHub pull request |
 
 ### Per-Section
 

--- a/src/vs/sessions/browser/menus.ts
+++ b/src/vs/sessions/browser/menus.ts
@@ -47,4 +47,5 @@ export const Menus = {
 	SessionsEditorTabsBarAddTab: new MenuId('SessionsEditorTabsBarAddTab'),
 	SessionHeaderMeta: new MenuId('SessionsSessionHeaderMeta'),
 	SessionHeaderContext: MenuId.SessionHeaderContext,
+	SessionItemContextMenu: MenuId.SessionItemContextMenu,
 } as const;

--- a/src/vs/sessions/contrib/github/browser/pullRequestActions.ts
+++ b/src/vs/sessions/contrib/github/browser/pullRequestActions.ts
@@ -14,7 +14,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
-import { Action2, MenuItemAction, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Action2, MenuId, MenuItemAction, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { asCssVariable } from '../../../../platform/theme/common/colorUtils.js';
@@ -26,6 +26,7 @@ import { SessionHasPullRequestContext } from '../../../common/contextkeys.js';
 import { ISessionContext } from '../../../services/sessions/browser/sessionContext.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
+import { ISession } from '../../../services/sessions/common/session.js';
 import { IGitHubPullRequest } from '../common/types.js';
 import { IGitHubService } from './githubService.js';
 import { createPullRequestHoverElement } from './pullRequestHover.js';
@@ -44,36 +45,40 @@ class OpenPullRequestAction extends Action2 {
 			// Pull request pill shown in the session header meta row
 			// (vs/sessions/browser/parts/sessionHeader.ts). Rendered with a
 			// custom action view item that shows the PR icon + live `#<number>` label.
-			menu: {
+			menu: [{
 				id: Menus.SessionHeaderMeta,
 				group: 'navigation',
 				order: 1,
 				when: SessionHasPullRequestContext
-			},
+			}, {
+				id: MenuId.SessionItemContextMenu,
+				group: 'navigation',
+				order: 0,
+				when: SessionHasPullRequestContext
+			}],
 		});
 	}
 
-	override async run(accessor: ServicesAccessor, session?: IActiveSession): Promise<void> {
+	override async run(accessor: ServicesAccessor, session?: IActiveSession | ISession | ISession[]): Promise<void> {
 		const openerService = accessor.get(IOpenerService);
 		const sessionsService = accessor.get(ISessionsService);
 
-		// The clicked session is forwarded as the argument by the session header,
-		// which has already promoted it to be the active session. Fall back to the
-		// active session when invoked without an explicit argument.
-		const targetSession = session ?? sessionsService.activeSession.get();
-		const pullRequestUri = getPullRequestUri(targetSession);
+		// The session header forwards the (active) session; the sessions list
+		// context menu forwards the selected session(s). Fall back to the active session.
+		const targetSession = (Array.isArray(session) ? session[0] : session) ?? sessionsService.activeSession.get();
+		const pullRequestUri = this._getPullRequestUri(targetSession);
 		if (!pullRequestUri) {
 			return;
 		}
 
 		await openerService.open(pullRequestUri, { openExternal: true });
 	}
+
+	private _getPullRequestUri(session: ISession | undefined): URI | undefined {
+		return session?.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get()?.pullRequest?.uri;
+	}
 }
 registerAction2(OpenPullRequestAction);
-
-function getPullRequestUri(session: IActiveSession | undefined): URI | undefined {
-	return session?.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get()?.pullRequest?.uri;
-}
 
 // --- Open Pull Request action view item (session header pull request pill)
 

--- a/src/vs/sessions/contrib/github/browser/pullRequestActions.ts
+++ b/src/vs/sessions/contrib/github/browser/pullRequestActions.ts
@@ -14,7 +14,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
-import { Action2, MenuId, MenuItemAction, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Action2, MenuItemAction, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { asCssVariable } from '../../../../platform/theme/common/colorUtils.js';
@@ -51,7 +51,7 @@ class OpenPullRequestAction extends Action2 {
 				order: 1,
 				when: SessionHasPullRequestContext
 			}, {
-				id: MenuId.SessionItemContextMenu,
+				id: Menus.SessionItemContextMenu,
 				group: 'navigation',
 				order: 0,
 				when: SessionHasPullRequestContext
@@ -63,8 +63,6 @@ class OpenPullRequestAction extends Action2 {
 		const openerService = accessor.get(IOpenerService);
 		const sessionsService = accessor.get(ISessionsService);
 
-		// The session header forwards the (active) session; the sessions list
-		// context menu forwards the selected session(s). Fall back to the active session.
 		const targetSession = (Array.isArray(session) ? session[0] : session) ?? sessionsService.activeSession.get();
 		const pullRequestUri = this._getPullRequestUri(targetSession);
 		if (!pullRequestUri) {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -28,7 +28,7 @@ import { MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/to
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
 import { MarshalledId } from '../../../../../base/common/marshallingIds.js';
-import { SessionProviderIdContext, SessionSupportsDeleteContext, SessionSupportsRenameContext, SessionTypeContext, IsPhoneLayoutContext, SessionIsArchivedContext, SessionIsReadContext } from '../../../../common/contextkeys.js';
+import { SessionProviderIdContext, SessionSupportsDeleteContext, SessionSupportsRenameContext, SessionTypeContext, IsPhoneLayoutContext, SessionIsArchivedContext, SessionIsReadContext, SessionHasPullRequestContext } from '../../../../common/contextkeys.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
@@ -2622,6 +2622,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			[SessionProviderIdContext.key, element.providerId],
 			[SessionSupportsRenameContext.key, element.capabilities.get().supportsRename ?? false],
 			[SessionSupportsDeleteContext.key, element.capabilities.get().supportsDelete ?? false],
+			[SessionHasPullRequestContext.key, !!element.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get()?.pullRequest],
 		];
 
 		const menu = this.menuService.createMenu(SessionItemContextMenuId, this.contextKeyService.createOverlay(contextOverlay));


### PR DESCRIPTION
## What

Right-clicking a session in the Agents window sessions list now shows an **Open Pull Request** action when that session is associated with a GitHub pull request. Activating it opens the PR on GitHub (same behavior as the existing session-header PR pill).

## Why

The session header already surfaces a pull request pill, but there was no way to open a session's PR directly from the sessions list without first navigating into the session. This adds the affordance where users right-click.

## Changes

- **`pullRequestActions.ts`** — Added a second menu contribution on the existing `OpenPullRequestAction` targeting `MenuId.SessionItemContextMenu` in the top `navigation` (open) group, next to "Open to the Side", gated on `SessionHasPullRequestContext`. `run` now also accepts the context menu's `ISession[]` argument, opening the PR for the clicked/selected session and falling back to the active session. The URI lookup helper is now a private method.
- **`sessionsList.ts`** — Added `sessionHasPullRequest` to the per-row context-key overlay built in `onContextMenu`, derived from the row's `gitRepository.gitHubInfo.pullRequest`, so the action's `when` clause resolves for the right-clicked session.
- **`SESSIONS_LIST.md`** — Documented the new context-menu action and the `sessionHasPullRequest` per-session context key.

## Notes

The action opens the PR externally (browser). It reuses the existing `OpenPullRequestAction`, so both entry points (session-header pill and the new context-menu item) stay in sync.