### PR TITLE
Add focus outline color to suggest widget for improved accessibility

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -356,6 +356,7 @@
 		"--vscode-editorSuggestWidget-background",
 		"--vscode-editorSuggestWidget-border",
 		"--vscode-editorSuggestWidget-focusHighlightForeground",
+		"--vscode-editorSuggestWidget-focusOutline",
 		"--vscode-editorSuggestWidget-foreground",
 		"--vscode-editorSuggestWidget-highlightForeground",
 		"--vscode-editorSuggestWidget-selectedBackground",

--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -139,6 +139,7 @@
 		"editorSuggestWidget.foreground": "#bfbfbf",
 		"editorSuggestWidget.highlightForeground": "#bfbfbf",
 		"editorSuggestWidget.selectedBackground": "#FFFFFF26",
+		"editorSuggestWidget.focusOutline": "#3994BCB3",
 		"editorHoverWidget.background": "#202122",
 		"editorHoverWidget.border": "#2A2B2CFF",
 		"widget.border": "#2A2B2CFF",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -147,6 +147,7 @@
 		"editorSuggestWidget.selectedBackground": "#00000025",
 		"editorSuggestWidget.selectedForeground": "#202020",
 		"editorSuggestWidget.selectedIconForeground": "#202020",
+		"editorSuggestWidget.focusOutline": "#0069CCFF",
 		"editorHoverWidget.background": "#FAFAFD",
 		"editorHoverWidget.border": "#E4E5E6FF",
 		"peekView.border": "#0069CC",

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -121,6 +121,8 @@
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused {
 	color: var(--vscode-editorSuggestWidget-selectedForeground);
+	outline: 1px solid var(--vscode-editorSuggestWidget-focusOutline);
+	outline-offset: -1px;
 }
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused .codicon {

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -46,6 +46,7 @@ export const editorSuggestWidgetForeground = registerColor('editorSuggestWidget.
 registerColor('editorSuggestWidget.selectedForeground', quickInputListFocusForeground, nls.localize('editorSuggestWidgetSelectedForeground', 'Foreground color of the selected entry in the suggest widget.'));
 registerColor('editorSuggestWidget.selectedIconForeground', quickInputListFocusIconForeground, nls.localize('editorSuggestWidgetSelectedIconForeground', 'Icon foreground color of the selected entry in the suggest widget.'));
 export const editorSuggestWidgetSelectedBackground = registerColor('editorSuggestWidget.selectedBackground', quickInputListFocusBackground, nls.localize('editorSuggestWidgetSelectedBackground', 'Background color of the selected entry in the suggest widget.'));
+export const editorSuggestWidgetFocusOutline = registerColor('editorSuggestWidget.focusOutline', activeContrastBorder, nls.localize('editorSuggestWidgetFocusOutline', 'Outline color of the focused (keyboard-navigated) entry in the suggest widget.'));
 registerColor('editorSuggestWidget.highlightForeground', listHighlightForeground, nls.localize('editorSuggestWidgetHighlightForeground', 'Color of the match highlights in the suggest widget.'));
 registerColor('editorSuggestWidget.focusHighlightForeground', listFocusHighlightForeground, nls.localize('editorSuggestWidgetFocusHighlightForeground', 'Color of the match highlights in the suggest widget when an item is focused.'));
 registerColor('editorSuggestWidgetStatus.foreground', transparent(editorSuggestWidgetForeground, .5), nls.localize('editorSuggestWidgetStatusForeground', 'Foreground color of the suggest widget status.'));
@@ -267,7 +268,7 @@ export class SuggestWidget implements IDisposable {
 		});
 		this._list.style(getListStyles({
 			listInactiveFocusBackground: editorSuggestWidgetSelectedBackground,
-			listInactiveFocusOutline: activeContrastBorder
+			listInactiveFocusOutline: editorSuggestWidgetFocusOutline
 		}));
 
 		this._status = instantiationService.createInstance(SuggestWidgetStatus, this.element.domNode, suggestWidgetStatusbarMenu, undefined);


### PR DESCRIPTION
Introduce a focus outline color for the suggest widget to enhance accessibility. This change allows users navigating with a keyboard to better identify the focused entry in the suggest widget.

Fixes https://github.com/microsoft/vscode/issues/320723