### PR TITLE
sessions: sync docked details panel min-width with sessions list, support sash-collapse

### DIFF
--- a/src/vs/sessions/browser/dockedAuxiliaryBarController.ts
+++ b/src/vs/sessions/browser/dockedAuxiliaryBarController.ts
@@ -6,6 +6,7 @@
 import { Disposable } from '../../base/common/lifecycle.js';
 import { ISashEvent, IVerticalSashLayoutProvider, Sash, SashState, Orientation as SashOrientation } from '../../base/browser/ui/sash/sash.js';
 import { Part } from '../../workbench/browser/part.js';
+import { SESSIONS_LIST_MINIMUM_WIDTH } from './parts/sidebarPart.js';
 
 /** Accessors the controller uses to read/write the docked panel width and query visibility. */
 export interface IDockedAuxiliaryBarHost {
@@ -45,6 +46,7 @@ export class DockedAuxiliaryBarController extends Disposable {
 	static readonly EDITOR_MIN_WIDTH = 300;
 	static readonly DEFAULT_WIDTH = 300;
 	static readonly COLLAPSE_WIDTH = 4;
+	static readonly NO_EDITOR_MIN_WIDTH = SESSIONS_LIST_MINIMUM_WIDTH;
 
 	private _docked = false;
 	private _sash: Sash | undefined;
@@ -103,7 +105,8 @@ export class DockedAuxiliaryBarController extends Disposable {
 		this.auxiliaryBarPart.layout(auxWidth, height, top, editorRect.width - auxWidth);
 
 		this._ensureSash();
-		this._sash!.state = SashState.Enabled;
+		// The real grid sash owns resizing/collapsing when editor content is hidden.
+		this._sash!.state = editorContentHidden ? SashState.Disabled : SashState.Enabled;
 		this._sash!.layout();
 	}
 
@@ -148,10 +151,7 @@ export class DockedAuxiliaryBarController extends Disposable {
 			const delta = e.startX - e.currentX;
 			const width = editorPartContainer.clientWidth;
 			const requestedWidth = this._sashStartWidth + delta;
-			const collapseWidth = this.host.isEditorVisible()
-				? DockedAuxiliaryBarController.COLLAPSE_WIDTH
-				: DockedAuxiliaryBarController.MIN_WIDTH;
-			if (requestedWidth < collapseWidth) {
+			if (requestedWidth < DockedAuxiliaryBarController.COLLAPSE_WIDTH) {
 				this._sashCollapsed = true;
 				this.host.hideAuxiliaryBar();
 				return;

--- a/src/vs/sessions/browser/parts/sidebarPart.ts
+++ b/src/vs/sessions/browser/parts/sidebarPart.ts
@@ -40,6 +40,9 @@ import { IConfigurationService } from '../../../platform/configuration/common/co
 import { hasNativeTitlebar, getTitleBarStyle } from '../../../platform/window/common/window.js';
 import { isMacintosh, isNative, isWeb } from '../../../base/common/platform.js';
 
+/** Sessions list minimum width; shared with the docked details panel so both snap closed alike. */
+export const SESSIONS_LIST_MINIMUM_WIDTH = isWeb ? 270 : 170;
+
 /**
  * Sidebar part specifically for agent sessions workbench.
  * This is a simplified version of the SidebarPart for agent session contexts.
@@ -68,10 +71,7 @@ export class SidebarPart extends AbstractPaneCompositePart {
 
 	//#region IView
 
-	// On web the titlebar hosts an additional host filter combo alongside the
-	// sidebar toggle; use a wider minimum so those controls always fit within
-	// the sidebar's rendered area (below this the sidebar snaps closed).
-	readonly minimumWidth: number = isWeb ? 270 : 170;
+	readonly minimumWidth: number = SESSIONS_LIST_MINIMUM_WIDTH;
 	readonly maximumWidth: number = Number.POSITIVE_INFINITY;
 	readonly minimumHeight: number = 0;
 	readonly maximumHeight: number = Number.POSITIVE_INFINITY;

--- a/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
+++ b/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
@@ -51,12 +51,26 @@ export class SinglePaneMainEditorPart extends MainEditorPart {
 		};
 	}
 
-	// Double-clicking the chat↔side-pane sash resets the side pane to this width
-	// (the grid's sash-reset reads `preferredWidth`). Use 60% of the window so it
-	// matches the side pane's reveal split. Scoped to single-pane: the classic
-	// layout keeps the standard distribute-on-reset.
+	// Double-click resets the sash to this width. Use the detail panel's default
+	// while editor content is hidden, not the 60% editor split.
 	get preferredWidth(): number | undefined {
+		if (!this.layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
+			return DockedAuxiliaryBarController.DEFAULT_WIDTH;
+		}
 		return Math.max(EDITOR_PART_MINIMUM_WIDTH, Math.floor(this.layoutService.mainContainerDimension.width * SIDE_PANE_WIDTH_RATIO));
+	}
+
+	// Matches the sessions list's minimum while only the detail panel is shown.
+	override get minimumWidth(): number {
+		if (!this.layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
+			return DockedAuxiliaryBarController.NO_EDITOR_MIN_WIDTH;
+		}
+		return super.minimumWidth;
+	}
+
+	// Snap-collapse via sash-drag, like the sessions list, only when detail-only.
+	override get snap(): boolean {
+		return !this.layoutService.isVisible(Parts.EDITOR_PART, mainWindow);
 	}
 
 	constructor(

--- a/src/vs/sessions/browser/singlePaneWorkbench.ts
+++ b/src/vs/sessions/browser/singlePaneWorkbench.ts
@@ -323,15 +323,24 @@ export class SinglePaneWorkbench extends Workbench {
 	}
 
 	/**
-	 * No-op: the editor-part grid view hosts the docked auxiliary bar, so its
-	 * visibility flips whenever the *detail* opens/closes (not the editor content).
-	 * Editor-content visibility and its part-visibility events are driven directly
-	 * by `setEditorHidden` / `_applyEditorVisibility` / `_applyAuxiliaryBarVisibility`
-	 * / `_syncEditorVisibility`, so mapping the shared node's grid visibility to
-	 * `setEditorHidden` here would wrongly reveal the editor when only the detail is
-	 * shown.
+	 * No-op unless detail-only (editor content hidden): there the shared node is a
+	 * snap view, so sash-drag collapse/reveal maps onto hiding/showing the auxiliary bar.
 	 */
-	protected override _onEditorPartGridVisibilityChange(_visible: boolean): void { }
+	protected override _onEditorPartGridVisibilityChange(visible: boolean): void {
+		if (this.partVisibility.editor) {
+			return;
+		}
+		if (!visible) {
+			const suppression = this.suppressEditorPartAutoVisibility();
+			try {
+				this.setAuxiliaryBarHiddenForResize(true);
+			} finally {
+				suppression.dispose();
+			}
+			return;
+		}
+		this.setAuxiliaryBarHiddenForResize(false);
+	}
 
 	protected override _applyAuxiliaryBarVisibility(hidden: boolean, source?: 'resize'): void {
 		// The auxiliary bar is docked inside the editor part (not a grid view), so

--- a/src/vs/sessions/test/browser/workbench.test.ts
+++ b/src/vs/sessions/test/browser/workbench.test.ts
@@ -13,6 +13,7 @@ import { Workbench } from '../../browser/workbench.js';
 import { DockedEditorSizeMemento, SinglePaneWorkbench } from '../../browser/singlePaneWorkbench.js';
 import { SinglePaneMainEditorPart } from '../../browser/parts/singlePaneEditorPart.js';
 import { DockedEditorInput } from '../../common/dockedEditorInput.js';
+import { SESSIONS_LIST_MINIMUM_WIDTH } from '../../browser/parts/sidebarPart.js';
 
 interface IViewSize { width: number; height: number }
 
@@ -35,6 +36,7 @@ suite('Sessions - Workbench', () => {
 	const setEditorMaximized = Reflect.get(Workbench.prototype, 'setEditorMaximized') as (this: IMaximizeTestHarness, maximized: boolean) => void;
 	const onEditorNodeResized = Reflect.get(SinglePaneWorkbench.prototype, '_onEditorNodeResized') as (this: ITestWorkbench, nodeWidth: number) => void;
 	const onGridDidChange = Reflect.get(SinglePaneWorkbench.prototype, '_onGridDidChange') as (this: ITestWorkbench) => void;
+	const onEditorPartGridVisibilityChange = Reflect.get(SinglePaneWorkbench.prototype, '_onEditorPartGridVisibilityChange') as (this: ITestWorkbench, visible: boolean) => void;
 	const persistedAuxiliaryBarWidth = Reflect.get(SinglePaneWorkbench.prototype, '_persistedGridViewSize') as (this: ITestWorkbench, view: object, dimension: 'width' | 'height', visible: boolean) => number | undefined;
 	const persistedEditorWidth = Reflect.get(SinglePaneWorkbench.prototype, '_persistedEditorWidth') as (this: ITestWorkbench, editorGridWidth: number | undefined) => number | undefined;
 	const rememberAttachedEditorMaximizedState = Reflect.get(Workbench.prototype, 'rememberAttachedEditorMaximizedState') as (this: IWorkbenchTestHarness) => void;
@@ -609,6 +611,46 @@ suite('Sessions - Workbench', () => {
 		]);
 	});
 
+	test('maps a native sash-drag collapse of the detail-only node onto hiding the auxiliary bar, like the sessions list', () => {
+		const host = createHost({ single: true, partVisibility: { editor: false, auxiliaryBar: true } });
+
+		onEditorPartGridVisibilityChange.call(host, false);
+
+		assert.deepStrictEqual({
+			auxiliaryBarVisible: host.partVisibility.auxiliaryBar,
+			events: host.events,
+		}, {
+			auxiliaryBarVisible: false,
+			events: [{ partId: Parts.AUXILIARYBAR_PART, visible: false, source: 'resize' }],
+		});
+	});
+
+	test('reveals the detail-only panel again when the collapsed node is dragged back open', () => {
+		const host = createHost({ single: true, partVisibility: { editor: false, auxiliaryBar: true } });
+
+		onEditorPartGridVisibilityChange.call(host, false);
+		onEditorPartGridVisibilityChange.call(host, true);
+
+		assert.deepStrictEqual({
+			auxiliaryBarVisible: host.partVisibility.auxiliaryBar,
+			events: host.events,
+		}, {
+			auxiliaryBarVisible: true,
+			events: [
+				{ partId: Parts.AUXILIARYBAR_PART, visible: false, source: 'resize' },
+				{ partId: Parts.AUXILIARYBAR_PART, visible: true, source: 'resize' },
+			],
+		});
+	});
+
+	test('ignores the shared node grid visibility while editor content is visible', () => {
+		const host = createHost({ single: true, partVisibility: { editor: true, auxiliaryBar: true } });
+
+		onEditorPartGridVisibilityChange.call(host, false);
+
+		assert.deepStrictEqual({ auxiliaryBarVisible: host.partVisibility.auxiliaryBar, events: host.events }, { auxiliaryBarVisible: true, events: [] });
+	});
+
 	test('fires onDidRevealSidePane only when the side pane transitions from fully hidden to visible', () => {
 		const host = createHost({ single: true, sessionsWidth: 1000, partVisibility: { editor: false, auxiliaryBar: false } });
 		const counts: number[] = [];
@@ -840,7 +882,7 @@ suite('Sessions - Workbench', () => {
 		// side-pane↔chat sash double-click resets the side pane to 60% of the window.
 		// Scoped to single-pane; the classic editor part has no `preferredWidth` override.
 		const preferredWidthGetter = Object.getOwnPropertyDescriptor(SinglePaneMainEditorPart.prototype, 'preferredWidth')!.get!;
-		const call = (windowWidth: number) => preferredWidthGetter.call({ layoutService: { mainContainerDimension: { width: windowWidth, height: 800 } } });
+		const call = (windowWidth: number) => preferredWidthGetter.call({ layoutService: { mainContainerDimension: { width: windowWidth, height: 800 }, isVisible: () => true } });
 
 		assert.deepStrictEqual({
 			wide: call(2000),
@@ -849,6 +891,30 @@ suite('Sessions - Workbench', () => {
 			wide: 1200,
 			narrow: 300,
 		});
+	});
+
+	test('single-pane editor part preferredWidth resets to the docked detail default width instead of 60% when editor content is hidden', () => {
+		// The docked detail panel's own resize sash sits at the same spot as this
+		// grid sash while the editor is hidden, so double-clicking there must reset
+		// to the detail panel's own default width, not a window-relative split.
+		const preferredWidthGetter = Object.getOwnPropertyDescriptor(SinglePaneMainEditorPart.prototype, 'preferredWidth')!.get!;
+		const preferredWidth = preferredWidthGetter.call({ layoutService: { mainContainerDimension: { width: 2000, height: 800 }, isVisible: () => false } });
+
+		assert.strictEqual(preferredWidth, DockedAuxiliaryBarController.DEFAULT_WIDTH);
+	});
+
+	test('single-pane editor part is a snap view only while editor content is hidden (docked detail-only)', () => {
+		const snapGetter = Object.getOwnPropertyDescriptor(SinglePaneMainEditorPart.prototype, 'snap')!.get!;
+		const call = (editorVisible: boolean) => snapGetter.call({ layoutService: { isVisible: () => editorVisible } });
+
+		assert.deepStrictEqual({ editorHidden: call(false), editorVisible: call(true) }, { editorHidden: true, editorVisible: false });
+	});
+
+	test('single-pane editor part minimumWidth matches the sessions-list minimum while editor content is hidden (docked detail-only)', () => {
+		const minimumWidthGetter = Object.getOwnPropertyDescriptor(SinglePaneMainEditorPart.prototype, 'minimumWidth')!.get!;
+		const minimumWidth = minimumWidthGetter.call({ layoutService: { isVisible: () => false } });
+
+		assert.strictEqual(minimumWidth, SESSIONS_LIST_MINIMUM_WIDTH);
 	});
 
 	test('applies an even split when revealing the docked editor with no captured width even after the initial split', () => {
@@ -1155,7 +1221,7 @@ suite('Sessions - Workbench', () => {
 
 	// --- DockedAuxiliaryBarController --------------------------------------
 
-	test('fills the narrowed docked detail node and keeps its sash enabled when editor content is hidden', () => {
+	test('fills the narrowed docked detail node and disables its overlay sash when editor content is hidden', () => {
 
 		const editorContainer = document.createElement('div');
 		const auxiliaryBarContainer = document.createElement('div');
@@ -1229,7 +1295,8 @@ suite('Sessions - Workbench', () => {
 				width: '260px',
 				height: '565px',
 			},
-			sashState: SashState.Enabled,
+			// The grid sash owns resizing/collapsing here; the overlay sash must be disabled.
+			sashState: SashState.Disabled,
 			sashLeft: 0,
 		});
 
@@ -1340,59 +1407,6 @@ suite('Sessions - Workbench', () => {
 		const change = Reflect.get(sash, '_onDidChange') as { fire(e: unknown): void };
 		start.fire({ startX: 0, currentX: 0, startY: 0, currentY: 0, altKey: false });
 		change.fire({ startX: 0, currentX: 270, startY: 0, currentY: 0, altKey: false });
-
-		assert.deepStrictEqual({ hideCount, persistedWidths }, { hideCount: 1, persistedWidths: [] });
-
-		controller.dispose();
-	});
-
-	test('hides the detail-only panel when its sash collapses below the minimum width', () => {
-		const editorContainer = document.createElement('div');
-		const auxiliaryBarContainer = document.createElement('div');
-		const persistedWidths: number[] = [];
-		let editorVisible = false;
-		let hideCount = 0;
-
-		Object.defineProperty(editorContainer, 'clientWidth', { value: 260 });
-		Object.defineProperty(editorContainer, 'clientHeight', { value: 600 });
-		editorContainer.getBoundingClientRect = () => ({
-			width: 260,
-			height: 600,
-			top: 0,
-			right: 260,
-			bottom: 600,
-			left: 0,
-			x: 0,
-			y: 0,
-			toJSON: () => undefined,
-		});
-
-		const auxiliaryBarPart = {
-			getContainer: () => auxiliaryBarContainer,
-			layout: () => { },
-		} as unknown as Part;
-		const host: IDockedAuxiliaryBarHost = {
-			getWidth: () => 260,
-			setWidth: width => persistedWidths.push(width),
-			isEditorAreaVisible: () => true,
-			isEditorVisible: () => editorVisible,
-			isAuxiliaryBarVisible: () => true,
-			hideAuxiliaryBar: () => {
-				hideCount++;
-				editorVisible = true;
-			},
-			setEditorContentRightInset: () => { },
-			getHeaderHeight: () => 0,
-		};
-		const controller = new DockedAuxiliaryBarController(editorContainer, auxiliaryBarPart, host);
-
-		controller.layout();
-		const sash = Reflect.get(controller, '_sash');
-		const start = Reflect.get(sash, '_onDidStart') as { fire(e: unknown): void };
-		const change = Reflect.get(sash, '_onDidChange') as { fire(e: unknown): void };
-		start.fire({ startX: 0, currentX: 0, startY: 0, currentY: 0, altKey: false });
-		change.fire({ startX: 0, currentX: 41, startY: 0, currentY: 0, altKey: false });
-		change.fire({ startX: 0, currentX: 0, startY: 0, currentY: 0, altKey: false });
 
 		assert.deepStrictEqual({ hideCount, persistedWidths }, { hideCount: 1, persistedWidths: [] });
 


### PR DESCRIPTION
## What changed

In the Agents Window's single side-pane layout, when the docked details view is shown without the editor area (editor content hidden), its minimum width now matches the sessions list's minimum width, and dragging the sash below that width collapses (hides) the panel — mirroring the sessions list's own snap-to-hide behavior.

## Why

Previously the shared editor/detail grid node had a fixed 300px minimum and no snap support, so it couldn't be collapsed via sash-drag the way the sessions list can, and its minimum width (220px) didn't match the sessions list's (170/270px). Double-clicking the sash also incorrectly reset the panel to 60% of the window width (meant for the editor+chat split) instead of the detail panel's own default width.

## Changes

- `sidebarPart.ts`: exports `SESSIONS_LIST_MINIMUM_WIDTH` as the shared minimum-width source of truth (previously inlined on `SidebarPart.minimumWidth`).
- `singlePaneEditorPart.ts` (`SinglePaneMainEditorPart`):
  - `minimumWidth` now returns `SESSIONS_LIST_MINIMUM_WIDTH` while editor content is hidden (detail-only).
  - `snap` returns `true` in that same state, letting the grid's native sash-drag collapse the node.
  - `preferredWidth` (used on sash double-click reset) returns the detail panel's own default width instead of 60% of the window while editor content is hidden.
- `singlePaneWorkbench.ts` (`SinglePaneWorkbench`): `_onEditorPartGridVisibilityChange` now maps the grid's native collapse/reveal of the shared node onto hiding/showing the auxiliary bar, while suppressing the unrelated "reveal editor instead" fallback during a drag-driven collapse.
- `dockedAuxiliaryBarController.ts` (`DockedAuxiliaryBarController`): disables its own manual overlay sash while editor content is hidden, since the real grid sash now owns resizing/collapsing there (avoids two overlapping/competing sashes).

## Testing

- `tsc --noEmit` and `valid-layers-check`: clean (only pre-existing unrelated `@vscode/os-proxy-resolver` module errors).
- Full `workbench.test.ts` suite: 70 passing, including new/updated tests covering the snap/minimumWidth getters, the native collapse/reveal mapping, and the disabled overlay sash.