### PR TITLE
Fix agent host Claude session deletion resurrection

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -1108,10 +1108,35 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		// {@link shutdown} already serializing teardown for this same
 		// session id awaits this work first (and vice versa). When the session
 		// has not yet been materialized, abort the controller (unblocks any
-		// racing `await sdk.startup()`) and drop the record. No SDK contact,
-		// no DB write — symmetric with `createSession`.
+		// racing `await sdk.startup()`) and drop the record — nothing was ever
+		// persisted, so there is no SDK transcript to delete.
+		//
+		// A materialized session DOES have a durable SDK transcript, and
+		// `disposeSession` is the permanent-delete path (`AgentService.disposeSession`
+		// pairs it with deleting the VS Code-side session data — see its "mirror
+		// the SDK-side cleanup performed by the provider" comment). Mirrors
+		// `CopilotAgent.disposeSession` and this file's own `_removeAllTurns`: await
+		// the live subprocess's actual exit first (its final transcript flush makes
+		// the on-disk `<id>.jsonl` stable) so no live writer can recreate it after
+		// `deleteSession` removes it, then delete the transcript before dropping the
+		// in-memory record — otherwise the SDK remains the source of truth for
+		// `listSessions()` and rediscovers the "deleted" session on the next list.
+		//
+		// A session absent from `_sessions` is ambiguous — never created (or
+		// already disposed) vs. materialized in an earlier process and simply
+		// not resumed into this one — so it's resolved the same way
+		// `_removeAllTurns`'s cold path does: ask the SDK.
 		const sessionId = AgentSession.id(session);
 		return this._disposeSequencer.queue(sessionId, async () => {
+			const existing = this._findAnySession(sessionId);
+			if (existing) {
+				if (existing.isPipelineReady) {
+					await existing.shutdownLiveQuery();
+					await this._sdkService.deleteSession(sessionId);
+				}
+			} else if (await this._sdkService.getSessionInfo(sessionId)) {
+				await this._sdkService.deleteSession(sessionId);
+			}
 			await this._teardownEntry(sessionId);
 			this._pruneActiveClientHandles(sessionId);
 		});
@@ -1127,8 +1152,8 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	 * No-ops for provisional sessions (never materialized, so nothing on disk to
 	 * resume from) and for sessions with a turn in flight — tearing the pipeline
 	 * down mid-turn would abort live work. Shares the same in-memory teardown as
-	 * {@link disposeSession}; the destructive difference (deleting durable data)
-	 * lives in the orchestrator, which only invokes it on dispose.
+	 * {@link disposeSession}; the destructive difference (deleting the durable
+	 * SDK transcript) is layered on top only by {@link disposeSession}.
 	 */
 	releaseSession(session: URI): Promise<void> {
 		const sessionId = AgentSession.id(session);

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -1639,7 +1639,9 @@ suite('ClaudeAgent', () => {
 
 		// Phase 3: simulate cross-window resume by tearing the in-memory
 		// entry down and forcing the resume branch on the next send.
-		await agent.disposeSession(created.session);
+		// `releaseSession` (not `disposeSession`) is the non-destructive
+		// unload: `disposeSession` now also deletes the SDK transcript.
+		await agent.releaseSession(created.session);
 		sdk.sessionList = [{ sessionId, cwd: '/work-resume', summary: '', lastModified: Date.now() }];
 		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
 		await agent.chats.sendMessage(defaultChatUri(created.session), 'turn 2', undefined, 'turn-2');
@@ -1798,7 +1800,9 @@ suite('ClaudeAgent', () => {
 		await agent.chats.sendMessage(defaultChatUri(created.session), 'first', undefined, 'turn-1');
 
 		// Unload the session from memory; the transcript stays resumable.
-		await agent.disposeSession(created.session);
+		// `releaseSession` is the non-destructive unload — `disposeSession`
+		// now also deletes the SDK transcript.
+		await agent.releaseSession(created.session);
 		assert.strictEqual(agent.getSessionForTesting(created.session), undefined, 'unloaded');
 		sdk.sessionList = [{ sessionId, cwd: '/work', summary: '', lastModified: Date.now() }];
 
@@ -1919,8 +1923,11 @@ suite('ClaudeAgent', () => {
 
 		// Unload the session from memory; the transcript stays on disk. The
 		// remove-all path then has no live `existing` and must read the cwd
-		// from `getSessionInfo` before deleting + recreating.
-		await agent.disposeSession(created.session);
+		// from `getSessionInfo` before deleting + recreating. `releaseSession`
+		// (not `disposeSession`) is the non-destructive unload: `disposeSession`
+		// now also deletes the SDK transcript (this is the bug fix under test
+		// elsewhere), which would defeat this test's cold-path setup.
+		await agent.releaseSession(created.session);
 		assert.strictEqual(agent.getSessionForTesting(created.session), undefined, 'unloaded');
 		sdk.sessionList = [{ sessionId, cwd: '/work', summary: '', lastModified: Date.now() }];
 
@@ -3486,24 +3493,16 @@ suite('ClaudeAgent', () => {
 		await third;
 	});
 
-	test('disposeSession removes the wrapper but does NOT delete the SDK or DB session', async () => {
-		// Plan section 3.3.4 — `disposeSession` is wrapper teardown, NOT
-		// session deletion. The SDK session and the per-session DB
-		// outlive `disposeSession`; permanent deletion is a Phase 13
-		// concern (deletion command) and goes through a different code
-		// path. The user-visible consequence: closing a tab in the
-		// workbench drops the wrapper but the session reappears in the
-		// session list (and its history is still on disk) until
-		// explicitly deleted. This invariant prevents accidental
-		// regression in Phase 6+ where wrapper teardown will gain real
-		// cleanup work (Query.interrupt) — that work MUST NOT spill
-		// into SDK-side or DB-side deletion.
+	test('disposeSession on a still-provisional session does not attempt SDK deletion (nothing durable to delete)', async () => {
+		// A session that never sent a first message has no on-disk SDK
+		// transcript — `createSession` only registers the in-memory
+		// provisional wrapper. `disposeSession` must not call
+		// `deleteSession` in that case: there is nothing to delete, and the
+		// SDK remains the source of truth for any external session that
+		// happens to share the id.
 		const { agent, sdk } = createTestContext(disposables);
 		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
 		const created = await agent.createSession({ workingDirectory: URI.file('/work') });
-		// Make the SDK report the just-created session as if its
-		// metadata had been written by an earlier `query()` turn —
-		// that's the steady state once Phase 6 sendMessage lands.
 		sdk.sessionList = [{
 			sessionId: AgentSession.id(created.session),
 			summary: 'Hello world',
@@ -3514,14 +3513,70 @@ suite('ClaudeAgent', () => {
 		const result = await agent.listSessions();
 
 		assert.deepStrictEqual({
+			deleted: sdk.deleteSessionCalls,
 			ids: result.map(r => AgentSession.id(r.session)),
 			summary: result[0]?.summary,
-			sdkCalls: sdk.listSessionsCallCount,
 		}, {
+			deleted: [],
 			ids: [AgentSession.id(created.session)],
 			summary: 'Hello world',
-			sdkCalls: 1,
 		});
+	});
+
+	test('disposeSession deletes the SDK transcript for a materialized session, so it does not reappear in listSessions() (issue #325673)', async () => {
+		// Regression test: `listSessions` treats the SDK transcript as the
+		// source of truth (by design — external CLI sessions have no
+		// per-session DB), so a `disposeSession` that only tore down the
+		// in-memory wrapper left the transcript behind and the "deleted"
+		// session reappeared on the next list/refresh. `disposeSession` must
+		// also delete the underlying SDK session once it has been
+		// materialized.
+		const { agent, sdk } = createTestContext(disposables);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+		const created = await agent.createSession({ workingDirectory: URI.file('/work') });
+		const sessionId = AgentSession.id(created.session);
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'first', undefined, 'turn-1');
+
+		await agent.disposeSession(created.session);
+
+		// Simulate the SDK-side effect of `deleteSession` (the fake SDK
+		// doesn't auto-mutate `sessionList`) to assert the session is gone
+		// from the next `listSessions()`/refresh, matching the issue's
+		// "does the session reappear" acceptance criterion.
+		sdk.sessionList = sdk.sessionList.filter(entry => entry.sessionId !== sessionId);
+		const result = await agent.listSessions();
+
+		assert.deepStrictEqual({
+			deleted: sdk.deleteSessionCalls,
+			ids: result.map(r => AgentSession.id(r.session)),
+		}, {
+			deleted: [sessionId],
+			ids: [],
+		});
+	});
+
+	test('disposeSession awaits the live query teardown (subprocess exit) before deleting the SDK transcript', async () => {
+		// Mirrors `truncateSession()`'s equivalent race guard: a premature
+		// `deleteSession` while the subprocess is still alive would race the
+		// dying writer re-flushing `<id>.jsonl`.
+		const { agent, sdk } = createTestContext(disposables);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+		const created = await agent.createSession({ workingDirectory: URI.file('/work') });
+		const sessionId = AgentSession.id(created.session);
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'first', undefined, 'turn-1');
+
+		const exitGate = new DeferredPromise<void>();
+		sdk.queryReturnGate = exitGate.p;
+
+		const disposed = agent.disposeSession(created.session);
+		await timeout(0);
+		assert.deepStrictEqual(sdk.deleteSessionCalls, [], 'deleteSession ran before the subprocess exited');
+
+		exitGate.complete();
+		await disposed;
+		assert.deepStrictEqual(sdk.deleteSessionCalls, [sessionId]);
 	});
 
 	test('getSessionMessages returns an empty transcript for any session', async () => {


### PR DESCRIPTION
# Fix #325673: Delete Claude SDK transcripts when deleting agent sessions

## Summary

Deleting a Claude agent-host session removed the VS Code session but left the underlying SDK transcript on disk, causing the session to reappear after a refresh.

This PR updates `ClaudeAgent.disposeSession()` to delete the SDK session before tearing down the in-memory wrapper, matching the existing behavior used by `CopilotAgent` and the transcript deletion flow in `_removeAllTurns`.

## Testing

* Verified materialized SDK sessions are deleted and no longer reappear after refresh.
* Verified provisional sessions are skipped since no transcript exists.
* Added regression tests covering transcript deletion and teardown ordering.