### PR TITLE
[WIP] Respect tab active border color customizations

### DIFF
--- a/src/vs/code/electron-browser/workbench/workbench.ts
+++ b/src/vs/code/electron-browser/workbench/workbench.ts
@@ -91,6 +91,13 @@
 		if (data?.layoutInfo) {
 			const { layoutInfo, colorInfo } = data;
 			const modernUI = layoutInfo.modernUI === true;
+			const inactiveTitleBar = !window.document.hasFocus();
+			const titleBarColorCustomizations = colorInfo.titleBarColorCustomizations;
+			const titleBarBackgroundCustomized = titleBarColorCustomizations
+				? inactiveTitleBar ? titleBarColorCustomizations.inactiveBackground : titleBarColorCustomizations.activeBackground
+				: colorInfo.titleBarColorsCustomized === true;
+			const titleBarBorderCustomized = titleBarColorCustomizations?.border ?? colorInfo.titleBarColorsCustomized === true;
+			const titleBarBackground = inactiveTitleBar ? colorInfo.titleBarInactiveBackground ?? colorInfo.titleBarBackground : colorInfo.titleBarBackground;
 			const floatingMargin = 4;
 			const floatingOuterMargin = floatingMargin * 2;
 			const floatingBorderWidth = 1;
@@ -174,11 +181,11 @@
 				titleDiv.style.height = `${layoutInfo.titleBarHeight}px`;
 				titleDiv.style.left = '0';
 				titleDiv.style.top = '0';
-				titleDiv.style.backgroundColor = modernUI ? 'transparent' : `${colorInfo.titleBarBackground}`;
+				titleDiv.style.backgroundColor = modernUI && !titleBarBackgroundCustomized ? 'transparent' : `${titleBarBackground}`;
 				(titleDiv.style as CSSStyleDeclaration & { '-webkit-app-region': string })['-webkit-app-region'] = 'drag';
 				splash.appendChild(titleDiv);
 
-				if (!modernUI && colorInfo.titleBarBorder) {
+				if ((!modernUI || titleBarBorderCustomized) && colorInfo.titleBarBorder) {
 					const titleBorder = document.createElement('div');
 					titleBorder.style.position = 'absolute';
 					titleBorder.style.width = '100%';

--- a/src/vs/editor/standalone/browser/standaloneThemeService.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeService.ts
@@ -118,6 +118,10 @@ class StandaloneTheme implements IStandaloneTheme {
 		return this.getColors().has(colorId);
 	}
 
+	public isColorCustomized(colorId: ColorIdentifier): boolean {
+		return false;
+	}
+
 	public get type(): ColorScheme {
 		switch (this.base) {
 			case VS_LIGHT_THEME_NAME: return ColorScheme.LIGHT;

--- a/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
+++ b/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
@@ -68,6 +68,8 @@ suite('TokenizationSupport2Adapter', () => {
 					throw new Error('Not implemented');
 				},
 
+				isColorCustomized: () => false,
+
 				getTokenStyleMetadata: (type: string, modifiers: string[], modelLanguage: string): ITokenStyle | undefined => {
 					return undefined;
 				},

--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -240,6 +240,8 @@ export interface IPartsSplash {
 		editorBackground: string | undefined;
 		titleBarBackground: string | undefined;
 		titleBarInactiveBackground: string | undefined;
+		titleBarForeground: string | undefined;
+		titleBarInactiveForeground: string | undefined;
 		titleBarBorder: string | undefined;
 		titleBarColorCustomizations?: ITitleBarColorCustomizations;
 		titleBarColorsCustomized?: boolean;

--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -61,6 +61,11 @@ export interface IColorTheme {
 	defines(color: ColorIdentifier): boolean;
 
 	/**
+	 * Returns whether the color has an explicit color customization.
+	 */
+	isColorCustomized(color: ColorIdentifier): boolean;
+
+	/**
 	 * Returns the token style for a given classification. The result uses the <code>MetadataConsts</code> format
 	 */
 	getTokenStyleMetadata(type: string, modifiers: string[], modelLanguage: string): ITokenStyle | undefined;
@@ -79,6 +84,14 @@ export interface IColorTheme {
 	 * Defines whether semantic highlighting should be enabled for the theme.
 	 */
 	readonly semanticHighlighting: boolean;
+}
+
+export interface ITitleBarColorCustomizations {
+	readonly activeForeground: boolean;
+	readonly inactiveForeground: boolean;
+	readonly activeBackground: boolean;
+	readonly inactiveBackground: boolean;
+	readonly border: boolean;
 }
 
 export class IFontTokenOptions {
@@ -226,7 +239,10 @@ export interface IPartsSplash {
 		foreground: string | undefined;
 		editorBackground: string | undefined;
 		titleBarBackground: string | undefined;
+		titleBarInactiveBackground: string | undefined;
 		titleBarBorder: string | undefined;
+		titleBarColorCustomizations?: ITitleBarColorCustomizations;
+		titleBarColorsCustomized?: boolean;
 		activityBarBackground: string | undefined;
 		activityBarBorder: string | undefined;
 		sideBarBackground: string | undefined;

--- a/src/vs/platform/theme/test/common/testThemeService.ts
+++ b/src/vs/platform/theme/test/common/testThemeService.ts
@@ -31,6 +31,10 @@ export class TestColorTheme implements IColorTheme {
 		throw new Error('Method not implemented.');
 	}
 
+	isColorCustomized(color: string): boolean {
+		return false;
+	}
+
 	getTokenStyleMetadata(type: string, modifiers: string[], modelLanguage: string): ITokenStyle | undefined {
 		return undefined;
 	}

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -33,7 +33,7 @@ import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { ThemeIcon } from '../../../base/common/themables.js';
 import { IThemeMainService } from '../../theme/electron-main/themeMainService.js';
 import { getMenuBarVisibility, IFolderToOpen, INativeWindowConfiguration, IWindowSettings, IWorkspaceToOpen, MenuBarVisibility, hasNativeTitlebar, useNativeFullScreen, useWindowControlsOverlay, DEFAULT_CUSTOM_TITLEBAR_HEIGHT, TitlebarStyle, MenuSettings } from '../../window/common/window.js';
-import { defaultBrowserWindowOptions, getAllWindowsExcludingOffscreen, IWindowsMainService, OpenContext, WindowStateValidator } from './windows.js';
+import { defaultBrowserWindowOptions, dimWindowControlsColor, getAllWindowsExcludingOffscreen, IWindowsMainService, OpenContext, WindowStateValidator } from './windows.js';
 import { ISingleFolderWorkspaceIdentifier, IWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier, toWorkspaceIdentifier } from '../../workspace/common/workspace.js';
 import { IWorkspacesManagementMainService } from '../../workspaces/electron-main/workspacesManagementMainService.js';
 import { IWindowState, ICodeWindow, ILoadEvent, WindowMode, WindowError, LoadReason, defaultWindowState, IBaseWindow } from '../../window/electron-main/window.js';
@@ -46,7 +46,6 @@ import { IInstantiationService } from '../../instantiation/common/instantiation.
 import { VSBuffer } from '../../../base/common/buffer.js';
 import { errorHandler } from '../../../base/common/errors.js';
 import { FocusMode } from '../../native/common/native.js';
-import { Color } from '../../../base/common/color.js';
 
 export interface IWindowCreationOptions {
 	readonly state: IWindowState;
@@ -435,8 +434,8 @@ export abstract class BaseWindow extends Disposable implements IBaseWindow {
 				this.lastWindowControlColors = { backgroundColor, foregroundColor };
 			}
 
-			const effectiveBackgroundColor = this.windowControlsDimmed && backgroundColor ? this.dimColor(backgroundColor) : backgroundColor;
-			const effectiveForegroundColor = this.windowControlsDimmed && foregroundColor ? this.dimColor(foregroundColor) : foregroundColor;
+			const effectiveBackgroundColor = this.windowControlsDimmed && backgroundColor ? dimWindowControlsColor(backgroundColor) : backgroundColor;
+			const effectiveForegroundColor = this.windowControlsDimmed && foregroundColor ? dimWindowControlsColor(foregroundColor) : foregroundColor;
 
 			win.setTitleBarOverlay({
 				color: effectiveBackgroundColor?.trim() === '' ? undefined : effectiveBackgroundColor,
@@ -458,24 +457,6 @@ export abstract class BaseWindow extends Disposable implements IBaseWindow {
 				win.setWindowButtonPosition({ x: offset + 1, y: offset });
 			}
 		}
-	}
-
-	private dimColor(color: string): string {
-
-		// Blend a CSS color with black at 50% opacity to match the
-		// dimming overlay of `rgba(0, 0, 0, 0.5)` used by modals.
-
-		const parsed = Color.Format.CSS.parse(color);
-		if (!parsed) {
-			return color;
-		}
-
-		const dimFactor = 0.5; // 1 - 0.5 opacity of black overlay
-		const r = Math.round(parsed.rgba.r * dimFactor);
-		const g = Math.round(parsed.rgba.g * dimFactor);
-		const b = Math.round(parsed.rgba.b * dimFactor);
-
-		return `rgb(${r}, ${g}, ${b})`;
 	}
 
 	//#endregion

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import electron, { Display, Rectangle } from 'electron';
-import { Color } from '../../../base/common/color.js';
+import { Color, RGBA } from '../../../base/common/color.js';
 import { Event } from '../../../base/common/event.js';
 import { join } from '../../../base/common/path.js';
 import { IProcessEnvironment, isLinux, isMacintosh, isWindows } from '../../../base/common/platform.js';
@@ -16,6 +16,7 @@ import { IEnvironmentMainService } from '../../environment/electron-main/environ
 import { ServicesAccessor, createDecorator } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
+import { IPartsSplash } from '../../theme/common/themeService.js';
 import { IThemeMainService } from '../../theme/electron-main/themeMainService.js';
 import { IOpenEmptyWindowOptions, IWindowOpenable, IWindowSettings, TitlebarStyle, WindowMinimumSize, hasNativeTitlebar, useNativeFullScreen, useWindowControlsOverlay, zoomLevelToZoomFactor } from '../../window/common/window.js';
 import { ICodeWindow, IWindowState, WindowMode, defaultWindowState } from '../../window/electron-main/window.js';
@@ -131,6 +132,50 @@ export interface IDefaultBrowserWindowOptionsOverrides {
 	backgroundColor?: string;
 }
 
+function parseCssColor(color: string | undefined): Color | undefined {
+	if (!color) {
+		return undefined;
+	}
+
+	try {
+		return Color.Format.CSS.parse(color) ?? undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function dimWindowControlsColor(color: string): string {
+	const parsed = parseCssColor(color);
+	if (!parsed) {
+		return color;
+	}
+
+	const dimFactor = 0.5;
+	return Color.Format.CSS.formatRGB(new Color(new RGBA(
+		Math.round(parsed.rgba.r * dimFactor),
+		Math.round(parsed.rgba.g * dimFactor),
+		Math.round(parsed.rgba.b * dimFactor),
+		parsed.rgba.a
+	)));
+}
+
+function getWindowControlsSymbolColor(backgroundColor: string, fallbackBackgroundColor: string): string {
+	return (parseCssColor(backgroundColor) ?? parseCssColor(fallbackBackgroundColor))?.isDarker() ? '#FFFFFF' : '#000000';
+}
+
+export function getWindowControlsOverlayColors(colorInfo: Pick<IPartsSplash['colorInfo'], 'editorBackground' | 'titleBarBackground' | 'titleBarForeground' | 'titleBarColorCustomizations' | 'titleBarColorsCustomized'> | undefined, modernUI: boolean, fallbackBackgroundColor: string): { color: string; symbolColor: string } {
+	const titleBarColor = modernUI && !(colorInfo?.titleBarColorCustomizations?.activeBackground ?? colorInfo?.titleBarColorsCustomized === true)
+		? 'transparent'
+		: colorInfo?.titleBarBackground ?? fallbackBackgroundColor;
+	const titleBarSymbolBackground = parseCssColor(titleBarColor)?.rgba.a === 0 ? colorInfo?.editorBackground ?? fallbackBackgroundColor : titleBarColor;
+	const titleBarForeground = colorInfo?.titleBarColorCustomizations?.activeForeground ? colorInfo.titleBarForeground : undefined;
+
+	return {
+		color: titleBarColor,
+		symbolColor: titleBarForeground || getWindowControlsSymbolColor(titleBarSymbolBackground, fallbackBackgroundColor)
+	};
+}
+
 export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowState: IWindowState, overrides?: IDefaultBrowserWindowOptionsOverrides, webPreferences?: electron.WebPreferences): electron.BrowserWindowConstructorOptions & { experimentalDarkMode: boolean } {
 	const themeMainService = accessor.get(IThemeMainService);
 	const productService = accessor.get(IProductService);
@@ -221,16 +266,11 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 
 				const splash = themeMainService.getWindowSplash(undefined);
 				const colorInfo = splash?.colorInfo;
-				const titleBarColor = splash?.layoutInfo?.modernUI === true && !(colorInfo?.titleBarColorCustomizations?.activeBackground ?? colorInfo?.titleBarColorsCustomized === true)
-					? 'transparent'
-					: colorInfo?.titleBarBackground ?? themeMainService.getBackgroundColor();
-				const titleBarSymbolBackground = titleBarColor === 'transparent' ? colorInfo?.editorBackground ?? themeMainService.getBackgroundColor() : titleBarColor;
-				const symbolColor = Color.fromHex(titleBarSymbolBackground).isDarker() ? '#FFFFFF' : '#000000';
+				const titleBarOverlayColors = getWindowControlsOverlayColors(colorInfo, splash?.layoutInfo?.modernUI === true, themeMainService.getBackgroundColor());
 
 				options.titleBarOverlay = {
 					height: 29, // the smallest size of the title bar on windows accounting for the border on windows 11
-					color: titleBarColor,
-					symbolColor
+					...titleBarOverlayColors
 				};
 			}
 		}

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -159,20 +159,24 @@ export function dimWindowControlsColor(color: string): string {
 	)));
 }
 
-function getWindowControlsSymbolColor(backgroundColor: string, fallbackBackgroundColor: string): string {
-	return (parseCssColor(backgroundColor) ?? parseCssColor(fallbackBackgroundColor))?.isDarker() ? '#FFFFFF' : '#000000';
+function getWindowControlsSymbolColor(backgroundColor: string, backdropColor: string): string {
+	const background = parseCssColor(backgroundColor);
+	const backdrop = parseCssColor(backdropColor);
+	const effectiveBackground = background && backdrop ? background.makeOpaque(backdrop) : background ?? backdrop;
+
+	return effectiveBackground?.isDarker() ? '#FFFFFF' : '#000000';
 }
 
 export function getWindowControlsOverlayColors(colorInfo: Pick<IPartsSplash['colorInfo'], 'editorBackground' | 'titleBarBackground' | 'titleBarForeground' | 'titleBarColorCustomizations' | 'titleBarColorsCustomized'> | undefined, modernUI: boolean, fallbackBackgroundColor: string): { color: string; symbolColor: string } {
 	const titleBarColor = modernUI && !(colorInfo?.titleBarColorCustomizations?.activeBackground ?? colorInfo?.titleBarColorsCustomized === true)
 		? 'transparent'
 		: colorInfo?.titleBarBackground ?? fallbackBackgroundColor;
-	const titleBarSymbolBackground = parseCssColor(titleBarColor)?.rgba.a === 0 ? colorInfo?.editorBackground ?? fallbackBackgroundColor : titleBarColor;
+	const titleBarBackdrop = colorInfo?.editorBackground ?? fallbackBackgroundColor;
 	const titleBarForeground = colorInfo?.titleBarColorCustomizations?.activeForeground ? colorInfo.titleBarForeground : undefined;
 
 	return {
 		color: titleBarColor,
-		symbolColor: titleBarForeground || getWindowControlsSymbolColor(titleBarSymbolBackground, fallbackBackgroundColor)
+		symbolColor: titleBarForeground || getWindowControlsSymbolColor(titleBarColor, titleBarBackdrop)
 	};
 }
 

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -219,12 +219,13 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 				options.titleBarOverlay = true;
 			} else {
 
-				// This logic will not perfectly guess the right colors
-				// to use on initialization, but prefer to keep things
-				// simple as it is temporary and not noticeable
-
-				const titleBarColor = themeMainService.getWindowSplash(undefined)?.colorInfo.titleBarBackground ?? themeMainService.getBackgroundColor();
-				const symbolColor = Color.fromHex(titleBarColor).isDarker() ? '#FFFFFF' : '#000000';
+				const splash = themeMainService.getWindowSplash(undefined);
+				const colorInfo = splash?.colorInfo;
+				const titleBarColor = splash?.layoutInfo?.modernUI === true && !(colorInfo?.titleBarColorCustomizations?.activeBackground ?? colorInfo?.titleBarColorsCustomized === true)
+					? 'transparent'
+					: colorInfo?.titleBarBackground ?? themeMainService.getBackgroundColor();
+				const titleBarSymbolBackground = titleBarColor === 'transparent' ? colorInfo?.editorBackground ?? themeMainService.getBackgroundColor() : titleBarColor;
+				const symbolColor = Color.fromHex(titleBarSymbolBackground).isDarker() ? '#FFFFFF' : '#000000';
 
 				options.titleBarOverlay = {
 					height: 29, // the smallest size of the title bar on windows accounting for the border on windows 11

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -159,24 +159,29 @@ export function dimWindowControlsColor(color: string): string {
 	)));
 }
 
-function getWindowControlsSymbolColor(backgroundColor: string, backdropColor: string): string {
+type IWindowControlsOverlayColorInfo = Pick<IPartsSplash['colorInfo'], 'editorBackground' | 'titleBarBackground' | 'titleBarForeground' | 'titleBarColorCustomizations' | 'titleBarColorsCustomized'> & Partial<Pick<IPartsSplash['colorInfo'], 'background'>>;
+
+function getWindowControlsSymbolColor(backgroundColor: string, editorBackgroundColor: string, windowBackgroundColor: string): string {
 	const background = parseCssColor(backgroundColor);
-	const backdrop = parseCssColor(backdropColor);
-	const effectiveBackground = background && backdrop ? background.makeOpaque(backdrop) : background ?? backdrop;
+	const editorBackground = parseCssColor(editorBackgroundColor);
+	const windowBackground = parseCssColor(windowBackgroundColor);
+	const effectiveEditorBackground = editorBackground && windowBackground ? editorBackground.makeOpaque(windowBackground) : editorBackground ?? windowBackground;
+	const effectiveBackground = background && effectiveEditorBackground ? background.makeOpaque(effectiveEditorBackground) : background ?? effectiveEditorBackground;
 
 	return effectiveBackground?.isDarker() ? '#FFFFFF' : '#000000';
 }
 
-export function getWindowControlsOverlayColors(colorInfo: Pick<IPartsSplash['colorInfo'], 'editorBackground' | 'titleBarBackground' | 'titleBarForeground' | 'titleBarColorCustomizations' | 'titleBarColorsCustomized'> | undefined, modernUI: boolean, fallbackBackgroundColor: string): { color: string; symbolColor: string } {
+export function getWindowControlsOverlayColors(colorInfo: IWindowControlsOverlayColorInfo | undefined, modernUI: boolean, fallbackBackgroundColor: string): { color: string; symbolColor: string } {
 	const titleBarColor = modernUI && !(colorInfo?.titleBarColorCustomizations?.activeBackground ?? colorInfo?.titleBarColorsCustomized === true)
 		? 'transparent'
 		: colorInfo?.titleBarBackground ?? fallbackBackgroundColor;
-	const titleBarBackdrop = colorInfo?.editorBackground ?? fallbackBackgroundColor;
+	const editorBackground = colorInfo?.editorBackground ?? fallbackBackgroundColor;
+	const windowBackground = colorInfo?.background ?? fallbackBackgroundColor;
 	const titleBarForeground = colorInfo?.titleBarColorCustomizations?.activeForeground ? colorInfo.titleBarForeground : undefined;
 
 	return {
 		color: titleBarColor,
-		symbolColor: titleBarForeground || getWindowControlsSymbolColor(titleBarColor, titleBarBackdrop)
+		symbolColor: titleBarForeground || getWindowControlsSymbolColor(titleBarColor, editorBackground, windowBackground)
 	};
 }
 

--- a/src/vs/platform/windows/test/electron-main/windows.test.ts
+++ b/src/vs/platform/windows/test/electron-main/windows.test.ts
@@ -38,11 +38,32 @@ suite('Window Controls Overlay', () => {
 				titleBarBackground: 'rgba(invalid)',
 				titleBarForeground: undefined,
 				titleBarColorCustomizations: titleBarCustomizations
-			}, false, '#1E1E1E')
+			}, false, '#1E1E1E'),
+			getWindowControlsOverlayColors({
+				editorBackground: '#FFFFFF',
+				titleBarBackground: 'rgba(0, 0, 0, 0.1)',
+				titleBarForeground: undefined,
+				titleBarColorCustomizations: { ...titleBarCustomizations, activeBackground: true }
+			}, true, '#1E1E1E'),
+			getWindowControlsOverlayColors({
+				editorBackground: '#181818',
+				titleBarBackground: 'rgba(0, 0, 0, 0.1)',
+				titleBarForeground: undefined,
+				titleBarColorCustomizations: { ...titleBarCustomizations, activeBackground: true }
+			}, true, '#1E1E1E'),
+			getWindowControlsOverlayColors({
+				editorBackground: '#FFFFFF',
+				titleBarBackground: undefined,
+				titleBarForeground: undefined,
+				titleBarColorCustomizations: titleBarCustomizations
+			}, false, 'rgba(0, 0, 0, 0.1)')
 		], [
 			{ color: 'transparent', symbolColor: '#000000' },
 			{ color: 'rgba(255, 255, 255, 0.5)', symbolColor: 'rgba(1, 2, 3, 0.5)' },
-			{ color: 'rgba(invalid)', symbolColor: '#FFFFFF' }
+			{ color: 'rgba(invalid)', symbolColor: '#FFFFFF' },
+			{ color: 'rgba(0, 0, 0, 0.1)', symbolColor: '#000000' },
+			{ color: 'rgba(0, 0, 0, 0.1)', symbolColor: '#FFFFFF' },
+			{ color: 'rgba(0, 0, 0, 0.1)', symbolColor: '#000000' }
 		]);
 	});
 

--- a/src/vs/platform/windows/test/electron-main/windows.test.ts
+++ b/src/vs/platform/windows/test/electron-main/windows.test.ts
@@ -56,14 +56,30 @@ suite('Window Controls Overlay', () => {
 				titleBarBackground: undefined,
 				titleBarForeground: undefined,
 				titleBarColorCustomizations: titleBarCustomizations
-			}, false, 'rgba(0, 0, 0, 0.1)')
+			}, false, 'rgba(0, 0, 0, 0.1)'),
+			getWindowControlsOverlayColors({
+				background: '#FFFFFF',
+				editorBackground: '#FFFFFF10',
+				titleBarBackground: undefined,
+				titleBarForeground: undefined,
+				titleBarColorCustomizations: titleBarCustomizations
+			}, true, '#1E1E1E'),
+			getWindowControlsOverlayColors({
+				background: '#181818',
+				editorBackground: '#FFFFFF10',
+				titleBarBackground: undefined,
+				titleBarForeground: undefined,
+				titleBarColorCustomizations: titleBarCustomizations
+			}, true, '#1E1E1E')
 		], [
 			{ color: 'transparent', symbolColor: '#000000' },
 			{ color: 'rgba(255, 255, 255, 0.5)', symbolColor: 'rgba(1, 2, 3, 0.5)' },
 			{ color: 'rgba(invalid)', symbolColor: '#FFFFFF' },
 			{ color: 'rgba(0, 0, 0, 0.1)', symbolColor: '#000000' },
 			{ color: 'rgba(0, 0, 0, 0.1)', symbolColor: '#FFFFFF' },
-			{ color: 'rgba(0, 0, 0, 0.1)', symbolColor: '#000000' }
+			{ color: 'rgba(0, 0, 0, 0.1)', symbolColor: '#000000' },
+			{ color: 'transparent', symbolColor: '#000000' },
+			{ color: 'transparent', symbolColor: '#FFFFFF' }
 		]);
 	});
 

--- a/src/vs/platform/windows/test/electron-main/windows.test.ts
+++ b/src/vs/platform/windows/test/electron-main/windows.test.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ITitleBarColorCustomizations } from '../../../theme/common/themeService.js';
+import { dimWindowControlsColor, getWindowControlsOverlayColors } from '../../electron-main/windows.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+
+suite('Window Controls Overlay', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const titleBarCustomizations: ITitleBarColorCustomizations = {
+		activeForeground: false,
+		inactiveForeground: false,
+		activeBackground: false,
+		inactiveBackground: false,
+		border: false
+	};
+
+	test('uses splash colors for initial window controls', () => {
+		assert.deepStrictEqual([
+			getWindowControlsOverlayColors({
+				editorBackground: '#FFFFFF',
+				titleBarBackground: '#181818',
+				titleBarForeground: '#CCCCCC',
+				titleBarColorCustomizations: titleBarCustomizations
+			}, true, '#1E1E1E'),
+			getWindowControlsOverlayColors({
+				editorBackground: '#181818',
+				titleBarBackground: 'rgba(255, 255, 255, 0.5)',
+				titleBarForeground: 'rgba(1, 2, 3, 0.5)',
+				titleBarColorCustomizations: { ...titleBarCustomizations, activeForeground: true }
+			}, false, '#1E1E1E'),
+			getWindowControlsOverlayColors({
+				editorBackground: '#181818',
+				titleBarBackground: 'rgba(invalid)',
+				titleBarForeground: undefined,
+				titleBarColorCustomizations: titleBarCustomizations
+			}, false, '#1E1E1E')
+		], [
+			{ color: 'transparent', symbolColor: '#000000' },
+			{ color: 'rgba(255, 255, 255, 0.5)', symbolColor: 'rgba(1, 2, 3, 0.5)' },
+			{ color: 'rgba(invalid)', symbolColor: '#FFFFFF' }
+		]);
+	});
+
+	test('preserves window control color alpha when dimming', () => {
+		assert.deepStrictEqual([
+			dimWindowControlsColor('transparent'),
+			dimWindowControlsColor('rgba(255, 255, 255, 0.5)'),
+			dimWindowControlsColor('#FFFFFF'),
+			dimWindowControlsColor('invalid')
+		], [
+			'rgba(0, 0, 0, 0)',
+			'rgba(128, 128, 128, 0.5)',
+			'rgb(128, 128, 128)',
+			'invalid'
+		]);
+	});
+});

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -32,7 +32,7 @@ import { coalesce } from '../../base/common/arrays.js';
 import { assertReturnsDefined } from '../../base/common/types.js';
 import { INotificationService, NotificationsFilter } from '../../platform/notification/common/notification.js';
 import { IThemeService } from '../../platform/theme/common/themeService.js';
-import { WINDOW_ACTIVE_BORDER, WINDOW_INACTIVE_BORDER } from '../common/theme.js';
+import { getModernUIColorCustomizations, WINDOW_ACTIVE_BORDER, WINDOW_INACTIVE_BORDER } from '../common/theme.js';
 import { LineNumbersType } from '../../editor/common/config/editorOptions.js';
 import { URI } from '../../base/common/uri.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../common/views.js';
@@ -103,6 +103,10 @@ enum LayoutClasses {
 	WINDOW_BORDER = 'border',
 	NO_SHADOWS = 'no-shadows',
 	FLOATING_PANELS = 'floating-panels',
+	MODERN_UI_TITLE_BAR_ACTIVE_BACKGROUND = 'modern-ui-titlebar-active-background',
+	MODERN_UI_TITLE_BAR_INACTIVE_BACKGROUND = 'modern-ui-titlebar-inactive-background',
+	MODERN_UI_TITLE_BAR_BORDER = 'modern-ui-titlebar-border',
+	MODERN_UI_ACTIVE_TAB_BORDER = 'modern-ui-active-tab-border',
 	// Presentation class for the Modern UI Update experiment, owned/toggled at
 	// runtime by `StyleOverridesContribution`. It is *also* applied here at render
 	// time (see `getLayoutClasses`) because parts read it back during layout (e.g.
@@ -450,6 +454,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			// Modern UI Update (floating panels presentation)
 			if (e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this.updateFloatingPanels();
+				this.updateModernUIColorCustomizations();
 				this.layout(); // re-layout so parts pick up the new floating margins
 			}
 
@@ -482,7 +487,10 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 
 		// Theme changes
-		this._register(this.themeService.onDidColorThemeChange(() => this.updateWindowBorder()));
+		this._register(this.themeService.onDidColorThemeChange(() => {
+			this.updateWindowBorder();
+			this.updateModernUIColorCustomizations();
+		}));
 
 		// Window active / focus changes
 		this._register(this.hostService.onDidChangeFocus(focused => this.onWindowFocusChanged(focused)));
@@ -502,6 +510,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 			const eventDisposables = disposables.add(new DisposableStore());
 			this._onDidAddContainer.fire({ container: window.container, disposables: eventDisposables });
+			this.updateModernUIColorCustomizations();
 
 			disposables.add(window.onDidLayout(dimension => this.handleContainerDidLayout(window.container, dimension)));
 		}));
@@ -637,6 +646,18 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// card margins) to the main container so auxiliary windows — whose parts do
 		// not apply the matching content insets in code — are left untouched.
 		this.mainContainer.classList.toggle(LayoutClasses.FLOATING_PANELS, this.isFloatingPanelsEnabled());
+	}
+
+	private updateModernUIColorCustomizations(): void {
+		const modernUI = this.isFloatingPanelsEnabled();
+		const customizations = getModernUIColorCustomizations(this.themeService.getColorTheme());
+
+		for (const container of this.containers) {
+			container.classList.toggle(LayoutClasses.MODERN_UI_TITLE_BAR_ACTIVE_BACKGROUND, modernUI && customizations.titleBar.activeBackground);
+			container.classList.toggle(LayoutClasses.MODERN_UI_TITLE_BAR_INACTIVE_BACKGROUND, modernUI && customizations.titleBar.inactiveBackground);
+			container.classList.toggle(LayoutClasses.MODERN_UI_TITLE_BAR_BORDER, modernUI && customizations.titleBar.border);
+			container.classList.toggle(LayoutClasses.MODERN_UI_ACTIVE_TAB_BORDER, modernUI && customizations.activeTabBorder);
+		}
 	}
 
 	private setSideBarPosition(position: Position): void {
@@ -1903,6 +1924,9 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	getLayoutClasses(): string[] {
+		const modernUI = this.isFloatingPanelsEnabled();
+		const modernUIColorCustomizations = modernUI ? getModernUIColorCustomizations(this.themeService.getColorTheme()) : undefined;
+
 		return coalesce([
 			!this.isVisible(Parts.SIDEBAR_PART) ? LayoutClasses.SIDEBAR_HIDDEN : undefined,
 			!this.isVisible(Parts.EDITOR_PART, mainWindow) ? LayoutClasses.MAIN_EDITOR_AREA_HIDDEN : undefined,
@@ -1911,9 +1935,13 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			!this.isVisible(Parts.STATUSBAR_PART) ? LayoutClasses.STATUSBAR_HIDDEN : undefined,
 			this.state.runtime.mainWindowFullscreen ? LayoutClasses.FULLSCREEN : undefined,
 			this.isShadowsDisabled() ? LayoutClasses.NO_SHADOWS : undefined,
-			this.isFloatingPanelsEnabled() ? LayoutClasses.FLOATING_PANELS : undefined,
+			modernUI ? LayoutClasses.FLOATING_PANELS : undefined,
+			modernUIColorCustomizations?.titleBar.activeBackground ? LayoutClasses.MODERN_UI_TITLE_BAR_ACTIVE_BACKGROUND : undefined,
+			modernUIColorCustomizations?.titleBar.inactiveBackground ? LayoutClasses.MODERN_UI_TITLE_BAR_INACTIVE_BACKGROUND : undefined,
+			modernUIColorCustomizations?.titleBar.border ? LayoutClasses.MODERN_UI_TITLE_BAR_BORDER : undefined,
+			modernUIColorCustomizations?.activeTabBorder ? LayoutClasses.MODERN_UI_ACTIVE_TAB_BORDER : undefined,
 			// Also seed the style-override class here (see `LayoutClasses.STYLE_OVERRIDE`).
-			this.isFloatingPanelsEnabled() ? LayoutClasses.STYLE_OVERRIDE : undefined,
+			modernUI ? LayoutClasses.STYLE_OVERRIDE : undefined,
 			`panel-position-${positionToString(this.getPanelPosition())}`,
 			`panel-alignment-${this.getPanelAlignment()}`
 		]);

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -127,13 +127,22 @@
 }
 
 /*
- * Activity bar, status bar and title bar blend into the shell: drop their own
- * background and borders so the editor-colored backdrop shows through.
+ * Activity and status bars blend into the shell: drop their own background and
+ * borders so the editor-colored backdrop shows through.
  */
 .monaco-workbench.floating-panels .part.activitybar,
-.monaco-workbench.floating-panels .part.statusbar,
-.monaco-workbench.floating-panels .part.titlebar {
+.monaco-workbench.floating-panels .part.statusbar {
 	background-color: transparent !important;
+	border-color: transparent !important;
+}
+
+/* Preserve active and inactive title-bar backgrounds independently. */
+.monaco-workbench.floating-panels:not(.modern-ui-titlebar-active-background) .part.titlebar:not(.inactive),
+.monaco-workbench.floating-panels:not(.modern-ui-titlebar-inactive-background) .part.titlebar.inactive {
+	background-color: transparent !important;
+}
+
+.monaco-workbench.floating-panels:not(.modern-ui-titlebar-border) .part.titlebar {
 	border-color: transparent !important;
 }
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -5,7 +5,7 @@
 
 import { localize } from '../../nls.js';
 import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground, toolbarHoverBackground, inputBorder, widgetBorder, scrollbarShadow } from '../../platform/theme/common/colorRegistry.js';
-import { IColorTheme } from '../../platform/theme/common/themeService.js';
+import { IColorTheme, ITitleBarColorCustomizations } from '../../platform/theme/common/themeService.js';
 import { Color } from '../../base/common/color.js';
 import { ColorScheme } from '../../platform/theme/common/theme.js';
 
@@ -689,6 +689,24 @@ export const TITLE_BAR_BORDER = registerColor('titleBar.border', {
 	hcDark: contrastBorder,
 	hcLight: contrastBorder
 }, localize('titleBarBorder', "Title bar border color."));
+
+export interface IModernUIColorCustomizations {
+	readonly titleBar: ITitleBarColorCustomizations;
+	readonly activeTabBorder: boolean;
+}
+
+export function getModernUIColorCustomizations(theme: IColorTheme): IModernUIColorCustomizations {
+	return {
+		titleBar: {
+			activeForeground: theme.isColorCustomized(TITLE_BAR_ACTIVE_FOREGROUND),
+			inactiveForeground: theme.isColorCustomized(TITLE_BAR_INACTIVE_FOREGROUND),
+			activeBackground: theme.isColorCustomized(TITLE_BAR_ACTIVE_BACKGROUND),
+			inactiveBackground: theme.isColorCustomized(TITLE_BAR_INACTIVE_BACKGROUND),
+			border: theme.isColorCustomized(TITLE_BAR_BORDER)
+		},
+		activeTabBorder: theme.isColorCustomized(TAB_ACTIVE_BORDER)
+	};
+}
 
 // < --- Menubar --- >
 

--- a/src/vs/workbench/contrib/splash/browser/partsSplash.ts
+++ b/src/vs/workbench/contrib/splash/browser/partsSplash.ts
@@ -5,13 +5,10 @@
 
 import { onDidChangeFullscreen, isFullscreen } from '../../../../base/browser/browser.js';
 import * as dom from '../../../../base/browser/dom.js';
-import { Color } from '../../../../base/common/color.js';
 import { Event } from '../../../../base/common/event.js';
 import { DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
-import { editorBackground, foreground } from '../../../../platform/theme/common/colorRegistry.js';
 import { getThemeTypeSelector, IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { DEFAULT_EDITOR_MIN_DIMENSIONS } from '../../../browser/parts/editor/editor.js';
-import * as themes from '../../../common/theme.js';
 import { IWorkbenchLayoutService, Parts, Position } from '../../../services/layout/browser/layoutService.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
@@ -22,6 +19,7 @@ import { ISplashStorageService } from './splash.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { ILifecycleService, LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { TitleBarSetting } from '../../../../platform/window/common/window.js';
+import { getPartsSplashColorInfo } from '../common/partsSplash.js';
 
 export class PartsSplash {
 
@@ -74,25 +72,7 @@ export class PartsSplash {
 		this._partSplashService.saveWindowSplash({
 			zoomLevel: this._configService.getValue<undefined>('window.zoomLevel'),
 			baseTheme: getThemeTypeSelector(theme.type),
-			colorInfo: {
-				foreground: theme.getColor(foreground)?.toString(),
-				background: Color.Format.CSS.formatHex(theme.getColor(editorBackground) || themes.WORKBENCH_BACKGROUND(theme)),
-				editorBackground: theme.getColor(editorBackground)?.toString(),
-				titleBarBackground: theme.getColor(themes.TITLE_BAR_ACTIVE_BACKGROUND)?.toString(),
-				titleBarBorder: theme.getColor(themes.TITLE_BAR_BORDER)?.toString(),
-				activityBarBackground: theme.getColor(themes.ACTIVITY_BAR_BACKGROUND)?.toString(),
-				activityBarBorder: theme.getColor(themes.ACTIVITY_BAR_BORDER)?.toString(),
-				sideBarBackground: theme.getColor(themes.SIDE_BAR_BACKGROUND)?.toString(),
-				sideBarBorder: theme.getColor(themes.SIDE_BAR_BORDER)?.toString(),
-				panelBackground: theme.getColor(themes.PANEL_BACKGROUND)?.toString(),
-				editorGroupBorder: theme.getColor(themes.EDITOR_GROUP_BORDER)?.toString(),
-				agentsPanelBackground: theme.getColor('agentsPanel.background')?.toString(),
-				agentsPanelBorder: theme.getColor('agentsPanel.border')?.toString(),
-				statusBarBackground: theme.getColor(themes.STATUS_BAR_BACKGROUND)?.toString(),
-				statusBarBorder: theme.getColor(themes.STATUS_BAR_BORDER)?.toString(),
-				statusBarNoFolderBackground: theme.getColor(themes.STATUS_BAR_NO_FOLDER_BACKGROUND)?.toString(),
-				windowBorder: theme.getColor(themes.WINDOW_ACTIVE_BORDER)?.toString() ?? theme.getColor(themes.WINDOW_INACTIVE_BORDER)?.toString()
-			},
+			colorInfo: getPartsSplashColorInfo(theme),
 			layoutInfo: !this._shouldSaveLayoutInfo() ? undefined : {
 				sideBarSide: this._layoutService.getSideBarPosition() === Position.RIGHT ? 'right' : 'left',
 				editorPartMinWidth: DEFAULT_EDITOR_MIN_DIMENSIONS.width,

--- a/src/vs/workbench/contrib/splash/common/partsSplash.ts
+++ b/src/vs/workbench/contrib/splash/common/partsSplash.ts
@@ -18,6 +18,8 @@ export function getPartsSplashColorInfo(theme: IColorTheme): IPartsSplash['color
 		editorBackground: theme.getColor(editorBackground)?.toString(),
 		titleBarBackground: theme.getColor(themes.TITLE_BAR_ACTIVE_BACKGROUND)?.toString(),
 		titleBarInactiveBackground: theme.getColor(themes.TITLE_BAR_INACTIVE_BACKGROUND)?.toString(),
+		titleBarForeground: theme.getColor(themes.TITLE_BAR_ACTIVE_FOREGROUND)?.toString(),
+		titleBarInactiveForeground: theme.getColor(themes.TITLE_BAR_INACTIVE_FOREGROUND)?.toString(),
 		titleBarBorder: theme.getColor(themes.TITLE_BAR_BORDER)?.toString(),
 		titleBarColorCustomizations,
 		titleBarColorsCustomized: Object.values(titleBarColorCustomizations).some(customized => customized),

--- a/src/vs/workbench/contrib/splash/common/partsSplash.ts
+++ b/src/vs/workbench/contrib/splash/common/partsSplash.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Color } from '../../../../base/common/color.js';
+import { editorBackground, foreground } from '../../../../platform/theme/common/colorRegistry.js';
+import { IColorTheme, IPartsSplash } from '../../../../platform/theme/common/themeService.js';
+import * as themes from '../../../common/theme.js';
+
+export function getPartsSplashColorInfo(theme: IColorTheme): IPartsSplash['colorInfo'] {
+	const modernUIColorCustomizations = themes.getModernUIColorCustomizations(theme);
+	const titleBarColorCustomizations = modernUIColorCustomizations.titleBar;
+
+	return {
+		foreground: theme.getColor(foreground)?.toString(),
+		background: Color.Format.CSS.formatHex(theme.getColor(editorBackground) || themes.WORKBENCH_BACKGROUND(theme)),
+		editorBackground: theme.getColor(editorBackground)?.toString(),
+		titleBarBackground: theme.getColor(themes.TITLE_BAR_ACTIVE_BACKGROUND)?.toString(),
+		titleBarInactiveBackground: theme.getColor(themes.TITLE_BAR_INACTIVE_BACKGROUND)?.toString(),
+		titleBarBorder: theme.getColor(themes.TITLE_BAR_BORDER)?.toString(),
+		titleBarColorCustomizations,
+		titleBarColorsCustomized: Object.values(titleBarColorCustomizations).some(customized => customized),
+		activityBarBackground: theme.getColor(themes.ACTIVITY_BAR_BACKGROUND)?.toString(),
+		activityBarBorder: theme.getColor(themes.ACTIVITY_BAR_BORDER)?.toString(),
+		sideBarBackground: theme.getColor(themes.SIDE_BAR_BACKGROUND)?.toString(),
+		sideBarBorder: theme.getColor(themes.SIDE_BAR_BORDER)?.toString(),
+		panelBackground: theme.getColor(themes.PANEL_BACKGROUND)?.toString(),
+		editorGroupBorder: theme.getColor(themes.EDITOR_GROUP_BORDER)?.toString(),
+		agentsPanelBackground: theme.getColor('agentsPanel.background')?.toString(),
+		agentsPanelBorder: theme.getColor('agentsPanel.border')?.toString(),
+		statusBarBackground: theme.getColor(themes.STATUS_BAR_BACKGROUND)?.toString(),
+		statusBarBorder: theme.getColor(themes.STATUS_BAR_BORDER)?.toString(),
+		statusBarNoFolderBackground: theme.getColor(themes.STATUS_BAR_NO_FOLDER_BACKGROUND)?.toString(),
+		windowBorder: theme.getColor(themes.WINDOW_ACTIVE_BORDER)?.toString() ?? theme.getColor(themes.WINDOW_INACTIVE_BORDER)?.toString()
+	};
+}

--- a/src/vs/workbench/contrib/splash/test/common/partsSplash.test.ts
+++ b/src/vs/workbench/contrib/splash/test/common/partsSplash.test.ts
@@ -64,11 +64,13 @@ suite('Parts Splash', () => {
 		]);
 	});
 
-	test('serializes active and inactive title bar backgrounds', () => {
+	test('serializes active and inactive title bar colors', () => {
 		const themeData = ColorThemeData.createUnloadedTheme('vs-dark default-modern', defaultModernThemeColors);
 		themeData.setCustomColors({
 			'titleBar.activeBackground': '#FF0000',
-			'titleBar.inactiveBackground': '#00FF00'
+			'titleBar.inactiveBackground': '#00FF00',
+			'titleBar.activeForeground': '#0000FF',
+			'titleBar.inactiveForeground': '#FFFF00'
 		});
 
 		const colorInfo = getPartsSplashColorInfo(themeData);
@@ -76,11 +78,15 @@ suite('Parts Splash', () => {
 		assert.deepStrictEqual({
 			titleBarBackground: colorInfo.titleBarBackground,
 			titleBarInactiveBackground: colorInfo.titleBarInactiveBackground,
+			titleBarForeground: colorInfo.titleBarForeground,
+			titleBarInactiveForeground: colorInfo.titleBarInactiveForeground,
 			titleBarColorCustomizations: colorInfo.titleBarColorCustomizations
 		}, {
 			titleBarBackground: '#ff0000',
 			titleBarInactiveBackground: '#00ff00',
-			titleBarColorCustomizations: { ...titleBarDefaults, activeBackground: true, inactiveBackground: true }
+			titleBarForeground: '#0000ff',
+			titleBarInactiveForeground: '#ffff00',
+			titleBarColorCustomizations: { ...titleBarDefaults, activeBackground: true, inactiveBackground: true, activeForeground: true, inactiveForeground: true }
 		});
 	});
 

--- a/src/vs/workbench/contrib/splash/test/common/partsSplash.test.ts
+++ b/src/vs/workbench/contrib/splash/test/common/partsSplash.test.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IColorCustomizations } from '../../../../services/themes/common/workbenchThemeService.js';
+import { ColorThemeData } from '../../../../services/themes/common/colorThemeData.js';
+import { ITitleBarColorCustomizations } from '../../../../../platform/theme/common/themeService.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { getPartsSplashColorInfo } from '../../common/partsSplash.js';
+
+suite('Parts Splash', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const defaultModernThemeColors = {
+		'titleBar.activeBackground': '#181818',
+		'titleBar.activeForeground': '#CCCCCC',
+		'titleBar.inactiveBackground': '#1F1F1F',
+		'titleBar.inactiveForeground': '#9D9D9D',
+		'titleBar.border': '#2B2B2B'
+	};
+	const titleBarDefaults: ITitleBarColorCustomizations = {
+		activeForeground: false,
+		inactiveForeground: false,
+		activeBackground: false,
+		inactiveBackground: false,
+		border: false
+	};
+
+	function getTitleBarColorCustomizations(colors: IColorCustomizations): ITitleBarColorCustomizations | undefined {
+		return getColorInfo(colors).titleBarColorCustomizations;
+	}
+
+	function getColorInfo(colors: IColorCustomizations) {
+		const themeData = ColorThemeData.createUnloadedTheme('vs-dark default-modern', defaultModernThemeColors);
+		themeData.setCustomColors(colors);
+		return getPartsSplashColorInfo(themeData);
+	}
+
+	test('serializes title bar color customizations independently', () => {
+		assert.deepStrictEqual([
+			getTitleBarColorCustomizations({}),
+			getTitleBarColorCustomizations({ 'titleBar.activeForeground': '#FF0000' }),
+			getTitleBarColorCustomizations({ 'titleBar.inactiveForeground': '#FF0000' }),
+			getTitleBarColorCustomizations({ 'titleBar.activeBackground': '#FF0000' }),
+			getTitleBarColorCustomizations({ 'titleBar.inactiveBackground': '#FF0000' }),
+			getTitleBarColorCustomizations({ 'titleBar.border': '#FF0000' }),
+			getTitleBarColorCustomizations({
+				'titleBar.activeForeground': '#FF0000',
+				'titleBar.activeBackground': '#FF0000',
+				'titleBar.border': '#FF0000'
+			}),
+			getTitleBarColorCustomizations({ 'titleBar.activeBackground': 'default' })
+		], [
+			titleBarDefaults,
+			{ ...titleBarDefaults, activeForeground: true },
+			{ ...titleBarDefaults, inactiveForeground: true },
+			{ ...titleBarDefaults, activeBackground: true },
+			{ ...titleBarDefaults, inactiveBackground: true },
+			{ ...titleBarDefaults, border: true },
+			{ ...titleBarDefaults, activeForeground: true, activeBackground: true, border: true },
+			titleBarDefaults
+		]);
+	});
+
+	test('serializes active and inactive title bar backgrounds', () => {
+		const themeData = ColorThemeData.createUnloadedTheme('vs-dark default-modern', defaultModernThemeColors);
+		themeData.setCustomColors({
+			'titleBar.activeBackground': '#FF0000',
+			'titleBar.inactiveBackground': '#00FF00'
+		});
+
+		const colorInfo = getPartsSplashColorInfo(themeData);
+
+		assert.deepStrictEqual({
+			titleBarBackground: colorInfo.titleBarBackground,
+			titleBarInactiveBackground: colorInfo.titleBarInactiveBackground,
+			titleBarColorCustomizations: colorInfo.titleBarColorCustomizations
+		}, {
+			titleBarBackground: '#ff0000',
+			titleBarInactiveBackground: '#00ff00',
+			titleBarColorCustomizations: { ...titleBarDefaults, activeBackground: true, inactiveBackground: true }
+		});
+	});
+
+	test('retains legacy title bar customization metadata', () => {
+		assert.deepStrictEqual([
+			getColorInfo({}).titleBarColorsCustomized,
+			getColorInfo({ 'titleBar.activeForeground': '#FF0000' }).titleBarColorsCustomized
+		], [false, true]);
+	});
+});

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -92,7 +92,7 @@
 }
 
 .style-override .part.editor .tabs-container > .tab .tab-border-top-container,
-.style-override .part.editor .tabs-container > .tab .tab-border-bottom-container {
+.style-override:not(.modern-ui-active-tab-border) .part.editor .tabs-container > .tab .tab-border-bottom-container {
 	display: none !important;
 }
 

--- a/src/vs/workbench/contrib/terminal/test/common/terminalColorRegistry.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/common/terminalColorRegistry.test.ts
@@ -22,6 +22,7 @@ function getMockTheme(type: ColorScheme): IColorTheme {
 		type: type,
 		getColor: (colorId: ColorIdentifier): Color | undefined => themingRegistry.resolveDefaultColor(colorId, theme),
 		defines: () => true,
+		isColorCustomized: () => false,
 		getTokenStyleMetadata: () => undefined,
 		tokenColorMap: [],
 		tokenFontMap: [],

--- a/src/vs/workbench/electron-browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/electron-browser/parts/titlebar/titlebarPart.ts
@@ -260,15 +260,21 @@ export class NativeTitlebarPart extends BrowserTitlebarPart {
 		// Part container
 		if (this.element) {
 			if (useWindowControlsOverlay(this.configurationService)) {
+				const backgroundColor = this.getWindowControlsBackgroundColor();
+				const foregroundColor = this.element.style.color;
 				if (
 					!this.cachedWindowControlStyles ||
-					this.cachedWindowControlStyles.bgColor !== this.getWindowControlsBackgroundColor() ||
-					this.cachedWindowControlStyles.fgColor !== this.element.style.color
+					this.cachedWindowControlStyles.bgColor !== backgroundColor ||
+					this.cachedWindowControlStyles.fgColor !== foregroundColor
 				) {
+					this.cachedWindowControlStyles = {
+						bgColor: backgroundColor,
+						fgColor: foregroundColor
+					};
 					this.nativeHostService.updateWindowControls({
 						targetWindowId: getWindowId(getWindow(this.element)),
-						backgroundColor: this.getWindowControlsBackgroundColor(),
-						foregroundColor: this.element.style.color
+						backgroundColor,
+						foregroundColor
 					});
 				}
 			}
@@ -279,7 +285,7 @@ export class NativeTitlebarPart extends BrowserTitlebarPart {
 		if (getWindow(this.element) === mainWindow && this.configurationService.getValue<boolean>(LayoutSettings.MODERN_UI) === true) {
 			const titleBarCustomizations = getModernUIColorCustomizations(this.themeService.getColorTheme()).titleBar;
 			if (this.element.classList.contains('inactive') ? !titleBarCustomizations.inactiveBackground : !titleBarCustomizations.activeBackground) {
-				return 'transparent';
+				return '';
 			}
 		}
 

--- a/src/vs/workbench/electron-browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/electron-browser/parts/titlebar/titlebarPart.ts
@@ -17,7 +17,7 @@ import { IActionViewItemService } from '../../../../platform/actions/browser/act
 import { BrowserTitlebarPart, BrowserTitleService, IAuxiliaryTitlebarPart } from '../../../browser/parts/titlebar/titlebarPart.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
-import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, LayoutSettings, Parts } from '../../../services/layout/browser/layoutService.js';
 import { INativeHostService } from '../../../../platform/native/common/native.js';
 import { hasNativeTitlebar, useWindowControlsOverlay, DEFAULT_CUSTOM_TITLEBAR_HEIGHT, hasNativeMenu } from '../../../../platform/window/common/window.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -29,6 +29,7 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { CodeWindow, mainWindow } from '../../../../base/browser/window.js';
 import { IsWindowAlwaysOnTopContext } from '../../../common/contextkeys.js';
+import { getModernUIColorCustomizations } from '../../../common/theme.js';
 
 export class NativeTitlebarPart extends BrowserTitlebarPart {
 
@@ -68,7 +69,7 @@ export class NativeTitlebarPart extends BrowserTitlebarPart {
 		@IConfigurationService configurationService: IConfigurationService,
 		@INativeWorkbenchEnvironmentService environmentService: INativeWorkbenchEnvironmentService,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IThemeService themeService: IThemeService,
+		@IThemeService protected override readonly themeService: IThemeService,
 		@IStorageService storageService: IStorageService,
 		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService,
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -116,6 +117,10 @@ export class NativeTitlebarPart extends BrowserTitlebarPart {
 
 	protected override onConfigurationChanged(event: IConfigurationChangeEvent): void {
 		super.onConfigurationChanged(event);
+
+		if (event.affectsConfiguration(LayoutSettings.MODERN_UI)) {
+			this.updateStyles();
+		}
 
 		if (event.affectsConfiguration('window.doubleClickIconToClose')) {
 			if (this.appIcon) {
@@ -257,17 +262,28 @@ export class NativeTitlebarPart extends BrowserTitlebarPart {
 			if (useWindowControlsOverlay(this.configurationService)) {
 				if (
 					!this.cachedWindowControlStyles ||
-					this.cachedWindowControlStyles.bgColor !== this.element.style.backgroundColor ||
+					this.cachedWindowControlStyles.bgColor !== this.getWindowControlsBackgroundColor() ||
 					this.cachedWindowControlStyles.fgColor !== this.element.style.color
 				) {
 					this.nativeHostService.updateWindowControls({
 						targetWindowId: getWindowId(getWindow(this.element)),
-						backgroundColor: this.element.style.backgroundColor,
+						backgroundColor: this.getWindowControlsBackgroundColor(),
 						foregroundColor: this.element.style.color
 					});
 				}
 			}
 		}
+	}
+
+	private getWindowControlsBackgroundColor(): string {
+		if (getWindow(this.element) === mainWindow && this.configurationService.getValue<boolean>(LayoutSettings.MODERN_UI) === true) {
+			const titleBarCustomizations = getModernUIColorCustomizations(this.themeService.getColorTheme()).titleBar;
+			if (this.element.classList.contains('inactive') ? !titleBarCustomizations.inactiveBackground : !titleBarCustomizations.activeBackground) {
+				return 'transparent';
+			}
+		}
+
+		return this.element.style.backgroundColor;
 	}
 
 	override layout(width: number, height: number): void {

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -392,6 +392,10 @@ export class ColorThemeData implements IWorkbenchColorTheme {
 		return customColor === undefined /* !== DEFAULT_COLOR_CONFIG_VALUE */ && this.colorMap.hasOwnProperty(colorId);
 	}
 
+	public isColorCustomized(colorId: ColorIdentifier): boolean {
+		return this.customColorMap[colorId] instanceof Color;
+	}
+
 	public setCustomizations(settings: ThemeConfiguration) {
 		this.setCustomColors(settings.colorCustomizations);
 		this.setCustomTokenColors(settings.tokenColorCustomizations);

--- a/src/vs/workbench/services/themes/test/node/tokenStyleResolving.test.ts
+++ b/src/vs/workbench/services/themes/test/node/tokenStyleResolving.test.ts
@@ -5,7 +5,8 @@
 
 import { ColorThemeData } from '../../common/colorThemeData.js';
 import assert from 'assert';
-import { ITokenColorCustomizations } from '../../common/workbenchThemeService.js';
+import { IColorCustomizations, ITokenColorCustomizations } from '../../common/workbenchThemeService.js';
+import { getModernUIColorCustomizations } from '../../../../common/theme.js';
 import { TokenStyle, getTokenClassificationRegistry } from '../../../../../platform/theme/common/tokenClassificationRegistry.js';
 import { Color } from '../../../../../base/common/color.js';
 import { isString } from '../../../../../base/common/types.js';
@@ -14,7 +15,7 @@ import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { DiskFileSystemProvider } from '../../../../../platform/files/node/diskFileSystemProvider.js';
 import { FileAccess, Schemas } from '../../../../../base/common/network.js';
 import { ExtensionResourceLoaderService } from '../../../../../platform/extensionResourceLoader/common/extensionResourceLoaderService.js';
-import { ITokenStyle } from '../../../../../platform/theme/common/themeService.js';
+import { ITitleBarColorCustomizations, ITokenStyle } from '../../../../../platform/theme/common/themeService.js';
 import { mock, TestProductService } from '../../../../test/common/workbenchTestServices.js';
 import { IRequestService } from '../../../../../platform/request/common/request.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
@@ -100,6 +101,66 @@ suite('Themes - TokenStyleResolving', () => {
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('modern UI color customizations', () => {
+		const modernThemeSettingsId = 'vs-dark default-modern';
+		const defaultModernThemeColors = {
+			'tab.activeBorder': '#1F1F1F',
+			'titleBar.activeBackground': '#181818',
+			'titleBar.activeForeground': '#CCCCCC',
+			'titleBar.inactiveBackground': '#1F1F1F',
+			'titleBar.inactiveForeground': '#9D9D9D',
+			'titleBar.border': '#2B2B2B'
+		};
+		const getCustomizations = (colors: IColorCustomizations) => {
+			const themeData = ColorThemeData.createUnloadedTheme(modernThemeSettingsId, defaultModernThemeColors);
+			themeData.settingsId = modernThemeSettingsId;
+			themeData.setCustomColors(colors);
+			return getModernUIColorCustomizations(themeData);
+		};
+		const titleBarDefaults: ITitleBarColorCustomizations = {
+			activeForeground: false,
+			inactiveForeground: false,
+			activeBackground: false,
+			inactiveBackground: false,
+			border: false
+		};
+		const expected = (titleBar: Partial<ITitleBarColorCustomizations> = {}, activeTabBorder = false) => ({
+			titleBar: { ...titleBarDefaults, ...titleBar },
+			activeTabBorder
+		});
+
+		assert.deepStrictEqual([
+			getCustomizations({}),
+			getCustomizations({ 'tab.activeBorder': '#FF0000' }),
+			getCustomizations({ 'titleBar.activeForeground': '#FF0000' }),
+			getCustomizations({ 'titleBar.inactiveForeground': '#FF0000' }),
+			getCustomizations({ 'titleBar.activeBackground': '#FF0000' }),
+			getCustomizations({ 'titleBar.inactiveBackground': '#FF0000' }),
+			getCustomizations({ 'titleBar.border': '#FF0000' }),
+			getCustomizations({
+				'tab.activeBorder': '#FF0000',
+				'titleBar.activeForeground': '#FF0000',
+				'titleBar.inactiveBackground': '#FF0000',
+				'titleBar.border': '#FF0000'
+			}),
+			getCustomizations({ '[vs-dark default-modern]': { 'titleBar.activeBackground': '#FF0000' } }),
+			getCustomizations({ '[different-theme]': { 'titleBar.activeBackground': '#FF0000' } }),
+			getCustomizations({ 'tab.activeBorder': 'default', 'titleBar.activeBackground': 'default' })
+		], [
+			expected(),
+			expected({}, true),
+			expected({ activeForeground: true }),
+			expected({ inactiveForeground: true }),
+			expected({ activeBackground: true }),
+			expected({ inactiveBackground: true }),
+			expected({ border: true }),
+			expected({ activeForeground: true, inactiveBackground: true, border: true }, true),
+			expected({ activeBackground: true }),
+			expected(),
+			expected()
+		]);
+	});
 
 	test('color defaults', async () => {
 		const themeData = ColorThemeData.createUnloadedTheme('foo');


### PR DESCRIPTION
## Summary

- preserve Modern UI transparent/borderless defaults unless colors are explicitly customized
- track title-bar foreground, background, and border customization provenance independently
- respect explicit `tab.activeBorder` customization without restoring default underlines
- carry customization provenance through startup splash state and Windows controls overlay
- add focused default/customization matrix tests

## Validation

- `npm run typecheck-client`
- `gulp compile-client`
- targeted theme and splash tests
- hygiene
- `npm run valid-layers-check`
- pre-commit hook

## Known WIP follow-ups

Final independent review identified two remaining Windows controls overlay issues before this should leave draft:

1. Startup WCO does not serialize/use customized title-bar foreground values, causing a temporary symbol-color mismatch.
2. Dimming a transparent WCO background can produce an opaque black strip; alpha-zero backgrounds must remain transparent.

## Manual verification

Enable Modern UI and compare defaults with foreground-only, active/inactive background-only, border-only, and `tab.activeBorder` customizations. Reload to inspect splash/runtime continuity and repeat with Modern UI disabled. On Windows, inspect startup controls and modal dimming.

Fixes #325250