### PR TITLE
[DO NOT MERGE] Flake probe: subagent-reopen replay test 20x

### DIFF
--- a/src/vs/platform/agentHost/test/node/protocol/README.md
+++ b/src/vs/platform/agentHost/test/node/protocol/README.md
@@ -191,6 +191,7 @@ Guidelines:
 - `GET /models` — a curated stub catalog (keeps unreleased models out of fixtures).
 - `POST /models/session`, `POST /models/session/intent` — auto-mode selection. Deliberately answered with a `500 + x-should-retry:false` so the SDK falls back to the configured model (auto-mode isn't wanted in replay). Not counted as a cache miss.
 - `/copilot_internal/*token*`, `/copilot_internal/*user*` — fake token + generic user/identity.
+- `GET /copilot/mcp_registry` — enterprise MCP registry policy. The Copilot CLI fetches this only when the developer has local MCP servers configured (`~/.copilot/mcp-config.json`) on an org/enterprise plan, so whether it's called varies per machine. Served as an empty registry (`{ mcp_registries: [] }`) so a developer's local MCP config never breaks replay (issue #325248).
 - `/telemetry`, `/agents*` — empty bodies.
 
 Everything else — i.e. the model endpoints `/v1/messages` and `/responses` — is recorded/replayed as turns.

--- a/src/vs/platform/agentHost/test/node/protocol/README.md
+++ b/src/vs/platform/agentHost/test/node/protocol/README.md
@@ -177,6 +177,7 @@ Guidelines:
 | `supportsWorktreeIsolation` | Gates the worktree test. |
 | `supportsPlanMode` | Gates the plan-mode test. |
 | `shellPermissionReplayUnstableOnWindows` | Skips the shell-permission test on **Windows** for that provider (e.g. Codex's `exec_command` tool call isn't emitted by the Codex CLI on Windows). |
+| `subagentReplayUnstableOnWindows` | Skips the subagent-reopen ("replay path") test on **Windows** for that provider (e.g. Claude rebuilds the transcript from the SDK's on-disk `subagents/*.jsonl`, not reliably visible there right after the turn). |
 | `RECORD` (env) | The `can abort a running turn` test is record-only — replay serves the truncated response instantly, so there's no window to abort. |
 | `isWindows` | The worktree test is skipped on Windows (POSIX-shaped `.worktrees` paths + host-terminal `pwd`). |
 

--- a/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
@@ -1138,8 +1138,13 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 				`Parent tool calls: ${JSON.stringify(parentStarts.map(a => a.toolName))}`);
 		});
 
-		// Windows-skipped for providers with on-disk subagent replay (see `subagentReplayUnstableOnWindows`).
-		((isWindows && config.subagentReplayUnstableOnWindows) ? test.skip : (config.supportsSubagents ? test : test.skip))('reopening a session keeps sub-agent messages out of the parent transcript (replay path)', async function () {
+		// FLAKE PROBE (throwaway branch — do NOT merge): register the subagent-reopen
+		// test many times, ungated on Windows, so CI empirically exercises the
+		// Claude/Windows path that motivated `subagentReplayUnstableOnWindows`. Every
+		// registration keeps the identical title so all runs reuse the one committed
+		// fixture. Count is env-tunable via AGENT_HOST_FLAKE_PROBE_COUNT.
+		const __reopenProbeCount = Number(process.env['AGENT_HOST_FLAKE_PROBE_COUNT'] ?? '20') || 1;
+		const __runReopenTest = async function (this: Mocha.Context) {
 			this.timeout(180_000);
 
 			const tempDir = mkdtempSync(`${tmpdir()}/ahp-subagent-replay-`);
@@ -1260,7 +1265,10 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 				`parent transcript must NOT contain the sub-agent's phrase after reopen ` +
 				`(replay path leaked sub-agent assistant.message into parent turns); ` +
 				`parent text: ${JSON.stringify(parentText).slice(0, 800)}`);
-		});
+		};
+		for (let __probe = 0; __probe < __reopenProbeCount; __probe++) {
+			(config.supportsSubagents ? test : test.skip)('reopening a session keeps sub-agent messages out of the parent transcript (replay path)', __runReopenTest);
+		}
 	});
 }
 

--- a/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
@@ -175,14 +175,12 @@ export interface IAgentHostE2EProviderConfig {
 	 */
 	readonly shellPermissionReplayUnstableOnWindows?: boolean;
 	/**
-	 * When set, this provider reconstructs a reopened subagent transcript by
-	 * reading the bundled SDK's on-disk session storage (Claude reads the
-	 * `subagents/agent-*.jsonl` files the SDK subprocess wrote during the live
-	 * turn). On Windows those files are not reliably flushed/visible by the time
-	 * the session is reopened, so the subagent-reopen test can intermittently see
-	 * an empty transcript there. Gate that one test to POSIX for such providers;
-	 * macOS/Linux keep full coverage, and providers that rebuild from the
-	 * in-process event log (Copilot) are unaffected and stay enabled on Windows.
+	 * When set, the subagent-reopen ("replay path") test is skipped on Windows for
+	 * this provider, which rebuilds the reopened transcript from the bundled SDK's
+	 * on-disk `subagents/agent-*.jsonl` files — not reliably visible on Windows
+	 * right after the turn, so the transcript can come back empty. macOS/Linux keep
+	 * full coverage; providers that rebuild from the in-process event log (Copilot)
+	 * are unaffected and stay enabled on Windows.
 	 */
 	readonly subagentReplayUnstableOnWindows?: boolean;
 	/**
@@ -1140,12 +1138,7 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 				`Parent tool calls: ${JSON.stringify(parentStarts.map(a => a.toolName))}`);
 		});
 
-		// Reopening rebuilds the subagent transcript from persisted SDK state. For
-		// providers that read the bundled SDK's on-disk subagent files (Claude),
-		// those files are not reliably visible on Windows right after the turn, so
-		// the reopened transcript can come back empty there — gate to POSIX for
-		// those providers (macOS/Linux keep coverage; Copilot rebuilds from the
-		// in-process event log and stays enabled on Windows). See PR #325284.
+		// Windows-skipped for providers with on-disk subagent replay (see `subagentReplayUnstableOnWindows`).
 		((isWindows && config.subagentReplayUnstableOnWindows) ? test.skip : (config.supportsSubagents ? test : test.skip))('reopening a session keeps sub-agent messages out of the parent transcript (replay path)', async function () {
 			this.timeout(180_000);
 

--- a/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
@@ -175,6 +175,17 @@ export interface IAgentHostE2EProviderConfig {
 	 */
 	readonly shellPermissionReplayUnstableOnWindows?: boolean;
 	/**
+	 * When set, this provider reconstructs a reopened subagent transcript by
+	 * reading the bundled SDK's on-disk session storage (Claude reads the
+	 * `subagents/agent-*.jsonl` files the SDK subprocess wrote during the live
+	 * turn). On Windows those files are not reliably flushed/visible by the time
+	 * the session is reopened, so the subagent-reopen test can intermittently see
+	 * an empty transcript there. Gate that one test to POSIX for such providers;
+	 * macOS/Linux keep full coverage, and providers that rebuild from the
+	 * in-process event log (Copilot) are unaffected and stay enabled on Windows.
+	 */
+	readonly subagentReplayUnstableOnWindows?: boolean;
+	/**
 	 * Whether the provider's plan-mode flow matches the shared test's
 	 * expectations (auto-approve session-state writes; reach the
 	 * exit-plan-mode tool as an `inputRequested`). Currently true only for
@@ -1129,7 +1140,13 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 				`Parent tool calls: ${JSON.stringify(parentStarts.map(a => a.toolName))}`);
 		});
 
-		(/*config.supportsSubagents ? test :*/ test.skip)('reopening a session keeps sub-agent messages out of the parent transcript (replay path)', async function () {
+		// Reopening rebuilds the subagent transcript from persisted SDK state. For
+		// providers that read the bundled SDK's on-disk subagent files (Claude),
+		// those files are not reliably visible on Windows right after the turn, so
+		// the reopened transcript can come back empty there — gate to POSIX for
+		// those providers (macOS/Linux keep coverage; Copilot rebuilds from the
+		// in-process event log and stays enabled on Windows). See PR #325284.
+		((isWindows && config.subagentReplayUnstableOnWindows) ? test.skip : (config.supportsSubagents ? test : test.skip))('reopening a session keeps sub-agent messages out of the parent transcript (replay path)', async function () {
 			this.timeout(180_000);
 
 			const tempDir = mkdtempSync(`${tmpdir()}/ahp-subagent-replay-`);

--- a/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
@@ -1139,10 +1139,12 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 		});
 
 		// FLAKE PROBE (throwaway branch — do NOT merge): register the subagent-reopen
-		// test many times, ungated on Windows, so CI empirically exercises the
-		// Claude/Windows path that motivated `subagentReplayUnstableOnWindows`. Every
-		// registration keeps the identical title so all runs reuse the one committed
-		// fixture. Count is env-tunable via AGENT_HOST_FLAKE_PROBE_COUNT.
+		// test many times to stress the shipped fix. The Windows gate
+		// (`subagentReplayUnstableOnWindows`) is KEPT, so this confirms the gated fix
+		// stays all-green under repeat: Windows skips Claude, macOS/Linux run Claude Nx,
+		// and Copilot runs Nx everywhere. Every registration keeps the identical title
+		// so all runs reuse the one committed fixture. Count is env-tunable via
+		// AGENT_HOST_FLAKE_PROBE_COUNT.
 		const __reopenProbeCount = Number(process.env['AGENT_HOST_FLAKE_PROBE_COUNT'] ?? '20') || 1;
 		const __runReopenTest = async function (this: Mocha.Context) {
 			this.timeout(180_000);
@@ -1267,7 +1269,7 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 				`parent text: ${JSON.stringify(parentText).slice(0, 800)}`);
 		};
 		for (let __probe = 0; __probe < __reopenProbeCount; __probe++) {
-			(config.supportsSubagents ? test : test.skip)('reopening a session keeps sub-agent messages out of the parent transcript (replay path)', __runReopenTest);
+			((isWindows && config.subagentReplayUnstableOnWindows) ? test.skip : (config.supportsSubagents ? test : test.skip))('reopening a session keeps sub-agent messages out of the parent transcript (replay path)', __runReopenTest);
 		}
 	});
 }

--- a/src/vs/platform/agentHost/test/node/protocol/capiReplayProxy.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/capiReplayProxy.ts
@@ -91,7 +91,7 @@ const SYSTEM_FIELD_RE = /("instructions"\s*:\s*)"(?:[^"\\]|\\.)*"/g;
 const SYSTEM_PROMPT_PLACEHOLDER = '${system}';
 
 /** GitHub-API path prefixes (routed to the GitHub upstream, not CAPI). */
-const GITHUB_API_PREFIXES = ['/copilot_internal', '/telemetry'];
+const GITHUB_API_PREFIXES = ['/copilot_internal', '/telemetry', '/copilot/mcp_registry'];
 
 export type CapiReplayMode = 'record' | 'replay';
 

--- a/src/vs/platform/agentHost/test/node/protocol/capiStubs.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/capiStubs.ts
@@ -136,6 +136,16 @@ export function getAncillaryStub(method: string, path: string): IStubResponse | 
 	if ((path === '/models/session' || path === '/models/session/intent') && method === 'POST') {
 		return { status: 500, headers: { 'content-type': 'text/plain', 'x-should-retry': 'false' }, body: 'auto-mode not available in replay' };
 	}
+	// Enterprise MCP registry policy. The Copilot CLI fetches this only when the
+	// developer has local MCP servers configured (`~/.copilot/mcp-config.json`)
+	// on an org/enterprise plan — a local customization that varies per machine,
+	// so it must never be a recorded turn (it would fail replay for anyone whose
+	// local config differs, see issue #325248). Serve an empty registry so the
+	// CLI applies no enterprise restrictions and proceeds exactly as it does
+	// when no registry is configured.
+	if (path === '/copilot/mcp_registry' && method === 'GET') {
+		return { status: 200, headers: JSON_HEADERS, body: JSON.stringify({ mcp_registries: [] }) };
+	}
 	if (path.startsWith('/copilot_internal/')) {
 		if (path.includes('/token') || path.includes('/nltoken')) {
 			return { status: 200, headers: JSON_HEADERS, body: tokenStubBody() };

--- a/src/vs/platform/agentHost/test/node/protocol/capiStubs.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/capiStubs.ts
@@ -136,13 +136,10 @@ export function getAncillaryStub(method: string, path: string): IStubResponse | 
 	if ((path === '/models/session' || path === '/models/session/intent') && method === 'POST') {
 		return { status: 500, headers: { 'content-type': 'text/plain', 'x-should-retry': 'false' }, body: 'auto-mode not available in replay' };
 	}
-	// Enterprise MCP registry policy. The Copilot CLI fetches this only when the
-	// developer has local MCP servers configured (`~/.copilot/mcp-config.json`)
-	// on an org/enterprise plan — a local customization that varies per machine,
-	// so it must never be a recorded turn (it would fail replay for anyone whose
-	// local config differs, see issue #325248). Serve an empty registry so the
-	// CLI applies no enterprise restrictions and proceeds exactly as it does
-	// when no registry is configured.
+	// Enterprise MCP registry policy — fetched only when the developer has local
+	// MCP servers configured (`~/.copilot/mcp-config.json`), so it varies per
+	// machine and must be stubbed, not recorded (issue #325248). Empty registry =
+	// no enterprise restrictions, exactly as when none is configured.
 	if (path === '/copilot/mcp_registry' && method === 'GET') {
 		return { status: 200, headers: JSON_HEADERS, body: JSON.stringify({ mcp_registries: [] }) };
 	}

--- a/src/vs/platform/agentHost/test/node/protocol/claudeAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/claudeAgentHostE2E.integrationTest.ts
@@ -66,6 +66,11 @@ const CLAUDE_CONFIG: IAgentHostE2EProviderConfig = {
 	// The shared suite skips that test when the flag is false.
 	supportsWorktreeIsolation: false,
 	supportsSubagents: true,
+	// Reopening a subagent transcript reads the bundled SDK's on-disk
+	// `subagents/agent-*.jsonl` files, which are not reliably flushed/visible on
+	// Windows right after the turn — so the subagent-reopen test is gated to
+	// POSIX for Claude (see PR #325284). macOS/Linux keep full coverage.
+	subagentReplayUnstableOnWindows: true,
 	// Plan mode is wired (`ExitPlanMode` interactive tool exists) but the
 	// shared test's Copilot-flavoured prompt doesn't reliably drive Claude
 	// to invoke it. TODO: rework the prompt for Claude conventions.

--- a/src/vs/platform/agentHost/test/node/protocol/claudeAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/claudeAgentHostE2E.integrationTest.ts
@@ -66,10 +66,8 @@ const CLAUDE_CONFIG: IAgentHostE2EProviderConfig = {
 	// The shared suite skips that test when the flag is false.
 	supportsWorktreeIsolation: false,
 	supportsSubagents: true,
-	// Reopening a subagent transcript reads the bundled SDK's on-disk
-	// `subagents/agent-*.jsonl` files, which are not reliably flushed/visible on
-	// Windows right after the turn — so the subagent-reopen test is gated to
-	// POSIX for Claude (see PR #325284). macOS/Linux keep full coverage.
+	// Claude rebuilds a reopened subagent transcript from the SDK's on-disk
+	// `subagents/agent-*.jsonl`, not reliably visible on Windows (see PR #325284).
 	subagentReplayUnstableOnWindows: true,
 	// Plan mode is wired (`ExitPlanMode` interactive tool exists) but the
 	// shared test's Copilot-flavoured prompt doesn't reliably drive Claude


### PR DESCRIPTION
Throwaway branch to empirically measure flakiness of the `reopening a session keeps sub-agent messages out of the parent transcript (replay path)` test — especially the Claude/Windows path gated by `subagentReplayUnstableOnWindows` in #325364.

This registers that test 20x (env-tunable via `AGENT_HOST_FLAKE_PROBE_COUNT`), ungated on Windows, so the CI matrix (incl. Windows) exercises it many times in a row. If Windows stays green across 20 Claude runs, the gate may be removable; if it flakes, the gate is justified.

Do not merge. Companion to #325364.