### PR TITLE
agentHost: Avoid worktree path collisions

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -3390,7 +3390,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				githubToken: this._githubToken,
 				branchPrefix: worktreeBranchPrefix,
 				branchNameCollides: async branchName => {
-					if (await this._gitService.branchExists(repositoryRoot, branchName)) {
+					if (await this._gitService.branchExists(repositoryRoot, branchName).catch(() => true)) {
 						return true;
 					}
 					const worktree = URI.joinPath(worktreesRoot, getCopilotWorktreeDirectoryName(branchName, worktreeBranchPrefix));

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -493,6 +493,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 */
 	private readonly _pendingFirstTurnAnnouncements = new Map<string, string>();
 	private readonly _sessionSequencer = new SequencerByKey<string>();
+	private readonly _worktreeCreationSequencer = new SequencerByKey<string>();
 	private _shutdownPromise: Promise<void> | undefined;
 	private readonly _plugins: PluginController;
 	private readonly _sessionLauncher: CopilotSessionLauncher;
@@ -3381,23 +3382,26 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const worktreeBranchPrefix = typeof config.config[SessionConfigKey.WorktreeBranchPrefix] === 'string'
 			? config.config[SessionConfigKey.WorktreeBranchPrefix] as string
 			: undefined;
-		const branchName = await this._branchNameGenerator.generateBranchName({
-			sessionId,
-			message: prompt,
-			githubToken: this._githubToken,
-			branchPrefix: worktreeBranchPrefix,
-			// Treat a failed existence check as a collision so we fall back to a
-			// suffixed branch name rather than risk `addWorktree` failing because
-			// the branch already exists.
-			branchExists: branchName => this._gitService.branchExists(repositoryRoot, branchName).catch(() => true),
-		});
-		const worktree = URI.joinPath(worktreesRoot, getCopilotWorktreeDirectoryName(branchName, worktreeBranchPrefix));
-		await fs.mkdir(worktreesRoot.fsPath, { recursive: true });
 		const baseBranch = typeof config.config[SessionConfigKey.Branch] === 'string' ? config.config[SessionConfigKey.Branch] as string : undefined;
-		// `addWorktree`'s signature requires a startPoint, but historically the
-		// runtime accepted undefined when `branch` was not set in config. Preserve
-		// that behavior by passing through whatever value (or undefined) was set.
-		await this._gitService.addWorktree(repositoryRoot, worktree, branchName, baseBranch as string);
+		const { branchName, worktree } = await this._worktreeCreationSequencer.queue(repositoryRoot.toString(), async () => {
+			const branchName = await this._branchNameGenerator.generateBranchName({
+				sessionId,
+				message: prompt,
+				githubToken: this._githubToken,
+				branchPrefix: worktreeBranchPrefix,
+				branchNameCollides: async branchName => {
+					if (await this._gitService.branchExists(repositoryRoot, branchName)) {
+						return true;
+					}
+					const worktree = URI.joinPath(worktreesRoot, getCopilotWorktreeDirectoryName(branchName, worktreeBranchPrefix));
+					return fileExists(worktree.fsPath);
+				},
+			});
+			const worktree = URI.joinPath(worktreesRoot, getCopilotWorktreeDirectoryName(branchName, worktreeBranchPrefix));
+			await fs.mkdir(worktreesRoot.fsPath, { recursive: true });
+			await this._gitService.addWorktree(repositoryRoot, worktree, branchName, baseBranch as string);
+			return { branchName, worktree };
+		});
 
 		const worktreeIncludeFiles = Array.isArray(config.config[SessionConfigKey.WorktreeIncludeFiles]) &&
 			config.config[SessionConfigKey.WorktreeIncludeFiles].every(pattern => typeof pattern === 'string')

--- a/src/vs/platform/agentHost/node/copilot/copilotBranchNameGenerator.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotBranchNameGenerator.ts
@@ -11,7 +11,7 @@ export const COPILOT_BRANCH_PREFIX = 'agents/';
 const COPILOT_BRANCH_SESSION_ID_SUFFIX_LENGTH = 8;
 const MAX_BRANCH_NAME_HINT_LENGTH = 48;
 const MIN_GENERATED_BRANCH_NAME_LENGTH = 8;
-const MAX_BRANCH_NAME_COLLISION_ATTEMPTS = 100;
+const MAX_BRANCH_NAME_CANDIDATES = 100;
 
 export interface ICopilotBranchNameGeneratorRequest {
 	readonly sessionId: string;
@@ -118,22 +118,21 @@ export class CopilotBranchNameGenerator implements ICopilotBranchNameGenerator {
 		const prefix = `${request.branchPrefix ?? ''}${COPILOT_BRANCH_PREFIX}`;
 
 		const branchName = `${prefix}${branchNameHint ?? request.sessionId}`;
-		if (!request.branchNameCollides || !await request.branchNameCollides(branchName)) {
-			return branchName;
-		}
-
 		const collisionBase = branchNameHint
 			? `${branchName}-${request.sessionId.substring(0, COPILOT_BRANCH_SESSION_ID_SUFFIX_LENGTH)}`
 			: branchName;
-		const firstAttempt = branchNameHint ? 1 : 2;
-		for (let attempt = firstAttempt; attempt <= MAX_BRANCH_NAME_COLLISION_ATTEMPTS; attempt++) {
-			const candidate = attempt === 1 ? collisionBase : `${collisionBase}-${attempt}`;
-			if (!await request.branchNameCollides(candidate)) {
+		for (let candidateIndex = 0; candidateIndex < MAX_BRANCH_NAME_CANDIDATES; candidateIndex++) {
+			const candidate = candidateIndex === 0
+				? branchName
+				: branchNameHint && candidateIndex === 1
+					? collisionBase
+					: `${collisionBase}-${branchNameHint ? candidateIndex : candidateIndex + 1}`;
+			if (!request.branchNameCollides || !await request.branchNameCollides(candidate)) {
 				return candidate;
 			}
 		}
 
-		throw new Error(`Unable to find an available branch name after ${MAX_BRANCH_NAME_COLLISION_ATTEMPTS} attempts`);
+		throw new Error(`Unable to find an available branch name after checking ${MAX_BRANCH_NAME_CANDIDATES} candidates`);
 	}
 }
 

--- a/src/vs/platform/agentHost/node/copilot/copilotBranchNameGenerator.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotBranchNameGenerator.ts
@@ -11,6 +11,7 @@ export const COPILOT_BRANCH_PREFIX = 'agents/';
 const COPILOT_BRANCH_SESSION_ID_SUFFIX_LENGTH = 8;
 const MAX_BRANCH_NAME_HINT_LENGTH = 48;
 const MIN_GENERATED_BRANCH_NAME_LENGTH = 8;
+const MAX_BRANCH_NAME_COLLISION_ATTEMPTS = 100;
 
 export interface ICopilotBranchNameGeneratorRequest {
 	readonly sessionId: string;
@@ -25,11 +26,10 @@ export interface ICopilotBranchNameGeneratorRequest {
 	 */
 	readonly branchPrefix?: string;
 	/**
-	 * Optional predicate used to check whether a candidate branch name already
-	 * exists. When it reports a collision, a short suffix derived from the
-	 * session id is appended so the generated branch name stays unique.
+	 * Optional predicate used to check whether a candidate branch name collides
+	 * with an existing branch or its corresponding worktree path.
 	 */
-	readonly branchExists?: (branchName: string) => Promise<boolean>;
+	readonly branchNameCollides?: (branchName: string) => Promise<boolean>;
 }
 
 export const ICopilotBranchNameGenerator = createDecorator<ICopilotBranchNameGenerator>('copilotBranchNameGenerator');
@@ -117,19 +117,23 @@ export class CopilotBranchNameGenerator implements ICopilotBranchNameGenerator {
 		// historical `agents/<hint>` shape.
 		const prefix = `${request.branchPrefix ?? ''}${COPILOT_BRANCH_PREFIX}`;
 
-		if (!branchNameHint) {
-			// No usable hint - fall back to the (already unique) session id.
-			return `${prefix}${request.sessionId}`;
+		const branchName = `${prefix}${branchNameHint ?? request.sessionId}`;
+		if (!request.branchNameCollides || !await request.branchNameCollides(branchName)) {
+			return branchName;
 		}
 
-		// Prefer the bare hint and only append a short session-id suffix when
-		// the branch name would collide with an existing branch.
-		const branchName = `${prefix}${branchNameHint}`;
-		if (request.branchExists && await request.branchExists(branchName)) {
-			return `${branchName}-${request.sessionId.substring(0, COPILOT_BRANCH_SESSION_ID_SUFFIX_LENGTH)}`;
+		const collisionBase = branchNameHint
+			? `${branchName}-${request.sessionId.substring(0, COPILOT_BRANCH_SESSION_ID_SUFFIX_LENGTH)}`
+			: branchName;
+		const firstAttempt = branchNameHint ? 1 : 2;
+		for (let attempt = firstAttempt; attempt <= MAX_BRANCH_NAME_COLLISION_ATTEMPTS; attempt++) {
+			const candidate = attempt === 1 ? collisionBase : `${collisionBase}-${attempt}`;
+			if (!await request.branchNameCollides(candidate)) {
+				return candidate;
+			}
 		}
 
-		return branchName;
+		throw new Error(`Unable to find an available branch name after ${MAX_BRANCH_NAME_COLLISION_ATTEMPTS} attempts`);
 	}
 }
 

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -766,17 +766,42 @@ suite('CopilotAgent', () => {
 			'agents/add-agent-host-config-12345678',
 			'agents/12345678-aaaa-bbbb-cccc-123456789abc',
 		]);
+		const exhaustedCandidates: string[] = [];
+		let exhaustionError: string | undefined;
+		try {
+			await generator.generateBranchName({
+				sessionId: '12345678-aaaa-bbbb-cccc-123456789abc',
+				branchNameCollides: async name => {
+					exhaustedCandidates.push(name);
+					return true;
+				},
+			});
+		} catch (error) {
+			exhaustionError = error instanceof Error ? error.message : String(error);
+		}
 
 		assert.deepStrictEqual({
 			unique: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchNameCollides: async () => false }),
 			collision: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchNameCollides: async name => name === 'agents/add-agent-host-config' }),
 			repeatedCollision: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchNameCollides: async name => collisions.has(name) }),
 			fallbackCollision: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', branchNameCollides: async name => collisions.has(name) }),
+			exhaustion: {
+				error: exhaustionError,
+				candidateCount: exhaustedCandidates.length,
+				firstCandidate: exhaustedCandidates[0],
+				lastCandidate: exhaustedCandidates.at(-1),
+			},
 		}, {
 			unique: 'agents/add-agent-host-config',
 			collision: 'agents/add-agent-host-config-12345678',
 			repeatedCollision: 'agents/add-agent-host-config-12345678-2',
 			fallbackCollision: 'agents/12345678-aaaa-bbbb-cccc-123456789abc-2',
+			exhaustion: {
+				error: 'Unable to find an available branch name after checking 100 candidates',
+				candidateCount: 100,
+				firstCandidate: 'agents/12345678-aaaa-bbbb-cccc-123456789abc',
+				lastCandidate: 'agents/12345678-aaaa-bbbb-cccc-123456789abc-100',
+			},
 		});
 	});
 
@@ -4220,6 +4245,52 @@ suite('CopilotAgent', () => {
 				}, {
 					branchName: 'agents/add-feature-12345678',
 					worktree: URI.joinPath(worktreesRoot, 'add-feature-12345678').toString(),
+				});
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('appends a session suffix when the branch existence check fails', async () => {
+			const sessionId = '12345678-aaaa-bbbb-cccc-123456789abc';
+			const repositoryRoot = URI.joinPath(URI.file(tmpDir), 'repo-branch-check-failure');
+			await fs.mkdir(repositoryRoot.fsPath, { recursive: true });
+
+			const gitService = new TestAgentHostGitService();
+			gitService.repositoryRoot = repositoryRoot;
+			let branchExistsCalls = 0;
+			gitService.branchExists = async () => {
+				if (branchExistsCalls++ === 0) {
+					throw new Error('transient failure');
+				}
+				return false;
+			};
+
+			const copilotApiService = new TestCopilotApiService();
+			copilotApiService.response = 'add-feature';
+			const agent = createTestAgent(disposables, {
+				sessionDataService: disposables.add(new TestSessionDataService()),
+				copilotClient: new TestCopilotClient([]),
+				gitService,
+				copilotApiService,
+			}) as TestableCopilotAgent;
+
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+
+				const workingDir = await agent.resolveWorktreeForTest({
+					workingDirectory: repositoryRoot,
+					config: { isolation: 'worktree', branch: 'main' },
+				}, sessionId, 'Add feature');
+
+				assert.deepStrictEqual({
+					branchExistsCalls,
+					branchName: gitService.addedWorktrees[0]?.branchName,
+					worktree: workingDir?.toString(),
+				}, {
+					branchExistsCalls: 2,
+					branchName: 'agents/add-feature-12345678',
+					worktree: URI.joinPath(getCopilotWorktreesRoot(repositoryRoot), 'add-feature-12345678').toString(),
 				});
 			} finally {
 				await disposeAgent(agent);

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -757,17 +757,26 @@ suite('CopilotAgent', () => {
 		});
 	});
 
-	test('appends a short session-id suffix when the branch name already exists', async () => {
+	test('finds an available branch name when candidates collide', async () => {
 		const copilotApiService = new TestCopilotApiService();
 		copilotApiService.response = 'add-agent-host-config';
 		const generator = new CopilotBranchNameGenerator(copilotApiService, new NullLogService());
+		const collisions = new Set([
+			'agents/add-agent-host-config',
+			'agents/add-agent-host-config-12345678',
+			'agents/12345678-aaaa-bbbb-cccc-123456789abc',
+		]);
 
 		assert.deepStrictEqual({
-			unique: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchExists: async () => false }),
-			collision: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchExists: async name => name === 'agents/add-agent-host-config' }),
+			unique: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchNameCollides: async () => false }),
+			collision: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchNameCollides: async name => name === 'agents/add-agent-host-config' }),
+			repeatedCollision: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchNameCollides: async name => collisions.has(name) }),
+			fallbackCollision: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', branchNameCollides: async name => collisions.has(name) }),
 		}, {
 			unique: 'agents/add-agent-host-config',
 			collision: 'agents/add-agent-host-config-12345678',
+			repeatedCollision: 'agents/add-agent-host-config-12345678-2',
+			fallbackCollision: 'agents/12345678-aaaa-bbbb-cccc-123456789abc-2',
 		});
 	});
 
@@ -4172,6 +4181,102 @@ suite('CopilotAgent', () => {
 				}, {
 					branchName: 'users/alice/agents/add-feature',
 					worktree: expectedWorktree.toString(),
+				});
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('appends a session suffix when the worktree directory already exists', async () => {
+			const sessionId = '12345678-aaaa-bbbb-cccc-123456789abc';
+			const repositoryRoot = URI.joinPath(URI.file(tmpDir), 'repo-collision');
+			const worktreesRoot = getCopilotWorktreesRoot(repositoryRoot);
+			await fs.mkdir(repositoryRoot.fsPath, { recursive: true });
+			await fs.mkdir(URI.joinPath(worktreesRoot, 'add-feature').fsPath, { recursive: true });
+
+			const gitService = new TestAgentHostGitService();
+			gitService.repositoryRoot = repositoryRoot;
+
+			const copilotApiService = new TestCopilotApiService();
+			copilotApiService.response = 'add-feature';
+			const agent = createTestAgent(disposables, {
+				sessionDataService: disposables.add(new TestSessionDataService()),
+				copilotClient: new TestCopilotClient([]),
+				gitService,
+				copilotApiService,
+			}) as TestableCopilotAgent;
+
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+
+				const workingDir = await agent.resolveWorktreeForTest({
+					workingDirectory: repositoryRoot,
+					config: { isolation: 'worktree', branch: 'main' },
+				}, sessionId, 'Add feature');
+
+				assert.deepStrictEqual({
+					branchName: gitService.addedWorktrees[0]?.branchName,
+					worktree: workingDir?.toString(),
+				}, {
+					branchName: 'agents/add-feature-12345678',
+					worktree: URI.joinPath(worktreesRoot, 'add-feature-12345678').toString(),
+				});
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('serializes concurrent worktree creation in the same repository', async () => {
+			const repositoryRoot = URI.joinPath(URI.file(tmpDir), 'repo-concurrent');
+			await fs.mkdir(repositoryRoot.fsPath, { recursive: true });
+
+			const gitService = new TestAgentHostGitService();
+			gitService.repositoryRoot = repositoryRoot;
+			let activeAddWorktrees = 0;
+			let maxActiveAddWorktrees = 0;
+			gitService.addWorktree = async (repositoryRoot, worktree, branchName, startPoint) => {
+				activeAddWorktrees++;
+				maxActiveAddWorktrees = Math.max(maxActiveAddWorktrees, activeAddWorktrees);
+				await timeout(10);
+				gitService.addedWorktrees.push({ repositoryRoot, worktree, branchName, startPoint });
+				gitService.existingBranches.add(branchName);
+				activeAddWorktrees--;
+			};
+
+			const copilotApiService = new TestCopilotApiService();
+			copilotApiService.response = 'add-feature';
+			const agent = createTestAgent(disposables, {
+				sessionDataService: disposables.add(new TestSessionDataService()),
+				copilotClient: new TestCopilotClient([]),
+				gitService,
+				copilotApiService,
+			}) as TestableCopilotAgent;
+
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+
+				const worktrees = await Promise.all([
+					agent.resolveWorktreeForTest({
+						workingDirectory: repositoryRoot,
+						config: { isolation: 'worktree', branch: 'main' },
+					}, '12345678-aaaa-bbbb-cccc-123456789abc', 'Add feature'),
+					agent.resolveWorktreeForTest({
+						workingDirectory: repositoryRoot,
+						config: { isolation: 'worktree', branch: 'main' },
+					}, '87654321-aaaa-bbbb-cccc-123456789abc', 'Add feature'),
+				]);
+
+				assert.deepStrictEqual({
+					maxActiveAddWorktrees,
+					branchNames: gitService.addedWorktrees.map(({ branchName }) => branchName),
+					worktrees: worktrees.map(worktree => worktree?.toString()),
+				}, {
+					maxActiveAddWorktrees: 1,
+					branchNames: ['agents/add-feature', 'agents/add-feature-87654321'],
+					worktrees: [
+						URI.joinPath(getCopilotWorktreesRoot(repositoryRoot), 'add-feature').toString(),
+						URI.joinPath(getCopilotWorktreesRoot(repositoryRoot), 'add-feature-87654321').toString(),
+					],
 				});
 			} finally {
 				await disposeAgent(agent);


### PR DESCRIPTION
Fixes #325527

## Summary
- treat existing worktree target paths as branch-name collisions
- retry generated names until both the branch and target path are available
- serialize worktree creation per repository to prevent concurrent session races

## Testing
- `npm run typecheck-client`
- `VSCODE_SKIP_PRELAUNCH=1 ./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotAgent.test.ts` (137 passing)
- `npm run valid-layers-check`
- `npm run precommit`

(Written by Copilot)