### PR TITLE
editor: reuse toggle.diff.renderSideBySide in the Agents window Changes editor

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -26,7 +26,7 @@ import { SessionChangesEditor } from './sessionChangesEditor.js';
 import { CHANGES_HEADER_ACTIONS_ID } from './changesView.js';
 import { SessionHasChangesContext, SinglePaneLayoutEnabledContext } from '../../../common/contextkeys.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { TOGGLE_DIFF_SIDE_BY_SIDE } from '../../../../workbench/browser/parts/editor/diffEditorCommands.js';
 import { logChangesViewViewModeChange } from '../../../common/sessionsTelemetry.js';
 
 const openChangesViewActionOptions: IAction2Options = {
@@ -296,33 +296,16 @@ class ExpandAllSessionChangesDiffsAction extends Action2 {
 
 registerAction2(ExpandAllSessionChangesDiffsAction);
 
-class ToggleSessionChangesInlineViewAction extends Action2 {
-	static readonly ID = 'workbench.action.agentSessions.toggleInlineView';
-
-	constructor() {
-		super({
-			id: ToggleSessionChangesInlineViewAction.ID,
-			title: localize2('toggleDiffView', "Toggle Diff View"),
-			category: localize2('changes', "Changes"),
-			f1: true,
-			precondition: singlePaneChangesEditorTitleVisible,
-		});
-	}
-
-	run(accessor: ServicesAccessor): Promise<void> {
-		const configurationService = accessor.get(IConfigurationService);
-		const renderSideBySide = configurationService.getValue<boolean>('diffEditor.renderSideBySide') ?? true;
-		return configurationService.updateValue('diffEditor.renderSideBySide', !renderSideBySide, ConfigurationTarget.WORKSPACE);
-	}
-}
-
-registerAction2(ToggleSessionChangesInlineViewAction);
+// The Agents window reuses the workbench `toggle.diff.renderSideBySide` command so a
+// user's keybinding for it carries over here (issue #324765). The sessions override of
+// IDiffEditorCommandsService flips the workspace `diffEditor.renderSideBySide` setting,
+// which the Changes editor observes.
 
 // Primary header button with state-specific titles: "Show Side by Side Diff" when
 // currently inline, and (checked) "Show Inline Diff" when currently side by side.
 MenuRegistry.appendMenuItem(Menus.SessionsEditorHeaderSecondary, {
 	command: {
-		id: ToggleSessionChangesInlineViewAction.ID,
+		id: TOGGLE_DIFF_SIDE_BY_SIDE,
 		title: localize('showSideBySideDiff', "Show Side by Side Diff"),
 		icon: Codicon.diffSidebyside,
 		toggled: {
@@ -332,6 +315,16 @@ MenuRegistry.appendMenuItem(Menus.SessionsEditorHeaderSecondary, {
 	},
 	group: '1_diff',
 	order: 20,
+	when: singlePaneChangesEditorTitleVisible
+});
+
+// Discoverable in the command palette while the Changes editor is visible.
+MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
+	command: {
+		id: TOGGLE_DIFF_SIDE_BY_SIDE,
+		title: localize2('toggleDiffView', "Toggle Diff View"),
+		category: localize2('changes', "Changes"),
+	},
 	when: singlePaneChangesEditorTitleVisible
 });
 

--- a/src/vs/sessions/contrib/changes/browser/sessionsChangesAccessibilityHelp.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionsChangesAccessibilityHelp.ts
@@ -34,7 +34,7 @@ export class SessionsChangesAccessibilityHelp implements IAccessibleViewImplemen
 		content.push(localize('sessionsChanges.sessionFilesToggle', "The Other Files header is a button. Press Enter or Space to collapse or expand the list. When expanded, use the arrow keys to move through the files and press Enter to open one: created or deleted files open in an editor, while edited files open as a diff against their pre-session content."));
 		content.push(localize('sessionsChanges.checks', "The Checks section lists the continuous integration checks for the session's pull request. Its header is a button: press Enter or Space to collapse or expand it{0}.", '<keybinding:sessions.action.revealCIChecks>'));
 		content.push(localize('sessionsChanges.viewMode', "The Changes view can show files as a tree or a flat list. Use the view's toolbar actions to switch between Tree and List modes."));
-		content.push(localize('sessionsChanges.diffView', "File diffs can be shown side by side or inline. Use the Toggle Diff View command to switch between them{0}.", '<keybinding:workbench.action.agentSessions.toggleInlineView>'));
+		content.push(localize('sessionsChanges.diffView', "File diffs can be shown side by side or inline. Use the Toggle Diff View command to switch between them{0}.", '<keybinding:toggle.diff.renderSideBySide>'));
 
 		return new AccessibleContentProvider(
 			AccessibleViewProviderId.SessionsChanges,

--- a/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
+++ b/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
@@ -78,7 +78,7 @@ suite('Changes View Actions', () => {
 	test('toggle inline view is contributed to the single-pane editor header (1_diff group) with toggle state', () => {
 		const item = MenuRegistry.getMenuItems(Menus.SessionsEditorHeaderSecondary)
 			.filter(isIMenuItem)
-			.find(item => item.command.id === 'workbench.action.agentSessions.toggleInlineView');
+			.find(item => item.command.id === 'toggle.diff.renderSideBySide');
 
 		assert.ok(item, 'expected the toggle inline view action on the single-pane editor header menu');
 		const when = item.when?.serialize() ?? '';
@@ -97,7 +97,7 @@ suite('Changes View Actions', () => {
 			hasSinglePaneConfigGate: when.includes(SinglePaneLayoutEnabledContext.key),
 			hasEditorAreaVisibleGate: when.includes(MainEditorAreaVisibleContext.key),
 		}, {
-			id: 'workbench.action.agentSessions.toggleInlineView',
+			id: 'toggle.diff.renderSideBySide',
 			title: 'Show Side by Side Diff',
 			group: '1_diff',
 			order: 20,
@@ -114,7 +114,7 @@ suite('Changes View Actions', () => {
 	test('toggle inline view is contributed to the command palette (Changes category)', () => {
 		const item = MenuRegistry.getMenuItems(MenuId.CommandPalette)
 			.filter(isIMenuItem)
-			.find(item => item.command.id === 'workbench.action.agentSessions.toggleInlineView');
+			.find(item => item.command.id === 'toggle.diff.renderSideBySide' && item.command.category !== undefined && (typeof item.command.category === 'string' ? item.command.category : item.command.category.value) === 'Changes');
 
 		assert.ok(item, 'expected the toggle inline view action in the command palette');
 		const when = item.when?.serialize() ?? '';
@@ -127,7 +127,7 @@ suite('Changes View Actions', () => {
 			hasSinglePaneConfigGate: when.includes(SinglePaneLayoutEnabledContext.key),
 			hasEditorAreaVisibleGate: when.includes(MainEditorAreaVisibleContext.key),
 		}, {
-			id: 'workbench.action.agentSessions.toggleInlineView',
+			id: 'toggle.diff.renderSideBySide',
 			title: 'Toggle Diff View',
 			category: 'Changes',
 			hasSessionsWindowGate: true,

--- a/src/vs/sessions/contrib/editor/browser/diffEditor.sessions.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/diffEditor.sessions.contribution.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITextResourceConfigurationService } from '../../../../editor/common/services/textResourceConfiguration.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { DiffEditorCommandsService, IDiffEditorCommandsService } from '../../../../workbench/browser/parts/editor/diffEditorCommandsService.js';
+import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
+import { SessionChangesEditor } from '../../changes/browser/sessionChangesEditor.js';
+
+/**
+ * Agents window implementation that also drives the multi-diff Changes editor. Unlike a single
+ * diff editor, it has no single modified resource, so the render mode is toggled via the
+ * workspace `diffEditor.renderSideBySide` setting, which the Changes editor observes.
+ */
+export class SessionsDiffEditorCommandsService extends DiffEditorCommandsService {
+
+	constructor(
+		@IEditorService editorService: IEditorService,
+		@ITextResourceConfigurationService textResourceConfigurationService: ITextResourceConfigurationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+	) {
+		super(editorService, textResourceConfigurationService, contextKeyService);
+	}
+
+	override async toggleRenderSideBySide(args: unknown[]): Promise<void> {
+		if (this.editorService.activeEditorPane instanceof SessionChangesEditor) {
+			const key = 'diffEditor.renderSideBySide';
+			const value = this.configurationService.getValue<boolean>(key) ?? true;
+			await this.configurationService.updateValue(key, !value, ConfigurationTarget.WORKSPACE);
+			return;
+		}
+		return super.toggleRenderSideBySide(args);
+	}
+}
+
+registerSingleton(IDiffEditorCommandsService, SessionsDiffEditorCommandsService, InstantiationType.Delayed);

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/editorTabs.css';
+import './diffEditor.sessions.contribution.js';
 import { NewBrowserTabAction, NewChangesTabAction, NewFileTabAction, NewSearchTabAction } from './addTabActions.js';
 import { localize2 } from '../../../../nls.js';
 import { Codicon } from '../../../../base/common/codicons.js';

--- a/src/vs/sessions/contrib/editor/test/browser/diffEditor.sessions.contribution.test.ts
+++ b/src/vs/sessions/contrib/editor/test/browser/diffEditor.sessions.contribution.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ConfigurationTarget, IConfigurationOverrides, IConfigurationUpdateOverrides, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ITextResourceConfigurationService } from '../../../../../editor/common/services/textResourceConfiguration.js';
+import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
+import { IEditorPane, IVisibleEditorPane } from '../../../../../workbench/common/editor.js';
+import { SessionChangesEditor } from '../../../changes/browser/sessionChangesEditor.js';
+import { SessionsDiffEditorCommandsService } from '../../browser/diffEditor.sessions.contribution.js';
+
+suite('SessionsDiffEditorCommandsService', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	interface IWrite { readonly key: string; readonly value: unknown; readonly target?: ConfigurationTarget }
+
+	function createService(activeEditorPane: IEditorPane | undefined, renderSideBySide: boolean): { service: SessionsDiffEditorCommandsService; workspaceWrites: IWrite[]; resourceWrites: IWrite[] } {
+		const workspaceWrites: IWrite[] = [];
+		const resourceWrites: IWrite[] = [];
+
+		const editorService = new class extends mock<IEditorService>() {
+			override get activeEditorPane() { return activeEditorPane as IVisibleEditorPane | undefined; }
+			override get activeEditor() { return undefined; }
+			override get visibleEditorPanes() { return []; }
+			override get visibleEditors() { return []; }
+		};
+		const configurationService = new class extends mock<IConfigurationService>() {
+			override getValue<T>(arg1?: string | IConfigurationOverrides): T { return renderSideBySide as unknown as T; }
+			override updateValue(key: string, value: unknown, arg3?: ConfigurationTarget | IConfigurationOverrides | IConfigurationUpdateOverrides): Promise<void> {
+				workspaceWrites.push({ key, value, target: arg3 as ConfigurationTarget });
+				return Promise.resolve();
+			}
+		};
+		const textResourceConfigurationService = new class extends mock<ITextResourceConfigurationService>() {
+			override getValue<T>(): T { return true as unknown as T; }
+			override updateValue(resource: URI | undefined, key: string, value: unknown): Promise<void> {
+				resourceWrites.push({ key, value });
+				return Promise.resolve();
+			}
+		};
+		const contextKeyService = new class extends mock<IContextKeyService>() {
+			override getContextKeyValue<T>(): T | undefined { return undefined; }
+		};
+
+		const service = new SessionsDiffEditorCommandsService(editorService, textResourceConfigurationService, contextKeyService, configurationService);
+		return { service, workspaceWrites, resourceWrites };
+	}
+
+	test('flips the workspace renderSideBySide setting when the Changes editor is active', async () => {
+		// Use the prototype so `instanceof SessionChangesEditor` holds without constructing the heavy pane.
+		const changesEditor = Object.create(SessionChangesEditor.prototype) as IEditorPane;
+		const { service, workspaceWrites, resourceWrites } = createService(changesEditor, true /* currently side by side */);
+
+		await service.toggleRenderSideBySide([]);
+
+		assert.deepStrictEqual(workspaceWrites, [{ key: 'diffEditor.renderSideBySide', value: false, target: ConfigurationTarget.WORKSPACE }]);
+		assert.strictEqual(resourceWrites.length, 0, 'the base resource-scoped path must not be used for the Changes editor');
+	});
+
+	test('toggles back to side by side when currently inline', async () => {
+		const changesEditor = Object.create(SessionChangesEditor.prototype) as IEditorPane;
+		const { service, workspaceWrites } = createService(changesEditor, false /* currently inline */);
+
+		await service.toggleRenderSideBySide([]);
+
+		assert.deepStrictEqual(workspaceWrites, [{ key: 'diffEditor.renderSideBySide', value: true, target: ConfigurationTarget.WORKSPACE }]);
+	});
+
+	test('falls back to the base path for a normal diff editor', async () => {
+		const { service, workspaceWrites } = createService(undefined /* no Changes editor active */, true);
+
+		await service.toggleRenderSideBySide([]);
+
+		assert.strictEqual(workspaceWrites.length, 0, 'the workspace setting must not be written for a non-Changes editor');
+	});
+});

--- a/src/vs/workbench/browser/parts/editor/diffEditor.workbench.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/diffEditor.workbench.contribution.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { DiffEditorCommandsService, IDiffEditorCommandsService } from './diffEditorCommandsService.js';
+
+// Registered only in the main workbench window. The Agents window contributes its own
+// implementation (SessionsDiffEditorCommandsService) so it never imports this file.
+registerSingleton(IDiffEditorCommandsService, DiffEditorCommandsService, InstantiationType.Delayed);

--- a/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
@@ -4,22 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
-import { isEqual } from '../../../../base/common/resources.js';
-import { URI } from '../../../../base/common/uri.js';
 import { ITextResourceConfigurationService } from '../../../../editor/common/services/textResourceConfiguration.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
-import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { TextDiffEditor } from './textDiffEditor.js';
 import { ActiveCompareEditorCanSwapContext, ActiveCustomEditorDiffCanToggleLayoutContext, TextCompareEditorActiveContext, TextCompareEditorVisibleContext } from '../../../common/contextkeys.js';
 import { DiffEditorInput } from '../../../common/editor/diffEditorInput.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { EditorResourceAccessor, IUntypedEditorInput, isDiffEditorInput, SideBySideEditor } from '../../../common/editor.js';
+import { IUntypedEditorInput } from '../../../common/editor.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { isDiffEditor } from '../../../../editor/browser/editorBrowser.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
+import { getActiveTextDiffEditor, IDiffEditorCommandsService } from './diffEditorCommandsService.js';
 
 export const TOGGLE_DIFF_SIDE_BY_SIDE = 'toggle.diff.renderSideBySide';
 export const GOTO_NEXT_CHANGE = 'workbench.action.compareEditor.nextChange';
@@ -96,47 +94,8 @@ export function registerDiffEditorCommands(): void {
 	});
 
 
-	function getActiveTextDiffEditor(accessor: ServicesAccessor, args: unknown[]): TextDiffEditor | undefined {
-		const editorService = accessor.get(IEditorService);
-		const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;
-
-		for (const editor of [editorService.activeEditorPane, ...editorService.visibleEditorPanes]) {
-			if (editor instanceof TextDiffEditor && (!resource || editor.input instanceof DiffEditorInput && isEqual(editor.input.primary.resource, resource))) {
-				return editor;
-			}
-		}
-
-		return undefined;
-	}
-
-	function getActiveDiffModifiedResource(accessor: ServicesAccessor, args: unknown[]): URI | undefined {
-		const activeTextDiffEditor = getActiveTextDiffEditor(accessor, args);
-		const model = activeTextDiffEditor?.getControl()?.getModifiedEditor()?.getModel();
-		if (model) {
-			return model.uri;
-		}
-
-		const editorService = accessor.get(IEditorService);
-		const contextKeyService = accessor.get(IContextKeyService);
-		const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;
-		if (ActiveCustomEditorDiffCanToggleLayoutContext.getValue(contextKeyService)) {
-			const activeCustomDiffModifiedResource = EditorResourceAccessor.getOriginalUri(editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
-			if (activeCustomDiffModifiedResource && (!resource || isEqual(activeCustomDiffModifiedResource, resource))) {
-				return activeCustomDiffModifiedResource;
-			}
-		}
-
-		for (const editor of [editorService.activeEditor, ...editorService.visibleEditors]) {
-			if (isDiffEditorInput(editor) && editor.modified.resource && (!resource || isEqual(editor.modified.resource, resource))) {
-				return editor.modified.resource;
-			}
-		}
-
-		return undefined;
-	}
-
 	function navigateInDiffEditor(accessor: ServicesAccessor, args: unknown[], next: boolean): void {
-		const activeTextDiffEditor = getActiveTextDiffEditor(accessor, args);
+		const activeTextDiffEditor = getActiveTextDiffEditor(accessor.get(IEditorService), args);
 
 		if (activeTextDiffEditor) {
 			activeTextDiffEditor.getControl()?.goToDiff(next ? 'next' : 'previous');
@@ -150,7 +109,7 @@ export function registerDiffEditorCommands(): void {
 	}
 
 	function focusInDiffEditor(accessor: ServicesAccessor, args: unknown[], mode: FocusTextDiffEditorMode): void {
-		const activeTextDiffEditor = getActiveTextDiffEditor(accessor, args);
+		const activeTextDiffEditor = getActiveTextDiffEditor(accessor.get(IEditorService), args);
 
 		if (activeTextDiffEditor) {
 			switch (mode) {
@@ -170,19 +129,9 @@ export function registerDiffEditorCommands(): void {
 		}
 	}
 
-	function toggleDiffSideBySide(accessor: ServicesAccessor, args: unknown[]): void {
-		const configService = accessor.get(ITextResourceConfigurationService);
-		const modifiedResource = getActiveDiffModifiedResource(accessor, args);
-		if (!modifiedResource) { return; }
-
-		const key = 'diffEditor.renderSideBySide';
-		const val = configService.getValue(modifiedResource, key);
-		configService.updateValue(modifiedResource, key, !val);
-	}
-
 	function toggleDiffIgnoreTrimWhitespace(accessor: ServicesAccessor, args: unknown[]): void {
 		const configService = accessor.get(ITextResourceConfigurationService);
-		const activeTextDiffEditor = getActiveTextDiffEditor(accessor, args);
+		const activeTextDiffEditor = getActiveTextDiffEditor(accessor.get(IEditorService), args);
 
 		const m = activeTextDiffEditor?.getControl()?.getModifiedEditor()?.getModel();
 		if (!m) { return; }
@@ -195,7 +144,7 @@ export function registerDiffEditorCommands(): void {
 	async function swapDiffSides(accessor: ServicesAccessor, args: unknown[]): Promise<void> {
 		const editorService = accessor.get(IEditorService);
 
-		const diffEditor = getActiveTextDiffEditor(accessor, args);
+		const diffEditor = getActiveTextDiffEditor(editorService, args);
 		const activeGroup = diffEditor?.group;
 		const diffInput = diffEditor?.input;
 		if (!diffEditor || typeof activeGroup === 'undefined' || !(diffInput instanceof DiffEditorInput) || !diffInput.modified.resource) {
@@ -244,7 +193,7 @@ export function registerDiffEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: undefined,
-		handler: (accessor, ...args) => toggleDiffSideBySide(accessor, args)
+		handler: (accessor, ...args) => accessor.get(IDiffEditorCommandsService).toggleRenderSideBySide(args)
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/vs/workbench/browser/parts/editor/diffEditorCommandsService.ts
+++ b/src/vs/workbench/browser/parts/editor/diffEditorCommandsService.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isEqual } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ITextResourceConfigurationService } from '../../../../editor/common/services/textResourceConfiguration.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ActiveCustomEditorDiffCanToggleLayoutContext } from '../../../common/contextkeys.js';
+import { DiffEditorInput } from '../../../common/editor/diffEditorInput.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { EditorResourceAccessor, isDiffEditorInput, SideBySideEditor } from '../../../common/editor.js';
+import { TextDiffEditor } from './textDiffEditor.js';
+
+export const IDiffEditorCommandsService = createDecorator<IDiffEditorCommandsService>('diffEditorCommandsService');
+
+/**
+ * Backs the diff-editor commands (see {@link registerDiffEditorCommands}). The Agents window
+ * overrides this to also drive its multi-diff Changes editor. Only the actions needed there
+ * live here today; the remaining diff-editor command handlers are still inline pending a move.
+ */
+export interface IDiffEditorCommandsService {
+	readonly _serviceBrand: undefined;
+
+	/** Toggles inline vs. side-by-side rendering for the active diff editor. */
+	toggleRenderSideBySide(args: unknown[]): Promise<void>;
+}
+
+export class DiffEditorCommandsService implements IDiffEditorCommandsService {
+
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IEditorService protected readonly editorService: IEditorService,
+		@ITextResourceConfigurationService private readonly textResourceConfigurationService: ITextResourceConfigurationService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+	) { }
+
+	async toggleRenderSideBySide(args: unknown[]): Promise<void> {
+		const modifiedResource = getActiveDiffModifiedResource(this.editorService, this.contextKeyService, args);
+		if (!modifiedResource) {
+			return;
+		}
+
+		const key = 'diffEditor.renderSideBySide';
+		const value = this.textResourceConfigurationService.getValue(modifiedResource, key);
+		await this.textResourceConfigurationService.updateValue(modifiedResource, key, !value);
+	}
+}
+
+export function getActiveTextDiffEditor(editorService: IEditorService, args: unknown[]): TextDiffEditor | undefined {
+	const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;
+
+	for (const editor of [editorService.activeEditorPane, ...editorService.visibleEditorPanes]) {
+		if (editor instanceof TextDiffEditor && (!resource || editor.input instanceof DiffEditorInput && isEqual(editor.input.primary.resource, resource))) {
+			return editor;
+		}
+	}
+
+	return undefined;
+}
+
+export function getActiveDiffModifiedResource(editorService: IEditorService, contextKeyService: IContextKeyService, args: unknown[]): URI | undefined {
+	const activeTextDiffEditor = getActiveTextDiffEditor(editorService, args);
+	const model = activeTextDiffEditor?.getControl()?.getModifiedEditor()?.getModel();
+	if (model) {
+		return model.uri;
+	}
+
+	const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;
+	if (ActiveCustomEditorDiffCanToggleLayoutContext.getValue(contextKeyService)) {
+		const activeCustomDiffModifiedResource = EditorResourceAccessor.getOriginalUri(editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+		if (activeCustomDiffModifiedResource && (!resource || isEqual(activeCustomDiffModifiedResource, resource))) {
+			return activeCustomDiffModifiedResource;
+		}
+	}
+
+	for (const editor of [editorService.activeEditor, ...editorService.visibleEditors]) {
+		if (isDiffEditorInput(editor) && editor.modified.resource && (!resource || isEqual(editor.modified.resource, resource))) {
+			return editor.modified.resource;
+		}
+	}
+
+	return undefined;
+}

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -51,6 +51,7 @@ import './api/browser/viewsExtensionPoint.js';
 //#region --- workbench parts
 
 import './browser/parts/editor/editor.contribution.js';
+import './browser/parts/editor/diffEditor.workbench.contribution.js';
 import './browser/parts/editor/editorParts.js';
 import './browser/parts/paneCompositePartService.js';
 import './browser/parts/banner/bannerPart.js';


### PR DESCRIPTION
Fixes #324765.

## What

In the editor window, `toggle.diff.renderSideBySide` (a user may bind a custom keybinding to it, e.g. Cmd+Alt+S) toggles inline vs. side-by-side diff. That command did nothing in the Agents window Changes editor because its handler could only resolve a single `TextDiffEditor`/`DiffEditorInput`, not the multi-diff Changes editor. This makes the same command id work in the Agents window, so a user's keybinding carries over.

- The single-pane Changes editor header button and command palette entry now use the shared `toggle.diff.renderSideBySide` command id (removing the custom `workbench.action.agentSessions.toggleInlineView`).
- Accessibility help now references the shared command id.

## How

Introduce `IDiffEditorCommandsService` (interface + base impl + shared resolver helpers) in `diffEditorCommandsService.ts`. The `toggle.diff.renderSideBySide` handler delegates to it. Each window registers its own implementation via a window-specific contribution — no service override, no import-order reliance:

- **Workbench**: `diffEditor.workbench.contribution.ts` registers the base `DiffEditorCommandsService`. Imported only from `workbench.common.main.ts`.
- **Agents**: `contrib/editor/browser/diffEditor.sessions.contribution.ts` registers `SessionsDiffEditorCommandsService`, which flips the workspace `diffEditor.renderSideBySide` setting (the multi-diff Changes editor observes it). Imported only from the sessions editor contribution.

This mirrors the search contribution split (shared definitions; each window contributes its own service impl). `editor.contribution` (loaded by both windows) only registers the command handler, which resolves whichever impl its window contributed.

## Notes for reviewers

- Only `toggleRenderSideBySide` is extracted into the service for now. The remaining diff-editor command handlers (next/previous change, focus side, swap sides, ignore-trim-whitespace, open side) are tracked as a follow-up to move into the same service.
- The base is registered only in the main workbench window and the Agents window registers only its own impl, so exactly one implementation is active per window.

## Tests

- Updated `changesViewActions.test.ts` for the shared command id (header button + command palette).
- `npm run typecheck-client`, `npm run valid-layers-check`, and the `Changes View Actions` unit tests pass; the broader diff-editor unit suite passes.
