### PR TITLE
copilot status bar hover: fix: status dashboard checkbox flicker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -54,7 +54,6 @@ const completionsConfigurationTargets = [
 	ConfigurationTarget.WORKSPACE,
 	ConfigurationTarget.USER_REMOTE,
 	ConfigurationTarget.USER_LOCAL,
-	ConfigurationTarget.USER,
 	ConfigurationTarget.APPLICATION,
 ] as const;
 
@@ -1038,7 +1037,7 @@ export class ChatStatusDashboard extends DomWidget {
 		const writeState = async (state: boolean | 'mixed') => {
 			const configuredValue = this.findConfiguredCompletionsValue(modeId) ?? this.findConfiguredCompletionsValue();
 			if (state === 'mixed') {
-				if (configuredValue && Object.prototype.hasOwnProperty.call(configuredValue.value, modeId)) {
+				for (const configuredValue of this.findConfiguredCompletionsValues(modeId)) {
 					const { [modeId]: _, ...rest } = configuredValue.value;
 					await this.configurationService.updateValue(settingId, rest, configuredValue.target);
 				}
@@ -1071,6 +1070,7 @@ export class ChatStatusDashboard extends DomWidget {
 			}).catch(error => {
 				if (pendingWrites === 0) {
 					renderState(getState());
+					onStateChange();
 				}
 				this.notificationService.error(error);
 			});
@@ -1110,14 +1110,19 @@ export class ChatStatusDashboard extends DomWidget {
 	}
 
 	private findConfiguredCompletionsValue(modeId?: string): { target: ConfigurationTarget; value: Record<string, boolean> } | undefined {
+		return this.findConfiguredCompletionsValues(modeId)[0];
+	}
+
+	private findConfiguredCompletionsValues(modeId?: string): { target: ConfigurationTarget; value: Record<string, boolean> }[] {
 		const inspected = this.configurationService.inspect<Record<string, boolean>>(defaultChat.completionsEnablementSetting);
+		const result: { target: ConfigurationTarget; value: Record<string, boolean> }[] = [];
 		for (const target of completionsConfigurationTargets) {
 			const value = getConfigValueInTarget(inspected, target);
 			if (isObject(value) && (!modeId || Object.prototype.hasOwnProperty.call(value, modeId))) {
-				return { target, value };
+				result.push({ target, value });
 			}
 		}
-		return undefined;
+		return result;
 	}
 
 	private getCompletionsSettingAccessor(modeId = '*'): ISettingsAccessor {

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -11,6 +11,7 @@ import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { SelectBox } from '../../../../../base/browser/ui/selectBox/selectBox.js';
 import { Checkbox, TriStateCheckbox } from '../../../../../base/browser/ui/toggle/toggle.js';
 import { IAction, toAction, WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification } from '../../../../../base/common/actions.js';
+import { Sequencer } from '../../../../../base/common/async.js';
 import { CancellationToken, cancelOnDispose } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { safeIntl } from '../../../../../base/common/date.js';
@@ -28,9 +29,10 @@ import { ILanguageFeaturesService } from '../../../../../editor/common/services/
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { localize } from '../../../../../nls.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, getConfigValueInTarget, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IHoverService, nativeHoverDelegate } from '../../../../../platform/hover/browser/hover.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { Link } from '../../../../../platform/opener/browser/link.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -47,6 +49,14 @@ import product from '../../../../../platform/product/common/product.js';
 import { isCompletionsEnabled } from '../../../../../editor/common/services/completionsEnablement.js';
 
 const defaultChat = product.defaultChatAgent;
+const completionsConfigurationTargets = [
+	ConfigurationTarget.WORKSPACE_FOLDER,
+	ConfigurationTarget.WORKSPACE,
+	ConfigurationTarget.USER_REMOTE,
+	ConfigurationTarget.USER_LOCAL,
+	ConfigurationTarget.USER,
+	ConfigurationTarget.APPLICATION,
+] as const;
 
 interface ISettingsAccessor {
 	readSetting: () => boolean;
@@ -128,6 +138,7 @@ export class ChatStatusDashboard extends DomWidget {
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		@INotificationService private readonly notificationService: INotificationService,
 	) {
 		super();
 
@@ -940,7 +951,8 @@ export class ChatStatusDashboard extends DomWidget {
 			const overriddenHint = globalSetting.appendChild($('span.setting-overridden'));
 			const updateOverriddenHint = () => {
 				const obj = this.configurationService.getValue<Record<string, boolean>>(defaultChat.completionsEnablementSetting);
-				const hasOverride = modeId && isObject(obj) && typeof obj[modeId] !== 'undefined' && Boolean(obj[modeId]) !== Boolean(obj['*']);
+				const configuredValue = modeId ? this.findConfiguredCompletionsValue(modeId) : undefined;
+				const hasOverride = modeId && configuredValue && isObject(obj) && Boolean(configuredValue.value[modeId]) !== Boolean(obj['*']);
 				overriddenHint.textContent = hasOverride ? localize('settings.overridden', "(overridden)") : '';
 			};
 			updateOverriddenHint();
@@ -1004,88 +1016,89 @@ export class ChatStatusDashboard extends DomWidget {
 		const settingId = defaultChat.completionsEnablementSetting;
 
 		const getState = (): boolean | 'mixed' => {
-			const obj = this.configurationService.getValue<Record<string, boolean>>(settingId);
-			if (!isObject(obj) || typeof obj[modeId] === 'undefined') {
-				return 'mixed'; // no override — inherits from *
-			}
-			return Boolean(obj[modeId]);
+			const configuredValue = this.findConfiguredCompletionsValue(modeId);
+			return configuredValue ? Boolean(configuredValue.value[modeId]) : 'mixed';
 		};
 
-		const checkbox = this._store.add(new TriStateCheckbox(label, getState(), { ...defaultCheckboxStyles }));
+		let requestedState = getState();
+		let pendingWrites = 0;
+		const checkbox = this._store.add(new TriStateCheckbox(label, requestedState, { ...defaultCheckboxStyles }));
 		container.appendChild(checkbox.domNode);
 
 		const settingLabel = append(container, $('span.setting-label', undefined, label));
 		this._store.add(Gesture.addTarget(settingLabel));
-
-		const cycleState = () => {
-			const current = checkbox.checked;
-			// Cycle: true → false → mixed → true
-			if (current === true) {
-				checkbox.checked = false;
-			} else if (current === false) {
-				checkbox.checked = 'mixed';
-			} else {
-				checkbox.checked = true;
-			}
+		const writeSequencer = new Sequencer();
+		const renderState = (state: boolean | 'mixed') => {
+			requestedState = state;
+			checkbox.checked = state;
+			checkbox.domNode.setAttribute('aria-checked', state === 'mixed' ? 'mixed' : String(state));
 		};
+		const getNextState = () => requestedState === true ? false : requestedState === false ? 'mixed' : true;
 
-		const writeState = (state: boolean | 'mixed') => {
-			let result = this.configurationService.getValue<Record<string, boolean>>(settingId);
-			if (!isObject(result)) {
-				result = Object.create(null);
-			}
-
+		const writeState = async (state: boolean | 'mixed') => {
+			const configuredValue = this.findConfiguredCompletionsValue(modeId) ?? this.findConfiguredCompletionsValue();
 			if (state === 'mixed') {
-				// Remove the language key to inherit from *
-				const { [modeId]: _, ...rest } = result;
-				const inheritedEnablement = typeof rest['*'] === 'boolean' ? (rest['*'] ? 'enabled' : 'disabled') : 'enabled';
-				this.telemetryService.publicLog2<ChatSettingChangedEvent, ChatSettingChangedClassification>('chatStatus.settingChanged', {
-					settingIdentifier: settingId,
-					settingMode: modeId,
-					settingEnablement: inheritedEnablement
-				});
-				this.configurationService.updateValue(settingId, rest);
+				if (configuredValue && Object.prototype.hasOwnProperty.call(configuredValue.value, modeId)) {
+					const { [modeId]: _, ...rest } = configuredValue.value;
+					await this.configurationService.updateValue(settingId, rest, configuredValue.target);
+				}
 			} else {
-				this.telemetryService.publicLog2<ChatSettingChangedEvent, ChatSettingChangedClassification>('chatStatus.settingChanged', {
-					settingIdentifier: settingId,
-					settingMode: modeId,
-					settingEnablement: state ? 'enabled' : 'disabled'
-				});
-				this.configurationService.updateValue(settingId, { ...result, [modeId]: state });
+				const value = { ...configuredValue?.value, [modeId]: state };
+				if (configuredValue) {
+					await this.configurationService.updateValue(settingId, value, configuredValue.target);
+				} else {
+					await this.configurationService.updateValue(settingId, value);
+				}
 			}
-			onStateChange();
-		};
 
-		// Track previous state so onChange can apply tri-state cycling
-		let previousState = getState();
-
-		const cycleAndWrite = () => {
-			cycleState();
-			previousState = checkbox.checked;
-			writeState(checkbox.checked);
+			const enabled = isCompletionsEnabled(this.configurationService, modeId);
+			this.telemetryService.publicLog2<ChatSettingChangedEvent, ChatSettingChangedClassification>('chatStatus.settingChanged', {
+				settingIdentifier: settingId,
+				settingMode: modeId,
+				settingEnablement: enabled ? 'enabled' : 'disabled'
+			});
 		};
+		const requestStateChange = () => {
+			const state = getNextState();
+			renderState(state);
+			pendingWrites++;
+			void writeSequencer.queue(async () => {
+				try {
+					await writeState(state);
+				} finally {
+					pendingWrites--;
+				}
+			}).catch(error => {
+				if (pendingWrites === 0) {
+					renderState(getState());
+				}
+				this.notificationService.error(error);
+			});
+		};
+		renderState(requestedState);
 
 		[EventType.CLICK, TouchEventType.Tap].forEach(eventType => {
 			this._store.add(addDisposableListener(settingLabel, eventType, e => {
 				if (checkbox?.enabled) {
 					EventHelper.stop(e, true);
-					cycleAndWrite();
+					requestStateChange();
 					checkbox.focus();
 				}
 			}));
 		});
 
 		this._store.add(checkbox.onChange(() => {
-			// The internal Toggle only cycles true↔false; revert and apply our tri-state cycle
-			checkbox.checked = previousState; // undo internal toggle
-			cycleAndWrite();
+			renderState(requestedState);
+			requestStateChange();
 		}));
 
 		this._store.add(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(settingId)) {
-				checkbox.checked = getState();
-				previousState = checkbox.checked;
-				onStateChange();
+				const state = getState();
+				if (pendingWrites === 0 || state === requestedState) {
+					renderState(state);
+					onStateChange();
+				}
 			}
 		}));
 
@@ -1094,6 +1107,17 @@ export class ChatStatusDashboard extends DomWidget {
 			checkbox.disable();
 			checkbox.checked = false;
 		}
+	}
+
+	private findConfiguredCompletionsValue(modeId?: string): { target: ConfigurationTarget; value: Record<string, boolean> } | undefined {
+		const inspected = this.configurationService.inspect<Record<string, boolean>>(defaultChat.completionsEnablementSetting);
+		for (const target of completionsConfigurationTargets) {
+			const value = getConfigValueInTarget(inspected, target);
+			if (isObject(value) && (!modeId || Object.prototype.hasOwnProperty.call(value, modeId))) {
+				return { target, value };
+			}
+		}
+		return undefined;
 	}
 
 	private getCompletionsSettingAccessor(modeId = '*'): ISettingsAccessor {

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -123,24 +123,27 @@ class TestCompletionsConfigurationService extends TestConfigurationService {
 		private readonly settingId: string,
 		private readonly defaultValue: Record<string, boolean>,
 		private userValue: Record<string, boolean>,
+		private workspaceValue?: Record<string, boolean>,
 	) {
 		super();
 	}
 
 	override getValue<T>(arg1?: string | IConfigurationOverrides, arg2?: IConfigurationOverrides): T | undefined {
 		if (arg1 === this.settingId) {
-			return { ...this.defaultValue, ...this.userValue } as T;
+			return { ...this.defaultValue, ...this.userValue, ...this.workspaceValue } as T;
 		}
 		return super.getValue<T>(arg1, arg2);
 	}
 
 	override inspect<T>(key: string, overrides?: IConfigurationOverrides): IConfigurationValue<T> {
 		if (key === this.settingId) {
+			const userValue = this.userValue as T;
 			return {
 				defaultValue: this.defaultValue as T,
-				userValue: this.userValue as T,
-				userLocalValue: this.userValue as T,
-				value: { ...this.defaultValue, ...this.userValue } as T,
+				userValue,
+				userLocalValue: userValue,
+				workspaceValue: this.workspaceValue as T | undefined,
+				value: { ...this.defaultValue, ...this.userValue, ...this.workspaceValue } as T,
 			};
 		}
 		return super.inspect<T>(key, overrides);
@@ -170,7 +173,13 @@ class TestCompletionsConfigurationService extends TestConfigurationService {
 		}
 
 		this.pendingUpdate = undefined;
-		this.userValue = pendingUpdate.value;
+		if (pendingUpdate.target === ConfigurationTarget.WORKSPACE) {
+			this.workspaceValue = pendingUpdate.value;
+		} else if (pendingUpdate.target === ConfigurationTarget.USER_LOCAL) {
+			this.userValue = pendingUpdate.value;
+		} else {
+			throw new Error(`Unexpected configuration target: ${pendingUpdate.target}`);
+		}
 		this.onDidChangeConfigurationEmitter.fire({
 			source: pendingUpdate.target,
 			affectedKeys: new Set([this.settingId]),
@@ -181,8 +190,26 @@ class TestCompletionsConfigurationService extends TestConfigurationService {
 		await timeout(0);
 	}
 
+	async failUpdate(error: Error): Promise<void> {
+		if (!this.pendingUpdate) {
+			await timeout(0);
+		}
+		const pendingUpdate = this.pendingUpdate;
+		if (!pendingUpdate) {
+			throw new Error('No configuration update is pending');
+		}
+
+		this.pendingUpdate = undefined;
+		await pendingUpdate.deferred.error(error);
+		await timeout(0);
+	}
+
 	get configuredValue(): Record<string, boolean> {
 		return this.userValue;
+	}
+
+	get configuredWorkspaceValue(): Record<string, boolean> | undefined {
+		return this.workspaceValue;
 	}
 }
 
@@ -345,6 +372,102 @@ suite('ChatStatusDashboard', () => {
 				overriddenHint: '(overridden)',
 				configuredValue: { '*': true, markdown: false },
 			},
+		});
+	});
+
+	test('removes inherited language overrides from every configured scope', async () => {
+		const defaultChat = product.defaultChatAgent;
+		assert.ok(defaultChat);
+
+		const configurationService = new TestCompletionsConfigurationService(
+			defaultChat.completionsEnablementSetting,
+			{ '*': true, markdown: false },
+			{ '*': true, markdown: true },
+			{ markdown: false },
+		);
+		const dashboard = createDashboard(createEntitlementService({ entitlement: ChatEntitlement.Pro }), {
+			dashboardOptions: {
+				...dashboardOptions,
+				disableInlineSuggestionsSettings: false,
+			},
+			configurationService,
+			activeTextEditorLanguageId: 'markdown',
+		});
+
+		const languageCheckbox = dashboard.element.querySelectorAll<HTMLElement>('.settings .monaco-checkbox').item(1);
+		const overriddenHint = dashboard.element.querySelector<HTMLElement>('.setting-overridden');
+		assert.ok(languageCheckbox && overriddenHint);
+
+		languageCheckbox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		await configurationService.completeUpdate();
+		const intermediateState = {
+			ariaChecked: languageCheckbox.getAttribute('aria-checked'),
+			overriddenHint: overriddenHint.textContent,
+			userValue: { ...configurationService.configuredValue },
+			workspaceValue: { ...configurationService.configuredWorkspaceValue },
+		};
+
+		await configurationService.completeUpdate();
+
+		assert.deepStrictEqual({
+			intermediate: intermediateState,
+			committed: {
+				ariaChecked: languageCheckbox.getAttribute('aria-checked'),
+				overriddenHint: overriddenHint.textContent,
+				userValue: configurationService.configuredValue,
+				workspaceValue: configurationService.configuredWorkspaceValue,
+			},
+		}, {
+			intermediate: {
+				ariaChecked: 'mixed',
+				overriddenHint: '(overridden)',
+				userValue: { '*': true, markdown: true },
+				workspaceValue: {},
+			},
+			committed: {
+				ariaChecked: 'mixed',
+				overriddenHint: '',
+				userValue: { '*': true },
+				workspaceValue: {},
+			},
+		});
+	});
+
+	test('restores the override hint when the final queued write fails', async () => {
+		const defaultChat = product.defaultChatAgent;
+		assert.ok(defaultChat);
+
+		const configurationService = new TestCompletionsConfigurationService(
+			defaultChat.completionsEnablementSetting,
+			{ '*': true, markdown: false },
+			{ '*': true, markdown: false },
+		);
+		const dashboard = createDashboard(createEntitlementService({ entitlement: ChatEntitlement.Pro }), {
+			dashboardOptions: {
+				...dashboardOptions,
+				disableInlineSuggestionsSettings: false,
+			},
+			configurationService,
+			activeTextEditorLanguageId: 'markdown',
+		});
+
+		const languageCheckbox = dashboard.element.querySelectorAll<HTMLElement>('.settings .monaco-checkbox').item(1);
+		const overriddenHint = dashboard.element.querySelector<HTMLElement>('.setting-overridden');
+		assert.ok(languageCheckbox && overriddenHint);
+
+		languageCheckbox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		languageCheckbox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		await configurationService.completeUpdate();
+		await configurationService.failUpdate(new Error('Unable to update configuration'));
+
+		assert.deepStrictEqual({
+			ariaChecked: languageCheckbox.getAttribute('aria-checked'),
+			overriddenHint: overriddenHint.textContent,
+			configuredValue: configurationService.configuredValue,
+		}, {
+			ariaChecked: 'mixed',
+			overriddenHint: '',
+			configuredValue: { '*': true },
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -5,14 +5,20 @@
 
 import assert from 'assert';
 import { mainWindow } from '../../../../../base/browser/window.js';
+import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../../base/common/observable.js';
+import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IInlineCompletionsService } from '../../../../../editor/browser/services/inlineCompletionsService.js';
+import { ConfigurationTarget, type IConfigurationOverrides, type IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
+import product from '../../../../../platform/product/common/product.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { ChatStatusDashboard, IChatStatusDashboardOptions } from '../../../chat/browser/chatStatus/chatStatusDashboard.js';
 import { IChatStatusItemService } from '../../../chat/browser/chatStatus/chatStatusItemService.js';
@@ -109,11 +115,87 @@ const dashboardOptions: IChatStatusDashboardOptions = {
 	disableCompletionsSnooze: true,
 };
 
+class TestCompletionsConfigurationService extends TestConfigurationService {
+
+	private pendingUpdate: { value: Record<string, boolean>; target: ConfigurationTarget; deferred: DeferredPromise<void> } | undefined;
+
+	constructor(
+		private readonly settingId: string,
+		private readonly defaultValue: Record<string, boolean>,
+		private userValue: Record<string, boolean>,
+	) {
+		super();
+	}
+
+	override getValue<T>(arg1?: string | IConfigurationOverrides, arg2?: IConfigurationOverrides): T | undefined {
+		if (arg1 === this.settingId) {
+			return { ...this.defaultValue, ...this.userValue } as T;
+		}
+		return super.getValue<T>(arg1, arg2);
+	}
+
+	override inspect<T>(key: string, overrides?: IConfigurationOverrides): IConfigurationValue<T> {
+		if (key === this.settingId) {
+			return {
+				defaultValue: this.defaultValue as T,
+				userValue: this.userValue as T,
+				userLocalValue: this.userValue as T,
+				value: { ...this.defaultValue, ...this.userValue } as T,
+			};
+		}
+		return super.inspect<T>(key, overrides);
+	}
+
+	override updateValue(key: string, value: unknown, target?: ConfigurationTarget): Promise<void> {
+		if (key !== this.settingId || typeof value !== 'object' || value === null || this.pendingUpdate) {
+			throw new Error('Unexpected configuration update');
+		}
+
+		const deferred = new DeferredPromise<void>();
+		this.pendingUpdate = {
+			value: { ...value } as Record<string, boolean>,
+			target: target ?? ConfigurationTarget.USER_LOCAL,
+			deferred,
+		};
+		return deferred.p;
+	}
+
+	async completeUpdate(): Promise<void> {
+		if (!this.pendingUpdate) {
+			await timeout(0);
+		}
+		const pendingUpdate = this.pendingUpdate;
+		if (!pendingUpdate) {
+			throw new Error('No configuration update is pending');
+		}
+
+		this.pendingUpdate = undefined;
+		this.userValue = pendingUpdate.value;
+		this.onDidChangeConfigurationEmitter.fire({
+			source: pendingUpdate.target,
+			affectedKeys: new Set([this.settingId]),
+			change: { keys: [this.settingId], overrides: [] },
+			affectsConfiguration: candidate => candidate === this.settingId,
+		});
+		await pendingUpdate.deferred.complete(undefined);
+		await timeout(0);
+	}
+
+	get configuredValue(): Record<string, boolean> {
+		return this.userValue;
+	}
+}
+
 suite('ChatStatusDashboard', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createDashboard(entitlementService: IChatEntitlementService): ChatStatusDashboard {
-		const instantiationService = workbenchInstantiationService(undefined, store);
+	function createDashboard(entitlementService: IChatEntitlementService, options: {
+		dashboardOptions?: IChatStatusDashboardOptions;
+		configurationService?: TestConfigurationService;
+		activeTextEditorLanguageId?: string;
+	} = {}): ChatStatusDashboard {
+		const configurationService = options.configurationService;
+		const instantiationService = workbenchInstantiationService(configurationService ? { configurationService: () => configurationService } : undefined, store);
 
 		instantiationService.stub(IChatEntitlementService, entitlementService);
 		instantiationService.stub(IChatStatusItemService, {
@@ -133,14 +215,148 @@ suite('ChatStatusDashboard', () => {
 		instantiationService.stub(IMarkdownRendererService, {
 			_serviceBrand: undefined,
 		});
+		if (options.activeTextEditorLanguageId) {
+			const activeTextEditorLanguageId = options.activeTextEditorLanguageId;
+			instantiationService.stub(IEditorService, new class extends mock<IEditorService>() {
+				override readonly activeTextEditorLanguageId = activeTextEditorLanguageId;
+			});
+		}
 
-		const dashboard = store.add(instantiationService.createInstance(ChatStatusDashboard, dashboardOptions));
+		const dashboard = store.add(instantiationService.createInstance(ChatStatusDashboard, options.dashboardOptions ?? dashboardOptions));
 
 		mainWindow.document.body.appendChild(dashboard.element);
 		store.add({ dispose: () => dashboard.element.remove() });
 
 		return dashboard;
 	}
+
+	test('commits inline suggestion language setting changes coherently', async () => {
+		const defaultChat = product.defaultChatAgent;
+		assert.ok(defaultChat);
+
+		const configurationService = new TestCompletionsConfigurationService(
+			defaultChat.completionsEnablementSetting,
+			{ '*': true, markdown: false },
+			{ '*': true, markdown: false },
+		);
+		const dashboard = createDashboard(createEntitlementService({ entitlement: ChatEntitlement.Pro }), {
+			dashboardOptions: {
+				...dashboardOptions,
+				disableInlineSuggestionsSettings: false,
+			},
+			configurationService,
+			activeTextEditorLanguageId: 'markdown',
+		});
+
+		const languageCheckbox = dashboard.element.querySelectorAll<HTMLElement>('.settings .monaco-checkbox').item(1);
+		const overriddenHint = dashboard.element.querySelector<HTMLElement>('.setting-overridden');
+		const status = dashboard.element.querySelector<HTMLElement>('.collapsible-status');
+		assert.ok(languageCheckbox && overriddenHint && status);
+		const getState = () => ({
+			ariaChecked: languageCheckbox.getAttribute('aria-checked'),
+			className: languageCheckbox.className,
+			status: status.textContent,
+			overriddenHint: overriddenHint.textContent,
+			configuredValue: { ...configurationService.configuredValue },
+		});
+
+		languageCheckbox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		const pointerRequestedState = getState();
+		await configurationService.completeUpdate();
+		const pointerCommittedState = getState();
+
+		const spaceEvent = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, shiftKey: true });
+		Object.defineProperty(spaceEvent, 'keyCode', { value: 32 });
+		languageCheckbox.dispatchEvent(spaceEvent);
+		const keyboardRequestedState = getState();
+		await configurationService.completeUpdate();
+		const keyboardCommittedState = getState();
+
+		languageCheckbox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		const pointerUncheckedRequestedState = getState();
+		await configurationService.completeUpdate();
+		const pointerUncheckedCommittedState = getState();
+
+		assert.deepStrictEqual({
+			pointerRequested: pointerRequestedState,
+			pointerCommitted: pointerCommittedState,
+			keyboardRequested: keyboardRequestedState,
+			keyboardCommitted: keyboardCommittedState,
+			pointerUncheckedRequested: pointerUncheckedRequestedState,
+			pointerUncheckedCommitted: pointerUncheckedCommittedState,
+		}, {
+			pointerRequested: {
+				ariaChecked: 'mixed',
+				className: 'monaco-custom-toggle monaco-checkbox codicon codicon-dash',
+				status: 'Disabled',
+				overriddenHint: '(overridden)',
+				configuredValue: { '*': true, markdown: false },
+			},
+			pointerCommitted: {
+				ariaChecked: 'mixed',
+				className: 'monaco-custom-toggle monaco-checkbox codicon codicon-dash',
+				status: 'Disabled',
+				overriddenHint: '',
+				configuredValue: { '*': true },
+			},
+			keyboardRequested: {
+				ariaChecked: 'true',
+				className: 'monaco-custom-toggle monaco-checkbox checked codicon codicon-check',
+				status: 'Disabled',
+				overriddenHint: '',
+				configuredValue: { '*': true },
+			},
+			keyboardCommitted: {
+				ariaChecked: 'true',
+				className: 'monaco-custom-toggle monaco-checkbox checked codicon codicon-check',
+				status: 'Enabled',
+				overriddenHint: '',
+				configuredValue: { '*': true, markdown: true },
+			},
+			pointerUncheckedRequested: {
+				ariaChecked: 'false',
+				className: 'monaco-custom-toggle monaco-checkbox',
+				status: 'Enabled',
+				overriddenHint: '',
+				configuredValue: { '*': true, markdown: true },
+			},
+			pointerUncheckedCommitted: {
+				ariaChecked: 'false',
+				className: 'monaco-custom-toggle monaco-checkbox',
+				status: 'Disabled',
+				overriddenHint: '(overridden)',
+				configuredValue: { '*': true, markdown: false },
+			},
+		});
+
+		for (let i = 0; i < 3; i++) {
+			languageCheckbox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		}
+		const rapidRequestedState = getState();
+		for (let i = 0; i < 3; i++) {
+			await configurationService.completeUpdate();
+		}
+
+		assert.deepStrictEqual({
+			requested: rapidRequestedState,
+			committed: getState(),
+		}, {
+			requested: {
+				ariaChecked: 'false',
+				className: 'monaco-custom-toggle monaco-checkbox',
+				status: 'Disabled',
+				overriddenHint: '(overridden)',
+				configuredValue: { '*': true, markdown: false },
+			},
+			committed: {
+				ariaChecked: 'false',
+				className: 'monaco-custom-toggle monaco-checkbox',
+				status: 'Disabled',
+				overriddenHint: '(overridden)',
+				configuredValue: { '*': true, markdown: false },
+			},
+		});
+	});
 
 	// --- COPILOT FREE ---
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -230,7 +230,7 @@ suite('ChatStatusDashboard', () => {
 		return dashboard;
 	}
 
-	test('commits inline suggestion language setting changes coherently', async () => {
+	test('preserves inline suggestion language setting state across writes', async () => {
 		const defaultChat = product.defaultChatAgent;
 		assert.ok(defaultChat);
 
@@ -250,12 +250,10 @@ suite('ChatStatusDashboard', () => {
 
 		const languageCheckbox = dashboard.element.querySelectorAll<HTMLElement>('.settings .monaco-checkbox').item(1);
 		const overriddenHint = dashboard.element.querySelector<HTMLElement>('.setting-overridden');
-		const status = dashboard.element.querySelector<HTMLElement>('.collapsible-status');
-		assert.ok(languageCheckbox && overriddenHint && status);
+		assert.ok(languageCheckbox && overriddenHint);
 		const getState = () => ({
 			ariaChecked: languageCheckbox.getAttribute('aria-checked'),
 			className: languageCheckbox.className,
-			status: status.textContent,
 			overriddenHint: overriddenHint.textContent,
 			configuredValue: { ...configurationService.configuredValue },
 		});
@@ -288,42 +286,36 @@ suite('ChatStatusDashboard', () => {
 			pointerRequested: {
 				ariaChecked: 'mixed',
 				className: 'monaco-custom-toggle monaco-checkbox codicon codicon-dash',
-				status: 'Disabled',
 				overriddenHint: '(overridden)',
 				configuredValue: { '*': true, markdown: false },
 			},
 			pointerCommitted: {
 				ariaChecked: 'mixed',
 				className: 'monaco-custom-toggle monaco-checkbox codicon codicon-dash',
-				status: 'Disabled',
 				overriddenHint: '',
 				configuredValue: { '*': true },
 			},
 			keyboardRequested: {
 				ariaChecked: 'true',
 				className: 'monaco-custom-toggle monaco-checkbox checked codicon codicon-check',
-				status: 'Disabled',
 				overriddenHint: '',
 				configuredValue: { '*': true },
 			},
 			keyboardCommitted: {
 				ariaChecked: 'true',
 				className: 'monaco-custom-toggle monaco-checkbox checked codicon codicon-check',
-				status: 'Enabled',
 				overriddenHint: '',
 				configuredValue: { '*': true, markdown: true },
 			},
 			pointerUncheckedRequested: {
 				ariaChecked: 'false',
 				className: 'monaco-custom-toggle monaco-checkbox',
-				status: 'Enabled',
 				overriddenHint: '',
 				configuredValue: { '*': true, markdown: true },
 			},
 			pointerUncheckedCommitted: {
 				ariaChecked: 'false',
 				className: 'monaco-custom-toggle monaco-checkbox',
-				status: 'Disabled',
 				overriddenHint: '(overridden)',
 				configuredValue: { '*': true, markdown: false },
 			},
@@ -344,14 +336,12 @@ suite('ChatStatusDashboard', () => {
 			requested: {
 				ariaChecked: 'false',
 				className: 'monaco-custom-toggle monaco-checkbox',
-				status: 'Disabled',
 				overriddenHint: '(overridden)',
 				configuredValue: { '*': true, markdown: false },
 			},
 			committed: {
 				ariaChecked: 'false',
 				className: 'monaco-custom-toggle monaco-checkbox',
-				status: 'Disabled',
 				overriddenHint: '(overridden)',
 				configuredValue: { '*': true, markdown: false },
 			},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The per-language inline suggestions checkbox could briefly show the requested state and then snap back because the dashboard read the merged setting, where a language default masked the absence of an explicit override. Repeated clicks also allowed intermediate configuration events to update parts of the hover independently.

This keeps the fix local to the Copilot status dashboard:
- derive the tri-state value from explicitly configured scopes instead of merged defaults
- show checkbox feedback immediately while serializing configuration writes
- ignore stale intermediate configuration events so the checkbox and override hint stay synchronized
- restore persisted state and surface an error if a write fails

The shared checkbox and toggle components are unchanged.

To test:
1. Open a Markdown file and open the Copilot status dashboard.
2. Repeatedly cycle "Ghost text suggestions for Markdown" through checked, unchecked, and inherited states.
3. Confirm the checkbox does not flicker or snap back and other workbench mouse interactions continue to work.
4. Repeat with Space or Enter while the checkbox is focused.

Fixes #325558

cc @pwang347 @hediet 