### PR TITLE
fix: sandbox smoke test configuration race

### DIFF
--- a/test/smoke/src/areas/chat/chatSandbox.test.ts
+++ b/test/smoke/src/areas/chat/chatSandbox.test.ts
@@ -78,6 +78,14 @@ function appendUserSettings(userDataPath: string, settings: Record<string, unkno
 	fs.writeFileSync(settingsPath, `${contents.slice(0, closingBrace)}${entries}${contents.slice(closingBrace)}`);
 }
 
+async function restartWithUpdatedSandboxSettings(app: Application, settings: Record<string, unknown>): Promise<void> {
+	assert.ok(app.userDataPath, 'expected a user data path');
+	appendUserSettings(app.userDataPath, settings);
+	await app.restart();
+	await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
+	await app.workbench.chat.waitForChatView();
+}
+
 async function warmUpChat(chat: Chat, logger: Logger): Promise<void> {
 	const deadline = Date.now() + 180_000;
 	let attempt = 0;
@@ -311,8 +319,7 @@ export function setup(logger: Logger): void {
 			const app = this.app as Application;
 
 			try {
-				assert.ok(app.userDataPath, 'expected a user data path');
-				appendUserSettings(app.userDataPath, {
+				await restartWithUpdatedSandboxSettings(app, {
 					'chat.agent.sandbox.allowNetwork': true,
 				});
 
@@ -371,9 +378,8 @@ export function setup(logger: Logger): void {
 			const app = this.app as Application;
 
 			try {
-				assert.ok(app.userDataPath, 'expected a user data path');
 				const fileSystemSetting = { allowRead: [homeFilePath] };
-				appendUserSettings(app.userDataPath, {
+				await restartWithUpdatedSandboxSettings(app, {
 					'chat.agent.sandbox.fileSystem.linux': fileSystemSetting,
 					'chat.agent.sandbox.fileSystem.mac': fileSystemSetting,
 				});


### PR DESCRIPTION
Test is failing across multiple runs on `main`, smoke test pipeline also caught it https://monacotools.visualstudio.com/Monaco/_build/results?buildId=455202&view=logs&j=4fef7b6a-0832-531b-580c-d58441e1a94f&t=b7778c04-0e12-58ac-d661-d425af5876ac

Restart the application after updating sandbox settings so configuration changes are loaded before running the allowRead and allowNetwork probes.

Fixes https://github.com/microsoft/vscode-engineering/issues/3280

cc @dileepyavan 
