### PR TITLE
Voice: report questions as waiting_for_input, not waiting_for_confirmation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -3270,6 +3270,21 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		return { state: realState, hideConfirmationDetail: false };
 	}
 
+	/**
+	 * Translate the internal `waiting_for_confirmation` state to the wire value
+	 * the backend expects. Approvals (yes/no) stay `waiting_for_confirmation`;
+	 * items needing a spoken/typed answer (questions, plan review, elicitation)
+	 * become `waiting_for_input` so the backend reads the question and accepts an
+	 * answer instead of prompting for confirmation. All internal timing/deferral
+	 * logic keeps using `waiting_for_confirmation`; only the emitted value differs.
+	 */
+	private _wireAgentState(reportedState: string, pendingKind: 'input' | 'approval' | undefined): string {
+		if (reportedState === 'waiting_for_confirmation' && pendingKind === 'input') {
+			return 'waiting_for_input';
+		}
+		return reportedState;
+	}
+
 	private _buildSessionContext(): IVoiceSessionContext {
 		const oneHourAgo = Date.now() - 60 * 60 * 1000;
 		const sessions = this.agentSessionsService.model.sessions.filter(s => {
@@ -3351,7 +3366,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return {
 				id: s.resource.toString(),
 				is_active: isActive,
-				agent_state: scoped.state,
+				agent_state: this._wireAgentState(scoped.state, stateInfo.pendingKind),
 				...(!scoped.hideConfirmationDetail && stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
 				...(shipSummary ? { last_response_summary: shipSummary } : {}),
 			};
@@ -3375,7 +3390,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			sessionList.push({
 				id: key,
 				is_active: isActive,
-				agent_state: scoped.state,
+				agent_state: this._wireAgentState(scoped.state, stateInfo.pendingKind),
 				...(!scoped.hideConfirmationDetail && stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
 				...(stateInfo.last_response_summary ? { last_response_summary: stateInfo.last_response_summary } : {}),
 			});
@@ -3508,7 +3523,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		return stateInfo.state;
 	}
 
-	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string } {
+	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string; pendingKind?: 'input' | 'approval' } {
 		if (!model) {
 			return { state: 'unknown' };
 		}
@@ -3564,6 +3579,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return {
 				state: 'waiting_for_confirmation',
 				detail: confirmDetail || pendingConfirmation.detail || '',
+				pendingKind: this._classifyPendingType(lastRequest!.response!),
 			};
 		}
 
@@ -3598,6 +3614,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				return {
 					state: 'waiting_for_confirmation',
 					detail: fallbackDetail,
+					pendingKind: this._classifyPendingType(lastRequest.response),
 				};
 			}
 		}
@@ -3612,14 +3629,19 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	private _classifyPendingType(response: { response: { value: readonly { kind: string }[] } }): 'approval' | 'input' {
-		// Return the type of the LAST pending part (most recently added)
+		// Classify the LAST pending part (most recently added). Items needing a
+		// spoken/typed answer are 'input' (questions, plan review, elicitation,
+		// askQuestions-style tools); yes/no gates are 'approval'.
 		let result: 'approval' | 'input' = 'input';
 		for (const part of response.response.value) {
 			if (part.kind === 'toolInvocation') {
 				const invocation = part as IChatToolInvocation;
 				const state = invocation.state.get();
-				if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation ||
-					state.type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
+				if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation) {
+					// askQuestions-style tools carry a `questions` param and need an answer.
+					const questions = (state.parameters as Record<string, unknown> | undefined)?.['questions'];
+					result = Array.isArray(questions) && questions.length > 0 ? 'input' : 'approval';
+				} else if (state.type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
 					result = 'approval';
 				}
 			}


### PR DESCRIPTION
### Problem

When the agent asks the user a **question** (question carousel, plan review, elicitation, or an `askQuestions`-style tool), the voice backend prompted for a **yes/no confirmation** instead of reading the question aloud and accepting a spoken answer.

Root cause: `voiceSessionController.ts` reported all pending items — questions *and* command approvals — to the backend with the same `agent_state: 'waiting_for_confirmation'`, so the backend could not tell a question (needs a spoken answer) from an approval (needs yes/no).

### Fix

- `_classifyPendingType` is now the single classifier for pending items: `input` (question carousel / plan review / elicitation / `askQuestions`-style tools) vs `approval` (command confirmations, `confirmation` parts, post-approval). It now recognizes `askQuestions`-style tools (a `toolInvocation` in `WaitingForConfirmation` carrying a `questions` param) as `input`.
- `_getAgentStateInfo` reuses that classifier to attach a `pendingKind`, and `_buildSessionContext` emits a new wire state **`waiting_for_input`** for input-type items (via `_wireAgentState`), while approvals keep `waiting_for_confirmation`.

Internal timing/deferral logic is untouched — it still uses `waiting_for_confirmation` everywhere; only the emitted wire value changes at the payload boundary. Non-active sessions still downgrade to `thinking` as before, and `agent_state_detail` (the question text) still ships.

### Backend requirements

This introduces a **new `agent_state` value on the wire: `waiting_for_input`**. The backend needs to handle it:

- **Recognize `waiting_for_input`** as a distinct state from `waiting_for_confirmation`. Today the backend only knows `waiting_for_confirmation` and treats it as a yes/no gate.
- On `waiting_for_input`, **read the question aloud from `agent_state_detail`** (the client ships the question text there, same as it does for confirmations) and **accept a free-form spoken answer** rather than prompting for a yes/no confirmation.
- Treat the **`thinking → waiting_for_input`** transition the same way it treats `thinking → waiting_for_confirmation` for narration timing (narrate on the transition; for background sessions the client still holds `thinking` until focus, then emits `waiting_for_input`).
- `waiting_for_confirmation` behavior is unchanged and should continue to drive the yes/no approval flow.

Until the backend recognizes `waiting_for_input`, questions would be sent with a state the backend doesn't understand — so backend support should land together with (or before) this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>