### PR TITLE
Preserve chat input text typed while a session is loading

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -275,10 +275,8 @@ export class ChatView extends AbstractChatView {
 		this._loadCts.value = cts;
 		const token = cts.token;
 
-		// The input editor is shared across chat switches and stays editable while
-		// the model loads. Capture whatever draft is already in it as we enter the
-		// load window so any text the user types during loading can be preserved
-		// when the model binds rather than being lost. See #325323.
+		// Capture the input draft before the load window opens so text typed
+		// during loading is preserved when the model binds. See #325323.
 		const inputBeforeLoad = this._widget.getInput();
 
 		const loadPromise = this.chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, token, 'ChatView').then(ref => {

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -19,6 +19,7 @@ import { IVoiceSessionController } from '../../../../workbench/contrib/chat/brow
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 import { EDITOR_DRAG_AND_DROP_BACKGROUND } from '../../../../workbench/common/theme.js';
 import { ChatWidget } from '../../../../workbench/contrib/chat/browser/widget/chatWidget.js';
+import { setModelPreservingInputTypedWhileLoading } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatModelReference, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { getChatSessionType } from '../../../../workbench/contrib/chat/common/model/chatUri.js';
@@ -274,6 +275,12 @@ export class ChatView extends AbstractChatView {
 		this._loadCts.value = cts;
 		const token = cts.token;
 
+		// The input editor is shared across chat switches and stays editable while
+		// the model loads. Capture whatever draft is already in it as we enter the
+		// load window so any text the user types during loading can be preserved
+		// when the model binds rather than being lost. See #325323.
+		const inputBeforeLoad = this._widget.getInput();
+
 		const loadPromise = this.chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, token, 'ChatView').then(ref => {
 			if (token.isCancellationRequested || !ref || !isEqual(this._currentChatResource, resource)) {
 				ref?.dispose();
@@ -281,7 +288,7 @@ export class ChatView extends AbstractChatView {
 			}
 			this._modelRef.value = ref;
 			this._updateWidgetLockState(getChatSessionType(ref.object.sessionResource));
-			this._widget.setModel(ref.object);
+			setModelPreservingInputTypedWhileLoading(this._widget, inputBeforeLoad, () => this._widget.setModel(ref.object));
 			// Expose the bound chat resource on the DOM so test automation
 			// can synchronize with the post-rebind state without polling timeouts.
 			// Set AFTER `setModel` so observers see the attribute only once the

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -483,27 +483,21 @@ export interface IChatWidget {
 }
 
 /**
- * Binds a freshly loaded model to a chat widget via `setModel`, preserving any
- * text the user typed into the input while the session was still loading.
+ * Binds a freshly loaded model to a chat widget, preserving any text the user
+ * typed into the input while the session was still loading (the input stays
+ * editable during the async load, and binding would otherwise reset it to the
+ * session's own draft). See #325323.
  *
- * A chat widget's input editor stays visible and editable while its session
- * loads asynchronously, but no view model is bound yet. When the model finally
- * binds, it resets the editor to the session's own (usually empty) draft, which
- * would discard whatever the user typed in the meantime. See #325323.
- *
- * @param widget The chat widget being (re)bound.
- * @param inputBeforeLoad The input value captured when the load window started,
- * used as a baseline so a previous session's leftover draft is not mistaken for
- * newly typed text.
+ * @param inputBeforeLoad Input value captured when the load window started, used
+ * as a baseline so a previous session's leftover draft is not mistaken for newly
+ * typed text.
  * @param setModel Callback that performs the actual `setModel` binding.
  */
 export function setModelPreservingInputTypedWhileLoading(widget: IChatWidget, inputBeforeLoad: string, setModel: () => void): void {
-	// Read what the user typed during loading before binding resets the editor.
 	const typedWhileLoading = widget.getInput();
 	setModel();
-	// Only restore when the user actually typed something new during the load and
-	// the loaded session has no draft of its own, so we never clobber a persisted
-	// draft or carry a previous session's leftover draft over on a plain switch.
+	// Restore only genuinely new text onto a session that has no draft of its own,
+	// so we never clobber a persisted draft or carry over a leftover draft.
 	if (typedWhileLoading && typedWhileLoading !== inputBeforeLoad && !widget.getInput()) {
 		widget.setInput(typedWhileLoading);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -482,6 +482,33 @@ export interface IChatWidget {
 	delegateScrollFromMouseWheelEvent(event: IMouseWheelEvent): void;
 }
 
+/**
+ * Binds a freshly loaded model to a chat widget via `setModel`, preserving any
+ * text the user typed into the input while the session was still loading.
+ *
+ * A chat widget's input editor stays visible and editable while its session
+ * loads asynchronously, but no view model is bound yet. When the model finally
+ * binds, it resets the editor to the session's own (usually empty) draft, which
+ * would discard whatever the user typed in the meantime. See #325323.
+ *
+ * @param widget The chat widget being (re)bound.
+ * @param inputBeforeLoad The input value captured when the load window started,
+ * used as a baseline so a previous session's leftover draft is not mistaken for
+ * newly typed text.
+ * @param setModel Callback that performs the actual `setModel` binding.
+ */
+export function setModelPreservingInputTypedWhileLoading(widget: IChatWidget, inputBeforeLoad: string, setModel: () => void): void {
+	// Read what the user typed during loading before binding resets the editor.
+	const typedWhileLoading = widget.getInput();
+	setModel();
+	// Only restore when the user actually typed something new during the load and
+	// the loaded session has no draft of its own, so we never clobber a persisted
+	// draft or carry a previous session's leftover draft over on a plain switch.
+	if (typedWhileLoading && typedWhileLoading !== inputBeforeLoad && !widget.getInput()) {
+		widget.setInput(typedWhileLoading);
+	}
+}
+
 
 export interface ICodeBlockActionContextProvider {
 	getCodeBlockContext(editor?: ICodeEditor): ICodeBlockActionContext | undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorContrib.ts
@@ -205,7 +205,14 @@ class InputEditorDecorations extends Disposable {
 
 		const viewModel = this.widget.viewModel;
 		if (!viewModel) {
+			// There is no bound view model yet (e.g. while a session is still
+			// loading). If the user has already started typing, make sure any
+			// previously-rendered placeholder decoration is cleared so it doesn't
+			// render on top of their text.
 			this.updateAriaPlaceholder(undefined);
+			if (inputValue) {
+				this.widget.inputEditor.setDecorationsByType(decorationDescription, placeholderDecorationType, []);
+			}
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorContrib.ts
@@ -205,11 +205,9 @@ class InputEditorDecorations extends Disposable {
 
 		const viewModel = this.widget.viewModel;
 		if (!viewModel) {
-			// There is no bound view model yet (e.g. while a session is still
-			// loading). If the user has already started typing, make sure any
-			// previously-rendered placeholder decoration is cleared so it doesn't
-			// render on top of their text.
 			this.updateAriaPlaceholder(undefined);
+			// No bound view model yet (e.g. session still loading): clear any stale
+			// placeholder decoration so it doesn't render over typed text. See #325323.
 			if (inputValue) {
 				this.widget.inputEditor.setDecorationsByType(decorationDescription, placeholderDecorationType, []);
 			}

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
@@ -34,6 +34,7 @@ import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { clearChatEditor } from '../../actions/chatClear.js';
 import { ChatEditorInput } from './chatEditorInput.js';
 import { ChatWidget } from '../../widget/chatWidget.js';
+import { setModelPreservingInputTypedWhileLoading } from '../../chat.js';
 
 export interface IChatEditorOptions extends IEditorOptions {
 	/**
@@ -220,6 +221,13 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 	}
 
 	override async setInput(input: ChatEditorInput, options: IChatEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
+		// The input editor is shared across editor inputs and stays editable while
+		// the model loads. Capture whatever draft is already in it as we enter the
+		// load window so that, once the session binds (and its own - usually empty -
+		// draft would otherwise clobber the editor), we can restore anything the
+		// user typed on top of this baseline instead of losing it. See #325323.
+		const inputBeforeLoad = this.widget?.getInput() ?? '';
+
 		// Show loading indicator early for non-local sessions to prevent layout shifts
 		let isContributedChatSession = false;
 		const chatSessionType = input.getSessionType();
@@ -273,7 +281,9 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 				editorModel.model.inputModel.setState(options.modelInputState);
 			}
 
-			this.updateModel(editorModel.model);
+			// Preserve any text the user typed into the input while the session
+			// was loading, rather than losing it when the model binds. See #325323.
+			setModelPreservingInputTypedWhileLoading(this.widget, inputBeforeLoad, () => this.updateModel(editorModel.model));
 
 			const viewState = this.loadEditorViewState(input, context);
 			if (viewState) {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
@@ -221,11 +221,8 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 	}
 
 	override async setInput(input: ChatEditorInput, options: IChatEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
-		// The input editor is shared across editor inputs and stays editable while
-		// the model loads. Capture whatever draft is already in it as we enter the
-		// load window so that, once the session binds (and its own - usually empty -
-		// draft would otherwise clobber the editor), we can restore anything the
-		// user typed on top of this baseline instead of losing it. See #325323.
+		// Capture the input draft before the load window opens so text typed
+		// during loading is preserved when the model binds. See #325323.
 		const inputBeforeLoad = this.widget?.getInput() ?? '';
 
 		// Show loading indicator early for non-local sessions to prevent layout shifts
@@ -281,8 +278,6 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 				editorModel.model.inputModel.setState(options.modelInputState);
 			}
 
-			// Preserve any text the user typed into the input while the session
-			// was loading, rather than losing it when the model binds. See #325323.
 			setModelPreservingInputTypedWhileLoading(this.widget, inputBeforeLoad, () => this.updateModel(editorModel.model));
 
 			const viewState = this.loadEditorViewState(input, context);

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -1073,15 +1073,14 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			&& !model.hasRequests;
 	}
 
-	private async showModel(token: CancellationToken, modelRef?: IChatModelReference | undefined, startNewSession = true, ignoreTransferredSession = false): Promise<IChatModel | undefined> {
+	private async showModel(token: CancellationToken, modelRef?: IChatModelReference | undefined, startNewSession = true, ignoreTransferredSession = false, inputBeforeLoad?: string): Promise<IChatModel | undefined> {
 		const oldModelResource = this.modelRef.value?.object.sessionResource;
 		this.modelRef.value = undefined;
 
-		// The input editor stays editable while the model loads asynchronously.
-		// Capture whatever draft is already in it as we enter the load window so
-		// any text the user types during loading can be preserved when the model
-		// binds rather than being lost. See #325323.
-		const inputBeforeLoad = this._widget?.getInput() ?? '';
+		// Baseline draft for preserving text typed during loading. `loadSession`
+		// opens its load window before calling us, so it passes its own baseline;
+		// otherwise this call's own await is the load window. See #325323.
+		const baselineInput = inputBeforeLoad ?? this._widget?.getInput() ?? '';
 
 		let ref: IChatModelReference | undefined;
 		if (startNewSession) {
@@ -1118,7 +1117,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		}
 
 		if (model) {
-			setModelPreservingInputTypedWhileLoading(this._widget, inputBeforeLoad, () => this._widget.setModel(model));
+			setModelPreservingInputTypedWhileLoading(this._widget, baselineInput, () => this._widget.setModel(model));
 		} else {
 			this._widget.setModel(model);
 		}
@@ -1189,6 +1188,11 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		const t0 = Date.now();
 		this.logService.trace(`[ChatViewPane] loadSession start uri=${sessionResource.toString()}`);
 
+		// Capture the input draft up front: the load window (clear + acquire below)
+		// opens before `showModel` binds, so text typed during loading must be
+		// baselined here to be preserved rather than erased. See #325323.
+		const inputBeforeLoad = this._widget?.getInput() ?? '';
+
 		// Cancel any in-flight loadSession call so the last one always wins
 		this.loadSessionCts.value?.cancel();
 		const cts = this.loadSessionCts.value = new CancellationTokenSource();
@@ -1231,7 +1235,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 					return undefined;
 				}
 
-				const result = await this.showModel(token, newModelRef);
+				const result = await this.showModel(token, newModelRef, true, false, inputBeforeLoad);
 				this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()}`);
 				return result;
 			} catch (err) {
@@ -1247,7 +1251,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				// is not left in a broken state without title or back button.
 				this.logService.error(`Failed to load chat session '${sessionResource.toString()}'`, err);
 				this.notificationService.error(localize('chat.loadSessionFailed', "Failed to open chat session: {0}", toErrorMessage(err)));
-				const result = await this.showModel(token, undefined);
+				const result = await this.showModel(token, undefined, true, false, inputBeforeLoad);
 				this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()} error=true`);
 				return result;
 			} finally {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -59,7 +59,7 @@ import { IChatViewsWelcomeDescriptor } from '../../viewsWelcome/chatViewsWelcome
 import { IWorkbenchLayoutService, LayoutSettings, Position } from '../../../../../services/layout/browser/layoutService.js';
 import { AgentSessionsViewerOrientation, AgentSessionsViewerPosition } from '../../agentSessions/agentSessions.js';
 import { IProgressService } from '../../../../../../platform/progress/common/progress.js';
-import { ChatViewId, IChatWidgetService } from '../../chat.js';
+import { ChatViewId, IChatWidgetService, setModelPreservingInputTypedWhileLoading } from '../../chat.js';
 import { IActivityService, ProgressBadge } from '../../../../../services/activity/common/activity.js';
 import { disposableTimeout } from '../../../../../../base/common/async.js';
 import { AgentSessionsFilter, AgentSessionsGrouping } from '../../agentSessions/agentSessionsFilter.js';
@@ -1077,6 +1077,12 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		const oldModelResource = this.modelRef.value?.object.sessionResource;
 		this.modelRef.value = undefined;
 
+		// The input editor stays editable while the model loads asynchronously.
+		// Capture whatever draft is already in it as we enter the load window so
+		// any text the user types during loading can be preserved when the model
+		// binds rather than being lost. See #325323.
+		const inputBeforeLoad = this._widget?.getInput() ?? '';
+
 		let ref: IChatModelReference | undefined;
 		if (startNewSession) {
 			if (modelRef) {
@@ -1111,7 +1117,11 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			this.viewState.sessionResource = model.sessionResource;
 		}
 
-		this._widget.setModel(model);
+		if (model) {
+			setModelPreservingInputTypedWhileLoading(this._widget, inputBeforeLoad, () => this._widget.setModel(model));
+		} else {
+			this._widget.setModel(model);
+		}
 
 		// Update title control
 		this.titleControl?.update(model);

--- a/src/vs/workbench/contrib/chat/test/browser/chatWidgetInputPreservation.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatWidgetInputPreservation.test.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IChatWidget, setModelPreservingInputTypedWhileLoading } from '../../browser/chat.js';
+
+suite('setModelPreservingInputTypedWhileLoading', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	/**
+	 * A minimal fake that models just the input editor of a chat widget. `bind`
+	 * simulates the model binding resetting the editor to the session's own draft
+	 * (mirroring `_syncFromModel` calling `setValue(state.inputText || '')`).
+	 */
+	class FakeInputWidget {
+		constructor(private input: string, private readonly boundDraft: string) { }
+		getInput(): string { return this.input; }
+		setInput(query?: string): void { this.input = query ?? ''; }
+		bind(): void { this.input = this.boundDraft; }
+		asWidget(): IChatWidget { return this as unknown as IChatWidget; }
+	}
+
+	test('restores text typed during load onto an empty session', () => {
+		const widget = new FakeInputWidget(/* initial */ '', /* boundDraft */ '');
+		const inputBeforeLoad = widget.getInput(); // '' - editor was empty when load started
+		widget.setInput('the'); // user types while loading
+
+		setModelPreservingInputTypedWhileLoading(widget.asWidget(), inputBeforeLoad, () => widget.bind());
+
+		assert.strictEqual(widget.getInput(), 'the');
+	});
+
+	test('does not clobber the loaded session\'s own persisted draft', () => {
+		const widget = new FakeInputWidget('', 'session draft');
+		const inputBeforeLoad = widget.getInput();
+		widget.setInput('the'); // user types while loading
+
+		setModelPreservingInputTypedWhileLoading(widget.asWidget(), inputBeforeLoad, () => widget.bind());
+
+		assert.strictEqual(widget.getInput(), 'session draft');
+	});
+
+	test('does not carry a previous session\'s leftover draft over on a plain switch', () => {
+		// Editor still holds the previous session's draft and the user did NOT type.
+		const widget = new FakeInputWidget('previous draft', '');
+		const inputBeforeLoad = widget.getInput(); // 'previous draft' == current input (no typing)
+
+		setModelPreservingInputTypedWhileLoading(widget.asWidget(), inputBeforeLoad, () => widget.bind());
+
+		assert.strictEqual(widget.getInput(), '');
+	});
+});


### PR DESCRIPTION
Fixes #325323

## Problem

When you open a chat session that loads slowly (e.g. one with a lot of history) and start typing into the input box while it loads, two things go wrong:

1. **Typed text is lost** — when the session model finishes loading and binds, it resets the input editor to the session's own (usually empty) draft, discarding whatever you typed in the meantime.
2. **The placeholder isn't removed** — the placeholder decoration keeps rendering on top of the text you're typing during loading.

Both symptoms are visible in the issue's recording (the chat **editor** tab). The same load-window gap exists in all three chat hosts: the editor (`ChatEditor.setInput`), the panel (`ChatViewPane.showModel`), and the Agents window (`ChatView.setChat`).

## Fix

- Add a shared helper `setModelPreservingInputTypedWhileLoading` in `chat.ts`, used by all three hosts. Each host captures the input value as it enters the load window (a baseline), and the helper restores text typed during loading **only** when it is genuinely new (`typed !== baseline`) and the loaded session has no draft of its own. This never clobbers a persisted draft and never carries a previous session's leftover draft over on a plain switch.
- In `chatInputEditorContrib.ts`, the placeholder-decoration update now clears the stale placeholder decoration when there is input text but no bound view model yet (the loading state).

## Verification

- New unit tests for the helper (including the leak-prevention cases).
- Verified live in the editor window by injecting a controllable load gate: with the fix, text typed during loading is preserved and the placeholder is hidden; with the fix bypassed (control), the text is lost and the placeholder returns — reproducing the reported bug.

(Written by Copilot)
