### PR TITLE
Add voice-mode speech-to-text chat input

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -896,6 +896,10 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		}
 	}
 
+	getInput(): string {
+		return this._editor?.getModel()?.getValue() ?? '';
+	}
+
 	sendQuery(text: string): void {
 		// A submit is already in flight (e.g. a rapid second transcript before the
 		// session is created); don't clobber the in-flight text or double-submit.

--- a/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
@@ -97,6 +97,7 @@ registerSingleton(INewChatVoiceTargetService, NewChatVoiceTargetService, Instant
 export const SessionsNewChatVoiceMenu = new MenuId('SessionsNewChatVoiceMenu');
 
 const WHEN_VOICE_ENABLED = ContextKeyExpr.equals('config.agents.voice.enabled', true);
+const WHEN_STT_ONLY = ContextKeyExpr.equals('config.agents.voice.chatInputSpeechToText.enabled', true);
 const WHEN_CONNECTING = ContextKeyExpr.equals('agentsVoiceConnecting', true);
 const WHEN_LISTENING = ContextKeyExpr.equals('agentsVoiceListening', true);
 const WHEN_CONNECTED = ContextKeyExpr.equals('agentsVoiceConnected', true);
@@ -105,37 +106,44 @@ const WHEN_VOICE_SURFACE = ContextKeyExpr.equals('newChatVoiceSurface', true);
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 	command: { id: 'agentsVoice.connecting', title: localize('agentsVoice.connecting', "Connecting..."), icon: Codicon.loading },
-	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_CONNECTING, WHEN_INITIATED_HERE),
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY.negate(), WHEN_CONNECTING, WHEN_INITIATED_HERE),
 	group: 'navigation',
 	order: -10,
 });
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 	command: { id: 'agentsVoice.startVoiceInChat', title: localize('agentsVoice.startVoiceInChat', "Voice Mode"), icon: Codicon.voiceMode },
-	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_VOICE_SURFACE, WHEN_LISTENING.negate(), WHEN_CONNECTING.negate()),
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY.negate(), WHEN_VOICE_SURFACE, WHEN_LISTENING.negate(), WHEN_CONNECTING.negate()),
 	group: 'navigation',
 	order: -10,
 });
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 	command: { id: 'agentsVoice.pttStopInChat', title: localize('agentsVoice.pttStopInChat', "Voice Mode: Stop Recording"), icon: Codicon.voiceMode },
-	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_LISTENING, WHEN_INITIATED_HERE),
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY.negate(), WHEN_LISTENING, WHEN_INITIATED_HERE),
 	group: 'navigation',
 	order: -10,
 });
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 	command: { id: 'agentsVoice.openSettings', title: localize('agentsVoice.openSettings', "Voice Mode Settings"), icon: Codicon.settingsGear },
-	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_CONNECTED, WHEN_INITIATED_HERE),
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY.negate(), WHEN_CONNECTED, WHEN_INITIATED_HERE),
 	group: 'navigation',
 	order: -9.5,
 });
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 	command: { id: 'agentsVoice.disconnect', title: localize('agentsVoice.disconnect', "Disconnect Voice Mode"), icon: Codicon.debugDisconnect },
-	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_CONNECTED, WHEN_INITIATED_HERE),
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY.negate(), WHEN_CONNECTED, WHEN_INITIATED_HERE),
 	group: 'navigation',
 	order: -9,
+});
+
+MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
+	command: { id: 'agentsVoice.speechToTextInChatInput', title: localize('agentsVoice.speechToTextInChatInput', "Speech to Text"), icon: Codicon.mic },
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY, WHEN_VOICE_SURFACE, WHEN_CONNECTING.negate()),
+	group: 'navigation',
+	order: -10,
 });
 
 export interface INewChatVoiceControllerOptions {

--- a/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
@@ -42,6 +42,8 @@ export interface INewChatVoiceComposer {
 	sendQuery(text: string): void;
 	/** Set `text` without submitting. */
 	prefillInput(text: string): void;
+	/** The composer's current draft text (empty when unmounted). */
+	getInput(): string;
 	/** Focus the composer input. */
 	focus(): void;
 }
@@ -106,7 +108,7 @@ const WHEN_VOICE_SURFACE = ContextKeyExpr.equals('newChatVoiceSurface', true);
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 	command: { id: 'agentsVoice.connecting', title: localize('agentsVoice.connecting', "Connecting..."), icon: Codicon.loading },
-	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY.negate(), WHEN_CONNECTING, WHEN_INITIATED_HERE),
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_CONNECTING, WHEN_INITIATED_HERE),
 	group: 'navigation',
 	order: -10,
 });
@@ -141,7 +143,14 @@ MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 	command: { id: 'agentsVoice.speechToTextInChatInput', title: localize('agentsVoice.speechToTextInChatInput', "Speech to Text"), icon: Codicon.mic },
-	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY, WHEN_VOICE_SURFACE, WHEN_CONNECTING.negate()),
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY, WHEN_VOICE_SURFACE, WHEN_CONNECTING.negate(), WHEN_LISTENING.negate()),
+	group: 'navigation',
+	order: -10,
+});
+
+MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
+	command: { id: 'agentsVoice.speechToTextStopInChatInput', title: localize('agentsVoice.speechToTextStopInChatInput', "Stop Dictation"), icon: Codicon.stopCircle },
+	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_STT_ONLY, WHEN_VOICE_SURFACE, WHEN_LISTENING),
 	group: 'navigation',
 	order: -10,
 });

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -80,6 +80,27 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 			}
 		}));
 
+		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.insertInput', (_accessor, text: string) => {
+			if (!text) {
+				return;
+			}
+			const composer = this._activeComposerTarget();
+			if (composer) {
+				const widget = this._activeSessionWidget();
+				const currentInput = widget?.getInput().trim() ?? '';
+				composer.prefillInput(currentInput ? `${currentInput} ${text}` : text);
+				composer.focus();
+				return;
+			}
+			const widget = this._activeSessionWidget() ?? this.chatWidgetService.lastFocusedWidget;
+			if (widget?.viewModel) {
+				const currentInput = widget.getInput().trim();
+				const nextInput = currentInput ? `${currentInput} ${text}` : text;
+				widget.setInput(nextInput);
+				widget.focusInput();
+			}
+		}));
+
 		// Report the shown session (the active Agents session), not DOM focus.
 		// Before a session exists, report the composer sentinel so dictation uses it.
 		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.getCurrentSession', (): string | undefined => {

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -86,15 +86,17 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 			}
 			const composer = this._activeComposerTarget();
 			if (composer) {
-				const widget = this._activeSessionWidget();
-				const currentInput = widget?.getInput().trim() ?? '';
+				// Read and append to the composer's OWN draft — not the parent
+				// session chat's input — so an in-progress composer draft is
+				// preserved verbatim rather than overwritten.
+				const currentInput = composer.getInput();
 				composer.prefillInput(currentInput ? `${currentInput} ${text}` : text);
 				composer.focus();
 				return;
 			}
 			const widget = this._activeSessionWidget() ?? this.chatWidgetService.lastFocusedWidget;
 			if (widget?.viewModel) {
-				const currentInput = widget.getInput().trim();
+				const currentInput = widget.getInput();
 				const nextInput = currentInput ? `${currentInput} ${text}` : text;
 				widget.setInput(nextInput);
 				widget.focusInput();

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -52,6 +52,7 @@ export const AGENTS_VOICE_WIDGET_FOCUSED = new RawContextKey<boolean>('agentsVoi
 const AGENTS_VOICE_CONNECTED = new RawContextKey<boolean>('agentsVoiceConnected', false);
 const AGENTS_VOICE_CONNECTING = new RawContextKey<boolean>('agentsVoiceConnecting', false);
 const AGENTS_VOICE_LISTENING = new RawContextKey<boolean>('agentsVoiceListening', false);
+const AGENTS_VOICE_STT_ONLY = ContextKeyExpr.equals('config.agents.voice.chatInputSpeechToText.enabled', true);
 
 // --- Context Key Binding ---
 
@@ -126,12 +127,14 @@ registerAction2(class extends Action2 {
 			icon: Codicon.loading,
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),
+				AGENTS_VOICE_STT_ONLY.negate(),
 				AGENTS_VOICE_CONNECTING.isEqualTo(true),
 			),
 			menu: {
 				id: MenuId.ChatExecute,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					AGENTS_VOICE_STT_ONLY.negate(),
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					AGENTS_VOICE_CONNECTING.isEqualTo(true),
 				),
@@ -151,11 +154,15 @@ registerAction2(class extends Action2 {
 			id: 'agentsVoice.startVoiceInChat',
 			title: nls.localize2('agentsVoice.startVoiceInChat', "Voice Mode"),
 			icon: Codicon.voiceMode,
-			precondition: ContextKeyExpr.equals('config.agents.voice.enabled', true),
+			precondition: ContextKeyExpr.and(
+				ContextKeyExpr.equals('config.agents.voice.enabled', true),
+				AGENTS_VOICE_STT_ONLY.negate(),
+			),
 			menu: {
 				id: MenuId.ChatExecute,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					AGENTS_VOICE_STT_ONLY.negate(),
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					ChatContextKeys.currentlyEditing.negate(),
 					AGENTS_VOICE_LISTENING.negate(),
@@ -196,12 +203,14 @@ registerAction2(class extends Action2 {
 			icon: Codicon.voiceMode,
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),
+				AGENTS_VOICE_STT_ONLY.negate(),
 				AGENTS_VOICE_LISTENING.isEqualTo(true),
 			),
 			menu: {
 				id: MenuId.ChatExecute,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					AGENTS_VOICE_STT_ONLY.negate(),
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					ChatContextKeys.currentlyEditing.negate(),
 					AGENTS_VOICE_LISTENING.isEqualTo(true),
@@ -217,6 +226,7 @@ registerAction2(class extends Action2 {
 				},
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					AGENTS_VOICE_STT_ONLY.negate(),
 					ChatContextKeys.inChatInput,
 					AGENTS_VOICE_LISTENING.isEqualTo(true),
 				),
@@ -232,6 +242,49 @@ registerAction2(class extends Action2 {
 	}
 });
 
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'agentsVoice.speechToTextInChatInput',
+			title: nls.localize2('agentsVoice.speechToTextInChatInput', "Speech to Text"),
+			icon: Codicon.mic,
+			precondition: ContextKeyExpr.and(
+				ContextKeyExpr.equals('config.agents.voice.enabled', true),
+				AGENTS_VOICE_STT_ONLY,
+				AGENTS_VOICE_CONNECTING.negate(),
+				ChatContextKeys.inChatInput,
+			),
+			menu: {
+				id: MenuId.ChatExecute,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					AGENTS_VOICE_STT_ONLY,
+					AGENTS_VOICE_CONNECTING.negate(),
+					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
+					ChatContextKeys.currentlyEditing.negate(),
+				),
+				group: 'navigation',
+				order: -10
+			},
+		});
+	}
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const voiceController = accessor.get(IVoiceSessionController);
+		if (voiceController.voiceState.get() === 'listening') {
+			voiceController.stopListening();
+			return;
+		}
+		if (!voiceController.isConnected.get()) {
+			await voiceController.connect(mainWindow);
+		}
+		if (!voiceController.isConnected.get() || voiceController.isConnecting.get()) {
+			return;
+		}
+		voiceController.pttDown();
+		voiceController.pttUp();
+	}
+});
+
 // --- Disconnect Voice (command palette + separate toolbar button when connected) ---
 
 registerAction2(class extends Action2 {
@@ -243,12 +296,14 @@ registerAction2(class extends Action2 {
 			f1: true,
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),
+				AGENTS_VOICE_STT_ONLY.negate(),
 				AGENTS_VOICE_CONNECTED.isEqualTo(true),
 			),
 			menu: {
 				id: MenuId.ChatExecute,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					AGENTS_VOICE_STT_ONLY.negate(),
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					ChatContextKeys.currentlyEditing.negate(),
 					AGENTS_VOICE_CONNECTED.isEqualTo(true),
@@ -264,6 +319,7 @@ registerAction2(class extends Action2 {
 				primary: KeyCode.Escape,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					AGENTS_VOICE_STT_ONLY.negate(),
 					ChatContextKeys.inChatInput,
 					AGENTS_VOICE_CONNECTED.isEqualTo(true),
 					EditorContextKeys.hoverVisible.toNegated(),
@@ -293,6 +349,7 @@ registerAction2(class extends Action2 {
 				id: MenuId.ChatExecute,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					AGENTS_VOICE_STT_ONLY.negate(),
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					ChatContextKeys.currentlyEditing.negate(),
 					AGENTS_VOICE_CONNECTED.isEqualTo(true),
@@ -496,6 +553,13 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('agents.voice.showTranscript', "Show the voice transcript overlay in the chat input area while voice mode is active. Enable this to read responses as text when `#agents.voice.speakResponses#` is disabled."),
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
+		},
+		'agents.voice.chatInputSpeechToText.enabled': {
+			type: 'boolean',
+			markdownDescription: nls.localize('agents.voice.chatInputSpeechToText.enabled', "Use the voice backend only for speech-to-text in chat inputs. When enabled, chat shows a microphone action that transcribes speech directly into the input without sending it or speaking assistant replies."),
+			default: false,
+			scope: ConfigurationScope.APPLICATION,
+			tags: ['advanced'],
 		},
 		'agents.voice.handsFree': {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -127,14 +127,12 @@ registerAction2(class extends Action2 {
 			icon: Codicon.loading,
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),
-				AGENTS_VOICE_STT_ONLY.negate(),
 				AGENTS_VOICE_CONNECTING.isEqualTo(true),
 			),
 			menu: {
 				id: MenuId.ChatExecute,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
-					AGENTS_VOICE_STT_ONLY.negate(),
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					AGENTS_VOICE_CONNECTING.isEqualTo(true),
 				),
@@ -260,6 +258,7 @@ registerAction2(class extends Action2 {
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
 					AGENTS_VOICE_STT_ONLY,
 					AGENTS_VOICE_CONNECTING.negate(),
+					AGENTS_VOICE_LISTENING.negate(),
 					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					ChatContextKeys.currentlyEditing.negate(),
 				),
@@ -270,10 +269,6 @@ registerAction2(class extends Action2 {
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const voiceController = accessor.get(IVoiceSessionController);
-		if (voiceController.voiceState.get() === 'listening') {
-			voiceController.stopListening();
-			return;
-		}
 		if (!voiceController.isConnected.get()) {
 			await voiceController.connect(mainWindow);
 		}
@@ -282,6 +277,41 @@ registerAction2(class extends Action2 {
 		}
 		voiceController.pttDown();
 		voiceController.pttUp();
+	}
+});
+
+// Stop control shown in place of the mic while dictation is active. A distinct
+// command with its own title/icon so screen reader users hear that activating
+// it stops recording (the icon-only mic would otherwise keep the name "Speech
+// to Text" while acting as a stop button).
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'agentsVoice.speechToTextStopInChatInput',
+			title: nls.localize2('agentsVoice.speechToTextStopInChatInput', "Stop Dictation"),
+			icon: Codicon.stopCircle,
+			precondition: ContextKeyExpr.and(
+				ContextKeyExpr.equals('config.agents.voice.enabled', true),
+				AGENTS_VOICE_STT_ONLY,
+				AGENTS_VOICE_LISTENING,
+				ChatContextKeys.inChatInput,
+			),
+			menu: {
+				id: MenuId.ChatExecute,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					AGENTS_VOICE_STT_ONLY,
+					AGENTS_VOICE_LISTENING,
+					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
+					ChatContextKeys.currentlyEditing.negate(),
+				),
+				group: 'navigation',
+				order: -10
+			},
+		});
+	}
+	async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IVoiceSessionController).stopListening();
 	}
 });
 
@@ -294,9 +324,12 @@ registerAction2(class extends Action2 {
 			title: nls.localize2('agentsVoice.disconnect', "Disconnect Voice Mode"),
 			icon: Codicon.debugDisconnect,
 			f1: true,
+			// Available whenever a voice session is connected — including STT-only
+			// mode, where `stopListening()` intentionally leaves the socket open,
+			// so the Command Palette is the supported teardown path. The toolbar
+			// item below stays hidden in STT mode.
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),
-				AGENTS_VOICE_STT_ONLY.negate(),
 				AGENTS_VOICE_CONNECTED.isEqualTo(true),
 			),
 			menu: {
@@ -556,7 +589,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'agents.voice.chatInputSpeechToText.enabled': {
 			type: 'boolean',
-			markdownDescription: nls.localize('agents.voice.chatInputSpeechToText.enabled', "Use the voice backend only for speech-to-text in chat inputs. When enabled, chat shows a microphone action that transcribes speech directly into the input without sending it or speaking assistant replies."),
+			markdownDescription: nls.localize('agents.voice.chatInputSpeechToText.enabled', "Use the voice backend only for speech-to-text in chat inputs. When enabled (and the voice feature `#agents.voice.enabled#` is also on), chat shows a microphone action that transcribes speech directly into the input without sending it or speaking assistant replies."),
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['advanced'],

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -78,7 +78,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'qui
 			content.push(localize('workbench.action.chat.openAgentHostFolderPicker', 'When starting an agent session in a multi-root workspace, you can choose which root folder it runs in by invoking the Folder command{0}, then selecting a folder from the list.', '<keybinding:workbench.action.chat.openAgentHostFolderPicker>'));
 		}
 		content.push(localize('chat.requestHistory', 'In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.'));
-		content.push(localize('chat.speechToTextInput', 'When `agents.voice.chatInputSpeechToText.enabled` is enabled, use the Speech to Text microphone action in the chat input toolbar to transcribe speech into the input without sending.'));
+		content.push(localize('chat.speechToTextInput', 'When both `agents.voice.enabled` and `agents.voice.chatInputSpeechToText.enabled` are enabled, use the Speech to Text microphone action in the chat input toolbar to transcribe speech into the input without sending.'));
 		content.push(localize('chat.attachments.removal', 'To remove attached contexts, focus an attachment and press Delete or Backspace.'));
 		content.push(localize('chat.inspectResponse', 'In the input box, inspect the last response in the accessible view{0}. Thinking content is included in order by default.', '<keybinding:editor.action.accessibleView>'));
 		content.push(localize('chat.inspectResponseThinkingToggle', 'To include or exclude thinking content in the accessible view, run the Toggle Thinking Content in Accessible View command from the Command Palette.'));

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -78,6 +78,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'qui
 			content.push(localize('workbench.action.chat.openAgentHostFolderPicker', 'When starting an agent session in a multi-root workspace, you can choose which root folder it runs in by invoking the Folder command{0}, then selecting a folder from the list.', '<keybinding:workbench.action.chat.openAgentHostFolderPicker>'));
 		}
 		content.push(localize('chat.requestHistory', 'In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.'));
+		content.push(localize('chat.speechToTextInput', 'When `agents.voice.chatInputSpeechToText.enabled` is enabled, use the Speech to Text microphone action in the chat input toolbar to transcribe speech into the input without sending.'));
 		content.push(localize('chat.attachments.removal', 'To remove attached contexts, focus an attachment and press Delete or Backspace.'));
 		content.push(localize('chat.inspectResponse', 'In the input box, inspect the last response in the accessible view{0}. Thinking content is included in order by default.', '<keybinding:editor.action.accessibleView>'));
 		content.push(localize('chat.inspectResponseThinkingToggle', 'To include or exclude thinking content in the accessible view, run the Toggle Thinking Content in Accessible View command from the Command Palette.'));

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1186,6 +1186,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 			this._updateUserTurn(text, e.committed ?? '', e.status === 'partial');
 			if (e.status !== 'partial') {
+				// Speech-to-text-only mode: the utterance is dictation bound for
+				// the chat input, not a task for the voice LLM. Handle the final
+				// transcript directly and bypass the backend's send_to_chat tool
+				// routing (which would drop utterances classified as chit-chat /
+				// status and keep the conversation state machine — auto-listen,
+				// reply watchdog — alive).
+				if (this._isSpeechToTextInputMode()) {
+					this._finalizeSpeechToTextTurn(text);
+					return;
+				}
 				if (!this._pttHeld) {
 					this._voiceState.set('processing', undefined);
 					this._statusText.set('Processing...', undefined);
@@ -1284,6 +1294,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// commands), not through the generic dispatch service.
 		this._voiceEventDisposables.add(this.voiceClientService.onToolCall(e => {
 			this.logService.trace(`[voice] tool_call received name=${e.name} coding_session_id=${typeof e.args?.['coding_session_id'] === 'string' ? String(e.args['coding_session_id']).slice(-32) : '<none>'} activeId=${this._getActiveSessionId()?.slice(-32) ?? '<none>'}`);
+			// Speech-to-text-only mode bypasses the voice LLM's tool routing
+			// entirely — the final transcript is inserted into the chat input
+			// directly from onTranscription. Ack the call so the backend isn't
+			// left waiting on this callId, but execute nothing.
+			if (this._isSpeechToTextInputMode()) {
+				this.voiceClientService.sendToolResult(e.callId, 'ok');
+				return;
+			}
 			const allowedTools = [
 				'send_to_chat',
 				'get_session_info', 'get_session_changes', 'get_session_thread',
@@ -1717,6 +1735,39 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	/**
+	 * Speech-to-text-only finalization. In this mode the utterance is dictation
+	 * bound for the chat input, not a task for the voice LLM, so the final
+	 * transcript is handled here and the conversation state machine is
+	 * deliberately bypassed: no send_to_chat tool routing, no reply watchdog,
+	 * and no auto-listen re-arm. The turn ends idle with the transcript
+	 * inserted into the focused chat input (existing draft preserved).
+	 */
+	private _finalizeSpeechToTextTurn(text: string): void {
+		// End any in-flight press / toggle and stop the auto-listen loop so the
+		// turn does not re-arm hands-free listening.
+		this._pttToggleMode = false;
+		this._autoListenSuppressed = true;
+		this._clearAutoListenTimer();
+		this._clearAwaitingReply();
+		this._stopBargeInMonitor();
+		if (this._pttHeld) {
+			this._finishPtt('local');
+		}
+		// Persist the user's final transcript (local-only, no backend coordination).
+		this._persistTurn('user', text);
+		// Insert into the focused chat input without submitting. Pass the raw
+		// transcript so the insert command preserves the existing draft verbatim.
+		if (text.trim()) {
+			this.commandService.executeCommand('_chat.voice.insertInput', text).catch(err => {
+				this.logService.warn('[voice] insertInput failed:', err);
+			});
+		}
+		// Explicit idle finalization — STT never enters processing / speaking.
+		this._voiceState.set('idle', undefined);
+		this._statusText.set('Tap to start', undefined);
+	}
+
+	/**
 	 * Strip a trailing stop phrase (e.g. "send it") from a transcript before it
 	 * is sent to chat. The backend is supposed to strip the matched phrase from
 	 * `agents.voice.turn.stopPhrases`, but when it doesn't the raw phrase leaks
@@ -1852,13 +1903,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * Otherwise sends to whatever is currently active via the view pane command.
 	 */
 	private async _sendTranscriptionToChat(text: string): Promise<void> {
-		if (this._isSpeechToTextInputMode()) {
-			await this.commandService.executeCommand('_chat.voice.insertInput', text).catch(err => {
-				this.logService.warn('[voice] insertInput failed:', err);
-			});
-			return;
-		}
-
 		const target = this._targetSession.get();
 		if (target) {
 			// Check if target is the currently visible session
@@ -2914,7 +2958,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				if (!this._isProcessingQueue) {
 					this._processQueue();
 				}
-				if (this._isHandsFreeEnabled()) {
+				if (this._isHandsFreeEnabled() && !this._isSpeechToTextInputMode()) {
 					this._scheduleAutoListen();
 				}
 			}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1712,6 +1712,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		return this.configurationService.getValue<boolean>('agents.voice.handsFree') !== false;
 	}
 
+	private _isSpeechToTextInputMode(): boolean {
+		return this.configurationService.getValue<boolean>('agents.voice.chatInputSpeechToText.enabled') === true;
+	}
+
 	/**
 	 * Strip a trailing stop phrase (e.g. "send it") from a transcript before it
 	 * is sent to chat. The backend is supposed to strip the matched phrase from
@@ -1848,6 +1852,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * Otherwise sends to whatever is currently active via the view pane command.
 	 */
 	private async _sendTranscriptionToChat(text: string): Promise<void> {
+		if (this._isSpeechToTextInputMode()) {
+			await this.commandService.executeCommand('_chat.voice.insertInput', text).catch(err => {
+				this.logService.warn('[voice] insertInput failed:', err);
+			});
+			return;
+		}
+
 		const target = this._targetSession.get();
 		if (target) {
 			// Check if target is the currently visible session
@@ -2878,7 +2889,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this.voicePlaybackService.notifyPlaybackStart(sessionResource, transcript);
 		}
 
-		const speakResponsesEnabled = this.configurationService.getValue<boolean>('agents.voice.speakResponses') !== false;
+		const speakResponsesEnabled = this.configurationService.getValue<boolean>('agents.voice.speakResponses') !== false && !this._isSpeechToTextInputMode();
 		if (speakResponsesEnabled && audio) {
 			// Claim the playback slot only when we actually have audio to play.
 			// A transcript-only frame (empty audio) must NOT claim it, or the

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -411,7 +411,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				if (!widget) {
 					return;
 				}
-				const currentInput = widget.getInput().trim();
+				const currentInput = widget.getInput();
 				const nextInput = currentInput ? `${currentInput} ${text}` : text;
 				widget.setInput(nextInput);
 				widget.focusInput();

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -402,6 +402,20 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 					}
 				}
 			}));
+			this._voiceBarDisposables.add(CommandsRegistry.registerCommand('_chat.voice.insertInput', (accessor, text: string) => {
+				if (!text) {
+					return;
+				}
+				const chatWidgetService = accessor.get(IChatWidgetService);
+				const widget = chatWidgetService.lastFocusedWidget ?? this._widget;
+				if (!widget) {
+					return;
+				}
+				const currentInput = widget.getInput().trim();
+				const nextInput = currentInput ? `${currentInput} ${text}` : text;
+				widget.setInput(nextInput);
+				widget.focusInput();
+			}));
 			this._voiceBarDisposables.add(CommandsRegistry.registerCommand('_chat.voice.switchToSession', (_accessor, resourceStr: string): boolean => {
 				if (!resourceStr) {
 					return false;


### PR DESCRIPTION
Adds a setting-gated speech-to-text-only mode that uses the voice backend to insert transcripts into chat input without speaking replies or auto-submitting. Includes workbench chat, Agents window chat input, and accessibility help updates.