### PR TITLE
Default BYOK utility model to GitHub Copilot

### DIFF
--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -195,10 +195,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 				case BYOKUtilityModelDefault.None:
 					throw this._createMissingUtilityModelError(family);
 				case BYOKUtilityModelDefault.Copilot:
-					// The Copilot utility models require a Copilot token (CAPI auth).
-					// For air-gapped / signed-out BYOK users there is no token source,
-					// so they can't be used. Treat this like 'none' and ask the user to
-					// choose a utility model.
+					// Copilot utility models require a Copilot token source (unavailable for air-gapped / signed-out BYOK).
 					if (!this._authService.hasCopilotTokenSource) {
 						throw this._createMissingUtilityModelError(family);
 					}
@@ -214,13 +211,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 		}
 	}
 
-	/**
-	 * Builds the error thrown when a BYOK main agent model is selected but no
-	 * utility model is available — either because the user opted out
-	 * (`chat.byokUtilityModelDefault: none`) or because the Copilot utility
-	 * models can't be used (air-gapped / signed-out BYOK). The message points
-	 * the user at the settings they can change to resolve it.
-	 */
+	/** Creates an actionable error for when no usable utility model is available for a BYOK main agent model. */
 	private _createMissingUtilityModelError(family: 'copilot-utility' | 'copilot-utility-small'): Error {
 		const utilityModelSetting = family === 'copilot-utility' ? 'chat.utilityModel' : 'chat.utilitySmallModel';
 		// 'copilot' is only usable when a Copilot token is available; for
@@ -233,9 +224,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 		const value = this._configService.getNonExtensionConfig<unknown>(ProductionEndpointProvider.BYOK_UTILITY_MODEL_DEFAULT_CONFIG_KEY);
 		switch (value) {
 			case undefined:
-				// Match the registered default in `chat.shared.contribution.ts`. When
-				// the setting is unset (or unregistered in an older core), BYOK
-				// utility flows use GitHub Copilot's utility models.
+				// Preserve the Copilot default when running against a core that does not register this setting.
 				return BYOKUtilityModelDefault.Copilot;
 			case BYOKUtilityModelDefault.None:
 			case BYOKUtilityModelDefault.MainAgent:

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -211,7 +211,10 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 		const value = this._configService.getNonExtensionConfig<unknown>(ProductionEndpointProvider.BYOK_UTILITY_MODEL_DEFAULT_CONFIG_KEY);
 		switch (value) {
 			case undefined:
-				return BYOKUtilityModelDefault.None;
+				// Match the registered default in `chat.shared.contribution.ts`. When
+				// the setting is unset (or unregistered in an older core), BYOK
+				// utility flows use GitHub Copilot's utility models.
+				return BYOKUtilityModelDefault.Copilot;
 			case BYOKUtilityModelDefault.None:
 			case BYOKUtilityModelDefault.MainAgent:
 			case BYOKUtilityModelDefault.Copilot:

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -222,7 +222,11 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 	 * the user at the settings they can change to resolve it.
 	 */
 	private _createMissingUtilityModelError(family: 'copilot-utility' | 'copilot-utility-small'): Error {
-		return new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK. Configure setting '${family === 'copilot-utility' ? 'chat.utilityModel' : 'chat.utilitySmallModel'}' or set 'chat.byokUtilityModelDefault' to 'mainAgent' or 'copilot'.`);
+		const utilityModelSetting = family === 'copilot-utility' ? 'chat.utilityModel' : 'chat.utilitySmallModel';
+		// 'copilot' is only usable when a Copilot token is available; for
+		// air-gapped / signed-out BYOK it cannot be used, so don't offer it.
+		const defaultOptions = this._authService.hasCopilotTokenSource ? `'mainAgent' or 'copilot'` : `'mainAgent'`;
+		return new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK. Configure setting '${utilityModelSetting}' or set 'chat.byokUtilityModelDefault' to ${defaultOptions}.`);
 	}
 
 	private _getBYOKUtilityModelDefault(): BYOKUtilityModelDefault {

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -193,8 +193,15 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 				case BYOKUtilityModelDefault.MainAgent:
 					return this._instantiationService.createInstance(ExtensionContributedChatEndpoint, this._mainAgentBYOKModel);
 				case BYOKUtilityModelDefault.None:
-					throw new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK. Configure '${family === 'copilot-utility' ? 'chat.utilityModel' : 'chat.utilitySmallModel'}' or set 'chat.byokUtilityModelDefault' to 'mainAgent' or 'copilot'.`);
+					throw this._createMissingUtilityModelError(family);
 				case BYOKUtilityModelDefault.Copilot:
+					// The Copilot utility models require a Copilot token (CAPI auth).
+					// For air-gapped / signed-out BYOK users there is no token source,
+					// so they can't be used. Treat this like 'none' and ask the user to
+					// choose a utility model.
+					if (!this._authService.hasCopilotTokenSource) {
+						throw this._createMissingUtilityModelError(family);
+					}
 					break;
 			}
 		}
@@ -205,6 +212,17 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 			case 'copilot-utility':
 				return CopilotUtilityChatEndpoint.resolve(this._modelFetcher, this._instantiationService);
 		}
+	}
+
+	/**
+	 * Builds the error thrown when a BYOK main agent model is selected but no
+	 * utility model is available — either because the user opted out
+	 * (`chat.byokUtilityModelDefault: none`) or because the Copilot utility
+	 * models can't be used (air-gapped / signed-out BYOK). The message points
+	 * the user at the settings they can change to resolve it.
+	 */
+	private _createMissingUtilityModelError(family: 'copilot-utility' | 'copilot-utility-small'): Error {
+		return new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK. Configure setting '${family === 'copilot-utility' ? 'chat.utilityModel' : 'chat.utilitySmallModel'}' or set 'chat.byokUtilityModelDefault' to 'mainAgent' or 'copilot'.`);
 	}
 
 	private _getBYOKUtilityModelDefault(): BYOKUtilityModelDefault {

--- a/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
@@ -196,8 +196,20 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		assert.strictEqual(endpoint.model, 'copilot-utility');
 	});
 
-	test('no override configured — does not use a Copilot utility model when the selected main agent model is BYOK', async () => {
+	test('no override configured — uses the Copilot utility model when the selected main agent model is BYOK and a Copilot token is available', async () => {
 		setFetcher([makeChatModel('copilot-utility')]);
+		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
+
+		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+
+		assert.strictEqual(endpoint.model, 'copilot-utility');
+	});
+
+	test('no override configured — rejects when the selected main agent model is BYOK and no Copilot token is available (air-gapped)', async () => {
+		setFetcher([makeChatModel('copilot-utility')]);
+		// Simulate a signed-out / air-gapped BYOK session with no Copilot token source.
+		// @ts-expect-error — access the protected auth service to stub its token-source signal.
+		sandbox.stub(endpointProvider._authService, 'hasCopilotTokenSource').get(() => false);
 		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
 
 		await assert.rejects(

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1390,7 +1390,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize('chat.byokUtilityModelDefault.mainAgent.description', "Use the selected BYOK main agent model."),
 				nls.localize('chat.byokUtilityModelDefault.copilot.description', "Use the default GitHub Copilot utility models."),
 			],
-			default: BYOKUtilityModelDefault.None,
+			default: BYOKUtilityModelDefault.Copilot,
 		},
 		[ChatConfiguration.UtilityModel]: {
 			type: 'string',


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/324243, https://github.com/microsoft/vscode/issues/325150,

**Problem**

When the selected main agent model is a bring-your-own-key (BYOK) model and no utility model is configured, built-in "utility" flows (title generation, participant/intent detection, @vscode question refinement, workspace search, commit-message generation, rename suggestions, etc.) had no model to run on. chat.byokUtilityModelDefault defaulted to none, so ProductionEndpointProvider._resolveUtilityFamily threw:
`No utility model is configured for 'copilot-utility-small' while the selected main agent model is BYOK.`

For fire-and-forget/background flows this surfaced as an unhandled-error in telemetry; for critical-path flows like @vscode it produced a blocking, user-visible error. 

**Fix**

Change the default of chat.byokUtilityModelDefault from none to copilot, so that when the main agent model is BYOK and the user hasn't configured a dedicated utility model, built-in utility flows fall back to GitHub Copilot's utility models. Users who explicitly want a different behavior can still choose mainAgent (reuse their BYOK model) or none (opt out), or set a specific model via chat.utilityModel / chat.utilitySmallModel setting.

For airgapped (not signed in) case, Copilot utility model cannot be used, and error message is shown asking user to choose a utility model.