### PR TITLE
Fix dictation "Listening…" placeholder and shimmer interim text

### DIFF
--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -35,6 +35,14 @@ const MAX_INTERIM_SECONDS = 45;
 const INTERIM_DEBOUNCE_MS = 1200;
 
 /**
+ * Silence (seconds) appended to the audio before the final transcription pass.
+ * Whisper frequently fails to emit the last word when the recording ends
+ * abruptly right after it (no trailing silence to mark the utterance end), so a
+ * short pad of zeros gives the model the context it needs to finalize the tail.
+ */
+const FINAL_PASS_TRAILING_SILENCE_SECONDS = 0.5;
+
+/**
  * transformers.js is a heavy, ESM-only dependency that also loads the native
  * onnxruntime-node addon. Import it lazily so forking the utility process stays
  * cheap; the model itself is only downloaded/loaded when dictation first runs.
@@ -182,7 +190,10 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._inferenceInFlight = true;
 		try {
 			const audio = this._mergedSamples();
-			const result = await pipe(audio, {
+			// Pad the final pass with trailing silence so Whisper reliably emits
+			// the last word even when the user stops speaking abruptly.
+			const input = isFinal ? this._withTrailingSilence(audio, FINAL_PASS_TRAILING_SILENCE_SECONDS) : audio;
+			const result = await pipe(input, {
 				chunk_length_s: 30,
 				stride_length_s: 5,
 				language: this._language,
@@ -216,6 +227,13 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		}
 		this._samples = [merged];
 		return merged;
+	}
+
+	/** Return `audio` with `seconds` of trailing silence (zeros) appended. */
+	private _withTrailingSilence(audio: Float32Array, seconds: number): Float32Array {
+		const padded = new Float32Array(audio.length + Math.round(SAMPLE_RATE * seconds));
+		padded.set(audio, 0);
+		return padded;
 	}
 
 	async stop(): Promise<string> {

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -823,7 +823,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		if (!domNode) {
 			return;
 		}
-		await startDictation(sttService, this._editor, dom.getWindow(domNode));
+		await startDictation(sttService, this._editor, dom.getWindow(domNode), this.logService);
 	}
 
 	// --- Input History (IHistoryNavigationWidget) ---

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -13,6 +13,7 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { spinningLoading } from '../../../../../platform/theme/common/iconRegistry.js';
@@ -89,7 +90,7 @@ class ToggleChatSpeechToTextAction extends Action2 {
 		}
 
 		const window = getWindow(widget.domNode) ?? getActiveWindow();
-		await startDictation(speechService, widget.inputEditor, window);
+		await startDictation(speechService, widget.inputEditor, window, accessor.get(ILogService));
 	}
 }
 
@@ -155,7 +156,7 @@ class HoldToSpeechToTextAction extends Action2 {
 
 		const window = getWindow(widget.domNode) ?? getActiveWindow();
 		const heldFrom = Date.now();
-		await startDictation(speechService, widget.inputEditor, window);
+		await startDictation(speechService, widget.inputEditor, window, accessor.get(ILogService));
 
 		await holdMode;
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -25,6 +25,7 @@ class LiveTranscriptInserter {
 	private _end: Position | undefined;
 	private _needsLeadingSpace = false;
 	private _shimmerDecorations: IEditorDecorationsCollection | undefined;
+	private _finalized = false;
 
 	constructor(private readonly _editor: ICodeEditor) { }
 
@@ -32,8 +33,19 @@ class LiveTranscriptInserter {
 	 * Render the cumulative transcript. While `interim` is true the text is not
 	 * yet finalized, so it is decorated with a shimmer animation; the final
 	 * update (`interim === false`) clears the shimmer, leaving solid text.
+	 *
+	 * Once a final update has been applied, later interim updates are ignored:
+	 * the transcription service can emit a trailing interim transcript as it
+	 * shuts down (after `stopAndTranscribe` resolves), which would otherwise
+	 * overwrite the final text and re-apply the shimmer.
 	 */
 	update(fullText: string, interim: boolean = true): void {
+		if (this._finalized && interim) {
+			return;
+		}
+		if (!interim) {
+			this._finalized = true;
+		}
 		const model = this._editor.getModel();
 		if (!model) {
 			return;

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -10,6 +10,7 @@ import { EditorOption } from '../../../../../editor/common/config/editorOptions.
 import { IEditorDecorationsCollection } from '../../../../../editor/common/editorCommon.js';
 import { Position } from '../../../../../editor/common/core/position.js';
 import { Range } from '../../../../../editor/common/core/range.js';
+import { Selection } from '../../../../../editor/common/core/selection.js';
 import { localize } from '../../../../../nls.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
@@ -109,21 +110,29 @@ class LiveTranscriptInserter {
 		}
 
 		const text = (this._needsLeadingSpace ? ' ' : '') + fullText;
-		this._editor.executeEdits('chatSpeechToText', [{
-			range: Range.fromPositions(this._anchor, this._end!),
-			text,
-			forceMoveMarkers: true,
-		}]);
+
+		// The edit replaces the region this inserter wrote last time (anchor ..
+		// previous end) with the new cumulative transcript.
+		const replaceRange = Range.fromPositions(this._anchor, this._end ?? this._anchor);
 
 		const lines = text.split('\n');
 		const endLine = this._anchor.lineNumber + lines.length - 1;
 		const endColumn = lines.length === 1 ? this._anchor.column + lines[0].length : lines[lines.length - 1].length + 1;
 		this._end = new Position(endLine, endColumn);
+
 		// While transcription is in progress keep the caret parked at the start
 		// of the dictated region (a blinking cursor at the beginning) rather than
 		// chasing the growing/revised interim text. Once finalized, move it to the
-		// end so the user can continue typing after the dictated text.
-		this._editor.setPosition(interim ? this._anchor : this._end);
+		// end so the user can continue typing after the dictated text. The caret
+		// is passed as executeEdits' endCursorState so the editor never briefly
+		// places it at the end of the applied edit first.
+		const caret = interim ? this._anchor : this._end;
+		this._editor.executeEdits(
+			'chatSpeechToText',
+			[{ range: replaceRange, text, forceMoveMarkers: true }],
+			[Selection.fromPositions(caret)],
+		);
+
 		this._updateInterimDecorations(text, fullText, interim);
 		this._prevInterimText = interim ? fullText : '';
 	}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -151,9 +151,9 @@ class LiveTranscriptInserter {
 	/**
 	 * Render the interim text in the placeholder color, shimmering only the
 	 * still-processing trailing portion. The settled prefix is the part of the
-	 * transcript that has not changed since the previous interim update (trimmed
-	 * back to a word boundary), so words stop shimmering once the recognizer
-	 * stops revising them. Cleared entirely once the text is finalized.
+	 * transcript that has not changed since the previous interim update, so words
+	 * stop shimmering once the recognizer stops revising them. Cleared entirely
+	 * once the text is finalized.
 	 */
 	private _updateInterimDecorations(text: string, fullText: string, interim: boolean): void {
 		if (!interim || !this._anchor || !this._end || Position.equals(this._anchor, this._end)) {
@@ -164,7 +164,13 @@ class LiveTranscriptInserter {
 		}
 
 		const leading = this._needsLeadingSpace ? 1 : 0;
-		const settledChars = wordBoundaryAtOrBefore(fullText, commonPrefixLength(fullText, this._prevInterimText));
+		const common = commonPrefixLength(fullText, this._prevInterimText);
+		// When the tail diverges from the previous interim (a word is being
+		// revised) settle only up to the last word boundary so the whole
+		// in-progress word shimmers. But once the transcript stops changing (the
+		// common prefix already covers the entire current text) settle
+		// everything, otherwise the last word would shimmer forever.
+		const settledChars = common >= fullText.length ? fullText.length : wordBoundaryAtOrBefore(fullText, common);
 		const splitPosition = this._positionAtOffset(text, leading + settledChars);
 
 		this._settledDecorations ??= this._editor.createDecorationsCollection();

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -3,13 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './media/dictationSession.css';
 import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { EditorOption } from '../../../../../editor/common/config/editorOptions.js';
+import { IEditorDecorationsCollection } from '../../../../../editor/common/editorCommon.js';
 import { Position } from '../../../../../editor/common/core/position.js';
 import { Range } from '../../../../../editor/common/core/range.js';
 import { localize } from '../../../../../nls.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
+
+/** Inline decoration class that shimmers not-yet-finalized dictation text. */
+const INTERIM_SHIMMER_CLASS = 'dictation-interim-shimmer';
 
 /**
  * Renders the cumulative transcript into a code editor, replacing its own
@@ -19,10 +24,16 @@ class LiveTranscriptInserter {
 	private _anchor: Position | undefined;
 	private _end: Position | undefined;
 	private _needsLeadingSpace = false;
+	private _shimmerDecorations: IEditorDecorationsCollection | undefined;
 
 	constructor(private readonly _editor: ICodeEditor) { }
 
-	update(fullText: string): void {
+	/**
+	 * Render the cumulative transcript. While `interim` is true the text is not
+	 * yet finalized, so it is decorated with a shimmer animation; the final
+	 * update (`interim === false`) clears the shimmer, leaving solid text.
+	 */
+	update(fullText: string, interim: boolean = true): void {
 		const model = this._editor.getModel();
 		if (!model) {
 			return;
@@ -50,6 +61,30 @@ class LiveTranscriptInserter {
 		const endColumn = lines.length === 1 ? this._anchor.column + lines[0].length : lines[lines.length - 1].length + 1;
 		this._end = new Position(endLine, endColumn);
 		this._editor.setPosition(this._end);
+		this._updateShimmer(interim);
+	}
+
+	/** Shimmer the inserted (interim) region, or clear it once finalized. */
+	private _updateShimmer(interim: boolean): void {
+		if (!interim || !this._anchor || !this._end || Position.equals(this._anchor, this._end)) {
+			this._shimmerDecorations?.clear();
+			return;
+		}
+		if (!this._shimmerDecorations) {
+			this._shimmerDecorations = this._editor.createDecorationsCollection();
+		}
+		this._shimmerDecorations.set([{
+			range: Range.fromPositions(this._anchor, this._end),
+			options: {
+				description: 'chatSpeechToText-interim',
+				inlineClassName: INTERIM_SHIMMER_CLASS,
+			},
+		}]);
+	}
+
+	/** Stop shimmering, leaving whatever text is currently inserted as solid. */
+	clearShimmer(): void {
+		this._shimmerDecorations?.clear();
 	}
 
 	/**
@@ -58,6 +93,7 @@ class LiveTranscriptInserter {
 	 * is cancelled so no dictated text is left behind.
 	 */
 	revert(): void {
+		this._shimmerDecorations?.clear();
 		const model = this._editor.getModel();
 		if (!model || !this._anchor || !this._end) {
 			return;
@@ -128,6 +164,9 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 		}
 	};
 	disposables.add(toDisposable(() => {
+		// Ensure the interim shimmer never lingers, regardless of how the session
+		// ends (final transcript, cancel, editor disposal, or a service-side error).
+		inserter.clearShimmer();
 		if (!editor.getModel() || editor.getOption(EditorOption.placeholder) !== listeningPlaceholder) {
 			return;
 		}
@@ -172,7 +211,8 @@ export async function stopDictation(): Promise<void> {
 	try {
 		const text = await active.service.stopAndTranscribe();
 		if (text !== undefined) {
-			active.inserter.update(text);
+			// Final transcript: render it solid (no shimmer).
+			active.inserter.update(text, false);
 		}
 	} finally {
 		active.disposables.dispose();

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -11,10 +11,13 @@ import { IEditorDecorationsCollection } from '../../../../../editor/common/edito
 import { Position } from '../../../../../editor/common/core/position.js';
 import { Range } from '../../../../../editor/common/core/range.js';
 import { localize } from '../../../../../nls.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
 
 /** Inline decoration class that shimmers not-yet-finalized dictation text. */
 const INTERIM_SHIMMER_CLASS = 'dictation-interim-shimmer';
+
+const LOG_PREFIX = '[chat-stt-dictation]';
 
 /**
  * Renders the cumulative transcript into a code editor, replacing its own
@@ -27,7 +30,10 @@ class LiveTranscriptInserter {
 	private _shimmerDecorations: IEditorDecorationsCollection | undefined;
 	private _finalized = false;
 
-	constructor(private readonly _editor: ICodeEditor) { }
+	constructor(
+		private readonly _editor: ICodeEditor,
+		private readonly _logService: ILogService,
+	) { }
 
 	/**
 	 * Render the cumulative transcript. While `interim` is true the text is not
@@ -40,7 +46,9 @@ class LiveTranscriptInserter {
 	 * overwrite the final text and re-apply the shimmer.
 	 */
 	update(fullText: string, interim: boolean = true): void {
+		this._logService.trace(`${LOG_PREFIX} inserter.update interim=${interim} finalized=${this._finalized} len=${fullText.length}`);
 		if (this._finalized && interim) {
+			this._logService.trace(`${LOG_PREFIX} inserter.update ignored (already finalized)`);
 			return;
 		}
 		if (!interim) {
@@ -48,6 +56,7 @@ class LiveTranscriptInserter {
 		}
 		const model = this._editor.getModel();
 		if (!model) {
+			this._logService.trace(`${LOG_PREFIX} inserter.update no model`);
 			return;
 		}
 
@@ -79,12 +88,14 @@ class LiveTranscriptInserter {
 	/** Shimmer the inserted (interim) region, or clear it once finalized. */
 	private _updateShimmer(interim: boolean): void {
 		if (!interim || !this._anchor || !this._end || Position.equals(this._anchor, this._end)) {
+			this._logService.trace(`${LOG_PREFIX} shimmer clear (interim=${interim})`);
 			this._shimmerDecorations?.clear();
 			return;
 		}
 		if (!this._shimmerDecorations) {
 			this._shimmerDecorations = this._editor.createDecorationsCollection();
 		}
+		this._logService.trace(`${LOG_PREFIX} shimmer set range=${this._anchor.lineNumber}:${this._anchor.column}-${this._end.lineNumber}:${this._end.column}`);
 		this._shimmerDecorations.set([{
 			range: Range.fromPositions(this._anchor, this._end),
 			options: {
@@ -96,6 +107,20 @@ class LiveTranscriptInserter {
 
 	/** Stop shimmering, leaving whatever text is currently inserted as solid. */
 	clearShimmer(): void {
+		this._logService.trace(`${LOG_PREFIX} clearShimmer`);
+		this._shimmerDecorations?.clear();
+	}
+
+	/**
+	 * Lock out further interim updates and stop shimmering immediately. Called
+	 * when the user stops talking, before the (async) final transcription
+	 * resolves, so a trailing interim transcript can neither overwrite the text
+	 * nor re-apply the shimmer. The subsequent final `update(text, false)` still
+	 * applies because it is not an interim update.
+	 */
+	beginFinalize(): void {
+		this._logService.trace(`${LOG_PREFIX} beginFinalize`);
+		this._finalized = true;
 		this._shimmerDecorations?.clear();
 	}
 
@@ -126,6 +151,7 @@ interface IActiveDictation {
 	readonly editor: ICodeEditor;
 	readonly inserter: LiveTranscriptInserter;
 	readonly disposables: DisposableStore;
+	readonly logService: ILogService;
 }
 
 /**
@@ -146,11 +172,11 @@ export function activeDictationEditor(): ICodeEditor | undefined {
 }
 
 /** Start dictating into `editor`, rendering the transcript live. */
-export async function startDictation(service: IChatSpeechToTextService, editor: ICodeEditor, window: Window & typeof globalThis): Promise<void> {
+export async function startDictation(service: IChatSpeechToTextService, editor: ICodeEditor, window: Window & typeof globalThis, logService: ILogService): Promise<void> {
 	if (_active || service.state !== ChatSpeechToTextState.Idle) {
 		return;
 	}
-	const inserter = new LiveTranscriptInserter(editor);
+	const inserter = new LiveTranscriptInserter(editor, logService);
 	const disposables = new DisposableStore();
 	// Show a "Listening…" placeholder only once the session is actually
 	// connected and recording, i.e. the service is in the Recording state and
@@ -184,9 +210,13 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 		}
 		editor.updateOptions({ placeholder: previousPlaceholder });
 	}));
-	disposables.add(service.onDidUpdateTranscript(text => inserter.update(text)));
+	disposables.add(service.onDidUpdateTranscript(text => {
+		logService.trace(`${LOG_PREFIX} onDidUpdateTranscript len=${text.length} state=${service.state}`);
+		inserter.update(text);
+	}));
 	disposables.add(service.onDidChangePreparingModel(() => applyPlaceholder()));
 	disposables.add(service.onDidChangeState(state => {
+		logService.trace(`${LOG_PREFIX} onDidChangeState ${state}`);
 		if (state === ChatSpeechToTextState.Idle && _active?.service === service) {
 			// If the service ends the session on its own (e.g. the model failed
 			// to load and it surfaced an error), drop the stale active reference
@@ -201,7 +231,7 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	// composer is closed); cancel dictation instead of leaving the microphone
 	// and local transcription running against a dead editor.
 	disposables.add(editor.onDidDispose(() => cancelDictation()));
-	_active = { service, editor, inserter, disposables };
+	_active = { service, editor, inserter, disposables, logService };
 	try {
 		await service.start(window);
 	} catch {
@@ -220,13 +250,24 @@ export async function stopDictation(): Promise<void> {
 		return;
 	}
 	_active = undefined;
+	active.logService.trace(`${LOG_PREFIX} stopDictation begin, state=${active.service.state}`);
+	// Stop shimmering and lock out interim updates right away so a trailing
+	// interim transcript emitted while transcription finalizes cannot re-apply
+	// the shimmer or overwrite the final text.
+	active.inserter.beginFinalize();
 	try {
 		const text = await active.service.stopAndTranscribe();
+		active.logService.trace(`${LOG_PREFIX} stopAndTranscribe resolved text=${text === undefined ? 'undefined' : `len=${text.length}`}`);
 		if (text !== undefined) {
 			// Final transcript: render it solid (no shimmer).
 			active.inserter.update(text, false);
+		} else {
+			// No final transcript to apply; make sure the shimmer does not linger
+			// over the last interim text.
+			active.inserter.clearShimmer();
 		}
 	} finally {
+		active.logService.trace(`${LOG_PREFIX} stopDictation dispose`);
 		active.disposables.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -14,10 +14,44 @@ import { localize } from '../../../../../nls.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
 
-/** Inline decoration class that shimmers not-yet-finalized dictation text. */
+/**
+ * Inline decoration class for the still-processing tail of not-yet-finalized
+ * dictation text: placeholder-colored with a shimmer animation.
+ */
 const INTERIM_SHIMMER_CLASS = 'dictation-interim-shimmer';
 
+/**
+ * Inline decoration class for the settled prefix of not-yet-finalized dictation
+ * text: placeholder-colored but no longer shimmering, because it has stopped
+ * changing between interim transcripts.
+ */
+const INTERIM_SETTLED_CLASS = 'dictation-interim-settled';
+
 const LOG_PREFIX = '[chat-stt-dictation]';
+
+/** Number of leading characters `a` and `b` share. */
+function commonPrefixLength(a: string, b: string): number {
+	const max = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < max && a.charCodeAt(i) === b.charCodeAt(i)) {
+		i++;
+	}
+	return i;
+}
+
+/**
+ * Back `index` up to the end of the last whole word at or before it, i.e. the
+ * offset just after the previous whitespace. This keeps a partially-transcribed
+ * trailing word in the shimmering (processing) region instead of prematurely
+ * settling it.
+ */
+function wordBoundaryAtOrBefore(text: string, index: number): number {
+	let i = index;
+	while (i > 0 && !/\s/.test(text.charAt(i - 1))) {
+		i--;
+	}
+	return i;
+}
 
 /**
  * Renders the cumulative transcript into a code editor, replacing its own
@@ -27,7 +61,9 @@ class LiveTranscriptInserter {
 	private _anchor: Position | undefined;
 	private _end: Position | undefined;
 	private _needsLeadingSpace = false;
+	private _settledDecorations: IEditorDecorationsCollection | undefined;
 	private _shimmerDecorations: IEditorDecorationsCollection | undefined;
+	private _prevInterimText = '';
 	private _finalized = false;
 
 	constructor(
@@ -37,8 +73,10 @@ class LiveTranscriptInserter {
 
 	/**
 	 * Render the cumulative transcript. While `interim` is true the text is not
-	 * yet finalized, so it is decorated with a shimmer animation; the final
-	 * update (`interim === false`) clears the shimmer, leaving solid text.
+	 * yet finalized, so it is rendered in the placeholder color: the settled
+	 * leading portion (unchanged since the previous interim transcript) is shown
+	 * statically, while the still-processing trailing portion shimmers. The final
+	 * update (`interim === false`) clears both decorations, leaving solid text.
 	 *
 	 * Once a final update has been applied, later interim updates are ignored:
 	 * the transcription service can emit a trailing interim transcript as it
@@ -82,32 +120,60 @@ class LiveTranscriptInserter {
 		const endColumn = lines.length === 1 ? this._anchor.column + lines[0].length : lines[lines.length - 1].length + 1;
 		this._end = new Position(endLine, endColumn);
 		this._editor.setPosition(this._end);
-		this._updateShimmer(interim);
+		this._updateInterimDecorations(text, fullText, interim);
+		this._prevInterimText = interim ? fullText : '';
 	}
 
-	/** Shimmer the inserted (interim) region, or clear it once finalized. */
-	private _updateShimmer(interim: boolean): void {
+	/** Position of the given character offset within the inserted `text`. */
+	private _positionAtOffset(text: string, offset: number): Position {
+		const anchor = this._anchor!;
+		const sub = text.slice(0, offset);
+		const lines = sub.split('\n');
+		if (lines.length === 1) {
+			return new Position(anchor.lineNumber, anchor.column + lines[0].length);
+		}
+		return new Position(anchor.lineNumber + lines.length - 1, lines[lines.length - 1].length + 1);
+	}
+
+	/**
+	 * Render the interim text in the placeholder color, shimmering only the
+	 * still-processing trailing portion. The settled prefix is the part of the
+	 * transcript that has not changed since the previous interim update (trimmed
+	 * back to a word boundary), so words stop shimmering once the recognizer
+	 * stops revising them. Cleared entirely once the text is finalized.
+	 */
+	private _updateInterimDecorations(text: string, fullText: string, interim: boolean): void {
 		if (!interim || !this._anchor || !this._end || Position.equals(this._anchor, this._end)) {
-			this._logService.trace(`${LOG_PREFIX} shimmer clear (interim=${interim})`);
+			this._logService.trace(`${LOG_PREFIX} interim decorations clear (interim=${interim})`);
+			this._settledDecorations?.clear();
 			this._shimmerDecorations?.clear();
 			return;
 		}
-		if (!this._shimmerDecorations) {
-			this._shimmerDecorations = this._editor.createDecorationsCollection();
-		}
-		this._logService.trace(`${LOG_PREFIX} shimmer set range=${this._anchor.lineNumber}:${this._anchor.column}-${this._end.lineNumber}:${this._end.column}`);
-		this._shimmerDecorations.set([{
-			range: Range.fromPositions(this._anchor, this._end),
-			options: {
-				description: 'chatSpeechToText-interim',
-				inlineClassName: INTERIM_SHIMMER_CLASS,
-			},
-		}]);
+
+		const leading = this._needsLeadingSpace ? 1 : 0;
+		const settledChars = wordBoundaryAtOrBefore(fullText, commonPrefixLength(fullText, this._prevInterimText));
+		const splitPosition = this._positionAtOffset(text, leading + settledChars);
+
+		this._settledDecorations ??= this._editor.createDecorationsCollection();
+		this._shimmerDecorations ??= this._editor.createDecorationsCollection();
+
+		const settled = Position.equals(this._anchor, splitPosition) ? [] : [{
+			range: Range.fromPositions(this._anchor, splitPosition),
+			options: { description: 'chatSpeechToText-settled', inlineClassName: INTERIM_SETTLED_CLASS },
+		}];
+		const shimmer = Position.equals(splitPosition, this._end) ? [] : [{
+			range: Range.fromPositions(splitPosition, this._end),
+			options: { description: 'chatSpeechToText-interim', inlineClassName: INTERIM_SHIMMER_CLASS },
+		}];
+		this._logService.trace(`${LOG_PREFIX} interim decorations settledChars=${settledChars} split=${splitPosition.lineNumber}:${splitPosition.column}`);
+		this._settledDecorations.set(settled);
+		this._shimmerDecorations.set(shimmer);
 	}
 
 	/** Stop shimmering, leaving whatever text is currently inserted as solid. */
 	clearShimmer(): void {
 		this._logService.trace(`${LOG_PREFIX} clearShimmer`);
+		this._settledDecorations?.clear();
 		this._shimmerDecorations?.clear();
 	}
 
@@ -121,6 +187,7 @@ class LiveTranscriptInserter {
 	beginFinalize(): void {
 		this._logService.trace(`${LOG_PREFIX} beginFinalize`);
 		this._finalized = true;
+		this._settledDecorations?.clear();
 		this._shimmerDecorations?.clear();
 	}
 
@@ -130,6 +197,7 @@ class LiveTranscriptInserter {
 	 * is cancelled so no dictated text is left behind.
 	 */
 	revert(): void {
+		this._settledDecorations?.clear();
 		this._shimmerDecorations?.clear();
 		const model = this._editor.getModel();
 		if (!model || !this._anchor || !this._end) {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -119,7 +119,11 @@ class LiveTranscriptInserter {
 		const endLine = this._anchor.lineNumber + lines.length - 1;
 		const endColumn = lines.length === 1 ? this._anchor.column + lines[0].length : lines[lines.length - 1].length + 1;
 		this._end = new Position(endLine, endColumn);
-		this._editor.setPosition(this._end);
+		// While transcription is in progress keep the caret parked at the start
+		// of the dictated region (a blinking cursor at the beginning) rather than
+		// chasing the growing/revised interim text. Once finalized, move it to the
+		// end so the user can continue typing after the dictated text.
+		this._editor.setPosition(interim ? this._anchor : this._end);
 		this._updateInterimDecorations(text, fullText, interim);
 		this._prevInterimText = interim ? fullText : '';
 	}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -104,13 +104,29 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	}
 	const inserter = new LiveTranscriptInserter(editor);
 	const disposables = new DisposableStore();
-	// Show a "Listening…" placeholder only once recording actually starts (the
-	// service transitions to Recording and plays the recording-started signal at
-	// the same moment), not during the preceding microphone acquisition and
-	// model preparation. The placeholder remains visible until transcript text
-	// is inserted, and is restored to its previous value when the session ends.
+	// Show a "Listening…" placeholder only once the session is actually
+	// connected and recording, i.e. the service is in the Recording state and
+	// the on-device model has finished preparing (downloading/loading). It must
+	// not appear during microphone acquisition or while the model is still being
+	// prepared, since transcription cannot happen yet. The placeholder remains
+	// visible until transcript text is inserted, and is restored to its previous
+	// value when the session ends.
 	const previousPlaceholder = editor.getOption(EditorOption.placeholder);
 	const listeningPlaceholder = localize('chatStt.listening', "Listening…");
+	const applyPlaceholder = () => {
+		if (!editor.getModel()) {
+			return;
+		}
+		const shouldListen = service.state === ChatSpeechToTextState.Recording && !service.isPreparingModel;
+		const current = editor.getOption(EditorOption.placeholder);
+		if (shouldListen) {
+			if (current !== listeningPlaceholder) {
+				editor.updateOptions({ placeholder: listeningPlaceholder });
+			}
+		} else if (current === listeningPlaceholder) {
+			editor.updateOptions({ placeholder: previousPlaceholder });
+		}
+	};
 	disposables.add(toDisposable(() => {
 		if (!editor.getModel() || editor.getOption(EditorOption.placeholder) !== listeningPlaceholder) {
 			return;
@@ -118,16 +134,17 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 		editor.updateOptions({ placeholder: previousPlaceholder });
 	}));
 	disposables.add(service.onDidUpdateTranscript(text => inserter.update(text)));
+	disposables.add(service.onDidChangePreparingModel(() => applyPlaceholder()));
 	disposables.add(service.onDidChangeState(state => {
-		if (state === ChatSpeechToTextState.Recording) {
-			editor.updateOptions({ placeholder: listeningPlaceholder });
-		} else if (state === ChatSpeechToTextState.Idle && _active?.service === service) {
+		if (state === ChatSpeechToTextState.Idle && _active?.service === service) {
 			// If the service ends the session on its own (e.g. the model failed
 			// to load and it surfaced an error), drop the stale active reference
 			// so the toolbar and glow reflect that dictation is no longer running.
 			_active = undefined;
 			disposables.dispose();
+			return;
 		}
+		applyPlaceholder();
 	}));
 	// The target editor can be disposed out from under us (e.g. the Agents
 	// composer is closed); cancel dictation instead of leaving the microphone

--- a/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationSession.css
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationSession.css
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/* Shimmer applied to not-yet-finalized (interim) dictation text as it streams
- * in, so the user can tell which portion is still being transcribed. Once the
- * transcript is finalized the decoration is removed, leaving solid text. */
+/* Not-yet-finalized (interim) dictation text is rendered in the input's
+ * placeholder color to signal it is provisional. The settled leading portion
+ * (which the recognizer has stopped revising) is shown statically, while the
+ * still-processing trailing portion shimmers. Both decorations are removed once
+ * the transcript is finalized, leaving solid text. */
 @keyframes dictation-interim-shimmer {
 	0% {
 		background-position: 120% 0;
@@ -16,13 +18,17 @@
 	}
 }
 
+.monaco-editor .dictation-interim-settled {
+	color: var(--vscode-input-placeholderForeground);
+}
+
 .monaco-editor .dictation-interim-shimmer {
 	background: linear-gradient(90deg,
-			var(--vscode-disabledForeground) 0%,
-			var(--vscode-disabledForeground) 30%,
+			var(--vscode-input-placeholderForeground) 0%,
+			var(--vscode-input-placeholderForeground) 30%,
 			var(--vscode-foreground) 50%,
-			var(--vscode-disabledForeground) 70%,
-			var(--vscode-disabledForeground) 100%);
+			var(--vscode-input-placeholderForeground) 70%,
+			var(--vscode-input-placeholderForeground) 100%);
 	background-size: 400% 100%;
 	background-clip: text;
 	-webkit-background-clip: text;

--- a/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationSession.css
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationSession.css
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Shimmer applied to not-yet-finalized (interim) dictation text as it streams
+ * in, so the user can tell which portion is still being transcribed. Once the
+ * transcript is finalized the decoration is removed, leaving solid text. */
+@keyframes dictation-interim-shimmer {
+	0% {
+		background-position: 120% 0;
+	}
+
+	100% {
+		background-position: -120% 0;
+	}
+}
+
+.monaco-editor .dictation-interim-shimmer {
+	background: linear-gradient(90deg,
+			var(--vscode-disabledForeground) 0%,
+			var(--vscode-disabledForeground) 30%,
+			var(--vscode-foreground) 50%,
+			var(--vscode-disabledForeground) 70%,
+			var(--vscode-disabledForeground) 100%);
+	background-size: 400% 100%;
+	background-clip: text;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	animation: dictation-interim-shimmer 2s linear infinite;
+	will-change: background-position;
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorContrib.ts
@@ -10,6 +10,7 @@ import { themeColorFromId } from '../../../../../../../base/common/themables.js'
 import { URI } from '../../../../../../../base/common/uri.js';
 import { MouseTargetType } from '../../../../../../../editor/browser/editorBrowser.js';
 import { ICodeEditorService } from '../../../../../../../editor/browser/services/codeEditorService.js';
+import { EditorOption } from '../../../../../../../editor/common/config/editorOptions.js';
 import { Position } from '../../../../../../../editor/common/core/position.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
 import { IDecorationOptions } from '../../../../../../../editor/common/editorCommon.js';
@@ -87,6 +88,15 @@ class InputEditorDecorations extends Disposable {
 		this.registeredDecorationTypes();
 		this.triggerInputEditorDecorationsUpdate();
 		this._register(this.widget.inputEditor.onDidChangeModelContent(() => this.triggerInputEditorDecorationsUpdate()));
+		this._register(this.widget.inputEditor.onDidChangeConfiguration(e => {
+			// The editor's placeholder option is set/cleared by features such as
+			// dictation ("Listening…"). When it is set, PlaceholderTextContribution
+			// renders it, so the decoration placeholder must yield to avoid two
+			// overlapping placeholders; re-run when the option changes.
+			if (e.hasChanged(EditorOption.placeholder)) {
+				this.triggerInputEditorDecorationsUpdate();
+			}
+		}));
 		this._register(this.widget.onDidChangeParsedInput(() => this.triggerInputEditorDecorationsUpdate()));
 		this._register(this.widget.onDidChangeViewModel(() => {
 			this.registerViewModelListeners();
@@ -215,6 +225,16 @@ class InputEditorDecorations extends Disposable {
 		}
 
 		if (!inputValue) {
+			// If the editor's placeholder option is set (e.g. dictation shows
+			// "Listening…"), PlaceholderTextContribution renders it already; skip
+			// the decoration placeholder so the two don't render on top of each
+			// other.
+			if (this.widget.inputEditor.getOption(EditorOption.placeholder)) {
+				this.updateAriaPlaceholder(undefined);
+				this.widget.inputEditor.setDecorationsByType(decorationDescription, placeholderDecorationType, []);
+				return;
+			}
+
 			const mode = this.widget.input.currentModeObs.get();
 			const placeholder = mode.argumentHint?.get() ?? mode.description.get() ?? '';
 			const displayPlaceholder = viewModel.inputPlaceholder || placeholder;


### PR DESCRIPTION


https://github.com/user-attachments/assets/5c3228bb-ca6b-491e-b12f-4b6c5b095fd4


## Summary

Fixes two bugs with the built-in chat voice dictation placeholder and adds a shimmer animation to not-yet-finalized (streaming) dictation text.

### Placeholder fixes
- **Overlap:** The dictation "Listening…" placeholder (set via `EditorOption.placeholder`) overlapped with the chat input's own placeholder (rendered via editor decorations). The decoration placeholder is now suppressed while `EditorOption.placeholder` is set, so only one shows at a time.
- **Premature display:** The placeholder appeared as soon as recording started, even while the on-device model was still downloading/loading. It now only shows once **connected** (recording *and* not preparing the model).

### Shimmer for interim text
- As interim (non-final) transcript text streams in, it now renders with a shimmer animation, matching the existing `chat-thinking-shimmer` pattern.
- When the transcript finalizes, the shimmer clears and the solid, finalized text replaces it.
- Added a `beginFinalize()` lock at the start of `stopDictation` plus a `_finalized` guard so a trailing interim event can't re-apply the shimmer after finalization (fixes the "final text never replaces the shimmer" race).
- Added `[chat-stt-dictation]` trace logging across the transcript/state lifecycle to aid diagnosis.

## Changes
- `dictationSession.ts`: placeholder gating, shimmer decoration, `beginFinalize()`/`_finalized` guard, trace logging.
- `chatInputEditorContrib.ts`: suppress decoration placeholder when `EditorOption.placeholder` is active.
- `speechToText/media/dictationSession.css`: new file with shimmer keyframes/class.
- `chatSpeechToTextActions.ts` / `newChatInput.ts`: thread `ILogService` into `startDictation`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>