### PR TITLE
terminal: add onWillDispose as a pre-disposal hook for xterm addon cleanup

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -974,7 +974,16 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 	readonly onIconChanged: Event<{ instance: ITerminalInstance; userInitiated: boolean }>;
 
 	/**
-	 * An event that fires when the terminal instance is disposed.
+	 * An event that fires just before the terminal instance is disposed, while `xterm.js` and
+	 * other instance-owned resources are still alive. Subscribe here if you need to clean up
+	 * state that depends on those resources (e.g. xterm.js addons). For "the instance is gone"
+	 * notifications, use {@link onDisposed} instead.
+	 */
+	readonly onWillDispose: Event<ITerminalInstance>;
+
+	/**
+	 * An event that fires when the terminal instance is disposed, after `xterm.js` has been
+	 * disposed.
 	 */
 	readonly onDisposed: Event<ITerminalInstance>;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -320,6 +320,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	// itself is disposed
 	private readonly _onExit = new Emitter<number | ITerminalLaunchError | undefined>();
 	readonly onExit = this._onExit.event;
+	private readonly _onWillDispose = this._register(new Emitter<ITerminalInstance>());
+	readonly onWillDispose = this._onWillDispose.event;
 	private readonly _onDisposed = this._register(new Emitter<ITerminalInstance>());
 	readonly onDisposed = this._onDisposed.event;
 	private readonly _onProcessIdReady = this._register(new Emitter<ITerminalInstance>());
@@ -655,7 +657,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 					contribution.xtermReady?.(xterm);
 				}
 			});
-			this._register(this.onDisposed(() => {
+			this._register(this.onWillDispose(() => {
 				contribution.dispose();
 				this._contributions.delete(desc.id);
 			}));
@@ -1306,6 +1308,29 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			this._horizontalScrollbar = undefined;
 		}
 
+		// Fire onWillDispose before disposing xterm so that contributions can clean
+		// up their xterm addons while the raw terminal is still alive. Disposing
+		// xterm first would cause AddonManager to remove addons from its list,
+		// and subsequent contribution disposal would fail with "Could not dispose
+		// an addon that has not been loaded".
+		this._onWillDispose.fire(this);
+
+		try {
+			this.xterm?.dispose();
+		} catch (err: unknown) {
+			// See https://github.com/microsoft/vscode/issues/153486
+			this._logService.error('Exception occurred during xterm disposal', err);
+		}
+
+		// HACK: Workaround for Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=559561,
+		// as 'blur' event in xterm.raw.textarea is not triggered on xterm.dispose()
+		// See https://github.com/microsoft/vscode/issues/138358
+		if (isFirefox) {
+			this.resetFocusContextKey();
+			this._terminalHasTextContextKey.reset();
+			this._onDidBlur.fire(this);
+		}
+
 		if (this._pressAnyKeyToCloseListener) {
 			this._pressAnyKeyToCloseListener.dispose();
 			this._pressAnyKeyToCloseListener = undefined;
@@ -1325,28 +1350,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		// hasn't happened yet
 		this._onProcessExit(undefined);
 
-		// Fire onDisposed before disposing xterm so that contributions can clean
-		// up their xterm addons while the raw terminal is still alive. Disposing
-		// xterm first would cause AddonManager to remove addons from its list,
-		// and subsequent contribution disposal would fail with "Could not dispose
-		// an addon that has not been loaded".
+		// Fire onDisposed only after xterm has been disposed so that subscribers
+		// observe a fully disposed instance.
 		this._onDisposed.fire(this);
-
-		try {
-			this.xterm?.dispose();
-		} catch (err: unknown) {
-			// See https://github.com/microsoft/vscode/issues/153486
-			this._logService.error('Exception occurred during xterm disposal', err);
-		}
-
-		// HACK: Workaround for Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=559561,
-		// as 'blur' event in xterm.raw.textarea is not triggered on xterm.dispose()
-		// See https://github.com/microsoft/vscode/issues/138358
-		if (isFirefox) {
-			this.resetFocusContextKey();
-			this._terminalHasTextContextKey.reset();
-			this._onDidBlur.fire(this);
-		}
 
 		super.dispose();
 	}

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -230,6 +230,42 @@ suite('Workbench - TerminalInstance', () => {
 			strictEqual(instance.shellType, GeneralShellType.CommandCode);
 		});
 
+		test('should fire onWillDispose before xterm disposal and onDisposed after xterm disposal', async () => {
+			const instance = await createTerminalInstance();
+			const xterm = await instance.xtermReadyPromise;
+			const disposalOrder: string[] = [];
+
+			store.add(instance.onWillDispose(() => disposalOrder.push('onWillDispose')));
+			store.add(xterm!.onDidDispose(() => disposalOrder.push('xterm')));
+			store.add(instance.onDisposed(() => disposalOrder.push('onDisposed')));
+
+			instance.dispose();
+
+			deepStrictEqual(disposalOrder, ['onWillDispose', 'xterm', 'onDisposed']);
+		});
+
+		test('disposing an xterm addon within onWillDispose should happen while xterm is alive (#315722)', async () => {
+			const instance = await createTerminalInstance();
+			const xterm = await instance.xtermReadyPromise;
+			let xtermDisposed = false;
+			let addonDisposedWhileXtermAlive = false;
+
+			store.add(xterm!.onDidDispose(() => xtermDisposed = true));
+			// Simulates a terminal contribution that owns an xterm addon and disposes it when the
+			// instance is being disposed. Doing this after xterm has been disposed throws "Could
+			// not dispose an addon that has not been loaded".
+			const addon = {
+				activate: () => { },
+				dispose: () => addonDisposedWhileXtermAlive = !xtermDisposed
+			};
+			xterm!.raw.loadAddon(addon);
+			store.add(instance.onWillDispose(() => addon.dispose()));
+
+			instance.dispose();
+
+			strictEqual(addonDisposedWhileXtermAlive, true);
+		});
+
 		test('custom key event handler should handle commands in DEFAULT_COMMANDS_TO_SKIP_SHELL in VS Code and not xterm when sendKeybindingsToShell is disabled', async () => {
 			const instance = await createTerminalInstance();
 			const keybindingService = instance['_keybindingService'];

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -244,26 +244,33 @@ suite('Workbench - TerminalInstance', () => {
 			deepStrictEqual(disposalOrder, ['onWillDispose', 'xterm', 'onDisposed']);
 		});
 
-		test('disposing an xterm addon within onWillDispose should happen while xterm is alive (#315722)', async () => {
+		test('should dispose contribution-owned xterm addons before xterm disposal', async () => {
 			const instance = await createTerminalInstance();
 			const xterm = await instance.xtermReadyPromise;
-			let xtermDisposed = false;
-			let addonDisposedWhileXtermAlive = false;
+			const disposalOrder: string[] = [];
+			let addonDisposeCount = 0;
 
-			store.add(xterm!.onDidDispose(() => xtermDisposed = true));
-			// Simulates a terminal contribution that owns an xterm addon and disposes it when the
-			// instance is being disposed. Doing this after xterm has been disposed throws "Could
-			// not dispose an addon that has not been loaded".
 			const addon = {
 				activate: () => { },
-				dispose: () => addonDisposedWhileXtermAlive = !xtermDisposed
+				dispose: () => {
+					addonDisposeCount++;
+					disposalOrder.push('addon');
+				}
 			};
 			xterm!.raw.loadAddon(addon);
-			store.add(instance.onWillDispose(() => addon.dispose()));
+			store.add(instance.onWillDispose(() => {
+				disposalOrder.push('onWillDispose');
+				addon.dispose();
+			}));
+			store.add(xterm!.onDidDispose(() => disposalOrder.push('xterm')));
+			store.add(instance.onDisposed(() => disposalOrder.push('onDisposed')));
 
 			instance.dispose();
 
-			strictEqual(addonDisposedWhileXtermAlive, true);
+			deepStrictEqual(
+				{ disposalOrder, addonDisposeCount },
+				{ disposalOrder: ['onWillDispose', 'addon', 'xterm', 'onDisposed'], addonDisposeCount: 1 }
+			);
 		});
 
 		test('custom key event handler should handle commands in DEFAULT_COMMANDS_TO_SKIP_SHELL in VS Code and not xterm when sendKeybindingsToShell is disabled', async () => {


### PR DESCRIPTION
Refs: https://github.com/microsoft/vscode/issues/315722,  https://github.com/microsoft/vscode/pull/318788, #315737

- Add an internal `ITerminalInstance.onWillDispose` event for cleanup that requires xterm and other instance-owned resources to remain alive.
- Move terminal contribution disposal to `onWillDispose` so contribution-owned xterm addons are released before xterm teardown.
- Keep `onDisposed` as the notification that xterm and process teardown have completed.
- Preserve the historical teardown order: contributions, xterm, Firefox blur fallback, process manager, `onDisposed`, then `super.dispose()`.
- Add tests covering the lifecycle event order and exactly-once disposal of a contribution-owned xterm addon.

Validation:

- `npm run typecheck-client`
- `scripts/test.sh --grep 'Workbench - TerminalInstance'` — 50 passing
- Manually terminate a task terminal with shell integration and sticky scroll enabled, then verify the developer console does not report an addon-manager disposal error.

The telemetry failure does not have a deterministic local reproduction. The tests therefore pin the lifecycle and ownership guarantees used to address it without claiming to reproduce the original telemetry bucket directly.

-----------------------------------------
Inspirations from:

- Moving terminal contribution cleanup to the early lifecycle hook comes from [`TerminalInstance` contribution registration](https://github.com/microsoft/vscode/blob/616be48bbc567bb19bc9498754db5a25be2758ff/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L654-L662).
- The teardown ordering comes from the final revision of [`TerminalInstance.dispose`](https://github.com/microsoft/vscode/blob/616be48bbc567bb19bc9498754db5a25be2758ff/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L1310-L1357), including the follow-up that restored xterm disposal to its historical position.