### PR TITLE
Use server-backed archived state for agent host sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -751,6 +751,12 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 	}
 
 	private isArchived(session: IInternalAgentSessionData): boolean {
+		// Agent host sessions have server-authoritative archived state, so ignore
+		// the local view-state overlay: a stale local value must not mask the
+		// server truth reported via `session.archived`.
+		if (isAgentHostTarget(session.providerType)) {
+			return Boolean(session.archived);
+		}
 		return this.resolveStateEntry(session)?.archived ?? Boolean(session.archived);
 	}
 


### PR DESCRIPTION
Fixes #325398

Agent host sessions have server-authoritative archived state (the `SessionStatus.IsArchived` bit, surfaced as `IChatSessionItem.archived`). `AgentSessionsModel.isArchived()` merged that provider value with a locally-persisted view-state overlay and gave the local overlay precedence, so a stale local `archived: false` could permanently mask the server's `archived: true`. As a result, a session the server reports as archived (e.g. an errored + archived session with status `66` = `Error | IsArchived`) stayed in the non-archived date sections.

## Change

For agent host sessions (`isAgentHostTarget(session.providerType)`), `isArchived()` now uses only the server-backed `session.archived` and ignores the local view-state overlay. Non-agent-host providers keep the existing overlay behavior.

## Note / follow-up

The chat sessions viewer's own Archive/Unarchive actions only write local model state (`session.setArchived(...)`) and never dispatch to the agent host (the `IChatSessionItemController` has no archive method). With this change, those local writes no longer affect an agent-host session's displayed archived state — only the Agents window path (`baseAgentHostSessionsProvider.archiveSession`) dispatches `SessionIsArchivedChanged` to the server. Routing those viewer buttons to the server is a possible follow-up.

(Written by Copilot)
