### PR TITLE
Make file changes counts the view-all button in chat turn pills

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
@@ -151,12 +151,21 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 
 	private _renderChangesHeader(header: HTMLElement, stats: IObservable<IDiffStats>, showChanges: IObservable<boolean>): IDisposable {
 		const filesLabel = header.appendChild($('span.chat-file-changes-label'));
-		const counts = header.appendChild($('span.chat-file-changes-counts', { 'aria-hidden': 'true' }));
+		const counts = header.appendChild(document.createElement('button'));
+		counts.classList.add('chat-file-changes-counts');
+		counts.type = 'button';
 		const addedLabel = counts.appendChild($('span.insertions'));
 		const removedLabel = counts.appendChild($('span.deletions'));
-		const viewAll = this._renderViewAllFileChangesButton(header);
 
-		return combinedDisposable(viewAll, autorun(reader => {
+		const hoverDisposable = this._hoverService.setupDelayedHover(counts, () => ({
+			content: localize2('chat.viewTurnFileChangesSummary', 'View All File Changes')
+		}));
+		const clickDisposable = dom.addDisposableListener(counts, 'click', (e) => {
+			this._openChanges();
+			dom.EventHelper.stop(e, true);
+		});
+
+		return combinedDisposable(hoverDisposable, clickDisposable, autorun(reader => {
 			const { files, insertions, deletions } = stats.read(reader);
 			const fileCountLabel = files === 1
 				? localize('chat.turnChanges.oneFile', '1 file changed')
@@ -164,6 +173,12 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 			filesLabel.textContent = fileCountLabel;
 			addedLabel.textContent = `+${insertions}`;
 			removedLabel.textContent = `-${deletions}`;
+			counts.setAttribute('aria-label', localize(
+				'chat.turnChanges.viewAllAccessible',
+				'View all file changes, {0} lines added, {1} lines deleted',
+				insertions,
+				deletions
+			));
 			header.setAttribute('aria-label', localize(
 				'chat.turnChanges.accessibleSummary',
 				'{0}, {1} lines added, {2} lines deleted',
@@ -175,26 +190,7 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 			const show = showChanges.read(reader);
 			filesLabel.classList.toggle('hidden', !show);
 			counts.classList.toggle('hidden', !show);
-			viewAll.element.classList.toggle('hidden', !show);
 		}));
-	}
-
-	private _renderViewAllFileChangesButton(header: HTMLElement): { readonly element: HTMLElement } & IDisposable {
-		const button = header.appendChild(document.createElement('button'));
-		button.classList.add('chat-view-changes-icon');
-		button.type = 'button';
-		button.classList.add(...ThemeIcon.asClassNameArray(Codicon.diffMultiple));
-		button.setAttribute('aria-label', localize('chat.viewTurnFileChangesSummary', 'View All File Changes'));
-		const hoverDisposable = this._hoverService.setupDelayedHover(button, () => ({
-			content: localize2('chat.viewTurnFileChangesSummary', 'View All File Changes')
-		}));
-
-		const clickDisposable = dom.addDisposableListener(button, 'click', (e) => {
-			this._openChanges();
-			dom.EventHelper.stop(e, true);
-		});
-
-		return { element: button, dispose: () => combinedDisposable(hoverDisposable, clickDisposable).dispose() };
 	}
 
 	private _renderPreviewAction(header: HTMLElement, previewFiles: IObservable<readonly IPreviewFile[]>, showPreview: IObservable<boolean>, resourceLabels: ResourceLabels): IDisposable {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -3018,6 +3018,29 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 /* Turn changes summary: reuses the compact checkpoint summary styling and adds an
 	inline resource-label action shown when the turn produced a previewable file. */
+
+/* In the pill part the +/- counts are themselves the "View All File Changes" button,
+	so reset the native button chrome and add the standard toolbar hover/focus affordances. */
+.interactive-session .chat-turn-pills-part .chat-file-changes-counts {
+	align-items: center;
+	padding: var(--vscode-spacing-sizeNone) var(--vscode-spacing-size20);
+	border: none;
+	border-radius: var(--vscode-cornerRadius-small);
+	color: inherit;
+	background: transparent;
+	font: inherit;
+	cursor: pointer;
+}
+
+.interactive-session .chat-turn-pills-part .chat-file-changes-counts:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.interactive-session .chat-turn-pills-part .chat-file-changes-counts:focus-visible {
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: calc(-1 * var(--vscode-strokeThickness));
+}
+
 .interactive-session .chat-turn-pills-part .chat-turn-preview {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
In the chat turn pills part, the `chat-file-changes-counts` element (the `+N -M` line counts) is now itself the button that opens the multi-diff view of all file changes. The separate multi-diff icon button (`chat-view-changes-icon` with `Codicon.diffMultiple`) has been removed from the pill part entirely.

- `chat-file-changes-counts` is now a `<button>` that calls `_openChanges()` with a delayed hover and an action-oriented aria-label (`View all file changes, ...`).
- Removed the `_renderViewAllFileChangesButton` method.
- The `<summary>` header keeps its own concise disclosure aria-label so screen reader announcements stay clear.
- Added scoped CSS under `.chat-turn-pills-part .chat-file-changes-counts` to reset native button chrome and add toolbar hover/focus affordances.
- The checkpoint changes summary part is untouched and still uses its own `chat-view-changes-icon` button.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>