### PR TITLE
Style overrides: Update activity bar dimensions

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -49,8 +49,8 @@ export class ActivitybarPart extends Part {
 	static readonly COMPACT_ACTIVITYBAR_WIDTH = 36;
 
 	/** Narrower dimensions used when the floating panels (Modern UI) experiment is enabled. */
-	static readonly FLOATING_ACTION_HEIGHT = 44;
-	static readonly FLOATING_ACTIVITYBAR_WIDTH = 44;
+	static readonly FLOATING_ACTION_HEIGHT = 36;
+	static readonly FLOATING_ACTIVITYBAR_WIDTH = 36;
 	static readonly FLOATING_COMPACT_ACTIVITYBAR_WIDTH = 32;
 
 	static readonly ICON_SIZE = 24;

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -43,7 +43,7 @@ import { SwitchCompositeViewAction } from '../compositeBarActions.js';
 export class ActivitybarPart extends Part {
 
 	static readonly ACTION_HEIGHT = 48;
-	static readonly COMPACT_ACTION_HEIGHT = 32;
+	static readonly COMPACT_ACTION_HEIGHT = 28;
 
 	static readonly ACTIVITYBAR_WIDTH = 48;
 	static readonly COMPACT_ACTIVITYBAR_WIDTH = 36;
@@ -51,7 +51,7 @@ export class ActivitybarPart extends Part {
 	/** Narrower dimensions used when the floating panels (Modern UI) experiment is enabled. */
 	static readonly FLOATING_ACTION_HEIGHT = 36;
 	static readonly FLOATING_ACTIVITYBAR_WIDTH = 36;
-	static readonly FLOATING_COMPACT_ACTIVITYBAR_WIDTH = 32;
+	static readonly FLOATING_COMPACT_ACTIVITYBAR_WIDTH = 28;
 
 	static readonly ICON_SIZE = 24;
 	static readonly COMPACT_ICON_SIZE = 16;

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -170,7 +170,7 @@
 }
 
 .monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
-	top: 17px;
+	top: 13px;
 	right: 6px;
 	min-width: 9px;
 	height: 13px;
@@ -197,7 +197,7 @@
 .monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .profile-badge .profile-text-overlay {
 	font-size: 8px;
 	line-height: 8px;
-	top: 14px;
+	top: 10px;
 	right: 2px;
 	padding: 2px 2px;
 	border-radius: 6px;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -18,7 +18,7 @@
  * pushed behind the icon (which lives on the action-label at z-index 1) so the
  * icon stays legible on top of the fill. The size is derived from the activity
  * bar's own CSS variables so it works for both the normal (36px) and compact
- * (32px wide / 32px tall) layouts. Bar width equals action height in both sizes,
+ * (28px wide / 28px tall) layouts. Bar width equals action height in both sizes,
  * so the box is a centered square and `left` keeps it horizontally centered.
  */
 .style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
@@ -31,10 +31,10 @@
 	background-color: var(--vscode-activityBar-activeBackground, var(--vscode-list-inactiveSelectionBackground));
 }
 
-/* Compact: minimal horizontal inset — 28×28px box centered in the 32px item. */
+/* Compact: minimal horizontal inset — 24×24px box centered in the 28px item. */
 .style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
-	width: calc(var(--activity-bar-action-height, 32px) - 4px);
-	height: calc(var(--activity-bar-action-height, 32px) - 4px);
+	width: calc(var(--activity-bar-action-height, 28px) - 4px);
+	height: calc(var(--activity-bar-action-height, 28px) - 4px);
 }
 
 /*
@@ -92,11 +92,11 @@
 	background-color: var(--vscode-list-hoverBackground);
 }
 
-/* Compact: minimal horizontal inset — 28×28px box centered in the 32px item. */
+/* Compact: minimal horizontal inset — 24×24px box centered in the 28px item. */
 .style-override .activitybar.compact > .content:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover::before {
 	left: 2px;
-	width: calc(var(--activity-bar-action-height, 32px) - 4px);
-	height: calc(var(--activity-bar-action-height, 32px) - 4px);
+	width: calc(var(--activity-bar-action-height, 28px) - 4px);
+	height: calc(var(--activity-bar-action-height, 28px) - 4px);
 }
 
 /*
@@ -329,6 +329,6 @@
 }
 
 .style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
-	top: 17px;
+	top: 13px;
 	right: 2px;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -17,16 +17,16 @@
  * Turn the active item indicator into an inset, rounded background box. It is
  * pushed behind the icon (which lives on the action-label at z-index 1) so the
  * icon stays legible on top of the fill. The size is derived from the activity
- * bar's own CSS variables so it works for both the normal (44px) and compact
+ * bar's own CSS variables so it works for both the normal (36px) and compact
  * (32px wide / 32px tall) layouts. Bar width equals action height in both sizes,
  * so the box is a centered square and `left` keeps it horizontally centered.
  */
 .style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
 	z-index: 0;
 	top: 0;
-	left: calc((var(--activity-bar-width, 44px) - var(--activity-bar-action-height, 44px) + 4px) / 2);
-	width: calc(var(--activity-bar-action-height, 44px) - 4px);
-	height: calc(var(--activity-bar-action-height, 44px) - 4px);
+	left: calc((var(--activity-bar-width, 36px) - var(--activity-bar-action-height, 36px) + 4px) / 2);
+	width: calc(var(--activity-bar-action-height, 36px) - 4px);
+	height: calc(var(--activity-bar-action-height, 36px) - 4px);
 	border-radius: var(--vscode-cornerRadius-medium);
 	background-color: var(--vscode-activityBar-activeBackground, var(--vscode-list-inactiveSelectionBackground));
 }
@@ -85,9 +85,9 @@
 	top: 0;
 	bottom: 0;
 	margin: auto;
-	left: calc((var(--activity-bar-width, 44px) - var(--activity-bar-action-height, 44px) + 4px) / 2);
-	width: calc(var(--activity-bar-action-height, 44px) - 4px);
-	height: calc(var(--activity-bar-action-height, 44px) - 4px);
+	left: calc((var(--activity-bar-width, 36px) - var(--activity-bar-action-height, 36px) + 4px) / 2);
+	width: calc(var(--activity-bar-action-height, 36px) - 4px);
+	height: calc(var(--activity-bar-action-height, 36px) - 4px);
 	border-radius: var(--vscode-cornerRadius-medium);
 	background-color: var(--vscode-list-hoverBackground);
 }
@@ -324,7 +324,7 @@
 }
 
 .style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
-	top: 26px;
+	top: 18px;
 	right: 2px;
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -332,3 +332,11 @@
 	top: 13px;
 	right: 2px;
 }
+
+.style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .profile-badge .profile-text-overlay {
+	top: 16px;
+}
+
+.style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .profile-badge .profile-text-overlay {
+	top: 10px;
+}

--- a/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
+++ b/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
@@ -134,7 +134,7 @@ suite('ActivitybarPart', () => {
 			},
 			{
 				width: 36,
-				actionHeight: 32,
+				actionHeight: 28,
 				iconSize: 16,
 			}
 		);
@@ -148,9 +148,9 @@ suite('ActivitybarPart', () => {
 				compactWidth: ActivitybarPart.FLOATING_COMPACT_ACTIVITYBAR_WIDTH,
 			},
 			{
-				width: 44,
-				actionHeight: 44,
-				compactWidth: 32,
+				width: 36,
+				actionHeight: 36,
+				compactWidth: 28,
 			}
 		);
 	});


### PR DESCRIPTION
This pull request updates the Activity Bar's sizing and layout to use smaller, more modern dimensions, especially for the floating panels and compact modes. The main focus is on aligning the TypeScript constants and CSS variables for action heights and widths, as well as adjusting badge positioning for better visual consistency.

<img width="1320" height="1536" alt="image" src="https://github.com/user-attachments/assets/8a465330-59c2-41b1-97e2-5121b433c808" />


**Activity Bar Dimension Updates:**

* Reduced the `COMPACT_ACTION_HEIGHT`, `FLOATING_ACTION_HEIGHT`, `FLOATING_ACTIVITYBAR_WIDTH`, and `FLOATING_COMPACT_ACTIVITYBAR_WIDTH` constants in `activitybarPart.ts` to smaller values for a more compact UI.
* Updated CSS variables in `activityBar.css` to match the new default and compact sizes (normal: 36px, compact: 28px), ensuring the active item indicator and hover backgrounds are correctly sized and centered. [[1]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL20-R37) [[2]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL88-R99)

**Badge Position Adjustments:**

* Modified the `.badge-content` `top` positions in both normal and compact modes for better alignment with the new, smaller Activity Bar dimensions.

Resolves https://github.com/microsoft/vscode/issues/325571