### PR TITLE
Voice agent always on streaming mode to support barge in

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -92,9 +92,6 @@ export interface IMicCaptureService {
 	/** Fired when a PTT segment ends. All chunks have been sent before this fires. */
 	readonly onPttEnd: Event<void>;
 
-	/** Base64 raw PCM16 chunks during barge-in monitoring (not turn input). */
-	readonly onMonitorAudioChunk: Event<string>;
-
 	/**
 	 * Fired after the diagnostic window closes (~1s after `pttUp`) with
 	 * per-press telemetry. Always fires AFTER `onPttEnd` for normal
@@ -132,12 +129,6 @@ export interface IMicCaptureService {
 	 */
 	abortPtt(): void;
 
-	/** Stream mic audio for barge-in detection (no PTT turn, no AEC gating). */
-	startMonitor(window: Window & typeof globalThis): Promise<void>;
-
-	/** Stop barge-in monitoring. Releases the mic only if no PTT press is active. */
-	stopMonitor(): void;
-
 	// --- Mute / AEC suppression ---
 	isMuted: boolean;
 
@@ -167,9 +158,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	private _isMuted = false;
 	private _suppressUntilTs = 0;
 	private _pttAcquiring = false;
-	private _capturePromise: Promise<void> | undefined;
 	private _pttReleasedDuringAcquire = false;
-	private _monitoring = false;
 
 	// --- Hardware mute detection. ---
 	// A hardware microphone kill switch (e.g. on Framework laptops) leaves
@@ -218,9 +207,6 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 
 	private readonly _onPttEnd = this._register(new Emitter<void>());
 	readonly onPttEnd: Event<void> = this._onPttEnd.event;
-
-	private readonly _onMonitorAudioChunk = this._register(new Emitter<string>());
-	readonly onMonitorAudioChunk: Event<string> = this._onMonitorAudioChunk.event;
 
 	private readonly _onPttDiagnostic = this._register(new Emitter<IPttDiagnostic>());
 	readonly onPttDiagnostic: Event<IPttDiagnostic> = this._onPttDiagnostic.event;
@@ -345,49 +331,8 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		this._scheduleDiagnosticFire();
 	}
 
-	async startMonitor(window: Window & typeof globalThis): Promise<void> {
-		this._window = window;
-		if (this._monitoring) { return; }
-		this._monitoring = true;
-		if (!this._isCapturing) {
-			try {
-				await this.startCapture(window);
-			} catch (err) {
-				// Rethrow so the controller resets its _bargeInMonitorActive flag.
-				this._monitoring = false;
-				this.logService.warn('[mic] barge-in monitor could not acquire microphone', err);
-				throw err;
-			}
-			// Cancelled mid-acquire: release the mic we just opened.
-			if (!this._monitoring && !this._pttHeld && !this._pttStreaming) {
-				this.stopCapture();
-			}
-		}
-	}
-
-	stopMonitor(): void {
-		if (!this._monitoring) { return; }
-		this._monitoring = false;
-		// Keep the mic if a PTT press is using it.
-		if (!this._pttHeld && !this._pttStreaming) {
-			this.stopCapture();
-		}
-	}
-
 	async startCapture(window: Window & typeof globalThis): Promise<void> {
 		this._window = window;
-		if (this._isCapturing) { return; }
-		// Serialize concurrent acquisitions (monitor + PTT) into one getUserMedia.
-		if (this._capturePromise) { return this._capturePromise; }
-		this._capturePromise = this._acquireCapture(window);
-		try {
-			await this._capturePromise;
-		} finally {
-			this._capturePromise = undefined;
-		}
-	}
-
-	private async _acquireCapture(window: Window & typeof globalThis): Promise<void> {
 		if (this._isCapturing) { return; }
 		const deviceId = this.storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION);
 		const audioConstraints: MediaTrackConstraints = {
@@ -480,14 +425,6 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 				return;
 			}
 
-			// Barge-in monitor: stream raw audio during playback (not a turn,
-			// not AEC-gated) so the backend can detect the user talking over it.
-			if (this._monitoring) {
-				const monitorData = e.inputBuffer.getChannelData(0);
-				const monitorSamples = new Float32Array(monitorData);
-				this._onMonitorAudioChunk.fire(encodeRawPcm16Base64(monitorSamples, this._window!));
-			}
-
 			if (nowTs < this._suppressUntilTs) {
 				if (isDrainCallback) { this._diagDrainSkippedBySuppression++; }
 				if (isPostReleaseCallback) { this._diagPostReleaseSkippedBySuppression++; }
@@ -577,7 +514,6 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		this._pttHeld = false;
 		this._pttStreaming = false;
 		this._pttReleasedDuringAcquire = false;
-		this._monitoring = false;
 	}
 
 	override dispose(): void {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -429,24 +429,6 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 		}
 	}
 
-	sendBargeInStart(): void {
-		if (this._ws?.readyState === WebSocket.OPEN) {
-			this._ws.send(JSON.stringify({ type: 'barge_in_start' }));
-		}
-	}
-
-	sendBargeInAudioChunk(audio: string): void {
-		if (this._ws?.readyState === WebSocket.OPEN) {
-			this._ws.send(JSON.stringify({ type: 'barge_in_audio_chunk', audio }));
-		}
-	}
-
-	sendBargeInStop(): void {
-		if (this._ws?.readyState === WebSocket.OPEN) {
-			this._ws.send(JSON.stringify({ type: 'barge_in_stop' }));
-		}
-	}
-
 	sendPttDiagnostic(turnId: string, metrics: Record<string, unknown>): void {
 		if (this._ws?.readyState === WebSocket.OPEN) {
 			this._ws.send(JSON.stringify({ type: 'ptt_diagnostic', turn_id: turnId, metrics }));

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1747,6 +1747,47 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this.pttUp();
 	}
 
+	/**
+	 * Hands-free barge-in listen: open a passive PTT streaming turn WITHOUT
+	 * interrupting the assistant's playback, so the backend's server-VAD keeps
+	 * receiving mic audio and can detect the user talking over the assistant.
+	 *
+	 * Unlike `pttDown()` (a user-driven interrupt) this does NOT stop playback,
+	 * clear the audio queue, or suppress incoming audio. The backend decides
+	 * when a real interruption happened and emits `speech_started` / `barge_in`
+	 * (already wired to cut off TTS). If the user stays silent the turn simply
+	 * stays open and becomes the next listening turn once playback ends
+	 * (`onPlaybackStopped` sees `_pttHeld` and stays in 'listening').
+	 *
+	 * Reuses the warm mic left by the previous turn's `abortPtt`, so no
+	 * `getUserMedia` re-acquisition occurs. Idempotent: a no-op while a turn is
+	 * already held.
+	 */
+	private _startBargeInListen(): void {
+		if (!this._isHandsFreeEnabled() || !this._isConnected.get() || this._pttHeld || this._autoListenSuppressed || !this._window) {
+			return;
+		}
+		this._clearAutoListenTimer();
+		this._pttCurrentTurnId = generateUuid();
+		this._pttHeld = true;
+		// Toggle mode so the turn stays open until the backend ends it
+		// (`turn_auto_ended`) or the user taps to stop — it must not auto-finish.
+		this._pttToggleMode = true;
+		// NOTE: this marks the turn start at playback time, not when the user
+		// actually starts speaking, so voice latency/hold telemetry in
+		// hands-free mode includes playback duration. Accepted known limitation
+		// (the backend latches `user_is_speaking` on `ptt_start`); a precise
+		// measure would key off the backend's first speech/transcription signal.
+		this._telemetryPttDownMs = Date.now();
+		this.micCaptureService.isMuted = false;
+		this.micCaptureService.suppressUntil(0);
+		this.micCaptureService.pttDown(this._pttCurrentTurnId).catch(err => {
+			this.logService.warn('[voice] barge-in listen failed to start', err);
+			this._pttHeld = false;
+			this._pttToggleMode = false;
+		});
+	}
+
 	/** Debounced re-listen after assistant stops speaking. */
 	private _scheduleAutoListen(): void {
 		this._clearAutoListenTimer();
@@ -2849,10 +2890,20 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._currentPlaybackSessionId = sessionId;
 			this._clearAutoListenTimer();
 			this._replyPlayedSinceSend = true;
-			this.micCaptureService.suppressUntil(Date.now() + 800);
 			this._voiceState.set('speaking', undefined);
 			this._statusText.set('Speaking...', undefined);
 			this.ttsPlaybackService.playAudioChunk(audio, isFinal, this._window!);
+			if (this._isHandsFreeEnabled()) {
+				// Hands-free: keep the mic streaming while the assistant speaks so
+				// the backend's server-VAD can hear the user barge in over it. The
+				// backend signals a real interruption via `speech_started` / `barge_in`
+				// (already wired to stop playback); until then this is a passive,
+				// non-interrupting listen that becomes the next listening turn if the
+				// user stays silent.
+				this._startBargeInListen();
+			} else {
+				this.micCaptureService.suppressUntil(Date.now() + 800);
+			}
 		} else if (!speakResponsesEnabled) {
 			this._replyPlayedSinceSend = true;
 			if (isFinal) {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -168,6 +168,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	// --- Internal state ---
 	private _pttHeld = false;
 	private _pttToggleMode = false;
+	/**
+	 * True while a passive hands-free barge-in listen is streaming during the
+	 * assistant's playback (opened by `_startBargeInListen`). It is NOT toggle
+	 * mode — an explicit `pttDown()` promotes this stream into a user-driven
+	 * interrupt rather than finishing it. Cleared once the turn ends, is
+	 * promoted, or transitions to a normal listening turn when playback stops.
+	 */
+	private _bargeInListenActive = false;
 	/** When true, the auto-listen loop is suppressed (user pressed Stop
 	 *  Recording). Cleared on the next explicit `pttDown` or on connect. */
 	private _autoListenSuppressed = false;
@@ -750,6 +758,15 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				setTimeout(() => this._processQueue(), 500);
 			} else {
 				if (this._pttHeld) {
+					if (this._bargeInListenActive) {
+						// The passive barge-in turn opened during playback is now
+						// a normal listening turn (the user stayed silent through
+						// playback). Behave like an auto-listen turn: a tap stops
+						// it, and the backend's server-VAD ends it via
+						// `turn_auto_ended`.
+						this._bargeInListenActive = false;
+						this._pttToggleMode = true;
+					}
 					this._voiceState.set('listening', undefined);
 					this._statusText.set('Listening...', undefined);
 				} else {
@@ -1401,6 +1418,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this.voiceClientService.disconnect();
 		this._pttHeld = false;
 		this._pttToggleMode = false;
+		this._bargeInListenActive = false;
 		this._isConnected.set(false, undefined);
 		this._voiceState.set('idle', undefined);
 		this._statusText.set('Tap to start', undefined);
@@ -1506,6 +1524,45 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this.logService.trace('[voice] pttDown: toggle-mode second tap -> finishing turn');
 			this._pttToggleMode = false;
 			this._finishPtt();
+			return;
+		}
+
+		// Promote a passive barge-in listen into a user-driven interrupt. The
+		// mic is already streaming this turn to the backend (ptt_start already
+		// sent), so we keep the SAME turn — do NOT re-acquire the mic or send a
+		// second ptt_start — and apply the interrupt side effects. Releasing the
+		// button afterwards goes through the normal `pttUp()` path.
+		if (this._bargeInListenActive) {
+			this.logService.trace('[voice] pttDown: promoting passive barge-in listen to user interrupt');
+			this._bargeInListenActive = false;
+			this._autoListenSuppressed = false;
+			this._pttWaitingForPlayback = false;
+			// Re-anchor hold timing to the real press so pttUp's tap/hold split works.
+			this._telemetryPttDownMs = Date.now();
+			this._telemetryFirstTranscriptionMs = undefined;
+			this._telemetryTurnCount++;
+			this._telemetryTtsInterrupted = this.ttsPlaybackService.isPlaying;
+			if (this._delayedMicStopTimer) {
+				clearTimeout(this._delayedMicStopTimer);
+				this._delayedMicStopTimer = undefined;
+			}
+			this._cancelTranscriptFade();
+			this._startUserTurn();
+			this._audioQueue.length = 0;
+			this._currentPlaybackSessionId = null;
+			this._isProcessingQueue = false;
+			this._suppressIncomingAudio = true;
+			this.ttsPlaybackService.stopPlayback();
+			this._voiceState.set('listening', undefined);
+			this._statusText.set('Listening...', undefined);
+			if (!this._pttMaxDurationTimer) {
+				this._pttMaxDurationTimer = setTimeout(() => {
+					if (this._pttHeld) {
+						this._statusText.set('Max duration reached', undefined);
+						this.pttUp();
+					}
+				}, VoiceSessionController._PTT_MAX_DURATION_MS);
+			}
 			return;
 		}
 
@@ -1626,6 +1683,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _finishPtt(reason: 'local' | 'auto' = 'local'): void {
 		// End toggle (hands-free) mode on every turn-ending path — even when not held — so an out-of-band finish can't leave a stale toggle that self-kills the next auto-listen.
 		this._pttToggleMode = false;
+		this._bargeInListenActive = false;
 		if (!this._pttHeld) { return; }
 		this._clearAutoListenTimer();
 		this._pttHeld = false;
@@ -1770,9 +1828,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._clearAutoListenTimer();
 		this._pttCurrentTurnId = generateUuid();
 		this._pttHeld = true;
-		// Toggle mode so the turn stays open until the backend ends it
-		// (`turn_auto_ended`) or the user taps to stop — it must not auto-finish.
-		this._pttToggleMode = true;
+		// Track this as a passive barge-in listen (NOT toggle mode) so an
+		// explicit `pttDown()` promotes it into a user-driven interrupt instead
+		// of the toggle branch finishing it. The turn stays open on its own —
+		// nothing calls `pttUp()`/`_finishPtt()` — until the backend ends it
+		// (`turn_auto_ended`), the user promotes it, or playback stops.
+		this._bargeInListenActive = true;
 		// NOTE: this marks the turn start at playback time, not when the user
 		// actually starts speaking, so voice latency/hold telemetry in
 		// hands-free mode includes playback duration. Accepted known limitation
@@ -1784,7 +1845,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this.micCaptureService.pttDown(this._pttCurrentTurnId).catch(err => {
 			this.logService.warn('[voice] barge-in listen failed to start', err);
 			this._pttHeld = false;
-			this._pttToggleMode = false;
+			this._bargeInListenActive = false;
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -204,9 +204,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Tracks whether the initial listen cue has been played after connecting. */
 	private _hasPlayedInitialListenCue = false;
 
-	/** True while streaming mic audio to the backend during playback (barge-in). */
-	private _bargeInMonitorActive = false;
-
 	// --- Audio FIFO queue ---
 	private readonly _audioQueue: { sessionId: string | undefined; chunks: { audio: string; isFirstChunk: boolean; isFinal: boolean; transcript: string | undefined }[] }[] = [];
 	private _currentPlaybackSessionId: string | undefined | null = null; // null = nothing playing
@@ -695,10 +692,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._voiceEventDisposables.add(this.micCaptureService.onPttEnd(() => {
 			this.voiceClientService.sendPttEnd();
 		}));
-		// Barge-in: stream mic audio to the backend during assistant playback.
-		this._voiceEventDisposables.add(this.micCaptureService.onMonitorAudioChunk(b64 => {
-			this.voiceClientService.sendBargeInAudioChunk(b64);
-		}));
 		this._voiceEventDisposables.add(this.micCaptureService.onPttDiagnostic((diag: IPttDiagnostic) => {
 			// Local log so the same correlation key surfaces in the
 			// VS Code log files even if the WS is closed mid-flight.
@@ -756,7 +749,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (this._audioQueue.length > 0) {
 				setTimeout(() => this._processQueue(), 500);
 			} else {
-				this._stopBargeInMonitor();
 				if (this._pttHeld) {
 					this._voiceState.set('listening', undefined);
 					this._statusText.set('Listening...', undefined);
@@ -1143,23 +1135,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// Speech started → stop TTS, suppress late chunks from the previous turn
 		// (same flow as pttDown, but for server-VAD path).
 		this._voiceEventDisposables.add(this.voiceClientService.onSpeechStarted(() => {
-			const wasMonitoring = this._bargeInMonitorActive;
 			this._clearAutoListenTimer();
-			if (wasMonitoring && !this._pttHeld) {
-				// Promote the monitor into a real turn (mic stays warm via pttDown).
-				this.pttDown();
-				this.pttUp();
-				// Clear the playback AEC suppression so the turn start isn't gated.
-				this.micCaptureService.suppressUntil(0);
-			} else {
-				this.ttsPlaybackService.stopPlayback();
-				this._audioQueue.length = 0;
-				this._currentPlaybackSessionId = null;
-				this._isProcessingQueue = false;
-				this._suppressIncomingAudio = true;
-				this._stopBargeInMonitor();
-				this._startUserTurn();
-			}
+			this.ttsPlaybackService.stopPlayback();
+			this._audioQueue.length = 0;
+			this._currentPlaybackSessionId = null;
+			this._isProcessingQueue = false;
+			this._suppressIncomingAudio = true;
+			this._startUserTurn();
 		}));
 
 		// Backend ended the held turn itself (server VAD silence / stop phrase).
@@ -1429,7 +1411,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._enterListenOnSessionInit = false;
 		this._hasPlayedInitialListenCue = false;
 		this._replyPlayedSinceSend = false;
-		this._bargeInMonitorActive = false;
 		this._audioQueue.length = 0;
 		this._currentPlaybackSessionId = null;
 		this._isProcessingQueue = false;
@@ -1562,6 +1543,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._suppressIncomingAudio = true;
 
 		this.micCaptureService.isMuted = false;
+		this.micCaptureService.suppressUntil(0);
 		// Lazily acquire the mic — fire-and-forget. The mic service handles
 		// the case where the user releases before acquisition completes.
 		this.micCaptureService.pttDown(this._pttCurrentTurnId).catch((err) => {
@@ -1578,9 +1560,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 			this.disconnect();
 		});
-		// Stop the monitor after mic pttDown so its _pttStreaming flag is set
-		// first, letting stopMonitor keep the mic warm instead of re-acquiring.
-		this._stopBargeInMonitor();
 		this.ttsPlaybackService.stopPlayback();
 		this._voiceState.set('listening', undefined);
 		this._statusText.set('Listening...', undefined);
@@ -1627,7 +1606,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._autoListenSuppressed = true;
 		this._pttToggleMode = false;
 		this._clearAutoListenTimer();
-		this._stopBargeInMonitor();
 		if (this._pttHeld) {
 			this._finishPtt('local');
 		} else {
@@ -1813,37 +1791,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			clearTimeout(this._awaitingReplyWatchdog);
 			this._awaitingReplyWatchdog = undefined;
 		}
-	}
-
-	/**
-	 * Start barge-in monitoring: stream mic audio to the backend during
-	 * playback so the user can talk over the assistant. Hands-free only;
-	 * the backend emits `speech_started`, which `onSpeechStarted` promotes
-	 * into a real turn. Inert until the backend consumes `barge_in_*`.
-	 */
-	private _startBargeInMonitor(): void {
-		if (this._bargeInMonitorActive || !this._isConnected.get() || this._pttHeld || !this._window) {
-			return;
-		}
-		if (!this._isHandsFreeEnabled()) {
-			return;
-		}
-		this._bargeInMonitorActive = true;
-		this.voiceClientService.sendBargeInStart();
-		this.micCaptureService.startMonitor(this._window).catch(err => {
-			this.logService.warn('[voice] barge-in monitor failed to start', err);
-			this._bargeInMonitorActive = false;
-		});
-	}
-
-	/** Stop barge-in monitoring and tell the backend to stop listening for it. */
-	private _stopBargeInMonitor(): void {
-		if (!this._bargeInMonitorActive) {
-			return;
-		}
-		this._bargeInMonitorActive = false;
-		this.micCaptureService.stopMonitor();
-		this.voiceClientService.sendBargeInStop();
 	}
 
 	/**
@@ -2905,8 +2852,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this.micCaptureService.suppressUntil(Date.now() + 800);
 			this._voiceState.set('speaking', undefined);
 			this._statusText.set('Speaking...', undefined);
-			// Hands-free: keep the mic open so the user can barge in.
-			this._startBargeInMonitor();
 			this.ttsPlaybackService.playAudioChunk(audio, isFinal, this._window!);
 		} else if (!speakResponsesEnabled) {
 			this._replyPlayedSinceSend = true;

--- a/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
@@ -165,13 +165,6 @@ export interface IVoiceClientService {
 	sendPttAudioChunk(audio: string): void;
 	sendPttEnd(): void;
 	/**
-	 * Barge-in: stream raw mic audio while the assistant speaks (hands-free) so
-	 * the backend can detect the user talking over it. Not a turn; not transcribed.
-	 */
-	sendBargeInStart(): void;
-	sendBargeInAudioChunk(audio: string): void;
-	sendBargeInStop(): void;
-	/**
 	 * Send a per-press post-mortem diagnostic payload for tail-loss
 	 * investigation. Fired ~500ms after `pttUp` by the mic service.
 	 * `metrics` is an opaque object echoed straight into a structured

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceClientService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceClientService.test.ts
@@ -16,7 +16,8 @@ import { IVoiceBargeIn } from '../../../common/voiceClient/voiceClientService.js
 class TestWebSocket {
 	static instance: TestWebSocket | undefined;
 
-	readonly readyState = 3;
+	readonly readyState = 1;
+	readonly sent: string[] = [];
 	onopen: (() => void) | null = null;
 	onmessage: ((event: MessageEvent) => void) | null = null;
 	onerror: (() => void) | null = null;
@@ -27,7 +28,9 @@ class TestWebSocket {
 	}
 
 	close(): void { }
-	send(): void { }
+	send(data: string): void {
+		this.sent.push(data);
+	}
 }
 
 function createTestWindow(): Window & typeof globalThis {
@@ -43,22 +46,26 @@ function createTestWindow(): Window & typeof globalThis {
 
 suite('VoiceClientService', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	const productService: IProductService = {
+		_serviceBrand: undefined,
+		...product,
+		voiceWsUrl: 'ws://voice.test/realtime/voice',
+	};
+
+	function createService(): VoiceClientService {
+		return store.add(new VoiceClientService(
+			new TestConfigurationService(),
+			new NullLogService(),
+			productService,
+		));
+	}
 
 	setup(() => {
 		TestWebSocket.instance = undefined;
 	});
 
 	test('emits barge-in events from the backend', async () => {
-		const productService: IProductService = {
-			_serviceBrand: undefined,
-			...product,
-			voiceWsUrl: 'ws://voice.test/realtime/voice',
-		};
-		const service = store.add(new VoiceClientService(
-			new TestConfigurationService(),
-			new NullLogService(),
-			productService,
-		));
+		const service = createService();
 		const events: IVoiceBargeIn[] = [];
 		store.add(service.onBargeIn(event => events.push(event)));
 
@@ -79,5 +86,20 @@ suite('VoiceClientService', () => {
 			turnId: 'interrupting-turn',
 			interruptedTurnId: 'cancelled-turn',
 		}]);
+	});
+
+	test('sends microphone audio using the PTT protocol', async () => {
+		const service = createService();
+
+		await service.connect(createTestWindow());
+		service.sendPttStart('turn-1');
+		service.sendPttAudioChunk('cGNt');
+		service.sendPttEnd();
+
+		assert.deepStrictEqual(TestWebSocket.instance?.sent, [
+			JSON.stringify({ type: 'ptt_start', turn_id: 'turn-1' }),
+			JSON.stringify({ type: 'ptt_audio_chunk', audio: 'cGNt' }),
+			JSON.stringify({ type: 'ptt_end' }),
+		]);
 	});
 });


### PR DESCRIPTION
> **Stacked on #326159** (voice barge-in protocol cleanup). This PR sits on top of that branch and should merge **after** it — its first commit is #326159's, and the net change is the single commit `Voice hands-free: stream mic during playback for backend barge-in`. Once #326159 lands, that commit drops out of this diff.

## What
In hands-free voice mode (`agents.voice.handsFree`), keep the microphone streaming while the assistant is speaking so the backend's server-VAD can detect the user talking over it (barge-in) — without requiring the user to hold the push-to-talk button.

## Why
After the #326159 cleanup the mic is **off** during assistant playback, so the backend receives no audio while it speaks and true hands-free barge-in is impossible — only a manual button interrupt works.

## How
Adds `_startBargeInListen()` to `VoiceSessionController`. During playback (hands-free only) it opens a **passive, non-interrupting** PTT turn that reuses the warm mic and streams frames using the **standard** PTT protocol (`ptt_start` / `ptt_audio_chunk` / `ptt_end`) — not the removed `barge_in_*` channel. The backend's `_handle_ptt_audio_chunk()` runs VAD and, on real speech, cancels its TTS and emits `barge_in` (already wired to `_interruptAssistantPlayback`).

Key properties:
- Does **not** stop playback, clear the audio queue, or suppress incoming audio — a silent user never disturbs the reply.
- If the user stays silent, the open turn seamlessly becomes the next listening turn when playback ends (`onPlaybackStopped` sees `_pttHeld`).
- Non-hands-free (manual PTT) mode keeps its prior `suppressUntil(+800)` behavior unchanged.

## Testing
- `VoiceClientService` unit tests pass (barge-in events + PTT protocol).
- `npm run typecheck-client` clean.
- Manually verified against the live backend: talking over a long spoken reply stops the assistant and transcribes the barge-in utterance.