### PR TITLE
test: skip flaky chat sandbox home-read smoke test

### DIFF
--- a/test/smoke/src/areas/chat/chatSandbox.test.ts
+++ b/test/smoke/src/areas/chat/chatSandbox.test.ts
@@ -374,7 +374,11 @@ export function setup(logger: Logger): void {
 		 * Input: Add the home test file to allowRead and ask chat to read it through the terminal tool.
 		 * Expected result: The sandbox permits the read and its output contains `HOME_READ_ALLOWED_EXIT_CODE=0`.
 		 */
-		it('allows reading a home directory file configured in allowRead', async function () {
+		// Skipped: flaky after the app restart introduced in #325532 — the
+		// restart tears down the warmed-up chat participant / mock LLM
+		// connection and the probe can time out. Tracked by
+		// https://github.com/microsoft/vscode-engineering/issues/3280.
+		it.skip('allows reading a home directory file configured in allowRead', async function () {
 			const app = this.app as Application;
 
 			try {


### PR DESCRIPTION
## Why

The `Chat Sandbox (darwin) > allows reading a home directory file configured in allowRead` smoke test is flaky and is **red on `release/1.129`** ([build 455304](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=455304&view=logs&j=e352877c-ff47-5dec-32e2-b206099d9704&t=e3dd7514-b813-5e5e-156d-669f9d8e2cfc&s=a56e7651-4213-56af-9488-c25fe636c10c)), and failed **9/20** in the flaky-test pipeline ([build 455265](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=455265&view=results)).

This **unblocks the build**. It is a stop-gap — a proper fix (re-warming chat after the restart) is being prepared separately.

## Root cause (for context)

This is the only active test that calls `app.restart()` (via `restartWithUpdatedSandboxSettings`, added in #325532 to make the `allowRead` setting reload deterministically). The restart tears down the extension host along with the warmed-up chat participant and its mock-LLM connection, but the helper only waits for the chat **view DOM** (`waitForChatView`) — it never re-runs the `warmUpChat` retry loop that the cold-start `before` hook relies on (which retries for up to 180s). So the first probe message races an unready chat and the response never renders → 120s timeout.

Two distinct failure signatures observed across the builds above:

- Flaky pipeline [build 455265](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=455265&view=results): response arrives but reports `HOME_READ_ALLOWED_EXIT_CODE=1` (the `allowRead` setting had not been reloaded).
- Release build [build 455304](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=455304&view=logs&j=e352877c-ff47-5dec-32e2-b206099d9704&t=e3dd7514-b813-5e5e-156d-669f9d8e2cfc&s=a56e7651-4213-56af-9488-c25fe636c10c): **times out** with no response (chat not re-warmed after the restart).

## Change

Marks the test `it.skip` with an explanatory comment. No other behavior changes.

Tracked by https://github.com/microsoft/vscode-engineering/issues/3280.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

cc @dileepyavan 
