### PR TITLE
sessions: fix docked detail panel gap at bottom in single-pane layout

### DIFF
--- a/src/vs/sessions/browser/parts/singlePaneAuxiliaryBarPart.ts
+++ b/src/vs/sessions/browser/parts/singlePaneAuxiliaryBarPart.ts
@@ -16,9 +16,12 @@ import { AuxiliaryBarPart } from './auxiliaryBarPart.js';
  */
 export class SinglePaneAuxiliaryBarPart extends AuxiliaryBarPart {
 
-	protected override createTitleArea(): HTMLElement | undefined {
-		// No title strip; the single tab bar lives on the editor part.
-		return undefined;
+	override create(parent: HTMLElement): void {
+		// No title strip; the single tab bar lives on the editor part. Clearing
+		// `hasTitle` also stops the part layout from reserving the title height,
+		// which otherwise leaves an empty gap at the bottom of the docked panel.
+		this.options = { ...this.options, hasTitle: false };
+		super.create(parent);
 	}
 
 	protected override shouldShowCompositeBar(): boolean {

--- a/src/vs/sessions/browser/parts/singlePaneAuxiliaryBarPart.ts
+++ b/src/vs/sessions/browser/parts/singlePaneAuxiliaryBarPart.ts
@@ -17,9 +17,7 @@ import { AuxiliaryBarPart } from './auxiliaryBarPart.js';
 export class SinglePaneAuxiliaryBarPart extends AuxiliaryBarPart {
 
 	override create(parent: HTMLElement): void {
-		// No title strip; the single tab bar lives on the editor part. Clearing
-		// `hasTitle` also stops the part layout from reserving the title height,
-		// which otherwise leaves an empty gap at the bottom of the docked panel.
+		// Clear `hasTitle` so PartLayout does not reserve title height (there is no title strip).
 		this.options = { ...this.options, hasTitle: false };
 		super.create(parent);
 	}


### PR DESCRIPTION
## What

In the Agents window single-pane layout, the docked detail panel (the auxiliary bar reparented into the editor area) was laid out with a gap at the bottom — its content didn't fill the full height of the docked rectangle.

## Why

`SinglePaneAuxiliaryBarPart` intentionally renders **no title strip** (the single tab bar lives on the editor part), but it inherited `hasTitle: true` from the base `AuxiliaryBarPart`. `PartLayout.layout` still subtracts the title height (~35px) from the content area whenever `hasTitle` is true — even though no title area actually exists. So the composite content was sized ~35px shorter than its container, leaving the empty gap.

## Fix

Override `create()` in `SinglePaneAuxiliaryBarPart` to clear `hasTitle` before the part layout is built, so the content fills the full docked rectangle. This also lets the base `createTitleArea` return `undefined` on its own, so the now-redundant `createTitleArea` override was removed.

## Notes for reviewers

- Change is confined to `src/vs/sessions/`.
- Typechecks clean and passes the layers checker.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
