### PR TITLE
Regenerate policy data with otel referencedSettings

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -51,7 +51,10 @@
             },
             "type": "string",
             "default": "",
-            "included": false
+            "included": false,
+            "referencedSettings": [
+                "github.copilot.chat.otel.protocol"
+            ]
         },
         {
             "key": "chat.agentHost.otel.serviceName",
@@ -66,7 +69,10 @@
             },
             "type": "string",
             "default": "",
-            "included": false
+            "included": false,
+            "referencedSettings": [
+                "github.copilot.chat.otel.serviceName"
+            ]
         },
         {
             "key": "chat.agentHost.otel.resourceAttributes",
@@ -81,7 +87,10 @@
             },
             "type": "object",
             "default": {},
-            "included": false
+            "included": false,
+            "referencedSettings": [
+                "github.copilot.chat.otel.resourceAttributes"
+            ]
         },
         {
             "key": "chat.agentHost.otel.headers",
@@ -96,7 +105,10 @@
             },
             "type": "object",
             "default": {},
-            "included": false
+            "included": false,
+            "referencedSettings": [
+                "github.copilot.chat.otel.headers"
+            ]
         },
         {
             "key": "mcp.enterpriseManagedAuth.idp",
@@ -249,7 +261,10 @@
             },
             "type": "boolean",
             "default": false,
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.enabled"
+            ]
         },
         {
             "key": "chat.agentHost.otel.exporterType",
@@ -288,7 +303,10 @@
                 "console",
                 "file"
             ],
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.exporterType"
+            ]
         },
         {
             "key": "chat.agentHost.otel.otlpEndpoint",
@@ -303,7 +321,10 @@
             },
             "type": "string",
             "default": "",
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.otlpEndpoint"
+            ]
         },
         {
             "key": "chat.agentHost.otel.captureContent",
@@ -318,7 +339,10 @@
             },
             "type": "boolean",
             "default": false,
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.captureContent"
+            ]
         },
         {
             "key": "chat.agentHost.otel.outfile",
@@ -333,7 +357,10 @@
             },
             "type": "string",
             "default": "",
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.outfile"
+            ]
         },
         {
             "key": "chat.defaultModel",

--- a/src/vs/workbench/contrib/policyExport/test/node/extensionPolicyFixture.json
+++ b/src/vs/workbench/contrib/policyExport/test/node/extensionPolicyFixture.json
@@ -22,6 +22,51 @@
 			"policyReference": {
 				"name": "Claude3PIntegration"
 			}
+		},
+		"github.copilot.chat.otel.enabled": {
+			"policyReference": {
+				"name": "CopilotOtelEnabled"
+			}
+		},
+		"github.copilot.chat.otel.exporterType": {
+			"policyReference": {
+				"name": "CopilotOtelProtocol"
+			}
+		},
+		"github.copilot.chat.otel.protocol": {
+			"policyReference": {
+				"name": "CopilotOtelOtlpProtocol"
+			}
+		},
+		"github.copilot.chat.otel.otlpEndpoint": {
+			"policyReference": {
+				"name": "CopilotOtelEndpoint"
+			}
+		},
+		"github.copilot.chat.otel.captureContent": {
+			"policyReference": {
+				"name": "CopilotOtelCaptureContent"
+			}
+		},
+		"github.copilot.chat.otel.serviceName": {
+			"policyReference": {
+				"name": "CopilotOtelServiceName"
+			}
+		},
+		"github.copilot.chat.otel.resourceAttributes": {
+			"policyReference": {
+				"name": "CopilotOtelResourceAttributes"
+			}
+		},
+		"github.copilot.chat.otel.headers": {
+			"policyReference": {
+				"name": "CopilotOtelHeaders"
+			}
+		},
+		"github.copilot.chat.otel.outfile": {
+			"policyReference": {
+				"name": "CopilotOtelOutfile"
+			}
 		}
 	}
 }


### PR DESCRIPTION
Regenerates `build/lib/policies/policyData.jsonc` to include the `referencedSettings` back-links for the `github.copilot.chat.otel.*` policy references, fixing the local `PolicyExport` integration test failure. Fixes #325755.