### PR TITLE
Default editor and panel chat to Agent Host Copilot when the agent host is enabled

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/chat.runInTerminal.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/chat.runInTerminal.test.ts
@@ -176,7 +176,7 @@ function extractTextContent(result: vscode.LanguageModelToolResult): string {
 		};
 
 		try {
-			await vscode.commands.executeCommand('workbench.action.chat.newChat');
+			await vscode.commands.executeCommand('workbench.action.chat.newLocalChat');
 			if (opts.autoAcceptConfirmation) {
 				acceptConfirmationInterval = setInterval(() => void acceptPendingConfirmation(), 200);
 			}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/chat.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/chat.test.ts
@@ -59,9 +59,12 @@ suite('chat', () => {
 		return emitter.event;
 	}
 
+	// Chat participants are a Local-harness feature, but the panel defaults to
+	// Agent Host Copilot when the agent host is enabled. `newLocalChat` opens the
+	// view directly into a Local session (from cold), so these tests run it first.
 	test('participant and slash command history', async () => {
 		const onRequest = setupParticipant();
-		await commands.executeCommand('workbench.action.chat.newChat');
+		await commands.executeCommand('workbench.action.chat.newLocalChat');
 		commands.executeCommand('workbench.action.chat.open', { query: '@participant /hello friend' });
 
 		const deferred = new DeferredPromise<void>();
@@ -103,6 +106,8 @@ suite('chat', () => {
 		};
 		disposables.push(participant);
 
+		// Participants are Local-only; open a Local chat first (see note above).
+		await commands.executeCommand('workbench.action.chat.newLocalChat');
 		commands.executeCommand('workbench.action.chat.open', { query: '@participant /hello friend' });
 		const result = await deferred.p;
 		assert.deepStrictEqual(result.metadata, { key: 'value' });
@@ -112,6 +117,8 @@ suite('chat', () => {
 		const onRequest = setupParticipant();
 		const onRequest2 = setupParticipant(true);
 
+		// Participants are Local-only; open a Local chat first (see note above).
+		await commands.executeCommand('workbench.action.chat.newLocalChat');
 		commands.executeCommand('workbench.action.chat.open', { query: '@participant hi' });
 		await asPromise(onRequest);
 
@@ -205,7 +212,8 @@ suite('chat', () => {
 		};
 		disposables.push(participant);
 
-		await commands.executeCommand('workbench.action.chat.newChat');
+		// Participants are Local-only; open a Local chat first (see note above).
+		await commands.executeCommand('workbench.action.chat.newLocalChat');
 		commands.executeCommand('workbench.action.chat.open', { query: '@participant /hello friend' });
 
 		// Wait for title provider to be called once

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -38,6 +38,7 @@ import { GitHubPaths, IDefaultAccountService } from '../../../../../platform/def
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspace, IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { ActiveEditorContext } from '../../../../common/contextkeys.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../../common/views.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
@@ -579,7 +580,7 @@ export function registerChatActions() {
 	 * honoring the remembered harness preference and then the configured default.
 	 */
 	function getNewChatEditorSessionUri(accessor: ServicesAccessor): URI {
-		return getDefaultNewChatSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService), accessor.get(IStorageService), accessor.get(IWorkspaceContextService).getWorkspace());
+		return getDefaultNewChatSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService), accessor.get(IStorageService), accessor.get(IWorkspaceContextService).getWorkspace(), accessor.get(IAgentHostEnablementService).enabled);
 	}
 
 	registerAction2(PrimaryOpenChatGlobalAction);
@@ -1777,6 +1778,13 @@ export async function clearChatSessionPreservingType(widget: IChatWidget, viewsS
 		if (isPreferCopilotHarnessSwap) {
 			markPreferredCopilotHarness(storageService);
 		}
+	} else if (isIChatViewViewContext(widget.viewContext) && sessionType === localChatSessionType) {
+		// Explicit "New Local Chat" in the sidebar: start a local session. A plain
+		// `widget.clear()` re-acquires the computed default, which is a non-local
+		// harness when the agent host is enabled, so the explicit local request
+		// would otherwise be lost.
+		const view = await viewsService.openView(ChatViewId) as ChatViewPane;
+		await view.startNewLocalSession();
 	} else {
 		// For the editor, clearChatEditor resolves and applies the new session type
 		// (including the one-time preferCopilotHarness swap) when clearing.

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -1769,26 +1769,30 @@ export async function clearChatSessionPreservingType(widget: IChatWidget, viewsS
 	const currentResource = widget.viewModel?.model.sessionResource;
 	const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
 	const { sessionType: newSessionType, isPreferCopilotHarnessSwap } = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, agentHostEnabled, { explicitOverride: sessionType, currentSessionType });
-	if (isIChatViewViewContext(widget.viewContext) && newSessionType !== localChatSessionType) {
-		// For the sidebar, we need to explicitly load a session with the same type
-		const newResource = URI.from({ scheme: newSessionType, path: `/untitled-${generateUuid()}` });
+	if (isIChatViewViewContext(widget.viewContext)) {
 		const view = await viewsService.openView(ChatViewId) as ChatViewPane;
-		await view.loadSession(newResource);
-		// Consume the one-time migration only now that the swap has been applied.
+		if (newSessionType !== localChatSessionType) {
+			// Load a session of the resolved type in the sidebar.
+			await view.loadSession(URI.from({ scheme: newSessionType, path: `/untitled-${generateUuid()}` }));
+			// Consume the one-time migration only now that the swap has been applied.
+			if (isPreferCopilotHarnessSwap) {
+				markPreferredCopilotHarness(storageService);
+			}
+		} else {
+			// The resolved type is local (an explicit request or session
+			// preservation). A plain `widget.clear()` re-acquires the computed
+			// default (a non-local harness when the agent host is enabled), so
+			// start a local session explicitly to honor the resolved type.
+			await view.startNewLocalSession();
+		}
+	} else {
+		// For the editor, thread the resolved type through the clear path so
+		// clearChatEditor opens a session of that type instead of recomputing
+		// the default (which would drop an explicit or preserved local request).
+		await widget.clear(newSessionType);
 		if (isPreferCopilotHarnessSwap) {
 			markPreferredCopilotHarness(storageService);
 		}
-	} else if (isIChatViewViewContext(widget.viewContext) && sessionType === localChatSessionType) {
-		// Explicit "New Local Chat" in the sidebar: start a local session. A plain
-		// `widget.clear()` re-acquires the computed default, which is a non-local
-		// harness when the agent host is enabled, so the explicit local request
-		// would otherwise be lost.
-		const view = await viewsService.openView(ChatViewId) as ChatViewPane;
-		await view.startNewLocalSession();
-	} else {
-		// For the editor, clearChatEditor resolves and applies the new session type
-		// (including the one-time preferCopilotHarness swap) when clearing.
-		await widget.clear();
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
@@ -11,15 +11,15 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
-import { IChatSessionsService } from '../../common/chatSessionsService.js';
+import { IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
 import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { getDefaultNewChatSessionResource, resolveDefaultNewChatSessionType } from '../../common/constants.js';
 import { markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
-import { getChatSessionType } from '../../common/model/chatUri.js';
+import { getChatSessionType, LocalChatSessionUri } from '../../common/model/chatUri.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
 
-export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInput?: ChatEditorInput): Promise<void> {
+export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInput?: ChatEditorInput, targetSessionType?: string): Promise<void> {
 	const editorService = accessor.get(IEditorService);
 	const configurationService = accessor.get(IConfigurationService);
 	const chatSessionsService = accessor.get(IChatSessionsService);
@@ -33,22 +33,31 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 	}
 
 	if (chatEditorInput instanceof ChatEditorInput) {
-		const currentResource = chatEditorInput.sessionResource;
 		let resource: URI;
-		if (currentResource && currentResource.scheme !== Schemas.vscodeLocalChatSession) {
-			// Contributed/non-local session: keep the same type for the new session.
-			resource = currentResource.with({ path: `/untitled-${generateUuid()}` });
+		if (targetSessionType !== undefined) {
+			// The caller already resolved the target type (honoring an explicit
+			// request, session preservation, or the preferCopilotHarness swap and
+			// its marker); apply it directly instead of recomputing the default.
+			resource = targetSessionType === localChatSessionType
+				? LocalChatSessionUri.getNewSessionUri()
+				: URI.from({ scheme: targetSessionType, path: `/untitled-${generateUuid()}` });
 		} else {
-			// Local (or brand-new) session. Honor the one-time preferCopilotHarness
-			// swap, consuming the migration marker only here where it is applied.
-			// Otherwise fall back to the computed default.
-			const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
-			const resolved = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled, { currentSessionType });
-			if (resolved.isPreferCopilotHarnessSwap) {
-				markPreferredCopilotHarness(storageService);
-				resource = URI.from({ scheme: resolved.sessionType, path: `/untitled-${generateUuid()}` });
+			const currentResource = chatEditorInput.sessionResource;
+			if (currentResource && currentResource.scheme !== Schemas.vscodeLocalChatSession) {
+				// Contributed/non-local session: keep the same type for the new session.
+				resource = currentResource.with({ path: `/untitled-${generateUuid()}` });
 			} else {
-				resource = getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled);
+				// Local (or brand-new) session. Honor the one-time preferCopilotHarness
+				// swap, consuming the migration marker only here where it is applied.
+				// Otherwise fall back to the computed default.
+				const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
+				const resolved = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled, { currentSessionType });
+				if (resolved.isPreferCopilotHarnessSwap) {
+					markPreferredCopilotHarness(storageService);
+					resource = URI.from({ scheme: resolved.sessionType, path: `/untitled-${generateUuid()}` });
+				} else {
+					resource = getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled);
+				}
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
@@ -10,9 +10,9 @@ import { ServicesAccessor } from '../../../../../platform/instantiation/common/i
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
-import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IChatSessionsService } from '../../common/chatSessionsService.js';
+import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { getDefaultNewChatSessionResource, resolveDefaultNewChatSessionType } from '../../common/constants.js';
 import { markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
@@ -48,7 +48,7 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 				markPreferredCopilotHarness(storageService);
 				resource = URI.from({ scheme: resolved.sessionType, path: `/untitled-${generateUuid()}` });
 			} else {
-				resource = getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace());
+				resource = getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled);
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -912,7 +912,7 @@ class SendToNewChatAction extends Action2 {
 		const chatSessionsService = accessor.get(IChatSessionsService);
 		const storageService = accessor.get(IStorageService);
 		const workspaceContextService = accessor.get(IWorkspaceContextService);
-		const agentHostEnabled = accessor.get(IAgentHostEnablementService).enabled;
+		const agentHostEnablementService = accessor.get(IAgentHostEnablementService);
 		const widget = context?.widget ?? widgetService.lastFocusedWidget;
 		if (!widget) {
 			return;
@@ -934,7 +934,7 @@ class SendToNewChatAction extends Action2 {
 		// Clear the input from the current session before creating a new one
 		widget.setInput('');
 
-		await clearChatSessionPreservingType(widget, viewsService, undefined, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnabled);
+		await clearChatSessionPreservingType(widget, viewsService, undefined, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled);
 
 		widget.acceptInput(inputBeforeClear, { storeToHistory: true });
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
@@ -20,6 +20,7 @@ import { IChatEditingSession } from '../../common/editing/chatEditingService.js'
 import { IChatService } from '../../common/chatService/chatService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
 import { ChatViewId, IChatWidgetService } from '../chat.js';
+import { ChatViewPane } from '../widgetHosts/viewPane/chatViewPane.js';
 import { EditingSessionAction, EditingSessionActionContext, getEditingSessionContext } from '../chatEditing/chatEditingActions.js';
 import { ACTION_ID_NEW_CHAT, ACTION_ID_NEW_EDIT_SESSION, CHAT_CATEGORY, clearChatSessionPreservingType, handleCurrentEditingSession } from './chatActions.js';
 import { clearChatEditor } from './chatClear.js';
@@ -194,6 +195,19 @@ export function registerNewChatActions() {
 
 			// Context from toolbar or lastFocusedWidget
 			const context = getEditingSessionContext(accessor, args);
+
+			// When no chat widget is open yet, opening the view resolves the
+			// computed default provider (a non-local harness when the agent host
+			// is enabled). Open the view, then explicitly start a local session:
+			// `startNewLocalSession` cancels that in-flight default resolution so
+			// the local request is honored without waiting for the agent host.
+			if (!context?.chatWidget) {
+				const view = await accessor.get(IViewsService).openView(ChatViewId, true) as ChatViewPane | null;
+				await view?.startNewLocalSession();
+				view?.focusInput();
+				return;
+			}
+
 			await runNewChatAction(accessor, context, executeCommandContext, AgentSessionProviders.Local);
 		}
 	});
@@ -322,7 +336,7 @@ async function runNewChatAction(
 	const chatSessionsService = accessor.get(IChatSessionsService);
 	const storageService = accessor.get(IStorageService);
 	const workspaceContextService = accessor.get(IWorkspaceContextService);
-	const agentHostEnabled = accessor.get(IAgentHostEnablementService).enabled;
+	const agentHostEnablementService = accessor.get(IAgentHostEnablementService);
 
 	const { editingSession, chatWidget: widget } = context ?? {};
 	if (!widget) {
@@ -339,7 +353,7 @@ async function runNewChatAction(
 	await editingSession?.stop();
 
 	// Create a new session, preserving the session type (or using the specified one)
-	await clearChatSessionPreservingType(widget, viewsService, sessionType, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnabled);
+	await clearChatSessionPreservingType(widget, viewsService, sessionType, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled);
 
 	widget.attachmentModel.clear(true);
 	widget.focusInput();

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -252,8 +252,12 @@ export interface IChatWidgetViewOptions {
 	renderInputToolbarBelowInput?: boolean;
 	supportsFileReferences?: boolean;
 	filter?: (item: ChatTreeItem) => boolean;
-	/** Action triggered when 'clear' is called on the widget. */
-	clear?: () => Promise<void>;
+	/**
+	 * Action triggered when 'clear' is called on the widget. The optional
+	 * `targetSessionType` carries the already-resolved new session type so the
+	 * host can open a session of that type instead of recomputing the default.
+	 */
+	clear?: (targetSessionType?: string) => Promise<void>;
 	rendererOptions?: IChatListItemRendererOptions;
 	menus?: {
 		/**
@@ -452,7 +456,7 @@ export interface IChatWidget {
 	getCodeBlockInfosForResponse(response: IChatResponseViewModel): IChatCodeBlockInfo[];
 	getFileTreeInfosForResponse(response: IChatResponseViewModel): IChatFileTreeInfo[];
 	getLastFocusedFileTreeForResponse(response: IChatResponseViewModel): IChatFileTreeInfo | undefined;
-	clear(): Promise<void>;
+	clear(targetSessionType?: string): Promise<void>;
 	getViewState(): IChatModelInputState | undefined;
 	lockToCodingAgent(name: string, displayName: string, agentId?: string, agentHostProviderId?: string): void;
 	unlockFromCodingAgent(): void;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1009,7 +1009,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		return responseItems[indexToFocus];
 	}
 
-	async clear(): Promise<void> {
+	async clear(targetSessionType?: string): Promise<void> {
 		this.logService.debug('ChatWidget#clear');
 		if (this._dynamicMessageLayoutData) {
 			this._dynamicMessageLayoutData.enabled = true;
@@ -1031,7 +1031,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.inputPart?.clearTodoListWidget(this.viewModel?.sessionResource, true);
 		this.inputPart?.clearArtifactsWidget();
 		this.chatSuggestNextWidget.hide();
-		await this.viewOptions.clear?.();
+		await this.viewOptions.clear?.(targetSessionType);
 	}
 
 	private onDidChangeItems(skipDynamicLayout?: boolean) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
@@ -19,6 +19,7 @@ import { IOpenerService } from '../../../../../../platform/opener/common/opener.
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../common/languageModels.js';
@@ -52,9 +53,10 @@ export class DelegationSessionPickerActionItem extends SessionTypePickerActionIt
 		@IConfigurationService configurationService: IConfigurationService,
 		@IStorageService storageService: IStorageService,
 		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
+		@IAgentHostEnablementService agentHostEnablementService: IAgentHostEnablementService,
 		@IGitService private readonly gitService: IGitService,
 	) {
-		super(action, chatSessionPosition, delegate, pickerOptions, actionWidgetService, keybindingService, contextKeyService, chatSessionsService, commandService, openerService, telemetryService, chatEntitlementService, languageModelsService, configurationService, storageService, workspaceContextService);
+		super(action, chatSessionPosition, delegate, pickerOptions, actionWidgetService, keybindingService, contextKeyService, chatSessionsService, commandService, openerService, telemetryService, chatEntitlementService, languageModelsService, configurationService, storageService, workspaceContextService, agentHostEnablementService);
 	}
 
 	protected override _run(sessionTypeItem: ISessionTypeItem): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -23,6 +23,7 @@ import { IOpenerService } from '../../../../../../platform/opener/common/opener.
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
@@ -104,6 +105,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 		@IConfigurationService protected readonly configurationService: IConfigurationService,
 		@IStorageService protected readonly storageService: IStorageService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@IAgentHostEnablementService private readonly agentHostEnablementService: IAgentHostEnablementService,
 	) {
 
 		const actionProvider: IActionWidgetDropdownActionProvider = {
@@ -169,7 +171,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 
 	protected _run(sessionTypeItem: ISessionTypeItem): void {
 		if (!this._isSessionsWindow) {
-			recordUserSelectedSessionType(this.storageService, this.configurationService, this.chatSessionsService, this.workspaceContextService.getWorkspace(), sessionTypeItem.type);
+			recordUserSelectedSessionType(this.storageService, this.configurationService, this.chatSessionsService, this.workspaceContextService.getWorkspace(), sessionTypeItem.type, this.agentHostEnablementService.enabled);
 		}
 
 		if (this.delegate.setActiveSessionProvider) {
@@ -263,12 +265,11 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 
 	/**
 	 * The default session type for the picker when no session is yet active.
-	 * Defaults to {@link AgentSessionProviders.Local} but is overridden based on
-	 * the experimental {@link ChatConfiguration.EditorPreferCopilotHarness} setting
-	 * when the selected provider is registered.
+	 * Defaults to Agent Host Copilot when the agent host is enabled, otherwise
+	 * {@link AgentSessionProviders.Local}.
 	 */
 	protected _getDefaultSessionType(): AgentSessionTarget {
-		return getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService, this.workspaceContextService.getWorkspace()) as AgentSessionTarget;
+		return getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService, this.workspaceContextService.getWorkspace(), this.agentHostEnablementService.enabled) as AgentSessionTarget;
 	}
 
 	protected _isVisible(type: AgentSessionTarget): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
@@ -93,9 +93,9 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 		super(ChatEditorInput.EditorID, group, ChatEditor.VIEW_STATE_KEY, telemetryService, instantiationService, storageService, textResourceConfigurationService, themeService, editorService, editorGroupService);
 	}
 
-	private async clear() {
+	private async clear(targetSessionType?: string) {
 		if (this.input) {
-			return this.instantiationService.invokeFunction(clearChatEditor, this.input as ChatEditorInput);
+			return this.instantiationService.invokeFunction(clearChatEditor, this.input as ChatEditorInput, targetSessionType);
 		}
 	}
 
@@ -116,7 +116,7 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 					autoScroll: mode => mode !== ChatModeKind.Ask,
 					renderFollowups: true,
 					supportsFileReferences: true,
-					clear: () => this.clear(),
+					clear: (targetSessionType?: string) => this.clear(targetSessionType),
 					rendererOptions: {
 						renderTextEditsAsSummary: (uri) => {
 							return true;

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
@@ -20,11 +20,12 @@ import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { registerIcon } from '../../../../../../platform/theme/common/iconRegistry.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { EditorInputCapabilities, IEditorIdentifier, IEditorSerializer, IUntypedEditorInput, Verbosity } from '../../../../../common/editor.js';
 import { EditorInput, IEditorCloseHandler } from '../../../../../common/editor/editorInput.js';
 import { IChatModelReference, IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
-import { ChatAgentLocation, ChatEditorTitleMaxLength, getComputedDefaultSessionResource, getComputedDefaultSessionType, getDefaultNewChatSessionResource } from '../../../common/constants.js';
+import { ChatAgentLocation, ChatEditorTitleMaxLength, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../../common/constants.js';
 import { IChatEditingSession, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
 import { IChatModel } from '../../../common/model/chatModel.js';
 import { LocalChatSessionUri, getChatSessionType, isUntitledChatSession } from '../../../common/model/chatUri.js';
@@ -71,6 +72,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		@IStorageService private readonly storageService: IStorageService,
 		@ILogService private readonly logService: ILogService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@IAgentHostEnablementService private readonly agentHostEnablementService: IAgentHostEnablementService,
 	) {
 		super();
 
@@ -234,7 +236,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			}
 
 			if (this.shouldReplaceEmptyLocalSession(this._sessionResource)) {
-				const defaultResource = getComputedDefaultSessionResource(this.configurationService, this.chatSessionsService, this.workspaceContextService.getWorkspace());
+				const defaultResource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService, this.workspaceContextService.getWorkspace(), this.agentHostEnablementService.enabled);
 				if (getChatSessionType(defaultResource) !== localChatSessionType) {
 					let modelRef: IChatModelReference | undefined;
 					try {
@@ -259,7 +261,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			if (this.options.explicitSessionType === localChatSessionType) {
 				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveExplicitLocal' });
 			} else {
-				const defaultResource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService, this.workspaceContextService.getWorkspace());
+				const defaultResource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService, this.workspaceContextService.getWorkspace(), this.agentHostEnablementService.enabled);
 				if (getChatSessionType(defaultResource) === localChatSessionType) {
 					this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveUntitled' });
 				} else {
@@ -304,7 +306,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			&& this.options.explicitSessionType !== localChatSessionType
 			&& !!this.model
 			&& !this.model.hasRequests
-			&& getComputedDefaultSessionType(this.configurationService, this.chatSessionsService, this.workspaceContextService.getWorkspace()) !== localChatSessionType;
+			&& getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService, this.workspaceContextService.getWorkspace(), this.agentHostEnablementService.enabled) !== localChatSessionType;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -10,6 +10,7 @@ import { Button } from '../../../../../../base/browser/ui/button/button.js';
 import { Orientation, Sash } from '../../../../../../base/browser/ui/sash/sash.js';
 import { DomScrollableElement } from '../../../../../../base/browser/ui/scrollbar/scrollableElement.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
+import { isCancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { MutableDisposable, toDisposable, DisposableStore, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { MarshalledId } from '../../../../../../base/common/marshallingIds.js';
@@ -51,7 +52,7 @@ import { CHAT_PROVIDER_ID } from '../../../common/participants/chatParticipantCo
 import { IChatModelReference, IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { LocalChatSessionUri, getChatSessionType } from '../../../common/model/chatUri.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getComputedDefaultSessionType, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../../common/constants.js';
 import { AgentSessionsControl } from '../../agentSessions/agentSessionsControl.js';
 import { ACTION_ID_NEW_CHAT } from '../../actions/chatActions.js';
 import { ChatWidget } from '../../widget/chatWidget.js';
@@ -65,6 +66,7 @@ import { IActivityService, ProgressBadge } from '../../../../../services/activit
 import { disposableTimeout } from '../../../../../../base/common/async.js';
 import { AgentSessionsFilter, AgentSessionsGrouping } from '../../agentSessions/agentSessionsFilter.js';
 import { IAgentSessionsService } from '../../agentSessions/agentSessionsService.js';
+import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { HoverPosition } from '../../../../../../base/browser/ui/hover/hoverWidget.js';
 import { IAgentSession } from '../../agentSessions/agentSessionsModel.js';
 import { ChatEntitlementContextKeys, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
@@ -108,6 +110,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 	private restoringSession: Promise<void> | undefined;
 	private readonly loadSessionCts = this._register(new MutableDisposable<CancellationTokenSource>());
+	private readonly _applyModelCts = this._register(new MutableDisposable<CancellationTokenSource>());
 	/** While > 0 the sessions list is suppressed so a session transition's transiently-empty widget does not reveal it (see {@link beginSessionsListSuppression}). */
 	private _sessionsListSuppressionCount = 0;
 	private readonly modelRef = this._register(new MutableDisposable<IChatModelReference>());
@@ -149,6 +152,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		@IVoicePlaybackService _voicePlaybackService: IVoicePlaybackService,
 		@IWorkbenchEnvironmentService _workbenchEnvironmentService: IWorkbenchEnvironmentService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@IAgentHostEnablementService private readonly agentHostEnablementService: IAgentHostEnablementService,
 	) {
 		super(options, keybindingService2, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 
@@ -1043,41 +1047,61 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	//#region Model Management
 
 	private applyModel(): void {
-		this.restoringSession = this._applyModel();
+		// Make the initial session resolution cancelable so an explicit request
+		// (e.g. New Local Chat via `startNewLocalSession`) can preempt a slow /
+		// blocking default-provider resolution instead of waiting for it.
+		const cts = this._applyModelCts.value = new CancellationTokenSource();
+		this.restoringSession = this._applyModel(cts.token).catch(err => {
+			if (!isCancellationError(err)) {
+				this.logService.error('ChatViewPane#applyModel failed', err);
+			}
+		});
 		this.restoringSession.finally(() => this.restoringSession = undefined);
 	}
 
-	private async _applyModel(): Promise<void> {
-		const modelRef = await this.acquireTransferredOrPersistedSession(CancellationToken.None, 'ChatViewPane#applyModel');
-		await this.showModel(CancellationToken.None, modelRef, true, !modelRef);
+	private async _applyModel(token: CancellationToken): Promise<void> {
+		const modelRef = await this.acquireTransferredOrPersistedSession(token, 'ChatViewPane#applyModel');
+		await this.showModel(token, modelRef, true, !modelRef);
 	}
 
 	/**
 	 * Force-start a new local chat session in the view, bypassing the
 	 * default-provider override applied by `showModel()`. Used by the
-	 * picker when the user explicitly selects "Local".
+	 * picker when the user explicitly selects "Local", and by New Local Chat.
 	 */
 	async startNewLocalSession(): Promise<IChatModel | undefined> {
+		// Preempt any in-flight initial session resolution (e.g. the computed
+		// default provider). Without this, opening the view kicks off a default
+		// resolution that, when the default is a non-local harness, blocks on
+		// agent host activation; canceling it lets this explicit local request
+		// win immediately.
+		this._applyModelCts.value?.cancel();
 		const ref = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { debugOwner: 'ChatViewPane#startNewLocalSession' });
 		return this.showModel(CancellationToken.None, ref);
 	}
 
 	/**
-	 * When the computed default session type is a provider other than local,
-	 * acquire a new session for it instead of the built-in local provider.
-	 * Returns `undefined` to fall back to `startNewLocalSession` (including when
-	 * acquisition of the non-local provider fails).
+	 * When the remembered or computed default session type is a non-local
+	 * provider (for example when the agent host is enabled), return a new session
+	 * reference for it instead of the built-in local provider. Returns
+	 * `undefined` to fall back to `startNewLocalSession`.
 	 */
 	private async acquireDefaultNewSession(token: CancellationToken): Promise<IChatModelReference | undefined> {
 		const workspace = this.workspaceContextService.getWorkspace();
-		const defaultType = getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService, workspace);
+		const defaultType = getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService, workspace, this.agentHostEnablementService.enabled);
 		if (defaultType === localChatSessionType) {
 			return undefined;
 		}
-		const resource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService, workspace);
+		const resource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService, workspace, this.agentHostEnablementService.enabled);
 		try {
 			return await this.chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, token, 'ChatViewPane#acquireDefaultNewSession');
 		} catch (error) {
+			// A cancellation means the caller (e.g. `startNewLocalSession`)
+			// deliberately preempted this resolution; propagate it so the
+			// initial `applyModel` bails instead of creating a fallback session.
+			if (isCancellationError(error)) {
+				throw error;
+			}
 			this.logService.warn(`[ChatViewPane] Failed to acquire default agent-host session, falling back to local`, error);
 			return undefined;
 		}
@@ -1104,7 +1128,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 	private shouldSkipRestoredLocalSession(sessionResource: URI, model: IChatModel): boolean {
 		const workspace = this.workspaceContextService.getWorkspace();
-		const defaultType = getComputedDefaultSessionType(this.configurationService, this.chatSessionsService, workspace);
+		const defaultType = getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService, workspace, this.agentHostEnablementService.enabled);
 		return defaultType !== localChatSessionType
 			&& getChatSessionType(sessionResource) === localChatSessionType
 			&& !model.hasRequests;

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -1050,6 +1050,10 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		// Make the initial session resolution cancelable so an explicit request
 		// (e.g. New Local Chat via `startNewLocalSession`) can preempt a slow /
 		// blocking default-provider resolution instead of waiting for it.
+		// Cancel any previous in-flight resolution first: assigning to the
+		// MutableDisposable only disposes the old source, and disposing a
+		// CancellationTokenSource does not cancel it.
+		this._applyModelCts.value?.cancel();
 		const cts = this._applyModelCts.value = new CancellationTokenSource();
 		this.restoringSession = this._applyModel(cts.token).catch(err => {
 			if (!isCancellationError(err)) {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DeferredPromise, raceTimeout } from '../../../../../base/common/async.js';
+import { DeferredPromise, raceCancellationError, raceTimeout } from '../../../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { IStringDictionary } from '../../../../../base/common/collections.js';
 import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
@@ -649,7 +649,7 @@ export class ChatService extends Disposable implements IChatService {
 			}
 		}
 
-		if (!await this.chatSessionService.canResolveChatSession(getChatSessionType(sessionResource))) {
+		if (!await raceCancellationError(this.chatSessionService.canResolveChatSession(getChatSessionType(sessionResource)), token)) {
 			return undefined;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -263,14 +263,21 @@ export function isSupportedChatFileScheme(accessor: ServicesAccessor, scheme: st
  * Returns the effective default session type for a new chat in the VS Code
  * editor window.
  *
- * Falls back to {@link localChatSessionType} when local is enabled, or to the
+ * When the agent host is enabled, Agent Host Copilot CLI is the default so that
+ * first-time users land on Copilot instead of the local harness. Otherwise it
+ * falls back to {@link localChatSessionType} when local is enabled, or to the
  * first visible non-local provider.
  */
 export function getComputedDefaultSessionType(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
-	workspace: IWorkspace
+	workspace: IWorkspace,
+	agentHostEnabled: boolean
 ): string {
+	if (agentHostEnabled) {
+		return SessionType.AgentHostCopilot;
+	}
+
 	if (isEditorLocalAgentEnabled(configurationService, workspace)) {
 		return localChatSessionType;
 	}
@@ -281,9 +288,10 @@ export function getComputedDefaultSessionType(
 export function getComputedDefaultSessionResource(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
-	workspace: IWorkspace
+	workspace: IWorkspace,
+	agentHostEnabled: boolean
 ): URI {
-	const defaultType = getComputedDefaultSessionType(configurationService, chatSessionsService, workspace);
+	const defaultType = getComputedDefaultSessionType(configurationService, chatSessionsService, workspace, agentHostEnabled);
 	return defaultType === localChatSessionType
 		? LocalChatSessionUri.getNewSessionUri()
 		: URI.from({ scheme: defaultType, path: `/untitled-${generateUuid()}` });
@@ -326,6 +334,7 @@ export function getDefaultNewChatSessionType(
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
 	storageService: IStorageService,
 	workspace: IWorkspace,
+	agentHostEnabled: boolean,
 	options?: IDefaultNewChatSessionTypeOptions
 ): string {
 	if (options?.explicitOverride) {
@@ -341,7 +350,7 @@ export function getDefaultNewChatSessionType(
 		return options.currentSessionType;
 	}
 
-	return getComputedDefaultSessionType(configurationService, chatSessionsService, workspace);
+	return getComputedDefaultSessionType(configurationService, chatSessionsService, workspace, agentHostEnabled);
 }
 
 export function resolveDefaultNewChatSessionType(
@@ -375,7 +384,7 @@ export function resolveDefaultNewChatSessionType(
 		return { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true };
 	}
 
-	return { sessionType: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, options), isPreferCopilotHarnessSwap: false };
+	return { sessionType: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, agentHostEnabled, options), isPreferCopilotHarnessSwap: false };
 }
 
 function getUsableRememberedSessionType(
@@ -393,9 +402,10 @@ export function getDefaultNewChatSessionResource(
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
 	storageService: IStorageService,
 	workspace: IWorkspace,
+	agentHostEnabled: boolean,
 	options?: IDefaultNewChatSessionTypeOptions
 ): URI {
-	const defaultType = getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, options);
+	const defaultType = getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, agentHostEnabled, options);
 	return defaultType === localChatSessionType
 		? LocalChatSessionUri.getNewSessionUri()
 		: URI.from({ scheme: defaultType, path: `/untitled-${generateUuid()}` });
@@ -406,9 +416,10 @@ export function recordUserSelectedSessionType(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
 	workspace: IWorkspace,
-	sessionType: string
+	sessionType: string,
+	agentHostEnabled: boolean
 ): void {
-	if (sessionType === getComputedDefaultSessionType(configurationService, chatSessionsService, workspace)) {
+	if (sessionType === getComputedDefaultSessionType(configurationService, chatSessionsService, workspace, agentHostEnabled)) {
 		clearUserSelectedSessionType(storageService);
 	} else {
 		storeUserSelectedSessionType(storageService, sessionType);

--- a/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
@@ -13,6 +13,7 @@ import { IInstantiationService } from '../../../../../../../platform/instantiati
 import { NullLogService } from '../../../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../../../platform/storage/common/storage.js';
 import { ChatEditorInput } from '../../../../browser/widgetHosts/editor/chatEditorInput.js';
+import { IAgentHostEnablementService } from '../../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IChatService, IChatSessionStartOptions } from '../../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../../common/chatSessionsService.js';
 import { ChatAgentLocation } from '../../../../common/constants.js';
@@ -56,6 +57,7 @@ suite('ChatEditorInput', () => {
 			{} as IStorageService,
 			new NullLogService(),
 			new TestContextService(),
+			{ enabled: false } as IAgentHostEnablementService,
 		);
 
 		try {
@@ -110,6 +112,7 @@ suite('ChatEditorInput', () => {
 			{} as IStorageService,
 			new NullLogService(),
 			new TestContextService(),
+			{ enabled: false } as IAgentHostEnablementService,
 		);
 
 		try {

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -8,11 +8,12 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IWorkspace, toWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
-import { ChatConfiguration, getComputedDefaultSessionType, getDefaultNewChatSessionType, isEditorLocalAgentEnabled, isRememberedSessionTypeUsable, isVisibleEditorChatSessionType, recordUserSelectedSessionType, resolveDefaultNewChatSessionType } from '../../common/constants.js';
+import { ChatConfiguration, getComputedDefaultSessionResource, getComputedDefaultSessionType, getDefaultNewChatSessionResource, getDefaultNewChatSessionType, isEditorLocalAgentEnabled, isRememberedSessionTypeUsable, isVisibleEditorChatSessionType, recordUserSelectedSessionType, resolveDefaultNewChatSessionType } from '../../common/constants.js';
 import { localChatSessionType, SessionType, IChatSessionsExtensionPoint } from '../../common/chatSessionsService.js';
 import { MockChatSessionsService } from './mockChatSessionsService.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
 import { getRememberedSessionType, hasPreferredCopilotHarness, markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
+import { getChatSessionType } from '../../common/model/chatUri.js';
 
 suite('ChatConfiguration defaults', () => {
 
@@ -37,14 +38,14 @@ suite('ChatConfiguration defaults', () => {
 		return service;
 	}
 
-	test('editor default returns local when local is enabled', () => {
+	test('editor default returns local when agent host disabled and local enabled', () => {
 		const configurationService = new TestConfigurationService();
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace, false),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false),
 			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
 		}, {
 			computed: localChatSessionType,
@@ -53,21 +54,37 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('preferCopilotHarness does not change the computed default or local visibility', () => {
-		const configurationService = new TestConfigurationService({
-			[ChatConfiguration.EditorPreferCopilotHarness]: true,
-		});
+	test('editor default prefers agent host Copilot when the agent host is enabled', () => {
+		const configurationService = new TestConfigurationService();
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace, true),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true),
 			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
 		}, {
-			computed: localChatSessionType,
-			rememberedAware: localChatSessionType,
+			computed: SessionType.AgentHostCopilot,
+			rememberedAware: SessionType.AgentHostCopilot,
 			localVisible: true,
+		});
+	});
+
+	test('editor default keeps agent host Copilot before contribution registers', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorLocalAgentEnabled]: false,
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.CopilotCLI);
+		const storageService = disposables.add(new TestStorageService());
+
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace, true),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
+		}, {
+			computed: SessionType.AgentHostCopilot,
+			rememberedAware: SessionType.AgentHostCopilot,
+			localVisible: false,
 		});
 	});
 
@@ -80,8 +97,8 @@ suite('ChatConfiguration defaults', () => {
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace, false),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false),
 			extensionHostVisible: isVisibleEditorChatSessionType(SessionType.CopilotCLI, configurationService, chatSessionsService, localWorkspace),
 		}, {
 			computed: SessionType.AgentHostCopilot,
@@ -90,7 +107,7 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('editor default keeps local as last resort when local is disabled without configured provider', () => {
+	test('editor default keeps local as last resort when local is disabled without any provider', () => {
 		const configurationService = new TestConfigurationService({
 			[ChatConfiguration.EditorLocalAgentEnabled]: false,
 		});
@@ -98,8 +115,8 @@ suite('ChatConfiguration defaults', () => {
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace, false),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false),
 			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
 		}, {
 			computed: localChatSessionType,
@@ -108,21 +125,19 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('remembered non-local selection wins over the one-time swap', () => {
-		const configurationService = new TestConfigurationService({
-			[ChatConfiguration.EditorPreferCopilotHarness]: true,
-		});
+	test('remembered non-local selection wins over the agent host default', () => {
+		const configurationService = new TestConfigurationService();
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude, true);
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace, true),
 			remembered: getRememberedSessionType(storageService),
 			rememberedAware: resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
 		}, {
-			computed: localChatSessionType,
+			computed: SessionType.AgentHostCopilot,
 			remembered: SessionType.AgentHostClaude,
 			rememberedAware: { sessionType: SessionType.AgentHostClaude, isPreferCopilotHarnessSwap: false },
 		});
@@ -133,11 +148,11 @@ suite('ChatConfiguration defaults', () => {
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude, false);
 
 		assert.deepStrictEqual({
 			remembered: getRememberedSessionType(storageService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, { explicitOverride: SessionType.AgentHostCopilot }),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { explicitOverride: SessionType.AgentHostCopilot }),
 		}, {
 			remembered: SessionType.AgentHostClaude,
 			rememberedAware: SessionType.AgentHostCopilot,
@@ -150,15 +165,15 @@ suite('ChatConfiguration defaults', () => {
 		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			withoutRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, { currentSessionType: SessionType.AgentHostCopilot }),
+			withoutRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { currentSessionType: SessionType.AgentHostCopilot }),
 		}, {
 			withoutRemembered: SessionType.AgentHostCopilot,
 		});
 
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude, false);
 
 		assert.deepStrictEqual({
-			withRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, { currentSessionType: SessionType.AgentHostCopilot }),
+			withRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { currentSessionType: SessionType.AgentHostCopilot }),
 		}, {
 			withRemembered: SessionType.AgentHostClaude,
 		});
@@ -171,33 +186,50 @@ suite('ChatConfiguration defaults', () => {
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
-		// Not swapped while the agent host is disabled.
-		const whileAgentHostDisabled = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { currentSessionType: localChatSessionType });
-
 		// Resolving does not consume the marker on its own: repeated resolves keep
 		// returning the swap until the caller applies it and marks it.
 		const firstResolve = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
 		const markerBeforeApply = hasPreferredCopilotHarness(storageService);
 		const secondResolveBeforeApply = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
 
-		// The caller applies the swap and marks it; further resolves stay local.
+		// The caller applies the swap and marks it; further resolves no longer swap.
 		markPreferredCopilotHarness(storageService);
 		const afterApply = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
 
 		assert.deepStrictEqual({
-			whileAgentHostDisabled,
 			firstResolve,
 			markerBeforeApply,
 			secondResolveBeforeApply,
 			afterApply,
 			markerAfterApply: hasPreferredCopilotHarness(storageService),
 		}, {
-			whileAgentHostDisabled: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
 			firstResolve: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
 			markerBeforeApply: false,
 			secondResolveBeforeApply: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
+			// After applying, the current local session is preserved (feature-2's
+			// computed default is Copilot, but session preservation keeps local).
 			afterApply: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
 			markerAfterApply: true,
+		});
+	});
+
+	test('one-time Copilot swap is skipped and unmarked when the agent host is disabled', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorPreferCopilotHarness]: true,
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		// With the agent host disabled (e.g. on web) the swap must not fire, so it
+		// neither returns an unresolvable Copilot type nor marks the transition.
+		const resolved = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { currentSessionType: localChatSessionType });
+
+		assert.deepStrictEqual({
+			resolved,
+			preferenceApplied: hasPreferredCopilotHarness(storageService),
+		}, {
+			resolved: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
+			preferenceApplied: false,
 		});
 	});
 
@@ -206,17 +238,107 @@ suite('ChatConfiguration defaults', () => {
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude);
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, localChatSessionType);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude, true);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostCopilot, true);
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace, true),
 			remembered: getRememberedSessionType(storageService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true),
 		}, {
-			computed: localChatSessionType,
+			computed: SessionType.AgentHostCopilot,
 			remembered: undefined,
+			rememberedAware: SessionType.AgentHostCopilot,
+		});
+	});
+
+	test('selecting local while the agent host default is Copilot remembers local as an opt-out', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		// With the agent host enabled the computed default is Copilot, so picking
+		// local differs from the default and must be persisted as an explicit opt-out.
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, localChatSessionType, true);
+
+		assert.deepStrictEqual({
+			remembered: getRememberedSessionType(storageService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true),
+		}, {
+			remembered: localChatSessionType,
 			rememberedAware: localChatSessionType,
+		});
+	});
+
+	test('one-time Copilot swap overrides a remembered local opt-out and stays redundant when agent host is enabled', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorPreferCopilotHarness]: true,
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		// Remember local (only reachable because the computed default is Copilot).
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, localChatSessionType, true);
+
+		// The `remembered !== local` guard lets the one-time swap replace the
+		// remembered local, even though the computed default is already Copilot.
+		// The resolver reports the swap but does not mark it (the caller does).
+		const swapped = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+
+		assert.deepStrictEqual({
+			swapped,
+			preferenceApplied: hasPreferredCopilotHarness(storageService),
+		}, {
+			swapped: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
+			preferenceApplied: false,
+		});
+	});
+
+	test('new chat from a local session preserves local even when the agent host default is Copilot', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		// No remembered selection and no preferred-harness setting: the current
+		// session type wins over the Copilot computed default (session preservation).
+		assert.deepStrictEqual({
+			resolved: resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
+			preferenceApplied: hasPreferredCopilotHarness(storageService),
+		}, {
+			resolved: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
+			preferenceApplied: false,
+		});
+	});
+
+	test('default session resource follows the agent host default', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		assert.deepStrictEqual({
+			computedWithAgentHost: getChatSessionType(getComputedDefaultSessionResource(configurationService, chatSessionsService, localWorkspace, true)),
+			computedWithoutAgentHost: getChatSessionType(getComputedDefaultSessionResource(configurationService, chatSessionsService, localWorkspace, false)),
+			defaultNewWithAgentHost: getChatSessionType(getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, localWorkspace, true)),
+			defaultNewWithoutAgentHost: getChatSessionType(getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, localWorkspace, false)),
+		}, {
+			computedWithAgentHost: SessionType.AgentHostCopilot,
+			computedWithoutAgentHost: localChatSessionType,
+			defaultNewWithAgentHost: SessionType.AgentHostCopilot,
+			defaultNewWithoutAgentHost: localChatSessionType,
+		});
+	});
+
+	test('agent host default wins over a virtual workspace local override', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorLocalAgentEnabled]: false,
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const workspace = createWorkspace(URI.parse('vscode-vfs://github/microsoft/vscode'));
+
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, workspace, true),
+		}, {
+			computed: SessionType.AgentHostCopilot,
 		});
 	});
 
@@ -266,8 +388,8 @@ suite('ChatConfiguration defaults', () => {
 		const workspace = createWorkspace(URI.parse('vscode-vfs://github/microsoft/vscode'));
 
 		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, workspace),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace),
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, workspace, false),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, false),
 			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, workspace),
 			localRememberedUsable: isRememberedSessionTypeUsable(localChatSessionType, configurationService, chatSessionsService, workspace),
 		}, {

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -310,6 +310,21 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
+	test('explicit New Local Chat wins over a non-local current session even when the agent host default is Copilot', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		// "New Local Chat" from a Copilot session must resolve to local: the explicit
+		// override outranks both the current session type and the computed default,
+		// so the clear path opens a local session instead of dropping the request.
+		assert.deepStrictEqual({
+			resolved: resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { explicitOverride: localChatSessionType, currentSessionType: SessionType.AgentHostCopilot }),
+		}, {
+			resolved: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
+		});
+	});
+
 	test('default session resource follows the agent host default', () => {
 		const configurationService = new TestConfigurationService();
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -36,6 +36,7 @@ import { IViewDescriptorService } from '../../../../common/views.js';
 import { ISCMService } from '../../../../contrib/scm/common/scm.js';
 import { IBrowserViewWorkbenchService } from '../../../../contrib/browserView/common/browserView.js';
 import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IAgentSubscription } from '../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { StateComponents } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSessions/agentSessionsService.js';
@@ -277,6 +278,9 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 	reg.defineInstance(IAgentHostNewSessionFolderService, new class extends mock<IAgentHostNewSessionFolderService>() {
 		override readonly onDidChangeFolder = Event.None;
 		override getFolder() { return undefined; }
+	}());
+	reg.defineInstance(IAgentHostEnablementService, new class extends mock<IAgentHostEnablementService>() {
+		override readonly enabled = false;
 	}());
 
 	const artifactGroups = options.artifactGroups ?? observableValue<readonly IArtifactSourceGroup[]>('artifactGroups', []);

--- a/test/smoke/extensions/vscode-smoketest-ext-host/extension.js
+++ b/test/smoke/extensions/vscode-smoketest-ext-host/extension.js
@@ -126,6 +126,19 @@ function activate(context) {
 			await vscode.commands.executeCommand(command);
 		})
 	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('smoketest.openLocalChat', async () => {
+			// Open the chat panel directly into the built-in Local harness. The
+			// panel default is Agent Host Copilot when the agent host is enabled,
+			// so tests that exercise the local participant harness must select it
+			// explicitly. `newLocalChat` opens the view from cold and is hidden
+			// from the palette (f1: false), hence this smoke-test wrapper.
+			const command = 'workbench.action.chat.newLocalChat';
+			await waitForCommand(command, 60_000);
+			await vscode.commands.executeCommand(command);
+		})
+	);
 }
 
 function deactivate() {

--- a/test/smoke/extensions/vscode-smoketest-ext-host/package.json
+++ b/test/smoke/extensions/vscode-smoketest-ext-host/package.json
@@ -31,6 +31,10 @@
 			{
 				"command": "smoketest.openClaudeChat",
 				"title": "Smoke Test: Open Claude Test Session"
+			},
+			{
+				"command": "smoketest.openLocalChat",
+				"title": "Smoke Test: Open Local Test Session"
 			}
 		]
 	}

--- a/test/smoke/src/areas/chat/chatModelConfig.test.ts
+++ b/test/smoke/src/areas/chat/chatModelConfig.test.ts
@@ -240,8 +240,10 @@ export function setup(logger: Logger) {
 
 			try {
 				// Open the panel chat (Agent mode is the default; the context-size
-				// override is applied on the agent request path).
-				await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
+				// override is applied on the agent request path). Select the local
+				// harness explicitly since the panel default is Agent Host Copilot
+				// when the agent host is enabled.
+				await app.workbench.quickaccess.runCommand('smoketest.openLocalChat');
 				await chat.waitForChatView();
 
 				// Retry the warm-up send until the model actually replies, which

--- a/test/smoke/src/areas/chat/chatSandbox.test.ts
+++ b/test/smoke/src/areas/chat/chatSandbox.test.ts
@@ -86,7 +86,12 @@ async function updateUserSettingsWhileChatIsOpen(app: Application, settings: [ke
 	await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
 
 	// Settings are changed between chat requests, so restore the view that the
-	// following test interacts with without restarting the application.
+	// following test interacts with without restarting the application. The
+	// panel already holds the local session opened by the suite setup, so reveal
+	// it with `chat.open` rather than starting a fresh local session: revealing
+	// the existing session focuses the input without tearing down and rebuilding
+	// the input editor, avoiding a focus race (and, since a session already
+	// exists, without resolving the Agent Host Copilot default).
 	await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
 	await app.workbench.chat.waitForChatView();
 }
@@ -173,7 +178,7 @@ export function setup(logger: Logger): void {
 
 		before(async function () {
 			const app = this.app as Application;
-			await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
+			await app.workbench.quickaccess.runCommand('smoketest.openLocalChat');
 			await app.workbench.chat.waitForChatView();
 			await warmUpChat(app.workbench.chat, logger);
 		});

--- a/test/smoke/src/areas/chat/chatSessions.test.ts
+++ b/test/smoke/src/areas/chat/chatSessions.test.ts
@@ -33,7 +33,7 @@ interface SessionConfig {
 const SESSIONS: readonly SessionConfig[] = [
 	{ name: 'Copilot CLI', command: 'smoketest.openCopilotCliChat', kind: 'editor', scenarioId: 'smoke-chat-sessions-copilot-cli', reply: 'MOCKED_CHAT_SESSIONS_COPILOT_CLI_RESPONSE', scenarioId2: 'smoke-chat-sessions-copilot-cli-2', reply2: 'MOCKED_CHAT_SESSIONS_COPILOT_CLI_RESPONSE_2' },
 	{ name: 'Claude', command: 'smoketest.openClaudeChat', kind: 'editor', scenarioId: 'smoke-chat-sessions-claude', reply: 'MOCKED_CHAT_SESSIONS_CLAUDE_RESPONSE', scenarioId2: 'smoke-chat-sessions-claude-2', reply2: 'MOCKED_CHAT_SESSIONS_CLAUDE_RESPONSE_2' },
-	{ name: 'Local', command: 'workbench.action.chat.open', kind: 'view', scenarioId: 'smoke-chat-sessions-local', reply: 'MOCKED_CHAT_SESSIONS_LOCAL_RESPONSE', scenarioId2: 'smoke-chat-sessions-local-2', reply2: 'MOCKED_CHAT_SESSIONS_LOCAL_RESPONSE_2' },
+	{ name: 'Local', command: 'smoketest.openLocalChat', kind: 'view', scenarioId: 'smoke-chat-sessions-local', reply: 'MOCKED_CHAT_SESSIONS_LOCAL_RESPONSE', scenarioId2: 'smoke-chat-sessions-local-2', reply2: 'MOCKED_CHAT_SESSIONS_LOCAL_RESPONSE_2' },
 ];
 
 /**
@@ -55,7 +55,7 @@ interface ShellSessionConfig {
 const SHELL_SESSIONS: readonly ShellSessionConfig[] = [
 	{ name: 'Copilot CLI', command: 'smoketest.openCopilotCliChat', kind: 'editor', scenarioId: 'smoke-chat-sessions-copilot-cli-shell', reply: 'MOCKED_CHAT_SESSIONS_COPILOT_CLI_SHELL_RESPONSE', scenarioFactory: shellEchoScenario },
 	{ name: 'Claude', command: 'smoketest.openClaudeChat', kind: 'editor', scenarioId: 'smoke-chat-sessions-claude-shell', reply: 'MOCKED_CHAT_SESSIONS_CLAUDE_SHELL_RESPONSE', scenarioFactory: shellEchoScenario },
-	{ name: 'Local', command: 'workbench.action.chat.open', kind: 'view', scenarioId: 'smoke-chat-sessions-local-terminal', reply: 'MOCKED_CHAT_SESSIONS_LOCAL_TERMINAL_RESPONSE', scenarioFactory: runInTerminalScenario },
+	{ name: 'Local', command: 'smoketest.openLocalChat', kind: 'view', scenarioId: 'smoke-chat-sessions-local-terminal', reply: 'MOCKED_CHAT_SESSIONS_LOCAL_TERMINAL_RESPONSE', scenarioFactory: runInTerminalScenario },
 ];
 
 async function openSession(app: Application, session: { readonly command: string; readonly kind: 'editor' | 'view' }): Promise<void> {


### PR DESCRIPTION
## What

**Stacked on #326178** (base: `tyleonha/prefer-copilot-harness`). Review that PR first; this PR shows only the feature-2 delta.

Makes **Agent Host Copilot** the computed default chat provider for both **editor** and **panel** chat whenever the agent host is enabled, so first-time users land on Copilot instead of Local. `chat.editor.preferCopilotHarness` (from the base PR) stays scoped to the one-time Local -> Copilot migration only.

## Changes

- Thread an `agentHostEnabled` flag (from `IAgentHostEnablementService`) through the default-session-type resolution and its callers.
- Keep Local visible and selectable; honor explicit and remembered selections.
- **New Local Chat opens a local session directly**: it cancels the in-flight default-provider resolution (which would otherwise block on agent host activation) so the local request wins immediately. The initial `ChatViewPane` session resolution is now cancelable.
- Open a Local chat first in all chat participant API tests, since chat participants are a Local-harness feature (this also prevents those tests hanging on remote).
- Add a `smoketest.openLocalChat` command for Local panel smoke scenarios; the sandbox reopen path reveals the existing local session to avoid a focus race.
- Register an `IAgentHostEnablementService` stub in the component fixtures.

## Verification

Local runs (darwin): constants unit (20) and chatEditorInput unit (3) pass; Electron + remote api chat participant/title tests pass; Chat Sandbox / Sessions / Model Config / Disabled smoke suites pass; component fixtures render clean. The only local failures are the known `run_in_terminal` shell-prompt artifact (#303531), which passes in CI's clean shell.
