### PR TITLE
Style overrides: Adjust status bar padding for floating panels

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -174,6 +174,15 @@
 	padding-right: var(--vscode-spacing-size20);
 }
 
+/* When the activity bar is hidden its grid cell loses the `visible` class the
+ * split view toggles. With no bar to align to, fall back to the standard 4px
+ * inset. This has higher specificity than the compact rule above, so a hidden
+ * compact bar still resolves to 4px. */
+.monaco-workbench.floating-panels:has(.split-view-view:not(.visible) .part.activitybar) .part.statusbar {
+	padding-left: var(--vscode-spacing-size40);
+	padding-right: var(--vscode-spacing-size40);
+}
+
 .monaco-workbench.floating-panels .part.statusbar > .items-container > .statusbar-item.left.first-visible-item,
 .monaco-workbench.floating-panels .part.statusbar > .items-container > .statusbar-item.left.first-visible-item > .statusbar-item-label {
 	padding-left: var(--vscode-spacing-size40);

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -160,19 +160,24 @@
 
 /* Inset and vertically center the status bar items within its floating gutter. */
 .monaco-workbench.floating-panels .part.statusbar {
-	padding: var(--vscode-spacing-size40);
+	padding-left: var(--vscode-spacing-size60);
+	padding-right: var(--vscode-spacing-size60);
 	padding-top: calc(var(--vscode-spacing-size40) - var(--vscode-strokeThickness)); /* offset for the border-top of the status bar */
 	padding-bottom: calc(var(--vscode-spacing-size40) + var(--vscode-strokeThickness)); /* offset for the border-bottom of the status bar */
 }
 
-.monaco-workbench.floating-panels .part.statusbar > .items-container > .statusbar-item.left.first-visible-item {
-	padding-left: 4px;
+/* With a compact activity bar the horizontal inset is tightened to match. The
+ * `compact` class lives on the activity bar element, so `:has()` lets the status
+ * bar (a sibling part) react without any code-side class plumbing. */
+.monaco-workbench.floating-panels:has(.part.activitybar.compact) .part.statusbar {
+	padding-left: var(--vscode-spacing-size20);
+	padding-right: var(--vscode-spacing-size20);
 }
 
+.monaco-workbench.floating-panels .part.statusbar > .items-container > .statusbar-item.left.first-visible-item,
 .monaco-workbench.floating-panels .part.statusbar > .items-container > .statusbar-item.left.first-visible-item > .statusbar-item-label {
-	padding-left: 4px;
+	padding-left: var(--vscode-spacing-size40);
 }
-
 /*
  * When the status bar is hidden every floating card sits directly against the window
  * bottom edge. Double the bottom margin (4px → 8px) to match the doubled outer gutter

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
@@ -89,3 +89,7 @@
 .style-override .part.statusbar > .items-container > .statusbar-item.compact-right > a.statusbar-item-label:hover:not(.disabled) {
 	background-image: linear-gradient(var(--vscode-toolbar-hoverBackground), var(--vscode-toolbar-hoverBackground));
 }
+
+.style-override .part.statusbar > .items-container > .statusbar-item.right.last-visible-item > .statusbar-item-label {
+	padding: 0 var(--vscode-spacing-size60);
+}


### PR DESCRIPTION
Improve the status bar padding for better alignment in floating panels, accommodating scenarios with a hidden activity bar and ensuring consistent spacing.

Fixes https://github.com/microsoft/vscode/issues/325761