### PR TITLE
sessions: add prompt timeline sticky header

### DIFF
--- a/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
+++ b/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
@@ -27,13 +27,11 @@
 /* Reserve room on the transcript's right edge so message content clears the rail's marks.
  * The chat "card" rows (sessions style.css) pad only 32px on the right — where the marks sit — so
  * bubbles crowd the pills. We reserve the rail's full width plus the minimum gap, but only while
- * the rail is mounted. `.prompt-timeline-host` is added to the same `.interactive-session`
- * element, so the compound plus the card-rule scope wins on specificity without touching the base
- * layout when the rail is absent. */
-.agent-sessions-workbench .part.sessionspart .prompt-timeline-host.interactive-session .interactive-item-container,
-.agent-sessions-workbench .part.sessionspart .prompt-timeline-host.interactive-session > .chat-suggest-next-widget,
-.agent-sessions-workbench .chat-editor-relative .prompt-timeline-host.interactive-session .interactive-item-container,
-.agent-sessions-workbench .chat-editor-relative .prompt-timeline-host.interactive-session > .chat-suggest-next-widget {
+ * the rail surface is mounted (`.prompt-timeline-with-rail`); header-only keeps the base layout. */
+.agent-sessions-workbench .part.sessionspart .prompt-timeline-host.prompt-timeline-with-rail.interactive-session .interactive-item-container,
+.agent-sessions-workbench .part.sessionspart .prompt-timeline-host.prompt-timeline-with-rail.interactive-session > .chat-suggest-next-widget,
+.agent-sessions-workbench .chat-editor-relative .prompt-timeline-host.prompt-timeline-with-rail.interactive-session .interactive-item-container,
+.agent-sessions-workbench .chat-editor-relative .prompt-timeline-host.prompt-timeline-with-rail.interactive-session > .chat-suggest-next-widget {
 	padding-right: calc(var(--prompt-timeline-rail-width) + var(--prompt-timeline-content-gap));
 }
 
@@ -44,6 +42,100 @@
 /* Not enough horizontal room next to the transcript: hide the marks but keep the rail laid out so its ResizeObserver can detect it fits again. */
 .prompt-timeline-rail.overflowing .prompt-timeline-ruler-marks {
 	display: none;
+}
+
+/* ---- Sticky prompt header ------------------------------------------------------------------
+ * A flat, opaque band pinned to the top of the transcript (editor "sticky scroll" pattern): it
+ * shares the transcript surface, carries only a hairline bottom border and a soft downward shadow,
+ * and names the prompt currently scrolled off the top. Independent of the rail: `.hidden` (toggled
+ * in JS once a prompt is pinned) drives the reveal, so it also works in header-only mode. */
+.prompt-timeline-sticky {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 9;
+	opacity: 0;
+	transform: translateY(-6px);
+	transition: opacity 140ms ease, transform 140ms ease;
+	pointer-events: none;
+}
+
+.prompt-timeline-sticky:not(.hidden) {
+	opacity: 1;
+	transform: translateY(0);
+	pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.prompt-timeline-sticky {
+		transition: none;
+		transform: none;
+	}
+}
+
+.prompt-timeline-sticky-button {
+	display: block;
+	width: 100%;
+	padding: 0;
+	border: none;
+	border-bottom: 1px solid var(--vscode-agentsPanel-border, transparent);
+	background: var(--vscode-agentsPanel-background);
+	box-shadow: 0 6px 6px -6px var(--vscode-widget-shadow, transparent);
+	color: var(--vscode-foreground);
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+
+/* Layer the (translucent) hover tint over the opaque surface so the band never turns see-through. */
+.prompt-timeline-sticky-button:hover {
+	background:
+		linear-gradient(var(--vscode-toolbar-hoverBackground), var(--vscode-toolbar-hoverBackground)),
+		var(--vscode-agentsPanel-background);
+}
+
+.prompt-timeline-sticky-button:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+/* Match the transcript's centered message column (chatView.css: max-width 950, margin auto, 32px inset)
+ * so the pinned prompt aligns with the prompts underneath. The right inset matches the column too:
+ * 32px normally, widened to clear the rail lane when the rail is present. */
+.prompt-timeline-sticky-content {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	height: 30px;
+	box-sizing: border-box;
+	max-width: 950px;
+	margin: 0 auto;
+	padding-left: 32px;
+	padding-right: 32px;
+}
+
+.prompt-timeline-host.prompt-timeline-with-rail .prompt-timeline-sticky-content {
+	padding-right: calc(var(--prompt-timeline-rail-width) + var(--prompt-timeline-content-gap));
+}
+
+.prompt-timeline-sticky-label {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.prompt-timeline-sticky-count {
+	flex: 0 0 auto;
+	color: var(--vscode-descriptionForeground);
+	font-variant-numeric: tabular-nums;
+}
+
+.prompt-timeline-sticky-chevron {
+	flex: 0 0 auto;
+	color: var(--vscode-descriptionForeground);
 }
 
 /* Interactive hover/focus card: prompt text, clickable diff stat, and files. */

--- a/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
+++ b/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
@@ -88,6 +88,12 @@
 	cursor: pointer;
 }
 
+/* High-contrast themes rely on the explicit contrast border and suppress decorative shadows. */
+.hc-black .prompt-timeline-sticky-button,
+.hc-light .prompt-timeline-sticky-button {
+	box-shadow: none;
+}
+
 /* Layer the (translucent) hover tint over the opaque surface so the band never turns see-through. */
 .prompt-timeline-sticky-button:hover {
 	background:

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimeline.contribution.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimeline.contribution.ts
@@ -17,14 +17,14 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		[PROMPT_TIMELINE_RAIL_SETTING]: {
 			type: 'boolean',
 			default: false,
-			description: localize('sessions.promptTimeline.rail', "Controls whether the prompt timeline rail is shown beside the chat transcript in the Agents window: a scrollbar that fans into prompt pills on scroll or hover, so you can scan and jump between the prompts you have sent."),
+			description: localize('sessions.promptTimeline.rail', "Controls whether the prompt timeline is shown next to the chat transcript in the Agents window."),
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},
 		[PROMPT_TIMELINE_STICKY_HEADER_SETTING]: {
 			type: 'boolean',
 			default: false,
-			description: localize('sessions.promptTimeline.stickyHeader', "Controls whether a sticky header pins the current prompt to the top of the chat transcript in the Agents window while scrolling. Select the header to jump to another prompt."),
+			description: localize('sessions.promptTimeline.stickyHeader', "Controls whether the current prompt is pinned to the top of the chat transcript while scrolling in the Agents window."),
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimeline.contribution.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimeline.contribution.ts
@@ -7,17 +7,24 @@ import { localize } from '../../../../nls.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { ChatWidget } from '../../../../workbench/contrib/chat/browser/widget/chatWidget.js';
-import { PROMPT_TIMELINE_ENABLED_SETTING } from '../common/promptTimeline.js';
+import { PROMPT_TIMELINE_RAIL_SETTING, PROMPT_TIMELINE_STICKY_HEADER_SETTING } from '../common/promptTimeline.js';
 import { registerPromptTimelineActions } from './promptTimelineActions.js';
 import { PromptTimelineWidgetContrib } from './promptTimelineWidgetContrib.js';
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	id: 'sessions',
 	properties: {
-		[PROMPT_TIMELINE_ENABLED_SETTING]: {
+		[PROMPT_TIMELINE_RAIL_SETTING]: {
 			type: 'boolean',
 			default: false,
-			description: localize('sessions.promptTimeline.enabled', "Controls whether the prompt timeline rail is shown alongside the chat transcript in the Agents window. The rail lets you scan and jump between the prompts you have sent."),
+			description: localize('sessions.promptTimeline.rail', "Controls whether the prompt timeline rail is shown beside the chat transcript in the Agents window: a scrollbar that fans into prompt pills on scroll or hover, so you can scan and jump between the prompts you have sent."),
+			tags: ['experimental'],
+			experiment: { mode: 'startup' },
+		},
+		[PROMPT_TIMELINE_STICKY_HEADER_SETTING]: {
+			type: 'boolean',
+			default: false,
+			description: localize('sessions.promptTimeline.stickyHeader', "Controls whether a sticky header pins the current prompt to the top of the chat transcript in the Agents window while scrolling. Select the header to jump to another prompt."),
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineActions.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineActions.ts
@@ -11,15 +11,18 @@ import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickin
 import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { PromptTimelineCommandId, PROMPT_TIMELINE_ENABLED_SETTING } from '../common/promptTimeline.js';
+import { PromptTimelineCommandId, PROMPT_TIMELINE_RAIL_SETTING, PROMPT_TIMELINE_STICKY_HEADER_SETTING } from '../common/promptTimeline.js';
 import { PromptTimelineWidgetContrib } from './promptTimelineWidgetContrib.js';
 
 const CATEGORY = localize2('promptTimeline.category', "Chat");
 
-/** True unless the prompt timeline setting is explicitly disabled. */
-const TIMELINE_ENABLED = ContextKeyExpr.notEquals(`config.${PROMPT_TIMELINE_ENABLED_SETTING}`, false);
+/** True when at least one prompt timeline surface (rail or sticky header) is enabled. */
+const TIMELINE_ENABLED = ContextKeyExpr.or(
+	ContextKeyExpr.equals(`config.${PROMPT_TIMELINE_RAIL_SETTING}`, true),
+	ContextKeyExpr.equals(`config.${PROMPT_TIMELINE_STICKY_HEADER_SETTING}`, true),
+);
 
-/** Commands require AI features to be on and the prompt timeline setting to be enabled. */
+/** Commands require AI features to be on and at least one prompt timeline surface to be enabled. */
 const TIMELINE_PRECONDITION = ContextKeyExpr.and(ChatContextKeys.enabled, TIMELINE_ENABLED);
 
 /** Resolves the prompt timeline contribution for the active session's chat widget. */

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineModel.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineModel.ts
@@ -121,6 +121,13 @@ export interface PromptEntry {
 	readonly stat?: PromptDiffStat;
 }
 
+/** The prompt currently pinned by the sticky header, with its 1-based position among all prompts. */
+export interface IActivePrompt {
+	readonly text: string;
+	readonly index: number;
+	readonly total: number;
+}
+
 /**
  * Derives the prompt timeline (bucketed ticks + the active tick) from a chat
  * widget's view model, and reveals prompts on request.
@@ -170,16 +177,24 @@ export class PromptTimelineModel extends Disposable {
 	private readonly _activeRequestId: ISettableObservable<string | undefined> = observableValue<string | undefined>(this, undefined);
 	get activeRequestId(): IObservable<string | undefined> { return this._activeRequestId; }
 
+	/** The exact request currently scrolled to the top, unbucketed — drives the sticky header's label/position. */
+	private readonly _activePromptId: ISettableObservable<string | undefined> = observableValue<string | undefined>(this, undefined);
+
 	/** True once the active prompt's own row has scrolled above the viewport top (drives the sticky header). */
 	private readonly _activePinned: ISettableObservable<boolean> = observableValue<boolean>(this, false);
 	get activePinned(): IObservable<boolean> { return this._activePinned; }
 
-	/** The decorated tick (with diff stat) for the active prompt, or undefined when none is active. */
-	private readonly _activeTick = derived<PromptTick | undefined>(this, reader => {
-		const id = this._activeRequestId.read(reader);
-		return id === undefined ? undefined : this._ticks.read(reader).find(t => t.requestId === id);
+	/** The active prompt with its 1-based position among all (unbucketed) prompts, for the sticky header. */
+	private readonly _activePrompt = derived<IActivePrompt | undefined>(this, reader => {
+		const id = this._activePromptId.read(reader);
+		if (id === undefined) {
+			return undefined;
+		}
+		const prompts = this._prompts.read(reader);
+		const index = prompts.findIndex(p => p.requestId === id);
+		return index < 0 ? undefined : { text: prompts[index].text, index: index + 1, total: prompts.length };
 	});
-	get activeTick(): IObservable<PromptTick | undefined> { return this._activeTick; }
+	get activePrompt(): IObservable<IActivePrompt | undefined> { return this._activePrompt; }
 
 	/** Fires when the transcript scroll offset or content height changes (drives the ruler rail). */
 	private readonly _scrollLayoutSignal: IObservableSignal<void> = observableSignal<void>(this);
@@ -357,6 +372,7 @@ export class PromptTimelineModel extends Disposable {
 		if (!items || ticks.length === 0) {
 			transaction(tx => {
 				this._activeRequestId.set(undefined, tx);
+				this._activePromptId.set(undefined, tx);
 				this._activePinned.set(false, tx);
 			});
 			return;
@@ -386,6 +402,7 @@ export class PromptTimelineModel extends Disposable {
 			// (the loop advances oldest -> newest as you scroll down). Nothing is pinned yet.
 			transaction(tx => {
 				this._activeRequestId.set(ticks.at(0)?.requestId, tx);
+				this._activePromptId.set(this._prompts.get().at(0)?.requestId, tx);
 				this._activePinned.set(false, tx);
 			});
 			return;
@@ -408,6 +425,8 @@ export class PromptTimelineModel extends Disposable {
 		const pinned = activeTop < scrollTop - 2;
 		transaction(tx => {
 			this._activeRequestId.set((activeTick ?? ticks[ticks.length - 1]).requestId, tx);
+			// The sticky header names the exact current prompt (unbucketed), not the bucket representative.
+			this._activePromptId.set(activeRequestId, tx);
 			this._activePinned.set(pinned, tx);
 		});
 	}

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineModel.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineModel.ts
@@ -170,6 +170,17 @@ export class PromptTimelineModel extends Disposable {
 	private readonly _activeRequestId: ISettableObservable<string | undefined> = observableValue<string | undefined>(this, undefined);
 	get activeRequestId(): IObservable<string | undefined> { return this._activeRequestId; }
 
+	/** True once the active prompt's own row has scrolled above the viewport top (drives the sticky header). */
+	private readonly _activePinned: ISettableObservable<boolean> = observableValue<boolean>(this, false);
+	get activePinned(): IObservable<boolean> { return this._activePinned; }
+
+	/** The decorated tick (with diff stat) for the active prompt, or undefined when none is active. */
+	private readonly _activeTick = derived<PromptTick | undefined>(this, reader => {
+		const id = this._activeRequestId.read(reader);
+		return id === undefined ? undefined : this._ticks.read(reader).find(t => t.requestId === id);
+	});
+	get activeTick(): IObservable<PromptTick | undefined> { return this._activeTick; }
+
 	/** Fires when the transcript scroll offset or content height changes (drives the ruler rail). */
 	private readonly _scrollLayoutSignal: IObservableSignal<void> = observableSignal<void>(this);
 	get onDidChangeScrollLayout(): IObservable<void> { return this._scrollLayoutSignal; }
@@ -344,7 +355,10 @@ export class PromptTimelineModel extends Disposable {
 		const ticks = this._baseTicks.get();
 		const items = this.widget.viewModel?.getItems();
 		if (!items || ticks.length === 0) {
-			this._activeRequestId.set(undefined, undefined);
+			transaction(tx => {
+				this._activeRequestId.set(undefined, tx);
+				this._activePinned.set(false, tx);
+			});
 			return;
 		}
 
@@ -355,20 +369,25 @@ export class PromptTimelineModel extends Disposable {
 		const threshold = 24;
 		let activeRequestId: string | undefined;
 		let activeTimestamp = 0;
+		let activeTop = -1;
 		for (const item of items) {
 			if (isRequestVM(item)) {
 				const top = this.widget.getElementTop(item);
 				if (top !== undefined && top <= scrollTop + threshold) {
 					activeRequestId = item.id;
 					activeTimestamp = item.timestamp;
+					activeTop = top;
 				}
 			}
 		}
 
 		if (activeRequestId === undefined) {
 			// Scrolled above the oldest prompt: the oldest tick is the active one
-			// (the loop advances oldest -> newest as you scroll down).
-			this._activeRequestId.set(ticks.at(0)?.requestId, undefined);
+			// (the loop advances oldest -> newest as you scroll down). Nothing is pinned yet.
+			transaction(tx => {
+				this._activeRequestId.set(ticks.at(0)?.requestId, tx);
+				this._activePinned.set(false, tx);
+			});
 			return;
 		}
 
@@ -384,7 +403,13 @@ export class PromptTimelineModel extends Disposable {
 				}
 			}
 		}
-		this._activeRequestId.set((activeTick ?? ticks[ticks.length - 1]).requestId, undefined);
+		// Pin the sticky header only once the active prompt's own row has scrolled above the
+		// viewport top; the small epsilon avoids flicker as its top crosses the edge.
+		const pinned = activeTop < scrollTop - 2;
+		transaction(tx => {
+			this._activeRequestId.set((activeTick ?? ticks[ticks.length - 1]).requestId, tx);
+			this._activePinned.set(pinned, tx);
+		});
 	}
 
 	/** Reveals the request with the given id near the top of the transcript. */

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineStickyHeader.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineStickyHeader.ts
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { $, addDisposableListener, append, EventType } from '../../../../base/browser/dom.js';
-import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
@@ -41,22 +39,17 @@ export class PromptTimelineStickyHeader extends Disposable {
 		this._count = append(content, $('span.prompt-timeline-sticky-count'));
 		append(content, $(`span.prompt-timeline-sticky-chevron${ThemeIcon.asCSSSelector(Codicon.chevronDown)}`));
 
+		// A native <button> already activates on click and on Enter/Space, so no manual key handling.
 		this._register(addDisposableListener(this._button, EventType.CLICK, () => this._onDidActivate.fire()));
-		this._register(addDisposableListener(this._button, EventType.KEY_DOWN, e => {
-			const event = new StandardKeyboardEvent(e);
-			if (event.keyCode === KeyCode.Enter || event.keyCode === KeyCode.Space) {
-				event.preventDefault();
-				this._onDidActivate.fire();
-			}
-		}));
 	}
 
-	/** Names the pinned prompt (1-based index within the visible prompts). */
+	/** Names the pinned prompt (1-based index within all prompts). */
 	update(text: string, index: number, total: number): void {
-		this._label.textContent = text;
+		const label = text || localize('promptTimeline.emptyPrompt', "(empty prompt)");
+		this._label.textContent = label;
 		this._count.textContent = localize('promptTimeline.stickyCount', "{0}/{1}", index, total);
-		this._button.title = text;
-		this._button.setAttribute('aria-label', localize('promptTimeline.stickyLabel', "Go to prompt {0} of {1}: {2}", index, total, text));
+		this._button.title = label;
+		this._button.setAttribute('aria-label', localize('promptTimeline.stickyLabel', "Go to prompt {0} of {1}: {2}", index, total, label));
 	}
 
 	setVisible(visible: boolean): void {

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineStickyHeader.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineStickyHeader.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $, addDisposableListener, append, EventType } from '../../../../base/browser/dom.js';
+import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { KeyCode } from '../../../../base/common/keyCodes.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { localize } from '../../../../nls.js';
+
+/**
+ * A flat, opaque header pinned to the top of the chat transcript, modelled on the editor's sticky
+ * scroll: it names the prompt currently scrolled off the top and, when activated, opens the prompt
+ * picker to jump elsewhere. Purely presentational — the owner drives its content and visibility.
+ */
+export class PromptTimelineStickyHeader extends Disposable {
+
+	private readonly _domNode: HTMLElement;
+	private readonly _button: HTMLButtonElement;
+	private readonly _label: HTMLElement;
+	private readonly _count: HTMLElement;
+
+	private readonly _onDidActivate = this._register(new Emitter<void>());
+	/** Fired when the header is clicked or activated by keyboard (opens the prompt picker). */
+	readonly onDidActivate: Event<void> = this._onDidActivate.event;
+
+	get domNode(): HTMLElement { return this._domNode; }
+
+	constructor(container: HTMLElement) {
+		super();
+		this._domNode = append(container, $('.prompt-timeline-sticky.hidden'));
+		this._button = append(this._domNode, $<HTMLButtonElement>('button.prompt-timeline-sticky-button'));
+		// The inner content is constrained to the transcript's message column (see promptTimeline.css)
+		// so the pinned prompt text lines up with the prompts scrolling underneath.
+		const content = append(this._button, $('.prompt-timeline-sticky-content'));
+		this._label = append(content, $('span.prompt-timeline-sticky-label'));
+		this._count = append(content, $('span.prompt-timeline-sticky-count'));
+		append(content, $(`span.prompt-timeline-sticky-chevron${ThemeIcon.asCSSSelector(Codicon.chevronDown)}`));
+
+		this._register(addDisposableListener(this._button, EventType.CLICK, () => this._onDidActivate.fire()));
+		this._register(addDisposableListener(this._button, EventType.KEY_DOWN, e => {
+			const event = new StandardKeyboardEvent(e);
+			if (event.keyCode === KeyCode.Enter || event.keyCode === KeyCode.Space) {
+				event.preventDefault();
+				this._onDidActivate.fire();
+			}
+		}));
+	}
+
+	/** Names the pinned prompt (1-based index within the visible prompts). */
+	update(text: string, index: number, total: number): void {
+		this._label.textContent = text;
+		this._count.textContent = localize('promptTimeline.stickyCount', "{0}/{1}", index, total);
+		this._button.title = text;
+		this._button.setAttribute('aria-label', localize('promptTimeline.stickyLabel', "Go to prompt {0} of {1}: {2}", index, total, text));
+	}
+
+	setVisible(visible: boolean): void {
+		this._domNode.classList.toggle('hidden', !visible);
+	}
+
+	override dispose(): void {
+		this._domNode.remove();
+		super.dispose();
+	}
+}

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
@@ -173,16 +173,16 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 			void this.commandService.executeCommand(PromptTimelineCommandId.GoToPrompt);
 		}));
 		this._enablement.add(autorun(reader => {
-			const ticks = model.ticks.read(reader);
-			const active = model.activeTick.read(reader);
+			// Drive the header from the unbucketed active prompt so the label and N/M position match
+			// the real prompt list (the rail's ticks are bucketed/capped and would misreport long chats).
+			const active = model.activePrompt.read(reader);
 			const pinned = model.activePinned.read(reader);
-			const index = active ? ticks.findIndex(t => t.requestId === active.requestId) : -1;
-			if (index >= 0) {
-				sticky.update(ticks[index].text, index + 1, ticks.length);
+			if (active) {
+				sticky.update(active.text, active.index, active.total);
 			}
 			// The header reveals once its prompt is pinned above the viewport; it is independent of the
 			// rail, so a narrow transcript (where the rail hides) still gets the header.
-			sticky.setVisible(pinned && index >= 0 && ticks.length >= MIN_PROMPTS);
+			sticky.setVisible(pinned && !!active && active.total >= MIN_PROMPTS);
 		}));
 	}
 

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
@@ -7,15 +7,17 @@ import { addDisposableListener, EventType, getWindow } from '../../../../base/br
 import { IMouseWheelEvent, StandardWheelEvent } from '../../../../base/browser/mouseEvent.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IChatWidget } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatWidgetContrib, ChatWidget } from '../../../../workbench/contrib/chat/browser/widget/chatWidget.js';
 import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/constants.js';
-import { MIN_PROMPTS, PROMPT_TIMELINE_CONTRIB_ID, PROMPT_TIMELINE_ENABLED_SETTING } from '../common/promptTimeline.js';
+import { MIN_PROMPTS, PromptTimelineCommandId, PROMPT_TIMELINE_CONTRIB_ID, PROMPT_TIMELINE_RAIL_SETTING, PROMPT_TIMELINE_STICKY_HEADER_SETTING } from '../common/promptTimeline.js';
 import { PromptTimelineModel, PromptEntry } from './promptTimelineModel.js';
 import { IPromptTimelineRail } from './promptTimelineRail.js';
 import { MIN_HOST_WIDTH, PromptTimelineRulerRail } from './promptTimelineRulerRail.js';
+import { PromptTimelineStickyHeader } from './promptTimelineStickyHeader.js';
 
 /** Normalized wheel distance (device-independent units, ~1 per notch) accumulated within {@link WHEEL_WINDOW_MS} to count as a hard/fast scroll. */
 const HARD_WHEEL_DISTANCE = 20;
@@ -23,10 +25,10 @@ const HARD_WHEEL_DISTANCE = 20;
 const WHEEL_WINDOW_MS = 120;
 
 /**
- * Per-widget contribution that overlays a prompt timeline rail on the chat
- * transcript and exposes a navigation API for keyboard-driven commands. The rail
- * exists only while `sessions.promptTimeline.enabled` is set, and is torn down
- * and re-created when the enablement changes.
+ * Per-widget contribution that overlays the prompt timeline on the chat transcript and exposes a
+ * navigation API for keyboard-driven commands. It shows the rail and/or the sticky header depending
+ * on `sessions.promptTimeline.rail` and `sessions.promptTimeline.stickyHeader`, and is torn down and
+ * re-created when either setting changes.
  */
 export class PromptTimelineWidgetContrib extends Disposable implements IChatWidgetContrib {
 
@@ -36,9 +38,8 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 	private _model: PromptTimelineModel | undefined;
 	private _rail: IPromptTimelineRail | undefined;
 
-	/** Holds the model, rail and all their wiring while the feature is enabled. */
+	/** Holds the model and every surface's wiring while at least one surface is enabled. */
 	private readonly _enablement = this._register(new DisposableStore());
-	private _enabled = false;
 	/** Latest tick count is at or above {@link MIN_PROMPTS}; combined with the host width to decide whether the rail replaces the native scrollbar. */
 	private _hasEnoughPrompts = false;
 
@@ -46,46 +47,81 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 		private readonly widget: IChatWidget,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super();
 
-		// The rail only makes sense for the main chat transcript location.
+		// The timeline only makes sense for the main chat transcript location.
 		if (widget.location !== ChatAgentLocation.Chat) {
 			return;
 		}
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(PROMPT_TIMELINE_ENABLED_SETTING)) {
-				this._updateRail();
+			if (e.affectsConfiguration(PROMPT_TIMELINE_RAIL_SETTING)
+				|| e.affectsConfiguration(PROMPT_TIMELINE_STICKY_HEADER_SETTING)) {
+				this._update();
 			}
 		}));
-		this._updateRail();
+		this._update();
 	}
 
-	/** Creates or disposes the rail to match the enablement setting. */
-	private _updateRail(): void {
-		const enabled = this.configurationService.getValue<boolean>(PROMPT_TIMELINE_ENABLED_SETTING) !== false;
-		if (enabled === this._enabled) {
-			return;
-		}
-		this._enabled = enabled;
+	/** (Re)builds the timeline to match the current settings, or tears it down if no surface is enabled. */
+	private _update(): void {
 		this._enablement.clear();
 		this._model = undefined;
 		this._rail = undefined;
 		this._hasEnoughPrompts = false;
-		if (enabled) {
-			this._createRail();
+		const railEnabled = this.configurationService.getValue<boolean>(PROMPT_TIMELINE_RAIL_SETTING) === true;
+		const stickyEnabled = this.configurationService.getValue<boolean>(PROMPT_TIMELINE_STICKY_HEADER_SETTING) === true;
+		if (railEnabled || stickyEnabled) {
+			this._createFeature(railEnabled, stickyEnabled);
 		}
 	}
 
-	private _createRail(): void {
+	/**
+	 * Builds the model shared by both surfaces, mounts the host anchor, then creates whichever surfaces
+	 * are enabled: the rail beside the transcript and/or the sticky header at the top. Each is
+	 * independently toggleable, so header-only and rail-only configurations both work.
+	 */
+	private _createFeature(railEnabled: boolean, stickyEnabled: boolean): void {
 		// CONTRIBS always constructs contribs with the concrete widget.
 		const model = this._enablement.add(this.instantiationService.createInstance(PromptTimelineModel, this.widget as ChatWidget));
-		const rail: IPromptTimelineRail = this._enablement.add(new PromptTimelineRulerRail());
 		this._model = model;
-		this._rail = rail;
 
-		this._mountRail(rail);
+		// The host class provides the positioning context and layout variables both surfaces anchor to.
+		const host = this.widget.domNode;
+		host.classList.add('prompt-timeline-host');
+		this._enablement.add(toDisposable(() => host.classList.remove('prompt-timeline-host', 'prompt-timeline-active', 'prompt-timeline-with-rail')));
+
+		// Track the prompt count and host width so the native-scrollbar gate (rail only) stays current.
+		this._enablement.add(autorun(reader => {
+			this._hasEnoughPrompts = model.ticks.read(reader).length >= MIN_PROMPTS;
+			this._updateNativeScrollbarHidden();
+		}));
+		const ResizeObserverCtor = getWindow(host).ResizeObserver;
+		if (ResizeObserverCtor) {
+			const observer = new ResizeObserverCtor(() => {
+				this._rail?.setHostWidth(host.clientWidth);
+				this._updateNativeScrollbarHidden();
+			});
+			observer.observe(host);
+			this._enablement.add(toDisposable(() => observer.disconnect()));
+		}
+
+		if (railEnabled) {
+			this._createRail(model, host);
+		}
+		if (stickyEnabled) {
+			this._createStickyHeader(model);
+		}
+	}
+
+	private _createRail(model: PromptTimelineModel, host: HTMLElement): void {
+		const rail: IPromptTimelineRail = this._enablement.add(new PromptTimelineRulerRail());
+		this._rail = rail;
+		host.classList.add('prompt-timeline-with-rail');
+		host.appendChild(rail.domNode);
+		this._enablement.add(toDisposable(() => rail.domNode.remove()));
 
 		rail.setFilesProvider(tick => model.getRequestFiles(tick));
 		this._enablement.add(rail.onDidSelect(requestId => model.reveal(requestId)));
@@ -98,13 +134,17 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 		// transcript's ScrollableElement consumes the wheel mid-content (see `_registerHardWheelDetector`).
 		this._enablement.add(this._registerHardWheelDetector(rail));
 
+		// Keep the rail above the input part so it only spans the transcript.
+		const inputPart = this.widget.inputPart;
+		this._enablement.add(autorun(reader => {
+			rail.domNode.style.setProperty('--prompt-timeline-bottom', `${inputPart.height.read(reader)}px`);
+		}));
+
 		this._enablement.add(autorun(reader => {
 			const ticks = model.ticks.read(reader);
 			// Toggle visibility before rendering so the rail's fit measurement in
 			// setTicks runs against the displayed (non-zero height) element.
-			this._hasEnoughPrompts = ticks.length >= MIN_PROMPTS;
-			rail.domNode.classList.toggle('hidden', !this._hasEnoughPrompts);
-			this._updateNativeScrollbarHidden();
+			rail.domNode.classList.toggle('hidden', ticks.length < MIN_PROMPTS);
 			rail.setTicks(ticks);
 		}));
 
@@ -117,37 +157,33 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 			model.onDidChangeScrollLayout.read(reader);
 			rail.setScrollLayout(model.getScrollLayout());
 		}));
-	}
 
-	private _mountRail(rail: IPromptTimelineRail): void {
-		const railNode = rail.domNode;
-		const host = this.widget.domNode;
-		// Anchor the absolutely-positioned overlay to the chat widget via a class
-		// we own, removed on teardown so we never leave the foreign container mutated.
-		host.classList.add('prompt-timeline-host');
-		this._enablement.add(toDisposable(() => host.classList.remove('prompt-timeline-host', 'prompt-timeline-active')));
-		host.appendChild(railNode);
-		this._enablement.add(toDisposable(() => railNode.remove()));
-
-		// Keep the rail above the input part so it only spans the transcript.
-		const inputPart = this.widget.inputPart;
-		this._enablement.add(autorun(reader => {
-			railNode.style.setProperty('--prompt-timeline-bottom', `${inputPart.height.read(reader)}px`);
-		}));
-
-		// Report the host width so the rail can hide on very narrow transcripts, and keep the native
-		// scrollbar whenever the rail is too narrow to replace it.
-		const ResizeObserverCtor = getWindow(host).ResizeObserver;
-		if (ResizeObserverCtor) {
-			const observer = new ResizeObserverCtor(() => {
-				rail.setHostWidth(host.clientWidth);
-				this._updateNativeScrollbarHidden();
-			});
-			observer.observe(host);
-			this._enablement.add(toDisposable(() => observer.disconnect()));
-		}
 		rail.setHostWidth(host.clientWidth);
 		this._updateNativeScrollbarHidden();
+	}
+
+	/**
+	 * Mounts the flat sticky header that pins the current prompt to the top of the transcript. It shows
+	 * only once that prompt's row has scrolled above the viewport (via {@link PromptTimelineModel.activePinned})
+	 * and, when activated, opens the existing prompt picker so any prompt can be jumped to.
+	 */
+	private _createStickyHeader(model: PromptTimelineModel): void {
+		const sticky = this._enablement.add(new PromptTimelineStickyHeader(this.widget.domNode));
+		this._enablement.add(sticky.onDidActivate(() => {
+			void this.commandService.executeCommand(PromptTimelineCommandId.GoToPrompt);
+		}));
+		this._enablement.add(autorun(reader => {
+			const ticks = model.ticks.read(reader);
+			const active = model.activeTick.read(reader);
+			const pinned = model.activePinned.read(reader);
+			const index = active ? ticks.findIndex(t => t.requestId === active.requestId) : -1;
+			if (index >= 0) {
+				sticky.update(ticks[index].text, index + 1, ticks.length);
+			}
+			// The header reveals once its prompt is pinned above the viewport; it is independent of the
+			// rail, so a narrow transcript (where the rail hides) still gets the header.
+			sticky.setVisible(pinned && index >= 0 && ticks.length >= MIN_PROMPTS);
+		}));
 	}
 
 	/**
@@ -174,9 +210,9 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 		}, { capture: true, passive: true });
 	}
 
-	/** Hide the transcript's native scrollbar only while the rail is actually acting as it: enough prompts AND wide enough (below {@link MIN_HOST_WIDTH} the rail hides, so the native slider must stay). */
+	/** Hide the transcript's native scrollbar only while the rail is actually acting as it: rail shown, enough prompts AND wide enough (below {@link MIN_HOST_WIDTH} the rail hides, so the native slider must stay). */
 	private _updateNativeScrollbarHidden(): void {
-		const active = this._hasEnoughPrompts && this.widget.domNode.clientWidth >= MIN_HOST_WIDTH;
+		const active = !!this._rail && this._hasEnoughPrompts && this.widget.domNode.clientWidth >= MIN_HOST_WIDTH;
 		this.widget.domNode.classList.toggle('prompt-timeline-active', active);
 	}
 

--- a/src/vs/sessions/contrib/promptTimeline/common/promptTimeline.ts
+++ b/src/vs/sessions/contrib/promptTimeline/common/promptTimeline.ts
@@ -6,8 +6,11 @@
 /** Id of the per-widget contribution that owns the prompt timeline rail. */
 export const PROMPT_TIMELINE_CONTRIB_ID = 'sessions.promptTimeline';
 
-/** Setting that controls whether the prompt timeline rail is shown in the Agents window. */
-export const PROMPT_TIMELINE_ENABLED_SETTING = 'sessions.promptTimeline.enabled';
+/** Setting that controls whether the timeline rail (the scrollbar that fans into prompt pills) is shown. */
+export const PROMPT_TIMELINE_RAIL_SETTING = 'sessions.promptTimeline.rail';
+
+/** Setting that controls whether the sticky prompt header pins the current prompt while scrolling. */
+export const PROMPT_TIMELINE_STICKY_HEADER_SETTING = 'sessions.promptTimeline.stickyHeader';
 
 /** Minimum number of user prompts before the rail is shown. */
 export const MIN_PROMPTS = 2;


### PR DESCRIPTION
## Summary

Adds a **flat, opaque sticky prompt header** to the Agents window chat transcript, modelled on the editor's sticky scroll. While you scroll, it pins the current prompt to the top of the transcript, names it with an `N/M` position, and opens the "Go to Prompt..." picker when selected so you can jump anywhere.

Builds on the prompt timeline rail (#326023). The timeline is now split into **two independently toggleable surfaces**:

| Setting | Default | Surface |
| --- | --- | --- |
| `sessions.promptTimeline.rail` | `false` | The scrollbar that fans into prompt pills on scroll/hover |
| `sessions.promptTimeline.stickyHeader` | `false` | The sticky prompt header (this PR) |

Rail-only, header-only, both, or neither all work. Both settings are `experimental` and backed by the experimentation service (`experiment: { mode: 'startup' }`).

## What changed

- **New `PromptTimelineStickyHeader`** widget — a flat button band (label + `N/M` + chevron) that reuses the transcript surface tokens (`agentsPanel.background`/`border`, editor-sticky-scroll–style hairline border + soft shadow). Its inner content is constrained to the transcript's message column so the pinned prompt lines up with the prompts scrolling underneath.
- **Model**: added `activeTick` and `activePinned` observables. `activePinned` becomes true once the active prompt's own row scrolls above the viewport top, driving the header's reveal.
- **Contribution**: removed the single `sessions.promptTimeline.enabled` setting in favour of the two per-surface settings. The widget contrib builds the shared model + host only when at least one surface is enabled, then mounts each surface independently.
- **Click** opens the existing accessible `Go to Prompt...` quick pick (no new custom dropdown).
- Reduced-motion friendly (the slide/fade transitions collapse).

## Notes

- The former `sessions.promptTimeline.enabled` key is removed; anyone who had it set opts back in via the two new settings. Since the feature is experimental and recently merged, this seemed preferable to keeping a deprecated alias — happy to add one if preferred.
- The rail's content-reservation padding and native-scrollbar hiding are now gated on a `prompt-timeline-with-rail` host class, so header-only mode keeps the base transcript layout.

🤖 Generated with [Copilot CLI](https://github.com/features/copilot)
