### PR TITLE
Fix voice barge-in protocol

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -92,9 +92,6 @@ export interface IMicCaptureService {
 	/** Fired when a PTT segment ends. All chunks have been sent before this fires. */
 	readonly onPttEnd: Event<void>;
 
-	/** Base64 raw PCM16 chunks during barge-in monitoring (not turn input). */
-	readonly onMonitorAudioChunk: Event<string>;
-
 	/**
 	 * Fired after the diagnostic window closes (~1s after `pttUp`) with
 	 * per-press telemetry. Always fires AFTER `onPttEnd` for normal
@@ -132,12 +129,6 @@ export interface IMicCaptureService {
 	 */
 	abortPtt(): void;
 
-	/** Stream mic audio for barge-in detection (no PTT turn, no AEC gating). */
-	startMonitor(window: Window & typeof globalThis): Promise<void>;
-
-	/** Stop barge-in monitoring. Releases the mic only if no PTT press is active. */
-	stopMonitor(): void;
-
 	// --- Mute / AEC suppression ---
 	isMuted: boolean;
 
@@ -167,9 +158,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	private _isMuted = false;
 	private _suppressUntilTs = 0;
 	private _pttAcquiring = false;
-	private _capturePromise: Promise<void> | undefined;
 	private _pttReleasedDuringAcquire = false;
-	private _monitoring = false;
 
 	// --- Hardware mute detection. ---
 	// A hardware microphone kill switch (e.g. on Framework laptops) leaves
@@ -218,9 +207,6 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 
 	private readonly _onPttEnd = this._register(new Emitter<void>());
 	readonly onPttEnd: Event<void> = this._onPttEnd.event;
-
-	private readonly _onMonitorAudioChunk = this._register(new Emitter<string>());
-	readonly onMonitorAudioChunk: Event<string> = this._onMonitorAudioChunk.event;
 
 	private readonly _onPttDiagnostic = this._register(new Emitter<IPttDiagnostic>());
 	readonly onPttDiagnostic: Event<IPttDiagnostic> = this._onPttDiagnostic.event;
@@ -345,49 +331,8 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		this._scheduleDiagnosticFire();
 	}
 
-	async startMonitor(window: Window & typeof globalThis): Promise<void> {
-		this._window = window;
-		if (this._monitoring) { return; }
-		this._monitoring = true;
-		if (!this._isCapturing) {
-			try {
-				await this.startCapture(window);
-			} catch (err) {
-				// Rethrow so the controller resets its _bargeInMonitorActive flag.
-				this._monitoring = false;
-				this.logService.warn('[mic] barge-in monitor could not acquire microphone', err);
-				throw err;
-			}
-			// Cancelled mid-acquire: release the mic we just opened.
-			if (!this._monitoring && !this._pttHeld && !this._pttStreaming) {
-				this.stopCapture();
-			}
-		}
-	}
-
-	stopMonitor(): void {
-		if (!this._monitoring) { return; }
-		this._monitoring = false;
-		// Keep the mic if a PTT press is using it.
-		if (!this._pttHeld && !this._pttStreaming) {
-			this.stopCapture();
-		}
-	}
-
 	async startCapture(window: Window & typeof globalThis): Promise<void> {
 		this._window = window;
-		if (this._isCapturing) { return; }
-		// Serialize concurrent acquisitions (monitor + PTT) into one getUserMedia.
-		if (this._capturePromise) { return this._capturePromise; }
-		this._capturePromise = this._acquireCapture(window);
-		try {
-			await this._capturePromise;
-		} finally {
-			this._capturePromise = undefined;
-		}
-	}
-
-	private async _acquireCapture(window: Window & typeof globalThis): Promise<void> {
 		if (this._isCapturing) { return; }
 		const deviceId = this.storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION);
 		const audioConstraints: MediaTrackConstraints = {
@@ -480,14 +425,6 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 				return;
 			}
 
-			// Barge-in monitor: stream raw audio during playback (not a turn,
-			// not AEC-gated) so the backend can detect the user talking over it.
-			if (this._monitoring) {
-				const monitorData = e.inputBuffer.getChannelData(0);
-				const monitorSamples = new Float32Array(monitorData);
-				this._onMonitorAudioChunk.fire(encodeRawPcm16Base64(monitorSamples, this._window!));
-			}
-
 			if (nowTs < this._suppressUntilTs) {
 				if (isDrainCallback) { this._diagDrainSkippedBySuppression++; }
 				if (isPostReleaseCallback) { this._diagPostReleaseSkippedBySuppression++; }
@@ -577,7 +514,6 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		this._pttHeld = false;
 		this._pttStreaming = false;
 		this._pttReleasedDuringAcquire = false;
-		this._monitoring = false;
 	}
 
 	override dispose(): void {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -429,24 +429,6 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 		}
 	}
 
-	sendBargeInStart(): void {
-		if (this._ws?.readyState === WebSocket.OPEN) {
-			this._ws.send(JSON.stringify({ type: 'barge_in_start' }));
-		}
-	}
-
-	sendBargeInAudioChunk(audio: string): void {
-		if (this._ws?.readyState === WebSocket.OPEN) {
-			this._ws.send(JSON.stringify({ type: 'barge_in_audio_chunk', audio }));
-		}
-	}
-
-	sendBargeInStop(): void {
-		if (this._ws?.readyState === WebSocket.OPEN) {
-			this._ws.send(JSON.stringify({ type: 'barge_in_stop' }));
-		}
-	}
-
 	sendPttDiagnostic(turnId: string, metrics: Record<string, unknown>): void {
 		if (this._ws?.readyState === WebSocket.OPEN) {
 			this._ws.send(JSON.stringify({ type: 'ptt_diagnostic', turn_id: turnId, metrics }));

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -204,9 +204,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Tracks whether the initial listen cue has been played after connecting. */
 	private _hasPlayedInitialListenCue = false;
 
-	/** True while streaming mic audio to the backend during playback (barge-in). */
-	private _bargeInMonitorActive = false;
-
 	// --- Audio FIFO queue ---
 	private readonly _audioQueue: { sessionId: string | undefined; chunks: { audio: string; isFirstChunk: boolean; isFinal: boolean; transcript: string | undefined }[] }[] = [];
 	private _currentPlaybackSessionId: string | undefined | null = null; // null = nothing playing
@@ -695,10 +692,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._voiceEventDisposables.add(this.micCaptureService.onPttEnd(() => {
 			this.voiceClientService.sendPttEnd();
 		}));
-		// Barge-in: stream mic audio to the backend during assistant playback.
-		this._voiceEventDisposables.add(this.micCaptureService.onMonitorAudioChunk(b64 => {
-			this.voiceClientService.sendBargeInAudioChunk(b64);
-		}));
 		this._voiceEventDisposables.add(this.micCaptureService.onPttDiagnostic((diag: IPttDiagnostic) => {
 			// Local log so the same correlation key surfaces in the
 			// VS Code log files even if the WS is closed mid-flight.
@@ -756,7 +749,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (this._audioQueue.length > 0) {
 				setTimeout(() => this._processQueue(), 500);
 			} else {
-				this._stopBargeInMonitor();
 				if (this._pttHeld) {
 					this._voiceState.set('listening', undefined);
 					this._statusText.set('Listening...', undefined);
@@ -1143,23 +1135,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// Speech started → stop TTS, suppress late chunks from the previous turn
 		// (same flow as pttDown, but for server-VAD path).
 		this._voiceEventDisposables.add(this.voiceClientService.onSpeechStarted(() => {
-			const wasMonitoring = this._bargeInMonitorActive;
 			this._clearAutoListenTimer();
-			if (wasMonitoring && !this._pttHeld) {
-				// Promote the monitor into a real turn (mic stays warm via pttDown).
-				this.pttDown();
-				this.pttUp();
-				// Clear the playback AEC suppression so the turn start isn't gated.
-				this.micCaptureService.suppressUntil(0);
-			} else {
-				this.ttsPlaybackService.stopPlayback();
-				this._audioQueue.length = 0;
-				this._currentPlaybackSessionId = null;
-				this._isProcessingQueue = false;
-				this._suppressIncomingAudio = true;
-				this._stopBargeInMonitor();
-				this._startUserTurn();
-			}
+			this.ttsPlaybackService.stopPlayback();
+			this._audioQueue.length = 0;
+			this._currentPlaybackSessionId = null;
+			this._isProcessingQueue = false;
+			this._suppressIncomingAudio = true;
+			this._startUserTurn();
 		}));
 
 		// Backend ended the held turn itself (server VAD silence / stop phrase).
@@ -1429,7 +1411,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._enterListenOnSessionInit = false;
 		this._hasPlayedInitialListenCue = false;
 		this._replyPlayedSinceSend = false;
-		this._bargeInMonitorActive = false;
 		this._audioQueue.length = 0;
 		this._currentPlaybackSessionId = null;
 		this._isProcessingQueue = false;
@@ -1562,6 +1543,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._suppressIncomingAudio = true;
 
 		this.micCaptureService.isMuted = false;
+		this.micCaptureService.suppressUntil(0);
 		// Lazily acquire the mic — fire-and-forget. The mic service handles
 		// the case where the user releases before acquisition completes.
 		this.micCaptureService.pttDown(this._pttCurrentTurnId).catch((err) => {
@@ -1578,9 +1560,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 			this.disconnect();
 		});
-		// Stop the monitor after mic pttDown so its _pttStreaming flag is set
-		// first, letting stopMonitor keep the mic warm instead of re-acquiring.
-		this._stopBargeInMonitor();
 		this.ttsPlaybackService.stopPlayback();
 		this._voiceState.set('listening', undefined);
 		this._statusText.set('Listening...', undefined);
@@ -1627,7 +1606,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._autoListenSuppressed = true;
 		this._pttToggleMode = false;
 		this._clearAutoListenTimer();
-		this._stopBargeInMonitor();
 		if (this._pttHeld) {
 			this._finishPtt('local');
 		} else {
@@ -1813,37 +1791,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			clearTimeout(this._awaitingReplyWatchdog);
 			this._awaitingReplyWatchdog = undefined;
 		}
-	}
-
-	/**
-	 * Start barge-in monitoring: stream mic audio to the backend during
-	 * playback so the user can talk over the assistant. Hands-free only;
-	 * the backend emits `speech_started`, which `onSpeechStarted` promotes
-	 * into a real turn. Inert until the backend consumes `barge_in_*`.
-	 */
-	private _startBargeInMonitor(): void {
-		if (this._bargeInMonitorActive || !this._isConnected.get() || this._pttHeld || !this._window) {
-			return;
-		}
-		if (!this._isHandsFreeEnabled()) {
-			return;
-		}
-		this._bargeInMonitorActive = true;
-		this.voiceClientService.sendBargeInStart();
-		this.micCaptureService.startMonitor(this._window).catch(err => {
-			this.logService.warn('[voice] barge-in monitor failed to start', err);
-			this._bargeInMonitorActive = false;
-		});
-	}
-
-	/** Stop barge-in monitoring and tell the backend to stop listening for it. */
-	private _stopBargeInMonitor(): void {
-		if (!this._bargeInMonitorActive) {
-			return;
-		}
-		this._bargeInMonitorActive = false;
-		this.micCaptureService.stopMonitor();
-		this.voiceClientService.sendBargeInStop();
 	}
 
 	/**
@@ -2905,8 +2852,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this.micCaptureService.suppressUntil(Date.now() + 800);
 			this._voiceState.set('speaking', undefined);
 			this._statusText.set('Speaking...', undefined);
-			// Hands-free: keep the mic open so the user can barge in.
-			this._startBargeInMonitor();
 			this.ttsPlaybackService.playAudioChunk(audio, isFinal, this._window!);
 		} else if (!speakResponsesEnabled) {
 			this._replyPlayedSinceSend = true;

--- a/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
@@ -165,13 +165,6 @@ export interface IVoiceClientService {
 	sendPttAudioChunk(audio: string): void;
 	sendPttEnd(): void;
 	/**
-	 * Barge-in: stream raw mic audio while the assistant speaks (hands-free) so
-	 * the backend can detect the user talking over it. Not a turn; not transcribed.
-	 */
-	sendBargeInStart(): void;
-	sendBargeInAudioChunk(audio: string): void;
-	sendBargeInStop(): void;
-	/**
 	 * Send a per-press post-mortem diagnostic payload for tail-loss
 	 * investigation. Fired ~500ms after `pttUp` by the mic service.
 	 * `metrics` is an opaque object echoed straight into a structured

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceClientService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceClientService.test.ts
@@ -16,7 +16,8 @@ import { IVoiceBargeIn } from '../../../common/voiceClient/voiceClientService.js
 class TestWebSocket {
 	static instance: TestWebSocket | undefined;
 
-	readonly readyState = 3;
+	readonly readyState = 1;
+	readonly sent: string[] = [];
 	onopen: (() => void) | null = null;
 	onmessage: ((event: MessageEvent) => void) | null = null;
 	onerror: (() => void) | null = null;
@@ -27,7 +28,9 @@ class TestWebSocket {
 	}
 
 	close(): void { }
-	send(): void { }
+	send(data: string): void {
+		this.sent.push(data);
+	}
 }
 
 function createTestWindow(): Window & typeof globalThis {
@@ -43,22 +46,26 @@ function createTestWindow(): Window & typeof globalThis {
 
 suite('VoiceClientService', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	const productService: IProductService = {
+		_serviceBrand: undefined,
+		...product,
+		voiceWsUrl: 'ws://voice.test/realtime/voice',
+	};
+
+	function createService(): VoiceClientService {
+		return store.add(new VoiceClientService(
+			new TestConfigurationService(),
+			new NullLogService(),
+			productService,
+		));
+	}
 
 	setup(() => {
 		TestWebSocket.instance = undefined;
 	});
 
 	test('emits barge-in events from the backend', async () => {
-		const productService: IProductService = {
-			_serviceBrand: undefined,
-			...product,
-			voiceWsUrl: 'ws://voice.test/realtime/voice',
-		};
-		const service = store.add(new VoiceClientService(
-			new TestConfigurationService(),
-			new NullLogService(),
-			productService,
-		));
+		const service = createService();
 		const events: IVoiceBargeIn[] = [];
 		store.add(service.onBargeIn(event => events.push(event)));
 
@@ -79,5 +86,20 @@ suite('VoiceClientService', () => {
 			turnId: 'interrupting-turn',
 			interruptedTurnId: 'cancelled-turn',
 		}]);
+	});
+
+	test('sends microphone audio using the PTT protocol', async () => {
+		const service = createService();
+
+		await service.connect(createTestWindow());
+		service.sendPttStart('turn-1');
+		service.sendPttAudioChunk('cGNt');
+		service.sendPttEnd();
+
+		assert.deepStrictEqual(TestWebSocket.instance?.sent, [
+			JSON.stringify({ type: 'ptt_start', turn_id: 'turn-1' }),
+			JSON.stringify({ type: 'ptt_audio_chunk', audio: 'cGNt' }),
+			JSON.stringify({ type: 'ptt_end' }),
+		]);
 	});
 });


### PR DESCRIPTION
Remove the unsupported outbound barge_in monitor messages and keep microphone streaming on the established PTT protocol. Clear playback suppression when PTT starts so backend VAD receives interruption audio immediately, while preserving the inbound barge_in playback cancellation event.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
