### PR TITLE
Style overrides: Add border-radius to SCM editor container in workbench

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -303,3 +303,7 @@
 .style-override.monaco-workbench .monaco-count-badge.long {
 	border-radius: var(--vscode-cornerRadius-small);
 }
+
+.style-override.monaco-workbench .part.panel .scm-view .scm-editor-container {
+	border-radius: var(--vscode-cornerRadius-small);
+}


### PR DESCRIPTION
Introduce a border-radius style to the SCM editor container for improved aesthetics. This change enhances the visual consistency of the workbench interface. Testing can be done by reviewing the SCM editor in the workbench to observe the updated styling.

