### PR TITLE
Merge identical branches in uriTemplate value joining

### DIFF
--- a/src/vs/base/common/uriTemplate.ts
+++ b/src/vs/base/common/uriTemplate.ts
@@ -263,14 +263,10 @@ export class UriTemplate {
 		} else if (isParam) {
 			// For param, if value is empty string, just append ;name
 			joined = vals.length ? prefix + vals.map(v => v.replace(/=\s*$/, '')).join(';') : '';
-		} else if (isForm) {
-			joined = vals.length ? prefix + vals.join('&') : '';
-		} else if (isFormCont) {
+		} else if (isForm || isFormCont) {
 			joined = vals.length ? prefix + vals.join('&') : '';
 		} else if (isFragment) {
 			joined = prefix + vals.join(',');
-		} else if (isReserved) {
-			joined = vals.join(',');
 		} else {
 			joined = vals.join(',');
 		}


### PR DESCRIPTION
In `UriTemplate`'s value-joining logic, the `isReserved` arm is byte-identical to the final `else` (`joined = vals.join(',')`). 

Reserved expansion differs only in encoding, which is already handled in `_encode`. The `isForm` and `isFormCont` arms are also identical to each other.

This merges the redundant branches. No behavior change.