### PR TITLE
feat: auto fetch models for custom endpoint BYOK

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2039,6 +2039,18 @@
               "title": "API Type",
               "markdownDescription": "Default request/response format for models in this group. Individual models can override this with their own `apiType` property; when both are unset the type is inferred from the URL path."
             },
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "Base URL for the endpoint provider. Used for model discovery when auto-fetching is enabled.",
+              "title": "Base URL"
+            },
+            "autoFetch": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to automatically fetch models from the base URL.",
+              "title": "Auto Fetch Models"
+            },
             "models": {
               "type": "array",
               "defaultSnippets": [

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -83,6 +83,7 @@ function apiTypeToSupportedEndpoints(apiType: CustomEndpointApiType): ModelSuppo
 export interface CustomEndpointModelProviderConfig extends LanguageModelChatConfiguration {
 	url?: string;
 	apiType?: CustomEndpointApiType;
+	autoFetch?: boolean;
 	models?: CustomEndpointModelConfig[];
 }
 
@@ -133,18 +134,61 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 	}
 
 	protected override async getAllModels(silent: boolean, apiKey: string | undefined, configuration: CustomEndpointModelProviderConfig | undefined): Promise<OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>[]> {
-		if (configuration?.url) {
-			return super.getAllModels(silent, apiKey, configuration);
+		const autoFetch = configuration?.autoFetch ?? (!configuration?.models || configuration.models.length === 0);
+		
+		let fetchedModels: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>[] = [];
+		if (autoFetch && configuration?.url) {
+			fetchedModels = await super.getAllModels(silent, apiKey, configuration);
 		}
+
+		const fetchedModelMap = new Map<string, OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>>();
+		for (const model of fetchedModels) {
+			fetchedModelMap.set(model.id, model);
+		}
+
 		const models: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>[] = [];
-		if (Array.isArray(configuration?.models)) {
-			for (const modelConfig of configuration.models) {
+		const explicitModels = configuration?.models || [];
+		const explicitIds = new Set(explicitModels.map(m => m.id));
+
+		for (const explicitModel of explicitModels) {
+			const fetched = fetchedModelMap.get(explicitModel.id);
+			const mergedConfig: CustomEndpointModelConfig = {
+				name: fetched?.name || explicitModel.id,
+				maxInputTokens: fetched?.maxInputTokens,
+				maxOutputTokens: fetched?.maxOutputTokens,
+				...explicitModel
+			} as CustomEndpointModelConfig;
+			
+			const url = mergedConfig.url || configuration?.url;
+			if (url) {
 				models.push({
-					...byokKnownModelToAPIInfoWithEffort(this._name, modelConfig.id, modelConfig),
-					url: modelConfig.url
+					...byokKnownModelToAPIInfoWithEffort(this._name, mergedConfig.id, mergedConfig),
+					url
 				});
 			}
 		}
+
+		if (autoFetch) {
+			for (const model of fetchedModels) {
+				if (!explicitIds.has(model.id)) {
+					const mergedConfig = {
+						id: model.id,
+						name: model.name,
+						maxInputTokens: model.maxInputTokens,
+						maxOutputTokens: model.maxOutputTokens,
+						url: configuration!.url!,
+						toolCalling: false,
+						vision: false
+					} as CustomEndpointModelConfig;
+					
+					models.push({
+						...byokKnownModelToAPIInfoWithEffort(this._name, model.id, mergedConfig),
+						url: configuration!.url!
+					});
+				}
+			}
+		}
+		
 		return models;
 	}
 
@@ -157,8 +201,8 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 			maxInputTokens: model.maxInputTokens,
 			maxOutputTokens: model.maxOutputTokens,
 			contextWindow: modelConfiguration?.contextWindow,
-			toolCalling: !!model.capabilities?.toolCalling || false,
-			vision: !!model.capabilities?.imageInput || false,
+			toolCalling: !!model.capabilities?.toolCalling,
+			vision: !!model.capabilities?.imageInput,
 			name: model.name,
 			url,
 			thinking: modelConfiguration?.thinking ?? false,
@@ -177,8 +221,34 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 		return this._instantiationService.createInstance(CustomEndpointOAIEndpoint, modelInfo, model.configuration?.apiKey ?? '', url);
 	}
 
-	protected getModelsBaseUrl(configuration: CustomEndpointModelProviderConfig | undefined): string | undefined {
-		return configuration?.url;
+	protected override getModelsBaseUrl(configuration: CustomEndpointModelProviderConfig | undefined): string | undefined {
+		if (!configuration?.url) {
+			return undefined;
+		}
+		try {
+			const parsed = new URL(configuration.url);
+			parsed.pathname = parsed.pathname
+				.replace(/\/chat\/completions\/?$/, '')
+				.replace(/\/messages\/?$/, '')
+				.replace(/\/responses\/?$/, '');
+			return parsed.toString();
+		} catch {
+			return configuration.url;
+		}
+	}
+
+	protected override resolveModelCapabilities(modelData: any): BYOKModelCapabilities | undefined {
+		if (!modelData || typeof modelData.id !== 'string') {
+			return undefined;
+		}
+		return {
+			name: modelData.name || modelData.id,
+			contextWindow: 128000,
+			maxOutputTokens: 8192,
+			maxInputTokens: 100000,
+			toolCalling: false,
+			vision: false
+		};
 	}
 }
 


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode/issues/325237 (PR 1 of 4: Auto fetch models)

### Description
This PR adds support for auto-fetching models from custom endpoint BYOK providers.

### Key Changes
- **Configuration Schema**: Added `url` (root-level endpoint base URL) and `autoFetch` flag to the `customendpoint` provider configuration.
- **Model Discovery**: Overrode `getModelsBaseUrl` to automatically normalize endpoint URLs (stripping `/chat/completions`, `/messages`, `/responses` paths before querying `/models`).
- **Capability Parsing**: Overrode `resolveModelCapabilities` in `CustomEndpointBYOKModelProvider` to parse dynamically discovered models with safe defaults instead of dropping them.
- **Merging**: Updated `getAllModels` to query `/models` when `autoFetch` is enabled or `models` is omitted, merging fetched models with explicit model configs.
