### PR TITLE
Emit v2 cloud agent sessionActivated telemetry from live task stream

### DIFF
--- a/extensions/copilot/docs/monitoring/agent_monitoring.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring.md
@@ -337,7 +337,7 @@ These metrics track the activity and outcomes of agentic code changes across all
 
 **`copilot_chat.cloud.pr_ready.count` attributes:** `github.copilot.cloud.backend_version` (`v1`, optional)
 
-**`copilot_chat.cloud.operation.count` attributes:** `operation` (`createSession`/`fetchSessionList`/`fetchContent`/`fetchEvents`/`pollUpdate`/`followUp`/`findTaskForPullRequest`/`createPullRequest`/`sessionActivated`), `github.copilot.cloud.backend_version` (`v1`/`v2`), `success`
+**`copilot_chat.cloud.operation.count` attributes:** `operation` (`createSession`/`fetchSessionList`/`fetchContent`/`fetchEvents`/`followUp`/`findTaskForPullRequest`/`createPullRequest`/`sessionActivated`), `github.copilot.cloud.backend_version` (`v1`/`v2`), `success`
 
 **`copilot_chat.cloud.operation.duration` attributes:** `operation`, `github.copilot.cloud.backend_version` (`v1`/`v2`)
 

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/cloudBackendTelemetry.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/cloudBackendTelemetry.ts
@@ -22,7 +22,6 @@ export type CloudBackendOperation =
 	| 'fetchSessionList'
 	| 'fetchContent'
 	| 'fetchEvents'
-	| 'pollUpdate'
 	| 'followUp'
 	| 'findTaskForPullRequest'
 	| 'createPullRequest';

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -380,6 +380,13 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 	/** Resolved Cloud Agent backend version (`v1` Jobs API | `v2` Task API) for this provider instance. */
 	private readonly _backendVersion: CloudBackendVersion;
 
+	/**
+	 * Task ids for which the v2 "session activated" signal has already been emitted, keeping the
+	 * live {@link TaskTurnStreamer} emission idempotent across re-opens and repeated stream ticks.
+	 * Owned here (rather than in the per-run streamer) so it persists across stream runs.
+	 */
+	private readonly _activatedTaskIds = new Set<string>();
+
 	constructor(
 		@IOctoKitService private readonly _octoKitService: IOctoKitService,
 		@IGitService private readonly _gitService: IGitService,
@@ -1630,7 +1637,18 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			}
 			this._activeTaskStreams.add(taskId);
 			try {
-				const streamer = new TaskTurnStreamer(backend, new ChatSessionContentBuilder(CopilotCloudSessionsProvider.TYPE, this._gitService, this.logService), this.logService);
+				// CloudBackendInstrumentation is a stateless wrapper over the telemetry/OTel services and
+				// backend version the provider already holds, so we build it from those rather than keeping
+				// a dedicated field. The streamer emits the v2 "session activated" signal itself, deduped
+				// per task via the shared _activatedTaskIds so re-opens/ticks don't double-count.
+				const instrumentation = new CloudBackendInstrumentation(this._backendVersion, this.telemetry, this._otelService);
+				const streamer = new TaskTurnStreamer(
+					backend,
+					new ChatSessionContentBuilder(CopilotCloudSessionsProvider.TYPE, this._gitService, this.logService),
+					this.logService,
+					instrumentation,
+					this._activatedTaskIds,
+				);
 				await streamer.stream(stream, taskId, baseline, token);
 			} finally {
 				this._activeTaskStreams.delete(taskId);

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -27,7 +27,7 @@ import { IExperimentationService } from '../../../platform/telemetry/common/null
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { DeferredPromise, IntervalTimer, retry, RunOnceScheduler, timeout } from '../../../util/vs/base/common/async';
 import { Event } from '../../../util/vs/base/common/event';
-import { Disposable, DisposableStore, toDisposable } from '../../../util/vs/base/common/lifecycle';
+import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../util/vs/base/common/lifecycle';
 import { ResourceMap } from '../../../util/vs/base/common/map';
 import { joinPath } from '../../../util/vs/base/common/resources';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
@@ -191,6 +191,15 @@ const DEFAULT_PARTNER_AGENT_ID = '___vscode_partner_agent_default___';
 const DEFAULT_REPOSITORY_ID = '___vscode_repository_default___';
 
 const ACTIVE_SESSION_POLL_INTERVAL_MS = 5 * 1000; // 5 seconds
+
+/** Poll interval for the v2 task activation monitor (see {@link CopilotCloudSessionsProvider.startTaskActivationMonitor}). */
+const TASK_ACTIVATION_POLL_INTERVAL_MS = 5 * 1000; // 5 seconds
+/**
+ * Upper bound on how long the activation monitor waits for a freshly-created task to produce its
+ * first turn before giving up. A task stuck queued past this window goes unreported rather than
+ * leaking a poll loop — the funnel favors under-counting over an unbounded monitor.
+ */
+const TASK_ACTIVATION_MONITOR_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 const SEEN_DELEGATION_PROMPT_KEY = 'seenDelegationPromptBefore';
 const OPEN_REPOSITORY_COMMAND_ID = 'github.copilot.chat.cloudSessions.openRepository';
 const CLEAR_CACHES_COMMAND_ID = 'github.copilot.chat.cloudSessions.clearCaches';
@@ -381,11 +390,18 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 	private readonly _backendVersion: CloudBackendVersion;
 
 	/**
-	 * Task ids for which the v2 "session activated" signal has already been emitted, keeping the
-	 * live {@link TaskTurnStreamer} emission idempotent across re-opens and repeated stream ticks.
-	 * Owned here (rather than in the per-run streamer) so it persists across stream runs.
+	 * Task ids for which the v2 `sessionActivated` signal has already been emitted, keeping the
+	 * activation monitor idempotent (a task is reported at most once).
 	 */
 	private readonly _activatedTaskIds = new Set<string>();
+
+	/**
+	 * In-flight activation monitors keyed by task id (see {@link startTaskActivationMonitor}). Armed
+	 * only for tasks created locally in this session, so an activation can never be reported without a
+	 * matching local creation. Disposing the entry cancels the monitor; the map is disposed with the
+	 * provider so no loop outlives it.
+	 */
+	private readonly _activationMonitors = this._register(new DisposableMap<string>());
 
 	constructor(
 		@IOctoKitService private readonly _octoKitService: IOctoKitService,
@@ -1637,17 +1653,10 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			}
 			this._activeTaskStreams.add(taskId);
 			try {
-				// CloudBackendInstrumentation is a stateless wrapper over the telemetry/OTel services and
-				// backend version the provider already holds, so we build it from those rather than keeping
-				// a dedicated field. The streamer emits the v2 "session activated" signal itself, deduped
-				// per task via the shared _activatedTaskIds so re-opens/ticks don't double-count.
-				const instrumentation = new CloudBackendInstrumentation(this._backendVersion, this.telemetry, this._otelService);
 				const streamer = new TaskTurnStreamer(
 					backend,
 					new ChatSessionContentBuilder(CopilotCloudSessionsProvider.TYPE, this._gitService, this.logService),
 					this.logService,
-					instrumentation,
-					this._activatedTaskIds,
 				);
 				await streamer.stream(stream, taskId, baseline, token);
 			} finally {
@@ -1658,6 +1667,83 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				await this.updatePullRequestToolbarContext(taskId);
 			}
 		};
+	}
+
+	/**
+	 * Start monitoring a freshly-created v2 task so its `sessionActivated` funnel signal fires once
+	 * the task produces its first turn — the v2 analogue of v1's PR becoming available. This runs
+	 * independently of whether the user opens the session, so fast tasks and never-opened tasks are
+	 * still reported.
+	 *
+	 * Arm only from local creation: because a monitor exists solely for tasks this session created,
+	 * an activation can never be reported without a matching local `sessionCreate`, preserving the
+	 * `activations ≤ creations` funnel invariant. A no-op unless the active backend is v2.
+	 */
+	private startTaskActivationMonitor(taskId: string): void {
+		const backend = this._backend;
+		if (backend.kind !== 'task') {
+			return;
+		}
+		if (this._activatedTaskIds.has(taskId) || this._activationMonitors.has(taskId)) {
+			return;
+		}
+		const cts = new vscode.CancellationTokenSource();
+		// Cancel and dispose the token when the entry is removed or the provider is disposed.
+		this._activationMonitors.set(taskId, toDisposable(() => {
+			cts.cancel();
+			cts.dispose();
+		}));
+		const instrumentation = new CloudBackendInstrumentation(this._backendVersion, this.telemetry, this._otelService);
+		void this._monitorTaskActivation(backend, taskId, instrumentation, cts.token)
+			.finally(() => this._activationMonitors.deleteAndDispose(taskId));
+	}
+
+	/**
+	 * Poll a created task until it produces observable output (an `assistant.*` event — genuine
+	 * evidence the agent started a turn) and emit activation, or until it reaches a terminal state
+	 * with no such output (e.g. "Failed to launch agent"), in which case nothing is emitted so
+	 * no-output failures don't inflate the funnel. Bounded by {@link TASK_ACTIVATION_MONITOR_TIMEOUT_MS}.
+	 */
+	private async _monitorTaskActivation(backend: TaskCloudAgentBackend, taskId: string, instrumentation: CloudBackendInstrumentation, token: vscode.CancellationToken): Promise<void> {
+		const startedAt = Date.now();
+		try {
+			while (!token.isCancellationRequested && Date.now() - startedAt < TASK_ACTIVATION_MONITOR_TIMEOUT_MS) {
+				const [content, events] = await Promise.all([
+					backend.fetchTaskContent(taskId).catch(() => undefined),
+					backend.fetchTaskEvents(taskId).catch(() => [] as readonly AgentTaskSessionEvent[]),
+				]);
+				const task = content?.task;
+				// Check for output evidence first so a task that finished quickly (terminal but with a
+				// completed turn) still counts as activated.
+				if (events.some(e => e.type.startsWith('assistant.'))) {
+					// Prefer the server's `created_at`; fall back to the monitor start (≈ creation time)
+					// if the task payload wasn't fetched this tick.
+					const createdAtMs = task?.created_at ? Date.parse(task.created_at) : startedAt;
+					this.reportTaskActivated(taskId, createdAtMs, instrumentation);
+					return;
+				}
+				// Terminal with no output evidence (failed to launch, cancelled before starting): don't emit.
+				if (task && !isActiveTaskState(task.state)) {
+					return;
+				}
+				await timeout(TASK_ACTIVATION_POLL_INTERVAL_MS, token);
+			}
+		} catch {
+			// Cancellation (provider dispose) or a persistent fetch failure — stop silently; a missed
+			// activation only under-counts, which the funnel tolerates.
+		}
+	}
+
+	/**
+	 * Emit the v2 `sessionActivated` funnel signal for a task exactly once. `createdAtMs` is the task's
+	 * creation epoch (ms); `durationMs` is measured from it to now.
+	 */
+	private reportTaskActivated(taskId: string, createdAtMs: number, instrumentation: CloudBackendInstrumentation): void {
+		if (this._activatedTaskIds.has(taskId)) {
+			return;
+		}
+		this._activatedTaskIds.add(taskId);
+		instrumentation.sessionActivated(Number.isNaN(createdAtMs) ? 0 : Math.max(0, Date.now() - createdAtMs));
 	}
 
 	async openSessionInBrowser(chatSessionItem: vscode.ChatSessionItem): Promise<void> {
@@ -3266,6 +3352,9 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 
 		if (result.kind !== 'pullRequest') {
 			// Task-shaped result (v2). Always open as a task; PR badging happens later.
+			// Start watching for the first turn so activation is reported even if the user never
+			// opens the session or the task finishes quickly.
+			this.startTaskActivationMonitor(result.taskId);
 			this.refresh();
 			return {
 				kind: 'task',

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/taskApiBackend.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/taskApiBackend.ts
@@ -44,9 +44,6 @@ import {
 } from '../vscode/cloudAgentBackend';
 import { extractTitle, SessionIdForPr, SessionIdForTask } from '../vscode/copilotCodingAgentUtils';
 
-const TASK_SESSION_POLL_INTERVAL_MS = 2_000;
-const TASK_SESSION_POLL_TIMEOUT_MS = 60_000;
-
 function mapTaskStateToSessionState(state: AgentTaskState): SessionInfo['state'] {
 	switch (state) {
 		case 'queued':
@@ -386,40 +383,6 @@ export class TaskApiBackend implements TaskCloudAgentBackend {
 			this._instrumentation.operationFailed('fetchEvents', e);
 			return events;
 		}
-	}
-
-	async waitForTaskUpdate(taskId: string, since: { turnCount: number; updatedAt?: string }, token?: vscode.CancellationToken): Promise<TaskContent | undefined> {
-		const startTime = Date.now();
-		while (Date.now() - startTime < TASK_SESSION_POLL_TIMEOUT_MS && !(token?.isCancellationRequested)) {
-			try {
-				const task = await this._taskApiClient.getTask(taskId);
-				const turnCount = task.sessions?.length ?? 0;
-				// Fire when any observable changed: a new turn was added, the task's
-				// `updated_at` advanced (covers in-place state transitions), or the latest
-				// turn left the in-progress/queued region.
-				const updatedAtChanged = since.updatedAt && task.updated_at && task.updated_at !== since.updatedAt;
-				const latestTurnState = task.sessions?.[turnCount - 1]?.state;
-				const latestTurnSettled = latestTurnState && latestTurnState !== 'in_progress' && latestTurnState !== 'queued' && latestTurnState !== 'idle' && latestTurnState !== 'waiting_for_user';
-				if (turnCount > since.turnCount || updatedAtChanged || latestTurnSettled) {
-					// First turn appearing (baseline had none) is the v2 "session activated" signal —
-					// the task has started producing output. Mirrors v1's PR-ready activation.
-					if (since.turnCount === 0 && turnCount >= 1) {
-						const createdAtMs = task.created_at ? Date.parse(task.created_at) : NaN;
-						this._instrumentation.sessionActivated(Number.isNaN(createdAtMs) ? 0 : Math.max(0, Date.now() - createdAtMs));
-					}
-					return {
-						task,
-						turns: [],
-						pullArtifact: taskToPullArtifactRef(task, undefined),
-					};
-				}
-			} catch (e) {
-				this._logService.warn(`Failed to poll task ${taskId}: ${e}`);
-				this._instrumentation.operationFailed('pollUpdate', e);
-			}
-			await new Promise(resolve => setTimeout(resolve, TASK_SESSION_POLL_INTERVAL_MS));
-		}
-		return undefined;
 	}
 
 	async sendFollowUpToTask(taskId: string, prompt: string): Promise<FollowUpResult | undefined> {

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/taskTurnStreamer.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/taskTurnStreamer.ts
@@ -14,6 +14,7 @@ import {
 } from '../common/sessionEventRenderer';
 import { TaskCloudAgentBackend } from '../vscode/cloudAgentBackend';
 import { isActiveTaskState, isFailedTaskState } from '../vscode/copilotCodingAgentUtils';
+import { ICloudBackendInstrumentation } from './cloudBackendTelemetry';
 import { ChatSessionContentBuilder, extractTaskErrorDetail, formatTaskStoppedMessage } from './copilotCloudSessionContentBuilder';
 
 /**
@@ -90,6 +91,13 @@ export class TaskTurnStreamer {
 		private readonly _backend: TaskCloudAgentBackend,
 		private readonly _contentBuilder: ChatSessionContentBuilder,
 		private readonly _logService: ILogService,
+		/** Telemetry surface used to emit the v2 "session activated" funnel signal. */
+		private readonly _instrumentation: ICloudBackendInstrumentation,
+		/**
+		 * Task ids already reported as activated, owned by the caller so the emit stays idempotent
+		 * across stream runs (re-opens of an in-progress first turn create a fresh streamer).
+		 */
+		private readonly _activatedTaskIds: Set<string>,
 		private readonly _pollIntervalMs: number = TaskTurnStreamer.DEFAULT_POLL_INTERVAL_MS,
 	) { }
 
@@ -151,6 +159,15 @@ export class TaskTurnStreamer {
 				sink.flush();
 
 				const sessions = task?.sessions;
+				// v2 activation signal: the task's first (and only) turn is streaming, i.e. it has
+				// started producing output. Mirrors v1's PR-becoming-available moment. Deduped per task
+				// via the caller-owned set so re-opens/ticks emit once. Follow-up turns (`mode: 'next'`)
+				// have `sessions.length >= 2`, so they never qualify.
+				if (task && sessions?.length === 1 && !this._activatedTaskIds.has(task.id)) {
+					this._activatedTaskIds.add(task.id);
+					const createdAtMs = task.created_at ? Date.parse(task.created_at) : NaN;
+					this._instrumentation.sessionActivated(Number.isNaN(createdAtMs) ? 0 : Math.max(0, Date.now() - createdAtMs));
+				}
 				const latestTurn = sessions?.[sessions.length - 1];
 				// Settle when the task itself reached a terminal state, even if its latest turn's
 				// session state is still active. A task that failed to launch (e.g. "Failed to

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/taskTurnStreamer.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/taskTurnStreamer.ts
@@ -14,7 +14,6 @@ import {
 } from '../common/sessionEventRenderer';
 import { TaskCloudAgentBackend } from '../vscode/cloudAgentBackend';
 import { isActiveTaskState, isFailedTaskState } from '../vscode/copilotCodingAgentUtils';
-import { ICloudBackendInstrumentation } from './cloudBackendTelemetry';
 import { ChatSessionContentBuilder, extractTaskErrorDetail, formatTaskStoppedMessage } from './copilotCloudSessionContentBuilder';
 
 /**
@@ -91,13 +90,6 @@ export class TaskTurnStreamer {
 		private readonly _backend: TaskCloudAgentBackend,
 		private readonly _contentBuilder: ChatSessionContentBuilder,
 		private readonly _logService: ILogService,
-		/** Telemetry surface used to emit the v2 "session activated" funnel signal. */
-		private readonly _instrumentation: ICloudBackendInstrumentation,
-		/**
-		 * Task ids already reported as activated, owned by the caller so the emit stays idempotent
-		 * across stream runs (re-opens of an in-progress first turn create a fresh streamer).
-		 */
-		private readonly _activatedTaskIds: Set<string>,
 		private readonly _pollIntervalMs: number = TaskTurnStreamer.DEFAULT_POLL_INTERVAL_MS,
 	) { }
 
@@ -159,15 +151,6 @@ export class TaskTurnStreamer {
 				sink.flush();
 
 				const sessions = task?.sessions;
-				// v2 activation signal: the task's first (and only) turn is streaming, i.e. it has
-				// started producing output. Mirrors v1's PR-becoming-available moment. Deduped per task
-				// via the caller-owned set so re-opens/ticks emit once. Follow-up turns (`mode: 'next'`)
-				// have `sessions.length >= 2`, so they never qualify.
-				if (task && sessions?.length === 1 && !this._activatedTaskIds.has(task.id)) {
-					this._activatedTaskIds.add(task.id);
-					const createdAtMs = task.created_at ? Date.parse(task.created_at) : NaN;
-					this._instrumentation.sessionActivated(Number.isNaN(createdAtMs) ? 0 : Math.max(0, Date.now() - createdAtMs));
-				}
 				const latestTurn = sessions?.[sessions.length - 1];
 				// Settle when the task itself reached a terminal state, even if its latest turn's
 				// session state is still active. A task that failed to launch (e.g. "Failed to

--- a/extensions/copilot/src/extension/chatSessions/vscode/cloudAgentBackend.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode/cloudAgentBackend.ts
@@ -207,16 +207,6 @@ export interface TaskCloudAgentBackend extends CloudAgentBackendCommon {
 	/** Fetch the typed event timeline for a task. */
 	fetchTaskEvents(taskId: string): Promise<readonly AgentTaskSessionEvent[]>;
 
-	/**
-	 * Block until the task has changed observably since the given baseline (new turn, an
-	 * advance of `updated_at`, or the latest turn leaving in-progress/queued).
-	 */
-	waitForTaskUpdate(
-		taskId: string,
-		since: { turnCount: number; updatedAt?: string },
-		token?: vscode.CancellationToken,
-	): Promise<TaskContent | undefined>;
-
 	/** Post a follow-up turn against a task via the steer endpoint. */
 	sendFollowUpToTask(
 		taskId: string,


### PR DESCRIPTION
## Problem

The v2 (Task API) cloud agent backend never emitted the `copilotcloud.chat.sessionActivated` funnel signal, so the v1-vs-v2 activation funnel (time-to-first-turn / activation rate) could not be compared in telemetry.

Root cause: the only call site for `sessionActivated` on v2 lived inside `TaskApiBackend.waitForTaskUpdate`, which had **no callers**. v1 emits the equivalent signal from `waitForJobWithPullRequest` during `createSession` — hence the asymmetry.

## Approach

A provider-owned **activation monitor** is started the moment a v2 task is created (`startTaskActivationMonitor`, wired into the delegation helper). It polls the task and emits `sessionActivated` once the task produces its first turn — the v2 analogue of v1's PR becoming available — then stops.

Key properties:

- **Reported regardless of the UI.** The monitor runs independently of whether the user opens the session, so freshly-created zero-session tasks and fast-finishing tasks are captured (not only tasks that happen to be live-streamed).
- **`activations ≤ creations` preserved.** Monitors are armed **only for locally-created tasks**, so activation can't be reported without a matching local `sessionCreate`. Monitors are cancelled on provider dispose; an ext-host reload drops them (under-count) rather than risking a double-count. State is intentionally not persisted — for a funnel, over-counting is worse than a missed activation.
- **Requires real output.** Activation fires only when an `assistant.*` event is observed (genuine turn output) and is suppressed for tasks that reach a terminal state with no output (e.g. "Failed to launch agent"), so no-output failures don't inflate the funnel.
- **`durationMs`** is measured from the task's `created_at` (falling back to monitor start ≈ creation time).

The `TaskTurnStreamer` remains a pure renderer with no telemetry dependency.

## Cleanup

- Removed the dead `waitForTaskUpdate` (method, `TaskCloudAgentBackend` interface declaration, unused poll constants).
- Removed the now-dead `pollUpdate` operation from the `CloudBackendOperation` union and from `agent_monitoring.md` (its only emitter was `waitForTaskUpdate`).

## Validation

- `tsgo` type-check: clean for all changed files.
- ESLint: clean.
- `copilotCloudSessionsProvider.spec.ts`: 32/32 passing.
