### PR TITLE
Improve error message for unconfigured BYOK utility model

### DIFF
--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -193,7 +193,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 				case BYOKUtilityModelDefault.MainAgent:
 					return this._instantiationService.createInstance(ExtensionContributedChatEndpoint, this._mainAgentBYOKModel);
 				case BYOKUtilityModelDefault.None:
-					throw new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK. Please set chat.byokUtilityModelDefault to 'mainAgent' or 'copilot'`);
+					throw new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK. Configure '${family === 'copilot-utility' ? 'chat.utilityModel' : 'chat.utilitySmallModel'}' or set 'chat.byokUtilityModelDefault' to 'mainAgent' or 'copilot'.`);
 				case BYOKUtilityModelDefault.Copilot:
 					break;
 			}

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -193,7 +193,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 				case BYOKUtilityModelDefault.MainAgent:
 					return this._instantiationService.createInstance(ExtensionContributedChatEndpoint, this._mainAgentBYOKModel);
 				case BYOKUtilityModelDefault.None:
-					throw new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK.`);
+					throw new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK. Please set chat.byokUtilityModelDefault to 'mainAgent' or 'copilot'`);
 				case BYOKUtilityModelDefault.Copilot:
 					break;
 			}


### PR DESCRIPTION
Enhance the error message when no utility model is configured for the BYOK main agent, providing clearer guidance on how to set the configuration.

