### PR TITLE
Fix Extensions view showing redundant Disable dropdown for workspace-enabled extensions

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1780,7 +1780,9 @@ export class DisableGloballyAction extends ExtensionAction {
 				return;
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				// EnabledWorkspace can mean the extension is disabled globally but re-enabled
+				// just for this workspace, in which case "Disable" (globally) shouldn't be offered.
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
@@ -860,6 +860,22 @@ suite('ExtensionsActions', () => {
 			});
 	});
 
+	test('Test DisableGloballyAction when the extension is disabled globally and enabled for workspace', () => {
+		const local = aLocalExtension('a');
+		return instantiationService.get(IWorkbenchExtensionEnablementService).setEnablement([local], EnablementState.DisabledGlobally)
+			.then(() => instantiationService.get(IWorkbenchExtensionEnablementService).setEnablement([local], EnablementState.EnabledWorkspace))
+			.then(() => {
+				instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [local]);
+
+				return instantiationService.get(IExtensionsWorkbenchService).queryLocal()
+					.then(extensions => {
+						const testObject: ExtensionsActions.DisableGloballyAction = disposables.add(instantiationService.createInstance(ExtensionsActions.DisableGloballyAction));
+						testObject.extension = extensions[0];
+						assert.ok(!testObject.enabled);
+					});
+			});
+	});
+
 	test('Test DisableGloballyAction when the extension is enabled', () => {
 		const local = aLocalExtension('a');
 		instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [local]);


### PR DESCRIPTION
## Summary

Fixes #244138.

When an extension is disabled globally and then explicitly re-enabled for the current workspace only, its `enablementState` becomes `EnablementState.EnabledWorkspace`. `DisableGloballyAction.update()` treated that state the same as `EnablementState.EnabledGlobally`, so the "Disable" (global) action stayed enabled and visible alongside "Disable (Workspace)" — producing a dropdown with both options even though the extension isn't actually enabled globally in this state.

This change restricts `DisableGloballyAction` to only be enabled when the extension's `enablementState` is `EnabledGlobally`, so in the workspace-override case the Extensions view shows a single "Disable (Workspace)" button with no dropdown, matching the expected behavior described in the issue.

## Test plan

- [ ] Install an extension and disable it globally.
- [ ] Enable the extension for the current workspace only.
- [ ] In the Extensions view, confirm the action button reads "Disable (Workspace)" with no dropdown arrow/menu.
- [ ] Confirm a normally (globally) enabled extension still shows the "Disable" dropdown with both "Disable" and "Disable (Workspace)" options, unchanged from before.