### PR TITLE
Style overrides: Adjust hover highlights for floating panels

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -323,7 +323,7 @@
  * gap. Match that larger bottom inset. Excluded when a bottom panel is present, since
  * then the side/aux bars abut the panel card and keep the normal 2px trailing margin.
  */
-.monaco-workbench.floating-panels.nostatusbar:not(.panel-position-bottom) .monaco-sash.vertical:not(.part .monaco-sash)::before {
+.monaco-workbench.floating-panels.nostatusbar:is(:not(.panel-position-bottom), .nopanel) .monaco-sash.vertical:not(.part .monaco-sash)::before {
 	bottom: calc(var(--vscode-spacing-size40) * 2);
 }
 

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -292,61 +292,67 @@
 /*
  * A vertical grid sash (between the editor and a side/auxiliary bar) spans the full
  * height of the content region, but the floating cards it divides are inset from the
- * region's bottom by the inter-card gap (the trailing card margin,
- * `--vscode-spacing-size20`). Left unadjusted, the hover highlight (`:before`)
- * overshoots below the two cards into that gap — the reported "sash extends past the
- * panels". Inset the highlight's bottom to line it up with the card edges. The cards
- * are flush with the title bar at the top (no top margin), so the highlight keeps
- * `top: 0`. Only the highlight is inset; the sash hit region is unchanged.
+ * region by the card margins. Left unadjusted, the hover highlight (`:before`)
+ * overshoots into those gaps — the reported "sash extends past the panels". Anchor the
+ * highlight with `top`/`bottom` (rather than `height`) so the two insets compose
+ * independently across layouts. The base leaves the cards flush with the title bar
+ * (`top: 0`) and insets the bottom by the 2px trailing card margin
+ * (`--vscode-spacing-size20`). Only the highlight is inset; the sash hit region is
+ * unchanged. In non-justify alignments a full-height side bar (spanning both the panel
+ * and editor rows) keeps its own margins, so its highlight may sit up to a card margin
+ * short on the abutting edge — an accepted minor cosmetic gap.
  */
 .monaco-workbench.floating-panels .monaco-sash.vertical:not(.part .monaco-sash)::before {
 	top: 0;
-	height: calc(100% - var(--vscode-spacing-size20));
+	bottom: var(--vscode-spacing-size20);
+	height: auto;
+}
+
+/*
+ * Panel docked at the top: the editor and its sibling side/aux bars take a top margin
+ * (`--vscode-spacing-size40`); inset the highlight's top to match so it does not
+ * overshoot above the cards into that gap.
+ */
+.monaco-workbench.floating-panels.panel-position-top:not(.nopanel) .monaco-sash.vertical:not(.part .monaco-sash)::before {
+	top: var(--vscode-spacing-size40);
 }
 
 /*
  * When the status bar is hidden the cards sit against the window bottom edge and take
  * the doubled outer gutter (`--vscode-spacing-size40` * 2) instead of the 2px inter-card
- * gap. Match that larger bottom inset so the highlight still lines up with the card
- * edges. Excluded when a bottom panel is present, since then the side/aux bars abut the
- * panel card and keep the normal 2px trailing margin.
+ * gap. Match that larger bottom inset. Excluded when a bottom panel is present, since
+ * then the side/aux bars abut the panel card and keep the normal 2px trailing margin.
  */
 .monaco-workbench.floating-panels.nostatusbar:not(.panel-position-bottom) .monaco-sash.vertical:not(.part .monaco-sash)::before {
-	height: calc(100% - var(--vscode-spacing-size40) * 2);
+	bottom: calc(var(--vscode-spacing-size40) * 2);
 }
 
 /*
  * A horizontal grid sash (the resize handle between the editor and a top/bottom panel)
- * draws its hover highlight full-width (`:before { width: 100% }`), but the panel card it
- * divides is inset from the column's side edges by the floating card margins — so the
- * line overshoots both ends. Inset the highlight's `left`/`width` to match the panel
- * card's leading (`--vscode-spacing-size40`) and trailing (`--vscode-spacing-size20`)
- * margins so it lines up with the cards. Either margin doubles to the outer gutter
- * (`--vscode-spacing-size40` * 2) when the panel is the outermost card on that window
- * edge; mirror that with `:has()` on the panel's outer-edge classes so the highlight
- * tracks the same margins the card uses, per layout. Ordered by `:has()` count so the
- * more specific outer-edge rules win for the edges they own.
+ * draws its hover highlight full-width, but the panel card it divides is inset from the
+ * column's side edges by the floating card margins — so the line overshoots both ends.
+ * Anchor the highlight with `left`/`right` (rather than `width`) so each side composes
+ * independently: the base uses the panel card's leading (`--vscode-spacing-size40`) and
+ * trailing (`--vscode-spacing-size20`) margins. Either margin doubles to the outer
+ * gutter (`--vscode-spacing-size40` * 2) when the panel is the outermost card on that
+ * window edge; mirror that with `:has()` on the panel's outer-edge classes so the
+ * highlight tracks the same margins the card uses, per layout. Both-edges is handled
+ * automatically since the two `:has()` rules touch independent properties.
  */
 .monaco-workbench.floating-panels:not(.nopanel) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
 	left: var(--vscode-spacing-size40);
-	width: calc(100% - var(--vscode-spacing-size40) - var(--vscode-spacing-size20));
+	right: var(--vscode-spacing-size20);
+	width: auto;
 }
 
 /* Panel owns the left window edge → its leading gutter doubles; match it. */
 .monaco-workbench.floating-panels:not(.nopanel):has(.part.panel.floating-part-outer-left) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
 	left: calc(var(--vscode-spacing-size40) * 2);
-	width: calc(100% - var(--vscode-spacing-size40) * 2 - var(--vscode-spacing-size20));
 }
 
 /* Panel owns the right window edge → its trailing gutter doubles; match it. */
 .monaco-workbench.floating-panels:not(.nopanel):has(.part.panel.floating-part-outer-right) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
-	width: calc(100% - var(--vscode-spacing-size40) - var(--vscode-spacing-size40) * 2);
-}
-
-/* Panel owns both window edges (e.g. a full-width bottom panel with no side bars). */
-.monaco-workbench.floating-panels:not(.nopanel):has(.part.panel.floating-part-outer-left):has(.part.panel.floating-part-outer-right) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
-	left: calc(var(--vscode-spacing-size40) * 2);
-	width: calc(100% - var(--vscode-spacing-size40) * 2 - var(--vscode-spacing-size40) * 2);
+	right: calc(var(--vscode-spacing-size40) * 2);
 }
 
 /*

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -290,6 +290,66 @@
 }
 
 /*
+ * A vertical grid sash (between the editor and a side/auxiliary bar) spans the full
+ * height of the content region, but the floating cards it divides are inset from the
+ * region's bottom by the inter-card gap (the trailing card margin,
+ * `--vscode-spacing-size20`). Left unadjusted, the hover highlight (`:before`)
+ * overshoots below the two cards into that gap — the reported "sash extends past the
+ * panels". Inset the highlight's bottom to line it up with the card edges. The cards
+ * are flush with the title bar at the top (no top margin), so the highlight keeps
+ * `top: 0`. Only the highlight is inset; the sash hit region is unchanged.
+ */
+.monaco-workbench.floating-panels .monaco-sash.vertical:not(.part .monaco-sash)::before {
+	top: 0;
+	height: calc(100% - var(--vscode-spacing-size20));
+}
+
+/*
+ * When the status bar is hidden the cards sit against the window bottom edge and take
+ * the doubled outer gutter (`--vscode-spacing-size40` * 2) instead of the 2px inter-card
+ * gap. Match that larger bottom inset so the highlight still lines up with the card
+ * edges. Excluded when a bottom panel is present, since then the side/aux bars abut the
+ * panel card and keep the normal 2px trailing margin.
+ */
+.monaco-workbench.floating-panels.nostatusbar:not(.panel-position-bottom) .monaco-sash.vertical:not(.part .monaco-sash)::before {
+	height: calc(100% - var(--vscode-spacing-size40) * 2);
+}
+
+/*
+ * A horizontal grid sash (the resize handle between the editor and a top/bottom panel)
+ * draws its hover highlight full-width (`:before { width: 100% }`), but the panel card it
+ * divides is inset from the column's side edges by the floating card margins — so the
+ * line overshoots both ends. Inset the highlight's `left`/`width` to match the panel
+ * card's leading (`--vscode-spacing-size40`) and trailing (`--vscode-spacing-size20`)
+ * margins so it lines up with the cards. Either margin doubles to the outer gutter
+ * (`--vscode-spacing-size40` * 2) when the panel is the outermost card on that window
+ * edge; mirror that with `:has()` on the panel's outer-edge classes so the highlight
+ * tracks the same margins the card uses, per layout. Ordered by `:has()` count so the
+ * more specific outer-edge rules win for the edges they own.
+ */
+.monaco-workbench.floating-panels:not(.nopanel) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
+	left: var(--vscode-spacing-size40);
+	width: calc(100% - var(--vscode-spacing-size40) - var(--vscode-spacing-size20));
+}
+
+/* Panel owns the left window edge → its leading gutter doubles; match it. */
+.monaco-workbench.floating-panels:not(.nopanel):has(.part.panel.floating-part-outer-left) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
+	left: calc(var(--vscode-spacing-size40) * 2);
+	width: calc(100% - var(--vscode-spacing-size40) * 2 - var(--vscode-spacing-size20));
+}
+
+/* Panel owns the right window edge → its trailing gutter doubles; match it. */
+.monaco-workbench.floating-panels:not(.nopanel):has(.part.panel.floating-part-outer-right) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
+	width: calc(100% - var(--vscode-spacing-size40) - var(--vscode-spacing-size40) * 2);
+}
+
+/* Panel owns both window edges (e.g. a full-width bottom panel with no side bars). */
+.monaco-workbench.floating-panels:not(.nopanel):has(.part.panel.floating-part-outer-left):has(.part.panel.floating-part-outer-right) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
+	left: calc(var(--vscode-spacing-size40) * 2);
+	width: calc(100% - var(--vscode-spacing-size40) * 2 - var(--vscode-spacing-size40) * 2);
+}
+
+/*
  * When the bottom panel is hidden, the grid keeps a collapsed (zero-height) panel
  * node whose reveal sash sits at the very bottom of the content region. Sashes are
  * centered on their boundary, so the sash's lower half overflows the content region

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -335,9 +335,10 @@
  * independently: the base uses the panel card's leading (`--vscode-spacing-size40`) and
  * trailing (`--vscode-spacing-size20`) margins. Either margin doubles to the outer
  * gutter (`--vscode-spacing-size40` * 2) when the panel is the outermost card on that
- * window edge; mirror that with `:has()` on the panel's outer-edge classes so the
- * highlight tracks the same margins the card uses, per layout. Both-edges is handled
- * automatically since the two `:has()` rules touch independent properties.
+ * window edge; mirror that with the `.floating-panel-outer-left` / `.floating-panel-outer-right`
+ * classes set on the workbench root (propagated from the panel's outer-edge state in
+ * paneCompositePart) so the highlight tracks the same margins the card uses, per layout.
+ * Both-edges is handled automatically since the two rules touch independent properties.
  */
 .monaco-workbench.floating-panels:not(.nopanel) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
 	left: var(--vscode-spacing-size40);
@@ -346,12 +347,12 @@
 }
 
 /* Panel owns the left window edge → its leading gutter doubles; match it. */
-.monaco-workbench.floating-panels:not(.nopanel):has(.part.panel.floating-part-outer-left) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
+.monaco-workbench.floating-panels:not(.nopanel).floating-panel-outer-left .monaco-sash.horizontal:not(.part .monaco-sash)::before {
 	left: calc(var(--vscode-spacing-size40) * 2);
 }
 
 /* Panel owns the right window edge → its trailing gutter doubles; match it. */
-.monaco-workbench.floating-panels:not(.nopanel):has(.part.panel.floating-part-outer-right) .monaco-sash.horizontal:not(.part .monaco-sash)::before {
+.monaco-workbench.floating-panels:not(.nopanel).floating-panel-outer-right .monaco-sash.horizontal:not(.part .monaco-sash)::before {
 	right: calc(var(--vscode-spacing-size40) * 2);
 }
 

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -615,6 +615,18 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		this.element.classList.toggle('floating-part-outer-left', outerGutter.left);
 		this.element.classList.toggle('floating-part-outer-right', outerGutter.right);
 
+		// Mirror the panel's outer-edge state onto the workbench container so the
+		// horizontal grid sash highlight can match the panel card's doubled outer
+		// gutter by selecting a direct class, rather than a `:has()` query on the
+		// workbench root (which would force selector invalidation across the whole
+		// workbench on every DOM change). Updated here in lockstep with the part-level
+		// classes above, so the timing is identical.
+		if (this.partId === Parts.PANEL_PART) {
+			const workbenchContainer = this.layoutService.getContainer(getWindow(this.element));
+			workbenchContainer.classList.toggle('floating-panel-outer-left', outerGutter.left);
+			workbenchContainer.classList.toggle('floating-panel-outer-right', outerGutter.right);
+		}
+
 		// Layout contents
 		super.layout(this.contentDimension.width, this.contentDimension.height, top, left);
 


### PR DESCRIPTION
Improve the alignment of hover highlights for floating panels to ensure they match the edges of the cards. This change enhances the visual consistency and user experience when interacting with floating panels.

