### PR TITLE
Fix + icon centering in chat input toolbar (#326207)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1893,6 +1893,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	font-size: 14px;
 }
 
+/* Optical alignment to center the '+' glyph visually within its button */
+.interactive-session .chat-input-toolbar .action-item:has(.codicon-add) .codicon-add::before {
+	display: inline-block;
+	transform: translateX(-0.5px) translateY(0.5px);
+}
+
 .monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,
 .monaco-workbench .interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down,
 .monaco-workbench .interactive-session .chat-secondary-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {


### PR DESCRIPTION
Fixes #326207

This PR corrects a minor visual alignment issue where the `+` glyph (`codicon-add`) inside the chat input toolbar button appeared off-center. 

Since font metrics for the `+` glyph can cause it to misalign inside flex-centered containers, this fix adds an optical alignment nudge (`translateX(-0.5px) translateY(0.5px)`) to the icon's pseudo-element. This centers the icon perfectly both horizontally and vertically within the button boundary.

**Changes:**
- Added optical centering transform to `.codicon-add::before` inside the `.chat-input-toolbar` in `chat.css`.
