### PR TITLE
fix: clear sticky DEC mouse modes after process exit and PTY replay

### DIFF
--- a/scripts/sticky-mouse-reload/decModeState.mjs
+++ b/scripts/sticky-mouse-reload/decModeState.mjs
@@ -1,0 +1,225 @@
+/**
+ * Minimal DEC private-mode state machine for sticky-mouse / Reload scenarios.
+ * Pure JS — no VS Code GUI. Run: node --test scenarios.test.mjs
+ */
+
+const MOUSE_MODES = new Set([9, 1000, 1002, 1003, 1006, 1015]);
+
+/** @returns {{ altScreen: boolean, mouse: boolean, focus: boolean, paste: boolean }} */
+export function createDecModeState() {
+	return {
+		altScreen: false,
+		mouse: false,
+		focus: false,
+		paste: false,
+		_mouseSet: new Set(),
+	};
+}
+
+/**
+ * @param {ReturnType<typeof createDecModeState>} state
+ * @param {string} data
+ */
+export function applyOutput(state, data) {
+	const re = /\x1b\[\?([\d;]+)([hl])/g;
+	let m;
+	while ((m = re.exec(data)) !== null) {
+		const modes = m[1].split(';').map(n => parseInt(n, 10)).filter(n => !Number.isNaN(n));
+		const on = m[2] === 'h';
+		for (const mode of modes) {
+			applyOne(state, mode, on);
+		}
+	}
+}
+
+function applyOne(state, mode, on) {
+	if (mode === 1049 || mode === 1047 || mode === 47) {
+		state.altScreen = on;
+		return;
+	}
+	if (mode === 1004) {
+		state.focus = on;
+		return;
+	}
+	if (mode === 2004) {
+		state.paste = on;
+		return;
+	}
+	if (MOUSE_MODES.has(mode)) {
+		if (on) state._mouseSet.add(mode);
+		else state._mouseSet.delete(mode);
+		state.mouse = state._mouseSet.size > 0;
+	}
+}
+
+export function snapshot(state) {
+	return {
+		altScreen: state.altScreen,
+		mouse: state.mouse,
+		focus: state.focus,
+		paste: state.paste,
+	};
+}
+
+export const CSI = {
+	enterAlt: '\x1b[?1049h',
+	leaveAlt: '\x1b[?1049l',
+	mouseEnable: '\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1015h\x1b[?1006h',
+	/** X10 mouse enable (xterm serialize re-emits when mouseTrackingMode is x10). */
+	mouseX10Enable: '\x1b[?9h',
+	mouseDisable: '\x1b[?9l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1015l\x1b[?1006l',
+	focusEnable: '\x1b[?1004h',
+	focusDisable: '\x1b[?1004l',
+	pasteEnable: '\x1b[?2004h',
+	pasteDisable: '\x1b[?2004l',
+	/** Real exit RESTORE_SEQ (leave alt + clear modes). */
+	restoreSeq:
+		'\x1b[?2026l\x1b[?25h\x1b[?9l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1015l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[<u\x1b[?1049l',
+	/** Host full mode reset (mouse + paste + focus; keeps alt). */
+	hostExitReset:
+		'\x1b[?9l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1015l\x1b[?1006l\x1b[?2004l\x1b[?1004l',
+	/** Host process-exit reset: full reset + leave alt screen + show cursor. */
+	hostProcessExitReset:
+		'\x1b[?9l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1015l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[?1049l\x1b[?25h',
+	/** Host mouse-only after replay (no CSI I focus synthesis — that is app-side). */
+	hostMouseOnlyReset:
+		'\x1b[?9l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1015l\x1b[?1006l',
+	/** Grok REASSERT_DISPLAY_SEQ (raw CSI). */
+	reassertDisplay:
+		'\x1b[?1049h\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1015h\x1b[?1006h\x1b[?1004h\x1b[?2004h\x1b[?25l',
+	/** App FocusGained reassert: mouse only (MOUSE_ENABLE_SEQ; no alt, no ?1004). */
+	mouseEnableOnly: '\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1015h\x1b[?1006h',
+};
+
+export function tuiEnterFullscreen(state) {
+	applyOutput(state, CSI.mouseDisable);
+	applyOutput(state, CSI.enterAlt + CSI.mouseEnable + CSI.focusEnable + CSI.pasteEnable);
+	applyOutput(state, 'Grok TUI content\n');
+}
+
+/** Strip mouse-enable CSI (host basePty policy). */
+export function stripMouseEnables(data) {
+	return data.replace(/\x1b\[\?([\d;]+)([hl])/g, (full, modes, flag) => {
+		if (flag === 'l') return full;
+		const parts = modes.split(';');
+		const mouse = new Set(['9', '1000', '1002', '1003', '1006', '1015']);
+		const kept = parts.filter(p => !mouse.has(p));
+		if (kept.length === parts.length) return full;
+		if (kept.length === 0) return '';
+		return `\x1b[?${kept.join(';')}h`;
+	});
+}
+
+/**
+ * DECRQM helpers (mirror xai-crash-handler pure API).
+ */
+export function decrqmRequest(mode) {
+	return `\x1b[?${mode}$p`;
+}
+
+/** @returns {{ mode: number, ps: number } | null} */
+export function parseDecrqmReply(data) {
+	const m = data.match(/\x1b\[\?(\d+);(\d+)\$y/);
+	if (!m) return null;
+	return { mode: parseInt(m[1], 10), ps: parseInt(m[2], 10) };
+}
+
+export function decrqmIndicatesReset(ps) {
+	return ps === 0 || ps === 2 || ps === 4;
+}
+
+/**
+ * Simulate Reload under simplified app policy:
+ * - Soft CTRL_CLOSE does NOT write RESTORE_SEQ (process may survive).
+ * - Host may strip mouse enables from replayed history.
+ * - App FocusGained: always reassert **mouse/focus enables only** (idempotent).
+ *   Never EnterAlternateScreen on focus.
+ *
+ * @param {string} recordedOutput
+ * @param {{ hostPostReplay?: 'none'|'mouseOnly'|'full', tuiReassert?: boolean, softReattach?: boolean, stripMouseOnReplay?: boolean, oldRestoreOnCtrlClose?: boolean }} opts
+ */
+export function simulateReload(recordedOutput, opts = {}) {
+	const {
+		hostPostReplay = 'mouseOnly',
+		tuiReassert = false,
+		softReattach = false,
+		stripMouseOnReplay = true,
+		/** Legacy bad path: CTRL_CLOSE wrote RESTORE_SEQ (for regression tests). */
+		oldRestoreOnCtrlClose = false,
+	} = opts;
+
+	let stream = recordedOutput;
+	if (oldRestoreOnCtrlClose) {
+		stream += CSI.restoreSeq;
+	}
+	if (stripMouseOnReplay) {
+		stream = stripMouseEnables(stream);
+	}
+
+	// softReattach models "CTRL_CLOSE did not RESTORE" (process may live).
+	// Renderer still replays stripped history into a fresh mode state.
+	const state = createDecModeState();
+	applyOutput(state, stream);
+
+	if (hostPostReplay === 'mouseOnly') {
+		applyOutput(state, CSI.hostMouseOnlyReset);
+	} else if (hostPostReplay === 'full') {
+		applyOutput(state, CSI.hostExitReset);
+	}
+
+	// Desired-state: FocusGained always reasserts non-destructive input modes.
+	// softReattach no longer selects full display reassert (alt wipe risk).
+	if (tuiReassert) {
+		applyOutput(state, CSI.mouseEnableOnly);
+		void softReattach; // policy flag retained for scenario naming only
+	}
+
+	return snapshot(state);
+}
+
+export function simulateColdStartWithSpuriousFocus() {
+	const state = createDecModeState();
+	tuiEnterFullscreen(state);
+	const afterWelcome = snapshot(state);
+	// Idempotent mouse reassert on FocusGained must not leave alt / wipe content.
+	applyOutput(state, CSI.mouseEnableOnly);
+	return { afterWelcome, afterSpuriousFocus: snapshot(state) };
+}
+
+export function isTuiScreenLocked(snap) {
+	return snap.altScreen === true;
+}
+
+export function isMouseOwnedByApp(snap) {
+	return snap.mouse === true;
+}
+
+/**
+ * Drain coalescing: each element is the number of request_mouse_reassert()
+ * calls in one event-loop drain. Writes = one per non-empty drain.
+ * Mirrors pager: N FocusGained+Resize in one batch → one mouse CSI write.
+ * Regression: per-event write without coalesce froze VS Code/ConPTY.
+ *
+ * @param {number[]} requestsPerDrain
+ */
+export function countMouseReassertWrites(requestsPerDrain) {
+	return requestsPerDrain.filter((n) => n > 0).length;
+}
+
+/**
+ * Mouse-only reassert CSI must not embed focus (?1004) or alt (?1049).
+ * Focus reporting is startup-only; re-firing ?1004h storms CSI I.
+ */
+export function mouseEnableSeqIsSafe(seq) {
+	const s = String(seq);
+	const hasMouse = s.includes('?1006h') || s.includes('?1000h');
+	const noFocus = !s.includes('1004');
+	const noAlt = !s.includes('1049');
+	return hasMouse && noFocus && noAlt;
+}
+
+/**
+ * Shell-garbage pattern after sticky focus/mouse modes (user screenshot).
+ * Host exit-reset + no app CSI I into bare shells prevent this.
+ */
+export const SHELL_FOCUS_GARBAGE_RE = /\[I(\[I)+/;

--- a/scripts/sticky-mouse-reload/headlessScenarios.test.mjs
+++ b/scripts/sticky-mouse-reload/headlessScenarios.test.mjs
@@ -1,0 +1,287 @@
+/**
+ * Ground-truth sticky-mouse / Reload scenarios with the REAL terminal engine.
+ *
+ * Unlike scenarios.test.mjs (hand-rolled DEC state machine), this file puts
+ * `@xterm/headless` + `@xterm/addon-serialize` in the loop — the exact
+ * libraries the VS Code pty host uses for persistent-session replay. The
+ * "pty host" terminal accumulates app output; Reload Window is modeled as
+ * `serialize()` written into a brand-new terminal (the recreated renderer),
+ * mirroring `XtermSerializer.generateReplayEvent` in ptyService.ts:
+ *   - reconnection (Reload Window): serialize() with NO excludes
+ *   - revive (window restart):      serialize({ excludeModes, excludeAltBuffer })
+ *
+ * Run: node --test .\scripts\sticky-mouse-reload\headlessScenarios.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createRequire } from 'node:module';
+import { CSI, stripMouseEnables } from './decModeState.mjs';
+
+const require = createRequire(import.meta.url);
+const { Terminal } = require('@xterm/headless');
+const { SerializeAddon } = require('@xterm/addon-serialize');
+
+// --- helpers ---------------------------------------------------------------
+
+function newTerm() {
+	return new Terminal({ cols: 80, rows: 24, scrollback: 1000, allowProposedApi: true });
+}
+
+function write(term, data) {
+	return new Promise(resolve => term.write(data, resolve));
+}
+
+/** Pty-host side: headless terminal + serializer (source of truth). */
+function newPtyHost() {
+	const term = newTerm();
+	const serializer = new SerializeAddon();
+	term.loadAddon(serializer);
+	return { term, serializer };
+}
+
+/** Observable renderer state via the public xterm modes/buffer API. */
+function observe(term) {
+	return {
+		mouse: term.modes.mouseTrackingMode,        // 'none' | 'x10' | 'vt200' | 'drag' | 'any'
+		focus: term.modes.sendFocusMode,            // ?1004
+		paste: term.modes.bracketedPasteMode,       // ?2004
+		alt: term.buffer.active.type === 'alternate',
+	};
+}
+
+function activeBufferText(term) {
+	const buf = term.buffer.active;
+	const lines = [];
+	for (let i = 0; i < buf.length; i++) {
+		lines.push(buf.getLine(i)?.translateToString(true) ?? '');
+	}
+	return lines.join('\n');
+}
+
+const SHELL_PROMPT = 'PS C:\\Users\\Louis> ';
+const WELCOME = 'Welcome to Grok build';
+
+/** Shell history, then grok enters fullscreen (alt + mouse + focus + paste). */
+async function grokSession(ptyHost) {
+	await write(ptyHost.term, SHELL_PROMPT + 'grok\r\n');
+	await write(ptyHost.term, CSI.enterAlt + CSI.mouseEnable + CSI.focusEnable + CSI.pasteEnable);
+	await write(ptyHost.term, WELCOME + '\r\n');
+}
+
+/**
+ * Reload Window (reconnection path): replay = serialize() with no excludes,
+ * optionally passed through the fork's basePty mouse strip, into a fresh
+ * renderer; then the fork's post-replay reset.
+ * @param {{ strip?: boolean, postReplay?: 'none'|'mouseOnly'|'full'|'processExit' }} opts
+ *   full = mouse+paste+focus (keeps alt); processExit = TERMINAL_PROCESS_EXIT_RESET (leave alt)
+ */
+async function reloadReconnect(ptyHost, opts = {}) {
+	const { strip = true, postReplay = 'none' } = opts;
+	const replayRaw = ptyHost.serializer.serialize();
+	const replay = strip ? stripMouseEnables(replayRaw) : replayRaw;
+	const renderer = newTerm();
+	await write(renderer, replay);
+	if (postReplay === 'mouseOnly') {
+		await write(renderer, CSI.hostMouseOnlyReset);
+	} else if (postReplay === 'full') {
+		await write(renderer, CSI.hostExitReset);
+	} else if (postReplay === 'processExit') {
+		await write(renderer, CSI.hostProcessExitReset);
+	}
+	return { renderer, replayRaw, replay };
+}
+
+/** Revive (window restart): ptyService serializeNormalBuffer → normalBufferOnly. */
+async function reviveReplay(ptyHost) {
+	const replay = ptyHost.serializer.serialize({ excludeModes: true, excludeAltBuffer: true });
+	const renderer = newTerm();
+	await write(renderer, replay);
+	return { renderer, replay };
+}
+
+// --- root-cause ground truth -------------------------------------------------
+
+describe('ground truth: serialize() replay re-arms modes (root cause of sticky [MC…)', () => {
+	it('unstripped reconnection replay restores mouse+alt+focus onto a fresh renderer', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		// Sanity: pty-host truth has everything on.
+		assert.deepEqual(observe(ptyHost.term), { mouse: 'any', focus: true, paste: true, alt: true });
+
+		const { renderer, replayRaw } = await reloadReconnect(ptyHost, { strip: false, postReplay: 'none' });
+		// The replay itself carries DECSET re-enables emitted from *state*, not history.
+		assert.ok(/\x1b\[\?100[023]h/.test(replayRaw), 'serialize() must emit mouse DECSETs');
+		assert.deepEqual(observe(renderer), { mouse: 'any', focus: true, paste: true, alt: true });
+	});
+
+	it('dead process + unstripped replay = sticky mouse over a shell (symptom 1)', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		// Grok killed hard (TerminateProcess / lost RESTORE race): pty host never
+		// sees teardown. Upstream VS Code (no strip, no reset) replays it all:
+		const { renderer } = await reloadReconnect(ptyHost, { strip: false, postReplay: 'none' });
+		assert.equal(observe(renderer).mouse, 'any', 'upstream behavior: mouse re-armed over a dead process');
+	});
+});
+
+// --- the fork's host policy ---------------------------------------------------
+
+describe('host policy: conditional strip + exit-only post-replay reset', () => {
+	it('dead process: strip + process-exit reset leaves clean shell', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		// Dead-at-generation: strip mouse enables; TERMINAL_PROCESS_EXIT_RESET at complete.
+		const { renderer } = await reloadReconnect(ptyHost, { strip: true, postReplay: 'processExit' });
+		assert.deepEqual(observe(renderer), { mouse: 'none', focus: false, paste: false, alt: false },
+			'dead path: strip + process-exit reset → clean shell');
+	});
+
+	it('dead process without exit reset: paste/focus/alt still leak (why exit reset is required)', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		const { renderer } = await reloadReconnect(ptyHost, { strip: true, postReplay: 'none' });
+		const leaked = observe(renderer);
+		assert.equal(leaked.mouse, 'none', 'strip alone clears mouse');
+		assert.equal(leaked.paste, true, '?2004 still re-armed without exit reset');
+		assert.equal(leaked.focus, true, '?1004 still re-armed without exit reset');
+		assert.equal(leaked.alt, true, 'alt buffer restored with no live owner');
+		await write(renderer, CSI.hostProcessExitReset);
+		assert.deepEqual(observe(renderer), { mouse: 'none', focus: false, paste: false, alt: false });
+	});
+
+	it('live TUI: verbatim replay keeps mouse+alt+focus (no strip, no post-replay reset)', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		// Conditional strip OFF for live root TUI — upstream serialize re-arm is correct.
+		const { renderer } = await reloadReconnect(ptyHost, { strip: false, postReplay: 'none' });
+		const snap = observe(renderer);
+		assert.equal(snap.alt, true, 'reconnection restores alternate buffer');
+		assert.equal(snap.focus, true, 'focus reporting survives');
+		assert.equal(snap.mouse, 'any', 'live TUI keeps mouse — no app reassert required');
+		assert.ok(activeBufferText(renderer).includes(WELCOME), 'alt-screen content restored');
+	});
+
+	it('live TUI + full exit reset would kill mouse/focus (must not run on live path)', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		const { renderer } = await reloadReconnect(ptyHost, { strip: false, postReplay: 'full' });
+		assert.equal(observe(renderer).mouse, 'none', 'full reset wrongly clears live mouse');
+		assert.equal(observe(renderer).focus, false, 'full reset kills ?1004');
+	});
+
+	it('Windows nested-dead shell policy: strip when shell has no children', async () => {
+		// Policy unit is in terminalMouseModeReset.test.ts; here verify strip
+		// alone is enough to prevent sticky mouse over a shell after reload.
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		const { renderer } = await reloadReconnect(ptyHost, { strip: true, postReplay: 'none' });
+		assert.equal(observe(renderer).mouse, 'none', 'stripped nested-dead: no [MC… into shell');
+		assert.equal(observe(renderer).alt, true, 'alt may remain until exit reset if root dies');
+	});
+});
+
+// --- the TUI's reassert paths ---------------------------------------------------
+
+describe('TUI reassert paths', () => {
+	it('FocusGained mouse-only re-arms mouse without touching alt buffer content', async () => {
+		// Preferred app policy: idempotent DECSET enables, no EnterAlternateScreen.
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		const { renderer } = await reloadReconnect(ptyHost);
+		await write(renderer, CSI.mouseEnableOnly);
+		const snap = observe(renderer);
+		assert.equal(snap.mouse, 'any');
+		assert.equal(snap.alt, true);
+		assert.ok(activeBufferText(renderer).includes(WELCOME), 'no welcome wipe from mouse-only reassert');
+	});
+
+	it('legacy full reassert while already in alt: xterm.js no-op (no wipe)', async () => {
+		// Kept for ConPTY comparison notes — app no longer uses full reassert on FocusGained.
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		const { renderer } = await reloadReconnect(ptyHost);
+		assert.equal(observe(renderer).alt, true);
+		await write(renderer, CSI.reassertDisplay);
+		const snap = observe(renderer);
+		assert.equal(snap.alt, true);
+		assert.equal(snap.mouse, 'any');
+		assert.ok(activeBufferText(renderer).includes(WELCOME), 'xterm.js: redundant re-entry does not wipe');
+	});
+
+	it('legacy RESTORE strands main buffer: full reassert recovers but wipes — prefer not to use on FocusGained', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		await write(ptyHost.term, CSI.restoreSeq); // legacy RESTORE stranded us on main
+		const { renderer } = await reloadReconnect(ptyHost);
+		assert.equal(observe(renderer).alt, false);
+		await write(renderer, CSI.mouseEnableOnly);
+		assert.equal(observe(renderer).alt, false, 'mouse-only cannot recover buffer ownership');
+		await write(renderer, CSI.reassertDisplay);
+		const snap = observe(renderer);
+		assert.equal(snap.alt, true);
+		assert.equal(snap.mouse, 'any');
+		assert.ok(!activeBufferText(renderer).includes(WELCOME),
+			'alt buffer is cleared on entry from main — only for rare recovery, not FocusGained');
+	});
+});
+
+// --- legacy / production grok and revive ---------------------------------------
+
+describe('legacy + revive regressions', () => {
+	it('production grok 0.2.101: RESTORE_SEQ before reload strands a live TUI on the main buffer (symptom 2)', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		// Old CTRL_CLOSE handler wrote RESTORE_SEQ into the pty; pty host applied it.
+		await write(ptyHost.term, CSI.restoreSeq);
+		const { renderer } = await reloadReconnect(ptyHost);
+		const snap = observe(renderer);
+		assert.equal(snap.alt, false, 'renderer lands on main buffer — terminal owns scroll');
+		assert.equal(snap.mouse, 'none');
+		// Mouse-only reassert is NOT sufficient here (still main buffer):
+		await write(renderer, CSI.mouseEnableOnly);
+		assert.equal(observe(renderer).alt, false, 'path 2 cannot recover buffer ownership');
+		// Only the full display reassert recovers:
+		await write(renderer, CSI.reassertDisplay);
+		const recovered = observe(renderer);
+		assert.equal(recovered.alt, true);
+		assert.equal(recovered.mouse, 'any');
+	});
+
+	it('revive (normalBufferOnly): alt buffer and modes are excluded by design', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		const { renderer, replay } = await reviveReplay(ptyHost);
+		const snap = observe(renderer);
+		assert.equal(snap.alt, false, 'upstream: revive never restores the alt buffer');
+		assert.equal(snap.mouse, 'none');
+		assert.equal(snap.focus, false);
+		assert.ok(!replay.includes(WELCOME), 'alt-screen content is not in the revive payload');
+		assert.ok(activeBufferText(renderer).includes('grok'), 'normal-buffer history (the launch command) survives');
+	});
+});
+
+// --- strip robustness against the real parser -----------------------------------
+
+describe('strip robustness (real emulator as oracle)', () => {
+	it('combined DECSET params: mouse stripped, alt-screen preserved', async () => {
+		const combined = '\x1b[?1049;1002;1006h' + WELCOME;
+		const stripped = stripMouseEnables(combined);
+		const renderer = newTerm();
+		await write(renderer, stripped);
+		const snap = observe(renderer);
+		assert.equal(snap.alt, true, 'combined ?1049 must survive the strip');
+		assert.equal(snap.mouse, 'none');
+	});
+
+	it('strip never touches resets (l) — a clean teardown replays as clean', async () => {
+		const ptyHost = newPtyHost();
+		await grokSession(ptyHost);
+		await write(ptyHost.term, CSI.restoreSeq); // clean exit teardown
+		await write(ptyHost.term, SHELL_PROMPT);   // shell prompt back
+		const { renderer } = await reloadReconnect(ptyHost);
+		const snap = observe(renderer);
+		assert.deepEqual(snap, { mouse: 'none', focus: false, paste: false, alt: false });
+		assert.ok(activeBufferText(renderer).includes(SHELL_PROMPT.trimEnd()));
+	});
+});

--- a/scripts/sticky-mouse-reload/parity.test.mjs
+++ b/scripts/sticky-mouse-reload/parity.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * Parity gate: CSI sequences must match across host TS, harness model, and
+ * (when present) grok-build Rust. Catches the three-copy drift failure mode.
+ *
+ *   node --test scripts/sticky-mouse-reload/parity.test.mjs
+ *   node --test scripts/sticky-mouse-reload/*.test.mjs   # full gate
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CSI } from './decModeState.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const vscodeRoot = path.resolve(__dirname, '../..');
+const hostTs = path.join(
+	vscodeRoot,
+	'src/vs/platform/terminal/common/terminalMouseModeReset.ts',
+);
+
+function read(p) {
+	return fs.readFileSync(p, 'utf8');
+}
+
+/** Pull a `export const NAME = '...' + '...'` style concatenation of escapes. */
+function extractConstString(src, name) {
+	const re = new RegExp(
+		`export const ${name}\\s*=\\s*([\\s\\S]*?);`,
+		'm',
+	);
+	const m = src.match(re);
+	if (!m) return null;
+	const body = m[1];
+	// Collect '\\x1b[...]' and '\x1b[...]' string literals
+	const parts = [];
+	const lit = /'\\x1b\[([^\']*)'|"\\x1b\[([^"]*)"/g;
+	let x;
+	while ((x = lit.exec(body)) !== null) {
+		parts.push('\x1b[' + (x[1] ?? x[2]));
+	}
+	// Also plain '\x1b[?1000l' forms already covered; handle concatenated IDENT only
+	if (parts.length === 0 && body.includes('TERMINAL_MOUSE_TRACKING_RESET')) {
+		// composed from other consts — resolve manually below
+		return body.trim();
+	}
+	return parts.length ? parts.join('') : null;
+}
+
+describe('CSI parity: host TS ↔ harness decModeState', () => {
+	const ts = read(hostTs);
+
+	it('host exports the three reset levels', () => {
+		assert.ok(ts.includes('TERMINAL_MOUSE_TRACKING_RESET'));
+		assert.ok(ts.includes('TERMINAL_MOUSE_MODE_RESET'));
+		assert.ok(ts.includes('TERMINAL_PROCESS_EXIT_RESET'));
+	});
+
+	it('mouse-only reset matches harness hostMouseOnlyReset', () => {
+		const tracking = extractConstString(ts, 'TERMINAL_MOUSE_TRACKING_RESET');
+		assert.ok(tracking, 'parse TERMINAL_MOUSE_TRACKING_RESET');
+		assert.equal(tracking, CSI.hostMouseOnlyReset);
+	});
+
+	it('full sticky reset (no leave-alt) matches harness hostExitReset mouse+paste+focus', () => {
+		// TERMINAL_MOUSE_MODE_RESET = TRACKING + paste + focus
+		const modeBody = extractConstString(ts, 'TERMINAL_MOUSE_MODE_RESET');
+		assert.ok(modeBody);
+		// May be composition expression — assert includes
+		assert.ok(ts.includes("'\\x1b[?2004l'") || ts.includes('"\\x1b[?2004l"') || ts.includes('\\x1b[?2004l'));
+		assert.ok(ts.includes('?1004l'));
+		assert.equal(CSI.hostExitReset, CSI.hostMouseOnlyReset + '\x1b[?2004l\x1b[?1004l');
+	});
+
+	it('process-exit reset includes leave-alt + show cursor (harness + host)', () => {
+		assert.ok(ts.includes('?1049l'));
+		assert.ok(ts.includes('?25h'));
+		// harness hostExitReset is intentionally mouse+paste+focus only; exit
+		// leave-alt lives on TERMINAL_PROCESS_EXIT_RESET. Keep both documented:
+		assert.ok(!CSI.hostExitReset.includes('1049'), 'harness hostExitReset stays leave-alt free (post-replay safe)');
+	});
+
+	it('strip keeps alt-screen and drops mouse enables including X10 ?9 (shared policy)', () => {
+		assert.ok(ts.includes('stripMouseTrackingEnableFromData'));
+		assert.ok(ts.includes('1000') && ts.includes('1006'));
+		assert.ok(
+			ts.includes("'9'") || ts.includes('"9"') || /MOUSE_TRACKING_ENABLE_MODES[\s\S]*\b9\b/.test(ts),
+			'strip set must include X10 mode 9',
+		);
+		assert.ok(CSI.hostMouseOnlyReset.includes('\x1b[?9l'));
+	});
+});
+
+describe('CSI parity: optional grok-build Rust (when checkout exists)', () => {
+	const candidates = [
+		path.resolve(vscodeRoot, '../grok-build/crates/codegen/xai-crash-handler/src/terminal.rs'),
+		path.resolve('C:/Users/Louis/Documents/clone/grok-build/crates/codegen/xai-crash-handler/src/terminal.rs'),
+	];
+	const rustPath = candidates.find(p => fs.existsSync(p));
+
+	it('MOUSE_ENABLE_SEQ / REASSERT / RESTORE present and sane when grok-build is local', function () {
+		if (!rustPath) {
+			this.skip();
+			return;
+		}
+		const rs = read(rustPath);
+		assert.ok(rs.includes('MOUSE_ENABLE_SEQ'));
+		assert.ok(rs.includes('REASSERT_DISPLAY_SEQ'));
+		assert.ok(rs.includes('RESTORE_SEQ'));
+		/** Capture the `b"..."` body for `pub const NAME`. */
+		const bytesBody = (name) => {
+			const re = new RegExp(
+				String.raw`pub const ${name}\s*:\s*&\[u8\]\s*=\s*b"([\s\S]*?)"\s*;`,
+			);
+			const m = rs.match(re);
+			assert.ok(m, `parse b"..." for ${name}`);
+			return m[1].replace(/\\\n\s*/g, '');
+		};
+		const mouseEn = bytesBody('MOUSE_ENABLE_SEQ');
+		const reassert = bytesBody('REASSERT_DISPLAY_SEQ');
+		const restore = bytesBody('RESTORE_SEQ');
+		assert.ok(!/1049/.test(mouseEn), 'mouse-only must not touch alt');
+		assert.ok(reassert.includes('?1049h'), 'reassert enters alt');
+		assert.ok(!reassert.includes('?1049l'), 'reassert must not leave alt');
+		assert.ok(restore.includes('?1049l'), 'RESTORE leaves alt on real exit');
+		assert.ok(mouseEn.includes('?1000h') && mouseEn.includes('?1006h'));
+		assert.ok(
+			!mouseEn.includes('?1004h'),
+			'mouse-only reassert must not re-fire focus reporting (storm risk)',
+		);
+		assert.ok(reassert.includes('?1006h') && reassert.includes('?1004h'));
+	});
+});

--- a/scripts/sticky-mouse-reload/run-mouse-modes-smoke.ps1
+++ b/scripts/sticky-mouse-reload/run-mouse-modes-smoke.ps1
@@ -1,0 +1,56 @@
+# Local A/B: sticky-mouse smoke (real Code OSS + Playwright + fake-tui fixture).
+# Requires: already-built out/ and .build/electron (rebuild-local.ps1 -Target vscode).
+#
+# Usage:
+#   pwsh -File scripts/sticky-mouse-reload/run-mouse-modes-smoke.ps1
+#   pwsh -File scripts/sticky-mouse-reload/run-mouse-modes-smoke.ps1 -Compile
+#
+# Filter is fixed to "Terminal Mouse Modes" so the full terminal suite is not run.
+
+param(
+  [switch]$Compile
+)
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+Set-Location $root
+
+$oss = Join-Path $root '.build\electron\Code - OSS.exe'
+if (-not (Test-Path $oss)) {
+  throw "Missing $oss — run rebuild-local.ps1 -Target vscode first"
+}
+$termOut = Join-Path $root 'out\vs\workbench\contrib\terminal\common\basePty.js'
+if (-not (Test-Path $termOut)) {
+  throw "Missing compiled out/ — run npm run compile first"
+}
+
+if ($Compile) {
+  Write-Host 'Compiling smoke + automation...'
+  Push-Location (Join-Path $root 'test\smoke')
+  try {
+    npm run compile
+    if ($LASTEXITCODE -ne 0) { throw "smoke compile failed ($LASTEXITCODE)" }
+  } finally {
+    Pop-Location
+  }
+} else {
+  $smokeMain = Join-Path $root 'test\smoke\out\main.js'
+  if (-not (Test-Path $smokeMain)) {
+    Write-Host 'smoke out/ missing — compiling once...'
+    Push-Location (Join-Path $root 'test\smoke')
+    try {
+      npm run compile
+      if ($LASTEXITCODE -ne 0) { throw "smoke compile failed ($LASTEXITCODE)" }
+    } finally {
+      Pop-Location
+    }
+  }
+}
+
+Write-Host 'Running Terminal Mouse Modes smoke (real Electron window will open)...'
+# Clear CI so the suite is not auto-skipped
+Remove-Item Env:CI -ErrorAction SilentlyContinue
+Remove-Item Env:VSCODE_SKIP_MOUSE_MODE_SMOKE -ErrorAction SilentlyContinue
+
+npm run smoketest-no-compile -- -f "Terminal Mouse Modes"
+exit $LASTEXITCODE

--- a/scripts/sticky-mouse-reload/scenarios.test.mjs
+++ b/scripts/sticky-mouse-reload/scenarios.test.mjs
@@ -1,0 +1,302 @@
+/**
+ * Deterministic sticky-mouse / Reload Window scenarios (Opus-aligned policy).
+ *
+ *   node --test scripts/sticky-mouse-reload/scenarios.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	CSI,
+	SHELL_FOCUS_GARBAGE_RE,
+	applyOutput,
+	countMouseReassertWrites,
+	createDecModeState,
+	decrqmIndicatesReset,
+	decrqmRequest,
+	isMouseOwnedByApp,
+	isTuiScreenLocked,
+	mouseEnableSeqIsSafe,
+	parseDecrqmReply,
+	simulateColdStartWithSpuriousFocus,
+	simulateReload,
+	snapshot,
+	stripMouseEnables,
+	tuiEnterFullscreen,
+} from './decModeState.mjs';
+
+function recordTuiSession() {
+	return (
+		CSI.mouseDisable +
+		CSI.enterAlt +
+		CSI.mouseEnable +
+		CSI.focusEnable +
+		CSI.pasteEnable +
+		'Grok UI\n'
+	);
+}
+
+describe('DEC mode state machine', () => {
+	it('starts unlocked with mouse off', () => {
+		const s = createDecModeState();
+		assert.deepEqual(snapshot(s), {
+			altScreen: false,
+			mouse: false,
+			focus: false,
+			paste: false,
+		});
+	});
+
+	it('TUI fullscreen init locks screen and enables mouse', () => {
+		const s = createDecModeState();
+		tuiEnterFullscreen(s);
+		const snap = snapshot(s);
+		assert.equal(isTuiScreenLocked(snap), true);
+		assert.equal(isMouseOwnedByApp(snap), true);
+	});
+
+	it('clean RESTORE_SEQ unlocks screen and clears mouse (real exit)', () => {
+		const s = createDecModeState();
+		tuiEnterFullscreen(s);
+		applyOutput(s, CSI.restoreSeq);
+		const snap = snapshot(s);
+		assert.equal(isTuiScreenLocked(snap), false);
+		assert.equal(isMouseOwnedByApp(snap), false);
+	});
+
+	it('unclean kill leaves sticky mouse; host exit reset clears it', () => {
+		const s = createDecModeState();
+		tuiEnterFullscreen(s);
+		assert.equal(snapshot(s).mouse, true);
+		applyOutput(s, CSI.hostExitReset);
+		assert.equal(snapshot(s).mouse, false);
+	});
+
+	it('stripMouseEnables keeps alt-screen enables', () => {
+		const raw = CSI.enterAlt + CSI.mouseEnable + 'hi';
+		const stripped = stripMouseEnables(raw);
+		assert.ok(stripped.includes('\x1b[?1049h'));
+		assert.ok(!stripped.includes('\x1b[?1000h'));
+		assert.ok(stripped.includes('hi'));
+	});
+
+	it('stripMouseEnables drops X10 ?9h (serializer x10 path)', () => {
+		const stripped = stripMouseEnables(CSI.mouseX10Enable + CSI.enterAlt);
+		assert.ok(!stripped.includes('\x1b[?9h'));
+		assert.ok(stripped.includes('\x1b[?1049h'));
+		assert.equal(stripMouseEnables('\x1b[?1049;9;1002h'), '\x1b[?1049h');
+	});
+});
+
+describe('DECRQM helpers', () => {
+	it('formats request', () => {
+		assert.equal(decrqmRequest(1049), '\x1b[?1049$p');
+		assert.equal(decrqmRequest(1006), '\x1b[?1006$p');
+	});
+
+	it('parses set/reset replies', () => {
+		assert.deepEqual(parseDecrqmReply('\x1b[?1049;1$y'), { mode: 1049, ps: 1 });
+		assert.deepEqual(parseDecrqmReply('\x1b[?1006;2$y'), { mode: 1006, ps: 2 });
+		assert.equal(parseDecrqmReply('nope'), null);
+	});
+
+	it('reset ps means reassert needed', () => {
+		assert.equal(decrqmIndicatesReset(1), false);
+		assert.equal(decrqmIndicatesReset(2), true);
+		assert.equal(decrqmIndicatesReset(0), true);
+	});
+});
+
+describe('Reload Window (idempotent FocusGained mouse reassert)', () => {
+	it('host strip: alt from buffer, mouse not re-armed from history', () => {
+		const snap = simulateReload(recordTuiSession(), {
+			hostPostReplay: 'none',
+			stripMouseOnReplay: true,
+			softReattach: false,
+		});
+		assert.equal(isTuiScreenLocked(snap), true);
+		assert.equal(isMouseOwnedByApp(snap), false);
+	});
+
+	it('without strip, mouse re-arms from history (sticky risk)', () => {
+		const snap = simulateReload(recordTuiSession(), {
+			hostPostReplay: 'none',
+			stripMouseOnReplay: false,
+			softReattach: false,
+		});
+		assert.equal(isMouseOwnedByApp(snap), true);
+	});
+
+	it('LEGACY BUG: CTRL_CLOSE RESTORE while alive → scroll escapes', () => {
+		const snap = simulateReload(recordTuiSession(), {
+			oldRestoreOnCtrlClose: true,
+			hostPostReplay: 'none',
+			stripMouseOnReplay: false,
+			tuiReassert: false,
+			softReattach: false,
+		});
+		assert.equal(isTuiScreenLocked(snap), false);
+		assert.equal(isMouseOwnedByApp(snap), false);
+	});
+
+	it('FocusGained mouse reassert after host strip → locked + mouse', () => {
+		// Preferred: soft CTRL_CLOSE (no RESTORE) + FocusGained mouse-only.
+		const snap = simulateReload(recordTuiSession(), {
+			softReattach: true,
+			hostPostReplay: 'mouseOnly',
+			stripMouseOnReplay: true,
+			tuiReassert: true,
+		});
+		assert.equal(isTuiScreenLocked(snap), true);
+		assert.equal(isMouseOwnedByApp(snap), true);
+	});
+
+	it('host strip without app reassert: mouse off after host (no sticky)', () => {
+		const snap = simulateReload(recordTuiSession(), {
+			softReattach: true,
+			hostPostReplay: 'mouseOnly',
+			stripMouseOnReplay: true,
+			tuiReassert: false,
+		});
+		assert.equal(isMouseOwnedByApp(snap), false);
+	});
+
+	it('host strip + mouse-only reassert (no CTRL_CLOSE): clicks work, no alt wipe', () => {
+		// Live process after Reload: host clears mouse; TUI re-enables mouse
+		// only (no second EnterAlternateScreen).
+		const snap = simulateReload(recordTuiSession(), {
+			softReattach: false,
+			hostPostReplay: 'mouseOnly',
+			stripMouseOnReplay: true,
+			tuiReassert: true,
+		});
+		assert.equal(isTuiScreenLocked(snap), true, 'alt kept from stripped replay');
+		assert.equal(isMouseOwnedByApp(snap), true, 'mouse re-enabled without wipe');
+	});
+
+	it('cold start: FocusGained mouse reassert must not leave alt / wipe welcome', () => {
+		const { afterWelcome, afterSpuriousFocus } = simulateColdStartWithSpuriousFocus();
+		assert.equal(afterWelcome.altScreen, true);
+		assert.equal(afterWelcome.mouse, true);
+		assert.equal(afterSpuriousFocus.altScreen, true);
+		assert.equal(afterSpuriousFocus.mouse, true);
+		// Idempotent re-enable may set focus reporting; alt+mouse must stay.
+		assert.deepEqual(
+			{ alt: afterSpuriousFocus.altScreen, mouse: afterSpuriousFocus.mouse },
+			{ alt: afterWelcome.altScreen, mouse: afterWelcome.mouse },
+		);
+	});
+
+	it('legacy REASSERT_DISPLAY enters alt and mouse without leave', () => {
+		const s = createDecModeState();
+		applyOutput(s, CSI.reassertDisplay);
+		assert.equal(snapshot(s).altScreen, true);
+		assert.equal(snapshot(s).mouse, true);
+		assert.equal(snapshot(s).focus, true);
+	});
+
+	it('init must not write leave-alt after enter-alt (RESTORE after EnterAlternateScreen)', () => {
+		// Models the grok_local bug: EnterAlternateScreen then RESTORE_SEQ.
+		const s = createDecModeState();
+		applyOutput(s, CSI.enterAlt);
+		assert.equal(snapshot(s).altScreen, true);
+		applyOutput(s, CSI.restoreSeq); // bad: leave-alt inside RESTORE
+		assert.equal(snapshot(s).altScreen, false, 'RESTORE undoes fullscreen');
+		// Fixed order: enter alt, mouse reset only (no leave), mouse enable.
+		const good = createDecModeState();
+		applyOutput(good, CSI.enterAlt + CSI.mouseDisable + CSI.mouseEnable + CSI.focusEnable);
+		assert.equal(snapshot(good).altScreen, true);
+		assert.equal(snapshot(good).mouse, true);
+	});
+});
+
+describe('prompt focus restore policy', () => {
+	/**
+	 * Mirrors event_loop FocusGained gate:
+	 * restore = should_restore && (needs_input_overlay || external_focus)
+	 */
+	function shouldApplyRestore(shouldRestore, needsInputOverlay, externalFocus) {
+		return shouldRestore && (needsInputOverlay || externalFocus);
+	}
+
+	it('idle non-vim on scrollback: restore only after FocusLost (external)', () => {
+		const shouldRestore = true; // idle non-vim on scrollback
+		const needsInput = false;
+		assert.equal(shouldApplyRestore(shouldRestore, needsInput, false), false);
+		assert.equal(shouldApplyRestore(shouldRestore, needsInput, true), true);
+	});
+
+	it('needs-input overlay: restore even without FocusLost', () => {
+		assert.equal(shouldApplyRestore(true, true, false), true);
+	});
+
+	it('already on prompt: should_restore false → no switch', () => {
+		assert.equal(shouldApplyRestore(false, false, true), false);
+	});
+});
+
+describe('acceptance', () => {
+	it('documents pass: soft reattach + reassert', () => {
+		const pass = simulateReload(CSI.enterAlt + CSI.mouseEnable + 'chat\n', {
+			softReattach: true,
+			tuiReassert: true,
+			hostPostReplay: 'mouseOnly',
+			stripMouseOnReplay: true,
+		});
+		assert.equal(pass.altScreen, true);
+		assert.equal(pass.mouse, true);
+	});
+
+	it('documents fail: legacy RESTORE on CTRL_CLOSE, no reassert', () => {
+		const fail = simulateReload(CSI.enterAlt + CSI.mouseEnable + 'chat\n', {
+			oldRestoreOnCtrlClose: true,
+			tuiReassert: false,
+			hostPostReplay: 'none',
+			stripMouseOnReplay: false,
+		});
+		assert.equal(fail.altScreen, false);
+		assert.equal(fail.mouse, false);
+	});
+
+	it('unclean kill: host process-exit reset clears mouse+focus (shell stays clean)', () => {
+		// Screenshot symptom: `[I[II…00[0…` at a bare shell = focus/mouse modes stuck.
+		// Host owns modes that outlive the process — full exit reset after death.
+		const s = createDecModeState();
+		tuiEnterFullscreen(s);
+		assert.equal(snapshot(s).mouse, true);
+		assert.equal(snapshot(s).focus, true);
+		// Process dies without app RESTORE (kill -9 / crash) → host exit reset.
+		applyOutput(s, CSI.hostProcessExitReset);
+		const after = snapshot(s);
+		assert.equal(after.mouse, false, 'mouse off — no [MC… / 00[0 garbage');
+		assert.equal(after.focus, false, 'focus off — no [I / [O garbage');
+		assert.equal(after.altScreen, false, 'left alt screen for shell');
+	});
+});
+
+describe('FocusGained reassert coalescing (freeze + [I[II) regression', () => {
+	it('mouse enable CSI is safe (no ?1004 / no alt)', () => {
+		assert.equal(mouseEnableSeqIsSafe(CSI.mouseEnableOnly), true);
+		assert.equal(mouseEnableSeqIsSafe(CSI.mouseEnableOnly + CSI.focusEnable), false);
+		assert.equal(mouseEnableSeqIsSafe(CSI.reassertDisplay), false, 'full reassert is not mouse-only');
+	});
+
+	it('one drain with FocusGained×N + Resize → exactly 1 write', () => {
+		// Event-loop coalescing: request N times, flush once per drain.
+		assert.equal(countMouseReassertWrites([3]), 1); // FG, FG, Resize
+		assert.equal(countMouseReassertWrites([50]), 1); // storm in one batch
+		assert.equal(countMouseReassertWrites([0]), 0);
+	});
+
+	it('separate drains each get a write if requested (no wall-clock suppress)', () => {
+		// Real host strip 700ms later must still repair — not blocked by cooldown.
+		assert.equal(countMouseReassertWrites([1, 1]), 2);
+		assert.equal(countMouseReassertWrites([2, 0, 1]), 2);
+	});
+
+	it('documents shell focus garbage pattern from stuck ?1004', () => {
+		const junk = '>[I[II';
+		assert.match(junk, SHELL_FOCUS_GARBAGE_RE);
+		assert.doesNotMatch('> hello', SHELL_FOCUS_GARBAGE_RE);
+	});
+});

--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -368,4 +368,11 @@ export interface ISerializedCommandDetectionCapability {
 export interface IPtyHostProcessReplayEvent {
 	events: ReplayEntry[];
 	commands: ISerializedCommandDetectionCapability;
+	/**
+	 * When true, the renderer strips mouse-tracking *enable* CSI from replay
+	 * data (dead root process, or Windows shell with no console children).
+	 * When false/omitted, replay is verbatim so a live full-screen TUI keeps
+	 * mouse modes without needing FocusGained reassert.
+	 */
+	shouldStripMouseTrackingEnables?: boolean;
 }

--- a/src/vs/platform/terminal/common/terminalMouseModeReset.ts
+++ b/src/vs/platform/terminal/common/terminalMouseModeReset.ts
@@ -1,0 +1,181 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * DEC private-mode resets for mouse tracking (and related sticky modes).
+ *
+ * Full-screen TUIs (vim, less, Claude Code, …) enable mouse reporting via
+ * CSI ?9/?1000/?1002/?1003/?1015/?1006. If those modes stay on when the
+ * consumer is a shell, xterm.js reports mouse as SGR/X10 text (`[M…`, `[MC…`).
+ *
+ * Host strategy (narrow, intentional scope):
+ * 1. **Root process exit** — when the terminal's root PTY process exits, write
+ *    {@link TERMINAL_PROCESS_EXIT_RESET}. Unconditional — process is gone.
+ * 2. **PTY replay (Reload / reconnect)** — strip mouse-tracking *enable* CSI
+ *    only when {@link shouldStripMouseTrackingOnReplay} says so (dead root, or
+ *    Windows shell with zero console children). Live full-screen TUIs replay
+ *    **verbatim** so mouse stays on without app FocusGained reassert.
+ * 3. **Replay complete** — full exit reset only if the root already exited
+ *    (`_exitCode` set). No mouse-only reset on the live path (that was itself
+ *    a live-TUI regression).
+ *
+ * Focus-in synthesis (`CSI I` on process stdin) is intentionally **not** done
+ * here: emulator ?1004 state can be stale after a dead child TUI, and would
+ * inject protocol input into a shell. App-side reassert remains defense-in-depth.
+ *
+ * Sequence parity: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+ */
+
+/** Shell-like process titles / types — root is a shell, not a full-screen TUI. */
+// Includes VS Code TerminalShellType string values (bash, pwsh, cmd, gitbash, wsl, nu, …).
+// Deliberately excludes TUI roots: claude, codex, copilot, gemini, node, python, …
+const SHELL_LIKE_RE = /^(bash|sh|zsh|fish|csh|tcsh|ksh|dash|pwsh|powershell|powershell_ise|cmd|cmd\.exe|gitbash|git-bash|wsl|nu|nushell|xonsh|elvish|oil|osh)(\.exe)?$/i;
+
+export interface IMouseReplayStripContext {
+	/** Root PTY process still running (not yet exited). */
+	processAlive: boolean;
+	/** From ChildProcessMonitor / Windows console process list. */
+	hasChildProcesses: boolean;
+	/** Best-effort shell type or process title. */
+	shellTypeOrTitle?: string | undefined;
+	/** `process.platform === 'win32'` at the pty host. */
+	isWindows: boolean;
+}
+
+/**
+ * Whether reconnection replay should strip mouse-tracking *enable* CSI.
+ *
+ * - Dead root → strip (no live owner; exit reset also runs at replay-complete).
+ * - Live root + Windows + shell-like + no console children → strip (nested TUI
+ *   died under a still-living shell; sticky modes would otherwise re-arm).
+ * - Otherwise → do **not** strip (live TUI / shell with children — upstream
+ *   serialize re-arm is correct).
+ */
+export function shouldStripMouseTrackingOnReplay(ctx: IMouseReplayStripContext): boolean {
+	if (!ctx.processAlive) {
+		return true;
+	}
+	if (!ctx.isWindows) {
+		// POSIX: no reliable child-liveness signal; accept residual nested-dead hole.
+		return false;
+	}
+	if (ctx.hasChildProcesses) {
+		return false;
+	}
+	const name = (ctx.shellTypeOrTitle || '').trim();
+	if (!name) {
+		// Unknown title — do not strip (could be a TUI as the root process).
+		return false;
+	}
+	// shellType enums are often bare names (PowerShell, GitBash); titles may be "pwsh.exe"
+	const normalized = name.replace(/\s+/g, '');
+	return SHELL_LIKE_RE.test(normalized) || SHELL_LIKE_RE.test(name.split(/[\\/]/).pop() || '');
+}
+
+/** Mouse tracking only — safe after replay (preserves focus / bracketed paste). */
+export const TERMINAL_MOUSE_TRACKING_RESET =
+	'\x1b[?9l' +    // X10 mouse tracking (serializer may re-emit ?9h)
+	'\x1b[?1000l' + // normal tracking
+	'\x1b[?1002l' + // button-event tracking
+	'\x1b[?1003l' + // any-event tracking
+	'\x1b[?1015l' + // urxvt extended
+	'\x1b[?1006l';  // SGR extended
+
+/**
+ * Full sticky-mode cleanup for root-process exit (mouse + paste + focus).
+ * Prefer this when the process is gone and the tab may host a shell next.
+ */
+export const TERMINAL_MOUSE_MODE_RESET =
+	TERMINAL_MOUSE_TRACKING_RESET +
+	'\x1b[?2004l' + // bracketed paste
+	'\x1b[?1004l';  // focus in/out
+
+/**
+ * Root-process exit reset: {@link TERMINAL_MOUSE_MODE_RESET} plus leave the
+ * alternate screen and show the cursor. Only for paths where the **root** PTY
+ * process is known dead — never write this while a process lives.
+ *
+ * Scope note: this runs on terminal process exit (the shell / root child of the
+ * PTY), not when a nested TUI exits back to a still-running shell.
+ */
+export const TERMINAL_PROCESS_EXIT_RESET =
+	TERMINAL_MOUSE_MODE_RESET +
+	'\x1b[?1049l' + // leave alternate screen
+	'\x1b[?25h';    // show cursor
+
+/** DEC private modes that enable mouse reporting (incl. X10 ?9). */
+const MOUSE_TRACKING_ENABLE_MODES = new Set(['9', '1000', '1002', '1003', '1006', '1015']);
+/** Tracking modes without SGR encoding — what SerializeAddon typically re-emits. */
+const MOUSE_TRACKING_WITHOUT_SGR = ['9', '1000', '1002', '1003'] as const;
+
+/**
+ * True if `data` contains a DECSET enable for any of `modes` (simple CSI or
+ * combined `?1000;1002h` form).
+ */
+function dataEnablesModes(data: string, modes: readonly string[]): boolean {
+	if (!data.includes('\x1b[?')) {
+		return false;
+	}
+	for (const m of modes) {
+		if (data.includes(`\x1b[?${m}h`)) {
+			return true;
+		}
+	}
+	const re = new RegExp(`\\x1b\\[\\?[\\d;]*\\b(?:${modes.join('|')})[\\d;]*h`);
+	return re.test(data);
+}
+
+/**
+ * Returns true if `data` looks like it contains DEC mouse-tracking enable
+ * sequences (used by tests / diagnostics). Includes X10 (`?9h`).
+ */
+export function dataEnablesMouseTracking(data: string): boolean {
+	return dataEnablesModes(data, [...MOUSE_TRACKING_ENABLE_MODES]);
+}
+
+/**
+ * Remove mouse-tracking **enable** modes from CSI DECSET sequences in `data`
+ * (including X10 `?9`). Resets (`l`) and non-mouse modes (e.g. ?1049, ?1004,
+ * ?2004) are preserved. Used only on PTY **replay** data — live process
+ * output must not be filtered.
+ */
+export function stripMouseTrackingEnableFromData(data: string): string {
+	if (!data.includes('\x1b[?')) {
+		return data;
+	}
+	return data.replace(/\x1b\[\?([\d;]+)([hl])/g, (full, modes: string, flag: string) => {
+		if (flag === 'l') {
+			return full;
+		}
+		const parts = modes.split(';');
+		const kept = parts.filter(p => !MOUSE_TRACKING_ENABLE_MODES.has(p));
+		if (kept.length === parts.length) {
+			return full;
+		}
+		if (kept.length === 0) {
+			return '';
+		}
+		return `\x1b[?${kept.join(';')}h`;
+	});
+}
+
+/**
+ * xterm SerializeAddon re-emits mouse *tracking* (?9/?1000/?1002/?1003) from
+ * `modes.mouseTrackingMode` but never SGR encoding (?1006). Without ?1006h,
+ * post-Reload clicks produce X10-style reports, not `\x1b[<…M`, so modern TUIs
+ * (and our smoke oracle) see no SGR log growth even when stripMouse=false.
+ *
+ * When replay already enables tracking and SGR is missing, append ?1006h.
+ * Only for the live-TUI path (caller must not strip mouse).
+ */
+export function ensureSgrMouseEncodingOnReplay(data: string): string {
+	if (!dataEnablesModes(data, MOUSE_TRACKING_WITHOUT_SGR)) {
+		return data;
+	}
+	if (dataEnablesModes(data, ['1006'])) {
+		return data;
+	}
+	return data + '\x1b[?1006h';
+}

--- a/src/vs/platform/terminal/node/childProcessMonitor.ts
+++ b/src/vs/platform/terminal/node/childProcessMonitor.ts
@@ -29,7 +29,14 @@ export const ignoreProcessNames: string[] = [];
  * calls into the monitor.
  */
 export class ChildProcessMonitor extends Disposable {
-	private _hasChildProcesses: boolean = false;
+	/**
+	 * Default **true** (fail-open). A failed process-tree lookup must not report
+	 * "no children" — that incorrectly makes {@link shouldStripMouseTrackingOnReplay}
+	 * strip mouse enables on Windows when `@vscode/windows-process-tree` cannot see
+	 * the shell pid (`Root process N not found`), killing sticky mouse for live
+	 * nested TUIs. Only a *successful* scan may set this to false.
+	 */
+	private _hasChildProcesses: boolean = true;
 	private set hasChildProcesses(value: boolean) {
 		if (this._hasChildProcesses !== value) {
 			this._hasChildProcesses = value;
@@ -86,7 +93,8 @@ export class ChildProcessMonitor extends Disposable {
 			const processItem = await listProcesses(this._pid);
 			this.hasChildProcesses = this._processContainsChildren(processItem);
 		} catch (e) {
-			this._logService.debug('ChildProcessMonitor: Fetching process tree failed', e);
+			// Do not force false — keep previous (default true). See field comment.
+			this._logService.debug('ChildProcessMonitor: Fetching process tree failed (keeping previous hasChildProcesses)', e);
 		}
 	}
 

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -26,6 +26,7 @@ import { ErrorNoTelemetry } from '../../../base/common/errors.js';
 import { ShellIntegrationAddon } from '../common/xterm/shellIntegrationAddon.js';
 import { formatMessageForTerminal } from '../common/terminalStrings.js';
 import { IPtyHostProcessReplayEvent } from '../common/capabilities/capabilities.js';
+import { shouldStripMouseTrackingOnReplay } from '../common/terminalMouseModeReset.js';
 import { IProductService } from '../../product/common/productService.js';
 import { join } from '../../../base/common/path.js';
 import { memoize } from '../../../base/common/decorators.js';
@@ -946,11 +947,25 @@ class PersistentTerminalProcess extends Disposable {
 			this._interactionState.setValue(InteractionState.ReplayOnly, 'triggerReplay');
 		}
 		const ev = await this._serializer.generateReplayEvent();
+		// Liveness at generation: strip only for dead root or Windows childless shell
+		// (nested TUI gone). Live full-screen root TUIs keep mouse from verbatim replay.
+		const shellHint = this._terminalProcess.shellType
+			?? this._terminalProcess.currentTitle
+			?? this._title;
+		ev.shouldStripMouseTrackingEnables = shouldStripMouseTrackingOnReplay({
+			processAlive: !this._terminalProcess.hasExited,
+			hasChildProcesses: this.hasChildProcesses,
+			shellTypeOrTitle: shellHint ? String(shellHint) : undefined,
+			isWindows,
+		});
 		let dataLength = 0;
 		for (const e of ev.events) {
 			dataLength += e.data.length;
 		}
-		this._logService.info(`Persistent process "${this._persistentProcessId}": Replaying ${dataLength} chars and ${ev.events.length} size events`);
+		this._logService.info(
+			`Persistent process "${this._persistentProcessId}": Replaying ${dataLength} chars and ${ev.events.length} size events` +
+			` (stripMouse=${ev.shouldStripMouseTrackingEnables})`
+		);
 		this._onProcessReplay.fire(ev);
 		this._terminalProcess.clearUnacknowledgedChars();
 		this._onPersistentProcessReady.fire();

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -119,7 +119,14 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 
 	get currentTitle(): string { return this._windowsShellHelper?.shellTitle || this._currentTitle; }
 	get shellType(): TerminalShellType | undefined { return isWindows ? this._windowsShellHelper?.shellType : posixShellTypeMap.get(this._currentTitle) || generalShellTypeMap.get(this._currentTitle); }
-	get hasChildProcesses(): boolean { return this._childProcessMonitor?.hasChildProcesses || false; }
+	/**
+	 * Fail-open when the monitor is not yet created: assume children exist so
+	 * {@link shouldStripMouseTrackingOnReplay} does not strip live nested TUIs.
+	 * (`|| false` would report "no children" and false-strip on Windows Reload.)
+	 */
+	get hasChildProcesses(): boolean { return this._childProcessMonitor?.hasChildProcesses ?? true; }
+	/** True after node-pty onExit (root process known dead or exiting). */
+	get hasExited(): boolean { return this._exitCode !== undefined; }
 
 	private readonly _onProcessData = this._register(new Emitter<string>());
 	readonly onProcessData = this._onProcessData.event;

--- a/src/vs/platform/terminal/test/common/terminalMouseModeReset.test.ts
+++ b/src/vs/platform/terminal/test/common/terminalMouseModeReset.test.ts
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import {
+	dataEnablesMouseTracking,
+	ensureSgrMouseEncodingOnReplay,
+	shouldStripMouseTrackingOnReplay,
+	stripMouseTrackingEnableFromData,
+	TERMINAL_MOUSE_MODE_RESET,
+	TERMINAL_MOUSE_TRACKING_RESET,
+	TERMINAL_PROCESS_EXIT_RESET,
+} from '../../common/terminalMouseModeReset.js';
+
+suite('Terminal mouse mode reset', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('TERMINAL_MOUSE_TRACKING_RESET disables mouse modes only (incl. X10 ?9)', () => {
+		for (const mode of ['9', '1000', '1002', '1003', '1015', '1006']) {
+			assert.ok(
+				TERMINAL_MOUSE_TRACKING_RESET.includes(`\x1b[?${mode}l`),
+				`must reset ?${mode}`,
+			);
+		}
+		// Must NOT clear focus / paste — live TUI needs FocusGained after Reload
+		assert.ok(!TERMINAL_MOUSE_TRACKING_RESET.includes('\x1b[?2004l'));
+		assert.ok(!TERMINAL_MOUSE_TRACKING_RESET.includes('\x1b[?1004l'));
+	});
+
+	test('TERMINAL_MOUSE_MODE_RESET is tracking reset plus paste/focus', () => {
+		assert.ok(TERMINAL_MOUSE_MODE_RESET.startsWith(TERMINAL_MOUSE_TRACKING_RESET));
+		assert.ok(TERMINAL_MOUSE_MODE_RESET.includes('\x1b[?2004l'));
+		assert.ok(TERMINAL_MOUSE_MODE_RESET.includes('\x1b[?1004l'));
+	});
+
+	test('TERMINAL_PROCESS_EXIT_RESET also leaves alt screen and shows cursor', () => {
+		assert.ok(TERMINAL_PROCESS_EXIT_RESET.startsWith(TERMINAL_MOUSE_MODE_RESET));
+		assert.ok(TERMINAL_PROCESS_EXIT_RESET.includes('\x1b[?1049l'));
+		assert.ok(TERMINAL_PROCESS_EXIT_RESET.includes('\x1b[?25h'));
+		// The live-TUI resets must never leave the alt screen:
+		assert.ok(!TERMINAL_MOUSE_TRACKING_RESET.includes('1049'));
+		assert.ok(!TERMINAL_MOUSE_MODE_RESET.includes('1049'));
+	});
+
+	test('reset is pure CSI (safe to write as process output)', () => {
+		assert.ok(TERMINAL_MOUSE_MODE_RESET.startsWith('\x1b'));
+		assert.ok(!TERMINAL_MOUSE_MODE_RESET.includes(' '));
+		assert.ok(!TERMINAL_MOUSE_MODE_RESET.includes('node'));
+	});
+
+	test('dataEnablesMouseTracking detects enable sequences including X10', () => {
+		assert.strictEqual(dataEnablesMouseTracking('hello'), false);
+		assert.strictEqual(dataEnablesMouseTracking('\x1b[?9h'), true);
+		assert.strictEqual(dataEnablesMouseTracking('\x1b[?1000h'), true);
+		assert.strictEqual(dataEnablesMouseTracking('\x1b[?1006h'), true);
+		assert.strictEqual(dataEnablesMouseTracking('\x1b[?1000;1002;1006h'), true);
+		assert.strictEqual(dataEnablesMouseTracking('\x1b[?9;1000h'), true);
+		assert.strictEqual(dataEnablesMouseTracking(TERMINAL_MOUSE_MODE_RESET), false);
+	});
+
+	test('stripMouseTrackingEnableFromData drops pure mouse enables including X10', () => {
+		assert.strictEqual(stripMouseTrackingEnableFromData('\x1b[?1000h'), '');
+		assert.strictEqual(stripMouseTrackingEnableFromData('\x1b[?9h'), '');
+		assert.strictEqual(
+			stripMouseTrackingEnableFromData('before\x1b[?1000h\x1b[?1006hafter'),
+			'beforeafter',
+		);
+		assert.strictEqual(stripMouseTrackingEnableFromData('\x1b[?1000l'), '\x1b[?1000l');
+		assert.strictEqual(
+			stripMouseTrackingEnableFromData('\x1b[?1000;2004h'),
+			'\x1b[?2004h',
+		);
+		// X10 combined with alt-screen: strip mouse, keep 1049
+		assert.strictEqual(
+			stripMouseTrackingEnableFromData('\x1b[?1049;9;1002h'),
+			'\x1b[?1049h',
+		);
+	});
+
+	test('shouldStripMouseTrackingOnReplay: dead root always strips', () => {
+		assert.strictEqual(shouldStripMouseTrackingOnReplay({
+			processAlive: false,
+			hasChildProcesses: true,
+			shellTypeOrTitle: 'grok',
+			isWindows: true,
+		}), true);
+		assert.strictEqual(shouldStripMouseTrackingOnReplay({
+			processAlive: false,
+			hasChildProcesses: false,
+			isWindows: false,
+		}), true);
+	});
+
+	test('shouldStripMouseTrackingOnReplay: live TUI root keeps mouse (no strip)', () => {
+		// Grok / Claude / vim as root with no children — do not strip
+		for (const title of ['grok', 'claude', 'vim', 'node', undefined, '']) {
+			assert.strictEqual(shouldStripMouseTrackingOnReplay({
+				processAlive: true,
+				hasChildProcesses: false,
+				shellTypeOrTitle: title,
+				isWindows: true,
+			}), false, `title=${title}`);
+		}
+		// Live shell with children (TUI under pwsh) — do not strip
+		assert.strictEqual(shouldStripMouseTrackingOnReplay({
+			processAlive: true,
+			hasChildProcesses: true,
+			shellTypeOrTitle: 'pwsh',
+			isWindows: true,
+		}), false);
+	});
+
+	test('shouldStripMouseTrackingOnReplay: Windows childless shell strips (nested-dead)', () => {
+		for (const shell of ['pwsh', 'powershell', 'PowerShell', 'cmd', 'bash', 'gitbash', 'GitBash']) {
+			assert.strictEqual(shouldStripMouseTrackingOnReplay({
+				processAlive: true,
+				hasChildProcesses: false,
+				shellTypeOrTitle: shell,
+				isWindows: true,
+			}), true, shell);
+		}
+	});
+
+	test('shouldStripMouseTrackingOnReplay: fail-open children keeps mouse on Windows shell', () => {
+		// ChildProcessMonitor defaults true; terminalProcess uses ?? true when monitor missing.
+		// hasChildProcesses=true must never strip a live shell (live nested TUI).
+		assert.strictEqual(shouldStripMouseTrackingOnReplay({
+			processAlive: true,
+			hasChildProcesses: true,
+			shellTypeOrTitle: 'pwsh',
+			isWindows: true,
+		}), false);
+	});
+
+	test('shouldStripMouseTrackingOnReplay: POSIX live never strips (residual hole accepted)', () => {
+		assert.strictEqual(shouldStripMouseTrackingOnReplay({
+			processAlive: true,
+			hasChildProcesses: false,
+			shellTypeOrTitle: 'bash',
+			isWindows: false,
+		}), false);
+	});
+
+	test('ensureSgrMouseEncodingOnReplay: appends ?1006h when tracking present without SGR', () => {
+		// SerializeAddon re-emits drag mode only (?1002h) — missing SGR encoding
+		const serialized = 'FAKE_TUI_READY\x1b[?2004h\x1b[?1004h\x1b[?1002h\x1b[?25l';
+		const fixed = ensureSgrMouseEncodingOnReplay(serialized);
+		assert.ok(fixed.endsWith('\x1b[?1006h'), fixed);
+		assert.ok(fixed.includes('\x1b[?1002h'));
+	});
+
+	test('ensureSgrMouseEncodingOnReplay: no-op when SGR already present or no tracking', () => {
+		const withSgr = 'x\x1b[?1002h\x1b[?1006hy';
+		assert.strictEqual(ensureSgrMouseEncodingOnReplay(withSgr), withSgr);
+		const noMouse = 'hello\x1b[?1049h\x1b[?25l';
+		assert.strictEqual(ensureSgrMouseEncodingOnReplay(noMouse), noMouse);
+		assert.strictEqual(ensureSgrMouseEncodingOnReplay('plain'), 'plain');
+	});
+});

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -47,6 +47,7 @@ import { TerminalCapabilityStoreMultiplexer } from '../../../../platform/termina
 import { IEnvironmentVariableCollection, IMergedEnvironmentVariableCollection } from '../../../../platform/terminal/common/environmentVariable.js';
 import { deserializeEnvironmentVariableCollections } from '../../../../platform/terminal/common/environmentVariableShared.js';
 import { GeneralShellType, IProcessDataEvent, IProcessPropertyMap, IReconnectionProperties, IShellLaunchConfig, ITerminalDimensionsOverride, ITerminalLaunchError, ITerminalLogService, PosixShellType, ProcessPropertyType, remoteResolverTerminal, ShellIntegrationStatus, TerminalExitReason, TerminalIcon, TerminalLocation, TerminalSettingId, TerminalShellType, TitleEventSource, WindowsShellType, type ShellIntegrationInjectionFailureReason } from '../../../../platform/terminal/common/terminal.js';
+import { TERMINAL_MOUSE_TRACKING_RESET, TERMINAL_PROCESS_EXIT_RESET } from '../../../../platform/terminal/common/terminalMouseModeReset.js';
 import { formatMessageForTerminal } from '../../../../platform/terminal/common/terminalStrings.js';
 import { editorBackground } from '../../../../platform/theme/common/colorRegistry.js';
 import { getIconRegistry } from '../../../../platform/theme/common/iconRegistry.js';
@@ -1578,7 +1579,17 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}));
 
 		this._initialDataEventsListener.value = processManager.onProcessData(ev => this._initialDataEvents?.push(ev.data));
-		this._register(processManager.onProcessReplayComplete(() => this._onProcessReplayComplete.fire()));
+		this._register(processManager.onProcessReplayComplete(() => {
+			if (this._exitCode !== undefined) {
+				// Root process already exited (possibly raced ahead of replay).
+				// Full cleanup incl. leave alt — only path that resets after replay.
+				this._resetStickyMouseModes('process-replay-complete-dead', 'exit');
+			}
+			// Live process: no mouse-only reset. Conditional strip on the pty host
+			// already handled nested-dead shells; live TUIs keep mouse from
+			// verbatim replay. Do not synthesize CSI I.
+			this._onProcessReplayComplete.fire();
+		}));
 		this._register(processManager.onEnvironmentVariableInfoChanged(e => this._onEnvironmentVariableInfoChanged(e)));
 		this._register(processManager.onPtyDisconnect(() => {
 			if (this.xterm) {
@@ -1725,8 +1736,15 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		await this._flushXtermData();
 
+		// Assign exit code before the sticky reset so a concurrent replay-complete
+		// handler can see a dead process and take the full-exit path.
 		this._exitCode = parsedExitResult?.code;
 		const exitMessage = parsedExitResult?.message;
+
+		// Root PTY process exited (shell / root child). Clear sticky DEC mouse
+		// modes left without teardown, leave alt screen, show cursor. Does not
+		// fire when a nested TUI (vim under bash) exits back to a live shell.
+		this._resetStickyMouseModes('process-exit', 'exit');
 
 		this._logService.debug('Terminal process exit', 'instanceId', this.instanceId, 'code', this._exitCode, 'processState', this._processManager.processState);
 
@@ -1794,6 +1812,37 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		if (this.isDisposed) {
 			this._onExit.dispose();
 		}
+	}
+
+	/**
+	 * Reset sticky DEC mouse modes on the xterm instance (app-output path).
+	 * @param kind 'mouse': clear mouse tracking only (live TUI keeps ?1004/?2004
+	 * so it can reassert on FocusGained). 'exit': root process is known dead —
+	 * also clear paste/focus, leave the alt screen and show the cursor.
+	 */
+	private _resetStickyMouseModes(reason: string, kind: 'mouse' | 'exit'): void {
+		const seq = kind === 'mouse' ? TERMINAL_MOUSE_TRACKING_RESET : TERMINAL_PROCESS_EXIT_RESET;
+		const writeReset = (xterm: XtermTerminal) => {
+			try {
+				xterm.raw.write(seq);
+				this._logService.info('Terminal mouse mode reset written', 'instanceId', this.instanceId, 'reason', reason, 'kind', kind);
+			} catch (err) {
+				this._logService.warn('Terminal mouse mode reset failed', 'instanceId', this.instanceId, 'reason', reason, err);
+			}
+		};
+
+		const xterm = this.xterm;
+		if (xterm) {
+			writeReset(xterm);
+			return;
+		}
+
+		this._logService.info('Terminal mouse mode reset deferred (no xterm yet)', 'instanceId', this.instanceId, 'reason', reason);
+		this._xtermReadyPromise.then(ready => {
+			if (ready && !this.isDisposed) {
+				writeReset(ready);
+			}
+		}).catch(() => { /* disposed during create */ });
 	}
 
 	private _relaunchWithShellIntegrationDisabled(exitMessage: string | undefined): void {

--- a/src/vs/workbench/contrib/terminal/common/basePty.ts
+++ b/src/vs/workbench/contrib/terminal/common/basePty.ts
@@ -10,6 +10,7 @@ import { isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import type { IPtyHostProcessReplayEvent, ISerializedCommandDetectionCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ProcessPropertyType, type IProcessDataEvent, type IProcessProperty, type IProcessPropertyMap, type IProcessReadyEvent, type ITerminalChildProcess } from '../../../../platform/terminal/common/terminal.js';
+import { ensureSgrMouseEncodingOnReplay, stripMouseTrackingEnableFromData } from '../../../../platform/terminal/common/terminalMouseModeReset.js';
 
 /**
  * Responsible for establishing and maintaining a connection with an existing terminal process
@@ -89,6 +90,9 @@ export abstract class BasePty extends Disposable implements Partial<ITerminalChi
 	}
 	async handleReplay(e: IPtyHostProcessReplayEvent) {
 		mark(`code/terminal/willHandleReplay/${this.id}`);
+		// Conditional strip: only when pty host says so (dead root / Windows
+		// childless shell). Live full-screen TUIs keep mouse from verbatim replay.
+		const stripMouse = e.shouldStripMouseTrackingEnables === true;
 		try {
 			this._inReplay = true;
 			for (const innerEvent of e.events) {
@@ -96,7 +100,12 @@ export abstract class BasePty extends Disposable implements Partial<ITerminalChi
 					// never override with 0x0 as that is a marker for an unknown initial size
 					this._onDidChangeProperty.fire({ type: ProcessPropertyType.OverrideDimensions, value: { cols: innerEvent.cols, rows: innerEvent.rows, forceExactSize: true } });
 				}
-				const e: IProcessDataEvent = { data: innerEvent.data, trackCommit: true };
+				// Live TUI: keep mouse enables and re-add SGR encoding if the
+				// serializer only restored tracking (?1002h) without ?1006h.
+				const data = stripMouse
+					? stripMouseTrackingEnableFromData(innerEvent.data)
+					: ensureSgrMouseEncodingOnReplay(innerEvent.data);
+				const e: IProcessDataEvent = { data, trackCommit: true };
 				this._onProcessData.fire(e);
 				await e.writePromise;
 			}

--- a/test/smoke/fixtures/fake-tui.mjs
+++ b/test/smoke/fixtures/fake-tui.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Deterministic fake full-screen TUI for sticky-mouse / Reload smoke tests.
+ *
+ * - Enables alt-screen + button-event mouse (SGR) + focus reporting
+ * - Prints FAKE_TUI_READY so tests can wait without internal probing
+ * - Appends every SGR mouse report (\x1b[<…M/m) to --log
+ * - Writes --pid for nested-dead / hard-kill scenarios
+ * - On clean exit (SIGINT / SIGTERM / q / Ctrl-C), writes restore sequences
+ *
+ * Usage:
+ *   node fake-tui.mjs --log <path> [--pid <path>] [--no-restore-on-exit]
+ *
+ * Do not use real grok_local here — LLM nondeterminism; this fixture is the
+ * behavioral oracle (Playwright click → log file grows).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+function argValue(flag) {
+	const i = process.argv.indexOf(flag);
+	if (i === -1 || i + 1 >= process.argv.length) {
+		return undefined;
+	}
+	return process.argv[i + 1];
+}
+
+const logPath = argValue('--log') || path.join(process.cwd(), 'fake-tui-mouse.log');
+const pidPath = argValue('--pid');
+const noRestoreOnExit = process.argv.includes('--no-restore-on-exit');
+
+const CSI = {
+	enterAlt: '\x1b[?1049h',
+	leaveAlt: '\x1b[?1049l',
+	// button-event + SGR (matches common TUI enable set)
+	mouseOn: '\x1b[?1002h\x1b[?1006h',
+	mouseOff: '\x1b[?1002l\x1b[?1006l\x1b[?1000l\x1b[?9l',
+	focusOn: '\x1b[?1004h',
+	focusOff: '\x1b[?1004l',
+	pasteOn: '\x1b[?2004h',
+	pasteOff: '\x1b[?2004l',
+	hideCursor: '\x1b[?25l',
+	showCursor: '\x1b[?25h',
+};
+
+function enable() {
+	process.stdout.write(
+		CSI.enterAlt +
+		CSI.mouseOn +
+		CSI.focusOn +
+		CSI.pasteOn +
+		CSI.hideCursor +
+		'FAKE_TUI_READY\r\n' +
+		'click the terminal — SGR mouse reports land in the log\r\n'
+	);
+}
+
+function restore() {
+	if (noRestoreOnExit) {
+		return;
+	}
+	try {
+		process.stdout.write(
+			CSI.showCursor +
+			CSI.mouseOff +
+			CSI.focusOff +
+			CSI.pasteOff +
+			CSI.leaveAlt
+		);
+	} catch {
+		// stdout may already be closed
+	}
+}
+
+// Fresh log each run
+try {
+	fs.mkdirSync(path.dirname(logPath), { recursive: true });
+} catch {
+	// ignore
+}
+fs.writeFileSync(logPath, '', 'utf8');
+if (pidPath) {
+	try {
+		fs.mkdirSync(path.dirname(pidPath), { recursive: true });
+	} catch {
+		// ignore
+	}
+	fs.writeFileSync(pidPath, String(process.pid), 'utf8');
+}
+
+enable();
+
+// Raw stdin so mouse reports are not cooked by the TTY layer
+if (process.stdin.isTTY) {
+	try {
+		process.stdin.setRawMode(true);
+	} catch {
+		// non-TTY (piped) — still listen
+	}
+}
+process.stdin.resume();
+process.stdin.setEncoding('utf8');
+
+/** @type {string} */
+let buf = '';
+const SGR_MOUSE_RE = /\x1b\[<\d+;\d+;\d+[Mm]/g;
+
+process.stdin.on('data', (chunk) => {
+	const s = String(chunk);
+	// Ctrl-C or 'q' → clean exit
+	if (s.includes('\u0003') || s === 'q' || s === 'Q') {
+		restore();
+		process.exit(0);
+		return;
+	}
+	buf += s;
+	// Keep a bounded window so multi-chunk sequences still match
+	if (buf.length > 4096) {
+		buf = buf.slice(-2048);
+	}
+	SGR_MOUSE_RE.lastIndex = 0;
+	let m;
+	while ((m = SGR_MOUSE_RE.exec(buf)) !== null) {
+		try {
+			fs.appendFileSync(logPath, m[0] + '\n', 'utf8');
+		} catch {
+			// ignore write races
+		}
+	}
+	// Drop fully-consumed prefix up to last match end
+	const last = buf.lastIndexOf('\x1b[');
+	if (last > 0) {
+		buf = buf.slice(last);
+	}
+});
+
+function onExit() {
+	restore();
+}
+process.on('SIGINT', () => {
+	onExit();
+	process.exit(0);
+});
+process.on('SIGTERM', () => {
+	onExit();
+	process.exit(0);
+});
+process.on('exit', onExit);
+
+// Stay alive
+setInterval(() => { /* keep event loop */ }, 60_000);

--- a/test/smoke/src/areas/terminal/terminal-mouseModes.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-mouseModes.test.ts
@@ -1,0 +1,658 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Sticky DEC mouse modes across Reload Window — headed Electron + Playwright.
+ *
+ * Fixture: `fixtures/fake-tui.mjs` (enables alt-screen + ?1002h/?1006h, logs SGR).
+ * Oracle: Playwright click on the terminal → `mouse.log` grows with `\x1b[<…M/m`.
+ *
+ * Lessons encoded here (do not re-break):
+ * - Settings: atomic User/settings.json write — never type into the settings editor.
+ * - Create: NewWithProfile + Enter (PowerShell is focused). Bare `terminal.new`
+ *   fuzzy-matches `newWithProfile` and hangs runCommand on waitForQuickInputClosed.
+ * - Live Reload: wait for persistent-session restore; Escape a *spurious* profile
+ *   picker — accepting it creates a new shell and orphans the live TUI.
+ * - After Reload clicks: xterm SerializeAddon re-emits ?1002h but not ?1006h;
+ *   host patches that via ensureSgrMouseEncodingOnReplay (basePty).
+ *
+ *   npm run smoketest-no-compile -- -f "Terminal Mouse Modes"
+ */
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Application, Terminal } from '../../../../automation';
+
+const FAKE_TUI = path.join(__dirname, '..', '..', '..', 'fixtures', 'fake-tui.mjs');
+const READY = 'FAKE_TUI_READY';
+const XTERM = '#terminal .xterm';
+const XTERM_SCREEN = '#terminal .xterm-screen';
+const TERMINAL_WRAPPER = '#terminal .terminal-wrapper';
+const TERMINAL_PANEL = '#terminal';
+const SGR_RE = /\x1b\[<\d+;\d+;\d+[Mm]/g;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise(r => setTimeout(r, ms));
+}
+
+function countMouseEvents(logPath: string): number {
+	if (!fs.existsSync(logPath)) {
+		return 0;
+	}
+	const m = fs.readFileSync(logPath, 'utf8').match(SGR_RE);
+	return m ? m.length : 0;
+}
+
+function readLogTail(logPath: string, max = 400): string {
+	if (!fs.existsSync(logPath)) {
+		return '<missing>';
+	}
+	const t = fs.readFileSync(logPath, 'utf8');
+	return t.length <= max ? t : t.slice(-max);
+}
+
+async function waitForFile(filePath: string, timeoutMs = 15_000): Promise<void> {
+	const start = Date.now();
+	while (!fs.existsSync(filePath) && Date.now() - start < timeoutMs) {
+		await sleep(100);
+	}
+	if (!fs.existsSync(filePath)) {
+		throw new Error(`Timed out waiting for file: ${filePath}`);
+	}
+}
+
+async function waitForMouseEvents(logPath: string, minCount: number, timeoutMs = 12_000): Promise<number> {
+	const start = Date.now();
+	let n = 0;
+	while (Date.now() - start < timeoutMs) {
+		n = countMouseEvents(logPath);
+		if (n >= minCount) {
+			return n;
+		}
+		await sleep(100);
+	}
+	throw new Error(`Expected >= ${minCount} mouse events, got ${n}. logTail=${JSON.stringify(readLogTail(logPath))}`);
+}
+
+async function screenshot(app: Application, name: string): Promise<void> {
+	try {
+		const dir = app.logsPath || path.join(os.tmpdir(), 'vsc-mouse-shots');
+		fs.mkdirSync(dir, { recursive: true });
+		const file = path.join(dir, `mouse-${name.replace(/[^\w.-]+/g, '_')}-${Date.now()}.png`);
+		await app.code.driver.currentPage.screenshot({ path: file, type: 'png' });
+		app.logger.log(`screenshot: ${file}`);
+	} catch (e) {
+		app.logger.log(`screenshot failed: ${e}`);
+	}
+}
+
+function makePaths(tag: string): { logPath: string; pidPath: string; dir: string } {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), `vsc-mouse-${tag}-`));
+	return { dir, logPath: path.join(dir, 'mouse.log'), pidPath: path.join(dir, 'pid.txt') };
+}
+
+function killPid(pid: number): void {
+	try {
+		if (process.platform === 'win32') {
+			execFileSync('taskkill', ['/F', '/PID', String(pid)], { stdio: 'ignore', windowsHide: true });
+		} else {
+			process.kill(pid, 'SIGKILL');
+		}
+	} catch {
+		// already gone
+	}
+}
+
+function processAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function shellQuote(p: string): string {
+	return process.platform === 'win32'
+		? `'${p.replace(/'/g, "''")}'`
+		: `'${p.replace(/'/g, `'\\''`)}'`;
+}
+
+function writeUserSettings(app: Application, settings: Record<string, unknown>): void {
+	if (!app.userDataPath) {
+		throw new Error('userDataPath required');
+	}
+	const userDir = path.join(app.userDataPath, 'User');
+	fs.mkdirSync(userDir, { recursive: true });
+	const settingsPath = path.join(userDir, 'settings.json');
+	const tmp = settingsPath + '.tmp';
+	fs.writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n', 'utf8');
+	fs.renameSync(tmp, settingsPath);
+}
+
+function baseSettings(): Record<string, unknown> {
+	const s: Record<string, unknown> = {
+		'editor.wordWrap': 'on',
+		'terminal.integrated.tabs.hideCondition': 'never',
+		'terminal.integrated.gpuAcceleration': 'off',
+		'terminal.integrated.enablePersistentSessions': true,
+		'terminal.integrated.confirmOnKill': 'never',
+		'terminal.integrated.confirmOnExit': 'never',
+		'workbench.secondarySideBar.defaultVisibility': 'hidden',
+		'chat.commandCenter.enabled': false,
+	};
+	if (process.platform === 'win32') {
+		s['terminal.integrated.defaultProfile.windows'] = 'PowerShell';
+	} else if (process.platform === 'darwin') {
+		s['terminal.integrated.defaultProfile.osx'] = 'zsh';
+	} else {
+		s['terminal.integrated.defaultProfile.linux'] = 'bash';
+	}
+	return s;
+}
+
+/** Quick-input open? Uses getBoundingClientRect (position:fixed has null offsetParent). */
+async function probeQuickInput(app: Application): Promise<{ open: boolean; isProfile: boolean; rows: number }> {
+	return app.code.driver.currentPage.evaluate(() => {
+		const w = document.querySelector('.quick-input-widget') as HTMLElement | null;
+		if (!w) {
+			return { open: false, isProfile: false, rows: 0 };
+		}
+		const style = window.getComputedStyle(w);
+		const r = w.getBoundingClientRect();
+		const open = style.display !== 'none' && style.visibility !== 'hidden' && r.width > 50 && r.height > 50;
+		const text = w.innerText || '';
+		const rows = w.querySelectorAll('.monaco-list-row').length;
+		const isProfile =
+			rows >= 2 &&
+			(/Select the terminal profile/i.test(text) ||
+				(/PowerShell/i.test(text) && /Command Prompt|Git Bash|Cygwin|Debian/i.test(text)));
+		return { open, isProfile, rows };
+	}).catch(() => ({ open: false, isProfile: false, rows: 0 }));
+}
+
+async function elementExists(app: Application, selector: string): Promise<boolean> {
+	try {
+		const els = await app.code.getElements(selector, false);
+		return Array.isArray(els) && els.length > 0;
+	} catch {
+		return false;
+	}
+}
+
+async function hasTerminal(app: Application): Promise<boolean> {
+	return (await elementExists(app, XTERM)) || (await elementExists(app, TERMINAL_WRAPPER));
+}
+
+/** Accept profile picker (create path). PowerShell is the focused first row. */
+async function acceptProfilePicker(app: Application, tag: string): Promise<boolean> {
+	const probe = await probeQuickInput(app);
+	if (!probe.open || !probe.isProfile) {
+		return false;
+	}
+	app.logger.log(`[${tag}] accept profile picker (rows=${probe.rows})`);
+	await screenshot(app, `${tag}-profile-picker`);
+	const page = app.code.driver.currentPage;
+	await page.keyboard.press('Enter').catch(() => { });
+	await sleep(600);
+	const still = await probeQuickInput(app);
+	if (still.open && still.isProfile) {
+		try {
+			await app.code.waitAndClick('.quick-input-widget .monaco-list-row.focused', undefined, undefined, 40);
+		} catch {
+			await page.keyboard.press('Enter').catch(() => { });
+		}
+		await sleep(500);
+	}
+	return true;
+}
+
+/** Dismiss profile picker without creating (live reload path). */
+async function dismissProfilePicker(app: Application, tag: string): Promise<void> {
+	const probe = await probeQuickInput(app);
+	if (!probe.open || !probe.isProfile) {
+		return;
+	}
+	app.logger.log(`[${tag}] dismiss spurious profile picker (Escape)`);
+	const page = app.code.driver.currentPage;
+	await page.keyboard.press('Escape').catch(() => { });
+	await sleep(200);
+	await page.keyboard.press('Escape').catch(() => { });
+	await sleep(200);
+}
+
+/** Clear non-profile quick inputs; accept profile if creating is OK. */
+async function clearQuickInput(app: Application, tag: string, acceptProfile: boolean): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < 8_000) {
+		const probe = await probeQuickInput(app);
+		if (!probe.open) {
+			return;
+		}
+		if (probe.isProfile) {
+			if (acceptProfile) {
+				await acceptProfilePicker(app, tag);
+			} else {
+				await dismissProfilePicker(app, tag);
+			}
+		} else {
+			await app.code.driver.currentPage.keyboard.press('Escape').catch(() => { });
+			await sleep(200);
+		}
+	}
+}
+
+async function createTerminalSafe(app: Application, tag: string): Promise<void> {
+	const page = app.code.driver.currentPage;
+	await clearQuickInput(app, `${tag}-pre`, true);
+	if (await hasTerminal(app)) {
+		return;
+	}
+
+	for (let attempt = 1; attempt <= 4; attempt++) {
+		if (await hasTerminal(app)) {
+			return;
+		}
+		// Accept picker left from a prior attempt
+		if (await acceptProfilePicker(app, `${tag}-a${attempt}`)) {
+			await sleep(800);
+			if (await hasTerminal(app)) {
+				return;
+			}
+		}
+
+		app.logger.log(`[${tag}] create attempt ${attempt}/4 via NewWithProfile`);
+		await page.keyboard.press('Control+Shift+P').catch(() => { });
+		await sleep(400);
+		await page.keyboard.type('Create New Terminal With Profile', { delay: 12 });
+		await sleep(400);
+		await page.keyboard.press('Enter').catch(() => { });
+		await sleep(500);
+		await page.keyboard.press('Enter').catch(() => { }); // PowerShell focused
+		await sleep(400);
+		await acceptProfilePicker(app, `${tag}-a${attempt}-accept`);
+
+		const t0 = Date.now();
+		while (Date.now() - t0 < 12_000) {
+			await acceptProfilePicker(app, `${tag}-a${attempt}-poll`);
+			if (await hasTerminal(app)) {
+				await sleep(1000);
+				return;
+			}
+			await sleep(300);
+		}
+		await sleep(1000 * attempt);
+	}
+	await screenshot(app, `${tag}-create-failed`);
+	throw new Error(`[${tag}] failed to create terminal`);
+}
+
+type BBox = { x: number; y: number; width: number; height: number };
+
+/** First visible terminal rect (Playwright boundingBox, then getBoundingClientRect). */
+async function terminalBox(app: Application, minW = 10, minH = 10): Promise<BBox | null> {
+	const page = app.code.driver.currentPage;
+	for (const sel of [XTERM_SCREEN, XTERM, TERMINAL_WRAPPER, TERMINAL_PANEL]) {
+		try {
+			const b = await page.locator(sel).first().boundingBox();
+			if (b && b.width > minW && b.height > minH) {
+				return b;
+			}
+		} catch {
+			// next
+		}
+	}
+	return page.evaluate(({ w, h }) => {
+		const el = document.querySelector('#terminal .xterm-screen, #terminal .xterm, #terminal') as HTMLElement | null;
+		if (!el) {
+			return null;
+		}
+		const r = el.getBoundingClientRect();
+		return r.width > w && r.height > h ? { x: r.x, y: r.y, width: r.width, height: r.height } : null;
+	}, { w: minW, h: minH }).catch(() => null);
+}
+
+async function typeInTerminal(app: Application, text: string, tag: string): Promise<void> {
+	await clearQuickInput(app, `${tag}-type`, true);
+	const page = app.code.driver.currentPage;
+	const box = await terminalBox(app, 10, 10);
+	if (box) {
+		await page.mouse.click(box.x + 20, box.y + 20);
+	}
+	await sleep(100);
+	await page.keyboard.type(text, { delay: 6 });
+	await page.keyboard.press('Enter');
+	await sleep(300);
+}
+
+async function ensureTerminalPanel(app: Application, tag: string): Promise<void> {
+	await clearQuickInput(app, tag, true);
+	if (!(await hasTerminal(app))) {
+		await createTerminalSafe(app, tag);
+	} else {
+		try {
+			await app.code.driver.currentPage.locator(TERMINAL_PANEL).first().click({ timeout: 1500, force: true });
+		} catch {
+			// ignore
+		}
+	}
+	const t0 = Date.now();
+	while (Date.now() - t0 < 15_000) {
+		if (await hasTerminal(app)) {
+			return;
+		}
+		await sleep(200);
+	}
+	throw new Error(`[${tag}] terminal panel never appeared`);
+}
+
+async function focusAndClickTerminal(app: Application, times: number, tag: string): Promise<void> {
+	await ensureTerminalPanel(app, tag);
+	await clearQuickInput(app, `${tag}-click`, false);
+	const page = app.code.driver.currentPage;
+
+	const box = await terminalBox(app, 40, 30);
+	if (!box) {
+		await screenshot(app, `${tag}-no-bbox`);
+		throw new Error(`[${tag}] No visible terminal click target`);
+	}
+	app.logger.log(`[${tag}] click target ${JSON.stringify(box)}`);
+
+	await page.mouse.click(box.x + Math.min(50, box.width / 3), box.y + Math.min(30, box.height / 3));
+	await sleep(80);
+	for (let i = 0; i < times; i++) {
+		await page.mouse.click(box.x + 30 + (i % 5) * 12, box.y + 28 + Math.floor(i / 5) * 10, { delay: 12 });
+		await sleep(90);
+	}
+}
+
+/**
+ * After Reload: wait for keep-process restore. Never accept profile picker when
+ * allowCreate=false (that orphans the live TUI onto a new empty shell).
+ */
+async function restoreTerminalAfterReload(
+	app: Application,
+	opts: { expectReadyText: boolean; tag: string; allowCreate: boolean },
+): Promise<void> {
+	const page = app.code.driver.currentPage;
+	await app.code.whenWorkbenchRestored();
+	await sleep(800);
+	await screenshot(app, `${opts.tag}-after-reload-raw`);
+
+	const t0 = Date.now();
+	while (Date.now() - t0 < 25_000) {
+		if (opts.allowCreate) {
+			await acceptProfilePicker(app, `${opts.tag}-poll`);
+		} else {
+			await dismissProfilePicker(app, `${opts.tag}-poll`);
+		}
+		if (await hasTerminal(app)) {
+			app.logger.log(`[${opts.tag}] restored xterm after ${Date.now() - t0}ms`);
+			break;
+		}
+		// Show panel without creating a terminal
+		try {
+			await page.locator('.composite-bar .action-label[aria-label*="Terminal"]').first().click({ timeout: 400, force: true });
+		} catch {
+			// ignore
+		}
+		const qi = await probeQuickInput(app);
+		if (!qi.open) {
+			await page.keyboard.press('Control+J').catch(() => { });
+		}
+		await sleep(500);
+	}
+
+	if (!(await hasTerminal(app))) {
+		if (opts.allowCreate) {
+			await createTerminalSafe(app, `${opts.tag}-restore`);
+		} else {
+			await dismissProfilePicker(app, `${opts.tag}-no-xterm`);
+			app.logger.log(`[${opts.tag}] no xterm after wait (sticky path expects restore)`);
+		}
+	}
+
+	try {
+		await page.locator(TERMINAL_PANEL).first().click({ timeout: 1500, force: true });
+	} catch {
+		// ignore
+	}
+	await sleep(500);
+	await screenshot(app, `${opts.tag}-after-reload-shown`);
+
+	if (opts.expectReadyText) {
+		try {
+			await app.workbench.terminal.waitForTerminalText(
+				buf => buf.some(l => l.includes(READY) || l.includes('click the terminal')),
+				'wait TUI after reload',
+			);
+		} catch {
+			app.logger.log(`[${opts.tag}] TUI text missing after reload`);
+		}
+	}
+	// Replay apply + ensureSgrMouseEncodingOnReplay
+	await sleep(1200);
+	await screenshot(app, `${opts.tag}-after-reload-ready`);
+}
+
+export function setup(options?: { skipSuite?: boolean }) {
+	const skip =
+		!!options?.skipSuite ||
+		!!process.env.CI ||
+		process.env.VSCODE_SKIP_MOUSE_MODE_SMOKE === '1';
+
+	(skip ? describe.skip : describe)('Terminal Mouse Modes (sticky / Reload)', function () {
+		this.timeout(150_000);
+		this.retries(0);
+
+		let app: Application;
+		let terminal: Terminal;
+		const tempDirs: string[] = [];
+
+		before(async function () {
+			app = this.app as Application;
+			terminal = app.workbench.terminal;
+			if (!fs.existsSync(FAKE_TUI)) {
+				throw new Error(`fake-tui missing: ${FAKE_TUI}`);
+			}
+			if (!app.userDataPath) {
+				throw new Error('userDataPath missing');
+			}
+			app.logger.log(`fake-tui=${FAKE_TUI} userData=${app.userDataPath}`);
+
+			writeUserSettings(app, baseSettings());
+			// Avoid runCommand here — hangs if a quick-input is open.
+			const page = app.code.driver.currentPage;
+			await page.keyboard.press('Escape').catch(() => { });
+			await sleep(200);
+			await app.code.driver.reload();
+			await app.code.whenWorkbenchRestored();
+			// PTY host registers after workbench-ready; creating too early → newWithProfile
+			await sleep(3500);
+			await clearQuickInput(app, 'suite-start', true);
+			await screenshot(app, 'suite-start');
+		});
+
+		after(async function () {
+			for (const d of tempDirs) {
+				try {
+					fs.rmSync(d, { recursive: true, force: true });
+				} catch {
+					// ignore
+				}
+			}
+		});
+
+		afterEach(async function () {
+			if (this.currentTest?.state === 'failed') {
+				await screenshot(app, `FAIL-${this.currentTest.title}`);
+				for (const d of tempDirs) {
+					const lp = path.join(d, 'mouse.log');
+					if (fs.existsSync(lp)) {
+						app.logger.log(`FAIL mouse.log: ${JSON.stringify(readLogTail(lp, 600))}`);
+					}
+				}
+			}
+			await dismissProfilePicker(app, 'afterEach');
+			const page = app.code.driver.currentPage;
+			await page.keyboard.press('Escape').catch(() => { });
+			// Parent Terminal suite KillAlls with a timeout — avoid double KillAll hang
+		});
+
+		async function startFakeTui(paths: { logPath: string; pidPath: string }, tag: string): Promise<number> {
+			await createTerminalSafe(app, `start-${tag}`);
+			await ensureTerminalPanel(app, `start-${tag}`);
+
+			// Wait for a real shell prompt (empty panel swallows typed commands)
+			const t0 = Date.now();
+			while (Date.now() - t0 < 20_000) {
+				try {
+					const buf = await app.code.driver.getTerminalBuffer(TERMINAL_WRAPPER);
+					if (buf?.some((l: string) => /PS\s+[A-Z]:\\/i.test(l) || />\s*$/.test(l.trim()) || /\$\s*$/.test(l.trim()))) {
+						break;
+					}
+				} catch {
+					// ignore
+				}
+				await sleep(250);
+			}
+			await screenshot(app, `shell-open-${tag}`);
+
+			const cmd = process.platform === 'win32'
+				? `& ${shellQuote(process.execPath)} ${shellQuote(FAKE_TUI)} --log ${shellQuote(paths.logPath)} --pid ${shellQuote(paths.pidPath)} --no-restore-on-exit`
+				: `${shellQuote(process.execPath)} ${shellQuote(FAKE_TUI)} --log ${shellQuote(paths.logPath)} --pid ${shellQuote(paths.pidPath)} --no-restore-on-exit`;
+			app.logger.log(`launching: ${cmd}`);
+			await typeInTerminal(app, cmd, tag);
+
+			try {
+				await waitForFile(paths.pidPath, 18_000);
+			} catch {
+				await typeInTerminal(app, cmd, `${tag}-retry`);
+				await waitForFile(paths.pidPath, 12_000);
+			}
+			const pid = parseInt(fs.readFileSync(paths.pidPath, 'utf8'), 10);
+			app.logger.log(`fake-tui pid=${pid} alive=${processAlive(pid)}`);
+			try {
+				await terminal.waitForTerminalText(buf => buf.some(l => l.includes(READY)), 'FAKE_TUI_READY');
+			} catch {
+				app.logger.log(`[${tag}] READY not in buffer; pid present — continuing`);
+			}
+			await sleep(300);
+			await screenshot(app, `tui-ready-${tag}`);
+			return pid;
+		}
+
+		it('live TUI: click produces SGR log events; survives Reload Window', async function () {
+			const paths = makePaths('live');
+			tempDirs.push(paths.dir);
+
+			const pid = await startFakeTui(paths, 'live');
+			await focusAndClickTerminal(app, 5, 'live-pre');
+			const before = await waitForMouseEvents(paths.logPath, 1, 15_000);
+			app.logger.log(`mouse events before reload: ${before}`);
+			await screenshot(app, 'live-before-reload');
+
+			await app.code.driver.reload();
+			await restoreTerminalAfterReload(app, { expectReadyText: true, tag: 'live', allowCreate: false });
+
+			const stillAlive = processAlive(pid);
+			app.logger.log(`fake-tui still alive after reload: ${stillAlive}`);
+			if (!stillAlive) {
+				await createTerminalSafe(app, 'live-re-shell');
+				await startFakeTui(paths, 'live-re');
+			} else {
+				try {
+					await terminal.waitForTerminalText(
+						buf => buf.some(l => l.includes(READY) || l.includes('click the terminal')),
+						'restored TUI buffer',
+					);
+				} catch {
+					await screenshot(app, 'live-wrong-terminal');
+					throw new Error('Process alive but buffer has no FAKE_TUI_READY — wrong terminal after reload');
+				}
+			}
+
+			const mid = countMouseEvents(paths.logPath);
+			app.logger.log(`mouse events mid: ${mid}`);
+			let after = mid;
+			for (let attempt = 1; attempt <= 3; attempt++) {
+				await focusAndClickTerminal(app, 6, `live-post-a${attempt}`);
+				await sleep(400);
+				after = countMouseEvents(paths.logPath);
+				app.logger.log(`post-reload attempt ${attempt}: events=${after} (need > ${mid})`);
+				if (after > mid) {
+					break;
+				}
+				await screenshot(app, `live-post-no-growth-a${attempt}`);
+			}
+			if (after <= mid) {
+				after = await waitForMouseEvents(paths.logPath, mid + 1, 5_000);
+			}
+			app.logger.log(`mouse events after reload: ${after} (mid=${mid})`);
+			await screenshot(app, 'live-after-post-reload-click');
+			if (after <= mid) {
+				throw new Error(`Expected mouse log to grow after Reload (mid=${mid}, after=${after})`);
+			}
+		});
+
+		it('unclean kill of TUI child: shell usable; no sticky [MC… dump', async function () {
+			const paths = makePaths('dead');
+			tempDirs.push(paths.dir);
+
+			const pid = await startFakeTui(paths, 'dead');
+			await focusAndClickTerminal(app, 2, 'dead-pre');
+			await waitForMouseEvents(paths.logPath, 1, 12_000);
+
+			killPid(pid);
+			await sleep(800);
+			await screenshot(app, 'dead-after-kill');
+
+			await ensureTerminalPanel(app, 'dead-shell');
+			await typeInTerminal(app, 'echo sticky_check_ok', 'dead-echo1');
+			await terminal.waitForTerminalText(buf => buf.some(l => l.includes('sticky_check_ok')));
+			await focusAndClickTerminal(app, 3, 'dead-click');
+			await sleep(200);
+			await typeInTerminal(app, 'echo after_click_ok', 'dead-echo2');
+			await terminal.waitForTerminalText(buf => {
+				const j = buf.join('\n');
+				return j.includes('after_click_ok') && !/\[MC/.test(j);
+			});
+			await screenshot(app, 'dead-shell-ok');
+		});
+
+		it('nested-dead + Reload: kill TUI child, Reload, shell clean of sticky [MC…', async function () {
+			const paths = makePaths('nested');
+			tempDirs.push(paths.dir);
+
+			const pid = await startFakeTui(paths, 'nested');
+			await focusAndClickTerminal(app, 2, 'nested-pre');
+			try {
+				await waitForMouseEvents(paths.logPath, 1, 6_000);
+			} catch {
+				app.logger.log('no mouse events before kill (continuing)');
+			}
+
+			killPid(pid);
+			await sleep(500);
+			await screenshot(app, 'nested-after-kill');
+
+			await app.code.driver.reload();
+			await restoreTerminalAfterReload(app, { expectReadyText: false, tag: 'nested', allowCreate: true });
+
+			await ensureTerminalPanel(app, 'nested-shell');
+			await typeInTerminal(app, 'echo nested_dead_ok', 'nested-echo');
+			await terminal.waitForTerminalText(buf => buf.some(l => l.includes('nested_dead_ok')));
+			await focusAndClickTerminal(app, 3, 'nested-post');
+			await sleep(200);
+			await terminal.waitForTerminalText(buf => {
+				const j = buf.join('\n');
+				return j.includes('nested_dead_ok') && !/\[MC/.test(j);
+			});
+			await screenshot(app, 'nested-ok');
+		});
+	});
+}

--- a/test/smoke/src/areas/terminal/terminal.test.ts
+++ b/test/smoke/src/areas/terminal/terminal.test.ts
@@ -13,6 +13,7 @@ import { setup as setupTerminalTabsTests } from './terminal-tabs.test';
 import { setup as setupTerminalSplitCwdTests } from './terminal-splitCwd.test';
 import { setup as setupTerminalStickyScrollTests } from './terminal-stickyScroll.test';
 import { setup as setupTerminalShellIntegrationTests } from './terminal-shellIntegration.test';
+import { setup as setupTerminalMouseModesTests } from './terminal-mouseModes.test';
 
 export function setup(logger: Logger) {
 	describe('Terminal', function () {
@@ -32,8 +33,25 @@ export function setup(logger: Logger) {
 		});
 
 		afterEach(async () => {
-			// Kill all terminals between every test for a consistent testing environment
-			await terminal.runCommand(TerminalCommandId.KillAll);
+			// Kill all terminals between every test for a consistent testing environment.
+			// Mouse-modes can leave the profile picker open (newWithProfile). runCommand
+			// then hangs forever on waitForQuickInputClosed — dismiss quick input first,
+			// and never block the suite for more than a few seconds.
+			try {
+				const page = app.code.driver.currentPage;
+				await page.keyboard.press('Escape').catch(() => { });
+				await page.keyboard.press('Escape').catch(() => { });
+			} catch {
+				// ignore
+			}
+			try {
+				await Promise.race([
+					terminal.runCommand(TerminalCommandId.KillAll),
+					new Promise<void>(resolve => setTimeout(resolve, 8_000)),
+				]);
+			} catch {
+				// ignore — flaky kill is acceptable between tests
+			}
 		});
 
 		// https://github.com/microsoft/vscode/issues/216564
@@ -49,5 +67,8 @@ export function setup(logger: Logger) {
 		// https://github.com/microsoft/vscode/pull/141974
 		// Windows is skipped here as well as it was never enabled from the start
 		setupTerminalSplitCwdTests({ skipSuite: process.platform === 'linux' || process.platform === 'win32' });
+		// Sticky DEC mouse / Reload — local A/B (real Electron). Skipped when CI=1.
+		// Filter: npm run smoketest-no-compile -- -f "Terminal Mouse Modes"
+		setupTerminalMouseModesTests({ skipSuite: process.platform === 'linux' });
 	});
 }


### PR DESCRIPTION
## Problem

Full-screen TUIs (vim, less, Claude Code, Grok, …) enable DEC mouse tracking
(`?1000` / `?1002` / `?1006`, …).

Two failure modes after **Reload Window** / unclean exit:

1. **Dead process** — modes stay on → next shell gets mouse as text (`[M…]`, `[MC…]`).
2. **Live process** — modes stripped or incomplete on restore → clicks stop working
   even though the app (and often the PTY) is still running.

## Split ownership (two PRs, one fix)

| Situation | Owner | Responsibility |
|-----------|--------|----------------|
| Dead process / sticky modes in a shell | **VS Code (host)** | Clear modes on root exit; strip mouse-enable CSI on PTY replay when there is no live owner |
| Soft Reload, process may still be alive | **App (e.g. Grok)** | Do not RESTORE on CTRL_CLOSE; drain-coalesced mouse-only reassert on FocusGained/Resize |

Neither side alone is enough: the host cannot repaint every app’s UI; the app cannot clear modes after it is already dead.

## This PR (host)

1. **Root process exit** — full sticky reset (mouse + paste/focus + leave alt + show cursor) when the **root** PTY process exits.
2. **Conditional strip on replay** — strip mouse-tracking *enable* CSI (incl. X10 `?9`) only when:
   - root is already dead, or
   - Windows + shell-like root + **no** console children (nested TUI died under a live shell).  
   Live full-screen TUI / shell with children → **verbatim** replay (no live-app regression).
3. **SGR on live replay** — SerializeAddon re-emits tracking (`?1002h`) but not SGR (`?1006h`). When tracking is present without SGR, append `?1006h` so modern apps still get `\x1b[<…M` clicks after Reload.
4. **Fail-open child detection** — if the process tree cannot be read, assume children exist so we never false-strip a live nested TUI.
5. **Replay complete** — full exit reset only if the root already exited.

**Intentionally not done:** host-synthesized focus-in (`CSI I`). Stale `?1004` after a dead child can inject protocol input into a shell. Live reassert is the app’s job (companion PR).

## Companion (app)

Soft CTRL_CLOSE (no full RESTORE) + drain-coalesced FocusGained **mouse-only** reassert (no EnterAlternateScreen; no soft-reattach latch; no wall-clock cooldown) for keep-process Reload:

https://github.com/xai-org/grok-build/compare/main...lmdc45:fix/sticky-mouse-tracking-after-unclean-exit?expand=1

Fork PR: https://github.com/lmdc45/grok-build/pull/1

## Tests

| Layer | What |
|-------|------|
| Unit | `src/vs/platform/terminal/test/common/terminalMouseModeReset.test.ts` — strip, conditional policy, ensure SGR |
| Headed smoke | Filter **Terminal Mouse Modes** — fake TUI + Playwright clicks; oracle = SGR growth in a log file |

| Case | Expect |
|------|--------|
| Live TUI + Reload | Process **alive**; SGR mouse log **grows** after Reload clicks |
| Unclean kill of TUI | Shell usable; **no** sticky `[MC…` |
| Nested-dead + Reload | Same after restore (Windows childless shell path) |

```text
npm run smoketest-no-compile -- -f "Terminal Mouse Modes"
```

## Risks / non-goals

| Item | Notes |
|------|--------|
| POSIX nested-dead + Reload | Residual hole (no reliable child signal) — same as upstream for that combo; root exit still cleans |
| False strip | Mitigated by fail-open children + shell-like gate |
| Host CSI I | Non-goal (unsafe into shells) |
| App-side soft Reload | Companion PR, not this change |

## Why this shape

- Host owns terminal state that **outlives** the process.
- Live apps keep mouse without requiring every TUI to reassert on FocusGained.
- Dead / nested-dead paths get a clean shell.
- Composes with keep-process Reload (inference can stay alive).
