### PR TITLE
Sets breadcrumbs.showEditorType to false by default.

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -171,7 +171,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		'breadcrumbs.showEditorType': {
 			markdownDescription: localize('showEditorType', "Controls whether the breadcrumbs bar shows a dropdown to switch between the editors that can open the current file (for example the text editor and a custom editor). The dropdown only appears when a more specialized editor is available."),
 			type: 'boolean',
-			default: true,
+			default: false,
 			tags: ['experimental']
 		},
 		'breadcrumbs.symbolPathSeparator': {


### PR DESCRIPTION
The editor context menu has now a "Reopen Editor With" submenu, which makes it already much easier to switch between different editor types.