### PR TITLE
Enable Agent Host debugging in the Agent Debug Logs panel

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatDebug.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatDebug.ts
@@ -78,10 +78,10 @@ export class MainThreadChatDebug extends Disposable implements MainThreadChatDeb
 
 		// Register a lazy fetcher so historical sessions are loaded from the
 		// extension only when the debug panel home page first needs them.
-		this._chatDebugService.registerAvailableSessionsFetcher(async (token) => {
+		disposables.add(this._chatDebugService.registerAvailableSessionsFetcher(async (token) => {
 			const entries = await this._proxy.$getAvailableDebugSessionResources(handle, token);
 			return entries.map(e => ({ uri: URI.revive(e.uri), title: e.title }));
-		});
+		}));
 	}
 
 	$unregisterChatDebugLogProvider(handle: number): void {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
@@ -25,7 +25,7 @@ import { ChatViewId, IChatWidgetService } from '../chat.js';
 import { CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from './chatActions.js';
 import { ChatDebugEditorInput } from '../chatDebug/chatDebugEditorInput.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { IChatDebugEditorOptions } from '../chatDebug/chatDebugTypes.js';
+import { IChatDebugEditorOptions, CHAT_DEBUG_ACTIVE_SESSION_IS_AGENT_HOST } from '../chatDebug/chatDebugTypes.js';
 import { LocalChatSessionUri } from '../../common/model/chatUri.js';
 
 /**
@@ -119,11 +119,11 @@ export function registerChatOpenAgentDebugPanelAction() {
 				icon: Codicon.chatExport,
 				f1: true,
 				category: Categories.Developer,
-				precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ChatContextKeys.chatIsAgentHostSession.negate()),
+				precondition: ChatContextKeys.enabled,
 				menu: [{
 					id: MenuId.EditorTitle,
 					group: 'navigation',
-					when: ActiveEditorContext.isEqualTo(ChatDebugEditorInput.ID),
+					when: ContextKeyExpr.and(ActiveEditorContext.isEqualTo(ChatDebugEditorInput.ID), CHAT_DEBUG_ACTIVE_SESSION_IS_AGENT_HOST.negate()),
 					order: 10
 				}],
 			});
@@ -188,7 +188,7 @@ export function registerChatOpenAgentDebugPanelAction() {
 				menu: [{
 					id: MenuId.EditorTitle,
 					group: 'navigation',
-					when: ActiveEditorContext.isEqualTo(ChatDebugEditorInput.ID),
+					when: ContextKeyExpr.and(ActiveEditorContext.isEqualTo(ChatDebugEditorInput.ID), CHAT_DEBUG_ACTIVE_SESSION_IS_AGENT_HOST.negate()),
 					order: 11
 				}],
 			});

--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -3,15 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { VSBuffer, type VSBufferReadableStream } from '../../../../../base/common/buffer.js';
-import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { joinPath } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
 import { Action2 } from '../../../../../platform/actions/common/actions.js';
-import { agentHostAuthority, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { AGENT_HOST_ENABLED_CONTEXT_KEY } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
 import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostService, remoteAgentHostLogOutputChannelId, AGENT_HOST_LOG_OUTPUT_CHANNEL_ID } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
@@ -19,7 +18,7 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { IsWebContext } from '../../../../../platform/contextkey/common/contextkeys.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
-import { IFileService, type IFileStatWithMetadata } from '../../../../../platform/files/common/files.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
 import { createDecorator, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
@@ -31,6 +30,7 @@ import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IChatWidgetService } from '../chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { buildLocalCopilotLogsUri, buildRemoteCopilotLogsUri, COPILOT_CLI_LOCAL_AH_SCHEME, getCopilotCliSessionRawId, parseRemoteAuthorityFromScheme, resolveEventsUri } from '../copilotCliEventsUri.js';
+import { getRemoteConnectionForSession, readCopilotLogsForSession, readRemoteAgentHostLog, sanitizeFilePart } from '../chatDebug/agentHostLogSources.js';
 
 /** Output channel ID for the agent host process logger (forwarded via RemoteLoggerChannelClient). */
 const AGENT_HOST_LOGGER_CHANNEL_ID = AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
@@ -38,9 +38,6 @@ const AGENT_HOST_LOGGER_CHANNEL_ID = AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
 const WINDOW_LOG_CHANNEL_ID = 'rendererLog';
 /** Output channel ID for the shared process compound log. */
 const SHARED_PROCESS_LOG_CHANNEL_ID = 'shared';
-/** Bound the best-effort scan of Copilot SDK process logs. */
-const MAX_COPILOT_LOG_SCAN_FILES = 20;
-const MAX_COPILOT_LOG_FILE_SIZE = 10 * 1024 * 1024;
 
 /**
  * Description of the agent-host session whose logs should be exported. If
@@ -235,101 +232,6 @@ export async function collectAgentHostDebugLogs(
 	return { files, exportName: `ah-logs${titleSlug}` };
 }
 
-async function readCopilotLogsForSession(
-	logsDir: URI,
-	rawSessionId: string,
-	fileService: IFileService,
-	logService: ILogService,
-): Promise<{ path: string; contents: string }[]> {
-	let children: IFileStatWithMetadata[] | undefined;
-	try {
-		children = (await fileService.resolve(logsDir, { resolveMetadata: true })).children;
-	} catch {
-		return [];
-	}
-
-	const files: { path: string; contents: string }[] = [];
-	const candidateLogs = (children ?? [])
-		.filter(child => !child.isDirectory && child.name.endsWith('.log') && child.size <= MAX_COPILOT_LOG_FILE_SIZE)
-		.sort((a, b) => b.mtime - a.mtime)
-		.slice(0, MAX_COPILOT_LOG_SCAN_FILES);
-	for (const child of candidateLogs) {
-		try {
-			if (await logStreamContains(child.resource, rawSessionId, fileService)) {
-				const content = await fileService.readFile(child.resource, { limits: { size: MAX_COPILOT_LOG_FILE_SIZE } });
-				const contents = content.value.toString();
-				files.push({ path: `copilot-logs/${child.name}`, contents });
-			}
-		} catch (error) {
-			logService.warn(`[ExportAgentHostDebugLogs] Failed to read Copilot log '${child.name}': ${error instanceof Error ? error.message : String(error)}`);
-		}
-	}
-	return files;
-}
-
-async function logStreamContains(
-	resource: URI,
-	rawSessionId: string,
-	fileService: IFileService,
-): Promise<boolean> {
-	const tokenSource = new CancellationTokenSource();
-	let stream: VSBufferReadableStream;
-	try {
-		stream = (await fileService.readFileStream(resource, {
-			length: MAX_COPILOT_LOG_FILE_SIZE,
-			limits: { size: MAX_COPILOT_LOG_FILE_SIZE },
-		}, tokenSource.token)).value;
-	} catch (error) {
-		tokenSource.dispose(true);
-		throw error;
-	}
-	return new Promise<boolean>((resolve, reject) => {
-		let settled = false;
-		let previous = '';
-
-		const cleanup = (removeErrorListener: boolean) => {
-			stream.removeListener('data', onData);
-			stream.removeListener('end', onEnd);
-			if (removeErrorListener) {
-				stream.removeListener('error', onError);
-			}
-		};
-		const settle = (contains: boolean) => {
-			if (settled) {
-				return;
-			}
-			settled = true;
-			tokenSource.dispose(contains);
-			cleanup(!contains);
-			resolve(contains);
-		};
-		const onData = (chunk: VSBuffer) => {
-			const text = previous + chunk.toString();
-			if (text.includes(rawSessionId)) {
-				settle(true);
-				return;
-			}
-			previous = text.slice(Math.max(0, text.length - rawSessionId.length + 1));
-		};
-		const onError = (error: Error) => {
-			if (settled) {
-				return;
-			}
-			settled = true;
-			tokenSource.dispose();
-			cleanup(true);
-			reject(error);
-		};
-		const onEnd = () => {
-			settle(false);
-		};
-
-		stream.on('error', onError);
-		stream.on('end', onEnd);
-		stream.on('data', onData);
-	});
-}
-
 export async function exportAgentHostDebugLogs(
 	accessor: ServicesAccessor,
 	activeSession: IActiveAgentHostSessionForExport | undefined,
@@ -404,15 +306,6 @@ export function toActiveAgentHostSession(resource: URI, title: string | undefine
 	return undefined;
 }
 
-function getRemoteConnectionForSession(sessionResource: URI, connections: readonly IRemoteAgentHostConnectionInfo[]): IRemoteAgentHostConnectionInfo | undefined {
-	const authority = parseRemoteAuthorityFromScheme(sessionResource.scheme);
-	return authority ? connections.find(connection => agentHostAuthority(connection.address) === authority) : undefined;
-}
-
-function sanitizeFilePart(value: string): string {
-	return value.replace(/[\\/:\*\?"<>|\s]+/g, '-').replace(/^-+|-+$/g, '') || 'connection';
-}
-
 async function exportFilesToLocalFolder(
 	fileDialogService: IFileDialogService,
 	fileService: IFileService,
@@ -458,81 +351,4 @@ function toSafeRelativePathSegments(path: string): string[] {
 			return segment.length > 0 && segment !== '.' && segment !== '..';
 		})
 		.map(segment => segment.replace(/[/\\:*?"<>|]/g, '-'));
-}
-
-/**
- * Reads the remote agent host's `agenthost.log` from the remote machine via the
- * `vscode-agent-host://` filesystem proxy. The CLI launches the server with its
- * default data dir at `<home>/<serverDataFolderName>/data/logs/<datestamp>/`,
- * so we list the logs directory and pick the most recent date-stamped folder.
- */
-async function readRemoteAgentHostLog(
-	connection: IRemoteAgentHostConnectionInfo,
-	serverDataFolderName: string | undefined,
-	fileService: IFileService,
-): Promise<string | undefined> {
-	const homePath = connection.defaultDirectory;
-	if (!homePath) {
-		return undefined;
-	}
-	const authority = agentHostAuthority(connection.address);
-	const homeUri = toAgentHostUri(URI.from({ scheme: 'file', path: homePath }), authority);
-
-	// Possible server data folder candidates. The renderer's own
-	// `serverDataFolderName` (which the user is running) is the most likely
-	// match, but the remote agent host may have been launched by a different
-	// quality of CLI. Dev builds also append `-dev`, which won't exist on
-	// any real built remote, so we strip that suffix as well.
-	const candidates = new Set<string>();
-	if (serverDataFolderName) {
-		candidates.add(serverDataFolderName);
-		if (serverDataFolderName.endsWith('-dev')) {
-			candidates.add(serverDataFolderName.slice(0, -'-dev'.length));
-		}
-	}
-	candidates.add('.vscode-server');
-	candidates.add('.vscode-server-insiders');
-	candidates.add('.vscode-server-oss');
-	candidates.add('.vscode-server-exploration');
-
-	// Enumerate every `<home>/<candidate>/data/logs/<datestamp>/agenthost.log`
-	// across all candidates and pick the one with the newest mtime. This avoids
-	// picking up a stale stable-quality folder when an insiders folder has a
-	// more recent log (or vice versa).
-	let best: { uri: URI; mtime: number } | undefined;
-	for (const folderName of candidates) {
-		const logsDirUri = joinPath(homeUri, folderName, 'data', 'logs');
-		let entries;
-		try {
-			const stat = await fileService.resolve(logsDirUri, { resolveMetadata: true });
-			entries = stat.children;
-		} catch {
-			continue;
-		}
-		if (!entries) {
-			continue;
-		}
-		for (const dir of entries) {
-			if (!dir.isDirectory) {
-				continue;
-			}
-			const logUri = joinPath(dir.resource, 'agenthost.log');
-			let logStat;
-			try {
-				logStat = await fileService.resolve(logUri, { resolveMetadata: true });
-			} catch {
-				continue;
-			}
-			const mtime = logStat.mtime ?? 0;
-			if (!best || mtime > best.mtime) {
-				best = { uri: logUri, mtime };
-			}
-		}
-	}
-
-	if (!best) {
-		return undefined;
-	}
-	const content = await fileService.readFile(best.uri);
-	return content.value.toString();
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -75,7 +75,7 @@ import { ChatPromptFilesExtensionPointHandler } from '../common/promptSyntax/cha
 import { isTildePath, PromptsConfig } from '../common/promptSyntax/config/config.js';
 import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION, DEFAULT_SKILL_SOURCE_FOLDERS, AGENTS_SOURCE_FOLDER, AGENT_FILE_EXTENSION, SKILL_FILENAME, CLAUDE_AGENTS_SOURCE_FOLDER, DEFAULT_HOOK_FILE_PATHS, DEFAULT_INSTRUCTIONS_SOURCE_FOLDERS, COPILOT_USER_AGENTS_SOURCE_FOLDER } from '../common/promptSyntax/config/promptFileLocations.js';
 import { PromptLanguageFeaturesProvider } from './promptSyntax/promptFileContributions.js';
-import { AGENT_DOCUMENTATION_URL, INSTRUCTIONS_DOCUMENTATION_URL, PROMPT_DOCUMENTATION_URL, SKILL_DOCUMENTATION_URL, HOOK_DOCUMENTATION_URL, PromptsType, PromptFileSource } from '../common/promptSyntax/promptTypes.js';
+import { AGENT_DOCUMENTATION_URL, INSTRUCTIONS_DOCUMENTATION_URL, PROMPT_DOCUMENTATION_URL, SKILL_DOCUMENTATION_URL, HOOK_DOCUMENTATION_URL, PromptsType, PromptFileSource, AgentHostAgentDebugLogEnabledSettingId, AgentHostAgentDebugLogMaxEventsSettingId } from '../common/promptSyntax/promptTypes.js';
 import { hookFileSchema, HOOK_SCHEMA_URI } from '../common/promptSyntax/hookSchema.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { Extensions as JSONExtensions, IJSONContributionRegistry } from '../../../../platform/jsonschemas/common/jsonContributionRegistry.js';
@@ -1248,6 +1248,25 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.ahpJsonlLogging', "When enabled, logs all AHP transport messages for agent host connections to JSONL files under the window's log directory."),
 			default: product.quality !== 'stable',
 			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostAgentDebugLogEnabledSettingId]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.agentHost.agentDebugLog.enabled', "Enable agent debug logging for agent host sessions: surface their debug events in the agent debug panel. Takes effect immediately; only sessions that run while this is enabled are captured."),
+			default: false,
+			tags: ['experimental', 'advanced'],
+			experiment: {
+				mode: 'startup'
+			},
+		},
+		[AgentHostAgentDebugLogMaxEventsSettingId]: {
+			type: 'number',
+			minimum: 10,
+			markdownDescription: nls.localize('chat.agentHost.agentDebugLog.maxEventsInMemory', "Maximum number of debug events kept in memory per agent host session for the agent debug panel. Older events beyond this limit are dropped from the in-memory buffer, which also lowers the totals (such as token usage) shown in the panel overview."),
+			default: 10000,
+			tags: ['experimental', 'advanced'],
+			experiment: {
+				mode: 'startup'
+			},
 		},
 		[AgentHostCustomTerminalToolEnabledSettingId]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostChatDebugProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostChatDebugProvider.ts
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { joinPath } from '../../../../../base/common/resources.js';
+import { dirname, joinPath } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -16,12 +17,15 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
 import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { IRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
-import { buildDefaultChatUri, StateComponents, type ChatState, type UsageInfo } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { buildDefaultChatUri, CustomizationType, readUsageInfoMeta, StateComponents, type ChatState, type ChildCustomization, type Customization, type UsageInfo } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
-import { ChatDebugLogLevel, IChatDebugEvent, IChatDebugLogProvider, IChatDebugMessageSection, IChatDebugModelTurnEvent, IChatDebugResolvedEventContent, IChatDebugService } from '../../common/chatDebugService.js';
-import { AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING } from '../../common/promptSyntax/promptTypes.js';
+import { ChatDebugHookResult, ChatDebugLogLevel, IChatDebugCustomizationLogEntry, IChatDebugEvent, IChatDebugFileEntry, IChatDebugLogProvider, IChatDebugMessageSection, IChatDebugModelTurnEvent, IChatDebugResolvedEventContent, IChatDebugService } from '../../common/chatDebugService.js';
+import { IAgentHostCustomizationService } from '../agentSessions/agentHost/agentHostCustomizationService.js';
+import { AgentHostAgentDebugLogEnabledSettingId } from '../../common/promptSyntax/promptTypes.js';
 import { COPILOT_CLI_EH_SCHEME, COPILOT_CLI_LOCAL_AH_SCHEME, getCopilotCliSessionRawId, resolveEventsUri } from '../copilotCliEventsUri.js';
+import { AgentHostCustomizationRecorder, AgentHostUsageRecorder, buildAgentHostCustomizationsUri, buildAgentHostUsageUri, readAgentHostCustomizationsSnapshot, readAgentHostUsageRecords, type IAgentHostUsageRecord } from './agentHostUsageSidecar.js';
 
 /**
  * One record in an Agent Host Copilot CLI `events.jsonl` stream. The CLI
@@ -73,9 +77,30 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 	/** Guards against concurrent/overlapping session discovery scans. */
 	private _discovering = false;
 
+	/** True once the lazy fetcher has run at least once (i.e. the panel has been opened). */
+	private _hasFetchedOnce = false;
+
 	/** Watches the currently-viewed session's events.jsonl for live refresh. */
 	private readonly _liveRefresh = this._register(new MutableDisposable<DisposableStore>());
 	private _watchedSessionKey: string | undefined;
+
+	/**
+	 * Incremental-read cache for the actively-viewed session's `events.jsonl`.
+	 * The CLI appends to the file, so each live refresh reads only the bytes
+	 * added since the last read and parses just the new lines, avoiding an
+	 * O(N) whole-file re-read + re-parse on every change. Bounded to a single
+	 * session (the one being viewed) and released when that session ends.
+	 */
+	private _liveRead: { key: string; consumedBytes: number; pendingBytes: VSBuffer; records: IAgentHostEventRecord[] } | undefined;
+
+	/**
+	 * Size-gated cache for the actively-viewed session's usage sidecar. The
+	 * sidecar is read on every live tick, but is append-only, so we re-read and
+	 * re-parse it only when its byte size changed since the last read (most
+	 * ticks — tool progress, etc. — add no usage records). Bounded to a single
+	 * session and released when that session ends.
+	 */
+	private _usageRead: { key: string; size: number; records: readonly IAgentHostUsageRecord[] } | undefined;
 
 	constructor(
 		@IChatDebugService private readonly _chatDebugService: IChatDebugService,
@@ -85,6 +110,8 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 		@IAgentHostService private readonly _agentHostService: IAgentHostService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILogService private readonly _logService: ILogService,
+		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
+		@IAgentHostCustomizationService private readonly _customizationService: IAgentHostCustomizationService,
 	) {
 		super();
 
@@ -94,6 +121,32 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 		};
 		this._register(this._chatDebugService.registerProvider(provider));
 
+		// Capture live token-usage actions to a stable client-local sidecar so
+		// per-turn/per-round metrics survive a VS Code restart and feed the Cache
+		// Explorer accurately (works for local and remote hosts alike). Gated on
+		// the same agent-host setting that gates the panel for CLI sessions.
+		this._register(new AgentHostUsageRecorder(
+			this._environmentService.userRoamingDataHome,
+			() => this._configurationService.getValue<boolean>(AgentHostAgentDebugLogEnabledSettingId),
+			this._fileService,
+			this._logService,
+			this._agentHostService,
+			this._remoteAgentHostService,
+		));
+
+		// Capture each session's loaded customizations (skills/hooks/agents/MCP)
+		// to a client-local snapshot so historical/closed sessions still surface
+		// them: the live customization service only knows sessions with an active
+		// state subscription, and the SDK's `session.*_loaded` events are ephemeral.
+		this._register(new AgentHostCustomizationRecorder(
+			this._environmentService.userRoamingDataHome,
+			() => this._configurationService.getValue<boolean>(AgentHostAgentDebugLogEnabledSettingId),
+			this._fileService,
+			this._logService,
+			this._agentHostService,
+			this._remoteAgentHostService,
+		));
+
 		// Stop the live file watcher when the session it follows is closed
 		// (e.g. navigating Home or closing the debug editor), so we don't keep
 		// re-reading and re-invoking providers for a session no longer shown.
@@ -101,33 +154,63 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 			if (sessionResource.toString() === this._watchedSessionKey) {
 				this._liveRefresh.clear();
 				this._watchedSessionKey = undefined;
+				this._liveRead = undefined; // release the per-session parse cache
+				this._usageRead = undefined; // release the per-session usage cache
 			}
 		}));
 
-		// Discover historical local sessions so they appear in the home list.
-		// Gated on the same setting that gates the panel; re-run when that
-		// setting is toggled on (e.g. via the panel's "Enable in Settings"
-		// button) so sessions appear without a window reload.
-		this._maybeDiscoverLocalSessions();
+		// Discover historical local sessions so they appear in the home list —
+		// but only when the debug panel actually needs them. Registering a lazy
+		// fetcher (invoked on the first `getAvailableSessionResources()`, i.e.
+		// when the home view first renders) keeps the startup/idle footprint at
+		// zero when the panel is never opened. When file logging is toggled on
+		// after the panel has already loaded once, re-scan directly so sessions
+		// surface without a window reload.
+		this._register(this._chatDebugService.registerAvailableSessionsFetcher(token => this._fetchLocalSessions(token)));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING)) {
+			if (e.affectsConfiguration(AgentHostAgentDebugLogEnabledSettingId) && this._hasFetchedOnce) {
 				this._maybeDiscoverLocalSessions();
 			}
 		}));
 	}
 
 	/**
-	 * Runs {@link _discoverLocalSessions} when file logging is enabled,
-	 * guarding against overlapping scans. Safe to call repeatedly:
-	 * {@link IChatDebugService.addAvailableSessionResources} dedupes by URI.
+	 * Lazy fetcher registered with {@link IChatDebugService}. Invoked (at most
+	 * once) when the home view first requests the available session list, so no
+	 * disk scan happens until the panel is opened. Returns nothing when file
+	 * logging is disabled.
+	 */
+	private async _fetchLocalSessions(token: CancellationToken): Promise<{ uri: URI; title?: string }[]> {
+		this._hasFetchedOnce = true;
+		if (!this._configurationService.getValue<boolean>(AgentHostAgentDebugLogEnabledSettingId)) {
+			return [];
+		}
+		try {
+			return await this._discoverLocalSessions(token);
+		} catch (err) {
+			this._logService.warn(`[AgentHostChatDebug] session discovery failed: ${toErrorMessage(err)}`);
+			return [];
+		}
+	}
+
+	/**
+	 * Runs {@link _discoverLocalSessions} when file logging is enabled and adds
+	 * the results to the available-sessions list, guarding against overlapping
+	 * scans. Used for the re-scan when logging is enabled after the panel has
+	 * already loaded once (the initial load goes through {@link _fetchLocalSessions}).
+	 * Safe to call repeatedly: {@link IChatDebugService.addAvailableSessionResources}
+	 * dedupes by URI.
 	 */
 	private async _maybeDiscoverLocalSessions(): Promise<void> {
-		if (this._discovering || !this._configurationService.getValue<boolean>(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING)) {
+		if (this._discovering || !this._configurationService.getValue<boolean>(AgentHostAgentDebugLogEnabledSettingId)) {
 			return;
 		}
 		this._discovering = true;
 		try {
-			await this._discoverLocalSessions();
+			const sessions = await this._discoverLocalSessions(CancellationToken.None);
+			if (sessions.length > 0) {
+				this._chatDebugService.addAvailableSessionResources(sessions);
+			}
 		} catch (err) {
 			this._logService.warn(`[AgentHostChatDebug] session discovery failed: ${toErrorMessage(err)}`);
 		} finally {
@@ -165,10 +248,19 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 		this._watchedSessionKey = key;
 		const store = new DisposableStore();
 		// Debounce: the CLI appends many records per turn; coalesce into one re-read.
-		const scheduler = store.add(new RunOnceScheduler(() => this._chatDebugService.invokeProviders(sessionResource), 400));
-		const watcher = store.add(this._fileService.createWatcher(eventsUri, { recursive: false, excludes: [] }));
+		const scheduler = store.add(new RunOnceScheduler(() => {
+			this._chatDebugService.invokeProviders(sessionResource);
+		}, 400));
+		// Watch the session-state directory (scoped to this file) rather than
+		// the single `events.jsonl`: the external Copilot CLI process writes
+		// that file from another process and a single-file watcher can miss
+		// those changes (e.g. atomic rename/replace), leaving the panel stale
+		// until the user re-navigates. A directory watch reliably surfaces
+		// appends to the file so the Logs view updates live.
+		const watcher = store.add(this._fileService.createWatcher(dirname(eventsUri), { recursive: false, excludes: [] }));
 		store.add(watcher.onDidChange(e => {
-			if (e.affects(eventsUri)) {
+			const affects = e.affects(eventsUri);
+			if (affects) {
 				scheduler.schedule();
 			}
 		}));
@@ -180,6 +272,10 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 		if (liveSub) {
 			store.add(liveSub.onDidChange(() => scheduler.schedule()));
 		}
+
+		// The set of loaded customizations (skills/hooks/agents/MCP) is sourced
+		// from live session state, not events.jsonl, so re-read when it changes.
+		store.add(this._customizationService.onDidChangeCustomizations(() => scheduler.schedule()));
 
 		this._liveRefresh.value = store; // disposes any previously-watched session
 	}
@@ -218,33 +314,112 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 		return sumChatStateUsage(chat);
 	}
 
+	/**
+	 * Reads the client-local usage sidecar for a session (exact per-request
+	 * token metrics captured live). Returns `undefined` when the session has no
+	 * sidecar (e.g. it ran before capture shipped), so the converter falls back
+	 * to the session.shutdown summary / live totals.
+	 */
+	private async _readUsageRecords(sessionResource: URI): Promise<readonly IAgentHostUsageRecord[] | undefined> {
+		const rawId = getCopilotCliSessionRawId(sessionResource);
+		if (!rawId) {
+			return undefined;
+		}
+		const uri = buildAgentHostUsageUri(this._environmentService.userRoamingDataHome, rawId);
+		const key = uri.toString();
+
+		let size: number;
+		try {
+			const stat = await this._fileService.stat(uri);
+			size = stat.size ?? 0;
+		} catch {
+			this._usageRead = undefined;
+			return undefined; // no sidecar for this session
+		}
+
+		// Append-only sidecar: reuse the parsed records when the size is unchanged.
+		if (this._usageRead?.key === key && this._usageRead.size === size) {
+			return this._usageRead.records.length > 0 ? this._usageRead.records : undefined;
+		}
+
+		const records = await readAgentHostUsageRecords(this._fileService, uri);
+		this._usageRead = { key, size, records };
+		return records.length > 0 ? records : undefined;
+	}
+
+	/**
+	 * Reads the client-local customization snapshot for a session (the last
+	 * loaded skills/hooks/agents/MCP captured live). Used as a fallback for
+	 * historical/closed sessions, where the live customization service has no
+	 * active state subscription and returns nothing. Returns `undefined` when no
+	 * snapshot exists (e.g. the session ran before capture shipped).
+	 */
+	private async _readCustomizationsSnapshot(sessionResource: URI): Promise<readonly Customization[] | undefined> {
+		const rawId = getCopilotCliSessionRawId(sessionResource);
+		if (!rawId) {
+			return undefined;
+		}
+		const uri = buildAgentHostCustomizationsUri(this._environmentService.userRoamingDataHome, rawId);
+		const snapshot = await readAgentHostCustomizationsSnapshot(this._fileService, uri);
+		return snapshot && snapshot.length > 0 ? snapshot : undefined;
+	}
+
 	private async _provideChatDebugLog(sessionResource: URI, token: CancellationToken): Promise<IChatDebugEvent[] | undefined> {
+		if (!this._configurationService.getValue<boolean>(AgentHostAgentDebugLogEnabledSettingId)) {
+			return undefined; // agent-host debug logging disabled
+		}
 		const eventsUri = this._resolveEventsUri(sessionResource);
 		if (!eventsUri) {
 			return undefined; // not an Agent Host Copilot CLI session
 		}
 
-		let text: string;
-		try {
-			const content = await this._fileService.readFile(eventsUri);
-			text = content.value.toString();
-		} catch {
-			return undefined; // session has no events.jsonl yet
+		// Keep the panel live: watch this session's events.jsonl and re-invoke
+		// providers on change. A full re-read handles new turns, tool
+		// start→complete transitions, and the session.shutdown usage summary.
+		// This must run BEFORE the read below: a brand-new session has no
+		// events.jsonl yet, and if we returned early on the failed read without
+		// arming the watcher, live updates would never surface until the panel
+		// is re-opened. The watcher targets the (already-existing) session-state
+		// directory, so it fires when the CLI first creates the file.
+		this._ensureLiveRefresh(sessionResource, eventsUri);
+
+		const records = await this._readEventRecords(eventsUri, token);
+		if (records === undefined) {
+			return undefined; // session has no events.jsonl yet, or read failed
 		}
 		if (token.isCancellationRequested) {
 			return undefined;
 		}
 
-		// Keep the panel live: watch this session's events.jsonl and re-invoke
-		// providers on change. A full re-read handles new turns, tool
-		// start→complete transitions, and the session.shutdown usage summary.
-		this._ensureLiveRefresh(sessionResource, eventsUri);
-
 		// For in-progress sessions (no session.shutdown yet), fall back to live
 		// Copilot AIU from the AHP session state so the usage tile isn't blank.
 		// (Input/cache stay blank until the session ends — see F1.)
 		const liveUsageTotals = this._getLiveUsageTotals(sessionResource);
-		const { events, resolved } = convertAgentHostEventsToDebugEvents(parseJsonl(text), sessionResource, liveUsageTotals);
+
+		// Prefer the client-local usage sidecar: it records exact per-request
+		// input/cache/AIU (captured live from ChatUsage actions) so metrics are
+		// correct per round and survive a restart. Falls back to the
+		// session.shutdown even-split / live totals when no sidecar exists.
+		const usageRecords = await this._readUsageRecords(sessionResource);
+		if (token.isCancellationRequested) {
+			return undefined;
+		}
+
+		// Loaded customizations (skills/hooks/agents/MCP) come from live session
+		// state — the SDK's `session.*_loaded` events are ephemeral and never
+		// written to events.jsonl — so surface them as discovery events, mirroring
+		// the local `PromptsDebugContribution`. Live state is empty for
+		// historical/closed sessions, so fall back to the client-local snapshot
+		// captured by `AgentHostCustomizationRecorder`.
+		let customizations = this._customizationService.getCustomizations(sessionResource);
+		if (customizations.length === 0) {
+			customizations = await this._readCustomizationsSnapshot(sessionResource) ?? customizations;
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
+		}
+
+		const { events, resolved } = convertAgentHostEventsToDebugEvents(records, sessionResource, liveUsageTotals, usageRecords, customizations);
 
 		// Merge the resolved-detail map, evicting oldest entries past the cap.
 		for (const [id, detail] of resolved) {
@@ -260,7 +435,94 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 		return events;
 	}
 
-	private async _discoverLocalSessions(): Promise<void> {
+	/**
+	 * Reads the session's `events.jsonl` into parsed records, reading only the
+	 * bytes appended since the last read for the actively-viewed session.
+	 *
+	 * The Copilot CLI appends to `events.jsonl` line-by-line from a separate
+	 * process, so a live session is an append-only stream. Rather than
+	 * re-reading and re-`JSON.parse`-ing the whole (potentially multi-MB) file
+	 * on every change — which is O(N) per tick and O(N^2) over a long session —
+	 * we cache the parsed records plus the byte offset consumed so far and read
+	 * only the new tail. A full read is used on first view, a cache miss, or
+	 * when the file shrank (rotation/truncation).
+	 *
+	 * Byte offsets are only ever advanced to a newline boundary (`\n` is a
+	 * single byte that never appears inside a multi-byte UTF-8 sequence), so a
+	 * tail read never starts mid-codepoint; any trailing partial line is kept
+	 * as `pendingBytes` and prepended to the next read.
+	 *
+	 * Returns `undefined` when the file does not exist yet or cannot be read.
+	 */
+	private async _readEventRecords(eventsUri: URI, token: CancellationToken): Promise<IAgentHostEventRecord[] | undefined> {
+		const key = eventsUri.toString();
+
+		let size: number;
+		try {
+			const stat = await this._fileService.stat(eventsUri);
+			size = stat.size ?? 0;
+		} catch {
+			this._liveRead = undefined;
+			return undefined; // session has no events.jsonl yet
+		}
+		if (token.isCancellationRequested) {
+			return undefined;
+		}
+
+		const cache = this._liveRead?.key === key ? this._liveRead : undefined;
+
+		// Incremental tail read: same session, file grew (or is unchanged).
+		if (cache && size >= cache.consumedBytes) {
+			if (size === cache.consumedBytes) {
+				return cache.records; // no new bytes (e.g. an unrelated dir change)
+			}
+			try {
+				const content = await this._fileService.readFile(eventsUri, { position: cache.consumedBytes, length: size - cache.consumedBytes });
+				if (token.isCancellationRequested) {
+					return undefined;
+				}
+				const combined = cache.pendingBytes.byteLength ? VSBuffer.concat([cache.pendingBytes, content.value]) : content.value;
+				const lastNewline = lastIndexOfNewline(combined);
+				if (lastNewline >= 0) {
+					appendJsonlRecords(combined.slice(0, lastNewline + 1).toString(), cache.records);
+					cache.pendingBytes = combined.slice(lastNewline + 1);
+				} else {
+					cache.pendingBytes = combined;
+				}
+				cache.consumedBytes = size;
+				return cache.records;
+			} catch {
+				// Fall through to a full read (e.g. transient error / offset moved).
+			}
+		}
+
+		// Full (re)read: first view, different session, file shrank, or tail read failed.
+		let buffer: VSBuffer;
+		try {
+			const content = await this._fileService.readFile(eventsUri);
+			buffer = content.value;
+		} catch {
+			this._liveRead = undefined;
+			return undefined;
+		}
+		if (token.isCancellationRequested) {
+			return undefined;
+		}
+		const lastNewline = lastIndexOfNewline(buffer);
+		const records: IAgentHostEventRecord[] = [];
+		if (lastNewline >= 0) {
+			appendJsonlRecords(buffer.slice(0, lastNewline + 1).toString(), records);
+		}
+		this._liveRead = {
+			key,
+			consumedBytes: buffer.byteLength,
+			pendingBytes: lastNewline >= 0 ? buffer.slice(lastNewline + 1) : buffer,
+			records,
+		};
+		return records;
+	}
+
+	private async _discoverLocalSessions(token: CancellationToken): Promise<{ uri: URI; title?: string }[]> {
 		const userHome = this._pathService.userHome({ preferLocal: true });
 		const sessionStateDir = joinPath(userHome, '.copilot', 'session-state');
 
@@ -268,7 +530,10 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 		try {
 			stat = await this._fileService.resolve(sessionStateDir, { resolveMetadata: true });
 		} catch {
-			return; // no local Copilot CLI sessions on disk
+			return []; // no local Copilot CLI sessions on disk
+		}
+		if (token.isCancellationRequested) {
+			return [];
 		}
 
 		const folders = (stat.children ?? [])
@@ -288,10 +553,10 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 			return { uri: URI.from({ scheme: COPILOT_CLI_LOCAL_AH_SCHEME, path: `/${folder.name}` }), title };
 		}));
 
-		const sessions = found.filter((s): s is NonNullable<typeof s> => s !== undefined);
-		if (sessions.length > 0) {
-			this._chatDebugService.addAvailableSessionResources(sessions);
+		if (token.isCancellationRequested) {
+			return [];
 		}
+		return found.filter((s): s is NonNullable<typeof s> => s !== undefined);
 	}
 }
 
@@ -319,12 +584,20 @@ export function convertAgentHostEventsToDebugEvents(
 	records: readonly IAgentHostEventRecord[],
 	sessionResource: URI,
 	fallbackUsageTotals?: ISessionUsageTotals,
+	usageRecords?: readonly IAgentHostUsageRecord[],
+	customizations?: readonly Customization[],
 ): { readonly events: IChatDebugEvent[]; readonly resolved: Map<string, IChatDebugResolvedEventContent> } {
 	// Pre-pass: index `tool.execution_complete` records by `toolCallId` (so a
 	// start can be merged with its completion) and `assistant.turn_start` records
-	// by `turnId` (so a turn's wall-clock duration can be measured).
+	// by `turnId` (so a turn's wall-clock duration can be measured). Also index
+	// `hook.end`, `permission.completed`, and `subagent.completed` so each can be
+	// folded onto its opening record (`hook.start` / `permission.requested` /
+	// `subagent.started`).
 	const completeByToolCallId = new Map<string, IAgentHostEventRecord>();
 	const turnStartByTurnId = new Map<string, IAgentHostEventRecord>();
+	const hookEndByInvocationId = new Map<string, IAgentHostEventRecord>();
+	const permissionCompleteByRequestId = new Map<string, IAgentHostEventRecord>();
+	const subagentCompleteByToolCallId = new Map<string, IAgentHostEventRecord>();
 	for (const record of records) {
 		if (record.type === 'tool.execution_complete') {
 			const toolCallId = asString(record.data.toolCallId);
@@ -336,43 +609,90 @@ export function convertAgentHostEventsToDebugEvents(
 			if (turnId) {
 				turnStartByTurnId.set(turnId, record);
 			}
+		} else if (record.type === 'hook.end') {
+			const invocationId = asString(record.data.hookInvocationId);
+			if (invocationId) {
+				hookEndByInvocationId.set(invocationId, record);
+			}
+		} else if (record.type === 'permission.completed') {
+			const requestId = asString(record.data.requestId);
+			if (requestId) {
+				permissionCompleteByRequestId.set(requestId, record);
+			}
+		} else if (record.type === 'subagent.completed') {
+			const toolCallId = asString(record.data.toolCallId);
+			if (toolCallId) {
+				subagentCompleteByToolCallId.set(toolCallId, record);
+			}
 		}
 	}
 
 	const events: IChatDebugEvent[] = [];
 	const resolved = new Map<string, IChatDebugResolvedEventContent>();
-	// Positions of emitted model-turn events, so session-cumulative usage from
-	// `session.shutdown` can be back-filled onto them (see below).
-	const modelTurnRefs: { readonly index: number; readonly id: string; readonly outputTokens?: number }[] = [];
+	// Positions of emitted model-turn events, so per-round usage from the sidecar
+	// (preferred) or session-cumulative usage from `session.shutdown` can be
+	// back-filled onto them (see below).
+	const modelTurnRefs: { readonly index: number; readonly id: string; readonly turnId?: string; readonly outputTokens?: number }[] = [];
 
 	// Logical-tree context. The "current message" pointers are tracked per agent
 	// (keyed by `agentId`, `''` for the main agent) so a sub-agent turn never
 	// re-parents a main-agent tool call, and vice versa.
 	let rootEventId: string | undefined;
+	let rootCreated: Date | undefined;
 	const currentUserMessageByAgent = new Map<string, string>();
 	const currentAssistantMessageByAgent = new Map<string, string>();
 	// Maps a `toolCallId` to the id of its emitted tool-call event, so a nested
 	// tool's `parentToolCallId` can be resolved to a surfaced parent.
 	const toolEventByToolCallId = new Map<string, string>();
 
+	// Whether the session has at least one enabled hook customization. The CLI
+	// emits `preToolUse` / `postToolUse` lifecycle `hook.start` records on *every*
+	// tool call regardless of user configuration (VS Code itself uses the
+	// `preToolUse` dispatch for tool-permission gating), and a routine successful
+	// run is byte-identical to the internal dispatch. We therefore only surface
+	// tool hooks when the user actually configured one — so the debug view can
+	// confirm it ran, whether it succeeded or failed — and suppress the pure
+	// internal-dispatch noise otherwise. `HookCustomization` does not expose which
+	// lifecycle events it registers, so this gate is session-level.
+	const hasConfiguredHooks = !!customizations
+		&& flattenCustomizations(customizations).some(c => c.type === CustomizationType.Hook && c.enabled);
+
 	for (const record of records) {
 		const created = new Date(record.timestamp);
 		const agentKey = record.agentId ?? '';
+		// Parent for events that annotate the turn in progress (errors, warnings,
+		// permissions, hooks, …): the current assistant message, else the current
+		// user message, else the session root.
+		const turnParent = currentAssistantMessageByAgent.get(agentKey) ?? currentUserMessageByAgent.get(agentKey) ?? rootEventId;
 
 		switch (record.type) {
 			case 'session.start': {
 				rootEventId = record.id;
+				rootCreated = created;
 				const model = asString(record.data.selectedModel);
 				const effort = asString(record.data.reasoningEffort);
-				const details = model
-					? (effort
+				const version = asString(record.data.copilotVersion);
+				const context = asRecord(record.data.context);
+				const repository = asString(context?.repository);
+				const branch = asString(context?.branch);
+				const parts: string[] = [];
+				if (model) {
+					parts.push(effort
 						? localize('agentHost.debug.sessionStartedDetails', "model={0}, reasoningEffort={1}", model, effort)
-						: localize('agentHost.debug.sessionStartedModel', "model={0}", model))
-					: undefined;
+						: localize('agentHost.debug.sessionStartedModel', "model={0}", model));
+				}
+				if (version) {
+					parts.push(localize('agentHost.debug.sessionCliVersion', "CLI {0}", version));
+				}
+				if (repository) {
+					parts.push(branch
+						? localize('agentHost.debug.sessionRepoBranch', "{0}@{1}", repository, branch)
+						: repository);
+				}
 				events.push({
 					kind: 'generic', id: record.id, sessionResource, created, parentEventId: undefined,
 					name: localize('agentHost.debug.sessionStarted', "Session Started"),
-					details, level: ChatDebugLogLevel.Info, category: 'session',
+					details: parts.length ? parts.join(', ') : undefined, level: ChatDebugLogLevel.Info, category: 'session',
 				});
 				break;
 			}
@@ -408,7 +728,7 @@ export function convertAgentHostEventsToDebugEvents(
 				const durationInMillis = turnStart ? diffMillis(turnStart.timestamp, record.timestamp) : undefined;
 
 				currentAssistantMessageByAgent.set(agentKey, record.id);
-				modelTurnRefs.push({ index: events.length, id: record.id, outputTokens });
+				modelTurnRefs.push({ index: events.length, id: record.id, turnId, outputTokens });
 				events.push({
 					kind: 'modelTurn', id: record.id, sessionResource, created, parentEventId,
 					model, requestName: 'copilotcli', outputTokens, durationInMillis,
@@ -456,42 +776,523 @@ export function convertAgentHostEventsToDebugEvents(
 				break;
 			}
 			// `tool.execution_complete` is folded into its start record above.
+			case 'session.error': {
+				const message = asString(record.data.message) ?? localize('agentHost.debug.unknownError', "Unknown error");
+				const errorType = asString(record.data.errorType);
+				const stack = asString(record.data.stack);
+				events.push({
+					kind: 'generic', id: record.id, sessionResource, created, parentEventId: turnParent,
+					name: errorType
+						? localize('agentHost.debug.sessionErrorTyped', "Error ({0})", errorType)
+						: localize('agentHost.debug.sessionError', "Error"),
+					details: truncate(message, MAX_EVENT_PAYLOAD),
+					level: ChatDebugLogLevel.Error, category: 'session',
+				});
+				const detailText = stack ? `${message}\n\n${stack}` : message;
+				resolved.set(record.id, { kind: 'text', value: truncate(detailText, MAX_DETAIL_PAYLOAD) ?? detailText });
+				break;
+			}
+			case 'session.warning': {
+				const message = asString(record.data.message) ?? '';
+				const warningType = asString(record.data.warningType);
+				events.push({
+					kind: 'generic', id: record.id, sessionResource, created, parentEventId: turnParent,
+					name: warningType
+						? localize('agentHost.debug.sessionWarningTyped', "Warning ({0})", warningType)
+						: localize('agentHost.debug.sessionWarning', "Warning"),
+					details: truncate(message, MAX_EVENT_PAYLOAD),
+					level: ChatDebugLogLevel.Warning, category: 'session',
+				});
+				if (message) {
+					resolved.set(record.id, { kind: 'text', value: truncate(message, MAX_DETAIL_PAYLOAD) ?? message });
+				}
+				break;
+			}
+			case 'session.model_change': {
+				const previousModel = asString(record.data.previousModel);
+				const newModel = asString(record.data.newModel);
+				const effort = asString(record.data.reasoningEffort);
+				const change = previousModel && newModel
+					? localize('agentHost.debug.modelChangeFromTo', "{0} → {1}", previousModel, newModel)
+					: newModel;
+				const details = change && effort
+					? localize('agentHost.debug.modelChangeEffort', "{0} (reasoningEffort={1})", change, effort)
+					: change;
+				events.push({
+					kind: 'generic', id: record.id, sessionResource, created, parentEventId: turnParent,
+					name: localize('agentHost.debug.modelChanged', "Model Changed"),
+					details, level: ChatDebugLogLevel.Info, category: 'session',
+				});
+				break;
+			}
+			case 'hook.start': {
+				const hookType = asString(record.data.hookType) ?? 'hook';
+				const invocationId = asString(record.data.hookInvocationId);
+				const end = invocationId ? hookEndByInvocationId.get(invocationId) : undefined;
+				const success = end ? asBoolean(end.data.success) : undefined;
+				const isError = hookType === 'errorOccurred';
+				// The CLI emits `preToolUse` / `postToolUse` lifecycle hooks on every
+				// tool call regardless of user configuration. Only surface them when the
+				// user actually configured a hook (so the view can confirm it ran); hide
+				// the pure internal-dispatch noise otherwise.
+				if ((hookType === 'preToolUse' || hookType === 'postToolUse') && !hasConfiguredHooks) {
+					break;
+				}
+				// A `preToolUse` hook fires *before* the `assistant.message` of the
+				// turn whose tool it precedes is finalized, so `turnParent` still
+				// points at the PREVIOUS model turn. Nesting it there is misleading —
+				// it belongs to the upcoming turn — so surface it at the
+				// turn-container (user message) level, as a sibling of the model
+				// turns rather than a child of the prior one.
+				const hookParent = hookType === 'preToolUse'
+					? (currentUserMessageByAgent.get(agentKey) ?? rootEventId)
+					: turnParent;
+				// Error notifications (`errorOccurred`) and failed hooks are surfaced
+				// prominently below. Routine lifecycle hooks (sessionStart / sessionEnd
+				// / userPromptSubmitted / …) are surfaced as low-key informational
+				// customization events so users can still see which hooks fired.
+				if (!isError && success !== false) {
+					events.push({
+						kind: 'generic', id: record.id, sessionResource, created, parentEventId: hookParent,
+						name: localize('agentHost.debug.hookRan', "Hook: {0}", hookType),
+						level: ChatDebugLogLevel.Info, category: 'hook',
+					});
+					const routineInput = stringifyPayload(record.data.input);
+					resolved.set(record.id, {
+						kind: 'hook', hookType,
+						result: success === undefined ? undefined : (success ? ChatDebugHookResult.Success : ChatDebugHookResult.Error),
+						input: truncate(routineInput, MAX_DETAIL_PAYLOAD),
+					});
+					break;
+				}
+				const input = asRecord(record.data.input);
+				const errorContext = asString(input?.errorContext);
+				const recoverable = asBoolean(input?.recoverable);
+				events.push({
+					kind: 'generic', id: record.id, sessionResource, created, parentEventId: hookParent,
+					name: isError
+						? (errorContext
+							? localize('agentHost.debug.hookErrorContext', "Error During {0}", errorContext)
+							: localize('agentHost.debug.hookError', "Error Occurred"))
+						: localize('agentHost.debug.hookFailed', "Hook Failed: {0}", hookType),
+					details: isError && recoverable !== undefined
+						? (recoverable
+							? localize('agentHost.debug.hookRecoverable', "Recoverable; retrying")
+							: localize('agentHost.debug.hookUnrecoverable', "Unrecoverable"))
+						: undefined,
+					level: isError
+						? (recoverable === false ? ChatDebugLogLevel.Error : ChatDebugLogLevel.Warning)
+						: ChatDebugLogLevel.Error,
+					category: 'hook',
+				});
+				const inputText = stringifyPayload(record.data.input);
+				// On failure the `hook.end` record carries the only distinguishing trace
+				// of the user's hook: `output` (per-tool denial messages) and `error`
+				// ({ message, source }, where `source` is the hook config file). The CLI
+				// never records the hook command text or its stdout, so this is the most
+				// we can surface about which hook acted and why.
+				const endError = asRecord(end?.data.error);
+				const errorParts = endError
+					? [asString(endError.message), asString(endError.source)].filter((s): s is string => !!s)
+					: [];
+				const outputText = end && end.data.output !== undefined ? stringifyPayload(end.data.output) : undefined;
+				resolved.set(record.id, {
+					kind: 'hook', hookType,
+					result: success === undefined ? undefined : (success ? ChatDebugHookResult.Success : ChatDebugHookResult.Error),
+					input: truncate(inputText, MAX_DETAIL_PAYLOAD),
+					output: outputText ? truncate(outputText, MAX_DETAIL_PAYLOAD) : undefined,
+					errorMessage: errorParts.length > 0 ? truncate(errorParts.join('\n'), MAX_DETAIL_PAYLOAD) : undefined,
+				});
+				break;
+			}
+			// `hook.end` is folded into its `hook.start` above.
+			case 'permission.requested': {
+				const requestId = asString(record.data.requestId);
+				const permissionRequest = asRecord(record.data.permissionRequest);
+				const kind = asString(permissionRequest?.kind) ?? 'permission';
+				const intention = asString(permissionRequest?.intention);
+				const toolCallId = asString(permissionRequest?.toolCallId);
+				const completed = requestId ? permissionCompleteByRequestId.get(requestId) : undefined;
+				const resultKind = completed ? asString(asRecord(completed.data.result)?.kind) : undefined;
+				// A routine approval is happy-path noise (the tool call is already
+				// shown); only surface denials and still-pending requests, which
+				// explain why a tool was blocked or a session appears stalled.
+				if (resultKind === 'approved') {
+					break;
+				}
+				const parentEventId = (toolCallId ? toolEventByToolCallId.get(toolCallId) : undefined) ?? turnParent;
+				events.push({
+					kind: 'generic', id: record.id, sessionResource, created, parentEventId,
+					name: resultKind
+						? localize('agentHost.debug.permissionResolved', "Permission {0}: {1}", resultKind, kind)
+						: localize('agentHost.debug.permissionPending', "Awaiting Permission: {0}", kind),
+					details: intention,
+					level: ChatDebugLogLevel.Warning, category: 'permission',
+				});
+				const path = asString(permissionRequest?.path);
+				const lines = [
+					localize('agentHost.debug.permissionKind', "kind: {0}", kind),
+					intention ? localize('agentHost.debug.permissionIntention', "intention: {0}", intention) : undefined,
+					path ? localize('agentHost.debug.permissionPath', "path: {0}", path) : undefined,
+					localize('agentHost.debug.permissionResult', "result: {0}", resultKind ?? localize('agentHost.debug.permissionPendingValue', "pending")),
+				].filter((l): l is string => !!l);
+				resolved.set(record.id, { kind: 'text', value: lines.join('\n') });
+				break;
+			}
+			// `permission.completed` is folded into its `permission.requested` above.
+			case 'subagent.started': {
+				const toolCallId = asString(record.data.toolCallId);
+				const agentName = asString(record.data.agentDisplayName) ?? asString(record.data.agentName) ?? 'subagent';
+				const description = asString(record.data.agentDescription);
+				const model = asString(record.data.model);
+				const complete = toolCallId ? subagentCompleteByToolCallId.get(toolCallId) : undefined;
+				const toolCallCount = complete ? asNumber(complete.data.totalToolCalls) : undefined;
+				const totalTokens = complete ? asNumber(complete.data.totalTokens) : undefined;
+				const durationInMillis = complete ? asNumber(complete.data.durationMs) : undefined;
+				// The sub-agent nests under the tool call that spawned it.
+				const parentEventId = (toolCallId ? toolEventByToolCallId.get(toolCallId) : undefined) ?? turnParent;
+				events.push({
+					kind: 'subagentInvocation', id: record.id, sessionResource, created, parentEventId,
+					agentName, description, status: complete ? 'completed' : 'running', toolCallCount, durationInMillis,
+				});
+				const lines = [
+					localize('agentHost.debug.subagentName', "agent: {0}", agentName),
+					model ? localize('agentHost.debug.subagentModel', "model: {0}", model) : undefined,
+					toolCallCount !== undefined ? localize('agentHost.debug.subagentToolCalls', "tool calls: {0}", toolCallCount) : undefined,
+					totalTokens !== undefined ? localize('agentHost.debug.subagentTokens', "tokens: {0}", totalTokens) : undefined,
+					description ? `\n${description}` : undefined,
+				].filter((l): l is string => !!l);
+				resolved.set(record.id, { kind: 'text', value: lines.join('\n') });
+				break;
+			}
+			// `subagent.completed` is folded into its `subagent.started` above.
+			case 'session.compaction_start': {
+				const systemTokens = asNumber(record.data.systemTokens) ?? 0;
+				const conversationTokens = asNumber(record.data.conversationTokens) ?? 0;
+				const toolTokens = asNumber(record.data.toolDefinitionsTokens) ?? 0;
+				events.push({
+					kind: 'generic', id: record.id, sessionResource, created, parentEventId: turnParent,
+					name: localize('agentHost.debug.compaction', "Context Compaction"),
+					details: localize('agentHost.debug.compactionTokens', "system={0}, conversation={1}, tools={2} tokens", systemTokens, conversationTokens, toolTokens),
+					level: ChatDebugLogLevel.Info, category: 'session',
+				});
+				break;
+			}
+			case 'session.compaction_complete': {
+				// A successful compaction is implied by its start row; only the
+				// failure case is diagnostically interesting.
+				if (asBoolean(record.data.success) !== false) {
+					break;
+				}
+				const error = asString(record.data.error);
+				events.push({
+					kind: 'generic', id: record.id, sessionResource, created, parentEventId: turnParent,
+					name: localize('agentHost.debug.compactionFailed', "Context Compaction Failed"),
+					details: truncate(error, MAX_EVENT_PAYLOAD),
+					level: ChatDebugLogLevel.Error, category: 'session',
+				});
+				if (error) {
+					resolved.set(record.id, { kind: 'text', value: truncate(error, MAX_DETAIL_PAYLOAD) ?? error });
+				}
+				break;
+			}
+			case 'abort': {
+				const reason = asString(record.data.reason);
+				events.push({
+					kind: 'generic', id: record.id, sessionResource, created, parentEventId: turnParent,
+					name: localize('agentHost.debug.aborted', "Aborted"),
+					details: reason, level: ChatDebugLogLevel.Warning, category: 'session',
+				});
+				break;
+			}
+			case 'skill.invoked': {
+				const name = asString(record.data.name) ?? 'skill';
+				const trigger = asString(record.data.trigger);
+				const source = asString(record.data.pluginName) ?? asString(record.data.source);
+				const content = asString(record.data.content);
+				events.push({
+					kind: 'generic', id: record.id, sessionResource, created, parentEventId: turnParent,
+					name: localize('agentHost.debug.skillInvoked', "Skill Invoked: {0}", name),
+					details: [trigger, source].filter(Boolean).join(' \u00b7 ') || undefined,
+					level: ChatDebugLogLevel.Info, category: 'customization',
+				});
+				if (content) {
+					resolved.set(record.id, { kind: 'text', value: truncate(content, MAX_DETAIL_PAYLOAD) ?? content });
+				}
+				break;
+			}
 			// `assistant.turn_start` seeds turn durations (pre-pass); its
-			// `assistant.turn_end`, `hook.*`, `permission.*`, and `system.message`
-			// siblings are not surfaced in this slice.
+			// `assistant.turn_end` and `system.message` siblings are not surfaced
+			// in this slice.
 		}
 	}
 
-	// `events.jsonl` records only `outputTokens` per turn. Cumulative input /
-	// cache-read tokens and Copilot AIU come from the `session.shutdown` summary
-	// (exact), or — for in-progress sessions — the live AHP state, which can
-	// only supply AIU reliably (see `sumChatStateUsage`). Spread the known
-	// totals across the model-turn events so the panel's Summary tiles (which
-	// sum over model turns) report them; the per-turn split is an even
-	// approximation but the column sums are exact. Totals that aren't known
-	// (e.g. input/cache on a live session) are left blank.
-	const totals = extractSessionUsageTotals(records) ?? fallbackUsageTotals;
-	if (totals && modelTurnRefs.length > 0) {
-		const n = modelTurnRefs.length;
-		const inputs = totals.inputTokens !== undefined ? distributeEvenly(totals.inputTokens, n) : undefined;
-		const cached = totals.cacheReadTokens !== undefined ? distributeEvenly(totals.cacheReadTokens, n) : undefined;
-		const aiu = distributeEvenly(totals.totalNanoAiu, n);
-		for (let i = 0; i < n; i++) {
-			const ref = modelTurnRefs[i];
-			const turn = events[ref.index] as IChatDebugModelTurnEvent;
-			const inputTokens = inputs?.[i];
-			const cachedTokens = cached?.[i];
-			const totalTokens = inputTokens !== undefined ? inputTokens + (ref.outputTokens ?? 0) : undefined;
-			const copilotUsageNanoAiu = aiu[i] > 0 ? aiu[i] : undefined;
-			events[ref.index] = { ...turn, inputTokens, cachedTokens, totalTokens, copilotUsageNanoAiu };
-			const detail = resolved.get(ref.id);
-			if (detail?.kind === 'modelTurn') {
-				resolved.set(ref.id, { ...detail, inputTokens, cachedTokens, totalTokens });
+	// Usage back-fill. `events.jsonl` records only `outputTokens` per turn;
+	// input/cache-read tokens and Copilot AIU come from elsewhere:
+	//   1. The client-local usage sidecar (preferred): exact per-request tokens
+	//      captured live from ChatUsage actions, mapped per round — restart-safe
+	//      and accurate for the Cache Explorer.
+	//   2. Else the `session.shutdown` summary (exact totals, spread evenly).
+	//   3. Else the live AHP state (AIU only) for in-progress sessions.
+	// The per-turn split in (2) is an even approximation but the column sums are
+	// exact; totals that aren't known (e.g. input/cache on a live session) are
+	// left blank.
+	if (usageRecords && usageRecords.length > 0 && modelTurnRefs.length > 0) {
+		applyPerTurnUsage(events, resolved, modelTurnRefs, usageRecords);
+	} else {
+		const totals = extractSessionUsageTotals(records) ?? fallbackUsageTotals;
+		if (totals && modelTurnRefs.length > 0) {
+			const n = modelTurnRefs.length;
+			const inputs = totals.inputTokens !== undefined ? distributeEvenly(totals.inputTokens, n) : undefined;
+			const cached = totals.cacheReadTokens !== undefined ? distributeEvenly(totals.cacheReadTokens, n) : undefined;
+			const aiu = distributeEvenly(totals.totalNanoAiu, n);
+			for (let i = 0; i < n; i++) {
+				const ref = modelTurnRefs[i];
+				const turn = events[ref.index] as IChatDebugModelTurnEvent;
+				const inputTokens = inputs?.[i];
+				const cachedTokens = cached?.[i];
+				const totalTokens = inputTokens !== undefined ? inputTokens + (ref.outputTokens ?? 0) : undefined;
+				const copilotUsageNanoAiu = aiu[i] > 0 ? aiu[i] : undefined;
+				events[ref.index] = { ...turn, inputTokens, cachedTokens, totalTokens, copilotUsageNanoAiu };
+				const detail = resolved.get(ref.id);
+				if (detail?.kind === 'modelTurn') {
+					resolved.set(ref.id, { ...detail, inputTokens, cachedTokens, totalTokens });
+				}
 			}
 		}
 	}
 
+	// Surface the session's loaded customizations (skills / hooks / agents / MCP
+	// servers / rules) as discovery events plus a summary, mirroring the local
+	// `PromptsDebugContribution`. Sourced from live session state (the SDK's
+	// `session.*_loaded` events are ephemeral and absent from events.jsonl).
+	if (customizations && customizations.length > 0) {
+		const created = rootCreated ?? (records.length > 0 ? new Date(records[0].timestamp) : new Date());
+		const { events: customEvents, resolved: customResolved } = buildCustomizationDebugEvents(customizations, sessionResource, rootEventId, created);
+		events.push(...customEvents);
+		for (const [id, detail] of customResolved) {
+			resolved.set(id, detail);
+		}
+	}
+
 	return { events, resolved };
+}
+
+/** Order in which loaded customization types are surfaced as discovery events. */
+const CUSTOMIZATION_TYPE_ORDER: readonly CustomizationType[] = [
+	CustomizationType.Skill, CustomizationType.Hook, CustomizationType.Agent,
+	CustomizationType.McpServer, CustomizationType.Rule, CustomizationType.Prompt,
+];
+
+/** A leaf customization flattened out of its container, with its context. */
+interface IFlatCustomization {
+	readonly type: CustomizationType;
+	readonly name: string;
+	readonly uri: string;
+	readonly enabled: boolean;
+	readonly description?: string;
+}
+
+/**
+ * Flattens the session's customization tree into its leaf children (skills,
+ * hooks, agents, MCP servers, rules, prompts). Container entries
+ * ({@link CustomizationType.Plugin} / {@link CustomizationType.Directory}) are
+ * descended into; a top-level {@link CustomizationType.McpServer} is kept as-is.
+ */
+function flattenCustomizations(customizations: readonly Customization[]): IFlatCustomization[] {
+	const out: IFlatCustomization[] = [];
+	const visit = (c: Customization | ChildCustomization): void => {
+		if (c.type === CustomizationType.Plugin || c.type === CustomizationType.Directory) {
+			for (const child of c.children ?? []) {
+				visit(child);
+			}
+			return;
+		}
+		out.push({
+			type: c.type,
+			name: c.name,
+			uri: c.uri,
+			enabled: (c as { enabled?: boolean }).enabled !== false,
+			description: (c as { description?: string }).description,
+		});
+	};
+	for (const c of customizations) {
+		visit(c);
+	}
+	return out;
+}
+
+/** Human-readable name for a per-type customization discovery event. */
+function customizationDiscoveryName(type: CustomizationType): string {
+	switch (type) {
+		case CustomizationType.Skill: return localize('agentHost.debug.skillDiscovery', "Skill Discovery");
+		case CustomizationType.Hook: return localize('agentHost.debug.hookDiscovery', "Hook Discovery");
+		case CustomizationType.Agent: return localize('agentHost.debug.agentDiscovery', "Agent Discovery");
+		case CustomizationType.McpServer: return localize('agentHost.debug.mcpDiscovery', "MCP Server Discovery");
+		case CustomizationType.Rule: return localize('agentHost.debug.ruleDiscovery', "Instructions Discovery");
+		case CustomizationType.Prompt: return localize('agentHost.debug.promptDiscovery', "Prompt Discovery");
+		default: return localize('agentHost.debug.customizationDiscovery', "Customization Discovery");
+	}
+}
+
+/** Maps a flattened customization to a summary-log category, if it has one. */
+function customizationSummaryCategory(c: IFlatCustomization): IChatDebugCustomizationLogEntry['category'] | undefined {
+	if (!c.enabled) {
+		return 'skipped';
+	}
+	switch (c.type) {
+		case CustomizationType.Skill: return 'skill';
+		case CustomizationType.Agent: return 'custom-agent';
+		case CustomizationType.Hook: return 'hook';
+		case CustomizationType.Rule: return 'applying';
+		default: return undefined; // Prompt / MCP have no summary category
+	}
+}
+
+/**
+ * Builds the customization discovery + summary debug events for a session from
+ * its loaded {@link Customization}s. Ids are deterministic (per session + type)
+ * so repeated live refreshes replace rather than duplicate them.
+ */
+export function buildCustomizationDebugEvents(
+	customizations: readonly Customization[],
+	sessionResource: URI,
+	parentEventId: string | undefined,
+	created: Date,
+): { readonly events: IChatDebugEvent[]; readonly resolved: Map<string, IChatDebugResolvedEventContent> } {
+	const events: IChatDebugEvent[] = [];
+	const resolved = new Map<string, IChatDebugResolvedEventContent>();
+	const flat = flattenCustomizations(customizations);
+	if (flat.length === 0) {
+		return { events, resolved };
+	}
+
+	const byType = new Map<CustomizationType, IFlatCustomization[]>();
+	for (const c of flat) {
+		const list = byType.get(c.type);
+		if (list) {
+			list.push(c);
+		} else {
+			byType.set(c.type, [c]);
+		}
+	}
+
+	const key = sessionResource.toString();
+
+	// Per-type discovery events, each expandable to its file list.
+	for (const type of CUSTOMIZATION_TYPE_ORDER) {
+		const list = byType.get(type);
+		if (!list || list.length === 0) {
+			continue;
+		}
+		const id = `agentHostCustomization:${key}:${type}`;
+		const loadedCount = list.filter(c => c.enabled).length;
+		const skippedCount = list.length - loadedCount;
+		events.push({
+			kind: 'generic', id, sessionResource, created, parentEventId,
+			name: customizationDiscoveryName(type),
+			details: skippedCount > 0
+				? localize('agentHost.debug.customizationLoadedSkipped', "{0} loaded, {1} disabled", loadedCount, skippedCount)
+				: localize('agentHost.debug.customizationLoaded', "{0} loaded", loadedCount),
+			level: ChatDebugLogLevel.Info, category: 'discovery',
+		});
+		const files: IChatDebugFileEntry[] = list.map(c => ({
+			uri: URI.parse(c.uri),
+			name: c.name,
+			status: c.enabled ? 'loaded' : 'skipped',
+			skipReason: c.enabled ? undefined : localize('agentHost.debug.customizationDisabled', "disabled"),
+		}));
+		resolved.set(id, { kind: 'fileList', discoveryType: type, durationInMillis: 0, files });
+	}
+
+	// Summary event mirroring the local "Resolve Customizations".
+	const logs: IChatDebugCustomizationLogEntry[] = [];
+	for (const c of flat) {
+		const category = customizationSummaryCategory(c);
+		if (!category) {
+			continue;
+		}
+		logs.push({ category, name: c.name, uri: URI.parse(c.uri), reason: c.description });
+	}
+	if (logs.length > 0) {
+		const id = `agentHostCustomization:${key}:summary`;
+		const counts = {
+			instructions: logs.filter(e => e.category === 'applying' || e.category === 'referenced').length,
+			skills: logs.filter(e => e.category === 'skill').length,
+			agents: logs.filter(e => e.category === 'custom-agent').length,
+			hooks: logs.filter(e => e.category === 'hook').length,
+			skipped: logs.filter(e => e.category === 'skipped').length,
+		};
+		events.push({
+			kind: 'generic', id, sessionResource, created, parentEventId,
+			name: localize('agentHost.debug.customizationsResolved', "Resolve Customizations"),
+			details: localize('agentHost.debug.customizationsResolvedDetails', "{0} skills, {1} agents, {2} hooks, {3} instructions", counts.skills, counts.agents, counts.hooks, counts.instructions),
+			level: ChatDebugLogLevel.Info, category: 'customization',
+		});
+		resolved.set(id, { kind: 'customizationSummary', resolutionLogs: logs, durationInMillis: 0, counts });
+	}
+
+	return { events, resolved };
+}
+function applyPerTurnUsage(
+	events: IChatDebugEvent[],
+	resolved: Map<string, IChatDebugResolvedEventContent>,
+	modelTurnRefs: readonly { readonly index: number; readonly id: string; readonly turnId?: string; readonly outputTokens?: number }[],
+	usageRecords: readonly IAgentHostUsageRecord[],
+): void {
+	const assign = (ref: typeof modelTurnRefs[number], inputTokens: number | undefined, cachedTokens: number | undefined, copilotUsageNanoAiu: number | undefined) => {
+		const turn = events[ref.index] as IChatDebugModelTurnEvent;
+		const totalTokens = inputTokens !== undefined ? inputTokens + (ref.outputTokens ?? 0) : undefined;
+		events[ref.index] = { ...turn, inputTokens, cachedTokens, totalTokens, copilotUsageNanoAiu };
+		const detail = resolved.get(ref.id);
+		if (detail?.kind === 'modelTurn') {
+			resolved.set(ref.id, { ...detail, inputTokens, cachedTokens, totalTokens });
+		}
+	};
+
+	// The sidecar and events.jsonl use DIFFERENT turn-id namespaces — the
+	// sidecar keys on the backend request id (one id per user turn, shared by
+	// its rounds) while events.jsonl keys on a per-turn round index that resets
+	// each user turn — so they can't be correlated by id. Both streams are
+	// chronological with one entry per model round, though, so correlate them
+	// positionally, using the `outputTokens` both report as an alignment guard:
+	// a ref whose output doesn't match the next record has no captured usage
+	// (e.g. a sub-agent round, whose usage folds into the parent aggregate and
+	// isn't recorded separately), so it's left blank and the record is kept for
+	// the next ref.
+
+	// Copilot AIU is cumulative per user turn (it resets each turn), so
+	// attribute each turn's max only to its LAST captured round — the summed
+	// per-turn total then stays exact. Turn boundaries are the runs of records
+	// sharing a `turnId`.
+	const aiuByRecordIndex = new Array<number | undefined>(usageRecords.length).fill(undefined);
+	for (let start = 0; start < usageRecords.length;) {
+		let end = start;
+		while (end + 1 < usageRecords.length && usageRecords[end + 1].turnId === usageRecords[start].turnId) {
+			end++;
+		}
+		let maxAiu = 0;
+		for (let i = start; i <= end; i++) {
+			maxAiu = Math.max(maxAiu, usageRecords[i].totalNanoAiu ?? 0);
+		}
+		if (maxAiu > 0) {
+			aiuByRecordIndex[end] = maxAiu;
+		}
+		start = end + 1;
+	}
+
+	let recordIndex = 0;
+	for (const ref of modelTurnRefs) {
+		if (recordIndex >= usageRecords.length) {
+			break;
+		}
+		const record = usageRecords[recordIndex];
+		if (ref.outputTokens !== undefined && record.outputTokens !== undefined && ref.outputTokens !== record.outputTokens) {
+			continue; // this ref has no captured usage record — leave it blank
+		}
+		assign(ref, record.inputTokens, record.cacheReadTokens, aiuByRecordIndex[recordIndex]);
+		recordIndex++;
+	}
 }
 
 /** Session usage totals distributed across model turns. */
@@ -588,21 +1389,21 @@ function sumChatStateUsage(chat: ChatState): ISessionUsageTotals | undefined {
 
 /** Reads `_meta.copilotUsage.totalNanoAiu` (per-turn cumulative AIU) from a usage report. */
 function readCopilotNanoAiu(usage: UsageInfo): number {
-	const meta = usage._meta;
-	if (!meta || typeof meta !== 'object') {
-		return 0;
-	}
-	const copilotUsage = (meta as Record<string, unknown>).copilotUsage;
-	if (!copilotUsage || typeof copilotUsage !== 'object') {
-		return 0;
-	}
-	const nano = (copilotUsage as Record<string, unknown>).totalNanoAiu;
-	return typeof nano === 'number' ? nano : 0;
+	return readUsageInfoMeta(usage).copilotUsage?.totalNanoAiu ?? 0;
 }
 
 /** Parses a line-delimited JSON stream, skipping blank or malformed lines. */
 export function parseJsonl(text: string): IAgentHostEventRecord[] {
 	const records: IAgentHostEventRecord[] = [];
+	appendJsonlRecords(text, records);
+	return records;
+}
+
+/**
+ * Parses each complete JSONL line in `text` and appends the well-formed
+ * records to `records` (used for both full and incremental tail reads).
+ */
+function appendJsonlRecords(text: string, records: IAgentHostEventRecord[]): void {
 	for (const line of text.split('\n')) {
 		const trimmed = line.trim();
 		if (!trimmed) {
@@ -626,7 +1427,17 @@ export function parseJsonl(text: string): IAgentHostEventRecord[] {
 			// Ignore partial trailing lines (common when reading a bounded head).
 		}
 	}
-	return records;
+}
+
+/** Byte index of the last `\n` in `buffer`, or -1 if none (safe UTF-8 split point). */
+function lastIndexOfNewline(buffer: VSBuffer): number {
+	const bytes = buffer.buffer;
+	for (let i = bytes.length - 1; i >= 0; i--) {
+		if (bytes[i] === 0x0A /* \n */) {
+			return i;
+		}
+	}
+	return -1;
 }
 
 /**
@@ -662,6 +1473,10 @@ function asNumber(value: unknown): number | undefined {
 
 function asBoolean(value: unknown): boolean | undefined {
 	return typeof value === 'boolean' ? value : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
 }
 
 function diffMillis(start: string, end: string): number | undefined {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostChatDebugProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostChatDebugProvider.ts
@@ -23,7 +23,7 @@ import { IWorkbenchEnvironmentService } from '../../../../services/environment/c
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { ChatDebugHookResult, ChatDebugLogLevel, IChatDebugCustomizationLogEntry, IChatDebugEvent, IChatDebugFileEntry, IChatDebugLogProvider, IChatDebugMessageSection, IChatDebugModelTurnEvent, IChatDebugResolvedEventContent, IChatDebugService } from '../../common/chatDebugService.js';
 import { IAgentHostCustomizationService } from '../agentSessions/agentHost/agentHostCustomizationService.js';
-import { AgentHostAgentDebugLogEnabledSettingId } from '../../common/promptSyntax/promptTypes.js';
+import { AgentHostAgentDebugLogEnabledSettingId, AgentHostAgentDebugLogMaxEventsSettingId } from '../../common/promptSyntax/promptTypes.js';
 import { COPILOT_CLI_EH_SCHEME, COPILOT_CLI_LOCAL_AH_SCHEME, getCopilotCliSessionRawId, resolveEventsUri } from '../copilotCliEventsUri.js';
 import { AgentHostCustomizationRecorder, AgentHostUsageRecorder, buildAgentHostCustomizationsUri, buildAgentHostUsageUri, readAgentHostCustomizationsSnapshot, readAgentHostUsageRecords, type IAgentHostUsageRecord } from './agentHostUsageSidecar.js';
 
@@ -54,6 +54,8 @@ const MAX_DISCOVERED_SESSIONS = 30;
 const TITLE_READ_BYTES = 64 * 1024;
 /** Cap on cached resolved-event details to bound memory. */
 const MAX_RESOLVED_DETAILS = 50_000;
+/** Fallback in-memory record cap when the configured value is missing/invalid. */
+const DEFAULT_MAX_EVENTS_IN_MEMORY = 10_000;
 /** Cap on a tool argument/result string stored on the (list-level) event. */
 const MAX_EVENT_PAYLOAD = 4_000;
 /** Cap on a tool argument/result string stored for the detail (expanded) view. */
@@ -454,9 +456,30 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 	 *
 	 * Returns `undefined` when the file does not exist yet or cannot be read.
 	 */
+	/**
+	 * The configured in-memory event cap for agent host sessions (see
+	 * {@link AgentHostAgentDebugLogMaxEventsSettingId}). The raw record cache is
+	 * trimmed to this many entries so a long-running session does not retain an
+	 * unbounded array, matching the capped public event buffer.
+	 */
+	private _maxRecordsInMemory(): number {
+		const configured = this._configurationService.getValue<number>(AgentHostAgentDebugLogMaxEventsSettingId);
+		if (typeof configured === 'number' && Number.isFinite(configured) && configured >= 1) {
+			return Math.floor(configured);
+		}
+		return DEFAULT_MAX_EVENTS_IN_MEMORY;
+	}
+
+	/** Trims `records` in place to the most recent {@link _maxRecordsInMemory} entries. */
+	private _capRecordsInMemory(records: IAgentHostEventRecord[]): void {
+		const max = this._maxRecordsInMemory();
+		if (records.length > max) {
+			records.splice(0, records.length - max);
+		}
+	}
+
 	private async _readEventRecords(eventsUri: URI, token: CancellationToken): Promise<IAgentHostEventRecord[] | undefined> {
 		const key = eventsUri.toString();
-
 		let size: number;
 		try {
 			const stat = await this._fileService.stat(eventsUri);
@@ -490,6 +513,7 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 					cache.pendingBytes = combined;
 				}
 				cache.consumedBytes = size;
+				this._capRecordsInMemory(cache.records);
 				return cache.records;
 			} catch {
 				// Fall through to a full read (e.g. transient error / offset moved).
@@ -513,6 +537,7 @@ export class AgentHostChatDebugContribution extends Disposable implements IWorkb
 		if (lastNewline >= 0) {
 			appendJsonlRecords(buffer.slice(0, lastNewline + 1).toString(), records);
 		}
+		this._capRecordsInMemory(records);
 		this._liveRead = {
 			key,
 			consumedBytes: buffer.byteLength,
@@ -632,7 +657,7 @@ export function convertAgentHostEventsToDebugEvents(
 	// Positions of emitted model-turn events, so per-round usage from the sidecar
 	// (preferred) or session-cumulative usage from `session.shutdown` can be
 	// back-filled onto them (see below).
-	const modelTurnRefs: { readonly index: number; readonly id: string; readonly turnId?: string; readonly outputTokens?: number }[] = [];
+	const modelTurnRefs: IModelTurnRef[] = [];
 
 	// Logical-tree context. The "current message" pointers are tracked per agent
 	// (keyed by `agentId`, `''` for the main agent) so a sub-agent turn never
@@ -1037,28 +1062,53 @@ export function convertAgentHostEventsToDebugEvents(
 	// The per-turn split in (2) is an even approximation but the column sums are
 	// exact; totals that aren't known (e.g. input/cache on a live session) are
 	// left blank.
-	if (usageRecords && usageRecords.length > 0 && modelTurnRefs.length > 0) {
-		applyPerTurnUsage(events, resolved, modelTurnRefs, usageRecords);
-	} else {
-		const totals = extractSessionUsageTotals(records) ?? fallbackUsageTotals;
-		if (totals && modelTurnRefs.length > 0) {
-			const n = modelTurnRefs.length;
-			const inputs = totals.inputTokens !== undefined ? distributeEvenly(totals.inputTokens, n) : undefined;
-			const cached = totals.cacheReadTokens !== undefined ? distributeEvenly(totals.cacheReadTokens, n) : undefined;
-			const aiu = distributeEvenly(totals.totalNanoAiu, n);
-			for (let i = 0; i < n; i++) {
-				const ref = modelTurnRefs[i];
-				const turn = events[ref.index] as IChatDebugModelTurnEvent;
-				const inputTokens = inputs?.[i];
-				const cachedTokens = cached?.[i];
-				const totalTokens = inputTokens !== undefined ? inputTokens + (ref.outputTokens ?? 0) : undefined;
-				const copilotUsageNanoAiu = aiu[i] > 0 ? aiu[i] : undefined;
-				events[ref.index] = { ...turn, inputTokens, cachedTokens, totalTokens, copilotUsageNanoAiu };
-				const detail = resolved.get(ref.id);
-				if (detail?.kind === 'modelTurn') {
-					resolved.set(ref.id, { ...detail, inputTokens, cachedTokens, totalTokens });
-				}
+
+	// Distributes cumulative `totals` evenly across the given turns.
+	const fillTurnsWithTotals = (targets: readonly IModelTurnRef[], totals: ISessionUsageTotals) => {
+		const n = targets.length;
+		if (n === 0) {
+			return;
+		}
+		const inputs = totals.inputTokens !== undefined ? distributeEvenly(totals.inputTokens, n) : undefined;
+		const cached = totals.cacheReadTokens !== undefined ? distributeEvenly(totals.cacheReadTokens, n) : undefined;
+		const aiu = distributeEvenly(totals.totalNanoAiu, n);
+		for (let i = 0; i < n; i++) {
+			const ref = targets[i];
+			const turn = events[ref.index] as IChatDebugModelTurnEvent;
+			const inputTokens = inputs?.[i];
+			const cachedTokens = cached?.[i];
+			const totalTokens = inputTokens !== undefined ? inputTokens + (ref.outputTokens ?? 0) : undefined;
+			const copilotUsageNanoAiu = aiu[i] > 0 ? aiu[i] : undefined;
+			events[ref.index] = { ...turn, inputTokens, cachedTokens, totalTokens, copilotUsageNanoAiu };
+			const detail = resolved.get(ref.id);
+			if (detail?.kind === 'modelTurn') {
+				resolved.set(ref.id, { ...detail, inputTokens, cachedTokens, totalTokens });
 			}
+		}
+	};
+
+	if (usageRecords && usageRecords.length > 0 && modelTurnRefs.length > 0) {
+		const coverage = applyPerTurnUsage(events, resolved, modelTurnRefs, usageRecords);
+		// The sidecar may only cover a prefix of the session's turns (logging
+		// enabled mid-session, or a dropped append). Reconcile the remaining
+		// turns from the authoritative shutdown/live totals so the Overview
+		// aggregates aren't undercounted, keeping the exact per-round values we
+		// did capture.
+		const uncovered = modelTurnRefs.filter((_ref, i) => !coverage.covered.has(i));
+		if (uncovered.length > 0) {
+			const totals = extractSessionUsageTotals(records) ?? fallbackUsageTotals;
+			if (totals) {
+				fillTurnsWithTotals(uncovered, {
+					inputTokens: totals.inputTokens !== undefined ? Math.max(0, totals.inputTokens - coverage.assignedInput) : undefined,
+					cacheReadTokens: totals.cacheReadTokens !== undefined ? Math.max(0, totals.cacheReadTokens - coverage.assignedCache) : undefined,
+					totalNanoAiu: Math.max(0, totals.totalNanoAiu - coverage.assignedAiu),
+				});
+			}
+		}
+	} else if (modelTurnRefs.length > 0) {
+		const totals = extractSessionUsageTotals(records) ?? fallbackUsageTotals;
+		if (totals) {
+			fillTurnsWithTotals(modelTurnRefs, totals);
 		}
 	}
 
@@ -1234,12 +1284,33 @@ export function buildCustomizationDebugEvents(
 
 	return { events, resolved };
 }
+
+/** A model-turn debug event plus the context needed to back-fill its usage. */
+interface IModelTurnRef {
+	readonly index: number;
+	readonly id: string;
+	readonly turnId?: string;
+	readonly outputTokens?: number;
+}
+
+/** What {@link applyPerTurnUsage} assigned, so callers can reconcile the rest. */
+interface IPerTurnUsageCoverage {
+	/** Positions in `modelTurnRefs` that received a sidecar usage record. */
+	readonly covered: ReadonlySet<number>;
+	/** Sum of input tokens assigned from the sidecar. */
+	readonly assignedInput: number;
+	/** Sum of cache-read tokens assigned from the sidecar. */
+	readonly assignedCache: number;
+	/** Sum of Copilot AIU (nano) assigned from the sidecar. */
+	readonly assignedAiu: number;
+}
+
 function applyPerTurnUsage(
 	events: IChatDebugEvent[],
 	resolved: Map<string, IChatDebugResolvedEventContent>,
-	modelTurnRefs: readonly { readonly index: number; readonly id: string; readonly turnId?: string; readonly outputTokens?: number }[],
+	modelTurnRefs: readonly IModelTurnRef[],
 	usageRecords: readonly IAgentHostUsageRecord[],
-): void {
+): IPerTurnUsageCoverage {
 	const assign = (ref: typeof modelTurnRefs[number], inputTokens: number | undefined, cachedTokens: number | undefined, copilotUsageNanoAiu: number | undefined) => {
 		const turn = events[ref.index] as IChatDebugModelTurnEvent;
 		const totalTokens = inputTokens !== undefined ? inputTokens + (ref.outputTokens ?? 0) : undefined;
@@ -1282,17 +1353,28 @@ function applyPerTurnUsage(
 	}
 
 	let recordIndex = 0;
-	for (const ref of modelTurnRefs) {
+	let assignedInput = 0;
+	let assignedCache = 0;
+	let assignedAiu = 0;
+	const covered = new Set<number>();
+	for (let refIdx = 0; refIdx < modelTurnRefs.length; refIdx++) {
 		if (recordIndex >= usageRecords.length) {
 			break;
 		}
+		const ref = modelTurnRefs[refIdx];
 		const record = usageRecords[recordIndex];
 		if (ref.outputTokens !== undefined && record.outputTokens !== undefined && ref.outputTokens !== record.outputTokens) {
 			continue; // this ref has no captured usage record — leave it blank
 		}
-		assign(ref, record.inputTokens, record.cacheReadTokens, aiuByRecordIndex[recordIndex]);
+		const aiu = aiuByRecordIndex[recordIndex];
+		assign(ref, record.inputTokens, record.cacheReadTokens, aiu);
+		assignedInput += record.inputTokens ?? 0;
+		assignedCache += record.cacheReadTokens ?? 0;
+		assignedAiu += aiu ?? 0;
+		covered.add(refIdx);
 		recordIndex++;
 	}
+	return { covered, assignedInput, assignedCache, assignedAiu };
 }
 
 /** Session usage totals distributed across model turns. */

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
@@ -1,0 +1,528 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { VSBuffer, type VSBufferReadableStream } from '../../../../../base/common/buffer.js';
+import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { agentHostAuthority, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { AgentHostAhpJsonlLoggingSettingId, IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { AGENT_HOST_LOG_OUTPUT_CHANNEL_ID, IRemoteAgentHostConnectionInfo, IRemoteAgentHostService, remoteAgentHostLogOutputChannelId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { IFileService, type IFileStatWithMetadata } from '../../../../../platform/files/common/files.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
+import { IOutputService } from '../../../../services/output/common/output.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
+import { buildLocalCopilotLogsUri, buildRemoteCopilotLogsUri, COPILOT_CLI_LOCAL_AH_SCHEME, getCopilotCliSessionRawId, parseRemoteAuthorityFromScheme, resolveEventsUri } from '../copilotCliEventsUri.js';
+
+/** Output channel ID for the current window's renderer log. */
+const WINDOW_LOG_CHANNEL_ID = 'rendererLog';
+/** Output channel ID for the shared process compound log. */
+const SHARED_PROCESS_LOG_CHANNEL_ID = 'shared';
+/** Bound the best-effort scan of Copilot SDK process logs. */
+export const MAX_COPILOT_LOG_SCAN_FILES = 20;
+export const MAX_COPILOT_LOG_FILE_SIZE = 10 * 1024 * 1024;
+/** Default cap for the amount of text loaded into the inline raw-log viewer. */
+export const DEFAULT_RAW_LOG_VIEW_CAP_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Discriminates the kind of agent-host log a {@link IAgentHostLogSource}
+ * points at, so the viewer can pick the appropriate reader and syntax.
+ */
+export const enum AgentHostLogSourceKind {
+	/** The Copilot CLI `events.jsonl` model/conversation stream. */
+	Events = 'events',
+	/** The client-side AHP JSON-RPC wire log (`<logsHome>/ahp/*.jsonl`). */
+	WireLog = 'wire',
+	/** The Copilot SDK process logs under `~/.copilot/logs`. */
+	CliLog = 'cliLog',
+	/** A VS Code output channel (agent host process, renderer, shared). */
+	ProcessChannel = 'processChannel',
+	/** The remote machine's `agenthost.log`, downloaded on demand. */
+	RemoteProcessLog = 'remoteProcessLog',
+}
+
+/**
+ * Describes one raw log source available for an agent-host session. Descriptors
+ * are cheap to enumerate; the actual (bounded) content is read lazily via
+ * {@link readAgentHostLogSourceContent} when the user selects the source.
+ */
+export interface IAgentHostLogSource {
+	readonly id: string;
+	readonly label: string;
+	readonly kind: AgentHostLogSourceKind;
+	readonly isRemote: boolean;
+	/** File resource for file-backed sources (events, wire log). */
+	readonly resource?: URI;
+	/** Output channel id for channel-backed sources. */
+	readonly channelId?: string;
+	/** Copilot logs directory + session id, for the lazy content-filtered CLI log read. */
+	readonly cliLogs?: { readonly dir: URI; readonly rawSessionId: string };
+	/** Remote connection for lazily downloading `agenthost.log`. */
+	readonly remoteConnection?: IRemoteAgentHostConnectionInfo;
+}
+
+/** Bag of services required to enumerate and read agent-host log sources. */
+export interface IAgentHostLogSourceServices {
+	readonly pathService: IPathService;
+	readonly agentHostService: IAgentHostService;
+	readonly remoteAgentHostService: IRemoteAgentHostService;
+	readonly outputService: IOutputService;
+	readonly fileService: IFileService;
+	readonly textModelService: ITextModelService;
+	readonly configurationService: IConfigurationService;
+	readonly environmentService: IEnvironmentService;
+	readonly productService: IProductService;
+	readonly logService: ILogService;
+}
+
+/** Result of a bounded raw-log read. */
+export interface IAgentHostLogContent {
+	readonly text: string;
+	/** Total size of the underlying source in bytes, when known. */
+	readonly totalBytes: number | undefined;
+	/** True when only the tail of the source was loaded. */
+	readonly truncated: boolean;
+	/** Full-fidelity resource to open in an editor, when the source is file-backed. */
+	readonly fileResource?: URI;
+}
+
+/**
+ * Returns true when the chat session belongs to an agent host (local or
+ * remote Copilot CLI). Only these sessions have AHP logs and agent-host
+ * process logs, so the AHP Log view is gated on this.
+ */
+export function isAgentHostSession(resource: URI | undefined): boolean {
+	if (!resource) {
+		return false;
+	}
+	return resource.scheme === COPILOT_CLI_LOCAL_AH_SCHEME || !!parseRemoteAuthorityFromScheme(resource.scheme);
+}
+
+/**
+ * Resolves the remote agent-host connection that backs a given remote session
+ * URI, or `undefined` for local/unknown sessions.
+ */
+export function getRemoteConnectionForSession(sessionResource: URI, connections: readonly IRemoteAgentHostConnectionInfo[]): IRemoteAgentHostConnectionInfo | undefined {
+	const authority = parseRemoteAuthorityFromScheme(sessionResource.scheme);
+	return authority ? connections.find(connection => agentHostAuthority(connection.address) === authority) : undefined;
+}
+
+/** Sanitizes a value for use as (part of) a file name. */
+export function sanitizeFilePart(value: string): string {
+	return value.replace(/[\\/:\*\?"<>|\s]+/g, '-').replace(/^-+|-+$/g, '') || 'connection';
+}
+
+/**
+ * Enumerates the raw log sources available for a given agent-host session.
+ * Cheap: performs at most a couple of directory stats and never reads file
+ * contents. Returns an empty array for non-agent-host sessions.
+ */
+export async function enumerateAgentHostLogSources(
+	services: IAgentHostLogSourceServices,
+	sessionResource: URI | undefined,
+): Promise<IAgentHostLogSource[]> {
+	if (!isAgentHostSession(sessionResource) || !sessionResource) {
+		return [];
+	}
+
+	const { pathService, agentHostService, remoteAgentHostService, outputService, fileService, configurationService, environmentService } = services;
+	const userHome = pathService.userHome({ preferLocal: true });
+	const isLocal = sessionResource.scheme === COPILOT_CLI_LOCAL_AH_SCHEME;
+	const remoteConnection = isLocal ? undefined : getRemoteConnectionForSession(sessionResource, remoteAgentHostService.connections);
+
+	const sources: IAgentHostLogSource[] = [];
+
+	// 1. events.jsonl (model/conversation stream)
+	const eventsResult = resolveEventsUri(
+		sessionResource,
+		userHome,
+		authority => remoteAgentHostService.connections.find(c => agentHostAuthority(c.address) === authority),
+	);
+	if (eventsResult.kind === 'ok') {
+		sources.push({
+			id: 'events',
+			label: localize('agentHostLogs.events', "Session Events (events.jsonl)"),
+			kind: AgentHostLogSourceKind.Events,
+			isRemote: !isLocal,
+			resource: eventsResult.resource,
+		});
+	}
+
+	// 2. AHP wire log(s) — only when wire logging is enabled.
+	if (configurationService.getValue<boolean>(AgentHostAhpJsonlLoggingSettingId)) {
+		const nameToken = isLocal
+			? sanitizeFilePart(agentHostService.clientId)
+			: remoteConnection ? sanitizeFilePart(remoteConnection.address) : undefined;
+		const wireFiles = await listWireLogFiles(fileService, environmentService, nameToken);
+		wireFiles.forEach((file, index) => {
+			sources.push({
+				id: `wire:${file.resource.toString()}`,
+				label: index === 0
+					? localize('agentHostLogs.wire', "AHP Log")
+					: localize('agentHostLogs.wireN', "AHP Log — {0}", file.name),
+				kind: AgentHostLogSourceKind.WireLog,
+				isRemote: !isLocal,
+				resource: file.resource,
+			});
+		});
+	}
+
+	// 3. Agent host process log (output channel) + window/shared logs.
+	const channelIds: string[] = [];
+	if (isLocal) {
+		channelIds.push(AGENT_HOST_LOG_OUTPUT_CHANNEL_ID);
+	} else if (remoteConnection) {
+		channelIds.push(remoteAgentHostLogOutputChannelId(remoteConnection.address));
+	}
+	channelIds.push(WINDOW_LOG_CHANNEL_ID, SHARED_PROCESS_LOG_CHANNEL_ID);
+	for (const channelId of channelIds) {
+		const descriptor = outputService.getChannelDescriptor(channelId);
+		if (!descriptor) {
+			continue;
+		}
+		sources.push({
+			id: `channel:${channelId}`,
+			label: localize('agentHostLogs.channel', "{0} (Log)", descriptor.label),
+			kind: AgentHostLogSourceKind.ProcessChannel,
+			isRemote: !isLocal,
+			channelId,
+		});
+	}
+
+	// 4. Remote agenthost.log (downloaded on demand).
+	if (remoteConnection?.defaultDirectory) {
+		sources.push({
+			id: 'remoteProcessLog',
+			label: localize('agentHostLogs.remoteProcess', "Remote Agent Host Log (agenthost.log)"),
+			kind: AgentHostLogSourceKind.RemoteProcessLog,
+			isRemote: true,
+			remoteConnection,
+		});
+	}
+
+	// 5. Copilot SDK process logs (~/.copilot/logs), content-filtered lazily by session id.
+	const rawSessionId = getCopilotCliSessionRawId(sessionResource);
+	if (rawSessionId) {
+		const copilotLogsDir = isLocal
+			? buildLocalCopilotLogsUri(userHome)
+			: remoteConnection ? buildRemoteCopilotLogsUri(remoteConnection) : undefined;
+		if (copilotLogsDir) {
+			sources.push({
+				id: 'cliLog',
+				label: localize('agentHostLogs.cliLog', "Copilot CLI Logs"),
+				kind: AgentHostLogSourceKind.CliLog,
+				isRemote: !isLocal,
+				cliLogs: { dir: copilotLogsDir, rawSessionId },
+			});
+		}
+	}
+
+	return sources;
+}
+
+/**
+ * Reads the (bounded) content of a log source. File-backed sources are tailed
+ * to at most `capBytes`; the returned {@link IAgentHostLogContent.fileResource}
+ * lets callers offer an "open full file" affordance.
+ */
+export async function readAgentHostLogSourceContent(
+	source: IAgentHostLogSource,
+	services: IAgentHostLogSourceServices,
+	capBytes: number = DEFAULT_RAW_LOG_VIEW_CAP_BYTES,
+): Promise<IAgentHostLogContent | undefined> {
+	const { fileService, outputService, textModelService, productService, logService } = services;
+
+	switch (source.kind) {
+		case AgentHostLogSourceKind.Events:
+		case AgentHostLogSourceKind.WireLog: {
+			if (!source.resource) {
+				return undefined;
+			}
+			return readFileTail(fileService, source.resource, capBytes);
+		}
+		case AgentHostLogSourceKind.ProcessChannel: {
+			if (!source.channelId) {
+				return undefined;
+			}
+			const channel = outputService.getChannel(source.channelId);
+			if (!channel) {
+				return undefined;
+			}
+			const modelRef = await textModelService.createModelReference(channel.uri);
+			try {
+				const value = modelRef.object.textEditorModel.getValue();
+				return tailString(value, capBytes);
+			} finally {
+				modelRef.dispose();
+			}
+		}
+		case AgentHostLogSourceKind.RemoteProcessLog: {
+			if (!source.remoteConnection) {
+				return undefined;
+			}
+			const value = await readRemoteAgentHostLog(source.remoteConnection, productService.serverDataFolderName, fileService);
+			return value === undefined ? undefined : tailString(value, capBytes);
+		}
+		case AgentHostLogSourceKind.CliLog: {
+			if (!source.cliLogs) {
+				return undefined;
+			}
+			const files = await readCopilotLogsForSession(source.cliLogs.dir, source.cliLogs.rawSessionId, fileService, logService);
+			if (files.length === 0) {
+				return { text: '', totalBytes: 0, truncated: false };
+			}
+			const combined = files.map(f => `===== ${f.path} =====\n${f.contents}`).join('\n\n');
+			return tailString(combined, capBytes);
+		}
+	}
+}
+
+/** Lists AHP wire log files, ranking those matching `nameToken` first. */
+async function listWireLogFiles(
+	fileService: IFileService,
+	environmentService: IEnvironmentService,
+	nameToken: string | undefined,
+): Promise<{ resource: URI; name: string; mtime: number }[]> {
+	const ahpDir = joinPath(environmentService.logsHome, 'ahp');
+	let children: IFileStatWithMetadata[] | undefined;
+	try {
+		children = (await fileService.resolve(ahpDir, { resolveMetadata: true })).children;
+	} catch {
+		return [];
+	}
+	const files = (children ?? [])
+		.filter(child => !child.isDirectory && child.name.endsWith('.jsonl'))
+		.map(child => ({ resource: child.resource, name: child.name, mtime: child.mtime ?? 0 }));
+
+	// Rank files matching the session's connection token first, newest first.
+	return files.sort((a, b) => {
+		if (nameToken) {
+			const am = a.name.includes(nameToken) ? 0 : 1;
+			const bm = b.name.includes(nameToken) ? 0 : 1;
+			if (am !== bm) {
+				return am - bm;
+			}
+		}
+		return b.mtime - a.mtime;
+	});
+}
+
+/** Reads at most `capBytes` from the tail of a file. */
+async function readFileTail(fileService: IFileService, resource: URI, capBytes: number): Promise<IAgentHostLogContent> {
+	let size: number | undefined;
+	try {
+		size = (await fileService.resolve(resource, { resolveMetadata: true })).size;
+	} catch {
+		size = undefined;
+	}
+
+	if (size !== undefined && size > capBytes) {
+		const content = await fileService.readFile(resource, { position: size - capBytes, length: capBytes });
+		let text = content.value.toString();
+		// Drop the leading partial line so the view starts on a record boundary.
+		const firstNewline = text.indexOf('\n');
+		if (firstNewline >= 0) {
+			text = text.slice(firstNewline + 1);
+		}
+		return { text, totalBytes: size, truncated: true, fileResource: resource };
+	}
+
+	const content = await fileService.readFile(resource, { limits: { size: capBytes } });
+	return { text: content.value.toString(), totalBytes: size, truncated: false, fileResource: resource };
+}
+
+/** Returns at most `capBytes` worth of text from the tail of a string. */
+function tailString(value: string, capBytes: number): IAgentHostLogContent {
+	if (value.length <= capBytes) {
+		return { text: value, totalBytes: value.length, truncated: false };
+	}
+	let text = value.slice(value.length - capBytes);
+	const firstNewline = text.indexOf('\n');
+	if (firstNewline >= 0) {
+		text = text.slice(firstNewline + 1);
+	}
+	return { text, totalBytes: value.length, truncated: true };
+}
+
+/**
+ * Scans a Copilot logs directory for `.log` files whose content mentions the
+ * given session id, returning their contents. Bounded by
+ * {@link MAX_COPILOT_LOG_SCAN_FILES} and {@link MAX_COPILOT_LOG_FILE_SIZE}.
+ */
+export async function readCopilotLogsForSession(
+	logsDir: URI,
+	rawSessionId: string,
+	fileService: IFileService,
+	logService: ILogService,
+): Promise<{ path: string; contents: string }[]> {
+	let children: IFileStatWithMetadata[] | undefined;
+	try {
+		children = (await fileService.resolve(logsDir, { resolveMetadata: true })).children;
+	} catch {
+		return [];
+	}
+
+	const files: { path: string; contents: string }[] = [];
+	const candidateLogs = (children ?? [])
+		.filter(child => !child.isDirectory && child.name.endsWith('.log') && child.size <= MAX_COPILOT_LOG_FILE_SIZE)
+		.sort((a, b) => b.mtime - a.mtime)
+		.slice(0, MAX_COPILOT_LOG_SCAN_FILES);
+	for (const child of candidateLogs) {
+		try {
+			if (await logStreamContains(child.resource, rawSessionId, fileService)) {
+				const content = await fileService.readFile(child.resource, { limits: { size: MAX_COPILOT_LOG_FILE_SIZE } });
+				files.push({ path: `copilot-logs/${child.name}`, contents: content.value.toString() });
+			}
+		} catch (error) {
+			logService.warn(`[AgentHostLogSources] Failed to read Copilot log '${child.name}': ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+	return files;
+}
+
+async function logStreamContains(
+	resource: URI,
+	rawSessionId: string,
+	fileService: IFileService,
+): Promise<boolean> {
+	const tokenSource = new CancellationTokenSource();
+	let stream: VSBufferReadableStream;
+	try {
+		stream = (await fileService.readFileStream(resource, {
+			length: MAX_COPILOT_LOG_FILE_SIZE,
+			limits: { size: MAX_COPILOT_LOG_FILE_SIZE },
+		}, tokenSource.token)).value;
+	} catch (error) {
+		tokenSource.dispose(true);
+		throw error;
+	}
+	return new Promise<boolean>((resolve, reject) => {
+		let settled = false;
+		let previous = '';
+
+		const cleanup = (removeErrorListener: boolean) => {
+			stream.removeListener('data', onData);
+			stream.removeListener('end', onEnd);
+			if (removeErrorListener) {
+				stream.removeListener('error', onError);
+			}
+		};
+		const settle = (contains: boolean) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			tokenSource.dispose(contains);
+			cleanup(!contains);
+			resolve(contains);
+		};
+		const onData = (chunk: VSBuffer) => {
+			const text = previous + chunk.toString();
+			if (text.includes(rawSessionId)) {
+				settle(true);
+				return;
+			}
+			previous = text.slice(Math.max(0, text.length - rawSessionId.length + 1));
+		};
+		const onError = (error: Error) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			tokenSource.dispose();
+			cleanup(true);
+			reject(error);
+		};
+		const onEnd = () => {
+			settle(false);
+		};
+
+		stream.on('error', onError);
+		stream.on('end', onEnd);
+		stream.on('data', onData);
+	});
+}
+
+/**
+ * Reads the remote agent host's `agenthost.log` from the remote machine via the
+ * `vscode-agent-host://` filesystem proxy. The CLI launches the server with its
+ * default data dir at `<home>/<serverDataFolderName>/data/logs/<datestamp>/`,
+ * so we list the logs directory and pick the most recent date-stamped folder.
+ */
+export async function readRemoteAgentHostLog(
+	connection: IRemoteAgentHostConnectionInfo,
+	serverDataFolderName: string | undefined,
+	fileService: IFileService,
+): Promise<string | undefined> {
+	const homePath = connection.defaultDirectory;
+	if (!homePath) {
+		return undefined;
+	}
+	const authority = agentHostAuthority(connection.address);
+	const homeUri = toAgentHostUri(URI.from({ scheme: 'file', path: homePath }), authority);
+
+	// Possible server data folder candidates. The renderer's own
+	// `serverDataFolderName` (which the user is running) is the most likely
+	// match, but the remote agent host may have been launched by a different
+	// quality of CLI. Dev builds also append `-dev`, which won't exist on
+	// any real built remote, so we strip that suffix as well.
+	const candidates = new Set<string>();
+	if (serverDataFolderName) {
+		candidates.add(serverDataFolderName);
+		if (serverDataFolderName.endsWith('-dev')) {
+			candidates.add(serverDataFolderName.slice(0, -'-dev'.length));
+		}
+	}
+	candidates.add('.vscode-server');
+	candidates.add('.vscode-server-insiders');
+	candidates.add('.vscode-server-oss');
+	candidates.add('.vscode-server-exploration');
+
+	// Enumerate every `<home>/<candidate>/data/logs/<datestamp>/agenthost.log`
+	// across all candidates and pick the one with the newest mtime. This avoids
+	// picking up a stale stable-quality folder when an insiders folder has a
+	// more recent log (or vice versa).
+	let best: { uri: URI; mtime: number } | undefined;
+	for (const folderName of candidates) {
+		const logsDirUri = joinPath(homeUri, folderName, 'data', 'logs');
+		let entries;
+		try {
+			const stat = await fileService.resolve(logsDirUri, { resolveMetadata: true });
+			entries = stat.children;
+		} catch {
+			continue;
+		}
+		if (!entries) {
+			continue;
+		}
+		for (const dir of entries) {
+			if (!dir.isDirectory) {
+				continue;
+			}
+			const logUri = joinPath(dir.resource, 'agenthost.log');
+			let logStat;
+			try {
+				logStat = await fileService.resolve(logUri, { resolveMetadata: true });
+			} catch {
+				continue;
+			}
+			const mtime = logStat.mtime ?? 0;
+			if (!best || mtime > best.mtime) {
+				best = { uri: logUri, mtime };
+			}
+		}
+	}
+
+	if (!best) {
+		return undefined;
+	}
+	const content = await fileService.readFile(best.uri);
+	return content.value.toString();
+}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
@@ -284,7 +284,15 @@ export async function readAgentHostLogSourceContent(
 	}
 }
 
-/** Lists AHP wire log files, ranking those matching `nameToken` first. */
+/**
+ * Lists AHP wire log files for a session's connection.
+ *
+ * When `nameToken` identifies the session's connection (its filenames embed
+ * `ahp-<timestamp>-<connectionId>.jsonl`), only matching files are returned —
+ * so unrelated connections' logs are not surfaced as spurious "rotated"
+ * sources. Falls back to all AHP logs (newest first) when the token is absent
+ * or matches nothing.
+ */
 async function listWireLogFiles(
 	fileService: IFileService,
 	environmentService: IEnvironmentService,
@@ -301,17 +309,13 @@ async function listWireLogFiles(
 		.filter(child => !child.isDirectory && child.name.endsWith('.jsonl'))
 		.map(child => ({ resource: child.resource, name: child.name, mtime: child.mtime ?? 0 }));
 
-	// Rank files matching the session's connection token first, newest first.
-	return files.sort((a, b) => {
-		if (nameToken) {
-			const am = a.name.includes(nameToken) ? 0 : 1;
-			const bm = b.name.includes(nameToken) ? 0 : 1;
-			if (am !== bm) {
-				return am - bm;
-			}
-		}
-		return b.mtime - a.mtime;
-	});
+	// Restrict to the session's connection when it can be identified; otherwise
+	// fall back to all files so a session is never left without any log.
+	const matching = nameToken ? files.filter(file => file.name.includes(nameToken)) : [];
+	const selected = matching.length > 0 ? matching : files;
+
+	// Newest first.
+	return selected.sort((a, b) => b.mtime - a.mtime);
 }
 
 /** Reads at most `capBytes` from the tail of a file. */

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostUsageSidecar.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostUsageSidecar.ts
@@ -1,0 +1,346 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Disposable, DisposableMap } from '../../../../../base/common/lifecycle.js';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
+import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { IRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { ActionType, type ActionEnvelope, type ChatUsageAction, type SessionCustomizationsChangedAction } from '../../../../../platform/agentHost/common/state/sessionActions.js';
+import { isDefaultChatUri, parseChatUri, readUsageInfoMeta, type Customization } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { getCopilotCliSessionRawId } from '../copilotCliEventsUri.js';
+
+/**
+ * Directory (under the client's user data home) that holds the per-session
+ * token-usage sidecar files. Kept separate from VS Code's other user-data
+ * folders and never written into the CLI's `~/.copilot` tree.
+ */
+const USAGE_DIR = 'agentHostUsage';
+
+/**
+ * One captured Copilot `ChatUsage` action, i.e. the usage report for a single
+ * model call. Persisted as a line in the session's sidecar so per-turn/per-round
+ * token metrics survive a VS Code restart (the reduced chat state keeps only the
+ * last request's input/cache per turn, and `events.jsonl` only records
+ * `outputTokens` until `session.shutdown`).
+ */
+export interface IAgentHostUsageRecord {
+	/** Turn the model call belongs to. */
+	readonly turnId: string;
+	/** Model that served the call, if reported. */
+	readonly model?: string;
+	/** Input tokens for this single call. */
+	readonly inputTokens?: number;
+	/** Output tokens for this single call. */
+	readonly outputTokens?: number;
+	/** Cache-read tokens for this single call. */
+	readonly cacheReadTokens?: number;
+	/** Per-turn cumulative Copilot AIU (nano) at the time of this call. */
+	readonly totalNanoAiu?: number;
+	/** ISO timestamp when the client captured the action. */
+	readonly ts: string;
+}
+
+/** Builds the sidecar URI for a session's usage records under `baseDir`. */
+export function buildAgentHostUsageUri(baseDir: URI, rawSessionId: string): URI {
+	return joinPath(baseDir, USAGE_DIR, `${sanitizeSessionId(rawSessionId)}.jsonl`);
+}
+
+/** Replaces characters that are unsafe in a file name so a raw id maps to one file. */
+function sanitizeSessionId(rawSessionId: string): string {
+	return rawSessionId.replace(/[^\w.-]/g, '_');
+}
+
+/**
+ * Reads a session's usage sidecar. Returns the records in capture order,
+ * skipping blank or malformed lines. Returns an empty array when the file does
+ * not exist (e.g. a session that ran before capture shipped).
+ */
+export async function readAgentHostUsageRecords(fileService: IFileService, uri: URI): Promise<IAgentHostUsageRecord[]> {
+	let text: string;
+	try {
+		const content = await fileService.readFile(uri);
+		text = content.value.toString();
+	} catch {
+		return [];
+	}
+	const records: IAgentHostUsageRecord[] = [];
+	for (const line of text.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed) {
+			continue;
+		}
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (parsed && typeof parsed.turnId === 'string' && typeof parsed.ts === 'string') {
+				records.push(parsed as IAgentHostUsageRecord);
+			}
+		} catch {
+			// Skip a malformed/partial line rather than dropping the whole file.
+		}
+	}
+	return records;
+}
+
+/**
+ * The minimal agent-host surface the recorders observe: a stream of protocol
+ * actions. Satisfied by {@link IAgentHostService} in production and by a bare
+ * emitter in tests, so the recorders don't depend on the full service.
+ */
+type IAgentHostActionSource = Pick<IAgentHostService, 'onDidAction'>;
+
+/**
+ * Shared client-side plumbing for recorders that observe agent-host protocol
+ * actions across the ambient (local) connection and every live remote
+ * connection, and persist derived data to a client-local sidecar. Enable
+ * gating and local/remote fan-out live here; subclasses implement
+ * {@link _onAction} for the action(s) they care about.
+ *
+ * Running on the client (where wire logs are captured) means every session's
+ * actions arrive through the same subscription reducers regardless of
+ * transport, so subclasses work uniformly for local and remote hosts.
+ */
+abstract class AgentHostActionRecorder extends Disposable {
+
+	/** Live per-remote-connection action listeners, keyed by agent-host authority. */
+	private readonly _remoteListeners = this._register(new DisposableMap<string>());
+
+	constructor(
+		protected readonly _isEnabled: () => boolean,
+		agentHostService: IAgentHostActionSource,
+		private readonly _remoteAgentHostService: IRemoteAgentHostService,
+	) {
+		super();
+
+		// Local agent-host sessions.
+		this._register(agentHostService.onDidAction(envelope => this._dispatch(envelope)));
+
+		// Remote agent-host connections (rebuilt as connections come and go).
+		this._register(this._remoteAgentHostService.onDidChangeConnections(() => this._syncRemoteListeners()));
+		this._syncRemoteListeners();
+	}
+
+	/** Gate on the enable predicate before handing the action to the subclass. */
+	private _dispatch(envelope: ActionEnvelope): void {
+		if (!this._isEnabled()) {
+			return;
+		}
+		this._onAction(envelope);
+	}
+
+	/** Handle a single action from any (local or remote) connection. */
+	protected abstract _onAction(envelope: ActionEnvelope): void;
+
+	/** Subscribes to `onDidAction` on each current remote connection; drops stale ones. */
+	private _syncRemoteListeners(): void {
+		const seen = new Set<string>();
+		for (const info of this._remoteAgentHostService.connections) {
+			const authority = agentHostAuthority(info.address);
+			seen.add(authority);
+			if (this._remoteListeners.has(authority)) {
+				continue;
+			}
+			const connection = this._remoteAgentHostService.getConnectionByAuthority(authority);
+			if (connection) {
+				this._remoteListeners.set(authority, connection.onDidAction(envelope => this._dispatch(envelope)));
+			}
+		}
+		for (const authority of [...this._remoteListeners.keys()]) {
+			if (!seen.has(authority)) {
+				this._remoteListeners.deleteAndDispose(authority);
+			}
+		}
+	}
+}
+
+/**
+ * Captures Copilot `ChatUsage` actions on the client and appends them to a
+ * stable, client-local per-session sidecar so token metrics survive a VS Code
+ * restart and feed accurate per-round Cache Explorer numbers.
+ *
+ * Dedup: a single model call can surface multiple `ChatUsage` actions —
+ *   1. a parent-scope emit on the session's DEFAULT chat channel, and
+ *   2. for sub-agent calls, a sub-agent-scope emit on a sub-agent chat channel
+ *      (`parseChatUri` maps both to the same session), and
+ *   3. an async re-emit carrying the same tokens plus `_meta.contextAttribution`.
+ * Capturing only actions on the default chat channel (1) that lack
+ * `contextAttribution` yields exactly one record per model call — and the
+ * parent aggregate already includes sub-agent token usage.
+ */
+export class AgentHostUsageRecorder extends AgentHostActionRecorder {
+
+	/** Per-session serialized append queue (keeps records ordered; no in-memory copy of the file). */
+	private readonly _queues = new Map<string, Promise<void>>();
+
+	constructor(
+		private readonly _baseDir: URI,
+		isEnabled: () => boolean,
+		private readonly _fileService: IFileService,
+		private readonly _logService: ILogService,
+		agentHostService: IAgentHostActionSource,
+		remoteAgentHostService: IRemoteAgentHostService,
+	) {
+		super(isEnabled, agentHostService, remoteAgentHostService);
+	}
+
+	protected _onAction(envelope: ActionEnvelope): void {
+		const action = envelope.action;
+		if (action.type !== ActionType.ChatUsage) {
+			return;
+		}
+		// Parent aggregate only (skips the sub-agent-scope duplicate on a
+		// sub-agent chat channel, which maps to the same session).
+		if (!isDefaultChatUri(envelope.channel)) {
+			return;
+		}
+		const usage = (action as ChatUsageAction).usage;
+		const meta = readUsageInfoMeta(usage);
+		// Skip the async re-emit (same tokens, enriched with context attribution).
+		if (meta.contextAttribution) {
+			return;
+		}
+		const session = parseChatUri(envelope.channel)?.session;
+		if (!session) {
+			return;
+		}
+		// The backend chat channel encodes a `copilotcli:/<rawId>` session URI;
+		// `getCopilotCliSessionRawId` yields the same raw id the reader derives
+		// from the client session resource.
+		const rawId = getCopilotCliSessionRawId(URI.parse(session));
+		if (!rawId) {
+			return;
+		}
+		const record: IAgentHostUsageRecord = {
+			turnId: (action as ChatUsageAction).turnId,
+			model: usage.model,
+			inputTokens: usage.inputTokens,
+			outputTokens: usage.outputTokens,
+			cacheReadTokens: usage.cacheReadTokens,
+			totalNanoAiu: meta.copilotUsage?.totalNanoAiu,
+			ts: new Date().toISOString(),
+		};
+		this._append(rawId, record);
+	}
+
+	/**
+	 * Appends a record to the session's sidecar. Uses the file system's append
+	 * capability so each record is a single small write (no read-modify-write of
+	 * the whole file, and no in-memory copy of the growing file) — writes are
+	 * still serialized per session to keep records ordered. Records written
+	 * before a restart are preserved because we append to the existing file.
+	 */
+	private _append(rawId: string, record: IAgentHostUsageRecord): void {
+		const uri = buildAgentHostUsageUri(this._baseDir, rawId);
+		const line = JSON.stringify(record) + '\n';
+		const previous = this._queues.get(rawId) ?? Promise.resolve();
+		const next = previous
+			.then(() => this._fileService.writeFile(uri, VSBuffer.fromString(line), { append: true }))
+			.then(() => undefined)
+			.catch(err => {
+				this._logService.trace(`[AgentHostUsageRecorder] append failed for ${rawId}: ${toErrorMessage(err)}`);
+			});
+		this._queues.set(rawId, next);
+	}
+}
+
+/**
+ * Directory (under the client's user data home) that holds the per-session
+ * customization snapshot sidecar files. Kept alongside — but separate from —
+ * the usage sidecar, and never written into the CLI's `~/.copilot` tree.
+ */
+const CUSTOMIZATIONS_DIR = 'agentHostCustomizations';
+
+/** Builds the sidecar URI for a session's customization snapshot under `baseDir`. */
+export function buildAgentHostCustomizationsUri(baseDir: URI, rawSessionId: string): URI {
+	return joinPath(baseDir, CUSTOMIZATIONS_DIR, `${sanitizeSessionId(rawSessionId)}.json`);
+}
+
+/**
+ * Reads a session's persisted customization snapshot — the last
+ * full-replacement `SessionCustomizationsChanged` payload captured live.
+ * Returns `undefined` when the file is absent (e.g. a session that ran before
+ * capture shipped) or malformed, so callers fall back to the live session
+ * state rather than showing nothing.
+ */
+export async function readAgentHostCustomizationsSnapshot(fileService: IFileService, uri: URI): Promise<Customization[] | undefined> {
+	let text: string;
+	try {
+		const content = await fileService.readFile(uri);
+		text = content.value.toString();
+	} catch {
+		return undefined;
+	}
+	try {
+		const parsed = JSON.parse(text);
+		if (Array.isArray(parsed)) {
+			return parsed as Customization[];
+		}
+	} catch {
+		// Ignore a malformed/partial snapshot rather than throwing.
+	}
+	return undefined;
+}
+
+/**
+ * Captures each session's loaded customizations (skills/hooks/agents/MCP) to a
+ * stable client-local snapshot so the debug view can surface them even for
+ * historical/closed sessions. This is necessary because the live
+ * {@link IAgentHostCustomizationService} only knows the customizations of
+ * sessions with an active state subscription, and the SDK's `session.*_loaded`
+ * events are ephemeral (never written to `events.jsonl`).
+ *
+ * Listens for the full-replacement `SessionCustomizationsChanged` action — the
+ * canonical way a host publishes its effective customization set — on the
+ * `<provider>:/<rawId>` session channel, and overwrites the session's snapshot.
+ * The raw id derived from the channel matches the one the reader derives from
+ * the client session resource (both are the URI path), so the snapshot lines up
+ * with the session it belongs to.
+ */
+export class AgentHostCustomizationRecorder extends AgentHostActionRecorder {
+
+	/** Per-session serialized write queue (last snapshot wins). */
+	private readonly _queues = new Map<string, Promise<void>>();
+
+	constructor(
+		private readonly _baseDir: URI,
+		isEnabled: () => boolean,
+		private readonly _fileService: IFileService,
+		private readonly _logService: ILogService,
+		agentHostService: IAgentHostActionSource,
+		remoteAgentHostService: IRemoteAgentHostService,
+	) {
+		super(isEnabled, agentHostService, remoteAgentHostService);
+	}
+
+	protected _onAction(envelope: ActionEnvelope): void {
+		if (envelope.action.type !== ActionType.SessionCustomizationsChanged) {
+			return;
+		}
+		const rawId = getCopilotCliSessionRawId(URI.parse(envelope.channel));
+		if (!rawId) {
+			return; // not a Copilot CLI session channel
+		}
+		this._write(rawId, (envelope.action as SessionCustomizationsChangedAction).customizations);
+	}
+
+	/** Overwrites the session's snapshot, serializing writes per session. */
+	private _write(rawId: string, customizations: readonly Customization[]): void {
+		const uri = buildAgentHostCustomizationsUri(this._baseDir, rawId);
+		const content = JSON.stringify(customizations);
+		const previous = this._queues.get(rawId) ?? Promise.resolve();
+		const next = previous
+			.then(() => this._fileService.writeFile(uri, VSBuffer.fromString(content)))
+			.then(() => undefined)
+			.catch(err => {
+				this._logService.trace(`[AgentHostCustomizationRecorder] write failed for ${rawId}: ${toErrorMessage(err)}`);
+			});
+		this._queues.set(rawId, next);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostUsageSidecar.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostUsageSidecar.ts
@@ -10,7 +10,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
-import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { IAgentHostService, type IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
 import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { IRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ActionType, type ActionEnvelope, type ChatUsageAction, type SessionCustomizationsChangedAction } from '../../../../../platform/agentHost/common/state/sessionActions.js';
@@ -112,6 +112,13 @@ abstract class AgentHostActionRecorder extends Disposable {
 	/** Live per-remote-connection action listeners, keyed by agent-host authority. */
 	private readonly _remoteListeners = this._register(new DisposableMap<string>());
 
+	/**
+	 * The connection object currently subscribed for each authority. Tracked so
+	 * a reconnect (which replaces the connection object under the same
+	 * authority) is detected and the listener re-subscribed to the live object.
+	 */
+	private readonly _remoteConnections = new Map<string, IAgentConnection>();
+
 	constructor(
 		protected readonly _isEnabled: () => boolean,
 		agentHostService: IAgentHostActionSource,
@@ -144,17 +151,24 @@ abstract class AgentHostActionRecorder extends Disposable {
 		for (const info of this._remoteAgentHostService.connections) {
 			const authority = agentHostAuthority(info.address);
 			seen.add(authority);
-			if (this._remoteListeners.has(authority)) {
+			const connection = this._remoteAgentHostService.getConnectionByAuthority(authority);
+			if (!connection) {
 				continue;
 			}
-			const connection = this._remoteAgentHostService.getConnectionByAuthority(authority);
-			if (connection) {
-				this._remoteListeners.set(authority, connection.onDidAction(envelope => this._dispatch(envelope)));
+			// Skip only when already subscribed to this exact connection object.
+			// After a reconnect the object is replaced under the same authority,
+			// so we must re-subscribe to the live one (DisposableMap.set
+			// disposes the previous, now-dead listener).
+			if (this._remoteConnections.get(authority) === connection) {
+				continue;
 			}
+			this._remoteConnections.set(authority, connection);
+			this._remoteListeners.set(authority, connection.onDidAction(envelope => this._dispatch(envelope)));
 		}
 		for (const authority of [...this._remoteListeners.keys()]) {
 			if (!seen.has(authority)) {
 				this._remoteListeners.deleteAndDispose(authority);
+				this._remoteConnections.delete(authority);
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -404,6 +404,21 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			this.renderSessionHealth(DOM.append(this.content, $('.chat-debug-cache-session-health')), report);
 		}
 
+		// When the request-side prompt was not captured (e.g. agent-host /
+		// Copilot CLI sessions, whose log records the model's output but not the
+		// request sent to it), the reported cache-hit numbers are still accurate
+		// but there is nothing to diff. Show the token-based performance only and
+		// skip the divergence analysis — running it against absent data would
+		// fabricate a "stable prefix" / "cache expiration" verdict.
+		const hasSignatureData = !!(a.system || a.tools || a.inputMessages.length || b.system || b.tools || b.inputMessages.length);
+		if (!hasSignatureData) {
+			this.renderTokenOnlySummary(a, b);
+			if (preserveScroll) {
+				this.content.scrollTop = prevScroll;
+			}
+			return;
+		}
+
 		const compareInputMessages = shouldCompareInputMessages(a, b);
 		const diff = compareInputMessages
 			? diffPromptSignature(a.inputMessages, b.inputMessages)
@@ -941,9 +956,6 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		row.appendChild(this.renderSideCard(b, localize('chatDebug.cache.requestTitle', "Request")));
 
 		const hit = computeCacheHit(b.event);
-		const inputTokens = b.event.inputTokens ?? 0;
-		const cachedTokens = b.event.cachedTokens ?? 0;
-		const lostTokens = Math.max(0, inputTokens - cachedTokens);
 
 		// Card border color tracks the worst finding \u2014 green/neutral when the
 		// loss is expected growth, red only for an avoidable break.
@@ -957,20 +969,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		headline.textContent = primary
 			? localize('chatDebug.cache.hitHeadlineVerdict', "{0}% cache hit \u2014 {1}", formatCachePct(hit), primary.title)
 			: localize('chatDebug.cache.hitHeadline', "{0}% cache hit", formatCachePct(hit));
-		const counts = DOM.append(breakCard, $('.chat-debug-cache-card-sub'));
-		counts.textContent = lostTokens > 0 && inputTokens > 0
-			? localize('chatDebug.cache.tokensReusedLost',
-				"{0} of {1} input tokens reused \u00b7 {2} uncached ({3}%)",
-				numberFormatter.value.format(cachedTokens),
-				numberFormatter.value.format(inputTokens),
-				numberFormatter.value.format(lostTokens),
-				formatCachePct((lostTokens / inputTokens) * 100),
-			)
-			: localize('chatDebug.cache.tokensReused',
-				"{0} of {1} input tokens reused",
-				numberFormatter.value.format(cachedTokens),
-				numberFormatter.value.format(inputTokens),
-			);
+		this.appendTokensReusedLine(breakCard, b.event);
 		if (b.requestShape.description) {
 			const shapeLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line.chat-debug-cache-request-shape-note'));
 			shapeLine.textContent = b.requestShape.description;
@@ -1130,6 +1129,50 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			const shapeLine = DOM.append(note, $('.chat-debug-cache-perf-line.chat-debug-cache-request-shape-note'));
 			shapeLine.textContent = b.requestShape.description;
 		}
+	}
+
+	/**
+	 * Render the token-based cache performance for a request pair when the
+	 * request-side prompt signature (system, tools, input messages) was not
+	 * captured for the session — e.g. agent-host (Copilot CLI) sessions, whose
+	 * log records the model's output but not the request sent to it. The reported
+	 * cache-hit numbers are still accurate, but there is nothing to diff, so the
+	 * divergence-based root-cause analysis is deliberately skipped.
+	 */
+	private renderTokenOnlySummary(a: ISideData, b: ISideData): void {
+		const row = DOM.append(this.content, $('.chat-debug-cache-summary'));
+		row.appendChild(this.renderSideCard(a, localize('chatDebug.cache.previousRequest', "Previous request")));
+		row.appendChild(this.renderSideCard(b, localize('chatDebug.cache.requestTitle', "Request")));
+
+		const card = DOM.append(row, $('.chat-debug-cache-card.break'));
+		DOM.append(card, $('.chat-debug-cache-card-h', undefined, localize('chatDebug.cache.performance', "Cache performance")));
+		const headline = DOM.append(card, $('.chat-debug-cache-card-headline'));
+		headline.textContent = localize('chatDebug.cache.hitHeadline', "{0}% cache hit", formatCachePct(computeCacheHit(b.event)));
+		this.appendTokensReusedLine(card, b.event);
+		DOM.append(card, $('.chat-debug-cache-perf-rule'));
+		const note = DOM.append(card, $('.chat-debug-cache-perf-line.chat-debug-cache-request-shape-note'));
+		note.textContent = localize('chatDebug.cache.noSignatureNote', "The request-side prompt (system instructions, tool catalog, and input messages) was not captured for this session, so the prompt-signature diff and root-cause findings are unavailable. The cache-hit numbers above come from reported token usage.");
+	}
+
+	/** Appends the "{cached} of {input} input tokens reused" sub-line for a request. */
+	private appendTokensReusedLine(parent: HTMLElement, event: IChatDebugModelTurnEvent): void {
+		const inputTokens = event.inputTokens ?? 0;
+		const cachedTokens = event.cachedTokens ?? 0;
+		const lostTokens = Math.max(0, inputTokens - cachedTokens);
+		const line = DOM.append(parent, $('.chat-debug-cache-card-sub'));
+		line.textContent = lostTokens > 0 && inputTokens > 0
+			? localize('chatDebug.cache.tokensReusedLost',
+				"{0} of {1} input tokens reused \u00b7 {2} uncached ({3}%)",
+				numberFormatter.value.format(cachedTokens),
+				numberFormatter.value.format(inputTokens),
+				numberFormatter.value.format(lostTokens),
+				formatCachePct((lostTokens / inputTokens) * 100),
+			)
+			: localize('chatDebug.cache.tokensReused',
+				"{0} of {1} input tokens reused",
+				numberFormatter.value.format(cachedTokens),
+				numberFormatter.value.format(inputTokens),
+			);
 	}
 
 	private appendKv(parent: HTMLElement, key: string, value: string, copyable: boolean = false): void {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
@@ -8,9 +8,10 @@ import './media/chatDebug.css';
 import * as DOM from '../../../../../base/browser/dom.js';
 import { Dimension } from '../../../../../base/browser/dom.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
-import { DisposableMap, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { DisposableMap, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { AgentHostAhpJsonlLoggingSettingId } from '../../../../../platform/agentHost/common/agentService.js';
+import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
@@ -21,17 +22,21 @@ import { EditorPane } from '../../../../browser/parts/editor/editorPane.js';
 import { IEditorOpenContext } from '../../../../common/editor.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
+import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
 import { IChatDebugService } from '../../common/chatDebugService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
-import { AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING } from '../../common/promptSyntax/promptTypes.js';
+import { AgentHostAgentDebugLogEnabledSettingId, AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING } from '../../common/promptSyntax/promptTypes.js';
 import { IChatWidgetService } from '../chat.js';
-import { ViewState, IChatDebugEditorOptions } from './chatDebugTypes.js';
+import { ViewState, IChatDebugEditorOptions, CHAT_DEBUG_ACTIVE_SESSION_IS_AGENT_HOST } from './chatDebugTypes.js';
 import { ChatDebugFilterState, registerFilterMenuItems } from './chatDebugFilters.js';
+import { isAgentHostSession } from './agentHostLogSources.js';
+import { isChatDebugLoggingEnabledForSession, isWireLogLoggingEnabled, renderChatDebugLoggingDisabledMessage, renderWireLogLoggingDisabledMessage } from './chatDebugEnablement.js';
 import { ChatDebugHomeView } from './chatDebugHomeView.js';
 import { ChatDebugOverviewView, OverviewNavigation } from './chatDebugOverviewView.js';
 import { ChatDebugLogsView, LogsNavigation } from './chatDebugLogsView.js';
 import { ChatDebugFlowChartView, FlowChartNavigation } from './chatDebugFlowChartView.js';
 import { ChatDebugCacheExplorerView, CacheExplorerNavigation } from './chatDebugCacheExplorerView.js';
+import { ChatDebugWireLogView, WireLogNavigation } from './chatDebugWireLogView.js';
 
 const $ = DOM.$;
 
@@ -64,7 +69,22 @@ export class ChatDebugEditor extends EditorPane {
 	private logsView: ChatDebugLogsView | undefined;
 	private flowChartView: ChatDebugFlowChartView | undefined;
 	private cacheExplorerView: ChatDebugCacheExplorerView | undefined;
+	private wireLogView: ChatDebugWireLogView | undefined;
 	private filterState: ChatDebugFilterState | undefined;
+
+	private _scopedContextKeyService: IContextKeyService | undefined;
+	private _activeSessionIsAgentHostContextKey: IContextKey<boolean> | undefined;
+
+	/**
+	 * Shared overlay shown in place of a session sub-view (Logs, Flow Chart,
+	 * Cache Explorer) when agent debug logging is disabled for the session.
+	 */
+	private disabledOverlay: HTMLElement | undefined;
+	private readonly disabledOverlayDisposables = this._register(new DisposableStore());
+
+	override get scopedContextKeyService(): IContextKeyService | undefined {
+		return this._scopedContextKeyService;
+	}
 
 	private readonly sessionModelListener = this._register(new MutableDisposable());
 	private readonly modelChangeListeners = this._register(new DisposableMap<string>());
@@ -80,6 +100,7 @@ export class ChatDebugEditor extends EditorPane {
 			this.chatDebugService.endSession(sessionResource);
 		}
 		this.chatDebugService.activeSessionResource = undefined;
+		this._activeSessionIsAgentHostContextKey?.set(false);
 	}
 
 	constructor(
@@ -93,6 +114,7 @@ export class ChatDebugEditor extends EditorPane {
 		@IChatService private readonly chatService: IChatService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IPreferencesService private readonly preferencesService: IPreferencesService,
 	) {
 		super(ChatDebugEditor.ID, group, telemetryService, themeService, storageService);
 	}
@@ -103,6 +125,8 @@ export class ChatDebugEditor extends EditorPane {
 		// Shared filter state used by both Logs and FlowChart views
 		this.filterState = this._register(new ChatDebugFilterState());
 		const scopedContextKeyService = this._register(this.contextKeyService.createScoped(this.container));
+		this._scopedContextKeyService = scopedContextKeyService;
+		this._activeSessionIsAgentHostContextKey = CHAT_DEBUG_ACTIVE_SESSION_IS_AGENT_HOST.bindTo(scopedContextKeyService);
 		this._register(registerFilterMenuItems(this.filterState, scopedContextKeyService));
 
 		// Create sub-views via DI
@@ -126,6 +150,9 @@ export class ChatDebugEditor extends EditorPane {
 					break;
 				case OverviewNavigation.CacheExplorer:
 					this.showView(ViewState.CacheExplorer);
+					break;
+				case OverviewNavigation.WireLog:
+					this.showView(ViewState.WireLog);
 					break;
 			}
 		}));
@@ -169,6 +196,19 @@ export class ChatDebugEditor extends EditorPane {
 			}
 		}));
 
+		this.wireLogView = this._register(this.instantiationService.createInstance(ChatDebugWireLogView, this.container));
+		this._register(this.wireLogView.onNavigate(nav => {
+			switch (nav) {
+				case WireLogNavigation.Home:
+					this.endActiveSession();
+					this.showView(ViewState.Home);
+					break;
+				case WireLogNavigation.Overview:
+					this.showView(ViewState.Overview);
+					break;
+			}
+		}));
+
 		// When new debug events arrive, refresh the active session view
 		this._register(this.chatDebugService.onDidAddEvent(event => {
 			if (this.viewState === ViewState.Home) {
@@ -180,6 +220,8 @@ export class ChatDebugEditor extends EditorPane {
 					this.flowChartView?.refresh();
 				} else if (this.viewState === ViewState.CacheExplorer) {
 					this.cacheExplorerView?.refresh();
+				} else if (this.viewState === ViewState.WireLog) {
+					this.wireLogView?.refresh();
 				}
 				// Note: Logs view is intentionally omitted here — it handles
 				// onDidAddEvent internally via loadEvents() → addEvent() →
@@ -202,11 +244,12 @@ export class ChatDebugEditor extends EditorPane {
 				if (e.kind === 'setCustomTitle') {
 					if (this.viewState === ViewState.Home) {
 						this.homeView?.render();
-					} else if (this.viewState === ViewState.Overview || this.viewState === ViewState.Logs || this.viewState === ViewState.FlowChart || this.viewState === ViewState.CacheExplorer) {
+					} else if (this.viewState === ViewState.Overview || this.viewState === ViewState.Logs || this.viewState === ViewState.FlowChart || this.viewState === ViewState.CacheExplorer || this.viewState === ViewState.WireLog) {
 						this.overviewView?.updateBreadcrumb();
 						this.logsView?.updateBreadcrumb();
 						this.flowChartView?.updateBreadcrumb();
 						this.cacheExplorerView?.updateBreadcrumb();
+						this.wireLogView?.updateBreadcrumb();
 					}
 				}
 			}));
@@ -215,6 +258,21 @@ export class ChatDebugEditor extends EditorPane {
 		this._register(this.chatService.onDidDisposeSession(() => {
 			if (this.viewState === ViewState.Home) {
 				this.homeView?.render();
+			}
+		}));
+
+		// Shared overlay shown when agent debug logging is disabled for the
+		// current session. Appended last so it stacks above the sub-views.
+		this.disabledOverlay = DOM.append(this.container, $('.chat-debug-disabled-overlay'));
+		DOM.hide(this.disabledOverlay);
+
+		// Re-evaluate the active view when an enablement setting changes so the
+		// disabled message appears/disappears without needing to re-navigate.
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(AgentHostAgentDebugLogEnabledSettingId)
+				|| e.affectsConfiguration(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING)
+				|| e.affectsConfiguration(AgentHostAhpJsonlLoggingSettingId)) {
+				this.displayView(this.viewState);
 			}
 		}));
 
@@ -232,6 +290,24 @@ export class ChatDebugEditor extends EditorPane {
 			viewState: state,
 		});
 
+		this.displayView(state);
+	}
+
+	private displayView(state: ViewState): void {
+		const session = this.chatDebugService.activeSessionResource;
+
+		// The data sub-views (Logs, Flow Chart, Cache Explorer) are gated on the
+		// agent debug logging setting; the AHP (wire) log is gated on its own
+		// AHP logging setting. When the governing setting is off there is
+		// nothing to show, so we render a shared "enable the setting" overlay
+		// instead of the (empty) view content. The Overview keeps its buttons
+		// and renders the hint inline.
+		const dataViewDisabled = (state === ViewState.Logs || state === ViewState.FlowChart || state === ViewState.CacheExplorer)
+			&& !isChatDebugLoggingEnabledForSession(this.configurationService, session);
+		const wireLogDisabled = state === ViewState.WireLog
+			&& isAgentHostSession(session)
+			&& !isWireLogLoggingEnabled(this.configurationService);
+
 		if (state === ViewState.Home) {
 			this.homeView?.show();
 		} else {
@@ -244,7 +320,7 @@ export class ChatDebugEditor extends EditorPane {
 			this.overviewView?.hide();
 		}
 
-		if (state === ViewState.Logs) {
+		if (state === ViewState.Logs && !dataViewDisabled) {
 			this.logsView?.show();
 			this.doLayout();
 			this.logsView?.focus();
@@ -252,21 +328,46 @@ export class ChatDebugEditor extends EditorPane {
 			this.logsView?.hide();
 		}
 
-		if (state === ViewState.FlowChart) {
+		if (state === ViewState.FlowChart && !dataViewDisabled) {
 			this.flowChartView?.show();
 		} else {
 			this.flowChartView?.hide();
 		}
 
-		if (state === ViewState.CacheExplorer) {
+		if (state === ViewState.CacheExplorer && !dataViewDisabled) {
 			this.cacheExplorerView?.show();
 		} else {
 			this.cacheExplorerView?.hide();
 		}
 
+		if (state === ViewState.WireLog && !wireLogDisabled) {
+			this.wireLogView?.show();
+			this.doLayout();
+		} else {
+			this.wireLogView?.hide();
+		}
+
+		this.updateDisabledOverlay(wireLogDisabled ? 'wirelog' : dataViewDisabled ? 'data' : undefined);
 	}
 
-	navigateToSession(sessionResource: URI, view?: 'logs' | 'overview' | 'flowchart' | 'cache'): void {
+	private updateDisabledOverlay(kind: 'data' | 'wirelog' | undefined): void {
+		if (!this.disabledOverlay) {
+			return;
+		}
+		this.disabledOverlayDisposables.clear();
+		DOM.clearNode(this.disabledOverlay);
+		if (kind === 'wirelog') {
+			renderWireLogLoggingDisabledMessage(this.disabledOverlay, this.preferencesService, this.disabledOverlayDisposables);
+			DOM.show(this.disabledOverlay);
+		} else if (kind === 'data') {
+			renderChatDebugLoggingDisabledMessage(this.disabledOverlay, this.chatDebugService.activeSessionResource, this.preferencesService, this.disabledOverlayDisposables);
+			DOM.show(this.disabledOverlay);
+		} else {
+			DOM.hide(this.disabledOverlay);
+		}
+	}
+
+	navigateToSession(sessionResource: URI, view?: 'logs' | 'overview' | 'flowchart' | 'cache' | 'wirelog'): void {
 		// End the previous session's streaming pipeline before switching
 		const previousSessionResource = this.chatDebugService.activeSessionResource;
 		if (previousSessionResource && previousSessionResource.toString() !== sessionResource.toString()) {
@@ -274,6 +375,7 @@ export class ChatDebugEditor extends EditorPane {
 		}
 
 		this.chatDebugService.activeSessionResource = sessionResource;
+		this._activeSessionIsAgentHostContextKey?.set(isAgentHostSession(sessionResource));
 		if (!this.chatDebugService.hasInvokedProviders(sessionResource)) {
 			this.chatDebugService.invokeProviders(sessionResource);
 		}
@@ -283,11 +385,13 @@ export class ChatDebugEditor extends EditorPane {
 		this.logsView?.setSession(sessionResource);
 		this.flowChartView?.setSession(sessionResource);
 		this.cacheExplorerView?.setSession(sessionResource);
+		this.wireLogView?.setSession(sessionResource);
 
 		const targetState = view === 'logs' ? ViewState.Logs
 			: view === 'flowchart' ? ViewState.FlowChart
 				: view === 'cache' ? ViewState.CacheExplorer
-					: ViewState.Overview;
+					: view === 'wirelog' ? ViewState.WireLog
+						: ViewState.Overview;
 		this.showView(targetState);
 	}
 
@@ -318,6 +422,17 @@ export class ChatDebugEditor extends EditorPane {
 		}
 	}
 
+	override clearInput(): void {
+		// Tear down the active session's streaming pipeline and live file
+		// watcher when the editor input is removed (tab closed or replaced),
+		// so nothing keeps reading the session's events.jsonl in the
+		// background while the panel is not open. Re-opening the editor runs
+		// setInput → _applyNavigationOptions → navigateToSession, which
+		// re-invokes providers and re-arms the watcher.
+		this.endActiveSession();
+		super.clearInput();
+	}
+
 	override async setInput(input: EditorInput, options: IEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
 		await super.setInput(input, options, context, token);
 		if (options) {
@@ -332,12 +447,22 @@ export class ChatDebugEditor extends EditorPane {
 		}
 	}
 
+	/**
+	 * The panel is enabled when either local file logging or agent-host (Copilot
+	 * CLI) debug logging is on. Each provider self-gates on its own setting, so
+	 * this only decides whether to fall back to the home view.
+	 */
+	private _isDebugEnabled(): boolean {
+		return this.configurationService.getValue<boolean>(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING)
+			|| this.configurationService.getValue<boolean>(AgentHostAgentDebugLogEnabledSettingId);
+	}
+
 	protected override setEditorVisible(visible: boolean): void {
 		super.setEditorVisible(visible);
 		if (visible) {
 			this.telemetryService.publicLog2<{}, ChatDebugPanelOpenedClassification>('chatDebugPanelOpened');
-			// If file logging is disabled, always reset to the home view
-			if (!this.configurationService.getValue<boolean>(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING)) {
+			// If debug logging is disabled, always reset to the home view
+			if (!this._isDebugEnabled()) {
 				this.endActiveSession();
 				this.showView(ViewState.Home);
 				return;
@@ -351,8 +476,8 @@ export class ChatDebugEditor extends EditorPane {
 	}
 
 	private _applyNavigationOptions(options: IChatDebugEditorOptions): void {
-		// If file logging is disabled, always show the home view
-		if (!this.configurationService.getValue<boolean>(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING)) {
+		// If debug logging is disabled, always show the home view
+		if (!this._isDebugEnabled()) {
 			this.endActiveSession();
 			this.showView(ViewState.Home);
 			return;
@@ -367,6 +492,8 @@ export class ChatDebugEditor extends EditorPane {
 			this.navigateToSession(sessionResource, 'cache');
 		} else if (viewHint === 'overview' && sessionResource) {
 			this.navigateToSession(sessionResource, 'overview');
+		} else if (viewHint === 'wirelog' && sessionResource) {
+			this.navigateToSession(sessionResource, 'wirelog');
 		} else if (viewHint === 'home') {
 			this.endActiveSession();
 			this.showView(ViewState.Home);
@@ -393,9 +520,13 @@ export class ChatDebugEditor extends EditorPane {
 	}
 
 	private doLayout(): void {
-		if (!this.currentDimension || this.viewState !== ViewState.Logs) {
+		if (!this.currentDimension) {
 			return;
 		}
-		this.logsView?.layout(this.currentDimension);
+		if (this.viewState === ViewState.Logs) {
+			this.logsView?.layout(this.currentDimension);
+		} else if (this.viewState === ViewState.WireLog) {
+			this.wireLogView?.layout();
+		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEnablement.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEnablement.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../../base/browser/dom.js';
+import { Button } from '../../../../../base/browser/ui/button/button.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { AgentHostAhpJsonlLoggingSettingId } from '../../../../../platform/agentHost/common/agentService.js';
+import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
+import { AgentHostAgentDebugLogEnabledSettingId, AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING } from '../../common/promptSyntax/promptTypes.js';
+import { isAgentHostSession } from './agentHostLogSources.js';
+
+const $ = DOM.$;
+
+/**
+ * Returns the debug-log enablement setting that governs a given session.
+ * Agent host (Copilot CLI) sessions are gated by the agent-host setting; all
+ * other sessions use the local file-logging setting.
+ */
+export function getChatDebugLoggingSettingId(sessionResource: URI | undefined): string {
+	return isAgentHostSession(sessionResource)
+		? AgentHostAgentDebugLogEnabledSettingId
+		: AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING;
+}
+
+/**
+ * Whether agent debug logging is enabled for the given session. When this is
+ * `false` no debug data is captured for the session, so the debug views should
+ * surface a hint to enable the setting rather than empty content.
+ */
+export function isChatDebugLoggingEnabledForSession(configurationService: IConfigurationService, sessionResource: URI | undefined): boolean {
+	return configurationService.getValue<boolean>(getChatDebugLoggingSettingId(sessionResource));
+}
+
+/**
+ * Renders an "enable the setting" hint into `container` alongside a button
+ * that opens the given setting. Shared by the debug views to explain why no
+ * data is shown when the governing setting is turned off.
+ */
+function renderEnableSettingMessage(
+	container: HTMLElement,
+	settingId: string,
+	message: string,
+	preferencesService: IPreferencesService,
+	disposables: DisposableStore,
+): void {
+	const wrapper = DOM.append(container, $('.chat-debug-logging-disabled'));
+	DOM.append(wrapper, $('p.chat-debug-logging-disabled-message', undefined, message));
+
+	const enableButton = disposables.add(new Button(wrapper, { ...defaultButtonStyles, secondary: true }));
+	enableButton.element.style.width = 'auto';
+	enableButton.label = localize('chatDebug.openSetting', "Enable in Settings");
+	disposables.add(enableButton.onDidClick(() => {
+		preferencesService.openSettings({ jsonEditor: false, query: settingId });
+	}));
+}
+
+/**
+ * Renders a message into `container` explaining that agent debug logging is
+ * disabled for the session, alongside a button that opens the relevant setting.
+ */
+export function renderChatDebugLoggingDisabledMessage(
+	container: HTMLElement,
+	sessionResource: URI | undefined,
+	preferencesService: IPreferencesService,
+	disposables: DisposableStore,
+): void {
+	renderEnableSettingMessage(
+		container,
+		getChatDebugLoggingSettingId(sessionResource),
+		localize('chatDebug.loggingDisabled', "Agent debug logging is turned off. Enable it to capture and view debug logs for this session."),
+		preferencesService,
+		disposables,
+	);
+}
+
+/**
+ * Whether AHP (client↔host protocol) logging is enabled. When `false` no
+ * protocol frames are captured, so the AHP Log view surfaces a hint to enable
+ * the setting instead of empty content.
+ */
+export function isWireLogLoggingEnabled(configurationService: IConfigurationService): boolean {
+	return configurationService.getValue<boolean>(AgentHostAhpJsonlLoggingSettingId);
+}
+
+/**
+ * Renders a message into `container` explaining that AHP logging is disabled,
+ * alongside a button that opens the relevant setting.
+ */
+export function renderWireLogLoggingDisabledMessage(
+	container: HTMLElement,
+	preferencesService: IPreferencesService,
+	disposables: DisposableStore,
+): void {
+	renderEnableSettingMessage(
+		container,
+		AgentHostAhpJsonlLoggingSettingId,
+		localize('chatDebug.wireLogLoggingDisabled', "AHP logging is turned off. Enable it and reproduce the issue to capture and view client↔host protocol frames for this session."),
+		preferencesService,
+		disposables,
+	);
+}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowGraph.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowGraph.ts
@@ -194,6 +194,18 @@ export function buildFlowGraph(events: readonly IChatDebugEvent[]): FlowNode[] {
 		}
 	}
 
+	// Order siblings chronologically so the flow reads in causal order. Events
+	// may arrive out of order — most notably Agent Host customization/discovery
+	// events, which are surfaced with a session-start timestamp but appended
+	// after the turns — so without this they would render as the last branch off
+	// the session-start root instead of at the beginning where they belong. The
+	// sort is stable, so events sharing a timestamp keep their emitted order.
+	const byCreated = (a: IChatDebugEvent, b: IChatDebugEvent): number => a.created.getTime() - b.created.getTime();
+	roots.sort(byCreated);
+	for (const children of idToChildren.values()) {
+		children.sort(byCreated);
+	}
+
 	function toFlowNode(event: IChatDebugEvent): FlowNode {
 		const children = event.id ? idToChildren.get(event.id) : undefined;
 

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
@@ -16,7 +16,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { IChatDebugService } from '../../common/chatDebugService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
-import { AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING } from '../../common/promptSyntax/promptTypes.js';
+import { AgentHostAgentDebugLogEnabledSettingId, AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING } from '../../common/promptSyntax/promptTypes.js';
 import { getChatSessionType, isUntitledChatSession, LocalChatSessionUri } from '../../common/model/chatUri.js';
 import { IChatWidgetService } from '../chat.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
@@ -58,7 +58,7 @@ export class ChatDebugHomeView extends Disposable {
 		this.scrollContent = DOM.append(this.container, $('div.chat-debug-home-content'));
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING)) {
+			if (e.affectsConfiguration(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING) || e.affectsConfiguration(AgentHostAgentDebugLogEnabledSettingId)) {
 				this.render();
 			}
 		}));
@@ -92,13 +92,23 @@ export class ChatDebugHomeView extends Disposable {
 	}
 
 	render(): void {
-		const isFileLoggingEnabled = this.configurationService.getValue<boolean>(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING);
+		const isEnabled = this._isDebugEnabled();
 		this._lastKnownSessionCount = this.chatDebugService.getSessionResources().length;
 
-		const sessionResources = isFileLoggingEnabled
+		const sessionResources = isEnabled
 			? this._getFilteredSessionResources(this.chatDebugService.getAvailableSessionResources())
 			: [];
 		this._renderWithSessions(sessionResources);
+	}
+
+	/**
+	 * The panel is enabled when either local file logging or agent-host (Copilot
+	 * CLI) debug logging is on; each provider self-gates on its own setting, so
+	 * the aggregated session list only contains the sources that are enabled.
+	 */
+	private _isDebugEnabled(): boolean {
+		return this.configurationService.getValue<boolean>(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING)
+			|| this.configurationService.getValue<boolean>(AgentHostAgentDebugLogEnabledSettingId);
 	}
 
 	private _getFilteredSessionResources(resources: readonly URI[]): URI[] {
@@ -113,7 +123,7 @@ export class ChatDebugHomeView extends Disposable {
 
 		DOM.append(this.scrollContent, $('h2.chat-debug-home-title', undefined, localize('chatDebug.title', "Agent Debug Logs")));
 
-		const isEnabled = this.configurationService.getValue<boolean>(AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING);
+		const isEnabled = this._isDebugEnabled();
 		if (!isEnabled) {
 			DOM.append(this.scrollContent, $('p.chat-debug-home-subtitle', undefined,
 				localize('chatDebug.disabled', "Enable to view debug logs and investigate chat issues with /troubleshoot.")
@@ -123,7 +133,7 @@ export class ChatDebugHomeView extends Disposable {
 			enableButton.element.style.width = 'auto';
 			enableButton.label = localize('chatDebug.openSetting', "Enable in Settings");
 			this.renderDisposables.add(enableButton.onDidClick(() => {
-				this.preferencesService.openSettings({ jsonEditor: false, query: `@id:${AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING}` });
+				this.preferencesService.openSettings({ jsonEditor: false, query: 'github.copilot.chat.agentDebugLog' });
 			}));
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
@@ -133,7 +133,7 @@ export class ChatDebugHomeView extends Disposable {
 			enableButton.element.style.width = 'auto';
 			enableButton.label = localize('chatDebug.openSetting', "Enable in Settings");
 			this.renderDisposables.add(enableButton.onDidClick(() => {
-				this.preferencesService.openSettings({ jsonEditor: false, query: 'github.copilot.chat.agentDebugLog' });
+				this.preferencesService.openSettings({ jsonEditor: false, query: 'agentDebugLog' });
 			}));
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
@@ -482,7 +482,14 @@ export class ChatDebugLogsView extends Disposable {
 			if (!this.currentSessionResource || sessionResource.toString() === this.currentSessionResource.toString()) {
 				this.events = [...this.chatDebugService.getEvents(this.currentSessionResource || undefined)];
 				this.filterDirty = true;
-				this.refreshList();
+				// Coalesce with the re-added events that follow in the same
+				// invokeProviders() pass instead of refreshing synchronously:
+				// a synchronous refresh here would momentarily collapse the
+				// list to the (near-empty) core-only set before the provider
+				// events are re-added, causing a visible flicker. Deferring
+				// lets the debounced refresh rebuild the list once with the
+				// full set.
+				this.scheduleRefresh();
 			}
 		});
 

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView.ts
@@ -13,6 +13,7 @@ import { Disposable, DisposableStore } from '../../../../../base/common/lifecycl
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { defaultBreadcrumbsWidgetStyles, defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { ChatDebugLogLevel, IChatDebugEvent, IChatDebugService } from '../../common/chatDebugService.js';
 import { safeIntl } from '../../../../../base/common/date.js';
@@ -21,6 +22,9 @@ import { ChatAgentLocation } from '../../common/constants.js';
 import { IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
 import { getChatSessionType, LocalChatSessionUri } from '../../common/model/chatUri.js';
 import { IChatWidgetService } from '../chat.js';
+import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
+import { isAgentHostSession } from './agentHostLogSources.js';
+import { isChatDebugLoggingEnabledForSession, renderChatDebugLoggingDisabledMessage } from './chatDebugEnablement.js';
 import { setupBreadcrumbKeyboardNavigation, TextBreadcrumbItem } from './chatDebugTypes.js';
 
 const $ = DOM.$;
@@ -33,6 +37,7 @@ export const enum OverviewNavigation {
 	Logs = 'logs',
 	FlowChart = 'flowchart',
 	CacheExplorer = 'cache',
+	WireLog = 'wirelog',
 }
 
 export class ChatDebugOverviewView extends Disposable {
@@ -56,6 +61,8 @@ export class ChatDebugOverviewView extends Disposable {
 		@IChatDebugService private readonly chatDebugService: IChatDebugService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IPreferencesService private readonly preferencesService: IPreferencesService,
 	) {
 		super();
 		this.container = DOM.append(parent, $('.chat-debug-overview'));
@@ -224,15 +231,24 @@ export class ChatDebugOverviewView extends Disposable {
 	}
 
 	private renderDerivedOverview(events: readonly IChatDebugEvent[], showShimmer: boolean): void {
-		const metricsSection = DOM.append(this.content, $('.chat-debug-overview-section'));
-		DOM.append(metricsSection, $('h3.chat-debug-overview-section-label', undefined, localize('chatDebug.summary', "Summary")));
-
-		this.metricsContainer = DOM.append(metricsSection, $('.chat-debug-overview-metrics'));
-
-		if (showShimmer) {
-			this.renderMetricsShimmer(this.metricsContainer);
+		// When agent debug logging is disabled for this session, no metrics are
+		// captured. Surface a hint to enable the setting instead of an empty
+		// summary, while still keeping the navigation buttons below.
+		if (!isChatDebugLoggingEnabledForSession(this.configurationService, this.currentSessionResource)) {
+			this.metricsContainer = undefined;
+			const disabledSection = DOM.append(this.content, $('.chat-debug-overview-section'));
+			renderChatDebugLoggingDisabledMessage(disabledSection, this.currentSessionResource, this.preferencesService, this.loadDisposables);
 		} else {
-			this.renderMetricsContent(this.metricsContainer, events);
+			const metricsSection = DOM.append(this.content, $('.chat-debug-overview-section'));
+			DOM.append(metricsSection, $('h3.chat-debug-overview-section-label', undefined, localize('chatDebug.summary', "Summary")));
+
+			this.metricsContainer = DOM.append(metricsSection, $('.chat-debug-overview-metrics'));
+
+			if (showShimmer) {
+				this.renderMetricsShimmer(this.metricsContainer);
+			} else {
+				this.renderMetricsContent(this.metricsContainer, events);
+			}
 		}
 
 		// Explore actions
@@ -261,6 +277,16 @@ export class ChatDebugOverviewView extends Disposable {
 		this.loadDisposables.add(cacheBtn.onDidClick(() => {
 			this._onNavigate.fire(OverviewNavigation.CacheExplorer);
 		}));
+
+		// The AHP log is only meaningful for Agent Host sessions.
+		if (isAgentHostSession(this.currentSessionResource)) {
+			const wireLogBtn = this.loadDisposables.add(new Button(row, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: localize('chatDebug.ahpLog', "AHP Log") }));
+			wireLogBtn.element.classList.add('chat-debug-overview-action-button');
+			wireLogBtn.label = `$(arrow-swap) ${localize('chatDebug.ahpLog', "AHP Log")}`;
+			this.loadDisposables.add(wireLogBtn.onDidClick(() => {
+				this._onNavigate.fire(OverviewNavigation.WireLog);
+			}));
+		}
 
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugTypes.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugTypes.ts
@@ -18,7 +18,7 @@ const $ = DOM.$;
  */
 export interface IChatDebugEditorOptions extends IEditorOptions {
 	readonly sessionResource?: URI;
-	readonly viewHint?: 'home' | 'overview' | 'logs' | 'flowchart' | 'cache';
+	readonly viewHint?: 'home' | 'overview' | 'logs' | 'flowchart' | 'cache' | 'wirelog';
 	/** When set, automatically applies this text as the log filter. */
 	readonly filter?: string;
 }
@@ -29,6 +29,7 @@ export const enum ViewState {
 	Logs = 'logs',
 	FlowChart = 'flowchart',
 	CacheExplorer = 'cache',
+	WireLog = 'wirelog',
 }
 
 export const enum LogsViewMode {
@@ -37,6 +38,7 @@ export const enum LogsViewMode {
 }
 
 export const CHAT_DEBUG_FILTER_ACTIVE = new RawContextKey<boolean>('chatDebugFilterActive', false);
+export const CHAT_DEBUG_ACTIVE_SESSION_IS_AGENT_HOST = new RawContextKey<boolean>('chatDebug.activeSessionIsAgentHost', false);
 export const CHAT_DEBUG_KIND_TOOL_CALL = new RawContextKey<boolean>('chatDebug.kindToolCall', true);
 export const CHAT_DEBUG_KIND_MODEL_TURN = new RawContextKey<boolean>('chatDebug.kindModelTurn', true);
 export const CHAT_DEBUG_KIND_PROMPT_DISCOVERY = new RawContextKey<boolean>('chatDebug.kindPromptDiscovery', true);

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugWireLogView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugWireLogView.ts
@@ -497,6 +497,10 @@ export class ChatDebugWireLogView extends Disposable {
 	}
 
 	private renderList(): void {
+		// Dispose the previous rows' stores (click listeners etc.) before
+		// clearing and rebuilding; otherwise they accumulate on every filter
+		// change, "Load more", or full live refresh.
+		this.contentDisposables.clear();
 		DOM.clearNode(this.list);
 		this.rowElements = [];
 		this.rowStores = [];
@@ -693,9 +697,15 @@ export class ChatDebugWireLogView extends Disposable {
 		}
 
 		const header = DOM.append(row, $('.chat-debug-wirelog-row-header'));
+		// Accessibility: the header is an expand/collapse toggle. Make it
+		// keyboard-focusable, expose button semantics + expanded state, and
+		// hide the purely-decorative chevron from assistive technology.
+		header.tabIndex = 0;
+		header.setAttribute('role', 'button');
 
 		// Expansion chevron.
 		const chevron = DOM.append(header, $(`span.chat-debug-wirelog-chevron${ThemeIcon.asCSSSelector(Codicon.chevronRight)}`));
+		chevron.setAttribute('aria-hidden', 'true');
 
 		// Direction indicator.
 		const outbound = frame.dir === 'c2s';
@@ -760,6 +770,7 @@ export class ChatDebugWireLogView extends Disposable {
 			row.classList.toggle('chat-debug-wirelog-row-expanded', expanded);
 			chevron.classList.toggle('codicon-chevron-down', expanded);
 			chevron.classList.toggle('codicon-chevron-right', !expanded);
+			header.setAttribute('aria-expanded', String(expanded));
 			if (scan) {
 				this.scrollable.scanDomNode();
 			}
@@ -770,6 +781,12 @@ export class ChatDebugWireLogView extends Disposable {
 		setExpanded(isError, false);
 
 		store.add(DOM.addDisposableListener(header, DOM.EventType.CLICK, () => setExpanded(!expanded, true)));
+		store.add(DOM.addDisposableListener(header, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				setExpanded(!expanded, true);
+			}
+		}));
 		return { row, store };
 	}
 
@@ -927,23 +944,33 @@ function parseWireFrames(text: string): IWireFrame[] {
  * Folds response frames into the request they answer (matched by id in
  * chronological order), leaving notifications and unmatched frames as
  * standalone entries.
+ *
+ * AHP is bidirectional: both client and host can originate requests, and their
+ * id namespaces are independent. A response therefore answers a request from
+ * the opposite direction (a c2s request is answered by an s2c response and vice
+ * versa), so pending requests are keyed by direction + id to avoid pairing a
+ * response with a same-id request from the other direction.
  */
 function buildWireEntries(frames: IWireFrame[]): IWireEntry[] {
 	const entries: IWireEntry[] = [];
-	const pendingById = new Map<string, IWireEntry>();
+	const pendingByKey = new Map<string, IWireEntry>();
+	const pendingKey = (dir: WireLogDirection, id: string) => `${dir}|${id}`;
 	for (const frame of frames) {
 		if (frame.kind === 'response' && frame.id !== undefined) {
-			const request = pendingById.get(frame.id);
+			// A response answers a request travelling in the opposite direction.
+			const requestDir: WireLogDirection = frame.dir === 'c2s' ? 's2c' : 'c2s';
+			const key = pendingKey(requestDir, frame.id);
+			const request = pendingByKey.get(key);
 			if (request) {
 				request.response = frame;
-				pendingById.delete(frame.id);
+				pendingByKey.delete(key);
 				continue;
 			}
 		}
 		const entry: IWireEntry = { frame, response: undefined };
 		entries.push(entry);
 		if (frame.kind === 'request' && frame.id !== undefined) {
-			pendingById.set(frame.id, entry);
+			pendingByKey.set(pendingKey(frame.dir, frame.id), entry);
 		}
 	}
 	return entries;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugWireLogView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugWireLogView.ts
@@ -1,0 +1,1030 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../../base/browser/dom.js';
+import { DomScrollableElement } from '../../../../../base/browser/ui/scrollbar/scrollableElement.js';
+import { BreadcrumbsWidget } from '../../../../../base/browser/ui/breadcrumbs/breadcrumbsWidget.js';
+import { Button } from '../../../../../base/browser/ui/button/button.js';
+import { SelectBox, ISelectOptionItem } from '../../../../../base/browser/ui/selectBox/selectBox.js';
+import { RunOnceScheduler } from '../../../../../base/common/async.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { URI, UriComponents } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { ScrollbarVisibility } from '../../../../../base/common/scrollable.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { IContextViewService } from '../../../../../platform/contextview/browser/contextView.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { defaultBreadcrumbsWidgetStyles, defaultButtonStyles, defaultSelectBoxStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
+import { AgentHostAhpJsonlLoggingSettingId, IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { ActionType } from '../../../../../platform/agentHost/common/state/sessionActions.js';
+import { IRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IOutputService } from '../../../../services/output/common/output.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
+import { IChatService } from '../../common/chatService/chatService.js';
+import { LocalChatSessionUri } from '../../common/model/chatUri.js';
+import { AgentHostLogSourceKind, enumerateAgentHostLogSources, IAgentHostLogSource, IAgentHostLogSourceServices, isAgentHostSession, readAgentHostLogSourceContent } from './agentHostLogSources.js';
+import { setupBreadcrumbKeyboardNavigation, TextBreadcrumbItem } from './chatDebugTypes.js';
+
+const $ = DOM.$;
+
+/** Debounce for live re-reads of the currently-shown wire log. */
+const LIVE_REFRESH_DELAY = 400;
+
+/** Debounce for re-rendering the list as the user types in the filter box. */
+const FILTER_DEBOUNCE_DELAY = 150;
+
+/** Number of frames rendered per page; grows via the "Load more" button. */
+const PAGE_SIZE = 1000;
+
+/** Cap the pretty-printed JSON shown per frame to keep the DOM light. */
+const MAX_DETAIL_JSON = 20000;
+
+/**
+ * Navigation events fired by the Wire Log breadcrumb.
+ */
+export const enum WireLogNavigation {
+	Home = 'home',
+	Overview = 'overview',
+}
+
+type WireLogDirection = 'c2s' | 's2c';
+
+/**
+ * A single parsed JSON-RPC frame from the AHP wire log, together with its
+ * `_ahpLog` transport metadata.
+ */
+interface IWireFrame {
+	readonly ts: number;
+	readonly dir: WireLogDirection;
+	readonly truncated: boolean;
+	readonly byteLength: number | undefined;
+	readonly id: string | undefined;
+	readonly method: string | undefined;
+	/**
+	 * A short identifying label surfaced inline in the row: the dispatched
+	 * action's `type` (for `action` / `dispatchAction` / `notification` frames)
+	 * or the target session (for `createSession` frames).
+	 */
+	readonly actionType: string | undefined;
+	readonly payload: unknown;
+	readonly error: { readonly code?: number; readonly message?: string; readonly data?: unknown } | undefined;
+	readonly kind: 'request' | 'notification' | 'response';
+}
+
+/**
+ * A request (or notification) frame, paired with its matching response frame
+ * when one is present in the loaded window.
+ */
+interface IWireEntry {
+	readonly frame: IWireFrame;
+	response: IWireFrame | undefined;
+}
+
+/**
+ * AHP Log view — a user-friendly rendering of the client↔host AHP JSON-RPC
+ * protocol frames. Instead of raw JSONL, it pairs requests with their
+ * responses, surfaces direction, latency, errors and unanswered ("pending")
+ * calls, and lets each frame's payload be expanded. Backed by the raw AHP log
+ * file; full fidelity is a click away via "Open Full File".
+ */
+export class ChatDebugWireLogView extends Disposable {
+
+	private readonly _onNavigate = this._register(new Emitter<WireLogNavigation>());
+	readonly onNavigate = this._onNavigate.event;
+
+	readonly container: HTMLElement;
+	private readonly breadcrumbWidget: BreadcrumbsWidget;
+	private readonly hintBar: HTMLElement;
+	private readonly toolbar: HTMLElement;
+	private readonly selectHost: HTMLElement;
+	private readonly filterInput: HTMLInputElement;
+	private readonly summary: HTMLElement;
+	private readonly body: HTMLElement;
+	private readonly list: HTMLElement;
+	private readonly footer: HTMLElement;
+	private readonly scrollable: DomScrollableElement;
+
+	private readonly headerDisposables = this._register(new DisposableStore());
+	private readonly contentDisposables = this._register(new DisposableStore());
+	/** Watches the currently-shown wire log for live updates. */
+	private readonly liveWatch = this._register(new MutableDisposable<DisposableStore>());
+	private readonly refreshScheduler: RunOnceScheduler;
+	/** Debounces list re-renders while the user types in the filter box. */
+	private readonly filterScheduler: RunOnceScheduler;
+
+	private selectBox: SelectBox | undefined;
+	private currentSessionResource: URI | undefined;
+	private sources: IAgentHostLogSource[] = [];
+	private selectedSourceId: string | undefined;
+	private currentFileResource: URI | undefined;
+	private entries: IWireEntry[] = [];
+	/** The filtered entries currently rendered in the list, in order. */
+	private renderedVisible: IWireEntry[] = [];
+	/** Row DOM nodes parallel to {@link renderedVisible}. */
+	private rowElements: HTMLElement[] = [];
+	/** Per-row disposables parallel to {@link renderedVisible}. */
+	private rowStores: DisposableStore[] = [];
+	/** True while the list is showing a status message instead of rows. */
+	private listShowingMessage = false;
+	private filterText = '';
+	/** Monotonic token guarding against out-of-order async loads. */
+	private loadGeneration = 0;
+	/** Max number of (filtered) frames rendered at once; grows via "Load more". */
+	private visibleLimit = PAGE_SIZE;
+	private readonly loadMoreContainer: HTMLElement;
+	private readonly loadMoreDisposables = this._register(new DisposableStore());
+	private loadMoreBtn: Button | undefined;
+	private loadMoreStatus: HTMLElement | undefined;
+	private loadMoreVisible = false;
+
+	constructor(
+		parent: HTMLElement,
+		@IChatService private readonly chatService: IChatService,
+		@IContextViewService private readonly contextViewService: IContextViewService,
+		@IEditorService private readonly editorService: IEditorService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IPathService private readonly pathService: IPathService,
+		@IAgentHostService private readonly agentHostService: IAgentHostService,
+		@IRemoteAgentHostService private readonly remoteAgentHostService: IRemoteAgentHostService,
+		@IOutputService private readonly outputService: IOutputService,
+		@IFileService private readonly fileService: IFileService,
+		@ITextModelService private readonly textModelService: ITextModelService,
+		@IEnvironmentService private readonly environmentService: IEnvironmentService,
+		@IProductService private readonly productService: IProductService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+		this.container = DOM.append(parent, $('.chat-debug-wirelog'));
+		DOM.hide(this.container);
+
+		this.refreshScheduler = this._register(new RunOnceScheduler(() => this.liveRefresh(), LIVE_REFRESH_DELAY));
+		this.filterScheduler = this._register(new RunOnceScheduler(() => this.applyFilter(), FILTER_DEBOUNCE_DELAY));
+
+		// Breadcrumb
+		const breadcrumbContainer = DOM.append(this.container, $('.chat-debug-breadcrumb'));
+		this.breadcrumbWidget = this._register(new BreadcrumbsWidget(breadcrumbContainer, 3, undefined, Codicon.chevronRight, defaultBreadcrumbsWidgetStyles));
+		this._register(setupBreadcrumbKeyboardNavigation(breadcrumbContainer, this.breadcrumbWidget));
+		this._register(this.breadcrumbWidget.onDidSelectItem(e => {
+			if (e.type === 'select' && e.item instanceof TextBreadcrumbItem) {
+				this.breadcrumbWidget.setSelection(undefined);
+				const idx = this.breadcrumbWidget.getItems().indexOf(e.item);
+				if (idx === 0) {
+					this._onNavigate.fire(WireLogNavigation.Home);
+				} else if (idx === 1) {
+					this._onNavigate.fire(WireLogNavigation.Overview);
+				}
+			}
+		}));
+
+		// Hint shown when wire logging is disabled.
+		this.hintBar = DOM.append(this.container, $('.chat-debug-wirelog-hint'));
+		DOM.hide(this.hintBar);
+
+		// Toolbar: source picker + filter + actions.
+		this.toolbar = DOM.append(this.container, $('.chat-debug-wirelog-toolbar'));
+		this.selectHost = DOM.append(this.toolbar, $('.chat-debug-wirelog-select'));
+		this.filterInput = DOM.append(this.toolbar, $('input.chat-debug-wirelog-filter')) as HTMLInputElement;
+		this.filterInput.type = 'text';
+		this.filterInput.placeholder = localize('chatDebug.wireLog.filterPlaceholder', "Filter by method, type, or id");
+		this.filterInput.setAttribute('aria-label', localize('chatDebug.wireLog.filterAria', "Filter AHP log frames"));
+		this._register(DOM.addDisposableListener(this.filterInput, DOM.EventType.INPUT, () => {
+			// Debounce so each keystroke does not trigger a full synchronous
+			// rebuild of the list, which keeps typing responsive.
+			this.filterScheduler.schedule();
+		}));
+
+		// Summary chips.
+		this.summary = DOM.append(this.container, $('.chat-debug-wirelog-summary'));
+		DOM.hide(this.summary);
+
+		// Body: scrollable list of frames.
+		this.body = DOM.append(this.container, $('.chat-debug-wirelog-body'));
+		this.list = $('.chat-debug-wirelog-list');
+		this.scrollable = this._register(new DomScrollableElement(this.list, {
+			horizontal: ScrollbarVisibility.Auto,
+			vertical: ScrollbarVisibility.Auto,
+		}));
+		DOM.append(this.body, this.scrollable.getDomNode());
+
+		// "Load more" affordance shown when frames are paginated.
+		this.loadMoreContainer = DOM.append(this.container, $('.chat-debug-wirelog-loadmore'));
+		DOM.hide(this.loadMoreContainer);
+
+		this.footer = DOM.append(this.container, $('.chat-debug-wirelog-footer'));
+	}
+
+	setSession(sessionResource: URI): void {
+		this.currentSessionResource = sessionResource;
+		this.selectedSourceId = undefined;
+		this.visibleLimit = PAGE_SIZE;
+	}
+
+	show(): void {
+		DOM.show(this.container);
+		this.load();
+	}
+
+	hide(): void {
+		DOM.hide(this.container);
+		this.refreshScheduler.cancel();
+		this.filterScheduler.cancel();
+		this.liveWatch.clear();
+	}
+
+	refresh(): void {
+		if (this.container.style.display !== 'none' && !this.refreshScheduler.isScheduled()) {
+			this.refreshScheduler.schedule();
+		}
+	}
+
+	updateBreadcrumb(): void {
+		if (!this.currentSessionResource) {
+			return;
+		}
+		const sessionTitle = this.chatService.getSessionTitle(this.currentSessionResource) || LocalChatSessionUri.parseLocalSessionId(this.currentSessionResource) || this.currentSessionResource.toString();
+		this.breadcrumbWidget.setItems([
+			new TextBreadcrumbItem(localize('chatDebug.title', "Agent Debug Logs"), true),
+			new TextBreadcrumbItem(sessionTitle, true),
+			new TextBreadcrumbItem(localize('chatDebug.ahpLog', "AHP Log")),
+		]);
+	}
+
+	focus(): void {
+		this.selectBox?.focus();
+	}
+
+	layout(): void {
+		// Give the scrollable content an explicit height so the list can
+		// overflow (and thus scroll) instead of growing the whole view. The
+		// body is the flex-sized region between the toolbar/summary and the
+		// footer.
+		const height = this.body.clientHeight;
+		if (height > 0) {
+			this.list.style.height = `${height}px`;
+		}
+		this.scrollable.scanDomNode();
+	}
+
+	private get logSourceServices(): IAgentHostLogSourceServices {
+		return {
+			pathService: this.pathService,
+			agentHostService: this.agentHostService,
+			remoteAgentHostService: this.remoteAgentHostService,
+			outputService: this.outputService,
+			fileService: this.fileService,
+			textModelService: this.textModelService,
+			configurationService: this.configurationService,
+			environmentService: this.environmentService,
+			productService: this.productService,
+			logService: this.logService,
+		};
+	}
+
+	private async load(): Promise<void> {
+		this.updateBreadcrumb();
+		this.headerDisposables.clear();
+		this.liveWatch.clear();
+		DOM.clearNode(this.selectHost);
+		this.selectBox = undefined;
+
+		const wireLoggingEnabled = this.configurationService.getValue<boolean>(AgentHostAhpJsonlLoggingSettingId);
+		DOM.clearNode(this.hintBar);
+		if (!wireLoggingEnabled) {
+			DOM.show(this.hintBar);
+			DOM.append(this.hintBar, $(`span${ThemeIcon.asCSSSelector(Codicon.info)}`));
+			DOM.append(this.hintBar, $('span', undefined, localize('chatDebug.wireLog.disabledHint', "AHP logging is disabled — enable {0} and reproduce to capture client↔host protocol frames.", AgentHostAhpJsonlLoggingSettingId)));
+		} else {
+			DOM.hide(this.hintBar);
+		}
+
+		if (!isAgentHostSession(this.currentSessionResource)) {
+			this.renderMessage(localize('chatDebug.wireLog.notAgentHost', "The AHP Log is available for Agent Host sessions."));
+			return;
+		}
+
+		const allSources = await enumerateAgentHostLogSources(this.logSourceServices, this.currentSessionResource);
+		this.sources = allSources.filter(source => source.kind === AgentHostLogSourceKind.WireLog);
+		if (this.sources.length === 0) {
+			this.renderMessage(wireLoggingEnabled
+				? localize('chatDebug.wireLog.noFrames', "No AHP log was found yet for this session. Interact with the agent to capture protocol frames.")
+				: localize('chatDebug.wireLog.enableToCapture', "No AHP log is available. Enable {0} and reproduce the issue to capture protocol frames.", AgentHostAhpJsonlLoggingSettingId));
+			return;
+		}
+
+		// Source picker (only when more than one rotated wire log exists).
+		if (this.sources.length > 1) {
+			DOM.show(this.selectHost);
+			const options: ISelectOptionItem[] = this.sources.map(source => ({ text: source.label }));
+			let selectedIndex = this.sources.findIndex(source => source.id === this.selectedSourceId);
+			if (selectedIndex < 0) {
+				selectedIndex = 0;
+			}
+			const selectBox = this.headerDisposables.add(new SelectBox(options, selectedIndex, this.contextViewService, defaultSelectBoxStyles, {
+				ariaLabel: localize('chatDebug.wireLog.sourceLabel', "AHP log file"),
+			}));
+			selectBox.render(this.selectHost);
+			this.headerDisposables.add(selectBox.onDidSelect(e => this.loadSource(e.index)));
+			this.selectBox = selectBox;
+		} else {
+			DOM.hide(this.selectHost);
+		}
+
+		// Actions.
+		const openBtn = this.headerDisposables.add(new Button(this.toolbar, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: localize('chatDebug.wireLog.openFile', "Open Full File") }));
+		openBtn.element.classList.add('chat-debug-wirelog-action');
+		openBtn.label = `$(go-to-file) ${localize('chatDebug.wireLog.openFile', "Open Full File")}`;
+		this.headerDisposables.add(openBtn.onDidClick(() => this.openCurrentFile()));
+
+		const refreshBtn = this.headerDisposables.add(new Button(this.toolbar, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: localize('chatDebug.wireLog.refresh', "Refresh") }));
+		refreshBtn.element.classList.add('chat-debug-wirelog-action');
+		refreshBtn.label = `$(refresh) ${localize('chatDebug.wireLog.refresh', "Refresh")}`;
+		this.headerDisposables.add(refreshBtn.onDidClick(() => this.reloadCurrentSource()));
+
+		let selectedIndex = this.sources.findIndex(source => source.id === this.selectedSourceId);
+		if (selectedIndex < 0) {
+			selectedIndex = 0;
+		}
+		await this.loadSource(selectedIndex);
+	}
+
+	private async loadSource(index: number): Promise<void> {
+		const source = this.sources[index];
+		if (!source) {
+			return;
+		}
+		this.selectedSourceId = source.id;
+		this.liveWatch.clear();
+		this.currentFileResource = undefined;
+		this.visibleLimit = PAGE_SIZE;
+
+		const generation = ++this.loadGeneration;
+		this.renderMessage(localize('chatDebug.wireLog.loading', "Loading…"));
+
+		let content;
+		try {
+			content = await readAgentHostLogSourceContent(source, this.logSourceServices);
+		} catch (error) {
+			if (generation !== this.loadGeneration) {
+				return;
+			}
+			this.renderMessage(localize('chatDebug.wireLog.error', "Failed to read AHP log: {0}", error instanceof Error ? error.message : String(error)));
+			return;
+		}
+		if (generation !== this.loadGeneration) {
+			return;
+		}
+
+		if (!content) {
+			this.renderMessage(localize('chatDebug.wireLog.unavailable', "This AHP log is unavailable."));
+			return;
+		}
+
+		this.currentFileResource = content.fileResource;
+		this.entries = buildWireEntries(parseWireFrames(content.text));
+		this.renderList();
+		this.renderFooter(source, content.truncated);
+		this.setupLiveWatch(source);
+	}
+
+	private reloadCurrentSource(): void {
+		const index = this.sources.findIndex(source => source.id === this.selectedSourceId);
+		if (index >= 0) {
+			this.loadSource(index);
+		}
+	}
+
+	private setupLiveWatch(source: IAgentHostLogSource): void {
+		const store = new DisposableStore();
+		if (source.resource?.scheme === Schemas.file) {
+			const watcher = store.add(this.fileService.createWatcher(source.resource, { recursive: false, excludes: [] }));
+			store.add(watcher.onDidChange(() => this.refresh()));
+		}
+		this.liveWatch.value = store;
+	}
+
+	private openCurrentFile(): void {
+		if (this.currentFileResource) {
+			this.editorService.openEditor({ resource: this.currentFileResource, options: { pinned: true } });
+		}
+	}
+
+	private renderMessage(message: string): void {
+		this.contentDisposables.clear();
+		this.rowElements = [];
+		this.rowStores = [];
+		this.renderedVisible = [];
+		this.listShowingMessage = true;
+		DOM.hide(this.summary);
+		DOM.clearNode(this.list);
+		this.list.classList.add('chat-debug-wirelog-message');
+		this.list.textContent = message;
+		this.scrollable.scanDomNode();
+		DOM.clearNode(this.footer);
+		if (this.loadMoreVisible) {
+			DOM.hide(this.loadMoreContainer);
+			this.loadMoreVisible = false;
+		}
+	}
+
+	private renderSummary(): void {
+		DOM.clearNode(this.summary);
+		let requests = 0;
+		let errors = 0;
+		let pending = 0;
+		let longest = 0;
+		for (const entry of this.entries) {
+			if (entry.frame.kind === 'request') {
+				requests++;
+				if (!entry.response) {
+					pending++;
+				} else {
+					const duration = entry.response.ts - entry.frame.ts;
+					if (duration > longest) {
+						longest = duration;
+					}
+				}
+			}
+			if (isErrorEntry(entry)) {
+				errors++;
+			}
+		}
+
+		DOM.show(this.summary);
+		this.appendChip(localize('chatDebug.wireLog.chip.frames', "{0} frames", this.entries.length));
+		this.appendChip(localize('chatDebug.wireLog.chip.requests', "{0} requests", requests));
+		if (errors > 0) {
+			this.appendChip(localize('chatDebug.wireLog.chip.errors', "{0} errors", errors), 'error');
+		}
+		if (pending > 0) {
+			this.appendChip(localize('chatDebug.wireLog.chip.pending', "{0} pending", pending), 'pending');
+		}
+		if (longest > 0) {
+			this.appendChip(localize('chatDebug.wireLog.chip.slowest', "slowest {0}", formatDuration(longest)));
+		}
+	}
+
+	private appendChip(text: string, tone?: 'error' | 'pending'): void {
+		const chip = DOM.append(this.summary, $('span.chat-debug-wirelog-chip', undefined, text));
+		if (tone) {
+			chip.classList.add(`chat-debug-wirelog-chip-${tone}`);
+		}
+	}
+
+	/**
+	 * Applies the current filter box value and re-renders the list. Invoked
+	 * (debounced) from the filter input's INPUT handler; skips work when the
+	 * effective filter text has not changed.
+	 */
+	private applyFilter(): void {
+		const next = this.filterInput.value.trim().toLowerCase();
+		if (next === this.filterText) {
+			return;
+		}
+		this.filterText = next;
+		this.visibleLimit = PAGE_SIZE;
+		this.renderList();
+	}
+
+	private renderList(): void {
+		DOM.clearNode(this.list);
+		this.rowElements = [];
+		this.rowStores = [];
+		this.renderedVisible = [];
+		this.listShowingMessage = false;
+
+		if (this.entries.length === 0) {
+			this.renderMessage(localize('chatDebug.wireLog.empty', "The AHP log is empty."));
+			return;
+		}
+
+		this.renderSummary();
+
+		const { filtered, display } = this.computeVisible(this.entries);
+
+		if (display.length === 0) {
+			const empty = DOM.append(this.list, $('.chat-debug-wirelog-noresults'));
+			empty.textContent = localize('chatDebug.wireLog.noMatches', "No frames match '{0}'.", this.filterText);
+			this.updateLoadMore(0);
+			this.scrollable.scanDomNode();
+			return;
+		}
+
+		for (const entry of display) {
+			this.appendRow(entry);
+		}
+		this.renderedVisible = display;
+		this.updateLoadMore(filtered.length);
+
+		this.scrollable.scanDomNode();
+	}
+
+	/**
+	 * Re-reads the current wire log and updates the list in place — appending
+	 * newly-captured frames and refreshing rows whose state changed (e.g. a
+	 * response arriving for a pending request) — instead of rebuilding the
+	 * whole view. Used for live refreshes so the panel does not flash back to
+	 * "Loading…" and lose scroll position on every turn.
+	 */
+	private async liveRefresh(): Promise<void> {
+		const index = this.sources.findIndex(source => source.id === this.selectedSourceId);
+		const source = this.sources[index];
+		if (!source) {
+			return;
+		}
+
+		const generation = ++this.loadGeneration;
+		let content;
+		try {
+			content = await readAgentHostLogSourceContent(source, this.logSourceServices);
+		} catch {
+			return; // keep showing the current content on a transient read error
+		}
+		if (generation !== this.loadGeneration || !content) {
+			return;
+		}
+
+		this.currentFileResource = content.fileResource;
+		this.applyEntries(buildWireEntries(parseWireFrames(content.text)));
+		this.renderFooter(source, content.truncated);
+	}
+
+	/**
+	 * Applies a freshly-parsed set of entries to the list. When the previously
+	 * rendered rows are still a prefix of the new (filtered) set, only the
+	 * changed and newly-appended rows are touched; otherwise a full render is
+	 * performed (e.g. after a filter change or log rotation).
+	 */
+	private applyEntries(newEntries: IWireEntry[]): void {
+		const { filtered, display } = this.computeVisible(newEntries);
+
+		const canReconcile = !this.listShowingMessage
+			&& this.renderedVisible.length > 0
+			&& display.length >= this.renderedVisible.length
+			&& this.renderedVisible.every((entry, i) => baseEntryKey(entry) === baseEntryKey(display[i]));
+
+		this.entries = newEntries;
+
+		if (!canReconcile) {
+			this.renderList();
+			return;
+		}
+
+		const wasAtBottom = this.isScrolledToBottom();
+
+		// Summary chips live outside the scroll list; cheap to rebuild.
+		this.renderSummary();
+
+		// Refresh rows whose state changed (e.g. a response arrived).
+		for (let i = 0; i < this.renderedVisible.length; i++) {
+			if (entryStateKey(this.renderedVisible[i]) !== entryStateKey(display[i])) {
+				this.replaceRow(i, display[i]);
+			}
+		}
+
+		// Append rows for newly-captured frames (up to the current page limit).
+		for (let i = this.renderedVisible.length; i < display.length; i++) {
+			this.appendRow(display[i]);
+		}
+
+		this.renderedVisible = display;
+		this.updateLoadMore(filtered.length);
+		this.scrollable.scanDomNode();
+		if (wasAtBottom) {
+			this.scrollToBottom();
+		}
+	}
+
+	/**
+	 * Computes the filtered entries and the (paginated) subset currently
+	 * displayed. Only the first {@link visibleLimit} matching frames are shown;
+	 * the rest are revealed via the "Load more" button.
+	 */
+	private computeVisible(entries: IWireEntry[]): { filtered: IWireEntry[]; display: IWireEntry[] } {
+		const filter = this.filterText;
+		const filtered = filter ? entries.filter(entry => matchesFilter(entry, filter)) : entries;
+		const display = filtered.length > this.visibleLimit ? filtered.slice(0, this.visibleLimit) : filtered;
+		return { filtered, display };
+	}
+
+	/**
+	 * Shows or hides the "Load more" affordance and updates its status label.
+	 */
+	private updateLoadMore(totalFiltered: number): void {
+		if (totalFiltered <= this.visibleLimit) {
+			if (this.loadMoreVisible) {
+				DOM.hide(this.loadMoreContainer);
+				this.loadMoreVisible = false;
+				this.layout();
+			}
+			return;
+		}
+
+		if (!this.loadMoreStatus) {
+			this.loadMoreStatus = DOM.append(this.loadMoreContainer, $('span.chat-debug-wirelog-loadmore-status'));
+		}
+		if (!this.loadMoreBtn) {
+			this.loadMoreBtn = this.loadMoreDisposables.add(new Button(this.loadMoreContainer, { ...defaultButtonStyles, secondary: true, title: localize('chatDebug.wireLog.loadMoreTitle', "Load more frames") }));
+			this.loadMoreDisposables.add(this.loadMoreBtn.onDidClick(() => {
+				this.visibleLimit += PAGE_SIZE;
+				this.renderList();
+			}));
+		}
+
+		const shown = Math.min(this.visibleLimit, totalFiltered);
+		const remaining = totalFiltered - shown;
+		this.loadMoreStatus.textContent = localize('chatDebug.wireLog.showingCount', "Showing {0} of {1} frames", shown, totalFiltered);
+		this.loadMoreBtn.label = localize('chatDebug.wireLog.loadMore', "Load More ({0})", remaining);
+
+		if (!this.loadMoreVisible) {
+			DOM.show(this.loadMoreContainer);
+			this.loadMoreVisible = true;
+			this.layout();
+		}
+	}
+
+	private appendRow(entry: IWireEntry): void {
+		const { row, store } = this.buildRow(entry);
+		this.contentDisposables.add(store);
+		this.rowElements.push(row);
+		this.rowStores.push(store);
+		this.list.appendChild(row);
+	}
+
+	private replaceRow(index: number, entry: IWireEntry): void {
+		const { row, store } = this.buildRow(entry);
+		this.contentDisposables.add(store);
+		const oldRow = this.rowElements[index];
+		this.list.replaceChild(row, oldRow);
+		this.rowStores[index].dispose();
+		this.rowElements[index] = row;
+		this.rowStores[index] = store;
+	}
+
+	private isScrolledToBottom(): boolean {
+		const dimensions = this.scrollable.getScrollDimensions();
+		const position = this.scrollable.getScrollPosition();
+		return position.scrollTop + dimensions.height >= dimensions.scrollHeight - 4;
+	}
+
+	private scrollToBottom(): void {
+		this.scrollable.setScrollPosition({ scrollTop: this.scrollable.getScrollDimensions().scrollHeight });
+	}
+
+	private buildRow(entry: IWireEntry): { row: HTMLElement; store: DisposableStore } {
+		const store = new DisposableStore();
+		const frame = entry.frame;
+		const isError = isErrorEntry(entry);
+		const isPending = frame.kind === 'request' && !entry.response;
+
+		const row = $('.chat-debug-wirelog-row');
+		if (isError) {
+			row.classList.add('chat-debug-wirelog-row-error');
+		}
+
+		const header = DOM.append(row, $('.chat-debug-wirelog-row-header'));
+
+		// Expansion chevron.
+		const chevron = DOM.append(header, $(`span.chat-debug-wirelog-chevron${ThemeIcon.asCSSSelector(Codicon.chevronRight)}`));
+
+		// Direction indicator.
+		const outbound = frame.dir === 'c2s';
+		const dirIcon = outbound ? Codicon.arrowRight : Codicon.arrowLeft;
+		const dirEl = DOM.append(header, $(`span.chat-debug-wirelog-dir${ThemeIcon.asCSSSelector(dirIcon)}`));
+		dirEl.title = outbound
+			? localize('chatDebug.wireLog.outbound', "VS Code → Agent Host")
+			: localize('chatDebug.wireLog.inbound', "Agent Host → VS Code");
+
+		// Method / response label.
+		const label = frame.method ?? localize('chatDebug.wireLog.responseLabel', "(response)");
+		DOM.append(header, $('span.chat-debug-wirelog-method', undefined, label));
+
+		// Inline type / session label (action / dispatchAction / notification / createSession).
+		if (frame.actionType) {
+			DOM.append(header, $('span.chat-debug-wirelog-type', undefined, frame.actionType));
+		}
+		// Kind badge.
+		const badgeText = frame.kind === 'request'
+			? localize('chatDebug.wireLog.badge.request', "request")
+			: frame.kind === 'notification'
+				? localize('chatDebug.wireLog.badge.notification', "notify")
+				: localize('chatDebug.wireLog.badge.response', "response");
+		DOM.append(header, $('span.chat-debug-wirelog-badge', undefined, badgeText));
+
+		// Status.
+		const status = DOM.append(header, $('span.chat-debug-wirelog-status'));
+		if (isError) {
+			status.classList.add('chat-debug-wirelog-status-error');
+			const code = entry.response?.error?.code ?? frame.error?.code;
+			status.textContent = code !== undefined
+				? localize('chatDebug.wireLog.statusErrorCode', "error {0}", code)
+				: localize('chatDebug.wireLog.statusError', "error");
+		} else if (isPending) {
+			status.classList.add('chat-debug-wirelog-status-pending');
+			status.textContent = localize('chatDebug.wireLog.statusPending', "pending");
+		} else if (entry.response) {
+			status.classList.add('chat-debug-wirelog-status-ok');
+			status.textContent = formatDuration(entry.response.ts - frame.ts);
+		}
+
+		// Timestamp (right-aligned).
+		const time = DOM.append(header, $('span.chat-debug-wirelog-time'));
+		time.textContent = formatClock(frame.ts);
+		if (frame.id !== undefined) {
+			time.title = localize('chatDebug.wireLog.frameId', "id: {0}", frame.id);
+		}
+
+		// Details are rendered lazily on first expand: pretty-printing every
+		// frame's JSON up-front dominates render time, so collapsed rows (the
+		// common case) never pay that cost.
+		const details = DOM.append(row, $('.chat-debug-wirelog-row-details'));
+		let detailsRendered = false;
+
+		let expanded = false;
+		const setExpanded = (value: boolean, scan: boolean) => {
+			expanded = value;
+			if (expanded && !detailsRendered) {
+				this.renderDetails(details, entry);
+				detailsRendered = true;
+			}
+			row.classList.toggle('chat-debug-wirelog-row-expanded', expanded);
+			chevron.classList.toggle('codicon-chevron-down', expanded);
+			chevron.classList.toggle('codicon-chevron-right', !expanded);
+			if (scan) {
+				this.scrollable.scanDomNode();
+			}
+		};
+		// Apply the initial (auto-expanded for errors) state without scanning:
+		// renderList scans once after all rows are appended, so scanning per
+		// row here would thrash layout during the build.
+		setExpanded(isError, false);
+
+		store.add(DOM.addDisposableListener(header, DOM.EventType.CLICK, () => setExpanded(!expanded, true)));
+		return { row, store };
+	}
+
+	private renderDetails(container: HTMLElement, entry: IWireEntry): void {
+		const frame = entry.frame;
+
+		// Request / notification payload.
+		if (frame.payload !== undefined) {
+			this.appendJsonSection(container, frame.kind === 'response'
+				? localize('chatDebug.wireLog.section.result', "Result")
+				: localize('chatDebug.wireLog.section.params', "Params"), frame.payload);
+		}
+		if (frame.error) {
+			this.appendJsonSection(container, localize('chatDebug.wireLog.section.error', "Error"), frame.error, true);
+		}
+
+		// Matched response payload / error.
+		if (entry.response) {
+			if (entry.response.error) {
+				this.appendJsonSection(container, localize('chatDebug.wireLog.section.responseError', "Response Error"), entry.response.error, true);
+			} else if (entry.response.payload !== undefined) {
+				this.appendJsonSection(container, localize('chatDebug.wireLog.section.result', "Result"), entry.response.payload);
+			}
+		}
+
+		if (frame.truncated || entry.response?.truncated) {
+			DOM.append(container, $('.chat-debug-wirelog-detail-note', undefined, localize('chatDebug.wireLog.truncatedFrame', "Large payload values were elided in the log. Open the full file for complete data.")));
+		}
+	}
+
+	private appendJsonSection(container: HTMLElement, title: string, value: unknown, isError = false): void {
+		const section = DOM.append(container, $('.chat-debug-wirelog-detail-section'));
+		DOM.append(section, $('.chat-debug-wirelog-detail-title', undefined, title));
+		const pre = DOM.append(section, $('pre.chat-debug-wirelog-detail-json'));
+		if (isError) {
+			pre.classList.add('chat-debug-wirelog-detail-json-error');
+		}
+		pre.textContent = stringifyBounded(value);
+	}
+
+	private renderFooter(source: IAgentHostLogSource, truncated: boolean): void {
+		DOM.clearNode(this.footer);
+		const parts: string[] = [];
+		if (truncated) {
+			parts.push(localize('chatDebug.wireLog.footerTail', "Showing the most recent frames"));
+		}
+		if (source.isRemote) {
+			parts.push(localize('chatDebug.wireLog.footerRemote', "remote"));
+		}
+		this.footer.textContent = parts.join(' · ');
+	}
+}
+
+/**
+ * Extracts a short identifying label for a frame from its payload, surfaced
+ * inline in the row next to the method:
+ * - `action` frames carry the dispatched action under `params.action`;
+ * - `notification` frames carry it under `params.notification`;
+ * - `dispatchAction` frames pass positional args `[channel, action, …]`, so the
+ *   action is the second argument;
+ * - `createSession` frames pass `[config]`, whose `session` field (a URI)
+ *   identifies the session being resumed or forked.
+ */
+function extractActionType(method: string | undefined, payload: unknown): string | undefined {
+	switch (method) {
+		case 'notification':
+			return typeStringOf(getProp(payload, 'notification'));
+		case 'dispatchAction':
+			return typeStringOf(Array.isArray(payload) ? payload[1] : undefined);
+		case 'createSession':
+			return uriStringOf(getProp(Array.isArray(payload) ? payload[0] : undefined, 'session'));
+		default:
+			return typeStringOf(getProp(payload, 'action'));
+	}
+}
+
+/** Reads a property off a value only when it is a non-null object. */
+function getProp(value: unknown, key: string): unknown {
+	return value && typeof value === 'object' ? (value as Record<string, unknown>)[key] : undefined;
+}
+
+/** Returns the `type` string of an action-like value, when present. */
+function typeStringOf(value: unknown): string | undefined {
+	const type = getProp(value, 'type');
+	return typeof type === 'string' ? type : undefined;
+}
+
+/** Renders a logged URI value (string or serialized components) as text. */
+function uriStringOf(value: unknown): string | undefined {
+	if (typeof value === 'string') {
+		return value;
+	}
+	if (value && typeof value === 'object') {
+		const external = (value as Record<string, unknown>).external;
+		if (typeof external === 'string') {
+			return external;
+		}
+		if (typeof (value as Record<string, unknown>).scheme === 'string') {
+			try {
+				return URI.revive(value as UriComponents).toString(true);
+			} catch {
+				return undefined;
+			}
+		}
+	}
+	return undefined;
+}
+
+/** Parses newline-delimited AHP frames, skipping any unparseable lines. */
+function parseWireFrames(text: string): IWireFrame[] {
+	const frames: IWireFrame[] = [];
+	for (const line of text.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed) {
+			continue;
+		}
+		let record: Record<string, unknown>;
+		try {
+			record = JSON.parse(trimmed);
+		} catch {
+			// A truncated tail can leave a partial first line; skip it.
+			continue;
+		}
+		const meta = record._ahpLog as Record<string, unknown> | undefined;
+		if (!meta) {
+			continue;
+		}
+		const dir: WireLogDirection = meta.dir === 's2c' ? 's2c' : 'c2s';
+		const ts = typeof meta.ts === 'string' ? Date.parse(meta.ts) : NaN;
+		const id = record.id !== undefined && record.id !== null ? String(record.id) : undefined;
+		const method = typeof record.method === 'string' ? record.method : undefined;
+		const hasResult = Object.prototype.hasOwnProperty.call(record, 'result');
+		const errorValue = record.error as { code?: number; message?: string; data?: unknown } | undefined;
+		const kind: IWireFrame['kind'] = method
+			? (id !== undefined ? 'request' : 'notification')
+			: 'response';
+		const payload = method ? record.params : (hasResult ? record.result : undefined);
+		frames.push({
+			ts: Number.isNaN(ts) ? 0 : ts,
+			dir,
+			truncated: meta.truncated === true,
+			byteLength: typeof meta.byteLength === 'number' ? meta.byteLength : undefined,
+			id,
+			method,
+			actionType: extractActionType(method, payload),
+			payload,
+			error: errorValue && typeof errorValue === 'object' ? errorValue : undefined,
+			kind,
+		});
+	}
+	return frames;
+}
+
+/**
+ * Folds response frames into the request they answer (matched by id in
+ * chronological order), leaving notifications and unmatched frames as
+ * standalone entries.
+ */
+function buildWireEntries(frames: IWireFrame[]): IWireEntry[] {
+	const entries: IWireEntry[] = [];
+	const pendingById = new Map<string, IWireEntry>();
+	for (const frame of frames) {
+		if (frame.kind === 'response' && frame.id !== undefined) {
+			const request = pendingById.get(frame.id);
+			if (request) {
+				request.response = frame;
+				pendingById.delete(frame.id);
+				continue;
+			}
+		}
+		const entry: IWireEntry = { frame, response: undefined };
+		entries.push(entry);
+		if (frame.kind === 'request' && frame.id !== undefined) {
+			pendingById.set(frame.id, entry);
+		}
+	}
+	return entries;
+}
+
+/**
+ * True when an entry represents a protocol error, whether it is a JSON-RPC
+ * error response or an agent-emitted `chat/error` action/notification frame.
+ * Used to color the row and count errors in the summary.
+ */
+function isErrorEntry(entry: IWireEntry): boolean {
+	const frame = entry.frame;
+	return !!entry.response?.error
+		|| (frame.kind === 'response' && !!frame.error)
+		|| frame.actionType === ActionType.ChatError;
+}
+
+/** True when an entry's method, action type, id, or response error matches the filter. */
+function matchesFilter(entry: IWireEntry, filter: string): boolean {
+	const frame = entry.frame;
+	if (frame.method?.toLowerCase().includes(filter)) {
+		return true;
+	}
+	if (frame.actionType?.toLowerCase().includes(filter)) {
+		return true;
+	}
+	if (frame.id !== undefined && frame.id.toLowerCase().includes(filter)) {
+		return true;
+	}
+	const errorMessage = entry.response?.error?.message ?? frame.error?.message;
+	return !!errorMessage && errorMessage.toLowerCase().includes(filter);
+}
+
+/**
+ * A stable key for an entry's request/notification frame (ignoring its
+ * response). Used to test whether previously-rendered rows still line up with a
+ * freshly-parsed set so a live refresh can reconcile in place.
+ */
+function baseEntryKey(entry: IWireEntry): string {
+	const frame = entry.frame;
+	return `${frame.dir}|${frame.kind}|${frame.id ?? ''}|${frame.ts}|${frame.method ?? ''}`;
+}
+
+/**
+ * A key capturing an entry's full render-relevant state, including whether (and
+ * how) its response has arrived, so a row can be re-rendered only when needed.
+ */
+function entryStateKey(entry: IWireEntry): string {
+	const response = entry.response;
+	const responseKey = response ? `R${response.ts}${response.error ? 'E' : ''}` : 'P';
+	return `${baseEntryKey(entry)}|${responseKey}`;
+}
+
+/** Pretty-prints a JSON value, bounded to keep the DOM light. */
+function stringifyBounded(value: unknown): string {
+	let text: string;
+	try {
+		text = JSON.stringify(value, undefined, 2) ?? String(value);
+	} catch {
+		text = String(value);
+	}
+	if (text.length > MAX_DETAIL_JSON) {
+		return `${text.slice(0, MAX_DETAIL_JSON)}…`;
+	}
+	return text;
+}
+
+/** Formats a millisecond duration into a compact human string. */
+function formatDuration(millis: number): string {
+	if (millis < 1000) {
+		return localize('chatDebug.wireLog.ms', "{0} ms", Math.round(millis));
+	}
+	return localize('chatDebug.wireLog.s', "{0} s", (millis / 1000).toFixed(millis < 10000 ? 1 : 0));
+}
+
+/** Formats a timestamp into an HH:MM:SS.mmm clock label. */
+function formatClock(ts: number): string {
+	if (!ts) {
+		return '';
+	}
+	const date = new Date(ts);
+	const pad = (value: number, length = 2) => String(value).padStart(length, '0');
+	return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`;
+}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -1936,6 +1936,10 @@ button.chat-debug-cache-finding.is-clickable:focus-visible {
 .chat-debug-wirelog-row-header:hover {
 	background: var(--vscode-list-hoverBackground);
 }
+.chat-debug-wirelog-row-header:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
 .chat-debug-wirelog-row-error {
 	border-left: 2px solid var(--vscode-errorForeground);
 }

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -9,6 +9,29 @@
 	overflow: hidden;
 }
 
+/* ---- Disabled overlay (shown in place of a sub-view when logging is off) ---- */
+.chat-debug-disabled-overlay {
+	display: flex;
+	flex: 1;
+	min-height: 0;
+	align-items: center;
+	justify-content: center;
+	padding: 48px 24px;
+	overflow-y: auto;
+}
+.chat-debug-logging-disabled {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+	max-width: 480px;
+}
+.chat-debug-logging-disabled-message {
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+	margin: 0 0 16px;
+}
+
 /* ---- Home view ---- */
 .chat-debug-home {
 	display: flex;
@@ -1784,4 +1807,250 @@ button.chat-debug-cache-finding.is-clickable:focus-visible {
 .chat-debug-cache-diff-line.remove .chat-debug-cache-diff-inner {
 	background: var(--vscode-diffEditor-removedTextBackground, rgba(244, 135, 113, 0.4));
 	border-radius: 2px;
+}
+
+/* ---- AHP Log (protocol frames) view ---- */
+.chat-debug-wirelog {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	flex: 1;
+	min-height: 0;
+}
+.chat-debug-wirelog-hint {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 12px;
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	background: var(--vscode-editorWidget-background);
+	border-bottom: 1px solid var(--vscode-widget-border, transparent);
+}
+.chat-debug-wirelog-toolbar {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 12px;
+	border-bottom: 1px solid var(--vscode-widget-border, transparent);
+	flex-shrink: 0;
+}
+.chat-debug-wirelog-select {
+	min-width: 220px;
+}
+.chat-debug-wirelog-select .monaco-select-box {
+	width: 100%;
+}
+.chat-debug-wirelog-filter {
+	flex: 1 1 auto;
+	min-width: 120px;
+	height: 24px;
+	padding: 2px 6px;
+	font-size: 12px;
+	color: var(--vscode-input-foreground);
+	background: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-border, transparent);
+	border-radius: 2px;
+}
+.chat-debug-wirelog-filter::placeholder {
+	color: var(--vscode-input-placeholderForeground);
+}
+.chat-debug-wirelog-filter:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+.chat-debug-wirelog-action {
+	flex-shrink: 0;
+	width: auto;
+}
+.chat-debug-wirelog-summary {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 12px;
+	flex-shrink: 0;
+	border-bottom: 1px solid var(--vscode-widget-border, transparent);
+}
+.chat-debug-wirelog-chip {
+	padding: 1px 8px;
+	font-size: 11px;
+	border-radius: 10px;
+	color: var(--vscode-badge-foreground);
+	background: var(--vscode-badge-background);
+}
+.chat-debug-wirelog-chip-error {
+	color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground));
+	background: var(--vscode-inputValidation-errorBackground, transparent);
+	border: 1px solid var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+}
+.chat-debug-wirelog-chip-pending {
+	color: var(--vscode-inputValidation-warningForeground, var(--vscode-foreground));
+	background: var(--vscode-inputValidation-warningBackground, transparent);
+	border: 1px solid var(--vscode-inputValidation-warningBorder, var(--vscode-editorWarning-foreground));
+}
+.chat-debug-wirelog-body {
+	flex: 1 1 auto;
+	min-height: 0;
+	position: relative;
+	overflow: hidden;
+}
+.chat-debug-wirelog-loadmore {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	padding: 6px 0;
+	flex-shrink: 0;
+	border-top: 1px solid var(--vscode-widget-border, transparent);
+}
+.chat-debug-wirelog-loadmore-status {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-wirelog-list {
+	padding: 4px 0;
+	user-select: text;
+	box-sizing: border-box;
+}
+.chat-debug-wirelog-list.chat-debug-wirelog-message {
+	padding: 12px;
+	color: var(--vscode-descriptionForeground);
+	white-space: pre-wrap;
+}
+.chat-debug-wirelog-noresults {
+	padding: 12px;
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-wirelog-row {
+	border-bottom: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.15));
+}
+.chat-debug-wirelog-row-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 12px;
+	cursor: pointer;
+	white-space: nowrap;
+}
+.chat-debug-wirelog-row-header:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+.chat-debug-wirelog-row-error {
+	border-left: 2px solid var(--vscode-errorForeground);
+}
+.chat-debug-wirelog-row-error .chat-debug-wirelog-row-header {
+	background: var(--vscode-inputValidation-errorBackground, transparent);
+}
+.chat-debug-wirelog-row-error .chat-debug-wirelog-method {
+	color: var(--vscode-errorForeground);
+}
+.chat-debug-wirelog-chevron {
+	flex-shrink: 0;
+	color: var(--vscode-descriptionForeground);
+	font-size: 14px;
+}
+.chat-debug-wirelog-dir {
+	flex-shrink: 0;
+	color: var(--vscode-descriptionForeground);
+	font-size: 14px;
+}
+.chat-debug-wirelog-method {
+	font-family: var(--monaco-monospace-font);
+	font-size: 12px;
+	color: var(--vscode-foreground);
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.chat-debug-wirelog-type {
+	flex-shrink: 0;
+	padding: 0 6px;
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+	border-radius: 3px;
+	color: var(--vscode-textPreformat-foreground);
+	background: var(--vscode-textPreformat-background);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.chat-debug-wirelog-badge {
+	flex-shrink: 0;
+	padding: 0 6px;
+	font-size: 10px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	border-radius: 3px;
+	color: var(--vscode-descriptionForeground);
+	background: var(--vscode-badge-background);
+}
+.chat-debug-wirelog-status {
+	flex-shrink: 0;
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-wirelog-status-ok {
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-wirelog-status-error {
+	color: var(--vscode-errorForeground);
+	font-weight: 600;
+}
+.chat-debug-wirelog-status-pending {
+	color: var(--vscode-editorWarning-foreground);
+}
+.chat-debug-wirelog-time {
+	flex-shrink: 0;
+	margin-left: auto;
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-wirelog-row-details {
+	display: none;
+	padding: 4px 12px 8px 34px;
+}
+.chat-debug-wirelog-row-expanded .chat-debug-wirelog-row-details {
+	display: block;
+}
+.chat-debug-wirelog-detail-section {
+	margin-bottom: 6px;
+}
+.chat-debug-wirelog-detail-title {
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--vscode-descriptionForeground);
+	margin-bottom: 2px;
+}
+.chat-debug-wirelog-detail-json {
+	margin: 0;
+	padding: 6px 8px;
+	font-family: var(--monaco-monospace-font);
+	font-size: 12px;
+	line-height: 1.4;
+	white-space: pre-wrap;
+	word-break: break-word;
+	tab-size: 2;
+	color: var(--vscode-foreground);
+	background: var(--vscode-textCodeBlock-background, var(--vscode-editorWidget-background));
+	border-radius: 3px;
+}
+.chat-debug-wirelog-detail-json-error {
+	color: var(--vscode-errorForeground);
+}
+.chat-debug-wirelog-detail-note {
+	font-size: 11px;
+	font-style: italic;
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-wirelog-footer {
+	flex-shrink: 0;
+	padding: 4px 12px;
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	border-top: 1px solid var(--vscode-widget-border, transparent);
+}
+.chat-debug-wirelog-footer:empty {
+	display: none;
 }

--- a/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
@@ -11,6 +11,8 @@ import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IChatDebugCustomizationLogEntry, IChatDebugEventFileListContent, IChatDebugResolvedEventContent, IChatDebugService } from '../common/chatDebugService.js';
+import { isAgentHostTarget } from '../common/chatSessionsService.js';
+import { getChatSessionType } from '../common/model/chatUri.js';
 import { IChatAgentService } from '../common/participants/chatAgents.js';
 import { IChatService } from '../common/chatService/chatService.js';
 import { ChatRequestHooks, formatHookCommandLabel } from '../common/promptSyntax/hookSchema.js';
@@ -68,7 +70,16 @@ export class PromptsDebugContribution extends Disposable implements IWorkbenchCo
 			if (isFirstInvocation) {
 				const cts = new CancellationTokenSource();
 				try {
-					const discoveryInfos = await Promise.all([PromptsType.agent, PromptsType.instructions, PromptsType.prompt, PromptsType.skill, PromptsType.hook].map(type => this.promptsService.getDiscoveryInfo(type, cts.token)));
+					// For agent-host (Copilot CLI) sessions, VS Code core still collects
+					// instructions and hooks and passes them into the agent-host request,
+					// so those discovery events are relevant. Agent / skill / slash-command
+					// discovery reflects VS Code's own chat-participant discovery, which the
+					// agent host does not consume (the agent host surfaces its actually loaded
+					// customizations separately), so we suppress those to avoid noise.
+					const discoveryTypes = isAgentHostTarget(getChatSessionType(sessionResource))
+						? [PromptsType.instructions, PromptsType.hook]
+						: [PromptsType.agent, PromptsType.instructions, PromptsType.prompt, PromptsType.skill, PromptsType.hook];
+					const discoveryInfos = await Promise.all(discoveryTypes.map(type => this.promptsService.getDiscoveryInfo(type, cts.token)));
 					for (const discoveryInfo of discoveryInfos) {
 						const { name, details } = this.getDiscoveryLogEntry(discoveryInfo);
 						const eventId = generateUuid();

--- a/src/vs/workbench/contrib/chat/common/chatDebugService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugService.ts
@@ -264,9 +264,11 @@ export interface IChatDebugService extends IDisposable {
 
 	/**
 	 * Register a callback that fetches available session resources from a provider.
-	 * Called lazily when `getAvailableSessionResources()` is first invoked.
+	 * Called lazily when `getAvailableSessionResources()` is first invoked. Multiple
+	 * fetchers may be registered (e.g. the extension host and local agent-host
+	 * discovery); each is invoked at most once. Dispose to unregister.
 	 */
-	registerAvailableSessionsFetcher(fetcher: (token: CancellationToken) => Promise<{ uri: URI; title?: string }[]>): void;
+	registerAvailableSessionsFetcher(fetcher: (token: CancellationToken) => Promise<{ uri: URI; title?: string }[]>): IDisposable;
 
 	/**
 	 * Get the stored title for a historical session discovered from disk.

--- a/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
@@ -115,6 +115,15 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	private readonly _providers = new Set<IChatDebugLogProvider>();
 	private readonly _invocationCts = new ResourceMap<CancellationTokenSource>();
 
+	/**
+	 * Sessions whose provider events should be cleared before the next batch of
+	 * provider events is applied. The clear is deferred until the first new
+	 * provider event actually arrives so that a provider which transiently
+	 * returns nothing (e.g. an Agent Host `events.jsonl` mid-rewrite) does not
+	 * wipe the events currently shown.
+	 */
+	private readonly _pendingProviderClear = new ResourceMap<boolean>();
+
 	/** Events that were returned by providers (not internally logged). */
 	private readonly _providerEvents = new WeakSet<IChatDebugEvent>();
 
@@ -264,6 +273,14 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	}
 
 	addProviderEvent(event: IChatDebugEvent): void {
+		// If a re-invocation is pending for this session, clear the previously
+		// loaded provider events now that fresh data has actually arrived. This
+		// is deferred (rather than done up front in invokeProviders) so that a
+		// provider which returns nothing this cycle keeps the current events.
+		if (this._pendingProviderClear.has(event.sessionResource)) {
+			this._pendingProviderClear.delete(event.sessionResource);
+			this._clearProviderEvents(event.sessionResource);
+		}
 		this._providerEvents.add(event);
 		this.addEvent(event);
 	}
@@ -394,10 +411,11 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 			existingCts.dispose();
 		}
 
-		// Clear only provider-sourced events for this session to avoid
-		// duplicates when re-invoking (e.g. navigating back to a session).
-		// Internally-logged events (e.g. prompt discovery) are preserved.
-		this._clearProviderEvents(sessionResource);
+		// Mark provider events for this session to be cleared before the next
+		// batch is applied. The clear is deferred to addProviderEvent so that a
+		// provider returning nothing this cycle preserves the current events;
+		// see _pendingProviderClear.
+		this._pendingProviderClear.set(sessionResource, true);
 
 		const cts = new CancellationTokenSource();
 		this._invocationCts.set(sessionResource, cts);

--- a/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
@@ -12,8 +12,10 @@ import { ResourceMap } from '../../../../base/common/map.js';
 import { extUri } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ChatDebugLogLevel, IChatDebugEvent, IChatDebugLogProvider, IChatDebugResolvedEventContent, IChatDebugService } from './chatDebugService.js';
-import { localChatSessionType } from './chatSessionsService.js';
+import { isAgentHostTarget, localChatSessionType } from './chatSessionsService.js';
 import { getChatSessionType } from './model/chatUri.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { AgentHostAgentDebugLogMaxEventsSettingId } from './promptSyntax/promptTypes.js';
 
 /**
  * Per-session circular buffer for debug events.
@@ -131,6 +133,12 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 
 	activeSessionResource: URI | undefined;
 
+	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+	) {
+		super();
+	}
+
 	/** Priority for deduplicating events with the same ID: lower = richer. */
 	private static readonly _eventKindPriority: Record<string, number> = {
 		subagentInvocation: 0,
@@ -158,6 +166,23 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 			|| this._importedSessions.has(sessionResource);
 	}
 
+	/**
+	 * The in-memory event capacity for a session. Agent host (Copilot CLI)
+	 * sessions honor a dedicated, configurable cap so their (potentially large)
+	 * on-disk logs can be surfaced without changing the local-session default;
+	 * all other sessions use {@link ChatDebugServiceImpl.MAX_EVENTS_PER_SESSION}.
+	 */
+	private _capacityForSession(sessionResource: URI): number {
+		if (!isAgentHostTarget(getChatSessionType(sessionResource))) {
+			return ChatDebugServiceImpl.MAX_EVENTS_PER_SESSION;
+		}
+		const configured = this._configurationService.getValue<number>(AgentHostAgentDebugLogMaxEventsSettingId);
+		if (typeof configured === 'number' && Number.isFinite(configured) && configured >= 1) {
+			return Math.floor(configured);
+		}
+		return ChatDebugServiceImpl.MAX_EVENTS_PER_SESSION;
+	}
+
 	log(sessionResource: URI, name: string, details?: string, level: ChatDebugLogLevel = ChatDebugLogLevel.Info, options?: { id?: string; category?: string; parentEventId?: string }): void {
 		if (!this._isDebugEligibleSession(sessionResource)) {
 			return;
@@ -176,6 +201,12 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	}
 
 	addEvent(event: IChatDebugEvent): void {
+		// Resolve the session's buffer (if any) once, and its capacity. New
+		// events during streaming target an existing buffer, so we reuse its
+		// capacity and avoid re-reading configuration on the hot path.
+		let buffer = this._sessionBuffers.get(event.sessionResource);
+		const capacity = buffer?.capacity ?? this._capacityForSession(event.sessionResource);
+
 		// Deduplicate events that share the same ID. The extension may emit
 		// both a subagentInvocation and a userMessage from the same span;
 		// keep the richer kind and discard the duplicate.
@@ -197,7 +228,7 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 			}
 			seen.set(event.id, event.kind);
 			// Cap the dedup map to prevent unbounded growth in long sessions.
-			if (seen.size > ChatDebugServiceImpl.MAX_EVENTS_PER_SESSION) {
+			if (seen.size > capacity) {
 				// Delete the oldest entry (first key in insertion order).
 				const firstKey = seen.keys().next().value;
 				if (firstKey !== undefined) {
@@ -206,14 +237,13 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 			}
 		}
 
-		let buffer = this._sessionBuffers.get(event.sessionResource);
 		if (!buffer) {
 			// Evict least-recently-used session if we are at the session cap.
 			if (this._sessionOrder.length >= ChatDebugServiceImpl.MAX_SESSIONS) {
 				const evicted = this._sessionOrder.shift()!;
 				this._evictSession(evicted);
 			}
-			buffer = new SessionEventBuffer(ChatDebugServiceImpl.MAX_EVENTS_PER_SESSION);
+			buffer = new SessionEventBuffer(capacity);
 			this._sessionBuffers.set(event.sessionResource, buffer);
 			this._sessionOrder.push(event.sessionResource);
 		} else {
@@ -485,9 +515,8 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 		}
 	}
 
-	/** Lazy fetcher for available sessions from the extension. */
-	private _availableSessionsFetcher: ((token: CancellationToken) => Promise<{ uri: URI; title?: string }[]>) | undefined;
-	private _availableSessionsFetchStarted = false;
+	/** Lazy fetchers for available sessions from providers. Each is invoked at most once. */
+	private readonly _availableSessionsFetchers = new Set<{ readonly fetcher: (token: CancellationToken) => Promise<{ uri: URI; title?: string }[]>; started: boolean }>();
 	private _availableSessionsRequested = false;
 
 	getAvailableSessionResources(): readonly URI[] {
@@ -506,25 +535,30 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 		return result;
 	}
 
-	registerAvailableSessionsFetcher(fetcher: (token: CancellationToken) => Promise<{ uri: URI; title?: string }[]>): void {
-		this._availableSessionsFetcher = fetcher;
-		this._availableSessionsFetchStarted = false;
+	registerAvailableSessionsFetcher(fetcher: (token: CancellationToken) => Promise<{ uri: URI; title?: string }[]>): IDisposable {
+		const entry = { fetcher, started: false };
+		this._availableSessionsFetchers.add(entry);
 		// If the UI already requested sessions before the fetcher was registered, fetch now.
 		this._tryFetchAvailableSessions();
+		return toDisposable(() => this._availableSessionsFetchers.delete(entry));
 	}
 
 	private _tryFetchAvailableSessions(): void {
-		if (!this._availableSessionsFetcher || !this._availableSessionsRequested || this._availableSessionsFetchStarted) {
+		if (!this._availableSessionsRequested) {
 			return;
 		}
-		this._availableSessionsFetchStarted = true;
-		// Fire-and-forget: don't block the caller.
-		const fetcher = this._availableSessionsFetcher;
-		fetcher(CancellationToken.None).then(entries => {
-			if (entries.length > 0) {
-				this.addAvailableSessionResources(entries);
+		for (const entry of this._availableSessionsFetchers) {
+			if (entry.started) {
+				continue;
 			}
-		}).catch(onUnexpectedError);
+			entry.started = true;
+			// Fire-and-forget: don't block the caller.
+			entry.fetcher(CancellationToken.None).then(entries => {
+				if (entries.length > 0) {
+					this.addAvailableSessionResources(entries);
+				}
+			}).catch(onUnexpectedError);
+		}
 	}
 
 	getHistoricalSessionTitle(sessionResource: URI): string | undefined {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/promptTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/promptTypes.ts
@@ -52,6 +52,19 @@ export const AGENT_DEBUG_LOG_ENABLED_SETTING = 'github.copilot.chat.agentDebugLo
 export const AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING = 'github.copilot.chat.agentDebugLog.fileLogging.enabled';
 
 /**
+ * Configuration key for enabling agent debug logging for agent host (Copilot CLI) sessions.
+ * Registered in core (see `chat.shared.contribution.ts`) since only core consumes it.
+ */
+export const AgentHostAgentDebugLogEnabledSettingId = 'chat.agentHost.agentDebugLog.enabled';
+
+/**
+ * Configuration key for the maximum number of debug events kept in memory for
+ * agent host (Copilot CLI) sessions. Registered in core (see
+ * `chat.shared.contribution.ts`) since only core consumes it.
+ */
+export const AgentHostAgentDebugLogMaxEventsSettingId = 'chat.agentHost.agentDebugLog.maxEventsInMemory';
+
+/**
  * The name of the troubleshoot slash command / skill.
  */
 export const TROUBLESHOOT_COMMAND_NAME = 'troubleshoot';

--- a/src/vs/workbench/contrib/chat/test/browser/agentHostChatDebugProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHostChatDebugProvider.test.ts
@@ -6,9 +6,10 @@
 import assert from 'assert';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { IChatDebugModelTurnEvent } from '../../common/chatDebugService.js';
-import { convertAgentHostEventsToDebugEvents, parseJsonl } from '../../browser/chatDebug/agentHostChatDebugProvider.js';
+import { IChatDebugModelTurnEvent, IChatDebugEventFileListContent, IChatDebugEventCustomizationSummaryContent } from '../../common/chatDebugService.js';
+import { buildCustomizationDebugEvents, convertAgentHostEventsToDebugEvents, parseJsonl } from '../../browser/chatDebug/agentHostChatDebugProvider.js';
 import { COPILOT_CLI_LOCAL_AH_SCHEME } from '../../browser/copilotCliEventsUri.js';
+import { CustomizationType, type Customization } from '../../../../../platform/agentHost/common/state/sessionState.js';
 
 suite('AgentHostChatDebugProvider - convertAgentHostEventsToDebugEvents', () => {
 
@@ -66,6 +67,96 @@ suite('AgentHostChatDebugProvider - convertAgentHostEventsToDebugEvents', () => 
 		]);
 	});
 
+	test('surfaces errors, warnings, model changes, error hooks and routine lifecycle hooks', () => {
+		// A failing session: a recoverable model-call error hook precedes a
+		// terminal session.error, plus a warning, a model change, and a routine
+		// (successful, non-error) hook that is now surfaced as an info event.
+		const failing = [
+			{ type: 'session.start', id: 's', parentId: null, timestamp: '2026-06-17T00:00:00.000Z', data: { selectedModel: 'echo', copilotVersion: '1.0.69', context: { repository: 'microsoft/vscode', branch: 'main' } } },
+			{ type: 'session.warning', id: 'w', parentId: 's', timestamp: '2026-06-17T00:00:00.100Z', data: { warningType: 'remote', message: 'Remote controlled sessions are not enabled.' } },
+			{ type: 'user.message', id: 'u', parentId: 'w', timestamp: '2026-06-17T00:00:00.200Z', data: { content: 'go' } },
+			{ type: 'hook.start', id: 'hs0', parentId: 'u', timestamp: '2026-06-17T00:00:00.300Z', data: { hookInvocationId: 'hi0', hookType: 'userPromptSubmitted', input: {} } },
+			{ type: 'hook.end', id: 'he0', parentId: 'hs0', timestamp: '2026-06-17T00:00:00.310Z', data: { hookInvocationId: 'hi0', hookType: 'userPromptSubmitted', success: true } },
+			{ type: 'hook.start', id: 'hs1', parentId: 'he0', timestamp: '2026-06-17T00:00:01.000Z', data: { hookInvocationId: 'hi1', hookType: 'errorOccurred', input: { errorContext: 'model_call', recoverable: true, error: {} } } },
+			{ type: 'hook.end', id: 'he1', parentId: 'hs1', timestamp: '2026-06-17T00:00:01.010Z', data: { hookInvocationId: 'hi1', hookType: 'errorOccurred', success: true } },
+			{ type: 'session.model_change', id: 'mc', parentId: 'he1', timestamp: '2026-06-17T00:00:02.000Z', data: { previousModel: 'echo', newModel: 'claude-opus-4.8', reasoningEffort: 'medium' } },
+			{ type: 'session.error', id: 'err', parentId: 'mc', timestamp: '2026-06-17T00:00:03.000Z', data: { errorType: 'query', message: 'Failed to get response; retried 5 times.', stack: 'Error: Failed\n    at me (app.js:1:1)' } },
+		];
+		const { events, resolved } = convertAgentHostEventsToDebugEvents(failing, sessionResource);
+
+		const projection = events.map(e => e.kind === 'generic'
+			? { kind: e.kind, id: e.id, parent: e.parentEventId, name: e.name, details: e.details, level: e.level, category: e.category }
+			: { kind: e.kind, id: e.id, parent: e.parentEventId });
+
+		// The routine `userPromptSubmitted` hook is surfaced as a low-key info
+		// event; the error/warning/model-change/error-hook events are surfaced
+		// with the right levels and nested under the active turn (or session root
+		// before any turn).
+		assert.deepStrictEqual(projection, [
+			{ kind: 'generic', id: 's', parent: undefined, name: 'Session Started', details: 'model=echo, CLI 1.0.69, microsoft/vscode@main', level: 1, category: 'session' },
+			{ kind: 'generic', id: 'w', parent: 's', name: 'Warning (remote)', details: 'Remote controlled sessions are not enabled.', level: 2, category: 'session' },
+			{ kind: 'userMessage', id: 'u', parent: 's' },
+			{ kind: 'generic', id: 'hs0', parent: 'u', name: 'Hook: userPromptSubmitted', details: undefined, level: 1, category: 'hook' },
+			{ kind: 'generic', id: 'hs1', parent: 'u', name: 'Error During model_call', details: 'Recoverable; retrying', level: 2, category: 'hook' },
+			{ kind: 'generic', id: 'mc', parent: 'u', name: 'Model Changed', details: 'echo → claude-opus-4.8 (reasoningEffort=medium)', level: 1, category: 'session' },
+			{ kind: 'generic', id: 'err', parent: 'u', name: 'Error (query)', details: 'Failed to get response; retried 5 times.', level: 3, category: 'session' },
+		]);
+
+		// The terminal error's expanded detail includes both message and stack.
+		assert.deepStrictEqual(resolved.get('err'), { kind: 'text', value: 'Failed to get response; retried 5 times.\n\nError: Failed\n    at me (app.js:1:1)' });
+	});
+
+	test('surfaces permissions, subagent lifecycle, compaction failures, aborts and skill invocations', () => {
+		const stream = [
+			{ type: 'session.start', id: 's', parentId: null, timestamp: '2026-06-17T00:00:00.000Z', data: { selectedModel: 'x' } },
+			{ type: 'user.message', id: 'u', parentId: 's', timestamp: '2026-06-17T00:00:00.100Z', data: { content: 'go' } },
+			{ type: 'assistant.message', id: 'm', parentId: 'u', timestamp: '2026-06-17T00:00:00.200Z', data: { model: 'x', outputTokens: 5 } },
+			{ type: 'tool.execution_start', id: 'tAgent', parentId: 'm', timestamp: '2026-06-17T00:00:00.300Z', data: { toolName: 'Agent', toolCallId: 'tcA', arguments: {} } },
+			{ type: 'subagent.started', id: 'sa', parentId: 'tAgent', timestamp: '2026-06-17T00:00:00.400Z', data: { toolCallId: 'tcA', agentName: 'explore', agentDisplayName: 'Explore Agent', agentDescription: 'desc', model: 'haiku' } },
+			{ type: 'subagent.completed', id: 'sac', parentId: 'sa', timestamp: '2026-06-17T00:00:02.400Z', data: { toolCallId: 'tcA', agentName: 'explore', model: 'haiku', totalToolCalls: 5, totalTokens: 1000, durationMs: 2000 } },
+			// A denied permission is surfaced; a following approved one is dropped as routine.
+			{ type: 'permission.requested', id: 'pReq', parentId: 'm', timestamp: '2026-06-17T00:00:02.500Z', data: { requestId: 'r1', permissionRequest: { kind: 'read', toolCallId: 'tc1', intention: 'Search', path: '/x' } } },
+			{ type: 'permission.completed', id: 'pComp', parentId: 'pReq', timestamp: '2026-06-17T00:00:02.600Z', data: { requestId: 'r1', toolCallId: 'tc1', result: { kind: 'denied' } } },
+			{ type: 'permission.requested', id: 'pReq2', parentId: 'pComp', timestamp: '2026-06-17T00:00:02.700Z', data: { requestId: 'r2', permissionRequest: { kind: 'read', toolCallId: 'tc2', intention: 'Read' } } },
+			{ type: 'permission.completed', id: 'pComp2', parentId: 'pReq2', timestamp: '2026-06-17T00:00:02.800Z', data: { requestId: 'r2', result: { kind: 'approved' } } },
+			// A successful compaction is implied by its start row; only failures are surfaced.
+			{ type: 'session.compaction_start', id: 'cs', parentId: 'pComp2', timestamp: '2026-06-17T00:00:03.000Z', data: { systemTokens: 100, conversationTokens: 200, toolDefinitionsTokens: 300 } },
+			{ type: 'session.compaction_complete', id: 'cc', parentId: 'cs', timestamp: '2026-06-17T00:00:03.100Z', data: { success: false, error: 'boom' } },
+			{ type: 'abort', id: 'ab', parentId: 'cc', timestamp: '2026-06-17T00:00:03.200Z', data: { reason: 'user_initiated' } },
+			{ type: 'skill.invoked', id: 'sk', parentId: 'ab', timestamp: '2026-06-17T00:00:03.300Z', data: { name: 'troubleshoot', trigger: 'auto', pluginName: 'myplugin', content: 'SKILL body' } },
+		];
+		const { events, resolved } = convertAgentHostEventsToDebugEvents(stream, sessionResource);
+
+		const projection = events.map(e => {
+			switch (e.kind) {
+				case 'generic': return { kind: e.kind, id: e.id, parent: e.parentEventId, name: e.name, details: e.details, level: e.level, category: e.category };
+				case 'subagentInvocation': return { kind: e.kind, id: e.id, parent: e.parentEventId, agentName: e.agentName, status: e.status, toolCallCount: e.toolCallCount, durationInMillis: e.durationInMillis };
+				case 'toolCall': return { kind: e.kind, id: e.id, parent: e.parentEventId, toolName: e.toolName };
+				default: return { kind: e.kind, id: e.id, parent: e.parentEventId };
+			}
+		});
+
+		// Subagent uses the dedicated `subagentInvocation` kind (folding started +
+		// completed) and nests under its spawning `Agent` tool call. The approved
+		// permission `pReq2` is dropped; the denied `pReq`, compaction failure,
+		// abort and skill invocation all nest under the active turn `m`.
+		assert.deepStrictEqual(projection, [
+			{ kind: 'generic', id: 's', parent: undefined, name: 'Session Started', details: 'model=x', level: 1, category: 'session' },
+			{ kind: 'userMessage', id: 'u', parent: 's' },
+			{ kind: 'modelTurn', id: 'm', parent: 'u' },
+			{ kind: 'toolCall', id: 'tAgent', parent: 'm', toolName: 'Agent' },
+			{ kind: 'subagentInvocation', id: 'sa', parent: 'tAgent', agentName: 'Explore Agent', status: 'completed', toolCallCount: 5, durationInMillis: 2000 },
+			{ kind: 'generic', id: 'pReq', parent: 'm', name: 'Permission denied: read', details: 'Search', level: 2, category: 'permission' },
+			{ kind: 'generic', id: 'cs', parent: 'm', name: 'Context Compaction', details: 'system=100, conversation=200, tools=300 tokens', level: 1, category: 'session' },
+			{ kind: 'generic', id: 'cc', parent: 'm', name: 'Context Compaction Failed', details: 'boom', level: 3, category: 'session' },
+			{ kind: 'generic', id: 'ab', parent: 'm', name: 'Aborted', details: 'user_initiated', level: 2, category: 'session' },
+			{ kind: 'generic', id: 'sk', parent: 'm', name: 'Skill Invoked: troubleshoot', details: 'auto \u00b7 myplugin', level: 1, category: 'customization' },
+		]);
+
+		assert.deepStrictEqual(resolved.get('pReq'), { kind: 'text', value: 'kind: read\nintention: Search\npath: /x\nresult: denied' });
+		assert.deepStrictEqual(resolved.get('sk'), { kind: 'text', value: 'SKILL body' });
+	});
+
 	test('back-fills session.shutdown usage onto model turns so tile sums are exact', () => {
 		const { events } = convertAgentHostEventsToDebugEvents(records, sessionResource);
 		const turns = events.filter((e): e is IChatDebugModelTurnEvent => e.kind === 'modelTurn');
@@ -95,6 +186,41 @@ suite('AgentHostChatDebugProvider - convertAgentHostEventsToDebugEvents', () => 
 		);
 	});
 
+	test('back-fills per-round usage from the sidecar, correlating positionally across mismatched turn-id namespaces', () => {
+		// Real-world shape: events.jsonl keys `turnId` on a per-user-turn ROUND
+		// index that resets each turn (0,1 then 0), while the client sidecar keys
+		// on the backend REQUEST id (one id per user turn, shared by its rounds).
+		// The two namespaces never match, so correlation must be positional; the
+		// matching `outputTokens` both report confirm the 1:1 alignment.
+		const inProgress = [
+			{ type: 'session.start', id: 's', parentId: null, timestamp: '2026-06-17T00:00:00.000Z', data: {} },
+			{ type: 'user.message', id: 'u1', parentId: 's', timestamp: '2026-06-17T00:00:00.000Z', data: { content: 'one' } },
+			{ type: 'assistant.turn_start', id: 'ts0', parentId: 'u1', timestamp: '2026-06-17T00:00:01.000Z', data: { turnId: '0' } },
+			{ type: 'assistant.message', id: 'm0', parentId: 'ts0', timestamp: '2026-06-17T00:00:01.100Z', data: { model: 'x', outputTokens: 144, turnId: '0' } },
+			{ type: 'assistant.turn_start', id: 'ts1', parentId: 'm0', timestamp: '2026-06-17T00:00:02.000Z', data: { turnId: '1' } },
+			{ type: 'assistant.message', id: 'm1', parentId: 'ts1', timestamp: '2026-06-17T00:00:02.100Z', data: { model: 'x', outputTokens: 127, turnId: '1' } },
+			{ type: 'user.message', id: 'u2', parentId: 'm1', timestamp: '2026-06-17T00:00:03.000Z', data: { content: 'two' } },
+			{ type: 'assistant.turn_start', id: 'ts2', parentId: 'u2', timestamp: '2026-06-17T00:00:04.000Z', data: { turnId: '0' } },
+			{ type: 'assistant.message', id: 'm2', parentId: 'ts2', timestamp: '2026-06-17T00:00:04.100Z', data: { model: 'x', outputTokens: 52, turnId: '0' } },
+		];
+		// Cumulative AIU resets per user turn (request_A: 1e9→2e9; request_B: 5e8),
+		// so the per-turn max (2e9 + 5e8) sums exactly to 2.5 AIC.
+		const usageRecords = [
+			{ turnId: 'request_A', model: 'x', inputTokens: 100, outputTokens: 144, cacheReadTokens: 0, totalNanoAiu: 1_000_000_000, ts: '2026-06-17T00:00:01.150Z' },
+			{ turnId: 'request_A', model: 'x', inputTokens: 200, outputTokens: 127, cacheReadTokens: 90, totalNanoAiu: 2_000_000_000, ts: '2026-06-17T00:00:02.150Z' },
+			{ turnId: 'request_B', model: 'x', inputTokens: 300, outputTokens: 52, cacheReadTokens: 250, totalNanoAiu: 500_000_000, ts: '2026-06-17T00:00:04.150Z' },
+		];
+
+		const { events } = convertAgentHostEventsToDebugEvents(inProgress, sessionResource, undefined, usageRecords);
+		const turns = events.filter((e): e is IChatDebugModelTurnEvent => e.kind === 'modelTurn');
+		const sum = (pick: (t: IChatDebugModelTurnEvent) => number | undefined) => turns.reduce((acc, t) => acc + (pick(t) ?? 0), 0);
+
+		assert.deepStrictEqual(
+			{ input: sum(t => t.inputTokens), cached: sum(t => t.cachedTokens), output: sum(t => t.outputTokens), total: sum(t => t.totalTokens), aic: sum(t => t.copilotUsageNanoAiu) / 1_000_000_000 },
+			{ input: 600, cached: 340, output: 323, total: 923, aic: 2.5 },
+		);
+	});
+
 	test('a zero-usage session.shutdown takes precedence over the live fallback', () => {
 		// A finished session whose shutdown summary reports zero usage must NOT
 		// fall back to live AIU: zero is then a known total, not "unknown".
@@ -114,6 +240,50 @@ suite('AgentHostChatDebugProvider - convertAgentHostEventsToDebugEvents', () => 
 			{ aiu: sum(t => t.copilotUsageNanoAiu), input: sum(t => t.inputTokens) },
 			{ aiu: 0, input: 0 },
 		);
+	});
+
+	test('surfaces loaded customizations (skills/hooks/agents/MCP) as discovery events plus a summary', () => {
+		// Customizations arrive as a container tree (plugin/directory with children)
+		// plus a top-level MCP server; a disabled skill is surfaced as skipped.
+		const customizations = [
+			{
+				type: CustomizationType.Directory, id: 'dir', uri: 'file:///ws/.github', name: '.github', enabled: true, contents: CustomizationType.Skill, writable: true,
+				children: [
+					{ type: CustomizationType.Skill, id: 'sk1', uri: 'file:///ws/.github/skills/troubleshoot/SKILL.md', name: 'troubleshoot', description: 'Diagnose issues' },
+					{ type: CustomizationType.Skill, id: 'sk2', uri: 'file:///ws/.github/skills/legacy/SKILL.md', name: 'legacy', enabled: false },
+					{ type: CustomizationType.Agent, id: 'ag1', uri: 'file:///ws/.github/agents/explore.agent.md', name: 'explore', description: 'Explore the codebase' },
+					{ type: CustomizationType.Hook, id: 'hk1', uri: 'file:///ws/.github/hooks/lint.json', name: 'lint-on-save' },
+				],
+			},
+			{ type: CustomizationType.McpServer, id: 'mcp1', uri: 'file:///ws/.mcp.json', name: 'github', enabled: true, state: { kind: 'running' } },
+		] as unknown as readonly Customization[];
+
+		const { events, resolved } = buildCustomizationDebugEvents(customizations, sessionResource, 's', new Date('2026-06-17T00:00:00.000Z'));
+
+		const projection = events.map(e => e.kind === 'generic'
+			? { id: e.id, parent: e.parentEventId, name: e.name, details: e.details, category: e.category }
+			: { id: e.id });
+
+		// One discovery event per present type (skills/hooks/agents/MCP) followed by
+		// the roll-up summary, all parented under the session root `s`.
+		assert.deepStrictEqual(projection, [
+			{ id: 'agentHostCustomization:' + sessionResource.toString() + ':skill', parent: 's', name: 'Skill Discovery', details: '1 loaded, 1 disabled', category: 'discovery' },
+			{ id: 'agentHostCustomization:' + sessionResource.toString() + ':hook', parent: 's', name: 'Hook Discovery', details: '1 loaded', category: 'discovery' },
+			{ id: 'agentHostCustomization:' + sessionResource.toString() + ':agent', parent: 's', name: 'Agent Discovery', details: '1 loaded', category: 'discovery' },
+			{ id: 'agentHostCustomization:' + sessionResource.toString() + ':mcpServer', parent: 's', name: 'MCP Server Discovery', details: '1 loaded', category: 'discovery' },
+			{ id: 'agentHostCustomization:' + sessionResource.toString() + ':summary', parent: 's', name: 'Resolve Customizations', details: '1 skills, 1 agents, 1 hooks, 0 instructions', category: 'customization' },
+		]);
+
+		// The skill discovery event expands to a file list marking the disabled skill skipped.
+		const skillList = resolved.get('agentHostCustomization:' + sessionResource.toString() + ':skill') as IChatDebugEventFileListContent;
+		assert.deepStrictEqual(skillList.files.map(f => ({ name: f.name, status: f.status })), [
+			{ name: 'troubleshoot', status: 'loaded' },
+			{ name: 'legacy', status: 'skipped' },
+		]);
+
+		// The summary counts loaded skills/agents/hooks and the one skipped skill.
+		const summary = resolved.get('agentHostCustomization:' + sessionResource.toString() + ':summary') as IChatDebugEventCustomizationSummaryContent;
+		assert.deepStrictEqual(summary.counts, { instructions: 0, skills: 1, agents: 1, hooks: 1, skipped: 1 });
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentHostCustomizationSidecar.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHostCustomizationSidecar.test.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../base/common/async.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { FileService } from '../../../../../platform/files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { NullRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { ActionType, type ActionEnvelope } from '../../../../../platform/agentHost/common/state/sessionActions.js';
+import { CustomizationType, type Customization } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { AgentHostCustomizationRecorder, buildAgentHostCustomizationsUri, readAgentHostCustomizationsSnapshot } from '../../browser/chatDebug/agentHostUsageSidecar.js';
+
+suite('AgentHostCustomizationRecorder', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	const baseDir = URI.file('/user');
+
+	function makeFileService(): FileService {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(Schemas.file, disposables.add(new InMemoryFileSystemProvider())));
+		return fileService;
+	}
+
+	const skills = [
+		{ type: CustomizationType.Skill, id: 'sk1', uri: 'file:///ws/.github/skills/troubleshoot/SKILL.md', name: 'troubleshoot', enabled: true },
+		{ type: CustomizationType.Hook, id: 'hk1', uri: 'file:///ws/.github/hooks/lint.json', name: 'lint-on-save', enabled: true },
+	] as unknown as Customization[];
+
+	/** Polls the sidecar until the snapshot appears (the recorder writes async). */
+	async function waitForSnapshot(fileService: FileService, rawId: string): Promise<Customization[] | undefined> {
+		const uri = buildAgentHostCustomizationsUri(baseDir, rawId);
+		for (let i = 0; i < 100; i++) {
+			const snapshot = await readAgentHostCustomizationsSnapshot(fileService, uri);
+			if (snapshot !== undefined) {
+				return snapshot;
+			}
+			await timeout(0);
+		}
+		return undefined;
+	}
+
+	test('round-trips a snapshot; missing and malformed files read as undefined', async () => {
+		const fileService = makeFileService();
+		const uri = buildAgentHostCustomizationsUri(baseDir, 'abc');
+
+		// Missing file → undefined.
+		assert.strictEqual(await readAgentHostCustomizationsSnapshot(fileService, uri), undefined);
+
+		// Written array round-trips exactly.
+		await fileService.writeFile(uri, VSBuffer.fromString(JSON.stringify(skills)));
+		assert.deepStrictEqual(await readAgentHostCustomizationsSnapshot(fileService, uri), skills);
+
+		// Malformed content → undefined (rather than throwing).
+		await fileService.writeFile(uri, VSBuffer.fromString('{ not json'));
+		assert.strictEqual(await readAgentHostCustomizationsSnapshot(fileService, uri), undefined);
+	});
+
+	test('writes the snapshot for a Copilot CLI session channel and ignores other channels/actions', async () => {
+		const fileService = makeFileService();
+		const actions = disposables.add(new Emitter<ActionEnvelope>());
+		disposables.add(new AgentHostCustomizationRecorder(
+			baseDir,
+			() => true,
+			fileService,
+			new NullLogService(),
+			{ onDidAction: actions.event },
+			new NullRemoteAgentHostService(),
+		));
+
+		// Ignored: a non-customization action, and a customization action on a
+		// non-Copilot-CLI channel — neither should produce a sidecar file.
+		actions.fire({ channel: 'copilotcli:/wrongtype', action: { type: ActionType.ChatUsage, turnId: '0', usage: {} }, serverSeq: 1, origin: undefined } as unknown as ActionEnvelope);
+		actions.fire({ channel: 'ahp-root://', action: { type: ActionType.SessionCustomizationsChanged, customizations: skills }, serverSeq: 2, origin: undefined } as unknown as ActionEnvelope);
+
+		// Captured: a full-replacement customizations change on the session's
+		// `copilotcli:/<rawId>` channel is persisted under that raw id.
+		actions.fire({ channel: 'copilotcli:/good', action: { type: ActionType.SessionCustomizationsChanged, customizations: skills }, serverSeq: 3, origin: undefined } as unknown as ActionEnvelope);
+
+		assert.deepStrictEqual(await waitForSnapshot(fileService, 'good'), skills);
+		// The ignored actions left no sidecar behind.
+		assert.strictEqual(await readAgentHostCustomizationsSnapshot(fileService, buildAgentHostCustomizationsUri(baseDir, 'wrongtype')), undefined);
+		assert.strictEqual(await readAgentHostCustomizationsSnapshot(fileService, buildAgentHostCustomizationsUri(baseDir, '')), undefined);
+	});
+
+	test('does not capture while disabled', async () => {
+		const fileService = makeFileService();
+		const actions = disposables.add(new Emitter<ActionEnvelope>());
+		let enabled = false;
+		disposables.add(new AgentHostCustomizationRecorder(
+			baseDir,
+			() => enabled,
+			fileService,
+			new NullLogService(),
+			{ onDidAction: actions.event },
+			new NullRemoteAgentHostService(),
+		));
+
+		actions.fire({ channel: 'copilotcli:/gated', action: { type: ActionType.SessionCustomizationsChanged, customizations: skills }, serverSeq: 1, origin: undefined } as unknown as ActionEnvelope);
+		await timeout(2);
+		assert.strictEqual(await readAgentHostCustomizationsSnapshot(fileService, buildAgentHostCustomizationsUri(baseDir, 'gated')), undefined);
+
+		// Once enabled, a subsequent action is captured.
+		enabled = true;
+		actions.fire({ channel: 'copilotcli:/gated', action: { type: ActionType.SessionCustomizationsChanged, customizations: skills }, serverSeq: 2, origin: undefined } as unknown as ActionEnvelope);
+		assert.deepStrictEqual(await waitForSnapshot(fileService, 'gated'), skills);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/chatEditing/chatEditingService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatEditing/chatEditingService.test.ts
@@ -52,6 +52,7 @@ import { MockChatVariablesService } from '../../common/mockChatVariables.js';
 import { MockPromptsService } from '../../common/promptSyntax/service/mockPromptsService.js';
 import { IChatDebugService } from '../../../common/chatDebugService.js';
 import { ChatDebugServiceImpl } from '../../../common/chatDebugServiceImpl.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 
 function getAgentData(id: string): IChatAgentData {
 	return {
@@ -91,7 +92,7 @@ suite('ChatEditingService', function () {
 		collection.set(IMcpService, new TestMcpService());
 		collection.set(IPromptsService, new MockPromptsService());
 		collection.set(ILanguageModelsService, new SyncDescriptor(NullLanguageModelsService));
-		collection.set(IChatDebugService, new ChatDebugServiceImpl());
+		collection.set(IChatDebugService, new ChatDebugServiceImpl(new TestConfigurationService()));
 		collection.set(IMultiDiffSourceResolverService, new class extends mock<IMultiDiffSourceResolverService>() {
 			override registerResolver(_resolver: IMultiDiffSourceResolver): IDisposable {
 				return Disposable.None;

--- a/src/vs/workbench/contrib/chat/test/browser/promptsDebugContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/promptsDebugContribution.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { Emitter } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ChatDebugLogLevel, IChatDebugEvent, IChatDebugGenericEvent, IChatDebugService } from '../../common/chatDebugService.js';
 import { ChatDebugServiceImpl } from '../../common/chatDebugServiceImpl.js';
@@ -46,7 +47,7 @@ suite('PromptsDebugContribution', () => {
 	setup(() => {
 		instaService = disposables.add(new TestInstantiationService());
 
-		chatDebugService = disposables.add(new ChatDebugServiceImpl());
+		chatDebugService = disposables.add(new ChatDebugServiceImpl(new TestConfigurationService()));
 		instaService.stub(IChatDebugService, chatDebugService);
 
 		willInvokeAgentEmitter = disposables.add(new Emitter<IChatAgentInvocationEvent>());

--- a/src/vs/workbench/contrib/chat/test/common/chatDebugServiceImpl.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatDebugServiceImpl.test.ts
@@ -8,6 +8,7 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../base/
 import { errorHandler } from '../../../../../base/common/errors.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ChatDebugLogLevel, IChatDebugEvent, IChatDebugGenericEvent, IChatDebugLogProvider, IChatDebugModelTurnEvent, IChatDebugResolvedEventContent, IChatDebugToolCallEvent } from '../../common/chatDebugService.js';
 import { ChatDebugServiceImpl } from '../../common/chatDebugServiceImpl.js';
 import { LocalChatSessionUri } from '../../common/model/chatUri.js';
@@ -27,7 +28,7 @@ suite('ChatDebugServiceImpl', () => {
 	const claudeCodeSession = URI.parse('claude-code:/test-session-id');
 
 	setup(() => {
-		service = disposables.add(new ChatDebugServiceImpl());
+		service = disposables.add(new ChatDebugServiceImpl(new TestConfigurationService()));
 	});
 
 	suite('addEvent and getEvents', () => {
@@ -333,6 +334,32 @@ suite('ChatDebugServiceImpl', () => {
 	});
 
 	suite('invokeProviders', () => {
+		test('re-invocation that returns undefined should preserve previously loaded events', async () => {
+			// A provider that succeeds once and then transiently fails (e.g. an
+			// Agent Host session's events.jsonl is mid-rewrite by the external
+			// CLI) must not wipe the events currently shown.
+			let succeed = true;
+			const provider: IChatDebugLogProvider = {
+				provideChatDebugLog: async () => succeed ? [{
+					kind: 'generic',
+					sessionResource: sessionGeneric,
+					created: new Date(),
+					name: 'provider-event',
+					level: ChatDebugLogLevel.Info,
+				}] : undefined,
+			};
+
+			disposables.add(service.registerProvider(provider));
+
+			await service.invokeProviders(sessionGeneric);
+			assert.strictEqual(service.getEvents(sessionGeneric).length, 1);
+
+			// Second invocation fails (returns undefined) — events are kept.
+			succeed = false;
+			await service.invokeProviders(sessionGeneric);
+			assert.strictEqual(service.getEvents(sessionGeneric).length, 1);
+		});
+
 		test('should invoke multiple providers and merge events', async () => {
 			const providerA: IChatDebugLogProvider = {
 				provideChatDebugLog: async () => [{

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -198,7 +198,7 @@ suite('ChatService', () => {
 		instantiationService.stub(IEnvironmentService, { workspaceStorageHome: URI.file('/test/path/to/workspaceStorage') });
 		instantiationService.stub(ILifecycleService, { onWillShutdown: Event.None });
 		instantiationService.stub(IWorkspaceEditingService, { onDidEnterWorkspace: Event.None });
-		instantiationService.stub(IChatDebugService, testDisposables.add(new ChatDebugServiceImpl()));
+		instantiationService.stub(IChatDebugService, testDisposables.add(new ChatDebugServiceImpl(new TestConfigurationService())));
 		editingSessionEntries = observableValue('editingSessionEntries', []);
 		instantiationService.stub(IChatEditingService, new class extends mock<IChatEditingService>() {
 			override startOrContinueGlobalEditingSession(): IChatEditingSession {


### PR DESCRIPTION

## Summary

Builds out the Agent Debug Logs panel so it can debug Agent Host (Copilot CLI) sessions — local and remote — alongside existing local chat sessions. Adds a AHP wire log view, per-session token-usage capture, and setting-based gating so the panel does no debug work (and clearly prompts to enable it) when the relevant setting is off. Other harness (Claude, Codex) will be addressed separately.

## What's included

### Agent Host session support
- `agentHostChatDebugProvider.ts` significantly expanded to discover and stream Copilot CLI sessions into the debug panel, including remote agent-host connections.
- `IChatDebugService.registerAvailableSessionsFetcher` now supports multiple fetchers (extension host + local agent-host discovery), each invoked once, and returns an `IDisposable` to unregister.

### New AHP Wire Log view (`chatDebugWireLogView.ts`)
- User-friendly rendering of client↔host AHP JSON-RPC frames: pairs requests with responses, shows direction/latency/errors, source picker for rotated logs, live refresh, filtering, and "Open Full File".

### Shared log-source module (`agentHostLogSources.ts`)
- Centralizes enumeration/reading of agent-host log sources (events.jsonl, AHP wire logs, Copilot SDK process logs, output channels). The export action was refactored to reuse these helpers (hence its net reduction).

### Token-usage sidecar (`agentHostUsageSidecar.ts`)
- Persists per-turn/per-call `ChatUsage` metrics to a sidecar so token totals survive restarts and aren't lost to reduced chat state.

### Setting-based gating (`chatDebugEnablement.ts`)
- When agent debug logging is off for a session, the Logs / Flow Chart / Cache Explorer sub-views and the Overview summary show an "Enable in Settings" message instead of empty content; navigation buttons stay visible.
- The AHP Log view is gated the same way on `AgentHostAhpJsonlLoggingSettingId`.
- Export/Import debug-log toolbar actions are hidden for Agent Host sessions via a new editor-scoped context key (`chatDebug.activeSessionIsAgentHost`).