### PR TITLE
Simplify redundant nested ternary in notebook cell sort comparator

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/notebookCellChanges.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/notebookCellChanges.ts
@@ -126,10 +126,8 @@ export function sortCellChanges(changes: ICellDiffInfo[]): ICellDiffInfo[] {
 		}
 
 		// Mixed types: compare based on available indices
-		const aIndex = a.type === 'delete' ? a.originalCellIndex :
-			(a.type === 'insert' ? a.modifiedCellIndex : a.modifiedCellIndex);
-		const bIndex = b.type === 'delete' ? b.originalCellIndex :
-			(b.type === 'insert' ? b.modifiedCellIndex : b.modifiedCellIndex);
+		const aIndex = a.type === 'delete' ? a.originalCellIndex : a.modifiedCellIndex;
+		const bIndex = b.type === 'delete' ? b.originalCellIndex : b.modifiedCellIndex;
 
 		return aIndex - bIndex;
 	});


### PR DESCRIPTION
In `sortCellChanges`, the mixed-type fallback computes:

```ts
const aIndex = a.type === 'delete' ? a.originalCellIndex :
    (a.type === 'insert' ? a.modifiedCellIndex : a.modifiedCellIndex);
```

The inner ternary returns `modifiedCellIndex` on both arms, so the `insert` check is dead code (same for `bIndex`). This collapses it to `a.type === 'delete' ? a.originalCellIndex : a.modifiedCellIndex`. No behavior change.