### PR TITLE
Telemetry: Chunk diffsJSON across multiple telemetry columns to avoid  truncation

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
@@ -12,7 +12,7 @@ import { IGitExtensionService } from '../../../platform/git/common/gitExtensionS
 import { getOrderedRepoInfosFromContext, IGitService, normalizeFetchUrl, RepoContext, ResolvedRepoRemoteInfo } from '../../../platform/git/common/gitService';
 import { Change, Repository } from '../../../platform/git/vscode/git';
 import { ILogService } from '../../../platform/log/common/logService';
-import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
+import { ITelemetryService, multiplexProperties } from '../../../platform/telemetry/common/telemetry';
 import { extUriBiasedIgnorePathCase } from '../../../util/vs/base/common/resources';
 import { IWorkspaceFileIndex } from '../../../platform/workspaceChunkSearch/node/workspaceFileIndex';
 
@@ -40,9 +40,12 @@ const STATUS_TO_STRING: Record<number, string> = {
 	18: 'BOTH_MODIFIED',
 };
 
-// Max telemetry payload size is 1MB, we add shared properties in further code and JSON structure overhead to that
-// so check our diff JSON size against 900KB to be conservative with space
-const MAX_DIFFS_JSON_SIZE = 900 * 1024;
+// The Application Insights SDK truncates any single custom string property at 8192 characters. When
+// the serialized diffs JSON exceeds that, `multiplexProperties` (see telemetry.ts) splits it across
+// up to 50 columns (`diffsJSON`, `diffsJSON_02`, `diffsJSON_03`, ...) so the full payload survives.
+// We cap the diffs JSON at the multiplex capacity (50 * 8192) so nothing is silently dropped; anything
+// larger yields `diffTooLarge`. Byte length is a conservative proxy for character length here.
+const MAX_DIFFS_JSON_SIZE = 50 * 8192;
 
 // Max changes to avoid degenerate cases like mass renames
 const MAX_CHANGES = 100;
@@ -236,9 +239,9 @@ export class RepoInfoTelemetry {
 
 			if (isInternal) {
 				const { headBranchName: _, fileRelativePaths: _2, ...msftProperties } = internalProperties;
-				this._telemetryService.sendInternalMSFTTelemetryEvent('request.repoInfo', msftProperties, data.measurements);
+				this._telemetryService.sendInternalMSFTTelemetryEvent('request.repoInfo', multiplexProperties(msftProperties), data.measurements);
 			}
-			this._telemetryService.sendEnhancedGHTelemetryEvent('request.repoInfo', internalProperties, data.measurements);
+			this._telemetryService.sendEnhancedGHTelemetryEvent('request.repoInfo', multiplexProperties(internalProperties), data.measurements);
 		}
 
 		return results;
@@ -452,7 +455,8 @@ export class RepoInfoTelemetry {
 
 			const diffsJSON = diffs.length > 0 ? JSON.stringify(diffs) : undefined;
 
-			// Check against our size limit to make sure our telemetry fits in the 1MB limit
+			// The total telemetry event payload is limited to 1MB. Cap the diffs JSON at the multiplex
+			// capacity (MAX_DIFFS_JSON_SIZE) so it fits within the available columns; larger diffs are dropped.
 			if (diffsJSON) {
 				const diffSizeBytes = Buffer.byteLength(diffsJSON, 'utf8');
 				measurements.diffSizeBytes = diffSizeBytes;

--- a/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
@@ -43,9 +43,12 @@ const STATUS_TO_STRING: Record<number, string> = {
 // The Application Insights SDK truncates any single custom string property at 8192 characters. When
 // the serialized diffs JSON exceeds that, `multiplexProperties` (see telemetry.ts) splits it across
 // up to 50 columns (`diffsJSON`, `diffsJSON_02`, `diffsJSON_03`, ...) so the full payload survives.
-// We cap the diffs JSON at the multiplex capacity (50 * 8192) so nothing is silently dropped; anything
-// larger yields `diffTooLarge`. Byte length is a conservative proxy for character length here.
-const MAX_DIFFS_JSON_SIZE = 50 * 8192;
+// Two independent limits guard the diffs JSON, and it is dropped (`diffTooLarge`) if EITHER is exceeded:
+// - MAX_DIFFS_JSON_BYTES: conservative total-payload byte budget under the 1MB event limit.
+// - MAX_DIFFS_JSON_CHARS: the multiplex capacity in characters (UTF-16 code units), matching how
+//   `multiplexProperties` measures and slices, so nothing is silently dropped past the 50 columns.
+const MAX_DIFFS_JSON_BYTES = 900 * 1024;
+const MAX_DIFFS_JSON_CHARS = 50 * 8192;
 
 // Max changes to avoid degenerate cases like mass renames
 const MAX_CHANGES = 100;
@@ -455,13 +458,14 @@ export class RepoInfoTelemetry {
 
 			const diffsJSON = diffs.length > 0 ? JSON.stringify(diffs) : undefined;
 
-			// The total telemetry event payload is limited to 1MB. Cap the diffs JSON at the multiplex
-			// capacity (MAX_DIFFS_JSON_SIZE) so it fits within the available columns; larger diffs are dropped.
+			// The total telemetry event payload is limited to 1MB, and each multiplexed column holds at
+			// most 8192 characters across 50 columns. Drop the diffs JSON if it exceeds either the byte
+			// budget or the multiplex character capacity so nothing is silently truncated.
 			if (diffsJSON) {
 				const diffSizeBytes = Buffer.byteLength(diffsJSON, 'utf8');
 				measurements.diffSizeBytes = diffSizeBytes;
 
-				if (diffSizeBytes > MAX_DIFFS_JSON_SIZE) {
+				if (diffSizeBytes > MAX_DIFFS_JSON_BYTES || diffsJSON.length > MAX_DIFFS_JSON_CHARS) {
 					return {
 						properties: { ...baseProperties, fileRelativePaths, diffsJSON: undefined, result: 'diffTooLarge' },
 						measurements

--- a/extensions/copilot/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
+++ b/extensions/copilot/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
@@ -1105,7 +1105,7 @@ suite('RepoInfoTelemetry', () => {
 			status: Status.MODIFIED
 		}] as any);
 
-		// Create a diff that exceeds the effective cap (50 chunks * 8192 bytes ~= 400KB) when serialized to JSON
+		// Create a diff that exceeds both the byte budget (900 KiB) and the character capacity (50 * 8192)
 		const largeDiff = 'x'.repeat(901 * 1024);
 		vi.spyOn(gitDiffService, 'getWorkingTreeDiffsFromRef').mockResolvedValue([{
 			uri: URI.file('/test/repo/file.ts'),
@@ -1137,6 +1137,92 @@ suite('RepoInfoTelemetry', () => {
 		assert.strictEqual(call[1].diffsJSON, undefined);
 		assert.strictEqual(call[1].remoteUrl, 'https://github.com/microsoft/vscode.git');
 		assert.strictEqual(call[1].headCommitHash, 'abc123');
+	});
+
+	test('should detect diffTooLarge via character capacity even when under the byte budget', async () => {
+		setupInternalUser();
+		mockGitServiceWithRepository();
+		mockGitExtensionWithUpstream('abc123');
+
+		vi.spyOn(gitService, 'diffWith').mockResolvedValue([{
+			uri: URI.file('/test/repo/file.ts'),
+			originalUri: URI.file('/test/repo/file.ts'),
+			renameUri: undefined,
+			status: Status.MODIFIED
+		}] as any);
+
+		// ASCII: ~500K chars = ~500KB bytes. Under the 900 KiB byte budget but over the 50 * 8192 (409600)
+		// character capacity, so it must still be rejected as diffTooLarge.
+		const largeDiff = 'x'.repeat(500 * 1024);
+		vi.spyOn(gitDiffService, 'getWorkingTreeDiffsFromRef').mockResolvedValue([{
+			uri: URI.file('/test/repo/file.ts'),
+			originalUri: URI.file('/test/repo/file.ts'),
+			renameUri: undefined,
+			status: Status.MODIFIED,
+			diff: largeDiff
+		}]);
+
+		const repoTelemetry = new RepoInfoTelemetry(
+			'test-message-id',
+			telemetryService,
+			gitService,
+			gitDiffService,
+			gitExtensionService,
+			logService,
+			fileSystemService,
+			workspaceFileIndex,
+			configurationService,
+			copilotTokenStore
+		);
+
+		await repoTelemetry.sendBeginTelemetryIfNeeded();
+
+		const call = (telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls[0];
+		assert.strictEqual(call[1].result, 'diffTooLarge');
+		assert.strictEqual(call[1].diffsJSON, undefined);
+	});
+
+	test('should detect diffTooLarge via byte budget even when under the character capacity', async () => {
+		setupInternalUser();
+		mockGitServiceWithRepository();
+		mockGitExtensionWithUpstream('abc123');
+
+		vi.spyOn(gitService, 'diffWith').mockResolvedValue([{
+			uri: URI.file('/test/repo/file.ts'),
+			originalUri: URI.file('/test/repo/file.ts'),
+			renameUri: undefined,
+			status: Status.MODIFIED
+		}] as any);
+
+		// A 3-byte UTF-8 CJK character repeated ~350K times: ~1.05MB bytes (over the 900 KiB byte budget)
+		// but only ~350K characters (under the 50 * 8192 (409600) capacity), so it must be rejected via bytes.
+		const largeDiff = '\u4e2d'.repeat(350 * 1024);
+		vi.spyOn(gitDiffService, 'getWorkingTreeDiffsFromRef').mockResolvedValue([{
+			uri: URI.file('/test/repo/file.ts'),
+			originalUri: URI.file('/test/repo/file.ts'),
+			renameUri: undefined,
+			status: Status.MODIFIED,
+			diff: largeDiff
+		}]);
+
+		const repoTelemetry = new RepoInfoTelemetry(
+			'test-message-id',
+			telemetryService,
+			gitService,
+			gitDiffService,
+			gitExtensionService,
+			logService,
+			fileSystemService,
+			workspaceFileIndex,
+			configurationService,
+			copilotTokenStore
+		);
+
+		await repoTelemetry.sendBeginTelemetryIfNeeded();
+
+		const call = (telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls[0];
+		assert.strictEqual(call[1].result, 'diffTooLarge');
+		assert.strictEqual(call[1].diffsJSON, undefined);
 	});
 
 	test('should chunk large diffs across multiple diffsJSON columns', async () => {
@@ -1661,7 +1747,7 @@ suite('RepoInfoTelemetry', () => {
 			status: Status.MODIFIED
 		}] as any);
 
-		// Create a diff that exceeds the effective cap (50 chunks * 8192 bytes ~= 400KB) when serialized to JSON
+		// Create a diff that exceeds both the byte budget (900 KiB) and the character capacity (50 * 8192)
 		const largeDiff = 'x'.repeat(901 * 1024);
 		vi.spyOn(gitDiffService, 'getWorkingTreeDiffsFromRef').mockResolvedValue([{
 			uri: URI.file('/test/repo/file.ts'),

--- a/extensions/copilot/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
+++ b/extensions/copilot/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
@@ -135,6 +135,7 @@ suite('RepoInfoTelemetry', () => {
 		// Properly mock the telemetry methods
 		(telemetryService as any).sendMSFTTelemetryEvent = vi.fn();
 		(telemetryService as any).sendInternalMSFTTelemetryEvent = vi.fn();
+		(telemetryService as any).sendEnhancedGHTelemetryEvent = vi.fn();
 	});
 
 	// ========================================
@@ -1104,7 +1105,7 @@ suite('RepoInfoTelemetry', () => {
 			status: Status.MODIFIED
 		}] as any);
 
-		// Create a diff that exceeds 900KB when serialized to JSON
+		// Create a diff that exceeds the effective cap (50 chunks * 8192 bytes ~= 400KB) when serialized to JSON
 		const largeDiff = 'x'.repeat(901 * 1024);
 		vi.spyOn(gitDiffService, 'getWorkingTreeDiffsFromRef').mockResolvedValue([{
 			uri: URI.file('/test/repo/file.ts'),
@@ -1136,6 +1137,67 @@ suite('RepoInfoTelemetry', () => {
 		assert.strictEqual(call[1].diffsJSON, undefined);
 		assert.strictEqual(call[1].remoteUrl, 'https://github.com/microsoft/vscode.git');
 		assert.strictEqual(call[1].headCommitHash, 'abc123');
+	});
+
+	test('should chunk large diffs across multiple diffsJSON columns', async () => {
+		setupInternalUser();
+		mockGitServiceWithRepository();
+		mockGitExtensionWithUpstream('abc123');
+
+		vi.spyOn(gitService, 'diffWith').mockResolvedValue([{
+			uri: URI.file('/test/repo/file.ts'),
+			originalUri: URI.file('/test/repo/file.ts'),
+			renameUri: undefined,
+			status: Status.MODIFIED
+		}] as any);
+
+		// Create a diff whose serialized JSON spans several 8192-char chunks but stays within the cap.
+		const largeDiff = 'x'.repeat(30 * 1024);
+		vi.spyOn(gitDiffService, 'getWorkingTreeDiffsFromRef').mockResolvedValue([{
+			uri: URI.file('/test/repo/file.ts'),
+			originalUri: URI.file('/test/repo/file.ts'),
+			renameUri: undefined,
+			status: Status.MODIFIED,
+			diff: largeDiff
+		}]);
+
+		const repoTelemetry = new RepoInfoTelemetry(
+			'test-message-id',
+			telemetryService,
+			gitService,
+			gitDiffService,
+			gitExtensionService,
+			logService,
+			fileSystemService,
+			workspaceFileIndex,
+			configurationService,
+			copilotTokenStore
+		);
+
+		await repoTelemetry.sendBeginTelemetryIfNeeded();
+
+		// Assert: success, and the diffs JSON is multiplexed (via multiplexProperties) across ordered
+		// columns (`diffsJSON`, `diffsJSON_02`, `diffsJSON_03`, ...) that each stay within the 8192-char
+		// per-property budget and losslessly reassemble to the original JSON.
+		const call = (telemetryService.sendEnhancedGHTelemetryEvent as any).mock.calls[0];
+		assert.strictEqual(call[1].result, 'success');
+
+		const chunkColumns: string[] = [];
+		for (let n = 1; ; n++) {
+			const key = n === 1 ? 'diffsJSON' : `diffsJSON_${n < 10 ? '0' : ''}${n}`;
+			const value = call[1][key];
+			if (value === undefined) {
+				break;
+			}
+			assert.ok(value.length <= 8192, `${key} exceeds 8192 characters`);
+			chunkColumns.push(value);
+		}
+
+		assert.ok(chunkColumns.length > 1, 'expected the diff to be split across multiple columns');
+
+		const diffs = JSON.parse(chunkColumns.join(''));
+		assert.strictEqual(diffs.length, 1);
+		assert.strictEqual(diffs[0].diff, largeDiff);
 	});
 
 	test('should send diff when within size limits', async () => {
@@ -1599,7 +1661,7 @@ suite('RepoInfoTelemetry', () => {
 			status: Status.MODIFIED
 		}] as any);
 
-		// Create a diff that exceeds 900KB when serialized to JSON
+		// Create a diff that exceeds the effective cap (50 chunks * 8192 bytes ~= 400KB) when serialized to JSON
 		const largeDiff = 'x'.repeat(901 * 1024);
 		vi.spyOn(gitDiffService, 'getWorkingTreeDiffsFromRef').mockResolvedValue([{
 			uri: URI.file('/test/repo/file.ts'),


### PR DESCRIPTION
**Problem**
In repoInfoTelemetry.ts, the diffsJSON property of the request.repoInfo telemetry event (sent via sendEnhancedGHTelemetryEvent and sendInternalMSFTTelemetryEvent) was being truncated to 8192 characters by the underlying Application Insights SDK, silently dropping diff data for larger changesets.

**Fix**
Multiplex the serialized diffsJSON across multiple columns using the existing multiplexProperties utility from telemetry.ts (already the established convention across the codebase). When the value exceeds 8192 characters, it is split into up to 50 ordered columns — diffsJSON, diffsJSON_02, diffsJSON_03, … — that reassemble losslessly by concatenation. The first chunk keeps the original diffsJSON name, so existing dashboards/queries continue to work for small diffs.