### PR TITLE
Fix webview font-family so it falls back to monospace for custom editor.fontFamily

### DIFF
--- a/src/vs/editor/common/config/fontInfo.ts
+++ b/src/vs/editor/common/config/fontInfo.ts
@@ -114,25 +114,36 @@ export class BareFontInfo {
 	 * @internal
 	 */
 	public getMassagedFontFamily(): string {
-		const fallbackFontFamily = EDITOR_FONT_DEFAULTS.fontFamily;
-		const fontFamily = BareFontInfo._wrapInQuotes(this.fontFamily);
-		if (fallbackFontFamily && this.fontFamily !== fallbackFontFamily) {
-			return `${fontFamily}, ${fallbackFontFamily}`;
-		}
-		return fontFamily;
+		return applyFontFamilyFallback(this.fontFamily);
 	}
+}
 
-	private static _wrapInQuotes(fontFamily: string): string {
-		if (/[,"']/.test(fontFamily)) {
-			// Looks like the font family might be already escaped
-			return fontFamily;
-		}
-		if (/[+ ]/.test(fontFamily)) {
-			// Wrap a font family using + or <space> with quotes
-			return `"${fontFamily}"`;
-		}
+/**
+ * Wraps a font family (if needed) and appends the platform's default
+ * monospace font family as a fallback, so that a custom or unavailable
+ * font family still degrades to a monospace font instead of the browser's
+ * default (often serif) font.
+ * @internal
+ */
+export function applyFontFamilyFallback(fontFamily: string): string {
+	const fallbackFontFamily = EDITOR_FONT_DEFAULTS.fontFamily;
+	const wrappedFontFamily = wrapFontFamilyInQuotes(fontFamily);
+	if (fallbackFontFamily && fontFamily !== fallbackFontFamily) {
+		return `${wrappedFontFamily}, ${fallbackFontFamily}`;
+	}
+	return wrappedFontFamily;
+}
+
+function wrapFontFamilyInQuotes(fontFamily: string): string {
+	if (/[,"']/.test(fontFamily)) {
+		// Looks like the font family might be already escaped
 		return fontFamily;
 	}
+	if (/[+ ]/.test(fontFamily)) {
+		// Wrap a font family using + or <space> with quotes
+		return `"${fontFamily}"`;
+	}
+	return fontFamily;
 }
 
 // change this whenever `FontInfo` members are changed

--- a/src/vs/editor/test/common/config/fontInfo.test.ts
+++ b/src/vs/editor/test/common/config/fontInfo.test.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { applyFontFamilyFallback, EDITOR_FONT_DEFAULTS } from '../../../common/config/fontInfo.js';
+
+suite('applyFontFamilyFallback', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const platformFallback = EDITOR_FONT_DEFAULTS.fontFamily;
+
+	test('appends the platform default font family as a fallback for a custom font', () => {
+		const result = applyFontFamilyFallback('MyCustomFont');
+		assert.strictEqual(result, `MyCustomFont, ${platformFallback}`);
+	});
+
+	test('wraps a font family containing a space in quotes before appending the fallback', () => {
+		const result = applyFontFamilyFallback('Fira Code');
+		assert.strictEqual(result, `"Fira Code", ${platformFallback}`);
+	});
+
+	test('does not double-wrap a font family that already looks escaped', () => {
+		const result = applyFontFamilyFallback('"My Font", Consolas');
+		assert.strictEqual(result, `"My Font", Consolas, ${platformFallback}`);
+	});
+
+	test('does not duplicate the fallback when the font family already equals the platform default', () => {
+		const result = applyFontFamilyFallback(platformFallback);
+		assert.strictEqual(result, platformFallback);
+	});
+});

--- a/src/vs/workbench/contrib/webview/browser/themeing.ts
+++ b/src/vs/workbench/contrib/webview/browser/themeing.ts
@@ -7,7 +7,7 @@ import { DEFAULT_FONT_FAMILY } from '../../../../base/browser/fonts.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IEditorOptions, EditorFontLigatures } from '../../../../editor/common/config/editorOptions.js';
-import { EDITOR_FONT_DEFAULTS } from '../../../../editor/common/config/fontInfo.js';
+import { applyFontFamilyFallback, EDITOR_FONT_DEFAULTS } from '../../../../editor/common/config/fontInfo.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import * as colorRegistry from '../../../../platform/theme/common/colorRegistry.js';
 import { getSizeRegistry, sizeValueToCss } from '../../../../platform/theme/common/sizeRegistry.js';
@@ -54,7 +54,7 @@ export class WebviewThemeDataProvider extends Disposable {
 	public getWebviewThemeData(): WebviewThemeData {
 		if (!this._cachedWebViewThemeData) {
 			const configuration = this._configurationService.getValue<IEditorOptions>('editor');
-			const editorFontFamily = configuration.fontFamily || EDITOR_FONT_DEFAULTS.fontFamily;
+			const editorFontFamily = applyFontFamilyFallback(configuration.fontFamily || EDITOR_FONT_DEFAULTS.fontFamily);
 			const editorFontWeight = configuration.fontWeight || EDITOR_FONT_DEFAULTS.fontWeight;
 			const editorFontSize = configuration.fontSize || EDITOR_FONT_DEFAULTS.fontSize;
 			const editorFontLigatures = new EditorFontLigatures().validate(configuration.fontLigatures);


### PR DESCRIPTION
## Problem

Reported in #324256: when `editor.fontFamily` is set to a custom font that either doesn't exist or doesn't itself include a generic `monospace` fallback, code blocks and inline code in the Markdown preview render in the browser's default font (often serif) instead of falling back to a monospace font.

## Root cause

Every webview (including the Markdown preview) gets its `--vscode-editor-font-family` CSS variable from `WebviewThemeDataProvider.getWebviewThemeData()` in `src/vs/workbench/contrib/webview/browser/themeing.ts`. That code used the raw `editor.fontFamily` setting verbatim:

```ts
const editorFontFamily = configuration.fontFamily || EDITOR_FONT_DEFAULTS.fontFamily;
```

`extensions/markdown-language-features/media/markdown.css` consumes this variable with a `var(--vscode-editor-font-family, <fallback list>)`, but that CSS fallback list only applies when the variable is *unset* — since `themeing.ts` always sets it to some string, the CSS-level fallback never kicks in.

The real Monaco text editor doesn't have this problem because `BareFontInfo.getMassagedFontFamily()` (`src/vs/editor/common/config/fontInfo.ts`) always appends the platform's default font family (which itself ends in the generic `monospace` keyword) as a fallback whenever the configured font differs from the default. `themeing.ts` never used this helper, which is the actual gap.

## Fix

- Extracted the fallback-appending logic out of `BareFontInfo.getMassagedFontFamily()` into a standalone exported function, `applyFontFamilyFallback()`, in `fontInfo.ts` (no behavior change for existing callers — `getMassagedFontFamily()` is now a thin wrapper around it).
- `themeing.ts` now calls `applyFontFamilyFallback()` when computing the webview's `editorFontFamily`, so `--vscode-editor-font-family` always carries a monospace fallback chain, matching the real editor's behavior.

This fixes the Markdown preview specifically, and also fixes the same issue for any other webview that relies on `--vscode-editor-font-family`.

## Testing performed

- Added `src/vs/editor/test/common/config/fontInfo.test.ts` covering `applyFontFamilyFallback()`: custom font gets the fallback appended, a font with spaces gets quoted before the fallback is appended, an already-escaped font family isn't double-wrapped, and a font family equal to the platform default isn't duplicated.
- `tsc -p src/tsconfig.json --noEmit` passes with no errors.
- `eslint` passes on all changed files.
- Manually verified the extracted fallback logic against the four test cases above with a standalone script producing the expected output on this platform's default (`'Droid Sans Mono', monospace` on Linux).

Fixes #324256