### PR TITLE
Collapse Agent Host per-session GitHub telemetry token map to the singleton token

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -385,7 +385,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private readonly _sessionLauncher: CopilotSessionLauncher;
 	private readonly _gitHubTelemetryForwarder: CopilotGitHubTelemetryForwarder;
 	private readonly _githubTelemetryRouter: AgentHostGitHubTelemetryRouter | undefined;
-	private readonly _githubTokensBySdkSession = new Map<string, string>();
 	readonly onDidCustomizationsChange: Event<void>;
 	/** Per-session active client state for tools + plugin snapshot tracking. */
 	private readonly _activeClients = new ResourceMap<ActiveClient>();
@@ -534,7 +533,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 			this._logService.info(`[Copilot] Startup config changed (${changed}), restarting CopilotClient`);
 			this._sessions.clearAndDisposeAll();
 			this._mcpNotificationSubs.clearAndDisposeAll();
-			this._githubTokensBySdkSession.clear();
 			await this._stopClient();
 		}
 	}
@@ -717,15 +715,15 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 
 		const sessionId = notification.sessionId;
-		const githubToken = sessionId ? this._githubTokensBySdkSession.get(sessionId) : undefined;
-		if (!sessionId || !githubToken) {
+		const githubToken = this._githubToken;
+		if (!githubToken) {
 			router.route(notification);
 			return;
 		}
 
 		try {
 			const context = await this._copilotApiService.resolveRestrictedTelemetryContext(githubToken);
-			if (this._githubTokensBySdkSession.get(sessionId) !== githubToken) {
+			if (this._githubToken !== githubToken) {
 				return;
 			}
 			router.route(notification, {
@@ -739,25 +737,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 		} catch (error) {
 			this._logService.debug(`[Copilot:${sessionId}] Restricted telemetry context resolution failed; dropping ${notification.event.kind}: ${error instanceof Error ? error.message : String(error)}`);
 		}
-	}
-
-	private _registerGitHubTelemetrySession(launchPlan: CopilotSessionLaunchPlan): () => void {
-		const previousToken = this._githubTokensBySdkSession.get(launchPlan.sessionId);
-		if (launchPlan.githubToken) {
-			this._githubTokensBySdkSession.set(launchPlan.sessionId, launchPlan.githubToken);
-		} else {
-			this._githubTokensBySdkSession.delete(launchPlan.sessionId);
-		}
-		return () => {
-			if (this._githubTokensBySdkSession.get(launchPlan.sessionId) !== launchPlan.githubToken) {
-				return;
-			}
-			if (previousToken) {
-				this._githubTokensBySdkSession.set(launchPlan.sessionId, previousToken);
-			} else {
-				this._githubTokensBySdkSession.delete(launchPlan.sessionId);
-			}
-		};
 	}
 
 	private async _refreshModels(attempt = 0): Promise<void> {
@@ -1773,7 +1752,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 		let agentSession: CopilotAgentSession | undefined;
 		let agent: AgentSelection | undefined;
-		let rollbackGitHubTelemetrySession = () => { };
 		try {
 			const resolvedAgent = await this._resolveAgentWhenMaterializing(provisional, snapshot, workingDirectory);
 			agent = resolvedAgent?.agent;
@@ -1792,12 +1770,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 				freeLongContext: this._isFreeLongContext(provisional.model?.id),
 				workspaceless: provisional.workspaceless,
 			};
-			rollbackGitHubTelemetrySession = this._registerGitHubTelemetrySession(launchPlan);
 			agentSession = this._createAgentSession(launchPlan, customizationDirectory, activeClient);
 			await agentSession.initializeSession();
 			this._registerInitializedSession(sessionId, agentSession);
 		} catch (error) {
-			rollbackGitHubTelemetrySession();
 			agentSession?.dispose();
 			throw error;
 		}
@@ -2289,7 +2265,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 				};
 			}
 			let agentSession: CopilotAgentSession | undefined;
-			const rollbackGitHubTelemetrySession = this._registerGitHubTelemetrySession(launchPlan);
 			try {
 				agentSession = this._createAgentSession(launchPlan, workingDirectory, activeClient, chat);
 				await agentSession.initializeSession();
@@ -2305,7 +2280,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 				result = { providerData: encodeProviderData(backing), backingSession: AgentSession.uri(this.id, sdkSessionId) };
 				this._logService.info(`[Copilot] Created additional chat ${chatKey} in session ${session.toString()}${options?.fork ? ' (forked)' : ''}`);
 			} catch (error) {
-				rollbackGitHubTelemetrySession();
 				agentSession?.dispose();
 				throw error;
 			}
@@ -2387,7 +2361,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._chatBackings.delete(chatKey);
 		this._sessions.get(AgentSession.id(session))?.disposePeerChat(chatKey);
 		if (sdkSessionId) {
-			this._githubTokensBySdkSession.delete(sdkSessionId);
 			try {
 				const client = await this._ensureClient();
 				await client.deleteSession(sdkSessionId);
@@ -2526,7 +2499,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 				fallback: { model: info.model, longContextWindow: this._longContextWindowFor(info.model?.id), freeLongContext: this._isFreeLongContext(info.model?.id) },
 			};
 			let agentSession: CopilotAgentSession | undefined;
-			const rollbackGitHubTelemetrySession = this._registerGitHubTelemetrySession(launchPlan);
 			try {
 				agentSession = this._createAgentSession(launchPlan, workingDirectory, activeClient, chat);
 				await agentSession.initializeSession();
@@ -2534,7 +2506,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 				this._logService.info(`[Copilot] Resumed additional chat ${chatKey} in session ${session.toString()}`);
 				return agentSession;
 			} catch (error) {
-				rollbackGitHubTelemetrySession();
 				agentSession?.dispose();
 				this._logService.warn(`[Copilot] Failed to resume additional chat ${chatKey}: ${error instanceof Error ? error.message : String(error)}`);
 				return undefined;
@@ -2641,24 +2612,19 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	async shutdown(): Promise<void> {
 		this._shutdownPromise ??= (async () => {
-			this._githubTokensBySdkSession.clear();
-			try {
-				// Cancel any pending model-refresh retry so its timer cannot fire
-				// after teardown and resurrect the client.
-				this._modelRefreshRetry.clear();
-				this._logService.info('[Copilot] Shutting down...');
-				const sessionIds = new Set([...this._sessions.keys()]);
-				for (const sessionId of sessionIds) {
-					await this._sessionSequencer.queue(sessionId, () => this._destroyAndDisposeSession(sessionId));
-				}
-				await this._client?.stop();
-				this._client = undefined;
-				// Release the BYOK proxy handle only after the runtime subprocess is
-				// gone, mirroring `_stopClient` and the proxy ownership invariant.
-				await this._sessionLauncher.disposeByokProxyHandle();
-			} finally {
-				this._githubTokensBySdkSession.clear();
+			// Cancel any pending model-refresh retry so its timer cannot fire
+			// after teardown and resurrect the client.
+			this._modelRefreshRetry.clear();
+			this._logService.info('[Copilot] Shutting down...');
+			const sessionIds = new Set([...this._sessions.keys()]);
+			for (const sessionId of sessionIds) {
+				await this._sessionSequencer.queue(sessionId, () => this._destroyAndDisposeSession(sessionId));
 			}
+			await this._client?.stop();
+			this._client = undefined;
+			// Release the BYOK proxy handle only after the runtime subprocess is
+			// gone, mirroring `_stopClient` and the proxy ownership invariant.
+			await this._sessionLauncher.disposeByokProxyHandle();
 		})();
 		return this._shutdownPromise;
 	}
@@ -2762,7 +2728,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._logService.info(`[Copilot] CAPI proxy changed after token update (${oldProxy ?? '(none)'} -> ${newProxy ?? '(none)'}); restarting CopilotClient`);
 		this._sessions.clearAndDisposeAll();
 		this._mcpNotificationSubs.clearAndDisposeAll();
-		this._githubTokensBySdkSession.clear();
 		await this._stopClient();
 	}
 
@@ -2881,9 +2846,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * latter reaps the worktree afterwards).
 	 */
 	private async _releaseSessionResources(sessionId: string): Promise<void> {
-		for (const chat of this._sessions.get(sessionId)?.allChatSessions() ?? []) {
-			this._githubTokensBySdkSession.delete(chat.sessionId);
-		}
 		// Tear down any peer chats owned by this session first so their SDK
 		// chats don't leak when the parent is deleted/disposed
 		// without each chat being individually disposed via `disposeChat`.
@@ -2992,12 +2954,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 		};
 
 		const agentSession = this._createAgentSession(launchPlan, customizationDirectory, activeClient);
-		const rollbackGitHubTelemetrySession = this._registerGitHubTelemetrySession(launchPlan);
 		try {
 			await agentSession.initializeSession();
 			this._registerInitializedSession(sessionId, agentSession);
 		} catch (err) {
-			rollbackGitHubTelemetrySession();
 			agentSession.dispose();
 			throw err;
 		}

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -809,9 +809,7 @@ suite('CopilotAgent', () => {
 			};
 			await forward(notification);
 
-			// A token refresh / account change swaps the current auth token; later
-			// events resolve their restricted context from the new token. token-b is
-			// opted out, so the second event emits nothing.
+			// Swapping the current auth token to opted-out token-b: later events resolve context from it and emit nothing.
 			await agent.authenticate('https://api.github.com', 'token-b');
 			await forward(notification);
 

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -75,10 +75,6 @@ function sessionsMap(agent: CopilotAgent): Map<string, CopilotSessionEntry> {
 	return (agent as unknown as { _sessions: Map<string, CopilotSessionEntry> })._sessions;
 }
 
-function githubTokensBySdkSession(agent: CopilotAgent): Map<string, string> {
-	return (agent as unknown as { _githubTokensBySdkSession: Map<string, string> })._githubTokensBySdkSession;
-}
-
 function defaultChatUri(session: URI): URI {
 	return URI.parse(buildDefaultChatUri(session));
 }
@@ -743,7 +739,6 @@ suite('CopilotAgent', () => {
 				await Promise.resolve();
 			}
 			await agent.listSessions();
-			githubTokensBySdkSession(agent).set('session-1', 'restricted-token');
 			const forward = getCreatedClientOptions(agent).at(-1)?.onGitHubTelemetry;
 			assert.ok(forward);
 
@@ -771,24 +766,23 @@ suite('CopilotAgent', () => {
 		}
 	});
 
-	test('routes exact targets with the originating session context across account changes and token refreshes', async () => {
+	test('routes exact targets using the current auth token and reflects token changes', async () => {
 		const client = new TestCopilotClient([]);
 		const copilotApiService = new TestCopilotApiService();
-		const sessionContext: IRestrictedTelemetryContext = {
+		copilotApiService.restrictedTelemetryContexts.set('token-a', {
 			restrictedTelemetryEnabled: true,
-			trackingId: 'session-a-tid',
-			telemetryEndpoint: 'https://session-a.telemetry.example/',
+			trackingId: 'token-a-tid',
+			telemetryEndpoint: 'https://token-a.telemetry.example/',
 			isInternal: true,
-			userName: 'session-a-user',
+			userName: 'token-a-user',
 			isVscodeTeamMember: true,
-		};
-		copilotApiService.restrictedTelemetryContexts.set('session-a-token', sessionContext);
-		copilotApiService.restrictedTelemetryContexts.set('current-b-token', {
+		});
+		copilotApiService.restrictedTelemetryContexts.set('token-b', {
 			restrictedTelemetryEnabled: false,
-			trackingId: 'current-b-tid',
+			trackingId: 'token-b-tid',
 			telemetryEndpoint: undefined,
 			isInternal: false,
-			userName: 'current-b-user',
+			userName: 'token-b-user',
 			isVscodeTeamMember: false,
 		});
 		const telemetryService = disposables.add(new class extends AgentHostTelemetryService {
@@ -803,9 +797,8 @@ suite('CopilotAgent', () => {
 		}(NullTelemetryService));
 		const agent = createTestAgent(disposables, { copilotClient: client, copilotApiService, telemetryService }) as TestableCopilotAgent;
 		try {
-			await agent.authenticate('https://api.github.com', 'current-b-token');
+			await agent.authenticate('https://api.github.com', 'token-a');
 			await agent.listSessions();
-			githubTokensBySdkSession(agent).set('session-a', 'session-a-token');
 			const forward = getCreatedClientOptions(agent).at(-1)?.onGitHubTelemetry;
 			assert.ok(forward);
 
@@ -816,11 +809,10 @@ suite('CopilotAgent', () => {
 			};
 			await forward(notification);
 
-			copilotApiService.restrictedTelemetryContexts.set('session-a-token', {
-				...sessionContext,
-				restrictedTelemetryEnabled: false,
-				isInternal: false,
-			});
+			// A token refresh / account change swaps the current auth token; later
+			// events resolve their restricted context from the new token. token-b is
+			// opted out, so the second event emits nothing.
+			await agent.authenticate('https://api.github.com', 'token-b');
 			await forward(notification);
 
 			assert.deepStrictEqual({
@@ -831,23 +823,21 @@ suite('CopilotAgent', () => {
 					userName: context.userName,
 					isVscodeTeamMember: context.isVscodeTeamMember,
 				})),
-				sessionContextCalls: copilotApiService.restrictedTelemetryContextCalls.filter(token => token === 'session-a-token'),
 			}, {
 				enhancedContexts: [{
 					restrictedTelemetryEnabled: true,
-					trackingId: 'session-a-tid',
-					telemetryEndpoint: 'https://session-a.telemetry.example/telemetry',
+					trackingId: 'token-a-tid',
+					telemetryEndpoint: 'https://token-a.telemetry.example/telemetry',
 					isInternal: true,
-					userName: 'session-a-user',
+					userName: 'token-a-user',
 					isVscodeTeamMember: true,
 				}],
 				internalContexts: [{
 					isInternal: true,
-					trackingId: 'session-a-tid',
-					userName: 'session-a-user',
+					trackingId: 'token-a-tid',
+					userName: 'token-a-user',
 					isVscodeTeamMember: true,
 				}],
-				sessionContextCalls: ['session-a-token', 'session-a-token'],
 			});
 		} finally {
 			await disposeAgent(agent);
@@ -1498,7 +1488,6 @@ suite('CopilotAgent', () => {
 
 				let disposed = false;
 				setDefaultSessionStub(agent, 'active', { dispose() { disposed = true; } });
-				githubTokensBySdkSession(agent).set('active', 'token');
 
 				configurationService.updateRootConfig({ [CopilotCliConfigKey.RubberDuck]: true });
 				await Promise.resolve();
@@ -1506,11 +1495,9 @@ suite('CopilotAgent', () => {
 				assert.deepStrictEqual({
 					stopCount: client.stopCount,
 					disposed,
-					telemetryToken: githubTokensBySdkSession(agent).get('active'),
 				}, {
 					stopCount: 1,
 					disposed: true,
-					telemetryToken: undefined,
 				});
 			} finally {
 				await disposeAgent(agent);
@@ -2777,11 +2764,9 @@ suite('CopilotAgent', () => {
 			const sessionDataService = disposables.add(new TestSessionDataService());
 			const client = new TestCopilotClient([]);
 			let capturedConfig: Parameters<ITestCopilotClient['createSession']>[0] | undefined;
-			let telemetryTokenDuringCreate: string | undefined;
 			const agent = createTestAgent(disposables, { sessionDataService, copilotClient: client });
 			client.createSession = async config => {
 				capturedConfig = config;
-				telemetryTokenDuringCreate = githubTokensBySdkSession(agent).get('session-level-token');
 				return new MockCopilotSession() as unknown as CopilotSession;
 			};
 
@@ -2798,22 +2783,15 @@ suite('CopilotAgent', () => {
 
 				assert.deepStrictEqual({
 					configToken: capturedConfig?.gitHubToken,
-					telemetryTokenDuringCreate,
-					telemetryToken: githubTokensBySdkSession(agent).get('session-level-token'),
 				}, {
 					configToken: 'gh-token-abc',
-					telemetryTokenDuringCreate: 'gh-token-abc',
-					telemetryToken: 'gh-token-abc',
 				});
-
-				await agent.releaseSession(result.session);
-				assert.strictEqual(githubTokensBySdkSession(agent).get('session-level-token'), undefined);
 			} finally {
 				await disposeAgent(agent);
 			}
 		});
 
-		test('failed materialization rolls back the SDK session telemetry token', async () => {
+		test('failed materialization surfaces the create error', async () => {
 			const sessionDataService = disposables.add(new TestSessionDataService());
 			const client = new TestCopilotClient([]);
 			client.createSession = async () => { throw new Error('create failed'); };
@@ -2826,7 +2804,6 @@ suite('CopilotAgent', () => {
 				});
 
 				await assert.rejects(agent.chats.sendMessage(defaultChatUri(result.session), 'hello', undefined), /create failed/);
-				assert.strictEqual(githubTokensBySdkSession(agent).get('failed-session-token'), undefined);
 			} finally {
 				await disposeAgent(agent);
 			}
@@ -3050,7 +3027,6 @@ suite('CopilotAgent', () => {
 				// Materialize the backing first, mirroring the orchestrator's
 				// restore handing back the persisted providerData.
 				await agent.materializeChat(chatUri, JSON.stringify({ sdkSessionId: 'sdk-a' }));
-				githubTokensBySdkSession(agent).set('sdk-a', 'token');
 
 				await agent.chats.disposeChat(chatUri);
 
@@ -3058,14 +3034,12 @@ suite('CopilotAgent', () => {
 				assert.deepStrictEqual({
 					backingCleared: internals._chatBackings.has(chatUri.toString()),
 					deleted: client.deletedSessionIds,
-					telemetryToken: githubTokensBySdkSession(agent).get('sdk-a'),
 					// The agent no longer owns the durable catalog, so it leaves
 					// the legacy blob untouched (orchestrator drops the entry).
 					legacyUntouched: remaining ? JSON.parse(remaining) : {},
 				}, {
 					backingCleared: false,
 					deleted: ['sdk-a'],
-					telemetryToken: undefined,
 					legacyUntouched: { 'peer-a': { sdkSessionId: 'sdk-a' } },
 				});
 			} finally {
@@ -3164,7 +3138,6 @@ suite('CopilotAgent', () => {
 					kind: captured?.kind,
 					backing: internals._chatBackings.get(chatUri.toString()),
 					providerData: result ? JSON.parse(result.providerData!) : undefined,
-					telemetryToken: githubTokensBySdkSession(agent).get(captured!.sessionId),
 					// The orchestrator now owns the durable catalog; the agent no
 					// longer writes its private `copilot.chats` metadata.
 					legacyCatalogWritten: raw !== undefined,
@@ -3175,7 +3148,6 @@ suite('CopilotAgent', () => {
 					kind: 'create',
 					backing: { sdkSessionId: captured!.sessionId, model: { id: 'gpt-x' } },
 					providerData: { sdkSessionId: captured!.sessionId, model: { id: 'gpt-x' } },
-					telemetryToken: 'token',
 					legacyCatalogWritten: false,
 				});
 			} finally {
@@ -3244,7 +3216,6 @@ suite('CopilotAgent', () => {
 					tracked: hasPeerChatStub(agent, chatUri),
 					backing: internals._chatBackings.get(chatUri.toString()),
 					providerData: result ? JSON.parse(result.providerData!) : undefined,
-					telemetryToken: githubTokensBySdkSession(agent).get('forked-sdk-id'),
 					legacyCatalogWritten: raw !== undefined,
 				}, {
 					sourceIsDefaultSession: true,
@@ -3254,7 +3225,6 @@ suite('CopilotAgent', () => {
 					tracked: true,
 					backing: { sdkSessionId: 'forked-sdk-id' },
 					providerData: { sdkSessionId: 'forked-sdk-id' },
-					telemetryToken: 'token',
 					legacyCatalogWritten: false,
 				});
 			} finally {
@@ -3990,7 +3960,7 @@ suite('CopilotAgent', () => {
 			}
 		});
 
-		test('shutdown during resume clears the SDK session telemetry token', async () => {
+		test('shutdown during resume cancels the in-flight resume', async () => {
 			const workingDirectory = await fs.mkdtemp(`${os.tmpdir()}/resume-telemetry-shutdown-`);
 			const client = new TestCopilotClient([sdkSession('s1', workingDirectory)]);
 			const deferredSession = new DeferredPromise<CopilotSession>();
@@ -4012,13 +3982,11 @@ suite('CopilotAgent', () => {
 					await timeout(0);
 				}
 				assert.strictEqual(resumeCalled, true);
-				assert.strictEqual(githubTokensBySdkSession(agent).get('s1'), 'token');
 
 				await agent.shutdown();
 				deferredSession.complete(new MockCopilotSession() as unknown as CopilotSession);
 
 				await assert.rejects(resumePromise, (error: unknown) => isCancellationError(error));
-				assert.strictEqual(githubTokensBySdkSession(agent).get('s1'), undefined);
 			} finally {
 				await fs.rm(workingDirectory, { recursive: true, force: true });
 				await disposeAgent(agent);


### PR DESCRIPTION
Follow-up to #325722 (restricted model telemetry routing in the Agent Host).

## What
Removes the per-session `_githubTokensBySdkSession` map and resolves the restricted telemetry context from `this._githubToken` directly in `_routeGitHubTelemetry`. Drops the associated `register`/`rollback` plumbing and the `clear`/`delete` calls across every launch and teardown path.

## Why
Addresses review feedback on #325722: *"There's only 1 auth token for all sessions. It's `this._githubToken`."*

That's accurate for VS Code today — VS Code only ever sources a single `_githubToken` and snapshots that same value into every session's launch plan, so the map held the same token under every session id and added lifecycle plumbing without changing behavior.

The map was there to match the runtime's session-scoped auth (the runtime supports distinct per-session tokens and live `setCredentials`), but VS Code doesn't exercise that path — sessions get the token once at launch and never swap it — so a divergent per-session token can't occur here. If per-session tokens are ever wired up from VS Code, this can be reintroduced against that concrete need.

The no-token / BYOK case stays fail-safe on both ends: no GitHub token → the router emits nothing restricted, and the runtime independently gates on `copilotUser`.

## Behavior
No functional change for current single-account usage. A token refresh / account change is now reflected by resolving each event's context from the current token (verified by the rewritten routing test).

## Validation
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck-client` — clean
- `./scripts/test.sh --grep "CopilotAgent"` — 304 passing
- hygiene — clean