### PR TITLE
sessions: add Fix CI row to blocked-sessions list items

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/checksActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksActions.ts
@@ -13,10 +13,11 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { bindContextKey } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
-import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { IChatWidget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { CHAT_CATEGORY } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
 import { IGitHubService } from '../../github/browser/githubService.js';
+import { GitHubPullRequestCIModel } from '../../github/browser/models/githubPullRequestCIModel.js';
 import { GitHubCheckConclusion, GitHubCheckStatus, IGitHubCICheck } from '../../github/common/types.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 export const hasActiveSessionFailedCIChecks = new RawContextKey<boolean>('sessions.hasActiveSessionFailedCIChecks', false);
@@ -115,6 +116,32 @@ export function buildFixChecksPrompt(failedChecks: ReadonlyArray<{ check: IGitHu
 }
 
 /**
+ * Submits the `fix-ci` prompt for a session's failing CI checks: fetches each
+ * failed check's annotations, builds the prompt, sends it to the given chat
+ * widget, and marks the fix as requested so the "Fix Checks" affordances hide
+ * until a new commit lands. Shared by the active-session action and the
+ * blocked-sessions list's per-session "Fix CI" row.
+ */
+export async function submitFixCIChecks(ciModel: GitHubPullRequestCIModel, chatWidget: IChatWidget): Promise<void> {
+	const checks = ciModel.checks.get();
+	const failedChecks = getFailedChecks(checks);
+	if (failedChecks.length === 0) {
+		return;
+	}
+
+	const failedCheckDetails = await Promise.all(failedChecks.map(async check => {
+		const annotations = await ciModel.getCheckRunAnnotations(check.id);
+		return { check, annotations };
+	}));
+
+	const prompt = buildFixChecksPrompt(failedCheckDetails, getPullRequestUrl(ciModel));
+	const response = await chatWidget.acceptInput(prompt);
+	if (response) {
+		ciModel.markFixRequested();
+	}
+}
+
+/**
  * Sets the `hasActiveSessionFailedCIChecks` context key to true when the
  * active session has a PR with CI checks and at least one has failed.
  */
@@ -183,18 +210,6 @@ class FixCIChecksAction extends Action2 {
 			return;
 		}
 
-		const checks = ciModel.checks.get();
-		const failedChecks = getFailedChecks(checks);
-		if (failedChecks.length === 0) {
-			return;
-		}
-
-		const failedCheckDetails = await Promise.all(failedChecks.map(async check => {
-			const annotations = await ciModel.getCheckRunAnnotations(check.id);
-			return { check, annotations };
-		}));
-
-		const prompt = buildFixChecksPrompt(failedCheckDetails, getPullRequestUrl(ciModel));
 		const sessionResource = activeSession.resource;
 		const chatWidget = chatWidgetService.getWidgetBySessionResource(sessionResource);
 		if (!chatWidget) {
@@ -202,10 +217,7 @@ class FixCIChecksAction extends Action2 {
 			return;
 		}
 
-		const response = await chatWidget.acceptInput(prompt);
-		if (response) {
-			ciModel.markFixRequested();
-		}
+		await submitFixCIChecks(ciModel, chatWidget);
 	}
 }
 

--- a/src/vs/sessions/contrib/changes/browser/checksActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksActions.ts
@@ -116,17 +116,16 @@ export function buildFixChecksPrompt(failedChecks: ReadonlyArray<{ check: IGitHu
 }
 
 /**
- * Submits the `fix-ci` prompt for a session's failing CI checks: fetches each
- * failed check's annotations, builds the prompt, sends it to the given chat
- * widget, and marks the fix as requested so the "Fix Checks" affordances hide
- * until a new commit lands. Shared by the active-session action and the
- * blocked-sessions list's per-session "Fix CI" row.
+ * Builds the `fix-ci` prompt for a CI model's failing checks: fetches each
+ * failed check's annotations and assembles the prompt text. Returns `undefined`
+ * when there are no failing checks. Shared by the widget-based active-session
+ * action and the blocked-sessions list's background fix.
  */
-export async function submitFixCIChecks(ciModel: GitHubPullRequestCIModel, chatWidget: IChatWidget): Promise<void> {
+export async function buildFixCIPrompt(ciModel: GitHubPullRequestCIModel): Promise<string | undefined> {
 	const checks = ciModel.checks.get();
 	const failedChecks = getFailedChecks(checks);
 	if (failedChecks.length === 0) {
-		return;
+		return undefined;
 	}
 
 	const failedCheckDetails = await Promise.all(failedChecks.map(async check => {
@@ -134,7 +133,22 @@ export async function submitFixCIChecks(ciModel: GitHubPullRequestCIModel, chatW
 		return { check, annotations };
 	}));
 
-	const prompt = buildFixChecksPrompt(failedCheckDetails, getPullRequestUrl(ciModel));
+	return buildFixChecksPrompt(failedCheckDetails, getPullRequestUrl(ciModel));
+}
+
+/**
+ * Submits the `fix-ci` prompt for a session's failing CI checks: builds the
+ * prompt, sends it to the given chat widget, and marks the fix as requested so
+ * the "Fix Checks" affordances hide until a new commit lands. Used by the
+ * active-session action; the blocked-sessions list sends in the background via
+ * {@link buildFixCIPrompt} instead.
+ */
+export async function submitFixCIChecks(ciModel: GitHubPullRequestCIModel, chatWidget: IChatWidget): Promise<void> {
+	const prompt = await buildFixCIPrompt(ciModel);
+	if (!prompt) {
+		return;
+	}
+
 	const response = await chatWidget.acceptInput(prompt);
 	if (response) {
 		ciModel.markFixRequested();

--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsCIFixModel.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsCIFixModel.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { derived, IObservable } from '../../../../base/common/observable.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+import { getFailedChecks, submitFixCIChecks } from '../../changes/browser/checksActions.js';
+import { IGitHubService } from '../../github/browser/githubService.js';
+import { GitHubPullRequestCIModel } from '../../github/browser/models/githubPullRequestCIModel.js';
+import { GitHubCheckStatus } from '../../github/common/types.js';
+import { ISessionCIFixModel, ISessionCIFixState } from './views/sessionsList.js';
+
+/**
+ * Backs the per-session "Fix CI" row shown in the blocked-sessions dropdown for
+ * sessions whose pull request has failing CI checks. Exposes a reactive summary
+ * of the failing/pending check counts and, on demand, opens the session and
+ * submits the `fix-ci` prompt for its failed checks.
+ */
+export class BlockedSessionsCIFixModel extends Disposable implements ISessionCIFixModel {
+
+	/** Cached CI-state observables, keyed by session, to keep references stable and GC-friendly. */
+	private readonly _states = new WeakMap<ISession, IObservable<ISessionCIFixState | undefined>>();
+
+	/** Session resources with an in-flight fix so repeated clicks don't submit duplicate prompts. */
+	private readonly _fixInFlight = new Set<string>();
+
+	constructor(
+		@IGitHubService private readonly _gitHubService: IGitHubService,
+		@ISessionsService private readonly _sessionsService: ISessionsService,
+		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+	}
+
+	getCIFix(session: ISession): IObservable<ISessionCIFixState | undefined> {
+		let obs = this._states.get(session);
+		if (!obs) {
+			obs = derived(this, reader => {
+				const gitHubInfo = session.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader);
+				if (!gitHubInfo?.pullRequest) {
+					return undefined;
+				}
+
+				const prRef = reader.store.add(this._gitHubService.createPullRequestModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number));
+				const livePR = prRef.object.pullRequest.read(reader);
+				if (!livePR) {
+					return undefined;
+				}
+
+				const ciRef = reader.store.add(this._gitHubService.createPullRequestCIModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number, livePR.headSha));
+				const ciModel = ciRef.object;
+
+				// Once a fix has been requested for the current head commit, hide the
+				// row until a new commit lands (mirrors the chat input CI banner).
+				if (ciModel.fixRequested.read(reader)) {
+					return undefined;
+				}
+
+				const checks = ciModel.checks.read(reader);
+				const failed = getFailedChecks(checks).length;
+				if (failed === 0) {
+					return undefined;
+				}
+				const completed = checks.filter(check => check.status === GitHubCheckStatus.Completed).length;
+				const pending = checks.length - completed;
+				return { failed, pending };
+			});
+			this._states.set(session, obs);
+		}
+		return obs;
+	}
+
+	fixCI(session: ISession): void {
+		const key = session.resource.toString();
+		if (this._fixInFlight.has(key)) {
+			return;
+		}
+		this._fixInFlight.add(key);
+		this._fixCI(session)
+			.catch(err => this._logService.error('[BlockedSessionsCIFixModel] Failed to fix CI checks', err))
+			.finally(() => this._fixInFlight.delete(key));
+	}
+
+	private async _fixCI(session: ISession): Promise<void> {
+		// Acquire our own CI-model reference for the duration: opening the session
+		// removes it from the blocked list, which drops the row's observers and
+		// would otherwise release the shared model reference mid-flight.
+		const store = new DisposableStore();
+		try {
+			const ciModel = this._acquireCIModel(session, store);
+			if (!ciModel) {
+				return;
+			}
+
+			await this._sessionsService.openSession(session.resource, { preserveFocus: true });
+
+			const chatWidget = this._chatWidgetService.getWidgetBySessionResource(session.resource);
+			if (!chatWidget) {
+				this._logService.error('[BlockedSessionsCIFixModel] Cannot fix CI checks: no chat widget found for session', session.resource.toString());
+				return;
+			}
+
+			await submitFixCIChecks(ciModel, chatWidget);
+		} finally {
+			store.dispose();
+		}
+	}
+
+	private _acquireCIModel(session: ISession, store: DisposableStore): GitHubPullRequestCIModel | undefined {
+		const gitHubInfo = session.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get();
+		if (!gitHubInfo?.pullRequest) {
+			return undefined;
+		}
+
+		const prRef = store.add(this._gitHubService.createPullRequestModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number));
+		const livePR = prRef.object.pullRequest.get();
+		if (!livePR) {
+			return undefined;
+		}
+
+		const ciRef = store.add(this._gitHubService.createPullRequestCIModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number, livePR.headSha));
+		return ciRef.object;
+	}
+}

--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsCIFixModel.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsCIFixModel.ts
@@ -3,13 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { derived, IObservable } from '../../../../base/common/observable.js';
+import { derived, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
-import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { ChatSendResult, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ISession } from '../../../services/sessions/common/session.js';
-import { getFailedChecks, submitFixCIChecks } from '../../changes/browser/checksActions.js';
+import { buildFixCIPrompt, getFailedChecks } from '../../changes/browser/checksActions.js';
 import { IGitHubService } from '../../github/browser/githubService.js';
 import { GitHubPullRequestCIModel } from '../../github/browser/models/githubPullRequestCIModel.js';
 import { GitHubCheckStatus } from '../../github/common/types.js';
@@ -18,21 +19,31 @@ import { ISessionCIFixModel, ISessionCIFixState } from './views/sessionsList.js'
 /**
  * Backs the per-session "Fix CI" row shown in the blocked-sessions dropdown for
  * sessions whose pull request has failing CI checks. Exposes a reactive summary
- * of the failing/pending check counts and, on demand, opens the session and
- * submits the `fix-ci` prompt for its failed checks.
+ * of the failing/pending check counts and, on demand, submits the `fix-ci`
+ * prompt to the session's chat **in the background** — the session starts
+ * working without being opened or made visible.
+ *
+ * While a fix is being submitted the session is reported via
+ * {@link hiddenSessions} so the blocked-sessions list can drop it immediately;
+ * by the time the submit resolves the session is in progress and so is no longer
+ * blocked, keeping it out of the list without a flicker.
  */
 export class BlockedSessionsCIFixModel extends Disposable implements ISessionCIFixModel {
 
 	/** Cached CI-state observables, keyed by session, to keep references stable and GC-friendly. */
 	private readonly _states = new WeakMap<ISession, IObservable<ISessionCIFixState | undefined>>();
 
-	/** Session resources with an in-flight fix so repeated clicks don't submit duplicate prompts. */
-	private readonly _fixInFlight = new Set<string>();
+	/**
+	 * Session ids whose fix-CI submission is in flight. Doubles as the guard that
+	 * stops repeated clicks submitting duplicate prompts, and as the set the
+	 * blocked-sessions indicator hides while the background work runs.
+	 */
+	private readonly _hiddenSessions: ISettableObservable<ReadonlySet<string>> = observableValue(this, new Set());
+	readonly hiddenSessions: IObservable<ReadonlySet<string>> = this._hiddenSessions;
 
 	constructor(
 		@IGitHubService private readonly _gitHubService: IGitHubService,
-		@ISessionsService private readonly _sessionsService: ISessionsService,
-		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
+		@IChatService private readonly _chatService: IChatService,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
@@ -77,20 +88,23 @@ export class BlockedSessionsCIFixModel extends Disposable implements ISessionCIF
 	}
 
 	fixCI(session: ISession): void {
-		const key = session.resource.toString();
-		if (this._fixInFlight.has(key)) {
+		if (this._hiddenSessions.get().has(session.sessionId)) {
 			return;
 		}
-		this._fixInFlight.add(key);
+		this._setHidden(session.sessionId, true);
 		this._fixCI(session)
 			.catch(err => this._logService.error('[BlockedSessionsCIFixModel] Failed to fix CI checks', err))
-			.finally(() => this._fixInFlight.delete(key));
+			// Release the optimistic hide once the submit settles: by now the
+			// request has been sent and the session is in progress, so the blocked
+			// model no longer reports it as blocked and it stays out of the list.
+			.finally(() => this._setHidden(session.sessionId, false));
 	}
 
 	private async _fixCI(session: ISession): Promise<void> {
-		// Acquire our own CI-model reference for the duration: opening the session
-		// removes it from the blocked list, which drops the row's observers and
-		// would otherwise release the shared model reference mid-flight.
+		// Hold our own CI-model reference for the whole flow: the session drops out
+		// of the blocked list as soon as we hide it, which releases the row's
+		// reference, so we must keep the model alive to build the prompt and mark
+		// the fix requested.
 		const store = new DisposableStore();
 		try {
 			const ciModel = this._acquireCIModel(session, store);
@@ -98,15 +112,33 @@ export class BlockedSessionsCIFixModel extends Disposable implements ISessionCIF
 				return;
 			}
 
-			await this._sessionsService.openSession(session.resource, { preserveFocus: true });
-
-			const chatWidget = this._chatWidgetService.getWidgetBySessionResource(session.resource);
-			if (!chatWidget) {
-				this._logService.error('[BlockedSessionsCIFixModel] Cannot fix CI checks: no chat widget found for session', session.resource.toString());
+			const prompt = await buildFixCIPrompt(ciModel);
+			if (!prompt) {
 				return;
 			}
 
-			await submitFixCIChecks(ciModel, chatWidget);
+			// Load the session's chat model in the background (without opening it in
+			// the UI) and submit the prompt. `session.resource.scheme` is the agent
+			// id used for routing (matching the agent-host skill-button flow); an
+			// unknown scheme falls back to the default agent.
+			const ref = await this._chatService.acquireOrLoadSession(session.resource, ChatAgentLocation.Chat, CancellationToken.None, 'BlockedSessionsCIFix');
+			if (!ref) {
+				this._logService.error('[BlockedSessionsCIFixModel] Cannot fix CI checks: failed to load session', session.resource.toString());
+				return;
+			}
+			try {
+				let result = await this._chatService.sendRequest(session.resource, prompt, { agentIdSilent: session.resource.scheme });
+				if (ChatSendResult.isQueued(result)) {
+					result = await result.deferred;
+				}
+				if (ChatSendResult.isSent(result)) {
+					ciModel.markFixRequested();
+				} else if (ChatSendResult.isRejected(result)) {
+					this._logService.error('[BlockedSessionsCIFixModel] Fix CI request rejected', result.reason);
+				}
+			} finally {
+				ref.dispose();
+			}
 		} finally {
 			store.dispose();
 		}
@@ -126,5 +158,19 @@ export class BlockedSessionsCIFixModel extends Disposable implements ISessionCIF
 
 		const ciRef = store.add(this._gitHubService.createPullRequestCIModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number, livePR.headSha));
 		return ciRef.object;
+	}
+
+	private _setHidden(sessionId: string, hidden: boolean): void {
+		const current = this._hiddenSessions.get();
+		if (current.has(sessionId) === hidden) {
+			return;
+		}
+		const next = new Set(current);
+		if (hidden) {
+			next.add(sessionId);
+		} else {
+			next.delete(sessionId);
+		}
+		this._hiddenSessions.set(next, undefined);
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsIndicatorModel.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsIndicatorModel.ts
@@ -12,6 +12,7 @@ import { IProductService } from '../../../../platform/product/common/productServ
 import { AgentSessionApprovalKind, AgentSessionApprovalModel, agentSessionApprovalId } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { BlockedSessionReason, BlockedSessions, IBlockedSession } from '../../blockedSessions/browser/blockedSessions.js';
+import { BlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
 import { getFirstApprovalAcrossChats, IApprovedSession } from './views/sessionsList.js';
 
 /**
@@ -56,6 +57,14 @@ export class BlockedSessionsIndicatorModel extends Disposable {
 	/** The approval model, shared with the dropdown list so both agree on each session's pending action. */
 	get approvalModel(): AgentSessionApprovalModel {
 		return this._approvalModel;
+	}
+
+	/** Drives the per-session "Fix CI" row; shared with the dropdown list. */
+	private readonly _ciFixModel: BlockedSessionsCIFixModel;
+
+	/** The CI-fix model, shared with the dropdown list so the fix action and the hide-while-fixing agree. */
+	get ciFixModel(): BlockedSessionsCIFixModel {
+		return this._ciFixModel;
 	}
 
 	/**
@@ -109,17 +118,19 @@ export class BlockedSessionsIndicatorModel extends Disposable {
 	constructor(
 		approvalModel: AgentSessionApprovalModel | undefined,
 		blockedSessions: BlockedSessions | undefined,
+		ciFixModel: BlockedSessionsCIFixModel | undefined,
 		@ISessionsService private readonly _sessionsService: ISessionsService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IProductService productService: IProductService,
 	) {
 		super();
 
-		// The model owns the approval model and blocked-sessions model; the optional
-		// parameters are test seams so fixtures/tests can supply preset instances (only
-		// register — and thus dispose — the ones we created ourselves).
+		// The model owns the approval model, blocked-sessions model and CI-fix model;
+		// the optional parameters are test seams so fixtures/tests can supply preset
+		// instances (only register — and thus dispose — the ones we created ourselves).
 		this._approvalModel = approvalModel ?? this._register(instantiationService.createInstance(AgentSessionApprovalModel));
 		this._blockedSessionsModel = blockedSessions ?? this._register(instantiationService.createInstance(BlockedSessions));
+		this._ciFixModel = ciFixModel ?? this._register(instantiationService.createInstance(BlockedSessionsCIFixModel));
 
 		// The blocked-sessions feature is only enabled outside of stable builds.
 		const enabled = productService.quality !== 'stable';
@@ -137,8 +148,12 @@ export class BlockedSessionsIndicatorModel extends Disposable {
 				}
 			}
 			const dismissed = this._dismissedApprovals.read(reader);
+			// Sessions whose CI fix is being submitted in the background are hidden
+			// immediately (before their status flips to in-progress) so the row
+			// disappears the moment the user clicks "Fix CI".
+			const ciFixHidden = this._ciFixModel.hiddenSessions.read(reader);
 			return this._blockedSessionsModel.blockedSessionsWithReasons.read(reader)
-				.filter(blocked => !visibleSessionIds.has(blocked.session.sessionId) && !this._isApprovalDismissed(blocked, dismissed, reader));
+				.filter(blocked => !visibleSessionIds.has(blocked.session.sessionId) && !ciFixHidden.has(blocked.session.sessionId) && !this._isApprovalDismissed(blocked, dismissed, reader));
 		});
 
 		// The homogeneous reason across all blocked sessions (or `undefined` for a

--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsList.ts
@@ -13,7 +13,7 @@ import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/a
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { Menus } from '../../../browser/menus.js';
 import { ISession } from '../../../services/sessions/common/session.js';
-import { IApprovedSession, SessionsFlatList } from './views/sessionsList.js';
+import { IApprovedSession, ISessionCIFixModel, SessionsFlatList } from './views/sessionsList.js';
 import { AgentSessionApprovalModel } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 
 /** Fixed width of the blocked-sessions list, in pixels. */
@@ -30,6 +30,8 @@ export interface IBlockedSessionsListOptions {
 	readonly width?: number;
 	/** Approval model forwarded to the underlying list (see {@link ISessionsFlatListOptions.approvalModel}). */
 	readonly approvalModel?: AgentSessionApprovalModel;
+	/** Fix-CI model forwarded to the underlying list (see {@link ISessionsFlatListOptions.ciFixModel}). */
+	readonly ciFixModel?: ISessionCIFixModel;
 }
 
 /**
@@ -84,6 +86,7 @@ export class BlockedSessionsList extends Disposable {
 			showSessionHover: true,
 			onSessionOpen: options.onSessionOpen,
 			approvalModel: options.approvalModel,
+			ciFixModel: options.ciFixModel,
 			approvalRowMaxLines: BLOCKED_LIST_APPROVAL_ROW_MAX_LINES,
 			toolbarActions: false,
 		}));

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -324,6 +324,46 @@
 			}
 		}
 	}
+
+	/* Fix-CI row — a single line shown for blocked sessions whose PR is failing
+		CI. Styled after the chat input's orange CI banner: an orange-tinted card
+		with a summary on the left and a prominent orange "Fix CI" button. */
+	.session-ci-row {
+		display: none;
+		gap: 8px;
+		margin-top: 4px;
+		margin-left: -6px;
+		padding: 4px 4px 4px 8px;
+		box-sizing: border-box;
+		border: var(--vscode-strokeThickness) solid var(--vscode-charts-orange);
+		border-radius: var(--vscode-cornerRadius-large);
+		background-color: color-mix(in srgb, var(--vscode-charts-orange) 6%, var(--vscode-editor-background));
+		color: var(--vscode-editor-foreground);
+		align-items: center;
+
+		&.visible {
+			display: flex;
+		}
+
+		.session-ci-label {
+			flex: 1;
+			min-width: 0;
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			font-size: var(--vscode-agents-fontSize-label1, 12px);
+		}
+
+		.session-ci-button {
+			flex-shrink: 0;
+
+			.monaco-button {
+				padding: 2px 10px;
+				font-size: var(--vscode-agents-fontSize-label1, 12px);
+				white-space: nowrap;
+			}
+		}
+	}
 }
 
 /* Show More */

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -335,6 +335,10 @@
 		margin-left: -6px;
 		padding: 4px 4px 4px 8px;
 		box-sizing: border-box;
+		/* Reset the inherited list-row line-height (set to the full row height),
+			otherwise the single-line label's line box grows to the whole row and
+			pushes the content out of the clipped row. */
+		line-height: 18px;
 		border: var(--vscode-strokeThickness) solid var(--vscode-charts-orange);
 		border-radius: var(--vscode-cornerRadius-large);
 		background-color: color-mix(in srgb, var(--vscode-charts-orange) 6%, var(--vscode-editor-background));

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -35,6 +35,7 @@ import { ISessionsService } from '../../../services/sessions/browser/sessionsSer
 import { getUntitledSessionTitle } from '../../../services/sessions/common/session.js';
 import { BlockedSessions } from '../../blockedSessions/browser/blockedSessions.js';
 import { BlockedSessionsList } from './blockedSessionsList.js';
+import { BlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
 import { SessionActionFeedback } from './sessionActionFeedback.js';
 import { AgentSessionApprovalModel } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { BlockedSessionsIndicatorModel, RequiresInputKind } from './blockedSessionsIndicatorModel.js';
@@ -117,6 +118,9 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	/** Model behind the "N sessions require input" indicator (blocked-session set, blink, labels). */
 	private readonly _blockedIndicator: BlockedSessionsIndicatorModel;
 
+	/** Backs the per-session "Fix CI" row shown for blocked sessions failing CI. */
+	private readonly _ciFixModel: BlockedSessionsCIFixModel;
+
 	/** The currently open blocked-sessions dropdown, if any. */
 	private _openContextView: IOpenContextView | undefined;
 	/** The blocked-sessions list rendered inside the open dropdown, if any. */
@@ -157,6 +161,9 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		// dismissals, labels and blink detection). The optional `approvalModel` and
 		// `blockedSessions` are test seams forwarded to it so fixtures can preset them.
 		this._blockedIndicator = this._register(this.instantiationService.createInstance(BlockedSessionsIndicatorModel, approvalModel, blockedSessions));
+
+		// Backs the per-session "Fix CI" row rendered in the blocked-sessions dropdown.
+		this._ciFixModel = this._register(this.instantiationService.createInstance(BlockedSessionsCIFixModel));
 
 		// Replay the attention blink when the model reports a genuinely new, not-yet-
 		// visible block. Invalidate the cached render state so the identical pill is
@@ -531,6 +538,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				const list = store.add(this.instantiationService.createInstance(BlockedSessionsList, viewContainer, {
 					width,
 					approvalModel: this._blockedIndicator.approvalModel,
+					ciFixModel: this._ciFixModel,
 					onSessionOpen: (resource, preserveFocus, sideBySide) => {
 						this._openContextView?.close();
 						this._openBlockedSession(resource, preserveFocus, sideBySide);

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -35,6 +35,7 @@ import { ISessionsService } from '../../../services/sessions/browser/sessionsSer
 import { getUntitledSessionTitle } from '../../../services/sessions/common/session.js';
 import { BlockedSessions } from '../../blockedSessions/browser/blockedSessions.js';
 import { BlockedSessionsList } from './blockedSessionsList.js';
+import { BlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
 import { SessionActionFeedback } from './sessionActionFeedback.js';
 import { AgentSessionApprovalModel } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { BlockedSessionsIndicatorModel, RequiresInputKind } from './blockedSessionsIndicatorModel.js';
@@ -134,6 +135,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		sessionActionFeedback: SessionActionFeedback | undefined,
 		approvalModel: AgentSessionApprovalModel | undefined,
 		blockedSessions: BlockedSessions | undefined,
+		ciFixModel: BlockedSessionsCIFixModel | undefined,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
@@ -154,9 +156,10 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 
 		// The blocked-session indicator model owns the requires-input logic (the
 		// visible-filtered blocked set, the requires-input kind, optimistic approval
-		// dismissals, labels and blink detection). The optional `approvalModel` and
-		// `blockedSessions` are test seams forwarded to it so fixtures can preset them.
-		this._blockedIndicator = this._register(this.instantiationService.createInstance(BlockedSessionsIndicatorModel, approvalModel, blockedSessions, undefined));
+		// dismissals, labels and blink detection). The optional `approvalModel`,
+		// `blockedSessions` and `ciFixModel` are test seams forwarded to it so
+		// fixtures can preset them.
+		this._blockedIndicator = this._register(this.instantiationService.createInstance(BlockedSessionsIndicatorModel, approvalModel, blockedSessions, ciFixModel));
 
 		// Replay the attention blink when the model reports a genuinely new, not-yet-
 		// visible block. Invalidate the cached render state so the identical pill is
@@ -728,7 +731,7 @@ export class SessionsTitleBarContribution extends Disposable implements IWorkben
 			if (!(action instanceof SubmenuItemAction)) {
 				return undefined;
 			}
-			return instantiationService.createInstance(SessionsTitleBarWidget, action, options, undefined, undefined, undefined);
+			return instantiationService.createInstance(SessionsTitleBarWidget, action, options, undefined, undefined, undefined, undefined);
 		}, undefined));
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -35,7 +35,6 @@ import { ISessionsService } from '../../../services/sessions/browser/sessionsSer
 import { getUntitledSessionTitle } from '../../../services/sessions/common/session.js';
 import { BlockedSessions } from '../../blockedSessions/browser/blockedSessions.js';
 import { BlockedSessionsList } from './blockedSessionsList.js';
-import { BlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
 import { SessionActionFeedback } from './sessionActionFeedback.js';
 import { AgentSessionApprovalModel } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { BlockedSessionsIndicatorModel, RequiresInputKind } from './blockedSessionsIndicatorModel.js';
@@ -118,9 +117,6 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	/** Model behind the "N sessions require input" indicator (blocked-session set, blink, labels). */
 	private readonly _blockedIndicator: BlockedSessionsIndicatorModel;
 
-	/** Backs the per-session "Fix CI" row shown for blocked sessions failing CI. */
-	private readonly _ciFixModel: BlockedSessionsCIFixModel;
-
 	/** The currently open blocked-sessions dropdown, if any. */
 	private _openContextView: IOpenContextView | undefined;
 	/** The blocked-sessions list rendered inside the open dropdown, if any. */
@@ -160,10 +156,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		// visible-filtered blocked set, the requires-input kind, optimistic approval
 		// dismissals, labels and blink detection). The optional `approvalModel` and
 		// `blockedSessions` are test seams forwarded to it so fixtures can preset them.
-		this._blockedIndicator = this._register(this.instantiationService.createInstance(BlockedSessionsIndicatorModel, approvalModel, blockedSessions));
-
-		// Backs the per-session "Fix CI" row rendered in the blocked-sessions dropdown.
-		this._ciFixModel = this._register(this.instantiationService.createInstance(BlockedSessionsCIFixModel));
+		this._blockedIndicator = this._register(this.instantiationService.createInstance(BlockedSessionsIndicatorModel, approvalModel, blockedSessions, undefined));
 
 		// Replay the attention blink when the model reports a genuinely new, not-yet-
 		// visible block. Invalidate the cached render state so the identical pill is
@@ -538,7 +531,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				const list = store.add(this.instantiationService.createInstance(BlockedSessionsList, viewContainer, {
 					width,
 					approvalModel: this._blockedIndicator.approvalModel,
-					ciFixModel: this._ciFixModel,
+					ciFixModel: this._blockedIndicator.ciFixModel,
 					onSessionOpen: (resource, preserveFocus, sideBySide) => {
 						this._openContextView?.close();
 						this._openBlockedSession(resource, preserveFocus, sideBySide);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -331,7 +331,7 @@ export interface ISessionCIFixModel {
 	 * failing checks (or the user already requested a fix for the current commit).
 	 */
 	getCIFix(session: ISession): IObservable<ISessionCIFixState | undefined>;
-	/** Kick off the fix-CI flow for the session (opens it and submits the fix prompt). */
+	/** Kick off the fix-CI flow for the session in the background (no session is opened). */
 	fixCI(session: ISession): void;
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -35,6 +35,8 @@ import { IKeybindingService } from '../../../../../platform/keybinding/common/ke
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { WorkbenchObjectTree } from '../../../../../platform/list/browser/listService.js';
 import { IStyleOverride, defaultButtonStyles, defaultFindWidgetStyles, defaultInputBoxStyles, defaultToggleStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { asCssVariable } from '../../../../../platform/theme/common/colorUtils.js';
+import { chartsOrange } from '../../../../../platform/theme/common/colors/chartsColors.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
@@ -202,6 +204,7 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 		private readonly _approvalModel: AgentSessionApprovalModel | undefined,
 		private readonly _isPhone: () => boolean,
 		private readonly _approvalRowMaxLines: number = DEFAULT_APPROVAL_ROW_MAX_LINES,
+		private readonly _ciFixModel: ISessionCIFixModel | undefined = undefined,
 	) { }
 
 	getHeight(element: SessionListItem): number {
@@ -222,11 +225,14 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 				height += SessionItemRenderer.getApprovalRowHeight(approval.label, this._approvalRowMaxLines);
 			}
 		}
+		if (this._ciFixModel && this._ciFixModel.getCIFix(element as ISession).get()) {
+			height += SessionItemRenderer.CI_ROW_HEIGHT;
+		}
 		return height;
 	}
 
 	hasDynamicHeight(element: SessionListItem): boolean {
-		return !!this._approvalModel && isSessionItem(element);
+		return (!!this._approvalModel || !!this._ciFixModel) && isSessionItem(element);
 	}
 
 	getTemplateId(element: SessionListItem): string {
@@ -287,6 +293,9 @@ interface ISessionItemTemplate {
 	readonly approvalRow: HTMLElement;
 	readonly approvalLabel: HTMLElement;
 	readonly approvalButtonContainer: HTMLElement;
+	readonly ciRow: HTMLElement;
+	readonly ciLabel: HTMLElement;
+	readonly ciButtonContainer: HTMLElement;
 	readonly contextKeyService: IContextKeyService;
 	readonly disposables: DisposableStore;
 	readonly elementDisposables: DisposableStore;
@@ -302,12 +311,39 @@ export interface IApprovedSession {
 	readonly approvalId: string;
 }
 
+/** Summary of a session's failing CI checks, backing its "Fix CI" row. */
+export interface ISessionCIFixState {
+	/** Number of checks that have completed with a failing conclusion. */
+	readonly failed: number;
+	/** Number of checks still running or queued. */
+	readonly pending: number;
+}
+
+/**
+ * Supplies the per-session "Fix CI" row shown for blocked sessions whose pull
+ * request has failing CI checks. Only the blocked-sessions dropdown provides one
+ * (via {@link ISessionsFlatListOptions.ciFixModel}), so the row never appears in
+ * any other session list.
+ */
+export interface ISessionCIFixModel {
+	/**
+	 * Observable CI-failure summary for a session, or `undefined` when it has no
+	 * failing checks (or the user already requested a fix for the current commit).
+	 */
+	getCIFix(session: ISession): IObservable<ISessionCIFixState | undefined>;
+	/** Kick off the fix-CI flow for the session (opens it and submits the fix prompt). */
+	fixCI(session: ISession): void;
+}
+
 class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, ISessionItemTemplate> {
 	static readonly TEMPLATE_ID = 'session-item';
 	readonly templateId = SessionItemRenderer.TEMPLATE_ID;
 
 	private static readonly _APPROVAL_ROW_LINE_HEIGHT = 18;
 	private static readonly _APPROVAL_ROW_OVERHEAD = 14;
+
+	/** Height of the single-line "Fix CI" row (label + orange button), including its top margin. */
+	static readonly CI_ROW_HEIGHT = 32;
 
 	static getApprovalRowHeight(label: string, maxLines: number = DEFAULT_APPROVAL_ROW_MAX_LINES): number {
 		const lineCount = Math.min(label.split(/\r?\n/).length, maxLines);
@@ -324,6 +360,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 	constructor(
 		private readonly options: { grouping: () => SessionsGrouping; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[]; isInChatsSection: (session: ISession) => boolean; showHover: boolean; approvalRowMaxLines: number; toolbarActions: boolean },
 		private readonly approvalModel: AgentSessionApprovalModel | undefined,
+		private readonly ciFixModel: ISessionCIFixModel | undefined,
 		private readonly instantiationService: IInstantiationService,
 		private readonly contextKeyService: IContextKeyService,
 		private readonly markdownRendererService: IMarkdownRendererService,
@@ -379,6 +416,19 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const approvalLabel = DOM.append(approvalRow, $('span.session-approval-label'));
 		const approvalButtonContainer = DOM.append(approvalRow, $('.session-approval-button'));
 
+		// Fix-CI row — shown only in the blocked-sessions list for sessions whose
+		// pull request has failing CI checks. Styled like the chat input's CI banner.
+		const ciRow = DOM.append(mainCol, $('.session-ci-row'));
+		const ciLabel = DOM.append(ciRow, $('span.session-ci-label'));
+		const ciButtonContainer = DOM.append(ciRow, $('.session-ci-button'));
+		// The list opens a session on click/tap. The "Fix CI" button opens the
+		// session itself as part of its flow, so swallow row clicks here to stop
+		// them bubbling to the tree and triggering a second, racing open.
+		for (const eventType of ['pointerdown', 'pointerup', 'click', 'dblclick'] as const) {
+			disposables.add(DOM.addDisposableListener(ciRow, eventType, e => e.stopPropagation()));
+		}
+		disposables.add(Gesture.ignoreTarget(ciRow));
+
 		const contextKeyService = disposables.add(this.contextKeyService.createScoped(container));
 		const scopedInstantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyService])));
 		// When toolbar actions are disabled (e.g. the blocked-sessions dropdown) the row
@@ -392,7 +442,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			}));
 		}
 
-		return { container, statusIcon, title, titleContainer, titleToolbar, pendingVoiceIndicator, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
+		return { container, statusIcon, title, titleContainer, titleToolbar, pendingVoiceIndicator, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, ciRow, ciLabel, ciButtonContainer, contextKeyService, disposables, elementDisposables };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionItemTemplate): void {
@@ -642,6 +692,11 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		if (this.approvalModel) {
 			this.renderApprovalRow(element, template);
 		}
+
+		// Fix-CI row — reactive (only supplied by the blocked-sessions list)
+		if (this.ciFixModel) {
+			this.renderCIRow(element, template);
+		}
 	}
 
 	private renderApprovalRow(element: ISession, template: ISessionItemTemplate): void {
@@ -704,6 +759,49 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 					info.confirm();
 					this._onDidApproveSession.fire({ session: element, approvalId });
 				}));
+			}
+
+			if (wasVisible !== visible) {
+				wasVisible = visible;
+				this._onDidChangeItemHeight.fire(element);
+			}
+		}));
+	}
+
+	private renderCIRow(element: ISession, template: ISessionItemTemplate): void {
+		if (!this.ciFixModel) {
+			return;
+		}
+
+		const ciFixModel = this.ciFixModel;
+		const stateObs = ciFixModel.getCIFix(element);
+		let wasVisible = !!stateObs.get();
+		template.ciRow.classList.toggle('visible', wasVisible);
+
+		const buttonStore = template.elementDisposables.add(new DisposableStore());
+
+		template.elementDisposables.add(autorun(reader => {
+			buttonStore.clear();
+
+			const state = stateObs.read(reader);
+			const visible = !!state;
+
+			template.ciRow.classList.toggle('visible', visible);
+
+			if (state) {
+				template.ciLabel.textContent = localize('ci.blockedRow', "{0} checks failed, {1} pending", state.failed, state.pending);
+
+				template.ciButtonContainer.textContent = '';
+				// Match the chat input CI banner's prominent orange action button.
+				const button = buttonStore.add(new Button(template.ciButtonContainer, {
+					title: localize('ci.fixCITooltip', "Fix failing CI checks"),
+					...defaultButtonStyles,
+					buttonBackground: asCssVariable(chartsOrange),
+					buttonHoverBackground: `color-mix(in srgb, ${asCssVariable(chartsOrange)} 88%, black)`,
+					buttonBorder: asCssVariable(chartsOrange),
+				}));
+				button.label = localize('ci.fixCI', "Fix CI");
+				buttonStore.add(button.onDidClick(() => ciFixModel.fixCI(element)));
 			}
 
 			if (wasVisible !== visible) {
@@ -1656,6 +1754,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		const sessionRenderer = new SessionItemRenderer(
 			{ grouping: this.options.grouping, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions, getMultiSelectedSessions: s => this.getMultiSelectedSessions(s), isInChatsSection: s => this._chatsSectionSessionIds.has(s.resource.toString()), showHover: true, approvalRowMaxLines: DEFAULT_APPROVAL_ROW_MAX_LINES, toolbarActions: true },
 			approvalModel,
+			undefined,
 			instantiationService,
 			contextKeyService,
 			markdownRendererService,
@@ -3256,6 +3355,12 @@ export interface ISessionsFlatListOptions {
 	 */
 	readonly approvalModel?: AgentSessionApprovalModel;
 	/**
+	 * Supplies the per-session "Fix CI" row for sessions whose pull request has
+	 * failing CI checks. Only the blocked-sessions dropdown passes one, so the row
+	 * never appears in other lists. When omitted no fix-CI rows are rendered.
+	 */
+	readonly ciFixModel?: ISessionCIFixModel;
+	/**
 	 * Maximum number of terminal-command lines shown in a session's approval
 	 * prompt. Defaults to the same limit as the main sessions list; the
 	 * blocked-sessions dropdown passes a larger value.
@@ -3327,6 +3432,7 @@ export class SessionsFlatList extends Disposable {
 				toolbarActions: this.options.toolbarActions ?? true,
 			},
 			approvalModel,
+			this.options.ciFixModel,
 			instantiationService,
 			contextKeyService,
 			markdownRendererService,
@@ -3336,7 +3442,7 @@ export class SessionsFlatList extends Disposable {
 			voicePlaybackService,
 		);
 
-		this._delegate = new SessionsTreeDelegate(approvalModel, () => false, this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES);
+		this._delegate = new SessionsTreeDelegate(approvalModel, () => false, this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES, this.options.ciFixModel);
 
 		this.tree = this._register(instantiationService.createInstance(
 			WorkbenchObjectTree<SessionListItem, FuzzyScore>,

--- a/src/vs/sessions/contrib/sessions/test/browser/blockedSessionsIndicatorModel.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/blockedSessionsIndicatorModel.test.ts
@@ -15,6 +15,7 @@ import { ISession } from '../../../../services/sessions/common/session.js';
 import { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { BlockedSessionReason, BlockedSessions, IBlockedSession } from '../../../blockedSessions/browser/blockedSessions.js';
+import { BlockedSessionsCIFixModel } from '../../browser/blockedSessionsCIFixModel.js';
 import { BlockedSessionsIndicatorModel, RequiresInputKind } from '../../browser/blockedSessionsIndicatorModel.js';
 
 suite('BlockedSessionsIndicatorModel', () => {
@@ -25,23 +26,26 @@ suite('BlockedSessionsIndicatorModel', () => {
 		model: BlockedSessionsIndicatorModel;
 		blockedModel: TestBlockedSessions;
 		approvalModel: TestApprovalModel;
+		ciFixModel: TestCIFixModel;
 		sessionsService: TestSessionsService;
 	} {
 		const blockedModel = new TestBlockedSessions();
 		const approvalModel = new TestApprovalModel();
+		const ciFixModel = new TestCIFixModel();
 		const sessionsService = new TestSessionsService();
 		const productService = { quality: options?.quality ?? 'insider' } as unknown as IProductService;
 		const instantiationService = new class extends mock<IInstantiationService>() { }();
 		const model = store.add(new BlockedSessionsIndicatorModel(
 			approvalModel as unknown as AgentSessionApprovalModel,
 			blockedModel as unknown as BlockedSessions,
+			ciFixModel as unknown as BlockedSessionsCIFixModel,
 			sessionsService as unknown as ISessionsService,
 			instantiationService,
 			productService,
 		));
 		// Keep the derived live so it recomputes on visibility/dismissal changes.
 		store.add(autorun(reader => { model.blockedSessions.read(reader); }));
-		return { model, blockedModel, approvalModel, sessionsService };
+		return { model, blockedModel, approvalModel, ciFixModel, sessionsService };
 	}
 
 	function blockedIds(model: BlockedSessionsIndicatorModel): string[] {
@@ -54,6 +58,16 @@ suite('BlockedSessionsIndicatorModel', () => {
 		const s2 = new TestSession('s2');
 		blockedModel.setBlocked([needsInput(s1), needsInput(s2)]);
 		sessionsService.setVisible([s1]);
+		assert.deepStrictEqual(blockedIds(model), ['s2']);
+	});
+
+	test('excludes sessions whose CI fix is being submitted', () => {
+		const { model, blockedModel, ciFixModel } = createModel();
+		const s1 = new TestSession('s1');
+		const s2 = new TestSession('s2');
+		blockedModel.setBlocked([failingCI(s1), failingCI(s2)]);
+		assert.deepStrictEqual(blockedIds(model), ['s1', 's2']);
+		ciFixModel.setHidden(['s1']);
 		assert.deepStrictEqual(blockedIds(model), ['s2']);
 	});
 
@@ -214,6 +228,10 @@ function needsInput(session: TestSession): IBlockedSession {
 	return { session: session as unknown as ISession, reason: BlockedSessionReason.NeedsInput };
 }
 
+function failingCI(session: TestSession): IBlockedSession {
+	return { session: session as unknown as ISession, reason: BlockedSessionReason.FailingCI };
+}
+
 function approval(kind: AgentSessionApprovalKind, since: Date = new Date()): IAgentSessionApprovalInfo {
 	return { kind, label: 'npm run build', languageId: undefined, since, confirm: () => { } };
 }
@@ -258,6 +276,14 @@ class TestApprovalModel {
 			this._approvals.set(key, obs);
 		}
 		return obs;
+	}
+}
+
+class TestCIFixModel {
+	readonly hiddenSessions = observableValue<ReadonlySet<string>>('ciFixHidden', new Set());
+
+	setHidden(sessionIds: readonly string[]): void {
+		this.hiddenSessions.set(new Set(sessionIds), undefined);
 	}
 }
 

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
@@ -27,6 +27,8 @@ import { ISessionsListModelService } from '../../../../../sessions/services/sess
 import { ISessionsProvidersService } from '../../../../../sessions/services/sessions/browser/sessionsProvidersService.js';
 // eslint-disable-next-line local/code-import-patterns
 import { BlockedSessionsList } from '../../../../../sessions/contrib/sessions/browser/blockedSessionsList.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionCIFixModel, ISessionCIFixState } from '../../../../../sessions/contrib/sessions/browser/views/sessionsList.js';
 import { IVoicePlaybackService } from '../../../../contrib/chat/common/voicePlaybackService.js';
 import { IChatService } from '../../../../contrib/chat/common/chatService/chatService.js';
 import { IChatModel } from '../../../../contrib/chat/common/model/chatModel.js';
@@ -151,6 +153,32 @@ function buildApprovalScenario(specs: readonly IBlockedSessionOptions[]): { sess
 	return { sessions, approvalModel: createApprovalModel(approvals) };
 }
 
+/** A CI-fix spec: a blocked session whose PR is failing CI, with the counts shown in its row. */
+interface ICIBlockedSessionOptions extends IBlockedSessionOptions {
+	ci: ISessionCIFixState;
+}
+
+function createCIFixModel(states: ReadonlyMap<string, ISessionCIFixState>): ISessionCIFixModel {
+	return {
+		getCIFix: (session: ISession) => constObservable(states.get(session.resource.toString())),
+		fixCI: () => { },
+	};
+}
+
+/**
+ * Build a set of sessions together with a matching CI-fix model: each session
+ * whose spec has a `ci` summary shows a "Fix CI" row with those counts.
+ */
+function buildCIFixScenario(specs: readonly ICIBlockedSessionOptions[]): { sessions: ISession[]; ciFixModel: ISessionCIFixModel } {
+	const states = new Map<string, ISessionCIFixState>();
+	const sessions = specs.map(spec => {
+		const session = createBlockedSession(spec);
+		states.set(session.resource.toString(), spec.ci);
+		return session;
+	});
+	return { sessions, ciFixModel: createCIFixModel(states) };
+}
+
 function createMockListModelService(): ISessionsListModelService {
 	return new class extends mock<ISessionsListModelService>() {
 		override readonly onDidChange = Event.None;
@@ -196,7 +224,7 @@ const unresolvedCommentsPr: IGitHubInfo['pullRequest'] = {
 // Render helper
 // ============================================================================
 
-function renderBlockedList(ctx: ComponentFixtureContext, sessions: readonly ISession[], approvalModel?: AgentSessionApprovalModel): void {
+function renderBlockedList(ctx: ComponentFixtureContext, sessions: readonly ISession[], approvalModel?: AgentSessionApprovalModel, ciFixModel?: ISessionCIFixModel): void {
 	const { container, disposableStore } = ctx;
 
 	const instantiationService = createEditorServices(disposableStore, {
@@ -252,6 +280,7 @@ function renderBlockedList(ctx: ComponentFixtureContext, sessions: readonly ISes
 	const list = disposableStore.add(instantiationService.createInstance(BlockedSessionsList, container, {
 		onSessionOpen: () => { },
 		approvalModel,
+		ciFixModel,
 	}));
 	list.setSessions(sessions);
 }
@@ -348,6 +377,31 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 				{ title: 'Reset and reinstall', status: SessionStatus.NeedsInput, minutesAgo: 20, workspace: createMockWorkspace('vscode', 'fix/clean-install'), approvalCommand: 'rm -rf node_modules\nrm -f package-lock.json\nnpm cache clean --force\nnpm install\nnpm run test:integration' },
 			]);
 			renderBlockedList(ctx, sessions, approvalModel);
+		},
+	}),
+
+	// One session whose PR is failing CI — shows the orange "Fix CI" row.
+	BlockedSessionsList_OneFixCI: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, ciFixModel } = buildCIFixScenario([
+				{ title: 'Add telemetry for startup performance', status: SessionStatus.Completed, minutesAgo: 62, workspace: createMockWorkspace('vscode', 'perf/startup-telemetry', failingChecksPr), changesSummary: createMockChangesSummary(8, 240, 58), ci: { failed: 2, pending: 3 } },
+			]);
+			renderBlockedList(ctx, sessions, undefined, ciFixModel);
+		},
+	}),
+
+	// A mix of a failing-CI session (fix-CI row) and a terminal-approval session
+	// (allow row) — the two per-session action rows shown side by side.
+	BlockedSessionsList_FixCIAndApproval: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions: ciSessions, ciFixModel } = buildCIFixScenario([
+				{ title: 'Add telemetry for startup performance', status: SessionStatus.Completed, minutesAgo: 62, workspace: createMockWorkspace('vscode', 'perf/startup-telemetry', failingChecksPr), changesSummary: createMockChangesSummary(8, 240, 58), ci: { failed: 5, pending: 0 } },
+				{ title: 'Investigate flaky terminal integration test', status: SessionStatus.Completed, minutesAgo: 320, workspace: createMockWorkspace('vscode', 'fix/flaky-terminal-test', failingChecksPr), changesSummary: createMockChangesSummary(3, 41, 12), ci: { failed: 1, pending: 7 } },
+			]);
+			const { sessions: approvalSessions, approvalModel } = buildApprovalScenario([
+				{ title: 'Push the auth fix', status: SessionStatus.NeedsInput, minutesAgo: 2, workspace: createMockWorkspace('vscode', 'feature/auth-fix'), approvalCommand: 'git push --force-with-lease origin feature/auth-fix' },
+			]);
+			renderBlockedList(ctx, [...ciSessions, ...approvalSessions], approvalModel, ciFixModel);
 		},
 	}),
 });

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
@@ -27,6 +27,8 @@ import { BlockedSessionReason, BlockedSessions, IBlockedSession } from '../../..
 import { SessionActionFeedback } from '../../../../../sessions/contrib/sessions/browser/sessionActionFeedback.js';
 // eslint-disable-next-line local/code-import-patterns
 import { SessionsTitleBarWidget } from '../../../../../sessions/contrib/sessions/browser/sessionsTitleBarWidget.js';
+// eslint-disable-next-line local/code-import-patterns
+import { BlockedSessionsCIFixModel } from '../../../../../sessions/contrib/sessions/browser/blockedSessionsCIFixModel.js';
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
 
@@ -165,7 +167,14 @@ function renderTitleBar(ctx: ComponentFixtureContext, state: ITitleBarState): vo
 		override readonly blockedSessionsWithReasons: IObservable<readonly IBlockedSession[]> = constObservable(blocked);
 	}();
 
-	const widget = disposableStore.add(instantiationService.createInstance(SessionsTitleBarWidget, action, undefined, sessionActionFeedback, approvalModel, blockedSessionsModel));
+	// A no-op CI-fix model seam: the fixture never clicks "Fix CI", so it only
+	// needs to report no sessions hidden. Supplying it avoids the real model,
+	// which would depend on services not registered in this fixture.
+	const ciFixModel = new class extends mock<BlockedSessionsCIFixModel>() {
+		override readonly hiddenSessions: IObservable<ReadonlySet<string>> = constObservable<ReadonlySet<string>>(new Set());
+	}();
+
+	const widget = disposableStore.add(instantiationService.createInstance(SessionsTitleBarWidget, action, undefined, sessionActionFeedback, approvalModel, blockedSessionsModel, ciFixModel));
 	widget.render(widgetHost);
 }
 


### PR DESCRIPTION
Blocked sessions whose pull request has failing CI checks now show a per-session **Fix CI** row in the blocked-sessions dropdown, mirroring the existing terminal-approval `Allow` row but styled after the chat input's orange CI banner.

## What
- Adds a single row with `N checks failed, X pending` on the left and a prominent **orange `Fix CI` button** on the right, matching the chat input CI banner styling.
- The row is **only** supplied to the blocked-sessions list (via `ISessionsFlatListOptions.ciFixModel`), so it never appears in any other sessions list.
- Clicking **Fix CI** opens the session and submits the `fix-ci` prompt for its failed checks (reusing the shared `submitFixCIChecks` helper extracted from the existing `FixCIChecksAction`). The row hides once a fix is requested for the current commit.

## Implementation
- `checksActions.ts`: extract `submitFixCIChecks(ciModel, chatWidget)` shared helper.
- `blockedSessionsCIFixModel.ts` (new): `ISessionCIFixModel` implementation computing per-session failed/pending counts from the GitHub PR/CI models and driving the fix action; in-flight guard prevents duplicate submissions; `WeakMap` cache keeps state GC-friendly.
- `views/sessionsList.ts`: `ISessionCIFixModel`/`ISessionCIFixState` interfaces, renderer CI row + `renderCIRow` autorun, delegate dynamic-height handling, row click-propagation guard.
- `blockedSessionsList.ts` / `sessionsTitleBarWidget.ts`: plumb the model to the blocked list only.

## Fixtures
Added `BlockedSessionsList_OneFixCI` and `BlockedSessionsList_FixCIAndApproval` component fixtures with a mock `ISessionCIFixModel`.

## Validation
`npm run typecheck-client`, `eslint` on changed files, and `npm run valid-layers-check` all pass.

> Note: The component explorer could not render fixtures in this environment because rolldown-vite's builtin JSON plugin rejects VS Code's JSONC theme files (a pre-existing toolchain issue affecting all session fixtures, not this change).