### PR TITLE
agentHost: skip unstable Codex shell replay on Linux

### DIFF
--- a/.github/skills/agent-host-e2e-tests/SKILL.md
+++ b/.github/skills/agent-host-e2e-tests/SKILL.md
@@ -52,6 +52,7 @@ Real-time streaming, mid-turn aborts, and POSIX-specific local execution (shell 
 - **Record-only** (no deterministic replay at all): `(RECORD ? test : test.skip)('…')` — see `can abort a running turn`.
 - **Subagent fixtures stale after an SDK bump**: re-record them (`AGENT_HOST_REPLAY_RECORD=1 …`). Subagent flows are the most SDK-version-sensitive (parent + child share one `/v1/messages` sequence), but replay reliably once re-recorded, so no gating is needed.
 - **POSIX-only** (fails on Windows): gate with `!isWindows`, or a targeted per-provider flag when only one provider diverges. See the worktree and subagent-reopen tests.
+- **Provider/OS-specific replay**: add a targeted config gate that still permits recording and unaffected platforms. See the Codex shell-tool Linux gate.
 
 Always add a comment explaining *why* the gate exists.
 

--- a/src/vs/platform/agentHost/test/node/protocol/README.md
+++ b/src/vs/platform/agentHost/test/node/protocol/README.md
@@ -220,6 +220,7 @@ To accept an AHP output change, run the affected test with `AGENT_HOST_UPDATE_AH
 | `supportsSubagents` | Gates the two subagent tests. |
 | `supportsWorktreeIsolation` | Gates the worktree test. |
 | `supportsPlanMode` | Gates the plan-mode test. |
+| `shellToolReplayUnstableOnLinux` | Skips shell-dependent replay tests on **Linux** for that provider. Recording and other platforms remain enabled. |
 | `subagentReplayUnstableOnWindows` | Skips the subagent-reopen ("replay path") test on **Windows** for that provider (e.g. Claude rebuilds the transcript from the SDK's on-disk `subagents/*.jsonl`, not reliably visible there right after the turn). |
 | `RECORD` (env) | Set by `AGENT_HOST_REPLAY_RECORD=1` and internally during the first `AGENT_HOST_UPDATE_SNAPSHOTS=1` pass. The `can abort a running turn` test runs only for direct record mode, not bulk snapshot updates. |
 | `isWindows` | The worktree test is skipped on Windows (POSIX-shaped `.worktrees` paths + host-terminal `pwd`). |
@@ -261,7 +262,7 @@ The fixture was never recorded (or the test title changed and orphaned it). Reco
 
 Usually the *local execution* diverges by platform (the model replay is byte-identical everywhere). Windows shells, `pwd`, `git worktree` paths, and some SDK tool calls behave differently. Gate the test off that platform (`!isWindows` or a per-provider flag) — don't bump timeouts to mask it.
 
-Codex fixtures use its unified `exec_command` tool, so Codex record/replay servers explicitly enable `features.unified_exec` rather than inheriting an app-server configuration that advertises the incompatible legacy `shell_command` tool.
+Codex fixtures use its unified `exec_command` tool, so Codex record/replay servers explicitly enable `features.unified_exec` rather than inheriting an app-server configuration that advertises the incompatible legacy `shell_command` tool. Packaged Linux still completes those recorded turns without command-execution notifications, so the shell-dependent Codex replay tests are gated there.
 
 ### A test passes on macOS/Linux but fails on Windows
 

--- a/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
@@ -62,6 +62,7 @@ const RUN_RECORD_ONLY_TESTS = RECORD && !UPDATE_SNAPSHOTS;
 const REPLAY_MODE: CapiReplayMode = RECORD ? 'record' : 'replay';
 const SERVER_SHUTDOWN_TIMEOUT_MS = 30_000;
 const TEMP_DIR_CLEANUP_TIMEOUT_MS = 30_000;
+const isLinux = process.platform === 'linux';
 /** Gate for agent host e2e tests whose local execution is POSIX-specific (shell tool
  * calls, git worktrees, `pwd`) and does not reproduce on Windows. */
 const isWindows = process.platform === 'win32';
@@ -226,6 +227,12 @@ export interface IAgentHostE2EProviderConfig {
 	 * session. Claude has not landed subagents yet (Phase 12 in roadmap).
 	 */
 	readonly supportsSubagents: boolean;
+	/**
+	 * When set, shell-dependent replay tests are skipped on Linux because this
+	 * provider completes recorded shell-tool turns without emitting tool-call
+	 * notifications there. Recording and other platforms keep full coverage.
+	 */
+	readonly shellToolReplayUnstableOnLinux?: boolean;
 	/**
 	 * When set, the subagent-reopen ("replay path") test is skipped on Windows for
 	 * this provider, which rebuilds the reopened transcript from the bundled SDK's
@@ -750,6 +757,7 @@ export class AgentHostE2EServerLease {
 export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): void {
 	(config.enabled ? suite : suite.skip)(config.suiteTitle, function () {
 
+		const shellToolReplayEnabled = RECORD || !isLinux || !config.shellToolReplayUnstableOnLinux;
 		let client: TestProtocolClient;
 		let lease: AgentHostE2EServerLease | undefined;
 		let suiteDataDir: string | undefined;
@@ -879,7 +887,7 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 			}
 		});
 
-		test('tool call triggers permission request and can be approved', async function () {
+		(shellToolReplayEnabled ? test : test.skip)('tool call triggers permission request and can be approved', async function () {
 			this.timeout(120_000);
 
 			const tempDir = mkdtempSync(`${tmpdir()}/ahp-perm-test-`);
@@ -1048,7 +1056,7 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 		// Worktree isolation asserts on resolved `.worktrees/...` paths and a
 		// host-terminal `pwd`, which are POSIX-shaped (the fixtures were recorded on
 		// macOS); skip on Windows where the worktree paths and shell differ.
-		(config.supportsWorktreeIsolation && !isWindows ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
+		(config.supportsWorktreeIsolation && !isWindows && shellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
 			this.timeout(120_000);
 
 			const tempDir = mkdtempSync(`${tmpdir()}/ahp-wt-test-`);

--- a/src/vs/platform/agentHost/test/node/protocol/codexAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/codexAgentHostE2E.integrationTest.ts
@@ -60,6 +60,8 @@ const CODEX_CONFIG: IAgentHostE2EProviderConfig = {
 	supportsHostTerminalTool: false,
 	supportsSubagents: false,
 	supportsPlanMode: false,
+	// Packaged Linux replay completes recorded exec_command turns without tool events.
+	shellToolReplayUnstableOnLinux: true,
 };
 
 defineAgentHostE2ETests(CODEX_CONFIG);


### PR DESCRIPTION
## Summary

- Skip the two Codex shell-dependent Agent Host replay tests on Linux.
- Keep those tests enabled while recording and on unaffected platforms.
- Document the targeted provider/OS replay gate.

## Why

After [#326068](https://github.com/microsoft/vscode/pull/326068) pinned `features.unified_exec=true`, packaged Linux build [456266](https://dev.azure.com/monacotools/a6d41577-0fa3-498e-af22-257312ff0545/_build/results?buildId=456266) still reproduced the same behavior: recorded `exec_command` turns completed as text-only turns without any command-execution notifications. macOS and Windows passed. The underlying packaged-Linux divergence remains unclear, so this gates only the affected replay coverage instead of continuing to break main CI.

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- Hygiene checks on modified TypeScript files
- Full Codex E2E suite on macOS: 6 passing, 11 expected pending
- Focused code review: no findings

(Written by Copilot)