### PR TITLE
Fix tab hover shadow when tab sizing is set to shrink

### DIFF
--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -104,7 +104,8 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		shrink: 80 as const,
 		fit: 120 as const
 	};
-	private static readonly STYLE_OVERRIDE_COMPACT_PINNED_TAB_WIDTH = 32 as const;
+	private static readonly STYLE_OVERRIDE_COMPACT_PINNED_TAB_WIDTH = 28 as const;
+	private static readonly STYLE_OVERRIDE_PINNED_TAB_SPACING = 4 as const;
 
 	private static readonly DRAG_OVER_OPEN_TAB_THRESHOLD = 1500;
 
@@ -2231,12 +2232,13 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 
 	private getStickyTabWidth(pinnedTabSizing: IEditorPartOptions['pinnedTabSizing']): number {
 		const hasStyleOverride = Boolean(this.parent.closest('.style-override'));
+		const styleOverrideSpacing = hasStyleOverride ? MultiEditorTabsControl.STYLE_OVERRIDE_PINNED_TAB_SPACING : 0;
 
 		switch (pinnedTabSizing) {
 			case 'compact':
-				return hasStyleOverride ? MultiEditorTabsControl.STYLE_OVERRIDE_COMPACT_PINNED_TAB_WIDTH : MultiEditorTabsControl.TAB_WIDTH.compact;
+				return (hasStyleOverride ? MultiEditorTabsControl.STYLE_OVERRIDE_COMPACT_PINNED_TAB_WIDTH : MultiEditorTabsControl.TAB_WIDTH.compact) + styleOverrideSpacing;
 			case 'shrink':
-				return MultiEditorTabsControl.TAB_WIDTH.shrink;
+				return MultiEditorTabsControl.TAB_WIDTH.shrink + styleOverrideSpacing;
 			default:
 				return 0;
 		}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -123,6 +123,16 @@
 	background-color: color-mix(in srgb, var(--vscode-foreground) 6%, transparent) !important;
 }
 
+.style-override.monaco-workbench .part.editor .tabs-container > .tab:is(.sizing-shrink, .sizing-fixed) > .tab-label > .monaco-icon-label-container {
+	flex: 1 !important;
+	min-width: 0;
+	text-overflow: ellipsis !important;
+}
+
+.style-override.monaco-workbench .part.editor .tabs-container > .tab:is(.sizing-shrink, .sizing-fixed) > .tab-label > .monaco-icon-label-container::after {
+	display: none;
+}
+
 /* Keep scrolling tabs from showing through compact pinned pills and their spacing. */
 .style-override .part.editor .tabs-container > .tab.sticky-compact {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 5%, var(--vscode-editor-background)) !important;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -29,14 +29,12 @@
 
 .style-override .part.editor .tabs-container > .tab {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 5%, transparent) !important;
-	background-clip: padding-box;
-	border-right: var(--vscode-spacing-size40) solid transparent !important;
+	border-right: none !important;
 	border-radius: var(--vscode-cornerRadius-small);
-	border-top-right-radius: calc(var(--vscode-cornerRadius-small) + var(--vscode-spacing-size40));
-	border-bottom-right-radius: calc(var(--vscode-cornerRadius-small) + var(--vscode-spacing-size40));
 	font-size: var(--vscode-fontSize-body1) !important;
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	box-shadow: none !important;
+	margin-right: var(--vscode-spacing-size40) !important;
 	padding: 0 0 0 4px !important;
 	--tab-border-top-color: transparent !important;
 }
@@ -85,10 +83,10 @@
 }
 
 .style-override .part.editor .tabs-container > .tab.sticky-compact {
-	width: 32px !important;
-	min-width: 32px !important;
-	max-width: 32px !important;
-	flex: 0 0 32px !important;
+	width: 28px !important;
+	min-width: 28px !important;
+	max-width: 28px !important;
+	flex: 0 0 28px !important;
 }
 
 /* Center tabs vertically and strip the bottom border so the pills float. */


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/325922
Fixes https://github.com/microsoft/vscode/issues/325566

<img width="1540" height="204" alt="ui-diff-20260716-123112" src="https://github.com/user-attachments/assets/c50034ef-3f60-4f42-8267-2ec7a97e7bbb" />