### PR TITLE
voice: send request_narration only after session context is sent

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -46,6 +46,10 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	private _isResuming = false;
 	private _window: (Window & typeof globalThis) | undefined;
 	private _lastSessionId: string | undefined;
+	// Set once start_session/resume_session (which carries session_context) has
+	// been sent on the current connection; reset per connection. Gates
+	// requestNarration so the backend has the session before a narration request.
+	private _sessionContextSent = false;
 
 	// --- Keep-alive ping/pong ---
 	private _pingTimer: ReturnType<Window['setInterval']> | undefined;
@@ -213,6 +217,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 			this._reconnectAttempts = 0;
 			this._reconnectStartedAt = undefined;
 			this._isResuming = !!this._lastSessionId;
+			this._sessionContextSent = false;
 			this._setConnected(true);
 			this._startPing();
 
@@ -602,7 +607,11 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	}
 
 	requestNarration(codingSessionId: string, kind: 'response' | 'confirmation', text: string): string | undefined {
-		if (this._ws?.readyState === WebSocket.OPEN) {
+		// Gate on session_context having been sent: the WS preserves send order,
+		// so the backend processes start_session/resume_session before any
+		// request_narration. Pre-session this returns undefined, so _narrate queues
+		// a retry that onSessionInit replays once the session exists.
+		if (this._ws?.readyState === WebSocket.OPEN && this._sessionContextSent) {
 			const narrationId = generateUuid();
 			this._ws.send(JSON.stringify({ type: 'request_narration', coding_session_id: codingSessionId, kind, text, narration_id: narrationId }));
 			this._logService.trace(`[voice] request_narration kind=${kind} id=${codingSessionId.slice(-32)} narration_id=${narrationId.slice(0, 8)}`);
@@ -644,6 +653,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 				payload.prior_timeline = priorTimeline;
 			}
 			this._ws.send(JSON.stringify(payload));
+			this._sessionContextSent = true;
 		}
 	}
 
@@ -653,6 +663,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 			// `auto_narrate: false` for the same reason as start_session: this client
 			// drives narration, so the backend must not also auto-narrate.
 			this._ws.send(JSON.stringify({ type: 'resume_session', session_id: this._lastSessionId, session_context: context, machine_id: machineId, turn_config: this._getTurnConfig(), voice: this._getVoice(), auto_narrate: false }));
+			this._sessionContextSent = true;
 		}
 	}
 


### PR DESCRIPTION
Stacked on #325682 (base = `megrogge/voice-backend-narrate-api`), follow-up to the auto-narrate opt-out from #325799.

## Problem
`requestNarration` only checks that the socket is `OPEN`. A focus- or state-driven narration can therefore be sent in the window between the WebSocket opening and `start_session` / `resume_session` being sent. The backend drops a `request_narration` that arrives before the session exists, but the client still gets a narration id back and treats the audio as inbound: it tears down listening via `_prepareForPlayback`, records a solicited narration id, and arms a safety timer for audio that never arrives. The narration is not queued for replay, so it is lost until the next focus/state event.

## Solution
Track whether `start_session` / `resume_session` (which carries `session_context`) has been sent on the current connection (`_sessionContextSent`, reset per connection in `onopen`, set after each send) and gate `requestNarration` on it. The WebSocket preserves send order, so this guarantees the backend has processed the session before it sees a narration request. Pre-session, `requestNarration` now returns `undefined`, so `_narrate` queues the item in `_pendingNarrationRetries` and `onSessionInit` replays it once the session exists — reusing the existing retry path.

## Tests
None. This file has no existing unit tests and the change is a small ordering guard on the WS send path; adding a WebSocket-mocking harness for it is out of scope for this follow-up. Verified by tracing the client/backend ordering and the `_narrate` / `onSessionInit` replay interaction.

## Risks
Low. Behavior only changes in the pre-session-init window: narration is deferred to `session_init` replay instead of being sent-then-dropped. Steady-state narration is unaffected (`_sessionContextSent` is true once the session is established).

## Non-goals
No backend changes; no change to the narration payload or the `auto_narrate` opt-out.