### PR TITLE
Check Agent Host dynamic dependencies

### DIFF
--- a/build/lib/test/agentHostDependencies.test.ts
+++ b/build/lib/test/agentHostDependencies.test.ts
@@ -15,6 +15,18 @@ const agentHostEntryPoints = [
 	'src/vs/platform/agentHost/node/agentHostMain.ts',
 	'src/vs/platform/agentHost/node/agentHostServerMain.ts',
 ];
+const excludedLiteralDynamicImports = new Set([
+	// Test-only provider loaded by the standalone server's --enable-mock-agent option.
+	literalDynamicImportKey(
+		path.join(repositoryRoot, 'src/vs/platform/agentHost/node/agentHostServerMain.ts'),
+		'../test/node/mockAgent.js'
+	),
+	// Built products use the downloaded SDK path; the bare package import is a dev fallback.
+	literalDynamicImportKey(
+		path.join(repositoryRoot, 'src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts'),
+		'@anthropic-ai/claude-agent-sdk'
+	),
+]);
 
 suite('Agent Host dependencies', () => {
 	test('runtime packages are included in the remote server', () => {
@@ -35,6 +47,40 @@ suite('Agent Host dependencies', () => {
 			.sort();
 
 		assert.deepStrictEqual(missingDependencies, []);
+	});
+
+	test('collects literal dynamic imports with narrow exclusions', () => {
+		const regularSource = ts.createSourceFile(
+			path.join(repositoryRoot, 'src/regular.ts'),
+			`import('node-pty'); import(\`ws\`); import('node-addon-api', { with: { type: 'json' } }); import('../test/node/mockAgent.js'); import('@anthropic-ai/claude-agent-sdk'); import(variable);`,
+			ts.ScriptTarget.Latest,
+			true,
+			ts.ScriptKind.TS
+		);
+		const mockAgentServerSource = ts.createSourceFile(
+			path.join(repositoryRoot, 'src/vs/platform/agentHost/node/agentHostServerMain.ts'),
+			`import('../test/node/mockAgent.js'); import('node-pty');`,
+			ts.ScriptTarget.Latest,
+			true,
+			ts.ScriptKind.TS
+		);
+		const claudeSdkServiceSource = ts.createSourceFile(
+			path.join(repositoryRoot, 'src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts'),
+			`import('@anthropic-ai/claude-agent-sdk'); import('node-pty');`,
+			ts.ScriptTarget.Latest,
+			true,
+			ts.ScriptKind.TS
+		);
+
+		assert.deepStrictEqual({
+			regular: getRuntimeModuleSpecifiers(regularSource),
+			mockAgentServer: getRuntimeModuleSpecifiers(mockAgentServerSource),
+			claudeSdkService: getRuntimeModuleSpecifiers(claudeSdkServiceSource),
+		}, {
+			regular: ['node-pty', 'ws', 'node-addon-api', '../test/node/mockAgent.js', '@anthropic-ai/claude-agent-sdk'],
+			mockAgentServer: ['node-pty'],
+			claudeSdkService: ['node-pty'],
+		});
 	});
 });
 
@@ -89,14 +135,24 @@ function getRuntimeModuleSpecifiers(sourceFile: ts.SourceFile): string[] {
 	}
 
 	const visit = (node: ts.Node): void => {
-		if (
-			ts.isCallExpression(node)
-			&& ts.isIdentifier(node.expression)
-			&& (node.expression.text === 'require' || node.expression.text === 'nativeRequire')
-			&& node.arguments.length === 1
-			&& ts.isStringLiteral(node.arguments[0])
-		) {
-			moduleSpecifiers.push(node.arguments[0].text);
+		if (ts.isCallExpression(node)) {
+			if (
+				node.expression.kind === ts.SyntaxKind.ImportKeyword
+				&& node.arguments.length > 0
+				&& ts.isStringLiteralLike(node.arguments[0])
+			) {
+				const moduleSpecifier = node.arguments[0].text;
+				if (!excludedLiteralDynamicImports.has(literalDynamicImportKey(sourceFile.fileName, moduleSpecifier))) {
+					moduleSpecifiers.push(moduleSpecifier);
+				}
+			} else if (
+				ts.isIdentifier(node.expression)
+				&& (node.expression.text === 'require' || node.expression.text === 'nativeRequire')
+				&& node.arguments.length === 1
+				&& ts.isStringLiteralLike(node.arguments[0])
+			) {
+				moduleSpecifiers.push(node.arguments[0].text);
+			}
 		}
 		ts.forEachChild(node, visit);
 	};
@@ -133,4 +189,8 @@ function resolveSourceImport(importer: string, moduleSpecifier: string): string 
 function getPackageName(moduleSpecifier: string): string {
 	const segments = moduleSpecifier.split('/');
 	return moduleSpecifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+}
+
+function literalDynamicImportKey(importer: string, moduleSpecifier: string): string {
+	return `${path.relative(repositoryRoot, importer)}\0${moduleSpecifier}`;
 }


### PR DESCRIPTION
Follow-up to #326019.

## Summary

- include statically named dynamic `import(...)` calls in the remote Agent Host dependency graph
- support string literals, no-substitution template literals, and import attributes
- narrowly exclude the standalone server mock-agent branch and the dev-only Claude SDK bare-import fallback by importer and specifier
- add focused coverage proving the exclusions do not become specifier-wide

## Testing

- `cd build && npm run typecheck`
- `cd build && npm test` (229 passing)
- `npm run precommit`
- verified the guard fails specifically on `node-pty` when that lazy dependency is removed from `remote/package.json`

(Written by Copilot)