### PR TITLE
agentHost: stabilize Codex shell replay tests

### DIFF
--- a/.github/skills/agent-host-e2e-tests/SKILL.md
+++ b/.github/skills/agent-host-e2e-tests/SKILL.md
@@ -51,7 +51,7 @@ Real-time streaming, mid-turn aborts, and POSIX-specific local execution (shell 
 
 - **Record-only** (no deterministic replay at all): `(RECORD ? test : test.skip)('…')` — see `can abort a running turn`.
 - **Subagent fixtures stale after an SDK bump**: re-record them (`AGENT_HOST_REPLAY_RECORD=1 …`). Subagent flows are the most SDK-version-sensitive (parent + child share one `/v1/messages` sequence), but replay reliably once re-recorded, so no gating is needed.
-- **POSIX-only** (fails on Windows): gate with `!isWindows`, or a per-provider flag like `shellPermissionReplayUnstableOnWindows` when only one provider diverges. See the worktree and shell-permission tests.
+- **POSIX-only** (fails on Windows): gate with `!isWindows`, or a targeted per-provider flag when only one provider diverges. See the worktree and subagent-reopen tests.
 
 Always add a comment explaining *why* the gate exists.
 

--- a/src/vs/platform/agentHost/test/node/protocol/README.md
+++ b/src/vs/platform/agentHost/test/node/protocol/README.md
@@ -220,7 +220,6 @@ To accept an AHP output change, run the affected test with `AGENT_HOST_UPDATE_AH
 | `supportsSubagents` | Gates the two subagent tests. |
 | `supportsWorktreeIsolation` | Gates the worktree test. |
 | `supportsPlanMode` | Gates the plan-mode test. |
-| `shellPermissionReplayUnstableOnWindows` | Skips the shell-permission test on **Windows** for that provider (e.g. Codex's `exec_command` tool call isn't emitted by the Codex CLI on Windows). |
 | `subagentReplayUnstableOnWindows` | Skips the subagent-reopen ("replay path") test on **Windows** for that provider (e.g. Claude rebuilds the transcript from the SDK's on-disk `subagents/*.jsonl`, not reliably visible there right after the turn). |
 | `RECORD` (env) | Set by `AGENT_HOST_REPLAY_RECORD=1` and internally during the first `AGENT_HOST_UPDATE_SNAPSHOTS=1` pass. The `can abort a running turn` test runs only for direct record mode, not bulk snapshot updates. |
 | `isWindows` | The worktree test is skipped on Windows (POSIX-shaped `.worktrees` paths + host-terminal `pwd`). |
@@ -262,9 +261,11 @@ The fixture was never recorded (or the test title changed and orphaned it). Reco
 
 Usually the *local execution* diverges by platform (the model replay is byte-identical everywhere). Windows shells, `pwd`, `git worktree` paths, and some SDK tool calls behave differently. Gate the test off that platform (`!isWindows` or a per-provider flag) — don't bump timeouts to mask it.
 
+Codex fixtures use its unified `exec_command` tool, so Codex record/replay servers explicitly enable `features.unified_exec` rather than inheriting an app-server configuration that advertises the incompatible legacy `shell_command` tool.
+
 ### A test passes on macOS/Linux but fails on Windows
 
-Same as above — it's platform-specific real execution, not the proxy. See `shellPermissionReplayUnstableOnWindows` and the worktree gate for the established pattern.
+Same as above — it's platform-specific real execution, not the proxy. See the worktree and subagent gates for established patterns.
 
 ### Fixture leaks a username / absolute path / token
 

--- a/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
@@ -227,13 +227,6 @@ export interface IAgentHostE2EProviderConfig {
 	 */
 	readonly supportsSubagents: boolean;
 	/**
-	 * When set, this provider's shell tool call is not reproduced by its bundled
-	 * SDK on Windows during replay (e.g. Codex's `exec_command` yields no
-	 * tool-call notification there), so the shell-permission test runs only on
-	 * POSIX. macOS/Linux keep full coverage.
-	 */
-	readonly shellPermissionReplayUnstableOnWindows?: boolean;
-	/**
 	 * When set, the subagent-reopen ("replay path") test is skipped on Windows for
 	 * this provider, which rebuilds the reopened transcript from the bundled SDK's
 	 * on-disk `subagents/agent-*.jsonl` files — not reliably visible on Windows
@@ -886,11 +879,7 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 			}
 		});
 
-		// Codex's `exec_command` shell tool call is not emitted by the bundled
-		// Codex CLI on Windows during replay (the turn streams text and completes
-		// with no tool call), so this shell-permission test is POSIX-only for such
-		// providers; Claude/Copilot still run it everywhere.
-		((isWindows && config.shellPermissionReplayUnstableOnWindows) ? test.skip : test)('tool call triggers permission request and can be approved', async function () {
+		test('tool call triggers permission request and can be approved', async function () {
 			this.timeout(120_000);
 
 			const tempDir = mkdtempSync(`${tmpdir()}/ahp-perm-test-`);

--- a/src/vs/platform/agentHost/test/node/protocol/codexAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/codexAgentHostE2E.integrationTest.ts
@@ -60,9 +60,6 @@ const CODEX_CONFIG: IAgentHostE2EProviderConfig = {
 	supportsHostTerminalTool: false,
 	supportsSubagents: false,
 	supportsPlanMode: false,
-	// Codex's `exec_command` shell tool call is not emitted by the bundled Codex
-	// CLI on Windows during replay, so the shell-permission test is POSIX-only.
-	shellPermissionReplayUnstableOnWindows: true,
 };
 
 defineAgentHostE2ETests(CODEX_CONFIG);

--- a/src/vs/platform/agentHost/test/node/protocol/testHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/testHelpers.ts
@@ -15,7 +15,7 @@ import { ActionType, type ActionEnvelope } from '../../../common/state/sessionAc
 import type { SessionAddedParams } from '../../../common/state/protocol/notifications.js';
 import { MessageKind, buildDefaultChatUri, mergeSessionWithDefaultChat, parseDefaultChatUri, type ChatState, type ISessionWithDefaultChat, type SessionState } from '../../../common/state/sessionState.js';
 import { PROTOCOL_VERSION } from '../../../common/state/protocol/version/registry.js';
-import { AgentHostCodexAgentEnabledEnvVar } from '../../../common/agentService.js';
+import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentEnabledEnvVar } from '../../../common/agentService.js';
 import {
 	isJsonRpcNotification,
 	isJsonRpcResponse,
@@ -400,6 +400,8 @@ export async function startRealServer(options?: { readonly claudeSdkRoot?: strin
 			// Codex defaults to disabled; opt it in for the agent host e2e suite when a
 			// codex SDK root is supplied so the provider actually registers.
 			...(options?.codexSdkRoot ? { [AgentHostCodexAgentEnabledEnvVar]: 'true' } : {}),
+			// Fixtures use Codex's unified exec tool, so keep record and replay on the same shell protocol.
+			...(options?.codexSdkRoot && options.capiReplay ? { [AgentHostCodexAgentBinaryArgsEnvVar]: JSON.stringify(['-c', 'features.unified_exec=true']) } : {}),
 			...(realCapture ? {
 				// Real-CAPI capture/replay: route all CAPI + GitHub-API traffic through
 				// the proxy. The real GitHub token flows via the `authenticate`


### PR DESCRIPTION
## Summary

- Pin Codex `features.unified_exec=true` whenever the Agent Host CAPI record/replay harness is active.
- Remove the obsolete Windows-only permission-test gate.
- Document the fixture/runtime shell-tool invariant.

## Why

The committed Codex fixtures call `exec_command`. If inherited app-server configuration disables unified exec, Codex advertises `shell_command` instead, ignores the recorded tool call, and completes with text only. Explicitly pinning the fixture's shell protocol keeps record and replay deterministic across CI environments.

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- Hygiene checks on modified TypeScript files
- Targeted permission and worktree tests with an inherited `features.unified_exec=false` override: 10/10 fresh-process runs passed
- Full Codex E2E suite: 6 passing, 11 expected pending

(Written by Copilot)