### PR TITLE
Git - handle autostash conflicts when pulling and show autostash entries in the stash list

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1031,9 +1031,12 @@ export function parseLsFiles(raw: string): LsFilesElement[] {
 		.map(([, mode, object, stage, file]) => ({ mode, object, stage, file }));
 }
 
-const stashRegex = /([0-9a-f]{40})\n(.*)\nstash@{(\d+)}\n(WIP\s)?on\s([^:]+):\s(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;
+// The reflog subject of a stash is `(WIP )on <branch>: <message>`, and git prefixes it even
+// when the message is user provided. Stashes created by git itself carry no branch (ex: the
+// `autostash` of `git pull --autostash`), so the branch is optional
+const stashRegex = /([0-9a-f]{40})\n(.*)\nstash@{(\d+)}\n(?:(WIP\s)?on\s([^:]+):\s)?(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;
 
-function parseGitStashes(raw: string): Stash[] {
+export function parseGitStashes(raw: string): Stash[] {
 	const result: Stash[] = [];
 
 	let match, hash, parents, index, wip, branchName, description, authorDate, commitDate;
@@ -1049,7 +1052,7 @@ function parseGitStashes(raw: string): Stash[] {
 			hash,
 			parents: parents.split(' '),
 			index: parseInt(index),
-			branchName: branchName.trim(),
+			branchName: branchName?.trim(),
 			description: wip ? `WIP (${description.trim()})` : description.trim(),
 			authorDate: authorDate ? new Date(Number(authorDate) * 1000) : undefined,
 			commitDate: commitDate ? new Date(Number(commitDate) * 1000) : undefined,
@@ -2473,12 +2476,13 @@ export class Repository {
 			args.push(branch);
 		}
 
+		let result: IExecutionResult<string>;
+
 		try {
-			const result = await this.exec(args, {
+			result = await this.exec(args, {
 				cancellationToken: options.cancellationToken,
 				env: { 'GIT_HTTP_USER_AGENT': this.git.userAgent }
 			});
-			return !/Already up to date/i.test(result.stdout);
 		} catch (err) {
 			if (/^CONFLICT \([^)]+\): \b/m.test(err.stdout || '')) {
 				err.gitErrorCode = GitErrorCodes.Conflict;
@@ -2499,6 +2503,22 @@ export class Repository {
 
 			throw err;
 		}
+
+		// `git pull --autostash` exits with 0 even when re-applying the autostash fails,
+		// so the conflict is only reported on stderr
+		if (options.autoStash && /Applying autostash resulted in conflicts/.test(result.stderr || '')) {
+			throw new GitError({
+				message: 'Failed to apply autostash',
+				stdout: result.stdout,
+				stderr: result.stderr,
+				exitCode: result.exitCode,
+				gitErrorCode: GitErrorCodes.StashConflict,
+				gitCommand: 'pull',
+				gitArgs: args
+			});
+		}
+
+		return !/Already up to date/i.test(result.stdout);
 	}
 
 	async rebase(branch: string, options: PullOptions = {}): Promise<void> {

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'mocha';
-import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
+import { Git, GitStatusParser, IExecutionResult, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors, parseGitStashes, Repository } from '../git';
+import { GitErrorCodes } from '../api/git.constants';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
 
@@ -641,6 +642,85 @@ suite('git', () => {
 				parseCoAuthors('Fix bug\n\nSigned-off-by: Admin <admin@corp.com>\nCo-authored-by: Jane Doe <jane@example.com>'),
 				[{ name: 'Jane Doe', email: 'jane@example.com' }]
 			);
+		});
+	});
+
+	suite('parseGitStashes', () => {
+		test('empty', function () {
+			assert.deepStrictEqual(parseGitStashes(''), []);
+		});
+
+		test('stash created by `git stash`', function () {
+			const input = '14301d5a5721241cca14e815ae760b15c35f1384\n09aa741a05ede93fc3f02e8184891be6e1e889ac\nstash@{0}\nWIP on main: 09aa741 init\n1784017026\n1784017026\x00';
+
+			assert.deepStrictEqual(parseGitStashes(input), [{
+				hash: '14301d5a5721241cca14e815ae760b15c35f1384',
+				parents: ['09aa741a05ede93fc3f02e8184891be6e1e889ac'],
+				index: 0,
+				branchName: 'main',
+				description: 'WIP (09aa741 init)',
+				authorDate: new Date(1784017026 * 1000),
+				commitDate: new Date(1784017026 * 1000)
+			}]);
+		});
+
+		test('stash named "autostash" by the user keeps its branch', function () {
+			const input = '14301d5a5721241cca14e815ae760b15c35f1384\n09aa741a05ede93fc3f02e8184891be6e1e889ac\nstash@{0}\nOn main: autostash\n1784017026\n1784017026\x00';
+
+			assert.deepStrictEqual(parseGitStashes(input), [{
+				hash: '14301d5a5721241cca14e815ae760b15c35f1384',
+				parents: ['09aa741a05ede93fc3f02e8184891be6e1e889ac'],
+				index: 0,
+				branchName: 'main',
+				description: 'autostash',
+				authorDate: new Date(1784017026 * 1000),
+				commitDate: new Date(1784017026 * 1000)
+			}]);
+		});
+
+		test('autostash created by `git pull --autostash` carries no branch', function () {
+			const input = '14301d5a5721241cca14e815ae760b15c35f1384\n09aa741a05ede93fc3f02e8184891be6e1e889ac 1cc119cbf97d36603218e1280e46a81f4ffe2cea\nstash@{0}\nautostash\n1784017026\n1784017026\x00';
+
+			assert.deepStrictEqual(parseGitStashes(input), [{
+				hash: '14301d5a5721241cca14e815ae760b15c35f1384',
+				parents: ['09aa741a05ede93fc3f02e8184891be6e1e889ac', '1cc119cbf97d36603218e1280e46a81f4ffe2cea'],
+				index: 0,
+				branchName: undefined,
+				description: 'autostash',
+				authorDate: new Date(1784017026 * 1000),
+				commitDate: new Date(1784017026 * 1000)
+			}]);
+		});
+	});
+
+	suite('Repository.pull', () => {
+		function createRepository(result: Partial<IExecutionResult<string>>): Repository {
+			const git = {
+				userAgent: 'git/test',
+				compareGitVersionTo: () => 1,
+				exec: async () => ({ exitCode: 0, stdout: '', stderr: '', ...result })
+			} as unknown as Git;
+
+			return new Repository(git, '/repo', undefined, { path: '/repo/.git', isBare: false }, undefined!);
+		}
+
+		test('autostash conflict is reported even though git exits with 0', async function () {
+			const repository = createRepository({
+				stderr: 'Applying autostash resulted in conflicts.\nYour changes are safe in the stash.\n'
+			});
+
+			await assert.rejects(
+				repository.pull(false, undefined, undefined, { autoStash: true }),
+				err => (err as { gitErrorCode?: string }).gitErrorCode === GitErrorCodes.StashConflict);
+		});
+
+		test('successful pull is not reported as an autostash conflict', async function () {
+			const repository = createRepository({
+				stdout: 'Updating 1cc119c..09aa741\n',
+				stderr: 'From https://github.com/microsoft/vscode\n   1cc119c..09aa741  main -> origin/main\n'
+			});
+
+			assert.strictEqual(await repository.pull(false, undefined, undefined, { autoStash: true }), true);
 		});
 	});
 


### PR DESCRIPTION
Fixes #262360

With `git.autoStash` enabled, a pull whose autostash fails to re-apply gives no indication of it: no notification, and the autostash entry git leaves behind is not listed under the stash actions.

Two causes, both in `git.ts`:

- `git pull --autostash` exits with 0 when re-applying the autostash fails and only reports it on stderr, so `pull()` never sets `GitErrorCodes.StashConflict` and the existing handler never runs. The manual stash apply notifies because `git stash pop` exits non-zero.
- The reflog subject of a stash is `(WIP )on <branch>: <message>`, which git writes even for a user provided message. The `autostash` entry carries no branch, so it never matches `stashRegex` and is dropped by `parseGitStashes`.

To test:

1. Set `"git.autoStash": true`.
2. Commit a change upstream so the branch is behind, then modify the same lines locally.
3. Run `Git: Pull`.
4. Observe the merge conflict warning, and the autostash entry in the stash list. Before, the pull appeared to succeed, the file was left conflicted, and the stash was invisible.

Adds `parseGitStashes` tests for a `WIP on <branch>` stash, a stash the user named `autostash`, and the branchless `autostash` entry.

Written with the assistance of an LLM and verified manually against a real repository.
