### PR TITLE
Fix: Preserve MCP server list selection/focus when list refreshes

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -154,6 +154,8 @@ export class ListMcpServerCommand extends Action2 {
 		store.add(autorun(reader => {
 			const servers = groupBy(mcpService.servers.read(reader).slice().sort((a, b) => a.collection.order - b.collection.order), s => s.collection.id);
 			const firstRun = pick.items.length === 0;
+			const previousActiveId = pick.activeItems[0]?.id;
+
 			pick.items = [
 				{ id: '$add', label: localize('mcp.addServer', 'Add Server'), description: localize('mcp.addServer.description', 'Add a new server configuration'), alwaysShow: true, iconClass: ThemeIcon.asClassName(Codicon.add) },
 				...Object.values(servers).filter(s => s!.length).flatMap((servers): (ItemType | IQuickPickSeparator)[] => [
@@ -170,6 +172,15 @@ export class ListMcpServerCommand extends Action2 {
 					}),
 				]),
 			];
+
+			// Preserve the previously selected item if it still exists, otherwise select the first server on first run
+			if (previousActiveId && previousActiveId !== '$add') {
+				const previousItem = pick.items.find((item): item is ItemType => !('type' in item) && item.id === previousActiveId);
+				if (previousItem) {
+					pick.activeItems = [previousItem];
+					return;
+				}
+			}
 
 			if (firstRun && pick.items.length > 3) {
 				pick.activeItems = pick.items.slice(2, 3) as ItemType[]; // select the first server by default
@@ -212,6 +223,7 @@ export class ListMcpServerCommand extends Action2 {
 
 		const refresh = () => {
 			const firstRun = pick.items.length === 0;
+			const previousActiveId = pick.activeItems[0]?.id;
 			const servers = agentHostCustomizations.getMcpServers(agentHostSession);
 
 			pick.items = [
@@ -237,6 +249,15 @@ export class ListMcpServerCommand extends Action2 {
 					alwaysShow: true,
 				} satisfies ItemType,
 			];
+
+			// Preserve the previously selected item if it still exists, otherwise select the first server on first run
+			if (previousActiveId && previousActiveId !== BACK_ID && previousActiveId !== '$empty') {
+				const previousItem = pick.items.find((item): item is ItemType => !('type' in item) && item.id === previousActiveId);
+				if (previousItem) {
+					pick.activeItems = [previousItem];
+					return;
+				}
+			}
 
 			if (firstRun && servers.length > 0) {
 				pick.activeItems = [pick.items[0] as ItemType];

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -174,7 +174,7 @@ export class ListMcpServerCommand extends Action2 {
 			];
 
 			// Preserve the previously selected item if it still exists, otherwise select the first server on first run
-			if (previousActiveId && previousActiveId !== '$add') {
+			if (previousActiveId) {
 				const previousItem = pick.items.find((item): item is ItemType => !('type' in item) && item.id === previousActiveId);
 				if (previousItem) {
 					pick.activeItems = [previousItem];
@@ -251,7 +251,7 @@ export class ListMcpServerCommand extends Action2 {
 			];
 
 			// Preserve the previously selected item if it still exists, otherwise select the first server on first run
-			if (previousActiveId && previousActiveId !== BACK_ID && previousActiveId !== '$empty') {
+			if (previousActiveId) {
 				const previousItem = pick.items.find((item): item is ItemType => !('type' in item) && item.id === previousActiveId);
 				if (previousItem) {
 					pick.activeItems = [previousItem];


### PR DESCRIPTION
When the MCP server picker list refreshes (e.g., servers are added/removed), the selection state was being lost and jumping back to the first entry. This was particularly noticeable when using arrow keys to navigate the list while the servers were being updated.

This fix preserves the currently selected item ID before updating the items list. When the list is updated, if the previously selected item still exists, it is restored as the active selection. This ensures smooth navigation and maintains user intent even when the underlying data changes.

Fixes #325588