### PR TITLE
security: route external references through trust ref

### DIFF
--- a/extensions/json-language-features/server/README.md
+++ b/extensions/json-language-features/server/README.md
@@ -29,7 +29,7 @@ The server implements the following capabilities of the language server protocol
   - syntax errors
   - structural validation based on the document's [JSON schema](http://json-schema.org/).
 
-In order to load JSON schemas, the JSON server uses NodeJS `fs` modules by default and delegates all other schema requests to the client. For all other features, the JSON server only relies on the documents and settings provided by the client through the LSP.
+In the Node.js build, the JSON server uses the `fs` module to load `file` schemas by default and delegates all other schema requests to the client. The browser build delegates all schema requests to the client. For all other features, the JSON server only relies on the documents and settings provided by the client through the LSP.
 
 ### Client requirements
 

--- a/extensions/json-language-features/server/README.md
+++ b/extensions/json-language-features/server/README.md
@@ -29,7 +29,7 @@ The server implements the following capabilities of the language server protocol
   - syntax errors
   - structural validation based on the document's [JSON schema](http://json-schema.org/).
 
-In order to load JSON schemas, the JSON server uses NodeJS `http` and `fs` modules. For all other features, the JSON server only relies on the documents and settings provided by the client through the LSP.
+In order to load JSON schemas, the JSON server uses NodeJS `fs` modules by default and delegates all other schema requests to the client. For all other features, the JSON server only relies on the documents and settings provided by the client through the LSP.
 
 ### Client requirements
 
@@ -127,7 +127,6 @@ let clientOptions: LanguageClientOptions = {
 
 If `handledSchemaProtocols` is not set, the JSON language server will load the following URLs itself:
 
-- `http`, `https`: Loaded using NodeJS's HTTP support. Proxies can be configured through the settings.
 - `file`: Loaded using NodeJS's `fs` support.
 
 #### Schema content request

--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -88,7 +88,7 @@ const sortCodeActionKind = CodeActionKind.Source.concat('.sort', '.json');
 
 export function startServer(connection: Connection, runtime: RuntimeEnvironment) {
 
-	function getSchemaRequestService(handledSchemas: string[] = ['https', 'http', 'file']) {
+	function getSchemaRequestService(handledSchemas: string[] = ['file']) {
 		const builtInHandlers: { [protocol: string]: RequestService | undefined } = {};
 		for (const protocol of handledSchemas) {
 			if (protocol === 'file') {
@@ -576,7 +576,6 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 function getFullRange(document: TextDocument): Range {
 	return Range.create(Position.create(0, 0), document.positionAt(document.getText().length));
 }
-
 
 
 


### PR DESCRIPTION
this pull request routes external references through trust refs when resolving schemas for json. Previously we were only requesting to trust the "root" schema, but it can ref into something external, which brings additional security concerns, e.g. https://www.schemastore.org/openapi-overlay-1.X.json which refs into https://spec.openapis.org/overlay/1.0/schema/2026-04-01