### PR TITLE
agentHost: unblock disconnected client tool calls

### DIFF
--- a/src/vs/platform/agentHost/common/pendingRequestRegistry.ts
+++ b/src/vs/platform/agentHost/common/pendingRequestRegistry.ts
@@ -91,6 +91,11 @@ export class PendingRequestRegistry<T> {
 		}
 	}
 
+	/** Whether a result arrived before a request registered under `key`. */
+	hasBufferedResult(key: string): boolean {
+		return this._earlyResults.has(key);
+	}
+
 	/**
 	 * Resolve every parked deferred with `denyValue` and clear the registry.
 	 *

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1010,6 +1010,14 @@ export class AgentSideEffects extends Disposable {
 		const autoApproval = await this._permissionManager.getAutoApproval(approvalEvent, sessionKey);
 		const part = this._stateManager.getSessionState(sessionKey)?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === e.state.toolCallId);
 		const toolCall = part?.kind === ResponsePartKind.ToolCall ? part.toolCall : undefined;
+		if (toolCall
+			&& toolCall.status !== ToolCallStatus.Streaming
+			&& toolCall.status !== ToolCallStatus.Running
+			&& toolCall.status !== ToolCallStatus.PendingConfirmation) {
+			this._toolCallAgents.delete(`${sessionKey}:${e.state.toolCallId}`);
+			this._logService.trace(`[AgentSideEffects] Dropping stale tool ready for ${e.state.toolCallId}: status=${toolCall.status}`);
+			return;
+		}
 		const contributor = e.state.contributor ?? toolCall?.contributor;
 		let effective = e;
 		const clientShouldAutoApprove = autoApproval !== undefined

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1882,6 +1882,15 @@ export class CopilotAgentSession extends Disposable {
 			const isShellRequest = request.kind === 'shell'
 				|| (request.kind === 'custom-tool' && typeof request.toolName === 'string' && isShellTool(request.toolName));
 
+			if (request.kind === 'custom-tool'
+				&& typeof request.toolName === 'string'
+				&& this._clientToolNames.has(request.toolName)
+				&& this._pendingClientToolCalls.hasBufferedResult(toolCallId)
+			) {
+				this._logService.info(`[Copilot:${this.sessionId}] Auto-approving client tool ${request.toolName} because its result arrived before the permission request`);
+				return { kind: 'approve-once' };
+			}
+
 			this._logService.info(`[Copilot:${this.sessionId}] Requesting confirmation for tool call: ${toolCallId}`);
 
 			const deferred = new DeferredPromise<boolean>();

--- a/src/vs/platform/agentHost/test/common/pendingRequestRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/common/pendingRequestRegistry.test.ts
@@ -102,6 +102,15 @@ suite('PendingRequestRegistry', () => {
 		assert.strictEqual(await promise, 'value');
 	});
 
+	test('hasBufferedResult reports only unconsumed early results', async () => {
+		const registry = new PendingRequestRegistry<string>();
+		assert.strictEqual(registry.hasBufferedResult('k'), false);
+		registry.respondOrBuffer('k', 'early');
+		assert.strictEqual(registry.hasBufferedResult('k'), true);
+		await registry.register('k');
+		assert.strictEqual(registry.hasBufferedResult('k'), false);
+	});
+
 	test('respondOrBuffer: a buffered `undefined` value still resolves a subsequent register', async () => {
 		// Guards against the `get() !== undefined` sentinel bug: when T includes
 		// undefined, a buffered undefined must be distinguished from "no entry"

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -2351,6 +2351,65 @@ suite('AgentSideEffects', () => {
 				'tool call should advance to PendingConfirmation for permission-gated tool_ready');
 		});
 
+		test('tool_ready is dropped when the tool completes while permission lookup is pending', async () => {
+			setupSession();
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			const envelopes: ActionEnvelope[] = [];
+			disposables.add(stateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+
+			agent.fireProgress({
+				kind: 'action', resource: URI.parse(defaultChatUri),
+				action: {
+					type: ActionType.ChatToolCallStart, turnId: 'turn-1',
+					toolCallId: 'tc-stale-ready', toolName: 'vscodeAPI', displayName: 'Get VS Code API References',
+					contributor: { kind: ToolCallContributorKind.Client, clientId: 'disconnected-client' },
+					_meta: { toolKind: undefined, language: undefined },
+				},
+			});
+			agent.fireProgress({
+				kind: 'pending_confirmation', chat: URI.parse(defaultChatUri),
+				state: {
+					status: ToolCallStatus.PendingConfirmation,
+					toolCallId: 'tc-stale-ready', toolName: 'vscodeAPI', displayName: 'Get VS Code API References',
+					invocationMessage: 'Get VS Code API References', toolInput: '{"query":"test"}',
+					confirmationTitle: 'Allow tool call?', edits: undefined,
+				},
+				permissionKind: 'custom-tool', permissionPath: undefined,
+			});
+
+			stateManager.dispatchServerAction(defaultChatUri, {
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tc-stale-ready',
+				invocationMessage: 'Get VS Code API References',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			});
+			stateManager.dispatchServerAction(defaultChatUri, {
+				type: ActionType.ChatToolCallComplete,
+				turnId: 'turn-1',
+				toolCallId: 'tc-stale-ready',
+				result: {
+					success: false,
+					pastTenseMessage: 'Get VS Code API References failed',
+					error: { message: 'Client disconnected' },
+				},
+			});
+
+			await Promise.resolve();
+
+			const toolCall = stateManager.getSessionState(sessionUri.toString())?.activeTurn?.responseParts
+				.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === 'tc-stale-ready');
+			assert.deepStrictEqual({
+				status: toolCall?.kind === ResponsePartKind.ToolCall ? toolCall.toolCall.status : undefined,
+				readyActions: envelopes.filter(e => e.action.type === ActionType.ChatToolCallReady).length,
+			}, {
+				status: ToolCallStatus.Completed,
+				readyActions: 1,
+			});
+		});
+
 		test('tool_ready for an additional chat is emitted on that chat channel', async () => {
 			setupSession();
 			const chatUri = buildChatUri(sessionUri.toString(), 'peer');

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -4119,7 +4119,10 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('permission request before client tool handler emits only confirmation ready', async () => {
-			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, {
+				clientSnapshot: snapshot,
+				activeClientToolSet: activeClientToolSetWith('test-client'),
+			});
 
 			mockSession.fire('tool.execution_start', {
 				toolCallId: 'tc-ready-data',
@@ -4267,6 +4270,53 @@ suite('CopilotAgentSession', () => {
 			const result = await invokeClientToolHandler(tools[0], 'tc-early');
 			assert.strictEqual(result.resultType, 'success');
 			assert.strictEqual(result.textResultForLlm, 'buffered result');
+		});
+
+		test('completion arriving before the permission request unblocks the SDK', async () => {
+			const activeClientToolSet = new ActiveClientToolSet();
+			activeClientToolSet.set('client-disconnected', snapshot.tools);
+			const { session, runtime, mockSession, signals } = await createAgentSession(disposables, { clientSnapshot: snapshot, activeClientToolSet });
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-complete-before-permission',
+				toolName: 'my_tool',
+				arguments: {},
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			session.handleClientToolCallComplete('tc-complete-before-permission', {
+				success: false,
+				pastTenseMessage: 'my_tool failed',
+				error: { message: 'Client disconnected' },
+			});
+
+			const permissionPromise = runtime.handlePermissionRequest({
+				kind: 'custom-tool',
+				toolCallId: 'tc-complete-before-permission',
+				toolName: 'my_tool',
+			});
+			let permissionResult: Awaited<typeof permissionPromise> | undefined;
+			void permissionPromise.then(result => permissionResult = result);
+			await Promise.resolve();
+			if (!permissionResult) {
+				session.respondToPermissionRequest('tc-complete-before-permission', false);
+				await permissionPromise;
+			}
+
+			const toolResult = await invokeClientToolHandler(runtime.createClientSdkTools()[0], 'tc-complete-before-permission');
+			assert.deepStrictEqual({
+				permissionResult,
+				pendingConfirmations: signals.filter(signal => signal.kind === 'pending_confirmation').length,
+				toolResult,
+			}, {
+				permissionResult: { kind: 'approve-once' },
+				pendingConfirmations: 0,
+				toolResult: {
+					textResultForLlm: 'Client disconnected',
+					resultType: 'failure',
+					error: 'Client disconnected',
+					binaryResultsForLlm: undefined,
+				},
+			});
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/protocol/captures/agentHostE2E/copilotcli-client-tool-disconnect-before-permission-still-completes-the-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/protocol/captures/agentHostE2E/copilotcli-client-tool-disconnect-before-permission-still-completes-the-turn.yaml
@@ -1,0 +1,36 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-haiku-4.5
+      system: ${system}
+      messages:
+        - role: user
+          content: Call the get_magic_word tool and then report whether it succeeded.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: get_magic_word
+          input: {}
+      stopReason: tool_use
+  - request:
+      model: claude-haiku-4.5
+      system: ${system}
+      messages:
+        - role: user
+          content: Call the get_magic_word tool and then report whether it succeeded.
+        - role: assistant
+          content:
+            - type: thinking
+            - type: tool_use
+              name: get_magic_word
+              input: {}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: Client copilot-client-tool-disconnect disconnected before completing get_magic_word
+    response:
+      content: The tool call **failed**. The client disconnected before the `get_magic_word` tool could complete. This appears to be a connectivity issue between the client and the runtime service.
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/protocol/copilotAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotAgentHostE2E.integrationTest.ts
@@ -90,6 +90,64 @@ suite('Agent Host E2E — Copilot (Copilot-specific)', function () {
 		await runAhpSnapshotTest(client, COPILOT_CONFIG, this.test!, createdSessions, tempDirs);
 	});
 
+	test('client tool disconnect before permission still completes the turn', async function () {
+		this.timeout(180_000);
+		const workingDirectory = await mkdtemp(join(tmpdir(), 'copilot-client-tool-disconnect-'));
+		tempDirs.push(workingDirectory);
+		const clientId = 'copilot-client-tool-disconnect';
+		const sessionUri = await createRealSession(client, COPILOT_CONFIG, clientId, createdSessions, URI.file(workingDirectory));
+
+		client.dispatch({
+			channel: sessionUri,
+			clientSeq: 1,
+			action: {
+				type: ActionType.SessionActiveClientSet,
+				activeClient: {
+					clientId,
+					displayName: 'Test Client',
+					tools: [{
+						name: 'get_magic_word',
+						description: 'Returns the secret magic word. Call this when asked for the magic word.',
+						inputSchema: { type: 'object', properties: {}, required: [] },
+					}],
+				},
+			},
+		});
+		dispatchTurn(client, sessionUri, 'turn-client-tool-disconnect', 'Call the get_magic_word tool and then report whether it succeeded.', 2);
+
+		const toolStart = await client.waitForNotification(n => {
+			if (!isActionNotification(n, 'chat/toolCallStart')) {
+				return false;
+			}
+			const action = getActionEnvelope(n).action as { toolName: string };
+			return action.toolName === 'get_magic_word';
+		}, 90_000);
+		const toolCallId = (getActionEnvelope(toolStart).action as { toolCallId: string }).toolCallId;
+
+		client.notify('unsubscribe', { channel: sessionUri });
+
+		const failedCompletion = await client.waitForNotification(n => {
+			if (!isActionNotification(n, 'chat/toolCallComplete')) {
+				return false;
+			}
+			const action = getActionEnvelope(n).action as { toolCallId: string; result: { success: boolean } };
+			return action.toolCallId === toolCallId && !action.result.success;
+		}, 30_000);
+		const failedCompletionSeq = getActionEnvelope(failedCompletion).serverSeq;
+
+		await client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), 90_000);
+
+		const staleReady = client.receivedNotifications(n => {
+			if (!isActionNotification(n, 'chat/toolCallReady')) {
+				return false;
+			}
+			const envelope = getActionEnvelope(n);
+			const action = envelope.action as { toolCallId: string };
+			return envelope.serverSeq > failedCompletionSeq && action.toolCallId === toolCallId;
+		});
+		assert.deepStrictEqual(staleReady, []);
+	});
+
 	suiteTeardown(async function () {
 		this.timeout(60_000);
 		await lease.dispose();


### PR DESCRIPTION
## Summary

- unblock Copilot client-tool permission requests when a disconnect result arrives first
- suppress stale tool-ready actions after terminal completion
- add unit and real Copilot Agent Host replay coverage for the race

## Validation

- npm run typecheck-client
- full CopilotAgentSession unit suite (184 passing)
- AgentSideEffects and PendingRequestRegistry unit suites
- Copilot Agent Host E2E record and strict replay
- npm run valid-layers-check
- hygiene checks