### PR TITLE
fix: hide next run time for disabled automations and restyle badge

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/automationsListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/automationsListWidget.ts
@@ -734,7 +734,7 @@ function dayName(day: number): string {
 }
 
 function formatNextRun(a: IAutomation): string {
-	if (a.schedule.interval === 'manual' || !a.nextRunAt) {
+	if (!a.enabled || a.schedule.interval === 'manual' || !a.nextRunAt) {
 		return localize('nextRunNever', "No scheduled run");
 	}
 	return localize('nextRun', "Next run {0}", formatRelativeTimeOrIso(a.nextRunAt));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -1937,12 +1937,10 @@ pane is first mounted. View switches inside the modal are not animated. */
 }
 
 .automations-list-widget .automations-row-disabled-badge {
-	font-size: 11px;
+	font-size: 12px;
 	font-weight: 400;
-	padding: 1px 6px;
-	border-radius: 3px;
-	background-color: var(--vscode-badge-background);
-	color: var(--vscode-badge-foreground);
+	font-style: italic;
+	color: var(--vscode-foreground);
 }
 
 .automations-list-widget .automations-row-meta {


### PR DESCRIPTION
- Don't show next run countdown when automation is disabled
- Change disabled badge from button-style to thin italic text

Fixes microsoft/vscode-internalbacklog#8335
Fixes microsoft/vscode-internalbacklog#8336