### PR TITLE
Style overrides: Restore whole-bar recolor for active style overrides in Modern UI

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -178,6 +178,16 @@
 	display: none !important;
 }
 
+/*
+ * Modern UI paints the status bar transparent, which suppresses the whole-bar
+ * recolor used to signal an active style override (e.g. an active debug session).
+ * While an override is active, restore the whole-bar recolor so the cue reads as
+ * clearly as it does in the classic UI.
+ */
+.monaco-workbench.floating-panels .part.statusbar.has-style-override {
+	background-color: color-mix(in srgb, var(--vscode-statusBar-debuggingBackground) 30%, transparent) !important;
+}
+
 /* Inset and vertically center the status bar items within its floating gutter. */
 .monaco-workbench.floating-panels .part.statusbar {
 	padding-left: var(--vscode-spacing-size60);

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -670,6 +670,11 @@ class StatusbarPart extends Part implements IStatusbarEntryContainer {
 		// Update compact entries to refresh hover colors based on current theme
 		this.updateCompactEntries();
 
+		// Mark the bar when a style override is active (currently only the debugging
+		// color) so Modern UI can restore the recolor, which floating mode otherwise
+		// paints transparent.
+		container.classList.toggle('has-style-override', !!styleOverride?.background);
+
 		// Border color
 		const borderColor = this.getColor(styleOverride?.border ?? (this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY ? STATUS_BAR_BORDER : STATUS_BAR_NO_FOLDER_BORDER)) || this.getColor(contrastBorder);
 		if (borderColor) {


### PR DESCRIPTION
Modern UI now correctly displays the whole-bar recolor when an active style override is present, such as during a debugging session. This change enhances visibility by ensuring the status bar reflects the active state clearly, similar to the classic UI.

Fixes https://github.com/microsoft/vscode/issues/325921