### PR TITLE
Agents window: revert accidental code-block word-wrap; cap Codex approvals picker width

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -177,14 +177,6 @@ export class ChatView extends AbstractChatView {
 				rendererOptions: {
 					referencesExpandedWhenEmptyResponse: false,
 					progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask,
-					// Wrap long lines in response code blocks so command/tool output pasted
-					// by the agent stays compact instead of overflowing horizontally.
-					// `wrappingIndent: 'none'` makes wrapped continuations start at column 1
-					// instead of inheriting the source line's indentation. Without it, monaco's
-					// default (`'same'`) injects the leading indent as real whitespace at every
-					// wrap boundary, which corrupts the rendered text's DOM `textContent`
-					// (splitting tokens mid-word) and breaks smoke tests that read it.
-					codeBlockRenderOptions: { editorOptions: { wordWrap: 'on', wrappingIndent: 'none' } },
 				},
 				enableImplicitContext: true,
 				enableWorkingSet: 'implicit',

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostCodexApprovalsPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostCodexApprovalsPicker.ts
@@ -3,12 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './media/agentHostCodexApprovalsPicker.css';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { IObservable } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
-import { ActionListItemKind, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
+import { ActionListItemKind, IActionListItem, IActionListOptions } from '../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { CodexSessionConfigKey } from '../../../../../platform/agentHost/common/codexSessionConfigKeys.js';
 import { SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
@@ -22,6 +23,33 @@ import { isWellKnownCodexApprovalsSchema } from './agentHostPermissionPickerDele
 
 const CODEX_APPROVALS_LEARN_MORE_URL = 'https://developers.openai.com/codex/concepts/sandboxing#how-you-control-it';
 const LEARN_MORE_VALUE = '__agentHostCodexApprovalsPicker.learnMore__';
+
+/**
+ * Class applied to the picker popup so the CSS in
+ * `media/agentHostCodexApprovalsPicker.css` can wrap the long preset
+ * descriptions within the bounded {@link CODEX_APPROVALS_PICKER_WIDTH}.
+ */
+const CODEX_APPROVALS_PICKER_CLASS = 'codex-approvals-picker';
+
+/**
+ * Fixed width of the approvals popup, applied as both the min and max width.
+ *
+ * Once the CSS lets `.detail` wrap, the descriptions no longer contribute their
+ * (long) single-line width to the action list's intrinsic-width measurement, so
+ * the popup would otherwise collapse to the width of the short labels (~220px)
+ * and wrap every description onto 5-6 cramped lines. Pinning a min width floors
+ * the popup wide enough that each description wraps to a uniform three lines.
+ */
+const CODEX_APPROVALS_PICKER_WIDTH = 340;
+
+/**
+ * Row height reserved for a preset's label plus its wrapped description. At
+ * {@link CODEX_APPROVALS_PICKER_WIDTH} every description wraps to three lines
+ * (~57px incl. the title) on macOS; this is sized for four lines so wider UI
+ * fonts on Linux/Windows (Ubuntu/Segoe) can't clip the text (`.detail` overflow
+ * is hidden in the fixed-height virtual list).
+ */
+const CODEX_APPROVALS_PICKER_DETAIL_ITEM_HEIGHT = 76;
 
 function getCodexApprovalsIcon(value: string | undefined): ThemeIcon | undefined {
 	switch (value) {
@@ -73,6 +101,15 @@ export class AgentHostCodexApprovalsPicker extends AgentHostSessionEnumPicker {
 
 	protected _getWidgetAriaLabel(): string {
 		return localize('agentHostCodexApprovalsPicker.ariaLabel', "Approvals Picker");
+	}
+
+	protected override _getListOptions(): IActionListOptions {
+		return {
+			className: CODEX_APPROVALS_PICKER_CLASS,
+			minWidth: CODEX_APPROVALS_PICKER_WIDTH,
+			maxWidth: CODEX_APPROVALS_PICKER_WIDTH,
+			detailItemHeight: CODEX_APPROVALS_PICKER_DETAIL_ITEM_HEIGHT,
+		};
 	}
 
 	protected override _getFooterActionItems(): readonly IActionListItem<IAgentHostSessionEnumPickerItem>[] {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
@@ -11,7 +11,7 @@ import { Disposable, DisposableMap, DisposableStore } from '../../../../../base/
 import { autorun, IObservable } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
-import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
+import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListOptions } from '../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
@@ -129,6 +129,14 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 	protected abstract _getWidgetAriaLabel(): string;
 	protected _getFooterActionItems(): readonly IActionListItem<IAgentHostSessionEnumPickerItem>[] { return []; }
 	protected _handleFooterActionItem(_item: IAgentHostSessionEnumPickerItem): boolean { return false; }
+
+	/**
+	 * Optional list-widget options for the picker popup. Subclasses whose
+	 * option descriptions are long (e.g. the Codex approvals presets) return a
+	 * bounded `maxWidth` plus a `className`/`detailItemHeight` so the detail text
+	 * wraps within a compact box instead of stretching the popup horizontally.
+	 */
+	protected _getListOptions(): IActionListOptions | undefined { return undefined; }
 
 	/**
 	 * `true` while the active session's provider is resolving its config.
@@ -282,6 +290,7 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 				getAriaLabel: i => i.label ?? '',
 				getWidgetAriaLabel: () => this._getWidgetAriaLabel(),
 			},
+			this._getListOptions(),
 		);
 		return true;
 	}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/media/agentHostCodexApprovalsPicker.css
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/media/agentHostCodexApprovalsPicker.css
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Codex "Approvals" preset picker.
+ *
+ * Each preset carries a fairly long description (e.g. "Codex can read and edit
+ * files in the workspace and run routine local commands..."). By default the
+ * action list keeps the detail on a single line, which stretches the popup far
+ * wider than the chip. Paired with the `maxWidth`/`detailItemHeight` list
+ * options in `agentHostCodexApprovalsPicker.ts`, these rules cap the popup
+ * width and let the description wrap onto multiple lines within a compact box.
+ */
+.action-widget .actionList.codex-approvals-picker .monaco-list .monaco-list-row.action .detail {
+	white-space: normal;
+	text-overflow: clip;
+	overflow: hidden;
+}


### PR DESCRIPTION
Post-merge follow-up to #325263 (Codex agent host: forking, subagent rendering, single approvals chip). Two small, self-contained changes.

## 1. Revert accidental response code-block word-wrap
An earlier mis-fix for the "Codex approvals picker is too wide" bug enabled `wordWrap` on **all** response code blocks in the Agents window (`codeBlockRenderOptions` in `chatView.ts`). It affected every agent-host provider (Copilot/Claude/Codex), was never requested, and only shipped because the local revert wasn't pushed before #325263 merged. Reverted here.

## 2. The correct fix: pin the Codex approvals picker width
The Codex **"Approvals"** preset picker rendered its long per-preset descriptions on a single line, stretching the popup far wider than the chip. This adds an overridable `_getListOptions()` hook to `AgentHostSessionEnumPicker` (threaded into `IActionWidgetService.show`); the Codex approvals picker returns:
- `minWidth: 340` **and** `maxWidth: 340` — pins the popup width,
- a scoped `codex-approvals-picker` class whose CSS lets `.detail` wrap (base `.detail` is `nowrap`),
- `detailItemHeight: 76` — reserves room for the wrapped descriptions so nothing clips in the fixed-height virtual list.

The base hook returns `undefined`, so every other picker is unaffected.

### Why both `minWidth` and `maxWidth`
`IActionListOptions.maxWidth` is only a *cap* — the popup's real width is `clamp(widestItemIntrinsicWidth, minWidth, maxWidth)`. Once the CSS lets `.detail` **wrap**, the descriptions stop contributing their long single-line width to that intrinsic measurement, so the widest item becomes the short labels (~200px) and the popup **collapses to ~223px** — wrapping every description onto 5–6 cramped lines and clipping the tallest in the fixed-height list. A `maxWidth`-only value therefore never widened the popup at all. Pinning `minWidth` **floors** the width so each description wraps to a uniform **3 lines**.

### Why 340 / 76
Measured live against the running app's real font metrics (`.detail` = 11px/14px): at width 340 the popup renders **350px** wide, all three descriptions wrap to a uniform **3 lines**, and every preset row measures `rowH = 76 = rowScrollH` (zero overflow → zero clip). `detailItemHeight: 76` fits 3 lines (~57px incl. title) with headroom for **4 lines** so wider UI fonts on Linux/Windows (Ubuntu/Segoe) can't clip.

## Verification
- `npm run typecheck-client` — clean.
- **Live-verified** in the running app: the Codex approvals picker popup renders 350px wide, each preset description wraps to 3 lines, and the focused "Default Permissions" box shows its full text (incl. the final "…or going beyond the workspace.") with the box border below it — no cropping.
- Pre-commit hygiene passed on all commits.
