### PR TITLE
fix: agent hang from leaked external-edit lock

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
@@ -258,7 +258,7 @@ export class ClaudeCodeSession extends Disposable {
 		});
 		// Initialize edit tracker with plan directory as ignored
 		const planDirUri = URI.joinPath(this.envService.userHome, '.claude', 'plans');
-		this._editTracker = new ExternalEditTracker([planDirUri]);
+		this._editTracker = new ExternalEditTracker([planDirUri], undefined, this.logService);
 		this._settingsChangeTracker = this._createSettingsChangeTracker();
 	}
 

--- a/extensions/copilot/src/extension/chatSessions/common/externalEditTracker.ts
+++ b/extensions/copilot/src/extension/chatSessions/common/externalEditTracker.ts
@@ -8,6 +8,7 @@ import { DeferredPromise, raceTimeout } from '../../../util/vs/base/common/async
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { isEqualOrParent } from '../../../util/vs/base/common/resources';
 import { URI } from '../../../util/vs/base/common/uri';
+import { ILogger } from '../../../platform/log/common/logService';
 
 /**
  * Maximum time to wait for VS Code core to acknowledge an external edit before proceeding anyway.
@@ -32,10 +33,12 @@ export class ExternalEditTracker {
 	 * Creates a new ExternalEditTracker.
 	 * @param ignoreDirectories Optional list of directory URIs to ignore when tracking edits
 	 * @param acknowledgmentTimeoutMs Maximum time to wait for core to acknowledge an external edit before proceeding anyway
+	 * @param logService Optional logger used to diagnose lost/missing core acknowledgments
 	 */
 	constructor(
 		private readonly ignoreDirectories: URI[] = [],
 		private readonly acknowledgmentTimeoutMs: number = EXTERNAL_EDIT_ACK_TIMEOUT_MS,
+		private readonly logService?: ILogger,
 	) { }
 
 	/**
@@ -65,13 +68,21 @@ export class ExternalEditTracker {
 
 		return new Promise<void>(proceedWithEdit => {
 			const deferred = new DeferredPromise<void>();
+			const startTime = Date.now();
+			this.logService?.trace(`[ExternalEditTracker] Awaiting core acknowledgment for edit ${editKey} (${filteredUris.length} file(s)), timeout ${this.acknowledgmentTimeoutMs}ms: ${filteredUris.map(uri => (URI.isUri(uri) ? uri : URI.from(uri)).toString()).join(', ')}`);
 
 			// The permission response is gated on this promise resolving. It must never wait forever
 			// on core acknowledging the external edit, so we proceed on whichever happens first: core
 			// acknowledges, the request is cancelled, or the safety timeout elapses. Only the timeout
 			// is tied to this permission gate — the cancellation listener must outlive it (see below).
 			let settled = false;
-			const timer = setTimeout(() => settle(), this.acknowledgmentTimeoutMs);
+			const timer = setTimeout(() => {
+				// The timeout firing means core never invoked the externalEdit proceed callback within
+				// the deadline (see https://github.com/microsoft/vscode/issues/320292). Log an error with
+				// enough detail to correlate with the core-side externalEdit trace next time it happens.
+				this.logService?.error(`[ExternalEditTracker] Core did not acknowledge external edit ${editKey} (${filteredUris.length} file(s)) within ${this.acknowledgmentTimeoutMs}ms; proceeding without attribution`);
+				settle();
+			}, this.acknowledgmentTimeoutMs);
 			const settle = () => {
 				if (settled) {
 					return;
@@ -88,6 +99,7 @@ export class ExternalEditTracker {
 			// externalEdit callback awaits — otherwise both leak forever. It is disposed when it fires
 			// or by completeEdit.
 			const cancellationListener = token?.onCancellationRequested(() => {
+				this.logService?.trace(`[ExternalEditTracker] Edit ${editKey} cancelled after ${Date.now() - startTime}ms`);
 				this._ongoingEdits.delete(editKey);
 				cancellationListener?.dispose();
 				deferred.complete();
@@ -95,6 +107,9 @@ export class ExternalEditTracker {
 			});
 
 			const onDidComplete = stream.externalEdit(filteredUris, async () => {
+				if (!settled) {
+					this.logService?.trace(`[ExternalEditTracker] Core acknowledged external edit ${editKey} after ${Date.now() - startTime}ms`);
+				}
 				settle();
 				await deferred.p;
 			});
@@ -119,7 +134,14 @@ export class ExternalEditTracker {
 			ongoingEdit.dispose();
 			ongoingEdit.complete();
 			// Bound the wait so a stalled core acknowledgment cannot block request finalization.
-			return await raceTimeout(Promise.resolve(ongoingEdit.onDidComplete), this.acknowledgmentTimeoutMs);
+			const startTime = Date.now();
+			const result = await raceTimeout(Promise.resolve(ongoingEdit.onDidComplete), this.acknowledgmentTimeoutMs);
+			if (result === undefined) {
+				this.logService?.warn(`[ExternalEditTracker] Core did not confirm completion of external edit ${editKey} within ${this.acknowledgmentTimeoutMs}ms`);
+			} else {
+				this.logService?.trace(`[ExternalEditTracker] External edit ${editKey} completed after ${Date.now() - startTime}ms`);
+			}
+			return result;
 		}
 	}
 }

--- a/extensions/copilot/src/extension/chatSessions/common/externalEditTracker.ts
+++ b/extensions/copilot/src/extension/chatSessions/common/externalEditTracker.ts
@@ -4,11 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as vscode from 'vscode';
-import { DeferredPromise } from '../../../util/vs/base/common/async';
+import { DeferredPromise, raceTimeout } from '../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
-import { IDisposable } from '../../../util/vs/base/common/lifecycle';
+import { DisposableStore, toDisposable } from '../../../util/vs/base/common/lifecycle';
 import { isEqualOrParent } from '../../../util/vs/base/common/resources';
 import { URI } from '../../../util/vs/base/common/uri';
+
+/**
+ * Maximum time to wait for VS Code core to acknowledge an external edit before proceeding anyway.
+ *
+ * Granting a write permission is gated on core invoking the `externalEdit` proceed callback so the
+ * edit is attributed correctly in the UI. If core never acknowledges the edit (e.g. the acknowledgment
+ * is dropped), that wait must not block the permission response indefinitely — otherwise the whole
+ * agent turn hangs with no user action (see https://github.com/microsoft/vscode/issues/320292). Edit
+ * attribution is best-effort, so after this timeout we proceed with the already-decided permission.
+ */
+const EXTERNAL_EDIT_ACK_TIMEOUT_MS = 10_000;
 
 /**
  * Tracks ongoing external edit operations for agent tools.
@@ -21,9 +32,11 @@ export class ExternalEditTracker {
 	/**
 	 * Creates a new ExternalEditTracker.
 	 * @param ignoreDirectories Optional list of directory URIs to ignore when tracking edits
+	 * @param acknowledgmentTimeoutMs Maximum time to wait for core to acknowledge an external edit before proceeding anyway
 	 */
 	constructor(
-		private readonly ignoreDirectories: URI[] = []
+		private readonly ignoreDirectories: URI[] = [],
+		private readonly acknowledgmentTimeoutMs: number = EXTERNAL_EDIT_ACK_TIMEOUT_MS,
 	) { }
 
 	/**
@@ -51,22 +64,40 @@ export class ExternalEditTracker {
 			return;
 		}
 
-		return new Promise(proceedWithEdit => {
+		return new Promise<void>(proceedWithEdit => {
 			const deferred = new DeferredPromise<void>();
-			let cancelListen: IDisposable | undefined;
+			const store = new DisposableStore();
+
+			// The permission response is gated on this promise resolving. It must never wait forever
+			// on core acknowledging the external edit, so we proceed on whichever happens first:
+			// core acknowledges, the request is cancelled, or the safety timeout elapses.
+			let settled = false;
+			const settle = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				store.dispose();
+				proceedWithEdit();
+			};
 
 			// Handle cancellation if token provided
 			if (token) {
-				cancelListen = token.onCancellationRequested(() => {
+				store.add(token.onCancellationRequested(() => {
 					this._ongoingEdits.delete(editKey);
 					deferred.complete();
-				});
+					settle();
+				}));
 			}
 
+			// Safety net: proceed with the already-decided permission if core never acknowledges the
+			// edit within the timeout, so a dropped acknowledgment can't hang the agent turn.
+			const timer = setTimeout(() => settle(), this.acknowledgmentTimeoutMs);
+			store.add(toDisposable(() => clearTimeout(timer)));
+
 			const onDidComplete = stream.externalEdit(filteredUris, async () => {
-				proceedWithEdit();
+				settle();
 				await deferred.p;
-				cancelListen?.dispose();
 			});
 
 			this._ongoingEdits.set(editKey, {
@@ -86,7 +117,8 @@ export class ExternalEditTracker {
 		if (ongoingEdit) {
 			this._ongoingEdits.delete(editKey);
 			ongoingEdit.complete();
-			return await ongoingEdit.onDidComplete;
+			// Bound the wait so a stalled core acknowledgment cannot block request finalization.
+			return await raceTimeout(Promise.resolve(ongoingEdit.onDidComplete), this.acknowledgmentTimeoutMs);
 		}
 	}
 }

--- a/extensions/copilot/src/extension/chatSessions/common/externalEditTracker.ts
+++ b/extensions/copilot/src/extension/chatSessions/common/externalEditTracker.ts
@@ -6,7 +6,6 @@
 import type * as vscode from 'vscode';
 import { DeferredPromise, raceTimeout } from '../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
-import { DisposableStore, toDisposable } from '../../../util/vs/base/common/lifecycle';
 import { isEqualOrParent } from '../../../util/vs/base/common/resources';
 import { URI } from '../../../util/vs/base/common/uri';
 
@@ -27,7 +26,7 @@ const EXTERNAL_EDIT_ACK_TIMEOUT_MS = 10_000;
  * externalEdit API to ensure proper tracking and attribution of file changes.
  */
 export class ExternalEditTracker {
-	private _ongoingEdits = new Map<string, { complete: () => void; onDidComplete: Thenable<string> }>();
+	private _ongoingEdits = new Map<string, { complete: () => void; onDidComplete: Thenable<string>; dispose: () => void }>();
 
 	/**
 	 * Creates a new ExternalEditTracker.
@@ -66,34 +65,34 @@ export class ExternalEditTracker {
 
 		return new Promise<void>(proceedWithEdit => {
 			const deferred = new DeferredPromise<void>();
-			const store = new DisposableStore();
 
 			// The permission response is gated on this promise resolving. It must never wait forever
-			// on core acknowledging the external edit, so we proceed on whichever happens first:
-			// core acknowledges, the request is cancelled, or the safety timeout elapses.
+			// on core acknowledging the external edit, so we proceed on whichever happens first: core
+			// acknowledges, the request is cancelled, or the safety timeout elapses. Only the timeout
+			// is tied to this permission gate — the cancellation listener must outlive it (see below).
 			let settled = false;
+			const timer = setTimeout(() => settle(), this.acknowledgmentTimeoutMs);
 			const settle = () => {
 				if (settled) {
 					return;
 				}
 				settled = true;
-				store.dispose();
+				clearTimeout(timer);
 				proceedWithEdit();
 			};
 
-			// Handle cancellation if token provided
-			if (token) {
-				store.add(token.onCancellationRequested(() => {
-					this._ongoingEdits.delete(editKey);
-					deferred.complete();
-					settle();
-				}));
-			}
-
-			// Safety net: proceed with the already-decided permission if core never acknowledges the
-			// edit within the timeout, so a dropped acknowledgment can't hang the agent turn.
-			const timer = setTimeout(() => settle(), this.acknowledgmentTimeoutMs);
-			store.add(toDisposable(() => clearTimeout(timer)));
+			// The cancellation listener must live for the full edit lifecycle, not just until the
+			// permission gate settles: the request can be cancelled after core acknowledges (or the
+			// timeout fires) but before completeEdit runs. A cancelled tool may never emit a completion
+			// event, so cancellation is what deletes the map entry and completes the deferred that the
+			// externalEdit callback awaits — otherwise both leak forever. It is disposed when it fires
+			// or by completeEdit.
+			const cancellationListener = token?.onCancellationRequested(() => {
+				this._ongoingEdits.delete(editKey);
+				cancellationListener?.dispose();
+				deferred.complete();
+				settle();
+			});
 
 			const onDidComplete = stream.externalEdit(filteredUris, async () => {
 				settle();
@@ -102,7 +101,8 @@ export class ExternalEditTracker {
 
 			this._ongoingEdits.set(editKey, {
 				onDidComplete,
-				complete: () => deferred.complete()
+				complete: () => deferred.complete(),
+				dispose: () => cancellationListener?.dispose()
 			});
 		});
 	}
@@ -116,6 +116,7 @@ export class ExternalEditTracker {
 		const ongoingEdit = this._ongoingEdits.get(editKey);
 		if (ongoingEdit) {
 			this._ongoingEdits.delete(editKey);
+			ongoingEdit.dispose();
 			ongoingEdit.complete();
 			// Bound the wait so a stalled core acknowledgment cannot block request finalization.
 			return await raceTimeout(Promise.resolve(ongoingEdit.onDidComplete), this.acknowledgmentTimeoutMs);

--- a/extensions/copilot/src/extension/chatSessions/common/externalEditTracker.ts
+++ b/extensions/copilot/src/extension/chatSessions/common/externalEditTracker.ts
@@ -22,12 +22,26 @@ import { ILogger } from '../../../platform/log/common/logService';
 const EXTERNAL_EDIT_ACK_TIMEOUT_MS = 10_000;
 
 /**
+ * A single tracked external edit for one file, awaiting core's externalEdit acknowledgment.
+ */
+interface IOngoingEdit {
+	complete: () => void;
+	onDidComplete: Thenable<string>;
+	dispose: () => void;
+}
+
+/**
  * Tracks ongoing external edit operations for agent tools.
  * Manages the lifecycle of external edits by coordinating with VS Code's
  * externalEdit API to ensure proper tracking and attribution of file changes.
  */
 export class ExternalEditTracker {
-	private _ongoingEdits = new Map<string, { complete: () => void; onDidComplete: Thenable<string>; dispose: () => void }>();
+	// A single edit key (e.g. one tool call) can track multiple files, each of which requires its
+	// own externalEdit acknowledgment from core. They must be stored as a list — keying by editKey
+	// alone and overwriting would strand the earlier file's deferred, so its core externalEdit
+	// callback never returns and the per-resource streaming-edit lock in core leaks forever, wedging
+	// every future edit to that file (see https://github.com/microsoft/vscode/issues/320292).
+	private _ongoingEdits = new Map<string, IOngoingEdit[]>();
 
 	/**
 	 * Creates a new ExternalEditTracker.
@@ -68,8 +82,6 @@ export class ExternalEditTracker {
 
 		return new Promise<void>(proceedWithEdit => {
 			const deferred = new DeferredPromise<void>();
-			const startTime = Date.now();
-			this.logService?.trace(`[ExternalEditTracker] Awaiting core acknowledgment for edit ${editKey} (${filteredUris.length} file(s)), timeout ${this.acknowledgmentTimeoutMs}ms: ${filteredUris.map(uri => (URI.isUri(uri) ? uri : URI.from(uri)).toString()).join(', ')}`);
 
 			// The permission response is gated on this promise resolving. It must never wait forever
 			// on core acknowledging the external edit, so we proceed on whichever happens first: core
@@ -92,56 +104,75 @@ export class ExternalEditTracker {
 				proceedWithEdit();
 			};
 
-			// The cancellation listener must live for the full edit lifecycle, not just until the
-			// permission gate settles: the request can be cancelled after core acknowledges (or the
-			// timeout fires) but before completeEdit runs. A cancelled tool may never emit a completion
-			// event, so cancellation is what deletes the map entry and completes the deferred that the
-			// externalEdit callback awaits — otherwise both leak forever. It is disposed when it fires
-			// or by completeEdit.
+			// Listener must outlive the permission gate: a cancel after ack/timeout but before completeEdit is what releases this file's deferred and entry.
+			const entry: IOngoingEdit = {
+				onDidComplete: undefined!,
+				complete: () => deferred.complete(),
+				dispose: () => cancellationListener?.dispose(),
+			};
+
+			const removeEntry = () => {
+				const entries = this._ongoingEdits.get(editKey);
+				if (!entries) {
+					return;
+				}
+				const index = entries.indexOf(entry);
+				if (index !== -1) {
+					entries.splice(index, 1);
+				}
+				if (entries.length === 0) {
+					this._ongoingEdits.delete(editKey);
+				}
+			};
+
 			const cancellationListener = token?.onCancellationRequested(() => {
-				this.logService?.trace(`[ExternalEditTracker] Edit ${editKey} cancelled after ${Date.now() - startTime}ms`);
-				this._ongoingEdits.delete(editKey);
+				removeEntry();
 				cancellationListener?.dispose();
 				deferred.complete();
 				settle();
 			});
 
-			const onDidComplete = stream.externalEdit(filteredUris, async () => {
-				if (!settled) {
-					this.logService?.trace(`[ExternalEditTracker] Core acknowledged external edit ${editKey} after ${Date.now() - startTime}ms`);
-				}
+			entry.onDidComplete = stream.externalEdit(filteredUris, async () => {
 				settle();
 				await deferred.p;
 			});
 
-			this._ongoingEdits.set(editKey, {
-				onDidComplete,
-				complete: () => deferred.complete(),
-				dispose: () => cancellationListener?.dispose()
-			});
+			const entries = this._ongoingEdits.get(editKey);
+			if (entries) {
+				entries.push(entry);
+			} else {
+				this._ongoingEdits.set(editKey, [entry]);
+			}
 		});
 	}
 
 	/**
 	 * Completes tracking of an external edit operation.
+	 *
+	 * A single edit key may cover multiple files (one entry per tracked file); all of them are
+	 * completed and awaited so every file's core acknowledgment resolves and its streaming-edit lock
+	 * is released. Returns the first defined edit id for attribution, preserving the previous
+	 * single-file return contract.
+	 *
 	 * @param editKey Unique identifier for the edit operation to complete
 	 * @returns Promise that resolves when VS Code has finished tracking the edit
 	 */
 	public async completeEdit(editKey: string): Promise<string | undefined> {
-		const ongoingEdit = this._ongoingEdits.get(editKey);
-		if (ongoingEdit) {
-			this._ongoingEdits.delete(editKey);
+		const ongoingEdits = this._ongoingEdits.get(editKey);
+		if (!ongoingEdits || ongoingEdits.length === 0) {
+			return;
+		}
+		this._ongoingEdits.delete(editKey);
+		const results = await Promise.all(ongoingEdits.map(async ongoingEdit => {
 			ongoingEdit.dispose();
 			ongoingEdit.complete();
 			// Bound the wait so a stalled core acknowledgment cannot block request finalization.
-			const startTime = Date.now();
 			const result = await raceTimeout(Promise.resolve(ongoingEdit.onDidComplete), this.acknowledgmentTimeoutMs);
 			if (result === undefined) {
 				this.logService?.warn(`[ExternalEditTracker] Core did not confirm completion of external edit ${editKey} within ${this.acknowledgmentTimeoutMs}ms`);
-			} else {
-				this.logService?.trace(`[ExternalEditTracker] External edit ${editKey} completed after ${Date.now() - startTime}ms`);
 			}
 			return result;
-		}
+		}));
+		return results.find(result => result !== undefined);
 	}
 }

--- a/extensions/copilot/src/extension/chatSessions/common/test/externalEditTracker.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/common/test/externalEditTracker.spec.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SpyChatResponseStream } from '../../../../util/common/test/mockChatResponseStream';
-import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import { CancellationToken, CancellationTokenSource } from '../../../../util/vs/base/common/cancellation';
 import { URI } from '../../../../util/vs/base/common/uri';
 import { ExternalEditTracker } from '../externalEditTracker';
 
@@ -116,6 +116,73 @@ describe('ExternalEditTracker', () => {
 
 			// No files should be tracked
 			expect(stream.externalEditUris.length).toBe(0);
+		});
+	});
+
+	describe('acknowledgment handling', () => {
+		// Stream whose externalEdit records the edit but never invokes the proceed callback and
+		// never resolves — reproducing core dropping the externalEdit acknowledgment (#320292).
+		class SilentExternalEditStream extends SpyChatResponseStream {
+			override externalEdit(): Promise<string> {
+				return new Promise<string>(() => { /* never resolves, callback never invoked */ });
+			}
+		}
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('proceeds after the timeout when core never acknowledges the edit', async () => {
+			const tracker = new ExternalEditTracker([], 1000);
+			const stream = new SilentExternalEditStream();
+			const file = URI.file('/workspace/src/test.ts');
+
+			let resolved = false;
+			const tracking = tracker.trackEdit('edit-timeout', [file], stream, CancellationToken.None).then(() => { resolved = true; });
+
+			// Before the timeout elapses the edit is still pending.
+			await vi.advanceTimersByTimeAsync(999);
+			expect(resolved).toBe(false);
+
+			// Once the timeout elapses the permission is allowed to proceed anyway.
+			await vi.advanceTimersByTimeAsync(1);
+			await tracking;
+			expect(resolved).toBe(true);
+		});
+
+		it('proceeds immediately when the request is cancelled while awaiting acknowledgment', async () => {
+			const tracker = new ExternalEditTracker([], 1000);
+			const stream = new SilentExternalEditStream();
+			const file = URI.file('/workspace/src/test.ts');
+			const tokenSource = new CancellationTokenSource();
+
+			let resolved = false;
+			const tracking = tracker.trackEdit('edit-cancel', [file], stream, tokenSource.token).then(() => { resolved = true; });
+
+			tokenSource.cancel();
+			await tracking;
+			expect(resolved).toBe(true);
+			tokenSource.dispose();
+		});
+
+		it('completeEdit resolves even when core never acknowledges the edit', async () => {
+			const tracker = new ExternalEditTracker([], 1000);
+			const stream = new SilentExternalEditStream();
+			const file = URI.file('/workspace/src/test.ts');
+
+			// Start tracking and let the timeout release the permission response.
+			const tracking = tracker.trackEdit('edit-complete', [file], stream, CancellationToken.None);
+			await vi.advanceTimersByTimeAsync(1000);
+			await tracking;
+
+			// Finalizing the request must not hang on the missing acknowledgment.
+			const completion = tracker.completeEdit('edit-complete');
+			await vi.advanceTimersByTimeAsync(1000);
+			await expect(completion).resolves.toBeUndefined();
 		});
 	});
 });

--- a/extensions/copilot/src/extension/chatSessions/common/test/externalEditTracker.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/common/test/externalEditTracker.spec.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
 import { SpyChatResponseStream } from '../../../../util/common/test/mockChatResponseStream';
 import { CancellationToken, CancellationTokenSource } from '../../../../util/vs/base/common/cancellation';
 import { URI } from '../../../../util/vs/base/common/uri';
@@ -183,6 +184,40 @@ describe('ExternalEditTracker', () => {
 			const completion = tracker.completeEdit('edit-complete');
 			await vi.advanceTimersByTimeAsync(1000);
 			await expect(completion).resolves.toBeUndefined();
+		});
+
+		it('cancellation after acknowledgment still finishes the tracked edit', async () => {
+			// Stream that acknowledges the edit immediately (invokes the proceed callback) and then
+			// keeps the edit open until the tracked deferred resolves — mirroring core keeping the
+			// edit in progress until completeEdit. `callbackResolved` flips only once the deferred is
+			// completed, so it proves cancellation released the edit rather than leaking it.
+			class AckThenWaitStream extends SpyChatResponseStream {
+				callbackResolved = false;
+				override async externalEdit(_target: vscode.Uri | vscode.Uri[], callback: () => Thenable<unknown>): Promise<string> {
+					await callback();
+					this.callbackResolved = true;
+					return 'done';
+				}
+			}
+
+			const tracker = new ExternalEditTracker([], 1000);
+			const stream = new AckThenWaitStream();
+			const file = URI.file('/workspace/src/test.ts');
+			const tokenSource = new CancellationTokenSource();
+
+			// Core acknowledges immediately, so the permission gate resolves without the timeout.
+			await tracker.trackEdit('edit-cancel-after-ack', [file], stream, tokenSource.token);
+			expect(stream.callbackResolved).toBe(false); // edit still open, awaiting completion
+
+			// Cancelling after acknowledgment but before completeEdit must finish the edit, not leak
+			// the map entry and the pending proceed callback (regression for the disposed-listener bug).
+			tokenSource.cancel();
+			for (let i = 0; i < 5; i++) {
+				await Promise.resolve();
+			}
+			expect(stream.callbackResolved).toBe(true);
+
+			tokenSource.dispose();
 		});
 	});
 });

--- a/extensions/copilot/src/extension/chatSessions/common/test/externalEditTracker.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/common/test/externalEditTracker.spec.ts
@@ -121,8 +121,8 @@ describe('ExternalEditTracker', () => {
 	});
 
 	describe('acknowledgment handling', () => {
-		// Stream whose externalEdit records the edit but never invokes the proceed callback and
-		// never resolves — reproducing core dropping the externalEdit acknowledgment (#320292).
+		// Stream whose externalEdit never invokes the proceed callback and never resolves —
+		// reproducing core dropping the externalEdit acknowledgment (#320292).
 		class SilentExternalEditStream extends SpyChatResponseStream {
 			override externalEdit(): Promise<string> {
 				return new Promise<string>(() => { /* never resolves, callback never invoked */ });
@@ -218,6 +218,42 @@ describe('ExternalEditTracker', () => {
 			expect(stream.callbackResolved).toBe(true);
 
 			tokenSource.dispose();
+		});
+	});
+
+	describe('multiple files per edit key', () => {
+		// Stream that acknowledges each edit immediately but keeps it open until the tracked deferred
+		// resolves (mirroring core). `resolvedCount` only increments once a file's proceed callback
+		// returns, so it proves how many of the key's files were actually released.
+		class MultiFileAckStream extends SpyChatResponseStream {
+			resolvedCount = 0;
+			override async externalEdit(_target: vscode.Uri | vscode.Uri[], callback: () => Thenable<unknown>): Promise<string> {
+				await callback();
+				this.resolvedCount++;
+				return 'edit-id';
+			}
+		}
+
+		it('completeEdit releases every file tracked under the same edit key', async () => {
+			// The Copilot CLI path calls trackEdit once per file with the same tool call id. Each file
+			// must keep its own edit open — overwriting on the shared key would strand the earlier
+			// file's proceed callback and leak core's per-resource streaming-edit lock (#320292).
+			const tracker = new ExternalEditTracker([], 1000);
+			const stream = new MultiFileAckStream();
+			const file1 = URI.file('/workspace/src/client.go');
+			const file2 = URI.file('/workspace/src/serve.go');
+
+			await tracker.trackEdit('tool-1', [file1], stream, CancellationToken.None);
+			await tracker.trackEdit('tool-1', [file2], stream, CancellationToken.None);
+
+			// Both edits are acknowledged but still open, awaiting completion.
+			expect(stream.resolvedCount).toBe(0);
+
+			const editId = await tracker.completeEdit('tool-1');
+
+			// Completing the shared key must release both files, not just the last one tracked.
+			expect(stream.resolvedCount).toBe(2);
+			expect(editId).toBe('edit-id');
 		});
 	});
 });

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -1210,7 +1210,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		// the model call natively and never produces a JS span we could observe directly).
 		const modelTurnUsages: IModelTurnUsage[] = [];
 		const invokeAgentTraceContext = invokeAgentSpan.getSpanContext();
-		const editTracker = new ExternalEditTracker();
+		const editTracker = new ExternalEditTracker([], undefined, this.logService);
 		let sdkRequestId: string | undefined;
 		let isQuotaError = false;
 		const toolIdEditMap = new Map<string, Promise<string | undefined>>();

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/permissionHelpers.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/permissionHelpers.ts
@@ -151,7 +151,7 @@ export async function handleWritePermission(
 
 		if (autoApprove) {
 			logService.trace(`[CopilotCLISession] Auto Approving request ${editFile.fsPath}`);
-			await trackEditIfNeeded(editTracker, toolCall, editFile, stream, logService);
+			await trackEditIfNeeded(editTracker, toolCall, editFile, stream, logService, token);
 			return { kind: 'approve-once' };
 		}
 	}
@@ -175,13 +175,13 @@ export async function handleWritePermission(
 	if (!toolParams) {
 		// No confirmation needed (e.g. no file to edit) — auto-approve.
 		if (editFile) {
-			await trackEditIfNeeded(editTracker, toolCall, editFile, stream, logService);
+			await trackEditIfNeeded(editTracker, toolCall, editFile, stream, logService, token);
 		}
 		return { kind: 'approve-once' };
 	}
 	const result = await invokeConfirmationTool(toolParams, toolParentCallId, toolsService, toolInvocationToken, logService, token);
 	if (result.kind === 'approve-once' && editFile) {
-		await trackEditIfNeeded(editTracker, toolCall, editFile, stream, logService);
+		await trackEditIfNeeded(editTracker, toolCall, editFile, stream, logService, token);
 	}
 	return result;
 }
@@ -350,10 +350,10 @@ export function isFileFromSessionWorkspace(file: URI, workspaceInfo: IWorkspaceI
  * Starts edit tracking if we have a tool call and a stream.
  * This ensures the UI shows the edit-in-progress indicator and waits for core to acknowledge the edit.
  */
-async function trackEditIfNeeded(editTracker: ExternalEditTracker, toolCall: ToolCall | undefined, editFile: URI, stream: ChatResponseStream | undefined, logService: ILogService): Promise<void> {
+async function trackEditIfNeeded(editTracker: ExternalEditTracker, toolCall: ToolCall | undefined, editFile: URI, stream: ChatResponseStream | undefined, logService: ILogService, token: CancellationToken): Promise<void> {
 	if (toolCall && stream) {
 		try {
-			await editTracker.trackEdit(toolCall.toolCallId, [editFile], stream);
+			await editTracker.trackEdit(toolCall.toolCallId, [editFile], stream, token);
 		} catch (error) {
 			logService.error(error, `[CopilotCLISession] Failed to track edit for toolCallId ${toolCall.toolCallId}`);
 		}

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/permissionHelpers.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/permissionHelpers.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { CancellationToken, ChatParticipantToolToken } from 'vscode';
+import type { CancellationToken, ChatParticipantToolToken, ChatResponseStream } from 'vscode';
 import { ILogService } from '../../../../../platform/log/common/logService';
 import { IWorkspaceService } from '../../../../../platform/workspace/common/workspaceService';
 import { CancellationTokenSource } from '../../../../../util/vs/base/common/cancellation';
@@ -17,6 +17,7 @@ import { ToolName } from '../../../../tools/common/toolNames';
 import { IToolsService } from '../../../../tools/common/toolsService';
 import { ExternalEditTracker } from '../../../common/externalEditTracker';
 import { IWorkspaceInfo } from '../../../common/workspaceInfo';
+import { ToolCall } from '../../common/copilotCLITools';
 import { ICopilotCLIImageSupport } from '../copilotCLIImageSupport';
 import { buildMcpConfirmationParams, buildShellConfirmationParams, handleReadPermission, handleWritePermission, isFileFromSessionWorkspace, PermissionRequest, requiresFileEditconfirmation, showInteractivePermissionPrompt } from '../permissionHelpers';
 
@@ -519,6 +520,57 @@ describe('CopilotCLI permissionHelpers', () => {
 			);
 			// No file => getFileEditConfirmationToolParams returns undefined => auto-approve
 			expect(result.kind).toBe('approve-once');
+		});
+
+		it('forwards the request cancellation token to trackEdit on the auto-approval path', async () => {
+			const worktree = URI.file('/worktree');
+			const filePath = URI.file('/worktree/src/foo.ts').fsPath;
+			const stream = {} as ChatResponseStream;
+			const toolCall: ToolCall = { toolName: 'edit', toolCallId: 'tc-auto', arguments: { path: filePath } };
+			const req = { kind: 'write', fileName: filePath, diff: '', intention: '' } as any;
+
+			const result = await handleWritePermission(
+				'session-1', req, toolCall, undefined, stream, editTracker,
+				makeWorkspaceInfo({
+					folder: URI.file('/workspace'),
+					worktree,
+					worktreeProperties: { autoCommit: true, baseCommit: 'abc', branchName: 'test', repositoryPath: '/repo', worktreePath: '/worktree', version: 1 },
+				}),
+				makeWorkspaceService([]),
+				instaService, makeToolsService('no'),
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+
+			expect(result.kind).toBe('approve-once');
+			expect(editTracker.trackEdit).toHaveBeenCalledTimes(1);
+			const [callToolCallId, callUris, callStream, callToken] = vi.mocked(editTracker.trackEdit).mock.calls[0];
+			expect(callToolCallId).toBe('tc-auto');
+			expect(callUris.map(u => u.fsPath)).toEqual([filePath]);
+			expect(callStream).toBe(stream);
+			expect(callToken).toBe(token);
+		});
+
+		it('forwards the request cancellation token to trackEdit on the confirmed path', async () => {
+			const filePath = URI.file('/external/foo.ts').fsPath;
+			const stream = {} as ChatResponseStream;
+			const toolCall: ToolCall = { toolName: 'edit', toolCallId: 'tc-confirm', arguments: { path: filePath } };
+			const req = { kind: 'write', fileName: filePath, diff: '', intention: '' } as any;
+
+			const result = await handleWritePermission(
+				'session-1', req, toolCall, undefined, stream, editTracker,
+				makeWorkspaceInfo({ folder: URI.file('/workspace') }),
+				makeWorkspaceService([URI.file('/workspace')]),
+				instaService, makeToolsService('yes'),
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+
+			expect(result.kind).toBe('approve-once');
+			expect(editTracker.trackEdit).toHaveBeenCalledTimes(1);
+			const [callToolCallId, callUris, callStream, callToken] = vi.mocked(editTracker.trackEdit).mock.calls[0];
+			expect(callToolCallId).toBe('tc-confirm');
+			expect(callUris.map(u => u.fsPath)).toEqual([filePath]);
+			expect(callStream).toBe(stream);
+			expect(callToken).toBe(token);
 		});
 	});
 

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -498,6 +498,10 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 						? await chatSession.editingSession.startExternalEdits(response, responsePartHandle, revive(progress.resources), progress.undoStopId)
 						: await chatSession.editingSession.stopExternalEdits(response, responsePartHandle);
 					chatProgressParts.push(...parts);
+				} else {
+					// The edit proceeds on the extension side without attribution here; log why so a
+					// missing acknowledgment can be distinguished from a stalled one (see #320292).
+					this._logService.warn(`MainThreadChatAgents2#$handleProgressChunk: dropping externalEdits ${progress.start ? 'start' : 'stop'} chunk for request ${requestId} (editingSession=${!!chatSession?.editingSession}, operation=${responsePartHandle}, response=${!!response})`);
 				}
 				continue;
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DeferredPromise, ITask, Sequencer, SequencerByKey, timeout } from '../../../../../base/common/async.js';
+import { DeferredPromise, ITask, Sequencer, SequencerByKey, disposableTimeout, timeout } from '../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
@@ -59,6 +59,14 @@ const enum NotExistBehavior {
 	Create,
 	Abort,
 }
+
+/**
+ * How long {@link ChatEditingSession.startExternalEdits} may run before a warning is logged naming
+ * the stuck phase. Fires before the extension-side ack timeout so the core breadcrumb is written
+ * first (see https://github.com/microsoft/vscode/issues/320292).
+ */
+const EXTERNAL_EDIT_START_WATCHDOG_MS = 5_000;
+
 
 type ChatEditingSessionInfoEvent = {
 	editSessionId: string;
@@ -673,75 +681,109 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		const progress: IChatProgress[] = [];
 		const telemetryInfo = this._getTelemetryInfoForModel(responseModel);
 
-		await chatEditingSessionIsReady(this);
+		// Must fire before the extension-side ack timeout so the stalled phase/resource is logged before the agent turn hangs.
+		const startTime = Date.now();
+		let phase = 'awaiting-session-ready';
+		const resourcePhases = new Map<string, string>();
+		const watchdog = disposableTimeout(() => {
+			const pending = Array.from(resourcePhases.entries()).filter(([, resourcePhase]) => resourcePhase !== 'acquired').map(([uri, resourcePhase]) => `${uri} (${resourcePhase})`);
+			const detail = pending.length ? `; unfinished resources: ${pending.join(', ')}` : '';
+			this._logService.warn(`[ChatEditingSession] startExternalEdits operation ${operationId} still pending after ${Date.now() - startTime}ms in phase '${phase}' for ${resources.length} resource(s) (undoStop ${undoStopId})${detail}`);
+		}, EXTERNAL_EDIT_START_WATCHDOG_MS);
 
-		// Acquire locks for each resource and take snapshots
-		for (let i = 0; i < resources.length; i++) {
-			const resource = resources[i];
-			const contentSource = contentFor?.[i];
-			const releaseLock = new DeferredPromise<void>();
-			releaseLockPromises.push(releaseLock);
+		try {
+			await chatEditingSessionIsReady(this);
+			phase = 'acquiring-locks';
 
-			const acquiredLock = new DeferredPromise<void>();
-			acquiredLockPromises.push(acquiredLock);
+			// Acquire locks for each resource and take snapshots
+			for (let i = 0; i < resources.length; i++) {
+				const resource = resources[i];
+				const contentSource = contentFor?.[i];
+				const releaseLock = new DeferredPromise<void>();
+				releaseLockPromises.push(releaseLock);
 
-			this._streamingEditLocks.queue(resource.toString(), async () => {
-				if (this.isDisposed) {
-					acquiredLock.complete();
-					return;
-				}
+				const acquiredLock = new DeferredPromise<void>();
+				acquiredLockPromises.push(acquiredLock);
 
-				let initialContent: string | undefined;
-				if (contentSource) {
-					// Read the before-content from the provided URI instead of disk
+				resourcePhases.set(resource.toString(), 'waiting-lock');
+				this._streamingEditLocks.queue(resource.toString(), async () => {
 					try {
-						const data = await this._fileService.readFile(contentSource);
-						initialContent = data.value.toString();
-					} catch {
-						initialContent = '';
+						if (this.isDisposed) {
+							resourcePhases.set(resource.toString(), 'acquired');
+							acquiredLock.complete();
+							return;
+						}
+
+						resourcePhases.set(resource.toString(), 'reading-content');
+						let initialContent: string | undefined;
+						if (contentSource) {
+							// Read the before-content from the provided URI instead of disk
+							try {
+								const data = await this._fileService.readFile(contentSource);
+								initialContent = data.value.toString();
+							} catch {
+								initialContent = '';
+							}
+						}
+
+						resourcePhases.set(resource.toString(), 'creating-entry');
+						const entry = await this._getOrCreateModifiedFileEntry(resource, NotExistBehavior.Abort, telemetryInfo, initialContent);
+						if (entry) {
+							await this._acceptStreamingEditsStart(responseModel, undoStopId, resource);
+						}
+
+						const notebookUri = CellUri.parse(resource)?.notebook || resource;
+						progress.push(...createOpeningEditCodeBlock(resource, this._notebookService.hasSupportedNotebooks(notebookUri), undoStopId));
+
+						resourcePhases.set(resource.toString(), 'snapshotting');
+						if (initialContent !== undefined) {
+							if (entry) {
+								entry.initialContent = initialContent;
+								await entry.resetEditTrackerToInitialContent(); // in case it's reused
+							}
+							snapshots.set(resource, initialContent);
+						} else {
+							// Save to disk to ensure disk state is current before external edits
+							await entry?.save();
+							// Take snapshot of current state
+							snapshots.set(resource, entry && this._getCurrentTextOrNotebookSnapshot(entry));
+						}
+						entry?.startExternalEdit();
+						resourcePhases.set(resource.toString(), 'acquired');
+						acquiredLock.complete();
+
+						// Wait for the lock to be released by stopExternalEdits
+						return releaseLock.p;
+					} catch (error) {
+						// This task is fire-and-forget, so a rejection before acquiredLock resolves would leave
+						// Promise.all(acquiredLockPromises) pending forever and hang the agent turn. Release the
+						// gate and record the failure for the watchdog instead of leaking.
+						resourcePhases.set(resource.toString(), 'failed');
+						this._logService.error(`[ChatEditingSession] startExternalEdits operation ${operationId} failed acquiring lock for ${resource.toString()}`, error);
+						if (!acquiredLock.isSettled) {
+							acquiredLock.complete();
+						}
+						return;
 					}
-				}
+				});
+			}
 
-				const entry = await this._getOrCreateModifiedFileEntry(resource, NotExistBehavior.Abort, telemetryInfo, initialContent);
-				if (entry) {
-					await this._acceptStreamingEditsStart(responseModel, undoStopId, resource);
-				}
+			await Promise.all(acquiredLockPromises.map(p => p.p));
+			phase = 'creating-session-snapshot';
+			this.createSnapshot(responseModel.requestId, undoStopId);
 
-				const notebookUri = CellUri.parse(resource)?.notebook || resource;
-				progress.push(...createOpeningEditCodeBlock(resource, this._notebookService.hasSupportedNotebooks(notebookUri), undoStopId));
-
-				if (initialContent !== undefined) {
-					if (entry) {
-						entry.initialContent = initialContent;
-						await entry.resetEditTrackerToInitialContent(); // in case it's reused
-					}
-					snapshots.set(resource, initialContent);
-				} else {
-					// Save to disk to ensure disk state is current before external edits
-					await entry?.save();
-					// Take snapshot of current state
-					snapshots.set(resource, entry && this._getCurrentTextOrNotebookSnapshot(entry));
-				}
-				entry?.startExternalEdit();
-				acquiredLock.complete();
-
-				// Wait for the lock to be released by stopExternalEdits
-				return releaseLock.p;
+			// Store the operation state
+			this._externalEditOperations.set(operationId, {
+				responseModel,
+				snapshots,
+				undoStopId,
+				releaseLocks: () => releaseLockPromises.forEach(p => p.complete())
 			});
+
+			return progress;
+		} finally {
+			watchdog.dispose();
 		}
-
-		await Promise.all(acquiredLockPromises.map(p => p.p));
-		this.createSnapshot(responseModel.requestId, undoStopId);
-
-		// Store the operation state
-		this._externalEditOperations.set(operationId, {
-			responseModel,
-			snapshots,
-			undoStopId,
-			releaseLocks: () => releaseLockPromises.forEach(p => p.complete())
-		});
-
-		return progress;
 	}
 
 	async stopExternalEdits(responseModel: IChatResponseModel, operationId: number, contentFor?: URI[]): Promise<IChatProgress[]> {


### PR DESCRIPTION
A single agent tool call that writes multiple files tracked all of them under one edit key, so later files overwrote earlier ones. The overwritten edit never acknowledged, VS Code core leaked that file's streaming-edit lock, and every later write to the same file hung the agent turn with no user action.

ExternalEditTracker now tracks each file separately per edit key and completes them all, so no lock is leaked. Waiting for a core acknowledgment is also bounded by cancellation and a safety timeout so a dropped ack can never wedge a turn, and bad-path diagnostics were added to make any future stall visible. Shared by the Copilot CLI and Claude agents.

Fixes #320292