### PR TITLE
Enable inspector before debugging extension host

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-browser/debugExtensionHostAction.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/debugExtensionHostAction.ts
@@ -37,7 +37,7 @@ async function getExtensionHostPort(
 	dialogService: IDialogService,
 	productService: IProductService,
 ): Promise<number | undefined> {
-	const inspectPorts = await extensionService.getInspectPorts(ExtensionHostKind.LocalProcess, false);
+	const inspectPorts = await extensionService.getInspectPorts(ExtensionHostKind.LocalProcess, true);
 	if (inspectPorts.length === 0) {
 		const res = await dialogService.confirm({
 			message: nls.localize('restart1', "Debug Extensions"),

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/debugExtensionHostAction.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/debugExtensionHostAction.test.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { INativeHostService } from '../../../../../platform/native/common/native.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { TestProductService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { ExtensionHostKind } from '../../../../services/extensions/common/extensionHostKind.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
+import { DebugExtensionHostInNewWindowAction } from '../../electron-browser/debugExtensionHostAction.js';
+
+suite('DebugExtensionHostInNewWindowAction', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	teardown(() => sinon.restore());
+
+	test('enables the inspector before opening a debug window', async () => {
+		const state: {
+			extensionHostKind?: ExtensionHostKind;
+			tryEnableInspector?: boolean;
+			openedWindow: boolean;
+		} = { openedWindow: false };
+		const instantiationService = store.add(new TestInstantiationService());
+
+		instantiationService.stub(IExtensionService, {
+			async getInspectPorts(extensionHostKind, tryEnableInspector) {
+				state.extensionHostKind = extensionHostKind;
+				state.tryEnableInspector = tryEnableInspector;
+				return [{ host: 'localhost', port: 9229 }];
+			}
+		});
+		instantiationService.stub(INativeHostService, {});
+		instantiationService.stub(IDialogService, {});
+		instantiationService.stub(IProductService, TestProductService);
+		instantiationService.stub(IInstantiationService, instantiationService);
+		instantiationService.stub(IStorageService, store.add(new TestStorageService()));
+		instantiationService.stub(IHostService, {
+			async openWindow() {
+				state.openedWindow = true;
+			}
+		});
+
+		await new DebugExtensionHostInNewWindowAction().run(instantiationService);
+
+		assert.deepStrictEqual(state, {
+			extensionHostKind: ExtensionHostKind.LocalProcess,
+			tryEnableInspector: true,
+			openedWindow: true,
+		});
+	});
+});


### PR DESCRIPTION
Fixes #85422

The Running Extensions debug action currently queries inspect ports without allowing the extension service to enable the inspector. As a result, a normally running local extension host reports no port and the action immediately offers a restart.

This change lets `getInspectPorts` enable the inspector first. The existing restart flow remains the fallback when an inspect port still cannot be obtained. A focused regression test verifies both the dynamic-inspector request and the subsequent debug-window launch.

Tests:
- `npm run typecheck-client`
- `eslint` on the changed source and test files
- `scripts\\test.bat --run src/vs/workbench/contrib/extensions/test/electron-browser/debugExtensionHostAction.test.ts --disable-gpu --no-sandbox --timeout 10000` (2 passing)