### PR TITLE
Builds: retry on "Unexpected status code: 5xx" errors

### DIFF
--- a/build/azure-pipelines/common/retry.ts
+++ b/build/azure-pipelines/common/retry.ts
@@ -10,7 +10,7 @@ export async function retry<T>(fn: (attempt: number) => Promise<T>): Promise<T> 
 		try {
 			return await fn(run);
 		} catch (err) {
-			if (!/fetch failed|terminated|aborted|timeout|TimeoutError|Timeout Error|RestError|Client network socket disconnected|socket hang up|ECONNRESET|CredentialUnavailableError|endpoints_resolution_error|Audience validation failed|end of central directory record signature not found/i.test(err.message)) {
+			if (!/fetch failed|terminated|aborted|timeout|TimeoutError|Timeout Error|RestError|Client network socket disconnected|socket hang up|ECONNRESET|CredentialUnavailableError|endpoints_resolution_error|Audience validation failed|end of central directory record signature not found|Unexpected status code: 5\d\d/i.test(err.message)) {
 				throw err;
 			}
 


### PR DESCRIPTION
Seeing some flakiness from artifacts downloads throwing `Unexpected status code: 500`. This updates the retry logic to retry for these (and any similar 5xx errors)