### PR TITLE
sessions: fix listener leak in copilot chat session grouping

### DIFF
--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -10,7 +10,7 @@ import { CancellationError } from '../../../../../base/common/errors.js';
 import { IMarkdownString, MarkdownString, markdownStringEqual } from '../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, IDisposable, DisposableMap, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { autorun, constObservable, derived, derivedOpts, IObservable, IReader, ISettableObservable, ITransaction, observableSignalFromEvent, observableValue, observableValueOpts, transaction } from '../../../../../base/common/observable.js';
+import { autorun, constObservable, derived, derivedOpts, IObservable, IObservableSignal, IReader, ISettableObservable, ITransaction, observableSignal, observableValue, observableValueOpts, transaction } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -203,22 +203,6 @@ function dateEquals(a: Date | undefined, b: Date | undefined): boolean {
 
 function markdownStringEquals(a: IMarkdownString | undefined, b: IMarkdownString | undefined): boolean {
 	return a === b || !!a && !!b && markdownStringEqual(a, b);
-}
-
-/**
- * Structural equality for a group's chat list keyed on each chat's resource.
- * `_toChat` returns a fresh wrapper on every recompute, so identity comparison
- * would always differ; comparing resources lets a group-membership recompute
- * that produced the same set of chats avoid propagating downstream.
- */
-function chatArraysEqualByResource(a: readonly IChat[] | undefined, b: readonly IChat[] | undefined): boolean {
-	if (a === b) {
-		return true;
-	}
-	if (!a || !b || a.length !== b.length) {
-		return false;
-	}
-	return a.every((chat, i) => chat.resource.toString() === b[i].resource.toString());
 }
 
 /**
@@ -1470,13 +1454,25 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	private readonly _onDidGroupMembershipChange = this._register(new Emitter<{ sessionId: string }>());
 
 	/**
-	 * A single shared signal that ticks on every group membership change. Session
-	 * chat observables read this instead of each subscribing to
-	 * `_onDidGroupMembershipChange` with a per-session filter, so the number of
-	 * listeners on the emitter stays constant rather than growing with the number
-	 * of sessions (which previously leaked listeners as sessions accumulated).
+	 * Per-group signals, keyed by `sessionId`, that invalidate a single group's
+	 * chats observable. A group's chats derived observes only its own signal, so a
+	 * membership change recomputes just the affected group rather than every observed
+	 * group.
 	 */
-	private readonly _onDidGroupMembershipChangeSignal = observableSignalFromEvent(this, this._onDidGroupMembershipChange.event);
+	private readonly _groupMembershipSignals = new Map<string, IObservableSignal<void>>();
+
+	/**
+	 * A single subscription to `_onDidGroupMembershipChange` that fans each event out
+	 * to the affected group's own signal. Subscribing exactly once (instead of once per
+	 * session) keeps the emitter's listener count constant regardless of how many
+	 * sessions exist — the per-session subscriptions previously leaked listeners as
+	 * sessions accumulated.
+	 */
+	private _registerGroupMembershipFanOut(): void {
+		this._register(this._onDidGroupMembershipChange.event(e => {
+			this._groupMembershipSignals.get(e.sessionId)?.trigger(undefined, undefined);
+		}));
+	}
 
 	private readonly _multiChatEnabled: boolean;
 
@@ -1567,6 +1563,8 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		this._register(this.agentSessionsService.model.onDidChangeSessions(() => {
 			this._refreshSessionCache();
 		}));
+
+		this._registerGroupMembershipFanOut();
 	}
 
 	// -- Sessions --
@@ -2991,6 +2989,38 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	}
 
 	/**
+	 * Get (creating on first use) the membership signal for a group, keyed by
+	 * `sessionId`. The group's chats observable observes this signal so a membership
+	 * change recomputes only the affected group; the single fan-out subscription in
+	 * `_groupMembershipSubscription` triggers it.
+	 */
+	private _getGroupMembershipSignal(sessionId: string): IObservableSignal<void> {
+		let signal = this._groupMembershipSignals.get(sessionId);
+		if (!signal) {
+			signal = observableSignal<void>(this);
+			this._groupMembershipSignals.set(sessionId, signal);
+		}
+		return signal;
+	}
+
+	/**
+	 * Structural equality for a group's chat list keyed on each chat's resource.
+	 * `_toChat` returns a fresh wrapper on every recompute, so identity comparison
+	 * would always differ; comparing resources lets a recompute that produced the
+	 * same set of chats avoid propagating downstream. Uses the URI identity comparer
+	 * so scheme-specific path casing and normalization are handled consistently.
+	 */
+	private _chatArraysEqual(a: readonly IChat[] | undefined, b: readonly IChat[] | undefined): boolean {
+		if (a === b) {
+			return true;
+		}
+		if (!a || !b || a.length !== b.length) {
+			return false;
+		}
+		return a.every((chat, i) => this.uriIdentityService.extUri.isEqual(chat.resource, b[i].resource));
+	}
+
+	/**
 	 * Wraps a primary {@link ICopilotChatSession} and its sibling chats into an {@link ISession}.
 	 * When multi-chat is enabled, the `chats` observable is derived from `sessionParentId`
 	 * metadata and updates when group membership changes.
@@ -3020,17 +3050,18 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		// reflects the real backend resource without rebuilding the cached wrapper.
 		const mainChat = primaryChat.mainChat;
 
+		const membershipSignal = this._getGroupMembershipSignal(sessionId);
 		const groupChatsObs = derivedOpts<readonly IChat[] | undefined>({
 			owner: this,
-			equalsFn: chatArraysEqualByResource,
+			equalsFn: (a, b) => this._chatArraysEqual(a, b),
 		}, reader => {
-			// Recompute the group's chats whenever any group membership changes.
-			// Reading the single shared signal (rather than a per-session filtered
-			// event) keeps the listener count on `_onDidGroupMembershipChange`
-			// constant regardless of how many sessions exist; the `equalsFn` then
-			// stops sessions whose membership didn't actually change from
-			// propagating downstream.
-			this._onDidGroupMembershipChangeSignal.read(reader);
+			// Recompute this group's chats only when its own membership signal ticks.
+			// A single provider-wide listener on `_onDidGroupMembershipChange` fans out
+			// to per-group signals (see `_groupMembershipSubscription`), so the emitter's
+			// listener count stays constant while invalidation remains targeted to the
+			// affected group. The `equalsFn` then stops a recompute that produced the
+			// same chat set from propagating downstream.
+			membershipSignal.read(reader);
 			const chatIds = this._getChatIdsInGroup(sessionId);
 			if (chatIds.length === 0) {
 				return undefined;

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -10,7 +10,7 @@ import { CancellationError } from '../../../../../base/common/errors.js';
 import { IMarkdownString, MarkdownString, markdownStringEqual } from '../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, IDisposable, DisposableMap, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { autorun, constObservable, derived, IObservable, IReader, ISettableObservable, ITransaction, observableFromEvent, observableValue, observableValueOpts, transaction } from '../../../../../base/common/observable.js';
+import { autorun, constObservable, derived, derivedOpts, IObservable, IReader, ISettableObservable, ITransaction, observableSignalFromEvent, observableValue, observableValueOpts, transaction } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -203,6 +203,22 @@ function dateEquals(a: Date | undefined, b: Date | undefined): boolean {
 
 function markdownStringEquals(a: IMarkdownString | undefined, b: IMarkdownString | undefined): boolean {
 	return a === b || !!a && !!b && markdownStringEqual(a, b);
+}
+
+/**
+ * Structural equality for a group's chat list keyed on each chat's resource.
+ * `_toChat` returns a fresh wrapper on every recompute, so identity comparison
+ * would always differ; comparing resources lets a group-membership recompute
+ * that produced the same set of chats avoid propagating downstream.
+ */
+function chatArraysEqualByResource(a: readonly IChat[] | undefined, b: readonly IChat[] | undefined): boolean {
+	if (a === b) {
+		return true;
+	}
+	if (!a || !b || a.length !== b.length) {
+		return false;
+	}
+	return a.every((chat, i) => chat.resource.toString() === b[i].resource.toString());
 }
 
 /**
@@ -1452,6 +1468,15 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	 * used to update the chats observable in `_chatToSession`.
 	 */
 	private readonly _onDidGroupMembershipChange = this._register(new Emitter<{ sessionId: string }>());
+
+	/**
+	 * A single shared signal that ticks on every group membership change. Session
+	 * chat observables read this instead of each subscribing to
+	 * `_onDidGroupMembershipChange` with a per-session filter, so the number of
+	 * listeners on the emitter stays constant rather than growing with the number
+	 * of sessions (which previously leaked listeners as sessions accumulated).
+	 */
+	private readonly _onDidGroupMembershipChangeSignal = observableSignalFromEvent(this, this._onDidGroupMembershipChange.event);
 
 	private readonly _multiChatEnabled: boolean;
 
@@ -2995,27 +3020,33 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		// reflects the real backend resource without rebuilding the cached wrapper.
 		const mainChat = primaryChat.mainChat;
 
-		const groupChatsObs = observableFromEvent<readonly IChat[] | undefined>(
-			this,
-			Event.filter(this._onDidGroupMembershipChange.event, e => e.sessionId === sessionId),
-			() => {
-				const chatIds = this._getChatIdsInGroup(sessionId);
-				if (chatIds.length === 0) {
-					return undefined;
+		const groupChatsObs = derivedOpts<readonly IChat[] | undefined>({
+			owner: this,
+			equalsFn: chatArraysEqualByResource,
+		}, reader => {
+			// Recompute the group's chats whenever any group membership changes.
+			// Reading the single shared signal (rather than a per-session filtered
+			// event) keeps the listener count on `_onDidGroupMembershipChange`
+			// constant regardless of how many sessions exist; the `equalsFn` then
+			// stops sessions whose membership didn't actually change from
+			// propagating downstream.
+			this._onDidGroupMembershipChangeSignal.read(reader);
+			const chatIds = this._getChatIdsInGroup(sessionId);
+			if (chatIds.length === 0) {
+				return undefined;
+			}
+			const resolved: ICopilotChatSession[] = [];
+			for (const id of chatIds) {
+				const c = this._sessionCache.get(this._localIdFromchatId(id));
+				if (c) {
+					resolved.push(c);
 				}
-				const resolved: ICopilotChatSession[] = [];
-				for (const id of chatIds) {
-					const c = this._sessionCache.get(this._localIdFromchatId(id));
-					if (c) {
-						resolved.push(c);
-					}
-				}
-				if (resolved.length === 0) {
-					return undefined;
-				}
-				return resolved.map(c => this._toChat(c));
-			},
-		);
+			}
+			if (resolved.length === 0) {
+				return undefined;
+			}
+			return resolved.map(c => this._toChat(c));
+		});
 
 		// When the group has no resolved chats (typical for a new session before
 		// commit), fall back to the settable `mainChat` so it stays in sync after

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -9,6 +9,7 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
+import { autorun } from '../../../../../../base/common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ConfigurationTarget, IConfigurationService, IConfigurationValue } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -1080,6 +1081,50 @@ suite('CopilotChatSessionsProvider', () => {
 		const lastChange = changes[changes.length - 1];
 		assert.strictEqual(lastChange.removed.length, 1);
 		assert.strictEqual(lastChange.removed[0].sessionId, chat2Id);
+	});
+
+	test('observing many grouped sessions keeps one membership listener and recomputes only the affected group', () => {
+		// Several independent root groups, each observed for its chat list.
+		const sessionCount = 8;
+		for (let i = 0; i < sessionCount; i++) {
+			const resource = URI.from({ scheme: AgentSessionProviders.Background, path: `/root-${i}` });
+			model.addSession(createMockAgentSession(resource, { title: `Root ${i}`, createdAt: 1 }));
+		}
+
+		const provider = createProvider(disposables, model);
+		const sessions = provider.getSessions();
+		assert.strictEqual(sessions.length, sessionCount);
+
+		// Observe every session's chat list. Before the fix each observed session added
+		// its own filtered listener to the shared membership emitter, so listeners grew
+		// with the session count; now a single provider-wide fan-out serves all of them.
+		const chatCounts = sessions.map(() => 0);
+		sessions.forEach((session, i) => {
+			disposables.add(autorun(reader => {
+				session.chats.read(reader);
+				chatCounts[i]++;
+			}));
+		});
+
+		// Exactly one listener on the membership emitter regardless of how many sessions
+		// are observed (the provider-wide fan-out), and each autorun ran once initially.
+		const membershipEmitter = (provider as unknown as { _onDidGroupMembershipChange: { _size: number } })._onDidGroupMembershipChange;
+		assert.strictEqual(membershipEmitter._size, 1);
+		assert.deepStrictEqual(chatCounts, sessions.map(() => 1));
+
+		// Add a child chat into the FIRST group only, changing just that group's membership.
+		const child = URI.from({ scheme: AgentSessionProviders.Background, path: '/root-0-child' });
+		model.addSession(createMockAgentSession(child, {
+			title: 'Child',
+			createdAt: 2,
+			metadata: { repositoryPath: '/test/repo', sessionParentId: 'root-0' },
+		}));
+
+		// Listener count is still one, only the first group recomputed (its chat list grew
+		// to two), and no other session's chats observable published a change.
+		assert.strictEqual(membershipEmitter._size, 1);
+		assert.strictEqual(sessions[0].chats.get().length, 2);
+		assert.deepStrictEqual(chatCounts, [2, ...sessions.slice(1).map(() => 1)]);
 	});
 
 	test('getSessions does not create duplicate groups on repeated calls', () => {


### PR DESCRIPTION
## What

Fixes an unbounded event-listener leak surfaced by the listener-leak detector:

```
[7c8] potential listener LEAK detected, having 245 listeners already. MOST frequent listener (71): …
```

## Why

In `CopilotChatSessionsProvider._chatToSession`, each cached session built its group-chats observable via:

```ts
observableFromEvent(this, Event.filter(this._onDidGroupMembershipChange.event, e => e.sessionId === sessionId), …)
```

Every session installed its **own** filtered listener on the single shared `_onDidGroupMembershipChange` emitter. Since sessions are cached for the provider''s lifetime and accumulate over time, the listener count on that one emitter grew without bound (O(number of sessions) — 71 in the trace), tripping the leak detector.

## How

- Subscribe to `_onDidGroupMembershipChange` **once** via `observableSignalFromEvent` (which attaches a single listener regardless of observer count).
- Each session''s group-chats observable is now a `derivedOpts` that reads that shared signal instead of adding its own filtered event listener, so the emitter''s listener count stays constant.
- Added an `equalsFn` (`chatArraysEqualByResource`) so a session whose membership didn''t actually change returns an equal array and doesn''t propagate downstream — preserving the previous behavior where only the affected session recomputed.

## Notes for reviewers

- Type-check (`npm run typecheck-client`) and ESLint both pass.
- Removed the now-unused `observableFromEvent` / `Event.filter` usage.
