### PR TITLE
Don't let voice-controls init break the new-session picker render

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -680,11 +680,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 
 		// Voice controls (mic/stop/settings/disconnect). The hand-built toolbar
 		// can't use the shared `MenuId.ChatExecute`, so a dedicated menu is used.
-		// Instantiating the controller pulls in the whole voice stack; if any of
-		// that fails, degrade to a voice-less composer rather than aborting the
-		// render of the new-session view (which also builds the session-type
-		// picker further down in `render`). Otherwise a voice-init failure would
-		// leave the new-session view without its picker entirely.
+		// Keep the session picker usable when optional voice initialization fails.
 		const voiceContainer = dom.append(toolbar, dom.$('.sessions-chat-voice-toolbar'));
 		try {
 			this._register(this.instantiationService.createInstance(NewChatVoiceController, {

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -680,12 +680,21 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 
 		// Voice controls (mic/stop/settings/disconnect). The hand-built toolbar
 		// can't use the shared `MenuId.ChatExecute`, so a dedicated menu is used.
+		// Instantiating the controller pulls in the whole voice stack; if any of
+		// that fails, degrade to a voice-less composer rather than aborting the
+		// render of the new-session view (which also builds the session-type
+		// picker further down in `render`). Otherwise a voice-init failure would
+		// leave the new-session view without its picker entirely.
 		const voiceContainer = dom.append(toolbar, dom.$('.sessions-chat-voice-toolbar'));
-		this._register(this.instantiationService.createInstance(NewChatVoiceController, {
-			toolbarContainer: voiceContainer,
-			inputContainer: container,
-			composer: this,
-		}));
+		try {
+			this._register(this.instantiationService.createInstance(NewChatVoiceController, {
+				toolbarContainer: voiceContainer,
+				inputContainer: container,
+				composer: this,
+			}));
+		} catch (error) {
+			this.logService.error('Failed to create new-session voice controls:', error);
+		}
 
 		this._loadingSpinner = dom.append(toolbar, dom.$('.sessions-chat-loading-spinner'));
 		const loadingIcon = dom.append(this._loadingSpinner, renderIcon(ThemeIcon.modify(Codicon.loading, 'spin')));


### PR DESCRIPTION
Fixes microsoft/vscode-engineering#3257.

### Problem

The Agents Window smoke suite began timing out for **all 5 tests** at the very first step (`startNewSession` → `waitForNewSessionView`), waiting on `.sessions-chat-session-type-picker .action-label` that never appears.

### Root cause

`NewChatInputWidget.render()` builds the input toolbar (`_createInputToolbar`) **before** it renders the session-type picker — both in the same synchronous method:

```
render()
  ├─ _createInputToolbar()        // instantiates NewChatVoiceController
  └─ sessionTypePicker.render()   // the element the smoke test waits for
```

`_createInputToolbar` synchronously does `createInstance(NewChatVoiceController, …)`, which pulls in the entire voice stack (`IVoiceSessionController` and its many workbench dependencies, mic/TTS services, scoped menus, input decorations). If any of that throws, the exception aborts `render()` **before** the session-type picker is created, so the new-session view renders without its picker — exactly the observed smoke-test symptom.

This was introduced by #325138 (voice mode in the Agents/Sessions window), which added the voice-controller instantiation to the new-session composer's toolbar build.

### Fix

Guard the voice-controller instantiation in a `try/catch`. A voice-init failure now degrades to a voice-less composer and logs the error, instead of taking down the whole new-session view (and its picker) with it.

### Notes

- The related macOS issue microsoft/vscode-engineering#3007 fails *later* (at the assistant response), meaning the picker rendered there — so this is not an unconditional throw but something environment-specific in the Windows smoke run. The guard makes the new-session view resilient regardless of the underlying voice-init failure.
- Typecheck clean.
