### PR TITLE
Voice: show "Answered" instead of "Skipped" for externally-answered questions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2856,10 +2856,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// the carousel with the server's authoritative answers.
 		let latestProtocolAnswers: Record<string, ChatInputAnswer> | undefined = inputReq.answers;
 
-		// Track the last completion outcome seen via `ChatInputCompleted`. An
-		// `Accept` without structured answers means the input was answered
-		// outside the carousel UI (e.g. a voice/free-text response the model
-		// interpreted), which must render as "Answered" rather than "Skipped".
+		// An `Accept` without structured answers means the input was answered
+		// outside the carousel UI (e.g. via voice), so render "Answered" not "Skipped".
 		let latestResponseKind: ChatInputResponseKind | undefined;
 
 		// Capture protocol answers from `ChatInputCompleted` BEFORE the

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2856,6 +2856,12 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// the carousel with the server's authoritative answers.
 		let latestProtocolAnswers: Record<string, ChatInputAnswer> | undefined = inputReq.answers;
 
+		// Track the last completion outcome seen via `ChatInputCompleted`. An
+		// `Accept` without structured answers means the input was answered
+		// outside the carousel UI (e.g. a voice/free-text response the model
+		// interpreted), which must render as "Answered" rather than "Skipped".
+		let latestResponseKind: ChatInputResponseKind | undefined;
+
 		// Capture protocol answers from `ChatInputCompleted` BEFORE the
 		// reducer drops the request from state — by the time disposal runs,
 		// the action payload is no longer reachable. Also overwrite the
@@ -2868,11 +2874,13 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			if (action.type !== ActionType.ChatInputCompleted || action.requestId !== inputReq.id) {
 				return;
 			}
+			latestResponseKind = action.response;
 			latestProtocolAnswers = action.response === ChatInputResponseKind.Accept
 				? (action as ChatInputCompletedAction).answers ?? latestProtocolAnswers
 				: undefined;
 			const carouselAnswers = convertProtocolAnswers(latestProtocolAnswers);
 			carousel.data = carouselAnswers ?? {};
+			carousel.answeredExternally = latestResponseKind === ChatInputResponseKind.Accept && !carouselAnswers;
 			carousel.draftAnswers = undefined;
 			carousel.draftCurrentIndex = undefined;
 			carousel.draftCollapsed = undefined;
@@ -2922,6 +2930,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			const carouselAnswers = convertProtocolAnswers(latestProtocolAnswers);
 			carousel.data = carouselAnswers ?? {};
 			carousel.isUsed = true;
+			carousel.answeredExternally = latestResponseKind === ChatInputResponseKind.Accept && !carouselAnswers;
 			carousel.draftAnswers = undefined;
 			carousel.draftCurrentIndex = undefined;
 			carousel.draftCollapsed = undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -1567,16 +1567,24 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	}
 
 	/**
-	 * Renders a "Skipped" message when the carousel is dismissed without answers.
+	 * Renders a terminal-state message (Skipped/Answered) when the carousel is
+	 * dismissed without structured answers.
 	 */
 	private renderSkippedMessage(): void {
 		const skippedContainer = dom.$('.chat-question-carousel-summary');
-		const skippedMessage = dom.$('.chat-question-summary-skipped');
 		const isDismissedByTerminal = this.carousel instanceof ChatQuestionCarouselData && this.carousel.dismissedByTerminalInput;
-		skippedMessage.textContent = isDismissedByTerminal
-			? localize('chat.questionCarousel.deferredToTerminal', "Deferring to user's input in the terminal")
-			: localize('chat.questionCarousel.skipped', 'Skipped');
-		skippedContainer.appendChild(skippedMessage);
+		if (this.carousel.answeredExternally) {
+			// Accepted/answered outside the carousel UI (e.g. a voice/free-text response the model interpreted).
+			const answeredMessage = dom.$('.chat-question-summary-answered');
+			answeredMessage.textContent = localize('chat.questionCarousel.answered', 'Answered');
+			skippedContainer.appendChild(answeredMessage);
+		} else {
+			const skippedMessage = dom.$('.chat-question-summary-skipped');
+			skippedMessage.textContent = isDismissedByTerminal
+				? localize('chat.questionCarousel.deferredToTerminal', "Deferring to user's input in the terminal")
+				: localize('chat.questionCarousel.skipped', 'Skipped');
+			skippedContainer.appendChild(skippedMessage);
+		}
 		this.domNode.appendChild(skippedContainer);
 	}
 
@@ -1584,7 +1592,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	 * Renders a summary of answers when the carousel is already used.
 	 */
 	private renderSummary(): void {
-		// If no answers, show skipped message
+		// If no answers, show the terminal-state (Skipped/Answered) message
 		if (this._answers.size === 0) {
 			if (this.carousel.isUsed) {
 				this.renderSkippedMessage();

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -539,10 +539,10 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		// Dispose interactive UI and clear DOM
 		this.clearInteractiveResources();
 
-		// Hide UI and show skipped message
+		// Hide UI and show terminal-state (Skipped/Answered) message
 		this.domNode.classList.add('chat-question-carousel-used');
 		dom.clearNode(this.domNode);
-		this.renderSkippedMessage();
+		this.renderTerminalStateMessage();
 		this._onDidChangeHeight.fire();
 		return true;
 	}
@@ -1570,22 +1570,21 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	 * Renders a terminal-state message (Skipped/Answered) when the carousel is
 	 * dismissed without structured answers.
 	 */
-	private renderSkippedMessage(): void {
-		const skippedContainer = dom.$('.chat-question-carousel-summary');
+	private renderTerminalStateMessage(): void {
+		const summaryContainer = dom.$('.chat-question-carousel-summary');
 		const isDismissedByTerminal = this.carousel instanceof ChatQuestionCarouselData && this.carousel.dismissedByTerminalInput;
 		if (this.carousel.answeredExternally) {
-			// Accepted/answered outside the carousel UI (e.g. a voice/free-text response the model interpreted).
 			const answeredMessage = dom.$('.chat-question-summary-answered');
 			answeredMessage.textContent = localize('chat.questionCarousel.answered', 'Answered');
-			skippedContainer.appendChild(answeredMessage);
+			summaryContainer.appendChild(answeredMessage);
 		} else {
 			const skippedMessage = dom.$('.chat-question-summary-skipped');
 			skippedMessage.textContent = isDismissedByTerminal
 				? localize('chat.questionCarousel.deferredToTerminal', "Deferring to user's input in the terminal")
 				: localize('chat.questionCarousel.skipped', 'Skipped');
-			skippedContainer.appendChild(skippedMessage);
+			summaryContainer.appendChild(skippedMessage);
 		}
-		this.domNode.appendChild(skippedContainer);
+		this.domNode.appendChild(summaryContainer);
 	}
 
 	/**
@@ -1595,7 +1594,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		// If no answers, show the terminal-state (Skipped/Answered) message
 		if (this._answers.size === 0) {
 			if (this.carousel.isUsed) {
-				this.renderSkippedMessage();
+				this.renderTerminalStateMessage();
 			}
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -548,12 +548,7 @@
 		overflow-wrap: break-word;
 	}
 
-	.chat-question-summary-skipped {
-		color: var(--vscode-descriptionForeground);
-		font-style: italic;
-		font-size: var(--vscode-chat-font-size-body-s);
-	}
-
+	.chat-question-summary-skipped,
 	.chat-question-summary-answered {
 		color: var(--vscode-descriptionForeground);
 		font-style: italic;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -553,4 +553,10 @@
 		font-style: italic;
 		font-size: var(--vscode-chat-font-size-body-s);
 	}
+
+	.chat-question-summary-answered {
+		color: var(--vscode-descriptionForeground);
+		font-style: italic;
+		font-size: var(--vscode-chat-font-size-body-s);
+	}
 }

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -483,6 +483,8 @@ export interface IChatQuestionCarousel {
 	data?: IChatQuestionAnswers;
 	/** Whether the carousel has been submitted/skipped */
 	isUsed?: boolean;
+	/** True when the input was accepted/answered outside the carousel UI (e.g. a voice or free-text response the model interpreted) without structured answers. */
+	answeredExternally?: boolean;
 	/** Top-level message shown above the questions (e.g. from MCP elicitation message) */
 	message?: string | IMarkdownString;
 	/** Source attribution (e.g. MCP server) */

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -483,7 +483,7 @@ export interface IChatQuestionCarousel {
 	data?: IChatQuestionAnswers;
 	/** Whether the carousel has been submitted/skipped */
 	isUsed?: boolean;
-	/** True when the input was accepted/answered outside the carousel UI (e.g. a voice or free-text response the model interpreted) without structured answers. */
+	/** True when accepted/answered outside the carousel UI (e.g. via voice) without structured answers. */
 	answeredExternally?: boolean;
 	/** Top-level message shown above the questions (e.g. from MCP elicitation message) */
 	message?: string | IMarkdownString;

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatQuestionCarouselData.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatQuestionCarouselData.ts
@@ -26,6 +26,13 @@ export class ChatQuestionCarouselData implements IChatQuestionCarousel {
 	public dismissedByTerminalInput?: boolean;
 
 	/**
+	 * True when the input was accepted/answered outside the carousel UI (e.g.
+	 * a voice or free-text response the model interpreted) without structured
+	 * answers, so the summary should read "Answered" rather than "Skipped".
+	 */
+	public answeredExternally?: boolean;
+
+	/**
 	 * Marks the carousel as dismissed with the given answers and clears draft
 	 * state. Safe to call multiple times — subsequent calls are no-ops.
 	 */
@@ -60,6 +67,7 @@ export class ChatQuestionCarouselData implements IChatQuestionCarousel {
 			resolveId: this.resolveId,
 			data: this.data,
 			isUsed: this.isUsed,
+			answeredExternally: this.answeredExternally,
 			message: this.message,
 			source: this.source,
 			terminalId: this.terminalId,

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatQuestionCarouselData.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatQuestionCarouselData.ts
@@ -27,8 +27,7 @@ export class ChatQuestionCarouselData implements IChatQuestionCarousel {
 
 	/**
 	 * True when the input was accepted/answered outside the carousel UI (e.g.
-	 * a voice or free-text response the model interpreted) without structured
-	 * answers, so the summary should read "Answered" rather than "Skipped".
+	 * via voice) without structured answers, so the summary reads "Answered".
 	 */
 	public answeredExternally?: boolean;
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -3639,12 +3639,56 @@ suite('AgentHostChatContribution', () => {
 
 			assert.strictEqual(carousel.isUsed, true);
 			assert.deepStrictEqual(carousel.data, {});
+			assert.ok(!carousel.answeredExternally, 'cancelled input should not be marked answered');
 			assert.ok(carousel instanceof ChatQuestionCarouselData, 'AgentHost input request should use runtime carousel data');
 			assert.strictEqual((await carousel.completion.p).answers, undefined);
 			assert.deepStrictEqual(chatWidgetService.clearQuestionCarouselCalls.map(call => ({ responseId: call.responseId, resolveId: call.resolveId })), [
 				{ responseId: undefined, resolveId: 'input-1' },
 			]);
 			assert.strictEqual(agentHostService.dispatchedActions.some(dispatched => dispatched.action.type === ActionType.ChatInputCompleted), false);
+
+			fire({ type: ActionType.ChatTurnComplete, turnId } as ChatAction);
+			await turnPromise;
+		}));
+
+		test('input request accepted without answers is marked answered, not skipped', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService, chatAgentService, chatWidgetService } = createContribution(disposables);
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/new-answered-externally-input-request-test' });
+			chatWidgetService.setWidgetForSession(sessionResource);
+
+			const { turnPromise, collected, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, { sessionResource });
+
+			fire({
+				type: ActionType.ChatInputRequested,
+				request: {
+					id: 'input-1',
+					message: 'What is your favorite color?',
+					questions: [{
+						kind: ChatInputQuestionKind.Text,
+						id: 'question-1',
+						message: 'What is your favorite color?',
+						required: true,
+					}],
+				},
+			} as ChatAction);
+			await timeout(10);
+
+			const carousel = collected.flat().find(part => part.kind === 'questionCarousel');
+			assert.ok(carousel, 'input request should render a question carousel');
+
+			agentHostService.dispatchedActions.length = 0;
+			// User answered via voice: server accepts the request with no structured answers.
+			fire({
+				type: ActionType.ChatInputCompleted,
+				requestId: 'input-1',
+				response: ChatInputResponseKind.Accept,
+			} as ChatAction);
+			await timeout(10);
+
+			assert.strictEqual(carousel.isUsed, true);
+			assert.deepStrictEqual(carousel.data, {});
+			assert.strictEqual(carousel.answeredExternally, true, 'accepted input without answers should be marked answered');
+			assert.ok(carousel instanceof ChatQuestionCarouselData, 'AgentHost input request should use runtime carousel data');
 
 			fire({ type: ActionType.ChatTurnComplete, turnId } as ChatAction);
 			await turnPromise;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
@@ -898,6 +898,25 @@ suite('ChatQuestionCarouselPart', () => {
 			const skippedMessage = summary?.querySelector('.chat-question-summary-skipped');
 			assert.ok(skippedMessage, 'Should show skipped message when no data');
 		});
+
+		test('shows answered message when answeredExternally but no data', () => {
+			const carousel: IChatQuestionCarousel = {
+				kind: 'questionCarousel',
+				questions: [
+					{ id: 'q1', type: 'text', title: 'Question 1' }
+				],
+				allowSkip: true,
+				isUsed: true,
+				answeredExternally: true
+			};
+			createWidget(carousel);
+
+			assert.ok(widget.domNode.classList.contains('chat-question-carousel-used'), 'Should have used class');
+			const summary = widget.domNode.querySelector('.chat-question-carousel-summary');
+			assert.ok(summary, 'Should show summary container');
+			assert.ok(!summary?.querySelector('.chat-question-summary-skipped'), 'Should not show skipped message');
+			assert.ok(summary?.querySelector('.chat-question-summary-answered'), 'Should show answered message when answered externally');
+		});
 	});
 
 	suite('Description and Message', () => {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatQuestionCarouselData.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatQuestionCarouselData.test.ts
@@ -66,6 +66,15 @@ suite('ChatQuestionCarouselData', () => {
 		assert.strictEqual((json as { draftCurrentIndex?: unknown }).draftCurrentIndex, undefined, 'toJSON should not include draftCurrentIndex');
 	});
 
+	test('toJSON preserves answeredExternally', () => {
+		const carousel = new ChatQuestionCarouselData(createQuestions(), true, 'test-resolve-id', {}, true);
+		carousel.answeredExternally = true;
+
+		const json = carousel.toJSON();
+
+		assert.strictEqual(json.answeredExternally, true, 'toJSON should preserve answeredExternally');
+	});
+
 	test('multiple carousels can have independent completion promises', async () => {
 		const carousel1 = new ChatQuestionCarouselData(createQuestions(), true, 'resolve-1');
 		const carousel2 = new ChatQuestionCarouselData(createQuestions(), true, 'resolve-2');


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8157

### Problem
When a question the agent asks is answered outside the carousel UI — e.g. by a **voice** or free-text response the model interprets — the agent host completes the input request with `Accept` but **no structured answers**. The carousel summary then rendered **"Skipped"**, even though the user actually did respond.

### Fix
- Track the completion outcome (`ChatInputResponseKind`) in `agentHostSessionHandler`, and mark the carousel `answeredExternally` when it is **accepted without structured answers** (both the live `ChatInputCompleted` echo and the disposal settle path).
- Add `answeredExternally` to `IChatQuestionCarousel` / `ChatQuestionCarouselData` (serialized via `toJSON` so it survives reload).
- Render **"Answered"** instead of **"Skipped"** in the carousel summary when `answeredExternally` is set.

Genuinely skipped/cancelled/abandoned questions (no `Accept`) still render "Skipped".

### Tests
- `shows answered message when answeredExternally but no data`
- `toJSON preserves answeredExternally`

All 71 carousel tests pass.