### PR TITLE
Migrate BranchPicker to core & decouple from active sessions via IBranchPickerModel

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/branchPicker.ts
@@ -3,25 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as dom from '../../../../../base/browser/dom.js';
-import { Gesture, EventType as TouchEventType } from '../../../../../base/browser/touch.js';
-import { Codicon } from '../../../../../base/common/codicons.js';
-import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
-import { autorun, IObservable } from '../../../../../base/common/observable.js';
-import { localize } from '../../../../../nls.js';
-import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
-import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
-import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
-import { reportNewChatPickerClosed } from '../../../chat/browser/newChatPickerTelemetry.js';
+import * as dom from '../../../../base/browser/dom.js';
+import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { autorun, IObservable } from '../../../../base/common/observable.js';
+import { localize } from '../../../../nls.js';
+import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
+import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 
 const FILTER_THRESHOLD = 10;
 
 /** Minimal contract the BranchPicker needs to render and interact. */
 export interface IBranchPickerModel {
 	readonly branches: IObservable<readonly string[]>;
-	readonly branch: IObservable<string | undefined>;
-	readonly loading: IObservable<boolean>;
+	readonly selectedBranch: IObservable<string | undefined>;
 	readonly disabled: IObservable<boolean>;
 	setBranch(name: string): void;
 }
@@ -50,9 +49,8 @@ export class BranchPicker extends Disposable {
 		this._register(autorun(reader => {
 			const model = this._model.read(reader);
 			if (model) {
-				model.loading.read(reader);
 				model.branches.read(reader);
-				model.branch.read(reader);
+				model.selectedBranch.read(reader);
 				model.disabled.read(reader);
 			}
 			this._updateTriggerLabel();
@@ -95,7 +93,7 @@ export class BranchPicker extends Disposable {
 			return;
 		}
 
-		const selectedBranch = model?.branch.get();
+		const selectedBranch = model?.selectedBranch.get();
 		const items: IActionListItem<IBranchItem>[] = branches.map(branch => ({
 			kind: ActionListItemKind.Action,
 			label: branch,
@@ -146,9 +144,8 @@ export class BranchPicker extends Disposable {
 		dom.clearNode(this._triggerElement);
 
 		const model = this._model.get();
-		const isLoading = model?.loading.get() ?? false;
-		const isDisabled = model?.disabled.get() ?? false;
-		const label = model?.branch.get() ?? localize('branchPicker.select', "Branch");
+		const isDisabled = model?.disabled.get() ?? true;
+		const label = model?.selectedBranch.get() ?? localize('branchPicker.select', "Branch");
 
 		dom.append(this._triggerElement, renderIcon(Codicon.gitBranch));
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
@@ -157,8 +154,8 @@ export class BranchPicker extends Disposable {
 
 		this._triggerElement.ariaLabel = localize('branchPicker.triggerAriaLabel', "Pick Branch, {0}", label);
 
-		this._slotElement?.classList.toggle('disabled', isLoading || isDisabled);
-		this._triggerElement.setAttribute('aria-disabled', String(isLoading || isDisabled));
-		this._triggerElement.tabIndex = (isLoading || isDisabled) ? -1 : 0;
+		this._slotElement?.classList.toggle('disabled', isDisabled);
+		this._triggerElement.setAttribute('aria-disabled', String(isDisabled));
+		this._triggerElement.tabIndex = isDisabled ? -1 : 0;
 	}
 }

--- a/src/vs/sessions/contrib/chat/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/branchPicker.ts
@@ -3,159 +3,49 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as dom from '../../../../base/browser/dom.js';
-import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
-import { Codicon } from '../../../../base/common/codicons.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { autorun, IObservable } from '../../../../base/common/observable.js';
-import { localize } from '../../../../nls.js';
-import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
-import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IObservable } from '../../../../base/common/observable.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { BranchPickerWidget, IBranchPickerModel } from '../../../../workbench/contrib/chat/browser/widget/input/branchPickerWidget.js';
 import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 
-const FILTER_THRESHOLD = 10;
-
-/** Minimal contract the BranchPicker needs to render and interact. */
-export interface IBranchPickerModel {
-	readonly branches: IObservable<readonly string[]>;
-	readonly selectedBranch: IObservable<string | undefined>;
-	readonly disabled: IObservable<boolean>;
-	setBranch(name: string): void;
-}
-
-interface IBranchItem {
-	readonly name: string;
-}
+export { IBranchPickerModel } from '../../../../workbench/contrib/chat/browser/widget/input/branchPickerWidget.js';
 
 /**
- * A widget for selecting a git branch.
- * Renders branch state from the provided {@link IBranchPickerModel}.
+ * Sessions-layer wrapper around the core {@link BranchPickerWidget} that adds
+ * picker-closed telemetry via {@link reportNewChatPickerClosed}.
  */
 export class BranchPicker extends Disposable {
 
-	private readonly _renderDisposables = this._register(new DisposableStore());
-	private _slotElement: HTMLElement | undefined;
-	private _triggerElement: HTMLElement | undefined;
+	private readonly _widget: BranchPickerWidget;
 
 	constructor(
-		private readonly _model: IObservable<IBranchPickerModel | undefined>,
-		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
+		model: IObservable<IBranchPickerModel | undefined>,
+		@IInstantiationService instantiationService: IInstantiationService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
-		this._register(autorun(reader => {
-			const model = this._model.read(reader);
-			if (model) {
-				model.branches.read(reader);
-				model.selectedBranch.read(reader);
-				model.disabled.read(reader);
-			}
-			this._updateTriggerLabel();
+		this._widget = this._register(instantiationService.createInstance(BranchPickerWidget, model));
+		this._register(this._widget.onDidSelectBranch(e => {
+			reportNewChatPickerClosed(this.telemetryService, {
+				id: 'NewChatBranchPicker',
+				name: 'NewChatBranchPicker',
+				optionIdBefore: e.branchBefore,
+				optionIdAfter: e.branchAfter,
+				optionLabelBefore: e.branchBefore,
+				optionLabelAfter: e.branchAfter,
+				isPII: true,
+			});
 		}));
 	}
 
 	render(container: HTMLElement): void {
-		this._renderDisposables.clear();
-
-		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot'));
-		this._slotElement = slot;
-		this._renderDisposables.add({ dispose: () => slot.remove() });
-
-		const trigger = dom.append(slot, dom.$('a.action-label'));
-		trigger.tabIndex = 0;
-		trigger.role = 'button';
-		this._triggerElement = trigger;
-		this._updateTriggerLabel();
-
-		this._renderDisposables.add(Gesture.addTarget(trigger));
-		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
-			this._renderDisposables.add(dom.addDisposableListener(trigger, eventType, (e) => {
-				dom.EventHelper.stop(e, true);
-				this.showPicker();
-			}));
-		}
-
-		this._renderDisposables.add(dom.addDisposableListener(trigger, dom.EventType.KEY_DOWN, (e) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				dom.EventHelper.stop(e, true);
-				this.showPicker();
-			}
-		}));
+		this._widget.render(container);
 	}
 
 	showPicker(): void {
-		const model = this._model.get();
-		const branches = model?.branches.get() ?? [];
-		if (!this._triggerElement || this.actionWidgetService.isVisible || branches.length === 0 || model?.disabled.get()) {
-			return;
-		}
-
-		const selectedBranch = model?.selectedBranch.get();
-		const items: IActionListItem<IBranchItem>[] = branches.map(branch => ({
-			kind: ActionListItemKind.Action,
-			label: branch,
-			group: { title: '', icon: Codicon.gitBranch },
-			item: { name: branch, checked: branch === selectedBranch || undefined },
-		}));
-
-		const triggerElement = this._triggerElement;
-		const delegate: IActionListDelegate<IBranchItem> = {
-			onSelect: (item) => {
-				this.actionWidgetService.hide();
-				reportNewChatPickerClosed(this.telemetryService, {
-					id: 'NewChatBranchPicker',
-					name: 'NewChatBranchPicker',
-					optionIdBefore: selectedBranch,
-					optionIdAfter: item.name,
-					optionLabelBefore: selectedBranch,
-					optionLabelAfter: item.name,
-					isPII: true,
-				});
-				model?.setBranch(item.name);
-			},
-			onHide: () => { triggerElement.focus(); },
-		};
-
-		const totalActions = items.filter(i => i.kind === ActionListItemKind.Action).length;
-
-		this.actionWidgetService.show<IBranchItem>(
-			'branchPicker',
-			false,
-			items,
-			delegate,
-			this._triggerElement,
-			undefined,
-			[],
-			{
-				getAriaLabel: (item) => item.label ?? '',
-				getWidgetAriaLabel: () => localize('branchPicker.ariaLabel', "Branch Picker"),
-			},
-			totalActions > FILTER_THRESHOLD ? { showFilter: true, filterPlaceholder: localize('branchPicker.filter', "Filter branches...") } : undefined,
-		);
-	}
-
-	private _updateTriggerLabel(): void {
-		if (!this._triggerElement) {
-			return;
-		}
-		dom.clearNode(this._triggerElement);
-
-		const model = this._model.get();
-		const isDisabled = model?.disabled.get() ?? true;
-		const label = model?.selectedBranch.get() ?? localize('branchPicker.select', "Branch");
-
-		dom.append(this._triggerElement, renderIcon(Codicon.gitBranch));
-		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
-		labelSpan.textContent = label;
-		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
-
-		this._triggerElement.ariaLabel = localize('branchPicker.triggerAriaLabel', "Pick Branch, {0}", label);
-
-		this._slotElement?.classList.toggle('disabled', isDisabled);
-		this._triggerElement.setAttribute('aria-disabled', String(isDisabled));
-		this._triggerElement.tabIndex = isDisabled ? -1 : 0;
+		this._widget.showPicker();
 	}
 }

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/branchPicker.ts
@@ -14,11 +14,17 @@ import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { reportNewChatPickerClosed } from '../../../chat/browser/newChatPickerTelemetry.js';
-import { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
-import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
-import { CopilotChatSessionsProvider, ICopilotChatSession } from './copilotChatSessionsProvider.js';
 
 const FILTER_THRESHOLD = 10;
+
+/** Minimal contract the BranchPicker needs to render and interact. */
+export interface IBranchPickerModel {
+	readonly branches: IObservable<readonly string[]>;
+	readonly branch: IObservable<string | undefined>;
+	readonly loading: IObservable<boolean>;
+	readonly disabled: IObservable<boolean>;
+	setBranch(name: string): void;
+}
 
 interface IBranchItem {
 	readonly name: string;
@@ -26,8 +32,7 @@ interface IBranchItem {
 
 /**
  * A widget for selecting a git branch.
- * Reads branch list and selected branch from the active session,
- * which is the source of truth for branch state.
+ * Renders branch state from the provided {@link IBranchPickerModel}.
  */
 export class BranchPicker extends Disposable {
 
@@ -36,34 +41,22 @@ export class BranchPicker extends Disposable {
 	private _triggerElement: HTMLElement | undefined;
 
 	constructor(
-		private readonly _session: IObservable<IActiveSession | undefined>,
+		private readonly _model: IObservable<IBranchPickerModel | undefined>,
 		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
-		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
 		this._register(autorun(reader => {
-			const session = this._session.read(reader);
-			const provider = session ? this.sessionsProvidersService.getProvider(session.providerId) : undefined;
-			const providerSession = provider instanceof CopilotChatSessionsProvider ? provider.getSession(session!.sessionId) : undefined;
-			if (providerSession) {
-				providerSession.loading.read(reader);
-				providerSession.branches.read(reader);
-				providerSession.branch.read(reader);
-				providerSession.isolationMode.read(reader);
+			const model = this._model.read(reader);
+			if (model) {
+				model.loading.read(reader);
+				model.branches.read(reader);
+				model.branch.read(reader);
+				model.disabled.read(reader);
 			}
 			this._updateTriggerLabel();
 		}));
-	}
-
-	private _getSession(): ICopilotChatSession | undefined {
-		const session = this._session.get();
-		if (!session) {
-			return undefined;
-		}
-		const provider = this.sessionsProvidersService.getProvider(session.providerId);
-		return provider instanceof CopilotChatSessionsProvider ? provider.getSession(session.sessionId) : undefined;
 	}
 
 	render(container: HTMLElement): void {
@@ -96,13 +89,13 @@ export class BranchPicker extends Disposable {
 	}
 
 	showPicker(): void {
-		const session = this._getSession();
-		const branches = session?.branches.get() ?? [];
-		if (!this._triggerElement || this.actionWidgetService.isVisible || branches.length === 0 || session?.isolationMode.get() === 'workspace') {
+		const model = this._model.get();
+		const branches = model?.branches.get() ?? [];
+		if (!this._triggerElement || this.actionWidgetService.isVisible || branches.length === 0 || model?.disabled.get()) {
 			return;
 		}
 
-		const selectedBranch = session?.branch.get();
+		const selectedBranch = model?.branch.get();
 		const items: IActionListItem<IBranchItem>[] = branches.map(branch => ({
 			kind: ActionListItemKind.Action,
 			label: branch,
@@ -123,7 +116,7 @@ export class BranchPicker extends Disposable {
 					optionLabelAfter: item.name,
 					isPII: true,
 				});
-				session?.setBranch(item.name);
+				model?.setBranch(item.name);
 			},
 			onHide: () => { triggerElement.focus(); },
 		};
@@ -152,11 +145,10 @@ export class BranchPicker extends Disposable {
 		}
 		dom.clearNode(this._triggerElement);
 
-		const session = this._getSession();
-		const branches = session?.branches.get() ?? [];
-		const isLoading = session?.loading.get() ?? false;
-		const isDisabled = session?.isolationMode.get() === 'workspace' || branches.length === 0;
-		const label = session?.branch.get() ?? localize('branchPicker.select', "Branch");
+		const model = this._model.get();
+		const isLoading = model?.loading.get() ?? false;
+		const isDisabled = model?.disabled.get() ?? false;
+		const label = model?.branch.get() ?? localize('branchPicker.select', "Branch");
 
 		dom.append(this._triggerElement, renderIcon(Codicon.gitBranch));
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -17,7 +17,7 @@ import { Menus } from '../../../../browser/menus.js';
 import { SessionHasGitRepositoryContext, SessionProviderIdContext, SessionTypeContext, IsNewChatSessionContext } from '../../../../common/contextkeys.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
-import { BranchPicker, IBranchPickerModel } from './branchPicker.js';
+import { BranchPicker, IBranchPickerModel } from '../../../chat/browser/branchPicker.js';
 import { ClaudePermissionModePicker } from './claudePermissionModePicker.js';
 import { ClaudeCodeSessionType, COPILOT_PROVIDER_ID, CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
 import { LocalSessionType } from '../../localChatSessions/browser/localChatSessionsProvider.js';
@@ -207,9 +207,11 @@ class CopilotPickerActionViewItemContribution extends Disposable implements IWor
 					}
 					return {
 						branches: copilotSession.branches,
-						branch: copilotSession.branch,
-						loading: copilotSession.loading,
-						disabled: derived(reader => copilotSession.isolationMode.read(reader) === 'workspace' || copilotSession.branches.read(reader).length === 0),
+						selectedBranch: copilotSession.branch,
+						disabled: derived(reader =>
+							copilotSession.loading.read(reader)
+							|| copilotSession.isolationMode.read(reader) === 'workspace'
+							|| copilotSession.branches.read(reader).length === 0),
 						setBranch: name => copilotSession.setBranch(name),
 					};
 				});

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -5,7 +5,7 @@
 
 import { BaseActionViewItem } from '../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
-import { IReader, autorun } from '../../../../../base/common/observable.js';
+import { IReader, autorun, derived } from '../../../../../base/common/observable.js';
 import { isWeb } from '../../../../../base/common/platform.js';
 import { localize2 } from '../../../../../nls.js';
 import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
@@ -17,7 +17,7 @@ import { Menus } from '../../../../browser/menus.js';
 import { SessionHasGitRepositoryContext, SessionProviderIdContext, SessionTypeContext, IsNewChatSessionContext } from '../../../../common/contextkeys.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
-import { BranchPicker } from './branchPicker.js';
+import { BranchPicker, IBranchPickerModel } from './branchPicker.js';
 import { ClaudePermissionModePicker } from './claudePermissionModePicker.js';
 import { ClaudeCodeSessionType, COPILOT_PROVIDER_ID, CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
 import { LocalSessionType } from '../../localChatSessions/browser/localChatSessionsProvider.js';
@@ -195,7 +195,25 @@ class CopilotPickerActionViewItemContribution extends Disposable implements IWor
 			Menus.NewSessionRepositoryConfig, 'sessions.defaultCopilot.branchPicker',
 			(_action, _options, scopedInstantiationService) => {
 				const { session } = scopedInstantiationService.invokeFunction(accessor => accessor.get(ISessionContext));
-				const picker = scopedInstantiationService.createInstance(BranchPicker, session);
+				const model = derived<IBranchPickerModel | undefined>(reader => {
+					const s = session.read(reader);
+					if (!s) {
+						return undefined;
+					}
+					const provider = sessionsProvidersService.getProvider(s.providerId);
+					const copilotSession = provider instanceof CopilotChatSessionsProvider ? provider.getSession(s.sessionId) : undefined;
+					if (!copilotSession) {
+						return undefined;
+					}
+					return {
+						branches: copilotSession.branches,
+						branch: copilotSession.branch,
+						loading: copilotSession.loading,
+						disabled: derived(reader => copilotSession.isolationMode.read(reader) === 'workspace' || copilotSession.branches.read(reader).length === 0),
+						setBranch: name => copilotSession.setBranch(name),
+					};
+				});
+				const picker = scopedInstantiationService.createInstance(BranchPicker, model);
 				return new PickerActionViewItem(picker);
 			},
 		));

--- a/src/vs/workbench/contrib/chat/browser/widget/input/branchPickerWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/branchPickerWidget.ts
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../../base/browser/dom.js';
+import { Gesture, EventType as TouchEventType } from '../../../../../../base/browser/touch.js';
+import { renderIcon } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { autorun, IObservable } from '../../../../../../base/common/observable.js';
+import { localize } from '../../../../../../nls.js';
+import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
+import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
+
+const FILTER_THRESHOLD = 10;
+
+/** Minimal contract the BranchPickerWidget needs to render and interact. */
+export interface IBranchPickerModel {
+	readonly branches: IObservable<readonly string[]>;
+	readonly selectedBranch: IObservable<string | undefined>;
+	readonly disabled: IObservable<boolean>;
+	setBranch(name: string): void;
+}
+
+export interface IBranchSelectionEvent {
+	readonly branchBefore: string | undefined;
+	readonly branchAfter: string;
+}
+
+interface IBranchItem {
+	readonly name: string;
+}
+
+/**
+ * A widget for selecting a git branch. Renders a trigger button that opens an
+ * {@link IActionWidgetService} dropdown populated from an {@link IBranchPickerModel}.
+ *
+ * Fires {@link onDidSelectBranch} when the user picks a branch so that consumers
+ * can handle telemetry or other side-effects.
+ */
+export class BranchPickerWidget extends Disposable {
+
+	private readonly _renderDisposables = this._register(new DisposableStore());
+	private _slotElement: HTMLElement | undefined;
+	private _triggerElement: HTMLElement | undefined;
+
+	private readonly _onDidSelectBranch = this._register(new Emitter<IBranchSelectionEvent>());
+	readonly onDidSelectBranch: Event<IBranchSelectionEvent> = this._onDidSelectBranch.event;
+
+	constructor(
+		private readonly _model: IObservable<IBranchPickerModel | undefined>,
+		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
+	) {
+		super();
+
+		this._register(autorun(reader => {
+			const model = this._model.read(reader);
+			if (model) {
+				model.branches.read(reader);
+				model.selectedBranch.read(reader);
+				model.disabled.read(reader);
+			}
+			this._updateTriggerLabel();
+		}));
+	}
+
+	render(container: HTMLElement): void {
+		this._renderDisposables.clear();
+
+		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot'));
+		this._slotElement = slot;
+		this._renderDisposables.add({ dispose: () => slot.remove() });
+
+		const trigger = dom.append(slot, dom.$('a.action-label'));
+		trigger.tabIndex = 0;
+		trigger.role = 'button';
+		this._triggerElement = trigger;
+		this._updateTriggerLabel();
+
+		this._renderDisposables.add(Gesture.addTarget(trigger));
+		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
+			this._renderDisposables.add(dom.addDisposableListener(trigger, eventType, (e) => {
+				dom.EventHelper.stop(e, true);
+				this.showPicker();
+			}));
+		}
+
+		this._renderDisposables.add(dom.addDisposableListener(trigger, dom.EventType.KEY_DOWN, (e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				dom.EventHelper.stop(e, true);
+				this.showPicker();
+			}
+		}));
+	}
+
+	showPicker(): void {
+		const model = this._model.get();
+		const branches = model?.branches.get() ?? [];
+		if (!this._triggerElement || this.actionWidgetService.isVisible || branches.length === 0 || model?.disabled.get()) {
+			return;
+		}
+
+		const selectedBranch = model?.selectedBranch.get();
+		const items: IActionListItem<IBranchItem>[] = branches.map(branch => ({
+			kind: ActionListItemKind.Action,
+			label: branch,
+			group: { title: '', icon: Codicon.gitBranch },
+			item: { name: branch, checked: branch === selectedBranch || undefined },
+		}));
+
+		const triggerElement = this._triggerElement;
+		const delegate: IActionListDelegate<IBranchItem> = {
+			onSelect: (item) => {
+				this.actionWidgetService.hide();
+				this._onDidSelectBranch.fire({
+					branchBefore: selectedBranch,
+					branchAfter: item.name,
+				});
+				model?.setBranch(item.name);
+			},
+			onHide: () => { triggerElement.focus(); },
+		};
+
+		const totalActions = items.filter(i => i.kind === ActionListItemKind.Action).length;
+
+		this.actionWidgetService.show<IBranchItem>(
+			'branchPicker',
+			false,
+			items,
+			delegate,
+			this._triggerElement,
+			undefined,
+			[],
+			{
+				getAriaLabel: (item) => item.label ?? '',
+				getWidgetAriaLabel: () => localize('branchPicker.ariaLabel', "Branch Picker"),
+			},
+			totalActions > FILTER_THRESHOLD ? { showFilter: true, filterPlaceholder: localize('branchPicker.filter', "Filter branches...") } : undefined,
+		);
+	}
+
+	private _updateTriggerLabel(): void {
+		if (!this._triggerElement) {
+			return;
+		}
+		dom.clearNode(this._triggerElement);
+
+		const model = this._model.get();
+		const isDisabled = model?.disabled.get() ?? true;
+		const label = model?.selectedBranch.get() ?? localize('branchPicker.select', "Branch");
+
+		dom.append(this._triggerElement, renderIcon(Codicon.gitBranch));
+		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
+		labelSpan.textContent = label;
+		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
+
+		this._triggerElement.ariaLabel = localize('branchPicker.triggerAriaLabel', "Pick Branch, {0}", label);
+
+		this._slotElement?.classList.toggle('disabled', isDisabled);
+		this._triggerElement.setAttribute('aria-disabled', String(isDisabled));
+		this._triggerElement.tabIndex = isDisabled ? -1 : 0;
+	}
+}


### PR DESCRIPTION
Introduces IBranchPickerModel so the BranchPicker can be reused without a session (e.g. automations dialog).

Part 2: https://github.com/microsoft/vscode/pull/325886
Part 3: https://github.com/microsoft/vscode/pull/325887