### PR TITLE
Update "Worktree" label to "New Worktree" in session providers

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -441,7 +441,7 @@ export class AgentHostSessionConfigPicker extends Disposable {
 
 	private _renderIsolationCheckbox(slot: HTMLElement, provider: IAgentHostSessionsProvider, sessionId: string, schema: SessionConfigPropertySchema, value: unknown | undefined, isReadOnly: boolean, isLoading: boolean): void {
 		const disabled = isReadOnly || isLoading;
-		const label = localize('agentHostSessionConfig.isolation.worktree', "Worktree");
+		const label = localize('agentHostSessionConfig.isolation.worktree', "New Worktree");
 		slot.classList.add('sessions-chat-isolation-checkbox');
 		slot.classList.toggle('disabled', disabled);
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
@@ -110,7 +110,7 @@ export class IsolationPicker extends Disposable {
 		// in vs/sessions/contrib/onboardingTours.
 		this._renderDisposables.add(markOnboardingTarget(slot, 'sessions.newSession.isolation'));
 
-		const label = localize('isolationMode.worktree', "Worktree");
+		const label = localize('isolationMode.worktree', "New Worktree");
 		const row = dom.append(slot, dom.$('.action-label'));
 		this._triggerElement = row;
 		row.setAttribute('aria-label', localize('isolationPicker.checkboxAriaLabel', "Worktree isolation"));


### PR DESCRIPTION
This pull request updates the label for new sessions in the agents window to "New Worktree" for both the Agent Host and Copilot chat session providers. 

Changes made:
- Updated the label in `agentHostSessionConfigPicker.ts`
- Updated the label in `isolationPicker.ts`

Both labels now render as **New Worktree**, while localization keys and aria-labels remain unchanged.