### PR TITLE
Voice: fix session-state storm and confirmation narration preemption

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -551,7 +551,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 			removes,
 			...(activeChanged && context.active_session ? { active_session: context.active_session } : {}),
 		}));
-		this._logService.trace(`[voice] _sendDelta upserts=[${upserts.map(u => `${String(u.id).slice(-8)}:${u.agent_state ?? '(no-state)'}${Object.prototype.hasOwnProperty.call(u, 'agent_state_detail') ? '+detail' : ''}`).join(', ')}] removes=${removes.length} activeChanged=${activeChanged}`);
+		this._logService.trace(`[voice] _sendDelta upserts=[${upserts.map(u => `${String(u.id).slice(-8)}:${u.agent_state ?? '(no-state)'}${Object.prototype.hasOwnProperty.call(u, 'agent_state_detail') ? '+detail' : ''}${Object.prototype.hasOwnProperty.call(u, 'last_response_summary') && u.last_response_summary ? '+summary' : ''}`).join(', ')}] removes=${removes.length} activeChanged=${activeChanged}`);
 	}
 
 	private _seedTracking(context: IVoiceSessionContext): void {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -551,6 +551,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 			removes,
 			...(activeChanged && context.active_session ? { active_session: context.active_session } : {}),
 		}));
+		this._logService.trace(`[voice] _sendDelta upserts=[${upserts.map(u => `${String(u.id).slice(-8)}:${u.agent_state ?? '(no-state)'}${Object.prototype.hasOwnProperty.call(u, 'agent_state_detail') ? '+detail' : ''}`).join(', ')}] removes=${removes.length} activeChanged=${activeChanged}`);
 	}
 
 	private _seedTracking(context: IVoiceSessionContext): void {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -291,7 +291,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 		};
 
 		ws.onclose = (evt: CloseEvent) => {
-			this._logService.warn('[voice] ws.onclose', { code: evt.code, reason: evt.reason, wasClean: evt.wasClean });
+			this._logService.trace(`[voice] ws.onclose code=${evt.code} reason=${evt.reason ?? ''} wasClean=${evt.wasClean}`);
 			if (this._ws === ws) {
 				if (evt.code === 1000 || evt.code === 1001) {
 					this._cleanup();
@@ -332,7 +332,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	}
 
 	disconnect(): void {
-		this._logService.warn('[voice] disconnect() called', new Error('disconnect trace').stack);
+		this._logService.trace('[voice] disconnect() called');
 		if (this._ws && this._ws.readyState < WebSocket.CLOSING) {
 			this._ws.close();
 		}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -875,9 +875,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					// --- Helper: subscribe to a chat model's observables and detect state changes ---
 					const processModel = (model: IChatModel, resource: URI, label: string) => {
 						const sessionId = resource.toString();
-						// The model is now resident so its idle transition will carry a
-						// proper summary; drop any pending deferral/suppression.
-						this._pendingIdleNarration.delete(sessionId);
 						const lastReq = model.lastRequestObs.read(reader);
 						if (lastReq?.response) {
 							lastReq.response.isIncomplete.read(reader);
@@ -903,12 +900,20 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 						// Detect state changes
 						const info = this._getAgentStateInfo(model);
-						const currentState = info.state;
+						// Hold a summary-less idle while an eager reload is still
+						// replaying this session's response (see _effectiveResidentState),
+						// so the idle transition isn't consumed before the summary
+						// exists. Once we stop holding, the model is resident with a
+						// proper summary, so drop the pending idle deferral.
+						const currentState = this._effectiveResidentState(sessionId, info);
+						if (currentState === info.state) {
+							this._pendingIdleNarration.delete(sessionId);
+						}
 						const detail = info.detail;
 						const lastResponseSummary = info.last_response_summary;
 						// Capture the summary while the model is resident so a later
 						// completion reported after disposal can still narrate.
-						this._cacheResponseSummary(sessionId, currentState, lastResponseSummary);
+						this._cacheResponseSummary(sessionId, info.state, lastResponseSummary);
 
 						const prev = this._prevSessionStates.get(sessionId);
 						const isStateTransition = prev !== undefined && prev.state !== currentState && currentState !== 'unknown';
@@ -3062,13 +3067,18 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			let lastResponseSummary: string | undefined;
 			if (model) {
 				const info = this._getAgentStateInfo(model);
-				currentState = info.state;
+				// Hold a summary-less idle while an eager reload is still replaying
+				// (see _effectiveResidentState); once we stop holding the model is
+				// resident with a proper summary, so drop the pending idle deferral.
+				currentState = this._effectiveResidentState(sessionId, info);
 				detail = info.detail;
-				lastResponseSummary = info.last_response_summary;
+				lastResponseSummary = currentState === info.state ? info.last_response_summary : undefined;
 				// Capture the summary while resident so a later completion after
-				// disposal can still narrate; also drop any pending idle deferral.
-				this._cacheResponseSummary(sessionId, currentState, lastResponseSummary);
-				this._pendingIdleNarration.delete(sessionId);
+				// disposal can still narrate.
+				this._cacheResponseSummary(sessionId, info.state, info.last_response_summary);
+				if (currentState === info.state) {
+					this._pendingIdleNarration.delete(sessionId);
+				}
 			} else {
 				currentState = s.status === AgentSessionStatus.InProgress ? 'thinking'
 					: s.status === AgentSessionStatus.NeedsInput ? 'waiting_for_confirmation'
@@ -3271,15 +3281,20 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const detailPending = stateInfo.state === 'waiting_for_confirmation' && !stateInfo.detail;
 			// One-shot: hold as `thinking` so `is_active` ships before the real state.
 			const forceThinking = this._forceThinkingOnce.has(s.resource.toString());
+			// Hold a summary-less idle while an eager reload is still replaying the
+			// response, so we don't ship (and consume) the idle before the summary
+			// is ready. See _effectiveResidentState.
+			const heldState = this._effectiveResidentState(s.resource.toString(), stateInfo);
 			const scoped = (detailPending || forceThinking)
 				? { state: 'thinking', hideConfirmationDetail: true }
-				: this._reportedAgentState(stateInfo.state, isActive);
+				: this._reportedAgentState(heldState, isActive);
+			const shipSummary = heldState === stateInfo.state ? stateInfo.last_response_summary : undefined;
 			return {
 				id: s.resource.toString(),
 				is_active: isActive,
 				agent_state: scoped.state,
 				...(!scoped.hideConfirmationDetail && stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
-				...(stateInfo.last_response_summary ? { last_response_summary: stateInfo.last_response_summary } : {}),
+				...(shipSummary ? { last_response_summary: shipSummary } : {}),
 			};
 		});
 
@@ -3395,6 +3410,30 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		} else if (state === 'thinking') {
 			this._lastResponseSummaryById.delete(sessionId);
 		}
+	}
+
+	/**
+	 * The state to report for a resident model, applying the idle-narration hold.
+	 *
+	 * When a completion is detected for an unfocused session we eagerly reload
+	 * its (disposed) model to recover ``last_response_summary``. That reloaded
+	 * model is briefly resident with an EMPTY response while its history is still
+	 * replaying, so reporting its bare ``idle`` now would ship a summary-less
+	 * completion (which the backend never narrates) AND consume the ``idle``
+	 * transition before the summary exists. While the eager load is still in
+	 * flight we therefore hold — report the prior state — so the ``idle`` isn't
+	 * shipped until it can carry the summary. The load always resolves (its
+	 * callback clears ``_eagerModelLoading``), so the hold can never last forever.
+	 */
+	private _effectiveResidentState(sessionId: string, stateInfo: { state: string; last_response_summary?: string }): string {
+		if (stateInfo.state === 'idle'
+			&& !stateInfo.last_response_summary
+			&& this._pendingIdleNarration.has(sessionId)
+			&& this._eagerModelLoading.has(sessionId)) {
+			const prev = this._prevSessionStates.get(sessionId);
+			return prev?.state ?? 'thinking';
+		}
+		return stateInfo.state;
 	}
 
 	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string } {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -377,6 +377,19 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 */
 	private readonly _pendingIdleNarration = new Set<string>();
 
+	/**
+	 * Last response summary captured per session WHILE its chat model was
+	 * resident. Copilot/remote session models are disposed as soon as the user
+	 * switches away, so a completion that lands while the session is unfocused
+	 * would otherwise be reported to the backend as a summary-less ``idle`` and
+	 * never narrated (the eager reload to recover the summary races the switch's
+	 * re-disposal). Caching the summary here — independent of the model's
+	 * lifetime — lets the no-model paths still report ``last_response_summary``.
+	 * Refreshed whenever a resident model exposes a summary; cleared when the
+	 * session starts a new turn (``thinking``) so a stale reply is never narrated.
+	 */
+	private readonly _lastResponseSummaryById = new Map<string, string>();
+
 	// --- Telemetry tracking ---
 	private _telemetrySessionIndex = 0;
 	private _telemetrySessionStart: number | undefined;
@@ -893,6 +906,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 						const currentState = info.state;
 						const detail = info.detail;
 						const lastResponseSummary = info.last_response_summary;
+						// Capture the summary while the model is resident so a later
+						// completion reported after disposal can still narrate.
+						this._cacheResponseSummary(sessionId, currentState, lastResponseSummary);
 
 						const prev = this._prevSessionStates.get(sessionId);
 						const isStateTransition = prev !== undefined && prev.state !== currentState && currentState !== 'unknown';
@@ -931,6 +947,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 								: s.status === AgentSessionStatus.NeedsInput ? 'waiting_for_confirmation'
 									: s.status === AgentSessionStatus.Completed ? 'idle'
 										: 'unknown';
+							// A new turn (thinking) supersedes any cached summary even
+							// without a resident model, so a later completion never
+							// narrates the previous reply.
+							this._cacheResponseSummary(sessionId, currentState, undefined);
 							if (s.status === AgentSessionStatus.NeedsInput) {
 								this._ensureModelLoaded(s.resource);
 							}
@@ -940,12 +960,22 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 							// Remote/Copilot sessions don't keep their model resident, so a
 							// coarse ``idle`` transition would carry no last_response_summary
-							// and the backend would narrate an empty completion. Defer the
-							// transition: eagerly load the model and let the autorun re-fire
-							// with the summary once it resolves. Do not record the idle state
-							// yet so the transition is still detected after the model loads.
+							// and the backend would narrate an empty completion. If we
+							// captured the summary while the model was resident, narrate
+							// now using the cache. Otherwise defer: eagerly load the model
+							// and let the autorun re-fire with the summary once it resolves
+							// (do not record the idle state yet so the transition is still
+							// detected after the model loads).
 							if (isStateTransition && currentState === 'idle') {
-								this._deferIdleNarrationUntilModelLoaded(s.resource);
+								const cachedSummary = this._lastResponseSummaryById.get(sessionId);
+								if (!cachedSummary) {
+									this._deferIdleNarrationUntilModelLoaded(s.resource);
+									continue;
+								}
+								if (!this._userCancelledSessions.has(sessionId)) {
+									stateChanges.push({ sessionId, currentState, label: s.label || 'Untitled session', lastResponseSummary: cachedSummary });
+								}
+								this._prevSessionStates.set(sessionId, { state: currentState, detail: '' });
 								continue;
 							}
 
@@ -1384,6 +1414,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._eagerModelRefs.clear();
 		this._eagerModelLoading.clear();
 		this._pendingIdleNarration.clear();
+		this._lastResponseSummaryById.clear();
 		this._userLogin = undefined;
 		this._lastPersistedTurnId = undefined;
 		this._pendingPriorTimeline = [];
@@ -3034,13 +3065,18 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				currentState = info.state;
 				detail = info.detail;
 				lastResponseSummary = info.last_response_summary;
-				// Model is resident now; drop any pending idle deferral/suppression.
+				// Capture the summary while resident so a later completion after
+				// disposal can still narrate; also drop any pending idle deferral.
+				this._cacheResponseSummary(sessionId, currentState, lastResponseSummary);
 				this._pendingIdleNarration.delete(sessionId);
 			} else {
 				currentState = s.status === AgentSessionStatus.InProgress ? 'thinking'
 					: s.status === AgentSessionStatus.NeedsInput ? 'waiting_for_confirmation'
 						: s.status === AgentSessionStatus.Completed ? 'idle'
 							: 'unknown';
+				// A new turn supersedes any cached summary even without a resident
+				// model, so a later completion never narrates the previous reply.
+				this._cacheResponseSummary(sessionId, currentState, undefined);
 				if (s.status === AgentSessionStatus.NeedsInput) {
 					this._ensureModelLoaded(s.resource);
 				}
@@ -3050,11 +3086,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const isStateChange = prev !== undefined && prev.state !== currentState && currentState !== 'unknown';
 			const isDetailChange = !isStateChange && prev !== undefined && currentState === 'waiting_for_confirmation' && (detail ?? '') !== prev.detail;
 
-			// Defer summary-less idle transitions for remote/Copilot sessions until
-			// their model loads (see _deferIdleNarrationUntilModelLoaded).
+			// Summary-less idle transitions for remote/Copilot sessions: narrate
+			// from the cached summary if we have one, otherwise defer until the
+			// model loads (see _deferIdleNarrationUntilModelLoaded).
 			if (!model && currentState === 'idle' && isStateChange) {
-				this._deferIdleNarrationUntilModelLoaded(s.resource);
-				continue;
+				const cachedSummary = this._lastResponseSummaryById.get(sessionId);
+				if (!cachedSummary) {
+					this._deferIdleNarrationUntilModelLoaded(s.resource);
+					continue;
+				}
+				lastResponseSummary = cachedSummary;
 			}
 
 			if (isStateChange || isDetailChange) {
@@ -3191,7 +3232,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				// If this idle transition is deferred until the model loads, keep
 				// reporting the prior state so the backend doesn't narrate a
 				// premature, summary-less completion. See _pendingIdleNarration.
-				if (fallbackState === 'idle' && this._pendingIdleNarration.has(sessionIdStr)) {
+				// If we already cached a summary while the model was resident we
+				// can narrate now, so don't hold in that case.
+				if (fallbackState === 'idle' && this._pendingIdleNarration.has(sessionIdStr) && !this._lastResponseSummaryById.has(sessionIdStr)) {
 					const prev = this._prevSessionStates.get(sessionIdStr);
 					if (prev?.state) {
 						fallbackState = prev.state;
@@ -3207,13 +3250,21 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					fallbackState = 'thinking';
 				}
 				const scoped = this._reportedAgentState(fallbackState, isActive);
+				// Supply the summary captured while the model was resident, so an
+				// idle completion that lands after the model is disposed still
+				// narrates instead of shipping a summary-less (silent) idle.
+				const cachedSummary = fallbackState === 'idle' ? this._lastResponseSummaryById.get(sessionIdStr) : undefined;
 				return {
 					id: sessionIdStr,
 					is_active: isActive,
 					agent_state: scoped.state,
+					...(cachedSummary ? { last_response_summary: cachedSummary } : {}),
 				};
 			}
 			const stateInfo = this._getAgentStateInfo(model);
+			// Capture the summary while the model is resident so a later
+			// completion reported after the model is disposed can still narrate.
+			this._cacheResponseSummary(s.resource.toString(), stateInfo.state, stateInfo.last_response_summary);
 			// A confirmation whose detail hasn't rendered yet is held as
 			// `thinking` for the same reason as the no-model case above: narrate
 			// exactly once, with the detail, rather than a detail-less one first.
@@ -3328,6 +3379,22 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _deferIdleNarrationUntilModelLoaded(resource: URI): void {
 		this._pendingIdleNarration.add(resource.toString());
 		this._ensureModelLoaded(resource);
+	}
+
+	/**
+	 * Cache (or invalidate) a session's response summary based on the current
+	 * state observed from its resident model. Called wherever a resident model's
+	 * state is computed so the summary survives the model's disposal.
+	 * - `idle` with a summary → cache it (the completed reply).
+	 * - `thinking` → a new turn started; drop the stale summary so a later
+	 *   completion never narrates the previous reply.
+	 */
+	private _cacheResponseSummary(sessionId: string, state: string, summary: string | undefined): void {
+		if (state === 'idle' && summary) {
+			this._lastResponseSummaryById.set(sessionId, summary);
+		} else if (state === 'thinking') {
+			this._lastResponseSummaryById.delete(sessionId);
+		}
 	}
 
 	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string } {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1255,12 +1255,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					this._liveReplyKey = undefined;
 					// Record this heard reply so an immediate backend re-narration
 					// of it (on activation) is dropped as a re-read, and so later
-					// on-focus re-reads of it are deduped by content.
-					if (codingSessionId && e.transcript) {
+					// on-focus re-reads of it are deduped by content. Untagged
+					// audio that plays live still belongs to the active session, so
+					// attribute it there; otherwise a later TAGGED re-narration of
+					// the same reply would not match and be read a second time.
+					const heardSessionId = codingSessionId ?? this._getActiveSessionId();
+					if (heardSessionId && e.transcript) {
 						const heard = this._normalizeTranscript(e.transcript);
 						if (heard) {
-							this._lastHeardTranscriptById.set(codingSessionId, heard);
-							this._recentlyReadResponse.set(codingSessionId, { transcript: heard, at: Date.now() });
+							this._lastHeardTranscriptById.set(heardSessionId, heard);
+							this._recentlyReadResponse.set(heardSessionId, { transcript: heard, at: Date.now() });
 						}
 					}
 				}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -325,18 +325,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private static readonly _CONFIRMATION_FLUSH_DELAY_MS = 1500;
 
 	/**
-	 * Coalesced session state-change emission. Transitions detected by the
-	 * reactive autorun are buffered here (latest per session) and flushed once
-	 * after a short settle window instead of synchronously. This collapses the
-	 * rapid ``thinking <-> idle`` storm emitted while a remote session's history
-	 * is replayed on load (each replayed request briefly re-opens the last
-	 * response) into a single settled emission. Without it, every intermediate
-	 * flip is flushed to the backend as an ``agent_state`` delta, spamming it
-	 * with dozens of contradictory transitions per load and causing spurious or
-	 * duplicated narrations. Genuine transitions still ship after the settle,
-	 * well within the confirmation flush watchdog's tolerance.
+	 * Latest state change per session, buffered and flushed once after a short
+	 * settle window (see {@link _emitPendingStateChanges}) so a rapid
+	 * ``thinking <-> idle`` replay storm coalesces into a single net emission
+	 * instead of spamming the backend with contradictory transitions. Each entry
+	 * also records the burst's baseline (``fromState``/``fromDetail``) so a wobble
+	 * that returns to its starting state is recognized as net-zero.
 	 */
-	private readonly _pendingStateChanges = new Map<string, { sessionId: string; currentState: string; label: string; detail?: string; lastResponseSummary?: string; detailOnly?: boolean }>();
+	private readonly _pendingStateChanges = new Map<string, { sessionId: string; currentState: string; label: string; detail?: string; lastResponseSummary?: string; fromState: string; fromDetail: string }>();
 	private _stateChangeEmitTimer: ReturnType<typeof setTimeout> | undefined;
 	private static readonly _STATE_CHANGE_SETTLE_MS = 120;
 
@@ -868,7 +864,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				const autorunDisposable = autorun(reader => {
 					const agentSessions = this.agentSessionsService.model.sessions.filter(s => !s.isArchived());
 					let needsRecheck = false;
-					const stateChanges: { sessionId: string; currentState: string; label: string; detail?: string; lastResponseSummary?: string; detailOnly?: boolean }[] = [];
+					const stateChanges: { sessionId: string; currentState: string; label: string; detail?: string; lastResponseSummary?: string; fromState: string; fromDetail: string }[] = [];
 					const waitingForConfirmationSessions: { sessionId: string; label: string; detail?: string; transition: boolean }[] = [];
 					const processedResources = new Set<string>();
 
@@ -927,7 +923,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 								clearTimeout(cancelExpiry);
 								this._userCancelledSessions.delete(sessionId);
 							} else {
-								stateChanges.push({ sessionId, currentState, label, detail, lastResponseSummary, detailOnly: isDetailTransition });
+								stateChanges.push({ sessionId, currentState, label, detail, lastResponseSummary, fromState: prev?.state ?? currentState, fromDetail: prev?.detail ?? '' });
 							}
 						}
 						if (currentState !== 'unknown') {
@@ -978,7 +974,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 									continue;
 								}
 								if (!this._userCancelledSessions.has(sessionId)) {
-									stateChanges.push({ sessionId, currentState, label: s.label || 'Untitled session', lastResponseSummary: cachedSummary });
+									stateChanges.push({ sessionId, currentState, label: s.label || 'Untitled session', lastResponseSummary: cachedSummary, fromState: prev?.state ?? currentState, fromDetail: prev?.detail ?? '' });
 								}
 								this._prevSessionStates.set(sessionId, { state: currentState, detail: '' });
 								continue;
@@ -990,7 +986,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 									clearTimeout(cancelExpiry);
 									this._userCancelledSessions.delete(sessionId);
 								} else {
-									stateChanges.push({ sessionId, currentState, label: s.label || 'Untitled session' });
+									stateChanges.push({ sessionId, currentState, label: s.label || 'Untitled session', fromState: prev?.state ?? currentState, fromDetail: prev?.detail ?? '' });
 								}
 							}
 							if (currentState !== 'unknown') {
@@ -1014,6 +1010,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					if (needsRecheck) {
 						setTimeout(() => this._autoApproveCheck(), 500);
 					}
+					// Evict per-session caches for sessions that are no longer tracked
+					// (archived/removed/disposed), so long-lived voice connections don't
+					// retain summaries or state for sessions that will never be narrated.
+					this._pruneSessionCaches(processedResources);
 					// The session_context delta is the sole narration trigger
 					// on the BE side. Its handler detects per-session
 					// ``agent_state`` transitions and fires ``_proactive_status_update``
@@ -1022,17 +1022,28 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					// in addition causes the BE to chain a SECOND narration after
 					// the first (see ``_chain_proactive``), which manifested as
 					// duplicate / mid-stream-replaced narrations.
-					this._sendContext();
 					if (stateChanges.length > 0) {
 						// Coalesce rapid transitions into a single settled emission
 						// (see _pendingStateChanges). Buffer the latest change per
-						// session and (re)arm the settle timer; the immediate flush,
-						// cache invalidation and timeline persist all happen once the
-						// storm settles, in _emitPendingStateChanges().
+						// session (preserving the burst's baseline so a net-zero
+						// wobble is recognized) and (re)arm the settle timer; the
+						// flush, cache invalidation and timeline persist all happen
+						// once the storm settles, in _emitPendingStateChanges().
+						//
+						// Deliberately do NOT `_sendContext()` here: staging the
+						// intermediate (glitching) state into the shared pending
+						// context would let a `flushSessionContext()` during the
+						// settle window (e.g. _activateShownSession) ship the wobble
+						// and bypass coalescing.
 						for (const change of stateChanges) {
-							this._pendingStateChanges.set(change.sessionId, change);
+							const existing = this._pendingStateChanges.get(change.sessionId);
+							this._pendingStateChanges.set(change.sessionId, existing
+								? { ...change, fromState: existing.fromState, fromDetail: existing.fromDetail }
+								: change);
 						}
 						this._scheduleStateChangeEmit();
+					} else {
+						this._sendContext();
 					}
 
 					// Arm a paranoid re-flush watchdog for any session currently
@@ -2351,7 +2362,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		const model = this.chatService.getSession(resource);
 		const activatedState = model ? this._getAgentStateInfo(model).state : 'no-model';
 		const awaitingConfirmation = activatedState === 'waiting_for_confirmation';
-		this.logService.trace(`[voice] _activateShownSession key=${key} state=${activatedState} activeId=${this._getActiveSessionId() ?? '<none>'} hadDeferred=${hadDeferred} heardBefore=${this._lastHeardTranscriptById.has(key)} recentlyRead=${this._recentlyReadResponse.has(key)}`);
+		this.logService.trace(`[voice] _activateShownSession key=${key.slice(-32)} state=${activatedState} activeId=${this._getActiveSessionId()?.slice(-32) ?? '<none>'} hadDeferred=${hadDeferred} heardBefore=${this._lastHeardTranscriptById.has(key)} recentlyRead=${this._recentlyReadResponse.has(key)}`);
 		if (awaitingConfirmation) {
 			this._narrateConfirmationViaTwoPhase(key);
 			return;
@@ -2956,12 +2967,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	/**
-	 * Flush the coalesced session state changes to the backend exactly once and
-	 * persist them to the local timeline. Because {@link _sendContext} rebuilds
-	 * the full context from the now-settled model state and `_sendDelta`
-	 * merge-patches against the last-sent snapshot, an oscillation that returned
-	 * to its prior state produces no delta and is silently dropped - only a real
-	 * net transition reaches the backend.
+	 * Flush the coalesced session state changes to the backend and persist only
+	 * true net changes to the local timeline. {@link _sendContext} rebuilds the
+	 * full context from the now-settled model state and `_sendDelta` merge-patches
+	 * against the last-sent snapshot, so an oscillation that returned to its prior
+	 * state produces no delta. Each buffered change carries the burst's baseline
+	 * (`fromState`/`fromDetail`); we compare the settled state against it so a
+	 * net-zero wobble is neither traced nor persisted as a `coding_event` (which
+	 * would otherwise replay a phantom transition to the backend on reconnect),
+	 * and a detail change reached via an intermediate state (e.g.
+	 * `waiting(old) → thinking → waiting(new)`) is still treated as detail-only.
 	 */
 	private _emitPendingStateChanges(): void {
 		const changes = [...this._pendingStateChanges.values()];
@@ -2969,18 +2984,35 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (changes.length === 0) {
 			return;
 		}
-		// For detail-only transitions (same agent_state but different
-		// confirmation content), invalidate the cache so _sendDelta treats the
-		// session as new and includes agent_state + agent_state_detail together.
+		// Keep only changes whose settled state differs from the burst baseline;
+		// classify a same-state confirmation whose detail changed as detail-only.
+		const netChanges: { change: typeof changes[number]; detailOnly: boolean }[] = [];
 		for (const change of changes) {
-			if (change.detailOnly) {
+			const detail = change.detail ?? '';
+			const stateChanged = change.fromState !== change.currentState;
+			const detailOnly = !stateChanged && change.currentState === 'waiting_for_confirmation' && change.fromDetail !== detail;
+			if (stateChanged || detailOnly) {
+				netChanges.push({ change, detailOnly });
+			}
+		}
+		if (netChanges.length === 0) {
+			// The storm settled back to the baseline; still send a fresh context
+			// (idempotent — _sendDelta emits nothing) but trace/persist nothing.
+			this._sendContext();
+			return;
+		}
+		// For detail-only transitions (same agent_state but different confirmation
+		// content), invalidate the cache so _sendDelta treats the session as new
+		// and includes agent_state + agent_state_detail together.
+		for (const { change, detailOnly } of netChanges) {
+			if (detailOnly) {
 				this.voiceClientService.invalidateSessionCache(change.sessionId);
 			}
 		}
 		this._sendContext();
-		this.logService.trace(`[voice] emitting ${changes.length} settled stateChange(s): ${changes.map(c => `${c.label}:${c.currentState}${c.detailOnly ? ' (detail-only)' : ''}`).join(', ')}`);
+		this.logService.trace(`[voice] emitting ${netChanges.length} settled stateChange(s): ${netChanges.map(({ change, detailOnly }) => `${change.label}:${change.currentState}${detailOnly ? ' (detail-only)' : ''}`).join(', ')}`);
 		this.voiceClientService.flushSessionContext();
-		for (const change of changes) {
+		for (const { change } of netChanges) {
 			// Persist as a coding_event in the local timeline so
 			// "session X went from thinking → waiting_for_confirmation"
 			// can be replayed as cross-session context on reconnect.
@@ -3409,6 +3441,19 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._lastResponseSummaryById.set(sessionId, summary);
 		} else if (state === 'thinking') {
 			this._lastResponseSummaryById.delete(sessionId);
+		}
+	}
+
+	/**
+	 * Drop per-session caches for sessions no longer in the tracked set, so a
+	 * long-lived voice connection doesn't retain summaries/state for archived,
+	 * removed, or disposed sessions that will never be narrated again.
+	 */
+	private _pruneSessionCaches(liveSessionIds: Set<string>): void {
+		for (const id of this._lastResponseSummaryById.keys()) {
+			if (!liveSessionIds.has(id)) {
+				this._lastResponseSummaryById.delete(id);
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -325,6 +325,22 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private static readonly _CONFIRMATION_FLUSH_DELAY_MS = 1500;
 
 	/**
+	 * Coalesced session state-change emission. Transitions detected by the
+	 * reactive autorun are buffered here (latest per session) and flushed once
+	 * after a short settle window instead of synchronously. This collapses the
+	 * rapid ``thinking <-> idle`` storm emitted while a remote session's history
+	 * is replayed on load (each replayed request briefly re-opens the last
+	 * response) into a single settled emission. Without it, every intermediate
+	 * flip is flushed to the backend as an ``agent_state`` delta, spamming it
+	 * with dozens of contradictory transitions per load and causing spurious or
+	 * duplicated narrations. Genuine transitions still ship after the settle,
+	 * well within the confirmation flush watchdog's tolerance.
+	 */
+	private readonly _pendingStateChanges = new Map<string, { sessionId: string; currentState: string; label: string; detail?: string; lastResponseSummary?: string; detailOnly?: boolean }>();
+	private _stateChangeEmitTimer: ReturnType<typeof setTimeout> | undefined;
+	private static readonly _STATE_CHANGE_SETTLE_MS = 120;
+
+	/**
 	 * Pending confirmation phase 2 (see `_activateShownSession`): send
 	 * `agent_state` after `is_active` has settled so it narrates.
 	 *
@@ -334,6 +350,18 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 */
 	private readonly _confirmationActivateTimers = new Map<string, ReturnType<typeof setTimeout>>();
 	private static readonly _CONFIRMATION_ACTIVATE_DELAY_MS = 250;
+
+	/**
+	 * The focused session whose confirmation transition we just shipped and
+	 * expect the backend to narrate. If a tagged narration for a DIFFERENT
+	 * session arrives before this one's own audio, the backend preempted this
+	 * confirmation (it narrates one thing at a time and the session's state does
+	 * not transition again, so it would be lost forever). We re-assert it once.
+	 * Cleared when this session's own audio arrives, or when it stops being the
+	 * active/awaiting-confirmation session.
+	 */
+	private _confirmationNarrationPending: { sessionId: string; at: number; reasserted: boolean } | undefined;
+	private static readonly _CONFIRMATION_REASSERT_WINDOW_MS = 12000;
 
 	/** Model refs eagerly loaded for sessions awaiting input (no UI focus needed). */
 	private readonly _eagerModelRefs = new Map<string, IChatModelReference>();
@@ -961,39 +989,15 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					// duplicate / mid-stream-replaced narrations.
 					this._sendContext();
 					if (stateChanges.length > 0) {
-						// For detail-only transitions (same agent_state but
-						// different confirmation content), invalidate the
-						// cache so _sendDelta treats the session as new and
-						// includes agent_state + agent_state_detail together.
+						// Coalesce rapid transitions into a single settled emission
+						// (see _pendingStateChanges). Buffer the latest change per
+						// session and (re)arm the settle timer; the immediate flush,
+						// cache invalidation and timeline persist all happen once the
+						// storm settles, in _emitPendingStateChanges().
 						for (const change of stateChanges) {
-							if (change.detailOnly) {
-								this.voiceClientService.invalidateSessionCache(change.sessionId);
-							}
+							this._pendingStateChanges.set(change.sessionId, change);
 						}
-						// Re-send after cache invalidation so the delta
-						// picks up the full session fields.
-						if (stateChanges.some(c => c.detailOnly)) {
-							this._sendContext();
-						}
-						this.logService.trace(`[voice] autorun stateChanges=${stateChanges.length} flushing immediately: ${stateChanges.map(c => `${c.label}:${c.currentState}${c.detailOnly ? ' (detail-only)' : ''}`).join(', ')}`);
-						// Flush the 500 ms debounce so the BE picks up the
-						// transition (and the accompanying detail / summary)
-						// promptly.
-						this.voiceClientService.flushSessionContext();
-					}
-					for (const change of stateChanges) {
-						// Persist as a coding_event in the local timeline so
-						// "session X went from thinking → waiting_for_confirmation"
-						// can be replayed as cross-session context on reconnect.
-						this._persistEntry(
-							'coding_event',
-							`session "${change.label}" → ${change.currentState}`,
-							{
-								codingSessionId: change.sessionId,
-								codingStatus: change.currentState,
-								codingSessionLabel: change.label,
-							},
-						);
+						this._scheduleStateChangeEmit();
 					}
 
 					// Arm a paranoid re-flush watchdog for any session currently
@@ -1165,6 +1169,20 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// (otherwise it is stranded and never read). Untagged / non-agent-host
 			// ids pass through unchanged.
 			const codingSessionId = this._canonicalSessionId(e.codingSessionId);
+			// Confirmation preemption recovery: the backend narrates one thing at
+			// a time. If we just shipped a focused session's confirmation and a
+			// TAGGED narration for a DIFFERENT session arrives first, the backend
+			// preempted the confirmation and — because the session's state does not
+			// transition again — it would be lost forever. Detect that here and
+			// re-assert the confirmation once (see _confirmationNarrationPending).
+			//
+			// TODO: interim client mitigation. The real fix is backend-side: it
+			// should serialize/queue proactive narrations (or re-narrate a
+			// still-pending confirmation on the next session_context) instead of
+			// dropping one when another is in flight. Remove once that lands.
+			if (e.isFirstChunk) {
+				this._reconcileConfirmationNarration(codingSessionId);
+			}
 			// If this response is for a session the user isn't currently looking
 			// at, don't play it now: buffer it until that session is focused and
 			// notify with a short audio cue instead.
@@ -1215,6 +1233,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// honors the user-picked _targetSession and the workbench chat
 		// commands), not through the generic dispatch service.
 		this._voiceEventDisposables.add(this.voiceClientService.onToolCall(e => {
+			this.logService.trace(`[voice] tool_call received name=${e.name} coding_session_id=${typeof e.args?.['coding_session_id'] === 'string' ? String(e.args['coding_session_id']).slice(-32) : '<none>'} activeId=${this._getActiveSessionId()?.slice(-32) ?? '<none>'}`);
 			const allowedTools = [
 				'send_to_chat',
 				'get_session_info', 'get_session_changes', 'get_session_thread',
@@ -1267,7 +1286,15 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				this._suppressIncomingAudio = false;
 				this._setAwaitingReply();
 				this.voiceToolDispatchService.dispatchToolCall(e).then(result => {
-					this.voiceClientService.sendToolResult(e.callId, result);
+					// Approve/reject outcomes are surfaced for diagnosis, but the
+					// backend contract for these has always been a bare 'ok' ack;
+					// preserve that so only the diagnostic changes, not behavior.
+					if (e.name === 'approve_confirmation' || e.name === 'reject_confirmation') {
+						this.logService.trace(`[voice] ${e.name} dispatch result=${result} coding_session_id=${typeof e.args?.['coding_session_id'] === 'string' ? String(e.args['coding_session_id']).slice(-32) : '<none>'}`);
+						this.voiceClientService.sendToolResult(e.callId, 'ok');
+					} else {
+						this.voiceClientService.sendToolResult(e.callId, result);
+					}
 					this._voiceState.set('idle', undefined);
 					this._statusText.set('Hold to speak...', undefined);
 					this._sendContext();
@@ -1350,6 +1377,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._userCancelledSessions.clear();
 		for (const t of this._confirmationFlushWatchdogs.values()) { clearTimeout(t); }
 		this._confirmationFlushWatchdogs.clear();
+		if (this._stateChangeEmitTimer) { clearTimeout(this._stateChangeEmitTimer); this._stateChangeEmitTimer = undefined; }
+		this._pendingStateChanges.clear();
+		this._confirmationNarrationPending = undefined;
 		for (const ref of this._eagerModelRefs.values()) { ref.dispose(); }
 		this._eagerModelRefs.clear();
 		this._eagerModelLoading.clear();
@@ -2263,6 +2293,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _activateShownSession(resource: URI): void {
 		const key = resource.toString();
 		this._lastShownSessionId = key;
+		const hadDeferred = this._deferredResponses.has(key);
 		this._flushDeferredResponse(key);
 		this._clearConfirmationIndicator(key);
 		if (this._confirmationDetailPending(resource)) {
@@ -2282,33 +2313,103 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// the confirmation and `is_active` together and the backend narrates only
 		// on the next activation — so it's read on the second focus, not the first.
 		const model = this.chatService.getSession(resource);
-		const awaitingConfirmation = model ? this._getAgentStateInfo(model).state === 'waiting_for_confirmation' : false;
+		const activatedState = model ? this._getAgentStateInfo(model).state : 'no-model';
+		const awaitingConfirmation = activatedState === 'waiting_for_confirmation';
+		this.logService.trace(`[voice] _activateShownSession key=${key} state=${activatedState} activeId=${this._getActiveSessionId() ?? '<none>'} hadDeferred=${hadDeferred} heardBefore=${this._lastHeardTranscriptById.has(key)} recentlyRead=${this._recentlyReadResponse.has(key)}`);
 		if (awaitingConfirmation) {
-			// Phase 1: flip is_active while holding the session as `thinking`.
-			this._forceThinkingOnce.add(key);
-			this._sendContext();
-			this.voiceClientService.flushSessionContext();
-			// Phase 2: after `is_active` settles, send `waiting_for_confirmation`.
-			// Timers are keyed per session so activating another confirmation
-			// session can't cancel this one's phase-2 (which would strand it as
-			// `thinking` and narrate only on a second focus).
-			const existing = this._confirmationActivateTimers.get(key);
-			if (existing) {
-				clearTimeout(existing);
-			}
-			this._confirmationActivateTimers.set(key, setTimeout(() => {
-				this._confirmationActivateTimers.delete(key);
-				this._forceThinkingOnce.delete(key);
-				// Only ship the transition if this session is still active.
-				if (this._getActiveSessionId() === key) {
-					this._sendContext();
-					this.voiceClientService.flushSessionContext();
-				}
-			}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS));
+			this._narrateConfirmationViaTwoPhase(key);
 			return;
 		}
 		this._sendContext();
 		this.voiceClientService.flushSessionContext();
+	}
+
+	/**
+	 * Narrate a focused session's pending confirmation by splitting it across two
+	 * deltas: flip `is_active` while holding the session as `thinking`, then send
+	 * `waiting_for_confirmation` so the backend observes a fresh
+	 * `thinking -> waiting_for_confirmation` transition and narrates it. Without
+	 * the split, the confirmation and `is_active` ship together and the backend
+	 * only narrates on the next activation (read on the second focus).
+	 *
+	 * Records {@link _confirmationNarrationPending} so a competing narration for
+	 * another session (which preempts this one on the backend) can be detected
+	 * and this confirmation re-asserted rather than lost. See onAudioResponse.
+	 */
+	private _narrateConfirmationViaTwoPhase(key: string, isReassert: boolean = false): void {
+		// Phase 1: flip is_active while holding the session as `thinking`.
+		this._forceThinkingOnce.add(key);
+		this._sendContext();
+		this.voiceClientService.flushSessionContext();
+		// Phase 2: after `is_active` settles, send `waiting_for_confirmation`.
+		// Timers are keyed per session so activating another confirmation
+		// session can't cancel this one's phase-2 (which would strand it as
+		// `thinking` and narrate only on a second focus).
+		const existing = this._confirmationActivateTimers.get(key);
+		if (existing) {
+			clearTimeout(existing);
+		}
+		this._confirmationActivateTimers.set(key, setTimeout(() => {
+			this._confirmationActivateTimers.delete(key);
+			this._forceThinkingOnce.delete(key);
+			// Only ship the transition if this session is still active.
+			if (this._getActiveSessionId() === key) {
+				this._sendContext();
+				this.voiceClientService.flushSessionContext();
+				// Expect this confirmation to narrate now; track it so a competing
+				// narration that preempts it can trigger a single re-assert. If
+				// this send is ITSELF the re-assert, mark it consumed so we never
+				// loop re-asserting the same confirmation.
+				this._confirmationNarrationPending = { sessionId: key, at: Date.now(), reasserted: isReassert };
+			}
+		}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS));
+	}
+
+	/**
+	 * Reconcile a just-shipped confirmation narration against an incoming audio
+	 * response, recovering the "focused a confirmation but it was never read"
+	 * case caused by backend narration preemption.
+	 *
+	 * - Audio for the SAME session clears the pending marker: the confirmation
+	 *   (or a following reply) for it narrated, nothing to recover.
+	 * - A TAGGED narration for a DIFFERENT session while our confirmation session
+	 *   is still the active, still-awaiting-confirmation one means the backend
+	 *   narrated that instead and dropped ours. Re-assert the confirmation once
+	 *   (fresh `thinking -> waiting_for_confirmation` transition) so it is read.
+	 *
+	 * The one-shot `reasserted` guard prevents an oscillation loop, and clearing
+	 * on the session's own audio prevents a double-read when it did narrate.
+	 */
+	private _reconcileConfirmationNarration(codingSessionId: string | undefined): void {
+		const pending = this._confirmationNarrationPending;
+		if (!pending) {
+			return;
+		}
+		// Our confirmation session's own narration arrived — it was read.
+		if (codingSessionId === pending.sessionId) {
+			this._confirmationNarrationPending = undefined;
+			return;
+		}
+		// Only a tagged narration for another session is unambiguous evidence of
+		// preemption; ignore untagged audio (can't attribute it).
+		if (!codingSessionId) {
+			return;
+		}
+		const expired = Date.now() - pending.at > VoiceSessionController._CONFIRMATION_REASSERT_WINDOW_MS;
+		const stillActive = this._getActiveSessionId() === pending.sessionId;
+		let stillAwaiting = false;
+		if (stillActive) {
+			const model = this.chatService.getSession(URI.parse(pending.sessionId));
+			stillAwaiting = !!model && this._getAgentStateInfo(model).state === 'waiting_for_confirmation';
+		}
+		if (pending.reasserted || expired || !stillActive || !stillAwaiting) {
+			// Give up: navigated away, resolved, already retried, or timed out.
+			this._confirmationNarrationPending = undefined;
+			return;
+		}
+		this.logService.trace(`[voice] confirmation for ${pending.sessionId.slice(-32)} preempted by narration for ${codingSessionId.slice(-32)}; re-asserting`);
+		this._confirmationNarrationPending = undefined;
+		this._narrateConfirmationViaTwoPhase(pending.sessionId, /* isReassert */ true);
 	}
 
 	/**
@@ -2800,6 +2901,63 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 	private _sendContext(): void {
 		this.voiceClientService.sendSessionContext(this._buildSessionContext());
+	}
+
+	/**
+	 * (Re)arm the settle timer that emits buffered session state changes. Each
+	 * detected transition resets the timer, so a rapid burst (e.g. the history
+	 * replay ``thinking <-> idle`` storm) is collapsed to one emission once the
+	 * state stops changing. See {@link _pendingStateChanges}.
+	 */
+	private _scheduleStateChangeEmit(): void {
+		if (this._stateChangeEmitTimer) {
+			clearTimeout(this._stateChangeEmitTimer);
+		}
+		this._stateChangeEmitTimer = setTimeout(() => {
+			this._stateChangeEmitTimer = undefined;
+			this._emitPendingStateChanges();
+		}, VoiceSessionController._STATE_CHANGE_SETTLE_MS);
+	}
+
+	/**
+	 * Flush the coalesced session state changes to the backend exactly once and
+	 * persist them to the local timeline. Because {@link _sendContext} rebuilds
+	 * the full context from the now-settled model state and `_sendDelta`
+	 * merge-patches against the last-sent snapshot, an oscillation that returned
+	 * to its prior state produces no delta and is silently dropped - only a real
+	 * net transition reaches the backend.
+	 */
+	private _emitPendingStateChanges(): void {
+		const changes = [...this._pendingStateChanges.values()];
+		this._pendingStateChanges.clear();
+		if (changes.length === 0) {
+			return;
+		}
+		// For detail-only transitions (same agent_state but different
+		// confirmation content), invalidate the cache so _sendDelta treats the
+		// session as new and includes agent_state + agent_state_detail together.
+		for (const change of changes) {
+			if (change.detailOnly) {
+				this.voiceClientService.invalidateSessionCache(change.sessionId);
+			}
+		}
+		this._sendContext();
+		this.logService.trace(`[voice] emitting ${changes.length} settled stateChange(s): ${changes.map(c => `${c.label}:${c.currentState}${c.detailOnly ? ' (detail-only)' : ''}`).join(', ')}`);
+		this.voiceClientService.flushSessionContext();
+		for (const change of changes) {
+			// Persist as a coding_event in the local timeline so
+			// "session X went from thinking → waiting_for_confirmation"
+			// can be replayed as cross-session context on reconnect.
+			this._persistEntry(
+				'coding_event',
+				`session "${change.label}" → ${change.currentState}`,
+				{
+					codingSessionId: change.sessionId,
+					codingStatus: change.currentState,
+					codingSessionLabel: change.label,
+				},
+			);
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
@@ -232,13 +232,16 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 									? IChatToolInvocation.confirmWith(part as IChatToolInvocation, { type: ToolConfirmKind.UserAction })
 									: IChatToolInvocation.confirmWith(part as IChatToolInvocation, { type: ToolConfirmKind.Denied });
 								if (confirmed) {
-									break;
+									return toolCall.name === 'approve_confirmation' ? 'approved' : 'rejected';
 								}
 							}
 						}
 					}
+					// Found a model but no tool invocation was awaiting confirmation.
+					return 'no pending confirmation';
 				}
-				break;
+				// No target session could be resolved for the confirmation.
+				return 'no session';
 			}
 			case 'auto_approve_session': {
 				delegate.addAllAutoApprovedSessions();


### PR DESCRIPTION
## Summary

Makes voice-mode session narration reliable in the Agents window under multi-session use (two+ sessions, switching + approving confirmations). Four client-side fixes + trace diagnostics, all found and verified via trace logs.

After these fixes, **confirmations and response completions narrate reliably** in the multi-session/rapid-switch scenario. One residual class of drops — a proactive narration being dropped when another is already playing — has a backend root cause tracked in **microsoft/vscode-internalbacklog#8374**; the client mitigation for it here (Fix 2) is a racy stopgap marked with a TODO and can be deleted once the backend serializes narrations.

## Fixes

### Fix 1 — Coalesce session state-change emission (storm)
Loading/opening a remote session replays its history — each replayed request briefly re-opens the previous response, so the computed `agent_state` glitches `thinking↔idle` many times within milliseconds, and each glitch was flushed to the backend as a real delta (dozens of contradictory transitions per load). Now transitions are buffered per session and flushed once after a 120 ms settle window; an oscillation that returns to its prior state produces no delta (merge-patch), so only genuine net transitions ship. **Pure client bug, fully fixed.** _Verified:_ storms collapse to a single `emitting 1 settled stateChange` per load.

### Fix 2 — Recover confirmation narration preempted by a competing narration
The `_sendDelta` trace shows the client ships byte-identical correct `thinking → waiting_for_confirmation+detail` transitions for both confirmations; the backend narrates one thing at a time and silently drops one when another session's narration is in flight, and the session never re-transitions so it's lost. When a tagged narration for a different session arrives while a just-shipped confirmation for the focused session hasn't narrated, we re-assert it once (guarded: still-active + still-awaiting + one-shot + 12 s window). _Verified:_ `confirmation for X preempted by narration for Y; re-asserting` → confirmation then narrated. **Interim mitigation — inherently racy (inferred from audio timing, no ack; confirmation-only; one-shot). The real fix is backend narration serialization (microsoft/vscode-internalbacklog#8374); this can be deleted once that lands.**

### Fix 3 — Cache response summary off the model
Copilot/remote session models are disposed as soon as the user switches away, so a completion landing on an unfocused session was reported as a summary-less `idle` (which the backend never narrates). Cache `last_response_summary` per session while its model is resident, independent of the model's lifetime, and supply it on later summary-less idles. No model refs are held alive (no leak risk); the cache is cleared on each new turn so a stale reply is never narrated. Handles completions where the model was resident at the completion moment.

### Fix 4 — Hold a summary-less idle until the eager-reloaded model replays the response
Under rapid switching the model is disposed while still `thinking`, and the completion lands *after* disposal — so Fix 3's cache misses and we eagerly reload the model to recover the summary. That reloaded model is briefly resident with an **empty** response while its history is still replaying; we were shipping a summary-less `idle` immediately, consuming the `idle` transition before the summary existed (and once `agent_state` was `idle`, the merge-patch wobble-guard dropped the summary that arrived later). Now, while an eager reload is in flight and the resident model still reports `idle` with an empty summary, we report the prior state (`thinking`) to **hold** the idle until it can carry the summary (`_effectiveResidentState`, applied in `processModel` / `_buildSessionContext` / `_checkSessionStateChanges`). The eager load always resolves, so the hold can never last forever — a genuinely empty response ships a bare idle once loading completes. **This is what made unfocused completions narrate reliably** — the held session ships `thinking → idle+summary` once replay finishes and is read on focus.

Fixes 3 + 4 together make the completion case client-reliable, so it no longer depends on the backend narrating a summary-less idle.

### Diagnostics (trace-level only, no behavior change)
`_sendDelta` per-session `agent_state`, `_activateShownSession` state, `onToolCall` received tool calls, and approve/reject dispatch outcome (`approved` / `rejected` / `no pending confirmation` / `no session`). Approve/reject backend result preserved as `'ok'`.

## What's still needed from the backend (microsoft/vscode-internalbacklog#8374)

**Serialize/queue proactive narrations** so an overlapping confirmation/completion is never silently dropped when another narration is already playing. This is the one thing the client cannot fully fix:

- It closes the residual drops — in particular **response-vs-response preemption** (two completions landing while the backend is busy), which the client can't recover because the backend never emits that audio, so there is nothing to defer/replay. Fix 2 only covers confirmations and is one-shot.
- Once it lands, **Fix 2's racy re-assert can be deleted** (marked with a TODO pointing at the issue).

Not a blocker for this PR — the client fixes make narration reliable in practice; the backend fix makes it correct by construction and removes the stopgap.

## Testing

`npm run typecheck-client` passes; pre-commit hygiene passes. All fixes reproduced and verified against live trace logs in the Agents window (OSS); the multi-session confirmation + completion scenario now narrates reliably.

## Notes

Reverted two earlier speculative attempts during investigation (an `_isRenarration` prefix tweak and an `_unheardCompletions` feature) after logs proved those paths were never involved.
