### PR TITLE
Fix incomplete streaming Markdown tokens

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -891,8 +891,13 @@ function hasStartOfLinkTargetAndNoLinkText(str: string): boolean {
 	return !!str.match(/^[^\[]*\]\([^\)]*$/);
 }
 
-function completeBlockquotePattern(blockquote: marked.Tokens.Blockquote): marked.Tokens.Blockquote | undefined {
-	const lastToken = blockquote.tokens.at(-1);
+function completeBlockquotePattern(blockquote: marked.Tokens.Blockquote, links: marked.Links): marked.Tokens.Blockquote | undefined {
+	let lastInterestingIndex = blockquote.tokens.length - 1;
+	while (lastInterestingIndex >= 0 && blockquote.tokens[lastInterestingIndex].type === 'space') {
+		lastInterestingIndex--;
+	}
+
+	const lastToken = blockquote.tokens[lastInterestingIndex];
 	if (lastToken?.type !== 'paragraph') {
 		return undefined;
 	}
@@ -903,7 +908,12 @@ function completeBlockquotePattern(blockquote: marked.Tokens.Blockquote): marked
 	}
 
 	const completion = completedToken.raw.slice(lastToken.raw.trimEnd().length);
-	const completedBlockquote = completeWithString(blockquote, completion);
+	const trailingQuoteOnlyLines = blockquote.raw.match(/(?:\n[ \t]*>[ \t]*(?=\n|$))+\n?$/)?.[0] ?? '';
+	const insertionIndex = blockquote.raw.length - trailingQuoteOnlyLines.length;
+	const completedRaw = blockquote.raw.slice(0, insertionIndex) + completion + trailingQuoteOnlyLines;
+	const lexer = new marked.Lexer();
+	lexer.tokens.links = links;
+	const completedBlockquote = lexer.lex(completedRaw)[0];
 	if (completedBlockquote.type === 'blockquote') {
 		return completedBlockquote as marked.Tokens.Blockquote;
 	}
@@ -1047,7 +1057,7 @@ function fillInIncompleteTokensOnce(tokens: marked.TokensList): marked.TokensLis
 	}
 
 	if (!newTokens && lastInterestingToken?.type === 'blockquote') {
-		const newBlockquoteToken = completeBlockquotePattern(lastInterestingToken as marked.Tokens.Blockquote);
+		const newBlockquoteToken = completeBlockquotePattern(lastInterestingToken as marked.Tokens.Blockquote, tokens.links);
 		if (newBlockquoteToken) {
 			newTokens = [newBlockquoteToken, ...trailingTokens];
 			i = lastInterestingIdx;

--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -883,13 +883,32 @@ function completeSingleLinePattern(token: marked.Tokens.Text | marked.Tokens.Par
 }
 
 function hasLinkTextAndStartOfLinkTarget(str: string): boolean {
-	// The `[` may be preceded by start-of-line, whitespace, or an emphasis/strikethrough marker
-	// (e.g. `**[text](htt`) so that links nested inside bold/italic/strikethrough are detected.
-	return !!str.match(/(^|\s|\*|_|~)\[.*\]\(\w*/);
+	// Allow links after opening parentheses and emphasis/strikethrough markers, such as `**[text](htt`.
+	return !!str.match(/(?:^|[\s(*_~])\[.*\]\(\w*/);
 }
 
 function hasStartOfLinkTargetAndNoLinkText(str: string): boolean {
 	return !!str.match(/^[^\[]*\]\([^\)]*$/);
+}
+
+function completeBlockquotePattern(blockquote: marked.Tokens.Blockquote): marked.Tokens.Blockquote | undefined {
+	const lastToken = blockquote.tokens.at(-1);
+	if (lastToken?.type !== 'paragraph') {
+		return undefined;
+	}
+
+	const completedToken = completeSingleLinePattern(lastToken as marked.Tokens.Paragraph);
+	if (!completedToken) {
+		return undefined;
+	}
+
+	const completion = completedToken.raw.slice(lastToken.raw.trimEnd().length);
+	const completedBlockquote = completeWithString(blockquote, completion);
+	if (completedBlockquote.type === 'blockquote') {
+		return completedBlockquote as marked.Tokens.Blockquote;
+	}
+
+	return undefined;
 }
 
 function completeListItemPattern(list: marked.Tokens.List): marked.Tokens.List | undefined {
@@ -1023,6 +1042,14 @@ function fillInIncompleteTokensOnce(tokens: marked.TokensList): marked.TokensLis
 		const newListToken = completeListItemPattern(lastInterestingToken as marked.Tokens.List);
 		if (newListToken) {
 			newTokens = [newListToken, ...trailingTokens];
+			i = lastInterestingIdx;
+		}
+	}
+
+	if (!newTokens && lastInterestingToken?.type === 'blockquote') {
+		const newBlockquoteToken = completeBlockquotePattern(lastInterestingToken as marked.Tokens.Blockquote);
+		if (newBlockquoteToken) {
+			newTokens = [newBlockquoteToken, ...trailingTokens];
 			i = lastInterestingIdx;
 		}
 	}

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -906,6 +906,17 @@ suite('MarkdownRenderer', () => {
 			});
 		});
 
+		suite('blockquote', () => {
+			test('incomplete double star', () => {
+				const incomplete = '> **text';
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const completeTokens = marked.marked.lexer(incomplete + '**');
+				assert.deepStrictEqual(newTokens, completeTokens);
+			});
+		});
+
 		suite('codespan', () => {
 			simpleMarkdownTestSuite('codespan', '`');
 
@@ -1032,6 +1043,15 @@ suite('MarkdownRenderer', () => {
 
 			test('incomplete link target 2', () => {
 				const incomplete = 'foo [text](http://microsoft.com';
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const completeTokens = marked.marked.lexer(incomplete + ')');
+				assert.deepStrictEqual(newTokens, completeTokens);
+			});
+
+			test('incomplete link target inside parentheses', () => {
+				const incomplete = '([text](http://microsoft.com';
 				const tokens = marked.marked.lexer(incomplete);
 				const newTokens = fillInIncompleteTokens(tokens);
 

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -915,6 +915,24 @@ suite('MarkdownRenderer', () => {
 				const completeTokens = marked.marked.lexer(incomplete + '**');
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
+
+			test('incomplete double star before trailing quote-only lines', () => {
+				const incomplete = '> **text\n>\n>';
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const completeTokens = marked.marked.lexer('> **text**\n>\n>');
+				assert.deepStrictEqual(newTokens, completeTokens);
+			});
+
+			test('preserves reference links when completing inline tokens', () => {
+				const incomplete = '[id]: https://example.com\n\n> [label][id] **text';
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const completeTokens = marked.marked.lexer(incomplete + '**');
+				assert.deepStrictEqual(newTokens, completeTokens);
+			});
 		});
 
 		suite('codespan', () => {


### PR DESCRIPTION
## Summary
- complete streamed Markdown links that begin inside parentheses
- complete inline Markdown constructs in the final paragraph of a blockquote
- add regression coverage for parenthesized links and incomplete bold blockquotes

## Validation
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/base/test/browser/markdownRenderer.test.ts`
- `node --experimental-strip-types build/hygiene.ts src/vs/base/browser/markdownRenderer.ts src/vs/base/test/browser/markdownRenderer.test.ts`

(Written by Copilot)