### PR TITLE
chat: Keep local agent enabled in virtual workspaces

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/common/agentHostEnablementService.ts
@@ -68,7 +68,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'chat.editor.localAgent.enabled': {
 			type: 'boolean',
-			description: nls.localize('chat.editor.localAgent.enabled', "When enabled, shows the VS Code local chat harness in the chat picker."),
+			description: nls.localize('chat.editor.localAgent.enabled', "When enabled, shows the VS Code local chat harness in the chat picker. This setting is ignored in virtual workspaces, where the local chat harness is always available."),
 			default: true,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -37,6 +37,7 @@ import product from '../../../../../platform/product/common/product.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IWorkspace, IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ActiveEditorContext } from '../../../../common/contextkeys.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../../common/views.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
@@ -577,7 +578,7 @@ export function registerChatActions() {
 	 * honoring the remembered harness preference and then the configured default.
 	 */
 	function getNewChatEditorSessionUri(accessor: ServicesAccessor): URI {
-		return getDefaultNewChatSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService), accessor.get(IStorageService));
+		return getDefaultNewChatSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService), accessor.get(IStorageService), accessor.get(IWorkspaceContextService).getWorkspace());
 	}
 
 	registerAction2(PrimaryOpenChatGlobalAction);
@@ -1762,10 +1763,10 @@ export interface IClearEditingSessionConfirmationOptions {
  * Clears the current chat session and starts a new one using the shared
  * new-session harness resolver.
  */
-export async function clearChatSessionPreservingType(widget: IChatWidget, viewsService: IViewsService, sessionType: string | undefined, configurationService: IConfigurationService, chatSessionsService: IChatSessionsService, storageService: IStorageService): Promise<void> {
+export async function clearChatSessionPreservingType(widget: IChatWidget, viewsService: IViewsService, sessionType: string | undefined, configurationService: IConfigurationService, chatSessionsService: IChatSessionsService, storageService: IStorageService, workspace: IWorkspace): Promise<void> {
 	const currentResource = widget.viewModel?.model.sessionResource;
 	const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
-	const newSessionType = getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, { explicitOverride: sessionType, currentSessionType });
+	const newSessionType = getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, { explicitOverride: sessionType, currentSessionType });
 	if (isIChatViewViewContext(widget.viewContext) && newSessionType !== localChatSessionType) {
 		// For the sidebar, we need to explicitly load a session with the same type
 		const newResource = URI.from({ scheme: newSessionType, path: `/untitled-${generateUuid()}` });

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
@@ -8,6 +8,7 @@ import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IChatSessionsService } from '../../common/chatSessionsService.js';
 import { getDefaultNewChatSessionResource } from '../../common/constants.js';
@@ -19,6 +20,7 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 	const configurationService = accessor.get(IConfigurationService);
 	const chatSessionsService = accessor.get(IChatSessionsService);
 	const storageService = accessor.get(IStorageService);
+	const workspaceContextService = accessor.get(IWorkspaceContextService);
 
 	if (!chatEditorInput) {
 		const editorInput = editorService.activeEditor;
@@ -30,7 +32,7 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 		// Otherwise create a generic new chat editor.
 		const resource = chatEditorInput.sessionResource && chatEditorInput.sessionResource.scheme !== Schemas.vscodeLocalChatSession
 			? chatEditorInput.sessionResource.with({ path: `/untitled-${generateUuid()}` })
-			: getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService);
+			: getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace());
 
 		// A chat editor can only be open in one group
 		const identifier = editorService.findEditors(chatEditorInput.resource)[0];

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -23,6 +23,7 @@ import { KeybindingWeight } from '../../../../../platform/keybinding/common/keyb
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
@@ -909,6 +910,7 @@ class SendToNewChatAction extends Action2 {
 		const configurationService = accessor.get(IConfigurationService);
 		const chatSessionsService = accessor.get(IChatSessionsService);
 		const storageService = accessor.get(IStorageService);
+		const workspaceContextService = accessor.get(IWorkspaceContextService);
 		const widget = context?.widget ?? widgetService.lastFocusedWidget;
 		if (!widget) {
 			return;
@@ -930,7 +932,7 @@ class SendToNewChatAction extends Action2 {
 		// Clear the input from the current session before creating a new one
 		widget.setInput('');
 
-		await clearChatSessionPreservingType(widget, viewsService, undefined, configurationService, chatSessionsService, storageService);
+		await clearChatSessionPreservingType(widget, viewsService, undefined, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace());
 
 		widget.acceptInput(inputBeforeClear, { storeToHistory: true });
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
@@ -26,6 +26,7 @@ import { clearChatEditor } from './chatClear.js';
 import { AgentSessionProviders, AgentSessionsViewerOrientation } from '../agentSessions/agentSessions.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IChatSessionsService } from '../../common/chatSessionsService.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 
 export interface INewEditSessionActionContext {
 
@@ -319,6 +320,7 @@ async function runNewChatAction(
 	const configurationService = accessor.get(IConfigurationService);
 	const chatSessionsService = accessor.get(IChatSessionsService);
 	const storageService = accessor.get(IStorageService);
+	const workspaceContextService = accessor.get(IWorkspaceContextService);
 
 	const { editingSession, chatWidget: widget } = context ?? {};
 	if (!widget) {
@@ -335,7 +337,7 @@ async function runNewChatAction(
 	await editingSession?.stop();
 
 	// Create a new session, preserving the session type (or using the specified one)
-	await clearChatSessionPreservingType(widget, viewsService, sessionType, configurationService, chatSessionsService, storageService);
+	await clearChatSessionPreservingType(widget, viewsService, sessionType, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace());
 
 	widget.attachmentModel.clear(true);
 	widget.focusInput();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
@@ -18,10 +18,10 @@ import { IKeybindingService } from '../../../../../../platform/keybinding/common
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../common/languageModels.js';
-import { isVisibleEditorChatSessionType } from '../../../common/constants.js';
 import { ACTION_ID_NEW_CHAT } from '../../actions/chatActions.js';
 import { AgentSessionProviders, AgentSessionTarget, getAgentCanContinueIn, getAgentSessionProvider, isAgentHostTarget, isFirstPartyAgentSessionProvider } from '../../agentSessions/agentSessions.js';
 import { ISessionTypePickerDelegate } from '../../chat.js';
@@ -51,9 +51,10 @@ export class DelegationSessionPickerActionItem extends SessionTypePickerActionIt
 		@ILanguageModelsService languageModelsService: ILanguageModelsService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IStorageService storageService: IStorageService,
+		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
 		@IGitService private readonly gitService: IGitService,
 	) {
-		super(action, chatSessionPosition, delegate, pickerOptions, actionWidgetService, keybindingService, contextKeyService, chatSessionsService, commandService, openerService, telemetryService, chatEntitlementService, languageModelsService, configurationService, storageService);
+		super(action, chatSessionPosition, delegate, pickerOptions, actionWidgetService, keybindingService, contextKeyService, chatSessionsService, commandService, openerService, telemetryService, chatEntitlementService, languageModelsService, configurationService, storageService, workspaceContextService);
 	}
 
 	protected override _run(sessionTypeItem: ISessionTypeItem): void {
@@ -123,8 +124,8 @@ export class DelegationSessionPickerActionItem extends SessionTypePickerActionIt
 			return false;
 		}
 
-		// Apply the same visibility guards as the new-session picker (e.g. Local hidden when chat.editor.localAgent.enabled is false).
-		if (!isVisibleEditorChatSessionType(type, this.configurationService, this.chatSessionsService)) {
+		// Apply the same visibility guards as the new-session picker.
+		if (!super._isVisible(type)) {
 			return false;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -22,6 +22,7 @@ import { IKeybindingService } from '../../../../../../platform/keybinding/common
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
@@ -102,6 +103,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 		@ILanguageModelsService protected readonly languageModelsService: ILanguageModelsService,
 		@IConfigurationService protected readonly configurationService: IConfigurationService,
 		@IStorageService protected readonly storageService: IStorageService,
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 	) {
 
 		const actionProvider: IActionWidgetDropdownActionProvider = {
@@ -160,12 +162,14 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 			}
 		}));
 
+		this._register(this.workspaceContextService.onDidChangeWorkspaceFolders(() => this._updateAgentSessionItems()));
+
 		this._updateAgentSessionItems();
 	}
 
 	protected _run(sessionTypeItem: ISessionTypeItem): void {
 		if (!this._isSessionsWindow) {
-			recordUserSelectedSessionType(this.storageService, this.configurationService, this.chatSessionsService, sessionTypeItem.type);
+			recordUserSelectedSessionType(this.storageService, this.configurationService, this.chatSessionsService, this.workspaceContextService.getWorkspace(), sessionTypeItem.type);
 		}
 
 		if (this.delegate.setActiveSessionProvider) {
@@ -264,11 +268,11 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 	 * when the selected provider is registered.
 	 */
 	protected _getDefaultSessionType(): AgentSessionTarget {
-		return getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService) as AgentSessionTarget;
+		return getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService, this.workspaceContextService.getWorkspace()) as AgentSessionTarget;
 	}
 
 	protected _isVisible(type: AgentSessionTarget): boolean {
-		return isVisibleEditorChatSessionType(type, this.configurationService, this.chatSessionsService);
+		return isVisibleEditorChatSessionType(type, this.configurationService, this.chatSessionsService, this.workspaceContextService.getWorkspace());
 	}
 
 	protected _isSessionTypeEnabled(type: AgentSessionTarget): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
@@ -19,6 +19,7 @@ import { IInstantiationService } from '../../../../../../platform/instantiation/
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { registerIcon } from '../../../../../../platform/theme/common/iconRegistry.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { EditorInputCapabilities, IEditorIdentifier, IEditorSerializer, IUntypedEditorInput, Verbosity } from '../../../../../common/editor.js';
 import { EditorInput, IEditorCloseHandler } from '../../../../../common/editor/editorInput.js';
 import { IChatModelReference, IChatService } from '../../../common/chatService/chatService.js';
@@ -69,6 +70,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IStorageService private readonly storageService: IStorageService,
 		@ILogService private readonly logService: ILogService,
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 	) {
 		super();
 
@@ -232,7 +234,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			}
 
 			if (this.shouldReplaceEmptyLocalSession(this._sessionResource)) {
-				const defaultResource = getComputedDefaultSessionResource(this.configurationService, this.chatSessionsService);
+				const defaultResource = getComputedDefaultSessionResource(this.configurationService, this.chatSessionsService, this.workspaceContextService.getWorkspace());
 				if (getChatSessionType(defaultResource) !== localChatSessionType) {
 					let modelRef: IChatModelReference | undefined;
 					try {
@@ -257,7 +259,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			if (this.options.explicitSessionType === localChatSessionType) {
 				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveExplicitLocal' });
 			} else {
-				const defaultResource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService);
+				const defaultResource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService, this.workspaceContextService.getWorkspace());
 				if (getChatSessionType(defaultResource) === localChatSessionType) {
 					this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveUntitled' });
 				} else {
@@ -302,7 +304,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			&& this.options.explicitSessionType !== localChatSessionType
 			&& !!this.model
 			&& !this.model.hasRequests
-			&& getComputedDefaultSessionType(this.configurationService, this.chatSessionsService) !== localChatSessionType;
+			&& getComputedDefaultSessionType(this.configurationService, this.chatSessionsService, this.workspaceContextService.getWorkspace()) !== localChatSessionType;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -33,6 +33,7 @@ import { INotificationService } from '../../../../../../platform/notification/co
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { defaultButtonStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
 import { editorBackground } from '../../../../../../platform/theme/common/colorRegistry.js';
 import { ChatViewTitleControl } from './chatViewTitleControl.js';
@@ -50,7 +51,7 @@ import { CHAT_PROVIDER_ID } from '../../../common/participants/chatParticipantCo
 import { IChatModelReference, IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { LocalChatSessionUri, getChatSessionType } from '../../../common/model/chatUri.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getComputedDefaultSessionType, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getComputedDefaultSessionType, getDefaultNewChatSessionResource, getDefaultNewChatSessionType, isEditorLocalAgentEnabled } from '../../../common/constants.js';
 import { AgentSessionsControl } from '../../agentSessions/agentSessionsControl.js';
 import { ACTION_ID_NEW_CHAT } from '../../actions/chatActions.js';
 import { ChatWidget } from '../../widget/chatWidget.js';
@@ -147,6 +148,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		@IAgentTitleBarStatusService _agentTitleBarStatusService: IAgentTitleBarStatusService,
 		@IVoicePlaybackService _voicePlaybackService: IVoicePlaybackService,
 		@IWorkbenchEnvironmentService _workbenchEnvironmentService: IWorkbenchEnvironmentService,
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 	) {
 		super(options, keybindingService2, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 
@@ -1067,11 +1069,12 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	 * Returns `undefined` to fall back to `startNewLocalSession`.
 	 */
 	private async acquireDefaultNewSession(token: CancellationToken): Promise<IChatModelReference | undefined> {
-		const defaultType = getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService);
+		const workspace = this.workspaceContextService.getWorkspace();
+		const defaultType = getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService, workspace);
 		if (defaultType === localChatSessionType) {
 			return undefined;
 		}
-		const resource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService);
+		const resource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService, workspace);
 		try {
 			return await this.chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, token, 'ChatViewPane#acquireDefaultNewSession');
 		} catch (error) {
@@ -1100,8 +1103,9 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	}
 
 	private shouldSkipRestoredLocalSession(sessionResource: URI, model: IChatModel): boolean {
-		const defaultType = getComputedDefaultSessionType(this.configurationService, this.chatSessionsService);
-		const prefersAgentHostCopilot = this.configurationService.getValue<boolean>(ChatConfiguration.EditorLocalAgentEnabled) === false
+		const workspace = this.workspaceContextService.getWorkspace();
+		const defaultType = getComputedDefaultSessionType(this.configurationService, this.chatSessionsService, workspace);
+		const prefersAgentHostCopilot = !isEditorLocalAgentEnabled(this.configurationService, workspace)
 			&& this.configurationService.getValue<string>(ChatConfiguration.EditorDefaultProvider) === 'copilotAh';
 		return (defaultType !== localChatSessionType || prefersAgentHostCopilot)
 			&& getChatSessionType(sessionResource) === localChatSessionType

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -7,6 +7,8 @@ import { Schemas } from '../../../../base/common/network.js';
 import { IChatSessionsService, isAgentHostTarget, localChatSessionType, SessionType } from './chatSessionsService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { IWorkspace } from '../../../../platform/workspace/common/workspace.js';
+import { isVirtualWorkspace } from '../../../../platform/workspace/common/virtualWorkspace.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { ChatEntitlementContextKeys } from '../../../services/chat/common/chatEntitlementService.js';
@@ -266,30 +268,32 @@ export function isSupportedChatFileScheme(accessor: ServicesAccessor, scheme: st
  */
 export function getComputedDefaultSessionType(
 	configurationService: IConfigurationService,
-	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	workspace: IWorkspace
 ): string {
 	const defaultProvider = configurationService.getValue<string>(ChatConfiguration.EditorDefaultProvider);
 	const defaultType = getConfiguredEditorDefaultSessionType(defaultProvider);
-	if (defaultType === SessionType.AgentHostCopilot && !isEditorLocalAgentEnabled(configurationService)) {
+	if (defaultType === SessionType.AgentHostCopilot && !isEditorLocalAgentEnabled(configurationService, workspace)) {
 		return defaultType;
 	}
 
-	if (defaultType && isVisibleEditorChatSessionType(defaultType, configurationService, chatSessionsService)) {
+	if (defaultType && isVisibleEditorChatSessionType(defaultType, configurationService, chatSessionsService, workspace)) {
 		return defaultType;
 	}
 
-	if (isEditorLocalAgentEnabled(configurationService)) {
+	if (isEditorLocalAgentEnabled(configurationService, workspace)) {
 		return localChatSessionType;
 	}
 
-	return getVisibleNonLocalEditorChatSessionTypes(configurationService, chatSessionsService)[0] ?? localChatSessionType;
+	return getVisibleNonLocalEditorChatSessionTypes(configurationService, chatSessionsService, workspace)[0] ?? localChatSessionType;
 }
 
 export function getComputedDefaultSessionResource(
 	configurationService: IConfigurationService,
-	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	workspace: IWorkspace
 ): URI {
-	const defaultType = getComputedDefaultSessionType(configurationService, chatSessionsService);
+	const defaultType = getComputedDefaultSessionType(configurationService, chatSessionsService, workspace);
 	return defaultType === localChatSessionType
 		? LocalChatSessionUri.getNewSessionUri()
 		: URI.from({ scheme: defaultType, path: `/untitled-${generateUuid()}` });
@@ -298,10 +302,11 @@ export function getComputedDefaultSessionResource(
 export function isRememberedSessionTypeUsable(
 	sessionType: string,
 	configurationService: IConfigurationService,
-	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	workspace: IWorkspace
 ): boolean {
 	if (sessionType === localChatSessionType) {
-		return isEditorLocalAgentEnabled(configurationService);
+		return isEditorLocalAgentEnabled(configurationService, workspace);
 	}
 	if (isAgentHostTarget(sessionType)) {
 		return true;
@@ -318,6 +323,7 @@ export function getDefaultNewChatSessionType(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
 	storageService: IStorageService,
+	workspace: IWorkspace,
 	options?: IDefaultNewChatSessionTypeOptions
 ): string {
 	if (options?.explicitOverride) {
@@ -325,7 +331,7 @@ export function getDefaultNewChatSessionType(
 	}
 
 	const remembered = getRememberedSessionType(storageService);
-	if (remembered && isRememberedSessionTypeUsable(remembered, configurationService, chatSessionsService)) {
+	if (remembered && isRememberedSessionTypeUsable(remembered, configurationService, chatSessionsService, workspace)) {
 		return remembered;
 	}
 
@@ -333,16 +339,17 @@ export function getDefaultNewChatSessionType(
 		return options.currentSessionType;
 	}
 
-	return getComputedDefaultSessionType(configurationService, chatSessionsService);
+	return getComputedDefaultSessionType(configurationService, chatSessionsService, workspace);
 }
 
 export function getDefaultNewChatSessionResource(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
 	storageService: IStorageService,
+	workspace: IWorkspace,
 	options?: IDefaultNewChatSessionTypeOptions
 ): URI {
-	const defaultType = getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, options);
+	const defaultType = getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, options);
 	return defaultType === localChatSessionType
 		? LocalChatSessionUri.getNewSessionUri()
 		: URI.from({ scheme: defaultType, path: `/untitled-${generateUuid()}` });
@@ -352,29 +359,31 @@ export function recordUserSelectedSessionType(
 	storageService: IStorageService,
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	workspace: IWorkspace,
 	sessionType: string
 ): void {
-	if (sessionType === getComputedDefaultSessionType(configurationService, chatSessionsService)) {
+	if (sessionType === getComputedDefaultSessionType(configurationService, chatSessionsService, workspace)) {
 		clearUserSelectedSessionType(storageService);
 	} else {
 		storeUserSelectedSessionType(storageService, sessionType);
 	}
 }
 
-export function isEditorLocalAgentEnabled(configurationService: IConfigurationService): boolean {
-	return configurationService.getValue<boolean>(ChatConfiguration.EditorLocalAgentEnabled) ?? true;
+export function isEditorLocalAgentEnabled(configurationService: IConfigurationService, workspace: IWorkspace): boolean {
+	return isVirtualWorkspace(workspace) || (configurationService.getValue<boolean>(ChatConfiguration.EditorLocalAgentEnabled) ?? true);
 }
 
 export function isVisibleEditorChatSessionType(
 	sessionType: string,
 	configurationService: IConfigurationService,
-	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	workspace: IWorkspace
 ): boolean {
 	if (sessionType === localChatSessionType) {
-		if (!isEditorLocalAgentEnabled(configurationService) && configurationService.getValue<string>(ChatConfiguration.EditorDefaultProvider) === 'copilotAh') {
+		if (!isEditorLocalAgentEnabled(configurationService, workspace) && configurationService.getValue<string>(ChatConfiguration.EditorDefaultProvider) === 'copilotAh') {
 			return false;
 		}
-		return isEditorLocalAgentEnabled(configurationService) || getVisibleNonLocalEditorChatSessionTypes(configurationService, chatSessionsService).length === 0;
+		return isEditorLocalAgentEnabled(configurationService, workspace) || getVisibleNonLocalEditorChatSessionTypes(configurationService, chatSessionsService, workspace).length === 0;
 	}
 
 	if (sessionType === SessionType.CopilotCLI && configurationService.getValue<boolean>(ChatConfiguration.CopilotCliHideExtensionHostEditor)) {
@@ -399,11 +408,12 @@ function getConfiguredEditorDefaultSessionType(defaultProvider: string | undefin
 
 function getVisibleNonLocalEditorChatSessionTypes(
 	configurationService: IConfigurationService,
-	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	workspace: IWorkspace
 ): string[] {
 	const sessionTypes = new Set<string>();
 	for (const contribution of chatSessionsService.getAllChatSessionContributions()) {
-		if (contribution.type !== localChatSessionType && isVisibleEditorChatSessionType(contribution.type, configurationService, chatSessionsService)) {
+		if (contribution.type !== localChatSessionType && isVisibleEditorChatSessionType(contribution.type, configurationService, chatSessionsService, workspace)) {
 			sessionTypes.add(contribution.type);
 		}
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
@@ -18,6 +18,7 @@ import { IChatSessionsService, localChatSessionType } from '../../../../common/c
 import { ChatAgentLocation } from '../../../../common/constants.js';
 import { IChatModel } from '../../../../common/model/chatModel.js';
 import { LocalChatSessionUri } from '../../../../common/model/chatUri.js';
+import { TestContextService } from '../../../../../../test/common/workbenchTestServices.js';
 
 suite('ChatEditorInput', () => {
 
@@ -54,6 +55,7 @@ suite('ChatEditorInput', () => {
 			{} as IInstantiationService,
 			{} as IStorageService,
 			new NullLogService(),
+			new TestContextService(),
 		);
 
 		try {
@@ -107,6 +109,7 @@ suite('ChatEditorInput', () => {
 			{} as IInstantiationService,
 			{} as IStorageService,
 			new NullLogService(),
+			new TestContextService(),
 		);
 
 		try {

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -4,9 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { ChatConfiguration, getComputedDefaultSessionType, getDefaultNewChatSessionType, isRememberedSessionTypeUsable, isVisibleEditorChatSessionType, recordUserSelectedSessionType } from '../../common/constants.js';
+import { IWorkspace, toWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
+import { ChatConfiguration, getComputedDefaultSessionType, getDefaultNewChatSessionType, isEditorLocalAgentEnabled, isRememberedSessionTypeUsable, isVisibleEditorChatSessionType, recordUserSelectedSessionType } from '../../common/constants.js';
 import { localChatSessionType, SessionType, IChatSessionsExtensionPoint } from '../../common/chatSessionsService.js';
 import { MockChatSessionsService } from './mockChatSessionsService.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
@@ -15,6 +17,14 @@ import { getRememberedSessionType } from '../../common/chatSessionTypePreference
 suite('ChatConfiguration defaults', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	const localWorkspace = createWorkspace(URI.file('/workspace'));
+
+	function createWorkspace(...resources: URI[]): IWorkspace {
+		return {
+			id: resources.map(resource => resource.toString()).join(','),
+			folders: resources.map(toWorkspaceFolder),
+		};
+	}
 
 	function createChatSessionsService(...types: string[]): MockChatSessionsService {
 		const service = new MockChatSessionsService();
@@ -33,9 +43,9 @@ suite('ChatConfiguration defaults', () => {
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
-			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
 		}, {
 			computed: localChatSessionType,
 			rememberedAware: localChatSessionType,
@@ -52,9 +62,9 @@ suite('ChatConfiguration defaults', () => {
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
-			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
 		}, {
 			computed: SessionType.AgentHostCopilot,
 			rememberedAware: SessionType.AgentHostCopilot,
@@ -71,9 +81,9 @@ suite('ChatConfiguration defaults', () => {
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
-			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
 		}, {
 			computed: SessionType.AgentHostCopilot,
 			rememberedAware: SessionType.AgentHostCopilot,
@@ -91,9 +101,9 @@ suite('ChatConfiguration defaults', () => {
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
-			extensionHostVisible: isVisibleEditorChatSessionType(SessionType.CopilotCLI, configurationService, chatSessionsService),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			extensionHostVisible: isVisibleEditorChatSessionType(SessionType.CopilotCLI, configurationService, chatSessionsService, localWorkspace),
 		}, {
 			computed: SessionType.AgentHostCopilot,
 			rememberedAware: SessionType.AgentHostCopilot,
@@ -109,9 +119,9 @@ suite('ChatConfiguration defaults', () => {
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
-			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
 		}, {
 			computed: localChatSessionType,
 			rememberedAware: localChatSessionType,
@@ -124,12 +134,12 @@ suite('ChatConfiguration defaults', () => {
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostClaude);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude);
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
 			remembered: getRememberedSessionType(storageService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
 		}, {
 			computed: localChatSessionType,
 			remembered: SessionType.AgentHostClaude,
@@ -142,11 +152,11 @@ suite('ChatConfiguration defaults', () => {
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostClaude);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude);
 
 		assert.deepStrictEqual({
 			remembered: getRememberedSessionType(storageService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, { explicitOverride: SessionType.AgentHostCopilot }),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, { explicitOverride: SessionType.AgentHostCopilot }),
 		}, {
 			remembered: SessionType.AgentHostClaude,
 			rememberedAware: SessionType.AgentHostCopilot,
@@ -159,15 +169,15 @@ suite('ChatConfiguration defaults', () => {
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			withoutRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, { currentSessionType: SessionType.AgentHostCopilot }),
+			withoutRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, { currentSessionType: SessionType.AgentHostCopilot }),
 		}, {
 			withoutRemembered: SessionType.AgentHostCopilot,
 		});
 
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostClaude);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude);
 
 		assert.deepStrictEqual({
-			withRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, { currentSessionType: SessionType.AgentHostCopilot }),
+			withRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, { currentSessionType: SessionType.AgentHostCopilot }),
 		}, {
 			withRemembered: SessionType.AgentHostClaude,
 		});
@@ -181,13 +191,13 @@ suite('ChatConfiguration defaults', () => {
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostClaude);
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostCopilot);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostCopilot);
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
 			remembered: getRememberedSessionType(storageService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
 		}, {
 			computed: SessionType.AgentHostCopilot,
 			remembered: undefined,
@@ -200,11 +210,56 @@ suite('ChatConfiguration defaults', () => {
 		const chatSessionsService = createChatSessionsService();
 
 		assert.deepStrictEqual({
-			agentHost: isRememberedSessionTypeUsable(SessionType.AgentHostClaude, configurationService, chatSessionsService),
-			extensionContributed: isRememberedSessionTypeUsable('my-extension-agent', configurationService, chatSessionsService),
+			agentHost: isRememberedSessionTypeUsable(SessionType.AgentHostClaude, configurationService, chatSessionsService, localWorkspace),
+			extensionContributed: isRememberedSessionTypeUsable('my-extension-agent', configurationService, chatSessionsService, localWorkspace),
 		}, {
 			agentHost: true,
 			extensionContributed: false,
+		});
+	});
+
+	test('local agent setting is ignored only in fully virtual workspaces', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorLocalAgentEnabled]: false,
+		});
+		const remoteWorkspace = createWorkspace(URI.parse('vscode-remote://ssh-remote+test/workspace'));
+		const remoteRepositoriesWorkspace = createWorkspace(URI.parse('vscode-vfs://github/microsoft/vscode'));
+		const customVirtualWorkspace = createWorkspace(URI.parse('custom-vfs://provider/workspace'));
+		const mixedWorkspace = createWorkspace(URI.file('/workspace'), URI.parse('custom-vfs://provider/workspace'));
+
+		assert.deepStrictEqual({
+			local: isEditorLocalAgentEnabled(configurationService, localWorkspace),
+			remote: isEditorLocalAgentEnabled(configurationService, remoteWorkspace),
+			remoteRepositories: isEditorLocalAgentEnabled(configurationService, remoteRepositoriesWorkspace),
+			customVirtual: isEditorLocalAgentEnabled(configurationService, customVirtualWorkspace),
+			mixed: isEditorLocalAgentEnabled(configurationService, mixedWorkspace),
+		}, {
+			local: false,
+			remote: false,
+			remoteRepositories: true,
+			customVirtual: true,
+			mixed: false,
+		});
+	});
+
+	test('virtual workspace keeps local available when setting is disabled', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorLocalAgentEnabled]: false,
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+		const workspace = createWorkspace(URI.parse('vscode-vfs://github/microsoft/vscode'));
+
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, workspace),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, workspace),
+			localRememberedUsable: isRememberedSessionTypeUsable(localChatSessionType, configurationService, chatSessionsService, workspace),
+		}, {
+			computed: localChatSessionType,
+			rememberedAware: localChatSessionType,
+			localVisible: true,
+			localRememberedUsable: true,
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Treat the local chat agent as enabled in virtual workspaces regardless of `chat.editor.localAgent.enabled`
- Apply the effective setting consistently across picker visibility, default and remembered providers, session restore, and new-session flows
- Refresh picker state when workspace folders change and clarify the setting description
- Cover Remote Repositories (`vscode-vfs`), custom virtual, local, remote, and mixed workspaces

## Validation

- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/common/constants.test.ts --run src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts`
- `npm run valid-layers-check`
- `npm run precommit`

(Written by Copilot)