### PR TITLE
AgentHost - seed active-client customizations on Claude session creation

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -676,6 +676,10 @@ export class ClaudeAgent extends Disposable implements IAgent {
 
 		const existing = this._findAnySession(sessionId);
 		if (existing) {
+			// Re-apply the eager active client on reconnect: AgentService reissues
+			// `createSession` for an existing URI, so the reconnected client's
+			// tools/customizations must still reach Claude (mirrors Copilot).
+			await this._seedEagerActiveClient(sessionUri, config.activeClient);
 			if (!existing.isPipelineReady) {
 				return {
 					session: existing.sessionUri,
@@ -716,19 +720,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			this._instantiationService,
 		);
 		this._seedSessionEntry(sessionId, sessionUri, session);
-
-		// Seed the eagerly-claimed active client (mirrors the Copilot agent) so
-		// its synced customizations — e.g. the built-in skills bundle — reach the
-		// SDK at creation. Without this no follow-up `session/activeClientSet` is
-		// dispatched (the state already matches), so the sync would never fire.
-		if (config.activeClient) {
-			const seeded = config.activeClient;
-			const handle = this.getOrCreateActiveClient(sessionUri, { clientId: seeded.clientId, displayName: seeded.displayName });
-			handle.tools = seeded.tools;
-			if (seeded.customizations !== undefined) {
-				await this.syncClientCustomizations(sessionUri, seeded.clientId, seeded.customizations);
-			}
-		}
+		await this._seedEagerActiveClient(sessionUri, config.activeClient);
 
 		return {
 			session: sessionUri,
@@ -736,6 +728,28 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			provisional: true,
 			...(project ? { project } : {}),
 		};
+	}
+
+	/**
+	 * Seed the eagerly-claimed active client (tools + customizations) into the
+	 * SDK at session creation, mirroring the Copilot agent. Runs for fresh AND
+	 * reconnected sessions: when the workbench session state already carries the
+	 * active client, no follow-up `session/activeClientSet` is dispatched to
+	 * trigger the customization sync, so the built-in skills bundle would never
+	 * reach Claude otherwise. Progress is suppressed (`quiet`) because the AH
+	 * service has not created the session state yet — a
+	 * `SessionCustomizationUpdated` envelope would be orphaned; the completed
+	 * snapshot is provided via `getSessionCustomizations` immediately after.
+	 */
+	private async _seedEagerActiveClient(sessionUri: URI, activeClient: IAgentCreateSessionConfig['activeClient']): Promise<void> {
+		if (!activeClient) {
+			return;
+		}
+		const handle = this.getOrCreateActiveClient(sessionUri, { clientId: activeClient.clientId, displayName: activeClient.displayName });
+		handle.tools = activeClient.tools;
+		if (activeClient.customizations !== undefined) {
+			await this.syncClientCustomizations(sessionUri, activeClient.clientId, activeClient.customizations, { quiet: true });
+		}
 	}
 
 	/**
@@ -2041,7 +2055,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		entry?.defaultChat?.completeClientToolCall(toolCallId, result);
 	}
 
-	async syncClientCustomizations(session: URI, clientId: string, customizations: ClientPluginCustomization[]): Promise<ISyncedCustomization[]> {
+	async syncClientCustomizations(session: URI, clientId: string, customizations: ClientPluginCustomization[], options?: { readonly quiet?: boolean }): Promise<ISyncedCustomization[]> {
 		const sessionId = AgentSession.id(session);
 		const sess = this._findAnySession(sessionId);
 		if (!sess) {
@@ -2057,7 +2071,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			const synced = await this._pluginManager.syncCustomizations(
 				clientId,
 				customizations,
-				status => this._fireCustomizationUpdated(session, { customization: status }),
+				options?.quiet ? undefined : status => this._fireCustomizationUpdated(session, { customization: status }),
 			);
 			sess.adoptClientCustomizations(clientId, synced);
 			return synced;

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -717,6 +717,19 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		);
 		this._seedSessionEntry(sessionId, sessionUri, session);
 
+		// Seed the eagerly-claimed active client (mirrors the Copilot agent) so
+		// its synced customizations — e.g. the built-in skills bundle — reach the
+		// SDK at creation. Without this no follow-up `session/activeClientSet` is
+		// dispatched (the state already matches), so the sync would never fire.
+		if (config.activeClient) {
+			const seeded = config.activeClient;
+			const handle = this.getOrCreateActiveClient(sessionUri, { clientId: seeded.clientId, displayName: seeded.displayName });
+			handle.tools = seeded.tools;
+			if (seeded.customizations !== undefined) {
+				await this.syncClientCustomizations(sessionUri, seeded.clientId, seeded.customizations);
+			}
+		}
+
 		return {
 			session: sessionUri,
 			workingDirectory,

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -5918,6 +5918,39 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 		return { agent, proxy, api, sdk, sessionData, stateManager, configService, instantiationService, fileService };
 	}
 
+	test('createSession seeds the eager activeClient customizations to the plugin manager', async () => {
+		const pm = new FakeAgentPluginManager();
+		const { agent } = buildCtxWith(pm);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		const customizations = [makeClientCustomization('https://bundle', 'Synced')];
+		await agent.createSession({
+			session: AgentSession.uri('claude', 'eager'),
+			workingDirectory: URI.file('/work'),
+			activeClient: { clientId: 'client-1', tools: [], customizations },
+		});
+
+		// The eagerly-claimed active client's customizations must be synced at
+		// creation (mirrors the Copilot agent). Without this, built-in skills
+		// like `/create-pr` never reach the SDK: the workbench state already
+		// carries the active client, so no follow-up `session/activeClientSet`
+		// is dispatched to trigger the sync.
+		assert.deepStrictEqual(pm.syncCalls, [{ clientId: 'client-1', customizations }]);
+	});
+
+	test('createSession without an activeClient does not sync customizations', async () => {
+		const pm = new FakeAgentPluginManager();
+		const { agent } = buildCtxWith(pm);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		await agent.createSession({
+			session: AgentSession.uri('claude', 'no-eager'),
+			workingDirectory: URI.file('/work'),
+		});
+
+		assert.deepStrictEqual(pm.syncCalls, []);
+	});
+
 	test('setClientCustomizations forwards each item as a SessionCustomizationUpdated action', async () => {
 		const pm = new FakeAgentPluginManager();
 		pm.syncResult = [makeSyncedRef('https://a', '/p/a'), makeSyncedRef('https://b', '/p/b')];

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -5951,6 +5951,52 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 		assert.deepStrictEqual(pm.syncCalls, []);
 	});
 
+	test('createSession re-seeds the eager activeClient on reconnect to an existing session', async () => {
+		const pm = new FakeAgentPluginManager();
+		const { agent } = buildCtxWith(pm);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		const customizations = [makeClientCustomization('https://bundle', 'Synced')];
+		const cfg = {
+			session: AgentSession.uri('claude', 'reconnect'),
+			workingDirectory: URI.file('/work'),
+			activeClient: { clientId: 'client-1', tools: [], customizations },
+		};
+		await agent.createSession(cfg);
+		// AgentService reissues createSession for the same URI on reconnect; the
+		// eager client must be re-applied even though the session already exists.
+		await agent.createSession(cfg);
+
+		assert.deepStrictEqual(pm.syncCalls, [
+			{ clientId: 'client-1', customizations },
+			{ clientId: 'client-1', customizations },
+		]);
+	});
+
+	test('createSession eager seeding suppresses orphan customization progress', async () => {
+		const pm = new FakeAgentPluginManager();
+		pm.syncResult = [makeSyncedRef('https://bundle', '/p/bundle')];
+		const { agent } = buildCtxWith(pm);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		const updates: string[] = [];
+		disposables.add(agent.onDidSessionProgress(s => {
+			if (s.kind === 'action' && s.action.type === ActionType.SessionCustomizationUpdated) {
+				updates.push(s.action.customization.uri.toString());
+			}
+		}));
+
+		await agent.createSession({
+			session: AgentSession.uri('claude', 'quiet'),
+			workingDirectory: URI.file('/work'),
+			activeClient: { clientId: 'client-1', tools: [], customizations: [makeClientCustomization('https://bundle', 'Synced')] },
+		});
+
+		// The session state does not exist yet at create time, so the initial
+		// sync must be quiet — no orphan SessionCustomizationUpdated envelopes.
+		assert.deepStrictEqual(updates, []);
+	});
+
 	test('setClientCustomizations forwards each item as a SessionCustomizationUpdated action', async () => {
 		const pm = new FakeAgentPluginManager();
 		pm.syncResult = [makeSyncedRef('https://a', '/p/a'), makeSyncedRef('https://b', '/p/b')];


### PR DESCRIPTION
## Problem
Agent-host **Claude** sessions in the Agents window don't receive the synced customization bundle — the built-in skills backing `/create-pr`, `/fix-ci`, `/merge`, etc. — even though Copilot sessions do.

## Root cause
The workbench bakes the eagerly-claimed `activeClient` (which carries the resolved bundle) into the session state at creation. `copilotAgent.createSession` seeds it (`sessionConfig.activeClient` → `pluginController.sync`), but `claudeAgent.createSession` never did. Because the workbench state already contains that active client, no follow-up `session/activeClientSet` is dispatched (it dedups against the existing state), so `claudeAgent.syncClientCustomizations` never ran — leaving Claude sessions without the built-in skills.

## Fix
Seed the active client in `claudeAgent.createSession` (right after `_seedSessionEntry`), mirroring the Copilot agent: set the client's tools and `await syncClientCustomizations` for its customizations.

## Tests
- `createSession seeds the eager activeClient customizations to the plugin manager`
- `createSession without an activeClient does not sync customizations`

## Verification
Launched the Agents window and created an agent-host Claude session: the bundle now syncs + materializes, and `/create-pr`, `/create-draft-pr`, `/fix-ci` appear in the session's slash-command completion. Full `npm run test-node` suite green (12142 passing); `typecheck-client` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)