### PR TITLE
chat: move Open in Agents beside command center

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -506,7 +506,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 				toolbarOptions: {
 					primaryGroup: () => true,
 				},
-				actionViewItemProvider: (action, options) => this.actionViewItemProvider(action, options),
+				actionViewItemProvider: (action, options) => createActionViewItem(this.instantiationService, action, options),
 				hoverDelegate: this.hoverDelegate
 			}));
 
@@ -623,7 +623,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	private actionViewItemProvider(action: IAction, options: IBaseActionViewItemOptions): IActionViewItem | undefined {
 
 		// --- Custom view items registered via IActionViewItemService
-		for (const menuId of [MenuId.TitleBar, MenuId.TitleBarAdjacentCenter, MenuId.LayoutControlMenu]) {
+		for (const menuId of [MenuId.TitleBar, MenuId.LayoutControlMenu]) {
 			const customViewItem = this.actionViewItemService.lookUp(menuId, action.id);
 			if (customViewItem) {
 				const result = customViewItem(action, options, this.instantiationService, getWindowId(this.element ? getWindow(this.element) : mainWindow));

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -506,7 +506,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 				toolbarOptions: {
 					primaryGroup: () => true,
 				},
-				actionViewItemProvider: (action, options) => createActionViewItem(this.instantiationService, action, options),
+				actionViewItemProvider: (action, options) => this.actionViewItemProvider(action, options),
 				hoverDelegate: this.hoverDelegate
 			}));
 
@@ -623,7 +623,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	private actionViewItemProvider(action: IAction, options: IBaseActionViewItemOptions): IActionViewItem | undefined {
 
 		// --- Custom view items registered via IActionViewItemService
-		for (const menuId of [MenuId.TitleBar, MenuId.LayoutControlMenu]) {
+		for (const menuId of [MenuId.TitleBar, MenuId.TitleBarAdjacentCenter, MenuId.LayoutControlMenu]) {
 			const customViewItem = this.actionViewItemService.lookUp(menuId, action.id);
 			if (customViewItem) {
 				const result = customViewItem(action, options, this.instantiationService, getWindowId(this.element ? getWindow(this.element) : mainWindow));

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -25,7 +25,7 @@ import { Schemas } from '../../../../../base/common/network.js';
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../../platform/workspace/common/workspace.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
-import { TitleBarLeadingActionsGroup, ToggleTitleBarConfigAction } from '../../../../browser/parts/titlebar/titlebarActions.js';
+import { ToggleTitleBarConfigAction } from '../../../../browser/parts/titlebar/titlebarActions.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { CHAT_CATEGORY } from '../../browser/actions/chatActions.js';
 import { IChatWidgetService } from '../../browser/chat.js';
@@ -53,8 +53,7 @@ export class OpenWorkspaceInAgentsWindowAction extends Action2 {
 				order: 1,
 				when: OPEN_AGENTS_WINDOW_PRECONDITION,
 			}, {
-				id: MenuId.TitleBar,
-				group: TitleBarLeadingActionsGroup,
+				id: MenuId.TitleBarAdjacentCenter,
 				order: -1000,
 				when: ContextKeyExpr.and(
 					OPEN_AGENTS_WINDOW_PRECONDITION,
@@ -220,7 +219,7 @@ export class OpenWorkspaceInAgentsContribution extends Disposable implements IWo
 		@IProductService productService: IProductService,
 	) {
 		super();
-		this._register(actionViewItemService.register(MenuId.TitleBar, OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, (action, options) => {
+		this._register(actionViewItemService.register(MenuId.TitleBarAdjacentCenter, OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, (action, options) => {
 			return instantiationService.createInstance(OpenWorkspaceInAgentsTitleBarWidget, action, options);
 		}, undefined));
 	}
@@ -493,4 +492,3 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 		this._update();
 	}
 }
-


### PR DESCRIPTION
## Summary
- place the Open in Agents title-bar action adjacent to the command center
- preserve its custom hover/focus widget by resolving registered action view items in the adjacent toolbar

## Validation
- `npm run typecheck-client`
- targeted hygiene check
- pre-commit hygiene hook