### PR TITLE
Remove loaf count from chat perf regression metrics

### DIFF
--- a/.github/skills/chat-perf/SKILL.md
+++ b/.github/skills/chat-perf/SKILL.md
@@ -191,9 +191,10 @@ Only these metrics trigger a regression failure (when they exceed the threshold 
 - `timeToFirstToken`, `timeToComplete` — user-perceived latency
 - `layoutDurationMs` — total layout time from the trace (the *real* layout cost)
 - `forcedReflowCount` — forced synchronous layouts are always bad
-- `longTaskCount`, `longAnimationFrameCount` — main thread jank
+- `longTaskCount` — main thread jank
 
 These are reported but **informational only** (won't fail CI):
+- `longAnimationFrameCount` — number of long animation frames; noisy and compositor-driven, so tracked for signal but does not gate. Real jank is gated via `longTaskCount` / `layoutDurationMs`.
 - `layoutCount` — number of layout ops; inflated by CSS animations (compositor-driven, cheap). A build can do *more but cheaper* layouts, so gate on `layoutDurationMs`, not this count.
 - `recalcStyleCount` — number of style recalcs; inflated by CSS animations (compositor-driven, cheap)
 - `timeToRenderComplete` — includes typewriter animation tail

--- a/scripts/chat-simulation/config.jsonc
+++ b/scripts/chat-simulation/config.jsonc
@@ -19,8 +19,7 @@
 			"timeToComplete": 0.2,
 			"layoutDurationMs": 0.2,
 			"forcedReflowCount": 0.2,
-			"longTaskCount": 0.2,
-			"longAnimationFrameCount": 0.2
+			"longTaskCount": 0.2
 		}
 	},
 	"memLeaks": {

--- a/scripts/chat-simulation/merge-ci-summary.js
+++ b/scripts/chat-simulation/merge-ci-summary.js
@@ -270,10 +270,11 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 	];
 	// layoutCount / recalcStyleCount are informational (inflated by CSS
 	// animations, compositor-driven, cheap) and do NOT gate — real layout cost is
-	// gated via layoutDurationMs below / timeToComplete. See SKILL.md.
+	// gated via layoutDurationMs below / timeToComplete. longAnimationFrameCount
+	// is likewise informational only (noisy, compositor-driven). See SKILL.md.
 	const regressionMetricNames = new Set([
 		'timeToFirstToken', 'timeToComplete', 'layoutDurationMs',
-		'forcedReflowCount', 'longTaskCount', 'longAnimationFrameCount',
+		'forcedReflowCount', 'longTaskCount',
 	]);
 
 	const lines = [];

--- a/scripts/chat-simulation/test-chat-perf-regression.js
+++ b/scripts/chat-simulation/test-chat-perf-regression.js
@@ -1021,7 +1021,7 @@ function generateCISummary(jsonReport, baseline, opts) {
 		['extHostHeapDelta', 'extHost', 'MB'],
 		['extHostHeapDeltaPostGC', 'extHost', 'MB'],
 	];
-	const regressionMetricNames = new Set(['timeToFirstToken', 'timeToComplete', 'layoutDurationMs', 'forcedReflowCount', 'longTaskCount', 'longAnimationFrameCount']);
+	const regressionMetricNames = new Set(['timeToFirstToken', 'timeToComplete', 'layoutDurationMs', 'forcedReflowCount', 'longTaskCount']);
 
 	const lines = [];
 	const scenarios = Object.keys(jsonReport.scenarios);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
We already track duration, the count is just noise