### PR TITLE
Voice: route response deferral by shown session, not sticky target

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2499,6 +2499,24 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		return this._targetSession.get()?.toString() ?? this._activeSessionShown ?? this._lastShownSessionId ?? this._getFocusedSessionId();
 	}
 
+	/**
+	 * The session the user is currently LOOKING AT, used to route deferral. Unlike
+	 * {@link _getActiveSessionId} this deliberately ignores the sticky input
+	 * `_targetSession`: the target is where the user's next utterance is SENT, not
+	 * what they are viewing. Browsing another session (e.g. `openSession` in the
+	 * floating voice window) leaves `_targetSession` pointing elsewhere, so keying
+	 * deferral off the active-session chain would (a) play the target's background
+	 * narration live over an unrelated shown session and (b) defer the shown
+	 * session's own reply with no focus change to ever flush it. The awaited reply
+	 * to the user's own utterance is handled separately via `_awaitingReplyForSession`.
+	 */
+	private _shownSessionId(): string | undefined {
+		if (this._externalActiveSessionMode) {
+			return this._activeSessionShown;
+		}
+		return this._lastShownSessionId ?? this._getFocusedSessionId();
+	}
+
 	setActiveSessionShown(resource: URI | undefined): void {
 		this._externalActiveSessionMode = true;
 		const key = resource?.toString();
@@ -2534,12 +2552,17 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				this._liveReplyKey = key;
 				return false;
 			}
-			// Play immediately for the session the user is actively working with;
+			// Play immediately for the session the user is actively looking at,
+			// or the session whose reply they are actively awaiting (they just
+			// spoke to it, so route its answer live even if they glanced away);
 			// defer any other session's narration until the user looks at it.
+			// Key off the SHOWN session, not the active-session chain: the sticky
+			// input `_targetSession` must not force an unrelated background
+			// narration to play live over the session the user is viewing.
 			// Read live so a stale cache can't misroute the decision (e.g. when
 			// the focus event was missed while voice was busy).
 			this._focusedSessionId = this._getFocusedSessionId();
-			if (this._getActiveSessionId() === sessionId) {
+			if (this._shownSessionId() === sessionId || this._awaitingReplyForSession === sessionId) {
 				this._liveReplyKey = key;
 				return false;
 			}
@@ -2554,12 +2577,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (this._liveReplyKey === key) {
 			return false;
 		}
-		// Continuation whose first chunk we never observed: fall back to active.
+		// Continuation whose first chunk we never observed: fall back to the shown
+		// session (mirrors the first-chunk decision above).
 		if (!sessionId) {
 			return false;
 		}
 		this._focusedSessionId = this._getFocusedSessionId();
-		return this._getActiveSessionId() !== sessionId;
+		return !(this._shownSessionId() === sessionId || this._awaitingReplyForSession === sessionId);
 	}
 
 	private _deferResponse(sessionId: string, audio: string, isFirstChunk: boolean, isFinal: boolean, transcript: string | undefined): void {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -210,6 +210,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	// --- Audio FIFO queue ---
 	private readonly _audioQueue: { sessionId: string | undefined; chunks: { audio: string; isFirstChunk: boolean; isFinal: boolean; transcript: string | undefined }[] }[] = [];
 	private _currentPlaybackSessionId: string | undefined | null = null; // null = nothing playing
+	// True once the currently-playing response has received its final audio
+	// chunk. A same-session frame arriving after this marks a NEW response and
+	// must be serialized (queued) rather than fast-pathed, or its audio would be
+	// appended into the finalized playback turn and dropped past `node.stop()`.
+	private _currentPlaybackFinalized = false;
 	private _isProcessingQueue = false;
 
 	// True while we're suppressing in-flight assistant audio from the previous
@@ -751,6 +756,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 			this.voicePlaybackService.notifyPlaybackEnd(undefined);
 			this._currentPlaybackSessionId = null;
+			this._currentPlaybackFinalized = false;
 
 			// Check if there's more in the queue
 			if (this._audioQueue.length > 0) {
@@ -2826,7 +2832,15 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// If nothing is playing and queue is empty, or same session is playing, play immediately
 		const nothingPlaying = this._currentPlaybackSessionId === null;
 		const sameSession = !nothingPlaying && this._currentPlaybackSessionId === sessionId;
-		if ((nothingPlaying && this._audioQueue.length === 0) || sameSession) {
+		// Only fast-path CONTINUATION chunks of the response that is currently
+		// playing (same session AND not yet finalized). Once the current
+		// response's final chunk has been sent, the TTS service's single
+		// playback turn has scheduled `node.stop()` at that response's boundary;
+		// appending a new same-session response's audio into that same buffer
+		// plays it past the stop point, so it's silently dropped. Serializing it
+		// through the queue forces a fresh turn once the current one finishes.
+		const continuationOfCurrent = sameSession && !this._currentPlaybackFinalized;
+		if ((nothingPlaying && this._audioQueue.length === 0) || continuationOfCurrent) {
 			this._playChunk(sessionId, audio, isFirstChunk, isFinal, transcript);
 			return;
 		}
@@ -2872,6 +2886,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// (onPlaybackStopped never fires), deadlocking every other
 			// session's queued audio.
 			this._currentPlaybackSessionId = sessionId;
+			// A same-session frame arriving after the final chunk is a NEW
+			// response and must be serialized (see `_enqueueAudio`).
+			this._currentPlaybackFinalized = isFinal;
 			this._clearAutoListenTimer();
 			this._replyPlayedSinceSend = true;
 			this.micCaptureService.suppressUntil(Date.now() + 800);
@@ -2897,6 +2914,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// TTS enabled but no audio in this frame. Forward it so a final
 			// frame can flush/stop an in-flight playback turn; a non-final
 			// empty frame is a no-op and leaves the slot untouched.
+			// If this empty frame finalizes the currently-playing response,
+			// mark it so a later same-session frame serializes as a new turn.
+			if (isFinal && this._currentPlaybackSessionId === sessionId) {
+				this._currentPlaybackFinalized = true;
+			}
 			this.ttsPlaybackService.playAudioChunk(audio, isFinal, this._window!);
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2500,15 +2500,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	/**
-	 * The session the user is currently LOOKING AT, used to route deferral. Unlike
-	 * {@link _getActiveSessionId} this deliberately ignores the sticky input
-	 * `_targetSession`: the target is where the user's next utterance is SENT, not
-	 * what they are viewing. Browsing another session (e.g. `openSession` in the
-	 * floating voice window) leaves `_targetSession` pointing elsewhere, so keying
-	 * deferral off the active-session chain would (a) play the target's background
-	 * narration live over an unrelated shown session and (b) defer the shown
-	 * session's own reply with no focus change to ever flush it. The awaited reply
-	 * to the user's own utterance is handled separately via `_awaitingReplyForSession`.
+	 * The session the user is currently looking at, used to route deferral.
+	 * Unlike {@link _getActiveSessionId} it ignores the sticky input
+	 * `_targetSession` (where the next utterance is sent, not what is viewed).
 	 */
 	private _shownSessionId(): string | undefined {
 		if (this._externalActiveSessionMode) {
@@ -2536,9 +2530,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 	/**
 	 * A response is deferred when it is a background narration for a session the
-	 * user is NOT actively working with. It plays immediately when it is for the
-	 * active session (targeted or focused) or when it is untagged audio we can't
-	 * attribute to any session (chit-chat, greetings, direct answers).
+	 * user is NOT looking at. It plays immediately for the shown session, for a
+	 * reply the user is actively awaiting, or when it is untagged audio.
 	 *
 	 * The decision is made on the first chunk and recorded in `_liveReplyKey`;
 	 * remaining chunks follow the same decision so a response is never split
@@ -2552,15 +2545,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				this._liveReplyKey = key;
 				return false;
 			}
-			// Play immediately for the session the user is actively looking at,
-			// or the session whose reply they are actively awaiting (they just
-			// spoke to it, so route its answer live even if they glanced away);
-			// defer any other session's narration until the user looks at it.
-			// Key off the SHOWN session, not the active-session chain: the sticky
-			// input `_targetSession` must not force an unrelated background
-			// narration to play live over the session the user is viewing.
-			// Read live so a stale cache can't misroute the decision (e.g. when
-			// the focus event was missed while voice was busy).
+			// Play live for the shown session or an awaited reply; defer the rest.
 			this._focusedSessionId = this._getFocusedSessionId();
 			if (this._shownSessionId() === sessionId || this._awaitingReplyForSession === sessionId) {
 				this._liveReplyKey = key;
@@ -3102,14 +3087,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _checkSessionStateChanges(): void {
 		// Safety net: if the focus-change event was missed while voice was busy,
 		// flush any buffered response for the session now shown to the user so it
-		// never stays stuck as a pending indicator with no playback. Use the
-		// active session (last-shown / focused) rather than only the raw focused
-		// widget, which can lag when a session is opened without taking DOM focus.
-		// The flush itself matches the buffered key robustly (exact + URI equality).
+		// never stays stuck as a pending indicator with no playback. Use the SHOWN
+		// session (not `_getActiveSessionId()`, which prefers the sticky input
+		// `_targetSession` and would flush a background session's reply over the
+		// one the user is viewing). The flush matches the buffered key robustly.
 		if (this._deferredResponses.size > 0) {
-			const active = this._getActiveSessionId();
-			if (active) {
-				this._flushDeferredResponse(active);
+			const shown = this._shownSessionId();
+			if (shown) {
+				this._flushDeferredResponse(shown);
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -330,6 +330,17 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private static readonly _CONFIRMATION_FLUSH_DELAY_MS = 1500;
 
 	/**
+	 * Response analog of {@link _confirmationFlushWatchdogs}. When a reply
+	 * completes on the session that is currently on screen, the on-focus
+	 * re-narration path won't re-fire (no future focus event) and, on a fast
+	 * switch, may have already run before the unheard marker existed. A one-shot
+	 * watchdog re-checks shortly after: if the marker still survives (the backend
+	 * dropped the narration rather than a live one clearing it), it re-narrates.
+	 */
+	private readonly _responseRenarrateWatchdogs = new Map<string, ReturnType<typeof setTimeout>>();
+	private static readonly _RESPONSE_RENARRATE_WATCHDOG_MS = 1500;
+
+	/**
 	 * Latest state change per session, buffered and flushed once after a short
 	 * settle window (see {@link _emitPendingStateChanges}) so a rapid
 	 * ``thinking <-> idle`` replay storm coalesces into a single net emission
@@ -1273,9 +1284,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 			// The backend is narrating this session's reply now (live or deferred),
 			// so it's no longer an unheard background completion awaiting on-focus
-			// re-narration. Clear the marker so we don't read it twice.
-			if (codingSessionId && e.isFirstChunk) {
-				this._unheardResponseSessions.delete(codingSessionId);
+			// re-narration. Clear the marker so we don't read it twice. Untagged
+			// audio that plays live belongs to the active session, so attribute it
+			// there — otherwise a live-narrated reply on the active session keeps
+			// its marker and gets re-narrated a second time on focus / by the
+			// watchdog.
+			if (e.isFirstChunk) {
+				const heardId = codingSessionId ?? (defer ? undefined : this._getActiveSessionId());
+				if (heardId) {
+					this._unheardResponseSessions.delete(heardId);
+				}
 			}
 			if (defer) {
 				this._deferResponse(codingSessionId!, e.audio, e.isFirstChunk, e.isFinal, e.transcript);
@@ -1471,6 +1489,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._userCancelledSessions.clear();
 		for (const t of this._confirmationFlushWatchdogs.values()) { clearTimeout(t); }
 		this._confirmationFlushWatchdogs.clear();
+		for (const t of this._responseRenarrateWatchdogs.values()) { clearTimeout(t); }
+		this._responseRenarrateWatchdogs.clear();
 		if (this._stateChangeEmitTimer) { clearTimeout(this._stateChangeEmitTimer); this._stateChangeEmitTimer = undefined; }
 		this._pendingStateChanges.clear();
 		this._confirmationNarrationPending = undefined;
@@ -3172,14 +3192,24 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._sendContext();
 			return;
 		}
-		// Track background completions so an unheard reply can be re-narrated on
-		// focus (see _unheardResponseSessions). A completion for the session the
-		// user is currently viewing narrates live, so it is never marked.
+		// Track completions so an unheard reply can be re-narrated. Mark EVERY
+		// idle+summary completion as a candidate unheard reply — including the
+		// session currently on screen. The marker is cleared the instant the
+		// reply's audio is actually heard (see onAudioResponse), so a reply that
+		// narrates live is never re-read; only a reply whose narration the
+		// backend dropped survives. Keying the decision on "shown at emit time"
+		// was racy: on a fast switch the just-completed background session can
+		// already be the shown one by the time this debounced emit runs, which
+		// wrongly suppressed the marker and left the reply silently unheard.
 		const shownNow = this._shownSessionId();
 		for (const { change } of netChanges) {
 			if (change.currentState === 'idle' && change.lastResponseSummary) {
-				if (change.sessionId !== shownNow) {
-					this._unheardResponseSessions.add(change.sessionId);
+				this._unheardResponseSessions.add(change.sessionId);
+				// If the completed session is the one on screen, no future focus
+				// event will drive the on-focus re-narration, so arm a one-shot
+				// watchdog that re-narrates iff the reply is still unheard.
+				if (change.sessionId === shownNow) {
+					this._armResponseRenarrateWatchdog(change.sessionId);
 				}
 			} else if (change.currentState === 'thinking' || change.currentState === 'waiting_for_confirmation') {
 				// A new turn or confirmation supersedes any pending unheard reply.
@@ -3248,6 +3278,50 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this.voiceClientService.flushSessionContext();
 		}, VoiceSessionController._CONFIRMATION_FLUSH_DELAY_MS);
 		this._confirmationFlushWatchdogs.set(sessionId, timer);
+	}
+
+	/**
+	 * Re-narrate a reply that completed on the on-screen session if its narration
+	 * was dropped. Response analog of {@link _armConfirmationFlushWatchdog}.
+	 *
+	 * The on-focus re-narration in {@link _activateShownSession} only fires on a
+	 * focus event, so a reply that completes on the already-shown session (or on
+	 * a session focused a beat before its unheard marker was set, in a fast
+	 * switch) is never re-checked. This one-shot watchdog does that: after a short
+	 * delay it re-narrates iff the reply is still genuinely unheard — its marker
+	 * survived (a live narration would have cleared it), the session is still the
+	 * active, idle one, and nothing is buffered for it.
+	 */
+	private _armResponseRenarrateWatchdog(sessionId: string): void {
+		// Exactly one delayed re-check per completion; don't refresh the timer.
+		if (this._responseRenarrateWatchdogs.has(sessionId)) {
+			return;
+		}
+		this.logService.trace(`[voice] arming response re-narrate watchdog id=${sessionId.slice(-32)}`);
+		const timer = setTimeout(() => {
+			this._responseRenarrateWatchdogs.delete(sessionId);
+			// Marker cleared -> the reply's audio was heard; nothing to do.
+			if (!this._unheardResponseSessions.has(sessionId)) {
+				return;
+			}
+			// A buffered reply is flushed on focus instead; don't double-read.
+			if (this._deferredResponses.has(sessionId)) {
+				return;
+			}
+			// The two-phase only narrates the active session (is_active), and only
+			// while it is still idle with a reply — bail otherwise.
+			if (this._getActiveSessionId() !== sessionId) {
+				return;
+			}
+			const model = this.chatService.getSession(URI.parse(sessionId));
+			if (!model || this._getAgentStateInfo(model).state !== 'idle') {
+				return;
+			}
+			this.logService.trace(`[voice] response re-narrate watchdog firing id=${sessionId.slice(-32)}`);
+			this._unheardResponseSessions.delete(sessionId);
+			this._narrateResponseViaTwoPhase(sessionId, URI.parse(sessionId));
+		}, VoiceSessionController._RESPONSE_RENARRATE_WATCHDOG_MS);
+		this._responseRenarrateWatchdogs.set(sessionId, timer);
 	}
 
 	/**
@@ -3643,6 +3717,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		for (const id of this._unheardResponseSessions) {
 			if (!liveSessionIds.has(id)) {
 				this._unheardResponseSessions.delete(id);
+			}
+		}
+		for (const [id, timer] of this._responseRenarrateWatchdogs) {
+			if (!liveSessionIds.has(id)) {
+				clearTimeout(timer);
+				this._responseRenarrateWatchdogs.delete(id);
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -353,6 +353,23 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private static readonly _CONFIRMATION_ACTIVATE_DELAY_MS = 250;
 
 	/**
+	 * Sessions that completed (``idle`` with a reply) while in the background and
+	 * whose reply we have NOT narrated to the user. The backend narrates one
+	 * thing at a time and simply DROPS a completion's narration when another is
+	 * in flight (see onAudioResponse) — so unlike a deferred reply there is no
+	 * audio to buffer, and returning to the session finds it silent. We record
+	 * the completion here and, on focus, re-elicit narration via a forced
+	 * ``thinking -> idle`` transition (the backend's sole narration trigger),
+	 * mirroring {@link _narrateConfirmationViaTwoPhase}. Cleared when the
+	 * session's audio actually arrives (played or deferred), when a new turn
+	 * starts, or once we re-elicit on focus.
+	 */
+	private readonly _unheardResponseSessions = new Set<string>();
+
+	/** Per-session phase-2 timers for the response re-narration two-phase. */
+	private readonly _responseActivateTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+	/**
 	 * The focused session whose confirmation transition we just shipped and
 	 * expect the backend to narrate. If a tagged narration for a DIFFERENT
 	 * session arrives before this one's own audio, the backend preempted this
@@ -1242,6 +1259,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (e.isFirstChunk || e.isFinal) {
 				this.logService.trace(`[voice] audio_response codingSessionId=${codingSessionId ?? '<none>'} focused=${this._focusedSessionId ?? '<none>'} isFirstChunk=${e.isFirstChunk} isFinal=${e.isFinal} suppress=${this._suppressIncomingAudio} defer=${defer}`);
 			}
+			// The backend is narrating this session's reply now (live or deferred),
+			// so it's no longer an unheard background completion awaiting on-focus
+			// re-narration. Clear the marker so we don't read it twice.
+			if (codingSessionId && e.isFirstChunk) {
+				this._unheardResponseSessions.delete(codingSessionId);
+			}
 			if (defer) {
 				this._deferResponse(codingSessionId!, e.audio, e.isFirstChunk, e.isFinal, e.transcript);
 			} else if (this._isRenarration(codingSessionId, e.transcript, e.isFirstChunk, e.isFinal)) {
@@ -1428,6 +1451,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._awaitingReplyForSession = undefined;
 		for (const t of this._confirmationActivateTimers.values()) { clearTimeout(t); }
 		this._confirmationActivateTimers.clear();
+		for (const t of this._responseActivateTimers.values()) { clearTimeout(t); }
+		this._responseActivateTimers.clear();
+		this._unheardResponseSessions.clear();
 		this._prevSessionStates.clear();
 		for (const t of this._userCancelledSessions.values()) { clearTimeout(t); }
 		this._userCancelledSessions.clear();
@@ -2377,8 +2403,52 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._narrateConfirmationViaTwoPhase(key);
 			return;
 		}
+		// A reply that completed while this session was in the background may have
+		// had its narration dropped by the backend (it narrates one at a time),
+		// leaving nothing to flush. Re-elicit it now via a forced thinking->idle
+		// transition. Guarded by `hadDeferred` (a buffered reply was just flushed
+		// instead) and scoped to the main-window (non-external) flow the bug was
+		// reported in.
+		if (!this._externalActiveSessionMode && !hadDeferred && this._unheardResponseSessions.has(key)) {
+			this._unheardResponseSessions.delete(key);
+			this._narrateResponseViaTwoPhase(key, resource);
+			return;
+		}
 		this._sendContext();
 		this.voiceClientService.flushSessionContext();
+	}
+
+	/**
+	 * Re-narrate a focused session's completed reply that was never read because
+	 * the backend dropped its narration while the session was in the background.
+	 * Mirrors {@link _narrateConfirmationViaTwoPhase}: flip `is_active` while
+	 * holding the session as `thinking`, then send the real `idle` +
+	 * `last_response_summary` so the backend observes a fresh `thinking -> idle`
+	 * transition (its sole narration trigger) and narrates the reply. The model
+	 * is eagerly loaded so the summary is available for phase two.
+	 */
+	private _narrateResponseViaTwoPhase(key: string, resource: URI): void {
+		this.logService.trace(`[voice] re-narrating unheard response id=${key.slice(-32)}`);
+		this._ensureModelLoaded(resource);
+		// Phase 1: flip is_active while holding the session as `thinking`.
+		this._forceThinkingOnce.add(key);
+		this._sendContext();
+		this.voiceClientService.flushSessionContext();
+		// Phase 2: after `is_active` settles, send the real `idle` + summary.
+		const existing = this._responseActivateTimers.get(key);
+		if (existing) {
+			clearTimeout(existing);
+		}
+		this._responseActivateTimers.set(key, setTimeout(() => {
+			this._responseActivateTimers.delete(key);
+			this._forceThinkingOnce.delete(key);
+			// Only ship the transition if this session is still active, so we
+			// don't narrate a reply for a session the user already left.
+			if (this._getActiveSessionId() === key) {
+				this._sendContext();
+				this.voiceClientService.flushSessionContext();
+			}
+		}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS));
 	}
 
 	/**
@@ -3036,6 +3106,20 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._sendContext();
 			return;
 		}
+		// Track background completions so an unheard reply can be re-narrated on
+		// focus (see _unheardResponseSessions). A completion for the session the
+		// user is currently viewing narrates live, so it is never marked.
+		const shownNow = this._shownSessionId();
+		for (const { change } of netChanges) {
+			if (change.currentState === 'idle' && change.lastResponseSummary) {
+				if (change.sessionId !== shownNow) {
+					this._unheardResponseSessions.add(change.sessionId);
+				}
+			} else if (change.currentState === 'thinking' || change.currentState === 'waiting_for_confirmation') {
+				// A new turn or confirmation supersedes any pending unheard reply.
+				this._unheardResponseSessions.delete(change.sessionId);
+			}
+		}
 		// For detail-only transitions (same agent_state but different confirmation
 		// content), invalidate the cache so _sendDelta treats the session as new
 		// and includes agent_state + agent_state_detail together.
@@ -3488,6 +3572,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		for (const id of this._lastResponseSummaryById.keys()) {
 			if (!liveSessionIds.has(id)) {
 				this._lastResponseSummaryById.delete(id);
+			}
+		}
+		for (const id of this._unheardResponseSessions) {
+			if (!liveSessionIds.has(id)) {
+				this._unheardResponseSessions.delete(id);
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -208,7 +208,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _bargeInMonitorActive = false;
 
 	// --- Audio FIFO queue ---
-	private readonly _audioQueue: { sessionId: string | undefined; chunks: { audio: string; isFirstChunk: boolean; isFinal: boolean; transcript: string | undefined }[] }[] = [];
+	private readonly _audioQueue: { sessionId: string | undefined; finalized: boolean; chunks: { audio: string; isFirstChunk: boolean; isFinal: boolean; transcript: string | undefined }[] }[] = [];
 	private _currentPlaybackSessionId: string | undefined | null = null; // null = nothing playing
 	// True once the currently-playing response has received its final audio
 	// chunk. A same-session frame arriving after this marks a NEW response and
@@ -403,6 +403,17 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 */
 	private _responseNarrationPending: { sessionId: string; at: number; reasserted: boolean } | undefined;
 
+	/**
+	 * While a shown session's confirmation/response is being re-narrated via the
+	 * two-phase flow, force `_buildSessionContext` to mark THAT session
+	 * `is_active` — even if a different session is the sticky input
+	 * `_targetSession`. The backend narrates only the active session's
+	 * transition, so without this a re-narration for the viewed session would
+	 * never fire whenever the input target points elsewhere. Cleared once the
+	 * two-phase completes (or aborts).
+	 */
+	private _narrationActiveOverride: string | undefined;
+
 	/** Model refs eagerly loaded for sessions awaiting input (no UI focus needed). */
 	private readonly _eagerModelRefs = new Map<string, IChatModelReference>();
 
@@ -429,6 +440,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * session starts a new turn (``thinking``) so a stale reply is never narrated.
 	 */
 	private readonly _lastResponseSummaryById = new Map<string, string>();
+
+	/**
+	 * The `last_response_summary` of the most recent completion whose narration
+	 * was actually heard, per session. Used by `_maybeHoldBackgroundIdle` to tell
+	 * a fresh (unheard) background completion apart from one that already
+	 * narrated, robustly and independent of debounce/marker ordering: a summary
+	 * that matches this map was already read, so it isn't held or re-narrated.
+	 */
+	private readonly _narratedSummaryById = new Map<string, string>();
+
 
 	// --- Telemetry tracking ---
 	private _telemetrySessionIndex = 0;
@@ -1293,6 +1314,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				const heardId = codingSessionId ?? (defer ? undefined : this._getActiveSessionId());
 				if (heardId) {
 					this._unheardResponseSessions.delete(heardId);
+					// Remember which completion (by summary) was narrated, so a later
+					// background rebuild recognises it as already-heard and neither
+					// holds nor re-narrates it. Only record when actually playing it
+					// (not deferred) — a deferred reply hasn't been heard yet.
+					if (!defer) {
+						const narrated = this._lastResponseSummaryById.get(heardId);
+						if (narrated) {
+							this._narratedSummaryById.set(heardId, narrated);
+						}
+					}
 				}
 			}
 			if (defer) {
@@ -1376,6 +1407,19 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				return;
 			}
 			if (allowedTools.includes(e.name)) {
+				// Passive, backend-initiated queries (read-only session inspection)
+				// must NOT disturb the user's turn: dispatching them like an action
+				// tool calls _finishPtt() and drives the state machine to idle,
+				// which kills a just-started auto-listen the instant the backend
+				// probes the session on connect. Answer them without touching PTT,
+				// status, awaiting-reply, or voice state.
+				const passiveTools = ['get_session_info', 'get_session_changes', 'get_session_thread'];
+				if (passiveTools.includes(e.name)) {
+					this.voiceToolDispatchService.dispatchToolCall(e).then(result => {
+						this.voiceClientService.sendToolResult(e.callId, result);
+					});
+					return;
+				}
 				this._statusText.set(VoiceToolDispatchService.getActionLabel(e.name), undefined);
 				this._persistEntry('agent_tool_call', this._renderToolCallSummary(e.name, e.args), {
 					toolName: e.name,
@@ -1495,11 +1539,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._pendingStateChanges.clear();
 		this._confirmationNarrationPending = undefined;
 		this._responseNarrationPending = undefined;
+		this._narrationActiveOverride = undefined;
 		for (const ref of this._eagerModelRefs.values()) { ref.dispose(); }
 		this._eagerModelRefs.clear();
 		this._eagerModelLoading.clear();
 		this._pendingIdleNarration.clear();
 		this._lastResponseSummaryById.clear();
+		this._narratedSummaryById.clear();
 		this._userLogin = undefined;
 		this._lastPersistedTurnId = undefined;
 		this._pendingPriorTimeline = [];
@@ -1691,6 +1737,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (!this._pttHeld) { return; }
 		this._clearAutoListenTimer();
 		this._pttHeld = false;
+		// Finishing a turn always ends toggle (hands-free) mode. Clearing it here
+		// centralizes the invariant so callers that finish a turn out-of-band
+		// (e.g. a backend tool_call arriving mid-listen) can't leave a stale
+		// `toggle=true, held=false` state — which makes the next auto-listen's
+		// synthetic pttDown fire as a "second tap" and kill listening instantly.
+		this._pttToggleMode = false;
 		this._telemetryPttUpMs = Date.now();
 		const holdMs = this._telemetryPttDownMs ? Date.now() - this._telemetryPttDownMs : 0;
 		this.telemetryService.publicLog2<VoicePttEvent, VoicePttClassification>('voicePtt', { holdDurationMs: holdMs });
@@ -2464,7 +2516,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _narrateResponseViaTwoPhase(key: string, resource: URI, isReassert: boolean = false): void {
 		this.logService.trace(`[voice] re-narrating unheard response id=${key.slice(-32)}${isReassert ? ' (re-assert)' : ''}`);
 		this._ensureModelLoaded(resource);
-		// Phase 1: flip is_active while holding the session as `thinking`.
+		// Phase 1: flip is_active while holding the session as `thinking`. Force
+		// this session active for the duration so its transition narrates even if
+		// the sticky input target points elsewhere (see _narrationActiveOverride).
+		this._narrationActiveOverride = key;
 		this._forceThinkingOnce.add(key);
 		this._sendContext();
 		this.voiceClientService.flushSessionContext();
@@ -2476,9 +2531,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._responseActivateTimers.set(key, setTimeout(() => {
 			this._responseActivateTimers.delete(key);
 			this._forceThinkingOnce.delete(key);
-			// Only ship the transition if this session is still active, so we
-			// don't narrate a reply for a session the user already left.
-			if (this._getActiveSessionId() === key) {
+			// Only ship the transition if the user is still VIEWING this session
+			// (shown, not the sticky input target), so we don't narrate a reply
+			// for a session the user already navigated away from.
+			if (this._shownSessionId() === key) {
 				this._sendContext();
 				this.voiceClientService.flushSessionContext();
 				// Expect this reply to narrate now; track it so a competing
@@ -2486,6 +2542,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				// this send is ITSELF the re-assert, mark it consumed so we never
 				// loop re-asserting the same reply.
 				this._responseNarrationPending = { sessionId: key, at: Date.now(), reasserted: isReassert };
+			}
+			// Release the active override now the transition has shipped (or was
+			// aborted); the next context build reverts to the real target.
+			if (this._narrationActiveOverride === key) {
+				this._narrationActiveOverride = undefined;
 			}
 		}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS));
 	}
@@ -2521,7 +2582,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return;
 		}
 		const expired = Date.now() - pending.at > VoiceSessionController._CONFIRMATION_REASSERT_WINDOW_MS;
-		const stillActive = this._getActiveSessionId() === pending.sessionId;
+		// "Still viewing" is the shown session, not the sticky input target: a
+		// target selected elsewhere must not discard the reply for the session
+		// the user is actually looking at.
+		const stillActive = this._shownSessionId() === pending.sessionId;
 		let stillIdle = false;
 		if (stillActive) {
 			const model = this.chatService.getSession(URI.parse(pending.sessionId));
@@ -3001,15 +3065,25 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return;
 		}
 
-		// Check if there's already a queued entry for this session
-		let entry = this._audioQueue.find(e =>
-			e.sessionId === sessionId || (e.sessionId === undefined && sessionId === undefined)
-		);
+		// Queue this chunk. A response's chunks must never merge with a DIFFERENT
+		// response for the same session: playing a later response's audio into an
+		// already-finalized entry's buffer would push it past that entry's
+		// scheduled `node.stop()` and silently drop it. So every first chunk
+		// starts a fresh entry; continuation chunks attach to that session's most
+		// recent still-open (not-yet-finalized) entry.
+		let entry = isFirstChunk
+			? undefined
+			: [...this._audioQueue].reverse().find(e =>
+				!e.finalized && (e.sessionId === sessionId || (e.sessionId === undefined && sessionId === undefined))
+			);
 		if (!entry) {
-			entry = { sessionId, chunks: [] };
+			entry = { sessionId, finalized: false, chunks: [] };
 			this._audioQueue.push(entry);
 		}
 		entry.chunks.push({ audio, isFirstChunk, isFinal, transcript });
+		if (isFinal) {
+			entry.finalized = true;
+		}
 
 		// If nothing is currently playing, start processing
 		if (this._currentPlaybackSessionId === null && !this._isProcessingQueue) {
@@ -3169,6 +3243,25 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * and a detail change reached via an intermediate state (e.g.
 	 * `waiting(old) → thinking → waiting(new)`) is still treated as detail-only.
 	 */
+	/**
+	 * Mark (or clear) a completion for on-focus re-narration. An idle+summary
+	 * completion is recorded as a candidate unheard reply — including the shown
+	 * session, since the marker is cleared the instant its audio is heard (see
+	 * onAudioResponse), so a reply that narrates live is never re-read; only one
+	 * the backend dropped survives. A new turn/confirmation clears any pending
+	 * marker. Arms the shown-session watchdog when no focus event will fire.
+	 */
+	private _recordCompletionForRenarration(sessionId: string, currentState: string, lastResponseSummary: string | undefined, shownNow: string | undefined): void {
+		if (currentState === 'idle' && lastResponseSummary) {
+			this._unheardResponseSessions.add(sessionId);
+			if (sessionId === shownNow) {
+				this._armResponseRenarrateWatchdog(sessionId);
+			}
+		} else if (currentState === 'thinking' || currentState === 'waiting_for_confirmation') {
+			this._unheardResponseSessions.delete(sessionId);
+		}
+	}
+
 	private _emitPendingStateChanges(): void {
 		const changes = [...this._pendingStateChanges.values()];
 		this._pendingStateChanges.clear();
@@ -3192,29 +3285,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._sendContext();
 			return;
 		}
-		// Track completions so an unheard reply can be re-narrated. Mark EVERY
-		// idle+summary completion as a candidate unheard reply — including the
-		// session currently on screen. The marker is cleared the instant the
-		// reply's audio is actually heard (see onAudioResponse), so a reply that
-		// narrates live is never re-read; only a reply whose narration the
-		// backend dropped survives. Keying the decision on "shown at emit time"
-		// was racy: on a fast switch the just-completed background session can
-		// already be the shown one by the time this debounced emit runs, which
-		// wrongly suppressed the marker and left the reply silently unheard.
+		// Track completions so an unheard reply can be re-narrated (see
+		// _recordCompletionForRenarration). Both this coalesced path and the
+		// direct _checkSessionStateChanges path feed it, so remote/unloaded
+		// sessions surfaced only by the latter are covered too.
 		const shownNow = this._shownSessionId();
 		for (const { change } of netChanges) {
-			if (change.currentState === 'idle' && change.lastResponseSummary) {
-				this._unheardResponseSessions.add(change.sessionId);
-				// If the completed session is the one on screen, no future focus
-				// event will drive the on-focus re-narration, so arm a one-shot
-				// watchdog that re-narrates iff the reply is still unheard.
-				if (change.sessionId === shownNow) {
-					this._armResponseRenarrateWatchdog(change.sessionId);
-				}
-			} else if (change.currentState === 'thinking' || change.currentState === 'waiting_for_confirmation') {
-				// A new turn or confirmation supersedes any pending unheard reply.
-				this._unheardResponseSessions.delete(change.sessionId);
-			}
+			this._recordCompletionForRenarration(change.sessionId, change.currentState, change.lastResponseSummary, shownNow);
 		}
 		// For detail-only transitions (same agent_state but different confirmation
 		// content), invalidate the cache so _sendDelta treats the session as new
@@ -3308,9 +3385,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (this._deferredResponses.has(sessionId)) {
 				return;
 			}
-			// The two-phase only narrates the active session (is_active), and only
-			// while it is still idle with a reply — bail otherwise.
-			if (this._getActiveSessionId() !== sessionId) {
+			// The two-phase re-narrates the VIEWED session (it forces is_active),
+			// and only while it is still idle with a reply — bail otherwise.
+			if (this._shownSessionId() !== sessionId) {
 				return;
 			}
 			const model = this.chatService.getSession(URI.parse(sessionId));
@@ -3452,6 +3529,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// via onDidChangeSessions or the periodic poll rather than the autorun).
 		this._reconcileConfirmationIndicators(waitingSessionIds);
 
+		// Feed the same unheard-reply bookkeeping the coalesced autorun path uses,
+		// so completions surfaced ONLY here (e.g. remote/unloaded sessions) can
+		// still be re-narrated on focus if the backend drops their narration.
+		const shownNow = this._shownSessionId();
+		for (const change of stateChanges) {
+			this._recordCompletionForRenarration(change.sessionId, change.currentState, change.lastResponseSummary, shownNow);
+		}
+
 		if (stateChanges.length > 0) {
 			this.logService.trace(`[voice] onDidChangeSessions detected ${stateChanges.length} state change(s): ${stateChanges.map(c => `${c.label}: ${c.currentState}`).join(', ')}`);
 			// The session_context delta is the sole narration trigger; see
@@ -3502,6 +3587,54 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		return { state: realState, hideConfirmationDetail: false };
 	}
 
+	/**
+	 * Decide whether to hold a completed reply's `idle` state as `thinking` in the
+	 * backend context, and whether to withhold its `last_response_summary`.
+	 *
+	 * The backend narrates a session's completion only on a FRESH `-> idle`
+	 * transition while the session is active; a re-sent `idle` it has already seen
+	 * is deduped and never narrated (unlike `waiting_for_confirmation`, which it
+	 * narrates on every entry). So a reply that completes while its session is in
+	 * the background must NOT be reported as `idle` yet — otherwise the backend
+	 * records that idle (unnarrated, since the session is inactive) and later,
+	 * on focus, the re-elicited `idle` is deduped and silently dropped.
+	 *
+	 * Instead we hold it as `thinking` until the session becomes active, so the
+	 * on-focus release (`thinking -> idle` while active) is the backend's first
+	 * sighting of the completion and it narrates it. This mirrors how confirmations
+	 * are held as `thinking` while unfocused.
+	 *
+	 * Also self-heals {@link _unheardResponseSessions} from the current state (a
+	 * still-unheard, non-active idle reply) so a spurious `thinking` blip from an
+	 * eager model reload can't drop the marker before the session is focused.
+	 */
+	private _maybeHoldBackgroundIdle(id: string, state: string, summary: string | undefined, isActive: boolean): { state: string; suppressSummary: boolean } {
+		if (state !== 'idle' || isActive) {
+			return { state, suppressSummary: false };
+		}
+		// No summary means there's nothing to narrate; report idle as-is.
+		if (!summary) {
+			return { state, suppressSummary: false };
+		}
+		// If this exact completion (matched by summary) was already narrated,
+		// don't hold or re-narrate it — report idle normally. Matching by summary
+		// rather than the `_unheardResponseSessions` marker is deliberate: the
+		// marker is added by the debounced state-change emit, which can lag a
+		// context push (e.g. one triggered by an eager model reload) and let a
+		// raw idle+summary leak out first — after which the backend dedupes the
+		// on-focus re-send and the reply is silently dropped. Summary identity is
+		// available synchronously and survives that ordering race.
+		if (this._narratedSummaryById.get(id) === summary) {
+			return { state, suppressSummary: false };
+		}
+		// A fresh background completion: mark it unheard (for on-focus
+		// re-narration) and hold it as `thinking` — withholding the summary — so
+		// the backend's FIRST sighting of this idle happens once the session is
+		// focused, guaranteeing it narrates instead of being deduped.
+		this._unheardResponseSessions.add(id);
+		return { state: 'thinking', suppressSummary: true };
+	}
+
 	private _buildSessionContext(): IVoiceSessionContext {
 		const oneHourAgo = Date.now() - 60 * 60 * 1000;
 		const sessions = this.agentSessionsService.model.sessions.filter(s => {
@@ -3519,7 +3652,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// single active session to act on. Without this, when several sessions
 		// await confirmation the backend has no active session and asks the user
 		// which one to use.
-		const targetSessionId = this._getActiveSessionId();
+		// While re-narrating a shown session, force it active so the backend
+		// narrates its transition even if the sticky input target points at a
+		// different session. See _narrationActiveOverride.
+		const targetSessionId = this._narrationActiveOverride ?? this._getActiveSessionId();
 
 		const sessionList = sessions.map(s => {
 			const model = this.chatService.getSession(s.resource);
@@ -3550,6 +3686,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					this._ensureModelLoaded(s.resource);
 					fallbackState = 'thinking';
 				}
+				// Hold a background completion as `thinking` until active so the
+				// backend narrates it on focus (see _maybeHoldBackgroundIdle).
+				const bgHold = this._maybeHoldBackgroundIdle(sessionIdStr, fallbackState, this._lastResponseSummaryById.get(sessionIdStr), isActive);
+				fallbackState = bgHold.state;
 				const scoped = this._reportedAgentState(fallbackState, isActive);
 				// Supply the summary captured while the model was resident, so an
 				// idle completion that lands after the model is disposed still
@@ -3576,10 +3716,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// response, so we don't ship (and consume) the idle before the summary
 			// is ready. See _effectiveResidentState.
 			const heldState = this._effectiveResidentState(s.resource.toString(), stateInfo);
-			const scoped = (detailPending || forceThinking)
+			// Hold a background completion as `thinking` until its session is active
+			// so the backend narrates it on focus (see _maybeHoldBackgroundIdle).
+			const bgHold = this._maybeHoldBackgroundIdle(s.resource.toString(), heldState, stateInfo.last_response_summary, isActive);
+			const scoped = (detailPending || forceThinking || bgHold.suppressSummary)
 				? { state: 'thinking', hideConfirmationDetail: true }
-				: this._reportedAgentState(heldState, isActive);
-			const shipSummary = heldState === stateInfo.state ? stateInfo.last_response_summary : undefined;
+				: this._reportedAgentState(bgHold.state, isActive);
+			const shipSummary = (!forceThinking && !bgHold.suppressSummary && heldState === stateInfo.state) ? stateInfo.last_response_summary : undefined;
 			return {
 				id: s.resource.toString(),
 				is_active: isActive,
@@ -3603,13 +3746,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				if (lastActive < oneHourAgo) { continue; }
 			}
 			const isActive = key === targetSessionId;
-			const scoped = this._reportedAgentState(stateInfo.state, isActive);
+			// Hold a background completion as `thinking` until active so the
+			// backend narrates it on focus (see _maybeHoldBackgroundIdle).
+			const bgHold = this._maybeHoldBackgroundIdle(key, stateInfo.state, stateInfo.last_response_summary, isActive);
+			const scoped = this._reportedAgentState(bgHold.state, isActive);
 			sessionList.push({
 				id: key,
 				is_active: isActive,
 				agent_state: scoped.state,
 				...(!scoped.hideConfirmationDetail && stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
-				...(stateInfo.last_response_summary ? { last_response_summary: stateInfo.last_response_summary } : {}),
+				...(!bgHold.suppressSummary && stateInfo.last_response_summary ? { last_response_summary: stateInfo.last_response_summary } : {}),
 			});
 		}
 
@@ -3700,6 +3846,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._lastResponseSummaryById.set(sessionId, summary);
 		} else if (state === 'thinking') {
 			this._lastResponseSummaryById.delete(sessionId);
+			// A new turn supersedes the previously-narrated completion, so forget
+			// it — the next completion must be held/narrated even if its summary
+			// text happens to match the prior one.
+			this._narratedSummaryById.delete(sessionId);
 		}
 	}
 
@@ -3712,6 +3862,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		for (const id of this._lastResponseSummaryById.keys()) {
 			if (!liveSessionIds.has(id)) {
 				this._lastResponseSummaryById.delete(id);
+			}
+		}
+		for (const id of this._narratedSummaryById.keys()) {
+			if (!liveSessionIds.has(id)) {
+				this._narratedSummaryById.delete(id);
 			}
 		}
 		for (const id of this._unheardResponseSessions) {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -381,6 +381,17 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _confirmationNarrationPending: { sessionId: string; at: number; reasserted: boolean } | undefined;
 	private static readonly _CONFIRMATION_REASSERT_WINDOW_MS = 12000;
 
+	/**
+	 * The focused session whose response re-narration we just shipped and expect
+	 * the backend to narrate. Mirrors {@link _confirmationNarrationPending}: if a
+	 * tagged narration for a DIFFERENT session arrives before this one's own
+	 * audio, the backend preempted our re-narration (it narrates one at a time)
+	 * and, because the session stays `idle`, it would be lost — so we re-assert
+	 * once. Cleared when this session's own audio arrives, or when it stops being
+	 * the active/idle session.
+	 */
+	private _responseNarrationPending: { sessionId: string; at: number; reasserted: boolean } | undefined;
+
 	/** Model refs eagerly loaded for sessions awaiting input (no UI focus needed). */
 	private readonly _eagerModelRefs = new Map<string, IChatModelReference>();
 
@@ -1251,6 +1262,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// dropping one when another is in flight. Remove once that lands.
 			if (e.isFirstChunk) {
 				this._reconcileConfirmationNarration(codingSessionId);
+				this._reconcileResponseNarration(codingSessionId);
 			}
 			// If this response is for a session the user isn't currently looking
 			// at, don't play it now: buffer it until that session is focused and
@@ -1462,6 +1474,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (this._stateChangeEmitTimer) { clearTimeout(this._stateChangeEmitTimer); this._stateChangeEmitTimer = undefined; }
 		this._pendingStateChanges.clear();
 		this._confirmationNarrationPending = undefined;
+		this._responseNarrationPending = undefined;
 		for (const ref of this._eagerModelRefs.values()) { ref.dispose(); }
 		this._eagerModelRefs.clear();
 		this._eagerModelLoading.clear();
@@ -2427,8 +2440,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * transition (its sole narration trigger) and narrates the reply. The model
 	 * is eagerly loaded so the summary is available for phase two.
 	 */
-	private _narrateResponseViaTwoPhase(key: string, resource: URI): void {
-		this.logService.trace(`[voice] re-narrating unheard response id=${key.slice(-32)}`);
+	private _narrateResponseViaTwoPhase(key: string, resource: URI, isReassert: boolean = false): void {
+		this.logService.trace(`[voice] re-narrating unheard response id=${key.slice(-32)}${isReassert ? ' (re-assert)' : ''}`);
 		this._ensureModelLoaded(resource);
 		// Phase 1: flip is_active while holding the session as `thinking`.
 		this._forceThinkingOnce.add(key);
@@ -2447,8 +2460,60 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (this._getActiveSessionId() === key) {
 				this._sendContext();
 				this.voiceClientService.flushSessionContext();
+				// Expect this reply to narrate now; track it so a competing
+				// narration that preempts it can trigger a single re-assert. If
+				// this send is ITSELF the re-assert, mark it consumed so we never
+				// loop re-asserting the same reply.
+				this._responseNarrationPending = { sessionId: key, at: Date.now(), reasserted: isReassert };
 			}
 		}, VoiceSessionController._CONFIRMATION_ACTIVATE_DELAY_MS));
+	}
+
+	/**
+	 * Reconcile a just-shipped response re-narration against an incoming audio
+	 * response, recovering the "focused a completed session but its reply was
+	 * never read" case caused by backend narration preemption. Mirrors
+	 * {@link _reconcileConfirmationNarration}.
+	 *
+	 * - Audio for the SAME session clears the pending marker: its reply narrated.
+	 * - A TAGGED narration for a DIFFERENT session while our response session is
+	 *   still the active, still-idle one means the backend narrated that instead
+	 *   and dropped ours. Re-assert the reply once (fresh `thinking -> idle`
+	 *   transition) so it is read.
+	 *
+	 * The one-shot `reasserted` guard prevents an oscillation loop, and clearing
+	 * on the session's own audio prevents a double-read when it did narrate.
+	 */
+	private _reconcileResponseNarration(codingSessionId: string | undefined): void {
+		const pending = this._responseNarrationPending;
+		if (!pending) {
+			return;
+		}
+		// Our response session's own narration arrived — it was read.
+		if (codingSessionId === pending.sessionId) {
+			this._responseNarrationPending = undefined;
+			return;
+		}
+		// Only a tagged narration for another session is unambiguous evidence of
+		// preemption; ignore untagged audio (can't attribute it).
+		if (!codingSessionId) {
+			return;
+		}
+		const expired = Date.now() - pending.at > VoiceSessionController._CONFIRMATION_REASSERT_WINDOW_MS;
+		const stillActive = this._getActiveSessionId() === pending.sessionId;
+		let stillIdle = false;
+		if (stillActive) {
+			const model = this.chatService.getSession(URI.parse(pending.sessionId));
+			stillIdle = !!model && this._getAgentStateInfo(model).state === 'idle';
+		}
+		if (pending.reasserted || expired || !stillActive || !stillIdle) {
+			// Give up: navigated away, started a new turn, already retried, or timed out.
+			this._responseNarrationPending = undefined;
+			return;
+		}
+		this.logService.trace(`[voice] response for ${pending.sessionId.slice(-32)} preempted by narration for ${codingSessionId.slice(-32)}; re-asserting`);
+		this._responseNarrationPending = undefined;
+		this._narrateResponseViaTwoPhase(pending.sessionId, URI.parse(pending.sessionId), /* isReassert */ true);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2420,9 +2420,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// had its narration dropped by the backend (it narrates one at a time),
 		// leaving nothing to flush. Re-elicit it now via a forced thinking->idle
 		// transition. Guarded by `hadDeferred` (a buffered reply was just flushed
-		// instead) and scoped to the main-window (non-external) flow the bug was
-		// reported in.
-		if (!this._externalActiveSessionMode && !hadDeferred && this._unheardResponseSessions.has(key)) {
+		// instead). Runs in both the main window and the embedder-driven agents
+		// window — mirroring the confirmation two-phase above, which is likewise
+		// unconditional — since the backend drops responses in either mode.
+		if (!hadDeferred && this._unheardResponseSessions.has(key)) {
 			this._unheardResponseSessions.delete(key);
 			this._narrateResponseViaTwoPhase(key, resource);
 			return;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8424

https://github.com/user-attachments/assets/b0f2063b-b5f5-4a67-a710-59aeb05a9c2e


## Problem

Voice mode should store a session's response until that session is focused again. Two bugs violated this:

1. **A different session's response plays in an unrelated session** — a background narration for the input-target session played live while the user was viewing a different session.
2. **Listening mode when a pending reply should have been read on focus** — the reply for the session the user was actually viewing got deferred and never flushed (no focus change to trigger it), so the controller fell idle/into listening.

## Root cause

`_shouldDeferResponse` keyed the play-vs-defer decision off `_getActiveSessionId()`, whose precedence starts with the sticky input `_targetSession`. `_targetSession` is where the user's next utterance is sent, not what they are viewing. In the floating voice window, browsing a session via `openSession` changes the shown session but leaves `_targetSession` pointing elsewhere. With target=A while viewing B:

- A's background narration -> active==A -> played live over unrelated shown session B (bug 1).
- B's own reply -> active==A != B -> deferred, and since the user was already on B there was no focus change to flush it (bug 2).

## Fix

Add `_shownSessionId()` — the session the user is looking at (`_lastShownSessionId ?? focus`; `_activeSessionShown` in external mode), deliberately ignoring `_targetSession`. `_shouldDeferResponse` now plays live only for the shown session or `_awaitingReplyForSession` (so the awaited answer to the user's own utterance still plays even if they glanced away), and defers everything else. The continuation-chunk fallback mirrors the same decision.

## Agents/sessions window

No behavior change: external mode never sets `_targetSession`, so `_shownSessionId()` resolves to the same `_activeSessionShown` the old chain already used.

## Testing

- `npm run typecheck-client` passes.
- Please verify in the floating voice window: with a target session selected, browse to a different session and confirm (a) the target's background narrations are deferred (pending indicator, not played over the viewed session) and (b) the viewed session's own reply is read out immediately; and confirm the awaited answer to your own spoken utterance still plays live after glancing away.
