### PR TITLE
Watch materialized working directory for customization changes

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -7,7 +7,8 @@ import type { McpSdkServerConfigWithInstance, Options, PermissionMode, SDKUserMe
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { INativeEnvironmentService } from '../../../environment/common/environment.js';
 import { IFileService } from '../../../files/common/files.js';
@@ -141,6 +142,7 @@ export class ClaudeAgentSession extends Disposable {
 		return this._workingDirectory ?? this.workspace;
 	}
 	private _workingDirectory: URI | undefined;
+	private readonly _customizationWatcher = this._register(new DisposableStore());
 
 	/** Exposed for the materializer's MCP-server build closure. */
 	get pendingClientToolCalls(): PendingRequestRegistry<CallToolResult> { return this._pendingClientToolCalls; }
@@ -343,17 +345,18 @@ export class ClaudeAgentSession extends Disposable {
 		this.toolDiff = this._register(toolDiff);
 		this._register(this.clientCustomizationsDiff.onDidChange(() => this._onDidCustomizationsChange.fire()));
 
-		// Watch the on-disk Claude customization sources so edits made outside
-		// the session (a new `~/.claude/agents/*.md`, an edited skill, a changed
-		// `.mcp.json`) drive a workbench re-fetch. Active from construction so
-		// it covers the provisional (pre-materialize) window too.
-		const customizationWatcher = this._register(new ClaudeCustomizationWatcher(
-			this.workingDirectory,
+		this._watchCustomizations(this.workspace);
+	}
+
+	private _watchCustomizations(directory: URI | undefined): void {
+		this._customizationWatcher.clear();
+		const watcher = this._customizationWatcher.add(new ClaudeCustomizationWatcher(
+			directory,
 			this._environmentService.userHome,
 			this._fileService,
 			this._logService,
 		));
-		this._register(customizationWatcher.onDidChange(() => this._onDidCustomizationsChange.fire()));
+		this._customizationWatcher.add(watcher.onDidChange(() => this._onDidCustomizationsChange.fire()));
 	}
 
 	/**
@@ -423,8 +426,9 @@ export class ClaudeAgentSession extends Disposable {
 		// Adopt the host-resolved working directory (e.g. an isolated worktree)
 		// before it's read below; falls back to the session's `workspace` when the
 		// host didn't resolve a dedicated directory.
-		if (ctx.workingDirectory) {
+		if (ctx.workingDirectory && !isEqual(ctx.workingDirectory, this.workingDirectory)) {
 			this._workingDirectory = ctx.workingDirectory;
+			this._watchCustomizations(ctx.workingDirectory);
 		}
 		if (!this.workingDirectory) {
 			throw new Error(`Cannot materialize Claude session ${this.sessionId}: workingDirectory is required`);

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -2113,6 +2113,46 @@ suite('ClaudeAgent', () => {
 		});
 	});
 
+	test('materializing in a worktree reanchors customization discovery', async () => {
+		const { agent, sdk, fileService } = createTestContext(disposables);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		const workspace = URI.file('/workspace');
+		const worktree = URI.file('/workspace.worktrees/session');
+		const created = await agent.createSession({ workingDirectory: workspace });
+		const sessionId = AgentSession.id(created.session);
+		sdk.supportedCommandsResult = [{ name: 'worktree-skill', description: 'Worktree skill', argumentHint: '' }];
+		sdk.supportedAgentsResult = [];
+		sdk.mcpServerStatusResult = [];
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'hi', worktree, undefined, 'turn-1');
+
+		let sessionChanges = 0;
+		let agentChanges = 0;
+		disposables.add(agent.getSessionForTesting(created.session)!.onDidCustomizationsChange(() => sessionChanges++));
+		disposables.add(agent.onDidCustomizationsChange(() => agentChanges++));
+		await fileService.writeFile(
+			URI.joinPath(worktree, '.claude', 'skills', 'worktree-skill', 'SKILL.md'),
+			VSBuffer.fromString('---\nname: worktree-skill\ndescription: Worktree skill\n---\nbody'),
+		);
+		await timeout(1_000);
+		const customizations = await agent.getSessionCustomizations!(created.session);
+		const skills = customizations.find(customization => customization.uri === URI.joinPath(worktree, '.claude', 'skills').toString());
+
+		assert.deepStrictEqual({
+			sessionChanges,
+			agentChanges,
+			startupCwd: sdk.capturedStartupOptions[0]?.cwd,
+			skills: skills?.type === CustomizationType.Directory ? skills.children?.map(skill => skill.name) : undefined,
+		}, {
+			sessionChanges: 1,
+			agentChanges: 1,
+			startupCwd: worktree.fsPath,
+			skills: ['worktree-skill'],
+		});
+	}).timeout(5_000);
+
 	test('materialize resolves the SDK agent name from the file frontmatter, not the filename', async () => {
 		// `_resolveAgentName` parses the selected `~/.claude/agents/<file>.md`:
 		// the SDK keys agents by their frontmatter `name`, which need not match

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -2130,13 +2130,15 @@ suite('ClaudeAgent', () => {
 
 		let sessionChanges = 0;
 		let agentChanges = 0;
-		disposables.add(agent.getSessionForTesting(created.session)!.onDidCustomizationsChange(() => sessionChanges++));
+		const session = agent.getSessionForTesting(created.session)!;
+		const customizationChanged = Event.toPromise(session.onDidCustomizationsChange, disposables);
+		disposables.add(session.onDidCustomizationsChange(() => sessionChanges++));
 		disposables.add(agent.onDidCustomizationsChange(() => agentChanges++));
 		await fileService.writeFile(
 			URI.joinPath(worktree, '.claude', 'skills', 'worktree-skill', 'SKILL.md'),
 			VSBuffer.fromString('---\nname: worktree-skill\ndescription: Worktree skill\n---\nbody'),
 		);
-		await timeout(1_000);
+		await customizationChanged;
 		const customizations = await agent.getSessionCustomizations!(created.session);
 		const skills = customizations.find(customization => customization.uri === URI.joinPath(worktree, '.claude', 'skills').toString());
 

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -29,7 +29,7 @@ import {
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import type { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { isUUID } from '../../../../base/common/uuid.js';
 import { isCancellationError } from '../../../../base/common/errors.js';
@@ -2131,7 +2131,7 @@ suite('ClaudeAgent', () => {
 		let sessionChanges = 0;
 		let agentChanges = 0;
 		const session = agent.getSessionForTesting(created.session)!;
-		const customizationChanged = Event.toPromise(session.onDidCustomizationsChange, disposables);
+		const customizationChanged = Event.toPromise(session.onDidCustomizationsChange, disposables.add(new DisposableStore()));
 		disposables.add(session.onDidCustomizationsChange(() => sessionChanges++));
 		disposables.add(agent.onDidCustomizationsChange(() => agentChanges++));
 		await fileService.writeFile(


### PR DESCRIPTION
```Copilot Generated Description:``` Implement a watcher for the materialized working directory to detect customization changes. This allows the system to respond to edits made outside the session, ensuring that updates are reflected in real-time.

