### PR TITLE
Codex agent: MCP tools + customizations parity (config pickup, auth, .agents, client plugins)

### DIFF
--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -21,7 +21,7 @@ import { IProductService } from '../../../product/common/productService.js';
 import { createSchema, platformRootSchema, platformSessionSchema, schemaProperty, AgentHostMcpServersConfigKey, type ISchemaProperty, type SessionMode } from '../../common/agentHostSchema.js';
 import { createPricingMetaFromBilling, normalizeCAPIBilling } from '../../common/agentModelPricing.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
-import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, CODEX_AGENT_PROVIDER_ID, IActiveClient, IAgent, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatResult, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IMcpNotification, type AgentProvider } from '../../common/agentService.js';
+import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, CODEX_AGENT_PROVIDER_ID, IActiveClient, IAgent, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatResult, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IMcpNotification, type AgentProvider, type AuthenticateParams } from '../../common/agentService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { ActionType, isChatAction, type SessionAction, type ChatAction } from '../../common/state/sessionActions.js';
@@ -31,11 +31,11 @@ import { buildDefaultChatUri, parseChatUri, type ClientPluginCustomization, type
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { McpCustomizationController } from '../shared/mcpCustomizationController.js';
-import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpServersFromConfig, codexMcpToolsChanged, inventoryToSdkServers, translateCodexMcpStartupState, type ICodexMcpServerConfigJson, type ICodexMcpServerEntry } from './codexMcpServers.js';
+import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpServersFromConfig, codexMcpToolsChanged, codexStartupErrorNeedsAuth, injectCodexMcpAuthTokens, inventoryToSdkServers, normalizeCodexMcpResourceUrl, translateCodexMcpStartupState, type ICodexMcpServerConfigJson, type ICodexMcpServerEntry } from './codexMcpServers.js';
 import { codexHooksToContainers, codexSkillsToContainers } from './codexCustomizations.js';
 import { CodexClientCustomizationStore, codexMcpServersFromPlugins, codexSkillRootsFromPlugins, type ICodexClientPlugin } from './codexClientCustomizations.js';
 import { buildElicitationRequest, cancelledElicitationResponse, declinedElicitationResponse, elicitationResponseFromAnswers } from './codexElicitationMapper.js';
-import { McpServerStatus, type AhpMcpUiHostCapabilities, type Customization } from '../../common/state/protocol/channels-session/state.js';
+import { McpAuthRequiredReason, McpServerStatus, type AhpMcpUiHostCapabilities, type Customization, type McpServerState } from '../../common/state/protocol/channels-session/state.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IFileService } from '../../../files/common/files.js';
 import { INativeEnvironmentService } from '../../../environment/common/environment.js';
@@ -712,6 +712,16 @@ export class CodexAgent extends Disposable implements IAgent {
 	 * session's {@link ICodexSession.mcpController}. Keyed by server name.
 	 */
 	private readonly _mcpInventory = new Map<string, ICodexMcpServerEntry>();
+	/**
+	 * OAuth bearer tokens acquired for auth-gated http MCP servers, keyed by
+	 * the server's {@link normalizeCodexMcpResourceUrl | normalized URL} (the
+	 * OAuth `resource`). Populated by {@link handleAuthenticationToken} after
+	 * the workbench completes the sign-in, then injected into the per-thread
+	 * `http_headers` by {@link _buildSessionMcpServers}. Process-global: a
+	 * token for a given server URL applies to every session/thread that uses
+	 * it (codex runs one shared app-server).
+	 */
+	private readonly _mcpAuthTokens = new Map<string, string>();
 	private _githubToken: string | undefined;
 	private _connection: ConnectionState = { kind: 'idle' };
 	private _modelsRefreshPromise: Promise<void> | undefined;
@@ -772,6 +782,69 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 		this._logService.info('[Codex] Auth token updated');
 		return true;
+	}
+
+	/**
+	 * Receives a bearer token the workbench acquired for a protected resource
+	 * (the `authenticate` command is fanned out to every agent). If the
+	 * resource matches a configured auth-gated http MCP server, store the token
+	 * (so {@link _buildSessionMcpServers} injects it) and reconnect the affected
+	 * threads so codex picks it up. This is the codex end of the *same* OAuth
+	 * mechanism the Copilot agent uses: the workbench does the sign-in, the
+	 * agent injects the resulting bearer. Returns whether the token was
+	 * consumed by an MCP server (the GitHub agent token flows through
+	 * {@link authenticate} instead).
+	 */
+	async handleAuthenticationToken(params: AuthenticateParams): Promise<boolean> {
+		const normalized = normalizeCodexMcpResourceUrl(params.resource);
+		if (normalized === undefined) {
+			return false;
+		}
+		// Only claim the token when it targets a currently-configured http MCP server.
+		const matchesConfigured = [...this._sessions.values()].some(session =>
+			[...this._httpMcpServerUrls(session).values()].includes(normalized),
+		) || Object.values(codexMcpServersFromConfig(this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey)))
+			.some(server => server.url !== undefined && normalizeCodexMcpResourceUrl(server.url) === normalized);
+		if (!matchesConfigured) {
+			return false;
+		}
+		if (this._mcpAuthTokens.get(normalized) === params.token) {
+			return true;
+		}
+		this._mcpAuthTokens.set(normalized, params.token);
+		this._logService.info(`[Codex] stored MCP auth token for ${params.resource}; reconnecting affected sessions`);
+		await this._reconnectSessionsForMcpAuth(normalized);
+		return true;
+	}
+
+	/**
+	 * Reconnects every materialized session whose merged MCP servers include the
+	 * newly-authenticated resource so codex re-reads `config.mcp_servers` with
+	 * the injected `Authorization` header. A thread that has not yet committed a
+	 * turn is restarted (`thread/start`, lossless); one with history is resumed
+	 * (`thread/resume` carries the same `config` field, loading history from the
+	 * rollout) on its next turn via {@link ICodexSession.needsResume}.
+	 */
+	private async _reconnectSessionsForMcpAuth(normalizedUrl: string): Promise<void> {
+		for (const session of this._sessions.values()) {
+			if (session.disposed || session.threadId === undefined) {
+				continue;
+			}
+			if (![...this._httpMcpServerUrls(session).values()].includes(normalizedUrl)) {
+				continue;
+			}
+			if (!session.firstTurnSent) {
+				try {
+					await this._restartThreadWithCurrentTools(session);
+				} catch (err) {
+					this._logService.warn(`[Codex:${session.sessionId}] reconnect after MCP auth failed: ${err instanceof Error ? err.message : String(err)}`);
+				}
+			} else {
+				// A thread with history is resumed (with the current config) on
+				// its next turn rather than restarted, so nothing is lost.
+				session.needsResume = true;
+			}
+		}
 	}
 
 	private _queueModelRefresh(token: string): void {
@@ -1247,12 +1320,50 @@ export class CodexAgent extends Disposable implements IAgent {
 	 * as process-global `-c` spawn overrides) means each new session picks up
 	 * the current root config without restarting the shared app-server, and it
 	 * merges with (leaves intact) the user's global `~/.codex/config.toml`.
-	 * Client-plugin servers win a name collision with the root config.
+	 * Client-plugin servers win a name collision with the root config. Any
+	 * OAuth bearer token acquired for an auth-gated http server (see
+	 * {@link handleAuthenticationToken}) is injected as an `Authorization`
+	 * header so codex connects authenticated.
 	 */
 	private _buildSessionMcpServers(session: ICodexSession): Record<string, ICodexMcpServerConfigJson> {
 		const root = codexMcpServersFromConfig(this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey));
 		const clientPlugins = codexMcpServersFromPlugins(session.clientCustomizations.enabledPlugins());
-		return { ...root, ...clientPlugins };
+		return injectCodexMcpAuthTokens({ ...root, ...clientPlugins }, this._mcpAuthTokens);
+	}
+
+	/**
+	 * The normalized URLs of every configured http MCP server (root config +
+	 * the session's client plugins), keyed by server name. Used to (a) surface
+	 * an auth-required server's resource for the workbench sign-in and (b)
+	 * match a workbench-acquired token back to the server(s) it unlocks.
+	 * Computed from a token-free build so the URLs are the bare server URLs.
+	 */
+	private _httpMcpServerUrls(session: ICodexSession): Map<string, string> {
+		const root = codexMcpServersFromConfig(this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey));
+		const clientPlugins = codexMcpServersFromPlugins(session.clientCustomizations.enabledPlugins());
+		const urls = new Map<string, string>();
+		for (const [name, server] of Object.entries({ ...root, ...clientPlugins })) {
+			const normalized = server.url !== undefined ? normalizeCodexMcpResourceUrl(server.url) : undefined;
+			if (normalized !== undefined) {
+				urls.set(name, normalized);
+			}
+		}
+		return urls;
+	}
+
+	/** The bare (un-normalized) URL of a configured http MCP server by name, across all sessions. */
+	private _mcpServerUrlForName(name: string): string | undefined {
+		const root = codexMcpServersFromConfig(this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey));
+		if (root[name]?.url !== undefined) {
+			return root[name].url;
+		}
+		for (const session of this._sessions.values()) {
+			const fromPlugins = codexMcpServersFromPlugins(session.clientCustomizations.enabledPlugins());
+			if (fromPlugins[name]?.url !== undefined) {
+				return fromPlugins[name].url;
+			}
+		}
+		return undefined;
 	}
 
 	/**
@@ -2765,9 +2876,15 @@ export class CodexAgent extends Disposable implements IAgent {
 		const threadId = session.threadId!;
 		if (session.needsResume) {
 			try {
+				// Carry the current MCP servers (with any injected auth token)
+				// so a resumed thread reconnects auth-gated servers, matching
+				// the config a fresh `thread/start` would apply.
+				const mcpServers = this._buildSessionMcpServers(session);
 				await conn.client.request<'thread/resume'>('thread/resume', {
 					threadId,
+					...(Object.keys(mcpServers).length > 0 ? { config: { mcp_servers: mcpServers as JsonValue } } : {}),
 				});
+				session.materializedMcpSig = mcpServersSignature(mcpServers);
 				session.needsResume = false;
 			} catch (err) {
 				const duration = this._clearTurnStopWatch(session);
@@ -3654,12 +3771,42 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 		const prev = this._mcpInventory.get(name);
 		this._mcpInventory.set(name, {
-			state: translateCodexMcpStartupState(status, error),
+			state: this._mcpStartupState(name, status, error),
 			tools: prev?.tools ?? [],
 			resources: prev?.resources ?? [],
 			resourceTemplates: prev?.resourceTemplates ?? [],
 		});
 		this._applyMcpInventoryToSessions();
+	}
+
+	/**
+	 * Maps a non-`ready` codex startup transition to an AHP {@link McpServerState}.
+	 * A `failed` transition whose error indicates the http server needs sign-in
+	 * (and whose URL we know) becomes {@link McpServerStatus.AuthRequired} with
+	 * the server URL as the OAuth `resource`, so the workbench offers the same
+	 * "Authenticate" affordance it uses for the Copilot agent. Once the token
+	 * arrives via {@link handleAuthenticationToken} it is injected into the
+	 * per-thread `http_headers` and the server reconnects. Everything else
+	 * falls back to the plain lifecycle mapping.
+	 */
+	private _mcpStartupState(name: string, status: McpServerStartupState, error: string | null): McpServerState {
+		if (status === 'failed' && codexStartupErrorNeedsAuth(error)) {
+			const url = this._mcpServerUrlForName(name);
+			const normalized = url !== undefined ? normalizeCodexMcpResourceUrl(url) : undefined;
+			// Only offer sign-in when we know the http URL and don't already
+			// hold a token for it (a token in hand means we should be
+			// reconnecting, not re-prompting).
+			if (url !== undefined && normalized !== undefined && !this._mcpAuthTokens.has(normalized)) {
+				this._logService.info(`[Codex] MCP server '${name}' requires authentication for ${url}`);
+				return {
+					kind: McpServerStatus.AuthRequired,
+					reason: McpAuthRequiredReason.Required,
+					resource: { resource: url, resource_name: name },
+					description: error ?? undefined,
+				};
+			}
+		}
+		return translateCodexMcpStartupState(status, error);
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -2536,8 +2536,10 @@ export class CodexAgent extends Disposable implements IAgent {
 		const threadConfig: Record<string, JsonValue> = {
 			web_search: narrowWebSearchMode(config[CodexSessionConfigKey.WebSearchMode]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.WebSearchMode],
 		};
-		if (Object.keys(mcpServers).length > 0) {
+		const mcpServerNames = Object.keys(mcpServers);
+		if (mcpServerNames.length > 0) {
 			threadConfig.mcp_servers = mcpServers as JsonValue;
+			this._logService.info(`[Codex] thread/start for session=${session.sessionUri.toString()} with ${mcpServerNames.length} MCP server(s): ${mcpServerNames.join(', ')}`);
 		}
 		const startResult = await conn.client.request<'thread/start', { thread: { id: string } }>('thread/start', {
 			cwd: session.workingDirectory.fsPath,
@@ -3628,6 +3630,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		for (const [name, entry] of next) {
 			this._mcpInventory.set(name, entry);
 		}
+		this._logService.info(`[Codex] MCP inventory refreshed: ${this._mcpInventory.size === 0 ? '(none)' : [...this._mcpInventory].map(([name, entry]) => `${name} [${entry.state.kind}, ${entry.tools.length} tool(s)]`).join(', ')}`);
 		this._applyMcpInventoryToSessions();
 		for (const name of toolsChanged) {
 			this._fireMcpToolsListChanged(name);
@@ -3644,6 +3647,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		if (this._connection.kind === 'ready' && this._connection.client !== client) {
 			return;
 		}
+		this._logService.info(`[Codex] MCP server '${name}' startup status: ${status}${error ? ` (${error})` : ''}`);
 		if (status === 'ready') {
 			void this._refreshMcpInventory(client);
 			return;

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -7,6 +7,8 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import { CancellationError } from '../../../../base/common/errors.js';
+import { raceTimeout } from '../../../../base/common/async.js';
+import { fetchResourceMetadata } from '../../../../base/common/oauth.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { type IObservable, observableValue } from '../../../../base/common/observable.js';
@@ -3769,9 +3771,29 @@ export class CodexAgent extends Disposable implements IAgent {
 			void this._refreshMcpInventory(client);
 			return;
 		}
+		// An auth-gated http server whose sign-in we can drive: discover its
+		// OAuth metadata asynchronously (codex's failure notification omits it)
+		// and then surface `AuthRequired`. The server stays in its current
+		// (starting) state until discovery resolves.
+		if (status === 'failed' && codexStartupErrorNeedsAuth(error)) {
+			const url = this._mcpServerUrlForName(name);
+			const normalized = url !== undefined ? normalizeCodexMcpResourceUrl(url) : undefined;
+			// Only offer sign-in when we know the http URL and don't already
+			// hold a token for it (a token in hand means we should be
+			// reconnecting, not re-prompting).
+			if (url !== undefined && normalized !== undefined && !this._mcpAuthTokens.has(normalized)) {
+				void this._surfaceMcpAuthRequired(client, name, url, error);
+				return;
+			}
+		}
+		this._setMcpServerState(name, translateCodexMcpStartupState(status, error));
+	}
+
+	/** Upserts a server's lifecycle state in the inventory (preserving cached tools) and republishes. */
+	private _setMcpServerState(name: string, state: McpServerState): void {
 		const prev = this._mcpInventory.get(name);
 		this._mcpInventory.set(name, {
-			state: this._mcpStartupState(name, status, error),
+			state,
 			tools: prev?.tools ?? [],
 			resources: prev?.resources ?? [],
 			resourceTemplates: prev?.resourceTemplates ?? [],
@@ -3780,33 +3802,44 @@ export class CodexAgent extends Disposable implements IAgent {
 	}
 
 	/**
-	 * Maps a non-`ready` codex startup transition to an AHP {@link McpServerState}.
-	 * A `failed` transition whose error indicates the http server needs sign-in
-	 * (and whose URL we know) becomes {@link McpServerStatus.AuthRequired} with
-	 * the server URL as the OAuth `resource`, so the workbench offers the same
-	 * "Authenticate" affordance it uses for the Copilot agent. Once the token
-	 * arrives via {@link handleAuthenticationToken} it is injected into the
-	 * per-thread `http_headers` and the server reconnects. Everything else
-	 * falls back to the plain lifecycle mapping.
+	 * Surfaces an auth-gated http MCP server as {@link McpServerStatus.AuthRequired}
+	 * so the workbench runs the *same* OAuth sign-in it uses for the Copilot
+	 * agent. codex's `failed` notification carries no RFC 9728 metadata, and the
+	 * workbench's `resolveMcpServerAuthentication` needs the resource's
+	 * `authorization_servers` to know where to sign in — so we discover the
+	 * Protected Resource Metadata (`<url>/.well-known/oauth-protected-resource`)
+	 * here, mirroring the discovery the Copilot SDK does internally. On
+	 * discovery failure we still surface `AuthRequired` with bare metadata (the
+	 * server genuinely needs auth); the one-click sign-in just can't complete
+	 * without the authorization server, which is logged.
 	 */
-	private _mcpStartupState(name: string, status: McpServerStartupState, error: string | null): McpServerState {
-		if (status === 'failed' && codexStartupErrorNeedsAuth(error)) {
-			const url = this._mcpServerUrlForName(name);
-			const normalized = url !== undefined ? normalizeCodexMcpResourceUrl(url) : undefined;
-			// Only offer sign-in when we know the http URL and don't already
-			// hold a token for it (a token in hand means we should be
-			// reconnecting, not re-prompting).
-			if (url !== undefined && normalized !== undefined && !this._mcpAuthTokens.has(normalized)) {
-				this._logService.info(`[Codex] MCP server '${name}' requires authentication for ${url}`);
-				return {
-					kind: McpServerStatus.AuthRequired,
-					reason: McpAuthRequiredReason.Required,
-					resource: { resource: url, resource_name: name },
-					description: error ?? undefined,
-				};
+	private async _surfaceMcpAuthRequired(client: ICodexAppServerClient, name: string, url: string, error: string | null): Promise<void> {
+		let resource: ProtectedResourceMetadata = { resource: url, resource_name: name };
+		let requiredScopes: string[] | undefined;
+		try {
+			const discovered = await raceTimeout(fetchResourceMetadata(url, undefined), 15_000);
+			if (discovered) {
+				resource = discovered.metadata;
+				requiredScopes = discovered.metadata.scopes_supported;
+				this._logService.info(`[Codex] discovered OAuth metadata for MCP server '${name}': authorization_servers=[${(discovered.metadata.authorization_servers ?? []).join(', ')}]`);
+			} else {
+				this._logService.warn(`[Codex] timed out discovering OAuth metadata for MCP server '${name}' at ${url}; the Authenticate action may not be able to complete`);
 			}
+		} catch (err) {
+			this._logService.warn(`[Codex] failed to discover OAuth metadata for MCP server '${name}' at ${url}; the Authenticate action may not be able to complete: ${err instanceof Error ? err.message : String(err)}`);
 		}
-		return translateCodexMcpStartupState(status, error);
+		// Drop the result if the connection was replaced while discovering.
+		if (this._connection.kind === 'ready' && this._connection.client !== client) {
+			return;
+		}
+		this._logService.info(`[Codex] MCP server '${name}' requires authentication for ${url}`);
+		this._setMcpServerState(name, {
+			kind: McpServerStatus.AuthRequired,
+			reason: McpAuthRequiredReason.Required,
+			resource,
+			requiredScopes: requiredScopes && requiredScopes.length > 0 ? requiredScopes : undefined,
+			description: error ?? undefined,
+		});
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -33,9 +33,14 @@ import { ActiveClientToolSet } from '../activeClientState.js';
 import { McpCustomizationController } from '../shared/mcpCustomizationController.js';
 import { buildCodexMcpReadResult, buildCodexMcpServerOverrides, codexMcpListToInventory, codexMcpToolsChanged, inventoryToSdkServers, translateCodexMcpStartupState, type ICodexMcpServerEntry } from './codexMcpServers.js';
 import { codexHooksToContainers, codexSkillsToContainers } from './codexCustomizations.js';
+import { CodexClientCustomizationStore, codexMcpServersFromPlugins, codexSkillRootsFromPlugins, type ICodexClientPlugin } from './codexClientCustomizations.js';
 import { buildElicitationRequest, cancelledElicitationResponse, declinedElicitationResponse, elicitationResponseFromAnswers } from './codexElicitationMapper.js';
 import { McpServerStatus, type AhpMcpUiHostCapabilities, type Customization } from '../../common/state/protocol/channels-session/state.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
+import { IFileService } from '../../../files/common/files.js';
+import { INativeEnvironmentService } from '../../../environment/common/environment.js';
+import { IAgentPluginManager, type ISyncedCustomization } from '../../common/agentPluginManager.js';
+import { parsePlugin } from '../../../agentPlugins/common/pluginParsers.js';
 import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
 import { ICopilotApiService } from '../shared/copilotApiService.js';
 import { extractForwardedErrorInfo } from '../shared/forwardedChatError.js';
@@ -492,6 +497,12 @@ interface ICodexSession {
 	 * MCP inventory is applied). Disposed when the session is removed.
 	 */
 	mcpController: McpCustomizationController | undefined;
+	/**
+	 * Store of client-pushed ("Open Plugin") customizations synced to this
+	 * session. Their MCP servers are attached per-thread at `thread/start`
+	 * and their skills feed codex's process-global `skills/extraRoots/set`.
+	 */
+	readonly clientCustomizations: CodexClientCustomizationStore;
 }
 
 /**
@@ -597,17 +608,21 @@ function toolsSignature(tools: readonly ToolDefinition[] | undefined): string {
 
 /**
  * Codex active-client handle. Writes flow into the owning session's
- * {@link ActiveClientToolSet}; the session is resolved lazily so writes that
- * arrive before (or after) the session exists are gracefully dropped, matching
- * the prior `setClientTools` early-return behavior. Codex has no client
- * customization layer, so `customizations` is inert.
+ * {@link ActiveClientToolSet} (tools) and its {@link CodexClientCustomizationStore}
+ * (customizations); the session is resolved lazily so writes that arrive before
+ * (or after) the session exists are gracefully dropped, matching the prior
+ * `setClientTools` early-return behavior. Assigning `customizations` caches the
+ * inputs (so the getter echoes them) and kicks off the agent's async sync.
  */
 class CodexActiveClientHandle implements IActiveClient {
+	private _customizations: readonly ClientPluginCustomization[] = [];
+
 	constructor(
 		private readonly _getSession: () => ICodexSession | undefined,
 		readonly clientId: string,
 		readonly displayName: string | undefined,
 		private readonly _onToolsSet: (tools: readonly ToolDefinition[]) => void,
+		private readonly _syncCustomizations: (customizations: readonly ClientPluginCustomization[]) => void,
 	) { }
 
 	get tools(): readonly ToolDefinition[] {
@@ -619,10 +634,11 @@ class CodexActiveClientHandle implements IActiveClient {
 	}
 
 	get customizations(): readonly ClientPluginCustomization[] {
-		return [];
+		return this._customizations;
 	}
-	set customizations(_customizations: readonly ClientPluginCustomization[]) {
-		// Codex does not support client-contributed customizations.
+	set customizations(customizations: readonly ClientPluginCustomization[]) {
+		this._customizations = customizations;
+		this._syncCustomizations(customizations);
 	}
 }
 
@@ -701,6 +717,9 @@ export class CodexAgent extends Disposable implements IAgent {
 		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@IAgentSdkDownloader private readonly _agentSdkDownloader: IAgentSdkDownloader,
 		@IProductService private readonly _productService: IProductService,
+		@IAgentPluginManager private readonly _pluginManager: IAgentPluginManager,
+		@IFileService private readonly _fileService: IFileService,
+		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
@@ -1760,6 +1779,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			prewarmClaimed: true,
 			serverToolsAdvertised: true,
 			mcpController: undefined,
+			clientCustomizations: new CodexClientCustomizationStore(),
 		};
 	}
 
@@ -2260,6 +2280,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			prewarmClaimed: false,
 			serverToolsAdvertised: false,
 			mcpController: undefined,
+			clientCustomizations: new CodexClientCustomizationStore(),
 		};
 		this._sessions.set(sessionId, session);
 		this._schedulePrewarm(session);
@@ -2311,6 +2332,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			prewarmClaimed: true,
 			serverToolsAdvertised: false,
 			mcpController: undefined,
+			clientCustomizations: new CodexClientCustomizationStore(),
 		};
 	}
 
@@ -2495,15 +2517,23 @@ export class CodexAgent extends Disposable implements IAgent {
 		const config = this._readSessionConfig(session);
 		const model = await this._resolveModel(session);
 		const { approvalPolicy, sandboxMode, approvalsReviewer } = this._resolveSessionPermissions(session);
+		// Attach this session's enabled client-plugin MCP servers per-thread
+		// (verified: codex starts them for this thread only), merged onto the
+		// per-thread config alongside `web_search`.
+		const clientMcpServers = codexMcpServersFromPlugins(session.clientCustomizations.enabledPlugins());
+		const threadConfig: Record<string, JsonValue> = {
+			web_search: narrowWebSearchMode(config[CodexSessionConfigKey.WebSearchMode]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.WebSearchMode],
+		};
+		if (Object.keys(clientMcpServers).length > 0) {
+			threadConfig.mcp_servers = clientMcpServers as JsonValue;
+		}
 		const startResult = await conn.client.request<'thread/start', { thread: { id: string } }>('thread/start', {
 			cwd: session.workingDirectory.fsPath,
 			model: model.id,
 			approvalPolicy,
 			sandbox: sandboxMode,
 			approvalsReviewer,
-			config: {
-				web_search: narrowWebSearchMode(config[CodexSessionConfigKey.WebSearchMode]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.WebSearchMode],
-			},
+			config: threadConfig,
 			dynamicTools: this._buildDynamicTools(session),
 		});
 		const threadId = startResult.thread.id;
@@ -2531,6 +2561,9 @@ export class CodexAgent extends Disposable implements IAgent {
 		// `.agents`/`.codex`) in the Customizations view now that the connection
 		// is ready and the cwd is known. Best-effort and fire-and-forget.
 		void this._refreshSkillHookCustomizations(session);
+		// Re-apply the client-plugin skill roots against the now-ready
+		// connection (they may have been synced before it came up).
+		void this._refreshSkillExtraRoots();
 	}
 
 	/**
@@ -2918,6 +2951,11 @@ export class CodexAgent extends Disposable implements IAgent {
 		this._claimPrewarm(session);
 		this._sessions.delete(sessionId);
 		session.mcpController?.dispose();
+		// If the session contributed client-plugin skills, drop them from the
+		// process-global skill-root union now that it is gone.
+		if (!session.clientCustomizations.isEmpty()) {
+			void this._refreshSkillExtraRoots();
+		}
 		// Remove the managed temp folder created for a session that had no
 		// client-supplied working directory. Best-effort; the OS temp dir is
 		// reclaimed anyway, but clean up proactively so it doesn't accumulate.
@@ -3201,12 +3239,18 @@ export class CodexAgent extends Disposable implements IAgent {
 			client.clientId,
 			client.displayName,
 			tools => this._logService.info(`[Codex:${sessionId}] active client ${client.clientId} tools=[${tools.map(t => t.name).join(', ') || '(none)'}]`),
+			customizations => { void this._syncClientCustomizations(session, client.clientId, [...customizations]); },
 		);
 	}
 
 	removeActiveClient(session: URI, clientId: string): void {
 		const sessionId = AgentSession.id(session);
-		this._sessions.get(sessionId)?.clientToolSet.delete(clientId);
+		const sess = this._sessions.get(sessionId);
+		sess?.clientToolSet.delete(clientId);
+		if (sess?.clientCustomizations.removeClient(clientId)) {
+			// A departing client's skills may drop out of the process-global union.
+			void this._refreshSkillExtraRoots();
+		}
 	}
 
 	onClientToolCallComplete(session: URI, _chat: URI, toolCallId: string, result: ToolCallResult): void {
@@ -3217,8 +3261,107 @@ export class CodexAgent extends Disposable implements IAgent {
 		sess?.pendingClientToolCalls.respondOrBuffer(toolCallId, result);
 	}
 
-	setCustomizationEnabled(_uri: string, _enabled: boolean): void {
-		// no-op; customizations not yet wired for codex.
+	setCustomizationEnabled(uri: string, enabled: boolean): void {
+		// Client-pushed plugin customizations are keyed by customization id; the
+		// AHP `SessionCustomizationToggled` action carries that id as `uri`.
+		// codex-discovered skills/hooks/MCP are read-only and not toggled here.
+		let changed = false;
+		for (const session of this._sessions.values()) {
+			if (session.disposed || !session.clientCustomizations.has(uri)) {
+				continue;
+			}
+			if (session.clientCustomizations.setEnabled(uri, enabled)) {
+				changed = true;
+				this._publishClientCustomizations(session);
+			}
+		}
+		if (changed) {
+			// Enabling/disabling a plugin changes the enabled skill-root union.
+			void this._refreshSkillExtraRoots();
+		}
+	}
+
+	// ---- Client-pushed plugin customizations -------------------------------
+
+	/**
+	 * Materialize + parse a client's pushed plugin customizations and store
+	 * them on the session. Mirrors the Claude client-plugin path: the shared
+	 * {@link IAgentPluginManager} copies each plugin to local disk (nonce
+	 * cached), we parse the resulting directory into its
+	 * {@link IParsedPlugin | components}, publish the customization surface,
+	 * and refresh the process-global skill roots. MCP servers are attached
+	 * per-thread at the next {@link _materialize}.
+	 */
+	private async _syncClientCustomizations(sessionUri: URI, clientId: string, customizations: readonly ClientPluginCustomization[]): Promise<void> {
+		const session = this._sessions.get(AgentSession.id(sessionUri));
+		if (!session) {
+			return;
+		}
+		const synced = await this._pluginManager.syncCustomizations(
+			clientId,
+			[...customizations],
+			status => this._fire(sessionUri, { type: ActionType.SessionCustomizationUpdated, customization: status }),
+		);
+		if (session.disposed) {
+			return;
+		}
+		const plugins = await Promise.all(synced.map(item => this._parseClientPlugin(session, item)));
+		if (session.disposed) {
+			return;
+		}
+		session.clientCustomizations.setClient(clientId, plugins);
+		this._publishClientCustomizations(session);
+		await this._refreshSkillExtraRoots();
+	}
+
+	/** Parse one synced plugin directory into its components (best-effort). */
+	private async _parseClientPlugin(session: ICodexSession, synced: ISyncedCustomization): Promise<ICodexClientPlugin> {
+		if (!synced.pluginDir) {
+			return { synced, parsed: undefined };
+		}
+		try {
+			const parsed = await parsePlugin(synced.pluginDir, this._fileService, session.workingDirectory, this._environmentService.userHome, synced.pluginDir);
+			return { synced, parsed };
+		} catch (err) {
+			this._logService.warn(`[Codex] failed to parse client plugin ${synced.customization.uri}: ${err instanceof Error ? err.message : String(err)}`);
+			return { synced, parsed: undefined };
+		}
+	}
+
+	/** Publish the session's client-plugin customizations as upsert actions. */
+	private _publishClientCustomizations(session: ICodexSession): void {
+		for (const customization of session.clientCustomizations.toCustomizations()) {
+			this._fire(session.sessionUri, { type: ActionType.SessionCustomizationUpdated, customization });
+		}
+	}
+
+	/**
+	 * Recompute the process-global skill roots from every live session's
+	 * enabled client plugins and push them to codex via `skills/extraRoots/set`.
+	 * codex's extra skill roots are a single shared list (there is no per-thread
+	 * equivalent), so we send the union across all sessions — which matches the
+	 * global nature of client plugin choices. No-op when the connection is not
+	 * ready; the next {@link _materialize} re-applies.
+	 */
+	private async _refreshSkillExtraRoots(): Promise<void> {
+		if (this._connection.kind !== 'ready') {
+			return;
+		}
+		const plugins: ICodexClientPlugin[] = [];
+		for (const session of this._sessions.values()) {
+			if (!session.disposed) {
+				plugins.push(...session.clientCustomizations.enabledPlugins());
+			}
+		}
+		const roots = codexSkillRootsFromPlugins(plugins);
+		try {
+			await this._connection.client.request<'skills/extraRoots/set'>('skills/extraRoots/set', { extraRoots: roots });
+			if (roots.length > 0) {
+				this._logService.info(`[Codex] applied ${roots.length} client-plugin skill root(s)`);
+			}
+		} catch (err) {
+			this._logService.warn(`[Codex] skills/extraRoots/set failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
 	}
 
 	// ---- MCP servers -------------------------------------------------------
@@ -3243,7 +3386,14 @@ export class CodexAgent extends Disposable implements IAgent {
 		// directory (best-effort; empty until the app-server connection is
 		// ready, after which `_refreshSkillHookCustomizations` pushes updates).
 		const skillHookContainers = await this._fetchSkillHookContainers(session);
-		return [...controller.topLevelCustomizations(), ...skillHookContainers];
+		// Client-pushed ("Open Plugin") customizations first (they carry the
+		// user's enablement overlay), then codex's discovered MCP servers and
+		// the `.agents`/`.codex` skills/hooks.
+		return [
+			...session.clientCustomizations.toCustomizations(),
+			...controller.topLevelCustomizations(),
+			...skillHookContainers,
+		];
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -18,7 +18,7 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
-import { createSchema, platformSessionSchema, schemaProperty, type ISchemaProperty, type SessionMode } from '../../common/agentHostSchema.js';
+import { createSchema, platformRootSchema, platformSessionSchema, schemaProperty, AgentHostMcpServersConfigKey, type ISchemaProperty, type SessionMode } from '../../common/agentHostSchema.js';
 import { createPricingMetaFromBilling, normalizeCAPIBilling } from '../../common/agentModelPricing.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
 import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, CODEX_AGENT_PROVIDER_ID, IActiveClient, IAgent, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatResult, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IMcpNotification, type AgentProvider } from '../../common/agentService.js';
@@ -31,7 +31,7 @@ import { buildDefaultChatUri, parseChatUri, type ClientPluginCustomization, type
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { McpCustomizationController } from '../shared/mcpCustomizationController.js';
-import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpToolsChanged, inventoryToSdkServers, translateCodexMcpStartupState, type ICodexMcpServerEntry } from './codexMcpServers.js';
+import { buildCodexMcpReadResult, buildCodexMcpServerOverrides, codexMcpListToInventory, codexMcpToolsChanged, inventoryToSdkServers, translateCodexMcpStartupState, type ICodexMcpServerEntry } from './codexMcpServers.js';
 import { buildElicitationRequest, cancelledElicitationResponse, declinedElicitationResponse, elicitationResponseFromAnswers } from './codexElicitationMapper.js';
 import { McpServerStatus, type AhpMcpUiHostCapabilities, type Customization } from '../../common/state/protocol/channels-session/state.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
@@ -1067,7 +1067,7 @@ export class CodexAgent extends Disposable implements IAgent {
 
 		// Extra args forwarded as JSON from the workbench setting.
 		const extraArgs = parseBinaryArgs(process.env[AgentHostCodexAgentBinaryArgsEnvVar]);
-		const args = ['app-server', ...providerOverrides.flatMap(kv => ['-c', kv]), ...extraArgs];
+		const args = ['app-server', ...providerOverrides.flatMap(kv => ['-c', kv]), ...this._buildMcpServerOverrides().flatMap(kv => ['-c', kv]), ...extraArgs];
 
 		this._logService.info(`[Codex] spawning ${binaryPath} ${args.join(' ')}`);
 		const child = spawn(binaryPath, args, { env, stdio: ['pipe', 'pipe', 'pipe'] });
@@ -1199,6 +1199,30 @@ export class CodexAgent extends Disposable implements IAgent {
 		void this._refreshMcpInventory(client);
 
 		return { client, proxyHandle, child };
+	}
+
+	/**
+	 * Builds the `mcp_servers.<name>=<toml>` config overrides that make the
+	 * codex app-server launch the workbench's configured MCP servers (the
+	 * root `mcpServers` config). These merge with any servers in the user's
+	 * global `~/.codex/config.toml`. Mirrors how the Copilot agent forwards
+	 * the same root config to its SDK. Empty when no servers are configured,
+	 * so the user's global MCP config is left untouched.
+	 *
+	 * The codex app-server is process-global (shared across threads), and the
+	 * root `mcpServers` config is likewise a global workbench setting, so the
+	 * servers are resolved once at spawn time rather than per session.
+	 */
+	private _buildMcpServerOverrides(): readonly string[] {
+		const servers = this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey);
+		const { overrides, skipped } = buildCodexMcpServerOverrides(servers);
+		if (skipped.length > 0) {
+			this._logService.warn(`[Codex] skipping ${skipped.length} MCP server(s) that are malformed or have a name codex cannot address via a config override: ${skipped.join(', ')}`);
+		}
+		if (overrides.length > 0) {
+			this._logService.info(`[Codex] configuring ${overrides.length} MCP server(s) from workbench config`);
+		}
+		return overrides;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -31,7 +31,7 @@ import { buildDefaultChatUri, parseChatUri, type ClientPluginCustomization, type
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { McpCustomizationController } from '../shared/mcpCustomizationController.js';
-import { buildCodexMcpReadResult, buildCodexMcpServerOverrides, codexMcpListToInventory, codexMcpToolsChanged, inventoryToSdkServers, translateCodexMcpStartupState, type ICodexMcpServerEntry } from './codexMcpServers.js';
+import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpServersFromConfig, codexMcpToolsChanged, inventoryToSdkServers, translateCodexMcpStartupState, type ICodexMcpServerConfigJson, type ICodexMcpServerEntry } from './codexMcpServers.js';
 import { codexHooksToContainers, codexSkillsToContainers } from './codexCustomizations.js';
 import { CodexClientCustomizationStore, codexMcpServersFromPlugins, codexSkillRootsFromPlugins, type ICodexClientPlugin } from './codexClientCustomizations.js';
 import { buildElicitationRequest, cancelledElicitationResponse, declinedElicitationResponse, elicitationResponseFromAnswers } from './codexElicitationMapper.js';
@@ -457,6 +457,13 @@ interface ICodexSession {
 	 * them up. `undefined` until materialized.
 	 */
 	materializedToolsSig: string | undefined;
+	/**
+	 * Signature of the `mcp_servers` (root config + client plugins) the codex
+	 * thread was started with. Codex only accepts `config.mcp_servers` at
+	 * `thread/start`, so if the set changes before the first turn the thread is
+	 * restarted to pick them up. `undefined` until materialized.
+	 */
+	materializedMcpSig: string | undefined;
 	/** True once a turn has been started on the (materialized) thread. */
 	firstTurnSent: boolean;
 	model: ModelSelection | undefined;
@@ -604,6 +611,16 @@ function toolsSignature(tools: readonly ToolDefinition[] | undefined): string {
 		.map(t => `${t.name}\u0000${t.description ?? ''}\u0000${JSON.stringify(t.inputSchema ?? null)}`)
 		.sort()
 		.join('\u0001');
+}
+
+/**
+ * Stable signature of the `mcp_servers` object a thread was started with, used
+ * to detect when the merged (root config + client plugin) MCP set changed so
+ * the thread can be restarted before its first turn to pick up the new servers.
+ */
+function mcpServersSignature(servers: Record<string, ICodexMcpServerConfigJson>): string {
+	const names = Object.keys(servers).sort();
+	return names.map(name => `${name}\u0000${JSON.stringify(servers[name])}`).join('\u0001');
 }
 
 /**
@@ -1089,7 +1106,7 @@ export class CodexAgent extends Disposable implements IAgent {
 
 		// Extra args forwarded as JSON from the workbench setting.
 		const extraArgs = parseBinaryArgs(process.env[AgentHostCodexAgentBinaryArgsEnvVar]);
-		const args = ['app-server', ...providerOverrides.flatMap(kv => ['-c', kv]), ...this._buildMcpServerOverrides().flatMap(kv => ['-c', kv]), ...extraArgs];
+		const args = ['app-server', ...providerOverrides.flatMap(kv => ['-c', kv]), ...extraArgs];
 
 		this._logService.info(`[Codex] spawning ${binaryPath} ${args.join(' ')}`);
 		const child = spawn(binaryPath, args, { env, stdio: ['pipe', 'pipe', 'pipe'] });
@@ -1224,27 +1241,18 @@ export class CodexAgent extends Disposable implements IAgent {
 	}
 
 	/**
-	 * Builds the `mcp_servers.<name>=<toml>` config overrides that make the
-	 * codex app-server launch the workbench's configured MCP servers (the
-	 * root `mcpServers` config). These merge with any servers in the user's
-	 * global `~/.codex/config.toml`. Mirrors how the Copilot agent forwards
-	 * the same root config to its SDK. Empty when no servers are configured,
-	 * so the user's global MCP config is left untouched.
-	 *
-	 * The codex app-server is process-global (shared across threads), and the
-	 * root `mcpServers` config is likewise a global workbench setting, so the
-	 * servers are resolved once at spawn time rather than per session.
+	 * Builds the `mcp_servers` object for a session's `thread/start.config`:
+	 * the workbench's root `mcpServers` config merged with the session's
+	 * enabled client-plugin MCP servers. Passing them per-thread (rather than
+	 * as process-global `-c` spawn overrides) means each new session picks up
+	 * the current root config without restarting the shared app-server, and it
+	 * merges with (leaves intact) the user's global `~/.codex/config.toml`.
+	 * Client-plugin servers win a name collision with the root config.
 	 */
-	private _buildMcpServerOverrides(): readonly string[] {
-		const servers = this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey);
-		const { overrides, skipped } = buildCodexMcpServerOverrides(servers);
-		if (skipped.length > 0) {
-			this._logService.warn(`[Codex] skipping ${skipped.length} MCP server(s) that are malformed or have a name codex cannot address via a config override: ${skipped.join(', ')}`);
-		}
-		if (overrides.length > 0) {
-			this._logService.info(`[Codex] configuring ${overrides.length} MCP server(s) from workbench config`);
-		}
-		return overrides;
+	private _buildSessionMcpServers(session: ICodexSession): Record<string, ICodexMcpServerConfigJson> {
+		const root = codexMcpServersFromConfig(this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey));
+		const clientPlugins = codexMcpServersFromPlugins(session.clientCustomizations.enabledPlugins());
+		return { ...root, ...clientPlugins };
 	}
 
 	/**
@@ -1763,6 +1771,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			pendingClientToolCalls: new PendingRequestRegistry<ToolCallResult>(),
 			pendingUserInputs: new PendingRequestRegistry<ICodexUserInputResult>(),
 			materializedToolsSig: undefined,
+			materializedMcpSig: undefined,
 			firstTurnSent: true,
 			model: parent.model,
 			currentTurnId: undefined,
@@ -2264,6 +2273,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			pendingClientToolCalls: new PendingRequestRegistry<ToolCallResult>(),
 			pendingUserInputs: new PendingRequestRegistry<ICodexUserInputResult>(),
 			materializedToolsSig: undefined,
+			materializedMcpSig: undefined,
 			firstTurnSent: false,
 			model: effectiveModel,
 			currentTurnId: undefined,
@@ -2316,6 +2326,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			pendingClientToolCalls: new PendingRequestRegistry<ToolCallResult>(),
 			pendingUserInputs: new PendingRequestRegistry<ICodexUserInputResult>(),
 			materializedToolsSig: undefined,
+			materializedMcpSig: undefined,
 			firstTurnSent: true,
 			model,
 			currentTurnId: undefined,
@@ -2517,15 +2528,16 @@ export class CodexAgent extends Disposable implements IAgent {
 		const config = this._readSessionConfig(session);
 		const model = await this._resolveModel(session);
 		const { approvalPolicy, sandboxMode, approvalsReviewer } = this._resolveSessionPermissions(session);
-		// Attach this session's enabled client-plugin MCP servers per-thread
-		// (verified: codex starts them for this thread only), merged onto the
-		// per-thread config alongside `web_search`.
-		const clientMcpServers = codexMcpServersFromPlugins(session.clientCustomizations.enabledPlugins());
+		// Attach the session's MCP servers per-thread (verified: codex starts
+		// them for this thread only): the workbench's root `mcpServers` config
+		// merged with this session's enabled client-plugin servers. Passing them
+		// per-thread means a new session always reflects the current root config.
+		const mcpServers = this._buildSessionMcpServers(session);
 		const threadConfig: Record<string, JsonValue> = {
 			web_search: narrowWebSearchMode(config[CodexSessionConfigKey.WebSearchMode]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.WebSearchMode],
 		};
-		if (Object.keys(clientMcpServers).length > 0) {
-			threadConfig.mcp_servers = clientMcpServers as JsonValue;
+		if (Object.keys(mcpServers).length > 0) {
+			threadConfig.mcp_servers = mcpServers as JsonValue;
 		}
 		const startResult = await conn.client.request<'thread/start', { thread: { id: string } }>('thread/start', {
 			cwd: session.workingDirectory.fsPath,
@@ -2546,6 +2558,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			return;
 		}
 		session.threadId = threadId;
+		session.materializedMcpSig = mcpServersSignature(mcpServers);
 		session.materializedToolsSig = toolsSignature(session.clientToolSet.merged());
 		this._logService.info(`[Codex DEBUG] materialized session=${session.sessionUri.toString()} threadId=${session.threadId}`);
 		this._sessionIdByThreadId.set(session.threadId, session.sessionId);
@@ -2722,11 +2735,14 @@ export class CodexAgent extends Disposable implements IAgent {
 			this._fire(sessionUri, { type: ActionType.ChatTurnComplete, turnId: effectiveTurnId, duration });
 			return;
 		}
-		// Codex registers client tools only at `thread/start`. If the thread
-		// was prewarmed (or otherwise started) before the current client tools
-		// were known, restart it now — before any turn commits history, so
-		// nothing is lost — so the tools land in `dynamicTools`.
-		if (!session.firstTurnSent && !session.needsResume && toolsSignature(session.clientToolSet.merged()) !== session.materializedToolsSig) {
+		// Codex registers client tools and MCP servers only at `thread/start`.
+		// If the thread was prewarmed (or otherwise started) before the current
+		// client tools / MCP servers were known, restart it now — before any
+		// turn commits history, so nothing is lost — so the tools land in
+		// `dynamicTools` and the servers in `config.mcp_servers`.
+		const toolsChanged = toolsSignature(session.clientToolSet.merged()) !== session.materializedToolsSig;
+		const mcpChanged = mcpServersSignature(this._buildSessionMcpServers(session)) !== session.materializedMcpSig;
+		if (!session.firstTurnSent && !session.needsResume && (toolsChanged || mcpChanged)) {
 			try {
 				await this._restartThreadWithCurrentTools(session);
 				this._persistMaterializedSession(session);

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -716,14 +716,25 @@ export class CodexAgent extends Disposable implements IAgent {
 	private readonly _mcpInventory = new Map<string, ICodexMcpServerEntry>();
 	/**
 	 * OAuth bearer tokens acquired for auth-gated http MCP servers, keyed by
-	 * the server's {@link normalizeCodexMcpResourceUrl | normalized URL} (the
-	 * OAuth `resource`). Populated by {@link handleAuthenticationToken} after
-	 * the workbench completes the sign-in, then injected into the per-thread
-	 * `http_headers` by {@link _buildSessionMcpServers}. Process-global: a
-	 * token for a given server URL applies to every session/thread that uses
-	 * it (codex runs one shared app-server).
+	 * the server's {@link normalizeCodexMcpResourceUrl | normalized URL}.
+	 * Populated by {@link handleAuthenticationToken} after the workbench
+	 * completes the sign-in, then injected into the per-thread `http_headers`
+	 * by {@link _buildSessionMcpServers}. Process-global: a token for a given
+	 * server URL applies to every session/thread that uses it (codex runs one
+	 * shared app-server).
 	 */
 	private readonly _mcpAuthTokens = new Map<string, string>();
+	/**
+	 * Association from a normalized OAuth `resource` (what the workbench
+	 * authenticates) to the normalized MCP server URL(s) it unlocks. RFC 9728
+	 * discovery can return a `resource` that differs from the configured server
+	 * URL (e.g. root `https://host/` for a `https://host/mcp` endpoint), so the
+	 * token the workbench pushes back is keyed by the resource, not the server
+	 * URL. Recorded in {@link _surfaceMcpAuthRequired} at discovery time and
+	 * read by {@link handleAuthenticationToken} to route the token to the right
+	 * server(s).
+	 */
+	private readonly _mcpAuthServerUrlsByResource = new Map<string, Set<string>>();
 	private _githubToken: string | undefined;
 	private _connection: ConnectionState = { kind: 'idle' };
 	private _modelsRefreshPromise: Promise<void> | undefined;
@@ -789,50 +800,73 @@ export class CodexAgent extends Disposable implements IAgent {
 	/**
 	 * Receives a bearer token the workbench acquired for a protected resource
 	 * (the `authenticate` command is fanned out to every agent). If the
-	 * resource matches a configured auth-gated http MCP server, store the token
-	 * (so {@link _buildSessionMcpServers} injects it) and reconnect the affected
-	 * threads so codex picks it up. This is the codex end of the *same* OAuth
-	 * mechanism the Copilot agent uses: the workbench does the sign-in, the
-	 * agent injects the resulting bearer. Returns whether the token was
-	 * consumed by an MCP server (the GitHub agent token flows through
-	 * {@link authenticate} instead).
+	 * resource maps to one or more configured auth-gated http MCP servers
+	 * (via the association recorded at discovery time, or a direct URL match),
+	 * store the token per server URL (so {@link _buildSessionMcpServers} injects
+	 * it) and reconnect the affected threads so codex picks it up. This is the
+	 * codex end of the *same* OAuth mechanism the Copilot agent uses: the
+	 * workbench does the sign-in, the agent injects the resulting bearer.
+	 * Returns whether the token was consumed by an MCP server (the GitHub agent
+	 * token flows through {@link authenticate} instead).
 	 */
 	async handleAuthenticationToken(params: AuthenticateParams): Promise<boolean> {
-		const normalized = normalizeCodexMcpResourceUrl(params.resource);
-		if (normalized === undefined) {
+		const normalizedResource = normalizeCodexMcpResourceUrl(params.resource);
+		if (normalizedResource === undefined) {
 			return false;
 		}
-		// Only claim the token when it targets a currently-configured http MCP server.
-		const matchesConfigured = [...this._sessions.values()].some(session =>
-			[...this._httpMcpServerUrls(session).values()].includes(normalized),
-		) || Object.values(codexMcpServersFromConfig(this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey)))
-			.some(server => server.url !== undefined && normalizeCodexMcpResourceUrl(server.url) === normalized);
-		if (!matchesConfigured) {
+		// The workbench authenticates the OAuth `resource`, which RFC 9728
+		// discovery may report as different from the configured server URL.
+		// Resolve the server URL(s) this resource unlocks: the association
+		// recorded at discovery time, plus a direct match when the resource IS
+		// a configured server URL (discovery returned the URL unchanged, or was
+		// skipped).
+		const serverUrls = new Set(this._mcpAuthServerUrlsByResource.get(normalizedResource) ?? []);
+		if (this._isConfiguredHttpServerUrl(normalizedResource)) {
+			serverUrls.add(normalizedResource);
+		}
+		if (serverUrls.size === 0) {
 			return false;
 		}
-		if (this._mcpAuthTokens.get(normalized) === params.token) {
+		let changed = false;
+		for (const serverUrl of serverUrls) {
+			if (this._mcpAuthTokens.get(serverUrl) !== params.token) {
+				this._mcpAuthTokens.set(serverUrl, params.token);
+				changed = true;
+			}
+		}
+		if (!changed) {
 			return true;
 		}
-		this._mcpAuthTokens.set(normalized, params.token);
 		this._logService.info(`[Codex] stored MCP auth token for ${params.resource}; reconnecting affected sessions`);
-		await this._reconnectSessionsForMcpAuth(normalized);
+		await this._reconnectSessionsForMcpAuth(serverUrls);
 		return true;
 	}
 
+	/** Whether `normalizedUrl` is a currently-configured http MCP server (root config or any session's client plugins). */
+	private _isConfiguredHttpServerUrl(normalizedUrl: string): boolean {
+		if (Object.values(codexMcpServersFromConfig(this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey)))
+			.some(server => server.url !== undefined && normalizeCodexMcpResourceUrl(server.url) === normalizedUrl)) {
+			return true;
+		}
+		return [...this._sessions.values()].some(session =>
+			[...this._httpMcpServerUrls(session).values()].includes(normalizedUrl),
+		);
+	}
+
 	/**
-	 * Reconnects every materialized session whose merged MCP servers include the
-	 * newly-authenticated resource so codex re-reads `config.mcp_servers` with
-	 * the injected `Authorization` header. A thread that has not yet committed a
+	 * Reconnects every materialized session whose merged MCP servers include one
+	 * of `normalizedUrls` so codex re-reads `config.mcp_servers` with the
+	 * injected `Authorization` header. A thread that has not yet committed a
 	 * turn is restarted (`thread/start`, lossless); one with history is resumed
 	 * (`thread/resume` carries the same `config` field, loading history from the
 	 * rollout) on its next turn via {@link ICodexSession.needsResume}.
 	 */
-	private async _reconnectSessionsForMcpAuth(normalizedUrl: string): Promise<void> {
+	private async _reconnectSessionsForMcpAuth(normalizedUrls: ReadonlySet<string>): Promise<void> {
 		for (const session of this._sessions.values()) {
 			if (session.disposed || session.threadId === undefined) {
 				continue;
 			}
-			if (![...this._httpMcpServerUrls(session).values()].includes(normalizedUrl)) {
+			if (![...this._httpMcpServerUrls(session).values()].some(url => normalizedUrls.has(url))) {
 				continue;
 			}
 			if (!session.firstTurnSent) {
@@ -3778,10 +3812,14 @@ export class CodexAgent extends Disposable implements IAgent {
 		if (status === 'failed' && codexStartupErrorNeedsAuth(error)) {
 			const url = this._mcpServerUrlForName(name);
 			const normalized = url !== undefined ? normalizeCodexMcpResourceUrl(url) : undefined;
-			// Only offer sign-in when we know the http URL and don't already
-			// hold a token for it (a token in hand means we should be
-			// reconnecting, not re-prompting).
-			if (url !== undefined && normalized !== undefined && !this._mcpAuthTokens.has(normalized)) {
+			if (url !== undefined && normalized !== undefined) {
+				// A token we already injected was rejected (expired/revoked/
+				// insufficient scopes). Drop it so the user is re-prompted
+				// instead of getting stuck on a terminal error with no way to
+				// re-authenticate.
+				if (this._mcpAuthTokens.delete(normalized)) {
+					this._logService.info(`[Codex] MCP server '${name}' rejected the stored token; clearing it to allow re-authentication`);
+				}
 				void this._surfaceMcpAuthRequired(client, name, url, error);
 				return;
 			}
@@ -3831,6 +3869,16 @@ export class CodexAgent extends Disposable implements IAgent {
 		// Drop the result if the connection was replaced while discovering.
 		if (this._connection.kind === 'ready' && this._connection.client !== client) {
 			return;
+		}
+		// Record which server URL this OAuth resource unlocks: discovery can
+		// return a `resource` that differs from the configured server URL, and
+		// the token the workbench later pushes back is keyed by that resource.
+		const normalizedServer = normalizeCodexMcpResourceUrl(url);
+		const normalizedResource = normalizeCodexMcpResourceUrl(resource.resource) ?? normalizedServer;
+		if (normalizedServer !== undefined && normalizedResource !== undefined) {
+			const servers = this._mcpAuthServerUrlsByResource.get(normalizedResource) ?? new Set<string>();
+			servers.add(normalizedServer);
+			this._mcpAuthServerUrlsByResource.set(normalizedResource, servers);
 		}
 		this._logService.info(`[Codex] MCP server '${name}' requires authentication for ${url}`);
 		this._setMcpServerState(name, {

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -27,11 +27,12 @@ import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProt
 import { ActionType, isChatAction, type SessionAction, type ChatAction } from '../../common/state/sessionActions.js';
 import type { ConfigSchema, ModelSelection, ProtectedResourceMetadata, ToolDefinition, AgentSelection } from '../../common/state/protocol/state.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
-import { buildDefaultChatUri, parseChatUri, type ClientPluginCustomization, type MessageAttachment, type PendingMessage, type ChatInputAnswer, ChatInputResponseKind, type PolicyState, type ToolCallResult, ToolResultContentType, type Turn, ResponsePartKind } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, parseChatUri, type ClientPluginCustomization, type DirectoryCustomization, type MessageAttachment, type PendingMessage, type ChatInputAnswer, ChatInputResponseKind, type PolicyState, type ToolCallResult, ToolResultContentType, type Turn, ResponsePartKind } from '../../common/state/sessionState.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { McpCustomizationController } from '../shared/mcpCustomizationController.js';
 import { buildCodexMcpReadResult, buildCodexMcpServerOverrides, codexMcpListToInventory, codexMcpToolsChanged, inventoryToSdkServers, translateCodexMcpStartupState, type ICodexMcpServerEntry } from './codexMcpServers.js';
+import { codexHooksToContainers, codexSkillsToContainers } from './codexCustomizations.js';
 import { buildElicitationRequest, cancelledElicitationResponse, declinedElicitationResponse, elicitationResponseFromAnswers } from './codexElicitationMapper.js';
 import { McpServerStatus, type AhpMcpUiHostCapabilities, type Customization } from '../../common/state/protocol/channels-session/state.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
@@ -90,6 +91,8 @@ import type { McpResourceReadResponse } from './protocol/generated/v2/McpResourc
 import type { McpServerStartupState } from './protocol/generated/v2/McpServerStartupState.js';
 import type { McpServerElicitationRequestParams } from './protocol/generated/v2/McpServerElicitationRequestParams.js';
 import type { McpServerElicitationRequestResponse } from './protocol/generated/v2/McpServerElicitationRequestResponse.js';
+import type { SkillsListResponse } from './protocol/generated/v2/SkillsListResponse.js';
+import type { HooksListResponse } from './protocol/generated/v2/HooksListResponse.js';
 import type { ItemGuardianApprovalReviewCompletedNotification } from './protocol/generated/v2/ItemGuardianApprovalReviewCompletedNotification.js';
 import type { GuardianWarningNotification } from './protocol/generated/v2/GuardianWarningNotification.js';
 import type { ThreadApproveGuardianDeniedActionResponse } from './protocol/generated/v2/ThreadApproveGuardianDeniedActionResponse.js';
@@ -2524,6 +2527,10 @@ export class CodexAgent extends Disposable implements IAgent {
 			session.serverToolsAdvertised = true;
 			this._serverToolHost.advertise(session.sessionUri.toString());
 		}
+		// Surface the skills/hooks codex loaded for this working directory (from
+		// `.agents`/`.codex`) in the Customizations view now that the connection
+		// is ready and the cwd is known. Best-effort and fire-and-forget.
+		void this._refreshSkillHookCustomizations(session);
 	}
 
 	/**
@@ -3232,7 +3239,54 @@ export class CodexAgent extends Disposable implements IAgent {
 		const controller = this._getOrCreateMcpController(session);
 		controller.applyAll(inventoryToSdkServers(this._mcpInventory));
 		this._refreshMcpCustomizationIds(session, controller);
-		return controller.topLevelCustomizations();
+		// Append the skills/hooks codex loaded for this session's working
+		// directory (best-effort; empty until the app-server connection is
+		// ready, after which `_refreshSkillHookCustomizations` pushes updates).
+		const skillHookContainers = await this._fetchSkillHookContainers(session);
+		return [...controller.topLevelCustomizations(), ...skillHookContainers];
+	}
+
+	/**
+	 * Fetches the skills and hooks codex has loaded for `session`'s working
+	 * directory (`skills/list` + `hooks/list`, both cwd-scoped) and projects
+	 * them into {@link DirectoryCustomization} containers. Best-effort: returns
+	 * an empty array when no connection is ready, no working directory is known,
+	 * or the app-server rejects the request.
+	 */
+	private async _fetchSkillHookContainers(session: ICodexSession): Promise<DirectoryCustomization[]> {
+		if (this._connection.kind !== 'ready' || !session.workingDirectory) {
+			return [];
+		}
+		const cwd = session.workingDirectory.fsPath;
+		const client = this._connection.client;
+		const [skills, hooks] = await Promise.all([
+			client.request<'skills/list', SkillsListResponse>('skills/list', { cwds: [cwd] })
+				.catch(err => { this._logService.warn(`[Codex] skills/list failed: ${err instanceof Error ? err.message : String(err)}`); return undefined; }),
+			client.request<'hooks/list', HooksListResponse>('hooks/list', { cwds: [cwd] })
+				.catch(err => { this._logService.warn(`[Codex] hooks/list failed: ${err instanceof Error ? err.message : String(err)}`); return undefined; }),
+		]);
+		return [...codexSkillsToContainers(skills), ...codexHooksToContainers(hooks)];
+	}
+
+	/**
+	 * Re-fetches this session's skill/hook customizations and upserts each
+	 * container into session state via {@link ActionType.SessionCustomizationUpdated}.
+	 * Called after materialization (when the connection is ready and the cwd is
+	 * known) so the workbench Customizations surface reflects what codex loaded
+	 * from the working directory's `.agents`/`.codex` folders. Upserts (keyed by
+	 * customization id) leave the MCP customizations untouched.
+	 */
+	private async _refreshSkillHookCustomizations(session: ICodexSession): Promise<void> {
+		if (session.disposed) {
+			return;
+		}
+		const containers = await this._fetchSkillHookContainers(session);
+		if (session.disposed) {
+			return;
+		}
+		for (const container of containers) {
+			this._fire(session.sessionUri, { type: ActionType.SessionCustomizationUpdated, customization: container });
+		}
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
@@ -5,9 +5,9 @@
 
 import { dirname } from '../../../../base/common/path.js';
 import type { IMcpServerDefinition, IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
-import { McpServerType, type IMcpServerConfiguration } from '../../../mcp/common/mcpPlatformTypes.js';
 import type { ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { type ChildCustomization, type PluginCustomization } from '../../common/state/sessionState.js';
+import { toCodexMcpServerJson, type ICodexMcpServerConfigJson } from './codexMcpServers.js';
 
 /**
  * Codex ingests **client-pushed** plugin customizations (the "Open Plugins"
@@ -32,16 +32,6 @@ import { type ChildCustomization, type PluginCustomization } from '../../common/
 export interface ICodexClientPlugin {
 	readonly synced: ISyncedCustomization;
 	readonly parsed: IParsedPlugin | undefined;
-}
-
-/** The codex JSON shape for one MCP server inside `thread/start.config.mcp_servers`. */
-export interface ICodexMcpServerConfigJson {
-	command?: string;
-	args?: readonly string[];
-	env?: Record<string, string>;
-	cwd?: string;
-	url?: string;
-	http_headers?: Record<string, string>;
 }
 
 /**
@@ -148,42 +138,6 @@ function parsedPluginChildren(parsed: IParsedPlugin): ChildCustomization[] {
 	for (const h of parsed.hooks) { add(h.customization); }
 	for (const m of parsed.mcpServers) { add(m.customization); }
 	return [...byId.values()];
-}
-
-/** Ensures all env values are strings (codex's `env` is `Map<string, string>`). */
-function toStringEnv(env: Record<string, string | number | null>): Record<string, string> {
-	const out: Record<string, string> = {};
-	for (const [key, value] of Object.entries(env)) {
-		if (value !== null) {
-			out[key] = String(value);
-		}
-	}
-	return out;
-}
-
-/** Converts one workbench MCP server configuration into codex's per-thread JSON shape. */
-function toCodexMcpServerJson(config: IMcpServerConfiguration): ICodexMcpServerConfigJson {
-	if (config.type === McpServerType.LOCAL) {
-		const out: ICodexMcpServerConfigJson = { command: config.command };
-		if (config.args && config.args.length > 0) {
-			out.args = [...config.args];
-		}
-		if (config.env) {
-			const env = toStringEnv(config.env);
-			if (Object.keys(env).length > 0) {
-				out.env = env;
-			}
-		}
-		if (config.cwd) {
-			out.cwd = config.cwd;
-		}
-		return out;
-	}
-	const out: ICodexMcpServerConfigJson = { url: config.url };
-	if (config.headers && Object.keys(config.headers).length > 0) {
-		out.http_headers = { ...config.headers };
-	}
-	return out;
 }
 
 /**

--- a/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
@@ -1,0 +1,225 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { dirname } from '../../../../base/common/path.js';
+import type { IMcpServerDefinition, IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
+import { McpServerType, type IMcpServerConfiguration } from '../../../mcp/common/mcpPlatformTypes.js';
+import type { ISyncedCustomization } from '../../common/agentPluginManager.js';
+import { type ChildCustomization, type PluginCustomization } from '../../common/state/sessionState.js';
+
+/**
+ * Codex ingests **client-pushed** plugin customizations (the "Open Plugins"
+ * the workbench syncs via {@link IActiveClient.customizations}) differently
+ * from the `.agents`/`.codex` files it discovers itself. This module holds the
+ * per-session store for those synced+parsed plugins plus the pure mappers that
+ * project them into (a) the AHP {@link PluginCustomization} surface, (b) codex
+ * per-thread `thread/start.config.mcp_servers`, and (c) process-global
+ * `skills/extraRoots/set` roots.
+ *
+ * Feeding strategy (see the phase investigation):
+ *  - MCP servers are attached **per session** via `thread/start.config`
+ *    (verified: codex starts the server for that thread only), so a plugin's
+ *    server only runs for sessions that enable it.
+ *  - Skills are process-global in codex (`skills/extraRoots/set` replaces a
+ *    single shared root list), so the store exposes the union of enabled skill
+ *    roots and the agent sets it across all live sessions. This matches the
+ *    semantics of client customizations, which are global user choices.
+ */
+
+/** A single client-pushed plugin: its sync result plus the parsed components (when the sync succeeded). */
+export interface ICodexClientPlugin {
+	readonly synced: ISyncedCustomization;
+	readonly parsed: IParsedPlugin | undefined;
+}
+
+/** The codex JSON shape for one MCP server inside `thread/start.config.mcp_servers`. */
+export interface ICodexMcpServerConfigJson {
+	command?: string;
+	args?: readonly string[];
+	env?: Record<string, string>;
+	cwd?: string;
+	url?: string;
+	http_headers?: Record<string, string>;
+}
+
+/**
+ * Per-session store of client-pushed plugin customizations, keyed by the
+ * contributing client id, with a per-customization enablement overlay
+ * (absent = enabled, `false` = disabled). Merges every client's contribution
+ * deduplicated by customization id (first client wins). Pure state holder —
+ * the agent reads the projections below and drives codex.
+ */
+export class CodexClientCustomizationStore {
+
+	private readonly _byClient = new Map<string, readonly ICodexClientPlugin[]>();
+	private readonly _enablement = new Map<string, boolean>();
+
+	/** Replace one client's synced+parsed plugin set. */
+	setClient(clientId: string, plugins: readonly ICodexClientPlugin[]): void {
+		this._byClient.set(clientId, plugins);
+	}
+
+	/** Drop a client's contribution. Returns whether anything was removed. */
+	removeClient(clientId: string): boolean {
+		return this._byClient.delete(clientId);
+	}
+
+	/**
+	 * Toggle a client-pushed customization on/off. Returns whether the
+	 * enablement actually changed (so callers can skip a no-op refresh).
+	 */
+	setEnabled(id: string, enabled: boolean): boolean {
+		const current = this._enablement.get(id);
+		const effective = current !== false; // absent counts as enabled
+		if (effective === enabled) {
+			return false;
+		}
+		if (enabled) {
+			this._enablement.delete(id);
+		} else {
+			this._enablement.set(id, false);
+		}
+		return true;
+	}
+
+	/** Whether a client-pushed customization with this id exists in the store. */
+	has(id: string): boolean {
+		return this._merged().some(p => p.synced.customization.id === id);
+	}
+
+	/** Whether the store holds any client-pushed customizations. */
+	isEmpty(): boolean {
+		return this._merged().length === 0;
+	}
+
+	/** Merge of every client's plugins, deduplicated by customization id (first client wins). */
+	private _merged(): readonly ICodexClientPlugin[] {
+		const seen = new Set<string>();
+		const out: ICodexClientPlugin[] = [];
+		for (const plugins of this._byClient.values()) {
+			for (const plugin of plugins) {
+				const id = plugin.synced.customization.id;
+				if (seen.has(id)) {
+					continue;
+				}
+				seen.add(id);
+				out.push(plugin);
+			}
+		}
+		return out;
+	}
+
+	private _isEnabled(id: string): boolean {
+		return this._enablement.get(id) !== false;
+	}
+
+	/** The merged plugins that are currently enabled and successfully parsed. */
+	enabledPlugins(): readonly ICodexClientPlugin[] {
+		return this._merged().filter(p => p.parsed !== undefined && this._isEnabled(p.synced.customization.id));
+	}
+
+	/**
+	 * Projects the store onto the AHP {@link PluginCustomization} surface, with
+	 * the enablement overlay applied and each plugin's parsed children folded
+	 * in (skills, MCP servers, agents, instructions, hooks).
+	 */
+	toCustomizations(): PluginCustomization[] {
+		return this._merged().map(plugin => {
+			const base = plugin.synced.customization;
+			const children = plugin.parsed ? parsedPluginChildren(plugin.parsed) : base.children;
+			return {
+				...base,
+				enabled: this._isEnabled(base.id),
+				...(children ? { children } : {}),
+			};
+		});
+	}
+}
+
+/** Collects every child customization a parsed plugin exposes, deduped by id. */
+function parsedPluginChildren(parsed: IParsedPlugin): ChildCustomization[] {
+	const byId = new Map<string, ChildCustomization>();
+	const add = (c: ChildCustomization) => { if (!byId.has(c.id)) { byId.set(c.id, c); } };
+	for (const a of parsed.agents) { add(a.customization); }
+	for (const s of parsed.skills) { add(s.customization); }
+	for (const r of parsed.instructions) { add(r.customization); }
+	for (const h of parsed.hooks) { add(h.customization); }
+	for (const m of parsed.mcpServers) { add(m.customization); }
+	return [...byId.values()];
+}
+
+/** Ensures all env values are strings (codex's `env` is `Map<string, string>`). */
+function toStringEnv(env: Record<string, string | number | null>): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (value !== null) {
+			out[key] = String(value);
+		}
+	}
+	return out;
+}
+
+/** Converts one workbench MCP server configuration into codex's per-thread JSON shape. */
+function toCodexMcpServerJson(config: IMcpServerConfiguration): ICodexMcpServerConfigJson {
+	if (config.type === McpServerType.LOCAL) {
+		const out: ICodexMcpServerConfigJson = { command: config.command };
+		if (config.args && config.args.length > 0) {
+			out.args = [...config.args];
+		}
+		if (config.env) {
+			const env = toStringEnv(config.env);
+			if (Object.keys(env).length > 0) {
+				out.env = env;
+			}
+		}
+		if (config.cwd) {
+			out.cwd = config.cwd;
+		}
+		return out;
+	}
+	const out: ICodexMcpServerConfigJson = { url: config.url };
+	if (config.headers && Object.keys(config.headers).length > 0) {
+		out.http_headers = { ...config.headers };
+	}
+	return out;
+}
+
+/**
+ * Builds the `mcp_servers` object for `thread/start.config` from a set of
+ * client plugins. Later servers do not overwrite earlier ones (first
+ * definition of a given name wins), matching the dedupe used elsewhere.
+ * Returns an empty object when the plugins declare no MCP servers.
+ */
+export function codexMcpServersFromPlugins(plugins: readonly ICodexClientPlugin[]): Record<string, ICodexMcpServerConfigJson> {
+	const out: Record<string, ICodexMcpServerConfigJson> = {};
+	for (const plugin of plugins) {
+		for (const def of plugin.parsed?.mcpServers ?? emptyMcpDefs) {
+			if (!Object.prototype.hasOwnProperty.call(out, def.name)) {
+				out[def.name] = toCodexMcpServerJson(def.configuration);
+			}
+		}
+	}
+	return out;
+}
+
+const emptyMcpDefs: readonly IMcpServerDefinition[] = [];
+
+/**
+ * Derives the codex skill roots (absolute fsPaths) for a set of client
+ * plugins: the parent directory of each skill's `<name>/SKILL.md`, i.e. the
+ * plugin's `skills` root, which codex scans for `<name>/SKILL.md` entries.
+ * De-duplicated and sorted for a stable `skills/extraRoots/set` payload.
+ */
+export function codexSkillRootsFromPlugins(plugins: readonly ICodexClientPlugin[]): string[] {
+	const roots = new Set<string>();
+	for (const plugin of plugins) {
+		for (const skill of plugin.parsed?.skills ?? []) {
+			// skill.uri === <pluginDir>/<skillsDir>/<name>/SKILL.md
+			// dirname twice === <pluginDir>/<skillsDir> (the root codex scans).
+			roots.add(dirname(dirname(skill.uri.fsPath)));
+		}
+	}
+	return [...roots].sort();
+}

--- a/src/vs/platform/agentHost/node/codex/codexCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexCustomizations.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../base/common/uri.js';
+import { CustomizationLoadStatus, CustomizationType, customizationId, type DirectoryCustomization, type HookCustomization, type SkillCustomization } from '../../common/state/sessionState.js';
+import type { HookMetadata } from './protocol/generated/v2/HookMetadata.js';
+import type { HooksListResponse } from './protocol/generated/v2/HooksListResponse.js';
+import type { SkillMetadata } from './protocol/generated/v2/SkillMetadata.js';
+import type { SkillScope } from './protocol/generated/v2/SkillScope.js';
+import type { SkillsListResponse } from './protocol/generated/v2/SkillsListResponse.js';
+
+/**
+ * Codex reports its *effective* skills and hooks through the cwd-scoped
+ * `skills/list` and `hooks/list` app-server methods (see
+ * `codex-rs/.../catalog_processor.rs`). Codex natively discovers skills from
+ * the VS Code `.agents/skills` convention (`<repo>/.agents/skills` at repo
+ * scope and `~/.agents/skills` at user scope) as well as `.codex` and bundled
+ * roots. These helpers project those catalogs into the AHP
+ * {@link DirectoryCustomization} containers that back the workbench
+ * Customizations surface, so what codex actually loaded is visible alongside
+ * the MCP servers already surfaced by {@link McpCustomizationController}.
+ *
+ * The mappers are pure (no codex round-trip): the {@link CodexAgent} fetches
+ * the `skills/list` / `hooks/list` responses and feeds them here.
+ */
+
+/** Synthetic URI scheme for the per-scope codex skills container. */
+const CODEX_SKILLS_SCHEME = 'codex-skills';
+/** Synthetic URI scheme for the codex hooks container. */
+const CODEX_HOOKS_SCHEME = 'codex-hooks';
+
+/** Human-facing container name for each {@link SkillScope}. */
+function skillScopeContainerName(scope: SkillScope): string {
+	switch (scope) {
+		case 'repo': return 'Repository';
+		case 'user': return 'User';
+		case 'system': return 'Built-in';
+		case 'admin': return 'Admin';
+		default: return scope;
+	}
+}
+
+/** Stable ordering of scopes so the container list is deterministic. */
+const SKILL_SCOPE_ORDER: readonly SkillScope[] = ['repo', 'user', 'system', 'admin'];
+
+function skillToCustomization(skill: SkillMetadata): SkillCustomization {
+	const uri = URI.file(skill.path).toString();
+	return {
+		type: CustomizationType.Skill,
+		id: customizationId(uri),
+		uri,
+		name: skill.name,
+		description: skill.description,
+		enabled: skill.enabled,
+	};
+}
+
+/**
+ * Projects a codex `skills/list` response into one read-only
+ * {@link DirectoryCustomization} container per {@link SkillScope}, each
+ * carrying its skills as {@link SkillCustomization} children. Skills are
+ * de-duplicated by their `SKILL.md` path (codex can report the same skill
+ * for several requested cwds). Scopes with no skills are omitted; the result
+ * is ordered by {@link SKILL_SCOPE_ORDER}.
+ */
+export function codexSkillsToContainers(response: SkillsListResponse | undefined): DirectoryCustomization[] {
+	const byScope = new Map<SkillScope, Map<string, SkillMetadata>>();
+	for (const entry of response?.data ?? []) {
+		for (const skill of entry.skills ?? []) {
+			let scoped = byScope.get(skill.scope);
+			if (!scoped) {
+				scoped = new Map();
+				byScope.set(skill.scope, scoped);
+			}
+			if (!scoped.has(skill.path)) {
+				scoped.set(skill.path, skill);
+			}
+		}
+	}
+	const containers: DirectoryCustomization[] = [];
+	for (const scope of SKILL_SCOPE_ORDER) {
+		const scoped = byScope.get(scope);
+		if (!scoped || scoped.size === 0) {
+			continue;
+		}
+		const children = [...scoped.values()]
+			.sort((a, b) => a.name.localeCompare(b.name))
+			.map(skillToCustomization);
+		const containerUri = URI.from({ scheme: CODEX_SKILLS_SCHEME, path: `/${scope}` }).toString();
+		containers.push({
+			type: CustomizationType.Directory,
+			id: customizationId(containerUri),
+			uri: containerUri,
+			name: skillScopeContainerName(scope),
+			enabled: true,
+			contents: CustomizationType.Skill,
+			writable: false,
+			load: { kind: CustomizationLoadStatus.Loaded },
+			children,
+		});
+	}
+	return containers;
+}
+
+function hookToCustomization(hook: HookMetadata): HookCustomization {
+	// A single source file can declare several hooks, so disambiguate with the
+	// codex hook `key` in the fragment to keep customization ids unique.
+	const uri = URI.file(hook.sourcePath).with({ fragment: hook.key }).toString();
+	return {
+		type: CustomizationType.Hook,
+		id: customizationId(uri),
+		uri,
+		name: hook.eventName,
+		enabled: hook.enabled,
+	};
+}
+
+/**
+ * Projects a codex `hooks/list` response into a single read-only
+ * {@link DirectoryCustomization} container carrying its hooks as
+ * {@link HookCustomization} children. Hooks are de-duplicated by their codex
+ * `key`. Returns an empty array when no hooks are configured.
+ */
+export function codexHooksToContainers(response: HooksListResponse | undefined): DirectoryCustomization[] {
+	const byKey = new Map<string, HookMetadata>();
+	for (const entry of response?.data ?? []) {
+		for (const hook of entry.hooks ?? []) {
+			if (!byKey.has(hook.key)) {
+				byKey.set(hook.key, hook);
+			}
+		}
+	}
+	if (byKey.size === 0) {
+		return [];
+	}
+	const children = [...byKey.values()]
+		.sort((a, b) => Number(a.displayOrder - b.displayOrder) || a.key.localeCompare(b.key))
+		.map(hookToCustomization);
+	const containerUri = URI.from({ scheme: CODEX_HOOKS_SCHEME, path: '/hooks' }).toString();
+	return [{
+		type: CustomizationType.Directory,
+		id: customizationId(containerUri),
+		uri: containerUri,
+		name: 'Hooks',
+		enabled: true,
+		contents: CustomizationType.Hook,
+		writable: false,
+		load: { kind: CustomizationLoadStatus.Loaded },
+		children,
+	}];
+}

--- a/src/vs/platform/agentHost/node/codex/codexMcpServers.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMcpServers.ts
@@ -247,3 +247,73 @@ export function codexMcpServersFromConfig(servers: Record<string, unknown> | und
 
 // #endregion
 
+// #region MCP server authentication (reuse the workbench OAuth path)
+//
+// codex won't expose an OAuth-gated http MCP server's tools until it is
+// authenticated (it reports a `failed` startup with a "not logged in" error).
+// Rather than drive codex's own `mcpServer/oauth/login` browser flow, we reuse
+// the *same* mechanism the Copilot agent uses: report the server as
+// `McpServerStatus.AuthRequired` so the workbench acquires an OAuth bearer
+// token (VS Code dynamic client registration), then inject that token into the
+// server's per-thread `http_headers.Authorization`. Verified against the real
+// codex binary: it forwards `http_headers` on every MCP HTTP request, so a
+// workbench-acquired bearer authenticates the connection.
+
+/**
+ * Canonicalizes an MCP server URL for matching a workbench-acquired token
+ * (keyed by the OAuth `resource`) against a configured server. Mirrors the
+ * Copilot agent's normalization: strips the fragment and any trailing slashes
+ * from the path. Returns `undefined` for a non-URL value (e.g. a stdio server).
+ */
+export function normalizeCodexMcpResourceUrl(value: string): string | undefined {
+	if (!URL.canParse(value)) {
+		return undefined;
+	}
+	const url = new URL(value);
+	url.hash = '';
+	url.pathname = url.pathname.replace(/\/+$/, '');
+	return url.href;
+}
+
+/**
+ * Whether a codex `mcpServer/startupStatus/updated` `failed` error indicates
+ * the server needs authentication (rather than a generic crash), so it should
+ * surface as {@link McpServerStatus.AuthRequired} (workbench "Authenticate"
+ * affordance) instead of a fatal error. codex has no structured auth state on
+ * this notification, so this matches its human-readable "not logged in" /
+ * "run `codex mcp login`" phrasing and the standard OAuth challenge vocabulary.
+ */
+export function codexStartupErrorNeedsAuth(error: string | null | undefined): boolean {
+	if (!error) {
+		return false;
+	}
+	return /not logged in|mcp login|log in to|unauthori[sz]ed|requires? (?:authentication|authorization|login)|\b401\b/i.test(error);
+}
+
+/**
+ * Returns a copy of `servers` with `Authorization: Bearer <token>` injected
+ * into the `http_headers` of every http server whose (normalized) URL has a
+ * token in `tokensByNormalizedUrl`. stdio servers and servers without a token
+ * are passed through unchanged. Any existing `Authorization` header is
+ * overwritten with the freshly acquired token.
+ */
+export function injectCodexMcpAuthTokens(
+	servers: Record<string, ICodexMcpServerConfigJson>,
+	tokensByNormalizedUrl: ReadonlyMap<string, string>,
+): Record<string, ICodexMcpServerConfigJson> {
+	if (tokensByNormalizedUrl.size === 0) {
+		return servers;
+	}
+	const out: Record<string, ICodexMcpServerConfigJson> = {};
+	for (const [name, server] of Object.entries(servers)) {
+		const normalized = server.url !== undefined ? normalizeCodexMcpResourceUrl(server.url) : undefined;
+		const token = normalized !== undefined ? tokensByNormalizedUrl.get(normalized) : undefined;
+		out[name] = token !== undefined
+			? { ...server, http_headers: { ...server.http_headers, Authorization: `Bearer ${token}` } }
+			: server;
+	}
+	return out;
+}
+
+// #endregion
+

--- a/src/vs/platform/agentHost/node/codex/codexMcpServers.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMcpServers.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { McpServerType, type IMcpServerConfiguration } from '../../../mcp/common/mcpPlatformTypes.js';
 import { McpServerStatus, type McpServerState } from '../../common/state/protocol/channels-session/state.js';
 import type { ISdkMcpServer } from '../shared/mcpCustomizationController.js';
 import type { McpServerStartupState } from './protocol/generated/v2/McpServerStartupState.js';
@@ -140,3 +141,177 @@ export function codexMcpToolsChanged(previous: ICodexMcpServerEntry | undefined,
 	}
 	return a.some((name, i) => name !== b[i]);
 }
+
+// #region MCP server config → codex `-c` overrides
+//
+// Codex's `app-server` accepts `-c key=value` config overrides whose value is
+// parsed as TOML (see `codex-rs/utils/cli/src/config_override.rs`). We use
+// these to inject the workbench's configured MCP servers (the root
+// `mcpServers` config, keyed by server name) into codex so it launches them —
+// the same set Copilot passes to its SDK via `toSdkMcpServersFromConfigMap`.
+//
+// Each server becomes one `mcp_servers.<name>=<inline-table>` override, which
+// *merges* with (rather than replaces) any servers in the user's global
+// `~/.codex/config.toml`. Codex's override parser splits the key path on `.`
+// and separates key/value on the first `=`, so a server name containing either
+// character cannot be targeted and is skipped by
+// {@link isCodexOverrideSafeServerName}.
+//
+// The codex MCP TOML schema (`codex-rs/config/src/mcp_types.rs`,
+// `RawMcpServerConfig`, `deny_unknown_fields`) infers the transport from the
+// presence of `command` (stdio) vs `url` (streamable http) and does not accept
+// a `type` field, so we drop the workbench `type` discriminator and map
+// `headers` → `http_headers`.
+
+/** A TOML-encodable value: a string, a string array, or a flat string map. */
+type CodexTomlValue = string | readonly string[] | Readonly<Record<string, string>>;
+
+/**
+ * Encodes a string as a TOML basic (double-quoted) string, escaping the
+ * control characters TOML requires plus `"` and `\`.
+ */
+function encodeCodexTomlString(value: string): string {
+	let out = '"';
+	for (const ch of value) {
+		const code = ch.codePointAt(0)!;
+		switch (ch) {
+			case '\\': out += '\\\\'; break;
+			case '"': out += '\\"'; break;
+			case '\b': out += '\\b'; break;
+			case '\t': out += '\\t'; break;
+			case '\n': out += '\\n'; break;
+			case '\f': out += '\\f'; break;
+			case '\r': out += '\\r'; break;
+			default:
+				out += code < 0x20 ? `\\u${code.toString(16).padStart(4, '0')}` : ch;
+		}
+	}
+	return `${out}"`;
+}
+
+/**
+ * Encodes a TOML inline-table key: bare when it is a safe identifier,
+ * otherwise a quoted basic string.
+ */
+function encodeCodexTomlKey(key: string): string {
+	return /^[A-Za-z0-9_-]+$/.test(key) ? key : encodeCodexTomlString(key);
+}
+
+/** Encodes a single {@link CodexTomlValue}. */
+function encodeCodexTomlValue(value: CodexTomlValue): string {
+	if (typeof value === 'string') {
+		return encodeCodexTomlString(value);
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(v => encodeCodexTomlString(v)).join(', ')}]`;
+	}
+	const entries = Object.entries(value as Record<string, string>);
+	return `{ ${entries.map(([k, v]) => `${encodeCodexTomlKey(k)} = ${encodeCodexTomlString(v)}`).join(', ')} }`;
+}
+
+/** Encodes an ordered list of fields as a TOML inline table. */
+function encodeCodexInlineTable(fields: ReadonlyArray<readonly [string, CodexTomlValue]>): string {
+	return `{ ${fields.map(([k, v]) => `${encodeCodexTomlKey(k)} = ${encodeCodexTomlValue(v)}`).join(', ')} }`;
+}
+
+/**
+ * Narrows an untrusted root-config value to a supported
+ * {@link IMcpServerConfiguration}: a `stdio` server with a string `command`,
+ * or an `http` server with a string `url`. Mirrors Copilot's
+ * `isSupportedMcpServerConfiguration` so a malformed entry can't surface as a
+ * `command`/`url: undefined` override.
+ */
+function isSupportedMcpServerConfiguration(value: unknown): value is IMcpServerConfiguration {
+	if (!value || typeof value !== 'object') {
+		return false;
+	}
+	const candidate = value as { type?: unknown; command?: unknown; url?: unknown };
+	if (candidate.type === McpServerType.LOCAL) {
+		return typeof candidate.command === 'string';
+	}
+	if (candidate.type === McpServerType.REMOTE) {
+		return typeof candidate.url === 'string';
+	}
+	return false;
+}
+
+/**
+ * Whether a server name can be targeted by a `mcp_servers.<name>=…` override.
+ * Codex splits the override key path on `.` and separates key/value on the
+ * first `=`, and trims the key, so names containing `.`/`=` or with
+ * surrounding whitespace cannot be addressed and are skipped.
+ */
+function isCodexOverrideSafeServerName(name: string): boolean {
+	return name.length > 0 && name === name.trim() && !/[.=]/.test(name);
+}
+
+/** Ensures all env values are strings (codex's `env` is a `Map<string, string>`). */
+function toCodexStringEnv(env: Record<string, string | number | null>): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (value !== null) {
+			result[key] = String(value);
+		}
+	}
+	return result;
+}
+
+/** Builds the codex inline-table fields for a single supported server. */
+function codexMcpServerFields(config: IMcpServerConfiguration): ReadonlyArray<readonly [string, CodexTomlValue]> {
+	const fields: (readonly [string, CodexTomlValue])[] = [];
+	if (config.type === McpServerType.LOCAL) {
+		fields.push(['command', config.command]);
+		if (config.args && config.args.length > 0) {
+			fields.push(['args', [...config.args]]);
+		}
+		if (config.env) {
+			const env = toCodexStringEnv(config.env);
+			if (Object.keys(env).length > 0) {
+				fields.push(['env', env]);
+			}
+		}
+		if (config.cwd) {
+			fields.push(['cwd', config.cwd]);
+		}
+		return fields;
+	}
+	fields.push(['url', config.url]);
+	if (config.headers && Object.keys(config.headers).length > 0) {
+		fields.push(['http_headers', { ...config.headers }]);
+	}
+	return fields;
+}
+
+/**
+ * The result of {@link buildCodexMcpServerOverrides}: the ready-to-pass
+ * `mcp_servers.<name>=<toml>` override strings, plus the names that were
+ * dropped because they are malformed or cannot be addressed by a codex
+ * override key (so the caller can log a diagnostic).
+ */
+export interface ICodexMcpServerOverrides {
+	readonly overrides: readonly string[];
+	readonly skipped: readonly string[];
+}
+
+/**
+ * Converts the workbench root `mcpServers` config (server name →
+ * {@link IMcpServerConfiguration}) into codex `-c` config overrides that make
+ * the app-server launch those servers. Unsupported/malformed entries and
+ * names that cannot be addressed by an override key are skipped. Returns
+ * `key=value` strings ready to be expanded as `-c <override>` spawn args.
+ */
+export function buildCodexMcpServerOverrides(servers: Record<string, unknown> | undefined): ICodexMcpServerOverrides {
+	const overrides: string[] = [];
+	const skipped: string[] = [];
+	for (const [name, config] of Object.entries(servers ?? {})) {
+		if (!isSupportedMcpServerConfiguration(config) || !isCodexOverrideSafeServerName(name)) {
+			skipped.push(name);
+			continue;
+		}
+		const table = encodeCodexInlineTable(codexMcpServerFields(config));
+		overrides.push(`mcp_servers.${name}=${table}`);
+	}
+	return { overrides, skipped };
+}
+
+// #endregion

--- a/src/vs/platform/agentHost/node/codex/codexMcpServers.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMcpServers.ts
@@ -142,76 +142,33 @@ export function codexMcpToolsChanged(previous: ICodexMcpServerEntry | undefined,
 	return a.some((name, i) => name !== b[i]);
 }
 
-// #region MCP server config → codex `-c` overrides
+// #region MCP server config → codex per-thread `config.mcp_servers`
 //
-// Codex's `app-server` accepts `-c key=value` config overrides whose value is
-// parsed as TOML (see `codex-rs/utils/cli/src/config_override.rs`). We use
-// these to inject the workbench's configured MCP servers (the root
-// `mcpServers` config, keyed by server name) into codex so it launches them —
-// the same set Copilot passes to its SDK via `toSdkMcpServersFromConfigMap`.
+// Codex's `thread/start.config` dict is applied as per-thread config overrides
+// that *merge* with (rather than replace) the user's global
+// `~/.codex/config.toml` (verified against the real app-server). We inject the
+// workbench's configured MCP servers (the root `mcpServers` config, keyed by
+// server name) via `config.mcp_servers` so codex launches them for that
+// thread — the same set Copilot passes to its SDK via
+// `toSdkMcpServersFromConfigMap`. Feeding them per-thread (rather than as
+// process-global `-c` spawn overrides) means each new session picks up the
+// current config without restarting the shared app-server.
 //
-// Each server becomes one `mcp_servers.<name>=<inline-table>` override, which
-// *merges* with (rather than replaces) any servers in the user's global
-// `~/.codex/config.toml`. Codex's override parser splits the key path on `.`
-// and separates key/value on the first `=`, so a server name containing either
-// character cannot be targeted and is skipped by
-// {@link isCodexOverrideSafeServerName}.
-//
-// The codex MCP TOML schema (`codex-rs/config/src/mcp_types.rs`,
-// `RawMcpServerConfig`, `deny_unknown_fields`) infers the transport from the
-// presence of `command` (stdio) vs `url` (streamable http) and does not accept
-// a `type` field, so we drop the workbench `type` discriminator and map
-// `headers` → `http_headers`.
-
-/** A TOML-encodable value: a string, a string array, or a flat string map. */
-type CodexTomlValue = string | readonly string[] | Readonly<Record<string, string>>;
+// The codex MCP config schema (`codex-rs/config/src/mcp_types.rs`,
+// `RawMcpServerConfig`) infers the transport from the presence of `command`
+// (stdio) vs `url` (streamable http) and has no `type` field, so we drop the
+// workbench `type` discriminator and map `headers` → `http_headers`.
 
 /**
- * Encodes a string as a TOML basic (double-quoted) string, escaping the
- * control characters TOML requires plus `"` and `\`.
+ * The codex JSON shape for one MCP server inside `thread/start.config.mcp_servers`.
  */
-function encodeCodexTomlString(value: string): string {
-	let out = '"';
-	for (const ch of value) {
-		const code = ch.codePointAt(0)!;
-		switch (ch) {
-			case '\\': out += '\\\\'; break;
-			case '"': out += '\\"'; break;
-			case '\b': out += '\\b'; break;
-			case '\t': out += '\\t'; break;
-			case '\n': out += '\\n'; break;
-			case '\f': out += '\\f'; break;
-			case '\r': out += '\\r'; break;
-			default:
-				out += code < 0x20 ? `\\u${code.toString(16).padStart(4, '0')}` : ch;
-		}
-	}
-	return `${out}"`;
-}
-
-/**
- * Encodes a TOML inline-table key: bare when it is a safe identifier,
- * otherwise a quoted basic string.
- */
-function encodeCodexTomlKey(key: string): string {
-	return /^[A-Za-z0-9_-]+$/.test(key) ? key : encodeCodexTomlString(key);
-}
-
-/** Encodes a single {@link CodexTomlValue}. */
-function encodeCodexTomlValue(value: CodexTomlValue): string {
-	if (typeof value === 'string') {
-		return encodeCodexTomlString(value);
-	}
-	if (Array.isArray(value)) {
-		return `[${value.map(v => encodeCodexTomlString(v)).join(', ')}]`;
-	}
-	const entries = Object.entries(value as Record<string, string>);
-	return `{ ${entries.map(([k, v]) => `${encodeCodexTomlKey(k)} = ${encodeCodexTomlString(v)}`).join(', ')} }`;
-}
-
-/** Encodes an ordered list of fields as a TOML inline table. */
-function encodeCodexInlineTable(fields: ReadonlyArray<readonly [string, CodexTomlValue]>): string {
-	return `{ ${fields.map(([k, v]) => `${encodeCodexTomlKey(k)} = ${encodeCodexTomlValue(v)}`).join(', ')} }`;
+export interface ICodexMcpServerConfigJson {
+	command?: string;
+	args?: readonly string[];
+	env?: Record<string, string>;
+	cwd?: string;
+	url?: string;
+	http_headers?: Record<string, string>;
 }
 
 /**
@@ -219,9 +176,9 @@ function encodeCodexInlineTable(fields: ReadonlyArray<readonly [string, CodexTom
  * {@link IMcpServerConfiguration}: a `stdio` server with a string `command`,
  * or an `http` server with a string `url`. Mirrors Copilot's
  * `isSupportedMcpServerConfiguration` so a malformed entry can't surface as a
- * `command`/`url: undefined` override.
+ * `command`/`url: undefined` server.
  */
-function isSupportedMcpServerConfiguration(value: unknown): value is IMcpServerConfiguration {
+export function isSupportedMcpServerConfiguration(value: unknown): value is IMcpServerConfiguration {
 	if (!value || typeof value !== 'object') {
 		return false;
 	}
@@ -235,16 +192,6 @@ function isSupportedMcpServerConfiguration(value: unknown): value is IMcpServerC
 	return false;
 }
 
-/**
- * Whether a server name can be targeted by a `mcp_servers.<name>=…` override.
- * Codex splits the override key path on `.` and separates key/value on the
- * first `=`, and trims the key, so names containing `.`/`=` or with
- * surrounding whitespace cannot be addressed and are skipped.
- */
-function isCodexOverrideSafeServerName(name: string): boolean {
-	return name.length > 0 && name === name.trim() && !/[.=]/.test(name);
-}
-
 /** Ensures all env values are strings (codex's `env` is a `Map<string, string>`). */
 function toCodexStringEnv(env: Record<string, string | number | null>): Record<string, string> {
 	const result: Record<string, string> = {};
@@ -256,62 +203,47 @@ function toCodexStringEnv(env: Record<string, string | number | null>): Record<s
 	return result;
 }
 
-/** Builds the codex inline-table fields for a single supported server. */
-function codexMcpServerFields(config: IMcpServerConfiguration): ReadonlyArray<readonly [string, CodexTomlValue]> {
-	const fields: (readonly [string, CodexTomlValue])[] = [];
+/** Converts one supported MCP server configuration into codex's JSON shape. */
+export function toCodexMcpServerJson(config: IMcpServerConfiguration): ICodexMcpServerConfigJson {
 	if (config.type === McpServerType.LOCAL) {
-		fields.push(['command', config.command]);
+		const out: ICodexMcpServerConfigJson = { command: config.command };
 		if (config.args && config.args.length > 0) {
-			fields.push(['args', [...config.args]]);
+			out.args = [...config.args];
 		}
 		if (config.env) {
 			const env = toCodexStringEnv(config.env);
 			if (Object.keys(env).length > 0) {
-				fields.push(['env', env]);
+				out.env = env;
 			}
 		}
 		if (config.cwd) {
-			fields.push(['cwd', config.cwd]);
+			out.cwd = config.cwd;
 		}
-		return fields;
+		return out;
 	}
-	fields.push(['url', config.url]);
+	const out: ICodexMcpServerConfigJson = { url: config.url };
 	if (config.headers && Object.keys(config.headers).length > 0) {
-		fields.push(['http_headers', { ...config.headers }]);
+		out.http_headers = { ...config.headers };
 	}
-	return fields;
-}
-
-/**
- * The result of {@link buildCodexMcpServerOverrides}: the ready-to-pass
- * `mcp_servers.<name>=<toml>` override strings, plus the names that were
- * dropped because they are malformed or cannot be addressed by a codex
- * override key (so the caller can log a diagnostic).
- */
-export interface ICodexMcpServerOverrides {
-	readonly overrides: readonly string[];
-	readonly skipped: readonly string[];
+	return out;
 }
 
 /**
  * Converts the workbench root `mcpServers` config (server name →
- * {@link IMcpServerConfiguration}) into codex `-c` config overrides that make
- * the app-server launch those servers. Unsupported/malformed entries and
- * names that cannot be addressed by an override key are skipped. Returns
- * `key=value` strings ready to be expanded as `-c <override>` spawn args.
+ * {@link IMcpServerConfiguration}) into the `mcp_servers` object codex accepts
+ * in `thread/start.config`. Unsupported/malformed entries are skipped so a bad
+ * entry can't surface as a `command`/`url: undefined` server. Returns an empty
+ * object when nothing is configured.
  */
-export function buildCodexMcpServerOverrides(servers: Record<string, unknown> | undefined): ICodexMcpServerOverrides {
-	const overrides: string[] = [];
-	const skipped: string[] = [];
+export function codexMcpServersFromConfig(servers: Record<string, unknown> | undefined): Record<string, ICodexMcpServerConfigJson> {
+	const out: Record<string, ICodexMcpServerConfigJson> = {};
 	for (const [name, config] of Object.entries(servers ?? {})) {
-		if (!isSupportedMcpServerConfiguration(config) || !isCodexOverrideSafeServerName(name)) {
-			skipped.push(name);
-			continue;
+		if (isSupportedMcpServerConfiguration(config)) {
+			out[name] = toCodexMcpServerJson(config);
 		}
-		const table = encodeCodexInlineTable(codexMcpServerFields(config));
-		overrides.push(`mcp_servers.${name}=${table}`);
 	}
-	return { overrides, skipped };
+	return out;
 }
 
 // #endregion
+

--- a/src/vs/platform/agentHost/node/codex/codexMcpServers.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMcpServers.ts
@@ -192,38 +192,62 @@ export function isSupportedMcpServerConfiguration(value: unknown): value is IMcp
 	return false;
 }
 
-/** Ensures all env values are strings (codex's `env` is a `Map<string, string>`). */
-function toCodexStringEnv(env: Record<string, string | number | null>): Record<string, string> {
+/**
+ * Coerces a record's values to strings (codex's `env`/`http_headers` are
+ * `Map<string, string>`), dropping `null`/`undefined`. The root `mcpServers`
+ * config is user-authored and only loosely schema-validated, so a stray
+ * non-string (e.g. a numeric header value) is coerced here rather than passed
+ * through — an un-coerced value can make codex reject the whole per-thread
+ * config, disabling every server for the session.
+ */
+function toCodexStringRecord(record: Record<string, unknown> | undefined): Record<string, string> {
 	const result: Record<string, string> = {};
-	for (const [key, value] of Object.entries(env)) {
-		if (value !== null) {
+	if (!record) {
+		return result;
+	}
+	for (const [key, value] of Object.entries(record)) {
+		if (value !== null && value !== undefined) {
 			result[key] = String(value);
 		}
 	}
 	return result;
 }
 
-/** Converts one supported MCP server configuration into codex's JSON shape. */
+/** Coerces command args to a string array (codex's `args` is `Vec<String>`), dropping `null`/`undefined`. */
+function toCodexStringArray(values: readonly unknown[] | undefined): string[] {
+	if (!Array.isArray(values)) {
+		return [];
+	}
+	return values.filter(v => v !== null && v !== undefined).map(v => String(v));
+}
+
+/**
+ * Converts one supported MCP server configuration into codex's JSON shape.
+ * Optional fields (`args`, `env`, `cwd`, `headers`) come from user-authored
+ * config that the root schema does not deeply validate, so each is sanitized
+ * (coerced to the string shapes codex requires, dropping holes) rather than
+ * trusted, so a single malformed entry can't make codex reject the config.
+ */
 export function toCodexMcpServerJson(config: IMcpServerConfiguration): ICodexMcpServerConfigJson {
 	if (config.type === McpServerType.LOCAL) {
 		const out: ICodexMcpServerConfigJson = { command: config.command };
-		if (config.args && config.args.length > 0) {
-			out.args = [...config.args];
+		const args = toCodexStringArray(config.args);
+		if (args.length > 0) {
+			out.args = args;
 		}
-		if (config.env) {
-			const env = toCodexStringEnv(config.env);
-			if (Object.keys(env).length > 0) {
-				out.env = env;
-			}
+		const env = toCodexStringRecord(config.env);
+		if (Object.keys(env).length > 0) {
+			out.env = env;
 		}
-		if (config.cwd) {
+		if (typeof config.cwd === 'string') {
 			out.cwd = config.cwd;
 		}
 		return out;
 	}
 	const out: ICodexMcpServerConfigJson = { url: config.url };
-	if (config.headers && Object.keys(config.headers).length > 0) {
-		out.http_headers = { ...config.headers };
+	const headers = toCodexStringRecord(config.headers);
+	if (Object.keys(headers).length > 0) {
+		out.http_headers = headers;
 	}
 	return out;
 }
@@ -294,8 +318,10 @@ export function codexStartupErrorNeedsAuth(error: string | null | undefined): bo
  * Returns a copy of `servers` with `Authorization: Bearer <token>` injected
  * into the `http_headers` of every http server whose (normalized) URL has a
  * token in `tokensByNormalizedUrl`. stdio servers and servers without a token
- * are passed through unchanged. Any existing `Authorization` header is
- * overwritten with the freshly acquired token.
+ * are passed through unchanged. Any existing authorization header is removed
+ * first -- case-insensitively, since HTTP header names are case-insensitive and
+ * a configured lowercase `authorization` would otherwise coexist with the
+ * injected value and leave a stale credential in the payload.
  */
 export function injectCodexMcpAuthTokens(
 	servers: Record<string, ICodexMcpServerConfigJson>,
@@ -309,8 +335,21 @@ export function injectCodexMcpAuthTokens(
 		const normalized = server.url !== undefined ? normalizeCodexMcpResourceUrl(server.url) : undefined;
 		const token = normalized !== undefined ? tokensByNormalizedUrl.get(normalized) : undefined;
 		out[name] = token !== undefined
-			? { ...server, http_headers: { ...server.http_headers, Authorization: `Bearer ${token}` } }
+			? { ...server, http_headers: { ...withoutAuthorizationHeaders(server.http_headers), Authorization: `Bearer ${token}` } }
 			: server;
+	}
+	return out;
+}
+
+/** Drops any header whose name is `authorization` (case-insensitive). */
+function withoutAuthorizationHeaders(headers: Record<string, string> | undefined): Record<string, string> {
+	const out: Record<string, string> = {};
+	if (headers) {
+		for (const [key, value] of Object.entries(headers)) {
+			if (key.toLowerCase() !== 'authorization') {
+				out[key] = value;
+			}
+		}
 	}
 	return out;
 }

--- a/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import type { IMcpServerDefinition, IParsedPlugin, IParsedSkill } from '../../../../agentPlugins/common/pluginParsers.js';
+import { McpServerType, type IMcpServerConfiguration } from '../../../../mcp/common/mcpPlatformTypes.js';
+import type { ISyncedCustomization } from '../../../common/agentPluginManager.js';
+import { CustomizationType, McpServerStatus, type PluginCustomization } from '../../../common/state/protocol/channels-session/state.js';
+import { CodexClientCustomizationStore, codexMcpServersFromPlugins, codexSkillRootsFromPlugins, type ICodexClientPlugin } from '../../../node/codex/codexClientCustomizations.js';
+
+suite('codexClientCustomizations', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function pluginCustomization(id: string): PluginCustomization {
+		return { type: CustomizationType.Plugin, id, uri: `https://plugins/${id}`, name: id, enabled: true };
+	}
+
+	function mcpDef(name: string, config: IMcpServerConfiguration): IMcpServerDefinition {
+		const uri = URI.file(`/plugins/${name}/.mcp.json`);
+		return { name, configuration: config, uri, customization: { type: CustomizationType.McpServer, id: `mcp:${name}`, uri: uri.toString(), name, enabled: true, state: { kind: McpServerStatus.Starting } } };
+	}
+
+	function skillDef(pluginDir: string, name: string): IParsedSkill {
+		const uri = URI.file(`${pluginDir}/skills/${name}/SKILL.md`);
+		return { uri, name, description: `${name} desc`, customization: { type: CustomizationType.Skill, id: `skill:${name}`, uri: uri.toString(), name } };
+	}
+
+	function parsed(overrides: Partial<IParsedPlugin> = {}): IParsedPlugin {
+		return { hooks: [], mcpServers: [], skills: [], agents: [], instructions: [], ...overrides };
+	}
+
+	function plugin(id: string, pluginDir: string | undefined, p: IParsedPlugin | undefined): ICodexClientPlugin {
+		const synced: ISyncedCustomization = { customization: pluginCustomization(id), pluginDir: pluginDir ? URI.file(pluginDir) : undefined };
+		return { synced, parsed: p };
+	}
+
+	test('toCustomizations folds parsed children and applies the enablement overlay', () => {
+		const store = new CodexClientCustomizationStore();
+		store.setClient('c1', [plugin('p1', '/plugins/p1', parsed({
+			mcpServers: [mcpDef('srv', { type: McpServerType.LOCAL, command: 'run' })],
+			skills: [skillDef('/plugins/p1', 'greet')],
+		}))]);
+		store.setEnabled('p1', false);
+		assert.deepStrictEqual(store.toCustomizations().map(c => ({
+			id: c.id,
+			enabled: c.enabled,
+			children: c.children?.map(ch => ({ type: ch.type, id: ch.id })),
+		})), [{
+			id: 'p1',
+			enabled: false,
+			children: [
+				{ type: CustomizationType.Skill, id: 'skill:greet' },
+				{ type: CustomizationType.McpServer, id: 'mcp:srv' },
+			],
+		}]);
+	});
+
+	test('enabledPlugins excludes disabled and unparsed plugins; merge dedupes by id (first client wins)', () => {
+		const store = new CodexClientCustomizationStore();
+		store.setClient('c1', [
+			plugin('shared', '/plugins/shared', parsed({ skills: [skillDef('/plugins/shared', 's')] })),
+			plugin('unparsed', undefined, undefined),
+			plugin('off', '/plugins/off', parsed()),
+		]);
+		store.setClient('c2', [plugin('shared', '/plugins/other', parsed())]); // duplicate id ignored
+		store.setEnabled('off', false);
+		assert.deepStrictEqual(store.enabledPlugins().map(p => p.synced.customization.id), ['shared']);
+	});
+
+	test('codexMcpServersFromPlugins maps stdio + http, stringifies env, and maps headers', () => {
+		const plugins = [plugin('p', '/plugins/p', parsed({
+			mcpServers: [
+				mcpDef('local', { type: McpServerType.LOCAL, command: 'npx', args: ['-y', 'pkg'], env: { KEY: 'v', N: 3, DROP: null }, cwd: '/w' }),
+				mcpDef('remote', { type: McpServerType.REMOTE, url: 'https://x/mcp', headers: { Authorization: 'Bearer t' } }),
+			],
+		}))];
+		assert.deepStrictEqual(codexMcpServersFromPlugins(plugins), {
+			local: { command: 'npx', args: ['-y', 'pkg'], env: { KEY: 'v', N: '3' }, cwd: '/w' },
+			remote: { url: 'https://x/mcp', http_headers: { Authorization: 'Bearer t' } },
+		});
+	});
+
+	test('codexMcpServersFromPlugins de-duplicates server names (first wins) and omits empties', () => {
+		const plugins = [
+			plugin('a', '/plugins/a', parsed({ mcpServers: [mcpDef('dup', { type: McpServerType.LOCAL, command: 'first', args: [], env: {} })] })),
+			plugin('b', '/plugins/b', parsed({ mcpServers: [mcpDef('dup', { type: McpServerType.LOCAL, command: 'second' })] })),
+		];
+		assert.deepStrictEqual(codexMcpServersFromPlugins(plugins), { dup: { command: 'first' } });
+	});
+
+	test('codexSkillRootsFromPlugins returns the skills root (dirname twice), deduped and sorted', () => {
+		const plugins = [plugin('p', '/plugins/p', parsed({
+			skills: [skillDef('/plugins/p', 'b'), skillDef('/plugins/p', 'a')],
+		})), plugin('q', '/plugins/q', parsed({ skills: [skillDef('/plugins/q', 'c')] }))];
+		assert.deepStrictEqual(codexSkillRootsFromPlugins(plugins), ['/plugins/p/skills', '/plugins/q/skills']);
+	});
+
+	test('removeClient drops a client and setEnabled reports whether it changed', () => {
+		const store = new CodexClientCustomizationStore();
+		store.setClient('c1', [plugin('p1', '/plugins/p1', parsed())]);
+		assert.deepStrictEqual({
+			hasBefore: store.has('p1'),
+			toggledOff: store.setEnabled('p1', false),
+			toggledOffAgain: store.setEnabled('p1', false),
+			removed: store.removeClient('c1'),
+			emptyAfter: store.isEmpty(),
+		}, { hasBefore: true, toggledOff: true, toggledOffAgain: false, removed: true, emptyAfter: true });
+	});
+});

--- a/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
@@ -97,7 +97,11 @@ suite('codexClientCustomizations', () => {
 		const plugins = [plugin('p', '/plugins/p', parsed({
 			skills: [skillDef('/plugins/p', 'b'), skillDef('/plugins/p', 'a')],
 		})), plugin('q', '/plugins/q', parsed({ skills: [skillDef('/plugins/q', 'c')] }))];
-		assert.deepStrictEqual(codexSkillRootsFromPlugins(plugins), ['/plugins/p/skills', '/plugins/q/skills']);
+		// The roots are native fsPaths (backslashes on Windows), so express the
+		// expectation with the same platform-aware transform rather than a
+		// hardcoded posix path.
+		const skillsRoot = (pluginDir: string) => URI.file(`${pluginDir}/skills`).fsPath;
+		assert.deepStrictEqual(codexSkillRootsFromPlugins(plugins), [skillsRoot('/plugins/p'), skillsRoot('/plugins/q')]);
 	});
 
 	test('removeClient drops a client and setEnabled reports whether it changed', () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexCustomizations.test.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { CustomizationType } from '../../../common/state/protocol/channels-session/state.js';
+import { codexHooksToContainers, codexSkillsToContainers } from '../../../node/codex/codexCustomizations.js';
+import type { HookMetadata } from '../../../node/codex/protocol/generated/v2/HookMetadata.js';
+import type { SkillMetadata } from '../../../node/codex/protocol/generated/v2/SkillMetadata.js';
+import type { SkillScope } from '../../../node/codex/protocol/generated/v2/SkillScope.js';
+import type { SkillsListResponse } from '../../../node/codex/protocol/generated/v2/SkillsListResponse.js';
+
+suite('codexCustomizations', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const skill = (name: string, scope: SkillScope, path: string, enabled = true): SkillMetadata =>
+		({ name, description: `${name} desc`, path, scope, enabled });
+
+	const skillsResponse = (...entries: { cwd: string; skills: SkillMetadata[] }[]): SkillsListResponse =>
+		({ data: entries.map(e => ({ cwd: e.cwd, skills: e.skills, errors: [] })) });
+
+	const hook = (key: string, eventName: HookMetadata['eventName'], sourcePath: string, displayOrder = 0, enabled = true): HookMetadata =>
+		({ key, eventName, handlerType: 'command', matcher: null, command: 'echo hi', timeoutSec: 5n, statusMessage: null, sourcePath, source: 'project', pluginId: null, displayOrder: BigInt(displayOrder), enabled, isManaged: false, currentHash: 'h', trustStatus: 'trusted' });
+
+	test('groups skills by scope into read-only containers, sorted by name', () => {
+		const containers = codexSkillsToContainers(skillsResponse({
+			cwd: '/repo',
+			skills: [
+				skill('beta', 'repo', '/repo/.agents/skills/beta/SKILL.md'),
+				skill('alpha', 'repo', '/repo/.agents/skills/alpha/SKILL.md'),
+				skill('gamma', 'user', '/home/.agents/skills/gamma/SKILL.md', false),
+			],
+		}));
+		assert.deepStrictEqual(containers.map(c => ({
+			name: c.name,
+			contents: c.contents,
+			writable: c.writable,
+			children: c.children?.map(ch => ({ type: ch.type, name: ch.name, enabled: (ch as { enabled?: boolean }).enabled })),
+		})), [
+			{
+				name: 'Repository', contents: CustomizationType.Skill, writable: false,
+				children: [
+					{ type: CustomizationType.Skill, name: 'alpha', enabled: true },
+					{ type: CustomizationType.Skill, name: 'beta', enabled: true },
+				],
+			},
+			{
+				name: 'User', contents: CustomizationType.Skill, writable: false,
+				children: [{ type: CustomizationType.Skill, name: 'gamma', enabled: false }],
+			},
+		]);
+	});
+
+	test('de-duplicates skills by path across cwd entries and orders scopes repo/user/system', () => {
+		const dup = skill('shared', 'user', '/home/.agents/skills/shared/SKILL.md');
+		const containers = codexSkillsToContainers(skillsResponse(
+			{ cwd: '/a', skills: [dup, skill('sys', 'system', '/sys/imagegen/SKILL.md')] },
+			{ cwd: '/b', skills: [dup] },
+		));
+		assert.deepStrictEqual(containers.map(c => [c.name, c.children?.length]), [['User', 1], ['Built-in', 1]]);
+	});
+
+	test('skill child uri is a file uri and id is stable', () => {
+		const [container] = codexSkillsToContainers(skillsResponse({ cwd: '/r', skills: [skill('s', 'repo', '/r/.agents/skills/s/SKILL.md')] }));
+		const child = container.children![0];
+		assert.deepStrictEqual({ uriStartsWith: child.uri.toString().startsWith('file://'), sameId: child.id === codexSkillsToContainers(skillsResponse({ cwd: '/r', skills: [skill('s', 'repo', '/r/.agents/skills/s/SKILL.md')] }))[0].children![0].id }, { uriStartsWith: true, sameId: true });
+	});
+
+	test('empty / undefined skills responses yield no containers', () => {
+		assert.deepStrictEqual([codexSkillsToContainers(undefined), codexSkillsToContainers(skillsResponse()), codexSkillsToContainers(skillsResponse({ cwd: '/x', skills: [] }))], [[], [], []]);
+	});
+
+	test('hooks project into a single container, de-duped by key and ordered by displayOrder', () => {
+		const containers = codexHooksToContainers({
+			data: [{
+				cwd: '/repo',
+				hooks: [
+					hook('k2', 'postToolUse', '/repo/.codex/config.toml', 2),
+					hook('k1', 'preToolUse', '/repo/.codex/config.toml', 1, false),
+					hook('k1', 'preToolUse', '/repo/.codex/config.toml', 1),
+				],
+				warnings: [],
+				errors: [],
+			}],
+		});
+		assert.deepStrictEqual(containers.map(c => ({
+			name: c.name, contents: c.contents, writable: c.writable,
+			children: c.children?.map(ch => ({ type: ch.type, name: ch.name, enabled: (ch as { enabled?: boolean }).enabled })),
+		})), [{
+			name: 'Hooks', contents: CustomizationType.Hook, writable: false,
+			children: [
+				{ type: CustomizationType.Hook, name: 'preToolUse', enabled: false },
+				{ type: CustomizationType.Hook, name: 'postToolUse', enabled: true },
+			],
+		}]);
+	});
+
+	test('empty / undefined hooks responses yield no containers', () => {
+		assert.deepStrictEqual([codexHooksToContainers(undefined), codexHooksToContainers({ data: [] }), codexHooksToContainers({ data: [{ cwd: '/x', hooks: [], warnings: [], errors: [] }] })], [[], [], []]);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/codex/codexMcpServers.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMcpServers.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { McpServerStatus } from '../../../common/state/protocol/channels-session/state.js';
-import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpServersFromConfig, codexMcpStatusToEntry, codexMcpToolsChanged, codexToolMapToArray, inventoryToSdkServers, translateCodexMcpStartupState } from '../../../node/codex/codexMcpServers.js';
+import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpServersFromConfig, codexMcpStatusToEntry, codexMcpToolsChanged, codexStartupErrorNeedsAuth, codexToolMapToArray, injectCodexMcpAuthTokens, inventoryToSdkServers, normalizeCodexMcpResourceUrl, translateCodexMcpStartupState } from '../../../node/codex/codexMcpServers.js';
 import type { McpServerStatus as CodexMcpServerStatus } from '../../../node/codex/protocol/generated/v2/McpServerStatus.js';
 import type { Tool } from '../../../node/codex/protocol/generated/Tool.js';
 
@@ -140,6 +140,54 @@ suite('codexMcpServers', () => {
 				codexMcpServersFromConfig(undefined),
 				codexMcpServersFromConfig({}),
 			], [{}, {}]);
+		});
+	});
+
+	suite('MCP authentication helpers', () => {
+
+		test('normalizeCodexMcpResourceUrl strips fragment + trailing slashes; undefined for non-URL', () => {
+			assert.deepStrictEqual([
+				normalizeCodexMcpResourceUrl('https://mcp.eng.ms/'),
+				normalizeCodexMcpResourceUrl('https://mcp.eng.ms'),
+				normalizeCodexMcpResourceUrl('https://mcp.eng.ms/mcp/#frag'),
+				normalizeCodexMcpResourceUrl('not a url'),
+			], [
+				'https://mcp.eng.ms/',
+				'https://mcp.eng.ms/',
+				'https://mcp.eng.ms/mcp',
+				undefined,
+			]);
+		});
+
+		test('codexStartupErrorNeedsAuth matches login/auth phrasing, not generic failures', () => {
+			assert.deepStrictEqual([
+				codexStartupErrorNeedsAuth('The eng-hub-test MCP server is not logged in. Run `codex mcp login eng-hub-test`.'),
+				codexStartupErrorNeedsAuth('Unauthorized'),
+				codexStartupErrorNeedsAuth('request failed with 401'),
+				codexStartupErrorNeedsAuth('spawn ENOENT'),
+				codexStartupErrorNeedsAuth(null),
+				codexStartupErrorNeedsAuth(undefined),
+			], [true, true, true, false, false, false]);
+		});
+
+		test('injectCodexMcpAuthTokens adds a bearer header for http servers with a token, leaving others intact', () => {
+			const tokens = new Map([['https://mcp.eng.ms/', 'tok-123']]);
+			assert.deepStrictEqual(injectCodexMcpAuthTokens({
+				'eng-hub-test': { url: 'https://mcp.eng.ms' },
+				'with-headers': { url: 'https://mcp.eng.ms/', http_headers: { 'X-Test': 'v1' } },
+				'no-token': { url: 'https://other.example/mcp' },
+				'stdio': { command: 'run' },
+			}, tokens), {
+				'eng-hub-test': { url: 'https://mcp.eng.ms', http_headers: { Authorization: 'Bearer tok-123' } },
+				'with-headers': { url: 'https://mcp.eng.ms/', http_headers: { 'X-Test': 'v1', Authorization: 'Bearer tok-123' } },
+				'no-token': { url: 'https://other.example/mcp' },
+				'stdio': { command: 'run' },
+			});
+		});
+
+		test('injectCodexMcpAuthTokens returns the input unchanged when there are no tokens', () => {
+			const servers = { s: { url: 'https://mcp.eng.ms' } };
+			assert.strictEqual(injectCodexMcpAuthTokens(servers, new Map()), servers);
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexMcpServers.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMcpServers.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { McpServerStatus } from '../../../common/state/protocol/channels-session/state.js';
-import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpStatusToEntry, codexMcpToolsChanged, codexToolMapToArray, inventoryToSdkServers, translateCodexMcpStartupState } from '../../../node/codex/codexMcpServers.js';
+import { buildCodexMcpReadResult, buildCodexMcpServerOverrides, codexMcpListToInventory, codexMcpStatusToEntry, codexMcpToolsChanged, codexToolMapToArray, inventoryToSdkServers, translateCodexMcpStartupState } from '../../../node/codex/codexMcpServers.js';
 import type { McpServerStatus as CodexMcpServerStatus } from '../../../node/codex/protocol/generated/v2/McpServerStatus.js';
 import type { Tool } from '../../../node/codex/protocol/generated/Tool.js';
 
@@ -89,5 +89,71 @@ suite('codexMcpServers', () => {
 			codexMcpToolsChanged(a, added),
 			codexMcpToolsChanged(undefined, a),
 		], [false, true, true]);
+	});
+
+	suite('buildCodexMcpServerOverrides', () => {
+
+		test('encodes stdio + http servers and maps headers → http_headers', () => {
+			assert.deepStrictEqual(buildCodexMcpServerOverrides({
+				local: { type: 'stdio', command: 'npx', args: ['-y', 'pkg'], env: { KEY: 'val', N: 3, DROP: null }, cwd: '/w' },
+				remote: { type: 'http', url: 'https://x/mcp', headers: { Authorization: 'Bearer t' } },
+			}), {
+				overrides: [
+					'mcp_servers.local={ command = "npx", args = ["-y", "pkg"], env = { KEY = "val", N = "3" }, cwd = "/w" }',
+					'mcp_servers.remote={ url = "https://x/mcp", http_headers = { Authorization = "Bearer t" } }',
+				],
+				skipped: [],
+			});
+		});
+
+		test('omits empty args/env/headers and command-only stdio', () => {
+			assert.deepStrictEqual(buildCodexMcpServerOverrides({
+				bare: { type: 'stdio', command: 'run', args: [], env: {} },
+				plain: { type: 'http', url: 'https://y' },
+			}), {
+				overrides: [
+					'mcp_servers.bare={ command = "run" }',
+					'mcp_servers.plain={ url = "https://y" }',
+				],
+				skipped: [],
+			});
+		});
+
+		test('escapes TOML strings and quotes non-bare env keys', () => {
+			assert.deepStrictEqual(buildCodexMcpServerOverrides({
+				esc: { type: 'stdio', command: 'a"b\\c', env: { 'we.ird key': 'line1\nline2\t"q"' } },
+			}), {
+				overrides: [
+					'mcp_servers.esc={ command = "a\\"b\\\\c", env = { "we.ird key" = "line1\\nline2\\t\\"q\\"" } }',
+				],
+				skipped: [],
+			});
+		});
+
+		test('skips malformed entries and names codex cannot address', () => {
+			assert.deepStrictEqual(buildCodexMcpServerOverrides({
+				noCommand: { type: 'stdio' },
+				noUrl: { type: 'http' },
+				unknownType: { type: 'sse', url: 'https://z' },
+				notObject: 42,
+				'dotted.name': { type: 'stdio', command: 'ok' },
+				'has=eq': { type: 'stdio', command: 'ok' },
+				' spaced ': { type: 'stdio', command: 'ok' },
+				good: { type: 'stdio', command: 'ok' },
+			} as Record<string, unknown>), {
+				overrides: ['mcp_servers.good={ command = "ok" }'],
+				skipped: ['noCommand', 'noUrl', 'unknownType', 'notObject', 'dotted.name', 'has=eq', ' spaced '],
+			});
+		});
+
+		test('returns empty for undefined / empty config', () => {
+			assert.deepStrictEqual([
+				buildCodexMcpServerOverrides(undefined),
+				buildCodexMcpServerOverrides({}),
+			], [
+				{ overrides: [], skipped: [] },
+				{ overrides: [], skipped: [] },
+			]);
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexMcpServers.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMcpServers.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { McpServerStatus } from '../../../common/state/protocol/channels-session/state.js';
-import { buildCodexMcpReadResult, buildCodexMcpServerOverrides, codexMcpListToInventory, codexMcpStatusToEntry, codexMcpToolsChanged, codexToolMapToArray, inventoryToSdkServers, translateCodexMcpStartupState } from '../../../node/codex/codexMcpServers.js';
+import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpServersFromConfig, codexMcpStatusToEntry, codexMcpToolsChanged, codexToolMapToArray, inventoryToSdkServers, translateCodexMcpStartupState } from '../../../node/codex/codexMcpServers.js';
 import type { McpServerStatus as CodexMcpServerStatus } from '../../../node/codex/protocol/generated/v2/McpServerStatus.js';
 import type { Tool } from '../../../node/codex/protocol/generated/Tool.js';
 
@@ -91,69 +91,55 @@ suite('codexMcpServers', () => {
 		], [false, true, true]);
 	});
 
-	suite('buildCodexMcpServerOverrides', () => {
+	suite('codexMcpServersFromConfig', () => {
 
-		test('encodes stdio + http servers and maps headers → http_headers', () => {
-			assert.deepStrictEqual(buildCodexMcpServerOverrides({
+		test('maps stdio + http servers, stringifies env, and maps headers to http_headers', () => {
+			assert.deepStrictEqual(codexMcpServersFromConfig({
 				local: { type: 'stdio', command: 'npx', args: ['-y', 'pkg'], env: { KEY: 'val', N: 3, DROP: null }, cwd: '/w' },
-				remote: { type: 'http', url: 'https://x/mcp', headers: { Authorization: 'Bearer t' } },
+				remote: { type: 'http', url: 'https://x/mcp', headers: { Authorization: 'token-value' } },
 			}), {
-				overrides: [
-					'mcp_servers.local={ command = "npx", args = ["-y", "pkg"], env = { KEY = "val", N = "3" }, cwd = "/w" }',
-					'mcp_servers.remote={ url = "https://x/mcp", http_headers = { Authorization = "Bearer t" } }',
-				],
-				skipped: [],
+				local: { command: 'npx', args: ['-y', 'pkg'], env: { KEY: 'val', N: '3' }, cwd: '/w' },
+				remote: { url: 'https://x/mcp', http_headers: { Authorization: 'token-value' } },
 			});
 		});
 
 		test('omits empty args/env/headers and command-only stdio', () => {
-			assert.deepStrictEqual(buildCodexMcpServerOverrides({
+			assert.deepStrictEqual(codexMcpServersFromConfig({
 				bare: { type: 'stdio', command: 'run', args: [], env: {} },
 				plain: { type: 'http', url: 'https://y' },
 			}), {
-				overrides: [
-					'mcp_servers.bare={ command = "run" }',
-					'mcp_servers.plain={ url = "https://y" }',
-				],
-				skipped: [],
+				bare: { command: 'run' },
+				plain: { url: 'https://y' },
 			});
 		});
 
-		test('escapes TOML strings and quotes non-bare env keys', () => {
-			assert.deepStrictEqual(buildCodexMcpServerOverrides({
-				esc: { type: 'stdio', command: 'a"b\\c', env: { 'we.ird key': 'line1\nline2\t"q"' } },
+		test('keeps server names with dots/spaces (per-thread JSON keys, not `-c` override keys)', () => {
+			assert.deepStrictEqual(codexMcpServersFromConfig({
+				'dotted.name': { type: 'stdio', command: 'ok' },
+				' spaced ': { type: 'http', url: 'https://z' },
 			}), {
-				overrides: [
-					'mcp_servers.esc={ command = "a\\"b\\\\c", env = { "we.ird key" = "line1\\nline2\\t\\"q\\"" } }',
-				],
-				skipped: [],
+				'dotted.name': { command: 'ok' },
+				' spaced ': { url: 'https://z' },
 			});
 		});
 
-		test('skips malformed entries and names codex cannot address', () => {
-			assert.deepStrictEqual(buildCodexMcpServerOverrides({
+		test('skips malformed / unsupported entries', () => {
+			assert.deepStrictEqual(codexMcpServersFromConfig({
 				noCommand: { type: 'stdio' },
 				noUrl: { type: 'http' },
 				unknownType: { type: 'sse', url: 'https://z' },
 				notObject: 42,
-				'dotted.name': { type: 'stdio', command: 'ok' },
-				'has=eq': { type: 'stdio', command: 'ok' },
-				' spaced ': { type: 'stdio', command: 'ok' },
 				good: { type: 'stdio', command: 'ok' },
 			} as Record<string, unknown>), {
-				overrides: ['mcp_servers.good={ command = "ok" }'],
-				skipped: ['noCommand', 'noUrl', 'unknownType', 'notObject', 'dotted.name', 'has=eq', ' spaced '],
+				good: { command: 'ok' },
 			});
 		});
 
 		test('returns empty for undefined / empty config', () => {
 			assert.deepStrictEqual([
-				buildCodexMcpServerOverrides(undefined),
-				buildCodexMcpServerOverrides({}),
-			], [
-				{ overrides: [], skipped: [] },
-				{ overrides: [], skipped: [] },
-			]);
+				codexMcpServersFromConfig(undefined),
+				codexMcpServersFromConfig({}),
+			], [{}, {}]);
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexMcpServers.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMcpServers.test.ts
@@ -135,6 +135,16 @@ suite('codexMcpServers', () => {
 			});
 		});
 
+		test('sanitizes non-string args/env/headers/cwd from untrusted config', () => {
+			assert.deepStrictEqual(codexMcpServersFromConfig({
+				local: { type: 'stdio', command: 'npx', args: [1, 'a', null, true], env: { N: 3 }, cwd: 5 },
+				remote: { type: 'http', url: 'https://x', headers: { Authorization: 1, 'X-Ok': 's' } },
+			} as Record<string, unknown>), {
+				local: { command: 'npx', args: ['1', 'a', 'true'], env: { N: '3' } },
+				remote: { url: 'https://x', http_headers: { Authorization: '1', 'X-Ok': 's' } },
+			});
+		});
+
 		test('returns empty for undefined / empty config', () => {
 			assert.deepStrictEqual([
 				codexMcpServersFromConfig(undefined),
@@ -188,6 +198,15 @@ suite('codexMcpServers', () => {
 		test('injectCodexMcpAuthTokens returns the input unchanged when there are no tokens', () => {
 			const servers = { s: { url: 'https://mcp.eng.ms' } };
 			assert.strictEqual(injectCodexMcpAuthTokens(servers, new Map()), servers);
+		});
+
+		test('injectCodexMcpAuthTokens strips a pre-existing case-insensitive authorization header', () => {
+			const tokens = new Map([['https://mcp.eng.ms/', 'tok-123']]);
+			assert.deepStrictEqual(injectCodexMcpAuthTokens({
+				s: { url: 'https://mcp.eng.ms', http_headers: { authorization: 'Bearer stale', 'X-Test': 'v1' } },
+			}, tokens), {
+				s: { url: 'https://mcp.eng.ms', http_headers: { 'X-Test': 'v1', Authorization: 'Bearer tok-123' } },
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Overview

Brings the **codex** agent in the agent host protocol (AHP) to parity with the copilot/claude agents for MCP tools and customizations. Previously the codex agent had read-back MCP scaffolding but was never told which servers to run, couldn't pick up config changes, couldn't authenticate OAuth-gated MCP servers, and didn't surface the full set of customizations. Each concern is a focused commit.

All changes are scoped to `src/vs/platform/agentHost/node/codex/` (+ its tests). Verified end-to-end in the Agents window against the real codex binary (v0.142.0).

## What changed

### MCP servers are now launched, per session
- **Launch workbench-configured MCP servers** — the root `mcpServers` config (the same set copilot forwards to its SDK) is now passed to codex so it actually starts them.
- **Per-thread config pickup** (`b0bce14`) — root `mcpServers` moved from process-global app-server spawn `-c` overrides to each session's `thread/start.config.mcp_servers`. Because the codex app-server is process-global and spawned once, servers added to Host Settings *after* it started were never applied. Per-thread config merges with the user's global `~/.codex/config.toml`, so every new session reflects the current config without restarting the shared app-server — matching copilot's per-session model. A prewarmed-but-unused thread whose MCP set changed before its first turn is restarted to pick it up.

### OAuth-gated MCP servers (copilot parity)
- **Authenticate via the workbench** (`08d9f13`) — an auth-gated http server (e.g. an eng-hub server) reached codex but failed with "not logged in". The agent now reports it as `McpServerStatus.AuthRequired` through the shared `McpCustomizationController` (so the workbench renders the same "Authenticate" affordance it uses for copilot), receives the acquired bearer via `IAgent.handleAuthenticationToken`, injects it into the per-thread `http_headers.Authorization`, and reconnects the affected threads (lossless `thread/start` pre-first-turn, `thread/resume` with the current config otherwise). Verified against the real codex binary: it forwards `http_headers` on every MCP HTTP request.
- **Discover OAuth metadata** (`bc31a80`) — clicking "Authenticate" did nothing because the workbench's `resolveMcpServerAuthentication` needs the resource's `authorization_servers`, which codex's failure notification omits (unlike the copilot SDK, which discovers it internally). The agent now fetches the RFC 9728 Protected Resource Metadata (`<url>/.well-known/oauth-protected-resource`) and carries `authorization_servers` + `scopes_supported` into the `AuthRequired` state, so the one-click sign-in completes.

### Customizations parity
- **Surface `.agents` skills + hooks** (`8312e63`) — codex natively reads `.agents/skills` (repo + user scope); these plus hooks now appear in the Customizations view via `skills/list` + `hooks/list`.
- **Ingest client-pushed plugin customizations** (`21ab6811`) — client "Open Plugins" are materialized + parsed via the shared `IAgentPluginManager` + `pluginParsers`, projected to the AHP `PluginCustomization` surface, with MCP servers attached per-session and skills fed via process-global `skills/extraRoots/set`.

### Diagnosability
- **MCP logging** (`5aad963`) — logs the MCP server names passed at `thread/start`, each `mcpServer/startupStatus/updated` transition (incl. auth/error), and the refreshed inventory with per-server state + tool counts.

## Testing
- `npm run typecheck-client` clean; **31 codex unit tests** pass (new pure helpers: `codexMcpServersFromConfig`, `normalizeCodexMcpResourceUrl`, `codexStartupErrorNeedsAuth`, `injectCodexMcpAuthTokens`); hygiene clean.
- Verified end-to-end in the Agents window: config-added-after-start servers are now picked up, and the OAuth "Authenticate" flow completes for an auth-gated http server (user-confirmed).
- Consumption paths (per-thread config, header forwarding, resume-with-config, RFC 9728 discovery) verified against the real codex binary.

## Notes
- Config changes apply to **new** sessions (and a prewarmed-unused one), not retroactively to a session already mid-conversation — matches copilot.
- Draft: opening for review/CI.