### PR TITLE
Preserve inbound Anthropic PDF documents

### DIFF
--- a/extensions/copilot/src/extension/byok/common/anthropicMessageConverter.ts
+++ b/extensions/copilot/src/extension/byok/common/anthropicMessageConverter.ts
@@ -166,6 +166,12 @@ export function anthropicMessagesToRawMessagesForLogging(messages: MessageParam[
 					imageUrl: { url: '(image)' }
 				};
 			}
+			if (part.type === Raw.ChatCompletionContentPartKind.Document) {
+				return {
+					...part,
+					documentData: { ...part.documentData, data: '(document)' }
+				};
+			}
 			return part;
 		});
 
@@ -217,6 +223,15 @@ export function anthropicMessagesToRawMessages(messages: MessageParam[], system:
 			}
 		};
 
+		const toRawDocument = (document: DocumentBlockParam): Raw.ChatCompletionContentPartDocument | undefined => {
+			if (document.source.type === 'base64') {
+				return {
+					type: Raw.ChatCompletionContentPartKind.Document,
+					documentData: { data: document.source.data, mediaType: document.source.media_type }
+				};
+			}
+		};
+
 		const pushImage = (img: ImageBlockParam) => {
 			const imagePart = toRawImage(img);
 			if (imagePart) {
@@ -238,6 +253,12 @@ export function anthropicMessagesToRawMessages(messages: MessageParam[], system:
 				} else if (block.type === 'image') {
 					pushImage(block);
 					pushCache(block);
+				} else if (block.type === 'document') {
+					const documentPart = toRawDocument(block);
+					if (documentPart) {
+						content.push(documentPart);
+						pushCache(block);
+					}
 				} else if (block.type === 'thinking') {
 					// Include thinking content for logging
 					content.push({
@@ -274,6 +295,11 @@ export function anthropicMessagesToRawMessages(messages: MessageParam[], system:
 								const imagePart = toRawImage(c);
 								if (imagePart) {
 									toolContent.push(imagePart);
+								}
+							} else if (c.type === 'document') {
+								const documentPart = toRawDocument(c);
+								if (documentPart) {
+									toolContent.push(documentPart);
 								}
 							}
 						}

--- a/extensions/copilot/src/extension/byok/common/test/anthropicMessageConverter.spec.ts
+++ b/extensions/copilot/src/extension/byok/common/test/anthropicMessageConverter.spec.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MessageParam, TextBlockParam } from '@anthropic-ai/sdk/resources';
+import { Raw } from '@vscode/prompt-tsx';
 import { expect, suite, test } from 'vitest';
 import { LanguageModelChatMessage, LanguageModelDataPart, LanguageModelToolResultPart } from '../../../../vscodeTypes';
-import { anthropicMessagesToRawMessages, apiMessageToAnthropicMessage } from '../anthropicMessageConverter';
+import { anthropicMessagesToRawMessages, anthropicMessagesToRawMessagesForLogging, apiMessageToAnthropicMessage } from '../anthropicMessageConverter';
 
 suite('apiMessageToAnthropicMessage', function () {
 	test('converts PDF data parts to document blocks', function () {
@@ -55,6 +56,70 @@ suite('apiMessageToAnthropicMessage', function () {
 });
 
 suite('anthropicMessagesToRawMessages', function () {
+	test('converts base64 PDF document blocks', function () {
+		const messages: MessageParam[] = [{
+			role: 'user',
+			content: [{
+				type: 'document',
+				source: { type: 'base64', media_type: 'application/pdf', data: 'pdf-data' }
+			}]
+		}];
+
+		const result = anthropicMessagesToRawMessages(messages, { type: 'text', text: '' });
+
+		expect(result).toEqual([{
+			role: Raw.ChatRole.User,
+			content: [{
+				type: Raw.ChatCompletionContentPartKind.Document,
+				documentData: { data: 'pdf-data', mediaType: 'application/pdf' }
+			}]
+		}]);
+	});
+
+	test('converts base64 PDF document blocks in tool results', function () {
+		const messages: MessageParam[] = [{
+			role: 'user',
+			content: [{
+				type: 'tool_result',
+				tool_use_id: 'call_1',
+				content: [{
+					type: 'document',
+					source: { type: 'base64', media_type: 'application/pdf', data: 'pdf-data' }
+				}]
+			}]
+		}];
+
+		const result = anthropicMessagesToRawMessages(messages, { type: 'text', text: '' });
+
+		expect(result).toEqual([{
+			role: Raw.ChatRole.Tool,
+			toolCallId: 'call_1',
+			content: [{
+				type: Raw.ChatCompletionContentPartKind.Document,
+				documentData: { data: 'pdf-data', mediaType: 'application/pdf' }
+			}]
+		}]);
+	});
+
+	test('redacts base64 PDF data from logging messages', function () {
+		const messages: MessageParam[] = [{
+			role: 'user',
+			content: [{
+				type: 'document',
+				source: { type: 'base64', media_type: 'application/pdf', data: 'pdf-data' }
+			}]
+		}];
+
+		const result = anthropicMessagesToRawMessagesForLogging(messages, { type: 'text', text: '' });
+
+		expect(result).toEqual([{
+			role: Raw.ChatRole.User,
+			content: [{
+				type: Raw.ChatCompletionContentPartKind.Document,
+				documentData: { data: '(document)', mediaType: 'application/pdf' }
+			}]
+		}]);
+	});
 
 	test('converts simple text messages', function () {
 		const messages: MessageParam[] = [


### PR DESCRIPTION
Fixes #325672

## Summary

- Preserve base64 PDF `document` blocks when parsing inbound Anthropic-compatible requests.
- Preserve PDF documents nested inside `tool_result` content.
- Redact base64 document payloads from request logging while retaining their media type.

## Problem

The `/v1/messages` endpoint parses Anthropic request bodies with `anthropicMessagesToRawMessages`. That converter handled text, images, thinking blocks, tool calls, and tool results, but it did not handle `document` blocks.

As a result, a top-level PDF was omitted before the request reached the selected model. When a PDF was the only user content, the resulting empty user message could also be omitted entirely. Documents nested inside `tool_result` content were similarly discarded because only text and image blocks were converted there.

## Fix

Base64 Anthropic document sources are now converted to the existing Raw document content part, preserving both the base64 data and `application/pdf` media type. The same conversion is used for top-level message content and tool-result content.

The downstream Messages and Responses request builders already support Raw PDF document parts, so no endpoint-specific conversion changes are required. The logging conversion now replaces document data with a placeholder, matching the existing image and tool-result sanitization behavior.

## Validation

- `npm run gulp compile-extensions`
- `npx tsc --noEmit --project tsconfig.json` in `extensions/copilot`
- `npm run test:unit -- src/extension/byok/common/test/anthropicMessageConverter.spec.ts`
- `npm run test:unit -- src/platform/endpoint/test/node/messagesApi.spec.ts src/platform/endpoint/node/test/responsesApi.spec.ts`
- `npx eslint src/extension/byok/common/anthropicMessageConverter.ts src/extension/byok/common/test/anthropicMessageConverter.spec.ts`

The new regression coverage checks top-level PDF documents, documents inside tool results, and logging redaction.
