### PR TITLE
Remove dead CODEOWNERS rules for deleted no-package-lock / no-yarn-lock workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,5 @@
 # GitHub actions required reviewers
 .github/workflows/monaco-editor.yml @hediet @alexdima @lszomoru
-.github/workflows/no-package-lock-changes.yml @lszomoru @alexdima @sandy081 @TylerLeonhardt @rzhao271 @Yoyokrazy
-.github/workflows/no-yarn-lock-changes.yml @lszomoru @alexdima @sandy081 @TylerLeonhardt @rzhao271 @Yoyokrazy
 .github/workflows/pr-darwin-test.yml @lszomoru @alexdima @sandy081 @TylerLeonhardt @rzhao271 @Yoyokrazy
 .github/workflows/pr-linux-cli-test.yml @lszomoru @alexdima @sandy081 @TylerLeonhardt @rzhao271 @Yoyokrazy
 .github/workflows/pr-linux-test.yml @lszomoru @alexdima @sandy081 @TylerLeonhardt @rzhao271 @Yoyokrazy


### PR DESCRIPTION
Hi, and thank you for VS Code.

Small CODEOWNERS cleanup. `.github/CODEOWNERS` (lines 3–4) assign required reviewers to two workflow files that no longer exist:

```
.github/workflows/no-package-lock-changes.yml @lszomoru @alexdima @sandy081 @TylerLeonhardt @rzhao271 @Yoyokrazy
.github/workflows/no-yarn-lock-changes.yml    @lszomoru @alexdima @sandy081 @TylerLeonhardt @rzhao271 @Yoyokrazy
```

Both target files return 404:

```
$ gh api repos/microsoft/vscode/contents/.github/workflows/no-package-lock-changes.yml  # → 404
$ gh api repos/microsoft/vscode/contents/.github/workflows/no-yarn-lock-changes.yml     # → 404
```

Since the paths don't exist, these rules match nothing. This PR removes the two dead lines and leaves all the live workflow-owner rules untouched.

For transparency: I used AI assistance to spot and draft this; I verified the 404s myself.
