### PR TITLE
Add setting to keep unavailable entries in recently opened list

### DIFF
--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -22,7 +22,7 @@ import { IProductService } from '../../product/common/productService.js';
 import { IStateService } from '../../state/node/state.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { IUpdateService, StateType } from '../../update/common/update.js';
-import { INativeRunActionInWindowRequest, INativeRunKeybindingInWindowRequest, IWindowOpenable, hasNativeMenu } from '../../window/common/window.js';
+import { INativeRunActionInWindowRequest, INativeRunKeybindingInWindowRequest, IWindowOpenable, IWindowSettings, hasNativeMenu } from '../../window/common/window.js';
 import { IWindowsCountChangedEvent, IWindowsMainService, OpenContext } from '../../windows/electron-main/windows.js';
 import { IWorkspacesHistoryMainService } from '../../workspaces/electron-main/workspacesHistoryMainService.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
@@ -575,7 +575,7 @@ export class Menubar extends Disposable {
 					remoteAuthority: item.remoteAuthority
 				})).length > 0;
 
-				if (!success) {
+				if (!success && this.configurationService.getValue<IWindowSettings | undefined>('window')?.removeRecentEntriesWhenUnavailable !== false) {
 					await this.workspacesHistoryMainService.removeRecentlyOpened([revivedUri]);
 				}
 			}

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -202,6 +202,7 @@ export interface IWindowSettings {
 	readonly openWithoutArgumentsInNewWindow: 'on' | 'off';
 	readonly restoreWindows: 'preserve' | 'all' | 'folders' | 'one' | 'none';
 	readonly restoreFullscreen: boolean;
+	readonly removeRecentEntriesWhenUnavailable: boolean;
 	readonly zoomLevel: number;
 	readonly titleBarStyle: TitlebarStyle;
 	readonly controlsStyle: WindowControlsStyle;

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1243,7 +1243,10 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			const fileUri = URI.file(path);
 
 			// since file does not seem to exist anymore, remove from recent
-			this.workspacesHistoryMainService.removeRecentlyOpened([fileUri]);
+			// unless configured to keep entries that are currently unavailable
+			if (this.configurationService.getValue<IWindowSettings | undefined>('window')?.removeRecentEntriesWhenUnavailable !== false) {
+				this.workspacesHistoryMainService.removeRecentlyOpened([fileUri]);
+			}
 
 			// assume this is a file that does not yet exist
 			if (options.ignoreFileNotFound && error.code === 'ENOENT') {

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -200,6 +200,12 @@ import product from '../../platform/product/common/product.js';
 				'scope': ConfigurationScope.APPLICATION,
 				'description': localize('restoreFullscreen', "Controls whether a window should restore to full screen mode if it was exited in full screen mode.")
 			},
+			'window.removeRecentEntriesWhenUnavailable': {
+				'type': 'boolean',
+				'default': true,
+				'scope': ConfigurationScope.APPLICATION,
+				'description': localize('removeRecentEntriesWhenUnavailable', "Controls whether entries are removed from the recently opened list when they cannot be opened, for example because the path no longer exists. Turn this off if paths may only be temporarily unavailable, such as folders on removable or mapped drives.")
+			},
 			'window.zoomLevel': {
 				'type': 'number',
 				'default': 0,


### PR DESCRIPTION
Fixes #164491

## Problem

VS Code silently removes entries from the "Recently Opened" list whenever their path cannot be accessed. For users whose folders live on drives that are only temporarily unavailable (e.g. `subst`-mapped drives that are not yet mapped at startup, removable media, network shares), this permanently loses history that would be perfectly valid a minute later.

## Change

Adds a new setting, `window.removeRecentEntriesWhenUnavailable` (boolean, default `true`, application scope). The default preserves existing behavior; setting it to `false` keeps unavailable entries in the list.

Two removal sites are gated behind the setting:

- `WindowsMainService.doResolveFilePath`: removed an entry whenever `fs.stat` on its path threw. This is the code path that fires at startup when restoring windows and when opening a recent entry, and it covers folders, workspace files, and files alike.
- `Menubar.createOpenRecentMenuItem`: removed an entry when opening it from File > Open Recent failed.

Explicit user removals (the "Remove from Recently Opened" buttons) and removal on actual file-delete operations in `HistoryService` are intentionally left untouched, since those are genuine deletions rather than temporary unavailability. The "Path does not exist" dialog still shows when opening an unavailable entry; the only change is that the entry survives to be opened later.

## Testing

- `tsc --noEmit` on `src/tsconfig.json` passes.
- Manually verified on Windows by building from source and reproducing the issue scenario with a `subst` drive (isolated `--user-data-dir`/`--shared-data-dir`, inspecting the persisted `history.recentlyOpenedPathsList` after each run):
  - default setting, drive unmapped, relaunch: entry removed (existing behavior preserved)
  - setting `false`, drive unmapped, relaunch: entry kept, and the folder opens normally once the drive is mapped again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEcyivcz7hSfwq7H4DPkBz