### PR TITLE
Start initial Agent Host customization discovery immediately

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -3710,7 +3710,7 @@ class SessionDiscoveredEntry extends Disposable {
 		super();
 		this._discovery = this._register(instantiationService.createInstance(SessionCustomizationDiscovery, workingDirectory, userHome));
 		this._fileService = instantiationService.invokeFunction(accessor => accessor.get(IFileService));
-		this._settled = this._queueRefresh(false);
+		this._settled = this._queueRefresh(false, 0);
 		this._register(this._discovery.onDidChange(() => {
 			this._settled = this._queueRefresh(true);
 		}));
@@ -3730,7 +3730,7 @@ class SessionDiscoveredEntry extends Disposable {
 		return this._customizations;
 	}
 
-	private _queueRefresh(notify: boolean): Promise<void> {
+	private _queueRefresh(notify: boolean, delay = REFRESH_DEBOUNCE_MS): Promise<void> {
 		this._refreshPromise?.cancel();
 		this._refreshPromise = null;
 		this._pendingRefreshNotify = this._pendingRefreshNotify || notify;
@@ -3738,7 +3738,6 @@ class SessionDiscoveredEntry extends Disposable {
 		return this._refreshDelayer.trigger(() => {
 			const shouldNotify = this._pendingRefreshNotify;
 			this._pendingRefreshNotify = false;
-
 			const refreshPromise = this._refreshPromise = createCancelablePromise(async token => {
 				const didRefresh = await this._refresh(token);
 				if (didRefresh && shouldNotify) {
@@ -3759,7 +3758,7 @@ class SessionDiscoveredEntry extends Disposable {
 				}
 				throw err;
 			});
-		});
+		}, delay);
 	}
 
 	private async _refresh(token: CancellationToken): Promise<boolean> {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -20,7 +20,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { INativeEnvironmentService } from '../../../environment/common/environment.js';
 import { FileService } from '../../../files/common/fileService.js';
-import { IFileService } from '../../../files/common/files.js';
+import { IFileService, type IStat } from '../../../files/common/files.js';
 import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
@@ -2176,6 +2176,45 @@ suite('CopilotAgent', () => {
 					name: 'AGENTS.md',
 					alwaysApply: true,
 				} satisfies RuleCustomization]);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('getSessionCustomizations starts initial discovery without debounce', async () => {
+			class StatTrackingFileSystemProvider extends InMemoryFileSystemProvider {
+				trackStats = false;
+				statCalls = 0;
+
+				override async stat(resource: URI): Promise<IStat> {
+					if (this.trackStats) {
+						this.statCalls++;
+					}
+					return super.stat(resource);
+				}
+			}
+
+			const fileService = disposables.add(new FileService(new NullLogService()));
+			const provider = disposables.add(new StatTrackingFileSystemProvider());
+			disposables.add(fileService.registerProvider(Schemas.inMemory, provider));
+			const workspace = URI.from({ scheme: Schemas.inMemory, path: '/workspace' });
+			await fileService.createFolder(workspace);
+
+			const sessionDataService = disposables.add(new TestSessionDataService());
+			const client = new TestCopilotClient([]);
+			const { agent } = createTestAgentContext(disposables, { sessionDataService, copilotClient: client, fileService });
+
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				const session = AgentSession.uri('copilotcli', 'session-discovery-immediate');
+				await agent.createSession({ session, workingDirectory: workspace });
+
+				provider.trackStats = true;
+				const customizations = agent.getSessionCustomizations(session);
+				await timeout(50);
+
+				assert.ok(provider.statCalls > 0, 'expected discovery to start before the debounce interval');
+				await customizations;
 			} finally {
 				await disposeAgent(agent);
 			}


### PR DESCRIPTION
## Summary

Start the initial per-session customization discovery with zero delay while preserving the existing 100 ms debounce for file-watcher-driven refreshes. This removes an accidental delay from cold Agent Host session resume without changing watcher burst coalescing.

In a post-eviction session reopen, customization snapshot time decreased from 152.8 ms to 55.4 ms and total session initialization decreased from 364.7 ms to 147.9 ms.

## Validation

- `npm run typecheck-client`
- `npm run compile`
- focused `CopilotAgent` unit tests (134 passing)
- `npm run valid-layers-check`
- staged pre-commit hygiene
- live post-eviction Agents window measurement

(Written by Copilot)