### PR TITLE
Add telemetry for applied managed settings and device policies

### DIFF
--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -97,6 +97,7 @@ import { mainWindow } from '../../base/browser/window.js';
 import { INotificationService, Severity } from '../../platform/notification/common/notification.js';
 import { IDefaultAccountService } from '../../platform/defaultAccount/common/defaultAccount.js';
 import { DefaultAccountService } from '../services/accounts/browser/defaultAccount.js';
+import { INativeManagedSettingsService, IFileManagedSettingsService, NullNativeManagedSettingsService, NullFileManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
 import { AccountPolicyService, IAccountPolicyGateService } from '../services/policies/common/accountPolicyService.js';
 
 export interface IBrowserMainWorkbench {
@@ -367,6 +368,10 @@ export class BrowserMain extends Disposable {
 		serviceCollection.set(IDefaultAccountService, defaultAccountService);
 
 		// Policies
+		// Web has no native MDM / file managed-settings channels; register empty Null services so
+		// browser-layer consumers (e.g. policy telemetry) can depend on them uniformly.
+		serviceCollection.set(INativeManagedSettingsService, new NullNativeManagedSettingsService());
+		serviceCollection.set(IFileManagedSettingsService, new NullFileManagedSettingsService());
 		const policyService = new AccountPolicyService(logService, defaultAccountService);
 		serviceCollection.set(IPolicyService, policyService);
 		serviceCollection.set(IAccountPolicyGateService, policyService);

--- a/src/vs/workbench/services/policies/browser/policyTelemetry.contribution.ts
+++ b/src/vs/workbench/services/policies/browser/policyTelemetry.contribution.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { PolicyTelemetryContribution } from './policyTelemetryContribution.js';
+
+registerWorkbenchContribution2(PolicyTelemetryContribution.ID, PolicyTelemetryContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/services/policies/browser/policyTelemetryContribution.ts
+++ b/src/vs/workbench/services/policies/browser/policyTelemetryContribution.ts
@@ -1,0 +1,333 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RunOnceScheduler } from '../../../../base/common/async.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { PolicyName } from '../../../../base/common/policy.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
+import { IFileManagedSettingsService, INativeManagedSettingsService, MANAGED_SETTINGS_CHANNELS, ManagedSettingsChannel, pickManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { IPolicyService, PolicyValue } from '../../../../platform/policy/common/policy.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateService } from '../common/accountPolicyService.js';
+
+/**
+ * The delivery source attributed to an applied policy. Extends the managed-settings channels
+ * (native MDM / server / file) with the non-managed-settings origins a policy can also have:
+ * `osPolicy` (OS Group Policy / MDM config registry), `accountData` (the value is resolved from the
+ * GitHub account's server-delivered policy data, not from a managed-settings channel), and
+ * `accountGate` (the value is forced by the restricted Account Policy gate). `none` is used when a
+ * policy has no applied value.
+ */
+type PolicySource = ManagedSettingsChannel | 'osPolicy' | 'accountData' | 'accountGate' | 'none';
+
+/**
+ * Policy names whose applied values this contribution reports on, kept in one place for reuse.
+ * Keep these in sync with their declarations:
+ * - Chat policies: src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+ * - OTel policy: src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+ * - Telemetry policies: src/vs/platform/telemetry/common/telemetryService.ts
+ */
+const enum PolicyNames {
+	DefaultModel = 'ChatDefaultModel',
+	ToolsAutoApprove = 'ChatToolsAutoApprove',
+	EnabledPlugins = 'ChatEnabledPlugins',
+	ExtraMarketplaces = 'ChatExtraMarketplaces',
+	StrictMarketplaces = 'ChatStrictMarketplaces',
+	ApprovedOrgs = 'ChatApprovedAccountOrganizations',
+	OtelEnabled = 'CopilotOtelEnabled',
+	TelemetryLevel = 'TelemetryLevel',
+	EnableFeedback = 'EnableFeedback',
+}
+
+type PolicyAppliedEvent = {
+	policyCount: number;
+
+	defaultModelSet: boolean;
+	toolsAutoApproveSet: boolean;
+	enabledPluginsSet: boolean;
+	extraMarketplacesSet: boolean;
+	strictMarketplacesSet: boolean;
+	approvedOrgsSet: boolean;
+	otelSet: boolean;
+	telemetryLevelSet: boolean;
+	enableFeedbackSet: boolean;
+
+	defaultModelForcedToAuto: boolean;
+	toolsAutoApproveForcedOff: boolean;
+	strictMarketplacesLockdown: boolean;
+	otelForcedEnabled: boolean;
+	telemetryLevel: string | undefined;
+
+	sourceOsPolicyActive: boolean;
+	sourceNativeMdmActive: boolean;
+	sourceServerActive: boolean;
+	sourceFileActive: boolean;
+	sourceAccountDataActive: boolean;
+	serverFetchStatus: string | undefined;
+
+	defaultModelSource: PolicySource;
+	toolsAutoApproveSource: PolicySource;
+	otelSource: PolicySource;
+	telemetryLevelSource: PolicySource;
+};
+
+type PolicyAppliedClassification = {
+	owner: 'digitarald';
+	comment: 'Reports which enterprise-managed settings and device policies are applied, their value buckets, and their delivery source, to understand managed-configuration adoption. No raw policy values are collected.';
+
+	policyCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of policies with an applied value (the "applied" denominator).' };
+
+	defaultModelSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the default chat model policy is applied.' };
+	toolsAutoApproveSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the tools auto-approve policy is applied.' };
+	enabledPluginsSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the enabled-plugins policy is applied.' };
+	extraMarketplacesSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the extra-marketplaces policy is applied.' };
+	strictMarketplacesSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the strict-marketplaces policy is applied.' };
+	approvedOrgsSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the approved-account-organizations policy is applied.' };
+	otelSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the OpenTelemetry-enabled policy is applied.' };
+	telemetryLevelSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the telemetry-level policy is applied.' };
+	enableFeedbackSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the enable-feedback policy is applied.' };
+
+	defaultModelForcedToAuto: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the default chat model policy forces the "auto" model.' };
+	toolsAutoApproveForcedOff: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the tools auto-approve policy forces auto-approve off.' };
+	strictMarketplacesLockdown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the strict-marketplaces policy is an empty allowlist (blocks all marketplaces).' };
+	otelForcedEnabled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the OpenTelemetry policy forces export enabled.' };
+	telemetryLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The forced telemetry level bucket (off/crash/error/all, or "unknown") when the telemetry-level policy is applied.' };
+
+	sourceOsPolicyActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if at least one applied policy is delivered by OS Group Policy / config registry.' };
+	sourceNativeMdmActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if at least one applied policy is delivered by the native MDM managed-settings channel.' };
+	sourceServerActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if at least one applied policy is delivered by the server managed-settings channel.' };
+	sourceFileActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if at least one applied policy is delivered by the file managed-settings channel.' };
+	sourceAccountDataActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if at least one applied policy is resolved from the GitHub account server policy data (not a managed-settings channel).' };
+	serverFetchStatus: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Outcome bucket of the last managed-settings server fetch (ok/no-url/no-response/parse-error/HTTP status).' };
+
+	defaultModelSource: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Delivery source of the default chat model policy.' };
+	toolsAutoApproveSource: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Delivery source of the tools auto-approve policy.' };
+	otelSource: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Delivery source of the OpenTelemetry-enabled policy.' };
+	telemetryLevelSource: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Delivery source of the telemetry-level policy.' };
+};
+
+/**
+ * Observability contribution that reports which managed settings and device policies are applied,
+ * their value buckets, and the delivery source of each policy of interest. Emits one consolidated
+ * `policy.applied` event at startup and whenever the resolved policy state changes (deduped on the
+ * event payload, and debounced against bursts). Reports no raw policy values.
+ */
+export class PolicyTelemetryContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.policyTelemetry';
+
+	private lastSignature: string | undefined;
+
+	private readonly scheduler = this._register(new RunOnceScheduler(() => this.report(), 500));
+
+	constructor(
+		@IPolicyService private readonly policyService: IPolicyService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@INativeManagedSettingsService private readonly nativeManagedSettingsService: INativeManagedSettingsService,
+		@IFileManagedSettingsService private readonly fileManagedSettingsService: IFileManagedSettingsService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		@IAccountPolicyGateService private readonly accountPolicyGateService: IAccountPolicyGateService,
+	) {
+		super();
+
+		this.report();
+		// Re-report whenever anything that feeds the payload changes — not only policy values, but
+		// also the delivery source or the server fetch status (which can change while the effective
+		// value stays the same). The payload dedupe drops redundant emits. Managed-settings change
+		// events are `Event.None` (no-op) on hosts without those channels (e.g. web).
+		this._register(this.policyService.onDidChange(() => this.scheduler.schedule()));
+		this._register(this.defaultAccountService.onDidChangePolicyData(() => this.scheduler.schedule()));
+		this._register(this.nativeManagedSettingsService.onDidChangeManagedSettings(() => this.scheduler.schedule()));
+		this._register(this.fileManagedSettingsService.onDidChangeManagedSettings(() => this.scheduler.schedule()));
+		this._register(this.accountPolicyGateService.onDidChangeGateInfo(() => this.scheduler.schedule()));
+	}
+
+	private report(): void {
+		const event = this.buildEvent();
+		const signature = JSON.stringify(event);
+		if (signature === this.lastSignature) {
+			return;
+		}
+		this.lastSignature = signature;
+		this.telemetryService.publicLog2<PolicyAppliedEvent, PolicyAppliedClassification>('policy.applied', event);
+	}
+
+	private buildEvent(): PolicyAppliedEvent {
+		const serialized = this.policyService.serialize();
+
+		// `NullPolicyService` (no policy backend) returns undefined — report an explicit empty state
+		// so the "applied" denominator still has a data point.
+		if (serialized === undefined) {
+			return this.emptyEvent();
+		}
+
+		const definitions = this.policyService.policyDefinitions;
+		const value = (name: PolicyName): PolicyValue | undefined => this.policyService.getPolicyValue(name);
+
+		let policyCount = 0;
+		for (const name in definitions) {
+			if (this.policyService.getPolicyValue(name) !== undefined) {
+				policyCount++;
+			}
+		}
+
+		// Per-key managed-settings resolution, exactly as policy evaluation applies it, so source
+		// attribution can never drift from what is actually enforced.
+		const pick = pickManagedSettings(
+			this.nativeManagedSettingsService.managedSettings,
+			this.defaultAccountService.policyData?.managedSettings,
+			this.fileManagedSettingsService.managedSettings,
+		);
+
+		const gateInfo = this.accountPolicyGateService.gateInfo;
+		const gateRestricted = gateInfo.state === AccountPolicyGateState.Restricted
+			&& gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
+
+		const sourceOf = (name: PolicyName): PolicySource => {
+			if (value(name) === undefined) {
+				return 'none';
+			}
+			const definition = definitions[name];
+			// When the gate actively restricts, a policy that carries its own value/restricted value
+			// is forced to the gate's restricted value regardless of managed settings.
+			if (gateRestricted && definition && (definition.value !== undefined || definition.restrictedValue !== undefined)) {
+				return 'accountGate';
+			}
+			const declaredKeys = definition?.managedSettings ? Object.keys(definition.managedSettings) : [];
+			for (const channel of MANAGED_SETTINGS_CHANNELS) {
+				if (declaredKeys.some(key => pick.resolutions.get(key)?.source === channel)) {
+					return channel;
+				}
+			}
+			// A value produced by the policy's own `value()` callback (with no winning managed-settings
+			// channel) is resolved from the GitHub account's server-delivered policy data. Policies
+			// without a `value()` callback get their value from the OS Group Policy / config-registry
+			// channel instead.
+			if (definition?.value !== undefined) {
+				return 'accountData';
+			}
+			return 'osPolicy';
+		};
+
+		// Aggregate the delivery sources across every applied policy for the channel-active flags.
+		const activeSources = new Set<PolicySource>();
+		for (const name in definitions) {
+			if (this.policyService.getPolicyValue(name) !== undefined) {
+				activeSources.add(sourceOf(name));
+			}
+		}
+
+		const defaultModel = value(PolicyNames.DefaultModel);
+		const toolsAutoApprove = value(PolicyNames.ToolsAutoApprove);
+		const strictMarketplaces = value(PolicyNames.StrictMarketplaces);
+		const otel = value(PolicyNames.OtelEnabled);
+		const telemetryLevel = value(PolicyNames.TelemetryLevel);
+
+		return {
+			policyCount,
+
+			defaultModelSet: defaultModel !== undefined,
+			toolsAutoApproveSet: toolsAutoApprove !== undefined,
+			enabledPluginsSet: value(PolicyNames.EnabledPlugins) !== undefined,
+			extraMarketplacesSet: value(PolicyNames.ExtraMarketplaces) !== undefined,
+			strictMarketplacesSet: strictMarketplaces !== undefined,
+			approvedOrgsSet: value(PolicyNames.ApprovedOrgs) !== undefined,
+			otelSet: otel !== undefined,
+			telemetryLevelSet: telemetryLevel !== undefined,
+			enableFeedbackSet: value(PolicyNames.EnableFeedback) !== undefined,
+
+			defaultModelForcedToAuto: defaultModel === 'auto',
+			toolsAutoApproveForcedOff: toolsAutoApprove === false,
+			strictMarketplacesLockdown: isEmptyMarketplaceAllowlist(strictMarketplaces),
+			otelForcedEnabled: otel === true,
+			telemetryLevel: telemetryLevelBucket(telemetryLevel),
+
+			sourceOsPolicyActive: activeSources.has('osPolicy'),
+			sourceNativeMdmActive: activeSources.has('nativeMdm'),
+			sourceServerActive: activeSources.has('server'),
+			sourceFileActive: activeSources.has('file'),
+			sourceAccountDataActive: activeSources.has('accountData'),
+			serverFetchStatus: fetchStatusLabel(this.defaultAccountService.managedSettingsFetchStatus),
+
+			defaultModelSource: sourceOf(PolicyNames.DefaultModel),
+			toolsAutoApproveSource: sourceOf(PolicyNames.ToolsAutoApprove),
+			otelSource: sourceOf(PolicyNames.OtelEnabled),
+			telemetryLevelSource: sourceOf(PolicyNames.TelemetryLevel),
+		};
+	}
+
+	private emptyEvent(): PolicyAppliedEvent {
+		return {
+			policyCount: 0,
+
+			defaultModelSet: false,
+			toolsAutoApproveSet: false,
+			enabledPluginsSet: false,
+			extraMarketplacesSet: false,
+			strictMarketplacesSet: false,
+			approvedOrgsSet: false,
+			otelSet: false,
+			telemetryLevelSet: false,
+			enableFeedbackSet: false,
+
+			defaultModelForcedToAuto: false,
+			toolsAutoApproveForcedOff: false,
+			strictMarketplacesLockdown: false,
+			otelForcedEnabled: false,
+			telemetryLevel: undefined,
+
+			sourceOsPolicyActive: false,
+			sourceNativeMdmActive: false,
+			sourceServerActive: false,
+			sourceFileActive: false,
+			sourceAccountDataActive: false,
+			serverFetchStatus: fetchStatusLabel(this.defaultAccountService.managedSettingsFetchStatus),
+
+			defaultModelSource: 'none',
+			toolsAutoApproveSource: 'none',
+			otelSource: 'none',
+			telemetryLevelSource: 'none',
+		};
+	}
+}
+
+/**
+ * The strict-marketplaces policy carries a JSON-encoded array of allowlisted sources; an empty
+ * array (`[]`) is the "lockdown" case that blocks all marketplaces. Returns true only for that.
+ */
+function isEmptyMarketplaceAllowlist(rawValue: PolicyValue | undefined): boolean {
+	if (typeof rawValue !== 'string') {
+		return false;
+	}
+	try {
+		const parsed = JSON.parse(rawValue);
+		return Array.isArray(parsed) && parsed.length === 0;
+	} catch {
+		return false;
+	}
+}
+
+/** Normalize the managed-settings fetch status to a stable string bucket for telemetry. */
+function fetchStatusLabel(status: number | 'ok' | 'no-url' | 'no-response' | 'parse-error' | null | undefined): string | undefined {
+	if (status === null || status === undefined) {
+		return undefined;
+	}
+	return typeof status === 'number' ? `status:${status}` : status;
+}
+
+const KNOWN_TELEMETRY_LEVELS: ReadonlySet<string> = new Set(['off', 'crash', 'error', 'all']);
+
+/**
+ * Bucket the telemetry-level policy value into a known enum value, guarding the "no raw values"
+ * contract: an unexpected string is reported as `'unknown'` rather than leaked verbatim.
+ */
+function telemetryLevelBucket(rawValue: PolicyValue | undefined): string | undefined {
+	if (typeof rawValue !== 'string') {
+		return undefined;
+	}
+	return KNOWN_TELEMETRY_LEVELS.has(rawValue) ? rawValue : 'unknown';
+}
+

--- a/src/vs/workbench/services/policies/test/browser/policyTelemetryContribution.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/policyTelemetryContribution.test.ts
@@ -1,0 +1,299 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { IStringDictionary } from '../../../../../base/common/collections.js';
+import { IDefaultAccount, IDefaultAccountAuthenticationProvider, IPolicyData } from '../../../../../base/common/defaultAccount.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { ManagedSettingsData, PolicyName } from '../../../../../base/common/policy.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IDefaultAccountService, ManagedSettingsFetchStatus } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { COPILOT_MODEL_KEY, IFileManagedSettingsService, INativeManagedSettingsService } from '../../../../../platform/policy/common/copilotManagedSettings.js';
+import { IPolicyService, PolicyDefinition, PolicyValue } from '../../../../../platform/policy/common/policy.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateInfo, IAccountPolicyGateService } from '../../common/accountPolicyService.js';
+import { PolicyTelemetryContribution } from '../../browser/policyTelemetryContribution.js';
+
+class FakePolicyService extends Disposable implements IPolicyService {
+	readonly _serviceBrand: undefined;
+
+	private readonly _onDidChange = this._register(new Emitter<readonly PolicyName[]>());
+	readonly onDidChange = this._onDidChange.event;
+
+	policyDefinitions: IStringDictionary<PolicyDefinition> = {};
+	private readonly policies = new Map<PolicyName, PolicyValue>();
+
+	constructor(private readonly serializeReturnsUndefined = false) {
+		super();
+	}
+
+	setPolicy(name: string, definition: PolicyDefinition, value: PolicyValue | undefined): void {
+		this.policyDefinitions[name] = definition;
+		if (value === undefined) {
+			this.policies.delete(name);
+		} else {
+			this.policies.set(name, value);
+		}
+	}
+
+	fireChange(names: PolicyName[] = []): void {
+		this._onDidChange.fire(names);
+	}
+
+	async updatePolicyDefinitions(): Promise<IStringDictionary<PolicyValue>> { return {}; }
+	getPolicyValue(name: PolicyName): PolicyValue | undefined { return this.policies.get(name); }
+	serialize(): IStringDictionary<{ definition: PolicyDefinition; value: PolicyValue }> | undefined {
+		if (this.serializeReturnsUndefined) {
+			return undefined;
+		}
+		const out: IStringDictionary<{ definition: PolicyDefinition; value: PolicyValue }> = {};
+		for (const name of Object.keys(this.policyDefinitions)) {
+			out[name] = { definition: this.policyDefinitions[name], value: this.policies.get(name)! };
+		}
+		return out;
+	}
+}
+
+class FakeManagedSettingsService implements INativeManagedSettingsService, IFileManagedSettingsService {
+	readonly _serviceBrand: undefined;
+	readonly onDidChangeManagedSettings = Event.None;
+	constructor(public managedSettings: ManagedSettingsData = {}) { }
+	async updatePolicyDefinitions(): Promise<ManagedSettingsData> { return this.managedSettings; }
+}
+
+class FakeDefaultAccountService implements IDefaultAccountService {
+	readonly _serviceBrand: undefined;
+	readonly onDidChangeDefaultAccount = Event.None;
+	readonly onDidChangePolicyData = Event.None;
+	readonly currentDefaultAccount = null;
+	readonly copilotTokenInfo = null;
+	readonly onDidChangeCopilotTokenInfo = Event.None;
+	readonly managedSettingsFetchedAt = null;
+	readonly managedSettingsRawResponse = null;
+
+	constructor(
+		readonly policyData: IPolicyData | null = null,
+		readonly managedSettingsFetchStatus: ManagedSettingsFetchStatus = null,
+	) { }
+
+	async getDefaultAccount(): Promise<IDefaultAccount | null> { return null; }
+	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider { throw new Error('not implemented'); }
+	setDefaultAccountProvider(): void { }
+	async refresh(): Promise<IDefaultAccount | null> { return null; }
+	async signIn(): Promise<IDefaultAccount | null> { return null; }
+	async signOut(): Promise<void> { }
+	resolveGitHubUrl(path: string): string { return `https://github.com/${path}`; }
+}
+
+class FakeGateService implements IAccountPolicyGateService {
+	readonly _serviceBrand: undefined;
+	readonly onDidChangeGateInfo = Event.None;
+	constructor(readonly gateInfo: IAccountPolicyGateInfo = { state: AccountPolicyGateState.Inactive }) { }
+}
+
+const EMPTY_EVENT = {
+	policyCount: 0,
+	defaultModelSet: false,
+	toolsAutoApproveSet: false,
+	enabledPluginsSet: false,
+	extraMarketplacesSet: false,
+	strictMarketplacesSet: false,
+	approvedOrgsSet: false,
+	otelSet: false,
+	telemetryLevelSet: false,
+	enableFeedbackSet: false,
+	defaultModelForcedToAuto: false,
+	toolsAutoApproveForcedOff: false,
+	strictMarketplacesLockdown: false,
+	otelForcedEnabled: false,
+	telemetryLevel: undefined,
+	sourceOsPolicyActive: false,
+	sourceNativeMdmActive: false,
+	sourceServerActive: false,
+	sourceFileActive: false,
+	sourceAccountDataActive: false,
+	serverFetchStatus: undefined,
+	defaultModelSource: 'none',
+	toolsAutoApproveSource: 'none',
+	otelSource: 'none',
+	telemetryLevelSource: 'none',
+};
+
+suite('PolicyTelemetryContribution', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createContribution(options: {
+		policyService: FakePolicyService;
+		native?: ManagedSettingsData;
+		file?: ManagedSettingsData;
+		account?: FakeDefaultAccountService;
+		gate?: FakeGateService;
+	}): { events: { name: string; data: unknown }[] } {
+		const events: { name: string; data: unknown }[] = [];
+		const telemetryService = {
+			publicLog2: (name: string, data: unknown) => { events.push({ name, data }); },
+		};
+		store.add(options.policyService);
+		store.add(new PolicyTelemetryContribution(
+			options.policyService,
+			telemetryService as never,
+			new FakeManagedSettingsService(options.native),
+			new FakeManagedSettingsService(options.file),
+			options.account ?? new FakeDefaultAccountService(),
+			options.gate ?? new FakeGateService(),
+		));
+		return { events };
+	}
+
+	test('emits an empty applied event at startup when no policies are set', () => {
+		const { events } = createContribution({ policyService: new FakePolicyService() });
+
+		assert.strictEqual(events.length, 1);
+		assert.strictEqual(events[0].name, 'policy.applied');
+		assert.deepStrictEqual(events[0].data, EMPTY_EVENT);
+	});
+
+	test('reports policyCount 0 when the policy service has no backend (serialize undefined)', () => {
+		const { events } = createContribution({ policyService: new FakePolicyService(/* serializeReturnsUndefined */ true) });
+
+		assert.deepStrictEqual(events[0].data, EMPTY_EVENT);
+	});
+
+	test('attributes a server-delivered managed setting and buckets the forced value', () => {
+		const policyService = new FakePolicyService();
+		policyService.setPolicy(
+			'ChatDefaultModel',
+			{ type: 'string', managedSettings: { [COPILOT_MODEL_KEY]: { type: 'string' } }, value: () => undefined },
+			'auto',
+		);
+
+		const account = new FakeDefaultAccountService({ managedSettings: { [COPILOT_MODEL_KEY]: 'auto' } }, 'ok');
+		const { events } = createContribution({ policyService, account });
+
+		assert.deepStrictEqual(events[0].data, {
+			...EMPTY_EVENT,
+			policyCount: 1,
+			defaultModelSet: true,
+			defaultModelForcedToAuto: true,
+			sourceServerActive: true,
+			serverFetchStatus: 'ok',
+			defaultModelSource: 'server',
+		});
+	});
+
+	test('attributes a value with no managed-settings key to OS policy', () => {
+		const policyService = new FakePolicyService();
+		policyService.setPolicy('TelemetryLevel', { type: 'string' }, 'off');
+
+		const { events } = createContribution({ policyService });
+
+		assert.deepStrictEqual(events[0].data, {
+			...EMPTY_EVENT,
+			policyCount: 1,
+			telemetryLevelSet: true,
+			telemetryLevel: 'off',
+			sourceOsPolicyActive: true,
+			telemetryLevelSource: 'osPolicy',
+		});
+	});
+
+	test('native MDM wins over the server channel for the same managed-settings key', () => {
+		const policyService = new FakePolicyService();
+		policyService.setPolicy(
+			'ChatDefaultModel',
+			{ type: 'string', managedSettings: { [COPILOT_MODEL_KEY]: { type: 'string' } }, value: () => undefined },
+			'auto',
+		);
+		const account = new FakeDefaultAccountService({ managedSettings: { [COPILOT_MODEL_KEY]: 'gpt-4' } });
+		const { events } = createContribution({ policyService, account, native: { [COPILOT_MODEL_KEY]: 'auto' } });
+
+		assert.deepStrictEqual(events[0].data, {
+			...EMPTY_EVENT,
+			policyCount: 1,
+			defaultModelSet: true,
+			defaultModelForcedToAuto: true,
+			sourceNativeMdmActive: true,
+			defaultModelSource: 'nativeMdm',
+		});
+	});
+
+	test('attributes an account-data-driven policy (value callback, no managed key) to account data', () => {
+		const policyService = new FakePolicyService();
+		policyService.setPolicy('ChatToolsAutoApprove', { type: 'boolean', value: () => false }, false);
+
+		const { events } = createContribution({ policyService });
+
+		assert.deepStrictEqual(events[0].data, {
+			...EMPTY_EVENT,
+			policyCount: 1,
+			toolsAutoApproveSet: true,
+			toolsAutoApproveForcedOff: true,
+			sourceAccountDataActive: true,
+			toolsAutoApproveSource: 'accountData',
+		});
+	});
+
+	test('attributes a gate-restricted policy to the account gate', () => {
+		const policyService = new FakePolicyService();
+		policyService.setPolicy(
+			'ChatDefaultModel',
+			{ type: 'string', managedSettings: { [COPILOT_MODEL_KEY]: { type: 'string' } }, value: () => undefined },
+			'',
+		);
+		const account = new FakeDefaultAccountService({ managedSettings: { [COPILOT_MODEL_KEY]: 'auto' } });
+		const gate = new FakeGateService({ state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved });
+		const { events } = createContribution({ policyService, account, gate });
+
+		assert.deepStrictEqual(events[0].data, {
+			...EMPTY_EVENT,
+			policyCount: 1,
+			defaultModelSet: true,
+			defaultModelSource: 'accountGate',
+		});
+	});
+
+	test('re-emits when the resolved policy state changes', () => {
+		const clock = sinon.useFakeTimers();
+		try {
+			const policyService = new FakePolicyService();
+			const { events } = createContribution({ policyService });
+			assert.strictEqual(events.length, 1);
+
+			policyService.setPolicy('TelemetryLevel', { type: 'string' }, 'off');
+			policyService.fireChange();
+			clock.tick(1000);
+
+			assert.strictEqual(events.length, 2);
+			assert.deepStrictEqual(events[1].data, {
+				...EMPTY_EVENT,
+				policyCount: 1,
+				telemetryLevelSet: true,
+				telemetryLevel: 'off',
+				sourceOsPolicyActive: true,
+				telemetryLevelSource: 'osPolicy',
+			});
+		} finally {
+			clock.restore();
+		}
+	});
+
+	test('does not re-emit when the resolved policy state is unchanged', () => {
+		const clock = sinon.useFakeTimers();
+		try {
+			const policyService = new FakePolicyService();
+			const { events } = createContribution({ policyService });
+			assert.strictEqual(events.length, 1);
+
+			policyService.fireChange();
+			clock.tick(1000);
+
+			assert.strictEqual(events.length, 1);
+		} finally {
+			clock.restore();
+		}
+	});
+});

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -204,6 +204,9 @@ import './services/accounts/browser/defaultAccount.js';
 // Account Policy Gate
 import './services/policies/browser/accountPolicyGate.contribution.js';
 
+// Policy Telemetry
+import './services/policies/browser/policyTelemetry.contribution.js';
+
 // Telemetry
 import './contrib/telemetry/browser/telemetry.contribution.js';
 


### PR DESCRIPTION
## Summary

Adds a single consolidated `policy.applied` telemetry event that reports, per user/session, which enterprise-managed settings and OS/MDM device policies are applied, their value buckets, and per-policy delivery source.

Follows the established browser-layer workbench contribution pattern (mirrors `accountPolicyGateContribution`): consumes `IPolicyService`, fires once at startup and on relevant changes (policy, account policy data, native/file managed settings, gate), debounced 500ms and deduped on the payload signature. Handles `serialize() === undefined` (NullPolicyService) → `policyCount: 0`. **No raw policy values are collected.**

## What it reports
- `policyCount` — the applied denominator.
- **Set-flags** per policy of interest (default model, tools auto-approve, enabled plugins, extra/strict marketplaces, approved orgs, OTel, telemetry level, feedback).
- **Value buckets** — e.g. `defaultModelForcedToAuto`, `toolsAutoApproveForcedOff`, `strictMarketplacesLockdown`, `otelForcedEnabled`, `telemetryLevel`.
- **Source attribution** per policy — `osPolicy` / `nativeMdm` / `server` / `file` / `accountData` / `accountGate` / `none`, plus active-source flags and `serverFetchStatus`.

Source is derived via `pickManagedSettings` + declared `managedSettings` keys + gate state (no `as any` multiplex hack).

## Files
- **New** `policyTelemetryContribution.ts` — the contribution + GDPR event/classification.
- **New** `policyTelemetry.contribution.ts` — registers at `WorkbenchPhase.AfterRestored`.
- **New** `policyTelemetryContribution.test.ts` — 9 unit tests.
- **Edited** `workbench.common.main.ts` — imports the contribution.
- **Edited** `web.main.ts` — registers Null managed-settings services so required DI resolves on web.

## Validation
- `npm run typecheck-client`, `valid-layers-check`, ESLint — clean.
- 9 unit tests passing (empty/null-service, server/native precedence, OS policy, account data, account gate, dedup, re-emit-on-change).

## Notes
- GDPR `owner` set to `digitarald`.
- Sessions/Agents window is out of scope this pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
