### PR TITLE
MCP: fix infinite sign-in loop for servers that grant scopes but advertise none

### DIFF
--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -1016,11 +1016,10 @@ export class TokenStore implements Disposable {
 				// log
 			}
 		}
-		const scopes = token.scope
-			? token.scope.split(' ')
-			: claims?.scope
-				? claims.scope.split(' ')
-				: [];
+		// An explicit empty `token.scope` is authoritative (createSession/refresh stamp the requested scopes onto the token); only fall back to the JWT claims when scope is genuinely absent.
+		const scopes = token.scope !== undefined
+			? (token.scope ? token.scope.split(' ') : [])
+			: (claims?.scope ? claims.scope.split(' ') : []);
 		return {
 			id: stringHash(token.access_token, 0).toString(),
 			accessToken: token.access_token,

--- a/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogger } from '../../../../platform/log/common/log.js';
+import { IAuthorizationToken, TokenStore } from '../../common/extHostAuthentication.js';
+
+suite('TokenStore', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	/** Builds a structurally-valid JWT (header.payload.signature) carrying the given claims. */
+	function jwt(claims: object): string {
+		const segment = (value: object) => encodeBase64(VSBuffer.fromString(JSON.stringify(value)));
+		return `${segment({ alg: 'none', typ: 'JWT' })}.${segment(claims)}.signature`;
+	}
+
+	function createStore(initialTokens: IAuthorizationToken[]): TokenStore {
+		const persistence = {
+			onDidChange: disposables.add(new Emitter<IAuthorizationToken[]>()).event,
+			set: () => { }
+		};
+		return disposables.add(new TokenStore(persistence, initialTokens, new NullLogger()));
+	}
+
+	// Regression for the MCP sign-in loop: an explicit empty `token.scope` must derive empty session scopes, not the granted scopes from the JWT claims, else empty-scope lookups never match their own session.
+	test('derives session scopes from the stored token.scope, falling back to JWT claims only when scope is absent', () => {
+		const store = createStore([
+			// Explicit empty scope must win over the scopes embedded in the JWT claims.
+			{ access_token: jwt({ sub: 'a', scope: 'menu:read orders:create orders:cancel' }), token_type: 'Bearer', scope: '', created_at: 0 },
+			// Absent scope (undefined) falls back to the JWT claims.
+			{ access_token: jwt({ sub: 'b', scope: 'menu:read orders:create' }), token_type: 'Bearer', created_at: 0 },
+			// A non-empty scope is authoritative over the JWT claims.
+			{ access_token: jwt({ sub: 'c', scope: 'ignored:claim' }), token_type: 'Bearer', scope: 'read write', created_at: 0 },
+		]);
+
+		assert.deepStrictEqual(
+			store.sessions.map(session => session.scopes),
+			[[], ['menu:read', 'orders:create'], ['read', 'write']]
+		);
+	});
+});


### PR DESCRIPTION
## Problem

Connecting to an MCP server that requires OAuth but **advertises no scopes while still granting some** (e.g. a Descope-backed server such as `https://descoop-mcp.onrender.com/mcp`) sends VS Code into an infinite sign-in loop: every sign-in succeeds, the server even connects, but the session can never be found again so VS Code immediately re-authenticates. Servers that advertise scopes — or don't embed scopes in the token JWT — are unaffected.

## Root cause

In `TokenStore._getSessionFromToken` (`extHostAuthentication.ts`), the session scopes were derived with a *truthiness* check:

```ts
const scopes = token.scope
    ? token.scope.split(' ')
    : claims?.scope
        ? claims.scope.split(' ')
        : [];
```

When a session is created for an **empty** scope request, `createSession` (and the refresh path) overwrite `token.scope` with the requested value — the empty string. Because `''` is falsy, the deriver ignored the stored value and fell back to the scopes embedded in the JWT claims (e.g. `menu:read orders:create orders:cancel`).

Result: the stored session's `scopes` were non-empty even though the request — and every subsequent `getSessions` lookup — used empty scopes. `getSessions` filters by exact scope-array equality, so the session was never matched → each request re-triggered a full sign-in → loop.

## Fix

Honor an explicitly-set (possibly empty) `token.scope`, and only fall back to the JWT claims when `scope` is genuinely absent (`undefined`):

```ts
const scopes = token.scope !== undefined
    ? (token.scope ? token.scope.split(' ') : [])
    : (claims?.scope ? claims.scope.split(' ') : []);
```

## Tests

Adds a `TokenStore` unit test that asserts scope derivation through the public `sessions` getter across all three cases (explicit empty, absent, non-empty scope). Verified it **fails** without the fix and **passes** with it.

## Validation

Reproduced the loop end-to-end against `https://descoop-mcp.onrender.com/mcp` in a dev build (trace logs showed repeated `Found 0 sessions` → re-auth). With the fix, `getSessions` returns the stored session, the server reaches **Running** and stays there, and tools are discovered — no re-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)