### PR TITLE
Draw attention to blocking input prompts

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -13,6 +13,36 @@
 	box-shadow: var(--vscode-shadow-xl);
 }
 
+/*
+ * Blocking input prompts (for example window.showInputBox for authentication,
+ * SSH passphrases or API keys) appear at the top of the window and are easy to
+ * miss while the user's attention is on the terminal, editor or elsewhere.
+ * Briefly pulse the widget when such a prompt appears so it is obvious that
+ * input is required. See https://github.com/microsoft/vscode/issues/325764.
+ */
+.quick-input-widget.quick-input-needs-attention {
+	animation: quick-input-attention-pulse 500ms ease-out 0s 2;
+}
+
+@keyframes quick-input-attention-pulse {
+	0% {
+		box-shadow: var(--vscode-shadow-xl), 0 0 0 0 var(--vscode-focusBorder);
+	}
+	50% {
+		box-shadow: var(--vscode-shadow-xl), 0 0 0 3px var(--vscode-focusBorder);
+	}
+	100% {
+		box-shadow: var(--vscode-shadow-xl), 0 0 0 0 var(--vscode-focusBorder);
+	}
+}
+
+/* Respect users who prefer reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+	.quick-input-widget.quick-input-needs-attention {
+		animation: none;
+	}
+}
+
 .quick-input-titlebar {
 	cursor: grab;
 	display: flex;

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -696,6 +696,7 @@ export class QuickInputController extends Disposable {
 		}
 
 		this.setEnabled(true);
+		ui.container.classList.remove('quick-input-needs-attention');
 		ui.leftActionBar.setActions([]);
 		ui.title.textContent = '';
 		ui.description1.textContent = '';
@@ -746,6 +747,24 @@ export class QuickInputController extends Disposable {
 		this.onShowEmitter.fire();
 		ui.inputBox.setFocus();
 		this.quickInputTypeContext.set(controller.type);
+
+		// Blocking input prompts (window.showInputBox: git/ssh authentication,
+		// API keys, extension prompts, ...) render at the top of the window and
+		// are easy to miss, making it appear as if an operation has frozen.
+		// Briefly pulse the widget to signal that user input is required.
+		// See https://github.com/microsoft/vscode/issues/325764.
+		if (controller.type === QuickInputType.InputBox) {
+			this.drawAttention(ui);
+		}
+	}
+
+	private drawAttention(ui: QuickInputUI): void {
+		const { container } = ui;
+		container.classList.remove('quick-input-needs-attention');
+		// Force a reflow so the animation restarts if the widget element is
+		// reused for consecutive input prompts.
+		void container.offsetWidth;
+		container.classList.add('quick-input-needs-attention');
 	}
 
 	isVisible(): boolean {


### PR DESCRIPTION
Fixes #325764

### Problem

VS Code occasionally shows blocking input prompts (`window.showInputBox` / Quick Input) that must be answered before an operation can continue: git/ssh authentication, passphrase requests, API keys, extension configuration prompts, and so on.

These prompts render at the very top of the window, while the user's attention is usually on the terminal, editor, Debug Console, or an extension view. When the prompt is missed, the operation just waits for input, and it looks as though the terminal, an extension, or VS Code itself has frozen.

### Change

Briefly pulse the Quick Input widget when a blocking input prompt appears, so it is immediately obvious that input is required.

- The pulse is scoped to `QuickInputType.InputBox` (what `window.showInputBox` uses), so the **command palette** and **quick open** which the user opens intentionally are unaffected.
- Implemented as a short CSS ring animation on `.quick-input-widget` using `--vscode-focusBorder`, retriggered per prompt by toggling a `quick-input-needs-attention` class (with a forced reflow so it replays when the widget element is reused).
- Respects accessibility preferences: the animation is disabled under `@media (prefers-reduced-motion: reduce)`.

### Details

- `quickInputController.show()` adds the `quick-input-needs-attention` class when the controller type is `InputBox`, and clears it on every show so quick picks never inherit it.
- Screen reader users are unaffected: focus already moves into the input box, so the prompt is announced as before.

### Notes

The animation approach is one of the ideas suggested in the issue. If maintainers prefer, it would be straightforward to gate this behind a setting (e.g. `workbench.quickInput.pulseOnInputPrompt`) or to also surface an accessibility signal. Happy to adjust based on direction.

### Verification

- `tsc`/language-server diagnostics clean on the changed files.
- Manual: git authentication / `showInputBox` prompts pulse once on appearance; command palette and quick open do not; no pulse with reduced motion enabled.
