### PR TITLE
Let focus settle before focusing the browser view

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/features/webContentsViewRendererFeature.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/webContentsViewRendererFeature.ts
@@ -169,7 +169,7 @@ class WebContentsViewRendererFeature extends BrowserEditorContribution {
 			} else {
 				this.editor.ensureBrowserFocus();
 			}
-		}, 0);
+		}, 10);
 		return true;
 	}
 


### PR DESCRIPTION
When clicking back to the workbench from the browser, at first the browser container is still the active element and so receives a focus event, triggering the browser focusing flow. This is behind a timeout that cancels if the browser does not remain focused after a small delay. Currently the delay is set to 0ms, which is enough in many circumstances but can be insufficient if there is unusual timing.

This PR sets that delay to 10ms to let focus settle more definitively, while still being fast enough to be perceived as instant.

Fixes https://github.com/microsoft/vscode/issues/324813