### PR TITLE
Fix quota trajectory billing period calculation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
@@ -323,10 +323,7 @@ export class ChatQuotaNotificationContribution extends Disposable implements IWo
 		}
 
 		const periodStart = new Date(resetTime);
-		periodStart.setUTCDate(1);
 		periodStart.setUTCMonth(periodStart.getUTCMonth() - 1);
-		const daysInPreviousMonth = new Date(Date.UTC(periodStart.getUTCFullYear(), periodStart.getUTCMonth() + 1, 0)).getUTCDate();
-		periodStart.setUTCDate(Math.min(reset.getUTCDate(), daysInPreviousMonth));
 		const periodStartTime = periodStart.getTime();
 		const elapsedDays = Math.max(0, (Date.now() - periodStartTime) / TRAJECTORY_NUDGE_SPEC.msPerDay);
 		if (elapsedDays <= 0) {

--- a/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
@@ -30,7 +30,6 @@ const TRAJECTORY_NUDGE_SPEC = {
 	averageDailyUsageThreshold: 4.5,
 	minimumPercentUsed: 10,
 	maximumPercentUsed: 35,
-	billingPeriodDays: 30,
 	msPerDay: 24 * 60 * 60 * 1000,
 	learnMoreUrl: 'https://aka.ms/token-usage-tips',
 	learnMoreCommandId: 'workbench.action.chat.learnMoreAboutCreditUsage',
@@ -317,12 +316,18 @@ export class ChatQuotaNotificationContribution extends Disposable implements IWo
 			return undefined;
 		}
 
-		const resetTime = new Date(resetDate).getTime();
+		const reset = new Date(resetDate);
+		const resetTime = reset.getTime();
 		if (!Number.isFinite(resetTime)) {
 			return undefined;
 		}
 
-		const periodStartTime = resetTime - (TRAJECTORY_NUDGE_SPEC.billingPeriodDays * TRAJECTORY_NUDGE_SPEC.msPerDay);
+		const periodStart = new Date(resetTime);
+		periodStart.setUTCDate(1);
+		periodStart.setUTCMonth(periodStart.getUTCMonth() - 1);
+		const daysInPreviousMonth = new Date(Date.UTC(periodStart.getUTCFullYear(), periodStart.getUTCMonth() + 1, 0)).getUTCDate();
+		periodStart.setUTCDate(Math.min(reset.getUTCDate(), daysInPreviousMonth));
+		const periodStartTime = periodStart.getTime();
 		const elapsedDays = Math.max(0, (Date.now() - periodStartTime) / TRAJECTORY_NUDGE_SPEC.msPerDay);
 		if (elapsedDays <= 0) {
 			return undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
@@ -325,8 +325,8 @@ export class ChatQuotaNotificationContribution extends Disposable implements IWo
 		const periodStart = new Date(resetTime);
 		periodStart.setUTCMonth(periodStart.getUTCMonth() - 1);
 		const periodStartTime = periodStart.getTime();
-		const elapsedDays = Math.max(0, (Date.now() - periodStartTime) / TRAJECTORY_NUDGE_SPEC.msPerDay);
-		if (elapsedDays <= 0) {
+		const elapsedDays = (Date.now() - periodStartTime) / TRAJECTORY_NUDGE_SPEC.msPerDay;
+		if (elapsedDays < 0) {
 			return undefined;
 		}
 
@@ -335,7 +335,7 @@ export class ChatQuotaNotificationContribution extends Disposable implements IWo
 			return undefined;
 		}
 
-		const averageDailyUsage = percentUsed / elapsedDays;
+		const averageDailyUsage = percentUsed / Math.max(1, elapsedDays);
 		if (averageDailyUsage < TRAJECTORY_NUDGE_SPEC.averageDailyUsageThreshold) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
@@ -649,6 +649,15 @@ suite('ChatQuotaNotificationContribution', () => {
 	// --- Quota trajectory warning --------------------------------------------
 
 	suite('quota trajectory warning', () => {
+		let clock: sinon.SinonFakeTimers;
+
+		setup(() => {
+			clock = sinon.useFakeTimers({
+				now: new Date('2026-06-25T00:00:00Z'),
+				toFake: ['Date'],
+			});
+		});
+
 		test('does not show when experiment treatment is disabled', async () => {
 			const { notificationMock } = createContribution({
 				quotas: {
@@ -769,6 +778,31 @@ suite('ChatQuotaNotificationContribution', () => {
 			await flushPromises();
 
 			assert.strictEqual(notificationMock.getNotification(), undefined);
+		});
+
+		test('uses previous calendar month as period start for 31-day cycle', async () => {
+			clock.setSystemTime(new Date('2026-07-08T00:00:00Z'));
+			const telemetryService = new TestTelemetryService();
+			const { assignmentMock, notificationMock } = createContribution({
+				entitlement: ChatEntitlement.Pro,
+				quotas: {
+					resetDate: '2026-08-01T00:00:00Z',
+					usageBasedBilling: true,
+					premiumChat: makeQuotaSnapshot(72),
+				},
+			}, { trajectoryTreatment: true, telemetryService });
+
+			await flushPromises();
+
+			assert.deepStrictEqual({
+				treatments: assignmentMock.getTreatmentCalls,
+				events: telemetryService.events,
+				notification: notificationMock.getNotification(),
+			}, {
+				treatments: [],
+				events: [],
+				notification: undefined,
+			});
 		});
 
 		test('shows trajectory nudge only after treatment resolves', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
@@ -805,38 +805,6 @@ suite('ChatQuotaNotificationContribution', () => {
 			});
 		});
 
-		test('clamps month-end period start to the last day of the previous month', async () => {
-			const results = [];
-			for (const [now, resetDate] of [
-				['2026-03-10T00:00:00Z', '2026-03-31T00:00:00Z'],
-				['2028-03-10T00:00:00Z', '2028-03-31T00:00:00Z'],
-			]) {
-				clock.setSystemTime(new Date(now));
-				const telemetryService = new TestTelemetryService();
-				const { assignmentMock, notificationMock } = createContribution({
-					entitlement: ChatEntitlement.Pro,
-					quotas: {
-						resetDate,
-						usageBasedBilling: true,
-						premiumChat: makeQuotaSnapshot(72),
-					},
-				}, { trajectoryTreatment: true, telemetryService });
-
-				await flushPromises();
-
-				results.push({
-					treatments: assignmentMock.getTreatmentCalls,
-					events: telemetryService.events,
-					notification: notificationMock.getNotification(),
-				});
-			}
-
-			assert.deepStrictEqual(results, [
-				{ treatments: [], events: [], notification: undefined },
-				{ treatments: [], events: [], notification: undefined },
-			]);
-		});
-
 		test('shows trajectory nudge only after treatment resolves', async () => {
 			let resolveTreatment: ((value: boolean | undefined) => void) | undefined;
 			const trajectoryTreatment = new Promise<boolean | undefined>(resolve => {

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
@@ -780,29 +780,47 @@ suite('ChatQuotaNotificationContribution', () => {
 			assert.strictEqual(notificationMock.getNotification(), undefined);
 		});
 
-		test('uses previous calendar month as period start for 31-day cycle', async () => {
-			clock.setSystemTime(new Date('2026-07-08T00:00:00Z'));
-			const telemetryService = new TestTelemetryService();
-			const { assignmentMock, notificationMock } = createContribution({
-				entitlement: ChatEntitlement.Pro,
-				quotas: {
-					resetDate: '2026-08-01T00:00:00Z',
-					usageBasedBilling: true,
-					premiumChat: makeQuotaSnapshot(72),
+		test('counts the first billing day for 31-day and 28-day cycles', async () => {
+			const results = [];
+			for (const [now, resetDate] of [
+				['2026-01-01T00:00:00Z', '2026-02-01T00:00:00Z'],
+				['2026-02-01T00:00:00Z', '2026-03-01T00:00:00Z'],
+			]) {
+				clock.setSystemTime(new Date(now));
+				const telemetryService = new TestTelemetryService();
+				const { notificationMock } = createContribution({
+					entitlement: ChatEntitlement.Pro,
+					quotas: {
+						resetDate,
+						usageBasedBilling: true,
+						premiumChat: makeQuotaSnapshot(88),
+					},
+				}, { trajectoryTreatment: true, telemetryService });
+
+				await flushPromises();
+
+				results.push({
+					events: telemetryService.events,
+					notificationShown: notificationMock.getNotification() !== undefined,
+				});
+			}
+
+			assert.deepStrictEqual(results, [
+				{
+					events: [{
+						name: 'chatQuotaTrajectoryNudgeEnrolled',
+						data: { treatment: true, entitlement: 'Pro', averageDailyUsage: 12, percentUsed: 12 },
+					}],
+					notificationShown: true,
 				},
-			}, { trajectoryTreatment: true, telemetryService });
-
-			await flushPromises();
-
-			assert.deepStrictEqual({
-				treatments: assignmentMock.getTreatmentCalls,
-				events: telemetryService.events,
-				notification: notificationMock.getNotification(),
-			}, {
-				treatments: [],
-				events: [],
-				notification: undefined,
-			});
+				{
+					events: [{
+						name: 'chatQuotaTrajectoryNudgeEnrolled',
+						data: { treatment: true, entitlement: 'Pro', averageDailyUsage: 12, percentUsed: 12 },
+					}],
+					notificationShown: true,
+				},
+			]);
 		});
 
 		test('shows trajectory nudge only after treatment resolves', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
@@ -805,6 +805,38 @@ suite('ChatQuotaNotificationContribution', () => {
 			});
 		});
 
+		test('clamps month-end period start to the last day of the previous month', async () => {
+			const results = [];
+			for (const [now, resetDate] of [
+				['2026-03-10T00:00:00Z', '2026-03-31T00:00:00Z'],
+				['2028-03-10T00:00:00Z', '2028-03-31T00:00:00Z'],
+			]) {
+				clock.setSystemTime(new Date(now));
+				const telemetryService = new TestTelemetryService();
+				const { assignmentMock, notificationMock } = createContribution({
+					entitlement: ChatEntitlement.Pro,
+					quotas: {
+						resetDate,
+						usageBasedBilling: true,
+						premiumChat: makeQuotaSnapshot(72),
+					},
+				}, { trajectoryTreatment: true, telemetryService });
+
+				await flushPromises();
+
+				results.push({
+					treatments: assignmentMock.getTreatmentCalls,
+					events: telemetryService.events,
+					notification: notificationMock.getNotification(),
+				});
+			}
+
+			assert.deepStrictEqual(results, [
+				{ treatments: [], events: [], notification: undefined },
+				{ treatments: [], events: [], notification: undefined },
+			]);
+		});
+
 		test('shows trajectory nudge only after treatment resolves', async () => {
 			let resolveTreatment: ((value: boolean | undefined) => void) | undefined;
 			const trajectoryTreatment = new Promise<boolean | undefined>(resolve => {


### PR DESCRIPTION
## Summary
- compute quota trajectory elapsed days from one calendar month before the reset date
- clamp month-end reset dates to the last valid day of the previous month
- add deterministic 31-day billing-cycle coverage

## Validation
- `npm run typecheck-client`
- quota trajectory tests: 13 passing in Chromium, WebKit, and Firefox

Follow-up to microsoft/vscode#320683.