### PR TITLE
Quick Open: open exact relative paths without a full workspace file search

### DIFF
--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -618,38 +618,35 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 	}
 
 	private async doFileSearch(query: IPreparedQuery, token: CancellationToken): Promise<URI[]> {
-		const [fileSearchResults, relativePathFileResults] = await Promise.all([
 
-			// File search: this is a search over all files of the workspace using the provided pattern
-			this.getFileSearchResults(query, token),
+		// Start the fuzzy file search over all workspace files right away, but do
+		// not await it yet: if the query resolves to existing file(s) relative to
+		// a workspace folder we want to return those directly and skip the search.
+		// Pasting a full path (e.g. from a diff or a merge conflict) then opens
+		// instantly instead of waiting for a search over the entire workspace,
+		// while a query that does not resolve to a file still pays no extra
+		// latency because the search was already in flight. The relative path
+		// lookup also surfaces results that the fuzzy search would exclude (e.g.
+		// compilation outputs).
+		const fileSearchResults = this.getFileSearchResults(query, token);
+		fileSearchResults.catch(() => { /* handled below or superseded by an early return */ });
 
-			// Relative path search: we also want to consider results that match files inside the workspace
-			// by looking for relative paths that the user typed as query. This allows to return even excluded
-			// results into the picker if found (e.g. helps for opening compilation results that are otherwise
-			// excluded)
-			this.getRelativePathFileResults(query, token)
-		]);
-
+		const relativePathFileResults = await this.getRelativePathFileResults(query, token);
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
-		// Return quickly if no relative results are present
-		if (!relativePathFileResults) {
-			return fileSearchResults;
+		if (relativePathFileResults && relativePathFileResults.length > 0) {
+			return relativePathFileResults;
 		}
 
-		// Otherwise, make sure to filter relative path results from
-		// the search results to prevent duplicates
-		const relativePathFileResultsMap = new ResourceMap<boolean>(uri => this.uriIdentityService.extUri.getComparisonKey(uri));
-		for (const relativePathFileResult of relativePathFileResults) {
-			relativePathFileResultsMap.set(relativePathFileResult, true);
+		// Otherwise fall back to the fuzzy file search that is already running
+		const results = await fileSearchResults;
+		if (token.isCancellationRequested) {
+			return [];
 		}
 
-		return [
-			...fileSearchResults.filter(result => !relativePathFileResultsMap.has(result)),
-			...relativePathFileResults
-		];
+		return results;
 	}
 
 	private async getFileSearchResults(query: IPreparedQuery, token: CancellationToken): Promise<URI[]> {

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -18,7 +18,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { toLocalResource, dirname, basenameOrAuthority } from '../../../../base/common/resources.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
-import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { DisposableStore, IDisposable, toDisposable, MutableDisposable, Disposable } from '../../../../base/common/lifecycle.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { getIconClasses } from '../../../../editor/common/services/getIconClasses.js';
@@ -619,34 +619,46 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	private async doFileSearch(query: IPreparedQuery, token: CancellationToken): Promise<URI[]> {
 
-		// Start the fuzzy file search over all workspace files right away, but do
-		// not await it yet: if the query resolves to existing file(s) relative to
-		// a workspace folder we want to return those directly and skip the search.
-		// Pasting a full path (e.g. from a diff or a merge conflict) then opens
-		// instantly instead of waiting for a search over the entire workspace,
-		// while a query that does not resolve to a file still pays no extra
-		// latency because the search was already in flight. The relative path
-		// lookup also surfaces results that the fuzzy search would exclude (e.g.
-		// compilation outputs).
-		const fileSearchResults = this.getFileSearchResults(query, token);
-		fileSearchResults.catch(() => { /* handled below or superseded by an early return */ });
+		// Start the fuzzy file search over all workspace files right away under a
+		// cancellation source linked to the incoming token, but do not await it
+		// yet: if the query resolves to existing file(s) relative to a workspace
+		// folder we want to return those directly and cancel the search. Pasting a
+		// full path (e.g. from a diff or a merge conflict) then opens instantly
+		// instead of waiting for a search over the entire workspace, while a query
+		// that does not resolve to a file pays no extra latency because the search
+		// was already in flight. The relative path lookup also surfaces results
+		// that the fuzzy search would exclude (e.g. compilation outputs).
+		const fileSearchCts = new CancellationTokenSource(token);
+		const fileSearchResults = this.getFileSearchResults(query, fileSearchCts.token);
 
-		const relativePathFileResults = await this.getRelativePathFileResults(query, token);
-		if (token.isCancellationRequested) {
-			return [];
+		// Swallow rejections so that cancelling the search on an early return does
+		// not surface as an unhandled rejection; the miss path awaits and handles
+		// (or propagates) the result explicitly below.
+		fileSearchResults.catch(() => { });
+
+		try {
+			const relativePathFileResults = await this.getRelativePathFileResults(query, token);
+			if (token.isCancellationRequested) {
+				return [];
+			}
+
+			// On an exact relative path hit, cancel the fuzzy search that is no
+			// longer needed and return the resolved file(s) directly
+			if (relativePathFileResults && relativePathFileResults.length > 0) {
+				fileSearchCts.cancel();
+				return relativePathFileResults;
+			}
+
+			// Otherwise fall back to the fuzzy file search that is already running
+			const results = await fileSearchResults;
+			if (token.isCancellationRequested) {
+				return [];
+			}
+
+			return results;
+		} finally {
+			fileSearchCts.dispose();
 		}
-
-		if (relativePathFileResults && relativePathFileResults.length > 0) {
-			return relativePathFileResults;
-		}
-
-		// Otherwise fall back to the fuzzy file search that is already running
-		const results = await fileSearchResults;
-		if (token.isCancellationRequested) {
-			return [];
-		}
-
-		return results;
 	}
 
 	private async getFileSearchResults(query: IPreparedQuery, token: CancellationToken): Promise<URI[]> {

--- a/src/vs/workbench/test/browser/quickAccess.test.ts
+++ b/src/vs/workbench/test/browser/quickAccess.test.ts
@@ -24,6 +24,13 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/comm
 import { IContextKeyService, ContextKeyExpr } from '../../../platform/contextkey/common/contextkey.js';
 import { ContextKeyService } from '../../../platform/contextkey/browser/contextKeyService.js';
 import { TestConfigurationService } from '../../../platform/configuration/test/common/testConfigurationService.js';
+import { AnythingQuickAccessProvider } from '../../contrib/search/browser/anythingQuickAccess.js';
+import { IFileQuery, ISearchComplete, ISearchService, SearchCompletionExitCode } from '../../services/search/common/search.js';
+import { IQuickChatService } from '../../contrib/chat/browser/chat.js';
+import { TestFileService, createFileStat } from '../common/workbenchTestServices.js';
+import { IFileStatWithPartialMetadata } from '../../../platform/files/common/files.js';
+import { IPreparedQuery, prepareQuery } from '../../../base/common/fuzzyScorer.js';
+import { Event } from '../../../base/common/event.js';
 
 suite('QuickAccess', () => {
 
@@ -578,6 +585,97 @@ suite('QuickAccess', () => {
 
 		disposables.dispose();
 		restore();
+	});
+
+	//#endregion
+
+	//#region file search tests
+
+	class TestSearchService implements ISearchService {
+		declare readonly _serviceBrand: undefined;
+
+		fileSearchCallCount = 0;
+
+		// When set, `fileSearch` never resolves. Used to assert that a relative
+		// path hit returns without waiting for the fuzzy search to complete.
+		hangFileSearch = false;
+
+		async fileSearch(query: IFileQuery): Promise<ISearchComplete> {
+			this.fileSearchCallCount++;
+			if (this.hangFileSearch) {
+				return new Promise<ISearchComplete>(() => { });
+			}
+			return { results: [], messages: [], exit: SearchCompletionExitCode.Normal };
+		}
+
+		textSearch(): never { throw new Error('Method not implemented.'); }
+		aiTextSearch(): never { throw new Error('Method not implemented.'); }
+		getAIName(): never { throw new Error('Method not implemented.'); }
+		textSearchSplitSyncAsync(): never { throw new Error('Method not implemented.'); }
+		schemeHasFileSearchProvider(): never { throw new Error('Method not implemented.'); }
+		async clearCache(): Promise<void> { }
+		registerSearchResultProvider(): never { throw new Error('Method not implemented.'); }
+	}
+
+	class TestExistingFilesFileService extends TestFileService {
+		constructor(private readonly existingFiles: Set<string>) {
+			super();
+		}
+
+		override async stat(resource: URI): Promise<IFileStatWithPartialMetadata> {
+			if (this.existingFiles.has(resource.path)) {
+				return createFileStat(resource);
+			}
+			throw new Error('File not found');
+		}
+	}
+
+	type ProviderWithFileSearch = { doFileSearch(query: IPreparedQuery, token: CancellationToken): Promise<URI[]> };
+
+	function createFileSearchProvider(existingFiles: Set<string>): { provider: ProviderWithFileSearch; searchService: TestSearchService } {
+		const searchService = new TestSearchService();
+		const localInstantiationService = workbenchInstantiationService({
+			fileService: () => new TestExistingFilesFileService(existingFiles)
+		}, disposables);
+		localInstantiationService.stub(ISearchService, searchService);
+		localInstantiationService.stub(IQuickChatService, new class implements IQuickChatService {
+			declare readonly _serviceBrand: undefined;
+			readonly onDidClose = Event.None;
+			readonly enabled = false;
+			readonly focused = false;
+			toggle(): void { }
+			focus(): void { }
+			open(): void { }
+			close(): void { }
+			openInChatView(): void { }
+		});
+
+		const provider = disposables.add(localInstantiationService.createInstance(AnythingQuickAccessProvider));
+
+		return { provider: provider as unknown as ProviderWithFileSearch, searchService };
+	}
+
+	test('file search - existing relative path returns without waiting for the fuzzy file search', async () => {
+		// The test workspace folder is `/testWorkspace`, so `src/serialization.rs`
+		// resolves to `/testWorkspace/src/serialization.rs`.
+		const { provider, searchService } = createFileSearchProvider(new Set(['/testWorkspace/src/serialization.rs']));
+
+		// The fuzzy search never resolves; the relative path hit must still return.
+		searchService.hangFileSearch = true;
+
+		const results = await provider.doFileSearch(prepareQuery('src/serialization.rs'), CancellationToken.None);
+
+		assert.strictEqual(results.length, 1);
+		assert.strictEqual(results[0].path, '/testWorkspace/src/serialization.rs');
+	});
+
+	test('file search - non-existing relative path falls back to the fuzzy file search', async () => {
+		const { provider, searchService } = createFileSearchProvider(new Set());
+
+		const results = await provider.doFileSearch(prepareQuery('src/serialization.rs'), CancellationToken.None);
+
+		assert.strictEqual(searchService.fileSearchCallCount, 1);
+		assert.strictEqual(results.length, 0);
 	});
 
 	//#endregion

--- a/src/vs/workbench/test/browser/quickAccess.test.ts
+++ b/src/vs/workbench/test/browser/quickAccess.test.ts
@@ -596,16 +596,25 @@ suite('QuickAccess', () => {
 
 		fileSearchCallCount = 0;
 
-		// When set, `fileSearch` never resolves. Used to assert that a relative
-		// path hit returns without waiting for the fuzzy search to complete.
-		hangFileSearch = false;
+		// When set, `fileSearch` only resolves once its token is cancelled. Used
+		// to assert that a relative path hit returns without waiting for the fuzzy
+		// search and that the no longer needed search is cancelled.
+		blockFileSearchUntilCancelled = false;
 
-		async fileSearch(query: IFileQuery): Promise<ISearchComplete> {
+		fileSearchCancelled = false;
+
+		fileSearch(query: IFileQuery, token?: CancellationToken): Promise<ISearchComplete> {
 			this.fileSearchCallCount++;
-			if (this.hangFileSearch) {
-				return new Promise<ISearchComplete>(() => { });
+			if (this.blockFileSearchUntilCancelled) {
+				return new Promise<ISearchComplete>(resolve => {
+					const listener = token?.onCancellationRequested(() => {
+						listener?.dispose();
+						this.fileSearchCancelled = true;
+						resolve({ results: [], messages: [], exit: SearchCompletionExitCode.Normal });
+					});
+				});
 			}
-			return { results: [], messages: [], exit: SearchCompletionExitCode.Normal };
+			return Promise.resolve({ results: [], messages: [], exit: SearchCompletionExitCode.Normal });
 		}
 
 		textSearch(): never { throw new Error('Method not implemented.'); }
@@ -655,18 +664,20 @@ suite('QuickAccess', () => {
 		return { provider: provider as unknown as ProviderWithFileSearch, searchService };
 	}
 
-	test('file search - existing relative path returns without waiting for the fuzzy file search', async () => {
+	test('file search - existing relative path returns without waiting for the fuzzy file search and cancels it', async () => {
 		// The test workspace folder is `/testWorkspace`, so `src/serialization.rs`
 		// resolves to `/testWorkspace/src/serialization.rs`.
 		const { provider, searchService } = createFileSearchProvider(new Set(['/testWorkspace/src/serialization.rs']));
 
-		// The fuzzy search never resolves; the relative path hit must still return.
-		searchService.hangFileSearch = true;
+		// The fuzzy search only resolves once cancelled; the relative path hit must
+		// still return and must cancel the no longer needed search.
+		searchService.blockFileSearchUntilCancelled = true;
 
 		const results = await provider.doFileSearch(prepareQuery('src/serialization.rs'), CancellationToken.None);
 
 		assert.strictEqual(results.length, 1);
 		assert.strictEqual(results[0].path, '/testWorkspace/src/serialization.rs');
+		assert.strictEqual(searchService.fileSearchCancelled, true);
 	});
 
 	test('file search - non-existing relative path falls back to the fuzzy file search', async () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #325607

When a Quick Open query resolves to an existing file relative to a workspace folder, return it directly instead of waiting for the fuzzy file search over all workspace files. Pasting a full path (e.g. from a diff or a git merge conflict) then opens instantly instead of waiting for a search over the entire workspace, which is slow in large monorepos.

The fuzzy search is still started up front, but the relative-path lookup (`getRelativePathFileResults`) is awaited first and, on a hit, `doFileSearch` returns without awaiting the search. Previously both ran together via `Promise.all` and the result was awaited on **both**, so the picker always waited for the workspace search even when the pasted path already pinpointed a single file. Because the search is kept in flight rather than started only on a miss, a query that does *not* resolve to a file pays no extra latency (important for remote/virtual workspaces where each `stat` is a round-trip).

This mirrors the existing fast path for absolute paths, which already returns the single `stat` hit and skips the search
(`getAbsolutePathFileResult`). Partial queries that don't resolve to a file (e.g. `src/foo`) still fall through to the fuzzy search unchanged.

**Behavior change:** on an exact relative-path hit the picker now shows only that file instead of also merging in fuzzy matches, consistent with how absolute paths already behave.

Added unit tests in `quickAccess.test.ts`: one asserts that a relative-path hit returns even when the fuzzy search never resolves (i.e. it doesn't wait for it), and one asserts a non-existing relative path still falls back to the search.