### PR TITLE
Claude agent: allow 'max' reasoning effort on the runtime path

### DIFF
--- a/src/vs/platform/agentHost/common/claudeModelConfig.ts
+++ b/src/vs/platform/agentHost/common/claudeModelConfig.ts
@@ -18,38 +18,42 @@ export const CLAUDE_THINKING_LEVEL_KEY = 'thinkingLevel';
 
 /**
  * Reasoning-effort values accepted by the Claude SDK's `Options.effort`
- * (sdk.d.ts:443 + sdk.d.ts:1214). Hand-rolled here — not imported from the
- * SDK — to keep `common/` SDK-free; structurally identical to the SDK's
- * `EffortLevel` so it assigns into `Options.effort` without a cast.
- *
- * NOTE: the live hot-swap path `applyFlagSettings({ effortLevel })`
- * (sdk.d.ts:4292) only accepts a 4-value subset that omits `'max'`; that
- * clamp lives at the hot-swap seam (Phase 9), not here.
+ * (startup). Hand-rolled here — not imported from the SDK — to keep `common/`
+ * SDK-free; structurally identical to the SDK's exported `EffortLevel` so it
+ * assigns into `Options.effort` without a cast.
  */
 export type ClaudeEffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 /**
- * Subset of {@link ClaudeEffortLevel} accepted by the SDK runtime hot-swap
- * setter `Query.applyFlagSettings({ effortLevel })` (sdk.d.ts:4914) — the
- * runtime union deliberately excludes `'max'` because Copilot CAPI does
- * not yet route a `'max'` reasoning tier (no upstream model exposes it).
- * {@link clampEffortForRuntime} is the single seam that maps the wider
- * startup union onto this narrower runtime union.
+ * The effort union the SDK's runtime hot-swap setter
+ * `Query.applyFlagSettings({ effortLevel })` is *declared* to accept. Note it
+ * excludes `'max'` — but see {@link clampEffortForRuntime}: a `'max'` value can
+ * still flow through this type at runtime, because the SDK's declared type is
+ * narrower than what the API actually accepts.
  */
 export type ClaudeRuntimeEffortLevel = 'low' | 'medium' | 'high' | 'xhigh';
 
 /**
- * Clamp an effort level for the runtime SDK setter. `Options.effort`
- * (startup) accepts `'max'`; `Query.applyFlagSettings({ effortLevel })`
- * does not — Copilot CAPI does not currently expose a `'max'` reasoning
- * tier, so mid-session `'max'` selections degrade to `'xhigh'` here. If
- * CAPI later adds a `'max'` model, the SDK runtime union widens and this
- * clamp becomes a passthrough (CONTEXT.md M11 effort-clamp; Phase 9 D7).
+ * Coerce a startup {@link ClaudeEffortLevel} to the {@link ClaudeRuntimeEffortLevel}
+ * union the SDK's `applyFlagSettings({ effortLevel })` setter is typed to accept.
+ *
+ * This used to clamp `'max'` down to `'xhigh'`, because the SDK's
+ * `Settings.effortLevel` .d.ts type omits `'max'`. That type is wrong: the
+ * Anthropic API / Copilot CAPI accept `'max'` end-to-end — confirmed with
+ * Anthropic, and verified by watching a `'max'` turn round-trip successfully
+ * (the exported `EffortLevel` union and the wire `output_config.effort` field
+ * both include `'max'`). So `'max'` is now passed straight through.
+ *
+ * The cast is deliberate: this returns a value its own return type says it
+ * cannot — `'max'` is not a member of {@link ClaudeRuntimeEffortLevel}. Keeping
+ * the narrow return type lets every downstream consumer stay honest against the
+ * SDK's declared surface while the single lie lives here. Drop the cast (and
+ * widen the return type, or restore a real clamp) once the SDK's
+ * `Settings.effortLevel` type is corrected upstream
+ * (anthropics/claude-agent-sdk-typescript#377).
  */
 export function clampEffortForRuntime(effort: ClaudeEffortLevel | undefined): ClaudeRuntimeEffortLevel | undefined {
-	if (effort === undefined) { return undefined; }
-	if (effort === 'max') { return 'xhigh'; }
-	return effort;
+	return effort as ClaudeRuntimeEffortLevel | undefined;
 }
 
 /**

--- a/src/vs/platform/agentHost/common/claudeModelConfig.ts
+++ b/src/vs/platform/agentHost/common/claudeModelConfig.ts
@@ -27,7 +27,7 @@ export type ClaudeEffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 /**
  * The effort union the SDK's runtime hot-swap setter
  * `Query.applyFlagSettings({ effortLevel })` is *declared* to accept. Note it
- * excludes `'max'` — but see {@link clampEffortForRuntime}: a `'max'` value can
+ * excludes `'max'` — but see {@link toRuntimeEffortLevel}: a `'max'` value can
  * still flow through this type at runtime, because the SDK's declared type is
  * narrower than what the API actually accepts.
  */
@@ -52,7 +52,7 @@ export type ClaudeRuntimeEffortLevel = 'low' | 'medium' | 'high' | 'xhigh';
  * `Settings.effortLevel` type is corrected upstream
  * (anthropics/claude-agent-sdk-typescript#377).
  */
-export function clampEffortForRuntime(effort: ClaudeEffortLevel | undefined): ClaudeRuntimeEffortLevel | undefined {
+export function toRuntimeEffortLevel(effort: ClaudeEffortLevel | undefined): ClaudeRuntimeEffortLevel | undefined {
 	return effort as ClaudeRuntimeEffortLevel | undefined;
 }
 

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -736,9 +736,8 @@ export class ClaudeAgentSession extends Disposable {
 	 *   startup picks it up via `Options.model` / `Options.effort`.
 	 * - Post-materialize: queue the change on the pipeline; the SDK
 	 *   applies it on the NEXT user request via
-	 *   `Query.setModel` / `Query.applyFlagSettings`. `'max'` effort is
-	 *   clamped to `'xhigh'` on the runtime path (CAPI lacks a `'max'`
-	 *   tier today).
+	 *   `Query.setModel` / `Query.applyFlagSettings`. `'max'` flows through
+	 *   unchanged — see {@link clampEffortForRuntime}.
 	 *
 	 * In both cases the new model is persisted to the per-session
 	 * metadata overlay so a later resume sees the user's choice.
@@ -746,11 +745,6 @@ export class ClaudeAgentSession extends Disposable {
 	async setModel(model: ModelSelection): Promise<void> {
 		this._provisionalModel = model;
 		if (this._pipeline) {
-			const requestedEffort = resolveClaudeEffort(model);
-			const runtimeEffort = clampEffortForRuntime(requestedEffort);
-			if (requestedEffort === 'max') {
-				this._logService.warn(`[Claude:${this.sessionId}] setModel: 'max' effort clamped to 'xhigh' (Copilot CAPI has no 'max' model yet)`);
-			}
 			await this._pipeline.setModel(toSdkModelId(model.id));
 			// Always push the resolved effort, including `undefined`. Switching
 			// to a model that does not support reasoning effort (e.g. Haiku)
@@ -758,7 +752,7 @@ export class ClaudeAgentSession extends Disposable {
 			// SDK is still applying from a prior effort-capable model — otherwise
 			// the next turn replays e.g. `'high'` onto Haiku and the API 400s
 			// (`output_config.effort ... does not support reasoning effort`).
-			await this._pipeline.setEffort(runtimeEffort);
+			await this._pipeline.setEffort(clampEffortForRuntime(resolveClaudeEffort(model)));
 		}
 		await this._metadataStore.write(this._storageUri, { model });
 	}

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -16,7 +16,7 @@ import { ILogService } from '../../../log/common/log.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { ClaudePermissionMode } from '../../common/claudeSessionConfigKeys.js';
-import { ClaudeRuntimeEffortLevel, clampEffortForRuntime, resolveClaudeEffort } from '../../common/claudeModelConfig.js';
+import { ClaudeRuntimeEffortLevel, toRuntimeEffortLevel, resolveClaudeEffort } from '../../common/claudeModelConfig.js';
 import { AgentSignal, IAgentSessionProjectInfo } from '../../common/agentService.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
@@ -495,7 +495,7 @@ export class ClaudeAgentSession extends Disposable {
 		// config. Read provisional state directly off the session.
 		pipeline.seedCurrentConfig(
 			toSdkModelId(this._provisionalModel?.id),
-			clampEffortForRuntime(resolveClaudeEffort(this._provisionalModel)),
+			toRuntimeEffortLevel(resolveClaudeEffort(this._provisionalModel)),
 			permissionMode,
 		);
 
@@ -737,7 +737,7 @@ export class ClaudeAgentSession extends Disposable {
 	 * - Post-materialize: queue the change on the pipeline; the SDK
 	 *   applies it on the NEXT user request via
 	 *   `Query.setModel` / `Query.applyFlagSettings`. `'max'` flows through
-	 *   unchanged — see {@link clampEffortForRuntime}.
+	 *   unchanged — see {@link toRuntimeEffortLevel}.
 	 *
 	 * In both cases the new model is persisted to the per-session
 	 * metadata overlay so a later resume sees the user's choice.
@@ -752,7 +752,7 @@ export class ClaudeAgentSession extends Disposable {
 			// SDK is still applying from a prior effort-capable model — otherwise
 			// the next turn replays e.g. `'high'` onto Haiku and the API 400s
 			// (`output_config.effort ... does not support reasoning effort`).
-			await this._pipeline.setEffort(clampEffortForRuntime(resolveClaudeEffort(model)));
+			await this._pipeline.setEffort(toRuntimeEffortLevel(resolveClaudeEffort(model)));
 		}
 		await this._metadataStore.write(this._storageUri, { model });
 	}

--- a/src/vs/platform/agentHost/test/common/claudeModelConfig.test.ts
+++ b/src/vs/platform/agentHost/test/common/claudeModelConfig.test.ts
@@ -39,20 +39,20 @@ suite('resolveClaudeEffort (Phase 6.1 / Cycle E)', () => {
 	});
 });
 
-suite('clampEffortForRuntime (Phase 9 / Step 4)', () => {
+suite('clampEffortForRuntime', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('clamps `max` to `xhigh`; passes other levels through; preserves undefined', () => {
-		// `Query.applyFlagSettings({ effortLevel })` (sdk.d.ts:4914) only
-		// accepts `'low' | 'medium' | 'high' | 'xhigh'` — `'max'` is a
-		// startup-only level. The clamp seam keeps `'max'` selections from
-		// being lost entirely on the runtime path; genuine `'max'` would
-		// require the restart-required path (Phase 9 D7).
+	test('passes every level through unchanged — including `max` — and preserves undefined', () => {
+		// The SDK's runtime `Settings.effortLevel` type declares it can't accept
+		// `'max'`, but the Anthropic API / CAPI do accept it, so the clamp
+		// deliberately lets `'max'` flow through rather than degrading it to
+		// `'xhigh'`. The declared return type still excludes `'max'`; the value
+		// carried at runtime does not.
 		const inputs: readonly (ClaudeEffortLevel | undefined)[] = [undefined, 'low', 'medium', 'high', 'xhigh', 'max'];
 		assert.deepStrictEqual(
 			inputs.map(clampEffortForRuntime),
-			[undefined, 'low', 'medium', 'high', 'xhigh', 'xhigh'],
+			[undefined, 'low', 'medium', 'high', 'xhigh', 'max'],
 		);
 	});
 });

--- a/src/vs/platform/agentHost/test/common/claudeModelConfig.test.ts
+++ b/src/vs/platform/agentHost/test/common/claudeModelConfig.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { CLAUDE_THINKING_LEVEL_KEY, clampEffortForRuntime, createClaudeThinkingLevelSchema, isClaudeEffortLevel, resolveClaudeEffort, type ClaudeEffortLevel } from '../../common/claudeModelConfig.js';
+import { CLAUDE_THINKING_LEVEL_KEY, toRuntimeEffortLevel, createClaudeThinkingLevelSchema, isClaudeEffortLevel, resolveClaudeEffort, type ClaudeEffortLevel } from '../../common/claudeModelConfig.js';
 import type { ModelSelection } from '../../common/state/protocol/state.js';
 
 suite('resolveClaudeEffort (Phase 6.1 / Cycle E)', () => {
@@ -39,7 +39,7 @@ suite('resolveClaudeEffort (Phase 6.1 / Cycle E)', () => {
 	});
 });
 
-suite('clampEffortForRuntime', () => {
+suite('toRuntimeEffortLevel', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -51,7 +51,7 @@ suite('clampEffortForRuntime', () => {
 		// carried at runtime does not.
 		const inputs: readonly (ClaudeEffortLevel | undefined)[] = [undefined, 'low', 'medium', 'high', 'xhigh', 'max'];
 		assert.deepStrictEqual(
-			inputs.map(clampEffortForRuntime),
+			inputs.map(toRuntimeEffortLevel),
 			[undefined, 'low', 'medium', 'high', 'xhigh', 'max'],
 		);
 	});

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -5430,9 +5430,8 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 		});
 	});
 
-	test('changeModel with `max` effort clamps to `xhigh` on the runtime path and warns', async () => {
-		const log = new CapturingLogService();
-		const { ctx, sessionUri, query, advance } = await materialize({ logService: log });
+	test('changeModel with `max` effort passes `max` through on the runtime path', async () => {
+		const { ctx, sessionUri, query, advance } = await materialize();
 
 		await ctx.agent.chats.changeModel(defaultChatUri(sessionUri), { id: 'claude-opus-4.6', config: { thinkingLevel: 'max' } });
 		const p2 = ctx.agent.chats.sendMessage(defaultChatUri(sessionUri), 'next', undefined, undefined, 'turn-2');
@@ -5440,8 +5439,7 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 		advance.complete();
 		await p2;
 
-		assert.deepStrictEqual(query.recordedFlagSettings.map(s => s.effortLevel), ['xhigh']);
-		assert.ok(log.warns.some(w => w.includes('clamped to')), `expected clamp warning, got: ${log.warns.join(' | ')}`);
+		assert.deepStrictEqual(query.recordedFlagSettings.map(s => s.effortLevel), ['max']);
 	});
 
 	test('changeModel with same id and unchanged effort skips the SDK setters', async () => {


### PR DESCRIPTION
## What

`clampEffortForRuntime` now passes `max` reasoning effort straight through instead of degrading it to `xhigh` on the runtime (`applyFlagSettings`) path.

## Why

The SDK's `Settings.effortLevel` type — reused by `Query.applyFlagSettings({ effortLevel })` — is typed `low | medium | high | xhigh`, omitting `max`. That type is wrong: the Anthropic API / Copilot CAPI accept `max` end-to-end (the exported `EffortLevel` union and the wire `output_config.effort` field both include it). Confirmed with Anthropic and verified live — a `max` turn on Claude Opus 4.8 puts `output_config.effort:"max"` on the CAPI `/v1/messages` call and returns success. Previously a mid-session `max` pick was silently clamped to `xhigh`.

## How

- `clampEffortForRuntime` keeps its narrow `ClaudeRuntimeEffortLevel` return type but returns `max` at runtime via a single, documented cast — every downstream consumer stays typed against the SDK's declared surface while the one lie is contained in one place.
- Removed the now-incorrect `max`->`xhigh` warning in `setModel`.
- Tests updated to assert `max` passes through.

## Follow-up

Upstream SDK typing fix tracked at anthropics/claude-agent-sdk-typescript#377 — drop the cast once `Settings.effortLevel` includes `max`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)