### PR TITLE
Only activate the TS extension on trusted workspaces

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -20,23 +20,8 @@
       "description": "%virtualWorkspaces%"
     },
     "untrustedWorkspaces": {
-      "supported": "limited",
-      "description": "%workspaceTrust%",
-      "restrictedConfigurations": [
-        "typescript.tsdk",
-        "js/ts.tsdk.path",
-        "typescript.tsserver.pluginPaths",
-        "js/ts.tsserver.pluginPaths",
-        "typescript.npm",
-        "js/ts.tsserver.npm.path",
-        "typescript.tsserver.nodePath",
-        "js/ts.tsserver.node.path",
-        "js/ts.tsserver.diagnosticDir",
-        "js/ts.tsserver.heapProfile",
-        "js/ts.preferences.autoImportSpecifierExcludeRegexes",
-        "typescript.preferences.autoImportSpecifierExcludeRegexes",
-        "javascript.preferences.autoImportSpecifierExcludeRegexes"
-      ]
+      "supported": false,
+      "description": "%workspaceTrust%"
     }
   },
   "engines": {


### PR DESCRIPTION
Restrict the TypeScript extension activation to trusted workspaces only, enhancing security and user experience by preventing its use in untrusted environments. This change simplifies the configuration by marking untrusted workspaces as unsupported.

