### PR TITLE
Align compact activity bar chip size and spacing with top/bottom

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -31,10 +31,17 @@
 	background-color: var(--vscode-activityBar-activeBackground, var(--vscode-list-inactiveSelectionBackground));
 }
 
-/* Compact: minimal horizontal inset — 28×28px box centered in the 32px item. */
+/*
+ * Compact side bar: match the top/bottom horizontal activity bar's 24×24 chip
+ * (see composite-bar rules below) so icon density and selected/hover affordances
+ * stay consistent across activity bar positions. See #325127.
+ */
 .style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
-	width: calc(var(--activity-bar-action-height, 32px) - 4px);
-	height: calc(var(--activity-bar-action-height, 32px) - 4px);
+	top: 4px;
+	left: calc((var(--activity-bar-width, 32px) - 24px) / 2);
+	width: 24px;
+	height: 24px;
+	border-radius: var(--vscode-cornerRadius-small);
 }
 
 /*
@@ -92,11 +99,28 @@
 	background-color: var(--vscode-list-hoverBackground);
 }
 
-/* Compact: minimal horizontal inset — 28×28px box centered in the 32px item. */
+/* Compact: same 24×24 hover chip as top/bottom (and as the compact active chip). */
 .style-override .activitybar.compact > .content:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover::before {
-	left: 2px;
-	width: calc(var(--activity-bar-action-height, 32px) - 4px);
-	height: calc(var(--activity-bar-action-height, 32px) - 4px);
+	top: 4px;
+	bottom: auto;
+	margin: 0;
+	left: calc((var(--activity-bar-width, 32px) - 24px) / 2);
+	width: 24px;
+	height: 24px;
+	border-radius: var(--vscode-cornerRadius-small);
+}
+
+/*
+ * Match horizontal activity bar item spacing (4px). The vertical action bar
+ * uses `display: inline-block` for `.actions-container`, so CSS `gap` is a no-op
+ * — switch compact side bars to a column flex layout so the gap applies.
+ */
+.style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar.vertical .actions-container {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 4px;
+	height: auto;
 }
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -37,7 +37,10 @@
  * stay consistent across activity bar positions. See #325127.
  */
 .style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
+	/* Reset bottom/margin from activityaction.css so top+height center at 4px, matching hover. */
 	top: 4px;
+	bottom: auto;
+	margin: 0;
 	left: calc((var(--activity-bar-width, 32px) - 24px) / 2);
 	width: 24px;
 	height: 24px;


### PR DESCRIPTION
Fixes #325127

## Summary

In Modern UI compact mode, the side activity bar's selected/hover chips were **28×28** with a larger radius, while the top/bottom activity bar uses **24×24** chips with `cornerRadius-small`. Item spacing was also off on the side because the vertical action bar uses `display: inline-block`, so CSS `gap` never applied.

This brings the compact side bar in line with top/bottom: 24×24 chips, matching radius, and a 4px gap between items.

## Changes

In `activityBar.css`:

- Size compact active/hover indicators to 24×24 and center them in the 32px-wide bar
- Use `cornerRadius-small` (same as horizontal)
- Switch compact vertical `.actions-container` to a column flex layout so `gap: 4px` works
- Reset inherited `bottom`/`margin` on the active chip so it aligns with hover at `top: 4px`


### Screenshots

**Before — compact side (28×28, no gap)**

<img src="https://raw.githubusercontent.com/cipheraxat/cipheraxat/master/assets/vscode-325127/01-before-compact-side.png" width="48" alt="Before compact side" />

**Before — top (24×24 reference)**

<img src="https://raw.githubusercontent.com/cipheraxat/cipheraxat/master/assets/vscode-325127/02-before-top.png" height="40" alt="Before top" />

**After — compact side (24×24, 4px gap)**

<img src="https://raw.githubusercontent.com/cipheraxat/cipheraxat/master/assets/vscode-325127/03-after-compact-side.png" width="48" alt="After compact side" />

**After — top (unchanged)**

<img src="https://raw.githubusercontent.com/cipheraxat/cipheraxat/master/assets/vscode-325127/04-after-top.png" height="40" alt="After top" />

<details>
<summary>Full workbench</summary>

Before:

<img src="https://raw.githubusercontent.com/cipheraxat/cipheraxat/master/assets/vscode-325127/01-before-compact-side-workbench.png" width="720" alt="Before workbench" />

After:

<img src="https://raw.githubusercontent.com/cipheraxat/cipheraxat/master/assets/vscode-325127/03-after-compact-side-workbench.png" width="720" alt="After workbench" />

</details>

## How to test

1. Enable `"workbench.experimental.modernUI": true`
2. Set Activity Bar location to **Side** and size to **Compact** (or the equivalent layout that yields the 32px-wide bar)
3. Confirm the selected/hover chip is the same size as when Activity Bar is **Top** / **Bottom**
4. Confirm spacing between icons matches the horizontal bar