### PR TITLE
Keep worktree session configuration host-owned

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1434,13 +1434,13 @@ export interface IAgent {
 
 	// ---- Session lifecycle / configuration ---------------------------------
 
-	/** Create a new session. Returns server-owned session metadata. */
+	/** Create a new session. Host-owned worktree fields are omitted from `config.config`. */
 	createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult>;
 
-	/** Resolve the dynamic configuration schema for creating a session. */
+	/** Resolve provider-owned session configuration; host-owned worktree fields are omitted. */
 	resolveSessionConfig(params: IAgentResolveSessionConfigParams): Promise<ResolveSessionConfigResult>;
 
-	/** Return dynamic completions for a session configuration property. */
+	/** Return dynamic completions for a provider-owned session configuration property. */
 	sessionConfigCompletions(params: IAgentSessionConfigCompletionsParams): Promise<SessionConfigCompletionsResult>;
 
 	/**

--- a/src/vs/platform/agentHost/common/sessionConfigKeys.ts
+++ b/src/vs/platform/agentHost/common/sessionConfigKeys.ts
@@ -12,23 +12,24 @@
  * drives tool auto-approval) or that clients interpret via convention
  * (e.g. {@link SessionConfigKey.Branch}, {@link SessionConfigKey.Isolation}).
  *
- * Agents that opt into the corresponding behavior should use these exact
- * property names in their `resolveSessionConfig` response.
+ * Provider-owned platform properties use these names in an agent's
+ * `resolveSessionConfig` response. Worktree properties are owned and
+ * contributed by the host and are not passed to agents.
  */
 export const enum SessionConfigKey {
 	/** `'autoApprove'` — tool auto-approval level. */
 	AutoApprove = 'autoApprove',
 	/** `'permissions'` — per-tool session allow/deny lists. */
 	Permissions = 'permissions',
-	/** `'isolation'` — `'folder'` or `'worktree'`. */
+	/** `'isolation'` — host-owned `'folder'` or `'worktree'` selection. */
 	Isolation = 'isolation',
-	/** `'branch'` — base branch to work from. */
+	/** `'branch'` — host-owned base branch to work from. */
 	Branch = 'branch',
 	/** `'mode'` — agent execution mode (interactive / plan / autopilot). */
 	Mode = 'mode',
-	/** `'worktreeBranchPrefix'` — prefix for the worktree branch name. */
+	/** `'worktreeBranchPrefix'` — host-owned prefix for the worktree branch name. */
 	WorktreeBranchPrefix = 'worktreeBranchPrefix',
-	/** `'worktreeIncludeFiles'` — glob patterns for git-ignored files to copy into a new worktree. */
+	/** `'worktreeIncludeFiles'` — host-owned glob patterns for files copied into a new worktree. */
 	WorktreeIncludeFiles = 'worktreeIncludeFiles',
 }
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -84,6 +84,22 @@ import { AgentHostReviewService } from './agentHostReviewService.js';
  * provider-side session, worktree, and on-disk state.
  */
 const SESSION_GC_GRACE_MS = 30_000;
+
+const HOST_OWNED_SESSION_CONFIG_KEYS = [
+	SessionConfigKey.Isolation,
+	SessionConfigKey.Branch,
+	SessionConfigKey.WorktreeBranchPrefix,
+	SessionConfigKey.WorktreeIncludeFiles,
+] as const;
+
+function omitHostOwnedSessionConfig<T>(config: Record<string, T>): Record<string, T> {
+	const result = { ...config };
+	for (const key of HOST_OWNED_SESSION_CONFIG_KEYS) {
+		delete result[key];
+	}
+	return result;
+}
+
 /**
  * Grace period before an idle resource watch is torn down after its last
  * subscriber unsubscribes (mirrors {@link SESSION_GC_GRACE_MS}). Within
@@ -483,6 +499,13 @@ export class AgentService extends Disposable implements IAgentService {
 		this._worktree = worktree;
 		this._configurationService.setWorktreeIsolation(worktree);
 		this._sideEffects.setWorktreeIsolation(worktree);
+	}
+
+	private _toProviderConfig<T extends { readonly config?: Record<string, unknown> }>(request: T): T {
+		if (!this._worktree || !request.config) {
+			return request;
+		}
+		return { ...request, config: omitHostOwnedSessionConfig(request.config) };
 	}
 
 	/**
@@ -1221,7 +1244,7 @@ export class AgentService extends Disposable implements IAgentService {
 
 		let created: IAgentCreateSessionResult | undefined;
 		try {
-			created = await provider.createSession(config);
+			created = await provider.createSession(config ? this._toProviderConfig(config) : undefined);
 			if (deferWorktreeCreation && created.provisional) {
 				this._worktree?.notePending(AgentSession.id(created.session));
 			}
@@ -1530,7 +1553,7 @@ export class AgentService extends Disposable implements IAgentService {
 			// so without this a fresh worktree session's isolation is `undefined` at
 			// create time — the pending mark below is skipped and the send falls back
 			// to folder even though the user picked worktree.
-			const resolved = await this._withIsolationSchema(await provider.resolveSessionConfig(params), params);
+			const resolved = await this._withIsolationSchema(await provider.resolveSessionConfig(this._toProviderConfig(params)), params);
 			return { schema: resolved.schema, values: resolved.values };
 		} catch (err) {
 			this._logService.error(`[AgentService] Failed to resolve created session config for provider ${provider.id}`, err);
@@ -1544,65 +1567,44 @@ export class AgentService extends Disposable implements IAgentService {
 		if (!provider) {
 			throw new Error(`No agent provider registered for: ${providerId ?? '(none)'}`);
 		}
-		return this._withIsolationSchema(await provider.resolveSessionConfig(params), params);
+		return this._withIsolationSchema(await provider.resolveSessionConfig(this._toProviderConfig(params)), params);
 	}
 
 	/**
 	 * Host-owned contribution of the shared `isolation` (folder / worktree),
 	 * `branch`, `worktreeBranchPrefix`, and `worktreeIncludeFiles` session-config
-	 * properties on top of whatever an agent returned from `resolveSessionConfig`. This is what lets
-	 * every agent — including future ones — get the isolation picker for free.
-	 * Additive-if-absent: an agent that still contributes these keys itself is
-	 * left untouched, so the migration to host ownership is safe either way.
+	 * properties on top of whatever an agent returned from `resolveSessionConfig`. Provider-returned
+	 * properties and values with these keys are replaced by the host contribution.
 	 */
 	private async _withIsolationSchema(result: ResolveSessionConfigResult, params: IAgentResolveSessionConfigParams): Promise<ResolveSessionConfigResult> {
 		if (!this._worktree) {
 			return result;
 		}
-		const hasIsolation = result.schema.properties[SessionConfigKey.Isolation] !== undefined;
-		const hasBranch = result.schema.properties[SessionConfigKey.Branch] !== undefined;
-		const hasWorktreeBranchPrefix = result.schema.properties[SessionConfigKey.WorktreeBranchPrefix] !== undefined;
-		const hasWorktreeIncludeFiles = result.schema.properties[SessionConfigKey.WorktreeIncludeFiles] !== undefined;
 		const iso = await this._worktree.resolveIsolationConfig({ workingDirectory: params.workingDirectory, config: params.config });
-		if (hasIsolation
-			&& (hasBranch || !iso.branchProperty)
-			&& (hasWorktreeBranchPrefix || !iso.worktreeBranchPrefixProperty)
-			&& (hasWorktreeIncludeFiles || !iso.worktreeIncludeFilesProperty)) {
-			return result;
-		}
-		// Isolation goes first (UI ordering) when the host contributes it.
-		const properties: Record<string, SessionConfigPropertySchema> = hasIsolation
-			? { ...result.schema.properties }
-			: { [SessionConfigKey.Isolation]: iso.isolationProperty.protocol, ...result.schema.properties };
-		if (iso.branchProperty && !hasBranch) {
+		const properties: Record<string, SessionConfigPropertySchema> = {
+			[SessionConfigKey.Isolation]: iso.isolationProperty.protocol,
+			...omitHostOwnedSessionConfig(result.schema.properties),
+		};
+		if (iso.branchProperty) {
 			properties[SessionConfigKey.Branch] = iso.branchProperty.protocol;
 		}
-		if (iso.worktreeBranchPrefixProperty && !hasWorktreeBranchPrefix) {
+		if (iso.worktreeBranchPrefixProperty) {
 			properties[SessionConfigKey.WorktreeBranchPrefix] = iso.worktreeBranchPrefixProperty.protocol;
 		}
-		if (iso.worktreeIncludeFilesProperty && !hasWorktreeIncludeFiles) {
+		if (iso.worktreeIncludeFilesProperty) {
 			properties[SessionConfigKey.WorktreeIncludeFiles] = iso.worktreeIncludeFilesProperty.protocol;
 		}
-		const values = { ...result.values };
-		if (!hasIsolation && values[SessionConfigKey.Isolation] === undefined) {
-			values[SessionConfigKey.Isolation] = iso.isolationValue;
+		const values = omitHostOwnedSessionConfig(result.values);
+		values[SessionConfigKey.Isolation] = iso.isolationValue;
+		if (iso.branchProperty && iso.branchValue !== undefined) {
+			values[SessionConfigKey.Branch] = iso.branchValue;
 		}
-		if (iso.branchProperty && !hasBranch && iso.branchDefault !== undefined && values[SessionConfigKey.Branch] === undefined) {
-			values[SessionConfigKey.Branch] = iso.branchDefault;
-		}
-		// Echo the client-seeded `worktreeBranchPrefix` back so it rides the
-		// resolved config and survives isolation toggles (worktree → folder →
-		// worktree). It has no default; when the client doesn't supply one it
-		// simply stays unset.
-		if (iso.worktreeBranchPrefixProperty && !hasWorktreeBranchPrefix
-			&& typeof params.config?.[SessionConfigKey.WorktreeBranchPrefix] === 'string'
-			&& values[SessionConfigKey.WorktreeBranchPrefix] === undefined) {
+		if (iso.worktreeBranchPrefixProperty && typeof params.config?.[SessionConfigKey.WorktreeBranchPrefix] === 'string') {
 			values[SessionConfigKey.WorktreeBranchPrefix] = params.config[SessionConfigKey.WorktreeBranchPrefix];
 		}
-		if (iso.worktreeIncludeFilesProperty && !hasWorktreeIncludeFiles
+		if (iso.worktreeIncludeFilesProperty
 			&& Array.isArray(params.config?.[SessionConfigKey.WorktreeIncludeFiles])
-			&& params.config[SessionConfigKey.WorktreeIncludeFiles].every(pattern => typeof pattern === 'string')
-			&& values[SessionConfigKey.WorktreeIncludeFiles] === undefined) {
+			&& params.config[SessionConfigKey.WorktreeIncludeFiles].every(pattern => typeof pattern === 'string')) {
 			values[SessionConfigKey.WorktreeIncludeFiles] = params.config[SessionConfigKey.WorktreeIncludeFiles];
 		}
 		return { schema: { ...result.schema, properties }, values };
@@ -1619,7 +1621,7 @@ export class AgentService extends Disposable implements IAgentService {
 		if (!provider) {
 			throw new Error(`No agent provider registered for: ${providerId ?? '(none)'}`);
 		}
-		return provider.sessionConfigCompletions(params);
+		return provider.sessionConfigCompletions(this._toProviderConfig(params));
 	}
 
 	async completions(params: CompletionsParams): Promise<CompletionsResult> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -145,8 +145,8 @@ export type ICopilotPluginInfo = IParsedPlugin & { readonly pluginDir?: URI };
  * worktree to remove and no on-disk state to delete.
  *
  * `model` absorbs {@link CopilotAgent.changeModel} updates that arrive
- * before the first message. The latest session config (isolation / branch /
- * etc.) is read straight from the state manager via
+ * before the first message. The latest provider-owned session config is read
+ * straight from the state manager via
  * {@link IAgentConfigurationService.getSessionConfigValues} at
  * materialization time, so no bespoke forwarding is required for it.
  */
@@ -1671,8 +1671,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * naturally.
 	 *
 	 * The latest model lives on the provisional record (kept in sync via
-	 * {@link changeModel}). The latest session config (isolation / branch /
-	 * etc.) is read straight from the state manager via
+	 * {@link changeModel}). The latest provider-owned session config is read
+	 * straight from the state manager via
 	 * {@link IAgentConfigurationService.getSessionConfigValues} so any
 	 * `SessionConfigChanged` actions that arrived after `createSession` are
 	 * honoured without bespoke forwarding.

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -141,7 +141,7 @@ export interface IIsolationConfigContribution {
 	/**
 	 * Read-only carrier for the client's `git.branchPrefix`. Declared for both
 	 * isolations (like `branch`) so the value rides `_config.values` and
-	 * survives isolation toggles; the agent only *consumes* it for worktree
+	 * survives isolation toggles; the host only consumes it for worktree
 	 * isolation (see {@link WorktreeIsolation.resolveWorkingDirectory}).
 	 */
 	readonly worktreeBranchPrefixProperty: ISchemaProperty<string> | undefined;
@@ -149,6 +149,7 @@ export interface IIsolationConfigContribution {
 	readonly worktreeIncludeFilesProperty: ISchemaProperty<readonly string[]> | undefined;
 	readonly isolationValue: 'folder' | 'worktree';
 	readonly branchDefault: string | undefined;
+	readonly branchValue: string | undefined;
 }
 
 /** Parameters for {@link WorktreeIsolation.resolveWorkingDirectory}. */
@@ -317,11 +318,15 @@ export class WorktreeIsolation extends Disposable {
 
 		let branchProperty: ISchemaProperty<string> | undefined;
 		let branchDefault: string | undefined;
+		let branchValue: string | undefined;
 		let worktreeBranchPrefixProperty: ISchemaProperty<string> | undefined;
 		let worktreeIncludeFilesProperty: ISchemaProperty<readonly string[]> | undefined;
 		if (gitInfo) {
 			const branchReadOnly = isolationValue === 'folder';
 			branchDefault = isolationValue === 'worktree' ? gitInfo.defaultBranch : gitInfo.currentBranch;
+			branchValue = isolationValue === 'worktree' && typeof request.config?.[SessionConfigKey.Branch] === 'string'
+				? request.config[SessionConfigKey.Branch] as string
+				: branchDefault;
 			branchProperty = schemaProperty<string>({
 				type: 'string',
 				title: localize('agentHost.sessionConfig.branch', "Branch"),
@@ -334,15 +339,14 @@ export class WorktreeIsolation extends Disposable {
 				sessionMutable: false,
 			});
 
-			// Carrier for the client's `git.branchPrefix`: the agent prepends it
+			// Carrier for the client's `git.branchPrefix`: the host prepends it
 			// to the branch it creates for an isolated worktree. Declared for
 			// both isolations (like `branch`), so the value rides
 			// `_config.values` and survives isolation toggles — a user who flips
-			// worktree → folder → worktree keeps the prefix, and it reaches the
-			// agent via the send-time config snapshot. It has no
+			// worktree → folder → worktree keeps the prefix. It has no
 			// `enum`/`enumDynamic`, so the config picker treats it as
 			// non-pickable and never surfaces it as a chip: the client seeds it
-			// (from `git.branchPrefix`), the user never edits it, and the agent
+			// (from `git.branchPrefix`), the user never edits it, and the host
 			// only *consumes* it for worktree isolation (see
 			// {@link resolveWorkingDirectory}).
 			worktreeBranchPrefixProperty = schemaProperty<string>({
@@ -366,7 +370,7 @@ export class WorktreeIsolation extends Disposable {
 			});
 		}
 
-		return { isolationProperty, branchProperty, worktreeBranchPrefixProperty, worktreeIncludeFilesProperty, isolationValue, branchDefault };
+		return { isolationProperty, branchProperty, worktreeBranchPrefixProperty, worktreeIncludeFilesProperty, isolationValue, branchDefault, branchValue };
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -252,6 +252,117 @@ suite('AgentService (node dispatcher)', () => {
 		});
 	});
 
+	test('session config keeps host-owned values outside provider calls', async () => {
+		const workingDirectory = URI.file('/workspace/repo');
+		const gitService = createNoopGitService();
+		gitService.getRepositoryRoot = async () => workingDirectory;
+		gitService.revParse = async () => 'head';
+		gitService.getCurrentBranch = async () => 'feature';
+		gitService.getDefaultBranch = async () => 'origin/main';
+		const localService = disposables.add(new AgentService(new NullLogService(), fileService, nullSessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
+		localService.setWorktreeIsolation(disposables.add(new WorktreeIsolation(
+			{ generateBranchName: async () => 'agents/test' },
+			gitService,
+			new TestCopilotApiService(),
+			nullSessionDataService,
+			new NullLogService(),
+		)));
+		const agent = new MockAgent('codex');
+		const providerResolveConfigs: Array<Record<string, unknown> | undefined> = [];
+		const providerCompletionConfigs: Array<Record<string, unknown> | undefined> = [];
+		agent.resolveSessionConfig = async params => {
+			providerResolveConfigs.push(params.config);
+			return {
+				schema: {
+					type: 'object',
+					properties: {
+						[SessionConfigKey.Isolation]: { type: 'string', title: 'Provider Isolation' },
+						[SessionConfigKey.Branch]: { type: 'string', title: 'Provider Branch' },
+						providerSetting: { type: 'string', title: 'Provider Setting' },
+					},
+				},
+				values: {
+					...params.config,
+					[SessionConfigKey.Isolation]: 'folder',
+					[SessionConfigKey.Branch]: 'provider-branch',
+				},
+			};
+		};
+		agent.sessionConfigCompletions = async params => {
+			providerCompletionConfigs.push(params.config);
+			return { items: [] };
+		};
+		disposables.add(toDisposable(() => agent.dispose()));
+		localService.registerProvider(agent);
+
+		const initial = await localService.resolveSessionConfig({
+			provider: 'codex',
+			workingDirectory,
+			config: { [SessionConfigKey.Isolation]: 'worktree', providerSetting: 'initial' },
+		});
+		const selected = await localService.resolveSessionConfig({
+			provider: 'codex',
+			workingDirectory,
+			config: {
+				[SessionConfigKey.Isolation]: 'worktree',
+				[SessionConfigKey.Branch]: 'feature/config',
+				[SessionConfigKey.WorktreeBranchPrefix]: 'users/test/',
+				[SessionConfigKey.WorktreeIncludeFiles]: ['.env'],
+				providerSetting: 'selected',
+			},
+		});
+		const folder = await localService.resolveSessionConfig({
+			provider: 'codex',
+			workingDirectory,
+			config: { [SessionConfigKey.Isolation]: 'folder', [SessionConfigKey.Branch]: 'feature/config', providerSetting: 'folder' },
+		});
+		await localService.sessionConfigCompletions({
+			provider: 'codex',
+			workingDirectory,
+			config: {
+				[SessionConfigKey.Isolation]: 'worktree',
+				[SessionConfigKey.Branch]: 'feature/config',
+				[SessionConfigKey.WorktreeBranchPrefix]: 'users/test/',
+				[SessionConfigKey.WorktreeIncludeFiles]: ['.env'],
+				providerSetting: 'completion',
+			},
+			property: 'providerSetting',
+		});
+
+		assert.deepStrictEqual({
+			providerResolveConfigs,
+			providerCompletionConfigs,
+			initial: {
+				isolation: initial.values[SessionConfigKey.Isolation],
+				branchDefault: initial.schema.properties[SessionConfigKey.Branch]?.default,
+				branch: initial.values[SessionConfigKey.Branch],
+				providerSetting: initial.values.providerSetting,
+			},
+			selected: {
+				isolation: selected.values[SessionConfigKey.Isolation],
+				branch: selected.values[SessionConfigKey.Branch],
+				branchPrefix: selected.values[SessionConfigKey.WorktreeBranchPrefix],
+				includeFiles: selected.values[SessionConfigKey.WorktreeIncludeFiles],
+				providerSetting: selected.values.providerSetting,
+			},
+			folder: {
+				isolation: folder.values[SessionConfigKey.Isolation],
+				branch: folder.values[SessionConfigKey.Branch],
+				providerSetting: folder.values.providerSetting,
+			},
+		}, {
+			providerResolveConfigs: [
+				{ providerSetting: 'initial' },
+				{ providerSetting: 'selected' },
+				{ providerSetting: 'folder' },
+			],
+			providerCompletionConfigs: [{ providerSetting: 'completion' }],
+			initial: { isolation: 'worktree', branchDefault: 'origin/main', branch: 'origin/main', providerSetting: 'initial' },
+			selected: { isolation: 'worktree', branch: 'feature/config', branchPrefix: 'users/test/', includeFiles: ['.env'], providerSetting: 'selected' },
+			folder: { isolation: 'folder', branch: 'feature', providerSetting: 'folder' },
+		});
+	});
+
 	test('marks worktree isolation pending before a provisional provider can prewarm', async () => {
 		const session = AgentSession.uri('codex', 'pending-before-create');
 		const workingDirectory = URI.file('/workspace/repo');
@@ -270,10 +381,12 @@ suite('AgentService (node dispatcher)', () => {
 		));
 		localService.setWorktreeIsolation(isolation);
 		const pendingDuringCreate: boolean[] = [];
+		const providerCreateConfigs: Array<Record<string, unknown> | undefined> = [];
 		let failCreate = false;
 		class PrewarmingAgent extends MockAgent {
 			override async createSession(config?: import('../../common/agentService.js').IAgentCreateSessionConfig): Promise<import('../../common/agentService.js').IAgentCreateSessionResult> {
 				pendingDuringCreate.push(localService.configurationService.isWorkingDirectoryPending(config!.session!.toString()));
+				providerCreateConfigs.push(config?.config);
 				if (failCreate) {
 					throw new Error('create failed');
 				}
@@ -301,10 +414,12 @@ suite('AgentService (node dispatcher)', () => {
 
 		assert.deepStrictEqual({
 			pendingDuringCreate,
+			providerCreateConfigs,
 			pendingAfterCreate: localService.configurationService.isWorkingDirectoryPending(session.toString()),
 			pendingAfterFailure: localService.configurationService.isWorkingDirectoryPending(failedSession.toString()),
 		}, {
 			pendingDuringCreate: [true, true],
+			providerCreateConfigs: [{}, {}],
 			pendingAfterCreate: true,
 			pendingAfterFailure: false,
 		});


### PR DESCRIPTION
## Summary

- keep `isolation`, `branch`, `worktreeBranchPrefix`, and `worktreeIncludeFiles` inside the agent host instead of forwarding them to providers
- make the host authoritative when composing worktree configuration schema and values while preserving explicit branch selections
- cover provider resolve, completion, and create boundaries with focused regression tests

## Testing

- `npm run precommit`
- `npm run typecheck-client` on a clean worktree based on the latest `origin/main`
- focused `AgentService (node dispatcher)` tests for provider config boundaries and pending worktree creation