### PR TITLE
Fix margin calculation for overlay rectangle in InlineEditsInsertionView

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
@@ -285,7 +285,7 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 		)).read(reader);
 
 		const separatorWidth = this._input.map(i => i?.editorType === InlineCompletionEditorType.DiffEditor ? WIDGET_SEPARATOR_DIFF_EDITOR_WIDTH : WIDGET_SEPARATOR_WIDTH).read(reader);
-		const overlayRect = overlayLayoutObs.map(l => l.overlay.withMargin(0, BORDER_WIDTH, 0, l.startsAtContentLeft ? 0 : BORDER_WIDTH).intersectHorizontal(new OffsetRange(overlayHider.left, Number.MAX_SAFE_INTEGER)));
+		const overlayRect = overlayLayoutObs.map(l => l.overlay.withMargin(0, BORDER_WIDTH, BORDER_WIDTH, l.startsAtContentLeft ? 0 : BORDER_WIDTH).intersectHorizontal(new OffsetRange(overlayHider.left, Number.MAX_SAFE_INTEGER)));
 		const underlayRect = overlayRect.map(rect => rect.withMargin(separatorWidth, separatorWidth));
 
 		const editorBackground = getEditorBackgroundColor(this._input.read(undefined)?.editorType ?? InlineCompletionEditorType.TextEditor);


### PR DESCRIPTION
This pull request makes a minor adjustment to the layout of the inline edits insertion view. Specifically, it updates the overlay rectangle calculation to add a bottom margin, which will affect the visual spacing of the widget.

* Updated the `overlayRect` calculation in `inlineEditsInsertionView.ts` to include a bottom margin (`BORDER_WIDTH`), improving the layout of the overlay in the inline edits insertion view.

Resolves: https://github.com/microsoft/vscode/issues/325564

