### PR TITLE
Prefer Copilot harness once for editor sessions

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/common/agentHostEnablementService.ts
@@ -53,16 +53,10 @@ configurationRegistry.registerConfiguration({
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},
-		'chat.editor.defaultProvider': {
-			type: 'string',
-			enum: ['local', 'copilotEh', 'copilotAh'],
-			enumDescriptions: [
-				nls.localize('chat.editor.defaultProvider.local', "Use the built-in VS Code local chat harness"),
-				nls.localize('chat.editor.defaultProvider.copilotEh', "Use the Extension Host Copilot CLI"),
-				nls.localize('chat.editor.defaultProvider.copilotAh', "Use the Agent Host Copilot CLI"),
-			],
-			description: nls.localize('chat.editor.defaultProvider', "Controls which provider is used as the default for new editor chat sessions."),
-			default: 'local',
+		'chat.editor.preferCopilotHarness': {
+			type: 'boolean',
+			description: nls.localize('chat.editor.preferCopilotHarness', "When enabled, prefers the Agent Host Copilot CLI for new editor chat sessions. If the local harness is selected, it is replaced with Copilot once."),
+			default: false,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -59,6 +59,7 @@ import { ISCMHistoryItemChangeRangeVariableEntry, ISCMHistoryItemChangeVariableE
 import { IChatRequestViewModel, IChatResponseViewModel, isRequestVM } from '../../common/model/chatViewModel.js';
 import { IChatWidgetHistoryService } from '../../common/widget/chatWidgetHistoryService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getDefaultNewChatSessionResource, resolveDefaultNewChatSessionType } from '../../common/constants.js';
+import { markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
 import { AICustomizationManagementCommands } from '../aiCustomization/aiCustomizationManagement.js';
 import { ILanguageModelChatSelector, ILanguageModelsService } from '../../common/languageModels.js';
 import { CopilotUsageExtensionFeatureId } from '../../common/languageModelStats.js';
@@ -1766,14 +1767,19 @@ export interface IClearEditingSessionConfirmationOptions {
 export async function clearChatSessionPreservingType(widget: IChatWidget, viewsService: IViewsService, sessionType: string | undefined, configurationService: IConfigurationService, chatSessionsService: IChatSessionsService, storageService: IStorageService, workspace: IWorkspace, agentHostEnabled: boolean): Promise<void> {
 	const currentResource = widget.viewModel?.model.sessionResource;
 	const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
-	const newSessionType = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, agentHostEnabled, { explicitOverride: sessionType, currentSessionType });
+	const { sessionType: newSessionType, isPreferCopilotHarnessSwap } = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, agentHostEnabled, { explicitOverride: sessionType, currentSessionType });
 	if (isIChatViewViewContext(widget.viewContext) && newSessionType !== localChatSessionType) {
 		// For the sidebar, we need to explicitly load a session with the same type
 		const newResource = URI.from({ scheme: newSessionType, path: `/untitled-${generateUuid()}` });
 		const view = await viewsService.openView(ChatViewId) as ChatViewPane;
 		await view.loadSession(newResource);
+		// Consume the one-time migration only now that the swap has been applied.
+		if (isPreferCopilotHarnessSwap) {
+			markPreferredCopilotHarness(storageService);
+		}
 	} else {
-		// For the editor, widget.clear() already preserves the session type via clearChatEditor
+		// For the editor, clearChatEditor resolves and applies the new session type
+		// (including the one-time preferCopilotHarness swap) when clearing.
 		await widget.clear();
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -58,7 +58,7 @@ import { ElicitationState, IChatService, IChatToolInvocation } from '../../commo
 import { ISCMHistoryItemChangeRangeVariableEntry, ISCMHistoryItemChangeVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { IChatRequestViewModel, IChatResponseViewModel, isRequestVM } from '../../common/model/chatViewModel.js';
 import { IChatWidgetHistoryService } from '../../common/widget/chatWidgetHistoryService.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getDefaultNewChatSessionResource, resolveDefaultNewChatSessionType } from '../../common/constants.js';
 import { AICustomizationManagementCommands } from '../aiCustomization/aiCustomizationManagement.js';
 import { ILanguageModelChatSelector, ILanguageModelsService } from '../../common/languageModels.js';
 import { CopilotUsageExtensionFeatureId } from '../../common/languageModelStats.js';
@@ -1763,10 +1763,10 @@ export interface IClearEditingSessionConfirmationOptions {
  * Clears the current chat session and starts a new one using the shared
  * new-session harness resolver.
  */
-export async function clearChatSessionPreservingType(widget: IChatWidget, viewsService: IViewsService, sessionType: string | undefined, configurationService: IConfigurationService, chatSessionsService: IChatSessionsService, storageService: IStorageService, workspace: IWorkspace): Promise<void> {
+export async function clearChatSessionPreservingType(widget: IChatWidget, viewsService: IViewsService, sessionType: string | undefined, configurationService: IConfigurationService, chatSessionsService: IChatSessionsService, storageService: IStorageService, workspace: IWorkspace, agentHostEnabled: boolean): Promise<void> {
 	const currentResource = widget.viewModel?.model.sessionResource;
 	const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
-	const newSessionType = getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, { explicitOverride: sessionType, currentSessionType });
+	const newSessionType = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, agentHostEnabled, { explicitOverride: sessionType, currentSessionType });
 	if (isIChatViewViewContext(widget.viewContext) && newSessionType !== localChatSessionType) {
 		// For the sidebar, we need to explicitly load a session with the same type
 		const newResource = URI.from({ scheme: newSessionType, path: `/untitled-${generateUuid()}` });

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
@@ -4,14 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Schemas } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IChatSessionsService } from '../../common/chatSessionsService.js';
-import { getDefaultNewChatSessionResource } from '../../common/constants.js';
+import { getDefaultNewChatSessionResource, resolveDefaultNewChatSessionType } from '../../common/constants.js';
+import { markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
+import { getChatSessionType } from '../../common/model/chatUri.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
 
@@ -21,6 +25,7 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 	const chatSessionsService = accessor.get(IChatSessionsService);
 	const storageService = accessor.get(IStorageService);
 	const workspaceContextService = accessor.get(IWorkspaceContextService);
+	const agentHostEnablementService = accessor.get(IAgentHostEnablementService);
 
 	if (!chatEditorInput) {
 		const editorInput = editorService.activeEditor;
@@ -28,11 +33,24 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 	}
 
 	if (chatEditorInput instanceof ChatEditorInput) {
-		// If we have a contributed session, make sure we create an untitled session for it.
-		// Otherwise create a generic new chat editor.
-		const resource = chatEditorInput.sessionResource && chatEditorInput.sessionResource.scheme !== Schemas.vscodeLocalChatSession
-			? chatEditorInput.sessionResource.with({ path: `/untitled-${generateUuid()}` })
-			: getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace());
+		const currentResource = chatEditorInput.sessionResource;
+		let resource: URI;
+		if (currentResource && currentResource.scheme !== Schemas.vscodeLocalChatSession) {
+			// Contributed/non-local session: keep the same type for the new session.
+			resource = currentResource.with({ path: `/untitled-${generateUuid()}` });
+		} else {
+			// Local (or brand-new) session. Honor the one-time preferCopilotHarness
+			// swap, consuming the migration marker only here where it is applied.
+			// Otherwise fall back to the computed default.
+			const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
+			const resolved = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled, { currentSessionType });
+			if (resolved.isPreferCopilotHarnessSwap) {
+				markPreferredCopilotHarness(storageService);
+				resource = URI.from({ scheme: resolved.sessionType, path: `/untitled-${generateUuid()}` });
+			} else {
+				resource = getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace());
+			}
+		}
 
 		// A chat editor can only be open in one group
 		const identifier = editorService.findEditors(chatEditorInput.resource)[0];

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -24,6 +24,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
@@ -911,6 +912,7 @@ class SendToNewChatAction extends Action2 {
 		const chatSessionsService = accessor.get(IChatSessionsService);
 		const storageService = accessor.get(IStorageService);
 		const workspaceContextService = accessor.get(IWorkspaceContextService);
+		const agentHostEnabled = accessor.get(IAgentHostEnablementService).enabled;
 		const widget = context?.widget ?? widgetService.lastFocusedWidget;
 		if (!widget) {
 			return;
@@ -932,7 +934,7 @@ class SendToNewChatAction extends Action2 {
 		// Clear the input from the current session before creating a new one
 		widget.setInput('');
 
-		await clearChatSessionPreservingType(widget, viewsService, undefined, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace());
+		await clearChatSessionPreservingType(widget, viewsService, undefined, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnabled);
 
 		widget.acceptInput(inputBeforeClear, { storeToHistory: true });
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
@@ -27,6 +27,7 @@ import { AgentSessionProviders, AgentSessionsViewerOrientation } from '../agentS
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IChatSessionsService } from '../../common/chatSessionsService.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 
 export interface INewEditSessionActionContext {
 
@@ -321,6 +322,7 @@ async function runNewChatAction(
 	const chatSessionsService = accessor.get(IChatSessionsService);
 	const storageService = accessor.get(IStorageService);
 	const workspaceContextService = accessor.get(IWorkspaceContextService);
+	const agentHostEnabled = accessor.get(IAgentHostEnablementService).enabled;
 
 	const { editingSession, chatWidget: widget } = context ?? {};
 	if (!widget) {
@@ -337,7 +339,7 @@ async function runNewChatAction(
 	await editingSession?.stop();
 
 	// Create a new session, preserving the session type (or using the specified one)
-	await clearChatSessionPreservingType(widget, viewsService, sessionType, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace());
+	await clearChatSessionPreservingType(widget, viewsService, sessionType, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnabled);
 
 	widget.attachmentModel.clear(true);
 	widget.focusInput();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -152,7 +152,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 		}));
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(ChatConfiguration.EditorDefaultProvider) ||
+			if (e.affectsConfiguration(ChatConfiguration.EditorPreferCopilotHarness) ||
 				e.affectsConfiguration(ChatConfiguration.EditorLocalAgentEnabled) ||
 				e.affectsConfiguration(ChatConfiguration.CopilotCliHideExtensionHostEditor)) {
 				this._updateAgentSessionItems();
@@ -264,7 +264,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 	/**
 	 * The default session type for the picker when no session is yet active.
 	 * Defaults to {@link AgentSessionProviders.Local} but is overridden based on
-	 * the experimental {@link ChatConfiguration.EditorDefaultProvider} setting
+	 * the experimental {@link ChatConfiguration.EditorPreferCopilotHarness} setting
 	 * when the selected provider is registered.
 	 */
 	protected _getDefaultSessionType(): AgentSessionTarget {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -51,7 +51,7 @@ import { CHAT_PROVIDER_ID } from '../../../common/participants/chatParticipantCo
 import { IChatModelReference, IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { LocalChatSessionUri, getChatSessionType } from '../../../common/model/chatUri.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getComputedDefaultSessionType, getDefaultNewChatSessionResource, getDefaultNewChatSessionType, isEditorLocalAgentEnabled } from '../../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getComputedDefaultSessionType, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../../common/constants.js';
 import { AgentSessionsControl } from '../../agentSessions/agentSessionsControl.js';
 import { ACTION_ID_NEW_CHAT } from '../../actions/chatActions.js';
 import { ChatWidget } from '../../widget/chatWidget.js';
@@ -1063,7 +1063,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	}
 
 	/**
-	 * When the experimental `chat.editor.defaultProvider` setting selects a
+	 * When the experimental `chat.editor.preferCopilotHarness` setting selects a
 	 * provider other than local and that contribution is registered, return a
 	 * new session reference for it instead of the built-in local provider.
 	 * Returns `undefined` to fall back to `startNewLocalSession`.
@@ -1105,9 +1105,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	private shouldSkipRestoredLocalSession(sessionResource: URI, model: IChatModel): boolean {
 		const workspace = this.workspaceContextService.getWorkspace();
 		const defaultType = getComputedDefaultSessionType(this.configurationService, this.chatSessionsService, workspace);
-		const prefersAgentHostCopilot = !isEditorLocalAgentEnabled(this.configurationService, workspace)
-			&& this.configurationService.getValue<string>(ChatConfiguration.EditorDefaultProvider) === 'copilotAh';
-		return (defaultType !== localChatSessionType || prefersAgentHostCopilot)
+		return defaultType !== localChatSessionType
 			&& getChatSessionType(sessionResource) === localChatSessionType
 			&& !model.hasRequests;
 	}

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -1063,10 +1063,10 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	}
 
 	/**
-	 * When the experimental `chat.editor.preferCopilotHarness` setting selects a
-	 * provider other than local and that contribution is registered, return a
-	 * new session reference for it instead of the built-in local provider.
-	 * Returns `undefined` to fall back to `startNewLocalSession`.
+	 * When the computed default session type is a provider other than local,
+	 * acquire a new session for it instead of the built-in local provider.
+	 * Returns `undefined` to fall back to `startNewLocalSession` (including when
+	 * acquisition of the non-local provider fails).
 	 */
 	private async acquireDefaultNewSession(token: CancellationToken): Promise<IChatModelReference | undefined> {
 		const workspace = this.workspaceContextService.getWorkspace();

--- a/src/vs/workbench/contrib/chat/common/chatSessionTypePreference.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionTypePreference.ts
@@ -6,6 +6,7 @@
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 
 export const CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY = 'chat.userSelectedSessionType';
+const CHAT_PREFERRED_COPILOT_HARNESS_STORAGE_KEY = 'chat.preferredCopilotHarness';
 
 export function getRememberedSessionType(storageService: IStorageService): string | undefined {
 	return storageService.get(CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY, StorageScope.PROFILE);
@@ -17,4 +18,12 @@ export function storeUserSelectedSessionType(storageService: IStorageService, se
 
 export function clearUserSelectedSessionType(storageService: IStorageService): void {
 	storageService.remove(CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY, StorageScope.PROFILE);
+}
+
+export function hasPreferredCopilotHarness(storageService: IStorageService): boolean {
+	return storageService.getBoolean(CHAT_PREFERRED_COPILOT_HARNESS_STORAGE_KEY, StorageScope.PROFILE, false);
+}
+
+export function markPreferredCopilotHarness(storageService: IStorageService): void {
+	storageService.store(CHAT_PREFERRED_COPILOT_HARNESS_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.MACHINE);
 }

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -16,7 +16,7 @@ import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../comm
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { LocalChatSessionUri } from './model/chatUri.js';
-import { clearUserSelectedSessionType, getRememberedSessionType, hasPreferredCopilotHarness, markPreferredCopilotHarness, storeUserSelectedSessionType } from './chatSessionTypePreference.js';
+import { clearUserSelectedSessionType, getRememberedSessionType, hasPreferredCopilotHarness, storeUserSelectedSessionType } from './chatSessionTypePreference.js';
 
 export const enum BYOKUtilityModelDefault {
 	None = 'none',
@@ -309,6 +309,18 @@ export interface IDefaultNewChatSessionTypeOptions {
 	readonly currentSessionType?: string;
 }
 
+export interface IResolvedNewChatSessionType {
+	/** The session type to open for the new chat. */
+	readonly sessionType: string;
+	/**
+	 * True when {@link sessionType} is the one-time `chat.editor.preferCopilotHarness`
+	 * swap. The caller must persist the marker (via `markPreferredCopilotHarness`)
+	 * only once it has actually applied this session type, so the migration is not
+	 * consumed by a caller that discards the result.
+	 */
+	readonly isPreferCopilotHarnessSwap: boolean;
+}
+
 export function getDefaultNewChatSessionType(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
@@ -339,30 +351,31 @@ export function resolveDefaultNewChatSessionType(
 	workspace: IWorkspace,
 	agentHostEnabled: boolean,
 	options?: IDefaultNewChatSessionTypeOptions
-): string {
+): IResolvedNewChatSessionType {
 	if (options?.explicitOverride) {
-		return options.explicitOverride;
+		return { sessionType: options.explicitOverride, isPreferCopilotHarnessSwap: false };
 	}
 
 	const remembered = getUsableRememberedSessionType(storageService, configurationService, chatSessionsService, workspace);
 	if (remembered && remembered !== localChatSessionType) {
-		return remembered;
+		return { sessionType: remembered, isPreferCopilotHarnessSwap: false };
 	}
 
 	// One-time migration: when the agent host is enabled and the user has opted
 	// in via `chat.editor.preferCopilotHarness`, swap an existing local editor
 	// session to Copilot exactly once (guarded by the persisted marker). Never
 	// swap when the agent host is disabled, since the Copilot harness would be
-	// unavailable.
+	// unavailable. This function does not persist the marker itself; the caller
+	// marks it only after applying the swap, so a caller that discards the
+	// result does not consume the one-time migration.
 	if (options?.currentSessionType === localChatSessionType
 		&& agentHostEnabled
 		&& configurationService.getValue<boolean>(ChatConfiguration.EditorPreferCopilotHarness)
 		&& !hasPreferredCopilotHarness(storageService)) {
-		markPreferredCopilotHarness(storageService);
-		return SessionType.AgentHostCopilot;
+		return { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true };
 	}
 
-	return getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, options);
+	return { sessionType: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, options), isPreferCopilotHarnessSwap: false };
 }
 
 function getUsableRememberedSessionType(

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -16,7 +16,7 @@ import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../comm
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { LocalChatSessionUri } from './model/chatUri.js';
-import { clearUserSelectedSessionType, getRememberedSessionType, storeUserSelectedSessionType } from './chatSessionTypePreference.js';
+import { clearUserSelectedSessionType, getRememberedSessionType, hasPreferredCopilotHarness, markPreferredCopilotHarness, storeUserSelectedSessionType } from './chatSessionTypePreference.js';
 
 export const enum BYOKUtilityModelDefault {
 	None = 'none',
@@ -105,7 +105,7 @@ export enum ChatConfiguration {
 	ToolRiskAssessmentModel = 'chat.tools.riskAssessment.model',
 	DefaultNewSessionMode = 'chat.newSession.defaultMode',
 	CopilotCliHideExtensionHostAgents = 'chat.agents.copilotCli.hideExtensionHost',
-	EditorDefaultProvider = 'chat.editor.defaultProvider',
+	EditorPreferCopilotHarness = 'chat.editor.preferCopilotHarness',
 	EditorLocalAgentEnabled = 'chat.editor.localAgent.enabled',
 	CopilotCliHideExtensionHostEditor = 'chat.editor.copilotCli.hideExtensionHost',
 	AgentsHandoffTipMode = 'chat.agentsHandoffTip.mode',
@@ -261,30 +261,16 @@ export function isSupportedChatFileScheme(accessor: ServicesAccessor, scheme: st
 
 /**
  * Returns the effective default session type for a new chat in the VS Code
- * editor window, honoring the experimental
- * {@link ChatConfiguration.EditorDefaultProvider} setting:
- * - `'copilotAh'` selects the Agent Host Copilot CLI when its contribution is registered.
- * - `'copilotEh'` selects the Extension Host Copilot CLI when its contribution is
- *   registered and it is not hidden by {@link ChatConfiguration.CopilotCliHideExtensionHostEditor}.
+ * editor window.
  *
- * Falls back to {@link localChatSessionType} when local is enabled, or when no
- * visible non-local provider is available.
+ * Falls back to {@link localChatSessionType} when local is enabled, or to the
+ * first visible non-local provider.
  */
 export function getComputedDefaultSessionType(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
 	workspace: IWorkspace
 ): string {
-	const defaultProvider = configurationService.getValue<string>(ChatConfiguration.EditorDefaultProvider);
-	const defaultType = getConfiguredEditorDefaultSessionType(defaultProvider);
-	if (defaultType === SessionType.AgentHostCopilot && !isEditorLocalAgentEnabled(configurationService, workspace)) {
-		return defaultType;
-	}
-
-	if (defaultType && isVisibleEditorChatSessionType(defaultType, configurationService, chatSessionsService, workspace)) {
-		return defaultType;
-	}
-
 	if (isEditorLocalAgentEnabled(configurationService, workspace)) {
 		return localChatSessionType;
 	}
@@ -334,8 +320,8 @@ export function getDefaultNewChatSessionType(
 		return options.explicitOverride;
 	}
 
-	const remembered = getRememberedSessionType(storageService);
-	if (remembered && isRememberedSessionTypeUsable(remembered, configurationService, chatSessionsService, workspace)) {
+	const remembered = getUsableRememberedSessionType(storageService, configurationService, chatSessionsService, workspace);
+	if (remembered) {
 		return remembered;
 	}
 
@@ -344,6 +330,49 @@ export function getDefaultNewChatSessionType(
 	}
 
 	return getComputedDefaultSessionType(configurationService, chatSessionsService, workspace);
+}
+
+export function resolveDefaultNewChatSessionType(
+	configurationService: IConfigurationService,
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	storageService: IStorageService,
+	workspace: IWorkspace,
+	agentHostEnabled: boolean,
+	options?: IDefaultNewChatSessionTypeOptions
+): string {
+	if (options?.explicitOverride) {
+		return options.explicitOverride;
+	}
+
+	const remembered = getUsableRememberedSessionType(storageService, configurationService, chatSessionsService, workspace);
+	if (remembered && remembered !== localChatSessionType) {
+		return remembered;
+	}
+
+	// One-time migration: when the agent host is enabled and the user has opted
+	// in via `chat.editor.preferCopilotHarness`, swap an existing local editor
+	// session to Copilot exactly once (guarded by the persisted marker). Never
+	// swap when the agent host is disabled, since the Copilot harness would be
+	// unavailable.
+	if (options?.currentSessionType === localChatSessionType
+		&& agentHostEnabled
+		&& configurationService.getValue<boolean>(ChatConfiguration.EditorPreferCopilotHarness)
+		&& !hasPreferredCopilotHarness(storageService)) {
+		markPreferredCopilotHarness(storageService);
+		return SessionType.AgentHostCopilot;
+	}
+
+	return getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, options);
+}
+
+function getUsableRememberedSessionType(
+	storageService: IStorageService,
+	configurationService: IConfigurationService,
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	workspace: IWorkspace
+): string | undefined {
+	const remembered = getRememberedSessionType(storageService);
+	return remembered && isRememberedSessionTypeUsable(remembered, configurationService, chatSessionsService, workspace) ? remembered : undefined;
 }
 
 export function getDefaultNewChatSessionResource(
@@ -384,9 +413,6 @@ export function isVisibleEditorChatSessionType(
 	workspace: IWorkspace
 ): boolean {
 	if (sessionType === localChatSessionType) {
-		if (!isEditorLocalAgentEnabled(configurationService, workspace) && configurationService.getValue<string>(ChatConfiguration.EditorDefaultProvider) === 'copilotAh') {
-			return false;
-		}
 		return isEditorLocalAgentEnabled(configurationService, workspace) || getVisibleNonLocalEditorChatSessionTypes(configurationService, chatSessionsService, workspace).length === 0;
 	}
 
@@ -395,19 +421,6 @@ export function isVisibleEditorChatSessionType(
 	}
 
 	return !!chatSessionsService.getChatSessionContribution(sessionType);
-}
-
-function getConfiguredEditorDefaultSessionType(defaultProvider: string | undefined): string | undefined {
-	switch (defaultProvider) {
-		case 'local':
-			return localChatSessionType;
-		case 'copilotAh':
-			return SessionType.AgentHostCopilot;
-		case 'copilotEh':
-			return SessionType.CopilotCLI;
-		default:
-			return undefined;
-	}
 }
 
 function getVisibleNonLocalEditorChatSessionTypes(

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -8,11 +8,11 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IWorkspace, toWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
-import { ChatConfiguration, getComputedDefaultSessionType, getDefaultNewChatSessionType, isEditorLocalAgentEnabled, isRememberedSessionTypeUsable, isVisibleEditorChatSessionType, recordUserSelectedSessionType } from '../../common/constants.js';
+import { ChatConfiguration, getComputedDefaultSessionType, getDefaultNewChatSessionType, isEditorLocalAgentEnabled, isRememberedSessionTypeUsable, isVisibleEditorChatSessionType, recordUserSelectedSessionType, resolveDefaultNewChatSessionType } from '../../common/constants.js';
 import { localChatSessionType, SessionType, IChatSessionsExtensionPoint } from '../../common/chatSessionsService.js';
 import { MockChatSessionsService } from './mockChatSessionsService.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
-import { getRememberedSessionType } from '../../common/chatSessionTypePreference.js';
+import { getRememberedSessionType, hasPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
 
 suite('ChatConfiguration defaults', () => {
 
@@ -53,10 +53,9 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('editor default returns agent host Copilot when local is disabled and copilotAh is configured', () => {
+	test('preferCopilotHarness does not change the computed default or local visibility', () => {
 		const configurationService = new TestConfigurationService({
-			[ChatConfiguration.EditorLocalAgentEnabled]: false,
-			[ChatConfiguration.EditorDefaultProvider]: 'copilotAh',
+			[ChatConfiguration.EditorPreferCopilotHarness]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
 		const storageService = disposables.add(new TestStorageService());
@@ -66,35 +65,15 @@ suite('ChatConfiguration defaults', () => {
 			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
 			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
 		}, {
-			computed: SessionType.AgentHostCopilot,
-			rememberedAware: SessionType.AgentHostCopilot,
-			localVisible: false,
-		});
-	});
-
-	test('editor default keeps configured agent host Copilot before contribution registers', () => {
-		const configurationService = new TestConfigurationService({
-			[ChatConfiguration.EditorLocalAgentEnabled]: false,
-			[ChatConfiguration.EditorDefaultProvider]: 'copilotAh',
-		});
-		const chatSessionsService = createChatSessionsService(SessionType.CopilotCLI);
-		const storageService = disposables.add(new TestStorageService());
-
-		assert.deepStrictEqual({
-			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
-			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, localWorkspace),
-		}, {
-			computed: SessionType.AgentHostCopilot,
-			rememberedAware: SessionType.AgentHostCopilot,
-			localVisible: false,
+			computed: localChatSessionType,
+			rememberedAware: localChatSessionType,
+			localVisible: true,
 		});
 	});
 
 	test('editor default skips hidden extension host Copilot CLI', () => {
 		const configurationService = new TestConfigurationService({
 			[ChatConfiguration.EditorLocalAgentEnabled]: false,
-			[ChatConfiguration.EditorDefaultProvider]: 'copilotEh',
 			[ChatConfiguration.CopilotCliHideExtensionHostEditor]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.CopilotCLI, SessionType.AgentHostCopilot);
@@ -129,8 +108,10 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('remembered explicit selection wins for new sessions', () => {
-		const configurationService = new TestConfigurationService();
+	test('remembered non-local selection wins over the one-time swap', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorPreferCopilotHarness]: true,
+		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
@@ -139,7 +120,7 @@ suite('ChatConfiguration defaults', () => {
 		assert.deepStrictEqual({
 			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
 			remembered: getRememberedSessionType(storageService),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
+			rememberedAware: resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
 		}, {
 			computed: localChatSessionType,
 			remembered: SessionType.AgentHostClaude,
@@ -183,25 +164,52 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('selecting computed default clears remembered selection', () => {
+	test('preferCopilotHarness swaps local to Copilot once, only when the agent host is enabled', () => {
 		const configurationService = new TestConfigurationService({
-			[ChatConfiguration.EditorLocalAgentEnabled]: false,
-			[ChatConfiguration.EditorDefaultProvider]: 'copilotAh',
+			[ChatConfiguration.EditorPreferCopilotHarness]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
+		// Not swapped while the agent host is disabled, and the marker stays unset.
+		const whileAgentHostDisabled = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { currentSessionType: localChatSessionType });
+		const markerAfterDisabled = hasPreferredCopilotHarness(storageService);
+
+		// First swap once the agent host is enabled, then never again (marker set).
+		const firstNewSession = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+		const afterReturningToLocal = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+
+		assert.deepStrictEqual({
+			whileAgentHostDisabled,
+			markerAfterDisabled,
+			firstNewSession,
+			afterReturningToLocal,
+			markerApplied: hasPreferredCopilotHarness(storageService),
+		}, {
+			whileAgentHostDisabled: localChatSessionType,
+			markerAfterDisabled: false,
+			firstNewSession: SessionType.AgentHostCopilot,
+			afterReturningToLocal: localChatSessionType,
+			markerApplied: true,
+		});
+	});
+
+	test('selecting computed default clears remembered selection', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
+		const storageService = disposables.add(new TestStorageService());
+
 		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude);
-		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostCopilot);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, localChatSessionType);
 
 		assert.deepStrictEqual({
 			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace),
 			remembered: getRememberedSessionType(storageService),
 			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace),
 		}, {
-			computed: SessionType.AgentHostCopilot,
+			computed: localChatSessionType,
 			remembered: undefined,
-			rememberedAware: SessionType.AgentHostCopilot,
+			rememberedAware: localChatSessionType,
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -12,7 +12,7 @@ import { ChatConfiguration, getComputedDefaultSessionType, getDefaultNewChatSess
 import { localChatSessionType, SessionType, IChatSessionsExtensionPoint } from '../../common/chatSessionsService.js';
 import { MockChatSessionsService } from './mockChatSessionsService.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
-import { getRememberedSessionType, hasPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
+import { getRememberedSessionType, hasPreferredCopilotHarness, markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
 
 suite('ChatConfiguration defaults', () => {
 
@@ -124,7 +124,7 @@ suite('ChatConfiguration defaults', () => {
 		}, {
 			computed: localChatSessionType,
 			remembered: SessionType.AgentHostClaude,
-			rememberedAware: SessionType.AgentHostClaude,
+			rememberedAware: { sessionType: SessionType.AgentHostClaude, isPreferCopilotHarnessSwap: false },
 		});
 	});
 
@@ -164,33 +164,40 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('preferCopilotHarness swaps local to Copilot once, only when the agent host is enabled', () => {
+	test('preferCopilotHarness resolves the swap without consuming the marker until applied', () => {
 		const configurationService = new TestConfigurationService({
 			[ChatConfiguration.EditorPreferCopilotHarness]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
-		// Not swapped while the agent host is disabled, and the marker stays unset.
+		// Not swapped while the agent host is disabled.
 		const whileAgentHostDisabled = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { currentSessionType: localChatSessionType });
-		const markerAfterDisabled = hasPreferredCopilotHarness(storageService);
 
-		// First swap once the agent host is enabled, then never again (marker set).
-		const firstNewSession = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
-		const afterReturningToLocal = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+		// Resolving does not consume the marker on its own: repeated resolves keep
+		// returning the swap until the caller applies it and marks it.
+		const firstResolve = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+		const markerBeforeApply = hasPreferredCopilotHarness(storageService);
+		const secondResolveBeforeApply = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+
+		// The caller applies the swap and marks it; further resolves stay local.
+		markPreferredCopilotHarness(storageService);
+		const afterApply = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
 
 		assert.deepStrictEqual({
 			whileAgentHostDisabled,
-			markerAfterDisabled,
-			firstNewSession,
-			afterReturningToLocal,
-			markerApplied: hasPreferredCopilotHarness(storageService),
+			firstResolve,
+			markerBeforeApply,
+			secondResolveBeforeApply,
+			afterApply,
+			markerAfterApply: hasPreferredCopilotHarness(storageService),
 		}, {
-			whileAgentHostDisabled: localChatSessionType,
-			markerAfterDisabled: false,
-			firstNewSession: SessionType.AgentHostCopilot,
-			afterReturningToLocal: localChatSessionType,
-			markerApplied: true,
+			whileAgentHostDisabled: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
+			firstResolve: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
+			markerBeforeApply: false,
+			secondResolveBeforeApply: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
+			afterApply: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
+			markerAfterApply: true,
 		});
 	});
 


### PR DESCRIPTION
## What

Base PR of a stacked pair. Adds the `chat.editor.preferCopilotHarness` setting (replacing the `chat.editor.defaultProvider` enum).

When enabled, an existing **local** editor chat session is swapped to the **Agent Host Copilot CLI** exactly **once**, guarded by a persisted marker (`CHAT_PREFERRED_COPILOT_HARNESS_STORAGE_KEY`).

The one-time swap only fires when **the agent host is enabled** — we don't try to swap to a Copilot harness that isn't available. The setting has **no other effect**: it does not change the computed default provider or editor session-type visibility, so leaving it off (the default) preserves today's behavior. Fresh users are unaffected by this PR.

## Scope

- `chat.editor.preferCopilotHarness` setting.
- One-time Local -> Copilot swap in `resolveDefaultNewChatSessionType`, gated on the marker **and** `agentHostEnabled`.
- Thread `agentHostEnabled` (from `IAgentHostEnablementService`) into the swap path (`clearChatSessionPreservingType` and its callers).
- Unit tests in `constants.test.ts` (including the agent-host gate and the once-only marker).

## Stacked follow-up

The stacked PR (#326086) builds on this to make Agent Host Copilot the *default* for both editor and panel chat whenever the agent host is enabled (i.e. for first-time users), while `preferCopilotHarness` stays scoped to this one-time migration.
