### PR TITLE
Fix Markdown preview monospace fallback when editor font is missing

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -402,7 +402,7 @@ blockquote {
 }
 
 code {
-	font-family: var(--vscode-editor-font-family, "SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace);
+	font-family: var(--vscode-editor-font-family), "SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
 	font-size: 1em;
 	line-height: 1.357em;
 }

--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -275,7 +275,7 @@ export const activate: ActivationFunction<void> = (ctx) => {
 
 		code {
 			font-size: 1em;
-			font-family: var(--vscode-editor-font-family);
+			font-family: var(--vscode-editor-font-family), "SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
 		}
 
 		pre code {

--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -102,7 +102,7 @@ pre {
 }
 
 pre code {
-	font-family: var(--vscode-editor-font-family);
+	font-family: var(--vscode-editor-font-family), "SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
 	font-weight: var(--vscode-editor-font-weight);
 	font-size: var(--vscode-editor-font-size);
 	line-height: 1.5;


### PR DESCRIPTION
## Summary
- Markdown preview `code` used `font-family: var(--vscode-editor-font-family, …monospace)`. CSS only uses the `var()` fallback when the variable is **unset**; when `editor.fontFamily` names a missing font the variable is still set, so code rendered in a proportional/serif face.
- Append the monospace stack **outside** `var()` in preview CSS, notebook markdown `code`, and workbench `pre code`, matching how the editor massages font families.
- Does not change shared webview theming (`themeing.ts`) to keep blast radius preview-scoped.

Fixes #324256

## Test plan
- [ ] Set `"editor.fontFamily": "TotallyMissingFontName"` (no `monospace` in the stack)
- [ ] Open a `.md` with inline `` `code` `` and a fenced block; open Markdown Preview
- [ ] Confirm inline and fenced code render monospace
- [ ] With a valid stack (`Consolas, monospace`), preview fonts look unchanged
- [ ] Body text still follows `markdown.preview.fontFamily`