### PR TITLE
Add dark high contrast tab bar fixture

### DIFF
--- a/src/vs/workbench/test/browser/componentFixtures/editor/editorTabBar.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/editor/editorTabBar.fixture.ts
@@ -482,10 +482,10 @@ function render(modernUI: boolean, options: Omit<IRenderOptions, 'modernUI'>): (
 	return (ctx: ComponentFixtureContext) => renderTabBar(ctx, { ...options, modernUI });
 }
 
-function createFixtures(modernUI: boolean) {
+function createFixtures(modernUI: boolean, includeDarkHighContrast = false) {
 	return {
 		// Baseline: multiple tabs with mixed sticky / pinned / preview / dirty state.
-		Default: defineComponentFixture({ render: render(modernUI, {}) }),
+		Default: defineComponentFixture({ render: render(modernUI, {}), includeDarkHighContrast }),
 
 		// showTabs
 		ShowTabsSingle: defineComponentFixture({ render: render(modernUI, { partOptions: { showTabs: 'single' }, breadcrumbs: {} }) }),
@@ -586,5 +586,5 @@ function createFixtures(modernUI: boolean) {
 
 export default defineThemedFixtureGroup({ path: 'editor/editorTabBar/' }, {
 	ModernUIOff: defineThemedFixtureGroup(createFixtures(false)),
-	ModernUIOn: defineThemedFixtureGroup(createFixtures(true)),
+	ModernUIOn: defineThemedFixtureGroup(createFixtures(true, true)),
 });

--- a/src/vs/workbench/test/browser/componentFixtures/editor/editorTabBar.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/editor/editorTabBar.fixture.ts
@@ -40,7 +40,7 @@ import { IOutlineService } from '../../../../services/outline/browser/outline.js
 import { LayoutSettings } from '../../../../services/layout/browser/layoutService.js';
 import { TestContextService } from '../../../common/workbenchTestServices.js';
 import { workbenchInstantiationService } from '../../workbenchTestServices.js';
-import { ComponentFixtureContext, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
+import { ComponentFixtureAdditionalTheme, ComponentFixtureContext, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
 import '../../../../contrib/styleOverrides/browser/media/tabs.css';
 
 // ============================================================================
@@ -482,10 +482,10 @@ function render(modernUI: boolean, options: Omit<IRenderOptions, 'modernUI'>): (
 	return (ctx: ComponentFixtureContext) => renderTabBar(ctx, { ...options, modernUI });
 }
 
-function createFixtures(modernUI: boolean, includeDarkHighContrast = false) {
+function createFixtures(modernUI: boolean, additionalThemes: readonly ComponentFixtureAdditionalTheme[] = []) {
 	return {
 		// Baseline: multiple tabs with mixed sticky / pinned / preview / dirty state.
-		Default: defineComponentFixture({ render: render(modernUI, {}), includeDarkHighContrast }),
+		Default: defineComponentFixture({ render: render(modernUI, {}), additionalThemes }),
 
 		// showTabs
 		ShowTabsSingle: defineComponentFixture({ render: render(modernUI, { partOptions: { showTabs: 'single' }, breadcrumbs: {} }) }),
@@ -494,7 +494,7 @@ function createFixtures(modernUI: boolean, includeDarkHighContrast = false) {
 		// pinnedTabsOnSeparateRow
 		PinnedTabsOnSeparateRowAllPinned: defineComponentFixture({ render: render(modernUI, { partOptions: { pinnedTabsOnSeparateRow: true }, editors: allStickyEditorSpecs() }) }),
 		PinnedTabsOnSeparateRowAllUnpinned: defineComponentFixture({ render: render(modernUI, { partOptions: { pinnedTabsOnSeparateRow: true }, editors: allUnstickyEditorSpecs() }) }),
-		PinnedTabsOnSeparateRowMixed: defineComponentFixture({ render: render(modernUI, { partOptions: { pinnedTabsOnSeparateRow: true }, editors: stickyEditorSpecs() }) }),
+		PinnedTabsOnSeparateRowMixed: defineComponentFixture({ render: render(modernUI, { partOptions: { pinnedTabsOnSeparateRow: true }, editors: stickyEditorSpecs() }), additionalThemes }),
 
 		// breadcrumbs
 		BreadcrumbsFilePathLast: defineComponentFixture({ render: render(modernUI, { breadcrumbs: { filePath: 'last' }, editors: nestedActiveEditorSpecs() }) }),
@@ -559,10 +559,10 @@ function createFixtures(modernUI: boolean, includeDarkHighContrast = false) {
 
 		// Active and inactive group styling.
 		ActiveGroup: defineComponentFixture({ render: render(modernUI, { active: true }) }),
-		InactiveGroup: defineComponentFixture({ render: render(modernUI, { active: false }) }),
+		InactiveGroup: defineComponentFixture({ render: render(modernUI, { active: false }), additionalThemes }),
 
 		// Multi-selection: several tabs in the selected state at once.
-		MultiSelect: defineComponentFixture({ render: render(modernUI, { editors: multiSelectEditorSpecs() }) }),
+		MultiSelect: defineComponentFixture({ render: render(modernUI, { editors: multiSelectEditorSpecs() }), additionalThemes }),
 
 		// Inactive group with dirty editors: exercises the unfocused modified-border color path.
 		InactiveGroupDirty: defineComponentFixture({ render: render(modernUI, { editors: dirtyEditorSpecs(), active: false }) }),
@@ -585,6 +585,6 @@ function createFixtures(modernUI: boolean, includeDarkHighContrast = false) {
 }
 
 export default defineThemedFixtureGroup({ path: 'editor/editorTabBar/' }, {
-	ModernUIOff: defineThemedFixtureGroup(createFixtures(false)),
-	ModernUIOn: defineThemedFixtureGroup(createFixtures(true, true)),
+	ModernUIOff: defineThemedFixtureGroup(createFixtures(false, ['darkHighContrast'])),
+	ModernUIOn: defineThemedFixtureGroup(createFixtures(true, ['darkHighContrast'])),
 });

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -254,6 +254,7 @@ class NullStorageService implements IStorageService {
 import dark_modern from '../../../../../../extensions/theme-defaults/themes/dark_modern.json' with { type: 'json' };
 import dark_plus from '../../../../../../extensions/theme-defaults/themes/dark_plus.json' with { type: 'json' };
 import dark_vs from '../../../../../../extensions/theme-defaults/themes/dark_vs.json' with { type: 'json' };
+import hc_black from '../../../../../../extensions/theme-defaults/themes/hc_black.json' with { type: 'json' };
 import light_modern from '../../../../../../extensions/theme-defaults/themes/light_modern.json' with { type: 'json' };
 import light_plus from '../../../../../../extensions/theme-defaults/themes/light_plus.json' with { type: 'json' };
 import light_vs from '../../../../../../extensions/theme-defaults/themes/light_vs.json' with { type: 'json' };
@@ -263,6 +264,7 @@ const themeJsonModules: Record<string, string> = {
 	'/extensions/theme-defaults/themes/dark_modern.json': dark_modern as unknown as string,
 	'/extensions/theme-defaults/themes/dark_plus.json': dark_plus as unknown as string,
 	'/extensions/theme-defaults/themes/dark_vs.json': dark_vs as unknown as string,
+	'/extensions/theme-defaults/themes/hc_black.json': hc_black as unknown as string,
 	'/extensions/theme-defaults/themes/light_modern.json': light_modern as unknown as string,
 	'/extensions/theme-defaults/themes/light_plus.json': light_plus as unknown as string,
 	'/extensions/theme-defaults/themes/light_vs.json': light_vs as unknown as string,
@@ -293,21 +295,25 @@ function createBuiltInTheme(themePath: string, uiTheme: ThemeTypeSelector): Colo
 
 export const darkTheme = createBuiltInTheme('/extensions/theme-defaults/themes/dark_modern.json', ThemeTypeSelector.VS_DARK);
 export const lightTheme = createBuiltInTheme('/extensions/theme-defaults/themes/light_modern.json', ThemeTypeSelector.VS);
+export const darkHighContrastTheme = createBuiltInTheme('/extensions/theme-defaults/themes/hc_black.json', ThemeTypeSelector.HC_BLACK);
+
+const darkThemeVariant = { label: 'Dark', background: 'dark', theme: darkTheme } as const;
+const lightThemeVariant = { label: 'Light', background: 'light', theme: lightTheme } as const;
+const darkHighContrastThemeVariant = { label: 'DarkHighContrast', background: 'dark', theme: darkHighContrastTheme } as const;
+const themeVariants = [darkThemeVariant, lightThemeVariant, darkHighContrastThemeVariant];
+type ComponentFixtureThemeVariant = typeof themeVariants[number];
 
 let themesLoadedPromise: Promise<void> | undefined;
 function ensureThemesLoaded(): Promise<void> {
 	if (!themesLoadedPromise) {
-		themesLoadedPromise = Promise.all([
-			darkTheme.ensureLoaded(fixtureExtensionResourceLoaderService),
-			lightTheme.ensureLoaded(fixtureExtensionResourceLoaderService),
-		]).then(() => undefined);
+		themesLoadedPromise = Promise.all(themeVariants.map(({ theme }) => theme.ensureLoaded(fixtureExtensionResourceLoaderService))).then(() => undefined);
 	}
 	return themesLoadedPromise;
 }
 
 export async function setupTheme(container: HTMLElement, theme: ColorThemeData): Promise<void> {
 	await ensureThemesLoaded();
-	await ensureGlobalStylesInstalled([darkTheme, lightTheme]);
+	await ensureGlobalStylesInstalled(themeVariants.map(({ theme }) => theme));
 	container.classList.add('monaco-workbench', getPlatformClass(), 'disable-animations', ...theme.classNames);
 }
 
@@ -827,6 +833,7 @@ export interface ComponentFixtureOptions {
 	render: (context: ComponentFixtureContext) => void | Promise<void>;
 	labels?: ThemedFixtureGroupLabels;
 	virtualTime?: { enabled?: boolean; durationMs?: number; teardownDrainMs?: number };
+	includeDarkHighContrast?: boolean;
 }
 
 type ThemedFixtures = ReturnType<typeof defineFixtureVariants>;
@@ -846,7 +853,7 @@ if (logOutsideTime) {
 let fixtureRenderCounter = 0;
 
 /**
- * Creates Dark and Light fixture variants from a single render function.
+ * Creates Dark and Light fixture variants from a single render function, with an optional Dark High Contrast variant.
  * The render function receives a context with container and disposableStore.
  *
  * Note: If render returns a Promise, the async work will run in background.
@@ -854,13 +861,14 @@ let fixtureRenderCounter = 0;
  * which should be sufficient for most async setup, but timing is not guaranteed.
  */
 export function defineComponentFixture(options: ComponentFixtureOptions): ThemedFixtures {
-	const createFixture = (theme: typeof darkTheme | typeof lightTheme) => defineFixture({
+	const createFixture = (themeVariant: ComponentFixtureThemeVariant) => defineFixture({
 		isolation: 'none',
 		displayMode: { type: 'component' },
-		background: theme === darkTheme ? 'dark' : 'light',
+		background: themeVariant.background,
 		render: async (container: HTMLElement, context) => {
 			const disposableStore = new DisposableStore();
 			const input = parseFixtureInput(context.input);
+			const { label: themeLabel, theme } = themeVariant;
 
 			// Replace Math.random with a seeded PRNG so fixtures render deterministically.
 			disposableStore.add(pushRandomOverwrite(42));
@@ -1011,7 +1019,7 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 					if (virtualTimeEnabled && p.history.length > 0) {
 						const startTime = p.history[0].time;
 						const history = buildHistoryFromTasks(p.history, startTime);
-						console.error(`[ComponentFixture] ${theme === darkTheme ? 'Dark' : 'Light'} virtual-time history (${p.history.length} tasks):\n${renderSwimlanes(history)}`);
+						console.error(`[ComponentFixture] ${themeLabel} virtual-time history (${p.history.length} tasks):\n${renderSwimlanes(history)}`);
 					}
 					throw e;
 				} finally {
@@ -1025,7 +1033,6 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 			// output by the scheduler / processor shows exactly which fixture
 			// caused each queued or historical timer, plus the full chain of
 			// setTimeout/rAF calls that led to it.
-			const themeLabel = theme === darkTheme ? 'Dark' : 'Light';
 			const fixtureRoot = createTraceRoot(`render#${++fixtureRenderCounter}(${themeLabel})`);
 
 			await TraceContext.instance.runAsHandler(fixtureRoot, actualRender, {
@@ -1052,8 +1059,9 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 
 	const labels = resolveLabels(options.labels);
 	return defineFixtureVariants(labels.length > 0 ? { labels } : {}, {
-		Dark: createFixture(darkTheme),
-		Light: createFixture(lightTheme),
+		Dark: createFixture(darkThemeVariant),
+		Light: createFixture(lightThemeVariant),
+		...(options.includeDarkHighContrast ? { DarkHighContrast: createFixture(darkHighContrastThemeVariant) } : {}),
 	});
 }
 

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -295,25 +295,36 @@ function createBuiltInTheme(themePath: string, uiTheme: ThemeTypeSelector): Colo
 
 export const darkTheme = createBuiltInTheme('/extensions/theme-defaults/themes/dark_modern.json', ThemeTypeSelector.VS_DARK);
 export const lightTheme = createBuiltInTheme('/extensions/theme-defaults/themes/light_modern.json', ThemeTypeSelector.VS);
-export const darkHighContrastTheme = createBuiltInTheme('/extensions/theme-defaults/themes/hc_black.json', ThemeTypeSelector.HC_BLACK);
+const darkHighContrastTheme = createBuiltInTheme('/extensions/theme-defaults/themes/hc_black.json', ThemeTypeSelector.HC_BLACK);
 
-const darkThemeVariant = { label: 'Dark', background: 'dark', theme: darkTheme } as const;
-const lightThemeVariant = { label: 'Light', background: 'light', theme: lightTheme } as const;
-const darkHighContrastThemeVariant = { label: 'DarkHighContrast', background: 'dark', theme: darkHighContrastTheme } as const;
-const themeVariants = [darkThemeVariant, lightThemeVariant, darkHighContrastThemeVariant];
-type ComponentFixtureThemeVariant = typeof themeVariants[number];
+type ComponentFixtureThemeVariant = {
+	readonly label: string;
+	readonly background: 'dark' | 'light';
+	readonly theme: ColorThemeData;
+	readonly scopeThemingParticipants: boolean;
+};
+type ComponentFixtureAdditionalThemeVariant = ComponentFixtureThemeVariant & { readonly scopeThemingParticipants: true };
 
-let themesLoadedPromise: Promise<void> | undefined;
-function ensureThemesLoaded(): Promise<void> {
-	if (!themesLoadedPromise) {
-		themesLoadedPromise = Promise.all(themeVariants.map(({ theme }) => theme.ensureLoaded(fixtureExtensionResourceLoaderService))).then(() => undefined);
+const darkThemeVariant = { label: 'Dark', background: 'dark', theme: darkTheme, scopeThemingParticipants: false } as const satisfies ComponentFixtureThemeVariant;
+const lightThemeVariant = { label: 'Light', background: 'light', theme: lightTheme, scopeThemingParticipants: false } as const satisfies ComponentFixtureThemeVariant;
+const additionalThemeVariants = {
+	darkHighContrast: { label: 'DarkHighContrast', background: 'dark', theme: darkHighContrastTheme, scopeThemingParticipants: true },
+} as const satisfies Record<string, ComponentFixtureAdditionalThemeVariant>;
+export type ComponentFixtureAdditionalTheme = keyof typeof additionalThemeVariants;
+
+const themeLoadedPromises = new WeakMap<ColorThemeData, Promise<void>>();
+function ensureThemeLoaded(theme: ColorThemeData): Promise<void> {
+	let themeLoadedPromise = themeLoadedPromises.get(theme);
+	if (!themeLoadedPromise) {
+		themeLoadedPromise = theme.ensureLoaded(fixtureExtensionResourceLoaderService);
+		themeLoadedPromises.set(theme, themeLoadedPromise);
 	}
-	return themesLoadedPromise;
+	return themeLoadedPromise;
 }
 
-export async function setupTheme(container: HTMLElement, theme: ColorThemeData): Promise<void> {
-	await ensureThemesLoaded();
-	await ensureGlobalStylesInstalled(themeVariants.map(({ theme }) => theme));
+export async function setupTheme(container: HTMLElement, theme: ColorThemeData, scopeThemingParticipants = false): Promise<void> {
+	await ensureThemeLoaded(theme);
+	await ensureGlobalStylesInstalled(theme, scopeThemingParticipants);
 	container.classList.add('monaco-workbench', getPlatformClass(), 'disable-animations', ...theme.classNames);
 }
 
@@ -833,7 +844,7 @@ export interface ComponentFixtureOptions {
 	render: (context: ComponentFixtureContext) => void | Promise<void>;
 	labels?: ThemedFixtureGroupLabels;
 	virtualTime?: { enabled?: boolean; durationMs?: number; teardownDrainMs?: number };
-	includeDarkHighContrast?: boolean;
+	additionalThemes?: readonly ComponentFixtureAdditionalTheme[];
 }
 
 type ThemedFixtures = ReturnType<typeof defineFixtureVariants>;
@@ -853,7 +864,7 @@ if (logOutsideTime) {
 let fixtureRenderCounter = 0;
 
 /**
- * Creates Dark and Light fixture variants from a single render function, with an optional Dark High Contrast variant.
+ * Creates Dark and Light fixture variants from a single render function, with optional additional theme variants.
  * The render function receives a context with container and disposableStore.
  *
  * Note: If render returns a Promise, the async work will run in background.
@@ -868,7 +879,7 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 		render: async (container: HTMLElement, context) => {
 			const disposableStore = new DisposableStore();
 			const input = parseFixtureInput(context.input);
-			const { label: themeLabel, theme } = themeVariant;
+			const { label: themeLabel, theme, scopeThemingParticipants } = themeVariant;
 
 			// Replace Math.random with a seeded PRNG so fixtures render deterministically.
 			disposableStore.add(pushRandomOverwrite(42));
@@ -965,7 +976,7 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 			});
 
 			async function actualRender() {
-				await setupTheme(container, theme);
+				await setupTheme(container, theme, scopeThemingParticipants);
 
 				// The order-dependency fuzzer reorders the bundled CSS for just
 				// this render; the override is scoped to the fixture's lifetime
@@ -1058,10 +1069,14 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 	});
 
 	const labels = resolveLabels(options.labels);
+	const additionalFixtures = Object.fromEntries((options.additionalThemes ?? []).map(additionalTheme => {
+		const themeVariant = additionalThemeVariants[additionalTheme];
+		return [themeVariant.label, createFixture(themeVariant)];
+	}));
 	return defineFixtureVariants(labels.length > 0 ? { labels } : {}, {
 		Dark: createFixture(darkThemeVariant),
 		Light: createFixture(lightThemeVariant),
-		...(options.includeDarkHighContrast ? { DarkHighContrast: createFixture(darkHighContrastThemeVariant) } : {}),
+		...additionalFixtures,
 	});
 }
 

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtilsCss.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtilsCss.ts
@@ -7,7 +7,6 @@ import { IDisposable, toDisposable } from '../../../../base/common/lifecycle.js'
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { getIconsStyleSheet } from '../../../../platform/theme/browser/iconsStyleSheet.js';
-import { ColorScheme } from '../../../../platform/theme/common/theme.js';
 import { IThemingRegistry, Extensions as ThemingExtensions } from '../../../../platform/theme/common/themeService.js';
 import { generateColorThemeCSS } from '../../../services/themes/browser/colorThemeCss.js';
 import { ColorThemeData } from '../../../services/themes/common/colorThemeData.js';
@@ -21,8 +20,7 @@ let bundlePromise: Promise<Bundle> | undefined;
 let bundle: Bundle | undefined;
 let activeOverride: object | undefined;
 let iconsStyleSheetCache: CSSStyleSheet | undefined;
-let darkThemeStyleSheet: CSSStyleSheet | undefined;
-let lightThemeStyleSheet: CSSStyleSheet | undefined;
+const themeStyleSheetCache = new WeakMap<ColorThemeData, CSSStyleSheet>();
 
 /**
  * Controls how the bundled stylesheet documents are reordered.
@@ -172,12 +170,9 @@ function getIconsStyleSheetCached(): CSSStyleSheet {
 }
 
 function getThemeStyleSheet(theme: ColorThemeData): CSSStyleSheet {
-	const isDark = theme.type === ColorScheme.DARK;
-	if (isDark && darkThemeStyleSheet) {
-		return darkThemeStyleSheet;
-	}
-	if (!isDark && lightThemeStyleSheet) {
-		return lightThemeStyleSheet;
+	const cachedStyleSheet = themeStyleSheetCache.get(theme);
+	if (cachedStyleSheet) {
+		return cachedStyleSheet;
 	}
 
 	const scopeSelector = '.' + theme.classNames[0];
@@ -190,11 +185,7 @@ function getThemeStyleSheet(theme: ColorThemeData): CSSStyleSheet {
 	);
 	sheet.replaceSync(css.code);
 
-	if (isDark) {
-		darkThemeStyleSheet = sheet;
-	} else {
-		lightThemeStyleSheet = sheet;
-	}
+	themeStyleSheetCache.set(theme, sheet);
 	return sheet;
 }
 

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtilsCss.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtilsCss.ts
@@ -7,7 +7,7 @@ import { IDisposable, toDisposable } from '../../../../base/common/lifecycle.js'
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { getIconsStyleSheet } from '../../../../platform/theme/browser/iconsStyleSheet.js';
-import { IThemingRegistry, Extensions as ThemingExtensions } from '../../../../platform/theme/common/themeService.js';
+import { IThemingParticipant, IThemingRegistry, Extensions as ThemingExtensions } from '../../../../platform/theme/common/themeService.js';
 import { generateColorThemeCSS } from '../../../services/themes/browser/colorThemeCss.js';
 import { ColorThemeData } from '../../../services/themes/common/colorThemeData.js';
 
@@ -15,12 +15,13 @@ const themingRegistry = Registry.as<IThemingRegistry>(ThemingExtensions.ThemingC
 const mockEnvironmentService: IEnvironmentService = Object.create(null);
 
 let overlaySheet: CSSStyleSheet | undefined;
-let installedPromise: Promise<void> | undefined;
+let baseStylesInstalledPromise: Promise<void> | undefined;
 let bundlePromise: Promise<Bundle> | undefined;
 let bundle: Bundle | undefined;
 let activeOverride: object | undefined;
 let iconsStyleSheetCache: CSSStyleSheet | undefined;
 const themeStyleSheetCache = new WeakMap<ColorThemeData, CSSStyleSheet>();
+const installedThemes = new WeakSet<ColorThemeData>();
 
 /**
  * Controls how the bundled stylesheet documents are reordered.
@@ -169,18 +170,31 @@ function getIconsStyleSheetCached(): CSSStyleSheet {
 	return iconsStyleSheetCache;
 }
 
-function getThemeStyleSheet(theme: ColorThemeData): CSSStyleSheet {
+function createScopedThemingParticipant(scopeSelector: string, scopeRootSelector: string, participants: readonly IThemingParticipant[]): IThemingParticipant {
+	return (theme, collector, environment) => {
+		const rules = new Set<string>();
+		const scopedCollector = { addRule: (rule: string) => rules.add(rule) };
+		participants.forEach(participant => participant(theme, scopedCollector, environment));
+		const scopedRules = [...rules].map(rule => rule
+			.replace(/^(\s*):root(?=\s*\{)/, '$1:scope')
+			.replaceAll(scopeRootSelector, ':scope'));
+		collector.addRule(`@scope (${scopeSelector}) {\n${scopedRules.join('\n')}\n}`);
+	};
+}
+
+function getThemeStyleSheet(theme: ColorThemeData, scopeThemingParticipants: boolean): CSSStyleSheet {
 	const cachedStyleSheet = themeStyleSheetCache.get(theme);
 	if (cachedStyleSheet) {
 		return cachedStyleSheet;
 	}
 
 	const scopeSelector = '.' + theme.classNames[0];
+	const themingParticipants = themingRegistry.getThemingParticipants();
 	const sheet = new CSSStyleSheet();
 	const css = generateColorThemeCSS(
 		theme,
 		scopeSelector,
-		themingRegistry.getThemingParticipants(),
+		scopeThemingParticipants ? [createScopedThemingParticipant(scopeSelector, '.monaco-workbench', themingParticipants)] : themingParticipants,
 		mockEnvironmentService
 	);
 	sheet.replaceSync(css.code);
@@ -190,25 +204,29 @@ function getThemeStyleSheet(theme: ColorThemeData): CSSStyleSheet {
 }
 
 /**
- * Installs the runtime-generated global styles once: the icon-font sheet, a
- * scoped sheet per theme, and an (initially empty) reversal overlay, all as
- * `document.adoptedStyleSheets`. The overlay keeps a stable identity and a fixed
- * position so that, once filled by {@link overrideStylesheetOrder}, its reordered
- * copy reliably wins source-order cascade ties. Idempotent and effectively
- * write-once: after the returned promise resolves the global sheets never change
- * except through a scoped {@link overrideStylesheetOrder} override.
+ * Installs shared global styles once and appends a scoped stylesheet for each newly requested theme.
+ * The reversal overlay keeps a stable identity and position for {@link overrideStylesheetOrder}.
  */
-export function ensureGlobalStylesInstalled(themes: readonly ColorThemeData[]): Promise<void> {
-	return installedPromise ??= (async () => {
+export async function ensureGlobalStylesInstalled(theme: ColorThemeData, scopeThemingParticipants: boolean): Promise<void> {
+	baseStylesInstalledPromise ??= (async () => {
 		await readBundle();
 		const overlay = overlaySheet = new CSSStyleSheet();
 		document.adoptedStyleSheets = [
 			...document.adoptedStyleSheets,
 			overlay,
 			getIconsStyleSheetCached(),
-			...themes.map(getThemeStyleSheet),
 		];
 	})();
+	await baseStylesInstalledPromise;
+
+	if (installedThemes.has(theme)) {
+		return;
+	}
+	document.adoptedStyleSheets = [
+		...document.adoptedStyleSheets,
+		getThemeStyleSheet(theme, scopeThemingParticipants),
+	];
+	installedThemes.add(theme);
 }
 
 /**


### PR DESCRIPTION
## Summary

- add an opt-in Dark High Contrast component fixture theme
- cover the Modern UI tab bar default state with one high contrast screenshot fixture
- cache generated theme stylesheets per theme so Dark High Contrast gets its own scoped colors

## Review

- rubber-duck review completed
- fixed missing `hc_black.json` fixture resource registration found during review
- re-review found no remaining issues

## Validation

- CI