### PR TITLE
Style override: Set background color for integrated terminal tabs

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -341,6 +341,6 @@
 	line-height: 24px;
 }
 
-.style-override.monaco-workbench .pane-body.integrated-terminal .tabs-list-container {
+.style-override.monaco-workbench .pane-body.integrated-terminal .tabs-list-container:not(.drop-target) {
 	background-color: var(--vscode-panel-background);
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -340,3 +340,7 @@
 	padding: 0;
 	line-height: 24px;
 }
+
+.style-override.monaco-workbench .pane-body.integrated-terminal .tabs-list-container {
+	background-color: var(--vscode-panel-background);
+}


### PR DESCRIPTION
Add a background color to the integrated terminal tabs list container for improved visibility and aesthetics.

