### PR TITLE
[WIP] Visually balance session status icons with session label

### DIFF
--- a/src/vs/base/browser/ui/pixelSpinner/pixelSpinner.ts
+++ b/src/vs/base/browser/ui/pixelSpinner/pixelSpinner.ts
@@ -6,7 +6,7 @@
 import { getWindow, h, onDidUnregisterWindow } from '../../dom.js';
 import { synchronizeCSSAnimations } from '../../animationSync.js';
 import { CodeWindow } from '../../window.js';
-import { IDisposable } from '../../../common/lifecycle.js';
+import { IDisposable, markAsSingleton } from '../../../common/lifecycle.js';
 import './pixelSpinner.css';
 
 export interface IPixelSpinnerOptions {
@@ -104,13 +104,13 @@ function getObserverFor(targetWindow: CodeWindow): IntersectionObserver | undefi
 		observersByWindow.set(targetWindow, observer);
 
 		if (!unregisterWindowListener) {
-			unregisterWindowListener = onDidUnregisterWindow(window => {
+			unregisterWindowListener = markAsSingleton(onDidUnregisterWindow(window => {
 				const obs = observersByWindow.get(window);
 				if (obs) {
 					obs.disconnect();
 					observersByWindow.delete(window);
 				}
-			});
+			}));
 		}
 	}
 	return observer;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -96,7 +96,7 @@ interface IAgentSessionItemTemplate {
 	readonly disposables: IDisposable;
 }
 
-export class AgentSessionStatusIcon extends Disposable {
+class AgentSessionStatusIcon extends Disposable {
 
 	private static readonly PIXEL_SPINNER_GRID_KEY = '__pixel_spinner_grid__';
 	private static readonly PIXEL_SPINNER_RING_KEY = '__pixel_spinner_ring__';

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -96,7 +96,7 @@ interface IAgentSessionItemTemplate {
 	readonly disposables: IDisposable;
 }
 
-class AgentSessionStatusIcon extends Disposable {
+export class AgentSessionStatusIcon extends Disposable {
 
 	private static readonly PIXEL_SPINNER_GRID_KEY = '__pixel_spinner_grid__';
 	private static readonly PIXEL_SPINNER_RING_KEY = '__pixel_spinner_ring__';
@@ -175,26 +175,26 @@ class AgentSessionStatusIcon extends Disposable {
 
 export function getAgentSessionStatusIcon(session: IAgentSession): ThemeIcon {
 	if (session.status === AgentSessionStatus.InProgress) {
-		return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
+		return { ...Codicon.sessionInProgressCompact, color: themeColorFromId('textLink.foreground') };
 	}
 
 	if (session.status === AgentSessionStatus.NeedsInput) {
-		return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
+		return { ...Codicon.circleFilledCompact, color: themeColorFromId('list.warningForeground') };
 	}
 
 	if (session.status === AgentSessionStatus.Failed) {
-		return { ...Codicon.error, color: themeColorFromId('errorForeground') };
+		return { ...Codicon.errorCompact, color: themeColorFromId('errorForeground') };
 	}
 
 	if (session.isArchived()) {
-		return { ...Codicon.passFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+		return { ...Codicon.passFilledCompact, color: themeColorFromId('agentSessionReadIndicator.foreground') };
 	}
 
 	if (!session.isRead()) {
-		return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
+		return { ...Codicon.circleFilledCompact, color: themeColorFromId('textLink.foreground') };
 	}
 
-	return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+	return { ...Codicon.circleSmallFilledCompact, color: themeColorFromId('agentSessionReadIndicator.foreground') };
 }
 
 export interface IAgentSessionRendererOptions {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -31,11 +31,10 @@
 		animation: agent-session-needs-input-accent-pulse 3s ease-in-out infinite;
 	}
 
-	@media (prefers-reduced-motion: reduce) {
-		.monaco-list-row:not(.selected):not(.focused):not(:hover):has(.agent-session-icon.needs-input) {
-			animation: none;
-			background-color: color-mix(in srgb, var(--vscode-list-warningForeground) 8%, transparent);
-		}
+	&.monaco-reduce-motion .monaco-list-row:not(.selected):not(.focused):not(:hover):has(.agent-session-icon.needs-input),
+	.monaco-reduce-motion & .monaco-list-row:not(.selected):not(.focused):not(:hover):has(.agent-session-icon.needs-input) {
+		animation: none;
+		background-color: color-mix(in srgb, var(--vscode-list-warningForeground) 8%, transparent);
 	}
 
 	.monaco-list-row .force-no-twistie {
@@ -155,21 +154,28 @@
 			line-height: 17px;
 
 			.agent-session-icon {
-				flex-shrink: 0;
-				font-size: var(--vscode-codiconFontSize, 16px);
-				height: 16px;
+				flex: 0 0 var(--vscode-codiconFontSize);
+				width: var(--vscode-codiconFontSize);
+				height: var(--vscode-codiconFontSize);
 				display: flex;
 				align-items: center;
 				justify-content: center;
+
+				> .codicon {
+					font-size: var(--vscode-codiconFontSize-compact);
+				}
+
+				> .monaco-pixel-spinner {
+					transform: translateZ(0) scale(0.75);
+					transform-origin: center;
+				}
 
 				&.needs-input {
 					animation: agent-session-needs-input-pulse 2s ease-in-out infinite;
 				}
 
-				@media (prefers-reduced-motion: reduce) {
-					&.needs-input {
-						animation: none;
-					}
+				.monaco-reduce-motion &.needs-input {
+					animation: none;
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -154,18 +154,20 @@
 			line-height: 17px;
 
 			.agent-session-icon {
-				flex: 0 0 var(--vscode-codiconFontSize);
-				width: var(--vscode-codiconFontSize);
-				height: var(--vscode-codiconFontSize);
+				flex: 0 0 var(--vscode-codiconFontSize, 16px);
+				width: var(--vscode-codiconFontSize, 16px);
+				height: var(--vscode-codiconFontSize, 16px);
 				display: flex;
 				align-items: center;
 				justify-content: center;
 
 				> .codicon {
-					font-size: var(--vscode-codiconFontSize-compact);
+					font-size: var(--vscode-codiconFontSize-compact, 12px) !important;
 				}
 
 				> .monaco-pixel-spinner {
+					width: var(--vscode-codiconFontSize, 16px);
+					height: var(--vscode-codiconFontSize, 16px);
 					transform: translateZ(0) scale(0.75);
 					transform-origin: center;
 				}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -8,16 +8,27 @@ import { mainWindow } from '../../../../../../base/browser/window.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { AgentSessionStatusIcon, AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter, groupAgentSessionsByDate, getAgentSessionStatusIcon } from '../../../browser/agentSessions/agentSessionsViewer.js';
+import { AgentSessionRenderer, AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter, groupAgentSessionsByDate, getAgentSessionStatusIcon } from '../../../browser/agentSessions/agentSessionsViewer.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, isAgentSession, isAgentSessionSection, isAgentSessionShowLess, isAgentSessionShowMore } from '../../../browser/agentSessions/agentSessionsModel.js';
-import { ChatSessionStatus } from '../../../common/chatSessionsService.js';
-import { ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
+import { ChatSessionStatus, IChatSessionsService } from '../../../common/chatSessionsService.js';
+import { ITreeNode, ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { AgentSessionsGrouping, AgentSessionsSorting } from '../../../browser/agentSessions/agentSessionsFilter.js';
 import { shouldShowSessionInPicker } from '../../../browser/agentSessions/agentSessionsPicker.js';
 import { themeColorFromId } from '../../../../../../base/common/themables.js';
 import { TestAccessibilityService } from '../../../../../../platform/accessibility/test/common/testAccessibilityService.js';
+import { FuzzyScore } from '../../../../../../base/common/filters.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { MenuWorkbenchToolBar } from '../../../../../../platform/actions/browser/toolbar.js';
+import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IMarkdownRendererService } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
+import { IProductService } from '../../../../../../platform/product/common/productService.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { IVoicePlaybackService } from '../../../common/voicePlaybackService.js';
+import { HoverPosition } from '../../../../../../base/browser/ui/hover/hoverWidget.js';
 
 suite('sessionDateFromNow', () => {
 
@@ -150,44 +161,74 @@ suite('AgentSessionsDataSource', () => {
 		test('renders compact glyphs and scaled spinners in a centered status slot', () => {
 			const store = new DisposableStore();
 			try {
-				const createStatusIcon = (motionReduced: boolean) => {
+				const renderStatusIcon = (motionReduced: boolean, session: IAgentSession) => {
 					const root = mainWindow.document.createElement('div');
 					root.classList.add('monaco-workbench', motionReduced ? 'monaco-reduce-motion' : 'monaco-enable-motion');
 					const viewer = mainWindow.document.createElement('div');
 					viewer.classList.add('agent-sessions-viewer');
 					const listRow = mainWindow.document.createElement('div');
 					listRow.classList.add('monaco-list-row');
-					const item = mainWindow.document.createElement('div');
-					item.classList.add('agent-session-item');
-					const iconColumn = mainWindow.document.createElement('div');
-					iconColumn.classList.add('agent-session-icon-col');
-					const container = mainWindow.document.createElement('div');
-					iconColumn.appendChild(container);
-					item.appendChild(iconColumn);
-					listRow.appendChild(item);
 					viewer.appendChild(listRow);
 					root.appendChild(viewer);
 					mainWindow.document.body.appendChild(root);
 					store.add(toDisposable(() => root.remove()));
 
+					const instantiationService = store.add(new TestInstantiationService());
+					instantiationService.stubInstance(MenuWorkbenchToolBar, { dispose() { } });
 					const accessibilityService = new class extends TestAccessibilityService {
 						override isMotionReduced(): boolean {
 							return motionReduced;
 						}
 					}();
+					const renderer = store.add(new AgentSessionRenderer(
+						{ disableHover: true, getHoverPosition: () => HoverPosition.BELOW },
+						undefined,
+						observableValue<URI | undefined>('activeSessionResource', undefined),
+						new class extends mock<IMarkdownRendererService>() { }(),
+						new class extends mock<IProductService>() {
+							override readonly urlProtocol = 'vscode';
+						}(),
+						new class extends mock<IHoverService>() { }(),
+						instantiationService,
+						new MockContextKeyService(),
+						new class extends mock<IChatSessionsService>() {
+							override async resolveChatSessionItem() { return undefined; }
+						}(),
+						accessibilityService,
+						new class extends mock<IVoicePlaybackService>() {
+							override readonly pendingResponseVersion = observableValue<number>('pendingResponseVersion', 0);
+							override hasPendingResponse() { return false; }
+						}(),
+					));
+					const template = renderer.renderTemplate(listRow);
+					const render = (session: IAgentSession) => {
+						const treeNode: ITreeNode<IAgentSession, FuzzyScore> = {
+							element: session,
+							children: [],
+							depth: 0,
+							visibleChildrenCount: 0,
+							visibleChildIndex: 0,
+							collapsible: false,
+							collapsed: false,
+							visible: true,
+							filterData: undefined,
+						};
+						renderer.renderElement(treeNode, 0, template);
+					};
+					render(session);
+					store.add(toDisposable(() => renderer.disposeTemplate(template)));
 
 					return {
-						container,
-						statusIcon: store.add(new AgentSessionStatusIcon(container, getAgentSessionStatusIcon, accessibilityService)),
+						icon: listRow.querySelector<HTMLElement>('.agent-session-icon')!,
+						render,
 					};
 				};
 
-				const normalMotion = createStatusIcon(false);
-				normalMotion.statusIcon.setStatus(createMockSession({ status: ChatSessionStatus.InProgress }));
-				const inProgressSpinner = normalMotion.container.querySelector<HTMLElement>('.monaco-pixel-spinner');
+				const normalMotion = renderStatusIcon(false, createMockSession({ status: ChatSessionStatus.InProgress }));
+				const inProgressSpinner = normalMotion.icon.querySelector<HTMLElement>('.monaco-pixel-spinner');
 				assert.ok(inProgressSpinner);
 				assert.deepStrictEqual({
-					slotWidth: mainWindow.getComputedStyle(normalMotion.container).width,
+					slotWidth: mainWindow.getComputedStyle(normalMotion.icon).width,
 					spinnerWidth: mainWindow.getComputedStyle(inProgressSpinner).width,
 					spinnerTransform: mainWindow.getComputedStyle(inProgressSpinner).transform,
 					ariaHidden: inProgressSpinner.getAttribute('aria-hidden'),
@@ -198,17 +239,16 @@ suite('AgentSessionsDataSource', () => {
 					ariaHidden: 'true',
 				});
 
-				normalMotion.statusIcon.setStatus(createMockSession({ status: ChatSessionStatus.NeedsInput }));
-				assert.ok(normalMotion.container.querySelector('.monaco-pixel-spinner-ring'));
+				normalMotion.render(createMockSession({ status: ChatSessionStatus.NeedsInput }));
+				assert.ok(normalMotion.icon.querySelector('.monaco-pixel-spinner-ring'));
 
-				const reducedMotion = createStatusIcon(true);
-				reducedMotion.statusIcon.setStatus(createMockSession({ status: ChatSessionStatus.NeedsInput }));
-				const needsInputGlyph = reducedMotion.container.querySelector<HTMLElement>('.codicon');
+				const reducedMotion = renderStatusIcon(true, createMockSession({ status: ChatSessionStatus.NeedsInput }));
+				const needsInputGlyph = reducedMotion.icon.querySelector<HTMLElement>('.codicon');
 				assert.ok(needsInputGlyph);
 				assert.deepStrictEqual({
 					glyphFontSize: mainWindow.getComputedStyle(needsInputGlyph).fontSize,
-					iconAnimation: mainWindow.getComputedStyle(reducedMotion.container).animationName,
-					hasSpinner: !!reducedMotion.container.querySelector('.monaco-pixel-spinner'),
+					iconAnimation: mainWindow.getComputedStyle(reducedMotion.icon).animationName,
+					hasSpinner: !!reducedMotion.icon.querySelector('.monaco-pixel-spinner'),
 				}, {
 					glyphFontSize: '12px',
 					iconAnimation: 'none',

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -4,9 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { mainWindow } from '../../../../../../base/browser/window.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter, groupAgentSessionsByDate, getAgentSessionStatusIcon } from '../../../browser/agentSessions/agentSessionsViewer.js';
+import { AgentSessionStatusIcon, AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter, groupAgentSessionsByDate, getAgentSessionStatusIcon } from '../../../browser/agentSessions/agentSessionsViewer.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, isAgentSession, isAgentSessionSection, isAgentSessionShowLess, isAgentSessionShowMore } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { ChatSessionStatus } from '../../../common/chatSessionsService.js';
 import { ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
@@ -15,6 +17,7 @@ import { Event } from '../../../../../../base/common/event.js';
 import { AgentSessionsGrouping, AgentSessionsSorting } from '../../../browser/agentSessions/agentSessionsFilter.js';
 import { shouldShowSessionInPicker } from '../../../browser/agentSessions/agentSessionsPicker.js';
 import { themeColorFromId } from '../../../../../../base/common/themables.js';
+import { TestAccessibilityService } from '../../../../../../platform/accessibility/test/common/testAccessibilityService.js';
 
 suite('sessionDateFromNow', () => {
 
@@ -124,7 +127,7 @@ suite('AgentSessionsDataSource', () => {
 
 	suite('getAgentSessionStatusIcon', () => {
 
-		test('matches sessions window state icons', () => {
+		test('uses compact status icons', () => {
 			const cases = [
 				['read', createMockSession({ id: 'read' })],
 				['unread', createMockSession({ id: 'unread', isRead: false })],
@@ -135,13 +138,76 @@ suite('AgentSessionsDataSource', () => {
 			] as const;
 
 			assert.deepStrictEqual(cases.map(([name, session]) => [name, getAgentSessionStatusIcon(session)]), [
-				['read', { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') }],
-				['unread', { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') }],
-				['archived', { ...Codicon.passFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') }],
-				['in-progress', { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') }],
-				['needs-input', { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') }],
-				['failed', { ...Codicon.error, color: themeColorFromId('errorForeground') }],
+				['read', { ...Codicon.circleSmallFilledCompact, color: themeColorFromId('agentSessionReadIndicator.foreground') }],
+				['unread', { ...Codicon.circleFilledCompact, color: themeColorFromId('textLink.foreground') }],
+				['archived', { ...Codicon.passFilledCompact, color: themeColorFromId('agentSessionReadIndicator.foreground') }],
+				['in-progress', { ...Codicon.sessionInProgressCompact, color: themeColorFromId('textLink.foreground') }],
+				['needs-input', { ...Codicon.circleFilledCompact, color: themeColorFromId('list.warningForeground') }],
+				['failed', { ...Codicon.errorCompact, color: themeColorFromId('errorForeground') }],
 			]);
+		});
+
+		test('renders compact glyphs and scaled spinners in a centered status slot', () => {
+			const store = new DisposableStore();
+			try {
+				const createStatusIcon = (motionReduced: boolean) => {
+					const root = mainWindow.document.createElement('div');
+					root.classList.add('monaco-workbench', motionReduced ? 'monaco-reduce-motion' : 'monaco-enable-motion');
+					const viewer = mainWindow.document.createElement('div');
+					viewer.classList.add('agent-sessions-viewer');
+					const container = mainWindow.document.createElement('div');
+					viewer.appendChild(container);
+					root.appendChild(viewer);
+					mainWindow.document.body.appendChild(root);
+					store.add(toDisposable(() => root.remove()));
+
+					const accessibilityService = new class extends TestAccessibilityService {
+						override isMotionReduced(): boolean {
+							return motionReduced;
+						}
+					}();
+
+					return {
+						container,
+						statusIcon: store.add(new AgentSessionStatusIcon(container, getAgentSessionStatusIcon, accessibilityService)),
+					};
+				};
+
+				const normalMotion = createStatusIcon(false);
+				normalMotion.statusIcon.setStatus(createMockSession({ status: ChatSessionStatus.InProgress }));
+				const inProgressSpinner = normalMotion.container.querySelector<HTMLElement>('.monaco-pixel-spinner');
+				assert.ok(inProgressSpinner);
+				assert.deepStrictEqual({
+					slotWidth: mainWindow.getComputedStyle(normalMotion.container).width,
+					spinnerWidth: mainWindow.getComputedStyle(inProgressSpinner).width,
+					spinnerTransform: mainWindow.getComputedStyle(inProgressSpinner).transform,
+					ariaHidden: inProgressSpinner.getAttribute('aria-hidden'),
+				}, {
+					slotWidth: '16px',
+					spinnerWidth: '16px',
+					spinnerTransform: 'matrix(0.75, 0, 0, 0.75, 0, 0)',
+					ariaHidden: 'true',
+				});
+
+				normalMotion.statusIcon.setStatus(createMockSession({ status: ChatSessionStatus.NeedsInput }));
+				assert.ok(normalMotion.container.querySelector('.monaco-pixel-spinner-ring'));
+
+				const reducedMotion = createStatusIcon(true);
+				reducedMotion.statusIcon.setStatus(createMockSession({ status: ChatSessionStatus.NeedsInput }));
+				const needsInputGlyph = reducedMotion.container.querySelector<HTMLElement>('.codicon');
+				assert.ok(needsInputGlyph);
+				assert.deepStrictEqual({
+					glyphFontSize: mainWindow.getComputedStyle(needsInputGlyph).fontSize,
+					iconAnimation: mainWindow.getComputedStyle(reducedMotion.container).animationName,
+					hasSpinner: !!reducedMotion.container.querySelector('.monaco-pixel-spinner'),
+				}, {
+					glyphFontSize: '12px',
+					iconAnimation: 'none',
+					hasSpinner: false,
+				});
+			} finally {
+				store.dispose();
+			}
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -155,8 +155,17 @@ suite('AgentSessionsDataSource', () => {
 					root.classList.add('monaco-workbench', motionReduced ? 'monaco-reduce-motion' : 'monaco-enable-motion');
 					const viewer = mainWindow.document.createElement('div');
 					viewer.classList.add('agent-sessions-viewer');
+					const listRow = mainWindow.document.createElement('div');
+					listRow.classList.add('monaco-list-row');
+					const item = mainWindow.document.createElement('div');
+					item.classList.add('agent-session-item');
+					const iconColumn = mainWindow.document.createElement('div');
+					iconColumn.classList.add('agent-session-icon-col');
 					const container = mainWindow.document.createElement('div');
-					viewer.appendChild(container);
+					iconColumn.appendChild(container);
+					item.appendChild(iconColumn);
+					listRow.appendChild(item);
+					viewer.appendChild(listRow);
 					root.appendChild(viewer);
 					mainWindow.document.body.appendChild(root);
 					store.add(toDisposable(() => root.remove()));

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/agentSessionsViewer.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/agentSessionsViewer.fixture.ts
@@ -16,6 +16,8 @@ import { IMarkdownRendererService, MarkdownRendererService } from '../../../../.
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
+import { TestAccessibilityService } from '../../../../../platform/accessibility/test/common/testAccessibilityService.js';
 import { EditorMarkdownCodeBlockRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/editorMarkdownCodeBlockRenderer.js';
 import { AgentSessionRenderer, AgentSessionSectionRenderer, IAgentSessionRendererOptions } from '../../../../contrib/chat/browser/agentSessions/agentSessionsViewer.js';
 import { IChatSessionsService } from '../../../../contrib/chat/common/chatSessionsService.js';
@@ -95,7 +97,7 @@ function createMockApprovalModel(sessionResource: URI, info: IAgentSessionApprov
 	}();
 }
 
-function renderSessionItem(ctx: ComponentFixtureContext, session: IAgentSession, approvalModel?: AgentSessionApprovalModel): void {
+function renderSessionItem(ctx: ComponentFixtureContext, session: IAgentSession, approvalModel?: AgentSessionApprovalModel, motionReduced = true): void {
 	const { container, disposableStore } = ctx;
 
 	const instantiationService = createEditorServices(disposableStore, {
@@ -120,6 +122,11 @@ function renderSessionItem(ctx: ComponentFixtureContext, session: IAgentSession,
 				override hasPendingResponse() { return false; }
 				override hasLastPlayed() { return false; }
 				override getLastPlayed() { return undefined; }
+			}());
+			reg.defineInstance(IAccessibilityService, new class extends TestAccessibilityService {
+				override isMotionReduced(): boolean {
+					return motionReduced;
+				}
 			}());
 		},
 	});
@@ -150,6 +157,32 @@ function renderSessionItem(ctx: ComponentFixtureContext, session: IAgentSession,
 		renderer.disposeElement(treeNode, 0, template);
 		renderer.disposeTemplate(template);
 	}));
+}
+
+function renderStatusIconVariants(ctx: ComponentFixtureContext, motionReduced: boolean): void {
+	const now = Date.now();
+	ctx.container.classList.toggle('monaco-reduce-motion', motionReduced);
+	ctx.container.classList.toggle('monaco-enable-motion', !motionReduced);
+	const cases = [
+		{ label: 'Completed read', status: AgentSessionStatus.Completed },
+		{ label: 'Completed unread', status: AgentSessionStatus.Completed, isRead: () => false },
+		{ label: 'Archived', status: AgentSessionStatus.Completed, isArchived: () => true },
+		{ label: 'In progress', status: AgentSessionStatus.InProgress },
+		{ label: 'Needs input', status: AgentSessionStatus.NeedsInput },
+		{ label: 'Failed', status: AgentSessionStatus.Failed },
+	] as const;
+
+	for (const status of cases) {
+		renderSessionItem(ctx, createMockSession({
+			...status,
+			providerType: AgentSessionProviders.Local,
+			timing: {
+				created: now - 5 * 60 * 1000,
+				lastRequestStarted: now - 2 * 60 * 1000,
+				lastRequestEnded: status.status === AgentSessionStatus.Completed || status.status === AgentSessionStatus.Failed ? now - 60 * 1000 : undefined,
+			},
+		}), undefined, motionReduced);
+	}
 }
 
 function renderSectionItem(ctx: ComponentFixtureContext, section: IAgentSessionSection): void {
@@ -196,6 +229,10 @@ function renderSectionItem(ctx: ComponentFixtureContext, section: IAgentSessionS
 export default defineThemedFixtureGroup({
 
 	// --- Status variants ---
+
+	ReducedMotionStatusIconVariants: defineComponentFixture({
+		render: ctx => renderStatusIconVariants(ctx, true),
+	}),
 
 	CompletedRead: defineComponentFixture({
 		render: (ctx) => {


### PR DESCRIPTION
## Summary

- size Agent Sessions status glyphs to the adjacent text tier
- retain a stable centered icon slot for row alignment
- scope pixel-spinner sizing to Agent Sessions instead of changing shared spinner usage
- cover normal and reduced-motion status variants with focused tests and a component fixture

## Validation

- pre-commit hygiene passed
- earlier implementation pass passed `npm run typecheck-client`, targeted Agent Sessions tests, hygiene, and `npm run valid-layers-check`
- final revision agent/report was still running when this weekend-safe snapshot was pushed

## WIP status

An initial independent review found that parent font sizing did not override direct codicons and that animated spinners remained 16x16. This snapshot contains the focused revision and fixture/test expansion, but still requires final independent review and interactive visual verification.

## Manual verification

In Dark 2026 and Light 2026, inspect active, unread, needs-input, failed, and archived Agent Sessions. Repeat with reduced motion and confirm text-tier sizing, centered alignment, and no clipping.

Fixes #324892