### PR TITLE
fix performance regression caused by modern UI styles

### DIFF
--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -209,13 +209,16 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	}
 
 	private onDidOpen(composite: IComposite): void {
-		this.activePaneContextKey.set(composite.getId());
+		const compositeId = composite.getId();
+		this.activePaneContextKey.set(compositeId);
+		this.element.dataset.activeComposite = compositeId;
 	}
 
 	private onDidClose(composite: IComposite): void {
 		const id = composite.getId();
 		if (this.activePaneContextKey.get() === id) {
 			this.activePaneContextKey.reset();
+			delete this.element.dataset.activeComposite;
 		}
 	}
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -151,12 +151,12 @@
 /*
  * File Explorer titles — respect the real casing of the workspace / folder name
  * (user input). `text-transform: none` overrides both the base `uppercase` rule
- * and the `capitalize` override above (the `:has(...)` argument raises
- * specificity). System labels such as "Untitled (Workspace)" are already
- * title-cased in source, so they still render correctly; only user-provided
- * folder names (e.g. "vscode-dev") are left untouched.
+ * and the `capitalize` override above. System labels such as "Untitled
+ * (Workspace)" are already title-cased in source, so they still render
+ * correctly; only user-provided folder names (e.g. "vscode-dev") are left
+ * untouched.
  */
-.style-override.monaco-workbench .part:not(.editor):has(> .content > .composite.explorer-viewlet) > .title > .title-label h2,
+.style-override.monaco-workbench .part:not(.editor)[data-active-composite="workbench.view.explorer"] > .title > .title-label h2,
 .style-override .monaco-pane-view .pane > .pane-header:has(> .icon.codicon-explorer-view-icon) > .title {
 	text-transform: none;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #325984 

This issue is caused by the performance overhead of the `:has()` selector and is similar to the issue discussed in #324986 .

The regression was introduced by #325013 , which added these selectors for the modern UI styles.

Additional note: The `:has()` selector on `.pane-header` is intentionally left unchanged. Compared with the removed selector, it has a much narrower scope and does not cause the same level of style invalidation overhead, so keeping it should be reasonable.

For more details about the `:has()` pseudo-class, refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:has#performance_considerations).