### PR TITLE
sessions: align read-only chat banner with the tab strip

### DIFF
--- a/src/vs/sessions/browser/parts/media/sessionReadOnlyBanner.css
+++ b/src/vs/sessions/browser/parts/media/sessionReadOnlyBanner.css
@@ -16,12 +16,8 @@
 	box-sizing: border-box;
 	/* Match the VS Code editor read-only banner: 26px tall, 12px text. */
 	height: 26px;
-	/* Inset horizontally so the banner starts and ends flush with the tab strip:
-		the right edge matches the tab bar's `padding-right: 10px`, and the left
-		edge adds the header's status-icon column (icon + gap) on top of the shared
-		10px so it aligns under the first tab rather than the status icon (mirrors
-		`.session-chat-tabs-bar`'s `padding-left`). Pulled up slightly so only a
-		small gap remains under the tab strip. */
+	/* Match the tab strip's insets so the banner starts and ends flush with the
+		tabs; the extra left inset accounts for the header's status-icon column. */
 	margin: calc(-1 * var(--vscode-spacing-size20, 2px)) var(--vscode-spacing-size100, 10px) 0 calc(var(--vscode-spacing-size100, 10px) + var(--vscode-codiconFontSize, 16px) + var(--vscode-spacing-size60, 6px));
 	padding: 0 var(--vscode-spacing-size100, 10px);
 	background-color: color-mix(in srgb, var(--vscode-focusBorder) 4%, var(--vscode-editorWidget-background));

--- a/src/vs/sessions/browser/parts/media/sessionReadOnlyBanner.css
+++ b/src/vs/sessions/browser/parts/media/sessionReadOnlyBanner.css
@@ -16,9 +16,13 @@
 	box-sizing: border-box;
 	/* Match the VS Code editor read-only banner: 26px tall, 12px text. */
 	height: 26px;
-	/* Inset horizontally to align with the tab bar's content (its `padding: 0
-		10px`), and pull up slightly so only a small gap remains under the tab strip. */
-	margin: calc(-1 * var(--vscode-spacing-size20, 2px)) var(--vscode-spacing-size100, 10px) 0;
+	/* Inset horizontally so the banner starts and ends flush with the tab strip:
+		the right edge matches the tab bar's `padding-right: 10px`, and the left
+		edge adds the header's status-icon column (icon + gap) on top of the shared
+		10px so it aligns under the first tab rather than the status icon (mirrors
+		`.session-chat-tabs-bar`'s `padding-left`). Pulled up slightly so only a
+		small gap remains under the tab strip. */
+	margin: calc(-1 * var(--vscode-spacing-size20, 2px)) var(--vscode-spacing-size100, 10px) 0 calc(var(--vscode-spacing-size100, 10px) + var(--vscode-codiconFontSize, 16px) + var(--vscode-spacing-size60, 6px));
 	padding: 0 var(--vscode-spacing-size100, 10px);
 	background-color: color-mix(in srgb, var(--vscode-focusBorder) 4%, var(--vscode-editorWidget-background));
 	color: var(--vscode-descriptionForeground);


### PR DESCRIPTION
## What

Aligns the read-only chat banner ("This chat is read-only") with the chat tab strip so it starts and ends flush with the tabs.

## Why

The banner sits in the same centered band as the header and tab strip. The tab strip (`.session-chat-tabs-bar`) insets its left edge by the header's status-icon column (`padding: 0 10px 0 calc(10px + codiconFontSize + 6px)`) so the first tab aligns under the title/meta main column. The banner, however, only inset `10px` on both sides, so its left edge started further left than the first tab — visibly misaligned.

## Change

- Update the banner's `margin-left` to `calc(10px + codiconFontSize + 6px)`, mirroring the tab strip's `padding-left`, so the banner begins under the first tab rather than under the status-icon column.
- The right edge already matched the tab strip's `padding-right: 10px`, so the banner now starts and ends flush with the tabs.

CSS-only change in [sessionReadOnlyBanner.css](src/vs/sessions/browser/parts/media/sessionReadOnlyBanner.css).

## Notes for reviewers

No behavioral change; purely visual alignment. Uses the same spacing/codicon design tokens the tab strip relies on.