### PR TITLE
agentHost: Fix GitHub MCP initial authentication

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -85,6 +85,17 @@ interface IPendingMcpAuthRequest {
 const COPILOT_HOME_DIRECTORY = '.copilot';
 const SESSION_STATE_DIRECTORY = join(COPILOT_HOME_DIRECTORY, 'session-state');
 const EMPTY_TOOL_RESULT_TEXT = '<empty />';
+const DEFAULT_GITHUB_MCP_SERVER_URL = 'https://api.githubcopilot.com/mcp';
+
+function normalizeMcpServerUrl(value: string): string | undefined {
+	if (!URL.canParse(value)) {
+		return undefined;
+	}
+	const url = new URL(value);
+	url.hash = '';
+	url.pathname = url.pathname.replace(/\/+$/, '');
+	return url.href;
+}
 
 type IMappedSessionEvents = { turns: Turn[]; subagentTurnsByToolCallId: ReadonlyMap<string, Turn[]> };
 
@@ -1107,8 +1118,13 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	private async _handleMcpAuthRequest(request: McpAuthRequest): Promise<McpAuthResult | null | undefined> {
+		const githubToken = this._initialGitHubMcpToken(request);
+		if (githubToken) {
+			this._logService.info(`[Copilot:${this.sessionId}] Reusing the existing GitHub token for initial GitHub MCP authentication`);
+			return { kind: 'token', accessToken: githubToken };
+		}
 		const resource = this._protectedResourceFromMcpAuthRequest(request);
-		const requiredScopes = this._requiredScopesFromMcpAuthRequest(request, resource);
+		const requiredScopes = this._scopesFromChallenge(request.wwwAuthenticateParams?.scope);
 		const deferred = new DeferredPromise<McpAuthResult | null | undefined>();
 		this._pendingMcpAuthRequests.set(request.requestId, {
 			serverName: request.serverName,
@@ -1130,6 +1146,15 @@ export class CopilotAgentSession extends Disposable {
 		return deferred.p.finally(() => this._pendingMcpAuthRequests.delete(request.requestId));
 	}
 
+	private _initialGitHubMcpToken(request: McpAuthRequest): string | undefined {
+		if (request.reason !== 'initial' || this._scopesFromChallenge(request.wwwAuthenticateParams?.scope).length !== 0) {
+			return undefined;
+		}
+		const requestUrl = normalizeMcpServerUrl(request.serverUrl);
+		const configuredUrl = normalizeMcpServerUrl(DEFAULT_GITHUB_MCP_SERVER_URL);
+		return requestUrl !== undefined && requestUrl === configuredUrl ? this._launchPlan.githubToken : undefined;
+	}
+
 	private _protectedResourceFromMcpAuthRequest(request: McpAuthRequest): ProtectedResourceMetadata {
 		if (request.resourceMetadata) {
 			try {
@@ -1148,11 +1173,6 @@ export class CopilotAgentSession extends Disposable {
 			resource_name: request.serverName,
 			scopes_supported: scopes.length ? scopes.slice() : undefined,
 		};
-	}
-
-	private _requiredScopesFromMcpAuthRequest(request: McpAuthRequest, resource: ProtectedResourceMetadata): readonly string[] {
-		const challengeScopes = this._scopesFromChallenge(request.wwwAuthenticateParams?.scope);
-		return challengeScopes.length ? challengeScopes : resource.scopes_supported ?? [];
 	}
 
 	private _scopesFromChallenge(scope: string | undefined): readonly string[] {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -27,7 +27,7 @@ import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { ActionType, type ChatDeltaAction, type ChatErrorAction, type ChatInputRequestedAction, type ChatResponsePartAction, type ChatToolCallCompleteAction, type ChatToolCallReadyAction, type ChatToolCallStartAction, type ChatTurnCompleteAction, type ChatUsageAction, type SessionAction } from '../../common/state/sessionActions.js';
 import { MessageAttachmentKind, MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, readUsageInfoMeta, type ToolDefinition, type ToolResultContent, type ToolResultFileEditContent, type UsageInfoMeta } from '../../common/state/sessionState.js';
-import { McpAuthRequiredReason, McpServerStatus } from '../../common/state/protocol/channels-session/state.js';
+import { CustomizationType, McpAuthRequiredReason, McpServerStatus } from '../../common/state/protocol/channels-session/state.js';
 import { CopilotAgentSession } from '../../node/copilot/copilotAgentSession.js';
 import { ActiveClientToolSet } from '../../node/activeClientState.js';
 import { type CopilotSessionLaunchPlan, type IActiveClientSnapshot, type ICopilotSessionLauncher, type ICopilotSessionRuntime } from '../../node/copilot/copilotSessionLauncher.js';
@@ -274,6 +274,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	serverToolHost?: IAgentServerToolHost;
 	/** Platform used to compute the SDK sandbox policy. Defaults to `'linux'` so sandbox tests are deterministic. */
 	platform?: NodeJS.Platform;
+	githubToken?: string;
 }): Promise<{
 	session: CopilotAgentSession;
 	runtime: ICopilotSessionRuntime;
@@ -323,7 +324,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 		resolvedAgentName: undefined,
 		snapshot: options?.clientSnapshot ?? { tools: [], plugins: [], mcpServers: {} },
 		shellManager: undefined,
-		githubToken: undefined,
+		githubToken: options?.githubToken,
 		model: undefined,
 	};
 	let launchedRuntime: ICopilotSessionRuntime | undefined;
@@ -4753,21 +4754,50 @@ suite('CopilotAgentSession', () => {
 
 	suite('MCP server inventory', () => {
 
+		test('initial GitHub MCP auth reuses the existing token without requesting the advertised scope catalog', async () => {
+			const { runtime, signals } = await createAgentSession(disposables, { githubToken: 'existing-token' });
+
+			const result = await runtime.handleMcpAuthRequest({
+				requestId: 'faa18cc1-fe2d-492a-8350-9faa4bbb5389',
+				serverName: 'github',
+				serverUrl: 'https://api.githubcopilot.com/mcp/',
+				reason: 'initial',
+				resourceMetadata: JSON.stringify({
+					resource: 'https://api.githubcopilot.com/mcp/',
+					resource_name: 'GitHub MCP Server',
+					authorization_servers: ['https://github.com/login/oauth'],
+					scopes_supported: ['repo', 'read:org', 'read:user', 'user:email', 'read:packages', 'write:packages', 'read:project', 'project', 'gist', 'notifications', 'workflow', 'codespace'],
+				}),
+				wwwAuthenticateParams: {
+					resourceMetadataUrl: 'https://api.githubcopilot.com/.well-known/oauth-protected-resource/mcp/',
+					error: 'invalid_request',
+				},
+			}, { sessionId: 'test-session-1' });
+
+			assert.deepStrictEqual({
+				result,
+				customizationUpdates: getActions(signals).filter(action => action.type === ActionType.SessionCustomizationUpdated),
+			}, {
+				result: { kind: 'token', accessToken: 'existing-token' },
+				customizationUpdates: [],
+			});
+		});
+
 		test('MCP auth request publishes authRequired state and resolves with authenticate token', async () => {
-			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables, { githubToken: 'existing-token' });
 
 			const authPromise = runtime.handleMcpAuthRequest({
 				requestId: 'auth-1',
 				serverName: 'github',
-				serverUrl: 'https://mcp.example.com',
+				serverUrl: 'https://api.githubcopilot.com/mcp',
 				reason: 'upscope',
 				resourceMetadata: JSON.stringify({
-					resource: 'https://mcp.example.com',
-					resource_name: 'Example MCP',
-					authorization_servers: ['https://auth.example.com'],
-					scopes_supported: ['repo'],
+					resource: 'https://api.githubcopilot.com/mcp',
+					resource_name: 'GitHub MCP Server',
+					authorization_servers: ['https://github.com/login/oauth'],
+					scopes_supported: ['repo', 'notifications'],
 				}),
-				wwwAuthenticateParams: { scope: 'repo issues:write', error: 'insufficient_scope' },
+				wwwAuthenticateParams: { scope: 'repo notifications', error: 'insufficient_scope' },
 			}, { sessionId: 'test-session-1' });
 
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionCustomizationUpdated)) as IAgentActionSignal;
@@ -4783,20 +4813,56 @@ suite('CopilotAgentSession', () => {
 					kind: McpServerStatus.AuthRequired,
 					reason: McpAuthRequiredReason.InsufficientScope,
 					resource: {
-						resource: 'https://mcp.example.com',
-						resource_name: 'Example MCP',
-						authorization_servers: ['https://auth.example.com'],
-						scopes_supported: ['repo'],
+						resource: 'https://api.githubcopilot.com/mcp',
+						resource_name: 'GitHub MCP Server',
+						authorization_servers: ['https://github.com/login/oauth'],
+						scopes_supported: ['repo', 'notifications'],
 					},
-					requiredScopes: ['repo', 'issues:write'],
+					requiredScopes: ['repo', 'notifications'],
 					description: 'insufficient_scope',
 				},
 				channel: undefined,
 				mcpApp: { capabilities: { serverTools: { listChanged: true }, serverResources: {}, sampling: {} } },
 			});
 
-			assert.strictEqual(await session.resolveMcpAuthentication({ resource: 'https://mcp.example.com', scopes: ['repo', 'issues:write'], token: 'token-1' }), true);
+			assert.strictEqual(await session.resolveMcpAuthentication({ resource: 'https://api.githubcopilot.com/mcp', scopes: ['repo', 'notifications'], token: 'token-1' }), true);
 			assert.deepStrictEqual(await authPromise, { kind: 'token', accessToken: 'token-1' });
+		});
+
+		test('initial auth for a server impersonating the GitHub MCP name uses the normal auth flow', async () => {
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables, { githubToken: 'existing-token' });
+
+			const authPromise = runtime.handleMcpAuthRequest({
+				requestId: 'auth-lookalike',
+				serverName: 'github',
+				serverUrl: 'https://mcp.example.com',
+				reason: 'initial',
+				resourceMetadata: JSON.stringify({
+					resource: 'https://mcp.example.com',
+					resource_name: 'Lookalike MCP',
+					authorization_servers: ['https://github.com/login/oauth'],
+					scopes_supported: ['repo'],
+				}),
+			}, { sessionId: 'test-session-1' });
+
+			const signal = await waitForSignal(signal => isAction(signal, ActionType.SessionCustomizationUpdated)) as IAgentActionSignal;
+			const customization = (signal.action as Extract<SessionAction, { type: ActionType.SessionCustomizationUpdated }>).customization;
+			if (customization.type !== CustomizationType.McpServer) {
+				assert.fail(`Expected MCP server customization, got ${customization.type}`);
+			}
+			const resolved = await session.resolveMcpAuthentication({ resource: 'https://mcp.example.com', scopes: ['repo'], token: 'interactive-token' });
+
+			assert.deepStrictEqual({
+				resolved,
+				result: await authPromise,
+				requiredScopes: customization.state.kind === McpServerStatus.AuthRequired ? customization.state.requiredScopes : undefined,
+				supportedScopes: customization.state.kind === McpServerStatus.AuthRequired ? customization.state.resource.scopes_supported : undefined,
+			}, {
+				resolved: true,
+				result: { kind: 'token', accessToken: 'interactive-token' },
+				requiredScopes: undefined,
+				supportedScopes: ['repo'],
+			});
 		});
 
 		test('needs-auth status remains starting when no auth request details are available', async () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
@@ -162,6 +162,7 @@ export interface IAgentHostMcpAuthenticationOptionsBase {
 	readonly mcpServerId: string;
 	readonly mcpServerName: string;
 	readonly mcpServerUrl: string;
+	readonly scopes: readonly string[];
 	/**
 	 * Identifies the agent host backing this MCP server so remembered-auth
 	 * entries can be surfaced in their own section of the "Manage Trusted MCP
@@ -275,7 +276,7 @@ export async function resolveMcpServerAuthentication(
 	const agentHostMeta = options.agentHost
 		? { authority: options.agentHost.authority, label: accessor.get(ILabelService).getHostLabel(options.agentHost.scheme, options.agentHost.authority) }
 		: undefined;
-	const scopes = protectedResource.scopes_supported ?? [];
+	const scopes = options.scopes;
 	for (const authorizationServer of protectedResource.authorization_servers ?? []) {
 		const authorizationServerUri = URI.parse(authorizationServer);
 		const providerId = await getOrCreateProviderForMcpResource(authorizationServerUri, protectedResource, authenticationService, logService, options.logPrefix);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
@@ -175,17 +175,14 @@ export abstract class AbstractAgentHostCustomizationService extends Disposable i
 			return false;
 		}
 		const scopedServerId = agentHostMcpServerId(sessionResource.authority, server.name, server.state.resource.resource);
-		const resource = {
-			...server.state.resource,
-			scopes_supported: server.state.requiredScopes ?? server.state.resource.scopes_supported,
-		};
 		try {
-			return await this._instantiationService.invokeFunction(resolveMcpServerAuthentication, resource, {
+			return await this._instantiationService.invokeFunction(resolveMcpServerAuthentication, server.state.resource, {
 				allowInteraction: true,
 				logPrefix: '[AgentHost]',
 				mcpServerId: scopedServerId,
 				mcpServerName: server.name,
 				mcpServerUrl: server.state.resource.resource,
+				scopes: server.state.requiredScopes ?? [],
 				agentHost: { scheme: sessionResource.scheme, authority: sessionResource.authority },
 				authenticate: request => target.authenticate(request),
 			});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1887,6 +1887,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					name: server.name,
 					resource: state.resource.resource,
 					authorizationServers: state.resource.authorization_servers,
+					supportedScopes: state.resource.scopes_supported,
 					requiredScopes: state.requiredScopes,
 					reason: state.reason,
 				};
@@ -2305,13 +2306,14 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					resource: server.resource,
 					resource_name: server.name,
 					authorization_servers: server.authorizationServers ? [...server.authorizationServers] : undefined,
-					scopes_supported: server.requiredScopes ? [...server.requiredScopes] : undefined,
+					scopes_supported: server.supportedScopes ? [...server.supportedScopes] : undefined,
 				}, {
 					allowInteraction: false,
 					logPrefix: '[AgentHost]',
 					mcpServerId: agentHostMcpServerId(sessionResource.authority, server.name, server.resource),
 					mcpServerName: server.name,
 					mcpServerUrl: server.resource,
+					scopes: server.requiredScopes ?? [],
 					agentHost: { scheme: sessionResource.scheme, authority: sessionResource.authority },
 					authenticate: request => this._config.connection.authenticate(request),
 				});

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1236,6 +1236,7 @@ export interface IChatMcpAuthenticationRequiredServer {
 	readonly name: string;
 	readonly resource: string;
 	readonly authorizationServers?: readonly string[];
+	readonly supportedScopes?: readonly string[];
 	readonly requiredScopes?: readonly string[];
 	readonly reason?: string;
 }

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
@@ -8,9 +8,13 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { type AgentInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { IAuthenticationMcpAccessService } from '../../../../../services/authentication/browser/authenticationMcpAccessService.js';
+import { IAuthenticationMcpService } from '../../../../../services/authentication/browser/authenticationMcpService.js';
+import { IAuthenticationMcpUsageService } from '../../../../../services/authentication/browser/authenticationMcpUsageService.js';
 import { IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
-import { authenticateProtectedResources, resolveAuthenticationInteractively, resolveTokenForResource, AgentHostAuthTokenCache, agentHostMcpServerId } from '../../../browser/agentSessions/agentHost/agentHostAuth.js';
+import { authenticateProtectedResources, resolveAuthenticationInteractively, resolveTokenForResource, AgentHostAuthTokenCache, agentHostMcpServerId, resolveMcpServerAuthentication } from '../../../browser/agentSessions/agentHost/agentHostAuth.js';
 
 function createMockAuthService(overrides: {
 	getOrActivateProviderIdForServer?: (serverUri: URI, resourceUri: URI) => Promise<string | undefined>;
@@ -189,6 +193,49 @@ suite('AgentHostAuthTokenCache', () => {
 		cache.clear();
 		assert.strictEqual(cache.updateAndIsChanged('https://api.example.com', ['read'], 'tok1'), true);
 		assert.strictEqual(cache.updateAndIsChanged('https://other.example.com', ['read'], 'tok2'), true);
+	});
+});
+
+suite('resolveMcpServerAuthentication', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('uses challenge scopes without replacing the protected resource scope catalog', async () => {
+		const requestedScopes: (readonly string[] | undefined)[] = [];
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: () => Promise.resolve('provider-1'),
+			getSessions: (_providerId, scopes) => {
+				requestedScopes.push(scopes);
+				return Promise.resolve([]);
+			},
+		});
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IAuthenticationService, authService);
+		instantiationService.stub(IAuthenticationMcpAccessService, {});
+		instantiationService.stub(IAuthenticationMcpService, {
+			getAccountPreference: () => undefined,
+		});
+		instantiationService.stub(IAuthenticationMcpUsageService, {});
+		instantiationService.stub(ILogService, new NullLogService());
+
+		const result = await instantiationService.invokeFunction(resolveMcpServerAuthentication, {
+			resource: 'https://mcp.example.com',
+			authorization_servers: ['https://auth.example.com'],
+			scopes_supported: ['repo', 'read:org', 'notifications'],
+		}, {
+			allowInteraction: false,
+			logPrefix: '[AgentHost]',
+			mcpServerId: 'server-id',
+			mcpServerName: 'Example',
+			mcpServerUrl: 'https://mcp.example.com',
+			scopes: ['notifications'],
+			authenticate: async () => { },
+		});
+
+		assert.deepStrictEqual({ result, requestedScopes }, {
+			result: false,
+			requestedScopes: [['notifications']],
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary

- reuse the existing GitHub token for the official GitHub MCP server's initial scope-less authentication request
- preserve on-demand upscope authentication and keep challenged scopes separate from the server's supported scope catalog
- cover the observed `github` auth payload and reject token reuse for non-GitHub MCP endpoints

## Validation

- `npm run typecheck-client`
- `npm run gulp compile`
- Copilot MCP inventory tests: 6 passing
- Agent Host auth tests: 19 passing
- MCP auth prompt tests: 3 passing
- hygiene checks