### PR TITLE
Push BYOK models to the agent host instead of pulling them

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostByokLm.ts
+++ b/src/vs/platform/agentHost/common/agentHostByokLm.ts
@@ -135,14 +135,11 @@ export interface IAgentHostByokLmHandler {
 
 /**
  * Node-side connection to a single renderer's {@link IAgentHostByokLmHandler}.
- * Mirrors `IRemoteFilesystemConnection` for the reverse FS bridge.
+ * Mirrors `IRemoteFilesystemConnection` for the reverse FS bridge. The renderer
+ * pushes its models over {@link onDidChangeModels}; `chat` stays a round-trip.
  */
 export interface IByokLmBridgeConnection {
 	chat(request: IByokLmChatRequest): Promise<IByokLmChatResult>;
-	listModels(): Promise<IByokLmModelInfo[]>;
-	/**
-	 * Fires when the renderer's set of BYOK models changes, so the agent host
-	 * can re-enumerate. Optional: test fakes may omit it.
-	 */
-	readonly onDidChangeModels?: Event<void>;
+	/** Emits the renderer's current BYOK model snapshot on subscribe and on every change. */
+	readonly onDidChangeModels: Event<IByokLmModelInfo[]>;
 }

--- a/src/vs/platform/agentHost/common/agentHostClientByokLmChannel.ts
+++ b/src/vs/platform/agentHost/common/agentHostClientByokLmChannel.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../base/common/cancellation.js';
+import { Throttler } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { DisposableStore } from '../../../base/common/lifecycle.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
@@ -67,9 +68,13 @@ export class AgentHostClientByokLmChannel implements IServerChannel {
 	 * A snapshot stream of the renderer's BYOK models: emits the current models
 	 * when a subscriber attaches, then re-emits whenever the handler reports a
 	 * change. Enumeration is renderer-local, so the node side only ever receives.
+	 *
+	 * A {@link Throttler} serializes overlapping publishes and coalesces bursts,
+	 * so a slow enumeration can't fire a stale snapshot after a newer one.
 	 */
 	private _modelsSnapshotEvent(): Event<IByokLmModelInfo[]> {
 		const store = new DisposableStore();
+		const throttler = store.add(new Throttler());
 		const emitter = store.add(new Emitter<IByokLmModelInfo[]>({
 			onDidAddFirstListener: () => {
 				if (this._handler.onDidChangeModels) {
@@ -79,16 +84,22 @@ export class AgentHostClientByokLmChannel implements IServerChannel {
 			},
 			onDidRemoveLastListener: () => store.dispose(),
 		}));
-		const publish = async () => {
-			try {
-				const models = await this._handler.listModels(CancellationToken.None);
-				if (!store.isDisposed) {
-					emitter.fire(models);
-				}
-			} catch {
-				// Leave the snapshot unpublished so the node side treats this connection as non-serving.
-				this._logService.warn('AgentHostClientByokLmChannel: failed to enumerate BYOK models from the renderer');
+		const publish = () => {
+			if (store.isDisposed) {
+				return; // avoid a floating rejection from a disposed throttler
 			}
+			throttler.queue(async () => {
+				try {
+					const models = await this._handler.listModels(CancellationToken.None);
+					if (!store.isDisposed) {
+						emitter.fire(models);
+					}
+				} catch (err) {
+					// Leave the snapshot unpublished (the connection stays non-serving);
+					// surface the error so renderer-side failures are diagnosable.
+					this._logService.warn('AgentHostClientByokLmChannel: failed to enumerate BYOK models from the renderer', err);
+				}
+			});
 		};
 		return emitter.event;
 	}

--- a/src/vs/platform/agentHost/common/agentHostClientByokLmChannel.ts
+++ b/src/vs/platform/agentHost/common/agentHostClientByokLmChannel.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../base/common/cancellation.js';
-import { Event } from '../../../base/common/event.js';
-import { Lazy } from '../../../base/common/lazy.js';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { DisposableStore } from '../../../base/common/lifecycle.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
+import { ILogService } from '../../log/common/log.js';
 import {
 	IAgentHostByokLmHandler,
 	IByokLmBridgeConnection,
@@ -31,38 +32,65 @@ export const AGENT_HOST_CLIENT_BYOK_LM_CHANNEL = 'agentHostClientByokLm';
  * `UtilityProcessServer.getChannel`) into an {@link IByokLmBridgeConnection}
  * suitable for the node-side {@link IByokLmProxyService}. This is the node end
  * of the bridge: `chat()` ships the request to the renderer and resolves with
- * the buffered completion the renderer produced from the LM API.
+ * the buffered completion the renderer produced from the LM API, and
+ * `onDidChangeModels` is the renderer's pushed model snapshot stream.
  */
 export function createAgentHostClientByokLmConnection(channel: IChannel): IByokLmBridgeConnection {
-	// Reach for `channel.listen` lazily — only when a consumer actually
-	// subscribes to `onDidChangeModels` — mirroring the deferred `channel.call`
-	// usage below (and the reverse FS bridge). Touching the channel eagerly at
-	// construction would force every connection to register an IPC event handler
-	// up front, even when nothing listens.
-	const onDidChangeModels = new Lazy(() => channel.listen<void>('onDidChangeModels'));
 	return {
 		chat: (request) => channel.call('chat', request) as Promise<IByokLmChatResult>,
-		listModels: () => channel.call('listModels') as Promise<IByokLmModelInfo[]>,
-		onDidChangeModels: (listener, thisArgs, disposables) => onDidChangeModels.value(listener, thisArgs, disposables),
+		onDidChangeModels: channel.listen<IByokLmModelInfo[]>('models'),
 	};
 }
 
 /**
  * Server-side channel for in-process reverse BYOK LM RPCs from the local agent
  * host. Thin adapter — forwards `chat` calls to the renderer's
- * {@link IAgentHostByokLmHandler} (backed by `ILanguageModelsService`).
+ * {@link IAgentHostByokLmHandler} (backed by `ILanguageModelsService`) and
+ * serves the pushed `models` snapshot stream.
  */
+
 export class AgentHostClientByokLmChannel implements IServerChannel {
 
 	constructor(
 		@IAgentHostByokLmHandler private readonly _handler: IAgentHostByokLmHandler,
+		@ILogService private readonly _logService: ILogService,
 	) { }
 
 	listen<T>(_ctx: unknown, event: string): Event<T> {
-		if (event === 'onDidChangeModels') {
-			return (this._handler.onDidChangeModels ?? Event.None) as Event<T>;
+		if (event === 'models') {
+			return this._modelsSnapshotEvent() as Event<T>;
 		}
 		throw new Error(`No event '${event}' on AgentHostClientByokLmChannel`);
+	}
+
+	/**
+	 * A snapshot stream of the renderer's BYOK models: emits the current models
+	 * when a subscriber attaches, then re-emits whenever the handler reports a
+	 * change. Enumeration is renderer-local, so the node side only ever receives.
+	 */
+	private _modelsSnapshotEvent(): Event<IByokLmModelInfo[]> {
+		const store = new DisposableStore();
+		const emitter = store.add(new Emitter<IByokLmModelInfo[]>({
+			onDidAddFirstListener: () => {
+				if (this._handler.onDidChangeModels) {
+					store.add(this._handler.onDidChangeModels(() => void publish()));
+				}
+				void publish();
+			},
+			onDidRemoveLastListener: () => store.dispose(),
+		}));
+		const publish = async () => {
+			try {
+				const models = await this._handler.listModels(CancellationToken.None);
+				if (!store.isDisposed) {
+					emitter.fire(models);
+				}
+			} catch {
+				// Leave the snapshot unpublished so the node side treats this connection as non-serving.
+				this._logService.warn('AgentHostClientByokLmChannel: failed to enumerate BYOK models from the renderer');
+			}
+		};
+		return emitter.event;
 	}
 
 	async call<T>(_ctx: unknown, command: string, arg?: unknown): Promise<T> {
@@ -70,10 +98,6 @@ export class AgentHostClientByokLmChannel implements IServerChannel {
 			case 'chat': {
 				const result = await this._handler.chat(arg as IByokLmChatRequest, CancellationToken.None);
 				return result as T;
-			}
-			case 'listModels': {
-				const models = await this._handler.listModels(CancellationToken.None);
-				return models as T;
 			}
 		}
 		throw new Error(`Unknown command '${command}' on AgentHostClientByokLmChannel`);

--- a/src/vs/platform/agentHost/node/byokLmBridgeRegistry.ts
+++ b/src/vs/platform/agentHost/node/byokLmBridgeRegistry.ts
@@ -21,16 +21,16 @@ export const IByokLmBridgeRegistry = createDecorator<IByokLmBridgeRegistry>('byo
  * handler exposes the same set. Both the main workbench and the dedicated Agents
  * app register it (each runs a full extension host whose LM API holds the same
  * BYOK models), so either can serve. A connection that connects without binding
- * the handler registers a bridge whose `listModels()` rejects and is treated as
- * non-serving. The registry therefore does NOT aggregate per-window model sets;
- * it surfaces the models from any one *serving* window (preferring one that
- * actually has models) and routes inference there, automatically excluding
- * non-serving windows.
+ * the handler never pushes a snapshot and is treated as non-serving. The registry
+ * therefore does NOT aggregate per-window model sets; it surfaces the models from
+ * any one *serving* window (preferring one that actually has models) and routes
+ * inference there, automatically excluding non-serving windows.
  *
- * A connection becomes "serving" once its `listModels()` resolves (even to an
- * empty list). On registration (and whenever a connection reports
- * {@link IByokLmBridgeConnection.onDidChangeModels}) the registry enumerates it
- * and fires {@link onDidChangeModels} when the serving model set changes.
+ * **Push, not pull.** Each connection pushes its current model snapshot over
+ * {@link IByokLmBridgeConnection.onDidChangeModels} (on subscribe and on every
+ * change); the registry subscribes on {@link register}, caches each snapshot, and
+ * fires {@link onDidChangeModels} when the serving model set changes. A connection
+ * becomes "serving" once it pushes its first snapshot (even an empty one).
  */
 export interface IByokLmBridgeRegistry {
 	readonly _serviceBrand: undefined;
@@ -39,28 +39,20 @@ export interface IByokLmBridgeRegistry {
 	register(clientId: string, connection: IByokLmBridgeConnection): IDisposable;
 
 	/**
-	 * Re-enumerate the connected renderers, refresh the cache, and return the
-	 * serving window's BYOK models. Use this when freshness matters (e.g.
-	 * synthesizing a session's provider config at create time).
-	 */
-	listModels(): Promise<IByokLmModelInfo[]>;
-
-	/**
 	 * The serving window's BYOK models, read synchronously from the cache (no
 	 * enumeration). Use this for fast reads driven by {@link onDidChangeModels}.
 	 */
 	getModels(): readonly IByokLmModelInfo[];
 
 	/**
-	 * A connection that can serve BYOK inference (one whose enumeration has
-	 * resolved), or `undefined` when no connected window can. All serving
-	 * windows expose the same models, so any one of them is a valid target.
+	 * A connection that can serve BYOK inference, or `undefined` when none can.
+	 * All serving windows expose the same models, so any one is a valid target.
 	 */
 	getServingConnection(): IByokLmBridgeConnection | undefined;
 
 	/**
 	 * Subscribe to changes in the set of registered connections (a renderer
-	 * connecting or disconnecting) or in the serving window's models, so
+	 * connecting or disconnecting) or in the serving window's pushed models, so
 	 * consumers can re-read {@link getModels}. Disposing the result removes the
 	 * listener.
 	 */
@@ -68,11 +60,10 @@ export interface IByokLmBridgeRegistry {
 }
 
 /**
- * Per-connection registry entry. `models` is `undefined` until the connection's
- * first successful enumeration; a connection with defined `models` is "serving"
- * (it answered, even if with an empty list). Non-serving windows (those that did
- * not register the BYOK handler, whose `listModels()` rejects) keep
- * `models === undefined`.
+ * Per-connection registry entry. `models` is `undefined` until the connection
+ * pushes its first snapshot; a connection with defined `models` is "serving"
+ * (it pushed, even an empty list). Non-serving windows (those that did not
+ * register the BYOK handler and therefore never push) keep `models === undefined`.
  */
 interface IConnectionEntry {
 	readonly connection: IByokLmBridgeConnection;
@@ -110,16 +101,20 @@ export class ByokLmBridgeRegistry implements IByokLmBridgeRegistry {
 		const entry: IConnectionEntry = { connection, models: undefined, store };
 		this._entries.set(clientId, entry);
 
-		// Re-enumerate whenever the renderer reports its BYOK models changed.
-		if (connection.onDidChangeModels) {
-			store.add(connection.onDidChangeModels(() => {
-				void this._refreshConnection(clientId);
-			}));
-		}
+		// Cache each pushed snapshot; notify only when the serving set changes.
+		store.add(connection.onDidChangeModels(models => {
+			// Drop the push if the entry was removed/replaced meanwhile.
+			if (this._entries.get(clientId) !== entry) {
+				return;
+			}
+			if (entry.models === undefined || !modelsEqual(entry.models, models)) {
+				entry.models = models;
+				this._notifyChanged();
+			}
+		}));
 
-		// The connection set changed; enumerate the new connection's models.
+		// The connection set changed (a renderer connected).
 		this._notifyChanged();
-		void this._refreshConnection(clientId);
 
 		return toDisposable(() => {
 			if (this._entries.get(clientId) === entry) {
@@ -128,13 +123,6 @@ export class ByokLmBridgeRegistry implements IByokLmBridgeRegistry {
 				this._notifyChanged();
 			}
 		});
-	}
-
-	async listModels(): Promise<IByokLmModelInfo[]> {
-		// Actively re-enumerate every connection so callers that need freshness
-		// (e.g. session create) don't race a cold cache.
-		await Promise.all([...this._entries.keys()].map(clientId => this._refreshConnection(clientId)));
-		return [...this.getModels()];
 	}
 
 	getModels(): readonly IByokLmModelInfo[] {
@@ -146,14 +134,11 @@ export class ByokLmBridgeRegistry implements IByokLmBridgeRegistry {
 	}
 
 	/**
-	 * A connection that has answered an enumeration (`models` defined), preferring
-	 * one whose model set is non-empty. All serving windows expose the same models,
-	 * so any populated one is an equivalent source/target; the preference matters
-	 * when a window that is still starting up (e.g. the Agents app before its BYOK
-	 * extension has registered models) answers with an empty list first — it must
-	 * not shadow a peer that already has them, transiently or permanently. Falls
-	 * back to a serving-but-empty window when none have models yet; non-serving
-	 * windows (those that didn't register the BYOK handler) are skipped.
+	 * A serving connection (`models` defined), preferring one whose model set is
+	 * non-empty. All serving windows expose the same models, so any populated one
+	 * is equivalent; the preference matters when a still-starting window pushes an
+	 * empty list first — it must not shadow a peer that already has them. Falls
+	 * back to a serving-but-empty window; non-serving windows are skipped.
 	 */
 	private _servingEntry(): IConnectionEntry | undefined {
 		let emptyFallback: IConnectionEntry | undefined;
@@ -167,36 +152,6 @@ export class ByokLmBridgeRegistry implements IByokLmBridgeRegistry {
 			emptyFallback ??= entry;
 		}
 		return emptyFallback;
-	}
-
-	/**
-	 * Enumerate a single connection's models into its cache and notify listeners
-	 * when the result changes. A connection whose `listModels()` rejects (e.g. a
-	 * window that did not register the BYOK handler) is left non-serving.
-	 */
-	private async _refreshConnection(clientId: string): Promise<void> {
-		const entry = this._entries.get(clientId);
-		if (!entry) {
-			return;
-		}
-		let models: readonly IByokLmModelInfo[];
-		try {
-			models = await entry.connection.listModels();
-		} catch {
-			// The connection didn't answer (e.g. no BYOK handler registered);
-			// leave it non-serving.
-			return;
-		}
-		// Drop the result if the entry was removed/replaced while in flight.
-		if (this._entries.get(clientId) !== entry) {
-			return;
-		}
-		// The connection answered, so this entry is serving. Notify only when the
-		// serving model set actually changed.
-		if (entry.models === undefined || !modelsEqual(entry.models, models)) {
-			entry.models = models;
-			this._notifyChanged();
-		}
 	}
 }
 
@@ -222,10 +177,6 @@ export class NullByokLmBridgeRegistry implements IByokLmBridgeRegistry {
 
 	register(): IDisposable {
 		return Disposable.None;
-	}
-
-	async listModels(): Promise<IByokLmModelInfo[]> {
-		return [];
 	}
 
 	getModels(): readonly IByokLmModelInfo[] {

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -300,32 +300,19 @@ export function getCopilotContextTier(model: ModelSelection | undefined, longCon
  * Extracted from {@link CopilotSessionLauncher} so the synthesis and gating are
  * unit-testable without instantiating the launcher; the launcher passes a
  * `startProxy` thunk that memoizes the single shared proxy handle.
- *
- * `preferCache` (resume) reads the registry's warm cache to skip a renderer
- * round-trip, but only when that cache is already populated; an empty cache
- * falls back to a live enumeration. `create` always enumerates live.
  */
 export async function resolveByokSessionConfig(
 	sessionId: string,
 	bridgeRegistry: IByokLmBridgeRegistry,
 	startProxy: () => Promise<IByokLmProxyHandle>,
 	logService: ILogService,
-	preferCache = false,
 ): Promise<{ providers?: NamedProviderConfig[]; models?: ProviderModelConfig[] }> {
-	// Surface the serving window's BYOK models. The registry tracks every
-	// connected renderer but does not union their model sets — a window's BYOK
-	// models come from its installed extensions, so all serving windows expose
-	// the same set and the registry picks one serving window (see
-	// `IByokLmBridgeRegistry`). Inbound inference is routed to that same serving
-	// connection by the proxy (`getServingConnection`).
+	// Surface the serving window's BYOK models. The registry does not union
+	// windows' model sets — all serving windows expose the same set, so it picks
+	// one (see `IByokLmBridgeRegistry`) and the proxy routes inference there.
 	let byokModels: IByokLmModelInfo[];
 	try {
-		const cached = preferCache ? bridgeRegistry.getModels() : undefined;
-		if (cached && cached.length > 0) {
-			byokModels = [...cached];
-		} else {
-			byokModels = await bridgeRegistry.listModels();
-		}
+		byokModels = [...bridgeRegistry.getModels()];
 	} catch (err) {
 		logService.warn(`[Copilot:${sessionId}] Failed to enumerate BYOK models from renderer bridges`, err);
 		return {};
@@ -511,13 +498,13 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 	 * active bridge registry and a `startProxy` thunk that memoizes the single
 	 * shared proxy handle for this launcher (started lazily on first use).
 	 */
-	private _resolveByokSessionConfig(sessionId: string, preferCache: boolean): Promise<{ providers?: NamedProviderConfig[]; models?: ProviderModelConfig[] }> {
+	private _resolveByokSessionConfig(sessionId: string): Promise<{ providers?: NamedProviderConfig[]; models?: ProviderModelConfig[] }> {
 		return resolveByokSessionConfig(sessionId, this._byokLmBridgeRegistry, () => {
 			if (!this._byokProxyHandle) {
 				this._byokProxyHandle = this._byokLmProxyService.start();
 			}
 			return this._byokProxyHandle;
-		}, this._logService, preferCache);
+		}, this._logService);
 	}
 
 	/**
@@ -547,10 +534,9 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 	private async _buildSessionConfig(plan: CopilotSessionLaunchPlan, runtime: ICopilotSessionRuntime): Promise<CopilotSessionLaunchConfig> {
 		const plugins = plan.snapshot.plugins;
 		// Synthesize BYOK provider/model config (empty when BYOK is gated off or the
-		// renderer reports no BYOK models). Merged into the returned config so both
+		// renderer reports no BYOK models), merged into the returned config so both
 		// createSession and resumeSession advertise the models to the runtime.
-		// Resume prefers the registry's warm cache over a live renderer round-trip.
-		const byok = await this._resolveByokSessionConfig(plan.sessionId, plan.kind === 'resume');
+		const byok = await this._resolveByokSessionConfig(plan.sessionId);
 		const enableCustomTerminalTool = this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.EnableCustomTerminalTool) === true;
 		let shellTools: Awaited<ReturnType<typeof createShellTools>> = [];
 		if (enableCustomTerminalTool) {

--- a/src/vs/platform/agentHost/test/node/agentHostClientByokLmChannel.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostClientByokLmChannel.test.ts
@@ -4,22 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { Event } from '../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
 import type { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
 import type { IAgentHostByokLmHandler, IByokLmChatRequest, IByokLmChatResult, IByokLmModelInfo } from '../../common/agentHostByokLm.js';
 import { AgentHostClientByokLmChannel, createAgentHostClientByokLmConnection } from '../../common/agentHostClientByokLmChannel.js';
 
 suite('agentHostClientByokLmChannel', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	function handlerOf(
 		chat: (request: IByokLmChatRequest) => Promise<IByokLmChatResult>,
 		listModels: () => Promise<IByokLmModelInfo[]> = async () => [],
+		onDidChangeModels?: Event<void>,
 	): IAgentHostByokLmHandler {
-		return { _serviceBrand: undefined, chat: (request) => chat(request), listModels: () => listModels() };
+		return { _serviceBrand: undefined, chat: (request) => chat(request), listModels: () => listModels(), onDidChangeModels };
 	}
+
+	/** Resolves once the channel's async snapshot publish has settled. */
+	const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
 
 	/**
 	 * Wire the node-side connection straight to the renderer server channel,
@@ -27,13 +32,16 @@ suite('agentHostClientByokLmChannel', () => {
 	 * response round-trip can be exercised without the renderer or the SDK.
 	 */
 	function bridge(handler: IAgentHostByokLmHandler) {
-		const server = new AgentHostClientByokLmChannel(handler);
+		const server = new AgentHostClientByokLmChannel(handler, new NullLogService());
 		const channel: IChannel = {
 			call<T>(command: string, arg?: unknown): Promise<T> {
 				return server.call<T>(null, command, arg);
 			},
 			listen<T>(event: string): Event<T> {
-				return server.listen<T>(null, event);
+				// Mirror ChannelClient.listen: defer to the server channel only when
+				// the returned event is actually subscribed (lazy), so a connection
+				// that never listens allocates nothing.
+				return (listener, thisArgs?, disposables?) => server.listen<T>(null, event)(listener, thisArgs, disposables);
 			},
 		};
 		return createAgentHostClientByokLmConnection(channel);
@@ -59,19 +67,34 @@ suite('agentHostClientByokLmChannel', () => {
 		assert.strictEqual(result.error, 'no model');
 	});
 
-	test('round-trips listModels to the handler', async () => {
-		const models: IByokLmModelInfo[] = [{ vendor: 'acme', id: 'claude', name: 'Acme Claude', maxContextWindowTokens: 128000 }];
-		const connection = bridge(handlerOf(async () => ({ content: '' }), async () => models));
-		assert.deepStrictEqual(await connection.listModels(), models);
+	test('pushes the current model snapshot on subscribe and re-pushes on change', async () => {
+		const onDidChange = store.add(new Emitter<void>());
+		let models: IByokLmModelInfo[] = [{ vendor: 'acme', id: 'claude', name: 'Acme Claude', maxContextWindowTokens: 128000 }];
+		const connection = bridge(handlerOf(async () => ({ content: '' }), async () => models, onDidChange.event));
+
+		const pushed: IByokLmModelInfo[][] = [];
+		const sub = connection.onDidChangeModels(snapshot => pushed.push(snapshot));
+		await flush();
+
+		// A change on the handler triggers a fresh snapshot push.
+		models = [{ vendor: 'acme', id: 'gpt' }];
+		onDidChange.fire();
+		await flush();
+
+		sub.dispose();
+		assert.deepStrictEqual(pushed, [
+			[{ vendor: 'acme', id: 'claude', name: 'Acme Claude', maxContextWindowTokens: 128000 }],
+			[{ vendor: 'acme', id: 'gpt' }],
+		]);
 	});
 
 	test('rejects unknown channel commands', async () => {
-		const server = new AgentHostClientByokLmChannel(handlerOf(async () => ({ content: '' })));
+		const server = new AgentHostClientByokLmChannel(handlerOf(async () => ({ content: '' })), new NullLogService());
 		await assert.rejects(() => server.call(null, 'frobnicate'), /Unknown command/);
 	});
 
-	test('exposes no events', () => {
-		const server = new AgentHostClientByokLmChannel(handlerOf(async () => ({ content: '' })));
+	test('exposes only the models event', () => {
+		const server = new AgentHostClientByokLmChannel(handlerOf(async () => ({ content: '' })), new NullLogService());
 		assert.throws(() => server.listen(null, 'anything'), /No event/);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostClientByokLmChannel.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostClientByokLmChannel.test.ts
@@ -88,6 +88,28 @@ suite('agentHostClientByokLmChannel', () => {
 		]);
 	});
 
+	test('coalesces a burst of changes so the final snapshot reflects the latest models', async () => {
+		const onDidChange = store.add(new Emitter<void>());
+		let models: IByokLmModelInfo[] = [{ vendor: 'acme', id: 'v1' }];
+		const connection = bridge(handlerOf(async () => ({ content: '' }), async () => models, onDidChange.event));
+
+		const pushed: IByokLmModelInfo[][] = [];
+		const sub = connection.onDidChangeModels(snapshot => pushed.push(snapshot));
+		await flush();
+
+		// A rapid burst: several changes fire before any enumeration settles. The
+		// throttler serializes them, so the last snapshot must reflect the latest
+		// models rather than a stale enumeration finishing out of order.
+		models = [{ vendor: 'acme', id: 'v2' }];
+		onDidChange.fire();
+		models = [{ vendor: 'acme', id: 'v3' }];
+		onDidChange.fire();
+		await flush();
+
+		sub.dispose();
+		assert.deepStrictEqual(pushed.at(-1), [{ vendor: 'acme', id: 'v3' }]);
+	});
+
 	test('rejects unknown channel commands', async () => {
 		const server = new AgentHostClientByokLmChannel(handlerOf(async () => ({ content: '' })), new NullLogService());
 		await assert.rejects(() => server.call(null, 'frobnicate'), /Unknown command/);

--- a/src/vs/platform/agentHost/test/node/byokLmBridgeRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/byokLmBridgeRegistry.test.ts
@@ -10,48 +10,48 @@ import type { IByokLmBridgeConnection, IByokLmChatResult, IByokLmModelInfo } fro
 import { ByokLmBridgeRegistry } from '../../node/byokLmBridgeRegistry.js';
 
 /**
- * Pins the behaviour of {@link ByokLmBridgeRegistry}: it surfaces the models of a
- * single *serving* connection (preferring one that actually has models), routes
- * inference there, excludes connections whose enumeration rejects, and notifies
- * listeners on model/connection changes.
+ * Pins the behaviour of {@link ByokLmBridgeRegistry}: it caches the model
+ * snapshots pushed by each connection, surfaces the models of a single *serving*
+ * connection (preferring one that actually has models), routes inference there,
+ * excludes connections that never push, and notifies listeners on
+ * model/connection changes.
  */
 suite('ByokLmBridgeRegistry', () => {
 
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	/** A scripted bridge connection; `chat` is unused by these tests. */
-	function connectionOf(listModels: () => Promise<IByokLmModelInfo[]>, onDidChangeModels?: Emitter<void>): IByokLmBridgeConnection {
+	/**
+	 * A scripted bridge connection whose model snapshots are pushed on demand via
+	 * the returned `push`. A connection that never pushes stays non-serving.
+	 * `chat` is unused by these tests.
+	 */
+	function pushable(): { connection: IByokLmBridgeConnection; push: (models: IByokLmModelInfo[]) => void } {
+		const emitter = store.add(new Emitter<IByokLmModelInfo[]>());
 		return {
-			chat: async (): Promise<IByokLmChatResult> => ({ content: '' }),
-			listModels,
-			...(onDidChangeModels ? { onDidChangeModels: onDidChangeModels.event } : {}),
+			connection: {
+				chat: async (): Promise<IByokLmChatResult> => ({ content: '' }),
+				onDidChangeModels: emitter.event,
+			},
+			push: models => emitter.fire(models),
 		};
 	}
 
-	/** Resolves once every microtask-queued registry refresh has settled. */
-	const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
-
-	test('surfaces the serving window\'s models and routes inference to it; a non-serving window is excluded', async () => {
+	test('surfaces the serving window\'s models and routes inference to it; a non-serving window is excluded', () => {
 		const registry = new ByokLmBridgeRegistry();
-		// A serving window (its listModels resolves) and a window that connected
-		// without a BYOK handler, whose bridge rejects.
-		const serving = connectionOf(async () => [{ vendor: 'acme', id: 'claude' }, { vendor: 'acme', id: 'gpt' }]);
-		const nonServing: IByokLmBridgeConnection = {
-			chat: async (): Promise<IByokLmChatResult> => ({ content: '' }),
-			listModels: async () => { throw new Error('no BYOK handler in this window'); },
-		};
-		const regServing = registry.register('editor', serving);
-		const regNonServing = registry.register('no-handler', nonServing);
+		// A serving window (it pushes a snapshot) and a window that connected
+		// without a BYOK handler, which never pushes.
+		const serving = pushable();
+		const nonServing = pushable();
+		const regServing = registry.register('editor', serving.connection);
+		const regNonServing = registry.register('no-handler', nonServing.connection);
 
-		const models = await registry.listModels();
+		serving.push([{ vendor: 'acme', id: 'claude' }, { vendor: 'acme', id: 'gpt' }]);
 
 		assert.deepStrictEqual({
-			models,
-			cached: registry.getModels(),
-			serving: registry.getServingConnection() === serving,
+			models: registry.getModels(),
+			serving: registry.getServingConnection() === serving.connection,
 		}, {
 			models: [{ vendor: 'acme', id: 'claude' }, { vendor: 'acme', id: 'gpt' }],
-			cached: [{ vendor: 'acme', id: 'claude' }, { vendor: 'acme', id: 'gpt' }],
 			serving: true,
 		});
 
@@ -59,35 +59,36 @@ suite('ByokLmBridgeRegistry', () => {
 		regNonServing.dispose();
 	});
 
-	test('a window that answers with an empty list is still a valid serving target', async () => {
+	test('a window that pushes an empty list is still a valid serving target', () => {
 		const registry = new ByokLmBridgeRegistry();
-		const only = connectionOf(async () => []);
-		const reg = registry.register('client-only', only);
-		await registry.listModels();
+		const only = pushable();
+		const reg = registry.register('client-only', only.connection);
+		only.push([]);
 
 		assert.deepStrictEqual({
 			models: registry.getModels(),
-			serving: registry.getServingConnection() === only,
+			serving: registry.getServingConnection() === only.connection,
 		}, { models: [], serving: true });
 
 		reg.dispose();
 	});
 
-	test('a window that answered empty does not shadow a peer that has models, even when it connected first', async () => {
+	test('a window that pushed empty does not shadow a peer that has models, even when it connected first', () => {
 		const registry = new ByokLmBridgeRegistry();
-		// The Agents app connects first and answers empty (its BYOK extension has
-		// not registered models yet); a peer window answers with models. The peer
-		// must win — an empty-but-serving window must never shadow a populated one.
-		const empty = connectionOf(async () => []);
-		const withModels = connectionOf(async () => [{ vendor: 'acme', id: 'claude' }]);
-		const regEmpty = registry.register('agents', empty);
-		const regWithModels = registry.register('editor', withModels);
+		// The Agents app connects first and pushes empty (its BYOK extension has
+		// not registered models yet); a peer window pushes models. The peer must
+		// win — an empty-but-serving window must never shadow a populated one.
+		const empty = pushable();
+		const withModels = pushable();
+		const regEmpty = registry.register('agents', empty.connection);
+		const regWithModels = registry.register('editor', withModels.connection);
 
-		await registry.listModels();
+		empty.push([]);
+		withModels.push([{ vendor: 'acme', id: 'claude' }]);
 
 		assert.deepStrictEqual({
 			models: registry.getModels(),
-			serving: registry.getServingConnection() === withModels,
+			serving: registry.getServingConnection() === withModels.connection,
 		}, {
 			models: [{ vendor: 'acme', id: 'claude' }],
 			serving: true,
@@ -97,13 +98,14 @@ suite('ByokLmBridgeRegistry', () => {
 		regWithModels.dispose();
 	});
 
-	test('unregistering the serving connection drops its models and notifies listeners', async () => {
+	test('unregistering the serving connection drops its models and notifies listeners', () => {
 		const registry = new ByokLmBridgeRegistry();
 		let changes = 0;
 		store.add(registry.onDidChangeModels(() => { changes++; }));
 
-		const reg = registry.register('client-a', connectionOf(async () => [{ vendor: 'acme', id: 'claude' }]));
-		await registry.listModels();
+		const conn = pushable();
+		const reg = registry.register('client-a', conn.connection);
+		conn.push([{ vendor: 'acme', id: 'claude' }]);
 		assert.strictEqual(registry.getModels().length, 1);
 
 		const changesBeforeDispose = changes;
@@ -120,24 +122,16 @@ suite('ByokLmBridgeRegistry', () => {
 		});
 	});
 
-	test('re-enumerates and notifies when a connection reports onDidChangeModels', async () => {
+	test('caches and notifies when a connection pushes a new snapshot', () => {
 		const registry = new ByokLmBridgeRegistry();
-		const onDidChange = store.add(new Emitter<void>());
-		let models: IByokLmModelInfo[] = [];
-		const connection: IByokLmBridgeConnection = {
-			chat: async (): Promise<IByokLmChatResult> => ({ content: '' }),
-			listModels: async () => models,
-			onDidChangeModels: onDidChange.event,
-		};
-		const reg = registry.register('client-a', connection);
-		await registry.listModels();
+		const conn = pushable();
+		const reg = registry.register('client-a', conn.connection);
+		conn.push([]);
 		assert.strictEqual(registry.getModels().length, 0);
 
 		let changed = false;
 		store.add(registry.onDidChangeModels(() => { changed = true; }));
-		models = [{ vendor: 'acme', id: 'claude' }];
-		onDidChange.fire();
-		await flush();
+		conn.push([{ vendor: 'acme', id: 'claude' }]);
 
 		assert.deepStrictEqual({ changed, models: registry.getModels() }, {
 			changed: true,
@@ -147,26 +141,18 @@ suite('ByokLmBridgeRegistry', () => {
 		reg.dispose();
 	});
 
-	test('treats a change in only the model identifier as a model change (re-publishes)', async () => {
+	test('treats a change in only the model identifier as a model change (re-publishes)', () => {
 		const registry = new ByokLmBridgeRegistry();
-		const onDidChange = store.add(new Emitter<void>());
-		let models: IByokLmModelInfo[] = [{ vendor: 'openrouter', id: 'aion-labs/aion-3.0', modelIdentifier: 'openrouter/OpenRouter 1/aion-labs/aion-3.0' }];
-		const connection: IByokLmBridgeConnection = {
-			chat: async (): Promise<IByokLmChatResult> => ({ content: '' }),
-			listModels: async () => models,
-			onDidChangeModels: onDidChange.event,
-		};
-		const reg = store.add(registry.register('client-a', connection));
-		await registry.listModels();
+		const conn = pushable();
+		const reg = store.add(registry.register('client-a', conn.connection));
+		conn.push([{ vendor: 'openrouter', id: 'aion-labs/aion-3.0', modelIdentifier: 'openrouter/OpenRouter 1/aion-labs/aion-3.0' }]);
 
 		let changes = 0;
 		store.add(registry.onDidChangeModels(() => { changes++; }));
 
 		// Only the carried identifier changed (e.g. the user renamed the provider group) — the
 		// registry must still notice and re-publish so the picker keys visibility by the new id.
-		models = [{ vendor: 'openrouter', id: 'aion-labs/aion-3.0', modelIdentifier: 'openrouter/OpenRouter 2/aion-labs/aion-3.0' }];
-		onDidChange.fire();
-		await flush();
+		conn.push([{ vendor: 'openrouter', id: 'aion-labs/aion-3.0', modelIdentifier: 'openrouter/OpenRouter 2/aion-labs/aion-3.0' }]);
 
 		assert.deepStrictEqual({ changes, models: registry.getModels() }, {
 			changes: 1,

--- a/src/vs/platform/agentHost/test/node/byokLmProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/byokLmProxyService.test.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { Emitter, Event } from '../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
-import type { IByokLmChatRequest, IByokLmChatResult } from '../../common/agentHostByokLm.js';
+import type { IByokLmBridgeConnection, IByokLmChatRequest, IByokLmChatResult, IByokLmModelInfo } from '../../common/agentHostByokLm.js';
 import { ByokLmBridgeRegistry } from '../../node/byokLmBridgeRegistry.js';
 import { ByokLmProxyService, type IByokLmProxyHandle } from '../../node/copilot/byokLmProxyService.js';
 
@@ -20,16 +21,27 @@ import { ByokLmProxyService, type IByokLmProxyHandle } from '../../node/copilot/
  */
 suite('ByokLmProxyService', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	const sessionId = 'sess-1';
+
+	/**
+	 * A serving bridge connection: it pushes its model snapshot (default empty)
+	 * synchronously when the registry subscribes, so it is a valid routing target.
+	 */
+	function servingConnection(chat: IByokLmBridgeConnection['chat'], models: IByokLmModelInfo[] = []): IByokLmBridgeConnection {
+		const emitter = store.add(new Emitter<IByokLmModelInfo[]>({
+			onDidAddFirstListener: () => emitter.fire(models),
+		}));
+		return { chat, onDidChangeModels: emitter.event };
+	}
 
 	async function withProxy(
 		chat: (request: IByokLmChatRequest) => Promise<IByokLmChatResult>,
 		run: (handle: IByokLmProxyHandle) => Promise<void>,
 	): Promise<void> {
 		const registry = new ByokLmBridgeRegistry();
-		const registration = registry.register('client-1', { chat, listModels: async () => [] });
+		const registration = registry.register('client-1', servingConnection(chat));
 		const service = new ByokLmProxyService(new NullLogService(), registry);
 		const handle = await service.start();
 		try {
@@ -243,20 +255,18 @@ suite('ByokLmProxyService', () => {
 	test('routes requests to a serving window and excludes a non-serving one', async () => {
 		const registry = new ByokLmBridgeRegistry();
 		const calls: string[] = [];
-		// The serving window (editor): enumerates models and answers chat.
-		const regServing = registry.register('editor', {
-			chat: async () => { calls.push('serving'); return { content: 'from serving' }; },
-			listModels: async () => [{ vendor: 'acme', id: 'claude' }],
-		});
-		// A non-serving window (connected without a BYOK handler): its bridge
-		// rejects, so it must never be picked for routing even though it is connected.
+		// The serving window (editor): pushes models and answers chat.
+		const regServing = registry.register('editor', servingConnection(
+			async () => { calls.push('serving'); return { content: 'from serving' }; },
+			[{ vendor: 'acme', id: 'claude' }],
+		));
+		// A non-serving window (connected without a BYOK handler): it never pushes
+		// a snapshot, so it must never be picked for routing even though connected.
 		const regNonServing = registry.register('no-handler', {
 			chat: async () => { calls.push('no-handler'); return { content: 'from non-serving' }; },
-			listModels: async () => { throw new Error('no BYOK handler'); },
+			onDidChangeModels: Event.None,
 		});
 		const service = new ByokLmProxyService(new NullLogService(), registry);
-		// Warm the cache so the serving window is known before routing.
-		await registry.listModels();
 		const handle = await service.start();
 		try {
 			const res = await fetch(chatUrl(handle, 'acme'), {
@@ -277,7 +287,7 @@ suite('ByokLmProxyService', () => {
 
 	test('rebinds with a fresh nonce after every handle is disposed', async () => {
 		const registry = new ByokLmBridgeRegistry();
-		const registration = registry.register('client-1', { chat: async () => ({ content: 'ok' }), listModels: async () => [] });
+		const registration = registry.register('client-1', servingConnection(async () => ({ content: 'ok' })));
 		const service = new ByokLmProxyService(new NullLogService(), registry);
 		const first = await service.start();
 		const firstNonce = first.nonce;

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
-import type { IByokLmChatRequest, IByokLmChatResult, IByokLmModelInfo } from '../../common/agentHostByokLm.js';
+import type { IByokLmBridgeConnection, IByokLmChatRequest, IByokLmChatResult, IByokLmModelInfo } from '../../common/agentHostByokLm.js';
 import type { ModelSelection } from '../../common/state/protocol/state.js';
 import { ByokLmBridgeRegistry, IByokLmBridgeRegistry } from '../../node/byokLmBridgeRegistry.js';
 import { ByokLmProxyService, IByokLmProxyService, type IByokLmProxyHandle } from '../../node/copilot/byokLmProxyService.js';
@@ -27,14 +28,20 @@ import { CopilotSessionLauncher, getCopilotReasoningEffort, resolveByokSessionCo
  */
 suite('resolveByokSessionConfig', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	const sessionId = 'sess-1';
 	const log = new NullLogService();
 
-	/** Minimal bridge connection: a scripted `listModels` and an unused `chat`. */
-	function connectionOf(listModels: () => Promise<IByokLmModelInfo[]>) {
-		return { chat: async (): Promise<IByokLmChatResult> => ({ content: '' }), listModels };
+	/**
+	 * A bridge connection that pushes `models` as its snapshot synchronously when
+	 * the registry subscribes; `chat` is scripted (unused by most tests).
+	 */
+	function connectionOf(models: IByokLmModelInfo[], chat: IByokLmBridgeConnection['chat'] = async () => ({ content: '' })): IByokLmBridgeConnection {
+		const emitter = store.add(new Emitter<IByokLmModelInfo[]>({
+			onDidAddFirstListener: () => emitter.fire(models),
+		}));
+		return { chat, onDidChangeModels: emitter.event };
 	}
 
 	/** A fake proxy handle plus a `startProxy` thunk that records its call count. */
@@ -64,7 +71,7 @@ suite('resolveByokSessionConfig', () => {
 
 	test('returns empty and never starts the proxy when the bridge reports no models', async () => {
 		const registry = new ByokLmBridgeRegistry();
-		const registration = registry.register('client-1', connectionOf(async () => []));
+		const registration = registry.register('client-1', connectionOf([]));
 		const proxy = countingProxy();
 
 		const config = await resolveByokSessionConfig(sessionId, registry, proxy.startProxy, log);
@@ -74,9 +81,11 @@ suite('resolveByokSessionConfig', () => {
 		assert.strictEqual(proxy.starts, 0);
 	});
 
-	test('returns empty and never starts the proxy when enumeration fails', async () => {
+	test('returns empty and never starts the proxy for a window that never pushes a snapshot', async () => {
 		const registry = new ByokLmBridgeRegistry();
-		const registration = registry.register('client-1', connectionOf(async () => { throw new Error('renderer gone'); }));
+		// A window connected without a BYOK handler never pushes, so it stays
+		// non-serving and contributes no models.
+		const registration = registry.register('client-1', { chat: async (): Promise<IByokLmChatResult> => ({ content: '' }), onDidChangeModels: Event.None });
 		const proxy = countingProxy();
 
 		const config = await resolveByokSessionConfig(sessionId, registry, proxy.startProxy, log);
@@ -88,7 +97,7 @@ suite('resolveByokSessionConfig', () => {
 
 	test('synthesizes deduped providers and per-model config from the active bridge', async () => {
 		const registry = new ByokLmBridgeRegistry();
-		const registration = registry.register('client-1', connectionOf(async () => [
+		const registration = registry.register('client-1', connectionOf([
 			{ vendor: 'acme', id: 'claude', name: 'Acme Claude', maxContextWindowTokens: 200000 },
 			{ vendor: 'acme', id: 'gpt', name: undefined, maxContextWindowTokens: undefined },
 			{ vendor: 'globex', id: 'llama', name: 'Globex Llama' },
@@ -115,10 +124,10 @@ suite('resolveByokSessionConfig', () => {
 	test('synthesized provider config routes through a live proxy to the bridge', async () => {
 		const registry = new ByokLmBridgeRegistry();
 		let captured: IByokLmChatRequest | undefined;
-		const registration = registry.register('client-1', {
-			chat: async (request) => { captured = request; return { content: 'hello from byok' }; },
-			listModels: async () => [{ vendor: 'acme', id: 'claude' }],
-		});
+		const registration = registry.register('client-1', connectionOf(
+			[{ vendor: 'acme', id: 'claude' }],
+			async (request) => { captured = request; return { content: 'hello from byok' }; },
+		));
 		const service = new ByokLmProxyService(log, registry);
 		let handle: IByokLmProxyHandle | undefined;
 
@@ -143,83 +152,24 @@ suite('resolveByokSessionConfig', () => {
 		assert.strictEqual(captured?.modelId, 'claude');
 	});
 
-	test('resume reads the warm cache without a live renderer round-trip', async () => {
+	test('reads the latest pushed snapshot from the registry cache', async () => {
 		const registry = new ByokLmBridgeRegistry();
-		let calls = 0;
-		const registration = registry.register('client-1', connectionOf(async () => {
-			calls++;
-			return [{ vendor: 'acme', id: 'claude', name: 'Acme Claude' }];
-		}));
-		const proxy = countingProxy();
-
-		// Warm the cache so a serving window has answered.
-		await registry.listModels();
-		const callsAfterWarmup = calls;
-
-		const config = await resolveByokSessionConfig(sessionId, registry, proxy.startProxy, log, /*preferCache*/ true);
-		registration.dispose();
-
-		assert.deepStrictEqual({ calls, models: config.models }, {
-			calls: callsAfterWarmup,
-			models: [{ id: 'claude', provider: 'acme', name: 'Acme Claude' }],
+		const emitter = store.add(new Emitter<IByokLmModelInfo[]>());
+		const registration = registry.register('client-1', {
+			chat: async (): Promise<IByokLmChatResult> => ({ content: '' }),
+			onDidChangeModels: emitter.event,
 		});
-	});
-
-	test('resume falls back to a live enumeration when the cache is still cold', async () => {
-		const registry = new ByokLmBridgeRegistry();
-		let resolveList!: (models: IByokLmModelInfo[]) => void;
-		const gate = new Promise<IByokLmModelInfo[]>(resolve => { resolveList = resolve; });
-		const registration = registry.register('client-1', connectionOf(() => gate));
 		const proxy = countingProxy();
 
-		// The connection registered but hasn't answered yet, so the cache is cold.
-		assert.strictEqual(registry.getServingConnection(), undefined);
+		// The window starts serving-but-empty, then pushes a model; the resolved
+		// config reflects the latest cached push with no renderer round-trip.
+		emitter.fire([]);
+		emitter.fire([{ vendor: 'acme', id: 'claude', name: 'Acme Claude' }]);
 
-		const configPromise = resolveByokSessionConfig(sessionId, registry, proxy.startProxy, log, /*preferCache*/ true);
-		resolveList([{ vendor: 'acme', id: 'claude' }]);
-		const config = await configPromise;
+		const config = await resolveByokSessionConfig(sessionId, registry, proxy.startProxy, log);
 		registration.dispose();
 
-		assert.deepStrictEqual(config.models, [{ id: 'claude', provider: 'acme' }]);
-	});
-
-	test('resume falls back to a live enumeration when the warm cache is empty', async () => {
-		const registry = new ByokLmBridgeRegistry();
-		let models: IByokLmModelInfo[] = [];
-		const registration = registry.register('client-1', connectionOf(async () => models));
-		const proxy = countingProxy();
-
-		// Warm the cache while the window reports no models yet: serving, but empty.
-		await registry.listModels();
-		assert.notStrictEqual(registry.getServingConnection(), undefined);
-		assert.deepStrictEqual([...registry.getModels()], []);
-
-		// The window now has models; resume must re-enumerate to surface them
-		// rather than trust the stale empty cache.
-		models = [{ vendor: 'acme', id: 'claude' }];
-		const config = await resolveByokSessionConfig(sessionId, registry, proxy.startProxy, log, /*preferCache*/ true);
-		registration.dispose();
-
-		assert.deepStrictEqual(config.models, [{ id: 'claude', provider: 'acme' }]);
-	});
-
-	test('create enumerates live even when the cache is warm', async () => {
-		const registry = new ByokLmBridgeRegistry();
-		let calls = 0;
-		const registration = registry.register('client-1', connectionOf(async () => {
-			calls++;
-			return [{ vendor: 'acme', id: 'claude' }];
-		}));
-		const proxy = countingProxy();
-
-		// Warm the cache first, then confirm create still re-enumerates.
-		await registry.listModels();
-		const callsAfterWarmup = calls;
-
-		await resolveByokSessionConfig(sessionId, registry, proxy.startProxy, log, /*preferCache*/ false);
-		registration.dispose();
-
-		assert.strictEqual(calls > callsAfterWarmup, true);
+		assert.deepStrictEqual(config.models, [{ id: 'claude', provider: 'acme', name: 'Acme Claude' }]);
 	});
 });
 
@@ -236,9 +186,15 @@ suite('CopilotSessionLauncher BYOK proxy lifecycle', () => {
 
 	const sessionId = 'sess-1';
 
-	/** Minimal bridge connection: a scripted `listModels` and an unused `chat`. */
-	function connectionOf(listModels: () => Promise<IByokLmModelInfo[]>) {
-		return { chat: async (): Promise<IByokLmChatResult> => ({ content: '' }), listModels };
+	/**
+	 * A bridge connection that pushes `models` as its snapshot synchronously when
+	 * the registry subscribes; the backing emitter is owned by `store`.
+	 */
+	function connectionOf(store: DisposableStore, models: IByokLmModelInfo[]): IByokLmBridgeConnection {
+		const emitter = store.add(new Emitter<IByokLmModelInfo[]>({
+			onDidAddFirstListener: () => emitter.fire(models),
+		}));
+		return { chat: async (): Promise<IByokLmChatResult> => ({ content: '' }), onDidChangeModels: emitter.event };
 	}
 
 	/** A fake proxy service whose handles carry a unique nonce per `start()`. */
@@ -276,7 +232,7 @@ suite('CopilotSessionLauncher BYOK proxy lifecycle', () => {
 		const store = new DisposableStore();
 		const proxy = fakeProxyService();
 		const registry = new ByokLmBridgeRegistry();
-		store.add(registry.register('client-1', connectionOf(async () => [{ vendor: 'acme', id: 'claude' }])));
+		store.add(registry.register('client-1', connectionOf(store, [{ vendor: 'acme', id: 'claude' }])));
 		const launcher = createLauncher(store, proxy.service, registry);
 		const resolve = () => (launcher as unknown as { _resolveByokSessionConfig(id: string): Promise<{ providers?: { bearerToken: string }[] }> })._resolveByokSessionConfig(sessionId);
 


### PR DESCRIPTION
fixes #325692

Today the agent host pulls the renderer's BYOK models: whenever it needs the catalogue it calls listModels() over the bridge, and the session launcher juggles a "warm cache vs. live round-trip" dance (preferCache) to avoid doing that on a hot path.

This flips it around. 
- The renderer owns its model set and just pushes the current snapshot on subscribe, and again whenever it changes using onDidChangeModels. 
- The registry subscribes once per connection and caches whatever it's handed, so reads are synchronous and always current. 

