### PR TITLE
Add best practice: avoid body:has() workbench-wide selectors

### DIFF
--- a/.github/instructions/best-practices.instructions.md
+++ b/.github/instructions/best-practices.instructions.md
@@ -32,6 +32,7 @@ applyTo: src/vs/**
 ## Styling
 
 - Avoid `getComputedStyle`. If a style value is needed in both CSS and TypeScript, prefer hardcoding the value in TypeScript and setting it directly on the DOM element (e.g. `element.style.width = '100px'`), or set a CSS custom property via `element.style.setProperty('--my-var', value)` when the value is needed across multiple CSS rules.
+- Never anchor a `:has()` selector on `body` or another workbench-wide root (e.g. `body:has(.my-dialog) .context-view { … }`). A `:has()` on a global root forces the style engine to re-evaluate the selector against the whole document on nearly every DOM mutation, which degrades interaction smoothness across the entire workbench. It costs even in builds where the feature is disabled, because the CSS still ships. Instead, toggle a class on the specific container while the state is active and scope the rules to that class: add the class to `layoutService.activeContainer` when the state begins, remove it via a registered disposable when it ends, and write `.my-dialog-open .context-view { … }`. Capture the container reference once so the class is removed from the same element it was added to.
 
 ## Editor Decorations
 


### PR DESCRIPTION
Follow-up to #324986, which fixed a workbench UI perf regression caused by a `body:has(.automation-dialog)` selector. `:has()` anchored on `body` forces the style engine to re-evaluate against the whole document on nearly every DOM mutation, so the cost is workbench-wide (and ships even where the feature is disabled).

Adds one bullet under the Styling best practices documenting the footgun and the class-on-container alternative, so we do not reintroduce it.

Refs #324986