### PR TITLE
fix(markdown): prevent angle brackets from auto-closing inside math blocks

### DIFF
--- a/extensions/markdown-math/package.json
+++ b/extensions/markdown-math/package.json
@@ -44,6 +44,9 @@
         ],
         "embeddedLanguages": {
           "meta.embedded.math.markdown": "latex"
+        },
+        "tokenTypes": {
+          "meta.embedded.math.markdown": "string"
         }
       },
       {
@@ -55,6 +58,9 @@
         "embeddedLanguages": {
           "meta.embedded.math.markdown": "latex",
           "punctuation.definition.math.end.markdown": "latex"
+        },
+        "tokenTypes": {
+          "meta.embedded.math.markdown": "string"
         }
       },
       {
@@ -65,6 +71,9 @@
         ],
         "embeddedLanguages": {
           "meta.embedded.math.markdown": "latex"
+        },
+        "tokenTypes": {
+          "meta.embedded.math.markdown": "string"
         }
       }
     ],


### PR DESCRIPTION
Fixes #272922

When typing `<` inside markdown math blocks (`$ ... $`), it currently auto-closes to `<>` because the markdown language configuration specifies that angle brackets should auto-close unless inside a `string`.

This PR assigns the `meta.embedded.math.markdown` scope to the `string` token type in `extensions/markdown-math/package.json`. This elegantly prevents the unwanted auto-closing of `<` inside LaTeX math blocks without requiring any renaming of textmate scopes.