### PR TITLE
sessions: show add-feedback glyph only on first wrapped line

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
@@ -410,9 +410,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			options: {
 				description: 'agent-feedback-hover-glyph',
 				isWholeLine: true,
-				// Use `firstLineDecorationClassName` so the add-feedback glyph is
-				// rendered only on the first wrapped line of the model line rather
-				// than on every wrapped line when word wrap is enabled.
+				// Only render the glyph on the first wrapped line.
 				firstLineDecorationClassName: `${agentFeedbackHoverGlyphClassName} line-hover`,
 			},
 		}]);

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
@@ -410,7 +410,10 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			options: {
 				description: 'agent-feedback-hover-glyph',
 				isWholeLine: true,
-				linesDecorationsClassName: `${agentFeedbackHoverGlyphClassName} line-hover`,
+				// Use `firstLineDecorationClassName` so the add-feedback glyph is
+				// rendered only on the first wrapped line of the model line rather
+				// than on every wrapped line when word wrap is enabled.
+				firstLineDecorationClassName: `${agentFeedbackHoverGlyphClassName} line-hover`,
 			},
 		}]);
 	}


### PR DESCRIPTION
## What

The add-feedback hover glyph (the "+" affordance shown in the editor gutter when hovering a line in an agent feedback editor) was showing up on **every** wrapped visual line of a model line when word wrap was enabled, instead of only once per line.

## Why

The hover glyph decoration was registered with `linesDecorationsClassName` together with `isWholeLine: true`. The editor's lines-decorations view part renders `linesDecorationsClassName` across the entire view range of a model line — i.e. on each wrapped visual line — so the plus icon was duplicated across all wrapped segments.

## Fix

Switch the decoration to use `firstLineDecorationClassName` instead, which the editor renders only on `range.startLineNumber` (the first wrapped visual line). This is the same mechanism the folding icons use to stay on a single line. The class names applied are unchanged, so CSS styling and the hover/click target detection continue to work — the glyph now just renders on one visual line.

Fixes #324598