### PR TITLE
Authenticate Entra ID marketplace API requests via RFC 9728 PRM negotiation

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -174,6 +174,35 @@
             "included": false
         },
         {
+            "key": "extensions.gallery.authProvider",
+            "name": "ExtensionGalleryAuthProvider",
+            "category": "Extensions",
+            "minimumVersion": "1.99",
+            "localization": {
+                "description": {
+                    "key": "extensions.gallery.authProvider",
+                    "value": "Configure the authentication provider for the Extensions Marketplace"
+                },
+                "enumDescriptions": [
+                    {
+                        "key": "extensions.gallery.authProvider.github",
+                        "value": "Authenticate to the Extensions Marketplace using GitHub."
+                    },
+                    {
+                        "key": "extensions.gallery.authProvider.microsoft",
+                        "value": "Authenticate to the Extensions Marketplace using a Microsoft (Entra ID) account."
+                    }
+                ]
+            },
+            "type": "string",
+            "default": "",
+            "enum": [
+                "github",
+                "microsoft"
+            ],
+            "included": false
+        },
+        {
             "key": "extensions.allowed",
             "name": "AllowedExtensions",
             "category": "Extensions",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -177,7 +177,7 @@
             "key": "extensions.gallery.authProvider",
             "name": "ExtensionGalleryAuthProvider",
             "category": "Extensions",
-            "minimumVersion": "1.99",
+            "minimumVersion": "1.121",
             "localization": {
                 "description": {
                     "key": "extensions.gallery.authProvider",

--- a/product.json
+++ b/product.json
@@ -156,7 +156,8 @@
 		],
 		"github-enterprise": [
 			"GitHub.copilot-chat"
-		]
+		],
+		"microsoft": []
 	},
 	"onboardingKeymaps": [
 		{

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -139,6 +139,15 @@ export interface IProductConfiguration {
 
 	readonly agentSdks?: { readonly [packageId: string]: IAgentSdkProductConfig };
 
+	/**
+	 * Hard gate for the Entra ID (Microsoft) authentication path of the Extensions
+	 * Marketplace. When falsy, the `extensions.gallery.authProvider: microsoft`
+	 * setting is ignored and the GitHub/default auth path is used instead. This keeps
+	 * the Entra path dormant on builds where the Private Marketplace has not yet been
+	 * publicly released, independent of any admin policy configuration.
+	 */
+	readonly enableExtensionGalleryEntraAuth?: boolean;
+
 	readonly mcpGallery?: {
 		readonly serviceUrl: string;
 		readonly itemWebUrl: string;

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
@@ -3,9 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Event } from '../../../base/common/event.js';
+import { fetchResourceMetadata, parseWWWAuthenticateHeader } from '../../../base/common/oauth.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { RawContextKey } from '../../contextkey/common/contextkey.js';
+import { asJson, asText, IRequestService } from '../../request/common/request.js';
 
 /**
  * Context key exposing the effective Marketplace authentication provider (e.g. `github` or
@@ -104,6 +107,16 @@ export interface IExtensionGalleryManifestService {
 	readonly onDidChangeExtensionGalleryManifestStatus: Event<ExtensionGalleryManifestStatus>;
 	readonly onDidChangeExtensionGalleryManifest: Event<IExtensionGalleryManifest | null>;
 	getExtensionGalleryManifest(): Promise<IExtensionGalleryManifest | null>;
+
+	/**
+	 * Returns the bearer token to attach to authenticated marketplace API requests
+	 * (e.g. `extensionquery`, asset download), or `undefined` when the marketplace does
+	 * not require authentication. When the marketplace service index is `[Authorize]`-gated,
+	 * this is a resource-scoped token negotiated via RFC 9728 Protected Resource Metadata.
+	 * Consumers MUST only attach the token to requests whose target is same-origin HTTPS with
+	 * the marketplace service index to avoid leaking it to foreign or cleartext endpoints.
+	 */
+	getAccessToken(): Promise<string | undefined>;
 }
 
 export function getExtensionGalleryManifestResourceUri(manifest: IExtensionGalleryManifest, type: string): string | undefined {
@@ -131,8 +144,77 @@ export const ExtensionGalleryAuthProviderConfigKey = 'extensions.gallery.authPro
  *
  * Only standard OpenID Connect sign-in scopes are requested — enough to obtain a
  * Microsoft session that identifies the user. This intentionally does NOT request a
- * resource-scoped token (e.g. `api://<client-id>/access_as_user`). Acquiring resource
- * tokens for Private Marketplace API calls, per the server's Protected Resource
- * Metadata (RFC 9728), is deferred to a follow-up change.
+ * resource-scoped token (e.g. `api://<client-id>/access_as_user`) up front. When the
+ * marketplace service index is `[Authorize]`-gated, a resource-bound token is instead
+ * negotiated on demand from the server's `WWW-Authenticate` challenge (Protected
+ * Resource Metadata, RFC 9728); these scopes serve as the fallback sign-in scopes for
+ * that negotiation.
  */
 export const PRIVATE_MARKETPLACE_SCOPES: string[] = ['openid', 'profile', 'email', 'offline_access'];
+
+/**
+ * The subset of RFC 9728 Protected Resource Metadata the marketplace negotiation needs: the
+ * authorization server to acquire a token from and the resource-scoped scopes to request.
+ */
+export interface IMarketplaceProtectedResource {
+	/** The authorization server (`authorization_servers[0]`) to acquire the resource token from. */
+	readonly authorizationServer: string;
+	/** The resource-scoped scopes (`scopes_supported`) to request for the marketplace resource. */
+	readonly scopes: readonly string[];
+	/** The protected resource identifier (`resource`) the metadata describes. */
+	readonly resource: string;
+}
+
+/**
+ * Discovers the marketplace's Protected Resource Metadata (RFC 9728) so a resource-scoped token
+ * can be minted for an `[Authorize]`-gated marketplace index.
+ *
+ * Discovery is driven by the well-known endpoint (`/.well-known/oauth-protected-resource`) rather
+ * than the server's `WWW-Authenticate` challenge: `WWW-Authenticate` is not a CORS-safelisted
+ * response header, so the renderer's cross-origin index fetch frequently cannot read it. The
+ * metadata *body*, however, is CORS-readable, so well-known discovery is robust where the challenge
+ * header is not. The optional `wwwAuthenticate` string is used only as a best-effort hint for the
+ * explicit `resource_metadata` URL when the header happens to be readable.
+ *
+ * Returns `undefined` (never throws) when discovery fails or the metadata omits an authorization
+ * server, so callers can fall back to their existing sign-in / unreachable handling.
+ */
+export async function discoverMarketplaceProtectedResource(
+	requestService: IRequestService,
+	serviceIndexUrl: string,
+	wwwAuthenticate: string | undefined,
+	token: CancellationToken,
+): Promise<IMarketplaceProtectedResource | undefined> {
+	let resourceMetadataUrl: string | undefined;
+	if (wwwAuthenticate) {
+		for (const challenge of parseWWWAuthenticateHeader(wwwAuthenticate)) {
+			if (challenge.scheme.toLowerCase() === 'bearer' && challenge.params.resource_metadata) {
+				resourceMetadataUrl = challenge.params.resource_metadata;
+				break;
+			}
+		}
+	}
+	const fetcher = async (input: string, init: { method: string; headers: Record<string, string> }) => {
+		const context = await requestService.request({ type: init.method, url: input, headers: init.headers, callSite: 'extensionGalleryManifest.discoverMarketplaceProtectedResource' }, token);
+		return {
+			status: context.res.statusCode ?? 0,
+			statusText: '',
+			json: async (): Promise<unknown> => await asJson(context),
+			text: async (): Promise<string> => (await asText(context)) ?? '',
+		};
+	};
+	try {
+		const { metadata } = await fetchResourceMetadata(serviceIndexUrl, resourceMetadataUrl, { fetch: fetcher });
+		const authorizationServer = metadata.authorization_servers?.[0];
+		if (!authorizationServer) {
+			return undefined;
+		}
+		return {
+			authorizationServer,
+			scopes: metadata.scopes_supported ?? [],
+			resource: metadata.resource,
+		};
+	} catch {
+		return undefined;
+	}
+}

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
@@ -15,6 +15,7 @@ export const enum ExtensionGalleryResourceType {
 	ExtensionRatingViewUri = 'ExtensionRatingViewUriTemplate',
 	ExtensionResourceUri = 'ExtensionResourceUriTemplate',
 	ContactSupportUri = 'ContactSupportUri',
+	EligibilityService = 'EligibilityService',
 }
 
 export const enum Flag {
@@ -98,3 +99,17 @@ export function getExtensionGalleryManifestResourceUri(manifest: IExtensionGalle
 }
 
 export const ExtensionGalleryServiceUrlConfigKey = 'extensions.gallery.serviceUrl';
+
+export const ExtensionGalleryAuthProviderConfigKey = 'extensions.gallery.authProvider';
+
+/**
+ * Scope for requesting tokens against the Private Marketplace's own Entra app registration.
+ * Produces tokens with `aud = api://{private-marketplace-client-id}`, matching the server's
+ * `Marketplace:Authorization:Entra:Audience` config.
+ *
+ * Do NOT use `https://marketplace.visualstudio.com/.default` — that produces
+ * `aud: marketplace.visualstudio.com` and will be rejected with 401.
+ *
+ * `{private-marketplace-client-id}` is the Client ID from the deployment-time app registration.
+ */
+export const PRIVATE_MARKETPLACE_SCOPE = 'api://{private-marketplace-client-id}/access_as_user';

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
@@ -5,6 +5,15 @@
 
 import { Event } from '../../../base/common/event.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { RawContextKey } from '../../contextkey/common/contextkey.js';
+
+/**
+ * Context key exposing the effective Marketplace authentication provider (e.g. `github` or
+ * `microsoft`) for `when`-clause driven welcome content. Defined here in the platform layer so
+ * both the workbench service that sets it and the Extensions contribution that reads it can
+ * depend on it without a service-to-contribution dependency.
+ */
+export const CONTEXT_MARKETPLACE_AUTH_PROVIDER = new RawContextKey<string>('marketplaceAuthProvider', '');
 
 export const enum ExtensionGalleryResourceType {
 	ExtensionQueryService = 'ExtensionQueryService',

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
@@ -69,7 +69,21 @@ export const enum ExtensionGalleryManifestStatus {
 	Available = 'available',
 	RequiresSignIn = 'requiresSignIn',
 	AccessDenied = 'accessDenied',
-	Unavailable = 'unavailable'
+	Unavailable = 'unavailable',
+	/**
+	 * A marketplace is configured, and the user is (or is presumed) eligible, but its
+	 * gallery manifest could not be fetched — a transient network/server error. Unlike
+	 * {@link Unavailable} (which also means "no gallery configured"), this state is only
+	 * ever set after a failed fetch of a configured marketplace, so it is safe to surface
+	 * an informative message without affecting builds that have no gallery at all.
+	 */
+	Unreachable = 'unreachable',
+	/**
+	 * The marketplace is configured for Microsoft (Entra ID) authentication, but the
+	 * gallery manifest does not advertise an EligibilityService resource. Access is
+	 * refused (no silent fallback to another provider) until the server is corrected.
+	 */
+	Misconfigured = 'misconfigured'
 }
 
 export const IExtensionGalleryManifestService = createDecorator<IExtensionGalleryManifestService>('IExtensionGalleryManifestService');
@@ -103,13 +117,13 @@ export const ExtensionGalleryServiceUrlConfigKey = 'extensions.gallery.serviceUr
 export const ExtensionGalleryAuthProviderConfigKey = 'extensions.gallery.authProvider';
 
 /**
- * Scope for requesting tokens against the Private Marketplace's own Entra app registration.
- * Produces tokens with `aud = api://{private-marketplace-client-id}`, matching the server's
- * `Marketplace:Authorization:Entra:Audience` config.
+ * Scopes requested when signing in with Microsoft (Entra ID) to establish the
+ * user's identity for the Private Marketplace eligibility check.
  *
- * Do NOT use `https://marketplace.visualstudio.com/.default` — that produces
- * `aud: marketplace.visualstudio.com` and will be rejected with 401.
- *
- * `{private-marketplace-client-id}` is the Client ID from the deployment-time app registration.
+ * Only standard OpenID Connect sign-in scopes are requested — enough to obtain a
+ * Microsoft session that identifies the user. This intentionally does NOT request a
+ * resource-scoped token (e.g. `api://<client-id>/access_as_user`). Acquiring resource
+ * tokens for Private Marketplace API calls, per the server's Protected Resource
+ * Metadata (RFC 9728), is deferred to a follow-up change.
  */
-export const PRIVATE_MARKETPLACE_SCOPE = 'api://{private-marketplace-client-id}/access_as_user';
+export const PRIVATE_MARKETPLACE_SCOPES: string[] = ['openid', 'profile', 'email', 'offline_access'];

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
@@ -35,6 +35,14 @@ export class ExtensionGalleryManifestService extends Disposable implements IExte
 		super();
 	}
 
+	/**
+	 * The default marketplace is open (no authentication). Authenticated marketplaces are
+	 * handled by the workbench override, which negotiates and returns a resource-scoped token.
+	 */
+	async getAccessToken(): Promise<string | undefined> {
+		return undefined;
+	}
+
 	async getExtensionGalleryManifest(): Promise<IExtensionGalleryManifest | null> {
 		const extensionsGallery = this.productService.extensionsGallery as ExtensionGalleryConfig | undefined;
 		if (!extensionsGallery?.serviceUrl) {

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifestServiceIpc.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifestServiceIpc.ts
@@ -22,6 +22,7 @@ export class ExtensionGalleryManifestIPCService extends ExtensionGalleryManifest
 	override readonly onDidChangeExtensionGalleryManifestStatus = this._onDidChangeExtensionGalleryManifestStatus.event;
 
 	private _extensionGalleryManifest: IExtensionGalleryManifest | null | undefined;
+	private _accessToken: string | undefined;
 	private readonly barrier = new Barrier();
 
 	override get extensionGalleryManifestStatus(): ExtensionGalleryManifestStatus {
@@ -39,7 +40,7 @@ export class ExtensionGalleryManifestIPCService extends ExtensionGalleryManifest
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			call: async (context: any, command: string, args?: any): Promise<any> => {
 				switch (command) {
-					case 'setExtensionGalleryManifest': return Promise.resolve(this.setExtensionGalleryManifest(args[0]));
+					case 'setExtensionGalleryManifest': return Promise.resolve(this.setExtensionGalleryManifest(args[0], args[1]));
 				}
 				throw new Error('Invalid call');
 			}
@@ -51,9 +52,26 @@ export class ExtensionGalleryManifestIPCService extends ExtensionGalleryManifest
 		return this._extensionGalleryManifest ?? null;
 	}
 
-	private setExtensionGalleryManifest(manifest: IExtensionGalleryManifest | null): void {
+	/**
+	 * Returns the resource-scoped bearer token negotiated by the window process for a
+	 * `[Authorize]`-gated marketplace, or `undefined` for an open marketplace. The token is pushed
+	 * over the channel alongside the manifest (see {@link setExtensionGalleryManifest}); this
+	 * process (shared process / remote server) never negotiates it itself, so protected marketplace
+	 * requests it initiates — extension `getManifest`, VSIX download — would otherwise be anonymous
+	 * and rejected with 401.
+	 */
+	override async getAccessToken(): Promise<string | undefined> {
+		await this.barrier.wait();
+		return this._accessToken;
+	}
+
+	private setExtensionGalleryManifest(manifest: IExtensionGalleryManifest | null, accessToken?: string): void {
 		this.logService.trace(`[Marketplace] Setting manifest ${manifest ? 'available' : 'unavailable'}`);
 		this._extensionGalleryManifest = manifest;
+		// The token is coherent with the manifest: the window sets it before an eligible→Available
+		// transition and clears it on every non-Available transition, so a null manifest always
+		// arrives with an undefined token and a stale token can never outlive its access.
+		this._accessToken = accessToken;
 		this._onDidChangeExtensionGalleryManifest.fire(manifest);
 		this._onDidChangeExtensionGalleryManifestStatus.fire(this.extensionGalleryManifestStatus);
 		this.barrier.open();

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -638,6 +638,46 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		return this.extensionGalleryManifestService.extensionGalleryManifestStatus === ExtensionGalleryManifestStatus.Available;
 	}
 
+	/**
+	 * Returns an `Authorization` header for an authenticated marketplace API request, or an empty
+	 * object when no token applies. The negotiated bearer token (see
+	 * {@link IExtensionGalleryManifestService.getAccessToken}) is attached ONLY when `targetUrl` is
+	 * same-origin HTTPS with the marketplace's `extensionquery` service endpoint — this prevents the
+	 * resource-scoped token from leaking to foreign origins (e.g. asset/statistics endpoints hosted
+	 * on a third-party CDN, or a cleartext URL from a tampered manifest).
+	 *
+	 * @param manifest the current gallery manifest (source of the marketplace origin)
+	 * @param targetUrl the absolute URL the request will be sent to
+	 */
+	private async getMarketplaceAuthorizationHeader(manifest: IExtensionGalleryManifest, targetUrl: string): Promise<IHeaders> {
+		const token = await this.extensionGalleryManifestService.getAccessToken();
+		if (!token) {
+			return {};
+		}
+		const marketplaceApi = getExtensionGalleryManifestResourceUri(manifest, ExtensionGalleryResourceType.ExtensionQueryService);
+		if (!marketplaceApi || !AbstractExtensionGalleryService.isSameSecureOrigin(targetUrl, marketplaceApi)) {
+			return {};
+		}
+		return { Authorization: `Bearer ${token}` };
+	}
+
+	/**
+	 * True when both URLs are `https:` and share the same origin (scheme + authority). Fails closed:
+	 * any parse error or scheme mismatch returns false so a token is never attached to an
+	 * unverifiable or cleartext target.
+	 */
+	private static isSameSecureOrigin(targetUrl: string, baseUrl: string): boolean {
+		try {
+			const target = URI.parse(targetUrl);
+			const base = URI.parse(baseUrl);
+			return target.scheme === 'https'
+				&& base.scheme === 'https'
+				&& target.authority.toLowerCase() === base.authority.toLowerCase();
+		} catch {
+			return false;
+		}
+	}
+
 	getExtensions(extensionInfos: ReadonlyArray<IExtensionInfo>, token: CancellationToken): Promise<IGalleryExtension[]>;
 	getExtensions(extensionInfos: ReadonlyArray<IExtensionInfo>, options: IExtensionQueryOptions, token: CancellationToken): Promise<IGalleryExtension[]>;
 	async getExtensions(extensionInfos: ReadonlyArray<IExtensionInfo>, arg1: CancellationToken | IExtensionQueryOptions, arg2?: CancellationToken): Promise<IGalleryExtension[]> {
@@ -1417,8 +1457,10 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		});
 
 		const commonHeaders = await this.commonHeadersPromise;
+		const authHeader = await this.getMarketplaceAuthorizationHeader(extensionGalleryManifest, extensionsQueryApi);
 		const headers = {
 			...commonHeaders,
+			...authHeader,
 			'Content-Type': 'application/json',
 			'Accept': 'application/json;api-version=3.0-preview.1',
 			'Accept-Encoding': 'gzip',
@@ -1571,9 +1613,12 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		const stopWatch = new StopWatch();
 
 		try {
+			const manifest = await this.extensionGalleryManifestService.getExtensionGalleryManifest();
 			const commonHeaders = await this.commonHeadersPromise;
+			const authHeader = manifest ? await this.getMarketplaceAuthorizationHeader(manifest, uri.toString(true)) : {};
 			const headers = {
 				...commonHeaders,
+				...authHeader,
 				'Content-Type': 'application/json',
 				'Accept': 'application/json;api-version=7.2-preview',
 				'Accept-Encoding': 'gzip',
@@ -1677,7 +1722,8 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 
 		const Accept = '*/*;api-version=4.0-preview.1';
 		const commonHeaders = await this.commonHeadersPromise;
-		const headers = { ...commonHeaders, Accept };
+		const authHeader = await this.getMarketplaceAuthorizationHeader(manifest, url);
+		const headers = { ...commonHeaders, ...authHeader, Accept };
 		try {
 			await this.requestService.request({
 				type: 'POST',
@@ -1874,7 +1920,12 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 
 		const url = asset.uri;
 		const fallbackUrl = asset.fallbackUri;
-		const firstOptions = { ...options, url, timeout: this.getRequestTimeout(), callSite };
+		// The negotiated token is only attached when the asset is served from the marketplace's own
+		// (same) secure origin. Assets on a third-party CDN (a different origin) get no token. The
+		// primary and fallback URLs can differ in origin, so evaluate the guard independently for each.
+		const manifest = await this.extensionGalleryManifestService.getExtensionGalleryManifest();
+		const primaryAuthHeader = manifest ? await this.getMarketplaceAuthorizationHeader(manifest, url) : {};
+		const firstOptions = { ...options, headers: { ...headers, ...primaryAuthHeader }, url, timeout: this.getRequestTimeout(), callSite };
 
 		let context;
 		try {
@@ -1920,7 +1971,8 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 				endToEndId: this.getHeaderValue(context?.res.headers, END_END_ID_HEADER_NAME),
 			});
 
-			const fallbackOptions = { ...options, url: fallbackUrl, timeout: this.getRequestTimeout(), callSite: `${callSite}.fallback` };
+			const fallbackAuthHeader = manifest ? await this.getMarketplaceAuthorizationHeader(manifest, fallbackUrl) : {};
+			const fallbackOptions = { ...options, headers: { ...headers, ...fallbackAuthHeader }, url: fallbackUrl, timeout: this.getRequestTimeout(), callSite: `${callSite}.fallback` };
 			return this.requestService.request(fallbackOptions, token);
 		}
 	}
@@ -1936,9 +1988,11 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 			return { malicious: [], deprecated: {}, search: [], autoUpdate: {} };
 		}
 
+		const authHeader = await this.getMarketplaceAuthorizationHeader(manifest, this.extensionsControlUrl);
 		const context = await this.requestService.request({
 			type: 'GET',
 			url: this.extensionsControlUrl,
+			headers: authHeader,
 			timeout: this.getRequestTimeout(),
 			callSite: 'extensionGalleryService.getExtensionsControlManifest'
 		}, CancellationToken.None);

--- a/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
+++ b/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
@@ -41,7 +41,7 @@ class ExtensionResourceLoaderService extends AbstractExtensionResourceLoaderServ
 
 		const requestInit: RequestInit = {};
 		if (await this.isExtensionGalleryResource(uri)) {
-			requestInit.headers = await this.getExtensionGalleryRequestHeaders();
+			requestInit.headers = await this.getExtensionGalleryRequestHeaders(uri);
 			requestInit.mode = 'cors'; /* set mode to cors so that above headers are always passed */
 		}
 

--- a/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
+++ b/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
@@ -132,7 +132,7 @@ export abstract class AbstractExtensionResourceLoaderService extends Disposable 
 		return !!this._extensionGalleryAuthority && this._extensionGalleryAuthority === this._getExtensionGalleryAuthority(uri);
 	}
 
-	protected async getExtensionGalleryRequestHeaders(): Promise<Record<string, string>> {
+	protected async getExtensionGalleryRequestHeaders(resource?: URI): Promise<Record<string, string>> {
 		const headers: Record<string, string> = {
 			'X-Client-Name': `${this._productService.applicationName}${isWeb ? '-web' : ''}`,
 			'X-Client-Version': this._productService.version
@@ -143,7 +143,42 @@ export abstract class AbstractExtensionResourceLoaderService extends Disposable 
 		if (this._productService.commit) {
 			headers['X-Client-Commit'] = this._productService.commit;
 		}
+		if (resource) {
+			Object.assign(headers, await this.getMarketplaceAuthorizationHeader(resource));
+		}
 		return headers;
+	}
+
+	/**
+	 * Returns an `Authorization` header for a `[Authorize]`-gated marketplace resource request, or an
+	 * empty object when no token applies. The negotiated bearer token (see
+	 * {@link IExtensionGalleryManifestService.getAccessToken}) is attached ONLY when `resource` is
+	 * same-origin HTTPS with the marketplace's `extensionquery` service endpoint — this prevents the
+	 * resource-scoped token from leaking to a foreign origin (e.g. a third-party resource CDN whose
+	 * URL was advertised by the gallery manifest, or a cleartext URL). Mirrors the guard applied to
+	 * gallery API/asset requests in `ExtensionGalleryService`.
+	 */
+	private async getMarketplaceAuthorizationHeader(resource: URI): Promise<Record<string, string>> {
+		const token = await this._extensionGalleryManifestService.getAccessToken();
+		if (!token) {
+			return {};
+		}
+		const manifest = await this._extensionGalleryManifestService.getExtensionGalleryManifest();
+		const marketplaceApi = manifest ? getExtensionGalleryManifestResourceUri(manifest, ExtensionGalleryResourceType.ExtensionQueryService) : undefined;
+		if (!marketplaceApi || !AbstractExtensionResourceLoaderService.isSameSecureOrigin(resource, URI.parse(marketplaceApi))) {
+			return {};
+		}
+		return { Authorization: `Bearer ${token}` };
+	}
+
+	/**
+	 * True when both URIs are `https:` and share the same origin (scheme + authority). Fails closed:
+	 * a scheme mismatch returns false so a token is never attached to a cleartext target.
+	 */
+	private static isSameSecureOrigin(target: URI, base: URI): boolean {
+		return target.scheme === 'https'
+			&& base.scheme === 'https'
+			&& target.authority.toLowerCase() === base.authority.toLowerCase();
 	}
 
 	private _serviceMachineIdPromise: Promise<string> | undefined;

--- a/src/vs/platform/extensionResourceLoader/common/extensionResourceLoaderService.ts
+++ b/src/vs/platform/extensionResourceLoader/common/extensionResourceLoaderService.ts
@@ -33,7 +33,7 @@ export class ExtensionResourceLoaderService extends AbstractExtensionResourceLoa
 
 	async readExtensionResource(uri: URI): Promise<string> {
 		if (await this.isExtensionGalleryResource(uri)) {
-			const headers = await this.getExtensionGalleryRequestHeaders();
+			const headers = await this.getExtensionGalleryRequestHeaders(uri);
 			const requestContext = await this._requestService.request({ url: uri.toString(), headers, callSite: 'extensionResourceLoader.readExtensionResource' }, CancellationToken.None);
 			return (await asTextOrError(requestContext)) || '';
 		}

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -24,7 +24,7 @@ import { CommandsRegistry, ICommandService } from '../../../../platform/commands
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService, IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, PRIVATE_MARKETPLACE_SCOPE } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, PRIVATE_MARKETPLACE_SCOPES } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { areSameExtensions, getIdAndVersion } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
 import { ExtensionStorageService } from '../../../../platform/extensionManagement/common/extensionStorage.js';
@@ -363,10 +363,12 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			},
 			[ExtensionGalleryAuthProviderConfigKey]: {
 				type: 'string',
-				enum: ['github', 'microsoft'],
-				enumDescriptions: [
+				enum: product.enableExtensionGalleryEntraAuth ? ['github', 'microsoft'] : ['github'],
+				enumDescriptions: product.enableExtensionGalleryEntraAuth ? [
 					localize('extensions.gallery.authProvider.github', "Authenticate to the Extensions Marketplace using GitHub."),
 					localize('extensions.gallery.authProvider.microsoft', "Authenticate to the Extensions Marketplace using a Microsoft (Entra ID) account."),
+				] : [
+					localize('extensions.gallery.authProvider.github', "Authenticate to the Extensions Marketplace using GitHub."),
 				],
 				description: localize('extensions.gallery.authProvider', "Configure the authentication provider for the Extensions Marketplace"),
 				default: '',
@@ -375,7 +377,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				policy: {
 					name: 'ExtensionGalleryAuthProvider',
 					category: PolicyCategory.Extensions,
-					minimumVersion: '1.99',
+					minimumVersion: '1.121',
 					localization: {
 						description: {
 							key: 'extensions.gallery.authProvider',
@@ -2160,13 +2162,14 @@ registerAction2(class ExtensionsGallerySignInAction extends Action2 {
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const configurationService = accessor.get(IConfigurationService);
+		const productService = accessor.get(IProductService);
 		const authProvider = configurationService.getValue<string>(ExtensionGalleryAuthProviderConfigKey);
 
-		if (authProvider === 'microsoft') {
+		if (authProvider === 'microsoft' && productService.enableExtensionGalleryEntraAuth) {
 			const authenticationService = accessor.get(IAuthenticationService);
 			await authenticationService.createSession(
 				'microsoft',
-				[PRIVATE_MARKETPLACE_SCOPE]);
+				PRIVATE_MARKETPLACE_SCOPES);
 		} else {
 			const commandService = accessor.get(ICommandService);
 			await commandService.executeCommand(DEFAULT_ACCOUNT_SIGN_IN_COMMAND);

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -24,7 +24,7 @@ import { CommandsRegistry, ICommandService } from '../../../../platform/commands
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService, IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, PRIVATE_MARKETPLACE_SCOPE } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { areSameExtensions, getIdAndVersion } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
 import { ExtensionStorageService } from '../../../../platform/extensionManagement/common/extensionStorage.js';
@@ -69,6 +69,8 @@ import { IWebview } from '../../webview/browser/webview.js';
 import { Query } from '../common/extensionQuery.js';
 import { AutoRestartConfigurationKey, AutoUpdateConfigurationKey, CONTEXT_EXTENSIONS_GALLERY_STATUS, CONTEXT_HAS_GALLERY, DefaultViewsContext, ExtensionEditorTab, ExtensionRuntimeActionType, EXTENSIONS_CATEGORY, extensionsFilterSubMenu, extensionsSearchActionsMenu, HasOutdatedExtensionsContext, IExtensionArg, IExtensionsViewPaneContainer, IExtensionsWorkbenchService, INSTALL_ACTIONS_GROUP, INSTALL_EXTENSION_FROM_VSIX_COMMAND_ID, IWorkspaceRecommendedExtensionsView, LIST_WORKSPACE_UNSUPPORTED_EXTENSIONS_COMMAND_ID, OUTDATED_EXTENSIONS_VIEW_ID, SELECT_INSTALL_VSIX_EXTENSION_COMMAND_ID, THEME_ACTIONS_GROUP, TOGGLE_IGNORE_EXTENSION_ACTION_ID, UPDATE_ACTIONS_GROUP, VIEWLET_ID, WORKSPACE_RECOMMENDATIONS_VIEW_ID } from '../common/extensions.js';
 import { ExtensionsConfigurationSchema, ExtensionsConfigurationSchemaId } from '../common/extensionsFileTemplate.js';
+import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ExtensionsInput } from '../common/extensionsInput.js';
 import { KeymapExtensions } from '../common/extensionsUtils.js';
 import { SearchExtensionsTool, SearchExtensionsToolData } from '../common/searchExtensionsTool.js';
@@ -356,6 +358,39 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 							key: 'extensions.gallery.serviceUrl',
 							value: localize('extensions.gallery.serviceUrl', "Configure the Marketplace service URL to connect to"),
 						}
+					}
+				},
+			},
+			[ExtensionGalleryAuthProviderConfigKey]: {
+				type: 'string',
+				enum: ['github', 'microsoft'],
+				enumDescriptions: [
+					localize('extensions.gallery.authProvider.github', "Authenticate to the Extensions Marketplace using GitHub."),
+					localize('extensions.gallery.authProvider.microsoft', "Authenticate to the Extensions Marketplace using a Microsoft (Entra ID) account."),
+				],
+				description: localize('extensions.gallery.authProvider', "Configure the authentication provider for the Extensions Marketplace"),
+				default: '',
+				scope: ConfigurationScope.APPLICATION,
+				included: false,
+				policy: {
+					name: 'ExtensionGalleryAuthProvider',
+					category: PolicyCategory.Extensions,
+					minimumVersion: '1.99',
+					localization: {
+						description: {
+							key: 'extensions.gallery.authProvider',
+							value: localize('extensions.gallery.authProvider', "Configure the authentication provider for the Extensions Marketplace"),
+						},
+						enumDescriptions: [
+							{
+								key: 'extensions.gallery.authProvider.github',
+								value: localize('extensions.gallery.authProvider.github', "Authenticate to the Extensions Marketplace using GitHub."),
+							},
+							{
+								key: 'extensions.gallery.authProvider.microsoft',
+								value: localize('extensions.gallery.authProvider.microsoft', "Authenticate to the Extensions Marketplace using a Microsoft (Entra ID) account."),
+							},
+						]
 					}
 				},
 			},
@@ -2116,12 +2151,26 @@ registerAction2(class ExtensionsGallerySignInAction extends Action2 {
 			title: localize2('signInToMarketplace', 'Sign in to access Extensions Marketplace'),
 			menu: {
 				id: MenuId.AccountsContext,
-				when: CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.RequiresSignIn)
+				when: ContextKeyExpr.or(
+					CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.RequiresSignIn),
+					CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.AccessDenied),
+				)
 			},
 		});
 	}
-	run(accessor: ServicesAccessor): Promise<void> {
-		return accessor.get(ICommandService).executeCommand(DEFAULT_ACCOUNT_SIGN_IN_COMMAND);
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const configurationService = accessor.get(IConfigurationService);
+		const authProvider = configurationService.getValue<string>(ExtensionGalleryAuthProviderConfigKey);
+
+		if (authProvider === 'microsoft') {
+			const authenticationService = accessor.get(IAuthenticationService);
+			await authenticationService.createSession(
+				'microsoft',
+				[PRIVATE_MARKETPLACE_SCOPE]);
+		} else {
+			const commandService = accessor.get(ICommandService);
+			await commandService.executeCommand(DEFAULT_ACCOUNT_SIGN_IN_COMMAND);
+		}
 	}
 });
 

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -24,7 +24,7 @@ import { CommandsRegistry, ICommandService } from '../../../../platform/commands
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService, IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, PRIVATE_MARKETPLACE_SCOPES } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, PRIVATE_MARKETPLACE_SCOPES, discoverMarketplaceProtectedResource } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { areSameExtensions, getIdAndVersion } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
 import { ExtensionStorageService } from '../../../../platform/extensionManagement/common/extensionStorage.js';
@@ -70,6 +70,7 @@ import { Query } from '../common/extensionQuery.js';
 import { AutoRestartConfigurationKey, AutoUpdateConfigurationKey, CONTEXT_EXTENSIONS_GALLERY_STATUS, CONTEXT_HAS_GALLERY, DefaultViewsContext, ExtensionEditorTab, ExtensionRuntimeActionType, EXTENSIONS_CATEGORY, extensionsFilterSubMenu, extensionsSearchActionsMenu, HasOutdatedExtensionsContext, IExtensionArg, IExtensionsViewPaneContainer, IExtensionsWorkbenchService, INSTALL_ACTIONS_GROUP, INSTALL_EXTENSION_FROM_VSIX_COMMAND_ID, IWorkspaceRecommendedExtensionsView, LIST_WORKSPACE_UNSUPPORTED_EXTENSIONS_COMMAND_ID, OUTDATED_EXTENSIONS_VIEW_ID, SELECT_INSTALL_VSIX_EXTENSION_COMMAND_ID, THEME_ACTIONS_GROUP, TOGGLE_IGNORE_EXTENSION_ACTION_ID, UPDATE_ACTIONS_GROUP, VIEWLET_ID, WORKSPACE_RECOMMENDATIONS_VIEW_ID } from '../common/extensions.js';
 import { ExtensionsConfigurationSchema, ExtensionsConfigurationSchemaId } from '../common/extensionsFileTemplate.js';
 import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
+import { IRequestService } from '../../../../platform/request/common/request.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ExtensionsInput } from '../common/extensionsInput.js';
 import { KeymapExtensions } from '../common/extensionsUtils.js';
@@ -2172,9 +2173,26 @@ registerAction2(class ExtensionsGallerySignInAction extends Action2 {
 
 		if (authProvider === 'microsoft' && productService.enableExtensionGalleryEntraAuth) {
 			const authenticationService = accessor.get(IAuthenticationService);
+			// Establish the identity session used for the eligibility check.
 			await authenticationService.createSession(
 				'microsoft',
 				PRIVATE_MARKETPLACE_SCOPES);
+			// If the marketplace service index is itself Entra-gated, additionally acquire a
+			// resource-scoped token now (interactive consent). The silent negotiation on the
+			// re-validation cannot prompt, so first-time consent must happen here or the user
+			// would be returned to the sign-in prompt after authenticating.
+			const serviceUrl = configurationService.getValue<string>(ExtensionGalleryServiceUrlConfigKey);
+			if (serviceUrl) {
+				const requestService = accessor.get(IRequestService);
+				const protectedResource = await discoverMarketplaceProtectedResource(requestService, serviceUrl, undefined, CancellationToken.None);
+				if (protectedResource) {
+					const scopes = protectedResource.scopes.length ? protectedResource.scopes : PRIVATE_MARKETPLACE_SCOPES;
+					await authenticationService.createSession(
+						'microsoft',
+						[...scopes],
+						{ authorizationServer: URI.parse(protectedResource.authorizationServer) });
+				}
+			}
 		} else {
 			const commandService = accessor.get(ICommandService);
 			await commandService.executeCommand(DEFAULT_ACCOUNT_SIGN_IN_COMMAND);

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -363,12 +363,17 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			},
 			[ExtensionGalleryAuthProviderConfigKey]: {
 				type: 'string',
-				enum: product.enableExtensionGalleryEntraAuth ? ['github', 'microsoft'] : ['github'],
-				enumDescriptions: product.enableExtensionGalleryEntraAuth ? [
+				// The enum and its descriptions are intentionally NOT gated on
+				// `product.enableExtensionGalleryEntraAuth`: the policy metadata below always
+				// exports both enum descriptions, and the policy-artifact generator requires the
+				// schema `enum` and `enumDescriptions` to have equal length, so gating the enum
+				// would make a clean policy export invalid. The Entra product gate is enforced at
+				// runtime in `getEffectiveAuthProvider()` instead, and this setting is hidden
+				// (`included: false`), so listing `microsoft` here does not advertise it in the UI.
+				enum: ['github', 'microsoft'],
+				enumDescriptions: [
 					localize('extensions.gallery.authProvider.github', "Authenticate to the Extensions Marketplace using GitHub."),
 					localize('extensions.gallery.authProvider.microsoft', "Authenticate to the Extensions Marketplace using a Microsoft (Entra ID) account."),
-				] : [
-					localize('extensions.gallery.authProvider.github', "Authenticate to the Extensions Marketplace using GitHub."),
 				],
 				description: localize('extensions.gallery.authProvider', "Configure the authentication provider for the Extensions Marketplace"),
 				default: '',

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -145,7 +145,12 @@ export class ExtensionsViewletViewsContribution extends Disposable implements IW
 				ContextKeyExpr.or(
 					ContextKeyExpr.has('searchMarketplaceExtensions'), ContextKeyExpr.and(DefaultViewsContext)
 				),
-				ContextKeyExpr.or(CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.RequiresSignIn), CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.AccessDenied))
+				ContextKeyExpr.or(
+					CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.RequiresSignIn),
+					CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.AccessDenied),
+					CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.Misconfigured),
+					CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.Unreachable)
+				)
 			),
 			order: -1,
 		});
@@ -189,6 +194,16 @@ export class ExtensionsViewletViewsContribution extends Disposable implements IW
 					ContextKeyExpr.not('marketplaceAuthProvider')
 				)
 			)
+		});
+
+		viewRegistry.registerViewWelcomeContent('workbench.views.extensions.marketplaceAccess', {
+			content: localize('marketplace misconfigured', "The Extensions Marketplace is not configured correctly and cannot be reached. Please contact your administrator."),
+			when: CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.Misconfigured)
+		});
+
+		viewRegistry.registerViewWelcomeContent('workbench.views.extensions.marketplaceAccess', {
+			content: localize('marketplace unreachable', "The Extensions Marketplace is currently unavailable. Check your network connection and [try again]({0}).", `command:workbench.action.reloadWindow`),
+			when: CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.Unreachable)
 		});
 	}
 
@@ -1187,6 +1202,12 @@ export class ExtensionMarketplaceStatusUpdater extends Disposable implements IWo
 				break;
 			case ExtensionGalleryManifestStatus.AccessDenied:
 				badge = new WarningBadge(() => localize('accessDenied', "Access denied to marketplace"));
+				break;
+			case ExtensionGalleryManifestStatus.Misconfigured:
+				badge = new WarningBadge(() => localize('marketplaceMisconfigured', "Marketplace is misconfigured"));
+				break;
+			case ExtensionGalleryManifestStatus.Unreachable:
+				badge = new WarningBadge(() => localize('marketplaceUnreachable', "Marketplace is currently unavailable"));
 				break;
 		}
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -19,7 +19,7 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
-import { IExtensionsWorkbenchService, IExtensionsViewPaneContainer, VIEWLET_ID, CloseExtensionDetailsOnViewChangeKey, INSTALL_EXTENSION_FROM_VSIX_COMMAND_ID, WORKSPACE_RECOMMENDATIONS_VIEW_ID, AutoCheckUpdatesConfigurationKey, OUTDATED_EXTENSIONS_VIEW_ID, CONTEXT_HAS_GALLERY, extensionsSearchActionsMenu, AutoRestartConfigurationKey, ExtensionRuntimeActionType, SearchMcpServersContext, SearchAgentPluginsContext, DefaultViewsContext, CONTEXT_EXTENSIONS_GALLERY_STATUS } from '../common/extensions.js';
+import { IExtensionsWorkbenchService, IExtensionsViewPaneContainer, VIEWLET_ID, CloseExtensionDetailsOnViewChangeKey, INSTALL_EXTENSION_FROM_VSIX_COMMAND_ID, WORKSPACE_RECOMMENDATIONS_VIEW_ID, AutoCheckUpdatesConfigurationKey, OUTDATED_EXTENSIONS_VIEW_ID, CONTEXT_HAS_GALLERY, extensionsSearchActionsMenu, AutoRestartConfigurationKey, ExtensionRuntimeActionType, SearchMcpServersContext, SearchAgentPluginsContext, DefaultViewsContext, CONTEXT_EXTENSIONS_GALLERY_STATUS, CONTEXT_MARKETPLACE_AUTH_PROVIDER } from '../common/extensions.js';
 import { InstallLocalExtensionsInRemoteAction, InstallRemoteExtensionsInLocalAction } from './extensionsActions.js';
 import { IExtensionManagementService, ILocalExtension } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { IWorkbenchExtensionEnablementService, IExtensionManagementServerService, IExtensionManagementServer } from '../../../services/extensionManagement/common/extensionManagement.js';
@@ -69,7 +69,6 @@ import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { URI } from '../../../../base/common/uri.js';
-import { DEFAULT_ACCOUNT_SIGN_IN_COMMAND } from '../../../services/accounts/browser/defaultAccount.js';
 
 export const ExtensionsSortByContext = new RawContextKey<string>('extensionsSortByValue', '');
 export const SearchMarketplaceExtensionsContext = new RawContextKey<boolean>('searchMarketplaceExtensions', false);
@@ -155,13 +154,41 @@ export class ExtensionsViewletViewsContribution extends Disposable implements IW
 		viewRegistry.registerViews(viewDescriptors, this.container);
 
 		viewRegistry.registerViewWelcomeContent('workbench.views.extensions.marketplaceAccess', {
-			content: localize('sign in', "[Sign in to access Extensions Marketplace]({0})", `command:${DEFAULT_ACCOUNT_SIGN_IN_COMMAND}`),
-			when: CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.RequiresSignIn)
+			content: localize('sign in microsoft', "[Sign in with your Microsoft account]({0}) to access the Extensions Marketplace.", `command:workbench.extensions.actions.gallery.signIn`),
+			when: ContextKeyExpr.and(
+				CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.RequiresSignIn),
+				CONTEXT_MARKETPLACE_AUTH_PROVIDER.isEqualTo('microsoft')
+			)
 		});
 
 		viewRegistry.registerViewWelcomeContent('workbench.views.extensions.marketplaceAccess', {
-			content: localize('access denied', "Your account does not have access to the Extensions Marketplace. Please contact your administrator."),
-			when: CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.AccessDenied)
+			content: localize('sign in github', "[Sign in with GitHub]({0}) to access the Extensions Marketplace.", `command:workbench.extensions.actions.gallery.signIn`),
+			when: ContextKeyExpr.and(
+				CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.RequiresSignIn),
+				ContextKeyExpr.or(
+					CONTEXT_MARKETPLACE_AUTH_PROVIDER.isEqualTo('github'),
+					ContextKeyExpr.not('marketplaceAuthProvider')
+				)
+			)
+		});
+
+		viewRegistry.registerViewWelcomeContent('workbench.views.extensions.marketplaceAccess', {
+			content: localize('access denied microsoft', "Your Microsoft account does not have access to the Extensions Marketplace. An Entra ID (work or school) account or Visual Studio Subscription is required. Please contact your administrator."),
+			when: ContextKeyExpr.and(
+				CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.AccessDenied),
+				CONTEXT_MARKETPLACE_AUTH_PROVIDER.isEqualTo('microsoft')
+			)
+		});
+
+		viewRegistry.registerViewWelcomeContent('workbench.views.extensions.marketplaceAccess', {
+			content: localize('access denied github', "Your account does not have access to the Extensions Marketplace. Please contact your administrator."),
+			when: ContextKeyExpr.and(
+				CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.AccessDenied),
+				ContextKeyExpr.or(
+					CONTEXT_MARKETPLACE_AUTH_PROVIDER.isEqualTo('github'),
+					ContextKeyExpr.not('marketplaceAuthProvider')
+				)
+			)
 		});
 	}
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -178,7 +178,7 @@ export class ExtensionsViewletViewsContribution extends Disposable implements IW
 		});
 
 		viewRegistry.registerViewWelcomeContent('workbench.views.extensions.marketplaceAccess', {
-			content: localize('access denied microsoft', "Your Microsoft account does not have access to the Extensions Marketplace. An Entra ID (work or school) account or Visual Studio Subscription is required. Please contact your administrator."),
+			content: localize('access denied microsoft', "Your Microsoft account does not have access to the Extensions Marketplace. Please contact your administrator."),
 			when: ContextKeyExpr.and(
 				CONTEXT_EXTENSIONS_GALLERY_STATUS.isEqualTo(ExtensionGalleryManifestStatus.AccessDenied),
 				CONTEXT_MARKETPLACE_AUTH_PROVIDER.isEqualTo('microsoft')

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -268,7 +268,7 @@ export const SearchMcpServersContext = new RawContextKey<boolean>('searchMcpServ
 export const SearchAgentPluginsContext = new RawContextKey<boolean>('searchAgentPlugins', false);
 
 // Marketplace Eligibility Context Keys
-export const CONTEXT_MARKETPLACE_AUTH_PROVIDER = new RawContextKey<string>('marketplaceAuthProvider', '');
+export { CONTEXT_MARKETPLACE_AUTH_PROVIDER } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 
 // Context Menu Groups
 export const THEME_ACTIONS_GROUP = '_theme_';

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -267,6 +267,9 @@ export const ExtensionResultsListFocused = new RawContextKey<boolean>('extension
 export const SearchMcpServersContext = new RawContextKey<boolean>('searchMcpServers', false);
 export const SearchAgentPluginsContext = new RawContextKey<boolean>('searchAgentPlugins', false);
 
+// Marketplace Eligibility Context Keys
+export const CONTEXT_MARKETPLACE_AUTH_PROVIDER = new RawContextKey<string>('marketplaceAuthProvider', '');
+
 // Context Menu Groups
 export const THEME_ACTIONS_GROUP = '_theme_';
 export const INSTALL_ACTIONS_GROUP = '0_install';

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -12,7 +12,7 @@ import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
-import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri, PRIVATE_MARKETPLACE_SCOPES, CONTEXT_MARKETPLACE_AUTH_PROVIDER } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri, PRIVATE_MARKETPLACE_SCOPES, CONTEXT_MARKETPLACE_AUTH_PROVIDER, discoverMarketplaceProtectedResource } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { ExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
 import { resolveMarketplaceHeaders } from '../../../../platform/externalServices/common/marketplace.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -79,9 +79,41 @@ type MarketplaceAuthClassification = {
  * rather than mislabeling an auth-gated index as "unreachable".
  */
 class MarketplaceAuthRequiredError extends Error {
-	constructor(readonly statusCode: number) {
+	constructor(
+		readonly statusCode: number,
+		/**
+		 * The raw `WWW-Authenticate` challenge header returned alongside a 401, when present.
+		 * RFC 9728 negotiation reads the `resource_metadata` (and optionally `scope`) parameters
+		 * from this challenge to discover the marketplace's Protected Resource Metadata and the
+		 * resource-scoped token to acquire. Absent on 403 (the identity is refused, not
+		 * un-authenticated) and on servers that omit the header.
+		 */
+		readonly wwwAuthenticate?: string,
+	) {
 		super(`Extension gallery request requires authentication (status ${statusCode}).`);
 	}
+}
+
+/**
+ * Reads a response header case-insensitively. HTTP header names are case-insensitive
+ * (RFC 7230 §3.2) and different transports normalize casing differently (Node lowercases,
+ * others preserve the wire casing), so a fixed-case lookup on `WWW-Authenticate` is unsafe.
+ */
+function getResponseHeader(headers: IHeaders | undefined, name: string): string | undefined {
+	if (!headers) {
+		return undefined;
+	}
+	const lowerName = name.toLowerCase();
+	for (const key of Object.keys(headers)) {
+		if (key.toLowerCase() === lowerName) {
+			const value = headers[key];
+			// A header may be delivered as a single string or, if repeated, an array of values.
+			// RFC 7235 permits multiple challenges in a single `WWW-Authenticate` value, so join
+			// repeated headers with commas to reconstruct the full challenge list for the parser.
+			return Array.isArray(value) ? value.join(', ') : value;
+		}
+	}
+	return undefined;
 }
 
 export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryManifestService implements IExtensionGalleryManifestService {
@@ -108,6 +140,15 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 	// stale in-flight eligibility check could restore access for an account that is no longer
 	// current.
 	private validationEpoch = 0;
+
+	// The resource-scoped bearer token negotiated (RFC 9728) when the marketplace service index
+	// is `[Authorize]`-gated. It is set only when access was actually negotiated via a
+	// `WWW-Authenticate` challenge AND the user is eligible/Available, and is exposed via
+	// `getAccessToken()` so the gallery service can authenticate protected marketplace requests
+	// (extensionquery, asset download). It is cleared whenever access is revoked — every
+	// non-Available transition routes through `update(null, …)`, which resets it — so a stale
+	// token can never survive a sign-out, account switch, or config change.
+	private negotiatedAccessToken: string | undefined;
 
 	constructor(
 		@IProductService productService: IProductService,
@@ -186,6 +227,16 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		}
 		await this.extensionGalleryManifestPromise;
 		return this.extensionGalleryManifest;
+	}
+
+	/**
+	 * Returns the resource-scoped bearer token negotiated for a `[Authorize]`-gated marketplace,
+	 * or `undefined` for an open marketplace. Ensures the manifest resolution has completed first
+	 * so the token reflects the current access state.
+	 */
+	override async getAccessToken(): Promise<string | undefined> {
+		await this.getExtensionGalleryManifest();
+		return this.negotiatedAccessToken;
 	}
 
 	private async doGetExtensionGalleryManifest(): Promise<void> {
@@ -421,8 +472,27 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			return;
 		}
 		let manifest: IExtensionGalleryManifest;
+		// The token that successfully reads the service index. Starts as the initially-acquired
+		// (OpenID) session token; if the index is auth-gated and returns an RFC 9728 challenge,
+		// `fetchServiceIndexNegotiated` upgrades this to a resource-scoped token, which is then
+		// reused for the protected eligibility POST below.
+		let indexToken: string = session.accessToken;
+		// Whether the index was actually behind an RFC 9728 challenge (i.e. `indexToken` is a
+		// resource-scoped token that protected marketplace API requests must present), as opposed
+		// to an open index read with the plain sign-in token.
+		let indexWasNegotiated = false;
 		try {
-			manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl, session.accessToken);
+			const negotiated = await this.fetchServiceIndexNegotiated(
+				configuredServiceUrl,
+				'microsoft',
+				session.accessToken,
+				WorkbenchExtensionGalleryManifestService.MICROSOFT_AUTH_SCOPES,
+			);
+			manifest = negotiated.manifest;
+			// `negotiated.token` is only undefined when the initial token was undefined; on the
+			// Microsoft path we always start with the signed-in session token, so fall back to it.
+			indexToken = negotiated.token ?? session.accessToken;
+			indexWasNegotiated = negotiated.negotiated;
 		} catch (error) {
 			if (this.validationEpoch !== epoch) {
 				return;
@@ -479,7 +549,7 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 
 		// Check eligibility via server
 		try {
-			const result = await this.checkMicrosoftEligibility(eligibilityUrl, session.accessToken);
+			const result = await this.checkMicrosoftEligibility(eligibilityUrl, indexToken);
 			if (this.validationEpoch !== epoch) {
 				return;
 			}
@@ -500,6 +570,14 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 					eligible: result.eligible,
 				}
 			);
+			// The index was gated and we negotiated a resource-scoped token for it: expose that
+			// token (via getAccessToken) for protected marketplace API requests when the user is
+			// eligible. On the open-index path (indexWasNegotiated === false) the marketplace
+			// needs no bearer, so leave the token cleared. Any later non-Available transition
+			// routes through update(null, …) and clears it.
+			if (indexWasNegotiated && result.eligible) {
+				this.negotiatedAccessToken = indexToken;
+			}
 			this.applyEligibilityResult(result, manifest);
 		} catch (error) {
 			if (this.validationEpoch !== epoch) {
@@ -530,6 +608,86 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
 				this.update(null, ExtensionGalleryManifestStatus.Unreachable);
 			}
+		}
+	}
+
+	/**
+	 * Fetches the service index, negotiating a resource-scoped bearer token if the marketplace's
+	 * index is protected (RFC 9728). It first presents `initialToken`; if the marketplace responds
+	 * `401`, the marketplace's Protected Resource Metadata is discovered via its well-known endpoint
+	 * (RFC 9728) and a token bound to the advertised authorization server + resource scopes is
+	 * acquired silently (RFC 8707), then the index fetch is retried once with that token.
+	 *
+	 * Discovery deliberately does NOT depend on the `WWW-Authenticate` challenge header: that header
+	 * is not CORS-safelisted, so the renderer's cross-origin index fetch usually cannot read it. The
+	 * challenge is passed only as a best-effort hint for the explicit metadata URL.
+	 *
+	 * Returns the manifest together with the token that successfully read the index, so callers can
+	 * reuse it for subsequent protected requests (e.g. the Microsoft eligibility POST). Any auth
+	 * failure that negotiation cannot resolve (no metadata, no session obtainable, or a `401`/`403`
+	 * on the retry) propagates as a {@link MarketplaceAuthRequiredError} for the caller to classify.
+	 */
+	private async fetchServiceIndexNegotiated(
+		configuredServiceUrl: string,
+		providerId: string,
+		initialToken: string | undefined,
+		fallbackScopes: readonly string[],
+	): Promise<{ manifest: IExtensionGalleryManifest; token: string | undefined; negotiated: boolean }> {
+		try {
+			const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl, initialToken);
+			return { manifest, token: initialToken, negotiated: false };
+		} catch (error) {
+			// Only a 401 (index is auth-gated) is negotiable. A 403 (identity refused) or any other
+			// error is not — let it propagate so the caller applies its existing classification.
+			if (!(error instanceof MarketplaceAuthRequiredError) || error.statusCode !== 401) {
+				throw error;
+			}
+			const protectedResource = await discoverMarketplaceProtectedResource(
+				this.requestService,
+				configuredServiceUrl,
+				error.wwwAuthenticate,
+				CancellationToken.None,
+			);
+			if (!protectedResource) {
+				// The index is gated but exposes no Protected Resource Metadata we can act on —
+				// re-throw the original 401 so the caller prompts for sign-in.
+				throw error;
+			}
+			const session = await this.acquireResourceToken(providerId, protectedResource, fallbackScopes);
+			if (!session) {
+				// No resource-scoped session could be obtained silently (e.g. consent not yet
+				// granted) — re-throw the original 401 so the caller prompts for sign-in rather
+				// than mislabeling it.
+				throw error;
+			}
+			const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl, session.accessToken);
+			return { manifest, token: session.accessToken, negotiated: true };
+		}
+	}
+
+	/**
+	 * Silently acquires a resource-scoped bearer token bound to the marketplace's advertised
+	 * authorization server (RFC 8707). `getSessions` never prompts, so this returns `undefined`
+	 * when no consented session exists yet, leaving interactive acquisition to the sign-in action.
+	 * The advertised authorization server is validated against the provider's configured globs by
+	 * the authentication service; a mismatch throws, which we treat as "no session".
+	 */
+	private async acquireResourceToken(
+		providerId: string,
+		protectedResource: { authorizationServer: string; scopes: readonly string[] },
+		fallbackScopes: readonly string[],
+	): Promise<AuthenticationSession | undefined> {
+		const scopes = protectedResource.scopes.length ? protectedResource.scopes : fallbackScopes;
+		try {
+			const sessions = await this.authenticationService.getSessions(
+				providerId,
+				[...scopes],
+				{ authorizationServer: URI.parse(protectedResource.authorizationServer) },
+			);
+			return sessions[0];
+		} catch (error) {
+			this.logService.error('[Marketplace] Error acquiring resource-scoped marketplace token', error);
+			return undefined;
 		}
 	}
 
@@ -785,6 +943,13 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 
 	private update(manifest: IExtensionGalleryManifest | null, status?: ExtensionGalleryManifestStatus): void {
 		this.logService.debug(`[Marketplace] Updating manifest ${manifest ? 'available' : 'unavailable'}`);
+		if (!manifest) {
+			// Any transition to a non-Available state (sign-out, account switch, config change,
+			// access denied, unreachable, …) routes through here with a null manifest. Drop the
+			// negotiated resource token so it can never outlive the access that produced it; the
+			// eligible→Available path re-sets it after a successful negotiation.
+			this.negotiatedAccessToken = undefined;
+		}
 		if (this.extensionGalleryManifest !== manifest) {
 			this.extensionGalleryManifest = manifest;
 			this._onDidChangeExtensionGalleryManifest.fire(manifest);
@@ -837,8 +1002,13 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			if (context.res.statusCode === 401 || context.res.statusCode === 403) {
 				// The service index is auth-gated and this request was not authorized.
 				// Surface a typed error so the Entra path can prompt for sign-in (or treat a
-				// rejected token as denied) rather than mislabeling it as unreachable.
-				throw new MarketplaceAuthRequiredError(context.res.statusCode);
+				// rejected token as denied) rather than mislabeling it as unreachable. Capture
+				// the `WWW-Authenticate` challenge (present on a 401) so RFC 9728 negotiation
+				// can discover the Protected Resource Metadata and resource-scoped token.
+				throw new MarketplaceAuthRequiredError(
+					context.res.statusCode,
+					getResponseHeader(context.res.headers, 'WWW-Authenticate'),
+				);
 			}
 
 			if (context.res.statusCode && (context.res.statusCode < 200 || context.res.statusCode >= 300)) {

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -12,7 +12,7 @@ import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
-import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri, PRIVATE_MARKETPLACE_SCOPES } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri, PRIVATE_MARKETPLACE_SCOPES, CONTEXT_MARKETPLACE_AUTH_PROVIDER } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { ExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
 import { resolveMarketplaceHeaders } from '../../../../platform/externalServices/common/marketplace.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -29,7 +29,6 @@ import { IRemoteAgentService } from '../../remote/common/remoteAgentService.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHostService } from '../../host/browser/host.js';
 import { AuthenticationSession, IAuthenticationService } from '../../authentication/common/authentication.js';
-import { CONTEXT_MARKETPLACE_AUTH_PROVIDER } from '../../../contrib/extensions/common/extensions.js';
 
 interface ICachedAccess {
 	authProvider: 'github' | 'microsoft';
@@ -278,6 +277,12 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			this._register(this.authenticationService.onDidChangeSessions(e => {
 				if (e.providerId === 'microsoft') {
 					this.clearCachedAccess();
+					// Revoke the manifest that was authorized for the previous session before
+					// revalidating. Without this, the active status stays `Available`, and if the
+					// new session's validation hits a transient index/eligibility failure the catch
+					// paths preserve `Available` — leaking the prior account's authorization to the
+					// new (possibly ineligible) account.
+					this.update(null);
 					validate();
 				}
 			}));
@@ -288,6 +293,10 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		const validate = () => this.handleGitHubAccess(configuredServiceUrl, ++this.validationEpoch);
 		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => {
 			this.clearCachedAccess();
+			// Revoke the previously authorized manifest before revalidating (see the Microsoft
+			// path above) so a transient failure resolving the new account cannot preserve the
+			// old account's `Available` status.
+			this.update(null);
 			validate();
 		}));
 		return validate;
@@ -852,6 +861,15 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 				// fetch, rather than letting resource-URI discovery throw on a non-iterable
 				// `resources` outside this try/catch.
 				throw new Error('Service index response is not a valid extension gallery manifest.');
+			}
+
+			if (!extensionGalleryManifest.resources.every(resource => resource && typeof resource.id === 'string' && typeof resource.type === 'string')) {
+				// `resources` is an array but at least one entry is malformed (missing/non-string
+				// `id` or `type`). `getExtensionGalleryManifestResourceUri` calls `resource.type.split()`
+				// outside this fetch's try/catch during endpoint discovery, so an undefined `type`
+				// would throw there and reject initialization instead of being classified as a failed
+				// fetch. Reject here so the caller surfaces `Unreachable`.
+				throw new Error('Service index response contains malformed extension gallery resources.');
 			}
 
 			return extensionGalleryManifest;

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -333,13 +333,13 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			const validate = () => this.handleMicrosoftAccess(configuredServiceUrl, ++this.validationEpoch);
 			this._register(this.authenticationService.onDidChangeSessions(e => {
 				if (e.providerId === 'microsoft') {
-					this.clearCachedAccess();
-					// Revoke the manifest that was authorized for the previous session before
-					// revalidating. Without this, the active status stays `Available`, and if the
-					// new session's validation hits a transient index/eligibility failure the catch
-					// paths preserve `Available` — leaking the prior account's authorization to the
-					// new (possibly ineligible) account.
-					this.update(null);
+					// Re-validate on any Microsoft session change, but deliberately do NOT clear the
+					// cache or revoke the manifest here. `onDidChangeSessions` also fires on routine
+					// token refreshes for the SAME account, and unconditionally clearing would force
+					// a redundant eligibility round-trip (and a brief manifest flash) on every
+					// refresh. handleMicrosoftAccess resolves the current account and, only when it
+					// actually differs from the cached verdict (or no verdict is cached), revokes the
+					// prior authorization and re-checks eligibility.
 					validate();
 				}
 			}));
@@ -464,6 +464,24 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			return;
 		}
 
+		// Whether we already hold a durable eligibility verdict for THIS account against THIS
+		// marketplace. `getCachedAccess` returns the verdict only when it was written under the
+		// currently-effective provider and for the configured serviceUrl (dropping it otherwise),
+		// so a same-account match here means "same provider + same marketplace + same account".
+		// When present we skip the eligibility POST below — it is only needed on first sign-in or
+		// when the account changes. We still (re)negotiate the service index token so a gated
+		// marketplace's resource-scoped token is refreshed for this session.
+		const cached = this.getCachedAccess(configuredServiceUrl);
+		const matchedVerdict = cached && cached.accountId === session.account.id ? cached : undefined;
+		if (!matchedVerdict && this.currentStatus === ExtensionGalleryManifestStatus.Available) {
+			// No verdict for the current account, yet the marketplace is still showing Available
+			// for a previous account (e.g. an account switch). Revoke that authorization NOW,
+			// before the async negotiation/eligibility round-trip, so a transient failure below
+			// cannot preserve the prior account's manifest — the "unreachable" catch paths only
+			// overwrite the status when it is not already Available.
+			this.update(null);
+		}
+
 		// We have a token — fetch the service index (presenting the token so a gated index is
 		// readable), then discover the eligibility endpoint from it. The manifest is carried
 		// forward to `applyEligibilityResult` so it is fetched exactly once: this keeps the
@@ -530,6 +548,25 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		}
 
 		if (this.validationEpoch !== epoch) {
+			return;
+		}
+
+		// The service index read above succeeded with the current session's token, so the token
+		// is valid. If we already hold a durable verdict for this account+marketplace, apply it
+		// without re-POSTing eligibility — that check is only needed on first sign-in or when the
+		// account changes (both of which arrive with no matching cache). The negotiation above
+		// refreshed the resource-scoped token for this session; expose it when the index was gated
+		// and the user is eligible. Verdict invalidation for a rejected/expired token is handled by
+		// the negotiation catch above (401 → RequiresSignIn, 403 → AccessDenied) before we get here.
+		if (matchedVerdict) {
+			if (matchedVerdict.eligible) {
+				if (indexWasNegotiated) {
+					this.negotiatedAccessToken = indexToken;
+				}
+				this.applyEligibilityResult({ eligible: true }, manifest);
+			} else {
+				this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
+			}
 			return;
 		}
 

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -1087,7 +1087,18 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 
 			return extensionGalleryManifest;
 		} catch (error) {
-			this.logService.error('[Marketplace] Error retrieving extension gallery manifest', error);
+			// A 401/403 here is an expected step of RFC 9728 negotiation, not a failure: a gated
+			// service index answers the initial (anonymous or plain-token) read with a
+			// `WWW-Authenticate` challenge, which the caller uses to discover the Protected
+			// Resource Metadata and negotiate a resource-scoped token before retrying. Logging it
+			// at `error` surfaces a spurious "Error retrieving extension gallery manifest" for a
+			// normal handshake, so downgrade auth-required outcomes to `trace` and reserve
+			// `error` for genuinely unexpected failures.
+			if (error instanceof MarketplaceAuthRequiredError) {
+				this.logService.trace('[Marketplace] Service index requires authentication (status', error.statusCode, ') — RFC 9728 negotiation will handle it');
+			} else {
+				this.logService.error('[Marketplace] Error retrieving extension gallery manifest', error);
+			}
 			throw error;
 		}
 	}

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -6,12 +6,13 @@
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IDefaultAccount } from '../../../../base/common/defaultAccount.js';
 import { Emitter } from '../../../../base/common/event.js';
+import { URI } from '../../../../base/common/uri.js';
 import { IHeaders } from '../../../../base/parts/request/common/request.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
-import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri, PRIVATE_MARKETPLACE_SCOPE } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri, PRIVATE_MARKETPLACE_SCOPES } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { ExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
 import { resolveMarketplaceHeaders } from '../../../../platform/externalServices/common/marketplace.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -27,14 +28,20 @@ import { IDefaultAccountService } from '../../../../platform/defaultAccount/comm
 import { IRemoteAgentService } from '../../remote/common/remoteAgentService.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHostService } from '../../host/browser/host.js';
-import { IAuthenticationService } from '../../authentication/common/authentication.js';
+import { AuthenticationSession, IAuthenticationService } from '../../authentication/common/authentication.js';
 import { CONTEXT_MARKETPLACE_AUTH_PROVIDER } from '../../../contrib/extensions/common/extensions.js';
 
 interface ICachedAccess {
 	authProvider: 'github' | 'microsoft';
 	accountId: string;
 	eligible: boolean;
-	reason?: string;
+	/**
+	 * The `extensions.gallery.serviceUrl` the verdict was computed against. A verdict is scoped
+	 * to a specific marketplace (the eligibility endpoint is discovered per-marketplace), so a
+	 * cache written for one service URL must never be applied after the admin points the client
+	 * at a different marketplace.
+	 */
+	serviceUrl: string;
 }
 
 interface IEligibilityResponse {
@@ -46,7 +53,6 @@ interface IEligibilityResponse {
 type MarketplaceAuthEvent = {
 	authProvider: string;
 	eligible: boolean;
-	reason: string;
 };
 
 type MarketplaceAuthClassification = {
@@ -61,18 +67,27 @@ type MarketplaceAuthClassification = {
 		isMeasurement: true;
 		comment: 'Whether the user was granted marketplace access.';
 	};
-	reason: {
-		classification: 'SystemMetaData';
-		purpose: 'FeatureInsight';
-		comment: 'The eligibility reason returned by the server.';
-	};
 	owner: 'sandy081';
 	comment: 'Reports marketplace authentication results for enterprise marketplace access.';
 };
 
+/**
+ * Thrown by the service-index (gallery manifest) fetch when the request is rejected for
+ * authentication/authorization reasons (HTTP 401/403). The service index MAY be protected
+ * at the administrator's discretion, so this is kept distinct from transient/network
+ * failures: callers on the Entra path use it to decide whether to prompt for sign-in
+ * (no token was presented) or to treat the identity as denied (a token was rejected),
+ * rather than mislabeling an auth-gated index as "unreachable".
+ */
+class MarketplaceAuthRequiredError extends Error {
+	constructor(readonly statusCode: number) {
+		super(`Extension gallery request requires authentication (status ${statusCode}).`);
+	}
+}
+
 export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryManifestService implements IExtensionGalleryManifestService {
 
-	private static readonly MICROSOFT_AUTH_SCOPES = [PRIVATE_MARKETPLACE_SCOPE];
+	private static readonly MICROSOFT_AUTH_SCOPES = PRIVATE_MARKETPLACE_SCOPES;
 	private static readonly CACHED_ACCESS_KEY = 'marketplace.cachedAccess';
 
 	private readonly commonHeadersPromise: Promise<IHeaders>;
@@ -85,6 +100,15 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 	override get extensionGalleryManifestStatus(): ExtensionGalleryManifestStatus { return this.currentStatus; }
 	private _onDidChangeExtensionGalleryManifestStatus = this._register(new Emitter<ExtensionGalleryManifestStatus>());
 	override readonly onDidChangeExtensionGalleryManifestStatus = this._onDidChangeExtensionGalleryManifestStatus.event;
+
+	// Monotonic counter used to discard results from superseded validations. Each call to a
+	// `validate` closure captures the current epoch (via ++this.validationEpoch); any async
+	// continuation that later finds the epoch has advanced MUST NOT mutate status/cache/
+	// manifest, because a newer validation (e.g. triggered by sign-out, an account switch, or
+	// a config change) has taken over. This closes a time-of-check/time-of-use window where a
+	// stale in-flight eligibility check could restore access for an account that is no longer
+	// current.
+	private validationEpoch = 0;
 
 	constructor(
 		@IProductService productService: IProductService,
@@ -113,9 +137,10 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			storageService,
 			telemetryService);
 
-		// Set the auth provider context key for UX
-		const authProvider = this.configurationService.getValue<string>(ExtensionGalleryAuthProviderConfigKey);
-		CONTEXT_MARKETPLACE_AUTH_PROVIDER.bindTo(contextKeyService).set(authProvider || 'github');
+		// Set the auth provider context key for UX. The Entra (microsoft) path is gated
+		// behind a product flag; when it is off, coerce to the GitHub/default provider so
+		// the UI never advertises Microsoft sign-in.
+		CONTEXT_MARKETPLACE_AUTH_PROVIDER.bindTo(contextKeyService).set(this.getEffectiveAuthProvider());
 
 		const channels = [sharedProcessService.getChannel('extensionGalleryManifest')];
 		const remoteConnection = remoteAgentService.getConnection();
@@ -126,13 +151,24 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			this.logService.trace(`[Marketplace] Updating channels with manifest ${manifest ? 'available' : 'unavailable'}`);
 			channels.forEach(channel => channel.call('setExtensionGalleryManifest', [manifest]));
 		};
-		this.getExtensionGalleryManifest().then(manifest => {
+		// Defer the initial manifest bootstrap to a microtask so this service is fully
+		// constructed and cached in the DI container before it runs. The Entra (microsoft)
+		// access path resolves IAuthenticationService, whose dependency graph transitively
+		// re-enters this service; kicking the bootstrap off synchronously from the
+		// constructor would resolve IAuthenticationService mid-construction and throw
+		// "RECURSIVELY instantiating service 'IAuthenticationService'", corrupting the
+		// container and breaking workbench startup.
+		Promise.resolve().then(() => this.getExtensionGalleryManifest()).then(manifest => {
 			if (this._store.isDisposed) {
 				this.logService.trace('[Marketplace] Store is already disposed, skipping channel initialization');
 				return;
 			}
 			updateChannels(manifest);
 			this._register(this.onDidChangeExtensionGalleryManifest(manifest => updateChannels(manifest)));
+		}).catch(error => {
+			// The deferred bootstrap must never surface as an unhandled rejection — any
+			// failure here already results in an appropriate manifest status, so just log.
+			this.logService.error('[Marketplace] Error during initial gallery manifest bootstrap', error);
 		});
 	}
 
@@ -159,8 +195,24 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			return;
 		}
 
+		// Register the configuration listener BEFORE running the initial validation so a
+		// serviceUrl/provider change that lands during a slow startup validation is observed
+		// (it bumps the epoch to supersede the in-flight result and clears the cache) rather
+		// than being missed while we await initialization.
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ExtensionGalleryServiceUrlConfigKey)
+				|| e.affectsConfiguration(ExtensionGalleryAuthProviderConfigKey)) {
+				// Supersede any in-flight background validation for the previous
+				// marketplace/provider so its late-arriving result cannot re-populate the
+				// cache we are about to clear (the restart prompt is dismissable, so the
+				// process may keep running).
+				this.validationEpoch++;
+				this.clearCachedAccess();
+				this.requestRestart();
+			}
+		}));
+
 		const configuredServiceUrl = this.configurationService.getValue<string>(ExtensionGalleryServiceUrlConfigKey);
-		if (configuredServiceUrl) {
 		if (configuredServiceUrl) {
 			this.logService.trace('[Marketplace] Private marketplace configured, checking access and fetching manifest', configuredServiceUrl);
 			await this.initializePrivateMarketplace(configuredServiceUrl);
@@ -168,26 +220,23 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			const defaultExtensionGalleryManifest = await super.getExtensionGalleryManifest();
 			this.update(defaultExtensionGalleryManifest);
 		}
-
-		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(ExtensionGalleryServiceUrlConfigKey)
-				|| e.affectsConfiguration(ExtensionGalleryAuthProviderConfigKey)) {
-				this.clearCachedAccess();
-				this.requestRestart();
-			}
-		}));
 	}
 
 	private async initializePrivateMarketplace(configuredServiceUrl: string): Promise<void> {
-		// 1. Apply cache immediately before any auth calls
-		const cached = this.getCachedAccess();
+		// 1. Resolve the auth strategy FIRST so provider/session change listeners are active
+		//    before we apply any cached verdict. This lets a mid-application account/session
+		//    switch supersede the cache via the validationEpoch guard in applyCachedAccess,
+		//    rather than racing an unguarded cache application. resolveAccessStrategy only
+		//    registers listeners and returns the validate function — it performs no auth calls
+		//    itself, so this reordering does not change when the network is first touched.
+		const validateAccess = await this.resolveAccessStrategy(configuredServiceUrl);
+
+		// 2. Apply cache immediately (epoch-guarded) before awaiting foreground validation.
+		const cached = this.getCachedAccess(configuredServiceUrl);
 		if (cached) {
 			this.logService.debug('[Marketplace] Applying cached access result on startup');
-			await this.applyCachedAccess(cached, configuredServiceUrl);
+			await this.applyCachedAccess(cached, configuredServiceUrl, ++this.validationEpoch);
 		}
-
-		// 2. Resolve auth strategy — sets up event subscriptions and returns the validate function
-		const validateAccess = await this.resolveAccessStrategy(configuredServiceUrl);
 
 		// 3. Validate (foreground if no cache, background if cache was applied)
 		if (cached) {
@@ -198,33 +247,45 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 	}
 
 	/**
+	 * Resolves the effective marketplace auth provider, applying the Entra (microsoft)
+	 * product gate. When `product.enableExtensionGalleryEntraAuth` is falsy, a configured
+	 * `microsoft` provider is downgraded to the GitHub/default provider so the Entra path
+	 * stays dormant until the Private Marketplace is publicly released.
+	 */
+	private getEffectiveAuthProvider(): string {
+		const configuredAuthProvider = this.configurationService.getValue<string>(ExtensionGalleryAuthProviderConfigKey);
+		if (configuredAuthProvider === 'microsoft' && !this.productService.enableExtensionGalleryEntraAuth) {
+			return 'github';
+		}
+		return configuredAuthProvider || 'github';
+	}
+
+	/**
 	 * Resolves the effective auth provider, registers event subscriptions for
 	 * re-validation, and returns a function that validates current access.
 	 *
-	 * When configured as 'microsoft', discovers the eligibility URL from the
-	 * gallery manifest (ServiceIndex). Falls back to GitHub if the
-	 * EligibilityService resource is not advertised.
+	 * When the effective provider is 'microsoft', eligibility discovery and
+	 * validation happen inside {@link handleMicrosoftAccess}. There is deliberately
+	 * NO fallback to GitHub: once an administrator has explicitly configured
+	 * 'microsoft', a server that does not advertise an EligibilityService is treated
+	 * as misconfigured rather than silently downgraded.
 	 */
 	private async resolveAccessStrategy(configuredServiceUrl: string): Promise<() => Promise<void>> {
-		const configuredAuthProvider = this.configurationService.getValue<string>(ExtensionGalleryAuthProviderConfigKey);
+		const configuredAuthProvider = this.getEffectiveAuthProvider();
 
 		if (configuredAuthProvider === 'microsoft') {
-			const eligibilityUrl = await this.discoverEligibilityUrl(configuredServiceUrl);
-			if (eligibilityUrl) {
-				const validate = () => this.handleMicrosoftAccess(configuredServiceUrl, eligibilityUrl);
-				this._register(this.authenticationService.onDidChangeSessions(e => {
-					if (e.providerId === 'microsoft') {
-						this.clearCachedAccess();
-						validate();
-					}
-				}));
-				return validate;
-			}
-			this.logService.info('[Marketplace] EligibilityService not advertised — falling back to GitHub auth');
+			const validate = () => this.handleMicrosoftAccess(configuredServiceUrl, ++this.validationEpoch);
+			this._register(this.authenticationService.onDidChangeSessions(e => {
+				if (e.providerId === 'microsoft') {
+					this.clearCachedAccess();
+					validate();
+				}
+			}));
+			return validate;
 		}
 
 		// Default: GitHub
-		const validate = () => this.handleGitHubAccess(configuredServiceUrl);
+		const validate = () => this.handleGitHubAccess(configuredServiceUrl, ++this.validationEpoch);
 		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => {
 			this.clearCachedAccess();
 			validate();
@@ -232,37 +293,58 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		return validate;
 	}
 
-	private async discoverEligibilityUrl(configuredServiceUrl: string): Promise<string | undefined> {
-		try {
-			const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl);
-			return getExtensionGalleryManifestResourceUri(manifest, ExtensionGalleryResourceType.EligibilityService);
-		} catch (error) {
-			this.logService.error('[Marketplace] Error fetching manifest for eligibility URL discovery', error);
-			return undefined;
-		}
-	}
-
 	// --- GitHub access (existing DefaultAccountService-based check) ---
 
-	private async handleGitHubAccess(configuredServiceUrl: string): Promise<void> {
+	private async handleGitHubAccess(configuredServiceUrl: string, epoch: number): Promise<void> {
 		try {
 			const account = await this.defaultAccountService.getDefaultAccount();
+			if (this.validationEpoch !== epoch) {
+				// A newer validation superseded this one while we awaited — discard.
+				return;
+			}
 			if (!account) {
 				// Auth service responded: no account → invalidate cache
 				this.clearCachedAccess();
 				this.update(null, ExtensionGalleryManifestStatus.RequiresSignIn);
 			} else if (!this.checkAccess(account)) {
 				// Auth service responded: account exists but ineligible → cache the result
-				this.cacheAccess({ authProvider: 'github', accountId: account.accountName, eligible: false });
+				this.cacheAccess({ authProvider: 'github', accountId: account.accountName, eligible: false, serviceUrl: configuredServiceUrl });
 				this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
 			} else if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
-				const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl);
-				this.cacheAccess({ authProvider: 'github', accountId: account.accountName, eligible: true });
-				this.update(manifest);
+				try {
+					const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl);
+					if (this.validationEpoch !== epoch) {
+						return;
+					}
+					this.cacheAccess({ authProvider: 'github', accountId: account.accountName, eligible: true, serviceUrl: configuredServiceUrl });
+					this.update(manifest);
+					this.telemetryService.publicLog2<
+						{},
+						{
+							owner: 'sandy081';
+							comment: 'Reports when a user successfully accesses a custom marketplace';
+						}>('galleryservice:custom:marketplace');
+				} catch (error) {
+					if (this.validationEpoch !== epoch) {
+						return;
+					}
+					// Eligible, but the marketplace manifest could not be fetched — the
+					// marketplace is currently unreachable. Preserve cache; surface a message.
+					this.logService.error('[Marketplace] Failed to fetch gallery manifest (GitHub path)', error);
+					this.update(null, ExtensionGalleryManifestStatus.Unreachable);
+				}
 			}
 		} catch (error) {
+			if (this.validationEpoch !== epoch) {
+				return;
+			}
 			this.logService.error('[Marketplace] Error in GitHub access check', error);
-			// Network/transient error — never invalidate cache
+			// Network/transient error resolving the account — never invalidate cache. Unless we
+			// already have a working manifest to keep showing, surface an "unreachable" message so
+			// a configured marketplace isn't left on a blank (Unavailable) view with no explanation.
+			if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
+				this.update(null, ExtensionGalleryManifestStatus.Unreachable);
+			}
 		}
 	}
 
@@ -277,63 +359,182 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 
 	// --- Microsoft access (new Entra ID / VSS eligibility check) ---
 
-	private async handleMicrosoftAccess(configuredServiceUrl: string, eligibilityUrl: string): Promise<void> {
-		let sessions: ReadonlyArray<{ id: string; accessToken: string; account: { id: string; label: string }; scopes: ReadonlyArray<string> }>;
+	private async handleMicrosoftAccess(configuredServiceUrl: string, epoch: number): Promise<void> {
+		// Acquire an existing Microsoft session first. `getSessions` reads existing sessions
+		// silently and never prompts for sign-in.
+		let sessions: readonly AuthenticationSession[];
 		try {
 			sessions = await this.authenticationService.getSessions(
 				'microsoft',
 				WorkbenchExtensionGalleryManifestService.MICROSOFT_AUTH_SCOPES);
 		} catch (error) {
-			// Auth service unavailable — transient error, never invalidate cache
+			if (this.validationEpoch !== epoch) {
+				return;
+			}
+			// Auth service unavailable — transient error, never invalidate cache. Unless we
+			// already have a working manifest to keep showing, surface an "unreachable" message so
+			// a configured marketplace isn't left on a blank (Unavailable) view with no explanation.
 			this.logService.error('[Marketplace] Error getting Microsoft sessions', error);
+			if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
+				this.update(null, ExtensionGalleryManifestStatus.Unreachable);
+			}
 			return;
 		}
+		if (this.validationEpoch !== epoch) {
+			// A newer validation superseded this one while we awaited — discard.
+			return;
+		}
+		const session = sessions[0];
 
-		if (sessions.length === 0) {
-			// Auth service responded definitively: no sessions → invalidate cache
+		if (!session) {
+			// No token. When 'microsoft' is configured the service index MAY itself be
+			// auth-gated (admin's discretion), so an anonymous probe would, at best, return
+			// a guaranteed 401. Rather than issue that certain-to-fail request, go straight
+			// to sign-in. Eligibility and any misconfiguration/unreachable state are only
+			// evaluated once we can present a token (on the post-sign-in re-validation
+			// triggered by onDidChangeSessions). There is deliberately NO fallback to GitHub.
 			this.clearCachedAccess();
 			this.update(null, ExtensionGalleryManifestStatus.RequiresSignIn);
 			return;
 		}
 
+		// We have a token — fetch the service index (presenting the token so a gated index is
+		// readable), then discover the eligibility endpoint from it. The manifest is carried
+		// forward to `applyEligibilityResult` so it is fetched exactly once: this keeps the
+		// 401/403 vs transient classification below the single source of truth for the index
+		// fetch outcome.
+		if (!WorkbenchExtensionGalleryManifestService.isSafeTokenTarget(configuredServiceUrl, configuredServiceUrl)) {
+			// We will not attach a bearer token to a non-HTTPS service index. Without a token
+			// a gated index is unreadable, so this deployment is misconfigured for Entra auth.
+			this.logService.error('[Marketplace] Refusing to send the Microsoft token to a non-HTTPS service index URL — the marketplace is misconfigured for Entra auth.');
+			this.clearCachedAccess();
+			this.update(null, ExtensionGalleryManifestStatus.Misconfigured);
+			return;
+		}
+		let manifest: IExtensionGalleryManifest;
+		try {
+			manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl, session.accessToken);
+		} catch (error) {
+			if (this.validationEpoch !== epoch) {
+				return;
+			}
+			if (error instanceof MarketplaceAuthRequiredError) {
+				if (error.statusCode === 403) {
+					// 403: the token is accepted but this identity is forbidden from reading
+					// the service index — a durable denial. Cache it so we don't re-probe.
+					this.cacheAccess({ authProvider: 'microsoft', accountId: session.account.id, eligible: false, serviceUrl: configuredServiceUrl });
+					this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
+				} else {
+					// 401: the token was missing/expired/invalid (e.g. wrong audience). This
+					// is NOT a durable "ineligible" verdict — re-authentication may fix it —
+					// so do not cache a negative result; ask the user to (re-)sign in. A fresh
+					// sign-in fires onDidChangeSessions and re-runs this check with a new token.
+					this.clearCachedAccess();
+					this.update(null, ExtensionGalleryManifestStatus.RequiresSignIn);
+				}
+				return;
+			}
+			// Transient error fetching the manifest — the marketplace is currently
+			// unreachable. Preserve cache and, unless we already have a working manifest
+			// to keep showing, surface an "unreachable" message.
+			this.logService.error('[Marketplace] Error fetching the service index', error);
+			if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
+				this.update(null, ExtensionGalleryManifestStatus.Unreachable);
+			}
+			return;
+		}
+
+		if (this.validationEpoch !== epoch) {
+			return;
+		}
+
+		const eligibilityUrl = getExtensionGalleryManifestResourceUri(manifest, ExtensionGalleryResourceType.EligibilityService);
+		if (!eligibilityUrl) {
+			// Definitive: the manifest was fetched but advertises no EligibilityService.
+			this.logService.error('[Marketplace] authProvider is "microsoft" but the gallery manifest does not advertise an EligibilityService resource — the marketplace is misconfigured for Entra auth.');
+			this.clearCachedAccess();
+			this.update(null, ExtensionGalleryManifestStatus.Misconfigured);
+			return;
+		}
+
+		if (!WorkbenchExtensionGalleryManifestService.isSafeTokenTarget(eligibilityUrl, configuredServiceUrl)) {
+			// The manifest-advertised eligibility endpoint is not same-origin HTTPS with the
+			// admin-configured service index. Sending the Microsoft token there would risk
+			// leaking it to a foreign or cleartext origin (e.g. a compromised/misconfigured
+			// manifest), so refuse and treat the deployment as misconfigured.
+			this.logService.error('[Marketplace] The EligibilityService URL is not same-origin HTTPS with the configured service index — refusing to transmit the Microsoft token. The marketplace is misconfigured for Entra auth.');
+			this.clearCachedAccess();
+			this.update(null, ExtensionGalleryManifestStatus.Misconfigured);
+			return;
+		}
+
 		// Check eligibility via server
 		try {
-			const result = await this.checkMicrosoftEligibility(eligibilityUrl, sessions[0].accessToken);
-			// Server responded with 200 — this is a definitive result, cache it
+			const result = await this.checkMicrosoftEligibility(eligibilityUrl, session.accessToken);
+			if (this.validationEpoch !== epoch) {
+				return;
+			}
+			// Server responded with 200 — this is a definitive result, cache it. Note we do NOT
+			// persist the server-provided `reason` string: it is not used for any UI/gating
+			// decision and could carry account/tenant diagnostic text, so keeping it out of
+			// application storage avoids persisting unnecessary PII at rest.
 			this.cacheAccess({
 				authProvider: 'microsoft',
-				accountId: sessions[0].account.id,
+				accountId: session.account.id,
 				eligible: result.eligible,
-				reason: result.reason,
+				serviceUrl: configuredServiceUrl,
 			});
 			this.telemetryService.publicLog2<MarketplaceAuthEvent, MarketplaceAuthClassification>(
 				'marketplace:auth:checked',
 				{
 					authProvider: 'microsoft',
 					eligible: result.eligible,
-					reason: result.reason || '',
 				}
 			);
-			await this.applyEligibilityResult(result, configuredServiceUrl);
+			this.applyEligibilityResult(result, manifest);
 		} catch (error) {
+			if (this.validationEpoch !== epoch) {
+				// A newer validation superseded this one while we awaited — discard.
+				return;
+			}
+			if (error instanceof MarketplaceAuthRequiredError) {
+				if (error.statusCode === 403) {
+					// 403: the token is accepted but this identity is forbidden by the
+					// eligibility service — a durable denial. Cache it so we don't re-probe.
+					this.cacheAccess({ authProvider: 'microsoft', accountId: session.account.id, eligible: false, serviceUrl: configuredServiceUrl });
+					this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
+				} else {
+					// 401: the token was missing/expired/invalid (e.g. wrong audience) at the
+					// eligibility endpoint. This is NOT a durable "ineligible" verdict —
+					// re-authentication may fix it — so do not cache a negative result; ask
+					// the user to (re-)sign in. A fresh sign-in re-runs this check.
+					this.clearCachedAccess();
+					this.update(null, ExtensionGalleryManifestStatus.RequiresSignIn);
+				}
+				return;
+			}
 			this.logService.error('[Marketplace] Error checking Microsoft eligibility', error);
-			// Network/server error — never invalidate cache
+			// Network/5xx/malformed response at the eligibility endpoint — never invalidate the
+			// cache. We could not obtain a definitive verdict, so unless we already have a working
+			// manifest to keep showing, surface an "unreachable" message rather than leaving the
+			// user on a blank (Unavailable) marketplace with no explanation.
+			if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
+				this.update(null, ExtensionGalleryManifestStatus.Unreachable);
+			}
 		}
 	}
 
-	private async applyEligibilityResult(
-		result: { eligible: boolean; reason?: string },
-		configuredServiceUrl: string
-	): Promise<void> {
-		if (result.eligible && this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
-			try {
-				const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl);
+	/**
+	 * Applies a definitive (200) eligibility verdict using the already-fetched service index
+	 * manifest. No further network request is made here — the manifest was validated during
+	 * discovery, so an eligible user is taken straight to `Available`.
+	 */
+	private applyEligibilityResult(result: { eligible: boolean; reason?: string }, manifest: IExtensionGalleryManifest): void {
+		if (result.eligible) {
+			if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
 				this.update(manifest);
-			} catch (error) {
-				this.logService.error('[Marketplace] Error retrieving enterprise gallery manifest', error);
-				this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
 			}
-		} else if (!result.eligible) {
+		} else {
 			this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
 		}
 	}
@@ -349,44 +550,209 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 				'Content-Type': 'application/json',
 			},
 			callSite: 'extensionGalleryManifestService.checkMicrosoftEligibility',
+			// A bearer token is attached, so never follow redirects: the request service would
+			// forward the Authorization header to the (possibly cross-origin) redirect target and
+			// leak the token. A 3xx is treated as a non-200 error below.
+			followRedirects: 0,
 		}, CancellationToken.None);
 
 		if (context.res.statusCode !== 200) {
-			// Non-200 is NOT a definitive eligibility result — throw so callers
-			// know this is a transient/server error and don't cache it
+			if (context.res.statusCode === 401 || context.res.statusCode === 403) {
+				// Auth-specific outcome at the eligibility endpoint. Surface the status code
+				// so the caller can distinguish 401 (token missing/expired/wrong-audience —
+				// re-auth may fix it) from 403 (token accepted but identity forbidden — a
+				// durable denial), mirroring the service-index fetch classification.
+				throw new MarketplaceAuthRequiredError(context.res.statusCode);
+			}
+			// Any other non-200 is NOT a definitive eligibility result — throw a generic
+			// error so callers treat it as transient/server error and don't cache it.
 			throw new Error(`Eligibility endpoint returned status ${context.res.statusCode}`);
 		}
 
 		const response = await asJson<IEligibilityResponse>(context);
-		return { eligible: !!response?.eligible, reason: response?.reason };
+		if (!response || typeof response.eligible !== 'boolean') {
+			// A 200 with a missing/non-boolean `eligible` is not a definitive verdict — a server
+			// contract drift must not be coerced into a durable allow/deny. Throw so the caller
+			// treats it as transient and never caches it.
+			throw new Error('Eligibility endpoint returned a malformed response');
+		}
+		return { eligible: response.eligible, reason: response.reason };
+	}
+
+	/**
+	 * Guards bearer-token transport. A Microsoft token must only ever be attached to a request
+	 * whose target is (a) HTTPS and (b) same-origin as the admin-configured service index URL.
+	 * This prevents a compromised or misconfigured gallery manifest from redirecting a resource
+	 * URL (e.g. the EligibilityService) at a foreign or cleartext endpoint and exfiltrating the
+	 * token. Returns false on any parse failure so callers fail closed.
+	 */
+	private static isSafeTokenTarget(targetUrl: string, baseUrl: string): boolean {
+		let target: URI;
+		let base: URI;
+		try {
+			target = URI.parse(targetUrl, true);
+			base = URI.parse(baseUrl, true);
+		} catch {
+			return false;
+		}
+		if (target.scheme !== 'https') {
+			return false;
+		}
+		// Same-origin: scheme + authority (host:port) must match exactly.
+		return target.scheme === base.scheme && target.authority.toLowerCase() === base.authority.toLowerCase();
 	}
 
 	// --- Access caching (provider-agnostic) ---
 
-	private getCachedAccess(): ICachedAccess | null {
+	private getCachedAccess(configuredServiceUrl: string): ICachedAccess | null {
 		const raw = this.storageService.get(
 			WorkbenchExtensionGalleryManifestService.CACHED_ACCESS_KEY,
 			StorageScope.APPLICATION);
 		if (!raw) { return null; }
+		let parsed: unknown;
 		try {
-			return JSON.parse(raw);
+			parsed = JSON.parse(raw);
 		} catch {
+			// Corrupt cache entry — drop it so a bad value can't wedge startup.
+			this.clearCachedAccess();
 			return null;
+		}
+		if (!this.isValidCachedAccess(parsed)) {
+			// Unexpected shape (e.g. written by an incompatible/older build that predates a
+			// cache-schema field) — don't trust it.
+			this.clearCachedAccess();
+			return null;
+		}
+		// The cached verdict is an authorization input, so only trust it for the provider
+		// that is currently in effect. A cache written under a different provider (e.g. the
+		// admin switched `extensions.gallery.authProvider`, or the Entra product gate flipped)
+		// must not grant access here; drop it and let foreground validation re-establish
+		// access for the effective provider. Cross-account staleness within the same provider
+		// is corrected by the background re-validation that runs on every startup and by the
+		// onDidChangeSessions/onDidChangeDefaultAccount handlers which clear the cache.
+		if (parsed.authProvider !== this.getEffectiveAuthProvider()) {
+			this.clearCachedAccess();
+			return null;
+		}
+		// The verdict is also scoped to the marketplace it was computed against. If the admin
+		// has pointed the client at a different `extensions.gallery.serviceUrl` since the cache
+		// was written, the eligibility verdict for the previous marketplace does not apply —
+		// drop it so a stale verdict can't briefly grant access to a different marketplace.
+		if (parsed.serviceUrl !== configuredServiceUrl) {
+			this.clearCachedAccess();
+			return null;
+		}
+		return parsed;
+	}
+
+	private isValidCachedAccess(value: unknown): value is ICachedAccess {
+		if (!value || typeof value !== 'object') {
+			return false;
+		}
+		const candidate = value as Partial<ICachedAccess>;
+		return (candidate.authProvider === 'github' || candidate.authProvider === 'microsoft')
+			&& typeof candidate.accountId === 'string'
+			&& typeof candidate.eligible === 'boolean'
+			&& typeof candidate.serviceUrl === 'string';
+	}
+
+	/**
+	 * Resolves the account currently signed in for the given provider, WITHOUT prompting.
+	 * Returns `'account'` (with the account id, plus the session token for microsoft) when an
+	 * account is present, `'none'` when the provider responded but there is no account (durable),
+	 * and `'error'` when the lookup failed (transient — callers must not invalidate the cache).
+	 */
+	private async resolveCurrentAccount(authProvider: string): Promise<{ kind: 'account'; accountId: string; token?: string } | { kind: 'none' } | { kind: 'error' }> {
+		if (authProvider === 'microsoft') {
+			try {
+				const sessions = await this.authenticationService.getSessions(
+					'microsoft',
+					WorkbenchExtensionGalleryManifestService.MICROSOFT_AUTH_SCOPES);
+				const session = sessions[0];
+				return session
+					? { kind: 'account', accountId: session.account.id, token: session.accessToken }
+					: { kind: 'none' };
+			} catch {
+				return { kind: 'error' };
+			}
+		}
+		try {
+			const account = await this.defaultAccountService.getDefaultAccount();
+			return account ? { kind: 'account', accountId: account.accountName } : { kind: 'none' };
+		} catch {
+			return { kind: 'error' };
 		}
 	}
 
-	private async applyCachedAccess(cached: ICachedAccess, configuredServiceUrl: string): Promise<void> {
-		if (cached.eligible) {
-			try {
-				const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl);
-				this.update(manifest);
-			} catch (error) {
-				this.logService.error('[Marketplace] Error fetching manifest from cached access', error);
-				// Network error fetching manifest — don't invalidate cache,
-				// just skip the update. Background validation will retry.
+	private async applyCachedAccess(cached: ICachedAccess, configuredServiceUrl: string, epoch: number): Promise<void> {
+		// A cached verdict is an authorization input, so only trust it for the account it was
+		// written for. Resolve the current account (silently) and require it to match before
+		// applying an eligible cache — otherwise a stale cross-account entry could briefly grant
+		// access at cold start before background validation corrects it.
+		const current = await this.resolveCurrentAccount(cached.authProvider);
+		if (this.validationEpoch !== epoch) {
+			// A newer validation (e.g. an account/session change that fired while we resolved the
+			// account) superseded this cache application — let it own the outcome and don't touch
+			// status or cache here.
+			return;
+		}
+		if (current.kind === 'error') {
+			// Could not determine the current account (transient auth failure). Don't grant access
+			// from an unverifiable cache, but don't invalidate it either — background validation
+			// will retry. Surface "unreachable" so the marketplace isn't left blank.
+			if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
+				this.update(null, ExtensionGalleryManifestStatus.Unreachable);
 			}
-		} else {
+			return;
+		}
+		if (current.kind === 'none' || current.accountId !== cached.accountId) {
+			// No account, or a different account than the cache was written for — drop it and let
+			// foreground/background validation re-establish access for the current identity.
+			this.clearCachedAccess();
+			return;
+		}
+
+		if (!cached.eligible) {
 			this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
+			return;
+		}
+
+		// Eligible for the current account — fetch the manifest to render Available. On the
+		// Microsoft path present the session token so a gated index is readable, applying the
+		// same-origin token-transport guard first.
+		let accessToken: string | undefined;
+		if (cached.authProvider === 'microsoft') {
+			if (!WorkbenchExtensionGalleryManifestService.isSafeTokenTarget(configuredServiceUrl, configuredServiceUrl)) {
+				this.update(null, ExtensionGalleryManifestStatus.Misconfigured);
+				return;
+			}
+			accessToken = current.token;
+		}
+		try {
+			const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl, accessToken);
+			if (this.validationEpoch !== epoch) {
+				// A newer validation superseded this cache application while we fetched the
+				// manifest — do not apply a manifest for a possibly-stale account.
+				return;
+			}
+			this.update(manifest);
+		} catch (error) {
+			if (this.validationEpoch !== epoch) {
+				return;
+			}
+			if (error instanceof MarketplaceAuthRequiredError) {
+				// The cached token was rejected/expired at cold start. Leave the definitive
+				// classification (RequiresSignIn vs AccessDenied) to the background validation that
+				// runs right after; don't flash a misleading Unreachable.
+				return;
+			}
+			this.logService.error('[Marketplace] Error fetching manifest from cached access', error);
+			// Transient failure fetching the manifest — don't invalidate cache. Background
+			// validation will retry; surface an "unreachable" message in the meantime unless we
+			// already have a working manifest to keep showing.
+			if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
+				this.update(null, ExtensionGalleryManifestStatus.Unreachable);
+			}
 		}
 	}
 
@@ -396,7 +762,7 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			JSON.stringify(data),
 			StorageScope.APPLICATION,
 			StorageTarget.MACHINE);
-		this.logService.debug('[Marketplace] Cached access result:', data.authProvider, data.accountId, data.eligible);
+		this.logService.debug('[Marketplace] Cached access result:', data.authProvider, data.eligible);
 	}
 
 	private clearCachedAccess(): void {
@@ -434,26 +800,58 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		}
 	}
 
-	private async getExtensionGalleryManifestFromServiceUrl(url: string): Promise<IExtensionGalleryManifest> {
+	private async getExtensionGalleryManifestFromServiceUrl(url: string, accessToken?: string): Promise<IExtensionGalleryManifest> {
 		const commonHeaders = await this.commonHeadersPromise;
-		const headers = {
+		const headers: IHeaders = {
 			...commonHeaders,
 			'Content-Type': 'application/json',
 			'Accept-Encoding': 'gzip',
 		};
+		// The service index MAY be protected (admin's discretion). Present a bearer token
+		// when we have one; it is harmless on a public index and required on a gated one.
+		if (accessToken) {
+			headers['Authorization'] = `Bearer ${accessToken}`;
+		}
 
 		try {
 			const context = await this.requestService.request({
 				type: 'GET',
 				url,
 				headers,
+				// When a bearer token is attached, never follow redirects — the request service
+				// would forward the Authorization header to the redirect target (possibly a
+				// different origin) and leak the token. Anonymous fetches may still redirect.
+				followRedirects: accessToken ? 0 : undefined,
 				callSite: 'extensionGalleryManifestService.fetchManifest'
 			}, CancellationToken.None);
+
+			if (context.res.statusCode === 401 || context.res.statusCode === 403) {
+				// The service index is auth-gated and this request was not authorized.
+				// Surface a typed error so the Entra path can prompt for sign-in (or treat a
+				// rejected token as denied) rather than mislabeling it as unreachable.
+				throw new MarketplaceAuthRequiredError(context.res.statusCode);
+			}
+
+			if (context.res.statusCode && (context.res.statusCode < 200 || context.res.statusCode >= 300)) {
+				// Any other non-2xx (404/5xx/…) is an error, not a manifest. Reject before
+				// parsing so a JSON error body can never be mistaken for a valid service index.
+				throw new Error(`Service index returned status ${context.res.statusCode}`);
+			}
 
 			const extensionGalleryManifest = await asJson<IExtensionGalleryManifest>(context);
 
 			if (!extensionGalleryManifest) {
 				throw new Error('Unable to retrieve extension gallery manifest.');
+			}
+
+			if (!Array.isArray(extensionGalleryManifest.resources)) {
+				// A 200 whose body is valid JSON but not a service index (e.g. a server error
+				// object, or an HTML/JSON captive-portal page) must not be treated as a
+				// manifest — `resources` is required to discover gallery endpoints (including
+				// the EligibilityService). Reject here so callers classify it as a failed
+				// fetch, rather than letting resource-URI discovery throw on a non-iterable
+				// `resources` outside this try/catch.
+				throw new Error('Service index response is not a valid extension gallery manifest.');
 			}
 
 			return extensionGalleryManifest;

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -4,29 +4,76 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { IDefaultAccount } from '../../../../base/common/defaultAccount.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { IHeaders } from '../../../../base/parts/request/common/request.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
-import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryManifestStatus } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri, PRIVATE_MARKETPLACE_SCOPE } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { ExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
 import { resolveMarketplaceHeaders } from '../../../../platform/externalServices/common/marketplace.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ISharedProcessService } from '../../../../platform/ipc/electron-browser/services.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { asJson, IRequestService } from '../../../../platform/request/common/request.js';
-import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IRemoteAgentService } from '../../remote/common/remoteAgentService.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHostService } from '../../host/browser/host.js';
-import { IDefaultAccount } from '../../../../base/common/defaultAccount.js';
+import { IAuthenticationService } from '../../authentication/common/authentication.js';
+import { CONTEXT_MARKETPLACE_AUTH_PROVIDER } from '../../../contrib/extensions/common/extensions.js';
+
+interface ICachedAccess {
+	authProvider: 'github' | 'microsoft';
+	accountId: string;
+	eligible: boolean;
+	reason?: string;
+}
+
+interface IEligibilityResponse {
+	readonly accountType?: 'Entra' | 'MSA';
+	readonly eligible?: boolean;
+	readonly reason?: string;
+}
+
+type MarketplaceAuthEvent = {
+	authProvider: string;
+	eligible: boolean;
+	reason: string;
+};
+
+type MarketplaceAuthClassification = {
+	authProvider: {
+		classification: 'SystemMetaData';
+		purpose: 'FeatureInsight';
+		comment: 'The auth provider used (github, microsoft).';
+	};
+	eligible: {
+		classification: 'SystemMetaData';
+		purpose: 'FeatureInsight';
+		isMeasurement: true;
+		comment: 'Whether the user was granted marketplace access.';
+	};
+	reason: {
+		classification: 'SystemMetaData';
+		purpose: 'FeatureInsight';
+		comment: 'The eligibility reason returned by the server.';
+	};
+	owner: 'sandy081';
+	comment: 'Reports marketplace authentication results for enterprise marketplace access.';
+};
 
 export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryManifestService implements IExtensionGalleryManifestService {
+
+	private static readonly MICROSOFT_AUTH_SCOPES = [PRIVATE_MARKETPLACE_SCOPE];
+	private static readonly CACHED_ACCESS_KEY = 'marketplace.cachedAccess';
 
 	private readonly commonHeadersPromise: Promise<IHeaders>;
 	private extensionGalleryManifest: IExtensionGalleryManifest | null = null;
@@ -44,7 +91,7 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		@IEnvironmentService environmentService: IEnvironmentService,
 		@IFileService fileService: IFileService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
-		@IStorageService storageService: IStorageService,
+		@IStorageService private readonly storageService: IStorageService,
 		@IRemoteAgentService remoteAgentService: IRemoteAgentService,
 		@ISharedProcessService sharedProcessService: ISharedProcessService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -53,6 +100,8 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		@ILogService private readonly logService: ILogService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@IHostService private readonly hostService: IHostService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super(productService);
 		this.commonHeadersPromise = resolveMarketplaceHeaders(
@@ -63,6 +112,10 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			fileService,
 			storageService,
 			telemetryService);
+
+		// Set the auth provider context key for UX
+		const authProvider = this.configurationService.getValue<string>(ExtensionGalleryAuthProviderConfigKey);
+		CONTEXT_MARKETPLACE_AUTH_PROVIDER.bindTo(contextKeyService).set(authProvider || 'github');
 
 		const channels = [sharedProcessService.getChannel('extensionGalleryManifest')];
 		const remoteConnection = remoteAgentService.getConnection();
@@ -83,6 +136,14 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		});
 	}
 
+	// Lazily resolved to break a service dependency cycle: eager construction of this
+	// service must not pull in IAuthenticationService (-> IExtensionService -> gallery),
+	// so it is resolved on first asynchronous use instead of via constructor injection.
+	private _authenticationService: IAuthenticationService | undefined;
+	private get authenticationService(): IAuthenticationService {
+		return this._authenticationService ??= this.instantiationService.invokeFunction(accessor => accessor.get(IAuthenticationService));
+	}
+
 	private extensionGalleryManifestPromise: Promise<void> | undefined;
 	override async getExtensionGalleryManifest(): Promise<IExtensionGalleryManifest | null> {
 		if (!this.extensionGalleryManifestPromise) {
@@ -100,47 +161,252 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 
 		const configuredServiceUrl = this.configurationService.getValue<string>(ExtensionGalleryServiceUrlConfigKey);
 		if (configuredServiceUrl) {
+		if (configuredServiceUrl) {
 			this.logService.trace('[Marketplace] Private marketplace configured, checking access and fetching manifest', configuredServiceUrl);
-			await this.handleDefaultAccountAccess(configuredServiceUrl);
-			this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => this.handleDefaultAccountAccess(configuredServiceUrl)));
+			await this.initializePrivateMarketplace(configuredServiceUrl);
 		} else {
 			const defaultExtensionGalleryManifest = await super.getExtensionGalleryManifest();
 			this.update(defaultExtensionGalleryManifest);
 		}
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (!e.affectsConfiguration(ExtensionGalleryServiceUrlConfigKey)) {
-				return;
+			if (e.affectsConfiguration(ExtensionGalleryServiceUrlConfigKey)
+				|| e.affectsConfiguration(ExtensionGalleryAuthProviderConfigKey)) {
+				this.clearCachedAccess();
+				this.requestRestart();
 			}
-			this.requestRestart();
 		}));
 	}
 
-	private async handleDefaultAccountAccess(configuredServiceUrl: string): Promise<void> {
-		const account = await this.defaultAccountService.getDefaultAccount();
+	private async initializePrivateMarketplace(configuredServiceUrl: string): Promise<void> {
+		// 1. Apply cache immediately before any auth calls
+		const cached = this.getCachedAccess();
+		if (cached) {
+			this.logService.debug('[Marketplace] Applying cached access result on startup');
+			await this.applyCachedAccess(cached, configuredServiceUrl);
+		}
 
-		if (!account) {
-			this.logService.debug('[Marketplace] Enterprise marketplace configured but user not signed in');
+		// 2. Resolve auth strategy — sets up event subscriptions and returns the validate function
+		const validateAccess = await this.resolveAccessStrategy(configuredServiceUrl);
+
+		// 3. Validate (foreground if no cache, background if cache was applied)
+		if (cached) {
+			validateAccess();
+		} else {
+			await validateAccess();
+		}
+	}
+
+	/**
+	 * Resolves the effective auth provider, registers event subscriptions for
+	 * re-validation, and returns a function that validates current access.
+	 *
+	 * When configured as 'microsoft', discovers the eligibility URL from the
+	 * gallery manifest (ServiceIndex). Falls back to GitHub if the
+	 * EligibilityService resource is not advertised.
+	 */
+	private async resolveAccessStrategy(configuredServiceUrl: string): Promise<() => Promise<void>> {
+		const configuredAuthProvider = this.configurationService.getValue<string>(ExtensionGalleryAuthProviderConfigKey);
+
+		if (configuredAuthProvider === 'microsoft') {
+			const eligibilityUrl = await this.discoverEligibilityUrl(configuredServiceUrl);
+			if (eligibilityUrl) {
+				const validate = () => this.handleMicrosoftAccess(configuredServiceUrl, eligibilityUrl);
+				this._register(this.authenticationService.onDidChangeSessions(e => {
+					if (e.providerId === 'microsoft') {
+						this.clearCachedAccess();
+						validate();
+					}
+				}));
+				return validate;
+			}
+			this.logService.info('[Marketplace] EligibilityService not advertised — falling back to GitHub auth');
+		}
+
+		// Default: GitHub
+		const validate = () => this.handleGitHubAccess(configuredServiceUrl);
+		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => {
+			this.clearCachedAccess();
+			validate();
+		}));
+		return validate;
+	}
+
+	private async discoverEligibilityUrl(configuredServiceUrl: string): Promise<string | undefined> {
+		try {
+			const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl);
+			return getExtensionGalleryManifestResourceUri(manifest, ExtensionGalleryResourceType.EligibilityService);
+		} catch (error) {
+			this.logService.error('[Marketplace] Error fetching manifest for eligibility URL discovery', error);
+			return undefined;
+		}
+	}
+
+	// --- GitHub access (existing DefaultAccountService-based check) ---
+
+	private async handleGitHubAccess(configuredServiceUrl: string): Promise<void> {
+		try {
+			const account = await this.defaultAccountService.getDefaultAccount();
+			if (!account) {
+				// Auth service responded: no account → invalidate cache
+				this.clearCachedAccess();
+				this.update(null, ExtensionGalleryManifestStatus.RequiresSignIn);
+			} else if (!this.checkAccess(account)) {
+				// Auth service responded: account exists but ineligible → cache the result
+				this.cacheAccess({ authProvider: 'github', accountId: account.accountName, eligible: false });
+				this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
+			} else if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
+				const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl);
+				this.cacheAccess({ authProvider: 'github', accountId: account.accountName, eligible: true });
+				this.update(manifest);
+			}
+		} catch (error) {
+			this.logService.error('[Marketplace] Error in GitHub access check', error);
+			// Network/transient error — never invalidate cache
+		}
+	}
+
+	private checkAccess(account: IDefaultAccount): boolean {
+		if (account.entitlementsData?.access_type_sku
+			&& this.productService.extensionsGallery?.accessSKUs?.includes(
+				account.entitlementsData.access_type_sku)) {
+			return true;
+		}
+		return account.enterprise;
+	}
+
+	// --- Microsoft access (new Entra ID / VSS eligibility check) ---
+
+	private async handleMicrosoftAccess(configuredServiceUrl: string, eligibilityUrl: string): Promise<void> {
+		let sessions: ReadonlyArray<{ id: string; accessToken: string; account: { id: string; label: string }; scopes: ReadonlyArray<string> }>;
+		try {
+			sessions = await this.authenticationService.getSessions(
+				'microsoft',
+				WorkbenchExtensionGalleryManifestService.MICROSOFT_AUTH_SCOPES);
+		} catch (error) {
+			// Auth service unavailable — transient error, never invalidate cache
+			this.logService.error('[Marketplace] Error getting Microsoft sessions', error);
+			return;
+		}
+
+		if (sessions.length === 0) {
+			// Auth service responded definitively: no sessions → invalidate cache
+			this.clearCachedAccess();
 			this.update(null, ExtensionGalleryManifestStatus.RequiresSignIn);
-		} else if (!this.checkAccess(account)) {
-			this.logService.debug('[Marketplace] User signed in but lacks access to enterprise marketplace');
-			this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
-		} else if (this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
+			return;
+		}
+
+		// Check eligibility via server
+		try {
+			const result = await this.checkMicrosoftEligibility(eligibilityUrl, sessions[0].accessToken);
+			// Server responded with 200 — this is a definitive result, cache it
+			this.cacheAccess({
+				authProvider: 'microsoft',
+				accountId: sessions[0].account.id,
+				eligible: result.eligible,
+				reason: result.reason,
+			});
+			this.telemetryService.publicLog2<MarketplaceAuthEvent, MarketplaceAuthClassification>(
+				'marketplace:auth:checked',
+				{
+					authProvider: 'microsoft',
+					eligible: result.eligible,
+					reason: result.reason || '',
+				}
+			);
+			await this.applyEligibilityResult(result, configuredServiceUrl);
+		} catch (error) {
+			this.logService.error('[Marketplace] Error checking Microsoft eligibility', error);
+			// Network/server error — never invalidate cache
+		}
+	}
+
+	private async applyEligibilityResult(
+		result: { eligible: boolean; reason?: string },
+		configuredServiceUrl: string
+	): Promise<void> {
+		if (result.eligible && this.currentStatus !== ExtensionGalleryManifestStatus.Available) {
 			try {
 				const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl);
 				this.update(manifest);
-				this.telemetryService.publicLog2<
-					{},
-					{
-						owner: 'sandy081';
-						comment: 'Reports when a user successfully accesses a custom marketplace';
-					}>('galleryservice:custom:marketplace');
 			} catch (error) {
 				this.logService.error('[Marketplace] Error retrieving enterprise gallery manifest', error);
 				this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
 			}
+		} else if (!result.eligible) {
+			this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
 		}
 	}
+
+	private async checkMicrosoftEligibility(
+		url: string, token: string
+	): Promise<{ eligible: boolean; reason?: string }> {
+		const context = await this.requestService.request({
+			type: 'POST',
+			url,
+			headers: {
+				'Authorization': `Bearer ${token}`,
+				'Content-Type': 'application/json',
+			},
+			callSite: 'extensionGalleryManifestService.checkMicrosoftEligibility',
+		}, CancellationToken.None);
+
+		if (context.res.statusCode !== 200) {
+			// Non-200 is NOT a definitive eligibility result — throw so callers
+			// know this is a transient/server error and don't cache it
+			throw new Error(`Eligibility endpoint returned status ${context.res.statusCode}`);
+		}
+
+		const response = await asJson<IEligibilityResponse>(context);
+		return { eligible: !!response?.eligible, reason: response?.reason };
+	}
+
+	// --- Access caching (provider-agnostic) ---
+
+	private getCachedAccess(): ICachedAccess | null {
+		const raw = this.storageService.get(
+			WorkbenchExtensionGalleryManifestService.CACHED_ACCESS_KEY,
+			StorageScope.APPLICATION);
+		if (!raw) { return null; }
+		try {
+			return JSON.parse(raw);
+		} catch {
+			return null;
+		}
+	}
+
+	private async applyCachedAccess(cached: ICachedAccess, configuredServiceUrl: string): Promise<void> {
+		if (cached.eligible) {
+			try {
+				const manifest = await this.getExtensionGalleryManifestFromServiceUrl(configuredServiceUrl);
+				this.update(manifest);
+			} catch (error) {
+				this.logService.error('[Marketplace] Error fetching manifest from cached access', error);
+				// Network error fetching manifest — don't invalidate cache,
+				// just skip the update. Background validation will retry.
+			}
+		} else {
+			this.update(null, ExtensionGalleryManifestStatus.AccessDenied);
+		}
+	}
+
+	private cacheAccess(data: ICachedAccess): void {
+		this.storageService.store(
+			WorkbenchExtensionGalleryManifestService.CACHED_ACCESS_KEY,
+			JSON.stringify(data),
+			StorageScope.APPLICATION,
+			StorageTarget.MACHINE);
+		this.logService.debug('[Marketplace] Cached access result:', data.authProvider, data.accountId, data.eligible);
+	}
+
+	private clearCachedAccess(): void {
+		this.storageService.remove(
+			WorkbenchExtensionGalleryManifestService.CACHED_ACCESS_KEY,
+			StorageScope.APPLICATION);
+		this.logService.debug('[Marketplace] Cleared cached access');
+	}
+
+	// --- Status management ---
 
 	private update(manifest: IExtensionGalleryManifest | null, status?: ExtensionGalleryManifestStatus): void {
 		this.logService.debug(`[Marketplace] Updating manifest ${manifest ? 'available' : 'unavailable'}`);
@@ -156,16 +422,6 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			this.currentStatus = status;
 			this._onDidChangeExtensionGalleryManifestStatus.fire(status);
 		}
-	}
-
-	private checkAccess(account: IDefaultAccount): boolean {
-		this.logService.debug('[Marketplace] Checking Account SKU access for configured gallery', account.entitlementsData?.access_type_sku);
-		if (account.entitlementsData?.access_type_sku && this.productService.extensionsGallery?.accessSKUs?.includes(account.entitlementsData.access_type_sku)) {
-			this.logService.debug('[Marketplace] Account has access to configured gallery');
-			return true;
-		}
-		this.logService.debug('[Marketplace] Checking enterprise account access for configured gallery', account.enterprise);
-		return account.enterprise;
 	}
 
 	private async requestRestart(): Promise<void> {

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -189,7 +189,13 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		}
 		const updateChannels = (manifest: IExtensionGalleryManifest | null) => {
 			this.logService.trace(`[Marketplace] Updating channels with manifest ${manifest ? 'available' : 'unavailable'}`);
-			channels.forEach(channel => channel.call('setExtensionGalleryManifest', [manifest]));
+			// Push the negotiated resource token alongside the manifest so the shared process and
+			// remote server (which never negotiate it themselves) can authenticate the protected
+			// marketplace requests they initiate — extension getManifest and VSIX download. The
+			// token is coherent with the manifest here: it is set before the eligible→Available
+			// transition and cleared on every non-Available transition, so a null manifest always
+			// carries an undefined token.
+			channels.forEach(channel => channel.call('setExtensionGalleryManifest', [manifest, this.negotiatedAccessToken]));
 		};
 		// Defer the initial manifest bootstrap to a microtask so this service is fully
 		// constructed and cached in the DI container before it runs. The Entra (microsoft)

--- a/src/vs/workbench/services/extensionManagement/test/electron-browser/extensionGalleryManifestService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/electron-browser/extensionGalleryManifestService.test.ts
@@ -11,7 +11,7 @@ import { IRequestContext, IRequestOptions } from '../../../../../base/parts/requ
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
@@ -55,7 +55,7 @@ function createMicrosoftSession(accessToken = 'ms-token'): AuthenticationSession
 		id: 'ms-session-1',
 		accessToken,
 		account: { id: 'ms-account-1', label: 'user@contoso.com' },
-		scopes: ['api://{private-marketplace-client-id}/access_as_user'],
+		scopes: ['openid', 'profile', 'email', 'offline_access'],
 	};
 }
 
@@ -76,17 +76,19 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 	let instantiationService: TestInstantiationService;
 	let onDidChangeDefaultAccount: Emitter<IDefaultAccount | null>;
 	let onDidChangeSessions: Emitter<{ providerId: string; label: string; event: AuthenticationSessionsChangeEvent }>;
-	let requestHandler: (options: IRequestOptions) => IRequestContext;
+	let requestHandler: (options: IRequestOptions) => IRequestContext | Promise<IRequestContext>;
 	let defaultAccount: IDefaultAccount | null;
 	let microsoftSessions: AuthenticationSession[];
 	let configurationService: TestConfigurationService;
 	let storageData: Map<string, string>;
+	let entraAuthEnabled: boolean;
 
 	setup(() => {
 		defaultAccount = null;
 		microsoftSessions = [];
 		requestHandler = () => mockResponse(200, createGalleryManifest());
 		storageData = new Map();
+		entraAuthEnabled = true;
 
 		onDidChangeDefaultAccount = disposableStore.add(new Emitter<IDefaultAccount | null>());
 		onDidChangeSessions = disposableStore.add(new Emitter<{ providerId: string; label: string; event: AuthenticationSessionsChangeEvent }>());
@@ -104,6 +106,7 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 				accessSKUs: ['copilot_business'],
 			},
 			nameLong: 'VS Code Test',
+			get enableExtensionGalleryEntraAuth() { return entraAuthEnabled; },
 		} as any);
 
 		instantiationService.stub(IEnvironmentService, new class extends mock<IEnvironmentService>() {
@@ -282,18 +285,345 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.AccessDenied);
 	});
 
-	test('Microsoft provider — no EligibilityService in manifest → falls back to GitHub', async () => {
+	test('Microsoft provider — no EligibilityService in manifest → Misconfigured (no GitHub fallback)', async () => {
 		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
 		microsoftSessions = [createMicrosoftSession()];
-		defaultAccount = null;
+		defaultAccount = createDefaultAccount({ enterprise: true });
 		// Manifest has no EligibilityService resource
 		requestHandler = () => mockResponse(200, createGalleryManifest(false));
 
 		const service = createService();
 		await service.getExtensionGalleryManifest();
 
-		// Falls back to GitHub path — no account → RequiresSignIn
+		// The admin explicitly configured microsoft — refuse access, do NOT fall back to GitHub
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Misconfigured);
+	});
+
+	test('Microsoft provider — cross-origin EligibilityService URL → Misconfigured (token not sent)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		let eligibilityCalled = false;
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				eligibilityCalled = true;
+				return mockResponse(200, { eligible: true });
+			}
+			// Manifest points the eligibility endpoint at a foreign origin.
+			return mockResponse(200, { version: '1.0', resources: [{ id: 'https://evil.example.com/eligibility', type: 'EligibilityService' }] });
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Misconfigured);
+		assert.strictEqual(eligibilityCalled, false);
+	});
+
+	test('Microsoft provider — cleartext (http) EligibilityService URL → Misconfigured (token not sent)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		let eligibilityCalled = false;
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				eligibilityCalled = true;
+				return mockResponse(200, { eligible: true });
+			}
+			// Manifest points the eligibility endpoint at a cleartext (http) endpoint.
+			return mockResponse(200, { version: '1.0', resources: [{ id: 'http://marketplace.example.com/eligibility', type: 'EligibilityService' }] });
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Misconfigured);
+		assert.strictEqual(eligibilityCalled, false);
+	});
+
+	test('Microsoft provider — non-HTTPS service index URL → Misconfigured (no request issued)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		configurationService.setUserConfiguration(ExtensionGalleryServiceUrlConfigKey, 'http://marketplace.example.com');
+		microsoftSessions = [createMicrosoftSession()];
+		let requestIssued = false;
+		requestHandler = () => {
+			requestIssued = true;
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Misconfigured);
+		assert.strictEqual(requestIssued, false);
+	});
+
+	test('Microsoft provider — service index returns 500 with JSON body → Unreachable (not parsed as manifest)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// A 5xx error body is valid JSON and truthy; it must be rejected outright rather than
+		// mistaken for a manifest (which would otherwise land in Misconfigured).
+		requestHandler = () => mockResponse(500, { error: 'internal' });
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
+	});
+
+	test('Microsoft provider — manifest fetch fails, no cache → Unreachable', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// Manifest discovery fails transiently (network error)
+		requestHandler = () => { throw new Error('network down'); };
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// A configured marketplace whose manifest can't be fetched is Unreachable so the
+		// UI can surface a message (distinct from the initial no-gallery Unavailable).
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
+	});
+
+	test('Microsoft provider — no session → RequiresSignIn without probing the service index', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [];
+		// When 'microsoft' is configured and there is no session, we must NOT issue an
+		// anonymous request to the (possibly auth-gated) service index — that request is a
+		// guaranteed 401. We go straight to sign-in and only touch the index once a token
+		// exists. Assert no request was made.
+		let indexRequests = 0;
+		requestHandler = () => {
+			indexRequests++;
+			return mockResponse(401, { message: 'auth required' });
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
 		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+		assert.strictEqual(indexRequests, 0);
+	});
+
+	test('Microsoft provider — auth-gated service index, session token presented → Available', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// The index is gated: it returns 401 for anonymous reads but 200 once a bearer token
+		// is presented. This asserts the token is actually threaded into the manifest fetch.
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true, reason: 'EntraID' });
+			}
+			const hasAuth = !!(options.headers && options.headers['Authorization']);
+			return hasAuth
+				? mockResponse(200, createGalleryManifest(true))
+				: mockResponse(401, { message: 'auth required' });
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+	});
+
+	test('Microsoft provider — auth-gated service index, token forbidden (403) → AccessDenied', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// A token is presented but the server returns 403 — the identity is accepted but
+		// forbidden from reading the index. This is a durable denial and is cached.
+		requestHandler = () => mockResponse(403, { message: 'forbidden' });
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.AccessDenied);
+		const cached = storageData.get('marketplace.cachedAccess');
+		assert.ok(cached);
+		const parsed = JSON.parse(cached);
+		assert.strictEqual(parsed.authProvider, 'microsoft');
+		assert.strictEqual(parsed.accountId, 'ms-account-1');
+		assert.strictEqual(parsed.eligible, false);
+		assert.strictEqual(parsed.serviceUrl, 'https://marketplace.example.com');
+	});
+
+	test('Microsoft provider — service index returns a non-manifest 200 → Unreachable (not a crash, not cached)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// A 200 whose JSON body has no `resources` array must be rejected before eligibility
+		// discovery — otherwise resource-URI lookup throws on a non-iterable and escapes the
+		// fetch try/catch. It is a failed fetch, so it surfaces Unreachable and is not cached.
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true });
+			}
+			return mockResponse(200, { error: 'not a manifest' });
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('Microsoft provider — auth-gated service index, token rejected (401) → RequiresSignIn (not cached)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// A token is presented but the server returns 401 — the token was missing/expired/
+		// invalid (e.g. wrong audience). This is NOT a durable "ineligible" verdict, so we
+		// ask the user to re-authenticate and must NOT cache a negative result.
+		requestHandler = () => mockResponse(401, { message: 'auth required' });
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('Microsoft provider — eligibility endpoint forbids (403) → AccessDenied (cached ineligible)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// The service index is readable with the token, but the eligibility endpoint returns
+		// 403 — the identity is accepted yet not entitled. This is a durable denial and is
+		// cached so we don't re-probe on every startup.
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(403, { message: 'forbidden' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.AccessDenied);
+		assert.strictEqual(JSON.parse(storageData.get('marketplace.cachedAccess')!).eligible, false);
+	});
+
+	test('Microsoft provider — eligibility endpoint rejects token (401) → RequiresSignIn (not cached)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// The index is readable, but the eligibility endpoint returns 401 — the token was
+		// missing/expired/wrong-audience for that endpoint. This is NOT a durable verdict
+		// (re-auth may fix it), so we ask the user to (re-)sign in and must NOT cache it.
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(401, { message: 'auth required' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('Microsoft provider — stale validation superseded by sign-out does not restore access', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+
+		// Hold the eligibility POST open so the first (epoch 1) validation parks mid-flight
+		// after it has already read a valid session and a well-formed index.
+		let releaseEligibility!: (v: IRequestContext) => void;
+		const eligibilityGate = new Promise<IRequestContext>(resolve => { releaseEligibility = resolve; });
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return eligibilityGate;
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		const inflight = service.getExtensionGalleryManifest();
+
+		// Let the first validation advance to the point where it awaits the eligibility POST.
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// The user signs out — this supersedes the in-flight validation (epoch bumps).
+		microsoftSessions = [];
+		onDidChangeSessions.fire({ providerId: 'microsoft', label: 'Microsoft', event: { added: [], removed: [], changed: [] } });
+
+		// The superseding validation resolves to RequiresSignIn.
+		await new Promise(resolve => setTimeout(resolve, 0));
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+
+		// The stale eligibility POST finally returns "eligible" — it must be discarded.
+		releaseEligibility(mockResponse(200, { eligible: true, reason: 'EntraID' }));
+		await inflight.catch(() => { });
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+	});
+
+	test('Microsoft provider — stale validation superseded by config change does not re-cache access', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// Seed an eligible cache so startup applies it (Available) and kicks off a background
+		// re-validation that we can park mid-flight.
+		storageData.set('marketplace.cachedAccess', JSON.stringify({
+			authProvider: 'microsoft',
+			accountId: 'ms-account-1',
+			eligible: true,
+			serviceUrl: 'https://marketplace.example.com',
+		}));
+
+		// Hold the eligibility POST open so the background (epoch 1) validation parks after it
+		// has already read a session and a well-formed index.
+		let releaseEligibility!: (v: IRequestContext) => void;
+		const eligibilityGate = new Promise<IRequestContext>(resolve => { releaseEligibility = resolve; });
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return eligibilityGate;
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// Let the background validation advance to the point where it awaits the eligibility POST.
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// The marketplace/auth-provider configuration changes — this clears the cache and asks
+		// the user to restart (which they may decline). It must also supersede the in-flight
+		// validation so its late result cannot re-populate the cache we just cleared.
+		configurationService.onDidChangeConfigurationEmitter.fire({ affectsConfiguration: () => true } as unknown as IConfigurationChangeEvent);
+		await new Promise(resolve => setTimeout(resolve, 0));
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+
+		// The stale eligibility POST finally returns "eligible" — it must be discarded and must
+		// NOT re-write the cache.
+		releaseEligibility(mockResponse(200, { eligible: true, reason: 'EntraID' }));
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('GitHub provider — eligible account, manifest fetch fails → Unreachable', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = createDefaultAccount({ enterprise: true });
+		requestHandler = () => { throw new Error('network down'); };
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
+	});
+
+	test('Microsoft provider — Entra auth product-gated off → uses GitHub path', async () => {
+		entraAuthEnabled = false;
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		defaultAccount = createDefaultAccount({ enterprise: true });
+		// Manifest advertises EligibilityService, but the Entra path is gated off.
+		requestHandler = () => mockResponse(200, createGalleryManifest(true));
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// Entra path is skipped → GitHub path with enterprise account → Available
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
 	});
 
 	// --- Cache behavior ---
@@ -305,6 +635,7 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 			authProvider: 'github',
 			accountId: 'testuser',
 			eligible: true,
+			serviceUrl: 'https://marketplace.example.com',
 		}));
 
 		const service = createService();
@@ -320,22 +651,155 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 			authProvider: 'github',
 			accountId: 'testuser',
 			eligible: false,
+			serviceUrl: 'https://marketplace.example.com',
 		}));
 
 		const service = createService();
 		await service.getExtensionGalleryManifest();
 
-		// Even though there's no account, the cache initially said AccessDenied
-		// Then background validate fires and sees no account → RequiresSignIn
-		// Since background runs in the same tick (no real async for getSessions mock),
-		// the final state may be RequiresSignIn
-		assert.ok(
-			service.extensionGalleryManifestStatus === ExtensionGalleryManifestStatus.AccessDenied
-			|| service.extensionGalleryManifestStatus === ExtensionGalleryManifestStatus.RequiresSignIn
-		);
+		// The cache was written for account 'testuser' but there is no current account, so the
+		// cache is not trusted (dropped). Background github validation then sees no account and
+		// lands on RequiresSignIn.
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
 	});
 
-	test('Microsoft — server error (500), no cache → status unchanged', async () => {
+	test('cache for a different account of the same provider is dropped, not applied', async () => {
+		// The cache says the CURRENT provider's user is eligible, but it was written for a
+		// different account id than the one now signed in. A cached verdict is an authorization
+		// input scoped to an account, so it must not grant (or deny) access to a different
+		// account — it is dropped and fresh validation runs for the current identity.
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()]; // account id 'ms-account-1'
+		storageData.set('marketplace.cachedAccess', JSON.stringify({
+			authProvider: 'microsoft',
+			accountId: 'ms-account-2', // different account
+			eligible: true,
+			serviceUrl: 'https://marketplace.example.com',
+		}));
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true, reason: 'EntraID' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+		// Background validation for the current account runs fire-and-forget; give it a tick.
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// Background validation re-establishes access for the CURRENT account (ms-account-1),
+		// writing a fresh cache for it — proving the stale ms-account-2 entry was not applied.
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+		const cached = storageData.get('marketplace.cachedAccess');
+		assert.ok(cached);
+		assert.strictEqual(JSON.parse(cached).accountId, 'ms-account-1');
+	});
+
+	test('cache written for a different serviceUrl is dropped, not applied', async () => {
+		// A verdict is scoped to the marketplace it was computed against. Only the serviceUrl
+		// differs here (same provider + account), isolating service-URL scoping from account
+		// matching. The current account is NOT eligible, so if the stale eligible cache were
+		// wrongly trusted we'd see Available instead of AccessDenied.
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = createDefaultAccount(); // testuser, not enterprise → ineligible
+		storageData.set('marketplace.cachedAccess', JSON.stringify({
+			authProvider: 'github',
+			accountId: 'testuser',
+			eligible: true,
+			serviceUrl: 'https://old-marketplace.example.com', // differs from the configured URL
+		}));
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// Stale-URL cache dropped; fresh validation for the current marketplace denies access.
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.AccessDenied);
+		const cached = storageData.get('marketplace.cachedAccess');
+		assert.ok(cached);
+		const parsed = JSON.parse(cached);
+		assert.strictEqual(parsed.eligible, false);
+		assert.strictEqual(parsed.serviceUrl, 'https://marketplace.example.com');
+	});
+
+	test('session change during cached manifest fetch does not apply a stale manifest', async () => {
+		// The cache is applied with an epoch guard while listeners are already active. If the
+		// signed-in session changes while the cached manifest fetch is in flight, the stale
+		// fetch result must be discarded rather than applied for the previous account.
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		storageData.set('marketplace.cachedAccess', JSON.stringify({
+			authProvider: 'microsoft',
+			accountId: 'ms-account-1',
+			eligible: true,
+			serviceUrl: 'https://marketplace.example.com',
+		}));
+
+		// Park the cached-path index fetch so applyCachedAccess suspends mid-fetch.
+		let releaseIndex!: (v: IRequestContext) => void;
+		const indexGate = new Promise<IRequestContext>(resolve => { releaseIndex = resolve; });
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true });
+			}
+			return indexGate;
+		};
+
+		const service = createService();
+		const inflight = service.getExtensionGalleryManifest();
+
+		// Let cache application advance to the parked index fetch.
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// The user signs out while the cached fetch is parked — this supersedes it (epoch bumps).
+		microsoftSessions = [];
+		onDidChangeSessions.fire({ providerId: 'microsoft', label: 'Microsoft', event: { added: [], removed: [], changed: [] } });
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// Release the stale cached index fetch; its manifest must be discarded, not applied.
+		releaseIndex(mockResponse(200, createGalleryManifest(true)));
+		await inflight.catch(() => { });
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+	});
+
+	test('cache from a different provider is dropped, not trusted', async () => {
+		// The cache says the user is microsoft-eligible, but the effective provider is now
+		// github with no account. The stale microsoft cache is an authorization input for a
+		// different provider and must not grant access — it is dropped and github validation
+		// runs, ending at RequiresSignIn.
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = null;
+		storageData.set('marketplace.cachedAccess', JSON.stringify({
+			authProvider: 'microsoft',
+			accountId: 'ms-account-1',
+			eligible: true,
+			serviceUrl: 'https://marketplace.example.com',
+		}));
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('malformed cache entry is dropped without throwing', async () => {
+		// A cache entry with an unexpected shape (e.g. written by an incompatible build) must
+		// be discarded rather than trusted or allowed to crash startup.
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = null;
+		storageData.set('marketplace.cachedAccess', JSON.stringify({ unexpected: 'shape' }));
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('Microsoft — eligibility server error (500), no cache → Unreachable', async () => {
 		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
 		microsoftSessions = [createMicrosoftSession()];
 		requestHandler = (options) => {
@@ -348,8 +812,10 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 		const service = createService();
 		await service.getExtensionGalleryManifest();
 
-		// Server error with no cache — status stays at initial Unavailable
-		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unavailable);
+		// The service index was reachable but the eligibility verdict could not be obtained and
+		// there is no cache to fall back on — surface an "unreachable" message instead of leaving
+		// a blank (Unavailable) marketplace.
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
 	});
 
 	test('Microsoft — server error (500), with cache → cache preserved', async () => {
@@ -359,6 +825,7 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 			authProvider: 'microsoft',
 			accountId: 'ms-account-1',
 			eligible: true,
+			serviceUrl: 'https://marketplace.example.com',
 		}));
 		requestHandler = (options) => {
 			if (options.url?.includes('eligibility')) {
@@ -381,6 +848,7 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 			authProvider: 'microsoft',
 			accountId: 'ms-account-1',
 			eligible: true,
+			serviceUrl: 'https://marketplace.example.com',
 		}));
 		requestHandler = () => mockResponse(200, createGalleryManifest(true));
 
@@ -395,8 +863,10 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 		const service = createService();
 		await service.getExtensionGalleryManifest();
 
-		// Cache was applied on startup (Available), auth error doesn't invalidate
-		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+		// The current account can't be resolved (transient auth failure), so the eligible cache
+		// can't be verified for the current identity and must not be applied — but it is also NOT
+		// invalidated. The user sees "unreachable" while the cache is retained for a later retry.
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
 		assert.ok(storageData.has('marketplace.cachedAccess'));
 	});
 
@@ -432,7 +902,98 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 		const parsed = JSON.parse(cached);
 		assert.strictEqual(parsed.authProvider, 'microsoft');
 		assert.strictEqual(parsed.eligible, true);
-		assert.strictEqual(parsed.reason, 'EntraID');
+		// The server-provided `reason` must NOT be persisted (avoids unnecessary PII at rest).
+		assert.strictEqual(parsed.reason, undefined);
+	});
+
+	test('Microsoft — malformed eligibility 200 (no boolean) is treated as transient, not cached', async () => {
+		// A 200 whose body lacks a boolean `eligible` field is a server contract drift, not a
+		// definitive allow/deny. It must not be coerced into a durable verdict or cached.
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { notEligibleField: true });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// No definitive verdict + no cache → Unreachable, and nothing is cached.
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('corrupt (non-JSON) cache entry is dropped without throwing', async () => {
+		// A cache value that isn't valid JSON (e.g. truncated/corrupt storage) must be discarded
+		// rather than crash startup with a parse error.
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = null;
+		storageData.set('marketplace.cachedAccess', '{not valid json');
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('Microsoft — token-bearing requests disable redirect following (no header leak)', async () => {
+		// A bearer token must never be forwarded across a redirect (the request service would
+		// re-send the Authorization header to the redirect target). Both the token-bearing index
+		// fetch and the eligibility POST must set followRedirects: 0.
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		const seen: { url: string; followRedirects: number | undefined }[] = [];
+		requestHandler = (options) => {
+			seen.push({ url: options.url ?? '', followRedirects: options.followRedirects });
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true, reason: 'EntraID' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		const indexReq = seen.find(r => !r.url.includes('eligibility'));
+		const eligReq = seen.find(r => r.url.includes('eligibility'));
+		assert.strictEqual(indexReq?.followRedirects, 0);
+		assert.strictEqual(eligReq?.followRedirects, 0);
+	});
+
+	test('Microsoft — getSessions throws with no cache → Unreachable (not silent Unavailable)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		instantiationService.stub(IAuthenticationService, new class extends mock<IAuthenticationService>() {
+			override readonly onDidChangeSessions = onDidChangeSessions.event;
+			override async getSessions(): Promise<readonly AuthenticationSession[]> {
+				throw new Error('Auth service unavailable');
+			}
+		}());
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// No cache to fall back on and the account couldn't be resolved — the configured
+		// marketplace must show "unreachable" rather than a blank (Unavailable) view.
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
+	});
+
+	test('GitHub — getDefaultAccount throws with no cache → Unreachable (not silent Unavailable)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		instantiationService.stub(IDefaultAccountService, new class extends mock<IDefaultAccountService>() {
+			override readonly onDidChangeDefaultAccount = onDidChangeDefaultAccount.event;
+			override async getDefaultAccount(): Promise<IDefaultAccount> {
+				throw new Error('Account service unavailable');
+			}
+		}());
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
 	});
 
 	// --- Cache invalidation ---
@@ -496,8 +1057,8 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 		const service = createService();
 		await service.getExtensionGalleryManifest();
 
-		// Should use the parent class default behavior (null or default manifest)
-		// Status should be Unavailable since the default mock doesn't return a real manifest URL
-		assert.ok(service.extensionGalleryManifestStatus !== ExtensionGalleryManifestStatus.RequiresSignIn);
+		// With no configured marketplace serviceUrl the Entra/private-marketplace path is never
+		// engaged; the base class falls back to the product's default gallery → Available.
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
 	});
 });

--- a/src/vs/workbench/services/extensionManagement/test/electron-browser/extensionGalleryManifestService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/electron-browser/extensionGalleryManifestService.test.ts
@@ -1,0 +1,503 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { bufferToStream, VSBuffer } from '../../../../../base/common/buffer.js';
+import { IDefaultAccount } from '../../../../../base/common/defaultAccount.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { IRequestContext, IRequestOptions } from '../../../../../base/parts/request/common/request.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { ExtensionGalleryManifestStatus, ExtensionGalleryAuthProviderConfigKey, ExtensionGalleryServiceUrlConfigKey } from '../../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ISharedProcessService } from '../../../../../platform/ipc/electron-browser/services.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IRequestService } from '../../../../../platform/request/common/request.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { AuthenticationSession, AuthenticationSessionsChangeEvent, IAuthenticationService } from '../../../authentication/common/authentication.js';
+import { IHostService } from '../../../host/browser/host.js';
+import { IRemoteAgentService } from '../../../remote/common/remoteAgentService.js';
+import { WorkbenchExtensionGalleryManifestService } from '../../electron-browser/extensionGalleryManifestService.js';
+
+function mockResponse(statusCode: number, body: object): IRequestContext {
+	return {
+		res: { headers: {}, statusCode },
+		stream: bufferToStream(VSBuffer.fromString(JSON.stringify(body))),
+	};
+}
+
+function createDefaultAccount(overrides: Partial<IDefaultAccount> = {}): IDefaultAccount {
+	return {
+		authenticationProvider: { id: 'github', name: 'GitHub', enterprise: false },
+		accountName: 'testuser',
+		sessionId: 'session-1',
+		enterprise: false,
+		entitlementsData: undefined,
+		...overrides,
+	};
+}
+
+function createMicrosoftSession(accessToken = 'ms-token'): AuthenticationSession {
+	return {
+		id: 'ms-session-1',
+		accessToken,
+		account: { id: 'ms-account-1', label: 'user@contoso.com' },
+		scopes: ['api://{private-marketplace-client-id}/access_as_user'],
+	};
+}
+
+// Gallery manifest response stub
+function createGalleryManifest(includeEligibility = false) {
+	return {
+		version: '1.0',
+		resources: includeEligibility
+			? [{ id: 'https://marketplace.example.com/_apis/public/gallery/eligibility', type: 'EligibilityService' }]
+			: [],
+	};
+}
+
+suite('WorkbenchExtensionGalleryManifestService', () => {
+
+	const disposableStore = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+	let onDidChangeDefaultAccount: Emitter<IDefaultAccount | null>;
+	let onDidChangeSessions: Emitter<{ providerId: string; label: string; event: AuthenticationSessionsChangeEvent }>;
+	let requestHandler: (options: IRequestOptions) => IRequestContext;
+	let defaultAccount: IDefaultAccount | null;
+	let microsoftSessions: AuthenticationSession[];
+	let configurationService: TestConfigurationService;
+	let storageData: Map<string, string>;
+
+	setup(() => {
+		defaultAccount = null;
+		microsoftSessions = [];
+		requestHandler = () => mockResponse(200, createGalleryManifest());
+		storageData = new Map();
+
+		onDidChangeDefaultAccount = disposableStore.add(new Emitter<IDefaultAccount | null>());
+		onDidChangeSessions = disposableStore.add(new Emitter<{ providerId: string; label: string; event: AuthenticationSessionsChangeEvent }>());
+
+		configurationService = new TestConfigurationService({
+			[ExtensionGalleryServiceUrlConfigKey]: 'https://marketplace.example.com',
+		});
+
+		instantiationService = disposableStore.add(new TestInstantiationService());
+
+		instantiationService.stub(IProductService, {
+			version: '1.0.0',
+			extensionsGallery: {
+				serviceUrl: 'https://default-marketplace.example.com',
+				accessSKUs: ['copilot_business'],
+			},
+			nameLong: 'VS Code Test',
+		} as any);
+
+		instantiationService.stub(IEnvironmentService, new class extends mock<IEnvironmentService>() {
+		}());
+
+		instantiationService.stub(IFileService, new class extends mock<IFileService>() {
+		}());
+
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+
+		instantiationService.stub(IStorageService, new class extends mock<IStorageService>() {
+			override get(key: string, _scope: StorageScope, fallbackValue: string): string;
+			override get(key: string, _scope: StorageScope, fallbackValue?: string): string | undefined;
+			override get(key: string, _scope: StorageScope, fallbackValue?: string): string | undefined {
+				return storageData.get(key) ?? fallbackValue;
+			}
+			override store(key: string, value: string, _scope: StorageScope, _target: StorageTarget): void {
+				storageData.set(key, value);
+			}
+			override remove(key: string, _scope: StorageScope): void {
+				storageData.delete(key);
+			}
+		}());
+
+		instantiationService.stub(IRemoteAgentService, new class extends mock<IRemoteAgentService>() {
+			override getConnection() { return null; }
+		}());
+
+		instantiationService.stub(ISharedProcessService, new class extends mock<ISharedProcessService>() {
+			override getChannel(_channelName: string): any {
+				return {
+					call: () => Promise.resolve(),
+					listen: () => Event.None,
+				};
+			}
+		}());
+
+		instantiationService.stub(IConfigurationService, configurationService);
+
+		instantiationService.stub(IRequestService, new class extends mock<IRequestService>() {
+			override async request(options: IRequestOptions) {
+				return requestHandler(options);
+			}
+		}());
+
+		instantiationService.stub(IDefaultAccountService, new class extends mock<IDefaultAccountService>() {
+			override readonly onDidChangeDefaultAccount = onDidChangeDefaultAccount.event;
+			override async getDefaultAccount() { return defaultAccount; }
+		}());
+
+		instantiationService.stub(ILogService, new NullLogService());
+
+		instantiationService.stub(IDialogService, new class extends mock<IDialogService>() {
+			override async confirm() { return { confirmed: false }; }
+		}());
+
+		instantiationService.stub(IHostService, new class extends mock<IHostService>() {
+			override async restart() { }
+		}());
+
+		instantiationService.stub(IAuthenticationService, new class extends mock<IAuthenticationService>() {
+			override readonly onDidChangeSessions = onDidChangeSessions.event;
+			override async getSessions(providerId: string) {
+				if (providerId === 'microsoft') {
+					return microsoftSessions;
+				}
+				return [];
+			}
+			override async createSession(providerId: string) {
+				return createMicrosoftSession();
+			}
+		}());
+
+		instantiationService.stub(IContextKeyService, disposableStore.add(new MockContextKeyService()));
+	});
+
+	function createService(): WorkbenchExtensionGalleryManifestService {
+		return disposableStore.add(instantiationService.createInstance(WorkbenchExtensionGalleryManifestService));
+	}
+
+	// --- Provider routing ---
+
+	test('GitHub provider — enterprise account → Available', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = createDefaultAccount({ enterprise: true });
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+	});
+
+	test('GitHub provider — no account → RequiresSignIn', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = null;
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+	});
+
+	test('GitHub provider — non-enterprise account without SKU → AccessDenied', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = createDefaultAccount({ enterprise: false });
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.AccessDenied);
+	});
+
+	test('GitHub provider — account with matching SKU → Available', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = createDefaultAccount({
+			enterprise: false,
+			entitlementsData: { access_type_sku: 'copilot_business' } as any,
+		});
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+	});
+
+	test('default (no authProvider) — uses GitHub path', async () => {
+		// No authProvider config set
+		defaultAccount = createDefaultAccount({ enterprise: true });
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+	});
+
+	test('Microsoft provider — no session → RequiresSignIn', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [];
+		requestHandler = () => mockResponse(200, createGalleryManifest(true));
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+	});
+
+	test('Microsoft provider — eligible session → Available', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true, reason: 'EntraID' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+	});
+
+	test('Microsoft provider — ineligible session → AccessDenied', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: false, reason: 'MSA without VSS' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.AccessDenied);
+	});
+
+	test('Microsoft provider — no EligibilityService in manifest → falls back to GitHub', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		defaultAccount = null;
+		// Manifest has no EligibilityService resource
+		requestHandler = () => mockResponse(200, createGalleryManifest(false));
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// Falls back to GitHub path — no account → RequiresSignIn
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+	});
+
+	// --- Cache behavior ---
+
+	test('cache hit on startup — eligible result applied immediately', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = createDefaultAccount({ enterprise: true });
+		storageData.set('marketplace.cachedAccess', JSON.stringify({
+			authProvider: 'github',
+			accountId: 'testuser',
+			eligible: true,
+		}));
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+	});
+
+	test('cache hit on startup — ineligible result applied', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = null;
+		storageData.set('marketplace.cachedAccess', JSON.stringify({
+			authProvider: 'github',
+			accountId: 'testuser',
+			eligible: false,
+		}));
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// Even though there's no account, the cache initially said AccessDenied
+		// Then background validate fires and sees no account → RequiresSignIn
+		// Since background runs in the same tick (no real async for getSessions mock),
+		// the final state may be RequiresSignIn
+		assert.ok(
+			service.extensionGalleryManifestStatus === ExtensionGalleryManifestStatus.AccessDenied
+			|| service.extensionGalleryManifestStatus === ExtensionGalleryManifestStatus.RequiresSignIn
+		);
+	});
+
+	test('Microsoft — server error (500), no cache → status unchanged', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(500, { error: 'Internal Server Error' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// Server error with no cache — status stays at initial Unavailable
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unavailable);
+	});
+
+	test('Microsoft — server error (500), with cache → cache preserved', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		storageData.set('marketplace.cachedAccess', JSON.stringify({
+			authProvider: 'microsoft',
+			accountId: 'ms-account-1',
+			eligible: true,
+		}));
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(500, { error: 'Internal Server Error' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// Cache was applied on startup (Available), server error doesn't invalidate
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+		assert.ok(storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('cache NOT invalidated when getSessions throws', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		storageData.set('marketplace.cachedAccess', JSON.stringify({
+			authProvider: 'microsoft',
+			accountId: 'ms-account-1',
+			eligible: true,
+		}));
+		requestHandler = () => mockResponse(200, createGalleryManifest(true));
+
+		// Override auth service to throw
+		instantiationService.stub(IAuthenticationService, new class extends mock<IAuthenticationService>() {
+			override readonly onDidChangeSessions = onDidChangeSessions.event;
+			override async getSessions(): Promise<readonly AuthenticationSession[]> {
+				throw new Error('Auth service unavailable');
+			}
+		}());
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// Cache was applied on startup (Available), auth error doesn't invalidate
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+		assert.ok(storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('GitHub — result is cached after successful check', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = createDefaultAccount({ enterprise: true });
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		const cached = storageData.get('marketplace.cachedAccess');
+		assert.ok(cached);
+		const parsed = JSON.parse(cached);
+		assert.strictEqual(parsed.authProvider, 'github');
+		assert.strictEqual(parsed.eligible, true);
+	});
+
+	test('Microsoft — result is cached after successful eligibility check', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true, reason: 'EntraID' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		const cached = storageData.get('marketplace.cachedAccess');
+		assert.ok(cached);
+		const parsed = JSON.parse(cached);
+		assert.strictEqual(parsed.authProvider, 'microsoft');
+		assert.strictEqual(parsed.eligible, true);
+		assert.strictEqual(parsed.reason, 'EntraID');
+	});
+
+	// --- Cache invalidation ---
+
+	test('cache invalidated on onDidChangeSessions for microsoft provider', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true, reason: 'EntraID' });
+			}
+			return mockResponse(200, createGalleryManifest(true));
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.ok(storageData.has('marketplace.cachedAccess'));
+
+		// Simulate session change — should clear cache
+		microsoftSessions = [];
+		onDidChangeSessions.fire({
+			providerId: 'microsoft',
+			label: 'Microsoft',
+			event: { added: undefined, removed: undefined, changed: undefined },
+		});
+
+		// Wait for async handler
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// Cache should be cleared
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('cache invalidated on onDidChangeDefaultAccount for github provider', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'github');
+		defaultAccount = createDefaultAccount({ enterprise: true });
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.ok(storageData.has('marketplace.cachedAccess'));
+
+		// Simulate account change — should clear cache and re-evaluate
+		defaultAccount = null;
+		onDidChangeDefaultAccount.fire(null);
+
+		// Wait for async handler
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// Cache should be cleared (account is null)
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
+	});
+
+	// --- No configuredServiceUrl ---
+
+	test('no configuredServiceUrl — uses default gallery manifest', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryServiceUrlConfigKey, '');
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		// Should use the parent class default behavior (null or default manifest)
+		// Status should be Unavailable since the default mock doesn't return a real manifest URL
+		assert.ok(service.extensionGalleryManifestStatus !== ExtensionGalleryManifestStatus.RequiresSignIn);
+	});
+});

--- a/src/vs/workbench/services/extensionManagement/test/electron-browser/extensionGalleryManifestService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/electron-browser/extensionGalleryManifestService.test.ts
@@ -7,7 +7,8 @@ import assert from 'assert';
 import { bufferToStream, VSBuffer } from '../../../../../base/common/buffer.js';
 import { IDefaultAccount } from '../../../../../base/common/defaultAccount.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { IRequestContext, IRequestOptions } from '../../../../../base/parts/request/common/request.js';
+import { IHeaders, IRequestContext, IRequestOptions } from '../../../../../base/parts/request/common/request.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -32,9 +33,9 @@ import { IHostService } from '../../../host/browser/host.js';
 import { IRemoteAgentService } from '../../../remote/common/remoteAgentService.js';
 import { WorkbenchExtensionGalleryManifestService } from '../../electron-browser/extensionGalleryManifestService.js';
 
-function mockResponse(statusCode: number, body: object): IRequestContext {
+function mockResponse(statusCode: number, body: object, headers: IHeaders = {}): IRequestContext {
 	return {
-		res: { headers: {}, statusCode },
+		res: { headers, statusCode },
 		stream: bufferToStream(VSBuffer.fromString(JSON.stringify(body))),
 	};
 }
@@ -69,6 +70,21 @@ function createGalleryManifest(includeEligibility = false) {
 	};
 }
 
+// RFC 9728 Protected Resource Metadata stub served from the marketplace's well-known endpoint.
+// `resource` must equal the configured service URL's origin for discovery validation to pass.
+function createProtectedResourceMetadata() {
+	return {
+		resource: 'https://marketplace.example.com',
+		authorization_servers: ['https://login.microsoftonline.com/test-tenant/v2.0'],
+		scopes_supported: ['api://test-client-id/access_as_user'],
+	};
+}
+
+// True when a request targets the marketplace's well-known Protected Resource Metadata endpoint.
+function isProtectedResourceMetadataRequest(url: string | undefined): boolean {
+	return !!url?.includes('/.well-known/oauth-protected-resource');
+}
+
 suite('WorkbenchExtensionGalleryManifestService', () => {
 
 	const disposableStore = ensureNoDisposablesAreLeakedInTestSuite();
@@ -79,6 +95,7 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 	let requestHandler: (options: IRequestOptions) => IRequestContext | Promise<IRequestContext>;
 	let defaultAccount: IDefaultAccount | null;
 	let microsoftSessions: AuthenticationSession[];
+	let microsoftResourceSessions: AuthenticationSession[] | undefined;
 	let configurationService: TestConfigurationService;
 	let storageData: Map<string, string>;
 	let entraAuthEnabled: boolean;
@@ -86,6 +103,7 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 	setup(() => {
 		defaultAccount = null;
 		microsoftSessions = [];
+		microsoftResourceSessions = undefined;
 		requestHandler = () => mockResponse(200, createGalleryManifest());
 		storageData = new Map();
 		entraAuthEnabled = true;
@@ -169,8 +187,14 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 
 		instantiationService.stub(IAuthenticationService, new class extends mock<IAuthenticationService>() {
 			override readonly onDidChangeSessions = onDidChangeSessions.event;
-			override async getSessions(providerId: string) {
+			override async getSessions(providerId: string, _scopes?: readonly string[], options?: { authorizationServer?: URI }) {
 				if (providerId === 'microsoft') {
+					// A resource-scoped request (RFC 8707: getSessions carrying an authorizationServer
+					// discovered from well-known PRM) yields the resource-scoped session when the test
+					// provides one; otherwise fall back to the base (OpenID) sessions.
+					if (options?.authorizationServer) {
+						return microsoftResourceSessions ?? microsoftSessions;
+					}
 					return microsoftSessions;
 				}
 				return [];
@@ -422,6 +446,10 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 		await service.getExtensionGalleryManifest();
 
 		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+		// No RFC 9728 challenge was issued (the index accepted the initial token directly), so no
+		// resource-scoped token was negotiated — getAccessToken stays undefined. A resource token is
+		// only exposed when the index challenges and negotiation upgrades the token (covered below).
+		assert.strictEqual(await service.getAccessToken(), undefined);
 	});
 
 	test('Microsoft provider — auth-gated service index, token forbidden (403) → AccessDenied', async () => {
@@ -498,6 +526,100 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 
 		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.RequiresSignIn);
 		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
+	test('Microsoft provider — auth-gated index → well-known PRM discovery negotiates resource-scoped token → Available', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		// The initially-acquired (OpenID) token is not resource-scoped; the resource-scoped token
+		// is obtained by discovering the marketplace's well-known Protected Resource Metadata and
+		// acquiring a token bound to the advertised authorization server.
+		microsoftSessions = [createMicrosoftSession('ms-openid-token')];
+		microsoftResourceSessions = [createMicrosoftSession('ms-resource-token')];
+		const challenge = 'Bearer realm="marketplace", resource_metadata="https://marketplace.example.com/.well-known/oauth-protected-resource"';
+		let eligibilityAuthHeader: string | undefined;
+		requestHandler = (options) => {
+			if (isProtectedResourceMetadataRequest(options.url)) {
+				return mockResponse(200, createProtectedResourceMetadata());
+			}
+			const auth = options.headers?.['Authorization'] as string | undefined;
+			if (options.url?.includes('eligibility')) {
+				eligibilityAuthHeader = auth;
+				return mockResponse(200, { eligible: true });
+			}
+			// The service index only accepts the resource-scoped token; the OpenID token is
+			// challenged with a 401 carrying the RFC 9728 resource_metadata pointer.
+			if (auth === 'Bearer ms-resource-token') {
+				return mockResponse(200, createGalleryManifest(true));
+			}
+			return mockResponse(401, { message: 'auth required' }, { 'WWW-Authenticate': challenge });
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+		// The negotiated resource-scoped token — not the initial OpenID token — is reused for the
+		// protected eligibility POST.
+		assert.strictEqual(eligibilityAuthHeader, 'Bearer ms-resource-token');
+		// The negotiated resource-scoped token is exposed for authenticating protected marketplace
+		// API requests (extensionquery, asset download).
+		assert.strictEqual(await service.getAccessToken(), 'ms-resource-token');
+	});
+
+	test('Microsoft provider — auth-gated index 401 with NO WWW-Authenticate header (CORS-stripped) → well-known PRM discovery still negotiates → Available', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		// Regression: the renderer's cross-origin index fetch usually cannot read the
+		// WWW-Authenticate challenge header (it is not CORS-safelisted). Negotiation must not
+		// depend on it — discovery is driven by the well-known Protected Resource Metadata body,
+		// which IS CORS-readable. Here the 401 carries no challenge header at all.
+		microsoftSessions = [createMicrosoftSession('ms-openid-token')];
+		microsoftResourceSessions = [createMicrosoftSession('ms-resource-token')];
+		requestHandler = (options) => {
+			if (isProtectedResourceMetadataRequest(options.url)) {
+				return mockResponse(200, createProtectedResourceMetadata());
+			}
+			const auth = options.headers?.['Authorization'] as string | undefined;
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true });
+			}
+			// The index only accepts the resource-scoped token; the OpenID token is rejected with
+			// a bare 401 (no WWW-Authenticate header).
+			if (auth?.includes('ms-resource-token')) {
+				return mockResponse(200, createGalleryManifest(true));
+			}
+			return mockResponse(401, { message: 'auth required' });
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Available);
+		assert.strictEqual(await service.getAccessToken(), 'ms-resource-token');
+	});
+
+	test('Microsoft provider — negotiated token still forbidden on retry (403) → AccessDenied (cached ineligible)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession('ms-openid-token')];
+		microsoftResourceSessions = [createMicrosoftSession('ms-resource-token')];
+		const challenge = 'Bearer resource_metadata="https://marketplace.example.com/.well-known/oauth-protected-resource"';
+		// The challenge is negotiated and a resource-scoped token acquired, but the identity is
+		// still forbidden from the index (403) — a durable denial that is cached.
+		requestHandler = (options) => {
+			if (isProtectedResourceMetadataRequest(options.url)) {
+				return mockResponse(200, createProtectedResourceMetadata());
+			}
+			const auth = options.headers?.['Authorization'] as string | undefined;
+			if (auth === 'Bearer ms-resource-token') {
+				return mockResponse(403, { message: 'forbidden' });
+			}
+			return mockResponse(401, { message: 'auth required' }, { 'WWW-Authenticate': challenge });
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.AccessDenied);
+		assert.strictEqual(JSON.parse(storageData.get('marketplace.cachedAccess')!).eligible, false);
 	});
 
 	test('Microsoft provider — eligibility endpoint forbids (403) → AccessDenied (cached ineligible)', async () => {

--- a/src/vs/workbench/services/extensionManagement/test/electron-browser/extensionGalleryManifestService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/electron-browser/extensionGalleryManifestService.test.ts
@@ -464,6 +464,27 @@ suite('WorkbenchExtensionGalleryManifestService', () => {
 		assert.ok(!storageData.has('marketplace.cachedAccess'));
 	});
 
+	test('Microsoft provider — service index 200 with malformed resources → Unreachable (not a crash, not cached)', async () => {
+		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
+		microsoftSessions = [createMicrosoftSession()];
+		// `resources` is an array but an entry is missing `id`/`type`. Endpoint discovery calls
+		// `resource.type.split()` outside the fetch try/catch, so an undefined `type` would throw
+		// there and reject initialization. The response must instead be rejected as a failed
+		// fetch → Unreachable, and never cached.
+		requestHandler = (options) => {
+			if (options.url?.includes('eligibility')) {
+				return mockResponse(200, { eligible: true });
+			}
+			return mockResponse(200, { version: '1.0.0', resources: [{}] });
+		};
+
+		const service = createService();
+		await service.getExtensionGalleryManifest();
+
+		assert.strictEqual(service.extensionGalleryManifestStatus, ExtensionGalleryManifestStatus.Unreachable);
+		assert.ok(!storageData.has('marketplace.cachedAccess'));
+	});
+
 	test('Microsoft provider — auth-gated service index, token rejected (401) → RequiresSignIn (not cached)', async () => {
 		configurationService.setUserConfiguration(ExtensionGalleryAuthProviderConfigKey, 'microsoft');
 		microsoftSessions = [createMicrosoftSession()];


### PR DESCRIPTION
> **Scope: Microsoft Entra ID only.** This PR implements RFC 9728 PRM negotiation and resource-scoped token threading for the **Entra / Microsoft** provider. The **GitHub** auth-enabled path called for in #325412 — RFC 8693 token exchange at the deployment's embedded Authorization Server, onDidChangeSessions('github') invalidation, and the GitHub test scenarios — is intentionally **deferred to a separate follow-up PR**. The GitHub path here remains unchanged from #325331 (anonymous index fetch + client-side checkAccess()).

Builds on microsoft/vscode#325331, which adds Microsoft Entra ID sign-in as a *licensing signal* for a Private Marketplace. This PR depends on it, so the commit range below currently includes #325331's commits and will reduce to just the negotiation work once #325331 merges.

Partially addresses microsoft/vscode#325412 (Entra path only; the GitHub auth-enabled path is tracked for a separate PR).

## Summary

microsoft/vscode#325331 established Entra ID sign-in as a *licensing signal* for a Private Marketplace (index negotiation + eligibility check). This PR makes the marketplace's **API requests actually authenticate** against an `[Authorize]`-gated marketplace by negotiating a resource-scoped bearer token via **RFC 9728 Protected Resource Metadata (PRM)** discovery and threading that token to every process/surface that talks to the marketplace — **for the Entra/Microsoft provider**.

Discovery is driven by the marketplace's well-known `/.well-known/oauth-protected-resource` document (CORS-readable) rather than the `WWW-Authenticate` challenge header, which the renderer's cross-origin index fetch usually cannot read. The negotiated token is bound to the advertised authorization server and resource scopes (RFC 8707), set only on the eligible→Available transition, and cleared on every non-Available transition so it can never outlive its access.

## Commits (the negotiation work; #325331's commits also appear in the range until it merges)

1. **Add RFC 9728 Protected Resource Metadata discovery** — reusable `discoverMarketplaceProtectedResource` helper + types.
2. **Negotiate a resource-scoped token on a gated Microsoft service index** — 401 → PRM discovery → silent token acquisition → retry; exposed via `getAccessToken()`. *(includes tests: gated negotiation, CORS-stripped 401, open-index no-token, negotiated-but-forbidden 403).*
3. **Attach the token to gallery API requests** — extensionquery, asset & VSIX downloads, behind a same-secure-origin guard.
4. **Thread the token to the shared process** — so `getManifest` / VSIX download (which never negotiate) authenticate; pushed over the manifest channel.
5. **Attach the token to extension resource requests** — README images, web README/CHANGELOG.
6. **Acquire the token on interactive marketplace sign-in** — avoids a second silent negotiation round-trip.
7. **Check eligibility only on first sign-in or account change** — skip the redundant per-refresh eligibility POST; revoke prior authorization on account switch.
8. **Downgrade the expected negotiation 401 from error to trace** — the 401 handshake is expected, not a failure.

## Follow-up (separate PR)

- GitHub auth-ENABLED path: RFC 8693 token exchange (raw GitHub token never reaches the resource server), client-side `checkAccess()` retained, no `/eligibility` POST.
- `onDidChangeSessions('github')` invalidation for the auth-enabled path.
- GitHub test-matrix scenarios (index 401 / no session / session + checkAccess).

## Testing

- Unit tests in `extensionGalleryManifestService.test.ts` cover the Entra negotiation paths (commit 2).
- `typecheck-client` ✅ and `valid-layers-check` ✅.
- Manually validated against a local Private Marketplace with Entra auth enabled (index negotiation, eligibility, gallery + resource token threading).

## Notes

- For an **open** marketplace `getAccessToken()` returns `undefined` and all requests stay anonymous — no behavior change.
- Token is only ever attached to same-secure-origin targets; never leaked cross-origin or over cleartext.
