### PR TITLE
agentHost: support enterprise GitHub MCP initial auth

### DIFF
--- a/src/vs/platform/agentHost/common/githubEndpoints.ts
+++ b/src/vs/platform/agentHost/common/githubEndpoints.ts
@@ -25,6 +25,8 @@ export interface IGitHubEndpoints {
 	readonly enterpriseHost: string | undefined;
 }
 
+const GITHUB_DOT_COM_COPILOT_API_BASE_URI = 'https://api.githubcopilot.com';
+
 /** Canonical github.com endpoints, used when no enterprise URI is configured. */
 const GITHUB_DOT_COM_ENDPOINTS: IGitHubEndpoints = {
 	apiBaseUri: 'https://api.github.com',
@@ -79,6 +81,22 @@ export function deriveGitHubEndpoints(enterpriseUri: string | undefined): IGitHu
 		oauthServer: `${scheme}://${authority}/login/oauth`,
 		enterpriseHost: authority,
 	};
+}
+
+/**
+ * Derives the official GitHub MCP server URL from the per-user Copilot API
+ * endpoint returned by `/copilot_internal/user`.
+ */
+export function gitHubMcpServerUrl(copilotApiBaseUri: string | undefined): string | undefined {
+	try {
+		const uri = URI.parse(copilotApiBaseUri ?? GITHUB_DOT_COM_COPILOT_API_BASE_URI, true);
+		if (!uri.authority) {
+			return undefined;
+		}
+		return uri.with({ path: '/mcp', query: null, fragment: null }).toString(true);
+	} catch {
+		return undefined;
+	}
 }
 
 /**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -28,6 +28,7 @@ import { ILogService, LogLevel } from '../../../log/common/log.js';
 import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { CopilotCliConfigKey, copilotCliConfigSchema } from '../../common/copilotCliConfig.js';
 import type { ChatInputRequestWithPlanReview, IAgentHostPlanReviewAction } from '../../common/agentHostPlanReview.js';
+import { gitHubMcpServerUrl } from '../../common/githubEndpoints.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
 import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, platformRootSchema, platformSessionSchema } from '../../common/agentHostSchema.js';
 import { AgentSession, AgentSignal, AuthenticateParams, IMcpNotification, IRestoredSubagentSession, subagentChatTitle } from '../../common/agentService.js';
@@ -54,6 +55,7 @@ import { buildSandboxConfigForSdk, type ISdkSandboxConfig } from './sandboxConfi
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellIntention, getShellLanguage, getSubagentMetadata, getTaskCompleteMarkdown, getToolDisplayName, getToolInputString, getToolKind, isAgentCoordinationTool, isEditTool, isHiddenTool, isShellTool, isTaskCompleteTool, synthesizeSkillToolCall, tryStringify, type ITypedPermissionRequest } from './copilotToolDisplay.js';
 import { FileEditTracker } from '../shared/fileEditTracker.js';
+import { ICopilotApiService } from '../shared/copilotApiService.js';
 import { stripProxyErrorMarker, tryBuildChatErrorMeta, tryBuildChatErrorMetaFromFields } from '../shared/forwardedChatError.js';
 import { McpCustomizationController, type ISdkMcpServer } from '../shared/mcpCustomizationController.js';
 import { appendSdkToolResultContent, mapSessionEvents } from './mapSessionEvents.js';
@@ -93,7 +95,6 @@ interface IMcpAuthToolCall {
 const COPILOT_HOME_DIRECTORY = '.copilot';
 const SESSION_STATE_DIRECTORY = join(COPILOT_HOME_DIRECTORY, 'session-state');
 const EMPTY_TOOL_RESULT_TEXT = '<empty />';
-const DEFAULT_GITHUB_MCP_SERVER_URL = 'https://api.githubcopilot.com/mcp';
 
 function normalizeMcpServerUrl(value: string): string | undefined {
 	if (!URL.canParse(value)) {
@@ -676,6 +677,7 @@ export class CopilotAgentSession extends Disposable {
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
 	) {
 		super();
 		this.sessionId = options.rawSessionId;
@@ -1184,7 +1186,9 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	private async _handleMcpAuthRequest(request: McpAuthRequest): Promise<McpAuthResult | null | undefined> {
-		const githubToken = this._initialGitHubMcpToken(request);
+		const githubToken = request.reason === 'initial' && this._scopesFromChallenge(request.wwwAuthenticateParams?.scope).length === 0
+			? await this._initialGitHubMcpToken(request)
+			: undefined;
 		if (githubToken) {
 			this._logService.info(`[Copilot:${this.sessionId}] Reusing the existing GitHub token for initial GitHub MCP authentication`);
 			return { kind: 'token', accessToken: githubToken };
@@ -1238,13 +1242,21 @@ export class CopilotAgentSession extends Disposable {
 		return result;
 	}
 
-	private _initialGitHubMcpToken(request: McpAuthRequest): string | undefined {
-		if (request.reason !== 'initial' || this._scopesFromChallenge(request.wwwAuthenticateParams?.scope).length !== 0) {
+	private async _initialGitHubMcpToken(request: McpAuthRequest): Promise<string | undefined> {
+		const githubToken = this._launchPlan.githubToken;
+		const requestUrl = normalizeMcpServerUrl(request.serverUrl);
+		if (!githubToken || requestUrl === undefined) {
 			return undefined;
 		}
-		const requestUrl = normalizeMcpServerUrl(request.serverUrl);
-		const configuredUrl = normalizeMcpServerUrl(DEFAULT_GITHUB_MCP_SERVER_URL);
-		return requestUrl !== undefined && requestUrl === configuredUrl ? this._launchPlan.githubToken : undefined;
+		let configuredUrl: string | undefined;
+		try {
+			const resolvedUrl = gitHubMcpServerUrl(await this._copilotApiService.resolveApiEndpoint(githubToken));
+			configuredUrl = resolvedUrl ? normalizeMcpServerUrl(resolvedUrl) : undefined;
+		} catch (error) {
+			this._logService.warn(`[Copilot:${this.sessionId}] Failed to resolve the GitHub MCP server URL: ${getErrorMessage(error)}`);
+			return undefined;
+		}
+		return requestUrl === configuredUrl ? githubToken : undefined;
 	}
 
 	private _protectedResourceFromMcpAuthRequest(request: McpAuthRequest): ProtectedResourceMetadata {

--- a/src/vs/platform/agentHost/test/common/githubEndpoints.test.ts
+++ b/src/vs/platform/agentHost/test/common/githubEndpoints.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE } from '../../common/agentService.js';
-import { deriveGitHubEndpoints, gitHubCopilotResource, gitHubRepoResource } from '../../common/githubEndpoints.js';
+import { deriveGitHubEndpoints, gitHubCopilotResource, gitHubMcpServerUrl, gitHubRepoResource } from '../../common/githubEndpoints.js';
 
 suite('githubEndpoints', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -60,6 +60,20 @@ suite('githubEndpoints', () => {
 			graphQlUri: 'http://ghe.local/api/graphql',
 			oauthServer: 'http://ghe.local/login/oauth',
 			enterpriseHost: 'ghe.local',
+		});
+	});
+
+	test('gitHubMcpServerUrl derives the MCP endpoint from the per-user Copilot API host', () => {
+		assert.deepStrictEqual({
+			default: gitHubMcpServerUrl(undefined),
+			enterprise: gitHubMcpServerUrl('https://api.enterprise.githubcopilot.com/v1?tenant=acme#fragment'),
+			ghe: gitHubMcpServerUrl('https://copilot-api.ghe.acme.com'),
+			invalid: gitHubMcpServerUrl('not a uri'),
+		}, {
+			default: 'https://api.githubcopilot.com/mcp',
+			enterprise: 'https://api.enterprise.githubcopilot.com/mcp',
+			ghe: 'https://copilot-api.ghe.acme.com/mcp',
+			invalid: undefined,
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type Anthropic from '@anthropic-ai/sdk';
 import type { CopilotSession, PermissionAllowAllMode, SessionEvent, SessionEventHandler, SessionEventPayload, SessionEventType, Tool, ToolResultObject, TypedSessionEventHandler } from '@github/copilot-sdk';
+import type { CCAModel } from '@vscode/copilot-api';
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
@@ -41,6 +43,7 @@ import { AgentHostSandboxConfigKey, AgentHostSandboxKey } from '../../common/san
 import { AgentSandboxEnabledValue } from '../../../sandbox/common/settings.js';
 import { createSessionDataService, createZeroDiffComputeService } from '../common/sessionTestHelpers.js';
 import { IAgentServerToolHost } from '../../common/agentServerTools.js';
+import { ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
 
 // ---- Mock CopilotSession (SDK level) ----------------------------------------
 
@@ -91,6 +94,7 @@ class MockCopilotSession {
 			this._allHandlers.add(eventTypeOrHandler);
 			return () => { this._allHandlers.delete(eventTypeOrHandler); };
 		}
+
 		const eventType = eventTypeOrHandler;
 		let set = this._handlers.get(eventType);
 		if (!set) {
@@ -202,6 +206,22 @@ class MockCopilotSession {
 	mcpListError: unknown = undefined;
 }
 
+class TestCopilotApiService implements ICopilotApiService {
+	declare readonly _serviceBrand: undefined;
+
+	apiEndpoint: string | undefined;
+
+	messages(_githubToken: string, _request: Anthropic.MessageCreateParamsStreaming, _options?: ICopilotApiServiceRequestOptions): AsyncGenerator<Anthropic.MessageStreamEvent>;
+	messages(_githubToken: string, _request: Anthropic.MessageCreateParamsNonStreaming, _options?: ICopilotApiServiceRequestOptions): Promise<Anthropic.Message>;
+	messages(): AsyncGenerator<Anthropic.MessageStreamEvent> | Promise<Anthropic.Message> { throw new Error('not used'); }
+	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
+	async models(): Promise<CCAModel[]> { return []; }
+	async responses(): Promise<Response> { throw new Error('not used'); }
+	async utilityChatCompletion(_githubToken: string, _request: ICopilotUtilityChatCompletionRequest): Promise<string> { throw new Error('not used'); }
+	async resolveRestrictedTelemetryContext() { return { restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }; }
+	async resolveApiEndpoint() { return this.apiEndpoint; }
+}
+
 class CapturingLogService extends NullLogService {
 	readonly errors: Array<{ first: string | Error; args: unknown[] }> = [];
 	readonly warnings: Array<{ message: string; args: unknown[] }> = [];
@@ -297,6 +317,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	/** Platform used to compute the SDK sandbox policy. Defaults to `'linux'` so sandbox tests are deterministic. */
 	platform?: NodeJS.Platform;
 	githubToken?: string;
+	copilotApiEndpoint?: string;
 }): Promise<{
 	session: CopilotAgentSession;
 	runtime: ICopilotSessionRuntime;
@@ -367,6 +388,9 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	const services = new ServiceCollection();
 	services.set(ILogService, options?.logService ?? new NullLogService());
 	services.set(ITelemetryService, options?.telemetryService ?? new NullTelemetryServiceShape());
+	const copilotApiService = new TestCopilotApiService();
+	copilotApiService.apiEndpoint = options?.copilotApiEndpoint;
+	services.set(ICopilotApiService, copilotApiService);
 	const storedFileContents = new Map(Object.entries(options?.fileContents ?? {}));
 	services.set(IFileService, {
 		_serviceBrand: undefined,
@@ -5324,6 +5348,28 @@ suite('CopilotAgentSession', () => {
 				customizationUpdates: getActions(signals).filter(action => action.type === ActionType.SessionCustomizationUpdated),
 			}, {
 				result: { kind: 'token', accessToken: 'existing-token' },
+				customizationUpdates: [],
+			});
+		});
+
+		test('initial GitHub MCP auth reuses the existing token for the per-user enterprise endpoint', async () => {
+			const { runtime, signals } = await createAgentSession(disposables, {
+				githubToken: 'existing-enterprise-token',
+				copilotApiEndpoint: 'https://api.enterprise.githubcopilot.com',
+			});
+
+			const result = await runtime.handleMcpAuthRequest({
+				requestId: 'enterprise-initial-auth',
+				serverName: 'github',
+				serverUrl: 'https://api.enterprise.githubcopilot.com/mcp/',
+				reason: 'initial',
+			}, { sessionId: 'test-session-1' });
+
+			assert.deepStrictEqual({
+				result,
+				customizationUpdates: getActions(signals).filter(action => action.type === ActionType.SessionCustomizationUpdated),
+			}, {
+				result: { kind: 'token', accessToken: 'existing-enterprise-token' },
 				customizationUpdates: [],
 			});
 		});


### PR DESCRIPTION
Fixes #326073

Resolve the official GitHub MCP server URL from the per-user Copilot API endpoint before reusing the existing GitHub token for scope-less initial authentication. This supports Enterprise and GHE-specific hosts while retaining URL normalization and the normal interactive fallback for non-matching servers.

Adds regression coverage for endpoint derivation and enterprise initial-auth token reuse.

Validation:
- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/common/githubEndpoints.test.ts --run src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts`
- `npm run valid-layers-check`
- hygiene checks