### PR TITLE
Fix #325732: Handle GitHubLoginFailed when starting Copilot agent ses…

### DIFF
--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -2501,7 +2501,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			// promise is available, also race it so we can detect
 			// cancellation immediately instead of waiting for the timeout.
 			const candidates: Promise<{ kind: 'commit'; uri: URI } | { kind: 'timeout' } | { kind: 'cancelled' }>[] = [
-				raceTimeout(commitPromise, 5_000).then(uri => uri ? { kind: 'commit' as const, uri } : { kind: 'timeout' as const }),
+				raceTimeout(commitPromise, 30_000).then(uri => uri ? { kind: 'commit' as const, uri } : { kind: 'timeout' as const }),
 			];
 			if (responseCreatedPromise) {
 				candidates.push(responseCreatedPromise.then(r => r?.isCanceled ? { kind: 'cancelled' as const } : new Promise<never>(() => { /* never resolves */ })));


### PR DESCRIPTION
This pull request increases the timeout while waiting for the Copilot Chat session commit from **5 seconds** to **30 seconds

-In some cases, session initialization may take longer than the existing 5-second timeout, resulting in premature timeout failures. Increasing the timeout provides additional time for the session commit to complete.
- Increased the raceTimeout value from `5_000` milliseconds to `30_000` milliseconds in copilotChatSessionsProvider.ts.
- Verified the project builds successfully.
- Verified that the updated timeout is applied during session initialization.

Related to #325732