### PR TITLE
Style overrides: Improve alignment of notifications center and toasts

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -136,6 +136,15 @@
 }
 
 /*
+ * Notifications center header title — the shared ramp above only handles casing
+ * and size. Its semibold weight lives here so all of this header's typography
+ * stays in one module.
+ */
+.style-override.monaco-workbench > .notifications-center > .notifications-center-header > .notifications-center-header-title {
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
+}
+
+/*
  * File Explorer titles — respect the real casing of the workspace / folder name
  * (user input). `text-transform: none` overrides both the base `uppercase` rule
  * and the `capitalize` override above (the `:has(...)` argument raises

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
@@ -27,6 +27,56 @@
 	margin-left: 24px;
 }
 
+/*
+ * Reposition the notification center so it sits further inside the workbench
+ * edges. `!important` is required to win over the base positioning rules (which
+ * vary with the status bar) and, for `top-right`, over the inline `top` offset
+ * the notification controller applies in JS.
+ */
+.style-override.monaco-workbench > .notifications-center {
+	right: 8px !important;
+	bottom: 34px !important;
+}
+
+.style-override.monaco-workbench > .notifications-center.bottom-left {
+	right: auto !important;
+	left: 8px !important;
+	bottom: 34px !important;
+}
+
+.style-override.monaco-workbench > .notifications-center.top-right {
+	bottom: auto !important;
+	top: 35px !important;
+}
+
+/*
+ * Toasts match the center, but each toast carries a 4px margin, so the
+ * container offsets are reduced by 4px to keep the visible surface aligned.
+ */
+.style-override.monaco-workbench > .notifications-toasts {
+	right: 4px !important;
+	bottom: 30px !important;
+}
+
+.style-override.monaco-workbench > .notifications-toasts.bottom-left {
+	right: auto !important;
+	left: 4px !important;
+	bottom: 30px !important;
+}
+
+.style-override.monaco-workbench > .notifications-toasts.top-right {
+	bottom: auto !important;
+	top: 31px !important;
+}
+
+.style-override.monaco-workbench > .notifications-center > .notifications-center-header > .notifications-center-header-title {
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
+}
+
+.style-override.monaco-workbench > .notifications-center > .notifications-center-header {
+	padding-right: 2px;
+}
+
 .style-override .monaco-dialog-box {
 	padding: 4px;
 	min-width: 440px;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
@@ -28,10 +28,15 @@
 }
 
 /*
- * Reposition the notification center so it sits further inside the workbench
- * edges. `!important` is required to win over the base positioning rules (which
- * vary with the status bar) and, for `top-right`, over the inline `top` offset
- * the notification controller applies in JS.
+ * Reposition the notification center to sit within the Modern UI outer gutter:
+ * an 8px horizontal inset, and a bottom inset that clears the 22px status bar
+ * plus the gutter (34px total). `!important` is required to win over the base
+ * positioning rules (which vary with the status bar) and, for `top-right`, over
+ * the inline `top` offset the notification controller applies in JS.
+ *
+ * `top-right` uses a fixed 35px — the height of the custom title bar
+ * (DEFAULT_CUSTOM_TITLEBAR_HEIGHT), which the Modern UI experiment always shows
+ * — so the center tucks directly beneath it.
  */
 .style-override.monaco-workbench > .notifications-center {
 	right: 8px !important;
@@ -50,8 +55,9 @@
 }
 
 /*
- * Toasts match the center, but each toast carries a 4px margin, so the
- * container offsets are reduced by 4px to keep the visible surface aligned.
+ * Toasts mirror the center, but each toast carries a 4px margin, so every
+ * container offset is reduced by 4px to keep the visible toast surface aligned
+ * with the center (8px / 34px / 35px once the margin is added back).
  */
 .style-override.monaco-workbench > .notifications-toasts {
 	right: 4px !important;
@@ -67,10 +73,6 @@
 .style-override.monaco-workbench > .notifications-toasts.top-right {
 	bottom: auto !important;
 	top: 31px !important;
-}
-
-.style-override.monaco-workbench > .notifications-center > .notifications-center-header > .notifications-center-header-title {
-	font-weight: var(--vscode-agents-fontWeight-semiBold);
 }
 
 .style-override.monaco-workbench > .notifications-center > .notifications-center-header {


### PR DESCRIPTION
This pull request updates the notification center and toast notifications styling to better align with the Modern UI layout and improve typography consistency. The main changes include repositioning notification elements for consistent spacing, aligning toast notifications with the notification center, and applying a semibold font weight to the notification center header title.

<img width="2080" height="1892" alt="image" src="https://github.com/user-attachments/assets/6a9c41ac-08d7-40eb-8657-747310af9e1a" />


**Notification positioning and alignment:**

* Repositioned the notification center (`.notifications-center`) to sit within the Modern UI's outer gutter, adding an 8px horizontal inset and a 34px bottom inset to clear the status bar and gutter. Adjusted positioning for `bottom-left` and `top-right` variants to ensure consistent placement, including a fixed top offset for `top-right` to account for the custom title bar height. (`[src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.cssR30-R81](diffhunk://#diff-c5122c2b03b035b623843dbb023ad264a4b1b7da4ad722e800292178087267e5R30-R81)`)
* Updated toast notifications (`.notifications-toasts`) to mirror the notification center's alignment, reducing container offsets by 4px to account for the toast margin and maintain visual alignment. Positioning is adjusted for `bottom-left` and `top-right` variants as well. (`[src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.cssR30-R81](diffhunk://#diff-c5122c2b03b035b623843dbb023ad264a4b1b7da4ad722e800292178087267e5R30-R81)`)

**Typography improvements:**

* Applied a semibold font weight to the notification center header title (`.notifications-center-header-title`) to ensure consistent and distinct header typography. (`[src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.cssR138-R146](diffhunk://#diff-949ec94438c04f89d57f6ad30dfdd93a1ea7e72c5d2d51b032ed5e6c16d0901fR138-R146)`)
* Added a small padding adjustment (`padding-right: 2px`) to the notification center header for improved layout. (`[src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.cssR30-R81](diffhunk://#diff-c5122c2b03b035b623843dbb023ad264a4b1b7da4ad722e800292178087267e5R30-R81)`)