### PR TITLE
Remove low-usage tools from vscode-general tool set

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/clientToolSetsContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/clientToolSetsContribution.ts
@@ -72,10 +72,6 @@ export class ClientToolSetsContribution extends Disposable implements IWorkbench
 				'testFailure',
 				'rename',
 				'usages',
-				'extensions',
-				'installExtension',
-				'newWorkspace',
-				'runCommand',
 				'toolSearch',
 			],
 		}));

--- a/src/vs/workbench/contrib/chat/test/browser/tools/toolSetsContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/toolSetsContribution.test.ts
@@ -35,9 +35,7 @@ suite('ToolSetsContribution', () => {
 			toolReferenceName: name,
 			source: ToolDataSource.Internal,
 		});
-		// A tool that remains a member of the vscode-general set.
 		const toolSearch = makeTool('toolSearch');
-		// Tools that were removed from the vscode-general set.
 		const removed = ['extensions', 'installExtension', 'newWorkspace', 'runCommand', 'vscodeAPI'].map(makeTool);
 		for (const tool of [toolSearch, ...removed]) {
 			store.add(toolsService.registerToolData(tool));

--- a/src/vs/workbench/contrib/chat/test/browser/tools/toolSetsContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/toolSetsContribution.test.ts
@@ -26,24 +26,23 @@ suite('ToolSetsContribution', () => {
 		return store.add(instaService.createInstance(LanguageModelToolsService));
 	}
 
-	test('ClientToolSetsContribution omits VS Code API from Agent Host tools', () => {
+	test('ClientToolSetsContribution omits removed tools from vscode-general', () => {
 		const toolsService = createToolsService();
-		const toolSearch: IToolData = {
-			id: 'toolSearch',
-			modelDescription: 'Search for tools',
-			displayName: 'Tool Search',
-			toolReferenceName: 'toolSearch',
+		const makeTool = (name: string): IToolData => ({
+			id: name,
+			modelDescription: name,
+			displayName: name,
+			toolReferenceName: name,
 			source: ToolDataSource.Internal,
-		};
-		const vscodeAPI: IToolData = {
-			id: 'vscodeAPI',
-			modelDescription: 'Search VS Code API documentation',
-			displayName: 'VS Code API',
-			toolReferenceName: 'vscodeAPI',
-			source: ToolDataSource.Internal,
-		};
-		store.add(toolsService.registerToolData(toolSearch));
-		store.add(toolsService.registerToolData(vscodeAPI));
+		});
+		// A tool that remains a member of the vscode-general set.
+		const toolSearch = makeTool('toolSearch');
+		// Tools that were removed from the vscode-general set.
+		const removed = ['extensions', 'installExtension', 'newWorkspace', 'runCommand', 'vscodeAPI'].map(makeTool);
+		for (const tool of [toolSearch, ...removed]) {
+			store.add(toolsService.registerToolData(tool));
+		}
+
 
 		const workspaceService = new class extends mock<IAICustomizationWorkspaceService>() {
 			override readonly isSessionsWindow = true;


### PR DESCRIPTION
Remove low-usage tools from the `vscode-general` client tool set.