### PR TITLE
sessions: prompt timeline UX improvements

### DIFF
--- a/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
+++ b/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
@@ -22,9 +22,6 @@
 	--prompt-timeline-rail-width: 36px;
 	/* Minimum clear space guaranteed between the message content and the rail marks. */
 	--prompt-timeline-content-gap: 24px;
-	/* Gutter reserved for the transcript's native scrollbar (its ~10px width + a small gap) so the
-	 * marks sit to its left and it stays grabbable. */
-	--prompt-timeline-scrollbar-gutter: 16px;
 }
 
 /* Reserve room on the transcript's right edge so message content clears the rail's marks.
@@ -181,11 +178,80 @@
 	font-variant-numeric: tabular-nums;
 }
 
-/* Overview-ruler style: the session compressed into the rail height like the editor overview ruler. Marks sit in a gutter to the LEFT of the transcript's native scrollbar (via the right inset) so the pills never overlap the slider and the scrollbar stays grabbable. The gutter is set from the real scrollbar width by the contribution; the fallback covers the default 10px slider + a small gap. */
+/* Overview-ruler style: the session compressed into the rail height like the editor overview ruler.
+ * The marks column IS the scrollbar lane: it sits at the transcript's right edge over the (hidden)
+ * native slider, and the rail draws its own thumb below the marks. At rest the lane is a plain
+ * scrollbar (just the thumb); on engagement the thumb recedes and the marks fan in over the same
+ * column, so the scrollbar visually morphs into the fan. */
 .prompt-timeline-ruler-marks {
 	position: absolute;
-	inset: 0 var(--prompt-timeline-scrollbar-gutter, 16px) 0 0;
+	inset: 0 0 0 auto;
+	width: 22px;
+	/* The whole column is the hover/scrub surface: hovering blooms the fisheye "fan" and lets it
+	 * follow the cursor; dragging scrubs the transcript (see the rail's pointer handlers). */
+	pointer-events: auto;
+	/* The marks stay quiet (invisible) at rest and during gentle scrolling so the transcript reads
+	 * calm — only a deliberate gesture surfaces them: hovering the lane (`:hover`), the fisheye bloom
+	 * on a hard scroll (`.engaged`), a scrub drag (`.scrubbing`), or keyboard focus inside the rail
+	 * (`:focus-within`). */
+	opacity: 0;
+	transition: opacity 200ms ease;
+	z-index: 2;
+}
+
+/* Reveal the marks whenever the timeline is engaged: while scrolling + its linger (`.engaged`, which
+ * also covers reduced-motion where the fan is disabled), while hovering the lane, while scrubbing, or
+ * whenever keyboard focus is inside the rail (so tabbing to a mark and "Go to Prompt" always show it). */
+.prompt-timeline-rail.engaged .prompt-timeline-ruler-marks,
+.prompt-timeline-rail:hover .prompt-timeline-ruler-marks,
+.prompt-timeline-rail.scrubbing .prompt-timeline-ruler-marks,
+.prompt-timeline-rail:focus-within .prompt-timeline-ruler-marks {
+	opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.prompt-timeline-ruler-marks {
+		transition: none;
+	}
+}
+
+/* The rail's own scrollbar thumb (the transcript's native slider is hidden while the rail is active).
+ * A plain, translucent scrollbar at rest; it fades out as the fan blooms — or stays put while you
+ * drag it to scrub — so the lane reads as one surface morphing scrollbar <-> fan. Non-interactive:
+ * the marks column above owns hover + scrub. */
+.prompt-timeline-ruler-thumb {
+	position: absolute;
+	right: 4px;
+	width: 9px;
+	border-radius: 5px;
+	background-color: var(--vscode-scrollbarSlider-background);
 	pointer-events: none;
+	transition: opacity 160ms ease;
+	z-index: 1;
+}
+
+.prompt-timeline-ruler-thumb.hidden {
+	display: none;
+}
+
+/* The thumb recedes once the timeline is engaged (scrolling/hover), but stays visible while scrubbing
+ * so dragging the lane feels like grabbing a scrollbar. */
+.prompt-timeline-rail.engaged:not(.scrubbing) .prompt-timeline-ruler-thumb,
+.prompt-timeline-rail:hover:not(.scrubbing) .prompt-timeline-ruler-thumb {
+	opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.prompt-timeline-ruler-thumb {
+		transition: none;
+	}
+}
+
+/* The rail is the scrollbar while it is active, so hide the transcript's own vertical slider for a
+ * single lane. Scoped to the top-level transcript list via a direct-child chain (nested scrollables
+ * inside rows keep their sliders) and only while the rail is actually showing (`.prompt-timeline-active`). */
+.prompt-timeline-host.prompt-timeline-active .interactive-list > .monaco-list > .monaco-scrollable-element > .scrollbar.vertical {
+	display: none;
 }
 
 /* Each mark is a >=24px hit target positioned at its proportional scroll offset. */
@@ -227,7 +293,26 @@
 	height: 3px;
 	border-radius: 2px;
 	background-color: var(--vscode-scrollbarSlider-background);
-	transition: width 80ms ease, height 80ms ease, background-color 80ms ease;
+	/* `transform` is animated for the fisheye "fan" magnification; keep origin at the transcript
+	 * edge so the bar grows leftward, never across the scrollbar. */
+	transform-origin: right center;
+	transition: transform 90ms ease, width 80ms ease, height 80ms ease, background-color 80ms ease;
+}
+
+/* The mark button carries the fan's neighbour-spread (translateY); transition it so bloom and
+ * collapse both ease. `top` is only transitioned under `.glide` (drift), so this stays independent. */
+.prompt-timeline-ruler-mark {
+	transition: transform 90ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.prompt-timeline-ruler-bar {
+		transition: width 80ms ease, height 80ms ease, background-color 80ms ease;
+	}
+
+	.prompt-timeline-ruler-mark {
+		transition: none;
+	}
 }
 
 /* Two-tone edited signal: a green added segment and a red removed segment, sized by the turn's split. */

--- a/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
+++ b/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
@@ -223,7 +223,7 @@
 	position: absolute;
 	right: 4px;
 	width: 9px;
-	border-radius: 5px;
+	border-radius: var(--vscode-cornerRadius-circle);
 	background-color: var(--vscode-scrollbarSlider-background);
 	pointer-events: none;
 	transition: opacity 160ms ease;
@@ -234,10 +234,11 @@
 	display: none;
 }
 
-/* The thumb recedes once the timeline is engaged (scrolling/hover), but stays visible while scrubbing
- * so dragging the lane feels like grabbing a scrollbar. */
+/* The thumb recedes whenever the marks are revealed (engaged/hover/keyboard focus), but stays visible
+ * while scrubbing so dragging the lane feels like grabbing a scrollbar. */
 .prompt-timeline-rail.engaged:not(.scrubbing) .prompt-timeline-ruler-thumb,
-.prompt-timeline-rail:hover:not(.scrubbing) .prompt-timeline-ruler-thumb {
+.prompt-timeline-rail:hover:not(.scrubbing) .prompt-timeline-ruler-thumb,
+.prompt-timeline-rail:focus-within:not(.scrubbing) .prompt-timeline-ruler-thumb {
 	opacity: 0;
 }
 

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineModel.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineModel.ts
@@ -47,6 +47,10 @@ export interface IPromptScrollLayout {
 	readonly marks: readonly { readonly requestId: string; readonly top: number }[];
 	/** Total content height in the estimated space, matching `marks`. */
 	readonly total: number;
+	/** Current scroll offset (px, the transcript's real scroll space) — drives the rail's own scrollbar thumb. */
+	readonly scrollTop: number;
+	/** Full scrollable content height (px, the transcript's real scroll space). */
+	readonly scrollHeight: number;
 }
 
 /** A single tick shown on the prompt timeline rail. */
@@ -203,9 +207,10 @@ export class PromptTimelineModel extends Disposable {
 
 	/**
 	 * The prompts' positions for the overview-ruler rail, in an *estimated*
-	 * content space that stays stable while the transcript virtualizes. There is no
-	 * viewport thumb: the native scrollbar is the drag affordance and the active
-	 * mark is the "you-are-here", so the rail never draws a second slider.
+	 * content space that stays stable while the transcript virtualizes. The rail
+	 * draws its own scrollbar thumb from `scrollTop`/`scrollHeight` (the transcript's
+	 * native scrollbar is hidden while the rail is active) so the whole lane is one
+	 * surface: a plain scrollbar that blooms into the prompt fan on engagement.
 	 *
 	 * The chat list's own height model (`getElementTop`/`scrollHeight`) guesses
 	 * every un-rendered row at one flat default height (200px). Real turns are
@@ -231,7 +236,7 @@ export class PromptTimelineModel extends Disposable {
 				marks.push({ requestId: item.id, top: tops[i] });
 			}
 		}
-		return { marks, total };
+		return { marks, total, scrollTop: this.widget.scrollTop, scrollHeight: this.widget.scrollHeight };
 	}
 
 	/**

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineModel.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineModel.ts
@@ -51,6 +51,8 @@ export interface IPromptScrollLayout {
 	readonly scrollTop: number;
 	/** Full scrollable content height (px, the transcript's real scroll space). */
 	readonly scrollHeight: number;
+	/** Visible viewport height (px) of the transcript list — the scrollbar's `visibleSize`. */
+	readonly viewportHeight: number;
 }
 
 /** A single tick shown on the prompt timeline rail. */
@@ -236,7 +238,7 @@ export class PromptTimelineModel extends Disposable {
 				marks.push({ requestId: item.id, top: tops[i] });
 			}
 		}
-		return { marks, total, scrollTop: this.widget.scrollTop, scrollHeight: this.widget.scrollHeight };
+		return { marks, total, scrollTop: this.widget.scrollTop, scrollHeight: this.widget.scrollHeight, viewportHeight: this.widget.viewportHeight };
 	}
 
 	/**

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRail.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRail.ts
@@ -24,6 +24,8 @@ export interface IPromptTimelineRail extends IDisposable {
 
 	/** Fired when a mark is chosen (click / keyboard), with its request id. */
 	readonly onDidSelect: Event<string>;
+	/** Fired while dragging the rail lane to scrub, with the requested transcript scroll offset (px). */
+	readonly onDidScrub: Event<number>;
 	/** Fired to review all of a prompt's changes. */
 	readonly onDidReview: Event<PromptTick>;
 	/** Fired to review a single changed file of a prompt. */
@@ -31,6 +33,9 @@ export interface IPromptTimelineRail extends IDisposable {
 
 	setFilesProvider(provider: (tick: PromptTick) => readonly PromptFileDiff[]): void;
 	setTicks(ticks: readonly PromptTick[]): void;
+
+	/** Records a hard/fast wheel flick; the fan blooms only if a real transcript scroll follows shortly after. */
+	notifyHardWheel(): void;
 	setActive(requestId: string | undefined): void;
 	focusTick(requestId: string): void;
 	setHostWidth(width: number): void;

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { $, addDisposableListener, append, clearNode, EventType, getWindow, scheduleAtNextAnimationFrame } from '../../../../base/browser/dom.js';
+import { $, addDisposableGenericMouseDownListener, addDisposableGenericMouseMoveListener, addDisposableGenericMouseUpListener, addDisposableListener, append, clearNode, EventType, getWindow, scheduleAtNextAnimationFrame } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { disposableTimeout } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -18,8 +18,8 @@ import './media/promptTimeline.css';
 
 /** Minimum clickable target size (WCAG 2.5.8) for each mark's hit area. */
 const MIN_TARGET = 24;
-/** Below this transcript width the rail hides so it does not crowd the content. */
-const MIN_HOST_WIDTH = 320;
+/** Below this transcript width the rail hides so it does not crowd the content (and the native scrollbar is kept). */
+export const MIN_HOST_WIDTH = 320;
 /** Skip re-positioning a mark for sub-pixel drift, so estimate noise doesn't cause micro-jitter. */
 const RELAYOUT_MIN_DELTA = 0.5;
 /** Fisheye "fan" lens: standard deviation (px) of the magnification falloff around the focus. */
@@ -99,6 +99,8 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 	private _reducedMotion = false;
 	/** True while the user is dragging the lane to scrub the transcript. */
 	private _scrubbing = false;
+	/** True while keyboard focus is inside the rail: the marks stay revealed (`:focus-within`) but the fisheye is suppressed. */
+	private _focused = false;
 	/** Window listeners for the in-progress scrub drag; cleared on mouse-up (and on rail dispose). */
 	private readonly _scrubSession = this._register(new MutableDisposable<DisposableStore>());
 
@@ -160,8 +162,8 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 			}
 		}));
 		// Drag the lane (anywhere that is not a mark) to scrub the transcript, like grabbing a
-		// scrollbar. Marks stop the mousedown (below) so a click still jumps to that prompt.
-		this._register(addDisposableListener(this._marksContainer, EventType.MOUSE_DOWN, e => this._beginScrub(e)));
+		// scrollbar. Generic mouse-down so it also works with touch/pointer on iOS.
+		this._register(addDisposableGenericMouseDownListener(this._marksContainer, e => this._beginScrub(e)));
 
 		// The fan is a pointer-only flourish, so it must respect reduced-motion. Read it now and
 		// track changes; keyboard users always get the calm, static marks + card + navigation.
@@ -175,9 +177,15 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 			}));
 		}
 
-		// When keyboard focus leaves the rail entirely, hide the hover/focus card.
+		// Keyboard focus reveals a calm dock: the marks stay up (`:focus-within` in CSS) but the fisheye
+		// is suppressed, so tabbing through never leaves the pills magnified from an earlier scroll.
+		this._register(addDisposableListener(this._domNode, EventType.FOCUS_IN, () => {
+			this._focused = true;
+			this._collapseFan();
+		}));
 		this._register(addDisposableListener(this._domNode, EventType.FOCUS_OUT, () => {
 			if (!this._domNode.contains(getWindow(this._domNode).document.activeElement)) {
+				this._focused = false;
 				this._card.scheduleHide();
 			}
 		}));
@@ -216,8 +224,9 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 			this._renderMark(entry, tick);
 			const requestId = tick.requestId;
 			this._markDisposables.add(addDisposableListener(button, EventType.CLICK, () => this._onDidSelect.fire(requestId)));
-			// A mousedown on a mark must not start a lane scrub — let the click jump to the prompt.
-			this._markDisposables.add(addDisposableListener(button, EventType.MOUSE_DOWN, e => e.stopPropagation()));
+			// A press on a mark must not start a lane scrub — let the click jump to the prompt. Generic
+			// so it also intercepts the pointer-down used on iOS.
+			this._markDisposables.add(addDisposableGenericMouseDownListener(button, e => e.stopPropagation()));
 			this._markDisposables.add(addDisposableListener(button, EventType.MOUSE_ENTER, () => this._showCard(entry)));
 			this._markDisposables.add(addDisposableListener(button, EventType.FOCUS, () => { this._showCard(entry); this._updateTabStops(this._marks.indexOf(entry)); }));
 			this._markDisposables.add(addDisposableListener(button, EventType.MOUSE_LEAVE, () => this._card.scheduleHide()));
@@ -327,7 +336,12 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 			return undefined;
 		}
 		pts.sort((a, b) => a.contentTop - b.contentTop);
-		const scrollTop = layout.scrollTop;
+		// `contentTop`s are in the adaptive ESTIMATED space (summing to `layout.total`), but
+		// `layout.scrollTop`/`scrollHeight` are the transcript's REAL scroll space. Under virtualization
+		// those spaces differ, so scale the scroll position into the estimated space before comparing.
+		const scrollTop = layout.scrollHeight > 0
+			? (layout.scrollTop / layout.scrollHeight) * layout.total
+			: layout.scrollTop;
 		if (scrollTop <= pts[0].contentTop) {
 			return pts[0].center;
 		}
@@ -388,7 +402,7 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 	 * on their own, so this defers to them.
 	 */
 	private _onScrolled(): void {
-		if (this._hovering || this._scrubbing) {
+		if (this._hovering || this._scrubbing || this._focused) {
 			return;
 		}
 		if (this._domNode.classList.contains('engaged')) {
@@ -472,10 +486,10 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 			entry.button.style.top = `${y}px`;
 		}
 
-		// While the fan is open because of scrolling (not steered by the pointer), glide its focus with
-		// the viewport so the fisheye travels smoothly through the pills as you scroll. Runs once per
-		// animation frame (relayout is coalesced), and the marks' CSS transform transition eases it.
-		if (this._domNode.classList.contains('engaged') && !this._hovering && !this._scrubbing) {
+		// While the fan is open because of scrolling (not steered by the pointer, and not while keyboard
+		// focus is showing the calm dock), glide its focus with the viewport so the fisheye travels
+		// smoothly through the pills as you scroll.
+		if (this._domNode.classList.contains('engaged') && !this._hovering && !this._scrubbing && !this._focused) {
 			const scrollCenter = this._scrollFanCenter();
 			if (scrollCenter !== undefined) {
 				this._fanCenter = scrollCenter;
@@ -514,31 +528,45 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 	}
 
 	/**
-	 * Positions the rail's own scrollbar thumb from the transcript's real scroll offset, or hides it
-	 * when the content fits (nothing to scroll) or the rail is not showing. The rail's height stands
-	 * in for the viewport height (the rail spans the visible transcript), so this mirrors a normal
-	 * scrollbar's thumb math against the compressed lane.
+	 * The rail's scrollbar geometry, mapping the transcript's real scroll space onto the rail track,
+	 * exactly like the editor's {@link ScrollbarState}: the thumb size is the viewport's share of the
+	 * content (floored to a grabbable minimum), and the thumb travels `track - thumbSize` as the scroll
+	 * position travels `scrollHeight - viewportHeight`. Returns `undefined` when there is nothing to
+	 * scroll or the rail is too narrow to act as the scrollbar.
 	 */
-	private _layoutThumb(): void {
-		const height = this._railHeight;
+	private _thumbMetrics(): { size: number; ratio: number; maxScroll: number } | undefined {
+		const track = this._railHeight;
 		const layout = this._layout;
-		const scrollHeight = layout?.scrollHeight ?? 0;
-		const overflowing = this._hostWidth < MIN_HOST_WIDTH;
-		if (overflowing || height <= 0 || !layout || scrollHeight <= height + 1) {
+		if (!layout || track <= 0 || this._hostWidth < MIN_HOST_WIDTH) {
+			return undefined;
+		}
+		const viewport = layout.viewportHeight;
+		const scrollSize = layout.scrollHeight;
+		if (viewport <= 0 || scrollSize <= viewport + 1) {
+			return undefined; // content fits — no scrollbar needed
+		}
+		const size = Math.max(THUMB_MIN_HEIGHT, Math.floor(viewport / scrollSize * track));
+		const maxScroll = scrollSize - viewport;
+		const ratio = (track - size) / maxScroll;
+		return { size, ratio, maxScroll };
+	}
+
+	/** Positions the rail's own scrollbar thumb from the transcript's real scroll offset, or hides it when there is nothing to scroll. */
+	private _layoutThumb(): void {
+		const metrics = this._thumbMetrics();
+		if (!metrics) {
 			this._thumb.classList.add('hidden');
 			return;
 		}
-		const thumbHeight = Math.max(THUMB_MIN_HEIGHT, (height / scrollHeight) * height);
-		const top = Math.max(0, Math.min(height - thumbHeight, (layout.scrollTop / scrollHeight) * height));
+		const top = Math.max(0, Math.min(this._railHeight - metrics.size, this._layout!.scrollTop * metrics.ratio));
 		this._thumb.classList.remove('hidden');
 		this._thumb.style.top = `${top}px`;
-		this._thumb.style.height = `${thumbHeight}px`;
+		this._thumb.style.height = `${metrics.size}px`;
 	}
 
 	/** Begins a lane scrub (grab the scrollbar): scrolls to the pressed position and tracks the drag. */
 	private _beginScrub(e: MouseEvent): void {
-		const layout = this._layout;
-		if (!layout || this._railHeight <= 0 || layout.scrollHeight <= this._railHeight) {
+		if (!this._thumbMetrics()) {
 			return; // nothing to scroll
 		}
 		e.preventDefault();
@@ -548,10 +576,9 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		this._collapseFan();
 		this._domNode.classList.add('scrubbing');
 		this._scrubTo(e.clientY);
-		const win = getWindow(this._domNode);
 		const session = new DisposableStore();
-		session.add(addDisposableListener(win, EventType.MOUSE_MOVE, ev => this._scrubTo(ev.clientY)));
-		session.add(addDisposableListener(win, EventType.MOUSE_UP, () => {
+		session.add(addDisposableGenericMouseMoveListener(getWindow(this._domNode), (ev: MouseEvent) => this._scrubTo(ev.clientY)));
+		session.add(addDisposableGenericMouseUpListener(getWindow(this._domNode), () => {
 			this._scrubbing = false;
 			this._domNode.classList.remove('scrubbing');
 			this._scrubSession.clear();
@@ -569,16 +596,14 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 
 	/** Maps a client Y on the lane to a transcript scroll offset and requests it (viewport centred on the cursor). */
 	private _scrubTo(clientY: number): void {
-		const layout = this._layout;
-		const height = this._railHeight;
-		if (!layout || height <= 0) {
+		const metrics = this._thumbMetrics();
+		if (!metrics) {
 			return;
 		}
-		const scrollHeight = layout.scrollHeight;
-		const fraction = Math.max(0, Math.min(1, (clientY - this._laneTop) / height));
-		// Centre the viewport on the cursor, like grabbing the middle of a scrollbar thumb.
-		const target = fraction * scrollHeight - height / 2;
-		this._onDidScrub.fire(Math.max(0, Math.min(scrollHeight - height, target)));
+		// Centre the thumb on the cursor, then invert the thumb->scroll ratio, like ScrollbarState.
+		const desiredThumbTop = (clientY - this._laneTop) - metrics.size / 2;
+		const scrollTop = metrics.ratio > 0 ? desiredThumbTop / metrics.ratio : 0;
+		this._onDidScrub.fire(Math.max(0, Math.min(metrics.maxScroll, scrollTop)));
 	}
 
 	/**

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail.ts
@@ -5,6 +5,7 @@
 
 import { $, addDisposableListener, append, clearNode, EventType, getWindow, scheduleAtNextAnimationFrame } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
+import { disposableTimeout } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
@@ -21,6 +22,25 @@ const MIN_TARGET = 24;
 const MIN_HOST_WIDTH = 320;
 /** Skip re-positioning a mark for sub-pixel drift, so estimate noise doesn't cause micro-jitter. */
 const RELAYOUT_MIN_DELTA = 0.5;
+/** Fisheye "fan" lens: standard deviation (px) of the magnification falloff around the focus. */
+const FAN_SIGMA = 40;
+/** Fisheye "fan" lens: how far (px) neighbouring marks are pushed apart around the focus. */
+const FAN_SPREAD = 14;
+/** The fan lingers this long (ms) after the last scroll — while the pointer is away — before collapsing. */
+const FAN_LINGER = 2000;
+/** A hard wheel flick only reveals the fan if the transcript actually scrolls within this window (ms) — so flicking against the top/bottom limit, which moves nothing, never blooms it. */
+const HARD_WHEEL_REVEAL_WINDOW = 200;
+/** Minimum height (px) of the rail's own scrollbar thumb so it stays grabbable on tall transcripts. */
+const THUMB_MIN_HEIGHT = 24;
+/**
+ * Pill placement. `'proportional'` scatters pills at their real scroll position (an overview ruler);
+ * `'even'` stacks them as an evenly-spaced dock centred in the lane (stable under virtualization, and
+ * tidier when big responses would otherwise cluster the pills). The scrollbar thumb stays proportional
+ * either way, and scrubbing hides the pills, so `'even'` does not make dragging feel disconnected.
+ */
+const PILL_LAYOUT: 'proportional' | 'even' = 'even';
+/** Even layout: vertical gap (px) between pill centres — also the min so hit targets never overlap. */
+const EVEN_PILL_SPACING = 26;
 
 interface IMarkEntry {
 	tick: PromptTick;
@@ -28,6 +48,8 @@ interface IMarkEntry {
 	readonly bar: HTMLElement;
 	/** Last applied `top` (px) so tiny relayout deltas can be skipped. */
 	lastTop?: number;
+	/** Proportional (pre-fan) centre (px) from the last layout, used as the fan's rest position. */
+	baseCenter?: number;
 }
 
 /**
@@ -41,6 +63,8 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 
 	private readonly _domNode: HTMLElement;
 	private readonly _marksContainer: HTMLElement;
+	/** The rail's own scrollbar thumb (the transcript's native slider is hidden while the rail is active). Shown at rest as a plain scrollbar; recedes as the fan blooms. */
+	private readonly _thumb: HTMLElement;
 	private readonly _card: PromptTimelineCard;
 	private readonly _markDisposables = this._register(new DisposableStore());
 	private readonly _marks: IMarkEntry[] = [];
@@ -55,9 +79,34 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 	private _railHeight = 0;
 	/** Coalesces scroll-driven relayouts to one per animation frame. */
 	private readonly _relayoutScheduled = this._register(new MutableDisposable());
+	/** Lane-local Y the fisheye "fan" magnifies around, or undefined when the fan is at rest. */
+	private _fanCenter: number | undefined;
+	/** Cached top (client px) of the marks column, captured on pointer-enter so the fan can follow the cursor without a per-move reflow. */
+	private _laneTop = 0;
+	/** Cached client Y of the rail's top edge, refreshed on resize; used to place the hover card and derive the lane-local pointer Y without a per-hover forced reflow. */
+	private _domTop: number | undefined;
+	/** True while the pointer is over the lane (keeps the fan open; the linger only collapses once it leaves). */
+	private _hovering = false;
+	/** Timestamp (ms) of the last hard/fast wheel flick; the fan blooms only if a real scroll follows it within {@link HARD_WHEEL_REVEAL_WINDOW}. */
+	private _hardWheelAt = 0;
+	/** Last scroll offset seen, to detect real transcript movement (vs. a wheel that hit the scroll limit and moved nothing). */
+	private _lastScrollTop: number | undefined;
+	/** Collapses the fan {@link FAN_LINGER}ms after the last scroll, unless the pointer is keeping it open. */
+	private readonly _fanHide = this._register(new MutableDisposable());
+	/** Timestamp (ms) of the last scroll/leave that should keep the fan up; the linger timer re-checks this instead of being churned every scroll frame. */
+	private _lastFanActivityAt = 0;
+	/** When the user prefers reduced motion the fan is disabled (marks stay their calm rest size). */
+	private _reducedMotion = false;
+	/** True while the user is dragging the lane to scrub the transcript. */
+	private _scrubbing = false;
+	/** Window listeners for the in-progress scrub drag; cleared on mouse-up (and on rail dispose). */
+	private readonly _scrubSession = this._register(new MutableDisposable<DisposableStore>());
 
 	private readonly _onDidSelect = this._register(new Emitter<string>());
 	readonly onDidSelect: Event<string> = this._onDidSelect.event;
+
+	private readonly _onDidScrub = this._register(new Emitter<number>());
+	readonly onDidScrub: Event<number> = this._onDidScrub.event;
 
 	private readonly _onDidReview = this._register(new Emitter<PromptTick>());
 	readonly onDidReview: Event<PromptTick> = this._onDidReview.event;
@@ -74,6 +123,10 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		this._domNode.setAttribute('role', 'toolbar');
 		this._domNode.setAttribute('aria-orientation', 'vertical');
 		this._marksContainer = append(this._domNode, $('.prompt-timeline-ruler-marks'));
+		// The rail's own scrollbar thumb. It sits under the marks and shows the viewport position as
+		// a plain scrollbar at rest; while the fan is bloomed it fades out so the lane reads as one
+		// surface morphing from scrollbar → fan (the transcript's native slider is hidden via CSS).
+		this._thumb = append(this._domNode, $('.prompt-timeline-ruler-thumb'));
 		this._card = this._register(new PromptTimelineCard(this._domNode));
 		this._register(this._card.onDidReview(tick => this._onDidReview.fire(tick)));
 		this._register(this._card.onDidReviewFile(e => this._onDidReviewFile.fire(e)));
@@ -81,6 +134,48 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		// Toolbar keyboard model: one Tab stop, Arrow/Home/End move between marks.
 		this._register(addDisposableListener(this._marksContainer, EventType.KEY_DOWN, e => this._onMarksKeyDown(e)));
 
+		// The marks column IS the scrollbar lane. Hovering anywhere along it blooms the fisheye "fan"
+		// and lets it FOLLOW the cursor (a macOS-dock feel); dragging it scrubs the transcript like a
+		// scrollbar. The lane's top edge is cached (refreshed on resize) so each hover/move converts
+		// the pointer Y to lane-local space without a per-event getBoundingClientRect (a forced reflow
+		// that would stutter while the transcript's styles are dirty during scroll).
+		this._register(addDisposableListener(this._marksContainer, EventType.MOUSE_ENTER, e => {
+			this._laneTop = this._laneTopNow();
+			this._hovering = true;
+			this._fanHide.clear(); // hovering keeps the fan open — no linger countdown
+			if (!this._scrubbing) {
+				this._engage(e.clientY - this._laneTop);
+			}
+		}));
+		this._register(addDisposableListener(this._marksContainer, EventType.MOUSE_MOVE, e => {
+			this._hovering = true;
+			if (!this._scrubbing) {
+				this._engage(e.clientY - this._laneTop);
+			}
+		}));
+		this._register(addDisposableListener(this._marksContainer, EventType.MOUSE_LEAVE, () => {
+			this._hovering = false;
+			if (!this._scrubbing) {
+				this._scheduleFanHide();
+			}
+		}));
+		// Drag the lane (anywhere that is not a mark) to scrub the transcript, like grabbing a
+		// scrollbar. Marks stop the mousedown (below) so a click still jumps to that prompt.
+		this._register(addDisposableListener(this._marksContainer, EventType.MOUSE_DOWN, e => this._beginScrub(e)));
+
+		// The fan is a pointer-only flourish, so it must respect reduced-motion. Read it now and
+		// track changes; keyboard users always get the calm, static marks + card + navigation.
+		const win = getWindow(this._domNode);
+		const reducedMotionQuery = win.matchMedia?.('(prefers-reduced-motion: reduce)');
+		if (reducedMotionQuery) {
+			this._reducedMotion = reducedMotionQuery.matches;
+			this._register(addDisposableListener(reducedMotionQuery, 'change', () => {
+				this._reducedMotion = reducedMotionQuery.matches;
+				this._applyFan();
+			}));
+		}
+
+		// When keyboard focus leaves the rail entirely, hide the hover/focus card.
 		this._register(addDisposableListener(this._domNode, EventType.FOCUS_OUT, () => {
 			if (!this._domNode.contains(getWindow(this._domNode).document.activeElement)) {
 				this._card.scheduleHide();
@@ -121,6 +216,8 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 			this._renderMark(entry, tick);
 			const requestId = tick.requestId;
 			this._markDisposables.add(addDisposableListener(button, EventType.CLICK, () => this._onDidSelect.fire(requestId)));
+			// A mousedown on a mark must not start a lane scrub — let the click jump to the prompt.
+			this._markDisposables.add(addDisposableListener(button, EventType.MOUSE_DOWN, e => e.stopPropagation()));
 			this._markDisposables.add(addDisposableListener(button, EventType.MOUSE_ENTER, () => this._showCard(entry)));
 			this._markDisposables.add(addDisposableListener(button, EventType.FOCUS, () => { this._showCard(entry); this._updateTabStops(this._marks.indexOf(entry)); }));
 			this._markDisposables.add(addDisposableListener(button, EventType.MOUSE_LEAVE, () => this._card.scheduleHide()));
@@ -185,9 +282,76 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		}
 	}
 
+	/**
+	 * Records a hard/fast wheel flick. The fan does NOT bloom here — it blooms only if the transcript
+	 * actually scrolls shortly after (see {@link setScrollLayout}). This way a hard flick against the
+	 * top/bottom scroll limit, which moves nothing, never reveals the fan.
+	 */
+	notifyHardWheel(): void {
+		this._hardWheelAt = Date.now();
+	}
+
+	/** Lane-local Y of the active mark (the prompt currently scrolled to), or the nearest visible one. */
+	private _activeCenter(): number | undefined {
+		const active = this._marks.find(m => m.tick.requestId === this._activeRequestId && m.baseCenter !== undefined);
+		if (active?.baseCenter !== undefined) {
+			return active.baseCenter;
+		}
+		// Fall back to the last laid-out mark (or the first) so a scroll still blooms somewhere real.
+		const laidOut = this._marks.filter(m => m.baseCenter !== undefined);
+		return laidOut.at(-1)?.baseCenter;
+	}
+
+	/**
+	 * Lane-local Y for the fisheye focus while SCROLLING: glides continuously with the viewport by
+	 * interpolating between pills. Each prompt has a content position (`layout.marks[].top`) and a dock
+	 * position (`baseCenter`); we find where the viewport (`scrollTop`) sits between two prompts in
+	 * content space and place the focus at the matching fraction between their dock positions. So the
+	 * fisheye travels smoothly through the pills as you scroll (rather than snapping at prompt
+	 * boundaries), while still tracking the real scroll position. Returns `undefined` if not laid out.
+	 */
+	private _scrollFanCenter(): number | undefined {
+		const layout = this._layout;
+		if (!layout) {
+			return undefined;
+		}
+		const topById = new Map(layout.marks.map(m => [m.requestId, m.top]));
+		const pts: { contentTop: number; center: number }[] = [];
+		for (const entry of this._marks) {
+			const contentTop = topById.get(entry.tick.requestId);
+			if (contentTop !== undefined && entry.baseCenter !== undefined) {
+				pts.push({ contentTop, center: entry.baseCenter });
+			}
+		}
+		if (pts.length === 0) {
+			return undefined;
+		}
+		pts.sort((a, b) => a.contentTop - b.contentTop);
+		const scrollTop = layout.scrollTop;
+		if (scrollTop <= pts[0].contentTop) {
+			return pts[0].center;
+		}
+		const last = pts[pts.length - 1];
+		if (scrollTop >= last.contentTop) {
+			return last.center;
+		}
+		for (let i = 0; i < pts.length - 1; i++) {
+			const a = pts[i];
+			const b = pts[i + 1];
+			if (scrollTop >= a.contentTop && scrollTop <= b.contentTop) {
+				const span = b.contentTop - a.contentTop;
+				const frac = span > 0 ? (scrollTop - a.contentTop) / span : 0;
+				return a.center + frac * (b.center - a.center);
+			}
+		}
+		return last.center;
+	}
+
 	setActive(requestId: string | undefined): void {
 		this._activeRequestId = requestId;
 		this._updateActiveClasses();
+		// Note: the scroll-driven fan follow is handled continuously in `_relayout` (it glides with the
+		// viewport), so we do not re-centre here — that would snap the fan at prompt boundaries.
 	}
 
 	focusTick(requestId: string): void {
@@ -202,9 +366,44 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 	}
 
 	setScrollLayout(layout: IPromptScrollLayout | undefined): void {
+		const prevScrollTop = this._lastScrollTop;
 		this._layout = layout;
+		if (layout) {
+			this._lastScrollTop = layout.scrollTop;
+			// Only react to a REAL scroll movement. A wheel flick against the top/bottom limit fires
+			// wheel events (so notifyHardWheel runs) but doesn't change scrollTop, so it never reveals
+			// the fan here. Programmatic nudges during virtualization re-measure lack a recent hard
+			// wheel, so they don't reveal it either.
+			if (prevScrollTop !== undefined && Math.abs(layout.scrollTop - prevScrollTop) > 0.5) {
+				this._onScrolled();
+			}
+		}
 		// Scroll fires many events per frame; coalesce so we lay out (and touch the DOM) once.
 		this._scheduleRelayout();
+	}
+
+	/**
+	 * Handles a real transcript scroll: blooms the fan if it followed a deliberate hard flick, and
+	 * keeps it alive (re-arms the linger) while you keep scrolling. Pointer hover/scrub own the fan
+	 * on their own, so this defers to them.
+	 */
+	private _onScrolled(): void {
+		if (this._hovering || this._scrubbing) {
+			return;
+		}
+		if (this._domNode.classList.contains('engaged')) {
+			// Already open: keep it up while actively scrolling (the glide happens in `_relayout`).
+			this._scheduleFanHide();
+			return;
+		}
+		// Not open yet: only a deliberate hard flick that actually moved the transcript blooms it.
+		if (Date.now() - this._hardWheelAt <= HARD_WHEEL_REVEAL_WINDOW) {
+			const center = this._scrollFanCenter() ?? this._activeCenter();
+			if (center !== undefined) {
+				this._engage(center);
+				this._scheduleFanHide();
+			}
+		}
 	}
 
 	/** Coalesces relayout to at most once per animation frame. */
@@ -225,6 +424,8 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		const layout = this._layout;
 		const overflowing = this._hostWidth < MIN_HOST_WIDTH;
 		this._domNode.classList.toggle('overflowing', overflowing);
+		// Position the rail's own scrollbar thumb (independent of the marks, which may be absent).
+		this._layoutThumb();
 		if (overflowing || height <= 0 || !layout || layout.total <= 0) {
 			return;
 		}
@@ -238,19 +439,29 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 			if (top === undefined) {
 				entry.button.classList.add('hidden');
 				entry.lastTop = undefined;
+				entry.baseCenter = undefined;
+				entry.button.style.transform = '';
+				entry.bar.style.transform = '';
 				continue;
 			}
 			entry.button.classList.remove('hidden');
 			visible.push({ entry, center: top * scale });
 		}
 
-		// Prompts can sit arbitrarily close in content space (a short turn, or after height
-		// re-estimates settle), which would let the >=24px hit targets overlap. Push adjacent
-		// marks apart to keep a full target's spacing while staying as close to their
-		// proportional position as the rail allows.
-		spaceMarkCenters(visible, height, MIN_TARGET);
+		if (PILL_LAYOUT === 'even') {
+			// Evenly-spaced dock, centred vertically as a group. Stable under virtualization (pills do
+			// not drift as row heights re-measure) and tidy when big responses would cluster them.
+			this._spaceEvenCenters(visible, height);
+		} else {
+			// Prompts can sit arbitrarily close in content space (a short turn, or after height
+			// re-estimates settle), which would let the >=24px hit targets overlap. Push adjacent
+			// marks apart to keep a full target's spacing while staying as close to their
+			// proportional position as the rail allows.
+			spaceMarkCenters(visible, height, MIN_TARGET);
+		}
 
 		for (const { entry, center } of visible) {
+			entry.baseCenter = center;
 			// The button is a >=24px hit target centered on the mark's (spaced) position.
 			const y = center - MIN_TARGET / 2;
 			// Skip sub-pixel drift so estimate noise doesn't jitter the marks.
@@ -260,6 +471,189 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 			entry.lastTop = y;
 			entry.button.style.top = `${y}px`;
 		}
+
+		// While the fan is open because of scrolling (not steered by the pointer), glide its focus with
+		// the viewport so the fisheye travels smoothly through the pills as you scroll. Runs once per
+		// animation frame (relayout is coalesced), and the marks' CSS transform transition eases it.
+		if (this._domNode.classList.contains('engaged') && !this._hovering && !this._scrubbing) {
+			const scrollCenter = this._scrollFanCenter();
+			if (scrollCenter !== undefined) {
+				this._fanCenter = scrollCenter;
+			}
+		}
+
+		// Re-apply the pointer fisheye against the freshly measured rest positions.
+		this._applyFan();
+	}
+
+	/**
+	 * Even (dock) placement: stacks the pills at a fixed spacing and centres the whole group in the
+	 * lane. If the group is taller than the lane it distributes across the full height instead, so a
+	 * long session still fits. Mutates each item's `center` in place.
+	 */
+	private _spaceEvenCenters(visible: { entry: IMarkEntry; center: number }[], height: number): void {
+		const n = visible.length;
+		if (n === 0) {
+			return;
+		}
+		const groupHeight = n * EVEN_PILL_SPACING;
+		let start: number;
+		let step: number;
+		if (groupHeight <= height) {
+			// Compact group centred vertically.
+			step = EVEN_PILL_SPACING;
+			start = (height - groupHeight) / 2 + step / 2;
+		} else {
+			// Too many to fit at the ideal spacing: spread evenly across the full height.
+			step = (height - EVEN_PILL_SPACING) / (n - 1);
+			start = EVEN_PILL_SPACING / 2;
+		}
+		for (let i = 0; i < n; i++) {
+			visible[i].center = start + i * step;
+		}
+	}
+
+	/**
+	 * Positions the rail's own scrollbar thumb from the transcript's real scroll offset, or hides it
+	 * when the content fits (nothing to scroll) or the rail is not showing. The rail's height stands
+	 * in for the viewport height (the rail spans the visible transcript), so this mirrors a normal
+	 * scrollbar's thumb math against the compressed lane.
+	 */
+	private _layoutThumb(): void {
+		const height = this._railHeight;
+		const layout = this._layout;
+		const scrollHeight = layout?.scrollHeight ?? 0;
+		const overflowing = this._hostWidth < MIN_HOST_WIDTH;
+		if (overflowing || height <= 0 || !layout || scrollHeight <= height + 1) {
+			this._thumb.classList.add('hidden');
+			return;
+		}
+		const thumbHeight = Math.max(THUMB_MIN_HEIGHT, (height / scrollHeight) * height);
+		const top = Math.max(0, Math.min(height - thumbHeight, (layout.scrollTop / scrollHeight) * height));
+		this._thumb.classList.remove('hidden');
+		this._thumb.style.top = `${top}px`;
+		this._thumb.style.height = `${thumbHeight}px`;
+	}
+
+	/** Begins a lane scrub (grab the scrollbar): scrolls to the pressed position and tracks the drag. */
+	private _beginScrub(e: MouseEvent): void {
+		const layout = this._layout;
+		if (!layout || this._railHeight <= 0 || layout.scrollHeight <= this._railHeight) {
+			return; // nothing to scroll
+		}
+		e.preventDefault();
+		this._scrubbing = true;
+		this._laneTop = this._laneTopNow();
+		// Collapse the fan while scrubbing so the lane reads as a clean scrollbar being dragged.
+		this._collapseFan();
+		this._domNode.classList.add('scrubbing');
+		this._scrubTo(e.clientY);
+		const win = getWindow(this._domNode);
+		const session = new DisposableStore();
+		session.add(addDisposableListener(win, EventType.MOUSE_MOVE, ev => this._scrubTo(ev.clientY)));
+		session.add(addDisposableListener(win, EventType.MOUSE_UP, () => {
+			this._scrubbing = false;
+			this._domNode.classList.remove('scrubbing');
+			this._scrubSession.clear();
+			// Linger briefly after a scrub so the timeline stays up while the user reads where they landed.
+			if (!this._hovering) {
+				const center = this._activeCenter();
+				if (center !== undefined) {
+					this._engage(center);
+				}
+				this._scheduleFanHide();
+			}
+		}));
+		this._scrubSession.value = session;
+	}
+
+	/** Maps a client Y on the lane to a transcript scroll offset and requests it (viewport centred on the cursor). */
+	private _scrubTo(clientY: number): void {
+		const layout = this._layout;
+		const height = this._railHeight;
+		if (!layout || height <= 0) {
+			return;
+		}
+		const scrollHeight = layout.scrollHeight;
+		const fraction = Math.max(0, Math.min(1, (clientY - this._laneTop) / height));
+		// Centre the viewport on the cursor, like grabbing the middle of a scrollbar thumb.
+		const target = fraction * scrollHeight - height / 2;
+		this._onDidScrub.fire(Math.max(0, Math.min(scrollHeight - height, target)));
+	}
+
+	/**
+	 * Fisheye "fan": magnify the marks near {@link _fanCenter} and gently spread their neighbours
+	 * apart, so a dense cluster becomes easy to read and click. It is a pointer-only flourish layered
+	 * on top of the proportional layout — the marks' `top` (owned by `_relayout`) is untouched; the
+	 * fan only adds a CSS `transform`, so keyboard navigation and the base layout are unaffected.
+	 * Disabled entirely under reduced-motion.
+	 */
+	private _applyFan(): void {
+		const center = this._fanCenter;
+		const fanning = center !== undefined && !this._reducedMotion;
+		for (const entry of this._marks) {
+			if (entry.baseCenter === undefined) {
+				continue;
+			}
+			if (!fanning) {
+				entry.button.style.transform = '';
+				entry.bar.style.transform = '';
+				continue;
+			}
+			const d = entry.baseCenter - center!;
+			const m = Math.exp(-(d * d) / (2 * FAN_SIGMA * FAN_SIGMA));
+			// Spread neighbours away from the focus (dock feel) and grow the focused bar the most.
+			entry.button.style.transform = `translateY(${FAN_SPREAD * Math.tanh(d / FAN_SIGMA)}px)`;
+			entry.bar.style.transform = `scale(${1 + m * 0.9}, ${1 + m * 0.6})`;
+		}
+	}
+
+	/**
+	 * Opens the fan at {@link center} (lane-local Y): reveals the marks (via `.engaged`) and applies
+	 * the fisheye. Reveal happens even under reduced motion (the marks just don't magnify).
+	 */
+	private _engage(center: number): void {
+		this._domNode.classList.add('engaged');
+		this._fanCenter = center;
+		this._applyFan();
+	}
+
+	/** Collapses the fan back to the plain scrollbar (marks hidden, no fisheye). */
+	private _collapseFan(): void {
+		if (!this._domNode.classList.contains('engaged')) {
+			return;
+		}
+		this._domNode.classList.remove('engaged');
+		this._fanCenter = undefined;
+		this._applyFan();
+	}
+
+	/**
+	 * (Re)starts the linger countdown: {@link FAN_LINGER}ms after the last scroll the fan collapses —
+	 * but only if the pointer is not keeping it open. Called on every scroll frame and when the pointer
+	 * leaves, so it avoids churning the timer: it just stamps the activity time and, when the single
+	 * running timer fires, it re-arms for the remaining time if more scrolling happened since.
+	 */
+	private _scheduleFanHide(): void {
+		this._lastFanActivityAt = Date.now();
+		if (!this._fanHide.value) {
+			this._armFanHide(FAN_LINGER);
+		}
+	}
+
+	private _armFanHide(delay: number): void {
+		this._fanHide.value = disposableTimeout(() => {
+			this._fanHide.clear();
+			if (this._hovering) {
+				return; // hovering keeps it up; leaving re-arms the countdown
+			}
+			const remaining = FAN_LINGER - (Date.now() - this._lastFanActivityAt);
+			if (remaining > 0) {
+				this._armFanHide(remaining); // more scrolling happened since — keep waiting
+			} else {
+				this._collapseFan();
+			}
+		}, delay);
 	}
 
 	private _updateActiveClasses(): void {
@@ -274,10 +668,25 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		}
 	}
 
+	/** Lane-local Y (client px) of the marks column top, from the cached rail top (refreshed on resize). Reads layout lazily only if the cache is not yet primed, so hovering never forces a reflow mid-scroll. */
+	private _laneTopNow(): number {
+		if (this._domTop === undefined) {
+			this._domTop = this._domNode.getBoundingClientRect().top;
+		}
+		// The marks column is inset:0 at the top, so its client top equals the rail's.
+		return this._domTop;
+	}
+
 	private _showCard(entry: IMarkEntry): void {
-		const markRect = entry.button.getBoundingClientRect();
-		const domRect = this._domNode.getBoundingClientRect();
-		this._card.show(entry.tick, markRect.top - domRect.top + markRect.height / 2);
+		// Position the card from the mark's known lane-local centre instead of reading
+		// getBoundingClientRect (a forced synchronous layout that stutters while the transcript's
+		// styles are dirty during scroll). The marks column is inset:0 at the top, so `baseCenter`
+		// is the Y relative to the rail; the hovered mark sits near the fan focus, where its
+		// magnification translate is ~0, so this matches the visible position. Falls back to a
+		// measured rect only if the mark has not been laid out yet.
+		const centerY = entry.baseCenter
+			?? (entry.button.getBoundingClientRect().top - this._domNode.getBoundingClientRect().top + MIN_TARGET / 2);
+		this._card.show(entry.tick, centerY);
 	}
 
 	private _ensureResizeObserver(): void {
@@ -290,8 +699,10 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		}
 		this._resizeObserverReady = true;
 		const observer = new ResizeObserverCtor(() => {
-			// Height only changes here (window/input-part resize); refresh the cache and lay out.
+			// Height only changes here (window/input-part resize); refresh the cached height and top
+			// (used by hover/scrub to avoid per-event reflows) and lay out.
 			this._railHeight = this._domNode.clientHeight;
+			this._domTop = this._domNode.getBoundingClientRect().top;
 			this._relayout();
 		});
 		observer.observe(this._domNode);

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getWindow } from '../../../../base/browser/dom.js';
+import { addDisposableListener, getWindow } from '../../../../base/browser/dom.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -15,6 +15,11 @@ import { MIN_PROMPTS, PROMPT_TIMELINE_CONTRIB_ID, PROMPT_TIMELINE_ENABLED_SETTIN
 import { PromptTimelineModel, PromptEntry } from './promptTimelineModel.js';
 import { IPromptTimelineRail } from './promptTimelineRail.js';
 import { PromptTimelineRulerRail } from './promptTimelineRulerRail.js';
+
+/** Wheel distance (|deltaY|) that must accumulate within {@link WHEEL_WINDOW_MS} to count as a hard/fast scroll. */
+const HARD_WHEEL_DISTANCE = 800;
+/** Rolling window for the wheel-velocity accumulator; a pause longer than this resets it. */
+const WHEEL_WINDOW_MS = 120;
 
 /**
  * Per-widget contribution that overlays a prompt timeline rail on the chat
@@ -80,14 +85,53 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 
 		rail.setFilesProvider(tick => model.getRequestFiles(tick));
 		this._enablement.add(rail.onDidSelect(requestId => model.reveal(requestId)));
+		// Dragging the rail lane scrubs the transcript (the rail is the scrollbar now, so it drives scroll).
+		this._enablement.add(rail.onDidScrub(scrollTop => { (this.widget as ChatWidget).scrollTop = scrollTop; }));
 		this._enablement.add(rail.onDidReview(tick => { void model.reviewChanges(tick); }));
 		this._enablement.add(rail.onDidReviewFile(e => { void model.reviewChanges(e.tick, e.file); }));
+
+		// The transcript stays calm at rest AND during gentle scrolling — a plain scrollbar. Only a
+		// HARD / FAST scroll (a deliberate flick) that ACTUALLY moves the transcript reveals the
+		// timeline and blooms the fisheye "fan", which then follows the viewport as you continue. It
+		// lingers for a few seconds after you stop before collapsing back to a plain scrollbar.
+		//
+		// Two-part gate: (1) here we detect the hard flick from WHEEL velocity and record it via
+		// `notifyHardWheel()`; (2) the rail only blooms if a real scroll movement follows shortly after
+		// (see `setScrollLayout`). Splitting it this way means a flick against the top/bottom limit —
+		// which fires wheel events but scrolls nothing — never opens the fan, and programmatic scroll
+		// nudges during virtualization re-measure (no recent hard wheel) don't either.
+		//
+		// The listener is on the CAPTURE phase: the transcript's own ScrollableElement consumes the
+		// wheel and stops its propagation while there is room to scroll, so a bubble-phase listener
+		// here would only ever fire at the top/bottom scroll limit. Capturing on the widget root sees
+		// every wheel first, so a hard flick is detected anywhere in the transcript, not just the ends.
+		let wheelAcc = 0;
+		let wheelWindowStart = 0;
+		this._enablement.add(addDisposableListener(this.widget.domNode, 'wheel', (e: WheelEvent) => {
+			const now = Date.now();
+			// Rolling window: a pause longer than the window resets the accumulator, so only a sustained
+			// fast flick (lots of wheel distance in a short time) crosses the threshold — a gentle,
+			// steady scroll never accumulates enough.
+			if (now - wheelWindowStart > WHEEL_WINDOW_MS) {
+				wheelAcc = 0;
+				wheelWindowStart = now;
+			}
+			wheelAcc += Math.abs(e.deltaY);
+			if (wheelAcc >= HARD_WHEEL_DISTANCE) {
+				wheelAcc = 0;
+				rail.notifyHardWheel();
+			}
+		}, { capture: true, passive: true }));
 
 		this._enablement.add(autorun(reader => {
 			const ticks = model.ticks.read(reader);
 			// Toggle visibility before rendering so the rail's fit measurement in
 			// setTicks runs against the displayed (non-zero height) element.
-			rail.domNode.classList.toggle('hidden', ticks.length < MIN_PROMPTS);
+			const active = ticks.length >= MIN_PROMPTS;
+			rail.domNode.classList.toggle('hidden', !active);
+			// Mark the host so the transcript's native scrollbar is hidden only while the rail is
+			// actually showing (the rail becomes the scrollbar); few-prompt chats keep the native one.
+			this.widget.domNode.classList.toggle('prompt-timeline-active', active);
 			rail.setTicks(ticks);
 		}));
 
@@ -108,7 +152,7 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 		// Anchor the absolutely-positioned overlay to the chat widget via a class
 		// we own, removed on teardown so we never leave the foreign container mutated.
 		host.classList.add('prompt-timeline-host');
-		this._enablement.add(toDisposable(() => host.classList.remove('prompt-timeline-host')));
+		this._enablement.add(toDisposable(() => host.classList.remove('prompt-timeline-host', 'prompt-timeline-active')));
 		host.appendChild(railNode);
 		this._enablement.add(toDisposable(() => railNode.remove()));
 

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { addDisposableListener, getWindow } from '../../../../base/browser/dom.js';
-import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { addDisposableListener, EventType, getWindow } from '../../../../base/browser/dom.js';
+import { IMouseWheelEvent, StandardWheelEvent } from '../../../../base/browser/mouseEvent.js';
+import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -14,10 +15,10 @@ import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/con
 import { MIN_PROMPTS, PROMPT_TIMELINE_CONTRIB_ID, PROMPT_TIMELINE_ENABLED_SETTING } from '../common/promptTimeline.js';
 import { PromptTimelineModel, PromptEntry } from './promptTimelineModel.js';
 import { IPromptTimelineRail } from './promptTimelineRail.js';
-import { PromptTimelineRulerRail } from './promptTimelineRulerRail.js';
+import { MIN_HOST_WIDTH, PromptTimelineRulerRail } from './promptTimelineRulerRail.js';
 
-/** Wheel distance (|deltaY|) that must accumulate within {@link WHEEL_WINDOW_MS} to count as a hard/fast scroll. */
-const HARD_WHEEL_DISTANCE = 800;
+/** Normalized wheel distance (device-independent units, ~1 per notch) accumulated within {@link WHEEL_WINDOW_MS} to count as a hard/fast scroll. */
+const HARD_WHEEL_DISTANCE = 6;
 /** Rolling window for the wheel-velocity accumulator; a pause longer than this resets it. */
 const WHEEL_WINDOW_MS = 120;
 
@@ -38,6 +39,8 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 	/** Holds the model, rail and all their wiring while the feature is enabled. */
 	private readonly _enablement = this._register(new DisposableStore());
 	private _enabled = false;
+	/** Latest tick count is at or above {@link MIN_PROMPTS}; combined with the host width to decide whether the rail replaces the native scrollbar. */
+	private _hasEnoughPrompts = false;
 
 	constructor(
 		private readonly widget: IChatWidget,
@@ -69,6 +72,7 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 		this._enablement.clear();
 		this._model = undefined;
 		this._rail = undefined;
+		this._hasEnoughPrompts = false;
 		if (enabled) {
 			this._createRail();
 		}
@@ -90,48 +94,17 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 		this._enablement.add(rail.onDidReview(tick => { void model.reviewChanges(tick); }));
 		this._enablement.add(rail.onDidReviewFile(e => { void model.reviewChanges(e.tick, e.file); }));
 
-		// The transcript stays calm at rest AND during gentle scrolling — a plain scrollbar. Only a
-		// HARD / FAST scroll (a deliberate flick) that ACTUALLY moves the transcript reveals the
-		// timeline and blooms the fisheye "fan", which then follows the viewport as you continue. It
-		// lingers for a few seconds after you stop before collapsing back to a plain scrollbar.
-		//
-		// Two-part gate: (1) here we detect the hard flick from WHEEL velocity and record it via
-		// `notifyHardWheel()`; (2) the rail only blooms if a real scroll movement follows shortly after
-		// (see `setScrollLayout`). Splitting it this way means a flick against the top/bottom limit —
-		// which fires wheel events but scrolls nothing — never opens the fan, and programmatic scroll
-		// nudges during virtualization re-measure (no recent hard wheel) don't either.
-		//
-		// The listener is on the CAPTURE phase: the transcript's own ScrollableElement consumes the
-		// wheel and stops its propagation while there is room to scroll, so a bubble-phase listener
-		// here would only ever fire at the top/bottom scroll limit. Capturing on the widget root sees
-		// every wheel first, so a hard flick is detected anywhere in the transcript, not just the ends.
-		let wheelAcc = 0;
-		let wheelWindowStart = 0;
-		this._enablement.add(addDisposableListener(this.widget.domNode, 'wheel', (e: WheelEvent) => {
-			const now = Date.now();
-			// Rolling window: a pause longer than the window resets the accumulator, so only a sustained
-			// fast flick (lots of wheel distance in a short time) crosses the threshold — a gentle,
-			// steady scroll never accumulates enough.
-			if (now - wheelWindowStart > WHEEL_WINDOW_MS) {
-				wheelAcc = 0;
-				wheelWindowStart = now;
-			}
-			wheelAcc += Math.abs(e.deltaY);
-			if (wheelAcc >= HARD_WHEEL_DISTANCE) {
-				wheelAcc = 0;
-				rail.notifyHardWheel();
-			}
-		}, { capture: true, passive: true }));
+		// A deliberate hard/fast scroll reveals the fan; capture phase so it is seen before the
+		// transcript's ScrollableElement consumes the wheel mid-content (see `_registerHardWheelDetector`).
+		this._enablement.add(this._registerHardWheelDetector(rail));
 
 		this._enablement.add(autorun(reader => {
 			const ticks = model.ticks.read(reader);
 			// Toggle visibility before rendering so the rail's fit measurement in
 			// setTicks runs against the displayed (non-zero height) element.
-			const active = ticks.length >= MIN_PROMPTS;
-			rail.domNode.classList.toggle('hidden', !active);
-			// Mark the host so the transcript's native scrollbar is hidden only while the rail is
-			// actually showing (the rail becomes the scrollbar); few-prompt chats keep the native one.
-			this.widget.domNode.classList.toggle('prompt-timeline-active', active);
+			this._hasEnoughPrompts = ticks.length >= MIN_PROMPTS;
+			rail.domNode.classList.toggle('hidden', !this._hasEnoughPrompts);
+			this._updateNativeScrollbarHidden();
 			rail.setTicks(ticks);
 		}));
 
@@ -162,14 +135,49 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 			railNode.style.setProperty('--prompt-timeline-bottom', `${inputPart.height.read(reader)}px`);
 		}));
 
-		// Report the host width so the rail can hide on very narrow transcripts.
+		// Report the host width so the rail can hide on very narrow transcripts, and keep the native
+		// scrollbar whenever the rail is too narrow to replace it.
 		const ResizeObserverCtor = getWindow(host).ResizeObserver;
 		if (ResizeObserverCtor) {
-			const observer = new ResizeObserverCtor(() => rail.setHostWidth(host.clientWidth));
+			const observer = new ResizeObserverCtor(() => {
+				rail.setHostWidth(host.clientWidth);
+				this._updateNativeScrollbarHidden();
+			});
 			observer.observe(host);
 			this._enablement.add(toDisposable(() => observer.disconnect()));
 		}
 		rail.setHostWidth(host.clientWidth);
+		this._updateNativeScrollbarHidden();
+	}
+
+	/**
+	 * Detects a deliberate hard/fast scroll from wheel velocity and tells the rail (it only blooms if a
+	 * real scroll movement follows, so flicking against a scroll limit never opens it). Deltas are
+	 * normalized via {@link StandardWheelEvent} so line-mode devices are not stuck below the threshold,
+	 * and the listener is on the capture phase so it is seen before the transcript's ScrollableElement
+	 * consumes the wheel mid-content.
+	 */
+	private _registerHardWheelDetector(rail: IPromptTimelineRail): IDisposable {
+		let wheelAcc = 0;
+		let wheelWindowStart = 0;
+		return addDisposableListener(this.widget.domNode, EventType.MOUSE_WHEEL, (e: IMouseWheelEvent) => {
+			const now = Date.now();
+			if (now - wheelWindowStart > WHEEL_WINDOW_MS) {
+				wheelAcc = 0;
+				wheelWindowStart = now;
+			}
+			wheelAcc += Math.abs(new StandardWheelEvent(e).deltaY);
+			if (wheelAcc >= HARD_WHEEL_DISTANCE) {
+				wheelAcc = 0;
+				rail.notifyHardWheel();
+			}
+		}, { capture: true, passive: true });
+	}
+
+	/** Hide the transcript's native scrollbar only while the rail is actually acting as it: enough prompts AND wide enough (below {@link MIN_HOST_WIDTH} the rail hides, so the native slider must stay). */
+	private _updateNativeScrollbarHidden(): void {
+		const active = this._hasEnoughPrompts && this.widget.domNode.clientWidth >= MIN_HOST_WIDTH;
+		this.widget.domNode.classList.toggle('prompt-timeline-active', active);
 	}
 
 	// -- Navigation API (used by promptTimelineActions) --

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
@@ -18,7 +18,7 @@ import { IPromptTimelineRail } from './promptTimelineRail.js';
 import { MIN_HOST_WIDTH, PromptTimelineRulerRail } from './promptTimelineRulerRail.js';
 
 /** Normalized wheel distance (device-independent units, ~1 per notch) accumulated within {@link WHEEL_WINDOW_MS} to count as a hard/fast scroll. */
-const HARD_WHEEL_DISTANCE = 6;
+const HARD_WHEEL_DISTANCE = 20;
 /** Rolling window for the wheel-velocity accumulator; a pause longer than this resets it. */
 const WHEEL_WINDOW_MS = 120;
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -741,6 +741,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		return this.listWidget.scrollHeight;
 	}
 
+	get viewportHeight(): number {
+		return this.listWidget.renderHeight;
+	}
+
 	get attachmentModel(): ChatAttachmentModel {
 		return this.input.attachmentModel;
 	}


### PR DESCRIPTION
## What

Reshapes the Agents-window **prompt timeline** rail so it reads as a **single scrollbar lane** that blooms into a macOS-dock–style fisheye "fan", instead of a pill column sitting next to the transcript's native scrollbar.

At rest it's a plain scrollbar — the rail draws its own thumb and the transcript's native vertical slider is hidden while the rail is active. On a deliberate gesture the thumb recedes and the prompt pills fan in **over the same lane**.

## Behavior

**When the fan shows:**
- **Hard/fast scroll** — wheel-velocity gated (`HARD_WHEEL_DISTANCE`/`WHEEL_WINDOW_MS`), listened on the **capture phase** so it works mid-content (the transcript's `ScrollableElement` otherwise stops wheel propagation except at the scroll limits). Blooms centred on where you are and **glides continuously** with the viewport as you keep scrolling.
- **Hover the lane** — blooms the fan and lets the fisheye follow the cursor.
- **Scrub** — dragging the lane scrolls the transcript (the rail is the scrollbar now); the thumb stays visible during the drag.
- **Keyboard focus** — reveals the pills as a calm dock (no fisheye).

**When it hides:** quietly collapses back to a plain scrollbar after a short linger (`FAN_LINGER`) once you stop scrolling and aren't hovering.

**Robustness:** the scroll reveal is gated on a **real `scrollTop` change**, so flicking against the top/bottom limit — or programmatic virtualization scroll nudges — never opens the fan.

## Layout & preserved behavior

- Pills are laid out as an **evenly-spaced dock centred in the lane** (`PILL_LAYOUT = 'even'`), which is stable under virtualization rather than scattered by content position.
- The **two-tone green/red diff decoration** and the **hover card** are preserved; clicking a pill still jumps; roving-tabindex keyboard nav is intact.
- **Reduced motion** disables the fisheye magnification but still reveals the calm dock.

## Performance

- Removes forced synchronous reflows on the hover/scroll paths — the hover card and lane geometry are computed from cached values instead of `getBoundingClientRect`.
- The linger timer is no longer churned (cleared+recreated) on every scroll frame; it uses a single timer that re-checks activity when it fires.

> Note (investigated, out of scope): first-scroll-after-reload jank in dev builds is dominated by the dev-only disposable leak tracker and the chat list's first-time row-height measuring (`probeDynamicHeightForItem` → `offsetHeight`) + code-block syntax highlighting — not this feature (profiled: our code ≈ 0.3% of the trace, triggers 0ms of height probing).

## Files

- `promptTimelineRulerRail.ts` — rail widget: own thumb, engage/linger lifecycle, fisheye + continuous glide, even dock layout, scrub, reflow-free hover/card.
- `promptTimelineWidgetContrib.ts` — capture-phase wheel velocity → `notifyHardWheel`; scrub → scroll; toggles `prompt-timeline-active`.
- `promptTimelineModel.ts` — `IPromptScrollLayout` now carries `scrollTop`/`scrollHeight` for the rail's thumb.
- `promptTimelineRail.ts` — interface: `onDidScrub`, `notifyHardWheel`.
- `media/promptTimeline.css` — lane/thumb styles, reveal states, hides the native transcript slider while active.

## Testing

Enable `sessions.promptTimeline.enabled`, open an Agents chat with ≥2 prompts, and:
- Flick-scroll mid-transcript → fan blooms and glides; gentle scroll stays a plain scrollbar.
- Flick against the top/bottom limit → stays a plain scrollbar (no bloom).
- Hover the right edge → fisheye follows the cursor; drag it → scrubs; click a pill → jumps.

Draft while the "feel" constants (`HARD_WHEEL_DISTANCE`, `FAN_LINGER`, `EVEN_PILL_SPACING`, `FAN_SIGMA`/`FAN_SPREAD`) are still being tuned.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
