### PR TITLE
agentHost: Make session archive state server-owned

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -138,7 +138,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 
 	setChatSessionItemArchived(resource: URI, archived: boolean): void {
 		if (resource.scheme !== this._sessionType) {
-			throw new Error(`Session ${resource.toString()} does not belong to controller ${this._sessionType}`);
+			return;
 		}
 
 		this._sessionListStore.setSessionArchived(this._provider, AgentSession.id(resource), archived);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -136,6 +136,14 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		this._sessionListStore.removeSession(this._provider, rawId);
 	}
 
+	setChatSessionItemArchived(resource: URI, archived: boolean): void {
+		if (resource.scheme !== this._sessionType) {
+			throw new Error(`Session ${resource.toString()} does not belong to controller ${this._sessionType}`);
+		}
+
+		this._sessionListStore.setSessionArchived(this._provider, AgentSession.id(resource), archived);
+	}
+
 	async refresh(token: CancellationToken): Promise<void> {
 		// The store fans out a delta during the await when its list changes, which
 		// projects into a change event. When nothing changed (e.g. the store cache

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
@@ -9,7 +9,7 @@ import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { AgentSession, type IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
-import type { INotification } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
+import { ActionType, type INotification, type SessionAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { SessionStatus, type SessionSummary } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 
@@ -20,6 +20,7 @@ export interface IAgentHostSessionListConnection {
 	readonly onDidNotification: Event<INotification>;
 	listSessions(): Promise<IAgentSessionMetadata[]>;
 	disposeSession(session: URI): Promise<void>;
+	dispatch(channel: string, action: SessionAction): void;
 }
 
 /**
@@ -118,6 +119,32 @@ export class AgentHostSessionListStore extends Disposable {
 
 	async disposeSession(provider: string, rawId: string): Promise<void> {
 		await this._connection.disposeSession(AgentSession.uri(provider, rawId));
+	}
+
+	setSessionArchived(provider: string, rawId: string, archived: boolean): void {
+		const session = AgentSession.uri(provider, rawId);
+		const key = this._key(provider, rawId);
+		const cached = this._entries.get(key);
+		let updated: IAgentHostSessionListEntry | undefined;
+		if (cached) {
+			const status = archived
+				? cached.summary.status | SessionStatus.IsArchived
+				: cached.summary.status & ~SessionStatus.IsArchived;
+			if (status === cached.summary.status) {
+				return;
+			}
+			updated = { ...cached, summary: { ...cached.summary, status } };
+		}
+
+		this._mutationGeneration++;
+		this._connection.dispatch(session.toString(), {
+			type: ActionType.SessionIsArchivedChanged,
+			isArchived: archived,
+		});
+		if (updated) {
+			this._entries.set(key, updated);
+			this._onDidChangeSessions.fire({ addedOrUpdated: [updated] });
+		}
 	}
 
 	removeSession(provider: string, rawId: string): void {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -694,11 +694,22 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 			}
 		}
 
+		const sessionsWithChangedArchivedState: IInternalAgentSession[] = [];
+		for (const [, session] of sessions) {
+			const previousSession = this._sessions.get(session.resource);
+			if (previousSession && this.isArchived(previousSession) !== this.isArchived(session)) {
+				sessionsWithChangedArchivedState.push(session);
+			}
+		}
+
 		this._sessions = sessions;
 		this._resolved = true;
 
 		this.logger.logAllStatsIfTrace('Sessions resolved from providers');
 
+		for (const session of sessionsWithChangedArchivedState) {
+			this._onDidChangeSessionArchivedState.fire(session);
+		}
 		this._onDidChangeSessions.fire();
 	}
 
@@ -751,6 +762,9 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 	}
 
 	private isArchived(session: IInternalAgentSessionData): boolean {
+		if (this.chatSessionsService.canSetChatSessionItemArchived(session.resource)) {
+			return Boolean(session.archived);
+		}
 		return this.resolveStateEntry(session)?.archived ?? Boolean(session.archived);
 	}
 
@@ -761,6 +775,11 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 
 		if (archived === this.isArchived(session)) {
 			return; // no change
+		}
+
+		if (this.chatSessionsService.canSetChatSessionItemArchived(session.resource)) {
+			this.chatSessionsService.setChatSessionItemArchived(session.resource, archived);
+			return;
 		}
 
 		const state = this.resolveStateEntry(session) ?? {};

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -428,6 +428,18 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		return entry.controller.resolveChatSessionItem(resource, token);
 	}
 
+	canSetChatSessionItemArchived(sessionResource: URI): boolean {
+		return typeof this._getChatSessionItemController(sessionResource)?.controller.setChatSessionItemArchived === 'function';
+	}
+
+	setChatSessionItemArchived(sessionResource: URI, archived: boolean): void {
+		const controller = this._getChatSessionItemController(sessionResource)?.controller;
+		if (!controller?.setChatSessionItemArchived) {
+			throw new Error(`Session ${sessionResource.toString()} does not support archiving`);
+		}
+		controller.setChatSessionItemArchived(sessionResource, archived);
+	}
+
 	private async updateInProgressStatus(chatSessionType: string): Promise<void> {
 		try {
 			const items: IChatSessionItem[] = [];
@@ -1149,15 +1161,19 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	}
 
 	async deleteChatSessionItem(sessionResource: URI, token: CancellationToken): Promise<void> {
-		const sessionType = getChatSessionType(sessionResource);
-		const resolvedType = this._resolveToPrimaryType(sessionType) ?? sessionType;
-		const controllerData = this._itemControllers.get(resolvedType);
+		const controllerData = this._getChatSessionItemController(sessionResource);
 		if (!controllerData?.controller.deleteChatSessionItem) {
 			throw new Error(`Session ${sessionResource.toString()} does not support deletion`);
 		}
 
 		await controllerData.initialRefresh;
 		return controllerData.controller.deleteChatSessionItem(sessionResource, token);
+	}
+
+	private _getChatSessionItemController(sessionResource: URI) {
+		const sessionType = getChatSessionType(sessionResource);
+		const resolvedType = this._resolveToPrimaryType(sessionType) ?? sessionType;
+		return this._itemControllers.get(resolvedType);
 	}
 
 	public async getOrCreateChatSession(sessionResource: URI, token: CancellationToken): Promise<IChatSession> {

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -583,6 +583,11 @@ export interface IChatSessionItemController {
 	 * as a result of the deletion.
 	 */
 	deleteChatSessionItem?(resource: URI, token: CancellationToken): Promise<void>;
+
+	/**
+	 * Set the authoritative archived state for the session identified by `resource`.
+	 */
+	setChatSessionItemArchived?(resource: URI, archived: boolean): void;
 }
 
 export interface IChatSessionOptionsChangeEvent {
@@ -723,6 +728,16 @@ export interface IChatSessionsService {
 	 * Returns the resolved item, or undefined if no resolve handler is available.
 	 */
 	resolveChatSessionItem(chatSessionType: string, resource: URI, token: CancellationToken): Promise<IChatSessionItem | undefined>;
+
+	/**
+	 * Whether the registered item controller owns archived state for the session.
+	 */
+	canSetChatSessionItemArchived(sessionResource: URI): boolean;
+
+	/**
+	 * Sets archived state by delegating to the registered item controller.
+	 */
+	setChatSessionItemArchived(sessionResource: URI, archived: boolean): void;
 
 	// #endregion
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -1851,6 +1851,148 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(listController.items[0].archived, true);
 		});
 
+		test('archive mutations dispatch through AHP and reconcile server summaries', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const backendSession = AgentSession.uri('copilot', 'archivable');
+			const baseStatus = SessionStatus.InProgress | SessionStatus.IsRead;
+			agentHostService.addSession({
+				session: backendSession,
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Archivable session',
+				status: baseStatus,
+			});
+
+			const sessionListStore = createSessionListStore(disposables, instantiationService, agentHostService);
+			const listController = disposables.add(instantiationService.createInstance(AgentHostSessionListController, 'agent-host-copilot', 'copilot', sessionListStore, undefined, 'local'));
+			await listController.refresh(CancellationToken.None);
+			agentHostService.dispatchedActions.length = 0;
+
+			const archivedEvents: boolean[] = [];
+			disposables.add(listController.onDidChangeChatSessionItems(delta => {
+				for (const item of delta.addedOrUpdated ?? []) {
+					archivedEvents.push(Boolean(item.archived));
+				}
+			}));
+
+			const resource = listController.items[0].resource;
+			listController.setChatSessionItemArchived(resource, true);
+			listController.setChatSessionItemArchived(resource, true);
+			const archivedStatus = sessionListStore.getSessions('copilot')[0].summary.status;
+
+			listController.setChatSessionItemArchived(resource, false);
+			listController.setChatSessionItemArchived(resource, false);
+			const unarchivedStatus = sessionListStore.getSessions('copilot')[0].summary.status;
+
+			agentHostService.fireNotification({
+				type: 'root/sessionSummaryChanged',
+				channel: ROOT_STATE_URI,
+				session: backendSession.toString(),
+				changes: { status: baseStatus | SessionStatus.IsArchived },
+			});
+
+			assert.deepStrictEqual({
+				actions: agentHostService.dispatchedActions.map(({ channel, action }) => ({ channel, action })),
+				archivedStatus,
+				unarchivedStatus,
+				reconciledArchived: listController.items[0].archived,
+				archivedEvents,
+			}, {
+				actions: [{
+					channel: backendSession.toString(),
+					action: { type: ActionType.SessionIsArchivedChanged, isArchived: true },
+				}, {
+					channel: backendSession.toString(),
+					action: { type: ActionType.SessionIsArchivedChanged, isArchived: false },
+				}],
+				archivedStatus: baseStatus | SessionStatus.IsArchived,
+				unarchivedStatus: baseStatus,
+				reconciledArchived: true,
+				archivedEvents: [true, false, true],
+			});
+		});
+
+		test('archive mutation prevents an in-flight stale refresh from overwriting optimistic state', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const backendSession = AgentSession.uri('copilot', 'archive-refresh-race');
+			const metadata: IAgentSessionMetadata = {
+				session: backendSession,
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Archive refresh race',
+			};
+			agentHostService.addSession(metadata);
+
+			const sessionListStore = createSessionListStore(disposables, instantiationService, agentHostService);
+			const listController = disposables.add(instantiationService.createInstance(AgentHostSessionListController, 'agent-host-copilot', 'copilot', sessionListStore, undefined, 'local'));
+			await listController.refresh(CancellationToken.None);
+
+			let listCalls = 0;
+			const releaseListSessions = disposables.add(new Emitter<void>());
+			const released = Event.toPromise(releaseListSessions.event);
+			agentHostService.listSessions = async () => {
+				listCalls++;
+				if (listCalls === 1) {
+					await released;
+					return [metadata];
+				}
+				return [{ ...metadata, isArchived: true }];
+			};
+
+			sessionListStore.resetCache();
+			const refresh = listController.refresh(CancellationToken.None);
+			await timeout(0);
+			listController.setChatSessionItemArchived(listController.items[0].resource, true);
+			releaseListSessions.fire();
+			await refresh;
+
+			assert.deepStrictEqual({
+				listCalls,
+				archived: listController.items[0].archived,
+			}, {
+				listCalls: 2,
+				archived: true,
+			});
+		});
+
+		test('archive mutation invalidates an in-flight refresh before the session is cached', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const backendSession = AgentSession.uri('copilot', 'uncached-archive-refresh-race');
+			const metadata: IAgentSessionMetadata = {
+				session: backendSession,
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Uncached archive refresh race',
+			};
+
+			let listCalls = 0;
+			const releaseListSessions = disposables.add(new Emitter<void>());
+			const released = Event.toPromise(releaseListSessions.event);
+			agentHostService.listSessions = async () => {
+				listCalls++;
+				if (listCalls === 1) {
+					await released;
+					return [metadata];
+				}
+				return [{ ...metadata, isArchived: true }];
+			};
+
+			const listController = createSessionListController(disposables, instantiationService, agentHostService);
+			const refresh = listController.refresh(CancellationToken.None);
+			await timeout(0);
+			listController.setChatSessionItemArchived(URI.from({ scheme: 'agent-host-copilot', path: `/${AgentSession.id(backendSession)}` }), true);
+			releaseListSessions.fire();
+			await refresh;
+
+			assert.deepStrictEqual({
+				listCalls,
+				archived: listController.items[0].archived,
+			}, {
+				listCalls: 2,
+				archived: true,
+			});
+		});
+
 		test('refresh skips listSessions RPC after first successful call', async () => {
 			const { listController, agentHostService } = createContribution(disposables);
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -1912,6 +1912,14 @@ suite('AgentHostChatContribution', () => {
 			});
 		});
 
+		test('archive mutation ignores resources from another session type', () => {
+			const { listController, agentHostService } = createContribution(disposables);
+
+			listController.setChatSessionItemArchived(URI.from({ scheme: 'agent-host-other', path: '/session' }), true);
+
+			assert.deepStrictEqual(agentHostService.dispatchedActions, []);
+		});
+
 		test('archive mutation prevents an in-flight stale refresh from overwriting optimistic state', async () => {
 			const { instantiationService, agentHostService } = createTestServices(disposables);
 			const backendSession = AgentSession.uri('copilot', 'archive-refresh-race');

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -1284,6 +1284,27 @@ suite('AgentSessions', () => {
 		let instantiationService: TestInstantiationService;
 		let viewModel: AgentSessionsModel;
 
+		class MutableArchiveChatSessionItemController implements IChatSessionItemController {
+			readonly onDidChangeChatSessionItems = Event.None;
+			readonly archiveUpdates: boolean[] = [];
+
+			constructor(private sessionItem: IChatSessionItem) { }
+
+			get items(): readonly IChatSessionItem[] {
+				return [this.sessionItem];
+			}
+
+			async refresh(): Promise<void> { }
+
+			setChatSessionItemArchived(_resource: URI, archived: boolean): void {
+				this.archiveUpdates.push(archived);
+			}
+
+			setProviderArchived(archived: boolean): IChatSessionItem {
+				return this.sessionItem = { ...this.sessionItem, archived };
+			}
+		}
+
 		setup(() => {
 			mockChatSessionsService = new MockChatSessionsService();
 			instantiationService = disposables.add(workbenchInstantiationService(undefined, disposables));
@@ -1359,6 +1380,85 @@ suite('AgentSessions', () => {
 				// Try to archive again with same value
 				session.setArchived(true);
 				assert.strictEqual(changeEventFired, false);
+			});
+		});
+
+		test('should ignore stale local state for controller-owned archived state', async () => {
+			return runWithFakedTimers({}, async () => {
+				const item = makeSimpleSessionItem('session-1', { archived: true });
+				instantiationService.get(IStorageService).store(
+					'agentSessions.state.cache',
+					JSON.stringify([{ resource: item.resource.toString(), archived: false }]),
+					StorageScope.WORKSPACE,
+					StorageTarget.MACHINE,
+				);
+				const controller = new MutableArchiveChatSessionItemController(item);
+				mockChatSessionsService.registerChatSessionItemController(chatSessionTestType, controller);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+
+				await viewModel.resolve(undefined);
+				const session = viewModel.sessions[0];
+				session.setArchived(false);
+
+				assert.deepStrictEqual({
+					beforeProviderUpdate: session.isArchived(),
+					archiveUpdates: controller.archiveUpdates,
+				}, {
+					beforeProviderUpdate: true,
+					archiveUpdates: [false],
+				});
+			});
+		});
+
+		test('should not create a local overlay for controller-owned archive writes', async () => {
+			return runWithFakedTimers({}, async () => {
+				const item = makeSimpleSessionItem('session-1', { archived: false });
+				const controller = new MutableArchiveChatSessionItemController(item);
+				mockChatSessionsService.registerChatSessionItemController(chatSessionTestType, controller);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setArchived(true);
+				await viewModel.resolve(undefined);
+
+				assert.deepStrictEqual({
+					archived: viewModel.sessions[0].isArchived(),
+					archiveUpdates: controller.archiveUpdates,
+				}, {
+					archived: false,
+					archiveUpdates: [true],
+				});
+			});
+		});
+
+		test('should fire archive state changes only for effective provider transitions', async () => {
+			return runWithFakedTimers({}, async () => {
+				const item = makeSimpleSessionItem('session-1', { archived: false });
+				const controller = new MutableArchiveChatSessionItemController(item);
+				mockChatSessionsService.registerChatSessionItemController(chatSessionTestType, controller);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+
+				const archivedEvents: boolean[] = [];
+				disposables.add(viewModel.onDidChangeSessionArchivedState(session => archivedEvents.push(session.isArchived())));
+
+				const archivedItem = controller.setProviderArchived(true);
+				let sessionsChanged = Event.toPromise(viewModel.onDidChangeSessions);
+				mockChatSessionsService.fireDidChangeSessionItems({ addedOrUpdated: [archivedItem] });
+				await sessionsChanged;
+
+				const unchangedItem = controller.setProviderArchived(true);
+				sessionsChanged = Event.toPromise(viewModel.onDidChangeSessions);
+				mockChatSessionsService.fireDidChangeSessionItems({ addedOrUpdated: [unchangedItem] });
+				await sessionsChanged;
+
+				assert.deepStrictEqual({
+					archived: viewModel.sessions[0].isArchived(),
+					archivedEvents,
+				}, {
+					archived: true,
+					archivedEvents: [true],
+				});
 			});
 		});
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
@@ -197,6 +197,69 @@ suite('ChatSessionsService - getChatSessionItems availability', () => {
 	});
 });
 
+suite('ChatSessionsService - archive capability', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	class TestItemController implements IChatSessionItemController {
+		readonly onDidChangeChatSessionItems = Event.None;
+
+		constructor(
+			readonly setChatSessionItemArchived?: (resource: URI, archived: boolean) => void,
+		) { }
+
+		readonly items: readonly IChatSessionItem[] = [];
+
+		async refresh(): Promise<void> { }
+	}
+
+	let service: ChatSessionsService;
+
+	setup(() => {
+		const instantiationService = store.add(workbenchInstantiationService(undefined, store));
+		service = store.add(instantiationService.createInstance(ChatSessionsService));
+	});
+
+	test('delegates to the registered controller', () => {
+		const sessionType = 'supported-type';
+		const updates: { resource: string; archived: boolean }[] = [];
+		const controller = new TestItemController((resource, archived) => updates.push({ resource: resource.toString(), archived }));
+		store.add(service.registerChatSessionContribution({
+			type: sessionType,
+			name: sessionType,
+			displayName: sessionType,
+			description: '',
+		}));
+		store.add(service.registerChatSessionItemController(sessionType, controller));
+
+		const resource = URI.from({ scheme: sessionType, path: '/session-1' });
+		service.setChatSessionItemArchived(resource, true);
+
+		assert.deepStrictEqual({
+			canSetArchived: service.canSetChatSessionItemArchived(resource),
+			updates,
+		}, {
+			canSetArchived: true,
+			updates: [{ resource: resource.toString(), archived: true }],
+		});
+	});
+
+	test('reports and rejects an unsupported controller', () => {
+		const sessionType = 'unsupported-type';
+		store.add(service.registerChatSessionContribution({
+			type: sessionType,
+			name: sessionType,
+			displayName: sessionType,
+			description: '',
+		}));
+		store.add(service.registerChatSessionItemController(sessionType, new TestItemController()));
+
+		const resource = URI.from({ scheme: sessionType, path: '/session-1' });
+		assert.strictEqual(service.canSetChatSessionItemArchived(resource), false);
+		assert.throws(() => service.setChatSessionItemArchived(resource, true), /does not support archiving/);
+	});
+});
+
 suite('ChatSessionsService - untitled↔real session aliases', () => {
 
 	const store = ensureNoDisposablesAreLeakedInTestSuite();

--- a/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
@@ -136,6 +136,20 @@ export class MockChatSessionsService implements IChatSessionsService {
 		return undefined;
 	}
 
+	canSetChatSessionItemArchived(sessionResource: URI): boolean {
+		const sessionType = getChatSessionType(sessionResource);
+		return typeof this.sessionItemControllers.get(sessionType)?.controller.setChatSessionItemArchived === 'function';
+	}
+
+	setChatSessionItemArchived(sessionResource: URI, archived: boolean): void {
+		const sessionType = getChatSessionType(sessionResource);
+		const controller = this.sessionItemControllers.get(sessionType)?.controller;
+		if (!controller?.setChatSessionItemArchived) {
+			throw new Error(`Session ${sessionResource.toString()} does not support archiving`);
+		}
+		controller.setChatSessionItemArchived(sessionResource, archived);
+	}
+
 	registerChatSessionContentProvider(chatSessionType: string, provider: IChatSessionContentProvider): IDisposable {
 		this.contentProviders.set(chatSessionType, provider);
 		this._onDidChangeContentProviderSchemes.fire({ added: [chatSessionType], removed: [] });


### PR DESCRIPTION
## Summary

- add a controller capability for providers that own session archive state
- route Agent Host Archive/Unarchive actions through `SessionIsArchivedChanged`
- optimistically update the shared session list while reconciling server summaries
- preserve local archive overlays for providers without the capability
- emit archive-state events only for effective provider transitions

## Testing

- `npm run typecheck-client`
- focused archive/session-list unit tests (42 passing)
- `npm run valid-layers-check`
- `npm run precommit`

Fixes [#325398](https://github.com/microsoft/vscode/issues/325398).

(Written by Copilot)
