### PR TITLE
Enables voice to be controlled via exp

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -451,6 +451,9 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			description: nls.localize('agents.voice.enabled', "Enable the Voice Mode panel in the chat view for voice-driven coding conversations."),
 			default: false,
+			experiment: {
+				mode: 'auto',
+			},
 			scope: ConfigurationScope.APPLICATION,
 			restricted: true,
 			included: false,

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -454,6 +454,7 @@ configurationRegistry.registerConfiguration({
 			experiment: {
 				mode: 'auto',
 			},
+			tags: ['experimental', 'advanced'],
 			scope: ConfigurationScope.APPLICATION,
 			restricted: true,
 		},

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -456,7 +456,6 @@ configurationRegistry.registerConfiguration({
 			},
 			scope: ConfigurationScope.APPLICATION,
 			restricted: true,
-			included: false,
 		},
 		'agents.voice.backendUrl': {
 			type: 'string',


### PR DESCRIPTION
This pull request introduces an update to the configuration for the Voice Mode panel in the chat view, specifically targeting how the feature is rolled out to users.

Configuration rollout:

* Added an `experiment` property with `mode: 'auto'` to the `agents.voice.enabled` configuration option, allowing the Voice Mode panel to be enabled automatically for experimental or gradual rollout purposes.

