### PR TITLE
Update padding in extension bookmark container

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -15,7 +15,7 @@
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
-	padding: 0 0 0 20px;
+	padding: 0 0 0 var(--vscode-spacing-size160);
 	overflow: hidden;
 	display: flex;
 }


### PR DESCRIPTION
Adjust the padding in the extension bookmark container to use a variable for consistent spacing. This change enhances the layout and visual consistency across the extension interface.

Fixes https://github.com/microsoft/vscode/issues/325565