### PR TITLE
Preserve model attribution for cached inline edits

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
@@ -6,6 +6,7 @@
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { DocumentId } from '../../../platform/inlineEdits/common/dataTypes/documentId';
 import { IObservableDocument, ObservableWorkspace } from '../../../platform/inlineEdits/common/observableWorkspace';
+import type { IStatelessNextEditModelTelemetry } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { autorunWithChanges } from '../../../platform/inlineEdits/common/utils/observable';
 import { ILogger, ILogService } from '../../../platform/log/common/logService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
@@ -16,11 +17,13 @@ import { AnnotatedStringReplacement, StringEdit, StringReplacement } from '../..
 import { OffsetRange } from '../../../util/vs/editor/common/core/ranges/offsetRange';
 import { StringText } from '../../../util/vs/editor/common/core/text/abstractText';
 import { checkEditConsistency, EditDataWithIndex, NesRebaseConfigs, tryRebase } from '../common/editRebase';
-import { NextEditFetchRequest } from './nextEditProvider';
+import type { NextEditFetchRequest } from './nextEditProvider';
 import { RebaseFailureInfo, type RebaseResult } from './rebaseResult';
 
 export interface CachedEditOpts {
 	isFromCursorJump: boolean;
+	/** Model attribution for the request that produced this edit. */
+	modelTelemetry: IStatelessNextEditModelTelemetry;
 	/**
 	 * For cursor jump edits, this is the edit window around the original cursor position
 	 * (before the jump), allowing the edit to be served from cache when the cursor is
@@ -108,6 +111,8 @@ export interface CachedEdit {
 	 * edits, addressed by `rebasedEditIndex`, can be attributed to the right patch.
 	 */
 	patchIndices?: readonly (number | undefined)[];
+	/** Model attribution for the request that produced this edit. */
+	modelTelemetry: IStatelessNextEditModelTelemetry;
 	source: NextEditFetchRequest;
 	cacheTime: number;
 	/**
@@ -185,12 +190,12 @@ export class NextEditCache extends Disposable {
 		return docCache.setKthNextEdit(documentContents, editWindow, nextEdit, nextEdits, userEditSince, subsequentN, source, opts);
 	}
 
-	public setNoNextEdit(docId: DocumentId, documentContents: StringText, editWindow: OffsetRange | undefined, source: NextEditFetchRequest) {
+	public setNoNextEdit(docId: DocumentId, documentContents: StringText, editWindow: OffsetRange | undefined, source: NextEditFetchRequest, modelTelemetry: IStatelessNextEditModelTelemetry) {
 		const docCache = this._documentCaches.get(docId);
 		if (!docCache) {
 			return;
 		}
-		docCache.setNoNextEdit(documentContents, editWindow, source);
+		docCache.setNoNextEdit(documentContents, editWindow, source, modelTelemetry);
 	}
 
 	private _getNesRebaseConfigs(): NesRebaseConfigs {
@@ -288,7 +293,7 @@ class DocumentEditCache {
 
 	public setKthNextEdit(documentContents: StringText, editWindow: OffsetRange | undefined, nextEdit: StringReplacement, nextEdits: StringReplacement[] | undefined, userEditSince: StringEdit | undefined, subsequentN: number, source: NextEditFetchRequest, opts: CachedEditOpts): CachedEdit {
 		const key = this._getKey(documentContents.value);
-		const cachedEdit: CachedEdit = { docId: this.docId, targetDocId: opts.targetDocId, targetDocumentBeforeEdit: opts.targetDocumentBeforeEdit, edit: nextEdit, edits: nextEdits, detailedEdits: [], userEditSince, subsequentN, patchIndex: opts.patchIndex, patchIndices: opts.patchIndices, source, documentBeforeEdit: documentContents, editWindow, originalEditWindow: opts.originalEditWindow, cacheTime: Date.now(), isFromCursorJump: opts.isFromCursorJump, cursorOffsetAtCacheTime: opts.cursorOffset };
+		const cachedEdit: CachedEdit = { docId: this.docId, targetDocId: opts.targetDocId, targetDocumentBeforeEdit: opts.targetDocumentBeforeEdit, edit: nextEdit, edits: nextEdits, detailedEdits: [], userEditSince, subsequentN, patchIndex: opts.patchIndex, patchIndices: opts.patchIndices, modelTelemetry: opts.modelTelemetry, source, documentBeforeEdit: documentContents, editWindow, originalEditWindow: opts.originalEditWindow, cacheTime: Date.now(), isFromCursorJump: opts.isFromCursorJump, cursorOffsetAtCacheTime: opts.cursorOffset };
 		if (userEditSince) {
 			if (!checkEditConsistency(cachedEdit.documentBeforeEdit.value, userEditSince, this._doc.value.get().value, this._logger.createSubLogger('setKthNextEdit'))) {
 				cachedEdit.userEditSince = undefined;
@@ -307,9 +312,9 @@ class DocumentEditCache {
 		return cachedEdit;
 	}
 
-	public setNoNextEdit(documentContents: StringText, editWindow: OffsetRange | undefined, source: NextEditFetchRequest) {
+	public setNoNextEdit(documentContents: StringText, editWindow: OffsetRange | undefined, source: NextEditFetchRequest, modelTelemetry: IStatelessNextEditModelTelemetry) {
 		const key = this._getKey(documentContents.value);
-		const cachedEdit: CachedEdit = { docId: this.docId, edit: undefined, edits: [], detailedEdits: [], source, documentBeforeEdit: documentContents, editWindow, cacheTime: Date.now(), isFromCursorJump: false };
+		const cachedEdit: CachedEdit = { docId: this.docId, edit: undefined, edits: [], detailedEdits: [], modelTelemetry, source, documentBeforeEdit: documentContents, editWindow, cacheTime: Date.now(), isFromCursorJump: false };
 		const existing = this._sharedCache.get(key);
 		if (existing) {
 			this.evictedCachedEdit(existing);

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -12,7 +12,7 @@ import { RootedLineEdit } from '../../../platform/inlineEdits/common/dataTypes/r
 import { SpeculativeRequestsAutoExpandEditWindowLines, SpeculativeRequestsCursorPlacement, SpeculativeRequestsEnablement } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { InlineEditRequestLogContext, type MarkdownLoggable } from '../../../platform/inlineEdits/common/inlineEditLogContext';
 import { IObservableDocument, ObservableWorkspace } from '../../../platform/inlineEdits/common/observableWorkspace';
-import { IStatelessNextEditProvider, IStatelessNextEditTelemetry, NoNextEditReason, StatelessNextEditDocument, StatelessNextEditRequest, StatelessNextEditResult, StreamedEdit } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
+import { IStatelessNextEditModelTelemetry, IStatelessNextEditProvider, IStatelessNextEditTelemetry, NoNextEditReason, StatelessNextEditDocument, StatelessNextEditRequest, StatelessNextEditResult, StreamedEdit } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { autorunWithChanges } from '../../../platform/inlineEdits/common/utils/observable';
 import { DocumentHistory, HistoryContext, IHistoryContextProvider } from '../../../platform/inlineEdits/common/workspaceEditTracker/historyContextProvider';
 import { IXtabHistoryEditEntry, IXtabHistoryEntry, NesXtabHistoryTracker } from '../../../platform/inlineEdits/common/workspaceEditTracker/nesXtabHistoryTracker';
@@ -92,6 +92,13 @@ function convertLineEditToEdit(nextLineEdit: LineEdit, document: StringText): St
 	return suggestedEdit;
 }
 
+function getModelTelemetry(telemetry: IStatelessNextEditTelemetry): IStatelessNextEditModelTelemetry {
+	return {
+		modelName: telemetry.modelName,
+		modelConfig: telemetry.modelConfig,
+	};
+}
+
 interface DocState {
 	readonly baseDocState: StringText;
 	docContents: StringText;
@@ -115,6 +122,7 @@ interface RebaseAndCacheStreamedEditArgs {
 	};
 	/** User edits to track the first cached entry against for rebasing; `undefined` for speculative. */
 	readonly userEditSince: StringEdit | undefined;
+	readonly modelTelemetry: IStatelessNextEditModelTelemetry;
 	readonly source: NextEditFetchRequest;
 	readonly logger: ILogger;
 }
@@ -427,6 +435,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			}
 			telemetryBuilder.setHeaderRequestId(req.headerRequestId);
 			telemetryBuilder.setIsFromCache();
+			telemetryBuilder.setCachedModelTelemetry(cachedEdit.modelTelemetry);
 			telemetryBuilder.setSubsequentEditOrder(cachedEdit.rebasedEditIndex ?? cachedEdit.subsequentN);
 			// Attribute the served edit to its originating model patch.
 			telemetryBuilder.setSourcePatchIndex(getSourcePatchIndex(cachedEdit));
@@ -562,6 +571,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		nextEdit: StringReplacement,
 		streamedEdit: { readonly isFromCursorJump: boolean; readonly originalWindow?: OffsetRange; readonly patchIndex?: number },
 		source: NextEditFetchRequest,
+		modelTelemetry: IStatelessNextEditModelTelemetry,
 	): boolean {
 		if (ithEdit !== 0 || targetDocId === activeDocId) {
 			return false; // only the first streamed edit, and only when it targets a different document
@@ -575,7 +585,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			undefined, // no bundled edits: served by exact content match only
 			undefined, // no userEditSince: never tracked/rebased (edit is in target-doc coords)
 			source,
-			{ isFromCursorJump: streamedEdit.isFromCursorJump, originalEditWindow: streamedEdit.originalWindow, patchIndex: streamedEdit.patchIndex, targetDocId, targetDocumentBeforeEdit: targetDocContents }
+			{ isFromCursorJump: streamedEdit.isFromCursorJump, modelTelemetry, originalEditWindow: streamedEdit.originalWindow, patchIndex: streamedEdit.patchIndex, targetDocId, targetDocumentBeforeEdit: targetDocContents }
 		);
 		return true;
 	}
@@ -761,7 +771,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 	 * `firstEdit`, stream-end handling) stays with the callers.
 	 */
 	private _rebaseAndCacheStreamedEdit(args: RebaseAndCacheStreamedEditArgs): { lineEdit: LineEdit; rebasedEdit: StringEdit; docContentsBeforeEdit: StringText; cachedEdit: CachedOrRebasedEdit | undefined; crossFileCached: boolean } | undefined {
-		const { statePerDoc, streamedEdit, ithEdit, activeDoc, userEditSince, source, logger } = args;
+		const { statePerDoc, streamedEdit, ithEdit, activeDoc, userEditSince, modelTelemetry, source, logger } = args;
 
 		const targetDocState = statePerDoc.get(streamedEdit.targetDocument);
 
@@ -796,9 +806,9 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 				ithEdit === 0 ? targetDocState.nextEdits : undefined,
 				ithEdit === 0 ? userEditSince : undefined,
 				source,
-				{ isFromCursorJump: streamedEdit.isFromCursorJump, originalEditWindow: streamedEdit.originalWindow, cursorOffset: targetDocState.docId === activeDoc.id ? activeDoc.cursorOffset : undefined, patchIndex: streamedEdit.patchIndex, patchIndices: ithEdit === 0 ? targetDocState.patchIndices : undefined }
+				{ isFromCursorJump: streamedEdit.isFromCursorJump, modelTelemetry, originalEditWindow: streamedEdit.originalWindow, cursorOffset: targetDocState.docId === activeDoc.id ? activeDoc.cursorOffset : undefined, patchIndex: streamedEdit.patchIndex, patchIndices: ithEdit === 0 ? targetDocState.patchIndices : undefined }
 			);
-			crossFileCached = this._maybeCacheCrossFileEditUnderActiveDoc(ithEdit, activeDoc.id, activeDoc.contents, streamedEdit.window, targetDocState.docId, docContentsBeforeEdit, nextEditReplacement, streamedEdit, source);
+			crossFileCached = this._maybeCacheCrossFileEditUnderActiveDoc(ithEdit, activeDoc.id, activeDoc.contents, streamedEdit.window, targetDocState.docId, docContentsBeforeEdit, nextEditReplacement, streamedEdit, source, modelTelemetry);
 			logger.trace(`populated cache for ${ithEdit}`);
 		}
 
@@ -938,6 +948,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 				ithEdit,
 				activeDoc: { id: curDocId, contents: nextEditRequest.documentBeforeEdits, cursorOffset: activeDocSelection?.start },
 				userEditSince: nextEditRequest.intermediateUserEdit,
+				modelTelemetry: getModelTelemetry(telemetry),
 				source: req,
 				logger: myLogger,
 			});
@@ -981,7 +992,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 				if (completionReason instanceof NoNextEditReason.NoSuggestions && !didCacheCrossFileActiveDocEntry) {
 					const { documentBeforeEdits, window } = completionReason;
 					const reducedWindow = window ? computeReducedWindow(window, activeDocSelection, documentBeforeEdits) : undefined;
-					this._nextEditCache.setNoNextEdit(curDocId, documentBeforeEdits, reducedWindow, req);
+					this._nextEditCache.setNoNextEdit(curDocId, documentBeforeEdits, reducedWindow, req, getModelTelemetry(lastTelemetry));
 				}
 			}
 
@@ -1476,6 +1487,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 							ithEdit,
 							activeDoc: { id: curDocId, contents: nextEditRequest.documentBeforeEdits, cursorOffset },
 							userEditSince: undefined,
+							modelTelemetry: getModelTelemetry(res.value.telemetryBuilder),
 							source: req,
 							logger,
 						});

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
@@ -8,7 +8,7 @@ import { IGitExtensionService } from '../../../platform/git/common/gitExtensionS
 import { getUpstreamRemote } from '../../../platform/git/common/utils';
 import { DebugRecorderBookmark } from '../../../platform/inlineEdits/common/debugRecorderBookmark';
 import { IObservableDocument, ObservableWorkspace } from '../../../platform/inlineEdits/common/observableWorkspace';
-import { IStatelessNextEditTelemetry, StatelessNextEditRequest } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
+import { IStatelessNextEditModelTelemetry, IStatelessNextEditTelemetry, StatelessNextEditRequest } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { autorunWithChanges } from '../../../platform/inlineEdits/common/utils/observable';
 import { APIUsage } from '../../../platform/networking/common/openai';
 import { INotebookService } from '../../../platform/notebook/common/notebookService';
@@ -266,6 +266,8 @@ export class LlmNESTelemetryBuilder extends Disposable {
 			alternativeAction,
 
 			...this._statelessNextEditTelemetry,
+			modelName: this._statelessNextEditTelemetry?.modelName ?? this._cachedModelTelemetry?.modelName,
+			modelConfig: this._statelessNextEditTelemetry?.modelConfig ?? this._cachedModelTelemetry?.modelConfig,
 
 			activeDocumentRepository,
 			repositoryUrls,
@@ -346,6 +348,12 @@ export class LlmNESTelemetryBuilder extends Disposable {
 	private _isFromCache: boolean = false;
 	public setIsFromCache(): this {
 		this._isFromCache = true;
+		return this;
+	}
+
+	private _cachedModelTelemetry: IStatelessNextEditModelTelemetry | undefined;
+	public setCachedModelTelemetry(modelTelemetry: IStatelessNextEditModelTelemetry): this {
+		this._cachedModelTelemetry = modelTelemetry;
 		return this;
 	}
 

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheCursorDistance.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheCursorDistance.spec.ts
@@ -9,6 +9,7 @@ import { InMemoryConfigurationService } from '../../../../platform/configuration
 import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
 import { InlineEditRequestLogContext } from '../../../../platform/inlineEdits/common/inlineEditLogContext';
 import { MutableObservableWorkspace } from '../../../../platform/inlineEdits/common/observableWorkspace';
+import type { IStatelessNextEditModelTelemetry } from '../../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { LogServiceImpl } from '../../../../platform/log/common/logService';
 import { NullExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { URI } from '../../../../util/vs/base/common/uri';
@@ -19,6 +20,11 @@ import { OffsetRange } from '../../../../util/vs/editor/common/core/ranges/offse
 import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
 import { NextEditCache } from '../../node/nextEditCache';
 import { NextEditFetchRequest } from '../../node/nextEditProvider';
+
+const testModelTelemetry: IStatelessNextEditModelTelemetry = {
+	modelName: undefined,
+	modelConfig: undefined,
+};
 
 describe('NextEditCache cursor distance check', () => {
 
@@ -79,7 +85,7 @@ describe('NextEditCache cursor distance check', () => {
 			undefined, // nextEdits
 			undefined, // userEditSince
 			makeSource(),
-			{ isFromCursorJump: false, cursorOffset: lineStartOffset(cursorLine) },
+			{ isFromCursorJump: false, modelTelemetry: testModelTelemetry, cursorOffset: lineStartOffset(cursorLine) },
 		);
 	}
 
@@ -149,7 +155,7 @@ describe('NextEditCache cursor distance check', () => {
 				undefined,
 				undefined,
 				makeSource(),
-				{ isFromCursorJump: false, cursorOffset: lineStartOffset(5) },
+				{ isFromCursorJump: false, modelTelemetry: testModelTelemetry, cursorOffset: lineStartOffset(5) },
 			);
 
 			// Move cursor to line 1 (farther) — should still serve because it's subsequent
@@ -168,7 +174,7 @@ describe('NextEditCache cursor distance check', () => {
 				undefined,
 				undefined,
 				makeSource(),
-				{ isFromCursorJump: false }, // no cursorOffset
+				{ isFromCursorJump: false, modelTelemetry: testModelTelemetry }, // no cursorOffset
 			);
 
 			// Move cursor to line 1 (farther) — should still serve because no cursor offset recorded

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
@@ -9,6 +9,7 @@ import { InMemoryConfigurationService } from '../../../../platform/configuration
 import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
 import { InlineEditRequestLogContext } from '../../../../platform/inlineEdits/common/inlineEditLogContext';
 import { MutableObservableWorkspace } from '../../../../platform/inlineEdits/common/observableWorkspace';
+import type { IStatelessNextEditModelTelemetry } from '../../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { LogServiceImpl } from '../../../../platform/log/common/logService';
 import { NullExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { URI } from '../../../../util/vs/base/common/uri';
@@ -18,6 +19,11 @@ import { OffsetRange } from '../../../../util/vs/editor/common/core/ranges/offse
 import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
 import { NextEditCache } from '../../node/nextEditCache';
 import { NextEditFetchRequest } from '../../node/nextEditProvider';
+
+const testModelTelemetry: IStatelessNextEditModelTelemetry = {
+	modelName: 'test-patch-model',
+	modelConfig: JSON.stringify({ promptingStrategy: 'patchBased02' }),
+};
 
 /**
  * Regression test from a real scenario:
@@ -159,7 +165,7 @@ describe('NextEditCache rebase — Fibonacci scenario', () => {
 			],
 			StringEdit.single(new StringReplacement(new OffsetRange(classStart, classEndAtRequest18), 'class Fibonacci {\n\t')),
 			makeSource(),
-			{ isFromCursorJump: false, cursorOffset: classEndAtRequest18 },
+			{ isFromCursorJump: false, modelTelemetry: testModelTelemetry, cursorOffset: classEndAtRequest18 },
 		);
 
 		assert(cachedEdit !== undefined, 'setKthNextEdit should return the cached edit');
@@ -173,5 +179,6 @@ describe('NextEditCache rebase — Fibonacci scenario', () => {
 
 		assert(rebaseResult.edit !== undefined, 'should rebase successfully');
 		assert(rebaseResult.edit.rebasedEdit !== undefined, 'should have a rebased edit for the class body');
+		assert.strictEqual(rebaseResult.edit.modelTelemetry, testModelTelemetry, 'should preserve model attribution on the rebased edit');
 	});
 });

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderCaching.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderCaching.spec.ts
@@ -35,7 +35,10 @@ import { StringEdit } from '../../../../util/vs/editor/common/core/edits/stringE
 import { LineRange } from '../../../../util/vs/editor/common/core/ranges/lineRange';
 import { OffsetRange } from '../../../../util/vs/editor/common/core/ranges/offsetRange';
 import { NESInlineCompletionContext, NextEditProvider } from '../../node/nextEditProvider';
-import { NextEditProviderTelemetryBuilder } from '../../node/nextEditProviderTelemetry';
+import { ILlmNESTelemetry, NextEditProviderTelemetryBuilder } from '../../node/nextEditProviderTelemetry';
+
+const testModelName = 'test-patch-model';
+const testModelConfig = JSON.stringify({ promptingStrategy: 'patchBased02' });
 
 describe('NextEditProvider Caching', () => {
 
@@ -64,7 +67,9 @@ describe('NextEditProvider Caching', () => {
 		return {
 			ID: 'TestNextEditProvider',
 			provideNextEdit: async function*(request: StatelessNextEditRequest, logger: ILogger, logContext: InlineEditRequestLogContext, cancellationToken: CancellationToken) {
-				const telemetryBuilder = new StatelessNextEditTelemetryBuilder(request.headerRequestId);
+				const telemetryBuilder = new StatelessNextEditTelemetryBuilder(request.headerRequestId)
+					.setModelName(testModelName)
+					.setModelConfig(testModelConfig);
 				const lineEdit = LineEdit.createFromUnsorted(
 					[
 						new LineReplacement(
@@ -369,19 +374,105 @@ describe('NextEditProvider Caching', () => {
 		const logContext = new InlineEditRequestLogContext(doc.id.toString(), 1, context);
 		const cancellationToken = CancellationToken.None;
 
-		const servedPatchIndices: (number | undefined)[] = [];
+		const servedTelemetry: Pick<ILlmNESTelemetry, 'sourcePatchIndex' | 'isFromCache' | 'modelName' | 'modelConfig' | 'hadStatelessNextEditProviderCall'>[] = [];
 		for (let i = 0; i < 3; i++) {
 			const tb = new NextEditProviderTelemetryBuilder(gitExtensionService, mockNotebookService, workspaceService, nextEditProvider.ID, doc);
 			const result = await nextEditProvider.getNextEdit(doc.id, context, logContext, cancellationToken, tb.nesBuilder);
 			assert(result.result?.edit, `expected an edit on call ${i + 1}`);
-			servedPatchIndices.push(tb.nesBuilder.build(false).sourcePatchIndex);
+			const telemetry = tb.nesBuilder.build(false);
+			servedTelemetry.push({
+				sourcePatchIndex: telemetry.sourcePatchIndex,
+				isFromCache: telemetry.isFromCache,
+				modelName: telemetry.modelName,
+				modelConfig: telemetry.modelConfig,
+				hadStatelessNextEditProviderCall: telemetry.hadStatelessNextEditProviderCall,
+			});
 			tb.dispose();
 			doc.applyEdit(result.result.edit.toEdit());
 		}
 
 		// The first (fresh) edit must be attributed too, not just the cached ones;
 		// the split pair shares patch 0 while the final edit comes from patch 1.
-		expect(servedPatchIndices).toEqual([0, 0, 1]);
+		expect(servedTelemetry).toEqual([
+			{
+				sourcePatchIndex: 0,
+				isFromCache: false,
+				modelName: testModelName,
+				modelConfig: testModelConfig,
+				hadStatelessNextEditProviderCall: true,
+			},
+			{
+				sourcePatchIndex: 0,
+				isFromCache: true,
+				modelName: testModelName,
+				modelConfig: testModelConfig,
+				hadStatelessNextEditProviderCall: undefined,
+			},
+			{
+				sourcePatchIndex: 1,
+				isFromCache: true,
+				modelName: testModelName,
+				modelConfig: testModelConfig,
+				hadStatelessNextEditProviderCall: undefined,
+			},
+		]);
+	});
+
+	it('preserves model attribution for a cached no-edit result', async () => {
+		const obsWorkspace = new MutableObservableWorkspace();
+		const obsGit = new ObservableGit(gitExtensionService);
+		let providerCallCount = 0;
+		const statelessNextEditProvider: IStatelessNextEditProvider = {
+			ID: 'TestNoEditProvider',
+			provideNextEdit: async function*(request: StatelessNextEditRequest) {
+				providerCallCount++;
+				const telemetryBuilder = new StatelessNextEditTelemetryBuilder(request.headerRequestId)
+					.setModelName(testModelName)
+					.setModelConfig(testModelConfig);
+				const noSuggestions = new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, undefined);
+				return new WithStatelessProviderTelemetry(noSuggestions, telemetryBuilder.build(Result.error(noSuggestions)));
+			}
+		};
+		const nextEditProvider = new NextEditProvider(obsWorkspace, statelessNextEditProvider, new NesHistoryContextProvider(obsWorkspace, obsGit), new NesXtabHistoryTracker(obsWorkspace, undefined, configService, expService), undefined, configService, snippyService, logService, expService, requestLogger);
+		const doc = obsWorkspace.addDocument({
+			id: DocumentId.create(URI.file('/test/no-edit.ts').toString()),
+			initialValue: 'const value = 1;',
+		});
+		doc.setSelection([new OffsetRange(0, 0)], undefined);
+		doc.applyEdit(StringEdit.insert(15, '\n'));
+
+		const context: NESInlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined, requestUuid: generateUuid(), requestIssuedDateTime: Date.now(), earliestShownDateTime: Date.now(), enforceCacheDelay: false };
+		const logContext = new InlineEditRequestLogContext(doc.id.toString(), 1, context);
+
+		const firstBuilder = new NextEditProviderTelemetryBuilder(gitExtensionService, mockNotebookService, workspaceService, nextEditProvider.ID, doc);
+		const first = await nextEditProvider.getNextEdit(doc.id, context, logContext, CancellationToken.None, firstBuilder.nesBuilder);
+		firstBuilder.dispose();
+
+		const cachedBuilder = new NextEditProviderTelemetryBuilder(gitExtensionService, mockNotebookService, workspaceService, nextEditProvider.ID, doc);
+		const cached = await nextEditProvider.getNextEdit(doc.id, context, logContext, CancellationToken.None, cachedBuilder.nesBuilder);
+		const cachedTelemetry = cachedBuilder.nesBuilder.build(false);
+		cachedBuilder.dispose();
+
+		expect({
+			firstResult: first.result,
+			cachedResult: cached.result,
+			providerCallCount,
+			isFromCache: cachedTelemetry.isFromCache,
+			modelName: cachedTelemetry.modelName,
+			modelConfig: cachedTelemetry.modelConfig,
+			hadStatelessNextEditProviderCall: cachedTelemetry.hadStatelessNextEditProviderCall,
+		}).toEqual({
+			firstResult: undefined,
+			cachedResult: undefined,
+			providerCallCount: 1,
+			isFromCache: true,
+			modelName: testModelName,
+			modelConfig: testModelConfig,
+			hadStatelessNextEditProviderCall: undefined,
+		});
+
+		nextEditProvider.dispose();
+		doc.dispose();
 	});
 
 	/**
@@ -415,7 +506,9 @@ describe('NextEditProvider Caching', () => {
 		const provider: IStatelessNextEditProvider = {
 			ID: 'TestCrossFileNextEditProvider',
 			provideNextEdit: async function*(request: StatelessNextEditRequest, logger: ILogger, logContext: InlineEditRequestLogContext, cancellationToken: CancellationToken) {
-				const telemetryBuilder = new StatelessNextEditTelemetryBuilder(request.headerRequestId);
+				const telemetryBuilder = new StatelessNextEditTelemetryBuilder(request.headerRequestId)
+					.setModelName(testModelName)
+					.setModelConfig(testModelConfig);
 				callCount++;
 				const isFirstCall = callCount === 1;
 				try {
@@ -498,6 +591,7 @@ describe('NextEditProvider Caching', () => {
 		// so any served suggestion must come from the cache.
 		const tb2 = new NextEditProviderTelemetryBuilder(gitExtensionService, mockNotebookService, workspaceService, nextEditProvider.ID, docA);
 		const second = await nextEditProvider.getNextEdit(docA.id, context, logContext, cancellationToken, tb2.nesBuilder);
+		const secondTelemetry = tb2.nesBuilder.build(false);
 		tb2.dispose();
 
 		// Tear down the provider (which registers autoruns/watchers on `openDocuments` in its
@@ -509,11 +603,11 @@ describe('NextEditProvider Caching', () => {
 		docA.dispose();
 		docB.dispose();
 
-		return { first, second, docBId, getCallCount };
+		return { first, second, secondTelemetry, docBId, getCallCount };
 	}
 
 	it('re-serves a cross-file suggestion from cache while the cursor stays in the active document (surviving the no-suggestions stream end)', async () => {
-		const { first, second, docBId, getCallCount } = await runCrossFileScenario();
+		const { first, second, secondTelemetry, docBId, getCallCount } = await runCrossFileScenario();
 
 		// Fresh: the provider produced a suggestion that targets the other document.
 		assert(first.result?.edit, 'expected a cross-file edit on the first request');
@@ -527,6 +621,17 @@ describe('NextEditProvider Caching', () => {
 		expect(second.result.targetDocumentId).toBe(docBId);
 		expect(second.result.edit).toBe(first.result.edit);
 		expect(getCallCount()).toBe(1);
+		expect({
+			isFromCache: secondTelemetry.isFromCache,
+			modelName: secondTelemetry.modelName,
+			modelConfig: secondTelemetry.modelConfig,
+			hadStatelessNextEditProviderCall: secondTelemetry.hadStatelessNextEditProviderCall,
+		}).toEqual({
+			isFromCache: true,
+			modelName: testModelName,
+			modelConfig: testModelConfig,
+			hadStatelessNextEditProviderCall: undefined,
+		});
 	});
 
 	it('re-serves a cross-file suggestion from cache when the cursor is within the cached edit window', async () => {

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
@@ -14,7 +14,7 @@ import { SpeculativeRequestsAutoExpandEditWindowLines, SpeculativeRequestsEnable
 import { InlineEditRequestLogContext } from '../../../../platform/inlineEdits/common/inlineEditLogContext';
 import { ObservableGit } from '../../../../platform/inlineEdits/common/observableGit';
 import { MutableObservableWorkspace } from '../../../../platform/inlineEdits/common/observableWorkspace';
-import { EditStreamingWithTelemetry, IStatelessNextEditProvider, NoNextEditReason, RequestEditWindow, RequestEditWindowWithCursorJump, StatelessNextEditRequest, StatelessNextEditTelemetryBuilder, WithStatelessProviderTelemetry } from '../../../../platform/inlineEdits/common/statelessNextEditProvider';
+import { EditStreamingWithTelemetry, type IStatelessNextEditModelTelemetry, IStatelessNextEditProvider, NoNextEditReason, RequestEditWindow, RequestEditWindowWithCursorJump, StatelessNextEditRequest, StatelessNextEditTelemetryBuilder, WithStatelessProviderTelemetry } from '../../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { NesHistoryContextProvider } from '../../../../platform/inlineEdits/common/workspaceEditTracker/nesHistoryContextProvider';
 import { NesXtabHistoryTracker } from '../../../../platform/inlineEdits/common/workspaceEditTracker/nesXtabHistoryTracker';
 import { ILogger, ILogService, LogServiceImpl } from '../../../../platform/log/common/logService';
@@ -37,6 +37,11 @@ import { LineRange } from '../../../../util/vs/editor/common/core/ranges/lineRan
 import { OffsetRange } from '../../../../util/vs/editor/common/core/ranges/offsetRange';
 import { NESInlineCompletionContext, NextEditProvider } from '../../node/nextEditProvider';
 import { ILlmNESTelemetry, NextEditProviderTelemetryBuilder, ReusedRequestKind } from '../../node/nextEditProviderTelemetry';
+
+const testModelTelemetry: IStatelessNextEditModelTelemetry = {
+	modelName: 'test-speculative-patch-model',
+	modelConfig: JSON.stringify({ promptingStrategy: 'patchBased02WithRecentLineNumbers' }),
+};
 
 interface ICallRecord {
 	readonly request: StatelessNextEditRequest;
@@ -71,6 +76,8 @@ class TestStatelessNextEditProvider implements IStatelessNextEditProvider {
 	private readonly _behaviors: ProviderBehavior[] = [];
 	public readonly calls: ICallRecord[] = [];
 	private readonly _callDeferreds: DeferredPromise<void>[] = [];
+
+	constructor(private readonly _modelTelemetry?: IStatelessNextEditModelTelemetry) { }
 
 	/**
 	 * When set, each `provideNextEdit` call will assign this to `request.requestEditWindow`
@@ -113,6 +120,12 @@ class TestStatelessNextEditProvider implements IStatelessNextEditProvider {
 		const streamedEditWindow = this.editWindow?.window;
 		const streamedOriginalWindow = this.editWindow instanceof RequestEditWindowWithCursorJump ? this.editWindow.originalWindow : undefined;
 		const telemetryBuilder = new StatelessNextEditTelemetryBuilder(request.headerRequestId);
+		if (this._modelTelemetry?.modelName !== undefined) {
+			telemetryBuilder.setModelName(this._modelTelemetry.modelName);
+		}
+		if (this._modelTelemetry?.modelConfig !== undefined) {
+			telemetryBuilder.setModelConfig(this._modelTelemetry.modelConfig);
+		}
 		const activeDocId = request.getActiveDocument().id;
 		const cancellationRequested = new DeferredPromise<void>();
 		const completed = new DeferredPromise<void>();
@@ -643,7 +656,7 @@ describe('NextEditProvider speculative requests', () => {
 		it('cached speculative result has sp- headerRequestId and isFromCache=true', async () => {
 			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequests, SpeculativeRequestsEnablement.On);
 
-			const statelessProvider = new TestStatelessNextEditProvider();
+			const statelessProvider = new TestStatelessNextEditProvider(testModelTelemetry);
 			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(1, 'const value = 2;') });
 			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(2, 'console.log(value + 1);') });
 			const { nextEditProvider, workspace } = createProviderAndWorkspace(statelessProvider);
@@ -677,6 +690,9 @@ describe('NextEditProvider speculative requests', () => {
 			expect(telemetry.headerRequestId!.startsWith('sp-')).toBe(true);
 			expect(telemetry.isFromCache).toBe(true);
 			expect(telemetry.reusedRequest).toBeUndefined();
+			expect(telemetry.modelName).toBe(testModelTelemetry.modelName);
+			expect(telemetry.modelConfig).toBe(testModelTelemetry.modelConfig);
+			expect(telemetry.hadStatelessNextEditProviderCall).toBeUndefined();
 		});
 	});
 

--- a/extensions/copilot/src/platform/inlineEdits/common/statelessNextEditProvider.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/statelessNextEditProvider.ts
@@ -350,7 +350,14 @@ export class StatelessNextEditResult {
 	}
 }
 
-export interface IStatelessNextEditTelemetry {
+export interface IStatelessNextEditModelTelemetry {
+	/** Name of the model that handled the request. */
+	readonly modelName: string | undefined;
+	/** JSON-encoded model configuration from the model service. */
+	readonly modelConfig: string | undefined;
+}
+
+export interface IStatelessNextEditTelemetry extends IStatelessNextEditModelTelemetry {
 
 	readonly hadStatelessNextEditProviderCall: boolean;
 
@@ -359,7 +366,6 @@ export interface IStatelessNextEditTelemetry {
 	readonly isCursorAtEndOfLine: boolean | undefined;
 	readonly isInlineSuggestion: boolean | undefined;
 	readonly nLinesOfCurrentFileInPrompt: number | undefined;
-	readonly modelName: string | undefined;
 
 	/* options info */
 	readonly logProbThreshold: number | undefined;
@@ -440,8 +446,6 @@ export interface IStatelessNextEditTelemetry {
 	/* similar files context for telemetry (GhostText-style neighbor code snippets) */
 	readonly similarFilesContext: Promise<string | undefined> | undefined;
 
-	/* JSON-encoded model configuration from the model service */
-	readonly modelConfig: string | undefined;
 }
 
 export type FetchResultWithStats = {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Patch-based inline edit cache hits currently report `isFromCache = true` without `modelName` or `modelConfig`. This makes telemetry filtered by prompting strategy appear to have zero patch-model cache hits even though the cache is working.

This change stores only model attribution on cache entries and restores it when emitting cache-hit telemetry. Request-specific prompt, response, latency, usage, and other stateless provider metrics remain unset. The coverage includes regular, subsequent/rebased, speculative, cross-file, and cached no-edit results.

Testing:
- Type-check the Copilot extension.
- Run the focused inline edit cache, speculative request, rebase, cursor-distance, and telemetry unit tests.