### PR TITLE
Fix stale markdown "file does not exist" after linked file is created

### DIFF
--- a/extensions/markdown-language-features/src/client/fileWatchingManager.ts
+++ b/extensions/markdown-language-features/src/client/fileWatchingManager.ts
@@ -14,7 +14,6 @@ type DirWatcherEntry = {
 	readonly disposables: readonly IDisposable[];
 };
 
-
 export class FileWatcherManager {
 
 	readonly #fileWatchers = new Map<number, {
@@ -33,11 +32,13 @@ export class FileWatcherManager {
 			return;
 		}
 
-		// Watch the file as dirname + basename. RelativePattern(fileUri, '*') never matches
-		// events for that file (empty relative path), so creates did not clear the
-		// language service's cached "file does not exist" diagnostics.
+		// Watch the parent directory and filter to this file. RelativePattern(fileUri, '*')
+		// never matches events for that file (empty relative path), so creates did not
+		// clear the language service's cached "file does not exist" diagnostics. Using the
+		// basename as the glob pattern would also mis-handle names with glob metacharacters
+		// (e.g. `[draft].md`), so keep the pattern simple and filter by URI instead.
 		const watcher = vscode.workspace.createFileSystemWatcher(
-			new vscode.RelativePattern(Utils.dirname(uri), Utils.basename(uri)),
+			new vscode.RelativePattern(Utils.dirname(uri), '*'),
 			!listeners.create,
 			!listeners.change,
 			!listeners.delete,
@@ -45,9 +46,28 @@ export class FileWatcherManager {
 		const parentDirWatchers: DirWatcherEntry[] = [];
 		this.#fileWatchers.set(id, { watcher, dirWatchers: parentDirWatchers });
 
-		if (listeners.create) { watcher.onDidCreate(listeners.create); }
-		if (listeners.change) { watcher.onDidChange(listeners.change); }
-		if (listeners.delete) { watcher.onDidDelete(listeners.delete); }
+		const isTarget = (eventUri: vscode.Uri) => eventUri.toString() === uri.toString();
+		if (listeners.create) {
+			watcher.onDidCreate(eventUri => {
+				if (isTarget(eventUri)) {
+					listeners.create!();
+				}
+			});
+		}
+		if (listeners.change) {
+			watcher.onDidChange(eventUri => {
+				if (isTarget(eventUri)) {
+					listeners.change!();
+				}
+			});
+		}
+		if (listeners.delete) {
+			watcher.onDidDelete(eventUri => {
+				if (isTarget(eventUri)) {
+					listeners.delete!();
+				}
+			});
+		}
 
 		if (watchParentDirs && uri.scheme !== Schemes.untitled) {
 			// We need to watch the parent directories too for when these are deleted / created
@@ -56,7 +76,7 @@ export class FileWatcherManager {
 
 				let parentDirWatcher = this.#dirWatchers.get(dirUri);
 				if (!parentDirWatcher) {
-					const glob = new vscode.RelativePattern(Utils.dirname(dirUri), Utils.basename(dirUri));
+					const glob = new vscode.RelativePattern(Utils.dirname(dirUri), '*');
 					const parentWatcher = vscode.workspace.createFileSystemWatcher(glob, !listeners.create, true, !listeners.delete);
 					parentDirWatcher = { refCount: 0, watcher: parentWatcher };
 					this.#dirWatchers.set(dirUri, parentDirWatcher);
@@ -64,7 +84,10 @@ export class FileWatcherManager {
 				parentDirWatcher.refCount++;
 
 				if (listeners.create) {
-					disposables.push(parentDirWatcher.watcher.onDidCreate(async () => {
+					disposables.push(parentDirWatcher.watcher.onDidCreate(async (eventUri) => {
+						if (eventUri.toString() !== dirUri.toString()) {
+							return;
+						}
 						// Just because the parent dir was created doesn't mean our file was created
 						try {
 							const stat = await vscode.workspace.fs.stat(uri);
@@ -80,7 +103,11 @@ export class FileWatcherManager {
 				if (listeners.delete) {
 					// When the parent dir is deleted, consider our file deleted too
 					// TODO: this fires if the file previously did not exist and then the parent is deleted
-					disposables.push(parentDirWatcher.watcher.onDidDelete(listeners.delete));
+					disposables.push(parentDirWatcher.watcher.onDidDelete(eventUri => {
+						if (eventUri.toString() === dirUri.toString()) {
+							listeners.delete!();
+						}
+					}));
 				}
 
 				parentDirWatchers.push({ uri: dirUri, disposables });

--- a/extensions/markdown-language-features/src/client/fileWatchingManager.ts
+++ b/extensions/markdown-language-features/src/client/fileWatchingManager.ts
@@ -33,7 +33,15 @@ export class FileWatcherManager {
 			return;
 		}
 
-		const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(uri, '*'), !listeners.create, !listeners.change, !listeners.delete);
+		// Watch the file as dirname + basename. RelativePattern(fileUri, '*') never matches
+		// events for that file (empty relative path), so creates did not clear the
+		// language service's cached "file does not exist" diagnostics.
+		const watcher = vscode.workspace.createFileSystemWatcher(
+			new vscode.RelativePattern(Utils.dirname(uri), Utils.basename(uri)),
+			!listeners.create,
+			!listeners.change,
+			!listeners.delete,
+		);
 		const parentDirWatchers: DirWatcherEntry[] = [];
 		this.#fileWatchers.set(id, { watcher, dirWatchers: parentDirWatchers });
 


### PR DESCRIPTION
## Summary
- Markdown link validation caches missing targets and clears that cache when file watchers report creates.
- Watching with `RelativePattern(fileUri, '*')` never matched create/change/delete events for that file (empty relative path), so “File does not exist at path” stayed stale after the file was created until restart.
- Watch `dirname` + `basename` instead so creates invalidate the cache.

Fixes #324700

## Test plan
- [ ] Enable markdown link validation (`markdown.validate.enabled` / file link validation)
- [ ] In a `.md` file, add a link to a path that does not exist (e.g. `[x](./missing.md)`)
- [ ] Confirm diagnostic: file does not exist
- [ ] Create `missing.md` on disk (Explorer or terminal)
- [ ] Confirm the diagnostic clears without restarting VS Code
- [ ] Ctrl+Click the link and confirm the new file opens
- [ ] Delete the linked file again and confirm the diagnostic returns