### PR TITLE
Add shared GitBranchPickerModel for reusable branch loading logic

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/gitBranchPickerModel.ts
+++ b/src/vs/sessions/contrib/chat/browser/gitBranchPickerModel.ts
@@ -1,0 +1,212 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { autorun, derived, IObservable, ITransaction, observableValue, transaction } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IGitRepository, IGitService } from '../../../../workbench/contrib/git/common/gitService.js';
+import { IBranchPickerModel } from './branchPicker.js';
+import { COPILOT_WORKTREE_BRANCH_PREFIX } from '../common/constants.js';
+
+/**
+ * Shared model that loads git branches for a given folder and isolation mode,
+ * implementing {@link IBranchPickerModel} so it can drive the {@link BranchPicker} widget.
+ *
+ * Handles: repository opening, HEAD watching, ref fetching, worktree-branch
+ * filtering, and default-branch heuristics.
+ */
+export class GitBranchPickerModel extends Disposable implements IBranchPickerModel {
+
+	private readonly _branches = observableValue<readonly string[]>(this, []);
+	readonly branches: IObservable<readonly string[]> = this._branches;
+
+	private readonly _selectedBranch = observableValue<string | undefined>(this, undefined);
+	readonly selectedBranch: IObservable<string | undefined> = this._selectedBranch;
+
+	private readonly _loading = observableValue(this, false);
+	readonly disabled = derived(this, reader =>
+		this._loading.read(reader)
+		|| this._isolationMode.read(reader) !== 'worktree'
+		|| this._branches.read(reader).length === 0
+	);
+
+	private readonly _repositoryState = this._register(new MutableDisposable());
+	private readonly _refsCancellation = this._register(new MutableDisposable<CancellationTokenSource>());
+	private _repository: IGitRepository | undefined;
+	private _defaultBranch: string | undefined;
+	private _preferredBranch: string | undefined;
+	private _requestId = 0;
+	private _lastIsolationMode: string | undefined;
+
+	constructor(
+		initialBranch: string | undefined,
+		private readonly _folder: IObservable<URI | undefined>,
+		private readonly _isolationMode: IObservable<string | undefined>,
+		private readonly _onDidChangeBranch: (branch: string | undefined) => void,
+		@IGitService private readonly _gitService: IGitService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+		this._preferredBranch = initialBranch;
+		this._lastIsolationMode = this._isolationMode.get();
+
+		let didResolveFolder = false;
+		this._register(autorun(reader => {
+			const folder = this._folder.read(reader);
+			if (didResolveFolder) {
+				this._preferredBranch = undefined;
+			}
+			const preserveSelection = !didResolveFolder;
+			didResolveFolder = true;
+			this._resolveRepository(folder, preserveSelection);
+		}));
+
+		this._register(autorun(reader => {
+			const mode = this._isolationMode.read(reader);
+			if (mode === this._lastIsolationMode) {
+				return;
+			}
+			this._lastIsolationMode = mode;
+			if (mode === 'worktree') {
+				const branches = this._branches.read(undefined);
+				const selected = this._preferredBranch && branches.includes(this._preferredBranch)
+					? this._preferredBranch
+					: this._defaultBranch;
+				this._setSelectedBranch(selected);
+			} else {
+				this._syncFolderBranch();
+			}
+		}));
+	}
+
+	setBranch(name: string): void {
+		if (!this._branches.get().includes(name)) {
+			return;
+		}
+		this._preferredBranch = name;
+		this._setSelectedBranch(name);
+	}
+
+	private async _resolveRepository(folder: URI | undefined, preserveSelection: boolean): Promise<void> {
+		const requestId = ++this._requestId;
+		this._repositoryState.clear();
+		this._cancelRefsLoad();
+		this._repository = undefined;
+		this._defaultBranch = undefined;
+		transaction(tx => {
+			this._branches.set([], tx);
+			this._loading.set(!!folder, tx);
+			this._setSelectedBranch(preserveSelection ? this._preferredBranch : undefined, tx);
+		});
+
+		if (!folder) {
+			this._setSelectedBranch(undefined);
+			return;
+		}
+
+		let repository: IGitRepository | undefined;
+		try {
+			repository = await this._gitService.openRepository(folder);
+		} catch (error) {
+			if (requestId === this._requestId) {
+				this._logService.trace('[GitBranchPickerModel] Failed to open Git repository.', error);
+				transaction(tx => {
+					this._loading.set(false, tx);
+					this._setSelectedBranch(undefined, tx);
+				});
+			}
+			return;
+		}
+
+		if (requestId !== this._requestId || !repository) {
+			if (requestId === this._requestId) {
+				transaction(tx => {
+					this._loading.set(false, tx);
+					this._setSelectedBranch(undefined, tx);
+				});
+			}
+			return;
+		}
+
+		this._repository = repository;
+		this._repositoryState.value = autorun(reader => {
+			repository.state.read(reader);
+			if (this._isolationMode.read(reader) !== 'worktree') {
+				this._syncFolderBranch();
+			}
+		});
+
+		const cancellation = new CancellationTokenSource();
+		this._refsCancellation.value = cancellation;
+		try {
+			const refs = await repository.getRefs({ pattern: 'refs/heads' }, cancellation.token);
+			if (requestId !== this._requestId || cancellation.token.isCancellationRequested) {
+				return;
+			}
+
+			const branches = refs
+				.map(ref => ref.name)
+				.filter((name): name is string => !!name)
+				.filter(name => !name.includes(COPILOT_WORKTREE_BRANCH_PREFIX));
+			const currentBranch = this._getCurrentBranch();
+			this._defaultBranch = branches.find(branch => branch === 'main')
+				?? branches.find(branch => branch === 'master')
+				?? branches.find(branch => branch === currentBranch)
+				?? branches[0];
+
+			let selectedBranch: string | undefined;
+			if (this._isolationMode.get() === 'worktree') {
+				selectedBranch = this._preferredBranch && branches.includes(this._preferredBranch)
+					? this._preferredBranch
+					: this._defaultBranch;
+			} else {
+				selectedBranch = this._getCurrentBranch() ?? this._defaultBranch;
+			}
+			transaction(tx => {
+				this._branches.set(branches, tx);
+				this._setSelectedBranch(selectedBranch, tx);
+			});
+		} catch (error) {
+			if (!cancellation.token.isCancellationRequested && requestId === this._requestId) {
+				this._logService.trace('[GitBranchPickerModel] Failed to load Git branches.', error);
+				transaction(tx => {
+					this._branches.set([], tx);
+					this._setSelectedBranch(undefined, tx);
+				});
+			}
+		} finally {
+			if (requestId === this._requestId) {
+				this._loading.set(false, undefined);
+			}
+		}
+	}
+
+	private _syncFolderBranch(): void {
+		this._setSelectedBranch(this._getCurrentBranch() ?? this._defaultBranch);
+	}
+
+	private _getCurrentBranch(): string | undefined {
+		const head = this._repository?.state.get().HEAD;
+		return head?.commit ? head.name : undefined;
+	}
+
+	private _setSelectedBranch(branch: string | undefined, tx: ITransaction | undefined = undefined): void {
+		this._selectedBranch.set(branch, tx);
+		this._onDidChangeBranch(branch);
+	}
+
+	private _cancelRefsLoad(): void {
+		this._refsCancellation.value?.cancel();
+		this._refsCancellation.clear();
+	}
+
+	override dispose(): void {
+		++this._requestId;
+		this._cancelRefsLoad();
+		super.dispose();
+	}
+}

--- a/src/vs/sessions/contrib/chat/common/constants.ts
+++ b/src/vs/sessions/contrib/chat/common/constants.ts
@@ -4,3 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const NEW_SESSION_ACTION_ID = 'workbench.action.sessions.newChat';
+
+/** Branch name prefix used by worktree-isolated sessions; filtered out from branch pickers. */
+export const COPILOT_WORKTREE_BRANCH_PREFIX = 'copilot-worktree-';

--- a/src/vs/sessions/contrib/chat/test/browser/gitBranchPickerModel.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/gitBranchPickerModel.test.ts
@@ -1,0 +1,293 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { isEqual } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { GitRef, GitRefType, GitRepositoryState, IGitRepository, IGitService } from '../../../../../workbench/contrib/git/common/gitService.js';
+import { GitBranchPickerModel } from '../../browser/gitBranchPickerModel.js';
+
+function createRepository(rootUri: URI, branch: string, refs: readonly string[], options?: { getRefs?: (query: unknown, token?: CancellationToken) => Promise<GitRef[]> }): IGitRepository {
+	const state = observableValue<GitRepositoryState>('gitState', {
+		HEAD: { type: GitRefType.Head, name: branch, commit: 'commit' },
+		remotes: [],
+		mergeChanges: [],
+		indexChanges: [],
+		workingTreeChanges: [],
+		untrackedChanges: [],
+	});
+	return {
+		rootUri,
+		state,
+		updateState: next => state.set(next, undefined),
+		getRefs: options?.getRefs ?? (async () => refs.map(name => ({ type: GitRefType.Head, name } satisfies GitRef))),
+		diffBetweenWithStats: async () => [],
+		diffBetweenWithStats2: async () => [],
+	};
+}
+
+suite('GitBranchPickerModel', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('loads branches, filters generated worktrees, and restores a saved branch', async () => {
+		const folder = URI.file('/repo');
+		const repository = createRepository(folder, 'current', ['current', 'main', 'saved', 'copilot-worktree-old']);
+		const folderObs = observableValue<URI | undefined>('folder', folder);
+		const isolationMode = observableValue<string | undefined>('isolationMode', 'worktree');
+		let selectedBranch: string | undefined;
+		const gitService = upcastPartial<IGitService>({ openRepository: async () => repository });
+		const model = store.add(new GitBranchPickerModel('saved', folderObs, isolationMode, branch => selectedBranch = branch, gitService, new NullLogService()));
+
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			branches: model.branches.get(),
+			selectedBranch: model.selectedBranch.get(),
+			disabled: model.disabled.get(),
+			formBranch: selectedBranch,
+		}, {
+			branches: ['current', 'main', 'saved'],
+			selectedBranch: 'saved',
+			disabled: false,
+			formBranch: 'saved',
+		});
+	});
+
+	test('tracks HEAD in Folder mode and uses the default branch in Worktree mode', async () => {
+		const folder = URI.file('/repo');
+		const repository = createRepository(folder, 'feature', ['feature', 'main']);
+		const folderObs = observableValue<URI | undefined>('folder', folder);
+		const isolationMode = observableValue<string | undefined>('isolationMode', 'workspace');
+		let selectedBranch: string | undefined;
+		const gitService = upcastPartial<IGitService>({ openRepository: async () => repository });
+		const model = store.add(new GitBranchPickerModel(undefined, folderObs, isolationMode, branch => selectedBranch = branch, gitService, new NullLogService()));
+		await timeout(0);
+
+		isolationMode.set('worktree', undefined);
+		const worktreeState = {
+			selectedBranch: model.selectedBranch.get(),
+			disabled: model.disabled.get(),
+		};
+		model.setBranch('feature');
+		isolationMode.set('workspace', undefined);
+		repository.updateState({
+			...repository.state.get(),
+			HEAD: { type: GitRefType.Head, name: 'main', commit: 'next' },
+		});
+
+		assert.deepStrictEqual({
+			worktreeState,
+			folderBranch: model.selectedBranch.get(),
+			formBranch: selectedBranch,
+			disabled: model.disabled.get(),
+		}, {
+			worktreeState: { selectedBranch: 'main', disabled: false },
+			folderBranch: 'main',
+			formBranch: 'main',
+			disabled: true,
+		});
+	});
+
+	test('restores user-picked branch when re-enabling worktree mode', async () => {
+		const folder = URI.file('/repo');
+		const repository = createRepository(folder, 'main', ['main', 'feature', 'dev']);
+		const folderObs = observableValue<URI | undefined>('folder', folder);
+		const isolationMode = observableValue<string | undefined>('isolationMode', 'worktree');
+		let selectedBranch: string | undefined;
+		const gitService = upcastPartial<IGitService>({ openRepository: async () => repository });
+		const model = store.add(new GitBranchPickerModel(undefined, folderObs, isolationMode, branch => selectedBranch = branch, gitService, new NullLogService()));
+		await timeout(0);
+
+		// User explicitly picks 'feature'
+		model.setBranch('feature');
+		assert.strictEqual(model.selectedBranch.get(), 'feature');
+
+		// Toggle to workspace mode (tracks HEAD)
+		isolationMode.set('workspace', undefined);
+		assert.strictEqual(model.selectedBranch.get(), 'main');
+
+		// Toggle back to worktree mode — should restore 'feature', not 'main'
+		isolationMode.set('worktree', undefined);
+		assert.deepStrictEqual({
+			selectedBranch: model.selectedBranch.get(),
+			formBranch: selectedBranch,
+		}, {
+			selectedBranch: 'feature',
+			formBranch: 'feature',
+		});
+	});
+
+	test('ignores a stale repository result after the folder changes', async () => {
+		const firstFolder = URI.file('/first');
+		const secondFolder = URI.file('/second');
+		const firstRepository = new DeferredPromise<IGitRepository | undefined>();
+		const secondRepository = createRepository(secondFolder, 'second', ['second']);
+		const folderObs = observableValue<URI | undefined>('folder', firstFolder);
+		const isolationMode = observableValue<string | undefined>('isolationMode', 'worktree');
+		const gitService = upcastPartial<IGitService>({
+			openRepository: (folder: URI) => isEqual(folder, firstFolder)
+				? firstRepository.p
+				: Promise.resolve(secondRepository),
+		});
+		const model = store.add(new GitBranchPickerModel(undefined, folderObs, isolationMode, () => { }, gitService, new NullLogService()));
+
+		folderObs.set(secondFolder, undefined);
+		await timeout(0);
+		firstRepository.complete(createRepository(firstFolder, 'first', ['first']));
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			branches: model.branches.get(),
+			selectedBranch: model.selectedBranch.get(),
+		}, {
+			branches: ['second'],
+			selectedBranch: 'second',
+		});
+	});
+
+	test('handles openRepository rejection gracefully', async () => {
+		const folder = URI.file('/repo');
+		const folderObs = observableValue<URI | undefined>('folder', folder);
+		const isolationMode = observableValue<string | undefined>('isolationMode', 'worktree');
+		let selectedBranch: string | undefined = 'initial';
+		const gitService = upcastPartial<IGitService>({
+			openRepository: async () => { throw new Error('no git'); },
+		});
+		const model = store.add(new GitBranchPickerModel(undefined, folderObs, isolationMode, branch => selectedBranch = branch, gitService, new NullLogService()));
+
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			branches: model.branches.get(),
+			selectedBranch: model.selectedBranch.get(),
+			disabled: model.disabled.get(),
+			formBranch: selectedBranch,
+		}, {
+			branches: [],
+			selectedBranch: undefined,
+			disabled: true,
+			formBranch: undefined,
+		});
+	});
+
+	test('handles getRefs rejection gracefully', async () => {
+		const folder = URI.file('/repo');
+		const repository = createRepository(folder, 'main', [], {
+			getRefs: async () => { throw new Error('network error'); },
+		});
+		const folderObs = observableValue<URI | undefined>('folder', folder);
+		const isolationMode = observableValue<string | undefined>('isolationMode', 'worktree');
+		let selectedBranch: string | undefined = 'initial';
+		const gitService = upcastPartial<IGitService>({ openRepository: async () => repository });
+		const model = store.add(new GitBranchPickerModel(undefined, folderObs, isolationMode, branch => selectedBranch = branch, gitService, new NullLogService()));
+
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			branches: model.branches.get(),
+			selectedBranch: model.selectedBranch.get(),
+			disabled: model.disabled.get(),
+			formBranch: selectedBranch,
+		}, {
+			branches: [],
+			selectedBranch: undefined,
+			disabled: true,
+			formBranch: undefined,
+		});
+	});
+
+	test('cancels in-flight getRefs when folder changes', async () => {
+		const firstFolder = URI.file('/first');
+		const secondFolder = URI.file('/second');
+		const refsDeferred = new DeferredPromise<GitRef[]>();
+		const firstRepository = createRepository(firstFolder, 'first', [], {
+			getRefs: async (_query, token) => {
+				const result = await refsDeferred.p;
+				if (token?.isCancellationRequested) {
+					throw new Error('cancelled');
+				}
+				return result;
+			},
+		});
+		const secondRepository = createRepository(secondFolder, 'second', ['second']);
+		const folderObs = observableValue<URI | undefined>('folder', firstFolder);
+		const isolationMode = observableValue<string | undefined>('isolationMode', 'worktree');
+		const gitService = upcastPartial<IGitService>({
+			openRepository: (folder: URI) => isEqual(folder, firstFolder)
+				? Promise.resolve(firstRepository)
+				: Promise.resolve(secondRepository),
+		});
+		const model = store.add(new GitBranchPickerModel(undefined, folderObs, isolationMode, () => { }, gitService, new NullLogService()));
+
+		await timeout(0); // first repo opens, getRefs starts
+
+		folderObs.set(secondFolder, undefined);
+		await timeout(0); // second repo opens and resolves
+
+		// Resolve the first getRefs (should be ignored due to cancellation/stale requestId)
+		refsDeferred.complete([{ type: GitRefType.Head, name: 'stale' }]);
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			branches: model.branches.get(),
+			selectedBranch: model.selectedBranch.get(),
+		}, {
+			branches: ['second'],
+			selectedBranch: 'second',
+		});
+	});
+
+	test('disposal during pending openRepository does not invoke callback', async () => {
+		const folder = URI.file('/repo');
+		const openDeferred = new DeferredPromise<IGitRepository | undefined>();
+		const folderObs = observableValue<URI | undefined>('folder', folder);
+		const isolationMode = observableValue<string | undefined>('isolationMode', 'worktree');
+		let callbackInvoked = false;
+		const gitService = upcastPartial<IGitService>({ openRepository: async () => openDeferred.p });
+		const model = store.add(new GitBranchPickerModel(undefined, folderObs, isolationMode, () => { callbackInvoked = true; }, gitService, new NullLogService()));
+
+		// Reset the flag after initial construction callback
+		await timeout(0);
+		callbackInvoked = false;
+
+		model.dispose();
+		openDeferred.complete(createRepository(folder, 'main', ['main']));
+		await timeout(0);
+
+		assert.strictEqual(callbackInvoked, false, 'callback should not fire after disposal');
+	});
+
+	test('clearing folder sets branches to empty and notifies callback', async () => {
+		const folder = URI.file('/repo');
+		const repository = createRepository(folder, 'main', ['main', 'dev']);
+		const folderObs = observableValue<URI | undefined>('folder', folder);
+		const isolationMode = observableValue<string | undefined>('isolationMode', 'worktree');
+		let selectedBranch: string | undefined;
+		const gitService = upcastPartial<IGitService>({ openRepository: async () => repository });
+		const model = store.add(new GitBranchPickerModel(undefined, folderObs, isolationMode, branch => selectedBranch = branch, gitService, new NullLogService()));
+
+		await timeout(0);
+		assert.strictEqual(model.branches.get().length, 2);
+
+		folderObs.set(undefined, undefined);
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			branches: model.branches.get(),
+			selectedBranch: model.selectedBranch.get(),
+			formBranch: selectedBranch,
+		}, {
+			branches: [],
+			selectedBranch: undefined,
+			formBranch: undefined,
+		});
+	});
+});


### PR DESCRIPTION
Builds on top of https://github.com/microsoft/vscode/pull/325712, mimicking much of the branch logic that existed in `CopilotChatSessionProvider` (did not refactor that class to keep things scoped)

Merge order should be:
1. https://github.com/microsoft/vscode/pull/325712
2. This PR
3.  https://github.com/microsoft/vscode/pull/325887