### PR TITLE
Propagate asExternalUri resolver errors

### DIFF
--- a/src/vs/editor/browser/services/openerService.ts
+++ b/src/vs/editor/browser/services/openerService.ts
@@ -16,7 +16,7 @@ import { URI } from '../../../base/common/uri.js';
 import { ICodeEditorService } from './codeEditorService.js';
 import { ICommandService } from '../../../platform/commands/common/commands.js';
 import { EditorOpenSource } from '../../../platform/editor/common/editor.js';
-import { extractSelection, IExternalOpener, IExternalUriResolver, IOpener, IOpenerService, IResolvedExternalUri, IValidator, OpenOptions, ResolveExternalUriOptions } from '../../../platform/opener/common/opener.js';
+import { extractSelection, IExternalOpener, IExternalUriResolver, IOpener, IOpenerService, IResolvedExternalUri, IValidator, NoExternalUriResolverError, OpenOptions, ResolveExternalUriOptions } from '../../../platform/opener/common/opener.js';
 
 class CommandOpener implements IOpener {
 
@@ -199,6 +199,9 @@ export class OpenerService implements IOpenerService {
 	}
 
 	async resolveExternalUri(resource: URI, options?: ResolveExternalUriOptions): Promise<IResolvedExternalUri> {
+		let lastError: unknown;
+		let hasResolverError = false;
+
 		for (const resolver of this._resolvers) {
 			try {
 				const result = await resolver.resolveExternalUri(resource, options);
@@ -208,12 +211,17 @@ export class OpenerService implements IOpenerService {
 					}
 					return result;
 				}
-			} catch {
-				// noop
+			} catch (error) {
+				lastError = error;
+				hasResolverError = true;
 			}
 		}
 
-		throw new Error('Could not resolve external URI: ' + resource.toString());
+		if (hasResolverError) {
+			throw lastError;
+		}
+
+		throw new NoExternalUriResolverError(resource);
 	}
 
 	private async _doOpenExternal(resource: URI | string, options: OpenOptions | undefined): Promise<boolean> {

--- a/src/vs/editor/test/browser/services/openerService.test.ts
+++ b/src/vs/editor/test/browser/services/openerService.test.ts
@@ -13,6 +13,7 @@ import { NullCommandService } from '../../../../platform/commands/test/common/nu
 import { ITextEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { matchesScheme, matchesSomeScheme } from '../../../../base/common/network.js';
 import { TestThemeService } from '../../../../platform/theme/test/common/testThemeService.js';
+import { NoExternalUriResolverError } from '../../../../platform/opener/common/opener.js';
 
 suite('OpenerService', function () {
 	const themeService = new TestThemeService();
@@ -278,6 +279,57 @@ suite('OpenerService', function () {
 		const result = await openerService.resolveExternalUri(URI.parse('file:///Users/user/folder'));
 		assert.deepStrictEqual(result.resolved.toString(), 'file:///Users/user/folder');
 		disposable.dispose();
+	});
+
+	test('resolveExternalUri continues after resolver errors', async function () {
+		const openerService = new OpenerService(editorService, NullCommandService);
+		const uri = URI.parse('https://example.com/path');
+		const expectedError = new Error('first resolver failed');
+
+		store.add(openerService.registerExternalUriResolver({
+			async resolveExternalUri() {
+				throw expectedError;
+			}
+		}));
+		store.add(openerService.registerExternalUriResolver({
+			async resolveExternalUri(resource) {
+				return { resolved: resource, dispose() { } };
+			}
+		}));
+
+		const result = await openerService.resolveExternalUri(uri);
+
+		assert.strictEqual(result.resolved.toString(), uri.toString());
+	});
+
+	test('resolveExternalUri propagates the last resolver error', async function () {
+		const openerService = new OpenerService(editorService, NullCommandService);
+		const expectedError = new Error('resolver failed');
+
+		store.add(openerService.registerExternalUriResolver({
+			async resolveExternalUri() {
+				throw expectedError;
+			}
+		}));
+		store.add(openerService.registerExternalUriResolver({
+			async resolveExternalUri() {
+				return undefined;
+			}
+		}));
+
+		await assert.rejects(openerService.resolveExternalUri(URI.parse('https://example.com/path')), error => error === expectedError);
+	});
+
+	test('resolveExternalUri reports when no resolver handles the uri', async function () {
+		const openerService = new OpenerService(editorService, NullCommandService);
+
+		store.add(openerService.registerExternalUriResolver({
+			async resolveExternalUri() {
+				return undefined;
+			}
+		}));
+
+		await assert.rejects(openerService.resolveExternalUri(URI.parse('https://example.com/path')), NoExternalUriResolverError);
 	});
 
 	test('vscode.open command can\'t open HTTP URL with hash (#) in it [extension development] #140907', async function () {

--- a/src/vs/platform/opener/common/opener.ts
+++ b/src/vs/platform/opener/common/opener.ts
@@ -71,6 +71,12 @@ export interface IExternalUriResolver {
 	resolveExternalUri(resource: URI, options?: OpenOptions): Promise<{ resolved: URI; dispose(): void } | undefined>;
 }
 
+export class NoExternalUriResolverError extends Error {
+	constructor(resource: URI) {
+		super('Could not resolve external URI: ' + resource.toString());
+	}
+}
+
 export interface IOpenerService {
 
 	readonly _serviceBrand: undefined;

--- a/src/vs/workbench/api/browser/mainThreadWindow.ts
+++ b/src/vs/workbench/api/browser/mainThreadWindow.ts
@@ -5,8 +5,9 @@
 
 import { Event } from '../../../base/common/event.js';
 import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { matchesScheme, Schemas } from '../../../base/common/network.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
-import { IOpenerService } from '../../../platform/opener/common/opener.js';
+import { IOpenerService, NoExternalUriResolverError } from '../../../platform/opener/common/opener.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { ExtHostContext, ExtHostWindowShape, IOpenUriOptions, MainContext, MainThreadWindowShape } from '../common/extHost.protocol.js';
 import { IHostService } from '../../services/host/browser/host.js';
@@ -73,7 +74,17 @@ export class MainThreadWindow implements MainThreadWindowShape {
 	}
 
 	async $asExternalUri(uriComponents: UriComponents, options: IOpenUriOptions): Promise<UriComponents> {
-		const result = await this.openerService.resolveExternalUri(URI.revive(uriComponents), options);
-		return result.resolved;
+		const uri = URI.revive(uriComponents);
+
+		try {
+			const result = await this.openerService.resolveExternalUri(uri, options);
+			return result.resolved;
+		} catch (error) {
+			if (error instanceof NoExternalUriResolverError && (matchesScheme(uri, Schemas.http) || matchesScheme(uri, Schemas.https))) {
+				return uri;
+			}
+
+			throw error;
+		}
 	}
 }

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -9,7 +9,7 @@ import { AsyncIterableObject, raceCancellationError } from '../../../base/common
 import * as errors from '../../../base/common/errors.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { combinedDisposable } from '../../../base/common/lifecycle.js';
-import { Schemas, matchesScheme } from '../../../base/common/network.js';
+import { Schemas } from '../../../base/common/network.js';
 import Severity from '../../../base/common/severity.js';
 import { URI } from '../../../base/common/uri.js';
 import { TextEditorCursorStyle } from '../../../editor/common/config/editorOptions.js';
@@ -467,15 +467,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 					return extHostUrls.createAppUri(uri);
 				}
 
-				try {
-					return await extHostWindow.asExternalUri(uri, { allowTunneling: !!initData.remote.authority });
-				} catch (err) {
-					if (matchesScheme(uri, Schemas.http) || matchesScheme(uri, Schemas.https)) {
-						return uri;
-					}
-
-					throw err;
-				}
+				return extHostWindow.asExternalUri(uri, { allowTunneling: !!initData.remote.authority });
 			},
 			get remoteName() {
 				return getRemoteName(initData.remote.authority);

--- a/src/vs/workbench/api/test/browser/mainThreadWindow.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadWindow.test.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { OpenerService } from '../../../../editor/browser/services/openerService.js';
+import { TestCodeEditorService } from '../../../../editor/test/browser/editorTestServices.js';
+import { NullCommandService } from '../../../../platform/commands/test/common/nullCommandService.js';
+import { TestThemeService } from '../../../../platform/theme/test/common/testThemeService.js';
+import { MainThreadWindow } from '../../browser/mainThreadWindow.js';
+
+suite('MainThreadWindow', function () {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createOpenerService() {
+		return new OpenerService(store.add(new TestCodeEditorService(new TestThemeService())), NullCommandService);
+	}
+
+	function asExternalUri(openerService: OpenerService, uri: URI) {
+		const mainThreadWindow = { openerService } as unknown as MainThreadWindow;
+		return MainThreadWindow.prototype.$asExternalUri.call(mainThreadWindow, uri, { allowTunneling: false });
+	}
+
+	test('returns unresolved http uris unchanged', async function () {
+		const openerService = createOpenerService();
+		const uri = URI.parse('https://example.com/path');
+
+		const result = await asExternalUri(openerService, uri);
+
+		assert.strictEqual(URI.from(result).toString(), uri.toString());
+	});
+
+	test('propagates external uri resolver errors', async function () {
+		const openerService = createOpenerService();
+		const expectedError = new Error('resolver failed');
+		store.add(openerService.registerExternalUriResolver({
+			async resolveExternalUri() {
+				throw expectedError;
+			}
+		}));
+
+		await assert.rejects(asExternalUri(openerService, URI.parse('https://example.com/path')), error => error === expectedError);
+	});
+});


### PR DESCRIPTION
Fixes #162770

This change distinguishes an unhandled external URI from a resolver failure. HTTP and HTTPS URIs still fall back to the original URI when no resolver handles them, while actual resolver errors now propagate back to the extension. Resolver failures also do not prevent a later resolver from succeeding.

Tests cover the main-thread fallback and error path, plus multi-resolver success, failure, and unhandled cases.

Testing:
- `npm run typecheck-client`
- `npm run gulp compile-client`
- `scripts\test.bat --grep MainThreadWindow` (2 passing)
- `scripts\test.bat --grep OpenerService` (20 passing)
- `npm run eslint`
- `npm run valid-layers-check`