### PR TITLE
fix(extensions): remove global Disable action if extension is already disabled globally

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1780,7 +1780,7 @@ export class DisableGloballyAction extends ExtensionAction {
 				return;
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& (this.extension.enablementState === EnablementState.EnabledGlobally || (this.extension.enablementState === EnablementState.EnabledWorkspace && !this.extensionEnablementService.isDisabledGlobally(this.extension.local)))
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
Fixes #244138

When an extension is disabled globally and then enabled for a workspace, the `DisableGloballyAction` would still be enabled, causing the dropdown to show both `Disable` and `Disable (Workspace)`.

This PR updates `DisableGloballyAction.update()` to check `!this.extensionEnablementService.isDisabledGlobally(this.extension.local)` when the extension's state is `EnabledWorkspace`. This ensures the global Disable action is hidden if the extension is already globally disabled, leaving only the `Disable (Workspace)` button as expected.