### PR TITLE
Claude: rich rendering for Skill and task-list tools

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1221,7 +1221,7 @@ export interface IAgentToolPendingConfirmationSignal {
 	/** Protocol-shaped pending-confirmation state, dispatched verbatim into `ChatToolCallReady`. */
 	readonly state: ToolCallPendingConfirmationState;
 	/** Host-only auto-approval kind (not part of the dispatched action). */
-	readonly permissionKind?: 'shell' | 'write' | 'mcp' | 'read' | 'url' | 'custom-tool' | 'hook' | 'memory' | 'extension-management' | 'extension-permission-access';
+	readonly permissionKind?: 'shell' | 'write' | 'mcp' | 'read' | 'url' | 'skill' | 'custom-tool' | 'hook' | 'memory' | 'extension-management' | 'extension-permission-access';
 	/** Host-only auto-approval path target (not part of the dispatched action). */
 	readonly permissionPath?: string;
 	/**

--- a/src/vs/platform/agentHost/node/claude/claudeToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeToolDisplay.ts
@@ -39,6 +39,7 @@ export type ClaudePermissionKind =
 	| 'mcp'
 	| 'read'
 	| 'url'
+	| 'skill'
 	| 'custom-tool';
 
 /**
@@ -122,6 +123,15 @@ const TOOL_ROWS: { readonly [toolName: string]: ClaudeToolRow } = {
 	Agent: { permissionKind: 'custom-tool', toolKind: 'subagent' },
 	ExitPlanMode: { permissionKind: 'custom-tool', interactive: true },
 	AskUserQuestion: { permissionKind: 'custom-tool', interactive: true },
+
+	// skill + task-list family — host-routed custom tools that render in the
+	// generic tool renderer (no `toolKind`) but carry rich invocation /
+	// past-tense messages so their collapsed row is self-explanatory.
+	Skill: { permissionKind: 'skill' },
+	TaskCreate: { permissionKind: 'custom-tool' },
+	TaskUpdate: { permissionKind: 'custom-tool' },
+	TaskList: { permissionKind: 'custom-tool' },
+	TaskGet: { permissionKind: 'custom-tool' },
 };
 
 const MCP_TOOL_PREFIX = 'mcp__';
@@ -171,6 +181,11 @@ export function getClaudeToolDisplayName(toolName: string): string {
 		case 'Agent': return localize('claude.tool.task', "Run subagent task");
 		case 'ExitPlanMode': return localize('claude.tool.exitPlanMode', "Ready to code?");
 		case 'AskUserQuestion': return localize('claude.tool.askUserQuestion', "Ask user a question");
+		case 'Skill': return localize('claude.tool.skill', "Run skill");
+		case 'TaskCreate': return localize('claude.tool.taskCreate', "Create task");
+		case 'TaskUpdate': return localize('claude.tool.taskUpdate', "Update task");
+		case 'TaskList': return localize('claude.tool.taskList', "List tasks");
+		case 'TaskGet': return localize('claude.tool.taskGet', "Read task");
 	}
 	if (toolName.startsWith(MCP_TOOL_PREFIX)) {
 		return localize('claude.tool.mcp', "Run MCP tool {0}", toolName.slice(MCP_TOOL_PREFIX.length));
@@ -246,6 +261,8 @@ export function getClaudeConfirmationTitle(toolName: string): string {
 			return localize('claude.permission.read.title', "Read file?");
 		case 'url':
 			return localize('claude.permission.url.title', "Fetch URL?");
+		case 'skill':
+			return localize('claude.permission.skill.title', "Run skill?");
 		case 'mcp': {
 			const serverName = toolName.startsWith(MCP_TOOL_PREFIX)
 				? toolName.slice(MCP_TOOL_PREFIX.length).split('__')[0]
@@ -328,6 +345,17 @@ function readStringField(input: unknown, field: string): string | undefined {
 function firstShellLine(input: unknown): string | undefined {
 	const command = readStringField(input, 'command');
 	return command ? command.split('\n')[0] : undefined;
+}
+
+/**
+ * Reads the `status` field of a `TaskUpdate` call and narrows it to the three
+ * values that change the rendered verb ("Starting" / "Completing" / "Deleting").
+ * Any other or absent value yields `undefined`, so the caller falls back to the
+ * generic "Updating" / "Updated" message.
+ */
+function readTaskUpdateStatus(input: unknown): 'in_progress' | 'completed' | 'deleted' | undefined {
+	const status = readStringField(input, 'status');
+	return status === 'in_progress' || status === 'completed' || status === 'deleted' ? status : undefined;
 }
 
 /**
@@ -414,6 +442,31 @@ export function getClaudeInvocationMessage(
 			}
 			return displayName;
 		}
+		case 'Skill': {
+			const skill = readStringField(input, 'skill');
+			if (skill) {
+				return md(localize('claude.toolInvoke.skillNamed', "Running skill {0}", appendEscapedMarkdownInlineCode(truncate(skill, 80))));
+			}
+			return localize('claude.toolInvoke.skill', "Running skill");
+		}
+		case 'TaskCreate': {
+			const subject = readStringField(input, 'subject');
+			if (subject) {
+				return localize('claude.toolInvoke.taskCreateNamed', "Creating task: {0}", truncate(subject, 80));
+			}
+			return localize('claude.toolInvoke.taskCreate', "Creating task");
+		}
+		case 'TaskUpdate':
+			switch (readTaskUpdateStatus(input)) {
+				case 'in_progress': return localize('claude.toolInvoke.taskStart', "Starting task");
+				case 'completed': return localize('claude.toolInvoke.taskComplete', "Completing task");
+				case 'deleted': return localize('claude.toolInvoke.taskDelete', "Deleting task");
+				default: return localize('claude.toolInvoke.taskUpdate', "Updating task");
+			}
+		case 'TaskList':
+			return localize('claude.toolInvoke.taskList', "Reading task list");
+		case 'TaskGet':
+			return localize('claude.toolInvoke.taskGet', "Reading task");
 		default:
 			return displayName;
 	}
@@ -503,6 +556,31 @@ export function getClaudePastTenseMessage(
 		case 'Task':
 		case 'Agent':
 			return localize('claude.toolComplete.task', "Ran subagent");
+		case 'Skill': {
+			const skill = readStringField(input, 'skill');
+			if (skill) {
+				return md(localize('claude.toolComplete.skillNamed', "Ran skill {0}", appendEscapedMarkdownInlineCode(truncate(skill, 80))));
+			}
+			return localize('claude.toolComplete.skill', "Ran skill");
+		}
+		case 'TaskCreate': {
+			const subject = readStringField(input, 'subject');
+			if (subject) {
+				return localize('claude.toolComplete.taskCreateNamed', "Created task: {0}", truncate(subject, 80));
+			}
+			return localize('claude.toolComplete.taskCreate', "Created task");
+		}
+		case 'TaskUpdate':
+			switch (readTaskUpdateStatus(input)) {
+				case 'in_progress': return localize('claude.toolComplete.taskStart', "Started task");
+				case 'completed': return localize('claude.toolComplete.taskComplete', "Completed task");
+				case 'deleted': return localize('claude.toolComplete.taskDelete', "Deleted task");
+				default: return localize('claude.toolComplete.taskUpdate', "Updated task");
+			}
+		case 'TaskList':
+			return localize('claude.toolComplete.taskList', "Read task list");
+		case 'TaskGet':
+			return localize('claude.toolComplete.taskGet', "Read task");
 		default:
 			return displayName;
 	}

--- a/src/vs/platform/agentHost/node/claude/claudeToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeToolDisplay.ts
@@ -348,10 +348,8 @@ function firstShellLine(input: unknown): string | undefined {
 }
 
 /**
- * Reads the `status` field of a `TaskUpdate` call and narrows it to the three
- * values that change the rendered verb ("Starting" / "Completing" / "Deleting").
- * Any other or absent value yields `undefined`, so the caller falls back to the
- * generic "Updating" / "Updated" message.
+ * Narrows a `TaskUpdate` call's `status` to the values that change the rendered
+ * verb; any other or absent value yields `undefined` (generic "Updating" verb).
  */
 function readTaskUpdateStatus(input: unknown): 'in_progress' | 'completed' | 'deleted' | undefined {
 	const status = readStringField(input, 'status');

--- a/src/vs/platform/agentHost/test/node/claudeToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeToolDisplay.test.ts
@@ -36,6 +36,7 @@ suite('claudeToolDisplay — §4 mapping table', () => {
 			'Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'TodoWrite',
 			'WebFetch', 'Task',
 			'ExitPlanMode', 'AskUserQuestion',
+			'Skill', 'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet',
 		] as const;
 
 		const snapshot = TOOLS.map(t => [t, getClaudePermissionKind(t), getClaudeToolDisplayName(t)] as const);
@@ -58,6 +59,11 @@ suite('claudeToolDisplay — §4 mapping table', () => {
 			['Task', 'custom-tool', 'Run subagent task'],
 			['ExitPlanMode', 'custom-tool', 'Ready to code?'],
 			['AskUserQuestion', 'custom-tool', 'Ask user a question'],
+			['Skill', 'skill', 'Run skill'],
+			['TaskCreate', 'custom-tool', 'Create task'],
+			['TaskUpdate', 'custom-tool', 'Update task'],
+			['TaskList', 'custom-tool', 'List tasks'],
+			['TaskGet', 'custom-tool', 'Read task'],
 		]);
 	});
 
@@ -138,6 +144,7 @@ suite('claudeToolDisplay — §4 mapping table', () => {
 				url: getClaudeConfirmationTitle('WebFetch'),
 				mcpWithServer: getClaudeConfirmationTitle('mcp__github__listIssues'),
 				custom: getClaudeConfirmationTitle('Task'),
+				skill: getClaudeConfirmationTitle('Skill'),
 				unknown: getClaudeConfirmationTitle('SomeNewTool'),
 			},
 			{
@@ -147,6 +154,7 @@ suite('claudeToolDisplay — §4 mapping table', () => {
 				url: 'Fetch URL?',
 				mcpWithServer: 'Allow tool from github?',
 				custom: 'Allow tool call?',
+				skill: 'Run skill?',
 				unknown: 'Allow tool call?',
 			},
 		);
@@ -198,6 +206,11 @@ suite('claudeToolDisplay — §4 mapping table', () => {
 			Task: { description: 'find the bug', subagent_type: 'Explore' },
 			ExitPlanMode: { plan: '...' },
 			AskUserQuestion: { question: 'why?' },
+			Skill: { skill: 'deep-research', args: 'foo' },
+			TaskCreate: { subject: 'Fix auth bug', description: '...' },
+			TaskUpdate: { taskId: '1', status: 'completed' },
+			TaskList: {},
+			TaskGet: { taskId: '1' },
 		};
 
 		const TOOLS = Object.keys(SAMPLE_INPUT) as readonly (keyof typeof SAMPLE_INPUT)[];
@@ -234,7 +247,43 @@ suite('claudeToolDisplay — §4 mapping table', () => {
 			['Task', 'subagent', { toolKind: 'subagent' }, 'find the bug', 'Ran subagent', '"Run subagent task" failed', '{\n  "description": "find the bug",\n  "subagent_type": "Explore"\n}'],
 			['ExitPlanMode', undefined, undefined, 'Ready to code?', 'Ready to code?', '"Ready to code?" failed', '{\n  "plan": "..."\n}'],
 			['AskUserQuestion', undefined, undefined, 'Ask user a question', 'Ask user a question', '"Ask user a question" failed', '{\n  "question": "why?"\n}'],
+			['Skill', undefined, undefined, { markdown: 'Running skill `deep-research`' }, { markdown: 'Ran skill `deep-research`' }, '"Run skill" failed', '{\n  "skill": "deep-research",\n  "args": "foo"\n}'],
+			['TaskCreate', undefined, undefined, 'Creating task: Fix auth bug', 'Created task: Fix auth bug', '"Create task" failed', '{\n  "subject": "Fix auth bug",\n  "description": "..."\n}'],
+			['TaskUpdate', undefined, undefined, 'Completing task', 'Completed task', '"Update task" failed', '{\n  "taskId": "1",\n  "status": "completed"\n}'],
+			['TaskList', undefined, undefined, 'Reading task list', 'Read task list', '"List tasks" failed', '{}'],
+			['TaskGet', undefined, undefined, 'Reading task', 'Read task', '"Read task" failed', '{\n  "taskId": "1"\n}'],
 		]);
+	});
+
+	test('Phase 8.5 — TaskUpdate message varies by status', () => {
+		const invoke = (status?: string) =>
+			getClaudeInvocationMessage('TaskUpdate', 'Update task', status ? { taskId: '1', status } : { taskId: '1' });
+		const past = (status?: string) =>
+			getClaudePastTenseMessage('TaskUpdate', 'Update task', status ? { taskId: '1', status } : { taskId: '1' }, true);
+		assert.deepStrictEqual(
+			{
+				startInvoke: invoke('in_progress'),
+				startPast: past('in_progress'),
+				completeInvoke: invoke('completed'),
+				completePast: past('completed'),
+				deleteInvoke: invoke('deleted'),
+				deletePast: past('deleted'),
+				noStatusInvoke: invoke(),
+				noStatusPast: past(),
+				unknownStatusInvoke: invoke('bogus'),
+			},
+			{
+				startInvoke: 'Starting task',
+				startPast: 'Started task',
+				completeInvoke: 'Completing task',
+				completePast: 'Completed task',
+				deleteInvoke: 'Deleting task',
+				deletePast: 'Deleted task',
+				noStatusInvoke: 'Updating task',
+				noStatusPast: 'Updated task',
+				unknownStatusInvoke: 'Updating task',
+			},
+		);
 	});
 
 	test('Phase 8.5 — defensive input handling falls back to static display strings', () => {


### PR DESCRIPTION
Fixes #325389

### Problem

In the agent-host (Claude) chat, the `Skill`, `TaskCreate`, `TaskUpdate`, `TaskList` and `TaskGet` tool calls rendered as their **bare tool name** in the collapsed row — you had to expand them to learn what happened. Every other Claude built-in tool (`Bash`, `Read`, `Grep`, `Task`, …) already shows a rich, self-explanatory label. These tools were simply missing from the `claudeToolDisplay` mapping table.

### Change

All rendering flows through one pure source of truth, `src/vs/platform/agentHost/node/claude/claudeToolDisplay.ts`, consumed by the live / replay / confirmation seams — so one edit lights up every path.

Added rich invocation / past-tense messages:

| Tool | Collapsed row now reads |
|---|---|
| `Skill` | Running skill `<name>` / Ran skill `<name>` |
| `TaskCreate` | Creating task: `<subject>` / Created task: `<subject>` |
| `TaskUpdate` | status-aware — Starting / Completing / Deleting / Updating task |
| `TaskList` | Reading task list / Read task list |
| `TaskGet` | Reading task / Read task |

Task subjects render as plain text (no markdown-injection risk); the skill name renders as inline code. `TaskUpdate` keeps its present/past verbs in sync via a small `readTaskUpdateStatus` helper.

`Skill` also gets a dedicated **`skill` permissionKind** (added to the Claude `ClaudePermissionKind` union and the shared `IAgentToolPendingConfirmationSignal.permissionKind` union in `agentService.ts`, which the value flows into). Its confirmation prompt now reads **"Run skill?"** instead of the generic "Allow tool call?", driven by kind like every other tool. The new kind falls through `getAutoApproval` exactly like `custom-tool` (no auto-approve branch), so behavior is unchanged.

### Testing

- `claudeToolDisplay` snapshot suite extended to cover the 5 new tools + the four `TaskUpdate` status branches — **12/12 pass**.
- Core typecheck clean (the shared-union edit compiles across all consumers).
- Verified live in the Agents window against a real Claude session: `Skill` (caveman / grill-me / diagnose) rendered "Ran skill `<name>`" with the name in an inline-code chip, and `TaskCreate`/`TaskUpdate` rendered "Created task: …" / "Started task".

> Note: I could not surface a blocking **"Run skill?"** confirmation card live — the Claude SDK auto-approves the `Skill` tool in every available permission mode, so `getClaudeConfirmationTitle('Skill')` isn't reached in practice today. The title change is unit-tested and correct for when that path is hit (e.g. under a stricter/gated preset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)