### PR TITLE
Fix Modern UI scrollbar gap when window is maximized

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -369,3 +369,39 @@
 .monaco-workbench.floating-panels.nopanel .monaco-sash.horizontal.maximum:not(.part .monaco-sash)::before {
 	top: calc(50% - (var(--vscode-sash-hover-size) / 2) - (var(--vscode-sash-size) / 2));
 }
+
+/*
+ * Fitts's Law: When the window is maximized or fullscreen, the outermost floating cards
+ * should snap flush to the screen edges so that scrollbars and panel edges can be quickly
+ * targeted. We remove the outer margins, borders, border-radius, and any box shadows.
+ */
+.monaco-workbench.floating-panels:is(.maximized, .fullscreen) .part.floating-part-outer-left,
+.monaco-workbench.floating-panels:is(.maximized, .fullscreen) > .monaco-grid-view .part.editor.floating-editor-outer-left {
+	margin-left: 0 !important;
+	border-left: 0 !important;
+	border-top-left-radius: 0 !important;
+	border-bottom-left-radius: 0 !important;
+	box-shadow: none !important;
+}
+
+.monaco-workbench.floating-panels:is(.maximized, .fullscreen) .part.floating-part-outer-right,
+.monaco-workbench.floating-panels:is(.maximized, .fullscreen) > .monaco-grid-view .part.editor.floating-editor-outer-right {
+	margin-right: 0 !important;
+	border-right: 0 !important;
+	border-top-right-radius: 0 !important;
+	border-bottom-right-radius: 0 !important;
+	box-shadow: none !important;
+}
+
+.monaco-workbench.floating-panels.nostatusbar:is(.maximized, .fullscreen) .part.panel.bottom,
+.monaco-workbench.floating-panels.nostatusbar:is(.maximized, .fullscreen) .part.panel.left,
+.monaco-workbench.floating-panels.nostatusbar:is(.maximized, .fullscreen) .part.panel.right,
+.monaco-workbench.floating-panels.nostatusbar:is(.maximized, .fullscreen) .part.sidebar,
+.monaco-workbench.floating-panels.nostatusbar:is(.maximized, .fullscreen) .part.auxiliarybar,
+.monaco-workbench.floating-panels.nostatusbar:is(.maximized, .fullscreen) > .monaco-grid-view .part.editor {
+	margin-bottom: 0 !important;
+	border-bottom: 0 !important;
+	border-bottom-left-radius: 0 !important;
+	border-bottom-right-radius: 0 !important;
+	box-shadow: none !important;
+}

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -160,7 +160,7 @@ export abstract class Part<MementoType extends object = object> extends Componen
 		}
 	}
 
-	private relayout() {
+	protected relayout() {
 		const dimension = this.getRelayoutDimension();
 		if (dimension && this.contentPosition) {
 			this.layout(dimension.width, dimension.height, this.contentPosition.top, this.contentPosition.left);

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -199,6 +199,11 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 		this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationUpdated(e)));
 		this._register(this.themeService.onDidFileIconThemeChange(() => this.handleChangedPartOptions()));
 		this._register(this.onDidChangeMementoValue(StorageScope.WORKSPACE, this._store)(e => this.onDidChangeMementoState(e)));
+		this._register(this.layoutService.onDidChangeWindowMaximized(e => {
+			if (e.windowId === this.windowId) {
+				this.relayout();
+			}
+		}));
 	}
 
 	private onConfigurationUpdated(event: IConfigurationChangeEvent): void {
@@ -1438,8 +1443,11 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			const outerLeft = owners.left === Parts.EDITOR_PART;
 			const outerRight = owners.right === Parts.EDITOR_PART;
 
-			const leftMargin = outerLeft ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
-			const rightMargin = outerRight ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_INNER_MARGIN;
+			const targetWindow = getWindow(this.element);
+			const isMaximized = this.layoutService.isWindowMaximized(targetWindow) || this.layoutService.getContainer(targetWindow).classList.contains('fullscreen');
+
+			const leftMargin = (outerLeft && isMaximized) ? 0 : (outerLeft ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN);
+			const rightMargin = (outerRight && isMaximized) ? 0 : (outerRight ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_INNER_MARGIN);
 
 			width = Math.max(0, width - leftMargin - rightMargin);
 			const { topMargin, bottomMargin } = this.getFloatingPanelHeightInsets();

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -15,7 +15,7 @@ import { IView } from '../../../base/browser/ui/grid/grid.js';
 import { IWorkbenchLayoutService, Parts, Position, SINGLE_WINDOW_PARTS, FLOATING_PANEL_INNER_MARGIN, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges, getFloatingSidebarSiblingToEditorStatus } from '../../services/layout/browser/layoutService.js';
 import { CompositePart, ICompositePartOptions, ICompositeTitleLabel } from './compositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from './paneCompositeBar.js';
-import { Dimension, EventHelper, trackFocus, $, addDisposableListener, EventType, prepend, getWindow } from '../../../base/browser/dom.js';
+import { Dimension, EventHelper, trackFocus, $, addDisposableListener, EventType, prepend, getWindow, getWindowId } from '../../../base/browser/dom.js';
 import { Registry } from '../../../platform/registry/common/platform.js';
 import { INotificationService } from '../../../platform/notification/common/notification.js';
 import { IStorageService } from '../../../platform/storage/common/storage.js';
@@ -184,6 +184,11 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	private registerListeners(): void {
 		this._register(this.onDidPaneCompositeOpen(composite => this.onDidOpen(composite)));
 		this._register(this.onDidPaneCompositeClose(this.onDidClose, this));
+		this._register(this.layoutService.onDidChangeWindowMaximized(e => {
+			if (this.element && e.windowId === getWindowId(getWindow(this.element))) {
+				this.relayout();
+			}
+		}));
 
 		this._register(this.registry.onDidDeregister((viewletDescriptor: PaneCompositeDescriptor) => {
 
@@ -723,11 +728,14 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		const panelVisible = this.layoutService.isVisible(Parts.PANEL_PART);
 		const topMargin = this.getFloatingPartTopMargin(panelVisible, margin);
 		const isAtWindowBottom = this.isFloatingPartAtWindowBottomEdge(panelVisible);
-		const bottomMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, getWindow(this.element)) && isAtWindowBottom
-			? margin * 2 : FLOATING_PANEL_INNER_MARGIN;
+		const targetWindow = getWindow(this.element);
+		const isMaximized = this.layoutService.isWindowMaximized(targetWindow) || this.layoutService.getContainer(targetWindow).classList.contains('fullscreen');
+
+		const bottomMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, targetWindow) && isAtWindowBottom
+			? (isMaximized ? 0 : margin * 2) : FLOATING_PANEL_INNER_MARGIN;
 		const outerGutter = this.getFloatingOuterGutterEdges();
-		const leftMargin = outerGutter.left ? margin * 2 : margin;
-		const rightMargin = outerGutter.right ? margin * 2 : FLOATING_PANEL_INNER_MARGIN;
+		const leftMargin = outerGutter.left ? (isMaximized ? 0 : margin * 2) : margin;
+		const rightMargin = outerGutter.right ? (isMaximized ? 0 : margin * 2) : FLOATING_PANEL_INNER_MARGIN;
 		return {
 			width: leftMargin + rightMargin + borderTotal,
 			height: topMargin + bottomMargin + borderTotal


### PR DESCRIPTION
Fixes #326179

### Proposed Changes
- Removed the outer margin on floating panels (editor, sidebar, auxiliary bar, and bottom panel) specifically when the window is maximized or fullscreen.
- Exposed `relayout()` as `protected` in `Part.ts` and wired up `this.layoutService.onDidChangeWindowMaximized` listeners in `EditorPart` and `AbstractPaneCompositePart` to correctly recalculate margins when the state changes.
- This ensures that scrollbars and panel edges sit flush with the screen monitor bounds, restoring standard "Fitts's Law" quick-grab behavior when users maximize VS Code in Modern UI mode.

### How to test
1. Ensure the Modern UI is enabled (`"workbench.experimental.modernUI": true`).
2. Maximize the VS Code window.
3. Throw your mouse cursor all the way to the right edge of your monitor.
4. Verify you can successfully click and drag the vertical scrollbar of the rightmost floating card.
5. Verify the same edge-flushed behavior when snapping to the bottom of the screen (e.g. if the status bar is toggled off).
