### PR TITLE
sessions: polish hover tooltips on isolation checkbox and branch chip

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -352,11 +352,12 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			// keeping it focusable and using correct ARIA semantics. The
 			// click handler bails when resolving in `_showPicker`.
 			const trigger = renderPickerTrigger(slot, isReadOnly, this._renderDisposables, () => this._showPicker(provider, session.sessionId, property, schema, trigger));
-			// The Branch chip skips the hover: when read-only it just
-			// mirrors the current/default branch name (already visible as
-			// the label), and when editable the schema description reads
-			// awkwardly as a hover.
-			const tooltip = property === SessionConfigKey.Branch ? undefined : (schema.description ?? schema.title);
+			// The read-only Branch chip skips the hover: it just mirrors the
+			// current/default branch name (already visible as the label),
+			// and the schema description reads awkwardly as a hover for a
+			// fixed value. The editable Branch chip (worktree isolation)
+			// keeps its description, which is useful context there.
+			const tooltip = (property === SessionConfigKey.Branch && isReadOnly) ? undefined : (schema.description ?? schema.title);
 			if (tooltip) {
 				this._renderDisposables.add(this._hoverService.setupDelayedHover(trigger, { content: tooltip }));
 			}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -352,7 +352,11 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			// keeping it focusable and using correct ARIA semantics. The
 			// click handler bails when resolving in `_showPicker`.
 			const trigger = renderPickerTrigger(slot, isReadOnly, this._renderDisposables, () => this._showPicker(provider, session.sessionId, property, schema, trigger));
-			const tooltip = schema.description ?? schema.title;
+			// The Branch chip skips the hover: when read-only it just
+			// mirrors the current/default branch name (already visible as
+			// the label), and when editable the schema description reads
+			// awkwardly as a hover.
+			const tooltip = property === SessionConfigKey.Branch ? undefined : (schema.description ?? schema.title);
 			if (tooltip) {
 				this._renderDisposables.add(this._hoverService.setupDelayedHover(trigger, { content: tooltip }));
 			}
@@ -462,7 +466,12 @@ export class AgentHostSessionConfigPicker extends Disposable {
 		const labelSpan = dom.append(row, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = label;
 
-		const tooltip = schema.description ?? schema.title;
+		// Reuse the schema's own `worktree` enum description (e.g. "Create a
+		// Git worktree for isolation") since it already explains what
+		// checking the box does. Fall back to the schema's description/title
+		// if the enum shape is unexpected.
+		const worktreeIndex = schema.enum?.indexOf('worktree') ?? -1;
+		const tooltip = (worktreeIndex >= 0 ? schema.enumDescriptions?.[worktreeIndex] : undefined) ?? schema.description ?? schema.title;
 		if (tooltip) {
 			this._renderDisposables.add(this._hoverService.setupDelayedHover(row, { content: tooltip }));
 		}


### PR DESCRIPTION
## What changed
Two small hover-tooltip polish items on the new-session config picker, per tester feedback in #325662 (filed against #325500):

1. **Branch chip** - removed the hover tooltip on the read-only Branch chip. When Isolation is set to *Folder*, the Branch chip just mirrors the current branch name and cannot be changed; the value is already visible as the label, and the generic schema description read awkwardly as a hover for a fixed/informational value.
2. **New Worktree checkbox** - the hover now reuses the schema's own `worktree` enum description (e.g. "Create a Git worktree for isolation") instead of the generic isolation description ("Where the agent should make changes"), whose tense felt off for a checkbox.

## Why
Reported by @eleanorjboyd while testing #325500:
- The New Worktree checkbox tooltip read awkwardly.
- The greyed-out Branch chip had no explanation for why it's disabled - this PR simplifies by removing the confusing tooltip rather than adding new copy.

## Testing
- `npm run typecheck-client` - 0 errors
- `node --experimental-strip-types build/hygiene.ts` on the changed file - clean
- `npx gulp compile` - 0 errors

Fixes #325662

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
