### PR TITLE
Voice: opt out of backend auto-narration (auto_narrate: false)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -613,7 +613,9 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	sendStartSession(context: IVoiceSessionContext, machineId: string, priorTimeline?: readonly IVoicePriorTimelineEntry[]): void {
 		if (this._ws?.readyState === WebSocket.OPEN) {
 			this._seedTracking(context);
-			const payload: Record<string, unknown> = { type: 'start_session', session_context: context, machine_id: machineId, turn_config: this._getTurnConfig(), voice: this._getVoice() };
+			// This client drives narration itself via `requestNarration`, so opt out
+			// of the backend's default context-delta auto-narration to avoid double narration.
+			const payload: Record<string, unknown> = { type: 'start_session', session_context: context, machine_id: machineId, turn_config: this._getTurnConfig(), voice: this._getVoice(), auto_narrate: false };
 			if (priorTimeline && priorTimeline.length > 0) {
 				payload.prior_timeline = priorTimeline;
 			}
@@ -624,7 +626,9 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	sendResumeSession(context: IVoiceSessionContext, machineId: string): void {
 		if (this._ws?.readyState === WebSocket.OPEN && this._lastSessionId) {
 			this._seedTracking(context);
-			this._ws.send(JSON.stringify({ type: 'resume_session', session_id: this._lastSessionId, session_context: context, machine_id: machineId, turn_config: this._getTurnConfig(), voice: this._getVoice() }));
+			// `auto_narrate: false` for the same reason as start_session: this client
+			// drives narration, so the backend must not also auto-narrate.
+			this._ws.send(JSON.stringify({ type: 'resume_session', session_id: this._lastSessionId, session_context: context, machine_id: machineId, turn_config: this._getTurnConfig(), voice: this._getVoice(), auto_narrate: false }));
 		}
 	}
 


### PR DESCRIPTION
## Problem
The backend now supports client-driven narration: an explicit `request_narration` event plus an `auto_narrate` opt-out (see infinity-microsoft/yolo#54602). PR #325682 adds the `requestNarration` client API, but the client still lets the backend auto-narrate every reply, so assistant responses are spoken twice (once by backend auto-narration, once by the explicit request).

## Solution
Send `auto_narrate: false` in the `start_session` and `resume_session` payloads so the backend stops auto-narrating and the client drives narration itself via `requestNarration`.

The param is additive and optional: an older backend that doesn't read `auto_narrate` is unaffected, so this is not a breaking change.

## Tests
None added — this is a two-line change to the outbound session payloads in `voiceClientService.ts`; there is no existing unit harness for these payloads. Verified manually against a local voice_code backend.

## Risks
- Requires a backend that honors `auto_narrate` (infinity-microsoft/yolo#54602). Against an older backend the flag is ignored and behavior is unchanged.

## Non-goals
- Backend changes (separate PR: infinity-microsoft/yolo#54602).
- The `requestNarration` API itself (already added by #325682).

Stacked on `megrogge/voice-backend-narrate-api` (#325682); base this PR there so the diff is just the opt-out.