### PR TITLE
Fix file handle leak in zip extraction when the source stream errors

### DIFF
--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -94,7 +94,13 @@ function extractEntry(stream: Readable, fileName: string, mode: number, targetPa
 			istream = createWriteStream(targetFileName, { mode });
 			istream.once('close', () => c());
 			istream.once('error', e);
-			stream.once('error', e);
+			stream.once('error', err => {
+				// `stream.pipe()` does not destroy the destination when the
+				// source errors, so close the target file handle explicitly to
+				// avoid leaking it (mirrors the cancellation path above).
+				istream.destroy();
+				e(err);
+			});
 			stream.pipe(istream);
 		} catch (error) {
 			e(error);

--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -95,10 +95,7 @@ function extractEntry(stream: Readable, fileName: string, mode: number, targetPa
 			istream.once('close', () => c());
 			istream.once('error', e);
 			stream.once('error', err => {
-				// `stream.pipe()` does not destroy the destination when the
-				// source errors, so close the target file handle explicitly to
-				// avoid leaking it (mirrors the cancellation path above).
-				istream.destroy();
+				istream.destroy(); // pipe() doesn't destroy the sink on source error; close it so the fd isn't leaked
 				e(err);
 			});
 			stream.pipe(istream);


### PR DESCRIPTION
extractEntry() pipes the zip entry's read stream into a createWriteStream target. stream.pipe(istream) does not destroy the destination when the source errors, so on a corrupt/truncated entry the source 'error' handler rejected the promise but left istream (the target file handle) open, leaking the fd and a partially-written file. The cancellation path already destroys istream; the source-error path did not.

Destroy istream in the source 'error' handler, mirroring the existing cancellation cleanup.

Assisted-by: Claude Code (Opus 4.8)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
