### PR TITLE
Rename agents.voice.textToSpeech to agents.voice.speakResponses

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -462,9 +462,9 @@ configurationRegistry.registerConfiguration({
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
 		},
-		'agents.voice.textToSpeech': {
+		'agents.voice.speakResponses': {
 			type: 'boolean',
-			description: nls.localize('agents.voice.textToSpeech', "When enabled, the assistant reads responses aloud. When disabled, responses appear as text transcripts only."),
+			markdownDescription: nls.localize('agents.voice.speakResponses', "When enabled, the assistant reads responses aloud. When disabled, responses are not spoken; enable `#agents.voice.showTranscript#` to read them as a text transcript instead."),
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
 		},
@@ -484,7 +484,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'agents.voice.showTranscript': {
 			type: 'boolean',
-			description: nls.localize('agents.voice.showTranscript', "Show the voice transcript overlay in the chat input area while voice mode is active."),
+			markdownDescription: nls.localize('agents.voice.showTranscript', "Show the voice transcript overlay in the chat input area while voice mode is active. Enable this to read responses as text when `#agents.voice.speakResponses#` is disabled."),
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 		},

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2703,8 +2703,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this.voicePlaybackService.notifyPlaybackStart(sessionResource, transcript);
 		}
 
-		const ttsEnabled = this.configurationService.getValue<boolean>('agents.voice.speakResponses') !== false;
-		if (ttsEnabled && audio) {
+		const speakResponsesEnabled = this.configurationService.getValue<boolean>('agents.voice.speakResponses') !== false;
+		if (speakResponsesEnabled && audio) {
 			// Claim the playback slot only when we actually have audio to play.
 			// A transcript-only frame (empty audio) must NOT claim it, or the
 			// slot would stay pinned to a session that never starts playback
@@ -2719,7 +2719,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// Hands-free: keep the mic open so the user can barge in.
 			this._startBargeInMonitor();
 			this.ttsPlaybackService.playAudioChunk(audio, isFinal, this._window!);
-		} else if (!ttsEnabled) {
+		} else if (!speakResponsesEnabled) {
 			this._replyPlayedSinceSend = true;
 			if (isFinal) {
 				this._currentPlaybackSessionId = null;

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2703,7 +2703,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this.voicePlaybackService.notifyPlaybackStart(sessionResource, transcript);
 		}
 
-		const ttsEnabled = this.configurationService.getValue<boolean>('agents.voice.textToSpeech') !== false;
+		const ttsEnabled = this.configurationService.getValue<boolean>('agents.voice.speakResponses') !== false;
 		if (ttsEnabled && audio) {
 			// Claim the playback slot only when we actually have audio to play.
 			// A transcript-only frame (empty audio) must NOT claim it, or the


### PR DESCRIPTION
## Summary

Renames the `agents.voice.textToSpeech` setting to **`agents.voice.speakResponses`** and clarifies its description.

### Why

- **Clearer name:** `textToSpeech` names the underlying mechanism; `speakResponses` reads as "speak the responses" and says what the setting actually does.
- **Corrected description:** the old text claimed that when disabled, "responses appear as text transcripts only." That's misleading — the transcript overlay is gated on `agents.voice.showTranscript` (default `false`), so disabling speaking alone leaves no visible output. The new description states that you must enable `agents.voice.showTranscript` to read responses as text when speaking is off.

### Changes

- Rename the setting id `agents.voice.textToSpeech` → `agents.voice.speakResponses`.
- Use `markdownDescription` on both `agents.voice.speakResponses` and `agents.voice.showTranscript` so the backticked setting ids render as clickable links, and cross-reference the two.
- Update the single consumer in `voiceSessionController.ts`.

No migration is included (voice mode is experimental and not yet released).

### Testing

`npm run typecheck-client` passes; pre-commit hygiene passes.
