### PR TITLE
Style overrides: Update debug pane and session label styles in CSS

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -181,6 +181,10 @@
 	font-weight: var(--vscode-fontWeight-semiBold);
 }
 
+.style-override .debug-pane .debug-call-stack .session > .state.label {
+	font-size: var(--vscode-fontSize-label2);
+}
+
 .style-override.monaco-workbench .agent-sessions-viewer {
 	.agent-session-section {
 		text-transform: none;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -220,3 +220,11 @@
 .style-override.monaco-workbench .scm-view .monaco-list-row .resource > .name > .monaco-icon-label::after {
 	margin-right: 4px;
 }
+
+.style-override.monaco-workbench .monaco-count-badge.long {
+	padding: 2px 6px;
+}
+
+.style-override.monaco-workbench .debug-pane .debug-call-stack .session > .state.label {
+	margin-right: 0;
+}


### PR DESCRIPTION
This pull request makes targeted style adjustments to improve the appearance and consistency of the Debug Call Stack and count badge elements in the workbench UI. The main changes involve font sizing, padding, and margin tweaks.

<img width="740" height="447" alt="image" src="https://github.com/user-attachments/assets/12175b2f-b422-4efc-944a-9451ac3234e3" />


**Debug Call Stack styling:**
* Set a specific font size for the `.state.label` element within the Debug Call Stack to ensure consistency with the rest of the UI (`fontRamp.css`).
* Removed the right margin from the `.state.label` element to better align it visually (`padding.css`).

**Count badge styling:**
* Adjusted padding for long count badges (`.monaco-count-badge.long`) to improve their appearance and spacing (`padding.css`).