### PR TITLE
Respect explorer.compactFolders in the search results tree

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -980,6 +980,7 @@ export class SearchView extends ViewPane {
 			],
 			this.searchDataSource,
 			{
+				compressionEnabled: this.configurationService.getValue<boolean>('explorer.compactFolders'),
 				identityProvider,
 				accessibilityProvider: this.treeAccessibilityProvider,
 				dnd: this.instantiationService.createInstance(ResourceListDnDHandler, element => {
@@ -1008,6 +1009,9 @@ export class SearchView extends ViewPane {
 					return this.shouldCollapseAccordingToConfig(e);
 				}
 			}));
+
+		this._register(Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('explorer.compactFolders'))(() =>
+			this.tree.updateOptions({ compressionEnabled: this.configurationService.getValue<boolean>('explorer.compactFolders') })));
 
 		Constants.SearchContext.SearchResultListFocusedKey.bindTo(this.tree.contextKeyService);
 


### PR DESCRIPTION
Fixes #301832. The Search view's results tree (`WorkbenchCompressibleAsyncDataTree`) never set `compressionEnabled`, so it always compacted single-child folders regardless of `explorer.compactFolders`. This reads the setting at construction and updates on change, mirroring how the Explorer view already does it no new setting, just honoring the existing one in Search too.
