### PR TITLE
Recognise OCaml in settings labels

### DIFF
--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -236,6 +236,7 @@ knownTermMappings.set('powershell', 'PowerShell');
 knownTermMappings.set('javascript', 'JavaScript');
 knownTermMappings.set('typescript', 'TypeScript');
 knownTermMappings.set('github', 'GitHub');
+knownTermMappings.set('ocaml', 'OCaml');
 knownTermMappings.set('jet brains', 'JetBrains');
 knownTermMappings.set('jetbrains', 'JetBrains');
 knownTermMappings.set('re sharper', 'ReSharper');

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
@@ -132,6 +132,13 @@ suite('SettingsTree', () => {
 				category: 'PowerShell',
 				label: 'Some PowerShell Setting'
 			});
+
+		assert.deepStrictEqual(
+			settingKeyToDisplayFormat('ocaml.server.extendedHover'),
+			{
+				category: 'OCaml › Server',
+				label: 'Extended Hover'
+			});
 	});
 
 	test('parseQuery', () => {


### PR DESCRIPTION
## Summary

- recognise `ocaml` as the `OCaml` term when formatting settings labels
- add a regression test for nested OCaml settings

Configuration keys such as `ocaml.server.extendedHover` are currently rendered as `Ocaml › Server: Extended Hover`. This change uses the official `OCaml` spelling while leaving configuration keys unchanged.

@ulugbekna, could you please have a look? This affects the presentation of settings contributed by the OCaml extension.

## Testing

- `npm run typecheck-client`
- `npm run gulp compile-client`
- `./scripts/test.sh --grep 'settingKeyToDisplayFormat - known acronym/term'`
- `npm run eslint -- src/vs/workbench/contrib/preferences/common/preferences.ts src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts`
