### PR TITLE
Fix Mermaid preview flash/disappear on rerender

### DIFF
--- a/extensions/mermaid-markdown-features/package.json
+++ b/extensions/mermaid-markdown-features/package.json
@@ -246,7 +246,8 @@
     "typecheck-web": "node ../../node_modules/@typescript/native/lib/tsc.js --project ./tsconfig.browser.json --noEmit",
     "watch-web": "npm-run-all2 -lp watch-bundle-web watch-typecheck-web",
     "watch-bundle-web": "node ./esbuild.browser.mts --watch",
-    "watch-typecheck-web": "node ../../node_modules/@typescript/native/lib/tsc.js --project ./tsconfig.browser.json --noEmit --watch"
+    "watch-typecheck-web": "node ../../node_modules/@typescript/native/lib/tsc.js --project ./tsconfig.browser.json --noEmit --watch",
+    "test": "npm run build-ext && node --test ./out/test/**/*.test.js"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.0",

--- a/extensions/mermaid-markdown-features/preview-src/shared/index.ts
+++ b/extensions/mermaid-markdown-features/preview-src/shared/index.ts
@@ -140,7 +140,9 @@ function renderMermaidElement(
 				writeOut(mermaidContainer, renderResult.svg, false);
 				renderResult.bindFunctions?.(mermaidContainer);
 			} catch (error) {
-				if (error instanceof Error && error.name !== 'AbortError') {
+				// Mermaid often rejects with a plain `{ str, message, ... }` object, not an Error.
+				// Still surface those failures; only AbortError should stay silent.
+				if (!(error instanceof Error && error.name === 'AbortError')) {
 					markVsCodeContextAsError(mermaidContainer);
 					writeOut(mermaidContainer, createMermaidErrorElement(error).outerHTML, true);
 				}

--- a/extensions/mermaid-markdown-features/preview-src/shared/index.ts
+++ b/extensions/mermaid-markdown-features/preview-src/shared/index.ts
@@ -6,6 +6,7 @@ import elkLayouts from '@mermaid-js/layout-elk';
 import tidyTreeLayouts from '@mermaid-js/layout-tidy-tree';
 import zenuml from '@mermaid-js/mermaid-zenuml';
 import mermaid, { MermaidConfig } from 'mermaid';
+import { resolveMermaidSource } from '../../src/markdownMermaid/mermaidSource';
 import { iconPacks } from './iconPackConfig';
 import { ClickDragMode, MermaidExtensionConfig, ShowControlsMode } from './config';
 import { vsCodeMermaidTheme, VsCodeMermaidThemeTracker } from './vsCodeTheme';
@@ -60,37 +61,19 @@ export function markVsCodeContextAsError(el: HTMLElement): void {
 	el.dataset.vscodeContext = JSON.stringify({ ...context, mermaidError: true });
 }
 
-function hasRenderedMermaidOutput(mermaidContainer: HTMLElement): boolean {
-	return !!mermaidContainer.querySelector(':scope > svg, :scope > .mermaid-error');
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === 'AbortError';
 }
 
-function resolveMermaidSource(mermaidContainer: HTMLElement): string {
-	const rawText = (mermaidContainer.textContent ?? '').trim();
-
-	if (rawText && !hasRenderedMermaidOutput(mermaidContainer)) {
-		mermaidContainer.dataset.vscodeMermaidSource = rawText;
-		return rawText;
+/**
+ * Remove Mermaid's temporary render hosts (`id` starts with `dmermaid`).
+ * Do not remove `.mermaid > svg` — those are live diagrams; source recovery handles rerenders.
+ */
+function cleanupMermaidTempNodes(root: HTMLElement): void {
+	const doc = root.ownerDocument ?? document;
+	for (const el of doc.querySelectorAll('[id^="dmermaid"]')) {
+		el.remove();
 	}
-
-	const canonicalSource = (mermaidContainer.dataset.vscodeMermaidSource ?? '').trim();
-	if (canonicalSource) {
-		return canonicalSource;
-	}
-
-	try {
-		const context = JSON.parse(mermaidContainer.dataset.vscodeContext || '{}') as { mermaidSource?: string };
-		if (typeof context.mermaidSource === 'string') {
-			const source = context.mermaidSource.trim();
-			if (source) {
-				mermaidContainer.dataset.vscodeMermaidSource = source;
-				return source;
-			}
-		}
-	} catch {
-		// fall through
-	}
-
-	return '';
 }
 
 function renderMermaidElement(
@@ -140,14 +123,14 @@ function renderMermaidElement(
 				writeOut(mermaidContainer, renderResult.svg, false);
 				renderResult.bindFunctions?.(mermaidContainer);
 			} catch (error) {
-				// Mermaid often rejects with a plain `{ str, message, ... }` object, not an Error.
-				// Still surface those failures; only AbortError should stay silent.
-				if (!(error instanceof Error && error.name === 'AbortError')) {
-					markVsCodeContextAsError(mermaidContainer);
-					writeOut(mermaidContainer, createMermaidErrorElement(error).outerHTML, true);
+				if (isAbortError(error)) {
+					// Superseded by a newer init(); leave the container for the next pass.
+					return;
 				}
 
-				throw error;
+				// Mermaid often rejects with a plain `{ str, message, ... }` object, not an Error.
+				markVsCodeContextAsError(mermaidContainer);
+				writeOut(mermaidContainer, createMermaidErrorElement(error).outerHTML, true);
 			}
 		})()
 	};
@@ -161,6 +144,8 @@ export async function renderMermaidBlocksInElement(
 	// Track used IDs for this render pass
 	const usedIds = new Set<string>();
 
+	cleanupMermaidTempNodes(root);
+
 	// We need to generate all the container ids sync, but then do the actual rendering async
 	const renderPromises: Array<Promise<void>> = [];
 	for (const mermaidContainer of root.querySelectorAll<HTMLElement>('.mermaid')) {
@@ -172,7 +157,9 @@ export async function renderMermaidBlocksInElement(
 		}
 	}
 
-	await Promise.all(renderPromises);
+	// One diagram failing (or an aborted in-flight pass) must not reject the whole batch —
+	// otherwise retainStates / later diagrams never run.
+	await Promise.allSettled(renderPromises);
 }
 
 export async function registerMermaidAddons() {

--- a/extensions/mermaid-markdown-features/preview-src/shared/index.ts
+++ b/extensions/mermaid-markdown-features/preview-src/shared/index.ts
@@ -60,6 +60,41 @@ export function markVsCodeContextAsError(el: HTMLElement): void {
 	el.dataset.vscodeContext = JSON.stringify({ ...context, mermaidError: true });
 }
 
+function looksLikeRenderedMermaidOutput(text: string): boolean {
+	return text.startsWith('#dmermaid-')
+		|| text.includes('@keyframes')
+		|| text.includes('flowchartTitleText');
+}
+
+function resolveMermaidSource(mermaidContainer: HTMLElement): string {
+	const rawText = (mermaidContainer.textContent ?? '').trim();
+
+	if (rawText && !looksLikeRenderedMermaidOutput(rawText)) {
+		mermaidContainer.dataset.vscodeMermaidSource = rawText;
+		return rawText;
+	}
+
+	const canonicalSource = (mermaidContainer.dataset.vscodeMermaidSource ?? '').trim();
+	if (canonicalSource) {
+		return canonicalSource;
+	}
+
+	try {
+		const context = JSON.parse(mermaidContainer.dataset.vscodeContext || '{}') as { mermaidSource?: string };
+		if (typeof context.mermaidSource === 'string') {
+			const source = context.mermaidSource.trim();
+			if (source) {
+				mermaidContainer.dataset.vscodeMermaidSource = source;
+				return source;
+			}
+		}
+	} catch {
+		// fall through
+	}
+
+	return '';
+}
+
 function renderMermaidElement(
 	mermaidContainer: HTMLElement,
 	usedIds: Set<string>,
@@ -70,7 +105,7 @@ function renderMermaidElement(
 	contentHash: string;
 	p: Promise<void>;
 } | undefined {
-	const source = (mermaidContainer.textContent ?? '').trim();
+	const source = resolveMermaidSource(mermaidContainer);
 	if (!source) {
 		return;
 	}
@@ -125,16 +160,6 @@ export async function renderMermaidBlocksInElement(
 ): Promise<void> {
 	// Track used IDs for this render pass
 	const usedIds = new Set<string>();
-
-	// Delete existing mermaid outputs
-	for (const el of root.querySelectorAll('.mermaid > svg')) {
-		el.remove();
-	}
-	for (const svg of root.querySelectorAll('svg')) {
-		if (svg.parentElement?.id.startsWith('dmermaid')) {
-			svg.parentElement.remove();
-		}
-	}
 
 	// We need to generate all the container ids sync, but then do the actual rendering async
 	const renderPromises: Array<Promise<void>> = [];

--- a/extensions/mermaid-markdown-features/preview-src/shared/index.ts
+++ b/extensions/mermaid-markdown-features/preview-src/shared/index.ts
@@ -60,16 +60,14 @@ export function markVsCodeContextAsError(el: HTMLElement): void {
 	el.dataset.vscodeContext = JSON.stringify({ ...context, mermaidError: true });
 }
 
-function looksLikeRenderedMermaidOutput(text: string): boolean {
-	return text.startsWith('#dmermaid-')
-		|| text.includes('@keyframes')
-		|| text.includes('flowchartTitleText');
+function hasRenderedMermaidOutput(mermaidContainer: HTMLElement): boolean {
+	return !!mermaidContainer.querySelector(':scope > svg, :scope > .mermaid-error');
 }
 
 function resolveMermaidSource(mermaidContainer: HTMLElement): string {
 	const rawText = (mermaidContainer.textContent ?? '').trim();
 
-	if (rawText && !looksLikeRenderedMermaidOutput(rawText)) {
+	if (rawText && !hasRenderedMermaidOutput(mermaidContainer)) {
 		mermaidContainer.dataset.vscodeMermaidSource = rawText;
 		return rawText;
 	}

--- a/extensions/mermaid-markdown-features/src/markdownMermaid/markdownIt.ts
+++ b/extensions/mermaid-markdown-features/src/markdownMermaid/markdownIt.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import type MarkdownIt from 'markdown-it';
+import { escapeHtmlText } from '../util/html';
 
 const mermaidLanguageId = 'mermaid';
 const containerTokenName = 'mermaidContainer';
@@ -123,7 +124,9 @@ export function extendMarkdownItWithMermaid(md: MarkdownIt, config: { languageId
 		md.renderer.rules[containerTokenName] = (tokens: MarkdownIt.Token[], idx: number) => {
 			const token = tokens[idx];
 			const src = token.content;
-			return `<div class="${mermaidLanguageId}">${preProcess(src)}</div>`;
+			// Persist source on the element so preview rerenders can recover it when SVG/CSS
+			// pollutes textContent (see resolveMermaidSource / #323522).
+			return `<div class="${mermaidLanguageId}" data-vscode-mermaid-source="${escapeHtmlText(src.trim())}">${preProcess(src)}</div>`;
 		};
 	});
 
@@ -131,7 +134,7 @@ export function extendMarkdownItWithMermaid(md: MarkdownIt, config: { languageId
 	md.options.highlight = (code: string, lang: string, attrs: string) => {
 		const reg = new RegExp('\\b(' + config.languageIds().map(escapeRegExp).join('|') + ')\\b', 'i');
 		if (lang && reg.test(lang)) {
-			return `<pre class="${mermaidLanguageId}" style="all: unset;">${preProcess(code)}</pre>`;
+			return `<pre class="${mermaidLanguageId}" style="all: unset;" data-vscode-mermaid-source="${escapeHtmlText(code.trim())}">${preProcess(code)}</pre>`;
 		}
 		return highlight?.(code, lang, attrs) ?? code;
 	};

--- a/extensions/mermaid-markdown-features/src/markdownMermaid/mermaidSource.ts
+++ b/extensions/mermaid-markdown-features/src/markdownMermaid/mermaidSource.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Minimal container surface used to recover Mermaid source after preview rerenders.
+ *
+ * After the first render, morphdom may leave SVG (and its embedded `<style>`) inside
+ * `.mermaid`, so `textContent` is no longer safe to feed back into Mermaid.
+ */
+export interface MermaidSourceContainer {
+	textContent: string | null;
+	dataset: {
+		vscodeMermaidSource?: string;
+		vscodeContext?: string;
+	};
+	querySelector(selectors: string): unknown;
+}
+
+export function hasRenderedMermaidOutput(mermaidContainer: MermaidSourceContainer): boolean {
+	return !!mermaidContainer.querySelector(':scope > svg, :scope > .mermaid-error');
+}
+
+/**
+ * Resolve the canonical Mermaid source for a container.
+ *
+ * Preference order:
+ * 1. Live text when the container has not yet been rendered (or was replaced with fresh Markdown HTML)
+ * 2. `data-vscode-mermaid-source` persisted from a prior successful resolution / markdown-it
+ * 3. `mermaidSource` embedded in `data-vscode-context` (clipboard / context-menu path)
+ */
+export function resolveMermaidSource(mermaidContainer: MermaidSourceContainer): string {
+	const rawText = (mermaidContainer.textContent ?? '').trim();
+
+	if (rawText && !hasRenderedMermaidOutput(mermaidContainer)) {
+		mermaidContainer.dataset.vscodeMermaidSource = rawText;
+		return rawText;
+	}
+
+	const canonicalSource = (mermaidContainer.dataset.vscodeMermaidSource ?? '').trim();
+	if (canonicalSource) {
+		return canonicalSource;
+	}
+
+	try {
+		const context = JSON.parse(mermaidContainer.dataset.vscodeContext || '{}') as { mermaidSource?: string };
+		if (typeof context.mermaidSource === 'string') {
+			const source = context.mermaidSource.trim();
+			if (source) {
+				mermaidContainer.dataset.vscodeMermaidSource = source;
+				return source;
+			}
+		}
+	} catch {
+		// fall through
+	}
+
+	return '';
+}

--- a/extensions/mermaid-markdown-features/src/test/mermaidSource.test.ts
+++ b/extensions/mermaid-markdown-features/src/test/mermaidSource.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { describe, it } from 'node:test';
+import { hasRenderedMermaidOutput, MermaidSourceContainer, resolveMermaidSource } from '../markdownMermaid/mermaidSource';
+
+function createContainer(options: {
+	text?: string;
+	canonical?: string;
+	contextSource?: string;
+	child?: 'svg' | 'error' | 'none';
+}): MermaidSourceContainer {
+	const dataset: MermaidSourceContainer['dataset'] = {};
+	if (options.canonical) {
+		dataset.vscodeMermaidSource = options.canonical;
+	}
+	if (options.contextSource) {
+		dataset.vscodeContext = JSON.stringify({ mermaidSource: options.contextSource });
+	}
+
+	return {
+		textContent: options.text ?? '',
+		dataset,
+		querySelector(_selectors: string) {
+			if (options.child === 'svg' || options.child === 'error') {
+				return {};
+			}
+			return null;
+		},
+	};
+}
+
+describe('resolveMermaidSource', () => {
+	it('uses clean text on first render and persists it', () => {
+		const container = createContainer({ text: 'flowchart TD\n  A --> B' });
+		assert.strictEqual(resolveMermaidSource(container), 'flowchart TD\n  A --> B');
+		assert.strictEqual(container.dataset.vscodeMermaidSource, 'flowchart TD\n  A --> B');
+	});
+
+	it('does not treat valid source containing flowchartTitleText as rendered output', () => {
+		const container = createContainer({
+			text: 'flowchart TD\nflowchartTitleText --> B',
+			child: 'none',
+		});
+		assert.strictEqual(hasRenderedMermaidOutput(container), false);
+		assert.strictEqual(resolveMermaidSource(container), 'flowchart TD\nflowchartTitleText --> B');
+	});
+
+	it('falls back to data-vscode-mermaid-source when SVG pollutes textContent', () => {
+		const container = createContainer({
+			text: '#dmermaid-abc @keyframes flash { from { opacity: 0 } }',
+			canonical: 'flowchart TD\n  A --> B',
+			child: 'svg',
+		});
+		assert.strictEqual(resolveMermaidSource(container), 'flowchart TD\n  A --> B');
+	});
+
+	it('falls back to vscodeContext.mermaidSource when dataset is missing', () => {
+		const container = createContainer({
+			text: '#dmermaid-abc @keyframes flash { from { opacity: 0 } }',
+			contextSource: 'sequenceDiagram\n  A->>B: hi',
+			child: 'svg',
+		});
+		assert.strictEqual(resolveMermaidSource(container), 'sequenceDiagram\n  A->>B: hi');
+		assert.strictEqual(container.dataset.vscodeMermaidSource, 'sequenceDiagram\n  A->>B: hi');
+	});
+
+	it('does not overwrite canonical source with mermaid-error text', () => {
+		const container = createContainer({
+			text: 'No diagram type detected matching given configuration for text: #dmermaid-…',
+			canonical: 'flowchart TD\n  A --> B',
+			child: 'error',
+		});
+		assert.strictEqual(resolveMermaidSource(container), 'flowchart TD\n  A --> B');
+	});
+
+	it('returns empty string when no source can be recovered', () => {
+		const container = createContainer({
+			text: '#dmermaid-abc @keyframes flash',
+			child: 'svg',
+		});
+		assert.strictEqual(resolveMermaidSource(container), '');
+	});
+});


### PR DESCRIPTION
## Summary
- Persist canonical Mermaid diagram source in `data-vscode-mermaid-source` and fall back to `vscodeContext.mermaidSource` when container text is polluted by rendered SVG/CSS
- Detect rendered output via DOM children (`svg` / `.mermaid-error`) so rerenders no longer parse SVG style text as diagram source
- Surface Mermaid parse/render failures even when the rejection is a plain object (not an `Error`), so broken diagrams show an error instead of an empty box

Fixes #323522
Fixes #328449

## Root cause
On theme/content refresh, `renderMermaidBlocksInElement` re-read `.mermaid` `textContent`, which after first render can contain CSS from embedded SVG `<style>` tags. Mermaid then fails with errors like "No diagram type detected matching given configuration for text: #dmermaid-…". Those failures are often plain objects, so the old `instanceof Error` gate also left the container blank with no visible error.

## Test plan
- [ ] Open a `.md` file with a fenced `mermaid` block in Markdown Preview
- [ ] Confirm diagram renders on first open
- [ ] Toggle color theme (or edit/save to refresh preview) — diagram should remain visible
- [ ] Repeat with flowchart and class diagram types
- [ ] Break the Mermaid syntax — preview should show a real error message, not an empty box
- [ ] Confirm no conflicting third-party Mermaid extensions are required for the repro (built-in path only)