### PR TITLE
Show "Listening…" placeholder while dictating

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -256,7 +256,7 @@ configurationRegistry.registerConfiguration({
 		'chat.speechToText.enabled': {
 			type: 'boolean',
 			markdownDescription: nls.localize('chat.speechToText.enabled', "Enables dictating into the chat input using on-device speech-to-text. When enabled on a supported platform, a microphone button appears in the chat input; the transcription model is downloaded on first use and runs locally."),
-			default: false,
+			default: product.quality === 'insider',
 			tags: ['experimental']
 		},
 		'chat.speechToText.model': {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -104,10 +104,13 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	}
 	const inserter = new LiveTranscriptInserter(editor);
 	const disposables = new DisposableStore();
-	// The placeholder remains visible until transcript text is inserted.
+	// Show a "Listening…" placeholder only once recording actually starts (the
+	// service transitions to Recording and plays the recording-started signal at
+	// the same moment), not during the preceding microphone acquisition and
+	// model preparation. The placeholder remains visible until transcript text
+	// is inserted, and is restored to its previous value when the session ends.
 	const previousPlaceholder = editor.getOption(EditorOption.placeholder);
 	const listeningPlaceholder = localize('chatStt.listening', "Listening…");
-	editor.updateOptions({ placeholder: listeningPlaceholder });
 	disposables.add(toDisposable(() => {
 		if (!editor.getModel() || editor.getOption(EditorOption.placeholder) !== listeningPlaceholder) {
 			return;
@@ -115,11 +118,13 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 		editor.updateOptions({ placeholder: previousPlaceholder });
 	}));
 	disposables.add(service.onDidUpdateTranscript(text => inserter.update(text)));
-	// If the service ends the session on its own (e.g. the model failed to load
-	// and it surfaced an error), drop the stale active reference so the toolbar
-	// and glow reflect that dictation is no longer running.
 	disposables.add(service.onDidChangeState(state => {
-		if (state === ChatSpeechToTextState.Idle && _active?.service === service) {
+		if (state === ChatSpeechToTextState.Recording) {
+			editor.updateOptions({ placeholder: listeningPlaceholder });
+		} else if (state === ChatSpeechToTextState.Idle && _active?.service === service) {
+			// If the service ends the session on its own (e.g. the model failed
+			// to load and it surfaced an error), drop the stale active reference
+			// so the toolbar and glow reflect that dictation is no longer running.
 			_active = undefined;
 			disposables.dispose();
 		}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { EditorOption } from '../../../../../editor/common/config/editorOptions.js';
 import { Position } from '../../../../../editor/common/core/position.js';
 import { Range } from '../../../../../editor/common/core/range.js';
+import { localize } from '../../../../../nls.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
 
 /**
@@ -102,6 +104,19 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	}
 	const inserter = new LiveTranscriptInserter(editor);
 	const disposables = new DisposableStore();
+	// While recording and nothing has been transcribed yet the input is empty,
+	// so swap its placeholder to "Listening…" to signal dictation is live. The
+	// editor's placeholder is only shown while empty, so it disappears on its
+	// own once the first transcript is inserted, and is restored below when the
+	// session ends.
+	const previousPlaceholder = editor.getOption(EditorOption.placeholder);
+	editor.updateOptions({ placeholder: localize('chatStt.listening', "Listening…") });
+	disposables.add(toDisposable(() => {
+		if (!editor.getModel()) {
+			return; // editor was disposed; nothing to restore
+		}
+		editor.updateOptions({ placeholder: previousPlaceholder });
+	}));
 	disposables.add(service.onDidUpdateTranscript(text => inserter.update(text)));
 	// If the service ends the session on its own (e.g. the model failed to load
 	// and it surfaced an error), drop the stale active reference so the toolbar

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -106,10 +106,11 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	const disposables = new DisposableStore();
 	// The placeholder remains visible until transcript text is inserted.
 	const previousPlaceholder = editor.getOption(EditorOption.placeholder);
-	editor.updateOptions({ placeholder: localize('chatStt.listening', "Listening…") });
+	const listeningPlaceholder = localize('chatStt.listening', "Listening…");
+	editor.updateOptions({ placeholder: listeningPlaceholder });
 	disposables.add(toDisposable(() => {
-		if (!editor.getModel()) {
-			return; // editor was disposed; nothing to restore
+		if (!editor.getModel() || editor.getOption(EditorOption.placeholder) !== listeningPlaceholder) {
+			return;
 		}
 		editor.updateOptions({ placeholder: previousPlaceholder });
 	}));

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -104,11 +104,7 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	}
 	const inserter = new LiveTranscriptInserter(editor);
 	const disposables = new DisposableStore();
-	// While recording and nothing has been transcribed yet the input is empty,
-	// so swap its placeholder to "Listening…" to signal dictation is live. The
-	// editor's placeholder is only shown while empty, so it disappears on its
-	// own once the first transcript is inserted, and is restored below when the
-	// session ends.
+	// The placeholder remains visible until transcript text is inserted.
 	const previousPlaceholder = editor.getOption(EditorOption.placeholder);
 	editor.updateOptions({ placeholder: localize('chatStt.listening', "Listening…") });
 	disposables.add(toDisposable(() => {


### PR DESCRIPTION
## Summary

Adds a **"Listening…"** placeholder that appears in the chat input while dictation is active and nothing has been transcribed yet.

## Implementation

In `dictationSession.ts` (the shared dictation entry point used by all callers — the toggle action, hold-to-talk, and the Agents composer button), `startDictation` now:

- Captures the input editor's current placeholder and swaps it to a localized **"Listening…"** when a session begins.
- Restores the original placeholder when the session ends, via a disposable that covers all cleanup paths (normal stop, cancel, service-initiated idle, start failure, and editor disposal), guarding against a disposed editor.

Because the editor placeholder only renders while the input is empty, "Listening…" is shown precisely when dictation is live with no transcript yet, and disappears automatically the moment the first transcribed text lands in the input.

## Testing

- `npm run typecheck-client` passes.