### PR TITLE
Clarify Codex providers in the session picker

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
@@ -25,6 +25,10 @@ export interface IActionWidgetDropdownAction extends IAction {
 	 */
 	detail?: string;
 	/**
+	 * Optional description used in the accessible label instead of the visual description.
+	 */
+	ariaDescription?: string;
+	/**
 	 * Optional flyout hover configuration shown when focusing/hovering over the action.
 	 */
 	hover?: IActionListItemHover;
@@ -151,6 +155,7 @@ export class ActionWidgetDropdown extends BaseDropdown {
 					item: action,
 					tooltip: action.tooltip,
 					description: action.description,
+					ariaDescription: action.ariaDescription,
 					detail: action.detail,
 					hover: action.hover,
 					toolbarActions: action.toolbarActions,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -79,6 +79,17 @@ export function getAgentSessionProviderName(provider: AgentSessionTarget): strin
 	}
 }
 
+export function getAgentSessionProviderSource(provider: AgentSessionTarget): string | undefined {
+	switch (provider) {
+		case AgentSessionProviders.Codex:
+			return localize('chat.session.providerSource.openAIExtension', "(OpenAI Extension)");
+		case AgentSessionProviders.AgentHostCodex:
+			return localize('chat.session.providerSource.localAgentHost', "(Local Agent Host)");
+		default:
+			return undefined;
+	}
+}
+
 export function getAgentSessionProviderIcon(provider: AgentSessionTarget): ThemeIcon {
 	switch (provider) {
 		case AgentSessionProviders.Local:
@@ -186,7 +197,9 @@ export function getAgentSessionProviderDescription(provider: AgentSessionTarget)
 		case AgentSessionProviders.AgentHostClaude:
 			return localize('chat.session.providerDescription.claude', "Delegate tasks to the Claude Agent SDK using the Claude models included in your GitHub Copilot subscription. The agent iterates via chat and works interactively to implement changes on your main workspace.");
 		case AgentSessionProviders.Codex:
-			return localize('chat.session.providerDescription.codex', "Opens a new Codex session in the editor. Codex sessions can be managed from the chat sessions view.");
+			return localize('chat.session.providerDescription.codex', "Open a new Codex session using the Codex extension from OpenAI. Codex sessions can be managed from the chat sessions view.");
+		case AgentSessionProviders.AgentHostCodex:
+			return localize('chat.session.providerDescription.agentHostCodex', "Delegate tasks to the Codex App Server using the Codex models included in your GitHub Copilot subscription. The agent iterates via chat and works interactively to implement changes on your main workspace.");
 		case AgentSessionProviders.Growth:
 			return localize('chat.session.providerDescription.growth', "Learn about Copilot features.");
 		case AgentSessionProviders.AgentHostCopilot:

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -25,7 +25,7 @@ import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../common/languageModels.js';
-import { AgentSessionProviders, AgentSessionTarget, getAgentSessionProvider, getAgentSessionProviderDescription, getAgentSessionProviderIcon, getAgentSessionProviderName, isFirstPartyAgentSessionProvider } from '../../agentSessions/agentSessions.js';
+import { AgentSessionProviders, AgentSessionTarget, getAgentSessionProvider, getAgentSessionProviderDescription, getAgentSessionProviderIcon, getAgentSessionProviderName, getAgentSessionProviderSource, isFirstPartyAgentSessionProvider } from '../../agentSessions/agentSessions.js';
 import { getSessionTypeAvailability, getSessionTypeUnavailableDescription, getSessionTypeUnavailableHover, SessionTypeAvailability } from '../../agentSessions/sessionTypeAvailability.js';
 import { ChatConfiguration, getDefaultNewChatSessionType, isVisibleEditorChatSessionType, recordUserSelectedSessionType } from '../../../common/constants.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
@@ -77,6 +77,10 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 				for (const sessionTypeItem of this._sessionTypeItems) {
 					const availability = getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionTypeItem.type);
 					const unavailable = availability !== SessionTypeAvailability.Available;
+					const description = getSessionTypeUnavailableDescription(availability) ?? this._getSessionDescription(sessionTypeItem);
+					const hoverDescription = getSessionTypeUnavailableHover(availability) ?? sessionTypeItem.hoverDescription;
+					const ariaDescription = typeof description === 'string' ? description : description?.value;
+					const ariaHoverDescription = typeof hoverDescription === 'string' ? hoverDescription : hoverDescription?.value;
 					actions.push({
 						...action,
 						id: sessionTypeItem.commandId,
@@ -85,9 +89,12 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 						icon: this._getSessionIcon(sessionTypeItem),
 						enabled: unavailable ? false : this._isSessionTypeEnabled(sessionTypeItem.type),
 						category: this._getSessionCategory(sessionTypeItem),
-						description: getSessionTypeUnavailableDescription(availability) ?? this._getSessionDescription(sessionTypeItem),
+						description,
+						ariaDescription: ariaDescription && ariaHoverDescription
+							? localize('chat.sessionTarget.ariaDescription', "{0}. {1}", ariaDescription, ariaHoverDescription)
+							: undefined,
 						tooltip: '',
-						hover: { content: getSessionTypeUnavailableHover(availability) ?? sessionTypeItem.hoverDescription },
+						hover: { content: hoverDescription },
 						run: async () => {
 							this._run(sessionTypeItem);
 						},
@@ -256,7 +263,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 	}
 
 	protected _getSessionDescription(sessionTypeItem: ISessionTypeItem): string | undefined {
-		return undefined;
+		return getAgentSessionProviderSource(sessionTypeItem.type);
 	}
 
 	private _getSessionIcon(sessionTypeItem: ISessionTypeItem): ThemeIcon {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../../base/browser/dom.js';
+import { renderAsPlaintext } from '../../../../../../base/browser/markdownRenderer.js';
 import { renderLabelWithIcons } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { IAction } from '../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
@@ -43,6 +44,40 @@ export interface ISessionTypeItem {
 const firstPartyCategory = { label: localize('chat.sessionTarget.category.agent', "Agent Types"), order: 1 };
 const otherCategory = { label: localize('chat.sessionTarget.category.other', "Other"), order: 2 };
 
+export function createSessionTypePickerAction(
+	action: IAction,
+	sessionTypeItem: ISessionTypeItem,
+	currentType: AgentSessionTarget,
+	availability: SessionTypeAvailability,
+	enabled: boolean,
+	category: IActionWidgetDropdownAction['category'],
+	sourceDescription: string | undefined,
+	icon: ThemeIcon,
+	run: () => void,
+): IActionWidgetDropdownAction {
+	const unavailable = availability !== SessionTypeAvailability.Available;
+	const description = getSessionTypeUnavailableDescription(availability) ?? sourceDescription;
+	const hoverDescription = getSessionTypeUnavailableHover(availability) ?? sessionTypeItem.hoverDescription;
+	const ariaDescription = description ? renderAsPlaintext(description) : undefined;
+	const ariaHoverDescription = hoverDescription ? renderAsPlaintext(hoverDescription) : undefined;
+	return {
+		...action,
+		id: sessionTypeItem.commandId,
+		label: sessionTypeItem.label,
+		checked: currentType === sessionTypeItem.type,
+		icon,
+		enabled: unavailable ? false : enabled,
+		category,
+		description,
+		ariaDescription: ariaDescription && ariaHoverDescription
+			? localize('chat.sessionTarget.ariaDescription', "{0}. {1}", ariaDescription, ariaHoverDescription)
+			: undefined,
+		tooltip: '',
+		hover: { content: hoverDescription },
+		run: async () => run(),
+	};
+}
+
 /**
  * Action view item for selecting a session target in the chat interface.
  * This picker allows switching between different chat session types for new/empty sessions.
@@ -76,29 +111,17 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 				const actions: IActionWidgetDropdownAction[] = [...this._getAdditionalActions().map(a => ({ ...action, ...a }))];
 				for (const sessionTypeItem of this._sessionTypeItems) {
 					const availability = getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionTypeItem.type);
-					const unavailable = availability !== SessionTypeAvailability.Available;
-					const description = getSessionTypeUnavailableDescription(availability) ?? this._getSessionDescription(sessionTypeItem);
-					const hoverDescription = getSessionTypeUnavailableHover(availability) ?? sessionTypeItem.hoverDescription;
-					const ariaDescription = typeof description === 'string' ? description : description?.value;
-					const ariaHoverDescription = typeof hoverDescription === 'string' ? hoverDescription : hoverDescription?.value;
-					actions.push({
-						...action,
-						id: sessionTypeItem.commandId,
-						label: sessionTypeItem.label,
-						checked: currentType === sessionTypeItem.type,
-						icon: this._getSessionIcon(sessionTypeItem),
-						enabled: unavailable ? false : this._isSessionTypeEnabled(sessionTypeItem.type),
-						category: this._getSessionCategory(sessionTypeItem),
-						description,
-						ariaDescription: ariaDescription && ariaHoverDescription
-							? localize('chat.sessionTarget.ariaDescription', "{0}. {1}", ariaDescription, ariaHoverDescription)
-							: undefined,
-						tooltip: '',
-						hover: { content: hoverDescription },
-						run: async () => {
-							this._run(sessionTypeItem);
-						},
-					});
+					actions.push(createSessionTypePickerAction(
+						action,
+						sessionTypeItem,
+						currentType,
+						availability,
+						this._isSessionTypeEnabled(sessionTypeItem.type),
+						this._getSessionCategory(sessionTypeItem),
+						this._getSessionDescription(sessionTypeItem),
+						this._getSessionIcon(sessionTypeItem),
+						() => this._run(sessionTypeItem),
+					));
 				}
 
 				return actions;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -22,7 +22,7 @@ import { MenuId } from '../../../../../../platform/actions/common/actions.js';
 import { ILifecycleService } from '../../../../../services/lifecycle/common/lifecycle.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
-import { AgentSessionProviders, getAgentCanContinueIn, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName } from '../../../browser/agentSessions/agentSessions.js';
+import { AgentSessionProviders, getAgentCanContinueIn, getAgentSessionProvider, getAgentSessionProviderDescription, getAgentSessionProviderIcon, getAgentSessionProviderName, getAgentSessionProviderSource } from '../../../browser/agentSessions/agentSessions.js';
 
 class StaticChatSessionItemController implements IChatSessionItemController {
 	readonly onDidChangeChatSessionItems = Event.None;
@@ -2207,6 +2207,28 @@ suite('AgentSessions', () => {
 		test('should return correct icon for AgentHostCodex provider', () => {
 			const icon = getAgentSessionProviderIcon(AgentSessionProviders.AgentHostCodex);
 			assert.strictEqual(icon.id, Codicon.openai.id);
+		});
+
+		test('should distinguish Codex providers by source and description', () => {
+			assert.deepStrictEqual({
+				extension: {
+					source: getAgentSessionProviderSource(AgentSessionProviders.Codex),
+					description: getAgentSessionProviderDescription(AgentSessionProviders.Codex),
+				},
+				agentHost: {
+					source: getAgentSessionProviderSource(AgentSessionProviders.AgentHostCodex),
+					description: getAgentSessionProviderDescription(AgentSessionProviders.AgentHostCodex),
+				},
+			}, {
+				extension: {
+					source: '(OpenAI Extension)',
+					description: 'Open a new Codex session using the Codex extension from OpenAI. Codex sessions can be managed from the chat sessions view.',
+				},
+				agentHost: {
+					source: '(Local Agent Host)',
+					description: 'Delegate tasks to the Codex App Server using the Codex models included in your GitHub Copilot subscription. The agent iterates via chat and works interactively to implement changes on your main workspace.',
+				},
+			});
 		});
 
 		test('should resolve AgentHostClaude provider from session type', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -22,7 +22,7 @@ import { MenuId } from '../../../../../../platform/actions/common/actions.js';
 import { ILifecycleService } from '../../../../../services/lifecycle/common/lifecycle.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
-import { AgentSessionProviders, getAgentCanContinueIn, getAgentSessionProvider, getAgentSessionProviderDescription, getAgentSessionProviderIcon, getAgentSessionProviderName, getAgentSessionProviderSource } from '../../../browser/agentSessions/agentSessions.js';
+import { AgentSessionProviders, getAgentCanContinueIn, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName } from '../../../browser/agentSessions/agentSessions.js';
 
 class StaticChatSessionItemController implements IChatSessionItemController {
 	readonly onDidChangeChatSessionItems = Event.None;
@@ -2207,28 +2207,6 @@ suite('AgentSessions', () => {
 		test('should return correct icon for AgentHostCodex provider', () => {
 			const icon = getAgentSessionProviderIcon(AgentSessionProviders.AgentHostCodex);
 			assert.strictEqual(icon.id, Codicon.openai.id);
-		});
-
-		test('should distinguish Codex providers by source and description', () => {
-			assert.deepStrictEqual({
-				extension: {
-					source: getAgentSessionProviderSource(AgentSessionProviders.Codex),
-					description: getAgentSessionProviderDescription(AgentSessionProviders.Codex),
-				},
-				agentHost: {
-					source: getAgentSessionProviderSource(AgentSessionProviders.AgentHostCodex),
-					description: getAgentSessionProviderDescription(AgentSessionProviders.AgentHostCodex),
-				},
-			}, {
-				extension: {
-					source: '(OpenAI Extension)',
-					description: 'Open a new Codex session using the Codex extension from OpenAI. Codex sessions can be managed from the chat sessions view.',
-				},
-				agentHost: {
-					source: '(Local Agent Host)',
-					description: 'Delegate tasks to the Codex App Server using the Codex models included in your GitHub Copilot subscription. The agent iterates via chat and works interactively to implement changes on your main workspace.',
-				},
-			});
 		});
 
 		test('should resolve AgentHostClaude provider from session type', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/sessionTargetPickerActionItem.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/sessionTargetPickerActionItem.test.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IAction } from '../../../../../../../base/common/actions.js';
+import { Codicon } from '../../../../../../../base/common/codicons.js';
+import { IMarkdownString } from '../../../../../../../base/common/htmlContent.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { AgentSessionProviders, getAgentSessionProviderDescription, getAgentSessionProviderSource } from '../../../../browser/agentSessions/agentSessions.js';
+import { SessionTypeAvailability } from '../../../../browser/agentSessions/sessionTypeAvailability.js';
+import { createSessionTypePickerAction, ISessionTypeItem } from '../../../../browser/widget/input/sessionTargetPickerActionItem.js';
+
+const baseAction: IAction = {
+	id: 'base',
+	label: 'Base',
+	tooltip: '',
+	class: undefined,
+	enabled: true,
+	run: async () => { },
+};
+
+function createCodexItem(type: AgentSessionProviders.Codex | AgentSessionProviders.AgentHostCodex): ISessionTypeItem {
+	return {
+		type,
+		label: 'Codex',
+		hoverDescription: getAgentSessionProviderDescription(type),
+		commandId: `open.${type}`,
+	};
+}
+
+function getMarkdownValue(value: string | IMarkdownString | HTMLElement | undefined): string | undefined {
+	return typeof value === 'string' ? value : value instanceof HTMLElement ? value.textContent ?? undefined : value?.value;
+}
+
+suite('SessionTypePickerActionItem', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('creates an available Codex extension action with source and hover context', () => {
+		const item = createCodexItem(AgentSessionProviders.Codex);
+		const action = createSessionTypePickerAction(
+			baseAction,
+			item,
+			AgentSessionProviders.Codex,
+			SessionTypeAvailability.Available,
+			true,
+			{ label: 'Other', order: 2 },
+			getAgentSessionProviderSource(item.type),
+			Codicon.openai,
+			() => { },
+		);
+
+		assert.deepStrictEqual({
+			label: action.label,
+			checked: action.checked,
+			enabled: action.enabled,
+			description: getMarkdownValue(action.description),
+			ariaDescription: action.ariaDescription,
+			hover: getMarkdownValue(action.hover?.content),
+		}, {
+			label: 'Codex',
+			checked: true,
+			enabled: true,
+			description: '(OpenAI Extension)',
+			ariaDescription: '(OpenAI Extension). Open a new Codex session using the Codex extension from OpenAI. Codex sessions can be managed from the chat sessions view.',
+			hover: 'Open a new Codex session using the Codex extension from OpenAI. Codex sessions can be managed from the chat sessions view.',
+		});
+	});
+
+	test('creates plain accessible text for an unavailable Codex action', () => {
+		const item = createCodexItem(AgentSessionProviders.AgentHostCodex);
+		const action = createSessionTypePickerAction(
+			baseAction,
+			item,
+			AgentSessionProviders.Codex,
+			SessionTypeAvailability.SignInRequired,
+			true,
+			{ label: 'Other', order: 2 },
+			getAgentSessionProviderSource(item.type),
+			Codicon.openai,
+			() => { },
+		);
+
+		assert.deepStrictEqual({
+			label: action.label,
+			checked: action.checked,
+			enabled: action.enabled,
+			description: getMarkdownValue(action.description),
+			ariaDescription: action.ariaDescription,
+			hover: getMarkdownValue(action.hover?.content),
+		}, {
+			label: 'Codex',
+			checked: false,
+			enabled: false,
+			description: '[Sign in](command:workbench.action.chat.triggerSetup)',
+			ariaDescription: 'Sign in. Sign in to GitHub Copilot to use this agent.',
+			hover: '[Sign in to GitHub Copilot](command:workbench.action.chat.triggerSetup) to use this agent.',
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- distinguish the OpenAI extension and local Agent Host Codex entries in the session picker
- add provider-specific hover descriptions, including Codex App Server details for the local Agent Host
- preserve the source and hover context in accessible labels while converting Markdown links to plain text

<img width="229" height="260" alt="image" src="https://github.com/user-attachments/assets/00c83f16-b2f0-4025-b559-b1465e9a0316" />


## Testing

- `npm run typecheck-client`
- `npm run valid-layers-check`
- `npm run precommit`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/widget/input/sessionTargetPickerActionItem.test.ts`