### PR TITLE
Increase timeout on MacOS builds to 2h

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin-ci.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-ci.yml
@@ -7,7 +7,7 @@ parameters:
 jobs:
   - job: macOS${{ parameters.VSCODE_TEST_SUITE }}
     displayName: ${{ parameters.VSCODE_TEST_SUITE }} Tests
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
     variables:
       VSCODE_ARCH: arm64
       BUILDS_API_URL: $(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/

--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: macOSUniversal
     displayName: macOS (UNIVERSAL)
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
     variables:
       VSCODE_ARCH: universal
       BUILDS_API_URL: $(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -16,7 +16,7 @@ parameters:
 jobs:
   - job: macOS_${{ parameters.VSCODE_ARCH }}
     displayName: macOS (${{ upper(parameters.VSCODE_ARCH) }})
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
     variables:
       VSCODE_ARCH: ${{ parameters.VSCODE_ARCH }}
       BUILDS_API_URL: $(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/


### PR DESCRIPTION
The `✍️ Codesign & Notarize` step can take a while, causing the job to often hit the current 90min timeout and forcing a manual retry.