### PR TITLE
Place CDP-created browser tabs next to existing tabs.

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/browser.cdp.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/browser.cdp.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { window, workspace } from 'vscode';
+import { ViewColumn, window, workspace } from 'vscode';
 import { assertNoRpc, closeAllEditors } from '../utils';
 
 /**
@@ -175,7 +175,63 @@ const CAPTURED_DOMAINS = ['Browser', 'Target'];
 		return normalized;
 	}
 
+	function tabCountInColumn(column: ViewColumn): number {
+		return window.tabGroups.all.find(g => g.viewColumn === column)?.tabs.length ?? 0;
+	}
+
 	// #endregion
+
+	test('CDP Target.createTarget opens tab in bootstrap column', async function () {
+		this.timeout(30_000);
+
+		// Keep a text editor active in column 1.
+		const doc = await workspace.openTextDocument({ content: 'anchor' });
+		await window.showTextDocument(doc, { viewColumn: ViewColumn.One });
+
+		// Bootstrap browser tab in column 2 without stealing focus.
+		const bootstrap = await window.openBrowserTab('about:blank', {
+			viewColumn: ViewColumn.Two,
+			preserveFocus: true,
+		});
+
+		// Explicitly restore focus to the text editor in column 1.
+		await window.showTextDocument(doc, ViewColumn.One);
+
+		assert.strictEqual(
+			window.tabGroups.all.find(g => g.isActive)?.viewColumn,
+			ViewColumn.One,
+			'text editor group should remain active',
+		);
+		assert.strictEqual(tabCountInColumn(ViewColumn.One), 1, 'column 1 should have the text editor');
+		assert.strictEqual(tabCountInColumn(ViewColumn.Two), 1, 'column 2 should have the bootstrap browser tab');
+
+		const session = await bootstrap.startCDPSession();
+		const { cdpSend } = createHarness(session);
+
+		const browserAttach = await cdpSend('Target.attachToBrowserTarget');
+		const browserSessionId = browserAttach.sessionId;
+
+		const opened = new Promise<vscode.BrowserTab>(resolve => {
+			const disposable = window.onDidOpenBrowserTab(tab => {
+				if (tab !== bootstrap) {
+					disposable.dispose();
+					resolve(tab);
+				}
+			});
+		});
+
+		await cdpSend('Target.createTarget', { url: 'about:blank' }, browserSessionId);
+		const cdpTab = await opened;
+
+		assert.strictEqual(window.browserTabs.length, 2);
+
+		// CDP-created targets should inherit the bootstrap tab's column, not the active group.
+		assert.strictEqual(tabCountInColumn(ViewColumn.One), 1, 'CDP tab should not open in the active column');
+		assert.strictEqual(tabCountInColumn(ViewColumn.Two), 2, 'CDP tab should open in the bootstrap column');
+
+		await cdpTab.close();
+		await session.close();
+	});
 
 	// Loads `file:///<workspaceFolder>/index.html`. Skipped in remote
 	// workspaces: the workspace folder is a `vscode-remote://` URI so it

--- a/extensions/vscode-api-tests/src/singlefolder-tests/browser.cdp.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/browser.cdp.test.ts
@@ -233,6 +233,44 @@ const CAPTURED_DOMAINS = ['Browser', 'Target'];
 		await session.close();
 	});
 
+	test('CDP Target.createTarget falls back when bootstrap tab is closed', async function () {
+		this.timeout(30_000);
+
+		const doc = await workspace.openTextDocument({ content: 'anchor' });
+		await window.showTextDocument(doc, { viewColumn: ViewColumn.One });
+
+		const bootstrap = await window.openBrowserTab('about:blank', {
+			viewColumn: ViewColumn.Two,
+			preserveFocus: true,
+		});
+
+		const session = await bootstrap.startCDPSession();
+		const { cdpSend } = createHarness(session);
+
+		const browserAttach = await cdpSend('Target.attachToBrowserTarget');
+		const browserSessionId = browserAttach.sessionId;
+
+		await bootstrap.close();
+		assert.strictEqual(window.browserTabs.length, 0);
+
+		const opened = new Promise<vscode.BrowserTab>(resolve => {
+			const disposable = window.onDidOpenBrowserTab(tab => {
+				disposable.dispose();
+				resolve(tab);
+			});
+		});
+
+		await cdpSend('Target.createTarget', { url: 'about:blank' }, browserSessionId);
+		const cdpTab = await opened;
+
+		assert.strictEqual(window.browserTabs.length, 1);
+		assert.strictEqual(tabCountInColumn(ViewColumn.One), 2, 'CDP tab should fall back to the active column');
+		assert.strictEqual(tabCountInColumn(ViewColumn.Two), 0, 'bootstrap column should be empty');
+
+		await cdpTab.close();
+		await session.close();
+	});
+
 	// Loads `file:///<workspaceFolder>/index.html`. Skipped in remote
 	// workspaces: the workspace folder is a `vscode-remote://` URI so it
 	// isn't added to the local `file://` trust allowlist, and the harness

--- a/src/vs/platform/browserView/electron-main/browserViewGroup.ts
+++ b/src/vs/platform/browserView/electron-main/browserViewGroup.ts
@@ -205,7 +205,8 @@ export class BrowserViewGroup extends Disposable implements ICDPBrowserTarget, I
 			throw new Error(`Unknown browser context ${browserContextId}`);
 		}
 
-		const target = await this.browserViewMainService.createTarget(url, this.owner, browserContextId);
+		const parentViewId = this.views.keys().next().value;
+		const target = await this.browserViewMainService.createTarget(url, this.owner, browserContextId, parentViewId);
 		if (target instanceof BrowserView) {
 			await this.addView(target.id);
 			return this.viewTargets.get(target.id)!;

--- a/src/vs/platform/browserView/electron-main/browserViewMainService.ts
+++ b/src/vs/platform/browserView/electron-main/browserViewMainService.ts
@@ -32,7 +32,7 @@ export interface IBrowserViewMainService extends IBrowserViewService {
 	tryGetBrowserView(id: string): BrowserView | undefined;
 
 	/** Create a new target and return it. */
-	createTarget(url: string, owner: IBrowserViewOwner, browserContextId?: string): Promise<BrowserView>;
+	createTarget(url: string, owner: IBrowserViewOwner, browserContextId?: string, parentViewId?: string): Promise<BrowserView>;
 }
 
 export class BrowserViewMainService extends Disposable implements IBrowserViewMainService {
@@ -105,13 +105,13 @@ export class BrowserViewMainService extends Disposable implements IBrowserViewMa
 		return this.browserViews.get(id);
 	}
 
-	async createTarget(url: string, owner: IBrowserViewOwner, browserContextId?: string): Promise<BrowserView> {
+	async createTarget(url: string, owner: IBrowserViewOwner, browserContextId?: string, parentViewId?: string): Promise<BrowserView> {
 		const browserSession = browserContextId ? BrowserSession.get(browserContextId) : undefined;
 
 		return this.openNew(url, {
 			owner,
 			session: browserSession,
-			openOptions: { preserveFocus: true },
+			openOptions: { preserveFocus: true, parentViewId },
 			source: 'cdpCreated'
 		});
 	}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
@@ -436,7 +436,8 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 		} else if (opts.parentViewId) {
 			targetGroup = this._findEditorGroupForView(opts.parentViewId);
 			if (targetGroup === undefined) {
-				return; // If the parent isn't open, don't open the child either
+				// Bootstrap/parent tab was closed; fall back to normal placement.
+				targetGroup = await this.getPreferredGroup();
 			}
 		} else {
 			// Keep the browser docked in the main editor area even when editors


### PR DESCRIPTION
In the integrated browser, when an extension opens a new tab via CDP, its view is currently places next to the active tab. I'm trying to run tests inside the integrated browser and want all of the tabs be grouped together.

Fixed by passing another tab from the group as the `parentViewId`.

Ref https://github.com/microsoft/playwright/issues/41372.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
