### PR TITLE
flakytest: skip sandbox test causing build failure

### DIFF
--- a/test/smoke/src/areas/chat/chatSandbox.test.ts
+++ b/test/smoke/src/areas/chat/chatSandbox.test.ts
@@ -189,7 +189,7 @@ export function setup(logger: Logger): void {
 		 * Expected result: The command is sandbox-wrapped and its output contains
 		 * `${sandboxReply}` and `SANDBOX_EXIT_CODE=0`.
 		 */
-		it('runs terminal commands inside the sandbox', async function () {
+		it.skip('runs terminal commands inside the sandbox', async function () {
 			const app = this.app as Application;
 
 			try {


### PR DESCRIPTION
## Summary

Skip the `runs terminal commands inside the sandbox` smoke test because it is currently failing in Linux CI while checking `terminal.log` for sandbox-wrapped execution.

Failure:

```text
AssertionError [ERR_ASSERTION]: expected sandbox-wrapped terminal execution in .../terminal.log
```

## Validation

- Pre-commit hygiene passed
- No TypeScript diagnostics in `chatSandbox.test.ts`
- `git diff --check` passed
