### PR TITLE
Adjust line height for action labels and add gap for actions container

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -214,6 +214,7 @@
 .style-override .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon,
 .style-override .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon {
 	font-size: 16px;
+	line-height: 12px;
 }
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -228,3 +228,7 @@
 .style-override.monaco-workbench .debug-pane .debug-call-stack .session > .state.label {
 	margin-right: 0;
 }
+
+.style-override.monaco-workbench .sidebar .has-composite-bar.header-or-footer .monaco-action-bar .actions-container {
+	gap: 2px;
+}


### PR DESCRIPTION
Modify the line height for action labels and introduce a gap in the actions container to improve layout and spacing. No associated issue. Testing can be done by reviewing the updated styles in the activity bar and actions container.

