### PR TITLE
fix pinned sessions dropping from list when chat models unload (#325448)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { coalesce } from '../../../../../base/common/arrays.js';
+import { Throttler } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../base/common/event.js';
@@ -53,17 +54,20 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 	}
 
 	private _items = new ResourceMap<LocalChatSessionItem>();
-	private _refreshGeneration = 0;
+	private readonly _refreshThrottler = this._register(new Throttler());
 
 	get items(): readonly IChatSessionItem[] {
 		return Array.from(this._items.values());
 	}
 
-	async refresh(token: CancellationToken): Promise<void> {
-		const generation = ++this._refreshGeneration;
+	refresh(token: CancellationToken): Promise<void> {
+		return this._refreshThrottler.queue(() => this.doRefresh(token));
+	}
+
+	private async doRefresh(token: CancellationToken): Promise<void> {
 		const newItems = await this.provideChatSessionItems(token);
-		if (token.isCancellationRequested || generation !== this._refreshGeneration || this._isDisposed) {
-			return; // a newer refresh is in flight or completed
+		if (token.isCancellationRequested || this._isDisposed) {
+			return;
 		}
 
 		const newResources = new ResourceSet(newItems.map(i => i.resource));
@@ -101,7 +105,7 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 			}
 
 			await this.refresh(CancellationToken.None);
-			if (this._isDisposed) {
+			if (this._isDisposed || this.chatService.getSession(model.sessionResource) !== model) {
 				return;
 			}
 
@@ -137,6 +141,10 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 
 	private async tryUpdateLiveSessionItem(model: IChatModel): Promise<void> {
 		const updated = this.toChatSessionItem(await chatModelToChatDetail(model));
+		// Model may have been unloaded/replaced while we awaited detail conversion.
+		if (this.chatService.getSession(model.sessionResource) !== model) {
+			return;
+		}
 		if (!updated) {
 			// The session no longer qualifies as a list item (e.g. it has no requests
 			// yet, or its requests were removed). Drop any stale item we were showing.

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -75,7 +75,8 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 		const removed: URI[] = [];
 
 		for (const item of newItems) {
-			if (!this._items.has(item.resource)) {
+			const existing = this._items.get(item.resource);
+			if (!existing || !existing.isEqual(item)) {
 				addedOrUpdated.push(item);
 			}
 		}
@@ -131,8 +132,6 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 				this._modelListeners.deleteAndDispose(sessionResource);
 			}
 
-			// Dispose unloads the model from memory; rebuild from live + history so the
-			// session stays listed unless it was actually deleted (#325448).
 			if (e.sessionResources.some(resource => getChatSessionType(resource) === this.chatSessionType)) {
 				void this.refresh(CancellationToken.None);
 			}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -53,12 +53,18 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 	}
 
 	private _items = new ResourceMap<LocalChatSessionItem>();
+	private _refreshGeneration = 0;
+
 	get items(): readonly IChatSessionItem[] {
 		return Array.from(this._items.values());
 	}
 
 	async refresh(token: CancellationToken): Promise<void> {
+		const generation = ++this._refreshGeneration;
 		const newItems = await this.provideChatSessionItems(token);
+		if (token.isCancellationRequested || generation !== this._refreshGeneration || this._isDisposed) {
+			return; // a newer refresh is in flight or completed
+		}
 
 		const newResources = new ResourceSet(newItems.map(i => i.resource));
 		const addedOrUpdated: LocalChatSessionItem[] = [];

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -121,12 +121,10 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 				this._modelListeners.deleteAndDispose(sessionResource);
 			}
 
-			const removedSessionResources = e.sessionResources.filter(resource => getChatSessionType(resource) === this.chatSessionType);
-			if (removedSessionResources.length) {
-				for (const resource of removedSessionResources) {
-					this._items.delete(resource);
-				}
-				this._onDidChangeChatSessionItems.fire({ removed: removedSessionResources });
+			// Dispose unloads the model from memory; rebuild from live + history so the
+			// session stays listed unless it was actually deleted (#325448).
+			if (e.sessionResources.some(resource => getChatSessionType(resource) === this.chatSessionType)) {
+				void this.refresh(CancellationToken.None);
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -61,6 +61,7 @@ function createMockChatModel(options: {
 			linesAdded: number;
 			linesRemoved: number;
 			modifiedURI: URI;
+			getDiffInfo?: () => Promise<unknown>;
 		}>;
 	};
 }): MockChatModel {
@@ -98,6 +99,7 @@ function createMockChatModel(options: {
 		linesRemoved: observableValue('linesRemoved', entry.linesRemoved),
 		originalURI: entry.modifiedURI,
 		modifiedURI: entry.modifiedURI,
+		getDiffInfo: entry.getDiffInfo,
 	}));
 
 	const mockEditingSession = options.editingSession ? {
@@ -845,7 +847,7 @@ suite('LocalAgentsSessionsController', () => {
 			});
 		});
 
-		test('should ignore stale refresh results that complete out of order', async () => {
+		test('should apply a queued refresh after an in-flight refresh', async () => {
 			return runWithFakedTimers({}, async () => {
 				const controller = createController();
 
@@ -863,23 +865,86 @@ suite('LocalAgentsSessionsController', () => {
 
 				let releaseStale!: () => void;
 				const staleReady = new Promise<void>(resolve => { releaseStale = resolve; });
-				mockChatService.getLiveSessionItemsImpl = async () => {
+				const originalGetLiveSessionItems = mockChatService.getLiveSessionItems.bind(mockChatService);
+				mockChatService.getLiveSessionItems = async () => {
 					await staleReady;
 					return [detail];
 				};
 
 				const staleRefresh = controller.refresh(CancellationToken.None);
 
-				mockChatService.getLiveSessionItemsImpl = undefined;
+				mockChatService.getLiveSessionItems = originalGetLiveSessionItems;
 				mockChatService.removeSession(sessionResource);
 				mockChatService.setLiveSessionItems([]);
 				mockChatService.setHistorySessionItems([]);
-				await controller.refresh(CancellationToken.None);
-				assert.strictEqual(controller.items.length, 0, 'newer refresh should remove the deleted session');
+				const latestRefresh = controller.refresh(CancellationToken.None);
 
 				releaseStale();
-				await staleRefresh;
-				assert.strictEqual(controller.items.length, 0, 'stale refresh must not revive the deleted session');
+				await Promise.all([staleRefresh, latestRefresh]);
+				assert.strictEqual(controller.items.length, 0, 'queued refresh should remove the deleted session');
+			});
+		});
+
+		test('should not delete restored history item when stale live update completes after unload', async () => {
+			return runWithFakedTimers({}, async () => {
+				const controller = createController();
+				const sessionResource = LocalChatSessionUri.forSession('stale-live-update');
+
+				let holdDetail = false;
+				let releaseDetail!: () => void;
+				const detailReady = new Promise<void>(resolve => { releaseDetail = resolve; });
+
+				const mockModel = createMockChatModel({
+					sessionResource,
+					hasRequests: true,
+					customTitle: 'Keep Me',
+					editingSession: {
+						entries: [{
+							state: ModifiedFileEntryState.Modified,
+							linesAdded: 1,
+							linesRemoved: 0,
+							modifiedURI: URI.file('/test/file.ts'),
+							getDiffInfo: async () => {
+								if (holdDetail) {
+									await detailReady;
+								}
+							},
+						}]
+					}
+				});
+
+				const detail = {
+					sessionResource,
+					title: 'Keep Me',
+					lastMessageDate: Date.now(),
+					isActive: false,
+					lastResponseState: ResponseModelState.Complete,
+					timing: createTestTiming(),
+				};
+				mockChatService.setLiveSessionItems([detail]);
+				mockChatService.addSession(mockModel);
+				await timeout(0);
+				assert.strictEqual(controller.items.length, 1);
+
+				// Start a live update that will stay blocked in chatModelToChatDetail.
+				holdDetail = true;
+				mockModel.setCustomTitle('Keep Me Updated');
+				await timeout(0);
+
+				mockChatService.removeSession(sessionResource);
+				mockChatService.setLiveSessionItems([]);
+				mockChatService.setHistorySessionItems([detail]);
+				mockChatService.fireDidDisposeSession([sessionResource]);
+				await timeout(0);
+
+				assert.strictEqual(controller.items.length, 1, 'unload refresh should restore from history');
+				assert.strictEqual(controller.items[0].label, 'Keep Me');
+
+				releaseDetail();
+				await timeout(0);
+
+				assert.strictEqual(controller.items.length, 1, 'stale live update must not delete the restored history item');
+				assert.strictEqual(controller.items[0].label, 'Keep Me');
 			});
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -697,6 +697,47 @@ suite('LocalAgentsSessionsController', () => {
 			});
 		});
 
+		test('should include changed existing sessions in addedOrUpdated on refresh', async () => {
+			return runWithFakedTimers({}, async () => {
+				const controller = createController();
+
+				const sessionResource = LocalChatSessionUri.forSession('updated-session');
+				const timing = createTestTiming();
+				const detail = {
+					sessionResource,
+					title: 'Original Title',
+					lastMessageDate: timing.created,
+					isActive: false,
+					lastResponseState: ResponseModelState.Complete,
+					timing
+				};
+
+				mockChatService.setLiveSessionItems([]);
+				mockChatService.setHistorySessionItems([detail]);
+				await controller.refresh(CancellationToken.None);
+				assert.strictEqual(controller.items.length, 1);
+
+				const fired: { addedOrUpdated?: readonly IChatSessionItem[]; removed?: readonly URI[] }[] = [];
+				disposables.add(controller.onDidChangeChatSessionItems(delta => fired.push(delta)));
+
+				mockChatService.setHistorySessionItems([{ ...detail, title: 'Updated Title' }]);
+				await controller.refresh(CancellationToken.None);
+
+				assert.deepStrictEqual(
+					fired.map(delta => ({
+						addedOrUpdated: (delta.addedOrUpdated ?? []).map(item => item.label),
+						removed: (delta.removed ?? []).map(resource => resource.toString()),
+					})),
+					[{ addedOrUpdated: ['Updated Title'], removed: [] }]
+				);
+				assert.strictEqual(controller.items[0].label, 'Updated Title');
+
+				// A refresh without content changes must stay silent.
+				await controller.refresh(CancellationToken.None);
+				assert.strictEqual(fired.length, 1);
+			});
+		});
+
 		test('should add a newly started session once it gets its first request', async () => {
 			return runWithFakedTimers({}, async () => {
 				const controller = createController();

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -844,5 +844,43 @@ suite('LocalAgentsSessionsController', () => {
 				assert.ok(removedResources.some(r => r.toString() === sessionResource.toString()), 'removed event should fire');
 			});
 		});
+
+		test('should ignore stale refresh results that complete out of order', async () => {
+			return runWithFakedTimers({}, async () => {
+				const controller = createController();
+
+				const sessionResource = LocalChatSessionUri.forSession('stale-refresh');
+				const mockModel = createMockChatModel({
+					sessionResource,
+					hasRequests: true
+				});
+
+				mockChatService.addSession(mockModel);
+				const detail = await chatModelToChatDetail(mockModel);
+				mockChatService.setLiveSessionItems([detail]);
+				await controller.refresh(CancellationToken.None);
+				assert.strictEqual(controller.items.length, 1);
+
+				let releaseStale!: () => void;
+				const staleReady = new Promise<void>(resolve => { releaseStale = resolve; });
+				mockChatService.getLiveSessionItemsImpl = async () => {
+					await staleReady;
+					return [detail];
+				};
+
+				const staleRefresh = controller.refresh(CancellationToken.None);
+
+				mockChatService.getLiveSessionItemsImpl = undefined;
+				mockChatService.removeSession(sessionResource);
+				mockChatService.setLiveSessionItems([]);
+				mockChatService.setHistorySessionItems([]);
+				await controller.refresh(CancellationToken.None);
+				assert.strictEqual(controller.items.length, 0, 'newer refresh should remove the deleted session');
+
+				releaseStale();
+				await staleRefresh;
+				assert.strictEqual(controller.items.length, 0, 'stale refresh must not revive the deleted session');
+			});
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -784,23 +784,49 @@ suite('LocalAgentsSessionsController', () => {
 			});
 		});
 
-		test('should remove session from items and fire removed event on onDidDisposeSession', async () => {
+		test('should keep session in items when model is unloaded but still in history', async () => {
 			return runWithFakedTimers({}, async () => {
 				const controller = createController();
 
-				const sessionResource = LocalChatSessionUri.forSession('dispose-session');
+				const sessionResource = LocalChatSessionUri.forSession('unload-session');
+				const mockModel = createMockChatModel({
+					sessionResource,
+					hasRequests: true,
+					customTitle: 'Unloaded Session'
+				});
+
+				mockChatService.addSession(mockModel);
+				const detail = await chatModelToChatDetail(mockModel);
+				mockChatService.setLiveSessionItems([detail]);
+				await controller.refresh(CancellationToken.None);
+				assert.strictEqual(controller.items.length, 1);
+
+				mockChatService.removeSession(sessionResource);
+				mockChatService.setLiveSessionItems([]);
+				mockChatService.setHistorySessionItems([{ ...detail, isActive: false }]);
+				mockChatService.fireDidDisposeSession([sessionResource]);
+				await timeout(0);
+
+				assert.strictEqual(controller.items.length, 1, 'unloaded session should remain visible via history');
+				assert.strictEqual(controller.items[0].label, 'Unloaded Session');
+			});
+		});
+
+		test('should remove session from items when disposed and deleted from history', async () => {
+			return runWithFakedTimers({}, async () => {
+				const controller = createController();
+
+				const sessionResource = LocalChatSessionUri.forSession('deleted-session');
 				const mockModel = createMockChatModel({
 					sessionResource,
 					hasRequests: true
 				});
 
-				// Add the session and populate items
 				mockChatService.addSession(mockModel);
 				mockChatService.setLiveSessionItems([await chatModelToChatDetail(mockModel)]);
 				await controller.refresh(CancellationToken.None);
 				assert.strictEqual(controller.items.length, 1);
 
-				// Listen for the removed event
 				const removedResources: URI[] = [];
 				disposables.add(controller.onDidChangeChatSessionItems(delta => {
 					if (delta.removed) {
@@ -808,47 +834,14 @@ suite('LocalAgentsSessionsController', () => {
 					}
 				}));
 
-				// Fire onDidDisposeSession (simulates removeHistoryEntry)
-				mockChatService.fireDidDisposeSession([sessionResource]);
-
-				// Session should be removed from items immediately
-				assert.strictEqual(controller.items.length, 0, 'items should be empty after dispose');
-				assert.strictEqual(removedResources.length, 1, 'removed event should fire');
-				assert.strictEqual(removedResources[0].toString(), sessionResource.toString());
-
-				// Even if refresh is called again, the session should not reappear
-				// (because getLiveSessionItems would still return it, but shouldBeInHistory
-				// would filter it in the real ChatService — here we simulate by keeping
-				// liveSessionItems unchanged, but _items was already cleared)
-			});
-		});
-
-		test('should not re-add disposed session to items on refresh', async () => {
-			return runWithFakedTimers({}, async () => {
-				const controller = createController();
-
-				const sessionResource = LocalChatSessionUri.forSession('disposed-refresh-session');
-				const mockModel = createMockChatModel({
-					sessionResource,
-					hasRequests: true
-				});
-
-				// Add the session and populate items
-				mockChatService.addSession(mockModel);
-				mockChatService.setLiveSessionItems([await chatModelToChatDetail(mockModel)]);
-				await controller.refresh(CancellationToken.None);
-				assert.strictEqual(controller.items.length, 1);
-
-				// Dispose the session
-				mockChatService.fireDidDisposeSession([sessionResource]);
-				assert.strictEqual(controller.items.length, 0);
-
-				// Clear live items (simulates isDeleted filtering in real ChatService)
+				mockChatService.removeSession(sessionResource);
 				mockChatService.setLiveSessionItems([]);
+				mockChatService.setHistorySessionItems([]);
+				mockChatService.fireDidDisposeSession([sessionResource]);
+				await timeout(0);
 
-				// Refresh should not bring it back
-				await controller.refresh(CancellationToken.None);
-				assert.strictEqual(controller.items.length, 0, 'disposed session should not reappear after refresh');
+				assert.strictEqual(controller.items.length, 0, 'deleted session should leave the list');
+				assert.ok(removedResources.some(r => r.toString() === sessionResource.toString()), 'removed event should fire');
 			});
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
@@ -29,6 +29,9 @@ export class MockChatService implements IChatService {
 	private liveSessionItems: IChatDetail[] = [];
 	private historySessionItems: IChatDetail[] = [];
 
+	/** Test hook to override live-item fetching (e.g. delayed/stale snapshots). */
+	getLiveSessionItemsImpl?: () => Promise<IChatDetail[]>;
+
 	private readonly _onDidDisposeSession = new Emitter<{ sessionResources: URI[]; reason: 'cleared' }>();
 	readonly onDidDisposeSession = this._onDidDisposeSession.event;
 
@@ -184,6 +187,9 @@ export class MockChatService implements IChatService {
 	}
 
 	async getLiveSessionItems(): Promise<IChatDetail[]> {
+		if (this.getLiveSessionItemsImpl) {
+			return this.getLiveSessionItemsImpl();
+		}
 		return this.liveSessionItems;
 	}
 

--- a/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
@@ -29,9 +29,6 @@ export class MockChatService implements IChatService {
 	private liveSessionItems: IChatDetail[] = [];
 	private historySessionItems: IChatDetail[] = [];
 
-	/** Test hook to override live-item fetching (e.g. delayed/stale snapshots). */
-	getLiveSessionItemsImpl?: () => Promise<IChatDetail[]>;
-
 	private readonly _onDidDisposeSession = new Emitter<{ sessionResources: URI[]; reason: 'cleared' }>();
 	readonly onDidDisposeSession = this._onDidDisposeSession.event;
 
@@ -187,9 +184,6 @@ export class MockChatService implements IChatService {
 	}
 
 	async getLiveSessionItems(): Promise<IChatDetail[]> {
-		if (this.getLiveSessionItemsImpl) {
-			return this.getLiveSessionItemsImpl();
-		}
 		return this.liveSessionItems;
 	}
 


### PR DESCRIPTION
Fixes #325448:
- `onDidDisposeSession` was treated as removing the session from the Agent Sessions list when a chat model unloaded from memory. Refresh the local session list from live + history instead, so unloaded sessions stay visible until they are actually deleted.

Added Unit Tests:
  - covers unload-but-still-in-history (session stays listed)
  - covers dispose + deleted from history (session is removed)