### PR TITLE
agentHost: Resolve symlinked read paths before auto-approval

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -165,7 +165,7 @@ export class AgentSideEffects extends Disposable {
 		this._telemetryReporter = new AgentHostTelemetryReporter(this._telemetryService);
 		this._turnTracker = new AgentHostTurnTracker(this._telemetryReporter);
 		this._toolCallTracker = this._register(new AgentHostToolCallTracker(this._telemetryReporter));
-		this._permissionManager = this._register(instantiationService.createInstance(SessionPermissionManager, this._stateManager));
+		this._permissionManager = this._register(instantiationService.createInstance(SessionPermissionManager, this._stateManager, {}));
 		this._localCommands = this._register(instantiationService.createInstance(
 			AgentHostLocalCommands,
 			this._stateManager,

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -6,9 +6,10 @@
 import { realpath as fsRealpath } from 'fs';
 import { homedir } from 'os';
 import { promisify } from 'util';
-import { match as globMatch, parse as globParse, type ParsedPattern } from '../../../base/common/glob.js';
+import { match as globMatch } from '../../../base/common/glob.js';
 import { untildify } from '../../../base/common/labels.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
+import { Schemas } from '../../../base/common/network.js';
 import * as path from '../../../base/common/path.js';
 import { isMacintosh, isWindows } from '../../../base/common/platform.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../base/common/resources.js';
@@ -65,15 +66,7 @@ const DEFAULT_EDIT_AUTO_APPROVE_PATTERNS: Readonly<Record<string, boolean>> = {
 	'**/*-lock.{yaml,json}': false,
 };
 
-/**
- * Glob patterns matching dotfiles directly under the user's home directory
- * (e.g. `~/.ssh`, `~/.aws`). Writes to these always require confirmation,
- * even when the working directory sits inside the home directory.
- */
-const HOME_DOTFILE_PATTERNS: readonly ParsedPattern[] = [
-	globParse(homedir() + '/.*'),
-	globParse(homedir() + '/.*/**'),
-];
+const HOME_DIR = URI.file(homedir());
 
 /**
  * Absolute directory prefixes whose contents are platform configuration data
@@ -470,6 +463,9 @@ export class SessionPermissionManager extends Disposable {
 	 */
 	private async _resolveResourcesForApproval(resource: URI): Promise<URI[] | undefined> {
 		const resourcesToCheck = [resource];
+		if (resource.scheme !== Schemas.file) {
+			return resourcesToCheck;
+		}
 		try {
 			const resolved = await resolveRealPathForNonexistent(resource, this._realpath);
 			if (!extUriBiasedIgnorePathCase.isEqual(resolved, resource)) {
@@ -509,7 +505,9 @@ export class SessionPermissionManager extends Disposable {
 	 * allowed only when the working directory itself lives inside them.
 	 */
 	private _isPlatformRestrictedResource(resource: URI, workingDirectory: URI | undefined): boolean {
-		if (HOME_DOTFILE_PATTERNS.some(pattern => pattern(resource.fsPath))) {
+		const relativeToHome = extUriBiasedIgnorePathCase.relativePath(HOME_DIR, resource);
+		const topLevelName = relativeToHome?.split('/')[0];
+		if (extUriBiasedIgnorePathCase.isEqualOrParent(resource, HOME_DIR) && topLevelName?.startsWith('.')) {
 			return true;
 		}
 

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { realpath as fsRealpath } from 'fs';
 import { homedir } from 'os';
+import { promisify } from 'util';
 import { match as globMatch, parse as globParse, type ParsedPattern } from '../../../base/common/glob.js';
 import { untildify } from '../../../base/common/labels.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
@@ -12,7 +14,6 @@ import { isMacintosh, isWindows } from '../../../base/common/platform.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../base/common/resources.js';
 import { isDefined } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
-import { Promises } from '../../../base/node/pfs.js';
 import { localize } from '../../../nls.js';
 import { ILogService } from '../../log/common/log.js';
 import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, platformRootSchema, platformSessionSchema } from '../common/agentHostSchema.js';
@@ -87,6 +88,8 @@ const PLATFORM_RESTRICTED_DIRS: readonly string[] = (
 			: []
 ).filter(isDefined);
 
+const realpath = promisify(fsRealpath);
+
 /**
  * Validates that a path doesn't contain suspicious characters that could be
  * used to bypass security checks on Windows (e.g. NTFS Alternate Data Streams,
@@ -147,13 +150,14 @@ function assertPathIsSafe(fsPath: string, _isWindows = isWindows): void {
 }
 
 /**
- * Resolves the real path of `fsPath`, walking up the parent chain when the path
+ * Resolves the real path of `resource`, walking up the parent chain when the path
  * (or its ancestors) does not yet exist on disk. This ensures a symlink at any
  * ancestor is followed even for files that are about to be created.
  */
-async function resolveRealPathForNonexistent(fsPath: string): Promise<string> {
+async function resolveRealPathForNonexistent(resource: URI, realpath: (fsPath: string) => Promise<string>): Promise<URI> {
+	const fsPath = resource.fsPath;
 	try {
-		return await Promises.realpath(fsPath);
+		return URI.file(await realpath(fsPath));
 	} catch (e) {
 		if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
 			throw e;
@@ -166,11 +170,11 @@ async function resolveRealPathForNonexistent(fsPath: string): Promise<string> {
 		const parent = path.dirname(current);
 		if (parent === current) {
 			// Reached the filesystem root without finding an existing ancestor.
-			return fsPath;
+			return resource;
 		}
 		try {
-			const resolved = await Promises.realpath(current);
-			return path.join(resolved, ...tail);
+			const resolved = await realpath(current);
+			return URI.file(path.join(resolved, ...tail));
 		} catch (e) {
 			const code = (e as NodeJS.ErrnoException).code;
 			if (code !== 'ENOENT' && code !== 'ENOTDIR') {
@@ -204,17 +208,19 @@ async function resolveRealPathForNonexistent(fsPath: string): Promise<string> {
  */
 export class SessionPermissionManager extends Disposable {
 
-
 	// ---- Edit auto-approve patterns -----------------------------------------
 
 	private readonly _commandAutoApprover: CommandAutoApprover;
+	private readonly _realpath: (fsPath: string) => Promise<string>;
 
 	constructor(
 		private readonly _stateManager: AgentHostStateManager,
+		options: { realpath?: (fsPath: string) => Promise<string> },
 		@IAgentConfigurationService private readonly _configService: IAgentConfigurationService,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
+		this._realpath = options?.realpath ?? realpath;
 		this._commandAutoApprover = this._register(new CommandAutoApprover(this._logService));
 	}
 
@@ -245,6 +251,7 @@ export class SessionPermissionManager extends Disposable {
 	 */
 	async getAutoApproval(e: IToolApprovalEvent, sessionKey: ProtocolURI): Promise<ToolCallConfirmationReason | undefined> {
 		const workDir = this._configService.getEffectiveWorkingDirectory(sessionKey);
+		const workingDirectory = workDir ? URI.parse(workDir) : undefined;
 
 		// 0. Sandbox bypass: a shell command that opted out of the
 		// sandbox (`requestSandboxBypass`) escapes the sandbox's
@@ -270,7 +277,7 @@ export class SessionPermissionManager extends Disposable {
 
 		// 4. Read auto-approval
 		if (e.permissionKind === 'read' && e.permissionPath) {
-			if (this._isPathInWorkingDirectory(e.permissionPath, workDir)) {
+			if (await this._isReadAutoApproved(URI.file(e.permissionPath), workingDirectory)) {
 				this._logService.trace(`[SessionPermissionManager] Auto-approving read of ${e.permissionPath}`);
 				return ToolCallConfirmationReason.NotNeeded;
 			}
@@ -279,7 +286,7 @@ export class SessionPermissionManager extends Disposable {
 
 		// 5. Write auto-approval
 		if (e.permissionKind === 'write' && e.permissionPath) {
-			if (await this._isEditAutoApproved(e.permissionPath, workDir)) {
+			if (await this._isEditAutoApproved(URI.file(e.permissionPath), workingDirectory)) {
 				this._logService.trace(`[SessionPermissionManager] Auto-approving write to ${e.permissionPath}`);
 				return ToolCallConfirmationReason.NotNeeded;
 			}
@@ -293,7 +300,7 @@ export class SessionPermissionManager extends Disposable {
 			}
 			const result = this._commandAutoApprover.shouldAutoApprove(e.toolInput, {
 				autoApproveRules: this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveRulesConfigKey),
-				isWriteDestApproved: (dest) => this._isShellWriteDestApproved(dest, workDir),
+				isWriteDestApproved: dest => this._isShellWriteDestApproved(dest, workingDirectory),
 			});
 			if (result === 'approved') {
 				this._logService.trace('[SessionPermissionManager] Auto-approving shell command');
@@ -381,12 +388,26 @@ export class SessionPermissionManager extends Disposable {
 
 	// ---- Internal helpers ---------------------------------------------------
 
-	private _isPathInWorkingDirectory(filePath: string, workDir: string | undefined): boolean {
-		if (!workDir) {
+	private async _isReadAutoApproved(resource: URI, workingDirectory: URI | undefined): Promise<boolean> {
+		if (!workingDirectory) {
 			return false;
 		}
-		const workingDirectory = URI.parse(workDir);
-		return extUriBiasedIgnorePathCase.isEqualOrParent(normalizePath(URI.file(filePath)), workingDirectory);
+
+		const [resourcesToCheck, workingDirectories] = await Promise.all([
+			this._resolveResourcesForApproval(resource),
+			this._resolveResourcesForApproval(workingDirectory),
+		]);
+		return resourcesToCheck !== undefined
+			&& workingDirectories !== undefined
+			&& resourcesToCheck.every(candidate => workingDirectories.some(directory => this._isResourceInDirectory(candidate, directory)));
+	}
+
+	private _isResourceInWorkingDirectory(resource: URI, workingDirectory: URI | undefined): boolean {
+		return workingDirectory !== undefined && this._isResourceInDirectory(resource, workingDirectory);
+	}
+
+	private _isResourceInDirectory(resource: URI, directory: URI): boolean {
+		return extUriBiasedIgnorePathCase.isEqualOrParent(normalizePath(resource), normalizePath(directory));
 	}
 
 	/**
@@ -395,12 +416,12 @@ export class SessionPermissionManager extends Disposable {
 	 * rules that govern write tool calls: the destination must resolve to a
 	 * path inside the working directory and must not match a denied glob.
 	 */
-	private _isShellWriteDestApproved(dest: string, workDir: string | undefined): boolean {
-		const resolved = this._resolveShellRedirectPath(dest, workDir);
-		if (!resolved) {
+	private _isShellWriteDestApproved(dest: string, workingDirectory: URI | undefined): boolean {
+		const resource = this._resolveShellRedirectResource(dest, workingDirectory);
+		if (!resource) {
 			return false;
 		}
-		return this._checkWritePath(resolved, workDir);
+		return this._checkWriteResource(resource, workingDirectory);
 	}
 
 	/**
@@ -410,22 +431,22 @@ export class SessionPermissionManager extends Disposable {
 	 * the workspace. Returns `undefined` when resolution would require a
 	 * working directory that isn't configured.
 	 */
-	private _resolveShellRedirectPath(dest: string, workDir: string | undefined): string | undefined {
+	private _resolveShellRedirectResource(dest: string, workingDirectory: URI | undefined): URI | undefined {
 		const trimmed = untildify(dest.trim(), homedir());
 		if (!trimmed) {
 			return undefined;
 		}
 		if (path.isAbsolute(trimmed)) {
-			return trimmed;
+			return URI.file(trimmed);
 		}
-		if (!workDir) {
+		if (!workingDirectory) {
 			return undefined;
 		}
-		return path.resolve(URI.parse(workDir).fsPath, trimmed);
+		return URI.file(path.resolve(workingDirectory.fsPath, trimmed));
 	}
 
 	/**
-	 * Determines whether a write to `filePath` can be auto-approved. Mirrors the
+	 * Determines whether a write to `resource` can be auto-approved. Mirrors the
 	 * checks performed by the workbench edit-confirmation pipeline:
 	 *
 	 * 1. The path is resolved through any symlinks (following ancestors that do
@@ -437,71 +458,66 @@ export class SessionPermissionManager extends Disposable {
 	 *    `~/Library`, `%APPDATA%`, ...).
 	 * 5. The path must match the edit auto-approve glob rules.
 	 */
-	private async _isEditAutoApproved(filePath: string, workDir: string | undefined): Promise<boolean> {
-		const pathsToCheck = await this._resolveWritePaths(filePath);
-		return pathsToCheck !== undefined && pathsToCheck.every(p => this._checkWritePath(p, workDir));
+	private async _isEditAutoApproved(resource: URI, workingDirectory: URI | undefined): Promise<boolean> {
+		const resourcesToCheck = await this._resolveResourcesForApproval(resource);
+		return resourcesToCheck !== undefined && resourcesToCheck.every(candidate => this._checkWriteResource(candidate, workingDirectory));
 	}
 
 	/**
-	 * Returns the set of paths that must each pass the write checks: the literal
-	 * path plus, for absolute paths, the symlink-resolved real path. Returns
-	 * `undefined` when the path cannot be resolved due to missing permissions,
-	 * signalling that confirmation is required.
+	 * Returns the literal path plus, for absolute paths, the symlink-resolved
+	 * real path. Returns `undefined` when the path cannot be resolved due to
+	 * missing permissions, signalling that confirmation is required.
 	 */
-	private async _resolveWritePaths(filePath: string): Promise<string[] | undefined> {
-		const pathsToCheck = [filePath];
-		if (path.isAbsolute(filePath)) {
-			try {
-				const linked = await resolveRealPathForNonexistent(filePath);
-				if (linked !== filePath) {
-					pathsToCheck.push(linked);
-				}
-			} catch (e) {
-				const code = (e as NodeJS.ErrnoException).code;
-				if (code === 'EPERM' || code === 'EACCES') {
-					// No permission to resolve the path — require confirmation.
-					return undefined;
-				}
-				// Otherwise fall back to checking the literal path only.
+	private async _resolveResourcesForApproval(resource: URI): Promise<URI[] | undefined> {
+		const resourcesToCheck = [resource];
+		try {
+			const resolved = await resolveRealPathForNonexistent(resource, this._realpath);
+			if (!extUriBiasedIgnorePathCase.isEqual(resolved, resource)) {
+				resourcesToCheck.push(resolved);
 			}
+		} catch (e) {
+			const code = (e as NodeJS.ErrnoException).code;
+			if (code === 'EPERM' || code === 'EACCES') {
+				// No permission to resolve the path — require confirmation.
+				return undefined;
+			}
+			// Otherwise fall back to checking the literal resource only.
 		}
-		return pathsToCheck;
+		return resourcesToCheck;
 	}
 
-	/** Runs the per-path write checks for a single (already symlink-resolved) path. */
-	private _checkWritePath(filePath: string, workDir: string | undefined): boolean {
+	/** Runs the write checks for a single (already symlink-resolved) resource. */
+	private _checkWriteResource(resource: URI, workingDirectory: URI | undefined): boolean {
 		try {
-			assertPathIsSafe(filePath);
+			assertPathIsSafe(resource.fsPath);
 		} catch {
 			return false;
 		}
-		if (!this._isPathInWorkingDirectory(filePath, workDir)) {
+		if (!this._isResourceInWorkingDirectory(resource, workingDirectory)) {
 			return false;
 		}
-		if (this._isPlatformRestrictedPath(filePath, workDir)) {
+		if (this._isPlatformRestrictedResource(resource, workingDirectory)) {
 			return false;
 		}
-		return this._matchesEditAutoApprovePatterns(filePath);
+		return this._matchesEditAutoApprovePatterns(resource.fsPath);
 	}
 
 	/**
-	 * Returns whether `filePath` targets a platform-restricted location that
+	 * Returns whether `resource` targets a platform-restricted location that
 	 * should always require confirmation. Edits within home-directory dotfiles
 	 * are never auto-approved. Edits within platform config directories are
 	 * allowed only when the working directory itself lives inside them.
 	 */
-	private _isPlatformRestrictedPath(filePath: string, workDir: string | undefined): boolean {
-		if (HOME_DOTFILE_PATTERNS.some(pattern => pattern(filePath))) {
+	private _isPlatformRestrictedResource(resource: URI, workingDirectory: URI | undefined): boolean {
+		if (HOME_DOTFILE_PATTERNS.some(pattern => pattern(resource.fsPath))) {
 			return true;
 		}
 
-		const uri = URI.file(filePath);
-		const workspaceFolder = workDir ? URI.parse(workDir) : undefined;
 		for (const restricted of PLATFORM_RESTRICTED_DIRS) {
 			const parentURI = URI.file(restricted);
-			if (extUriBiasedIgnorePathCase.isEqualOrParent(uri, parentURI)) {
+			if (extUriBiasedIgnorePathCase.isEqualOrParent(resource, parentURI)) {
 				// Allow edits when the working directory is opened inside the restricted area.
-				return !(workspaceFolder && extUriBiasedIgnorePathCase.isEqualOrParent(workspaceFolder, parentURI));
+				return !(workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(workingDirectory, parentURI));
 			}
 		}
 		return false;

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
 import { join } from '../../../../base/common/path.js';
 import { isWindows } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -145,6 +146,16 @@ suite('SessionPermissionManager', () => {
 		const inside = await permissions.getAutoApproval(readEvent(join(workDir, 'a.txt')), sessionUri);
 		const outside = await permissions.getAutoApproval(readEvent(join(outsideDir, 'a.txt')), sessionUri);
 		assert.deepStrictEqual([inside, outside], [ToolCallConfirmationReason.NotNeeded, undefined]);
+	});
+
+	test('requires confirmation when the working directory is not a file URI', async () => {
+		const remoteSessionUri = URI.from({ scheme: 'copilot', path: '/remote' }).toString();
+		const remoteWorkingDirectory = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+host', path: URI.file(workDir).path });
+		manager.createSession(makeSummary(remoteSessionUri, remoteWorkingDirectory.toString()));
+
+		const result = await permissions.getAutoApproval(readEvent(join(workDir, 'a.txt'), remoteSessionUri), remoteSessionUri);
+
+		assert.strictEqual(result, undefined);
 	});
 
 	test('requires confirmation when a symlinked read ancestor redirects outside the working directory', async () => {

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -30,8 +30,8 @@ suite('SessionPermissionManager', () => {
 	// checks compare like-for-like (e.g. macOS `/var` -> `/private/var`).
 	let workDir: string;
 	let outsideDir: string;
-
 	const sessionUri = URI.from({ scheme: 'copilot', path: '/s' }).toString();
+	const directoryLinkType = isWindows ? 'junction' : 'dir';
 
 	function makeSummary(resource: string, workingDirectory?: string): SessionSummary {
 		return {
@@ -48,6 +48,10 @@ suite('SessionPermissionManager', () => {
 
 	function writeEvent(permissionPath: string): IToolApprovalEvent {
 		return { toolCallId: 'tc-1', session: URI.parse(sessionUri), permissionKind: 'write', permissionPath };
+	}
+
+	function readEvent(permissionPath: string, resource = sessionUri): IToolApprovalEvent {
+		return { toolCallId: 'tc-read', session: URI.parse(resource), permissionKind: 'read', permissionPath };
 	}
 
 	function shellEvent(commandLine: string): IToolApprovalEvent {
@@ -70,7 +74,7 @@ suite('SessionPermissionManager', () => {
 
 		manager = disposables.add(new AgentHostStateManager(new NullLogService()));
 		configService = disposables.add(new AgentConfigurationService(manager, new NullLogService()));
-		permissions = disposables.add(new SessionPermissionManager(manager, configService, new NullLogService()));
+		permissions = disposables.add(new SessionPermissionManager(manager, {}, configService, new NullLogService()));
 		await permissions.initialize();
 
 		manager.createSession(makeSummary(sessionUri, URI.file(workDir).toString()));
@@ -108,15 +112,15 @@ suite('SessionPermissionManager', () => {
 		assert.strictEqual(result, undefined);
 	});
 
-	(isWindows ? test.skip : test)('requires confirmation when a symlink redirects outside the working directory', async () => {
-		symlinkSync(outsideDir, join(workDir, 'link'), 'dir');
+	test('requires confirmation when a symlink redirects outside the working directory', async () => {
+		symlinkSync(outsideDir, join(workDir, 'link'), directoryLinkType);
 		const result = await permissions.getAutoApproval(writeEvent(join(workDir, 'link', 'secret.txt')), sessionUri);
 		assert.strictEqual(result, undefined);
 	});
 
-	(isWindows ? test.skip : test)('auto-approves when a symlink stays inside the working directory', async () => {
+	test('auto-approves when a symlink stays inside the working directory', async () => {
 		mkdirSync(join(workDir, 'real'));
-		symlinkSync(join(workDir, 'real'), join(workDir, 'link-in'), 'dir');
+		symlinkSync(join(workDir, 'real'), join(workDir, 'link-in'), directoryLinkType);
 		const result = await permissions.getAutoApproval(writeEvent(join(workDir, 'link-in', 'note.txt')), sessionUri);
 		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
 	});
@@ -138,15 +142,63 @@ suite('SessionPermissionManager', () => {
 	});
 
 	test('auto-approves reads inside but requires confirmation outside the working directory', async () => {
-		const inside = await permissions.getAutoApproval(
-			{ toolCallId: 'r', session: URI.parse(sessionUri), permissionKind: 'read', permissionPath: join(workDir, 'a.txt') },
-			sessionUri,
-		);
-		const outside = await permissions.getAutoApproval(
-			{ toolCallId: 'r', session: URI.parse(sessionUri), permissionKind: 'read', permissionPath: join(outsideDir, 'a.txt') },
-			sessionUri,
-		);
+		const inside = await permissions.getAutoApproval(readEvent(join(workDir, 'a.txt')), sessionUri);
+		const outside = await permissions.getAutoApproval(readEvent(join(outsideDir, 'a.txt')), sessionUri);
 		assert.deepStrictEqual([inside, outside], [ToolCallConfirmationReason.NotNeeded, undefined]);
+	});
+
+	test('requires confirmation when a symlinked read ancestor redirects outside the working directory', async () => {
+		mkdirSync(join(workDir, 'nested'));
+		symlinkSync(outsideDir, join(workDir, 'nested', 'link'), directoryLinkType);
+
+		const result = await permissions.getAutoApproval(readEvent(join(workDir, 'nested', 'link', 'secret.txt')), sessionUri);
+
+		assert.strictEqual(result, undefined);
+	});
+
+	test('auto-approves a read through a symlink that stays inside the working directory', async () => {
+		mkdirSync(join(workDir, 'real-read'));
+		symlinkSync(join(workDir, 'real-read'), join(workDir, 'link-read'), directoryLinkType);
+
+		const result = await permissions.getAutoApproval(readEvent(join(workDir, 'link-read', 'note.txt')), sessionUri);
+
+		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
+	});
+
+	test('requires confirmation when only the real read path is inside the working directory', async () => {
+		symlinkSync(workDir, join(outsideDir, 'link-to-workspace'), directoryLinkType);
+
+		const result = await permissions.getAutoApproval(readEvent(join(outsideDir, 'link-to-workspace', 'note.txt')), sessionUri);
+
+		assert.strictEqual(result, undefined);
+	});
+
+	test('auto-approves reads when the working directory is itself symlinked', async () => {
+		const linkedWorkDir = join(outsideDir, 'linked-workspace');
+		const linkedSessionUri = URI.from({ scheme: 'copilot', path: '/linked' }).toString();
+		symlinkSync(workDir, linkedWorkDir, directoryLinkType);
+		manager.createSession(makeSummary(linkedSessionUri, URI.file(linkedWorkDir).toString()));
+
+		const result = await permissions.getAutoApproval(readEvent(join(linkedWorkDir, 'note.txt'), linkedSessionUri), linkedSessionUri);
+
+		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
+	});
+
+	test('requires confirmation when read realpath resolution is denied', async () => {
+		const results: (ToolCallConfirmationReason | undefined)[] = [];
+		for (const code of ['EACCES', 'EPERM']) {
+			const deniedPermissions = disposables.add(new SessionPermissionManager(manager, {
+				realpath: async () => {
+					const error: NodeJS.ErrnoException = new Error(`realpath failed with ${code}`);
+					error.code = code;
+					throw error;
+				},
+			}, configService, new NullLogService()));
+			await deniedPermissions.initialize();
+			results.push(await deniedPermissions.getAutoApproval(readEvent(join(workDir, 'secret.txt')), sessionUri));
+		}
+
+		assert.deepStrictEqual(results, [undefined, undefined]);
 	});
 
 	test('auto-approves shell commands in default permission mode when terminal auto-approve is enabled', async () => {


### PR DESCRIPTION
## Summary

- resolve requested read paths through symlinked ancestors before auto-approval
- require both literal and resolved resources to remain inside the session working directory
- require confirmation when realpath resolution fails with `EACCES` or `EPERM`
- run directory-link containment coverage on Windows using junctions

## Verification

- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/sessionPermissions.test.ts`
- `npm run valid-layers-check`
- `npm run precommit`

(Written by Copilot)

Fix microsoft/vscode-internalbacklog#8435