### PR TITLE
sessions: show Submit Feedback action in the single-pane Changes editor

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorUtils.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorUtils.ts
@@ -14,6 +14,7 @@ import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/co
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { MultiDiffEditorInput } from '../../../../workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.js';
 import { ISessionFileChange } from '../../../services/sessions/common/session.js';
+import { SessionChangesEditorInput } from '../../changes/browser/sessionChangesEditorInput.js';
 
 export interface IAgentFeedbackContext {
 	readonly codeSelection?: string;
@@ -290,8 +291,9 @@ function renderHunkGroup(
 export function getActiveResourceCandidates(input: Parameters<typeof EditorResourceAccessor.getOriginalUri>[0]): URI[] {
 	const result: URI[] = [];
 
-	if (input instanceof MultiDiffEditorInput) {
-		const items = input.resources.get();
+	const multiDiffInput = input instanceof SessionChangesEditorInput ? input.multiDiffInput : input;
+	if (multiDiffInput instanceof MultiDiffEditorInput) {
+		const items = multiDiffInput.resources.get();
 		if (items) {
 			for (const item of items) {
 				if (item.originalUri) { result.push(item.originalUri); }

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditorInput.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditorInput.ts
@@ -71,6 +71,15 @@ export class SessionChangesEditorInput extends DockedEditorInput {
 		return this._innerInput;
 	}
 
+	/**
+	 * The wrapped multi-diff input, whose {@link MultiDiffEditorInput.resources}
+	 * expose the session's individual file diffs. Used to resolve the session's
+	 * files (e.g. for the agent feedback affordances) from this editor input.
+	 */
+	get multiDiffInput(): MultiDiffEditorInput {
+		return this.innerInput;
+	}
+
 	async getViewModel(): Promise<MultiDiffEditorViewModel> {
 		return this.innerInput.getViewModel();
 	}


### PR DESCRIPTION
## What

Fixes the **Submit Feedback** action (and the agent-feedback overlay toolbar: navigate/clear) not showing up in the custom Changes editor when the new single-pane side pane layout is enabled.

## Why

The agent-feedback overlay resolves a session's changed files from the active editor via `getActiveResourceCandidates`, which only special-cased a plain `MultiDiffEditorInput`. In the single-pane layout the Changes editor is a `SessionChangesEditorInput` that *wraps* a `MultiDiffEditorInput` internally, so resolution fell through to `EditorResourceAccessor.getOriginalUri` and returned only the opaque `changes-multi-diff-source:` URI instead of the individual file URIs. With no files resolved, the session couldn't be attached and the feedback affordances stayed hidden.

## Changes

- `sessionChangesEditorInput.ts`: expose the lazily-created wrapped input via a `multiDiffInput` getter.
- `agentFeedbackEditorUtils.ts`: unwrap a `SessionChangesEditorInput` to its `multiDiffInput` before the existing `MultiDiffEditorInput` branch, so the per-file original/modified URIs are returned identically in both layouts.

## Notes for reviewers

- Both files are within `src/vs/sessions`; no shared workbench code was modified.
- `valid-layers-check` passes; `typecheck-client` reported only pre-existing unrelated `@vscode/proxy-agent` version-mismatch errors.
- There are no existing unit tests for `getActiveResourceCandidates` (the classic `MultiDiffEditorInput` path is also untested); happy to add one if desired.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>