### PR TITLE
chat: preserve MCP apps in historic results

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -9,15 +9,17 @@ import { basename } from '../../../../base/common/path.js';
 import { isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
+import { AgentSession } from '../../common/agentService.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
-import { toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
+import { toToolCallMeta, type IToolCallUiMeta } from '../../common/meta/agentToolCallMeta.js';
 import { IFileEditRecord, ISessionDatabase } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/protocol/state.js';
-import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type AgentSelection, type Message, type ModelSelection, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolResultContent, type Turn, type UsageInfo } from '../../common/state/sessionState.js';
+import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type AgentSelection, type Message, type ModelSelection, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolResultContent, type Turn, type UsageInfo } from '../../common/state/sessionState.js';
 import { getInvocationMessage, getPastTenseMessage, getShellIntention, getShellLanguage, getSubagentMetadata, getTaskCompleteMarkdown, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isTaskCompleteTool, synthesizeSkillToolCall } from './copilotToolDisplay.js';
 import { buildSessionDbUri } from '../shared/fileEditTracker.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
+import { buildMcpChannel, buildMcpTopLevelCustomizationId } from '../shared/mcpCustomizationController.js';
 
 function tryStringify(value: unknown): string | undefined {
 	try {
@@ -77,6 +79,9 @@ interface IToolStartInfo {
 	readonly subagentDescription?: string;
 	readonly parameters: Record<string, unknown> | undefined;
 	readonly parentToolCallId?: string;
+	readonly mcpServerName?: string;
+	readonly mcpToolName?: string;
+	readonly mcpUiResourceUri?: string;
 }
 
 /** Subagent metadata seen via `subagent.started`, applied to the parent tool call's content at `tool.execution_complete`. */
@@ -117,7 +122,34 @@ function newTurnBuilder(id: string, text: string, options?: { attachments?: Mess
 	return { id, message, responseParts: [], usage: undefined, pendingTools: new Map() };
 }
 
-function makeToolStartInfo(toolName: string, rawArguments: unknown, parentToolCallId: string | undefined, workingDirectory: URI | undefined): IToolStartInfo | undefined {
+function readStringProperty(source: unknown, key: string): string | undefined {
+	if (!source || typeof source !== 'object' || Array.isArray(source)) {
+		return undefined;
+	}
+	const value = (source as Record<string, unknown>)[key];
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readMcpUiResourceUri(source: unknown): string | undefined {
+	if (!source || typeof source !== 'object' || Array.isArray(source)) {
+		return undefined;
+	}
+	const toolDescription = (source as Record<string, unknown>)['toolDescription'];
+	if (!toolDescription || typeof toolDescription !== 'object' || Array.isArray(toolDescription)) {
+		return undefined;
+	}
+	const meta = (toolDescription as Record<string, unknown>)['_meta'];
+	if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+		return undefined;
+	}
+	const ui = (meta as Record<string, unknown>)['ui'];
+	if (!ui || typeof ui !== 'object' || Array.isArray(ui)) {
+		return undefined;
+	}
+	return readStringProperty(ui, 'resourceUri');
+}
+
+function makeToolStartInfo(toolName: string, rawArguments: unknown, parentToolCallId: string | undefined, workingDirectory: URI | undefined, source: unknown): IToolStartInfo | undefined {
 	if (isHiddenTool(toolName)) {
 		return undefined;
 	}
@@ -146,6 +178,9 @@ function makeToolStartInfo(toolName: string, rawArguments: unknown, parentToolCa
 		subagentDescription: subagentMeta?.description,
 		parameters,
 		parentToolCallId,
+		mcpServerName: readStringProperty(source, 'mcpServerName'),
+		mcpToolName: readStringProperty(source, 'mcpToolName'),
+		mcpUiResourceUri: readMcpUiResourceUri(source),
 	};
 }
 
@@ -215,7 +250,7 @@ export async function mapSessionEvents(
 		if (e.type === 'tool.execution_start') {
 			const d = e.data;
 			const parentToolCallId = resolveParentToolCallId(e.agentId, d.parentToolCallId);
-			const info = makeToolStartInfo(d.toolName, d.arguments, parentToolCallId, workingDirectory);
+			const info = makeToolStartInfo(d.toolName, d.arguments, parentToolCallId, workingDirectory, d);
 			if (!info) {
 				continue;
 			}
@@ -249,6 +284,8 @@ export async function mapSessionEvents(
 	}
 
 	const sessionUriStr = session.toString();
+	const providerId = session.scheme;
+	const rawSessionId = AgentSession.id(session);
 	const turns: Turn[] = [];
 
 	// Subagent state. Each subagent has its own active turn builder; only
@@ -492,7 +529,7 @@ export async function mapSessionEvents(
 					// No active turn to attach this completion to.
 					continue;
 				}
-				const completedPart = makeCompletedToolCallPart(d, info, sessionUriStr, storedEdits, subagentInfoByToolCallId.get(d.toolCallId));
+				const completedPart = makeCompletedToolCallPart(d, info, sessionUriStr, providerId, rawSessionId, storedEdits, subagentInfoByToolCallId.get(d.toolCallId));
 				builder.responseParts.push(completedPart);
 				// When a parent tool call that spawned a subagent completes,
 				// flush the subagent's accumulated turn.
@@ -556,7 +593,7 @@ export async function mapSessionEvents(
 				continue;
 			}
 			const info = toolInfoByCallId.get(request.toolCallId)
-				?? makeToolStartInfo(request.name, request.arguments, parentToolCallId, workingDirectory);
+				?? makeToolStartInfo(request.name, request.arguments, parentToolCallId, workingDirectory, request);
 			if (!info) {
 				continue;
 			}
@@ -578,6 +615,8 @@ export async function mapSessionEvents(
 				completion ?? { toolCallId: request.toolCallId, success: true },
 				info,
 				sessionUriStr,
+				providerId,
+				rawSessionId,
 				storedEdits,
 				subagentInfoByToolCallId.get(request.toolCallId),
 			));
@@ -676,6 +715,8 @@ function makeCompletedToolCallPart(
 	d: ToolExecutionCompleteData,
 	info: IToolStartInfo,
 	sessionUriStr: string,
+	providerId: string,
+	rawSessionId: string,
 	storedEdits: Map<string, IFileEditRecord[]> | undefined,
 	subagent: ISubagentInfo | undefined,
 ): ResponsePart {
@@ -723,12 +764,23 @@ function makeCompletedToolCallPart(
 		});
 	}
 
+	const mcpServerName = info.mcpServerName ?? readStringProperty(d, 'mcpServerName');
+	const mcpToolName = info.mcpToolName ?? readStringProperty(d, 'mcpToolName');
+	const mcpUiResourceUri = info.mcpUiResourceUri ?? readMcpUiResourceUri(d);
+	const mcpUi: IToolCallUiMeta | undefined = mcpUiResourceUri
+		? {
+			resourceUri: mcpUiResourceUri,
+			...(mcpServerName ? { channel: buildMcpChannel(providerId, rawSessionId, mcpServerName) } : {}),
+		}
+		: undefined;
+
 	const tc: ToolCallCompletedState = {
 		status: ToolCallStatus.Completed,
 		toolCallId: d.toolCallId,
 		toolName: info.toolName,
 		displayName: info.displayName,
 		intention: info.intention,
+		...(mcpServerName ? { contributor: { kind: ToolCallContributorKind.MCP, customizationId: buildMcpTopLevelCustomizationId(providerId, rawSessionId, mcpServerName) } } : {}),
 		invocationMessage: info.invocationMessage,
 		toolInput: info.toolInput,
 		success: d.success,
@@ -741,6 +793,9 @@ function makeCompletedToolCallPart(
 			language: info.language,
 			subagentDescription: info.subagentDescription,
 			subagentAgentName: info.subagentAgentName,
+			mcpServerName,
+			mcpToolName,
+			ui: mcpUi,
 		}),
 	};
 	return { kind: ResponsePartKind.ToolCall, toolCall: tc };

--- a/src/vs/platform/agentHost/node/shared/mcpCustomizationController.ts
+++ b/src/vs/platform/agentHost/node/shared/mcpCustomizationController.ts
@@ -83,6 +83,14 @@ interface ILiveEntry {
 	readonly topLevelId?: string;
 }
 
+export function buildMcpTopLevelCustomizationId(providerId: string, sessionId: string, serverName: string): string {
+	return `mcp-top-level:${providerId}:${sessionId}:${serverName}`;
+}
+
+export function buildMcpChannel(providerId: string, sessionId: string, serverName: string): string {
+	return `mcp://${providerId}/${encodeURIComponent(sessionId)}/${encodeURIComponent(serverName)}`;
+}
+
 /**
  * Translates a stream of SDK-reported MCP server states into AHP
  * customization actions:
@@ -342,14 +350,14 @@ export class McpCustomizationController extends Disposable {
 	}
 
 	private _mintTopLevelId(serverName: string): string {
-		return `mcp-top-level:${this._options.providerId}:${this._options.sessionId}:${serverName}`;
+		return buildMcpTopLevelCustomizationId(this._options.providerId, this._options.sessionId, serverName);
 	}
 
 	private _buildChannel(serverName: string, state: McpServerState): string | undefined {
 		if (state.kind !== McpServerStatus.Ready) {
 			return undefined;
 		}
-		return `mcp://${this._options.providerId}/${encodeURIComponent(this._options.sessionId)}/${encodeURIComponent(serverName)}`;
+		return buildMcpChannel(this._options.providerId, this._options.sessionId, serverName);
 	}
 
 	private _buildTopLevel(id: string, serverName: string, state: McpServerState): McpServerCustomization {

--- a/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
+++ b/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
@@ -25,6 +25,7 @@ export interface ISessionEventToolStart {
 		arguments?: unknown;
 		mcpServerName?: string;
 		mcpToolName?: string;
+		toolDescription?: unknown;
 		/** @deprecated Use the envelope-level {@link ISessionEventToolStart.agentId} instead. */
 		parentToolCallId?: string;
 	};
@@ -45,6 +46,9 @@ export interface ISessionEventToolComplete {
 		error?: { message: string; code?: string };
 		isUserRequested?: boolean;
 		toolTelemetry?: unknown;
+		mcpServerName?: string;
+		mcpToolName?: string;
+		toolDescription?: unknown;
 		/** @deprecated Use the envelope-level {@link ISessionEventToolComplete.agentId} instead. */
 		parentToolCallId?: string;
 	};
@@ -60,7 +64,7 @@ export interface ISessionEventMessage {
 		messageId?: string;
 		interactionId?: string;
 		content?: string;
-		toolRequests?: readonly { toolCallId: string; name: string; arguments?: unknown; type?: 'function' | 'custom' }[];
+		toolRequests?: readonly { toolCallId: string; name: string; arguments?: unknown; type?: 'function' | 'custom'; mcpServerName?: string; mcpToolName?: string; toolDescription?: unknown }[];
 		reasoningOpaque?: string;
 		reasoningText?: string;
 		encryptedContent?: string;

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -6,8 +6,9 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { readToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { AgentSession } from '../../common/agentService.js';
-import { MessageAttachmentKind, MessageKind, ResponsePartKind, ToolCallStatus, ToolResultContentType, TurnState, type ResponsePart, type StringOrMarkdown, type ToolCallResponsePart } from '../../common/state/sessionState.js';
+import { MessageAttachmentKind, MessageKind, ResponsePartKind, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, TurnState, type ResponsePart, type StringOrMarkdown, type ToolCallResponsePart } from '../../common/state/sessionState.js';
 import { mapSessionEvents } from '../../node/copilot/mapSessionEvents.js';
 import { toSessionEvents, type ISessionEvent } from './copilotTestEvents.js';
 
@@ -122,6 +123,74 @@ suite('mapSessionEvents — history replay', () => {
 		assert.deepStrictEqual(partKinds(turns[0].responseParts), [
 			{ kind: ResponsePartKind.ToolCall },
 		]);
+	});
+
+	test('restores MCP app data for completed tool calls', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'call an MCP app tool' } },
+			{
+				type: 'assistant.message',
+				data: {
+					messageId: 'm2',
+					content: '',
+					toolRequests: [{
+						toolCallId: 'tc-1',
+						name: 'GitHub-get_me',
+						arguments: {},
+						type: 'function',
+						mcpServerName: 'GitHub',
+						mcpToolName: 'get_me',
+					}],
+				},
+			},
+			{
+				type: 'tool.execution_start',
+				data: {
+					toolCallId: 'tc-1',
+					toolName: 'GitHub-get_me',
+					arguments: {},
+					mcpServerName: 'GitHub',
+					mcpToolName: 'get_me',
+					toolDescription: {
+						_meta: {
+							ui: {
+								resourceUri: 'ui://github-mcp-server/get-me',
+							},
+						},
+					},
+				},
+			},
+			{
+				type: 'tool.execution_complete',
+				data: {
+					toolCallId: 'tc-1',
+					success: true,
+					result: { content: '{"login":"octocat"}' },
+				},
+			},
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		const part = turns[0].responseParts[0] as ToolCallResponsePart;
+		assert.strictEqual(part.kind, ResponsePartKind.ToolCall);
+		assert.deepStrictEqual({
+			contributor: part.toolCall.contributor,
+			meta: readToolCallMeta(part.toolCall),
+		}, {
+			contributor: {
+				kind: ToolCallContributorKind.MCP,
+				customizationId: 'mcp-top-level:copilot:test-session:GitHub',
+			},
+			meta: {
+				mcpServerName: 'GitHub',
+				mcpToolName: 'get_me',
+				ui: {
+					resourceUri: 'ui://github-mcp-server/get-me',
+					channel: 'mcp://copilot/test-session/GitHub',
+				},
+			},
+		});
 	});
 
 	test('derives shell tool intention from the description argument on replay', async () => {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -161,6 +161,12 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 				const outcome = IChatToolInvocation.executionConfirmedOrDenied(toolInvocation, reader);
 				return !!outcome && outcome.type !== ToolConfirmKind.Denied && outcome.type !== ToolConfirmKind.Skipped ? data : undefined;
 			});
+		} else {
+			const data = this.getMcpAppRenderData();
+			if (data) {
+				const outcome = IChatToolInvocation.executionConfirmedOrDenied(toolInvocation, undefined);
+				appData = constObservable(!!outcome && outcome.type !== ToolConfirmKind.Denied && outcome.type !== ToolConfirmKind.Skipped ? data : undefined);
+			}
 		}
 
 		// This part is a bit different, since IChatToolInvocation is not an immutable model object. So this part is able to rerender itself.

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -254,11 +254,16 @@ export function shouldShowPillsSummaryForSettings(isComplete: boolean, isAgentHo
 	return isComplete && isAgentHostSession && isChatTurnStatusPillsEnabled(turnStatusPills);
 }
 
-export function shouldPinToolInvocationToThinking(state: IChatToolInvocation.StateKind, hasConfirmationMessages: boolean): boolean {
-	return state !== IChatToolInvocation.StateKind.WaitingForConfirmation
+export function shouldPinToolInvocationToThinking(state: IChatToolInvocation.StateKind, hasConfirmationMessages: boolean, hasMcpAppData: boolean): boolean {
+	return !hasMcpAppData
+		&& state !== IChatToolInvocation.StateKind.WaitingForConfirmation
 		&& state !== IChatToolInvocation.StateKind.WaitingForPostApproval
 		&& state !== IChatToolInvocation.StateKind.WaitingForAuthentication
 		&& !hasConfirmationMessages;
+}
+
+function toolInvocationHasMcpAppData(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized): boolean {
+	return toolInvocation.toolSpecificData?.kind === 'input' && !!toolInvocation.toolSpecificData.mcpAppData;
 }
 
 const forceVerboseLayoutTracing = false
@@ -2265,16 +2270,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		if (part.kind === 'toolInvocation') {
-			// pin when streaming since we don't know if we have confirmation yet or not
-			if (IChatToolInvocation.isStreaming(part)) {
-				return true;
-			}
 			const state = part.state.get();
-			return shouldPinToolInvocationToThinking(state.type, !!IChatToolInvocation.getConfirmationMessages(part));
+			return shouldPinToolInvocationToThinking(state.type, !!IChatToolInvocation.getConfirmationMessages(part), toolInvocationHasMcpAppData(part));
 		}
 
 		if (part.kind === 'toolInvocationSerialized') {
-			return true;
+			return !toolInvocationHasMcpAppData(part);
 		}
 
 		return false;
@@ -2991,6 +2992,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		};
 
 		const currentState = toolInvocation.state.get();
+		if (toolInvocationHasMcpAppData(toolInvocation)) {
+			moveConfirmationWidgetOutOfThinking();
+			return;
+		}
+
 		if (currentState.type === IChatToolInvocation.StateKind.WaitingForConfirmation) {
 			if (!tryRouteConfirmationToCarousel()) {
 				moveConfirmationWidgetOutOfThinking();
@@ -3006,14 +3012,24 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			return;
 		}
 
-		let didRemoveConfirmationWidget = false;
+		let didMoveToolOut = false;
 		const disposable = autorun(reader => {
 			const state = toolInvocation.state.read(reader);
-			if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation || state.type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
-				if (didRemoveConfirmationWidget) {
+			toolInvocation.toolSpecificDataKind.read(reader);
+			if (toolInvocationHasMcpAppData(toolInvocation)) {
+				if (didMoveToolOut) {
 					return;
 				}
-				didRemoveConfirmationWidget = true;
+				didMoveToolOut = true;
+				disposable.dispose();
+				moveConfirmationWidgetOutOfThinking();
+				return;
+			}
+			if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation || state.type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
+				if (didMoveToolOut) {
+					return;
+				}
+				didMoveToolOut = true;
 				disposable.dispose();
 				if (state.type !== IChatToolInvocation.StateKind.WaitingForConfirmation || !tryRouteConfirmationToCarousel()) {
 					moveConfirmationWidgetOutOfThinking();

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -125,19 +125,23 @@ suite('ChatListRenderer', () => {
 	});
 
 	suite('shouldPinToolInvocationToThinking', () => {
-		test('keeps tool invocations requiring user input outside Thinking', () => {
+		test('keeps tool invocations requiring user input or MCP apps outside Thinking', () => {
 			assert.deepStrictEqual({
-				executionConfirmation: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.WaitingForConfirmation, false),
-				resultApproval: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.WaitingForPostApproval, false),
-				authentication: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.WaitingForAuthentication, false),
-				executingWithConfirmation: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.Executing, true),
-				executingWithoutConfirmation: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.Executing, false),
+				executionConfirmation: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.WaitingForConfirmation, false, false),
+				resultApproval: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.WaitingForPostApproval, false, false),
+				authentication: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.WaitingForAuthentication, false, false),
+				executingWithConfirmation: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.Executing, true, false),
+				executingWithoutConfirmation: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.Executing, false, false),
+				executingWithMcpApp: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.Executing, false, true),
+				streamingWithMcpApp: shouldPinToolInvocationToThinking(IChatToolInvocation.StateKind.Streaming, false, true),
 			}, {
 				executionConfirmation: false,
 				resultApproval: false,
 				authentication: false,
 				executingWithConfirmation: false,
 				executingWithoutConfirmation: true,
+				executingWithMcpApp: false,
+				streamingWithMcpApp: false,
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

Fixes MCP app rendering across current and historic chat results:

- keeps MCP apps out of collapsed Thinking results
- allows MCP apps to render from historic/serialized tool results
- restores MCP server, tool, UI resource, channel, and contributor metadata when loading older Copilot sessions

## Validation

- pre-commit hygiene checks passed
- focused coverage added for restored MCP metadata and MCP app pinning behavior