### PR TITLE
Style overrides: Add border-radius to webview overlay content

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -41,6 +41,18 @@
 	border-radius: var(--vscode-cornerRadius-large, 8px);
 }
 
+/*
+ * Webviews are iframes that cannot be reparented, so they are mounted at the workbench
+ * root and floated over their card via `OverlayLayoutElement` (see `overlayWebview.ts`).
+ * The overlay content directly wraps the iframe and already clips its overflow, so a
+ * `border-radius` here rounds the otherwise square iframe corners that would poke over the
+ * card's rounded corners. (Rounding the overlay *root* does not work: its `clip-path` does
+ * not clip the `position: fixed` content child.)
+ */
+.monaco-workbench.floating-panels .webview-overlay-content {
+	border-radius: var(--vscode-cornerRadius-large, 8px);
+}
+
 /* Keep the auxiliary bar background aligned with the primary sidebar in light theme. */
 .monaco-workbench.floating-panels .part.auxiliarybar {
 	background-color: var(--vscode-sideBar-background) !important;

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -46,8 +46,10 @@
  * root and floated over their card via `OverlayLayoutElement` (see `overlayWebview.ts`).
  * The overlay content directly wraps the iframe and already clips its overflow, so a
  * `border-radius` here rounds the otherwise square iframe corners that would poke over the
- * card's rounded corners. (Rounding the overlay *root* does not work: its `clip-path` does
- * not clip the `position: fixed` content child.)
+ * card's rounded corners.
+ *
+ * Note: rounding the overlay *root* instead does not work - its `clip-path` does not clip the
+ * `position: fixed` content child, so the square iframe corners remain.
  */
 .monaco-workbench.floating-panels .webview-overlay-content {
 	border-radius: var(--vscode-cornerRadius-large, 8px);

--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -114,6 +114,10 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 			this._overlayLayout = new OverlayLayoutElement();
 			this._overlayLayout.content.style.visibility = 'hidden';
 
+			// Marker used by floating panels (Modern UI) CSS to round the overlay content (and
+			// the iframe it directly hosts) to the card's rounded corners. See `floatingPanels.css`.
+			this._overlayLayout.content.classList.add('webview-overlay-content');
+
 			// Webviews cannot be reparented in the dom as it will destroy their contents.
 			// Mount them to a high level node to avoid this depending on the active container.
 			const root = this._layoutService.getContainer(this.window);


### PR DESCRIPTION
Introduce a border-radius to the webview overlay content for improved aesthetics. Include a note on the behavior of border-radius in relation to the overlay's structure to clarify implementation details.

