### PR TITLE
Revert "Use server-backed archived state for agent host sessions (#325399)"

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -751,12 +751,6 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 	}
 
 	private isArchived(session: IInternalAgentSessionData): boolean {
-		// Agent host sessions have server-authoritative archived state, so ignore
-		// the local view-state overlay: a stale local value must not mask the
-		// server truth reported via `session.archived`.
-		if (isAgentHostTarget(session.providerType)) {
-			return Boolean(session.archived);
-		}
 		return this.resolveStateEntry(session)?.archived ?? Boolean(session.archived);
 	}
 


### PR DESCRIPTION
Reverts the change from [#325399](https://github.com/microsoft/vscode/pull/325399) on `release/1.129`.

## Why

[#325399](https://github.com/microsoft/vscode/pull/325399) made `AgentSessionsModel.isArchived()` server-authoritative for agent-host sessions (ignoring the local view-state overlay). But the editor window has **no** path to write archived state back to the agent host — every editor-window archive entry point calls `AgentSessionsModel.setArchived`, which only writes the local overlay, and `IChatSessionItemController` has no archive method. Only the agent-window provider (`baseAgentHostSessionsProvider.archiveSession`) dispatches `SessionIsArchivedChanged` to the server.

As a result, with #325399 the editor-window Archive/Unarchive actions became visual no-ops for agent-host sessions (the local write is ignored on read). Reverting for now to restore the previous behavior while the correct approach is decided (either reconcile the stale overlay when server state changes, or wire the editor-window archive actions through to the server).

(Written by Copilot)
