### PR TITLE
Re-enable Chat Sandbox home-read smoke test by re-warming chat after restart

### DIFF
--- a/test/smoke/src/areas/chat/chatSandbox.test.ts
+++ b/test/smoke/src/areas/chat/chatSandbox.test.ts
@@ -78,12 +78,19 @@ function appendUserSettings(userDataPath: string, settings: Record<string, unkno
 	fs.writeFileSync(settingsPath, `${contents.slice(0, closingBrace)}${entries}${contents.slice(closingBrace)}`);
 }
 
-async function restartWithUpdatedSandboxSettings(app: Application, settings: Record<string, unknown>): Promise<void> {
+async function restartWithUpdatedSandboxSettings(app: Application, logger: Logger, settings: Record<string, unknown>): Promise<void> {
 	assert.ok(app.userDataPath, 'expected a user data path');
 	appendUserSettings(app.userDataPath, settings);
 	await app.restart();
 	await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
 	await app.workbench.chat.waitForChatView();
+	// A full restart tears down the extension host along with the warmed-up
+	// chat participant and its mock LLM connection. `waitForChatView` only
+	// waits for the chat view DOM, not for chat to be ready to answer, so the
+	// first probe message can race an unready chat and never receive a
+	// response. Re-run the same warm-up retry loop used on cold start so the
+	// probe is only sent once chat can reliably reach the mock LLM server.
+	await warmUpChat(app.workbench.chat, logger);
 }
 
 async function warmUpChat(chat: Chat, logger: Logger): Promise<void> {
@@ -319,7 +326,7 @@ export function setup(logger: Logger): void {
 			const app = this.app as Application;
 
 			try {
-				await restartWithUpdatedSandboxSettings(app, {
+				await restartWithUpdatedSandboxSettings(app, logger, {
 					'chat.agent.sandbox.allowNetwork': true,
 				});
 
@@ -374,16 +381,12 @@ export function setup(logger: Logger): void {
 		 * Input: Add the home test file to allowRead and ask chat to read it through the terminal tool.
 		 * Expected result: The sandbox permits the read and its output contains `HOME_READ_ALLOWED_EXIT_CODE=0`.
 		 */
-		// Skipped: flaky after the app restart introduced in #325532 — the
-		// restart tears down the warmed-up chat participant / mock LLM
-		// connection and the probe can time out. Tracked by
-		// https://github.com/microsoft/vscode-engineering/issues/3280.
-		it.skip('allows reading a home directory file configured in allowRead', async function () {
+		it('allows reading a home directory file configured in allowRead', async function () {
 			const app = this.app as Application;
 
 			try {
 				const fileSystemSetting = { allowRead: [homeFilePath] };
-				await restartWithUpdatedSandboxSettings(app, {
+				await restartWithUpdatedSandboxSettings(app, logger, {
 					'chat.agent.sandbox.fileSystem.linux': fileSystemSetting,
 					'chat.agent.sandbox.fileSystem.mac': fileSystemSetting,
 				});


### PR DESCRIPTION
## Problem

The `Chat Sandbox › allows reading a home directory file configured in allowRead` smoke test is flaky. It failed **9/20** times in the flaky-test pipeline and was red on the release build, so #325575 skipped it on `release/1.129` to unblock the build:

- Failing release build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=455304&view=logs&j=e352877c-ff47-5dec-32e2-b206099d9704&t=e3dd7514-b813-5e5e-156d-669f9d8e2cfc&s=a56e7651-4213-56af-9488-c25fe636c10c
- Flaky-test pipeline (9/20): https://dev.azure.com/monacotools/Monaco/_build/results?buildId=455265&view=results

The observed error:

```
Error: Timed out waiting for response matching /HOME_READ_ALLOWED_EXIT_CODE=(\d+)/ in
'div[id="workbench.panel.chat"] .interactive-item-container.interactive-response .rendered-markdown'
  at Chat.pollForResponseText (test/automation/out/chat.js:185:15)
```

This PR **re-enables** the test with a real fix.

## Root cause

The test (and the sibling `allowNetwork` test) call `restartWithUpdatedSandboxSettings`, which restarts the app so the `chat.agent.sandbox` settings reload deterministically (introduced in #325532). A full restart tears down the extension host along with the **warmed-up chat participant and its mock LLM connection**.

The helper only waited for the chat view DOM via `waitForChatView()` before sending the probe message. `waitForChatView` waits for the chat view to render, not for chat to be *ready to answer*. On loaded CI agents the first probe races an unready chat, the mock response never renders, and `pollForResponseText` times out after 120s.

#325532 fixed one race (settings not reloading → `HOME_READ_ALLOWED_EXIT_CODE=1`) but introduced this one (chat not re-warmed after restart → probe timeout).

## Fix

- Re-run the existing `warmUpChat` retry loop (already used on cold start, retries up to 180s) inside `restartWithUpdatedSandboxSettings`, right after `waitForChatView()`, so the probe is only sent once chat can reliably reach the mock LLM server.
- Remove the `it.skip` added in #325575 to re-enable the test.

## Verification (local A/B)

Ran the same loop locally against the installed Insiders build (`--build`/`--stable-build` pointed at `Visual Studio Code - Insiders.app`, 1.129.0-insider):

| | HOME_READ probe timeout (the bug) | Passed | Unrelated env failures* |
|---|---|---|---|
| **Without fix** (post-restart warm-up disabled) | **3/8** ❌ | 3/8 | 2/8 |
| **With fix** | **0/13** ✅ | 12/13 | 1/13 |

Without the fix the **exact** CI error reproduces (`Timed out waiting for response matching /HOME_READ_ALLOWED_EXIT_CODE=(\d+)/`) at ~38%, close to the CI flaky rate of 9/20 (45%). With the fix it never occurs across 13 runs (8 on a `main`-based branch, 5 on this `release/1.129`-based branch).

\* Unrelated failures are `Timeout of 300000ms exceeded … main.js` — the outer setup/`before` hook timing out from the loop launching the app repeatedly; not the chat race, and present in both columns.

## Targeting

This PR targets `release/1.129` (where the test is skipped) so the fix lands on the release branch and flows forward into `main`. Closes microsoft/vscode-engineering#3280.
