### PR TITLE
Style overrides: Improve layout consistency for floating panels and status bar

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -21,7 +21,7 @@
 
 .monaco-workbench.floating-panels .part.sidebar,
 .monaco-workbench.floating-panels .part.auxiliarybar {
-	margin: var(--vscode-spacing-size40);
+	margin: 0 var(--vscode-spacing-size20) var(--vscode-spacing-size20) var(--vscode-spacing-size40);
 	border: 1px solid var(--vscode-agentsPanel-border, var(--vscode-widget-border, transparent)) !important;
 	border-radius: var(--vscode-cornerRadius-large);
 	background-color: var(--vscode-agentsPanel-background) !important;
@@ -30,7 +30,7 @@
 
 /* Keep the panel surface aligned with the panel theme background in light theme. */
 .monaco-workbench.floating-panels .part.panel {
-	margin: var(--vscode-spacing-size40);
+	margin: var(--vscode-spacing-size40) var(--vscode-spacing-size20) var(--vscode-spacing-size20) var(--vscode-spacing-size40);
 	border: 1px solid var(--vscode-agentsPanel-border, var(--vscode-widget-border, transparent)) !important;
 	border-radius: var(--vscode-cornerRadius-large);
 	background-color: var(--vscode-panel-background) !important;
@@ -97,8 +97,7 @@
 
 /* Main editor: float like the other cards, but stay flush with the title bar. */
 .monaco-workbench.floating-panels > .monaco-grid-view .part.editor {
-	margin: var(--vscode-spacing-size40);
-	margin-top: 0;
+	margin: 0 var(--vscode-spacing-size20) var(--vscode-spacing-size20) var(--vscode-spacing-size40);
 }
 
 /* When the panel is at the top and visible the editor sits below it — give it a top margin
@@ -159,11 +158,11 @@
 	display: none !important;
 }
 
-/* Inset the status bar items so they respect the same gutter as the cards. */
+/* Inset and vertically center the status bar items within its floating gutter. */
 .monaco-workbench.floating-panels .part.statusbar {
-	padding-left: var(--vscode-spacing-size40);
-	padding-right: var(--vscode-spacing-size40);
-	padding-bottom: var(--vscode-spacing-size40);
+	padding: var(--vscode-spacing-size40);
+	padding-top: calc(var(--vscode-spacing-size40) - 1px); /* 1px for the border-top of the status bar */
+	padding-bottom: calc(var(--vscode-spacing-size40) + 1px); /* 1px for the border-bottom of the status bar */
 }
 
 .monaco-workbench.floating-panels .part.statusbar > .items-container > .statusbar-item.left.first-visible-item {
@@ -198,7 +197,7 @@
 
 /*
  * When a visible bottom panel directly abuts the sidebars and/or editor (they share
- * the same grid row), keep the normal 4px inter-card gap instead of the doubled 8px.
+ * the same grid row), keep the normal trailing 2px margin instead of the doubled 8px.
  * Which bars are in the same row as the editor depends on panel alignment:
  *   justify  → both sidebars are in the top row (above the full-width panel)
  *   left     → the bar on the LEFT is in the top row; the bar on the RIGHT is full-height
@@ -213,11 +212,25 @@
 .monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-right .part.sidebar.right,
 .monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-right .part.auxiliarybar.right,
 .monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel) > .monaco-grid-view .part.editor {
-	margin-bottom: var(--vscode-spacing-size40);
+	margin-bottom: var(--vscode-spacing-size20);
 }
 
 .monaco-workbench.floating-panels.nostatusbar .part.activitybar {
 	margin-bottom: calc(var(--vscode-spacing-size40) * 2);
+}
+
+/*
+ * Floating cards use a 4px leading margin and 2px trailing margin, placing the
+ * visual midpoint of their 6px gap 1px past the grid boundary. Shift only grid
+ * sashes to that midpoint; part-internal sashes and the hidden-panel reveal sash
+ * retain their own geometry.
+ */
+.monaco-workbench.floating-panels .monaco-sash.vertical:not(.part .monaco-sash) {
+	transform: translateX(1px);
+}
+
+.monaco-workbench.floating-panels:not(.nopanel) .monaco-sash.horizontal:not(.part .monaco-sash) {
+	transform: translateY(1px);
 }
 
 /*

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -161,8 +161,8 @@
 /* Inset and vertically center the status bar items within its floating gutter. */
 .monaco-workbench.floating-panels .part.statusbar {
 	padding: var(--vscode-spacing-size40);
-	padding-top: calc(var(--vscode-spacing-size40) - 1px); /* 1px for the border-top of the status bar */
-	padding-bottom: calc(var(--vscode-spacing-size40) + 1px); /* 1px for the border-bottom of the status bar */
+	padding-top: calc(var(--vscode-spacing-size40) - var(--vscode-strokeThickness)); /* offset for the border-top of the status bar */
+	padding-bottom: calc(var(--vscode-spacing-size40) + var(--vscode-strokeThickness)); /* offset for the border-bottom of the status bar */
 }
 
 .monaco-workbench.floating-panels .part.statusbar > .items-container > .statusbar-item.left.first-visible-item {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -24,7 +24,7 @@ import { EditorDropTarget } from './editorDropTarget.js';
 import { Color } from '../../../../base/common/color.js';
 import { CenteredViewLayout, CenteredViewState } from '../../../../base/browser/ui/centered/centeredViewLayout.js';
 import { onUnexpectedError } from '../../../../base/common/errors.js';
-import { Parts, IWorkbenchLayoutService, Position, FLOATING_PANEL_MARGIN, getFloatingOuterEdgeOwners } from '../../../services/layout/browser/layoutService.js';
+import { Parts, IWorkbenchLayoutService, Position, FLOATING_PANEL_INNER_MARGIN, FLOATING_PANEL_MARGIN, getFloatingOuterEdgeOwners } from '../../../services/layout/browser/layoutService.js';
 import { DeepPartial, assertType } from '../../../../base/common/types.js';
 import { CompositeDragAndDropObserver } from '../../dnd.js';
 import { DeferredPromise, Promises } from '../../../../base/common/async.js';
@@ -1439,7 +1439,7 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			const outerRight = owners.right === Parts.EDITOR_PART;
 
 			const leftMargin = outerLeft ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
-			const rightMargin = outerRight ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
+			const rightMargin = outerRight ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_INNER_MARGIN;
 
 			width = Math.max(0, width - leftMargin - rightMargin);
 			const { topMargin, bottomMargin } = this.getFloatingPanelHeightInsets();
@@ -1480,7 +1480,7 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 		// card (not the window edge), so keep the normal inter-card gap.
 		const panelAtBottom = panelVisible && this.layoutService.getPanelPosition() === Position.BOTTOM;
 		const bottomMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, mainWindow) && !panelAtBottom
-			? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
+			? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_INNER_MARGIN;
 		return { topMargin: panelAtTop ? FLOATING_PANEL_MARGIN : 0, bottomMargin };
 	}
 

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -12,7 +12,7 @@ import { IPaneComposite } from '../../common/panecomposite.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../common/views.js';
 import { DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { IView } from '../../../base/browser/ui/grid/grid.js';
-import { IWorkbenchLayoutService, Parts, Position, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges, getFloatingSidebarSiblingToEditorStatus } from '../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts, Position, SINGLE_WINDOW_PARTS, FLOATING_PANEL_INNER_MARGIN, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges, getFloatingSidebarSiblingToEditorStatus } from '../../services/layout/browser/layoutService.js';
 import { CompositePart, ICompositePartOptions, ICompositeTitleLabel } from './compositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from './paneCompositeBar.js';
 import { Dimension, EventHelper, trackFocus, $, addDisposableListener, EventType, prepend, getWindow } from '../../../base/browser/dom.js';
@@ -712,10 +712,10 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		const topMargin = this.getFloatingPartTopMargin(panelVisible, margin);
 		const isAtWindowBottom = this.isFloatingPartAtWindowBottomEdge(panelVisible);
 		const bottomMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, getWindow(this.element)) && isAtWindowBottom
-			? margin * 2 : margin;
+			? margin * 2 : FLOATING_PANEL_INNER_MARGIN;
 		const outerGutter = this.getFloatingOuterGutterEdges();
 		const leftMargin = outerGutter.left ? margin * 2 : margin;
-		const rightMargin = outerGutter.right ? margin * 2 : margin;
+		const rightMargin = outerGutter.right ? margin * 2 : FLOATING_PANEL_INNER_MARGIN;
 		return {
 			width: leftMargin + rightMargin + borderTotal,
 			height: topMargin + bottomMargin + borderTotal

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -19,7 +19,7 @@ import { contrastBorder, activeContrastBorder } from '../../../../platform/theme
 import { EventHelper, addDisposableListener, EventType, clearNode, getWindow, isHTMLElement, $ } from '../../../../base/browser/dom.js';
 import { createStyleSheet } from '../../../../base/browser/domStylesheets.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
-import { Parts, IWorkbenchLayoutService, LayoutSettings, FLOATING_PANEL_MARGIN } from '../../../services/layout/browser/layoutService.js';
+import { Parts, IWorkbenchLayoutService, LayoutSettings } from '../../../services/layout/browser/layoutService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { equals } from '../../../../base/common/arrays.js';
@@ -122,11 +122,11 @@ class StatusbarPart extends Part implements IStatusbarEntryContainer {
 	static readonly HEIGHT = 22;
 
 	/**
-	 * Bottom padding reserved below the main status bar under the floating panels
-	 * experiment so it floats off the window's bottom edge. The part grows by this
-	 * amount and the matching `padding-bottom` is applied in `part.css`.
+	 * Vertical padding reserved around the main status bar under the floating panels
+	 * experiment so its items remain centered. The part grows by this amount and
+	 * the matching padding is applied in `floatingPanels.css`.
 	 */
-	static readonly FLOATING_BOTTOM_PADDING = FLOATING_PANEL_MARGIN;
+	static readonly FLOATING_BOTTOM_PADDING = 10;
 
 	//#region IView
 

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -62,6 +62,14 @@ export const enum LayoutSettings {
  */
 export const FLOATING_PANEL_MARGIN = 4;
 
+/**
+ * The trailing card margin (in pixels) when the Modern UI Update experiment is
+ * enabled. Together with the next card's leading {@link FLOATING_PANEL_MARGIN},
+ * it forms the 6px inter-card gap. Keep in sync with the
+ * `--vscode-spacing-size20` (2px) token used in `floatingPanels.css`.
+ */
+export const FLOATING_PANEL_INNER_MARGIN = 2;
+
 export const enum ActivityBarPosition {
 	DEFAULT = 'default',
 	TOP = 'top',


### PR DESCRIPTION
This pull request refines the spacing and margin logic for floating panels in the workbench UI, improving visual consistency and alignment. The main focus is on introducing a new `FLOATING_PANEL_INNER_MARGIN` constant and updating both CSS and TypeScript files to use this margin for trailing (inner) gaps between floating cards, ensuring a consistent 6px inter-card gap. Additional CSS tweaks address the alignment and padding of the status bar and sashes.

<img width="5520" height="1908" alt="image" src="https://github.com/user-attachments/assets/7a0c82ef-5291-4a6c-9b96-ca4705a71894" />


**Margin and Spacing Adjustments:**

- Introduced the `FLOATING_PANEL_INNER_MARGIN` constant (`2px`) in `layoutService.ts` to standardize trailing margins between floating panels, matching the CSS variable `--vscode-spacing-size20`.
- Updated margin calculations in `editorPart.ts` and `paneCompositePart.ts` to use `FLOATING_PANEL_INNER_MARGIN` for inner/trailing gaps, while keeping outer margins at `FLOATING_PANEL_MARGIN` (`4px`). This ensures consistent spacing between cards and at window edges. [[1]](diffhunk://#diff-9ef2ceca71dfbda41fe00e81938e88f667381e4b23422aaab2b4047a1911f17cL27-R27) [[2]](diffhunk://#diff-9ef2ceca71dfbda41fe00e81938e88f667381e4b23422aaab2b4047a1911f17cL1442-R1442) [[3]](diffhunk://#diff-9ef2ceca71dfbda41fe00e81938e88f667381e4b23422aaab2b4047a1911f17cL1483-R1483) [[4]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31L15-R15) [[5]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31L715-R718)

**CSS and Visual Tweaks:**

- Modified `.sidebar`, `.auxiliarybar`, `.panel`, and `.editor` margin rules in `floatingPanels.css` to use a combination of leading and trailing margins for proper alignment. [[1]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3L24-R24) [[2]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3L33-R33) [[3]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3L100-R100)
- Adjusted the status bar's padding in `floatingPanels.css` to vertically center items and offset for border thickness, and updated the corresponding comment and padding constant in `statusbarPart.ts`. [[1]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3L162-R165) [[2]](diffhunk://#diff-e2402cd5a743ffaf3e48c4365bc26bd758aaeac48f1e1d80f683892b04b370b0L22-R22) [[3]](diffhunk://#diff-e2402cd5a743ffaf3e48c4365bc26bd758aaeac48f1e1d80f683892b04b370b0L125-R129)

**Sash Alignment:**

- Added CSS rules to shift grid sashes by `1px` to visually center the 6px gap between floating cards, ensuring sashes align with the visual midpoint of the gap.

**Documentation and Comments:**

- Updated comments throughout the codebase to clarify the purpose of the new margin and the logic behind margin calculations, improving maintainability. [[1]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3L201-R200) [[2]](diffhunk://#diff-e2402cd5a743ffaf3e48c4365bc26bd758aaeac48f1e1d80f683892b04b370b0L125-R129) [[3]](diffhunk://#diff-d132005d10db590379d0c566ff130fbccb332b4adf75ee6d94865b7431169d0aR65-R72)

Resolves https://github.com/microsoft/vscode/issues/324895
Resolves https://github.com/microsoft/vscode/issues/325759
Resolves https://github.com/microsoft/vscode/issues/325758