### PR TITLE
editor: consolidate diff-editor command handlers into IDiffEditorCommandsService

### DIFF
--- a/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/diffEditorCommands.ts
@@ -4,20 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
-import { ITextResourceConfigurationService } from '../../../../editor/common/services/textResourceConfiguration.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
-import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ActiveCompareEditorCanSwapContext, ActiveCustomEditorDiffCanToggleLayoutContext, TextCompareEditorActiveContext, TextCompareEditorVisibleContext } from '../../../common/contextkeys.js';
-import { DiffEditorInput } from '../../../common/editor/diffEditorInput.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { IUntypedEditorInput } from '../../../common/editor.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
-import { isDiffEditor } from '../../../../editor/browser/editorBrowser.js';
-import { EditorInput } from '../../../common/editor/editorInput.js';
-import { getActiveTextDiffEditor, IDiffEditorCommandsService } from './diffEditorCommandsService.js';
+import { FocusTextDiffEditorMode, IDiffEditorCommandsService } from './diffEditorCommandsService.js';
 
 export const TOGGLE_DIFF_SIDE_BY_SIDE = 'toggle.diff.renderSideBySide';
 export const GOTO_NEXT_CHANGE = 'workbench.action.compareEditor.nextChange';
@@ -35,25 +28,7 @@ export function registerDiffEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: EditorContextKeys.inDiffEditor,
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.Shift | KeyCode.KeyO),
-		handler: async accessor => {
-			const editorService = accessor.get(IEditorService);
-
-			const activeEditor = editorService.activeEditor;
-			const activeTextEditorControl = editorService.activeTextEditorControl;
-			if (!isDiffEditor(activeTextEditorControl) || !(activeEditor instanceof DiffEditorInput)) {
-				return;
-			}
-
-			let editor: EditorInput | undefined;
-			const originalEditor = activeTextEditorControl.getOriginalEditor();
-			if (originalEditor.hasTextFocus()) {
-				editor = activeEditor.original;
-			} else {
-				editor = activeEditor.modified;
-			}
-
-			return editorService.openEditor(editor);
-		}
+		handler: accessor => accessor.get(IDiffEditorCommandsService).openActiveDiffSide()
 	});
 
 	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
@@ -68,7 +43,7 @@ export function registerDiffEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: TextCompareEditorVisibleContext,
 		primary: KeyMod.Alt | KeyCode.F5,
-		handler: (accessor, ...args) => navigateInDiffEditor(accessor, args, true)
+		handler: (accessor, ...args) => accessor.get(IDiffEditorCommandsService).navigateInDiffEditor(args, true)
 	});
 
 	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
@@ -83,7 +58,7 @@ export function registerDiffEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: TextCompareEditorVisibleContext,
 		primary: KeyMod.Alt | KeyMod.Shift | KeyCode.F5,
-		handler: (accessor, ...args) => navigateInDiffEditor(accessor, args, false)
+		handler: (accessor, ...args) => accessor.get(IDiffEditorCommandsService).navigateInDiffEditor(args, false)
 	});
 
 	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
@@ -92,101 +67,6 @@ export function registerDiffEditorCommands(): void {
 			title: localize2('compare.previousChange', 'Go to Previous Change'),
 		}
 	});
-
-
-	function navigateInDiffEditor(accessor: ServicesAccessor, args: unknown[], next: boolean): void {
-		const activeTextDiffEditor = getActiveTextDiffEditor(accessor.get(IEditorService), args);
-
-		if (activeTextDiffEditor) {
-			activeTextDiffEditor.getControl()?.goToDiff(next ? 'next' : 'previous');
-		}
-	}
-
-	enum FocusTextDiffEditorMode {
-		Original,
-		Modified,
-		Toggle
-	}
-
-	function focusInDiffEditor(accessor: ServicesAccessor, args: unknown[], mode: FocusTextDiffEditorMode): void {
-		const activeTextDiffEditor = getActiveTextDiffEditor(accessor.get(IEditorService), args);
-
-		if (activeTextDiffEditor) {
-			switch (mode) {
-				case FocusTextDiffEditorMode.Original:
-					activeTextDiffEditor.getControl()?.getOriginalEditor().focus();
-					break;
-				case FocusTextDiffEditorMode.Modified:
-					activeTextDiffEditor.getControl()?.getModifiedEditor().focus();
-					break;
-				case FocusTextDiffEditorMode.Toggle:
-					if (activeTextDiffEditor.getControl()?.getModifiedEditor().hasWidgetFocus()) {
-						return focusInDiffEditor(accessor, args, FocusTextDiffEditorMode.Original);
-					} else {
-						return focusInDiffEditor(accessor, args, FocusTextDiffEditorMode.Modified);
-					}
-			}
-		}
-	}
-
-	function toggleDiffIgnoreTrimWhitespace(accessor: ServicesAccessor, args: unknown[]): void {
-		const configService = accessor.get(ITextResourceConfigurationService);
-		const activeTextDiffEditor = getActiveTextDiffEditor(accessor.get(IEditorService), args);
-
-		const m = activeTextDiffEditor?.getControl()?.getModifiedEditor()?.getModel();
-		if (!m) { return; }
-
-		const key = 'diffEditor.ignoreTrimWhitespace';
-		const val = configService.getValue(m.uri, key);
-		configService.updateValue(m.uri, key, !val);
-	}
-
-	async function swapDiffSides(accessor: ServicesAccessor, args: unknown[]): Promise<void> {
-		const editorService = accessor.get(IEditorService);
-
-		const diffEditor = getActiveTextDiffEditor(editorService, args);
-		const activeGroup = diffEditor?.group;
-		const diffInput = diffEditor?.input;
-		if (!diffEditor || typeof activeGroup === 'undefined' || !(diffInput instanceof DiffEditorInput) || !diffInput.modified.resource) {
-			return;
-		}
-
-		const untypedDiffInput = diffInput.toUntyped({ preserveViewState: activeGroup.id, preserveResource: true });
-		if (!untypedDiffInput) {
-			return;
-		}
-
-		// Since we are about to replace the diff editor, make
-		// sure to first open the modified side if it is not
-		// yet opened. This ensures that the swapping is not
-		// bringing up a confirmation dialog to save.
-		if (diffInput.modified.isModified() && editorService.findEditors({ resource: diffInput.modified.resource, typeId: diffInput.modified.typeId, editorId: diffInput.modified.editorId }).length === 0) {
-			const editorToOpen: IUntypedEditorInput = { ...untypedDiffInput.modified };
-			if (!editorToOpen.options) {
-				editorToOpen.options = {};
-			}
-			editorToOpen.options.pinned = true;
-			editorToOpen.options.inactive = true;
-
-			await editorService.openEditor(editorToOpen, activeGroup);
-		}
-
-		// Replace the input with the swapped variant
-		await editorService.replaceEditors([
-			{
-				editor: diffInput,
-				replacement: {
-					...untypedDiffInput,
-					original: untypedDiffInput.modified,
-					modified: untypedDiffInput.original,
-					options: {
-						...untypedDiffInput.options,
-						pinned: true
-					}
-				}
-			}
-		], activeGroup);
-	}
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
 		id: TOGGLE_DIFF_SIDE_BY_SIDE,
@@ -201,7 +81,7 @@ export function registerDiffEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: undefined,
-		handler: (accessor, ...args) => focusInDiffEditor(accessor, args, FocusTextDiffEditorMode.Modified)
+		handler: (accessor, ...args) => accessor.get(IDiffEditorCommandsService).focusInDiffEditor(args, FocusTextDiffEditorMode.Modified)
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
@@ -209,7 +89,7 @@ export function registerDiffEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: undefined,
-		handler: (accessor, ...args) => focusInDiffEditor(accessor, args, FocusTextDiffEditorMode.Original)
+		handler: (accessor, ...args) => accessor.get(IDiffEditorCommandsService).focusInDiffEditor(args, FocusTextDiffEditorMode.Original)
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
@@ -217,7 +97,7 @@ export function registerDiffEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: undefined,
-		handler: (accessor, ...args) => focusInDiffEditor(accessor, args, FocusTextDiffEditorMode.Toggle)
+		handler: (accessor, ...args) => accessor.get(IDiffEditorCommandsService).focusInDiffEditor(args, FocusTextDiffEditorMode.Toggle)
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
@@ -225,7 +105,7 @@ export function registerDiffEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: undefined,
-		handler: (accessor, ...args) => toggleDiffIgnoreTrimWhitespace(accessor, args)
+		handler: (accessor, ...args) => accessor.get(IDiffEditorCommandsService).toggleDiffIgnoreTrimWhitespace(args)
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
@@ -233,7 +113,7 @@ export function registerDiffEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: undefined,
-		handler: (accessor, ...args) => swapDiffSides(accessor, args)
+		handler: (accessor, ...args) => accessor.get(IDiffEditorCommandsService).swapDiffSides(args)
 	});
 
 	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {

--- a/src/vs/workbench/browser/parts/editor/diffEditorCommandsService.ts
+++ b/src/vs/workbench/browser/parts/editor/diffEditorCommandsService.ts
@@ -5,27 +5,50 @@
 
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
+import { isDiffEditor } from '../../../../editor/browser/editorBrowser.js';
 import { ITextResourceConfigurationService } from '../../../../editor/common/services/textResourceConfiguration.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ActiveCustomEditorDiffCanToggleLayoutContext } from '../../../common/contextkeys.js';
 import { DiffEditorInput } from '../../../common/editor/diffEditorInput.js';
+import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { EditorResourceAccessor, isDiffEditorInput, SideBySideEditor } from '../../../common/editor.js';
+import { EditorResourceAccessor, isDiffEditorInput, IUntypedEditorInput, SideBySideEditor } from '../../../common/editor.js';
 import { TextDiffEditor } from './textDiffEditor.js';
 
 export const IDiffEditorCommandsService = createDecorator<IDiffEditorCommandsService>('diffEditorCommandsService');
 
+/** Which side of the active diff editor to focus. */
+export const enum FocusTextDiffEditorMode {
+	Original,
+	Modified,
+	Toggle
+}
+
 /**
  * Backs the diff-editor commands (see {@link registerDiffEditorCommands}). The Agents window
- * overrides this to also drive its multi-diff Changes editor. Only the actions needed there
- * live here today; the remaining diff-editor command handlers are still inline pending a move.
+ * overrides this to also drive its multi-diff Changes editor.
  */
 export interface IDiffEditorCommandsService {
 	readonly _serviceBrand: undefined;
 
 	/** Toggles inline vs. side-by-side rendering for the active diff editor. */
 	toggleRenderSideBySide(args: unknown[]): Promise<void>;
+
+	/** Opens the original or modified side of the active diff editor, whichever has focus, as its own editor. */
+	openActiveDiffSide(): Promise<void>;
+
+	/** Navigates to the next or previous change in the active diff editor. */
+	navigateInDiffEditor(args: unknown[], next: boolean): void;
+
+	/** Focuses the original, modified, or currently unfocused side of the active diff editor. */
+	focusInDiffEditor(args: unknown[], mode: FocusTextDiffEditorMode): void;
+
+	/** Toggles whether the active diff editor ignores trim whitespace. */
+	toggleDiffIgnoreTrimWhitespace(args: unknown[]): Promise<void>;
+
+	/** Swaps the original and modified sides of the active diff editor. */
+	swapDiffSides(args: unknown[]): Promise<void>;
 }
 
 export class DiffEditorCommandsService implements IDiffEditorCommandsService {
@@ -39,7 +62,7 @@ export class DiffEditorCommandsService implements IDiffEditorCommandsService {
 	) { }
 
 	async toggleRenderSideBySide(args: unknown[]): Promise<void> {
-		const modifiedResource = getActiveDiffModifiedResource(this.editorService, this.contextKeyService, args);
+		const modifiedResource = this.getActiveDiffModifiedResource(args);
 		if (!modifiedResource) {
 			return;
 		}
@@ -48,40 +71,145 @@ export class DiffEditorCommandsService implements IDiffEditorCommandsService {
 		const value = this.textResourceConfigurationService.getValue(modifiedResource, key);
 		await this.textResourceConfigurationService.updateValue(modifiedResource, key, !value);
 	}
-}
 
-export function getActiveTextDiffEditor(editorService: IEditorService, args: unknown[]): TextDiffEditor | undefined {
-	const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;
+	async openActiveDiffSide(): Promise<void> {
+		const activeEditor = this.editorService.activeEditor;
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (!isDiffEditor(activeTextEditorControl) || !(activeEditor instanceof DiffEditorInput)) {
+			return;
+		}
 
-	for (const editor of [editorService.activeEditorPane, ...editorService.visibleEditorPanes]) {
-		if (editor instanceof TextDiffEditor && (!resource || editor.input instanceof DiffEditorInput && isEqual(editor.input.primary.resource, resource))) {
-			return editor;
+		let editor: EditorInput | undefined;
+		const originalEditor = activeTextEditorControl.getOriginalEditor();
+		if (originalEditor.hasTextFocus()) {
+			editor = activeEditor.original;
+		} else {
+			editor = activeEditor.modified;
+		}
+
+		await this.editorService.openEditor(editor);
+	}
+
+	navigateInDiffEditor(args: unknown[], next: boolean): void {
+		const activeTextDiffEditor = this.getActiveTextDiffEditor(args);
+
+		if (activeTextDiffEditor) {
+			activeTextDiffEditor.getControl()?.goToDiff(next ? 'next' : 'previous');
 		}
 	}
 
-	return undefined;
-}
+	focusInDiffEditor(args: unknown[], mode: FocusTextDiffEditorMode): void {
+		const activeTextDiffEditor = this.getActiveTextDiffEditor(args);
 
-export function getActiveDiffModifiedResource(editorService: IEditorService, contextKeyService: IContextKeyService, args: unknown[]): URI | undefined {
-	const activeTextDiffEditor = getActiveTextDiffEditor(editorService, args);
-	const model = activeTextDiffEditor?.getControl()?.getModifiedEditor()?.getModel();
-	if (model) {
-		return model.uri;
-	}
-
-	const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;
-	if (ActiveCustomEditorDiffCanToggleLayoutContext.getValue(contextKeyService)) {
-		const activeCustomDiffModifiedResource = EditorResourceAccessor.getOriginalUri(editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
-		if (activeCustomDiffModifiedResource && (!resource || isEqual(activeCustomDiffModifiedResource, resource))) {
-			return activeCustomDiffModifiedResource;
+		if (activeTextDiffEditor) {
+			switch (mode) {
+				case FocusTextDiffEditorMode.Original:
+					activeTextDiffEditor.getControl()?.getOriginalEditor().focus();
+					break;
+				case FocusTextDiffEditorMode.Modified:
+					activeTextDiffEditor.getControl()?.getModifiedEditor().focus();
+					break;
+				case FocusTextDiffEditorMode.Toggle:
+					if (activeTextDiffEditor.getControl()?.getModifiedEditor().hasWidgetFocus()) {
+						return this.focusInDiffEditor(args, FocusTextDiffEditorMode.Original);
+					} else {
+						return this.focusInDiffEditor(args, FocusTextDiffEditorMode.Modified);
+					}
+			}
 		}
 	}
 
-	for (const editor of [editorService.activeEditor, ...editorService.visibleEditors]) {
-		if (isDiffEditorInput(editor) && editor.modified.resource && (!resource || isEqual(editor.modified.resource, resource))) {
-			return editor.modified.resource;
+	async toggleDiffIgnoreTrimWhitespace(args: unknown[]): Promise<void> {
+		const activeTextDiffEditor = this.getActiveTextDiffEditor(args);
+
+		const model = activeTextDiffEditor?.getControl()?.getModifiedEditor()?.getModel();
+		if (!model) {
+			return;
 		}
+
+		const key = 'diffEditor.ignoreTrimWhitespace';
+		const value = this.textResourceConfigurationService.getValue(model.uri, key);
+		await this.textResourceConfigurationService.updateValue(model.uri, key, !value);
 	}
 
-	return undefined;
+	async swapDiffSides(args: unknown[]): Promise<void> {
+		const diffEditor = this.getActiveTextDiffEditor(args);
+		const activeGroup = diffEditor?.group;
+		const diffInput = diffEditor?.input;
+		if (!diffEditor || typeof activeGroup === 'undefined' || !(diffInput instanceof DiffEditorInput) || !diffInput.modified.resource) {
+			return;
+		}
+
+		const untypedDiffInput = diffInput.toUntyped({ preserveViewState: activeGroup.id, preserveResource: true });
+		if (!untypedDiffInput) {
+			return;
+		}
+
+		// Since we are about to replace the diff editor, make
+		// sure to first open the modified side if it is not
+		// yet opened. This ensures that the swapping is not
+		// bringing up a confirmation dialog to save.
+		if (diffInput.modified.isModified() && this.editorService.findEditors({ resource: diffInput.modified.resource, typeId: diffInput.modified.typeId, editorId: diffInput.modified.editorId }).length === 0) {
+			const editorToOpen: IUntypedEditorInput = { ...untypedDiffInput.modified };
+			if (!editorToOpen.options) {
+				editorToOpen.options = {};
+			}
+			editorToOpen.options.pinned = true;
+			editorToOpen.options.inactive = true;
+
+			await this.editorService.openEditor(editorToOpen, activeGroup);
+		}
+
+		// Replace the input with the swapped variant
+		await this.editorService.replaceEditors([
+			{
+				editor: diffInput,
+				replacement: {
+					...untypedDiffInput,
+					original: untypedDiffInput.modified,
+					modified: untypedDiffInput.original,
+					options: {
+						...untypedDiffInput.options,
+						pinned: true
+					}
+				}
+			}
+		], activeGroup);
+	}
+
+	private getActiveTextDiffEditor(args: unknown[]): TextDiffEditor | undefined {
+		const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;
+
+		for (const editor of [this.editorService.activeEditorPane, ...this.editorService.visibleEditorPanes]) {
+			if (editor instanceof TextDiffEditor && (!resource || editor.input instanceof DiffEditorInput && isEqual(editor.input.primary.resource, resource))) {
+				return editor;
+			}
+		}
+
+		return undefined;
+	}
+
+	private getActiveDiffModifiedResource(args: unknown[]): URI | undefined {
+		const activeTextDiffEditor = this.getActiveTextDiffEditor(args);
+		const model = activeTextDiffEditor?.getControl()?.getModifiedEditor()?.getModel();
+		if (model) {
+			return model.uri;
+		}
+
+		const resource = args.length > 0 && args[0] instanceof URI ? args[0] : undefined;
+		if (ActiveCustomEditorDiffCanToggleLayoutContext.getValue(this.contextKeyService)) {
+			const activeCustomDiffModifiedResource = EditorResourceAccessor.getOriginalUri(this.editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+			if (activeCustomDiffModifiedResource && (!resource || isEqual(activeCustomDiffModifiedResource, resource))) {
+				return activeCustomDiffModifiedResource;
+			}
+		}
+
+		for (const editor of [this.editorService.activeEditor, ...this.editorService.visibleEditors]) {
+			if (isDiffEditorInput(editor) && editor.modified.resource && (!resource || isEqual(editor.modified.resource, resource))) {
+				return editor.modified.resource;
+			}
+		}
+
+		return undefined;
+	}
 }

--- a/src/vs/workbench/test/browser/parts/editor/diffEditorCommandsService.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/diffEditorCommandsService.test.ts
@@ -1,0 +1,148 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ICodeEditor, IDiffEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { ITextResourceConfigurationService } from '../../../../../editor/common/services/textResourceConfiguration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { DiffEditorCommandsService, FocusTextDiffEditorMode } from '../../../../browser/parts/editor/diffEditorCommandsService.js';
+import { TextDiffEditor } from '../../../../browser/parts/editor/textDiffEditor.js';
+import { IEditorPane, IVisibleEditorPane } from '../../../../common/editor.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+
+suite('DiffEditorCommandsService', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	interface IWrite { readonly resource: URI | undefined; readonly key: string; readonly value: unknown }
+
+	function createModifiedEditor(model: ITextModel | undefined, hasFocus: boolean): ICodeEditor {
+		return new class extends mock<ICodeEditor>() {
+			override getModel() { return model ?? null; }
+			override focus() { focusCalls.push('modified'); }
+			override hasTextFocus() { return false; }
+			override hasWidgetFocus() { return hasFocus; }
+		};
+	}
+
+	function createOriginalEditor(hasFocus: boolean): ICodeEditor {
+		return new class extends mock<ICodeEditor>() {
+			override focus() { focusCalls.push('original'); }
+			override hasTextFocus() { return hasFocus; }
+			override hasWidgetFocus() { return hasFocus; }
+		};
+	}
+
+	let focusCalls: string[] = [];
+	let goToDiffCalls: Array<'next' | 'previous'> = [];
+
+	function createDiffEditorControl(model: ITextModel | undefined, originalFocused: boolean, modifiedFocused: boolean): IDiffEditor {
+		return new class extends mock<IDiffEditor>() {
+			override getOriginalEditor() { return createOriginalEditor(originalFocused); }
+			override getModifiedEditor() { return createModifiedEditor(model, modifiedFocused); }
+			override goToDiff(target: 'next' | 'previous') { goToDiffCalls.push(target); }
+		};
+	}
+
+	function createTextDiffEditor(control: IDiffEditor | undefined): TextDiffEditor {
+		const editor = Object.create(TextDiffEditor.prototype) as TextDiffEditor;
+		(editor as unknown as { getControl(): IDiffEditor | undefined }).getControl = () => control;
+		return editor;
+	}
+
+	function createService(activeEditorPane: IEditorPane | undefined): { service: DiffEditorCommandsService; resourceWrites: IWrite[] } {
+		const resourceWrites: IWrite[] = [];
+
+		const editorService = new class extends mock<IEditorService>() {
+			override get activeEditorPane() { return activeEditorPane as IVisibleEditorPane | undefined; }
+			override get activeEditor() { return undefined; }
+			override get visibleEditorPanes() { return []; }
+			override get visibleEditors() { return []; }
+		};
+		const textResourceConfigurationService = new class extends mock<ITextResourceConfigurationService>() {
+			override getValue<T>(): T { return true as unknown as T; }
+			override updateValue(resource: URI | undefined, key: string, value: unknown): Promise<void> {
+				resourceWrites.push({ resource, key, value });
+				return Promise.resolve();
+			}
+		};
+		const contextKeyService = new class extends mock<IContextKeyService>() {
+			override getContextKeyValue<T>(): T | undefined { return undefined; }
+		};
+
+		const service = new DiffEditorCommandsService(editorService, textResourceConfigurationService, contextKeyService);
+		return { service, resourceWrites };
+	}
+
+	setup(() => {
+		focusCalls = [];
+		goToDiffCalls = [];
+	});
+
+	test('navigateInDiffEditor goes to the next/previous change of the active text diff editor', () => {
+		const control = createDiffEditorControl(undefined, false, false);
+		const { service } = createService(createTextDiffEditor(control));
+
+		service.navigateInDiffEditor([], true);
+		service.navigateInDiffEditor([], false);
+
+		assert.deepStrictEqual(goToDiffCalls, ['next', 'previous']);
+	});
+
+	test('navigateInDiffEditor is a no-op when there is no active text diff editor', () => {
+		const { service } = createService(undefined);
+
+		service.navigateInDiffEditor([], true);
+
+		assert.deepStrictEqual(goToDiffCalls, []);
+	});
+
+	test('focusInDiffEditor focuses the requested side', () => {
+		const control = createDiffEditorControl(undefined, false, false);
+		const { service } = createService(createTextDiffEditor(control));
+
+		service.focusInDiffEditor([], FocusTextDiffEditorMode.Original);
+		service.focusInDiffEditor([], FocusTextDiffEditorMode.Modified);
+
+		assert.deepStrictEqual(focusCalls, ['original', 'modified']);
+	});
+
+	test('focusInDiffEditor toggle focuses the other side', () => {
+		const modifiedFocusedControl = createDiffEditorControl(undefined, false, true);
+		const { service: service1 } = createService(createTextDiffEditor(modifiedFocusedControl));
+		service1.focusInDiffEditor([], FocusTextDiffEditorMode.Toggle);
+		assert.deepStrictEqual(focusCalls, ['original']);
+
+		focusCalls = [];
+
+		const originalFocusedControl = createDiffEditorControl(undefined, false, false);
+		const { service: service2 } = createService(createTextDiffEditor(originalFocusedControl));
+		service2.focusInDiffEditor([], FocusTextDiffEditorMode.Toggle);
+		assert.deepStrictEqual(focusCalls, ['modified']);
+	});
+
+	test('toggleDiffIgnoreTrimWhitespace flips the setting for the modified side model', async () => {
+		const model = { uri: URI.file('/foo.txt') } as ITextModel;
+		const control = createDiffEditorControl(model, false, false);
+		const { service, resourceWrites } = createService(createTextDiffEditor(control));
+
+		await service.toggleDiffIgnoreTrimWhitespace([]);
+
+		assert.deepStrictEqual(resourceWrites, [{ resource: model.uri, key: 'diffEditor.ignoreTrimWhitespace', value: false }]);
+	});
+
+	test('toggleDiffIgnoreTrimWhitespace is a no-op when there is no modified model', async () => {
+		const control = createDiffEditorControl(undefined, false, false);
+		const { service, resourceWrites } = createService(createTextDiffEditor(control));
+
+		await service.toggleDiffIgnoreTrimWhitespace([]);
+
+		assert.deepStrictEqual(resourceWrites, []);
+	});
+});


### PR DESCRIPTION
## What

Tech-debt follow-up to #325382. Moves the remaining inline diff-editor command handlers out of `diffEditorCommands.ts` and into `IDiffEditorCommandsService`, matching the delegation pattern already established for `toggleRenderSideBySide`.

Handlers moved into the service (command handlers now delegate via `accessor.get(IDiffEditorCommandsService).<method>(...)`):
- `DIFF_OPEN_SIDE` -> `openActiveDiffSide()`
- `GOTO_NEXT_CHANGE` / `GOTO_PREVIOUS_CHANGE` -> `navigateInDiffEditor(args, next)`
- `DIFF_FOCUS_PRIMARY_SIDE` / `DIFF_FOCUS_SECONDARY_SIDE` / `DIFF_FOCUS_OTHER_SIDE` -> `focusInDiffEditor(args, mode)` (with the `FocusTextDiffEditorMode` enum now exported from the service)
- `TOGGLE_DIFF_IGNORE_TRIM_WHITESPACE` -> `toggleDiffIgnoreTrimWhitespace(args)`
- `DIFF_SWAP_SIDES` -> `swapDiffSides(args)`

## Why

`diffEditorCommands.ts` previously mixed command registration with inline handler logic that resolved services through `ServicesAccessor`. Consolidating the behavior into the service keeps command registration thin, centralizes the diff-editor logic in one place, and lets the Agents window override behavior where needed (today only `toggleRenderSideBySide`, for the multi-diff Changes editor).

## Notes for reviewers

- Services are injected in the service constructor rather than resolved via `ServicesAccessor` inside each method.
- Methods that perform config writes (`toggleDiffIgnoreTrimWhitespace`, `swapDiffSides`, `openActiveDiffSide`) are `async`/return `Promise<void>` and the command handlers return the promise, so failures propagate (consistent with the `toggleRenderSideBySide` change in #325382).
- The `getActiveTextDiffEditor` / `getActiveDiffModifiedResource` resolver helpers are now **private methods** on the service (they no longer have any external callers).
- `SessionsDiffEditorCommandsService` (Agents window) is unchanged: it still overrides only `toggleRenderSideBySide` and inherits the newly-consolidated methods from the base class. The other operations act on a single diff editor and need no Agents-window override.
- Adds `diffEditorCommandsService.test.ts` covering `navigateInDiffEditor`, `focusInDiffEditor` (incl. toggle), and `toggleDiffIgnoreTrimWhitespace`. `swapDiffSides` / `openActiveDiffSide` orchestrate `editorService.replaceEditors`/`findEditors`/`openEditor` and aren't meaningfully unit-testable with lightweight fakes.

## Validation

- `npm run typecheck-client` - clean
- `npm run valid-layers-check` - clean
- `gulp compile-client` - 0 errors
- Hygiene - clean
- Unit tests: new `DiffEditorCommandsService` suite + `SessionsDiffEditorCommandsService` (10 passing), full `workbench/test/browser/parts/editor` suite (178 passing)
