### PR TITLE
chat: true mid-turn steering for cloud sessions

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -25,7 +25,7 @@ import { GenAiMetrics } from '../../../platform/otel/common/genAiMetrics';
 import { IOTelService } from '../../../platform/otel/common/otelService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
-import { DeferredPromise, retry, RunOnceScheduler, timeout } from '../../../util/vs/base/common/async';
+import { DeferredPromise, IntervalTimer, retry, RunOnceScheduler, timeout } from '../../../util/vs/base/common/async';
 import { Event } from '../../../util/vs/base/common/event';
 import { Disposable, DisposableStore, toDisposable } from '../../../util/vs/base/common/lifecycle';
 import { ResourceMap } from '../../../util/vs/base/common/map';
@@ -331,6 +331,11 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 	// Task ids with an in-flight "Create pull request" toolbar request, used to guard against
 	// re-entrant invocations (e.g. rapid double-clicks) that would otherwise submit duplicate PRs.
 	private readonly _createPullRequestInFlightTaskIds = new Set<string>();
+	// Task ids with a live {@link TaskTurnStreamer} (activeResponseCallback or follow-up).
+	// When a stream is already active for a task, a mid-turn steering follow-up only needs to
+	// POST /steer — the running stream renders the injected result, so we skip starting a
+	// second streamer.
+	private readonly _activeTaskStreams = new Set<string>();
 	// Task id whose content currently drives the chat-input pull-request toolbar gates
 	// ({@link CAN_CREATE_PULL_REQUEST_CONTEXT_KEY} / {@link CAN_OPEN_PULL_REQUEST_CONTEXT_KEY}). Used so
 	// the gates can be re-applied as the viewed task changes state (settles, gains a PR) without a
@@ -1623,10 +1628,12 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			if (backend.kind !== 'task') {
 				return;
 			}
+			this._activeTaskStreams.add(taskId);
 			try {
 				const streamer = new TaskTurnStreamer(backend, new ChatSessionContentBuilder(CopilotCloudSessionsProvider.TYPE, this._gitService, this.logService), this.logService);
 				await streamer.stream(stream, taskId, baseline, token);
 			} finally {
+				this._activeTaskStreams.delete(taskId);
 				this.refresh();
 				// The turn settled: re-apply the toolbar gates so "Create pull request" appears for a
 				// now-settled PR-less task (or flips to "Open pull request") without a session switch.
@@ -2658,10 +2665,22 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		}
 	}
 
-	private async handleTaskFollowUp(taskId: string, prompt: string, stream: vscode.ChatResponseStream, token: vscode.CancellationToken): Promise<{}> {
+	private async handleTaskFollowUp(taskId: string, prompt: string, stream: vscode.ChatResponseStream, token: vscode.CancellationToken, context: vscode.ChatContext): Promise<{}> {
 		const backend = this._backend;
 		if (backend.kind !== 'task') {
 			stream.warning(vscode.l10n.t('Task follow-up is not available on the current backend.'));
+			return {};
+		}
+
+		// True mid-turn steering: if a stream is already rendering this task (the session's
+		// activeResponseCallback is live), just POST the steer and return. The running stream
+		// renders the injected result, so we must NOT start a second streamer here.
+		if (this._activeTaskStreams.has(taskId)) {
+			stream.progress(vscode.l10n.t('Steering'));
+			const steerResult = await backend.sendFollowUpToTask(taskId, prompt);
+			if (!steerResult) {
+				stream.markdown(vscode.l10n.t('Failed to send follow-up to the task.'));
+			}
 			return {};
 		}
 
@@ -2681,6 +2700,11 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		}
 		const priorTurnCount = before.task.sessions?.length ?? 0;
 		const seedEventIds = new Set(priorEvents.map(e => e.id));
+		// If the latest turn is already active, this steer injects into the *current* turn (no new
+		// `task.sessions[]` row appears), so render `mode:'current'` — waiting for a new turn
+		// (`mode:'next'`) would time out. Only a steer onto a settled task starts a new turn.
+		const latestBefore = before.task.sessions?.[before.task.sessions.length - 1];
+		const isMidTurnSteer = !!latestBefore && isActiveTaskState(latestBefore.state);
 
 		stream.progress(vscode.l10n.t('Delegating'));
 		const result = await backend.sendFollowUpToTask(taskId, prompt);
@@ -2689,7 +2713,29 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			return {};
 		}
 
-		await this._createTaskStreamCallback(taskId, { mode: 'next', seedEventIds, priorTurnCount })(stream, token);
+		// Stream the follow-up turn, but stay yield-aware (mirrors the CLI provider): while the
+		// stream renders, VS Code sets `context.yieldRequested = true` when the user steers again.
+		// On yield we cancel our local streamer and return, so the chat service can flush the
+		// queued steering message immediately (which re-enters here and POSTs the next /steer)
+		// instead of waiting for this turn to settle. The remote turn keeps running server-side.
+		const yieldCts = new vscode.CancellationTokenSource();
+		const disposables = new DisposableStore();
+		disposables.add(toDisposable(() => yieldCts.dispose()));
+		disposables.add(token.onCancellationRequested(() => yieldCts.cancel()));
+		const interval = disposables.add(new IntervalTimer());
+		interval.cancelAndSet(() => {
+			if (context.yieldRequested) {
+				yieldCts.cancel();
+			}
+		}, 100);
+		try {
+			const baseline: StreamBaseline = isMidTurnSteer
+				? { mode: 'current', seedEventIds }
+				: { mode: 'next', seedEventIds, priorTurnCount };
+			await this._createTaskStreamCallback(taskId, baseline)(stream, yieldCts.token);
+		} finally {
+			disposables.dispose();
+		}
 		return {};
 	}
 
@@ -2709,7 +2755,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		const resource = context.chatSessionContext.chatSessionItem.resource;
 		const taskParsed = SessionIdForTask.parse(resource);
 		if (taskParsed) {
-			return this.handleTaskFollowUp(taskParsed.taskId, prompt, stream, token);
+			return this.handleTaskFollowUp(taskParsed.taskId, prompt, stream, token, context);
 		}
 
 		// PR-keyed URI on v2: reverse-resolve to the underlying task and steer it.
@@ -2719,7 +2765,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			if (!isNaN(prNum)) {
 				const taskId = await this.resolveTaskIdForPrNumber(prNum);
 				if (taskId) {
-					return this.handleTaskFollowUp(taskId, prompt, stream, token);
+					return this.handleTaskFollowUp(taskId, prompt, stream, token, context);
 				}
 			}
 		}

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -2672,9 +2672,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			return {};
 		}
 
-		// True mid-turn steering: if a stream is already rendering this task (the session's
-		// activeResponseCallback is live), just POST the steer and return. The running stream
-		// renders the injected result, so we must NOT start a second streamer here.
+		// Active stream present: only POST the steer; that stream renders the injection (no second streamer).
 		if (this._activeTaskStreams.has(taskId)) {
 			stream.progress(vscode.l10n.t('Steering'));
 			const steerResult = await backend.sendFollowUpToTask(taskId, prompt);
@@ -2700,11 +2698,11 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		}
 		const priorTurnCount = before.task.sessions?.length ?? 0;
 		const seedEventIds = new Set(priorEvents.map(e => e.id));
-		// If the latest turn is already active, this steer injects into the *current* turn (no new
-		// `task.sessions[]` row appears), so render `mode:'current'` — waiting for a new turn
-		// (`mode:'next'`) would time out. Only a steer onto a settled task starts a new turn.
+		// A steer into a genuinely active turn injects into the current turn (no new `task.sessions[]`
+		// row), so render `mode:'current'`; `mode:'next'` would time out. Require both the task and its
+		// latest turn to be active so a terminal task with a stale `in_progress` latest turn isn't misread.
 		const latestBefore = before.task.sessions?.[before.task.sessions.length - 1];
-		const isMidTurnSteer = !!latestBefore && isActiveTaskState(latestBefore.state);
+		const isMidTurnSteer = isActiveTaskState(before.task.state) && !!latestBefore && isActiveTaskState(latestBefore.state);
 
 		stream.progress(vscode.l10n.t('Delegating'));
 		const result = await backend.sendFollowUpToTask(taskId, prompt);
@@ -2713,11 +2711,8 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			return {};
 		}
 
-		// Stream the follow-up turn, but stay yield-aware (mirrors the CLI provider): while the
-		// stream renders, VS Code sets `context.yieldRequested = true` when the user steers again.
-		// On yield we cancel our local streamer and return, so the chat service can flush the
-		// queued steering message immediately (which re-enters here and POSTs the next /steer)
-		// instead of waiting for this turn to settle. The remote turn keeps running server-side.
+		// Stay yield-aware (mirrors the CLI provider): steering must cancel only this local streamer,
+		// so the chat service can flush the next steer while the remote turn keeps running server-side.
 		const yieldCts = new vscode.CancellationTokenSource();
 		const disposables = new DisposableStore();
 		disposables.add(toDisposable(() => yieldCts.dispose()));

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -941,6 +941,8 @@ export class ChatService extends Disposable implements IChatService {
 					this._pendingRequests.deleteAndDispose(model.sessionResource);
 					cancellationListener.clear();
 					lastRequest.response?.complete();
+					// Flush any message queued/steered during the streamed turn (no-op if none, or server-managed).
+					this.processPendingRequests(model.sessionResource);
 				}
 			}));
 		} else {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -922,10 +922,60 @@ export class ChatService extends Disposable implements IChatService {
 				}));
 			}
 
+			// True mid-turn steering for streamed (activeResponseCallback) sessions.
+			// While a streamed turn is in progress the session holds a *synthetic* pending
+			// request (created by trackNewCancellableRequest; it has no `requestId`), so a
+			// message the user sends mid-turn is queued as a Steering message. For
+			// non-server-managed sessions (agent-host queues are drained by the server)
+			// dispatch that steering message to the participant immediately instead of waiting
+			// for the turn to complete, so the provider can inject it into the live server-side
+			// turn (e.g. POST /tasks/{id}/steer). The active stream keeps rendering the result.
+			//
+			// We only dispatch when the in-flight pending request is the synthetic tracker
+			// (`requestId === undefined`) or there is none — never when a *real* request is in
+			// flight (that would dispose it); those steers flush normally on completion.
+			if (!this._isServerManagedQueue(model.sessionResource)) {
+				let dispatchingImmediateSteer = false;
+				const canImmediatelyDispatch = () => {
+					if (!model.getPendingRequests().some(r => r.kind === ChatRequestQueueKind.Steering)) {
+						return false;
+					}
+					const pending = this._pendingRequests.get(model.sessionResource);
+					return !pending || pending.requestId === undefined;
+				};
+				disposables.add(model.onDidChangePendingRequests(() => {
+					if (dispatchingImmediateSteer || !canImmediatelyDispatch()) {
+						return;
+					}
+					dispatchingImmediateSteer = true;
+					// Defer to a microtask: this event fires *during* addPendingRequest, so
+					// dispatching synchronously would re-enter the model mid-mutation.
+					queueMicrotask(() => {
+						dispatchingImmediateSteer = false;
+						if (this._sessionModels.get(model.sessionResource) !== model || !canImmediatelyDispatch()) {
+							return;
+						}
+						// Release the synthetic pending request (if any) so the queue processor
+						// can run, then dispatch. Re-tracking happens on the next progress tick.
+						if (this._pendingRequests.has(model.sessionResource)) {
+							this._pendingRequests.deleteAndDispose(model.sessionResource);
+						}
+						this.processNextPendingRequest(model);
+					});
+				}));
+			}
+
 			// Single autorun that streams progress for whichever request is current.
 			disposables.add(autorun(reader => {
 				const progressArray = providedSession.progressObs?.read(reader) ?? [];
 				const isComplete = providedSession.isCompleteObs?.read(reader) ?? false;
+
+				// Keep the streamed turn tracked as in-progress even if an immediate steer
+				// dispatch briefly cleared the pending request (so `requestInProgress` stays
+				// true and subsequent messages continue to route through steering).
+				if (!isComplete) {
+					ensureCancellationTracking();
+				}
 
 				// Process only new progress items
 				if (lastRequest && progressArray.length > lastProgressLength) {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -162,6 +162,8 @@ export class ChatService extends Disposable implements IChatService {
 	private readonly _sessionModels: ChatModelStore;
 	private readonly _pendingRequests = this._register(new DisposableResourceMap<CancellableRequest>());
 	private readonly _queuedRequestDeferreds = new Map<string, DeferredPromise<ChatSendResult>>();
+	/** Pending requests that are synthetic streamed-turn trackers (not real in-flight requests). */
+	private readonly _syntheticPendingRequests = new WeakSet<CancellableRequest>();
 
 	/**
 	 * In-flight untitled→real materializations, keyed by the original untitled
@@ -869,6 +871,7 @@ export class ChatService extends Disposable implements IChatService {
 
 			const trackNewCancellableRequest = () => {
 				const cancellableRequest = this.instantiationService.createInstance(CancellableRequest, new CancellationTokenSource(), undefined, undefined, undefined);
+				this._syntheticPendingRequests.add(cancellableRequest);
 				this._pendingRequests.set(model.sessionResource, cancellableRequest);
 				this.telemetryService.publicLog2<ChatPendingRequestChangeEvent, ChatPendingRequestChangeClassification>(ChatPendingRequestChangeEventName, { action: 'add', source: 'remoteSession', chatSessionId: chatSessionResourceToId(model.sessionResource) });
 				cancellationListener.value = createCancellationListener(cancellableRequest.cancellationTokenSource.token);
@@ -922,18 +925,10 @@ export class ChatService extends Disposable implements IChatService {
 				}));
 			}
 
-			// True mid-turn steering for streamed (activeResponseCallback) sessions.
-			// While a streamed turn is in progress the session holds a *synthetic* pending
-			// request (created by trackNewCancellableRequest; it has no `requestId`), so a
-			// message the user sends mid-turn is queued as a Steering message. For
-			// non-server-managed sessions (agent-host queues are drained by the server)
-			// dispatch that steering message to the participant immediately instead of waiting
-			// for the turn to complete, so the provider can inject it into the live server-side
-			// turn (e.g. POST /tasks/{id}/steer). The active stream keeps rendering the result.
-			//
-			// We only dispatch when the in-flight pending request is the synthetic tracker
-			// (`requestId === undefined`) or there is none — never when a *real* request is in
-			// flight (that would dispose it); those steers flush normally on completion.
+			// Mid-turn steering for streamed sessions: dispatch a queued Steering message immediately
+			// (the provider POSTs it server-side) rather than waiting for the turn to complete, but only
+			// when the in-flight request is the synthetic streamed-turn tracker (or none), never a real
+			// request. Server-managed (agent-host) queues are drained by the server, so they're excluded.
 			if (!this._isServerManagedQueue(model.sessionResource)) {
 				let dispatchingImmediateSteer = false;
 				const canImmediatelyDispatch = () => {
@@ -941,26 +936,30 @@ export class ChatService extends Disposable implements IChatService {
 						return false;
 					}
 					const pending = this._pendingRequests.get(model.sessionResource);
-					return !pending || pending.requestId === undefined;
+					return !pending || this._syntheticPendingRequests.has(pending);
 				};
 				disposables.add(model.onDidChangePendingRequests(() => {
 					if (dispatchingImmediateSteer || !canImmediatelyDispatch()) {
 						return;
 					}
 					dispatchingImmediateSteer = true;
-					// Defer to a microtask: this event fires *during* addPendingRequest, so
-					// dispatching synchronously would re-enter the model mid-mutation.
+					// Defer past the in-progress addPendingRequest mutation to avoid re-entrancy.
 					queueMicrotask(() => {
 						dispatchingImmediateSteer = false;
 						if (this._sessionModels.get(model.sessionResource) !== model || !canImmediatelyDispatch()) {
 							return;
 						}
-						// Release the synthetic pending request (if any) so the queue processor
-						// can run, then dispatch. Re-tracking happens on the next progress tick.
+						// Release the synthetic tracker so the queue processor can run, then dispatch.
 						if (this._pendingRequests.has(model.sessionResource)) {
 							this._pendingRequests.deleteAndDispose(model.sessionResource);
 						}
 						this.processNextPendingRequest(model);
+						// Restore tracking when the dispatched request settles (stream still active).
+						this._pendingRequests.get(model.sessionResource)?.responseCompletePromise?.finally(() => {
+							if (this._sessionModels.get(model.sessionResource) === model && !(providedSession.isCompleteObs?.get() ?? false)) {
+								ensureCancellationTracking();
+							}
+						});
 					});
 				}));
 			}
@@ -970,9 +969,7 @@ export class ChatService extends Disposable implements IChatService {
 				const progressArray = providedSession.progressObs?.read(reader) ?? [];
 				const isComplete = providedSession.isCompleteObs?.read(reader) ?? false;
 
-				// Keep the streamed turn tracked as in-progress even if an immediate steer
-				// dispatch briefly cleared the pending request (so `requestInProgress` stays
-				// true and subsequent messages continue to route through steering).
+				// Backstop: keep the streamed turn tracked as in-progress across immediate-steer dispatches.
 				if (!isComplete) {
 					ensureCancellationTracking();
 				}

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -752,8 +752,10 @@ suite('ChatService', () => {
 		assert.ok(invokedRequests[1].includes('\n\n'), 'Combined message should use \\n\\n as separator');
 	});
 
-	test('queued steering message is flushed when a streamed (activeResponseCallback) turn completes (fix for cloud-session steering limbo)', async () => {
-		// A streamed session queues a mid-turn message as steering; completing the turn must flush it.
+	test('steering message on a streamed (activeResponseCallback) session dispatches immediately, mid-turn', async () => {
+		// True mid-turn steering: a steering message sent while a streamed turn is in progress is
+		// dispatched to the participant immediately (which POSTs the steer server-side), instead of
+		// waiting for the turn to complete.
 		const sessionType = 'remote-streamed-steer';
 		const sessionResource = URI.from({ scheme: sessionType, path: '/streamed-session' });
 
@@ -794,13 +796,74 @@ suite('ChatService', () => {
 		const steering = await testService.sendRequest(sessionResource, 'steering message', { agentId: sessionType, queue: ChatRequestQueueKind.Steering });
 		assert.ok(ChatSendResult.isQueued(steering));
 
+		// Dispatched immediately, without the streamed turn completing (isCompleteObs stays false).
+		await steeringInvoked.p;
+		await steering.deferred;
+		await timeout(0); // let the post-dispatch tracking restore run
+
+		assert.strictEqual(invokedMessages.filter(m => m.includes('steering message')).length, 1, 'steering message should be dispatched exactly once, immediately');
 		const model = testService.getSession(sessionResource) as ChatModel;
-		assert.strictEqual(model.getPendingRequests().length, 1, 'steering message should be queued while the streamed turn is in progress');
+		assert.strictEqual(model.getPendingRequests().length, 0, 'steering message should be dispatched, not left queued');
+
+		// In-progress tracking is preserved for the still-active stream: a plain send is rejected.
+		const plain = await testService.sendRequest(sessionResource, 'plain message', { agentId: sessionType });
+		assert.strictEqual(plain.kind, 'rejected');
+
+		// Completing the streamed turn must not re-dispatch the already-sent steering message.
+		isCompleteObs.set(true, undefined);
+		await timeout(0);
+		assert.strictEqual(invokedMessages.filter(m => m.includes('steering message')).length, 1, 'steering message must not be dispatched again on completion');
+	});
+
+	test('queued (non-steering) message is flushed when a streamed (activeResponseCallback) turn completes (fix for cloud-session queue limbo)', async () => {
+		// A non-steering queued message is not dispatched mid-turn; it must be flushed when the
+		// streamed turn completes (previously it was stranded in the pending queue forever).
+		const sessionType = 'remote-streamed-queue';
+		const sessionResource = URI.from({ scheme: sessionType, path: '/streamed-session' });
+
+		const isCompleteObs: ISettableObservable<boolean> = observableValue('isComplete', false);
+
+		const mockSessionsService = new MockChatSessionsService();
+		testDisposables.add(mockSessionsService.registerChatSessionContentProvider(sessionType, {
+			provideChatSessionContent: (resource: URI): Promise<IChatSession> => Promise.resolve({
+				sessionResource: resource,
+				history: [{ type: 'request', prompt: 'initial task', participant: sessionType }],
+				progressObs: constObservable<IChatProgress[]>([]),
+				isCompleteObs,
+				interruptActiveResponseCallback: async () => false,
+				onWillDispose: Event.None,
+				dispose: () => { },
+			}),
+		}));
+		instantiationService.stub(IChatSessionsService, mockSessionsService);
+
+		const invokedMessages: string[] = [];
+		const invoked = new DeferredPromise<void>();
+		const agent: IChatAgentImplementation = {
+			async invoke(request) {
+				invokedMessages.push(request.message);
+				invoked.complete();
+				return {};
+			},
+		};
+		testDisposables.add(chatAgentService.registerAgent(sessionType, { ...getAgentData(sessionType), isDefault: true }));
+		testDisposables.add(chatAgentService.registerAgentImplementation(sessionType, agent));
+
+		const testService = createChatService();
+		const ref = await testService.acquireOrLoadSession(sessionResource, ChatAgentLocation.Chat, CancellationToken.None);
+		assert.ok(ref);
+		testDisposables.add(ref);
+
+		const queued = await testService.sendRequest(sessionResource, 'queued message', { agentId: sessionType, queue: ChatRequestQueueKind.Queued });
+		assert.ok(ChatSendResult.isQueued(queued));
+
+		const model = testService.getSession(sessionResource) as ChatModel;
+		assert.strictEqual(model.getPendingRequests().length, 1, 'queued message should wait while the streamed turn is in progress');
 
 		isCompleteObs.set(true, undefined);
-		await steeringInvoked.p;
+		await invoked.p;
 
-		assert.ok(invokedMessages.some(m => m.includes('steering message')), 'queued steering message should be sent once the streamed turn completes');
+		assert.ok(invokedMessages.some(m => m.includes('queued message')), 'queued message should be sent once the streamed turn completes');
 		assert.strictEqual(model.getPendingRequests().length, 0, 'no pending requests should remain after the flush');
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -752,6 +752,58 @@ suite('ChatService', () => {
 		assert.ok(invokedRequests[1].includes('\n\n'), 'Combined message should use \\n\\n as separator');
 	});
 
+	test('queued steering message is flushed when a streamed (activeResponseCallback) turn completes (fix for cloud-session steering limbo)', async () => {
+		// A streamed session queues a mid-turn message as steering; completing the turn must flush it.
+		const sessionType = 'remote-streamed-steer';
+		const sessionResource = URI.from({ scheme: sessionType, path: '/streamed-session' });
+
+		const isCompleteObs: ISettableObservable<boolean> = observableValue('isComplete', false);
+
+		const mockSessionsService = new MockChatSessionsService();
+		testDisposables.add(mockSessionsService.registerChatSessionContentProvider(sessionType, {
+			provideChatSessionContent: (resource: URI): Promise<IChatSession> => Promise.resolve({
+				sessionResource: resource,
+				// History ends with a request, so the session has an in-progress (cancellable) turn.
+				history: [{ type: 'request', prompt: 'initial task', participant: sessionType }],
+				progressObs: constObservable<IChatProgress[]>([]),
+				isCompleteObs,
+				interruptActiveResponseCallback: async () => false,
+				onWillDispose: Event.None,
+				dispose: () => { },
+			}),
+		}));
+		instantiationService.stub(IChatSessionsService, mockSessionsService);
+
+		const invokedMessages: string[] = [];
+		const steeringInvoked = new DeferredPromise<void>();
+		const agent: IChatAgentImplementation = {
+			async invoke(request) {
+				invokedMessages.push(request.message);
+				steeringInvoked.complete();
+				return {};
+			},
+		};
+		testDisposables.add(chatAgentService.registerAgent(sessionType, { ...getAgentData(sessionType), isDefault: true }));
+		testDisposables.add(chatAgentService.registerAgentImplementation(sessionType, agent));
+
+		const testService = createChatService();
+		const ref = await testService.acquireOrLoadSession(sessionResource, ChatAgentLocation.Chat, CancellationToken.None);
+		assert.ok(ref);
+		testDisposables.add(ref);
+
+		const steering = await testService.sendRequest(sessionResource, 'steering message', { agentId: sessionType, queue: ChatRequestQueueKind.Steering });
+		assert.ok(ChatSendResult.isQueued(steering));
+
+		const model = testService.getSession(sessionResource) as ChatModel;
+		assert.strictEqual(model.getPendingRequests().length, 1, 'steering message should be queued while the streamed turn is in progress');
+
+		isCompleteObs.set(true, undefined);
+		await steeringInvoked.p;
+
+		assert.ok(invokedMessages.some(m => m.includes('steering message')), 'queued steering message should be sent once the streamed turn completes');
+		assert.strictEqual(model.getPendingRequests().length, 0, 'no pending requests should remain after the flush');
+	});
+
 	test('disabled Claude hooks hint is shown once per workspace (fix for #295079)', async () => {
 		// Set up a prompts service that reports disabled Claude hooks
 		const mockPromptsService = new class extends MockPromptsService {


### PR DESCRIPTION
## Problem

When steering a Copilot **cloud** chat session mid-turn, the message was stranded: it showed a "STEERING" pending bubble that only sent **after** the turn finished (queue behavior), rather than injecting into the running turn the way github.com/copilot/agents does.

## Scope

This PR now delivers **true mid-turn steering** for cloud sessions, in three layers:

1. **Queue-flush fix** — a message queued during a streamed (`activeResponseCallback`) turn is flushed when the turn completes (was previously stranded forever).
2. **Immediate mid-turn dispatch (core)** — a Steering message is dispatched to the participant immediately instead of waiting for completion, so the provider can POST the steer server-side while the turn runs.
3. **Provider injection + continuous rendering** — the cloud provider POSTs `/tasks/{id}/steer` and the running stream renders the injected result, matching github.com/copilot/agents.

## Core (`chatServiceImpl`)

For non-server-managed streamed sessions:
- Dispatch a queued `Steering` message immediately, but **only** when the in-flight pending request is the synthetic streamed-turn tracker (identified via an explicit `WeakSet`, since real requests are inserted into `_pendingRequests` before their `requestId` is assigned) — never a real in-flight request.
- Restore in-progress tracking deterministically when the dispatched request settles (via `responseCompletePromise`), so `requestInProgress` stays true for the still-active stream.
- Non-steering `Queued` messages are unaffected and still flush on completion.

## Extension (`copilotCloudSessionsProvider`)

- Track live `TaskTurnStreamer` task ids; when a stream is already active, `handleTaskFollowUp` only POSTs the steer (no second streamer).
- The follow-up stream is **yield-aware** (mirrors the Copilot CLI provider): it polls `context.yieldRequested` and cancels only its local streamer on yield, so the chat service flushes the next steer immediately.
- Render mode is chosen from the pre-steer state: a steer into a genuinely active turn (both task **and** latest turn active) renders `mode:'current'` (the injection produces no new `task.sessions[]` row, so `mode:'next'` would time out); a steer onto a settled task renders `mode:'next'`.

## Testing

Unit tests in `chatService.test.ts`:
- **Immediate dispatch** — a steering message on a streamed session is dispatched exactly once, mid-turn (stream not complete), preserves in-progress tracking (a plain send is rejected), and is not re-dispatched on completion.
- **Completion flush** — a non-steering `Queued` message waits during the turn and is flushed when it completes.

Verified end-to-end against a live cloud task: the steer POSTs within ~100ms and the injected message + continued output render inline. `typecheck-client` and the copilot extension typecheck are clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
