### PR TITLE
Add tool search to Copilot agent host

### DIFF
--- a/extensions/copilot/src/extension/tools/common/virtualTools/toolEmbeddingsComputer.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/toolEmbeddingsComputer.ts
@@ -40,7 +40,12 @@ export interface IToolEmbeddingsComputer {
 	 * Searches for tools similar to the given natural language query using embeddings.
 	 * Returns the names of the top matching tools.
 	 */
-	searchToolsByQuery(query: string, availableTools: readonly LanguageModelToolInformation[], limit: number, token: CancellationToken): Promise<string[]>;
+	searchToolsByQuery(query: string, availableTools: readonly LanguageModelToolInformation[], limit: number, token: CancellationToken, options?: IToolSearchEmbeddingOptions): Promise<string[]>;
+}
+
+export interface IToolSearchEmbeddingOptions {
+	/** Avoid cache contamination from dynamic Agent Host tool definitions. */
+	readonly useCache?: boolean;
 }
 
 export const IToolEmbeddingsComputer = createServiceIdentifier<IToolEmbeddingsComputer>('IToolEmbeddingsComputer');
@@ -101,7 +106,7 @@ export class ToolEmbeddingsComputer implements IToolEmbeddingsComputer {
 		return matched;
 	}
 
-	public async searchToolsByQuery(query: string, availableTools: readonly LanguageModelToolInformation[], limit: number, token: CancellationToken): Promise<string[]> {
+	public async searchToolsByQuery(query: string, availableTools: readonly LanguageModelToolInformation[], limit: number, token: CancellationToken, options?: IToolSearchEmbeddingOptions): Promise<string[]> {
 		await this._initialized.value;
 
 		if (!query || token.isCancellationRequested) {
@@ -111,6 +116,11 @@ export class ToolEmbeddingsComputer implements IToolEmbeddingsComputer {
 		const queryEmbedding = await this._embeddingsComputer.computeEmbeddings(this._embeddingType, [query], {}, new TelemetryCorrelationId('ToolEmbeddingsComputer::searchToolsByQuery'), token);
 		if (!queryEmbedding || queryEmbedding.values.length === 0) {
 			return [];
+		}
+
+		if (options?.useCache === false) {
+			const embeddings = await this.computeEmbeddingsForTools([...availableTools], token);
+			return this.rankEmbeddings(queryEmbedding.values[0], embeddings ?? [], limit).map(item => item.value);
 		}
 
 		return this.retrieveSimilarEmbeddingsForAvailableTools(queryEmbedding.values[0], availableTools, limit, token);

--- a/extensions/copilot/src/extension/tools/common/virtualTools/toolEmbeddingsComputer.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/toolEmbeddingsComputer.ts
@@ -40,12 +40,7 @@ export interface IToolEmbeddingsComputer {
 	 * Searches for tools similar to the given natural language query using embeddings.
 	 * Returns the names of the top matching tools.
 	 */
-	searchToolsByQuery(query: string, availableTools: readonly LanguageModelToolInformation[], limit: number, token: CancellationToken, options?: IToolSearchEmbeddingOptions): Promise<string[]>;
-}
-
-export interface IToolSearchEmbeddingOptions {
-	/** Avoid cache contamination from dynamic Agent Host tool definitions. */
-	readonly useCache?: boolean;
+	searchToolsByQuery(query: string, availableTools: readonly LanguageModelToolInformation[], limit: number, token: CancellationToken): Promise<string[]>;
 }
 
 export const IToolEmbeddingsComputer = createServiceIdentifier<IToolEmbeddingsComputer>('IToolEmbeddingsComputer');
@@ -106,7 +101,7 @@ export class ToolEmbeddingsComputer implements IToolEmbeddingsComputer {
 		return matched;
 	}
 
-	public async searchToolsByQuery(query: string, availableTools: readonly LanguageModelToolInformation[], limit: number, token: CancellationToken, options?: IToolSearchEmbeddingOptions): Promise<string[]> {
+	public async searchToolsByQuery(query: string, availableTools: readonly LanguageModelToolInformation[], limit: number, token: CancellationToken): Promise<string[]> {
 		await this._initialized.value;
 
 		if (!query || token.isCancellationRequested) {
@@ -116,11 +111,6 @@ export class ToolEmbeddingsComputer implements IToolEmbeddingsComputer {
 		const queryEmbedding = await this._embeddingsComputer.computeEmbeddings(this._embeddingType, [query], {}, new TelemetryCorrelationId('ToolEmbeddingsComputer::searchToolsByQuery'), token);
 		if (!queryEmbedding || queryEmbedding.values.length === 0) {
 			return [];
-		}
-
-		if (options?.useCache === false) {
-			const embeddings = await this.computeEmbeddingsForTools([...availableTools], token);
-			return this.rankEmbeddings(queryEmbedding.values[0], embeddings ?? [], limit).map(item => item.value);
 		}
 
 		return this.retrieveSimilarEmbeddingsForAvailableTools(queryEmbedding.values[0], availableTools, limit, token);

--- a/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import type { ILogService } from '../../../../platform/log/common/logService';
 import type { IToolDeferralService } from '../../../../platform/networking/common/toolDeferralService';
-import type { IToolEmbeddingsComputer, IToolSearchEmbeddingOptions } from '../../common/virtualTools/toolEmbeddingsComputer';
+import type { IToolEmbeddingsComputer } from '../../common/virtualTools/toolEmbeddingsComputer';
 import type { IToolsService } from '../../common/toolsService';
 import { ToolSearchTool } from '../toolSearchTool';
 
@@ -21,7 +21,7 @@ function text(result: vscode.LanguageModelToolResult): string {
 
 describe('ToolSearchTool', () => {
 	it('uses an injected Agent Host corpus instead of the extension registry', async () => {
-		const searchToolsByQuery = vi.fn(async (_query: string, tools: readonly vscode.LanguageModelToolInformation[], _limit: number, _token: vscode.CancellationToken, _options?: IToolSearchEmbeddingOptions) => tools.map(tool => tool.name));
+		const searchToolsByQuery = vi.fn(async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => tools.map(tool => tool.name));
 		const embeddings = { _serviceBrand: undefined, searchToolsByQuery } as unknown as IToolEmbeddingsComputer;
 		const toolsService = {
 			_serviceBrand: undefined,
@@ -41,12 +41,11 @@ describe('ToolSearchTool', () => {
 
 		expect(searchToolsByQuery).toHaveBeenCalledOnce();
 		expect(searchToolsByQuery.mock.calls[0][1].map(tool => tool.name)).toEqual(['everything-get-sum']);
-		expect(searchToolsByQuery.mock.calls[0][4]).toEqual({ useCache: false });
 		expect(text(result)).toBe('["everything-get-sum"]');
 	});
 
 	it('preserves the extension registry path when no corpus is injected', async () => {
-		const searchToolsByQuery = vi.fn(async (_query: string, tools: readonly vscode.LanguageModelToolInformation[], _limit: number, _token: vscode.CancellationToken, _options?: IToolSearchEmbeddingOptions) => tools.map(tool => tool.name));
+		const searchToolsByQuery = vi.fn(async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => tools.map(tool => tool.name));
 		const embeddings = { _serviceBrand: undefined, searchToolsByQuery } as unknown as IToolEmbeddingsComputer;
 		const toolsService = {
 			_serviceBrand: undefined,
@@ -62,6 +61,5 @@ describe('ToolSearchTool', () => {
 		await tool.invoke({ input: { query: 'deferred' }, toolInvocationToken: undefined } as vscode.LanguageModelToolInvocationOptions<any>, CancellationToken.None);
 
 		expect(searchToolsByQuery.mock.calls[0][1].map(tool => tool.name)).toEqual(['deferred-extension-tool']);
-		expect(searchToolsByQuery.mock.calls[0][4]).toBeUndefined();
 	});
 });

--- a/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+import { describe, expect, it, vi } from 'vitest';
+import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import type { ILogService } from '../../../../platform/log/common/logService';
+import type { IToolDeferralService } from '../../../../platform/networking/common/toolDeferralService';
+import type { IToolEmbeddingsComputer, IToolSearchEmbeddingOptions } from '../../common/virtualTools/toolEmbeddingsComputer';
+import type { IToolsService } from '../../common/toolsService';
+import { ToolSearchTool } from '../toolSearchTool';
+
+function text(result: vscode.LanguageModelToolResult): string {
+	return result.content.map(part => {
+		const value = part as { value?: unknown };
+		return value.value === undefined ? '' : String(value.value);
+	}).join('');
+}
+
+describe('ToolSearchTool', () => {
+	it('uses an injected Agent Host corpus instead of the extension registry', async () => {
+		const searchToolsByQuery = vi.fn(async (_query: string, tools: readonly vscode.LanguageModelToolInformation[], _limit: number, _token: vscode.CancellationToken, _options?: IToolSearchEmbeddingOptions) => tools.map(tool => tool.name));
+		const embeddings = { _serviceBrand: undefined, searchToolsByQuery } as unknown as IToolEmbeddingsComputer;
+		const toolsService = {
+			_serviceBrand: undefined,
+			tools: [{ name: 'extension-only', description: 'Extension tool', inputSchema: undefined, tags: [], source: undefined }],
+		} as unknown as IToolsService;
+		const deferral = { _serviceBrand: undefined, isNonDeferredTool: () => false } as IToolDeferralService;
+		const log = { _serviceBrand: undefined, trace: vi.fn() } as unknown as ILogService;
+		const tool = new ToolSearchTool(embeddings, toolsService, deferral, log);
+
+		const result = await tool.invoke({
+			input: {
+				query: 'add numbers',
+				candidateTools: [{ name: 'everything-get-sum', description: 'Adds numbers', inputSchema: { type: 'object' } }],
+			},
+			toolInvocationToken: undefined,
+		} as vscode.LanguageModelToolInvocationOptions<any>, CancellationToken.None);
+
+		expect(searchToolsByQuery).toHaveBeenCalledOnce();
+		expect(searchToolsByQuery.mock.calls[0][1].map(tool => tool.name)).toEqual(['everything-get-sum']);
+		expect(searchToolsByQuery.mock.calls[0][4]).toEqual({ useCache: false });
+		expect(text(result)).toBe('["everything-get-sum"]');
+	});
+
+	it('preserves the extension registry path when no corpus is injected', async () => {
+		const searchToolsByQuery = vi.fn(async (_query: string, tools: readonly vscode.LanguageModelToolInformation[], _limit: number, _token: vscode.CancellationToken, _options?: IToolSearchEmbeddingOptions) => tools.map(tool => tool.name));
+		const embeddings = { _serviceBrand: undefined, searchToolsByQuery } as unknown as IToolEmbeddingsComputer;
+		const toolsService = {
+			_serviceBrand: undefined,
+			tools: [
+				{ name: 'deferred-extension-tool', description: 'Deferred', inputSchema: undefined, tags: [], source: undefined },
+				{ name: 'core-tool', description: 'Core', inputSchema: undefined, tags: [], source: undefined },
+			],
+		} as unknown as IToolsService;
+		const deferral = { _serviceBrand: undefined, isNonDeferredTool: (name: string) => name === 'core-tool' } as IToolDeferralService;
+		const log = { _serviceBrand: undefined, trace: vi.fn() } as unknown as ILogService;
+		const tool = new ToolSearchTool(embeddings, toolsService, deferral, log);
+
+		await tool.invoke({ input: { query: 'deferred' }, toolInvocationToken: undefined } as vscode.LanguageModelToolInvocationOptions<any>, CancellationToken.None);
+
+		expect(searchToolsByQuery.mock.calls[0][1].map(tool => tool.name)).toEqual(['deferred-extension-tool']);
+		expect(searchToolsByQuery.mock.calls[0][4]).toBeUndefined();
+	});
+});

--- a/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
@@ -34,7 +34,7 @@ describe('ToolSearchTool', () => {
 		const result = await tool.invoke({
 			input: {
 				query: 'add numbers',
-				candidateTools: [{ name: 'everything-get-sum', description: 'Adds numbers', inputSchema: { type: 'object' } }],
+				candidateTools: [{ name: 'everything-get-sum', description: 'Adds numbers' }],
 			},
 			toolInvocationToken: undefined,
 		} as vscode.LanguageModelToolInvocationOptions<any>, CancellationToken.None);

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -23,7 +23,6 @@ export interface IToolSearchParams {
 export interface IToolSearchCandidate {
 	name: string;
 	description: string;
-	inputSchema?: object;
 }
 
 const DEFAULT_SEARCH_LIMIT = 5;
@@ -49,7 +48,7 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 			? candidateTools.map(tool => ({
 				name: tool.name,
 				description: tool.description,
-				inputSchema: tool.inputSchema,
+				inputSchema: undefined,
 				tags: [],
 				source: undefined,
 			}))

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -16,6 +16,14 @@ import { IToolEmbeddingsComputer } from '../common/virtualTools/toolEmbeddingsCo
 export interface IToolSearchParams {
 	query: string;
 	limit?: number;
+	/** Internal Agent Host corpus; not part of the model-facing schema. */
+	candidateTools?: readonly IToolSearchCandidate[];
+}
+
+export interface IToolSearchCandidate {
+	name: string;
+	description: string;
+	inputSchema?: object;
 }
 
 const DEFAULT_SEARCH_LIMIT = 5;
@@ -29,7 +37,7 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 	) { }
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<IToolSearchParams>, token: vscode.CancellationToken) {
-		const { query, limit } = options.input;
+		const { query, limit, candidateTools } = options.input;
 
 		if (!query) {
 			return new LanguageModelToolResult([
@@ -37,14 +45,23 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 			]);
 		}
 
-		const availableTools = this._toolsService.tools.filter(
-			tool => !this._toolDeferralService.isNonDeferredTool(tool.name),
-		);
+		const availableTools: readonly vscode.LanguageModelToolInformation[] = candidateTools !== undefined
+			? candidateTools.map(tool => ({
+				name: tool.name,
+				description: tool.description,
+				inputSchema: tool.inputSchema,
+				tags: [],
+				source: undefined,
+			}))
+			: this._toolsService.tools.filter(
+				tool => !this._toolDeferralService.isNonDeferredTool(tool.name),
+			);
 		const matchedToolNames = await this._toolEmbeddingsComputer.searchToolsByQuery(
 			query,
 			availableTools,
 			limit ?? DEFAULT_SEARCH_LIMIT,
 			token,
+			candidateTools !== undefined ? { useCache: false } : undefined,
 		);
 
 		this._logService.trace(`[custom-tool-search] Query "${query}" matched ${matchedToolNames.length} tools: ${JSON.stringify(matchedToolNames)}`);

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -61,7 +61,6 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 			availableTools,
 			limit ?? DEFAULT_SEARCH_LIMIT,
 			token,
-			candidateTools !== undefined ? { useCache: false } : undefined,
 		);
 
 		this._logService.trace(`[custom-tool-search] Query "${query}" matched ${matchedToolNames.length} tools: ${JSON.stringify(matchedToolNames)}`);

--- a/src/vs/platform/agentHost/common/copilotCliConfig.ts
+++ b/src/vs/platform/agentHost/common/copilotCliConfig.ts
@@ -21,6 +21,8 @@ export const enum CopilotCliConfigKey {
 	RubberDuck = 'rubberDuck',
 	/** Apply Opus 4.8-tuned system-prompt overrides on Opus 4.8 models. Off by default. */
 	Opus48Prompt = 'opus48Prompt',
+	/** Enable runtime tool search (deferred-tool loading) for Copilot SDK sessions. Off by default. */
+	ToolSearchEnabled = 'toolSearchEnabled',
 	/** Override reasoning effort regardless of the picker value; unsupported values are ignored. */
 	ReasoningEffortOverride = 'reasoningEffortOverride',
 	/** Per-model capability overrides (family aliases) keyed by model id. */
@@ -37,6 +39,8 @@ export const AgentHostCustomTerminalToolEnabledSettingId = 'chat.agentHost.custo
 export const AgentHostCopilotSdkLogLevelSettingId = 'chat.agentHost.copilotSdk.logLevel';
 
 export const AgentHostOpus48PromptEnabledSettingId = 'chat.agentHost.opus48Prompt.enabled';
+
+export const AgentHostToolSearchEnabledSettingId = 'chat.agentHost.copilot.toolSearch.enabled';
 
 export const AgentHostReasoningEffortOverrideSettingId = 'chat.agentHost.reasoningEffortOverride';
 
@@ -82,6 +86,12 @@ export const copilotCliConfigSchema = createSchema({
 		type: 'boolean',
 		title: localize('agentHost.config.opus48Prompt.title', "Opus 4.8 Agent Prompt"),
 		description: localize('agentHost.config.opus48Prompt.description', "When enabled, Copilot SDK sessions running a Claude Opus 4.8 model apply Opus 4.8-tuned system-prompt section overrides on top of the default system message."),
+		default: false,
+	}),
+	[CopilotCliConfigKey.ToolSearchEnabled]: schemaProperty<boolean>({
+		type: 'boolean',
+		title: localize('agentHost.config.toolSearchEnabled.title', "Agent Host Tool Search"),
+		description: localize('agentHost.config.toolSearchEnabled.description', "When enabled, Copilot SDK sessions defer MCP and non-core VS Code tools behind a tool-search tool so the model discovers them on demand instead of loading every tool definition up front."),
 		default: false,
 	}),
 	[CopilotCliConfigKey.ReasoningEffortOverride]: schemaProperty<string>({

--- a/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
@@ -54,7 +54,6 @@ export interface IToolCallMeta {
 export interface IToolSearchCandidate {
 	readonly name: string;
 	readonly description: string;
-	readonly inputSchema?: Record<string, unknown>;
 }
 
 /**
@@ -107,14 +106,9 @@ function readToolSearchCandidates(value: unknown): readonly IToolSearchCandidate
 		if (typeof raw['name'] !== 'string' || typeof raw['description'] !== 'string') {
 			return undefined;
 		}
-		const inputSchema = raw['inputSchema'];
-		if (inputSchema !== undefined && (!inputSchema || typeof inputSchema !== 'object' || Array.isArray(inputSchema))) {
-			return undefined;
-		}
 		result.push({
 			name: raw['name'],
 			description: raw['description'],
-			...(inputSchema ? { inputSchema: inputSchema as Record<string, unknown> } : {}),
 		});
 	}
 	return result;

--- a/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
@@ -46,6 +46,15 @@ export interface IToolCallMeta {
 	 * explicit user action), so the client can render it as setting-driven.
 	 */
 	readonly autoApproveBySetting?: boolean;
+	/** Transient runtime corpus for the local client tool-search invocation. */
+	readonly toolSearchCandidates?: readonly IToolSearchCandidate[];
+}
+
+/** Minimal metadata needed to embed and rank a deferred tool. */
+export interface IToolSearchCandidate {
+	readonly name: string;
+	readonly description: string;
+	readonly inputSchema?: Record<string, unknown>;
 }
 
 /**
@@ -85,6 +94,32 @@ function readToolCallUiMeta(value: unknown): IToolCallUiMeta | undefined {
 	return result;
 }
 
+function readToolSearchCandidates(value: unknown): readonly IToolSearchCandidate[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	const result: IToolSearchCandidate[] = [];
+	for (const candidate of value) {
+		if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+			return undefined;
+		}
+		const raw = candidate as Record<string, unknown>;
+		if (typeof raw['name'] !== 'string' || typeof raw['description'] !== 'string') {
+			return undefined;
+		}
+		const inputSchema = raw['inputSchema'];
+		if (inputSchema !== undefined && (!inputSchema || typeof inputSchema !== 'object' || Array.isArray(inputSchema))) {
+			return undefined;
+		}
+		result.push({
+			name: raw['name'],
+			description: raw['description'],
+			...(inputSchema ? { inputSchema: inputSchema as Record<string, unknown> } : {}),
+		});
+	}
+	return result;
+}
+
 /**
  * Reads the well-known {@link IToolCallMeta} keys from a tool call's `_meta`
  * bag, dropping unknown keys and wrong-typed values.
@@ -104,6 +139,8 @@ export function readToolCallMeta(source: IHasToolCallMeta): IToolCallMeta {
 	if (typeof meta['mcpServerName'] === 'string') { result.mcpServerName = meta['mcpServerName']; }
 	if (typeof meta['mcpToolName'] === 'string') { result.mcpToolName = meta['mcpToolName']; }
 	if (typeof meta['autoApproveBySetting'] === 'boolean') { result.autoApproveBySetting = meta['autoApproveBySetting']; }
+	const toolSearchCandidates = readToolSearchCandidates(meta['toolSearchCandidates']);
+	if (toolSearchCandidates) { result.toolSearchCandidates = toolSearchCandidates; }
 	const ui = readToolCallUiMeta(meta['ui']);
 	if (ui) { result.ui = ui; }
 	return result;

--- a/src/vs/platform/agentHost/common/toolSearchConstants.ts
+++ b/src/vs/platform/agentHost/common/toolSearchConstants.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Runtime/model-facing override name. */
+export const RUNTIME_TOOL_SEARCH_TOOL_NAME = 'tool_search_tool';
+
+/** Client/workbench-facing tool reference name. */
+export const CLIENT_TOOL_SEARCH_REFERENCE_NAME = 'toolSearch';

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -26,7 +26,7 @@ import { IFileService } from '../../../files/common/files.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService, LogLevel } from '../../../log/common/log.js';
 import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
-import { CopilotCliConfigKey, copilotCliConfigSchema } from '../../common/copilotCliConfig.js';
+import { CopilotCliConfigKey, applyModelFamilyAlias, copilotCliConfigSchema } from '../../common/copilotCliConfig.js';
 import type { ChatInputRequestWithPlanReview, IAgentHostPlanReviewAction } from '../../common/agentHostPlanReview.js';
 import { gitHubMcpServerUrl } from '../../common/githubEndpoints.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
@@ -755,8 +755,12 @@ export class CopilotAgentSession extends Disposable {
 		this._appliedSnapshot = options.clientSnapshot ?? { tools: [], plugins: [], mcpServers: {} };
 		this._clientToolNames = clientToolNamesFromSnapshot(this._appliedSnapshot);
 		const model = this._launchPlan.kind === 'create' ? this._launchPlan.model : this._launchPlan.fallback.model;
+		// Capability decisions use the family-aliased selection so an aliased
+		// preview model agrees with the launcher's tool-search gating (which
+		// also aliases before checking); the wire model id is unaffected.
+		const effectiveModel = applyModelFamilyAlias(model, this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.ModelCapabilityOverrides));
 		this._toolSearchActive = this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.ToolSearchEnabled) === true
-			&& agentHostModelSupportsToolSearch(model?.id)
+			&& agentHostModelSupportsToolSearch(effectiveModel?.id)
 			&& this._clientToolNames.has(CLIENT_TOOL_SEARCH_REFERENCE_NAME);
 		// Share the agent's live ActiveClientToolSet when provided so client
 		// contributions (and owner identity) are observed at stamp time.

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1138,7 +1138,6 @@ export class CopilotAgentSession extends Disposable {
 
 	private _clientToolName(toolName: string): string {
 		return this._isToolSearchActive()
-			&& this._clientToolNames.has(CLIENT_TOOL_SEARCH_REFERENCE_NAME)
 			&& toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME
 			? CLIENT_TOOL_SEARCH_REFERENCE_NAME
 			: toolName;
@@ -1149,8 +1148,7 @@ export class CopilotAgentSession extends Disposable {
 			.filter(tool => tool.deferLoading)
 			.map(tool => ({
 				name: tool.name,
-				description: tool.description,
-				...(tool.input_schema ? { inputSchema: tool.input_schema } : {}),
+				description: tool.description ?? '',
 			}));
 	}
 
@@ -1216,6 +1214,7 @@ export class CopilotAgentSession extends Disposable {
 			name: def.name,
 			description: def.description ?? '',
 			parameters: def.inputSchema ?? { type: 'object' as const, properties: {} },
+			defer: 'never' as const,
 			handler: async (args: Record<string, unknown>): Promise<ToolResultObject> => {
 				try {
 					const text = host.executeTool(this._chatChannelUri.toString(), def.name, args);
@@ -2149,7 +2148,7 @@ export class CopilotAgentSession extends Disposable {
 			if (recommendation === 'approve' && !request.requestSandboxBypass) {
 				if (request.kind === 'custom-tool'
 					&& typeof request.toolName === 'string'
-					&& this._clientToolNames.has(request.toolName)
+					&& this._clientToolNames.has(this._clientToolName(request.toolName))
 				) {
 					const trackedToolCall = this._activeToolCalls.get(toolCallId);
 					const displayName = trackedToolCall?.displayName ?? getToolDisplayName(request.toolName);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -651,8 +651,6 @@ export class CopilotAgentSession extends Disposable {
 	private readonly _toolSearchActive: boolean;
 	/** Deferred promises for pending client tool calls, keyed by toolCallId. */
 	private readonly _pendingClientToolCalls = new PendingRequestRegistry<ToolResultObject>();
-	/** Tool-start barrier for tool-search handlers that may race the SDK start event. */
-	private readonly _pendingClientToolStarts = new PendingRequestRegistry<boolean>();
 	/** Pending SDK MCP auth handler promises, keyed by SDK auth request id. */
 	private readonly _pendingMcpAuthRequests = new Map<string, IPendingMcpAuthRequest>();
 	/** `pending-edit-content:` URIs written during permission requests, keyed
@@ -816,7 +814,6 @@ export class CopilotAgentSession extends Disposable {
 			}));
 		}
 		this._register(toDisposable(() => this._cancelPendingClientToolCalls()));
-		this._register(toDisposable(() => this._pendingClientToolStarts.denyAll(false)));
 		this._register(toDisposable(() => {
 			for (const pending of this._pendingAutoApprovals.values()) {
 				pending.complete(undefined);
@@ -1102,15 +1099,6 @@ export class CopilotAgentSession extends Disposable {
 					skipPermission: true,
 					handler: async (_args: Record<string, unknown>, invocation) => {
 						try {
-							const started = await raceTimeout(
-								this._pendingClientToolStarts.register(invocation.toolCallId),
-								5_000,
-								() => this._pendingClientToolStarts.respond(invocation.toolCallId, false),
-							);
-							if (started !== true) {
-								return this._toolSearchFailure('Timed out waiting for the tool-search call to start.');
-							}
-
 							const candidates = this._toToolSearchCandidates(invocation.availableTools);
 							const clientResult = await raceTimeout(
 								this._pendingClientToolCalls.registerAndFire(invocation.toolCallId, () => this._emitToolSearchReady(invocation.toolCallId, candidates)),
@@ -3323,9 +3311,6 @@ export class CopilotAgentSession extends Disposable {
 				contributor,
 				_meta: toToolCallMeta(meta),
 			}, parentToolCallId);
-			if (e.data.toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME && clientToolName === CLIENT_TOOL_SEARCH_REFERENCE_NAME) {
-				this._pendingClientToolStarts.respondOrBuffer(e.data.toolCallId, true);
-			}
 
 			// No client is connected to run this client tool. Fail it
 			// immediately instead of leaving it pending until the

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { CopilotSession, ExitPlanModeRequest, McpServersLoadedServer, MessageOptions, PermissionAllowAllMode, PermissionAutoApproval, PermissionRequestResult, SessionConfig, Tool, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
-import { DeferredPromise, Sequencer } from '../../../../base/common/async.js';
+import type { CopilotSession, CurrentToolMetadata, ExitPlanModeRequest, McpServersLoadedServer, MessageOptions, PermissionAllowAllMode, PermissionAutoApproval, PermissionRequestResult, SessionConfig, Tool, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
+import { DeferredPromise, raceTimeout, Sequencer } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { CancellationError, getErrorMessage } from '../../../../base/common/errors.js';
@@ -34,7 +34,7 @@ import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledCo
 import { AgentSession, AgentSignal, AuthenticateParams, IMcpNotification, IRestoredSubagentSession, subagentChatTitle } from '../../common/agentService.js';
 import { META_DIFF_BASE_BRANCH } from '../../common/agentHostGitService.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
-import { readToolCallMeta, toToolCallMeta, type IToolCallMeta, type IToolCallUiMeta } from '../../common/meta/agentToolCallMeta.js';
+import { readToolCallMeta, toToolCallMeta, type IToolCallMeta, type IToolCallUiMeta, type IToolSearchCandidate } from '../../common/meta/agentToolCallMeta.js';
 import { OtelData, type OtelAttributeValue } from '../../common/otlp/otlpLogEmitter.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { resolveCopilotConfigSlashCommandOnSend } from '../../common/copilotConfigSlashCommands.js';
@@ -47,6 +47,7 @@ import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
 import { clientToolNamesFromSnapshot, type CopilotSessionLaunchPlan, type IActiveClientSnapshot, type ICopilotSessionLauncher, type ICopilotSessionRuntime } from './copilotSessionLauncher.js';
+import { agentHostModelSupportsToolSearch, CLIENT_TOOL_SEARCH_REFERENCE_NAME, NON_DEFERRED_CLIENT_TOOL_NAMES, RUNTIME_TOOL_SEARCH_TOOL_NAME } from './toolSearchDeferral.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { AgentHostTelemetryReporter } from '../agentHostTelemetryReporter.js';
 import { AgentHostRepoInfoTelemetry } from '../agentHostRepoInfoTelemetry.js';
@@ -646,8 +647,12 @@ export class CopilotAgentSession extends Disposable {
 	private readonly _activeClientToolSet: ActiveClientToolSet;
 	/** Tool names that are client-provided, derived from snapshot. */
 	private readonly _clientToolNames: ReadonlySet<string>;
+	/** Launch-time tool-search decision; kept stable for the lifetime of the SDK session. */
+	private readonly _toolSearchActive: boolean;
 	/** Deferred promises for pending client tool calls, keyed by toolCallId. */
 	private readonly _pendingClientToolCalls = new PendingRequestRegistry<ToolResultObject>();
+	/** Tool-start barrier for tool-search handlers that may race the SDK start event. */
+	private readonly _pendingClientToolStarts = new PendingRequestRegistry<boolean>();
 	/** Pending SDK MCP auth handler promises, keyed by SDK auth request id. */
 	private readonly _pendingMcpAuthRequests = new Map<string, IPendingMcpAuthRequest>();
 	/** `pending-edit-content:` URIs written during permission requests, keyed
@@ -749,6 +754,10 @@ export class CopilotAgentSession extends Disposable {
 
 		this._appliedSnapshot = options.clientSnapshot ?? { tools: [], plugins: [], mcpServers: {} };
 		this._clientToolNames = clientToolNamesFromSnapshot(this._appliedSnapshot);
+		const model = this._launchPlan.kind === 'create' ? this._launchPlan.model : this._launchPlan.fallback.model;
+		this._toolSearchActive = this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.ToolSearchEnabled) === true
+			&& agentHostModelSupportsToolSearch(model?.id)
+			&& this._clientToolNames.has(CLIENT_TOOL_SEARCH_REFERENCE_NAME);
 		// Share the agent's live ActiveClientToolSet when provided so client
 		// contributions (and owner identity) are observed at stamp time.
 		// Standalone / test construction uses a fresh empty registry, which
@@ -803,6 +812,7 @@ export class CopilotAgentSession extends Disposable {
 			}));
 		}
 		this._register(toDisposable(() => this._cancelPendingClientToolCalls()));
+		this._register(toDisposable(() => this._pendingClientToolStarts.denyAll(false)));
 		this._register(toDisposable(() => {
 			for (const pending of this._pendingAutoApprovals.values()) {
 				pending.complete(undefined);
@@ -1072,22 +1082,133 @@ export class CopilotAgentSession extends Disposable {
 		if (tools.length === 0) {
 			return [];
 		}
-		return tools.map(def => ({
-			name: def.name,
-			description: def.description ?? '',
-			parameters: def.inputSchema ?? { type: 'object' as const, properties: {} },
-			handler: async (_args: Record<string, unknown>, { toolCallId }) => {
-				try {
-					// The completion may legitimately arrive before this handler
-					// registers; the registry buffers early results so register()
-					// resolves immediately in that case.
-					return await this._pendingClientToolCalls.register(toolCallId);
-				} catch (error) {
-					this._logService.error(error, `[Copilot:${this.sessionId}] Failed in client tool handler: tool=${def.name}, toolCallId=${toolCallId}`);
-					throw error;
+		const toolSearchActive = this._isToolSearchActive();
+		const sessionTools = toolSearchActive
+			? tools
+			: tools.filter(def => def.name !== CLIENT_TOOL_SEARCH_REFERENCE_NAME);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		return sessionTools.map((def): Tool<any> => {
+			if (toolSearchActive && def.name === CLIENT_TOOL_SEARCH_REFERENCE_NAME) {
+				return {
+					name: RUNTIME_TOOL_SEARCH_TOOL_NAME,
+					description: def.description ?? '',
+					parameters: def.inputSchema ?? { type: 'object' as const, properties: {} },
+					overridesBuiltInTool: true,
+					defer: 'never',
+					skipPermission: true,
+					handler: async (_args: Record<string, unknown>, invocation) => {
+						try {
+							const started = await raceTimeout(
+								this._pendingClientToolStarts.register(invocation.toolCallId),
+								5_000,
+								() => this._pendingClientToolStarts.respond(invocation.toolCallId, false),
+							);
+							if (started !== true) {
+								return this._toolSearchFailure('Timed out waiting for the tool-search call to start.');
+							}
+
+							const candidates = this._toToolSearchCandidates(invocation.availableTools);
+							const clientResult = await raceTimeout(
+								this._pendingClientToolCalls.registerAndFire(invocation.toolCallId, () => this._emitToolSearchReady(invocation.toolCallId, candidates)),
+								15_000,
+								() => this._pendingClientToolCalls.respond(invocation.toolCallId, this._toolSearchFailure('Timed out waiting for client-side tool search.')),
+							);
+							if (!clientResult) {
+								return this._toolSearchFailure('Timed out waiting for client-side tool search.');
+							}
+							return this._toToolSearchResult(clientResult, invocation.availableTools);
+						} catch (error) {
+							this._logService.error(error, `[Copilot:${this.sessionId}] Failed in tool-search handler: toolCallId=${invocation.toolCallId}`);
+							return this._toolSearchFailure(getErrorMessage(error));
+						}
+					},
+				};
+			}
+			const defer: 'auto' | 'never' | undefined = toolSearchActive
+				? (NON_DEFERRED_CLIENT_TOOL_NAMES.has(def.name) ? 'never' : 'auto')
+				: undefined;
+			return {
+				name: def.name,
+				description: def.description ?? '',
+				parameters: def.inputSchema ?? { type: 'object' as const, properties: {} },
+				defer,
+				handler: async (_args: Record<string, unknown>, { toolCallId }) => {
+					try {
+						return await this._pendingClientToolCalls.register(toolCallId);
+					} catch (error) {
+						this._logService.error(error, `[Copilot:${this.sessionId}] Failed in client tool handler: tool=${def.name}, toolCallId=${toolCallId}`);
+						throw error;
+					}
+				},
+			};
+		});
+	}
+
+	private _isToolSearchActive(): boolean {
+		return this._toolSearchActive;
+	}
+
+	private _clientToolName(toolName: string): string {
+		return this._isToolSearchActive()
+			&& this._clientToolNames.has(CLIENT_TOOL_SEARCH_REFERENCE_NAME)
+			&& toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME
+			? CLIENT_TOOL_SEARCH_REFERENCE_NAME
+			: toolName;
+	}
+
+	private _toToolSearchCandidates(availableTools: readonly CurrentToolMetadata[] | undefined): readonly IToolSearchCandidate[] {
+		return (availableTools ?? [])
+			.filter(tool => tool.deferLoading)
+			.map(tool => ({
+				name: tool.name,
+				description: tool.description,
+				...(tool.input_schema ? { inputSchema: tool.input_schema } : {}),
+			}));
+	}
+
+	private _emitToolSearchReady(toolCallId: string, candidates: readonly IToolSearchCandidate[]): void {
+		const tracked = this._activeToolCalls.get(toolCallId);
+		if (!tracked) {
+			throw new Error(`Tool-search call '${toolCallId}' was not tracked.`);
+		}
+		this._emitAction({
+			type: ActionType.ChatToolCallReady,
+			turnId: this._turnId,
+			toolCallId,
+			invocationMessage: getInvocationMessage(tracked.toolName, tracked.displayName, tracked.parameters),
+			toolInput: getToolInputString(tracked.toolName, tracked.parameters, tracked.parameters ? tryStringify(tracked.parameters) : undefined),
+			confirmed: ToolCallConfirmationReason.NotNeeded,
+			_meta: toToolCallMeta({ ...(tracked.meta ?? {}), toolSearchCandidates: candidates }),
+		}, tracked.parentToolCallId);
+	}
+
+	private _toolSearchFailure(message: string): ToolResultObject {
+		return { textResultForLlm: message, resultType: 'failure', error: message, toolReferences: [] };
+	}
+
+	private _toToolSearchResult(clientResult: ToolResultObject, availableTools: readonly CurrentToolMetadata[] | undefined): ToolResultObject {
+		const deferred = new Set<string>();
+		for (const tool of availableTools ?? []) {
+			if (tool.deferLoading) {
+				deferred.add(tool.name);
+				if (tool.namespacedName) {
+					deferred.add(tool.namespacedName);
 				}
-			},
-		}));
+			}
+		}
+		const clientNames = this._parseToolSearchNames(clientResult.textResultForLlm);
+		const toolReferences = clientNames.filter(name => deferred.has(name));
+		this._logService.info(`[Copilot:${this.sessionId}] tool_search override: availableTools=${availableTools?.length ?? 0}, deferred=${deferred.size}, clientMatched=[${clientNames.join(', ')}] -> toolReferences=[${toolReferences.join(', ')}]`);
+		return { ...clientResult, toolReferences };
+	}
+
+	private _parseToolSearchNames(text: string): string[] {
+		try {
+			const parsed = JSON.parse(text);
+			return Array.isArray(parsed) ? parsed.filter((name): name is string => typeof name === 'string') : [];
+		} catch {
+			return [];
+		}
 	}
 
 	/**
@@ -2129,7 +2250,7 @@ export class CopilotAgentSession extends Disposable {
 
 			if (request.kind === 'custom-tool'
 				&& typeof request.toolName === 'string'
-				&& this._clientToolNames.has(request.toolName)
+				&& this._clientToolNames.has(this._clientToolName(request.toolName))
 				&& this._pendingClientToolCalls.hasBufferedResult(toolCallId)
 			) {
 				this._logService.info(`[Copilot:${this.sessionId}] Auto-approving client tool ${request.toolName} because its result arrived before the permission request`);
@@ -3139,8 +3260,9 @@ export class CopilotAgentSession extends Disposable {
 			const subagentMeta = toolKind === 'subagent' ? getSubagentMetadata(parameters) : undefined;
 
 			let contributor: { readonly kind: ToolCallContributorKind.Client; readonly clientId: string } | { readonly kind: ToolCallContributorKind.MCP; readonly customizationId: string } | undefined;
-			const isClientTool = this._clientToolNames.has(e.data.toolName);
-			const ownerClientId = isClientTool ? this._activeClientToolSet.ownerOf(e.data.toolName, this._currentTurn?.senderClientId) : undefined;
+			const clientToolName = this._clientToolName(e.data.toolName);
+			const isClientTool = this._clientToolNames.has(clientToolName);
+			const ownerClientId = isClientTool ? this._activeClientToolSet.ownerOf(clientToolName, this._currentTurn?.senderClientId) : undefined;
 			if (ownerClientId) {
 				contributor = { kind: ToolCallContributorKind.Client, clientId: ownerClientId };
 			} else if (e.data.mcpServerName) {
@@ -3197,6 +3319,9 @@ export class CopilotAgentSession extends Disposable {
 				contributor,
 				_meta: toToolCallMeta(meta),
 			}, parentToolCallId);
+			if (e.data.toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME && clientToolName === CLIENT_TOOL_SEARCH_REFERENCE_NAME) {
+				this._pendingClientToolStarts.respondOrBuffer(e.data.toolCallId, true);
+			}
 
 			// No client is connected to run this client tool. Fail it
 			// immediately instead of leaving it pending until the

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { CopilotSession, CurrentToolMetadata, ExitPlanModeRequest, McpServersLoadedServer, MessageOptions, PermissionAllowAllMode, PermissionAutoApproval, PermissionRequestResult, SessionConfig, Tool, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
-import { DeferredPromise, raceTimeout, Sequencer } from '../../../../base/common/async.js';
+import { DeferredPromise, Sequencer } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { CancellationError, getErrorMessage } from '../../../../base/common/errors.js';
@@ -1100,14 +1100,10 @@ export class CopilotAgentSession extends Disposable {
 					handler: async (_args: Record<string, unknown>, invocation) => {
 						try {
 							const candidates = this._toToolSearchCandidates(invocation.availableTools);
-							const clientResult = await raceTimeout(
-								this._pendingClientToolCalls.registerAndFire(invocation.toolCallId, () => this._emitToolSearchReady(invocation.toolCallId, candidates)),
-								15_000,
-								() => this._pendingClientToolCalls.respond(invocation.toolCallId, this._toolSearchFailure('Timed out waiting for client-side tool search.')),
+							const clientResult = await this._pendingClientToolCalls.registerAndFire(
+								invocation.toolCallId,
+								() => this._emitToolSearchReady(invocation.toolCallId, candidates),
 							);
-							if (!clientResult) {
-								return this._toolSearchFailure('Timed out waiting for client-side tool search.');
-							}
 							return this._toToolSearchResult(clientResult, invocation.availableTools);
 						} catch (error) {
 							this._logService.error(error, `[Copilot:${this.sessionId}] Failed in tool-search handler: toolCallId=${invocation.toolCallId}`);

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -606,7 +606,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			skillDirectories,
 			instructionDirectories,
 			systemMessage,
-			...(toolSearchActive ? { toolSearch: { enabled: true, deferThreshold: 1 } } : {}),
+toolSearch: toolSearchActive ? { enabled: true, deferThreshold: 1 } : { enabled: false }
 			pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
 				.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),
 			tools: [...shellTools, ...runtime.createClientSdkTools(), ...runtime.createServerSdkTools()],

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -557,8 +557,15 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		const instructionDirectories = toSdkInstructionDirectories(plugins.flatMap(p => p.instructions));
 		const model = plan.kind === 'create' ? plan.model : plan.fallback.model;
 		const clientToolNames = clientToolNamesFromSnapshot(plan.snapshot);
+		// Prompt routing and capability decisions use the family-aliased
+		// selection; the wire model id in _createSession comes from plan.model
+		// and is unaffected.
+		const effectiveModel = applyModelFamilyAlias(model, this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.ModelCapabilityOverrides));
+		if (model && effectiveModel !== model) {
+			this._logService.info(`[Copilot:${plan.sessionId}] Model capability override: routing prompt for '${model.id}' as family '${effectiveModel?.id}'`);
+		}
 		const toolSearchActive = this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.ToolSearchEnabled) === true
-			&& agentHostModelSupportsToolSearch(model?.id)
+			&& agentHostModelSupportsToolSearch(effectiveModel?.id)
 			&& clientToolNames.has(CLIENT_TOOL_SEARCH_REFERENCE_NAME);
 		const promptContext: IAgentHostPromptContext = {
 			getSetting: key => this._configurationService.getRootValue(copilotCliConfigSchema, key),
@@ -566,12 +573,6 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			workspaceless: plan.workspaceless === true,
 			toolSearchActive,
 		};
-		// Prompt routing uses the family-aliased selection; the wire model id in
-		// _createSession comes from plan.model and is unaffected.
-		const effectiveModel = applyModelFamilyAlias(model, this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.ModelCapabilityOverrides));
-		if (model && effectiveModel !== model) {
-			this._logService.info(`[Copilot:${plan.sessionId}] Model capability override: routing prompt for '${model.id}' as family '${effectiveModel?.id}'`);
-		}
 		// Resolved once per (re)launch — the SDK has no mid-session system-message
 		// update, so this reflects the model/tools/settings at launch time. Log a
 		// summary at info for prompt observability; the full config at trace.

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -10,6 +10,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { IFileService } from '../../../files/common/files.js';
 import { ILogService, LogLevel } from '../../../log/common/log.js';
 import { CopilotCliConfigKey, applyModelFamilyAlias, copilotCliConfigSchema } from '../../common/copilotCliConfig.js';
+import { agentHostModelSupportsToolSearch, CLIENT_TOOL_SEARCH_REFERENCE_NAME } from './toolSearchDeferral.js';
 import { AgentHostSessionSyncEnabledConfigKey, platformRootSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
@@ -555,13 +556,15 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		const skillDirectories = toSdkSkillDirectories(pluginsWithoutDirs.flatMap(p => p.skills));
 		const instructionDirectories = toSdkInstructionDirectories(plugins.flatMap(p => p.instructions));
 		const model = plan.kind === 'create' ? plan.model : plan.fallback.model;
-		// Client tools (browser tools, tasks, etc.) are addressed by the name the
-		// agent sees them under; used to gate tool-specific prompt sections.
 		const clientToolNames = clientToolNamesFromSnapshot(plan.snapshot);
+		const toolSearchActive = this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.ToolSearchEnabled) === true
+			&& agentHostModelSupportsToolSearch(model?.id)
+			&& clientToolNames.has(CLIENT_TOOL_SEARCH_REFERENCE_NAME);
 		const promptContext: IAgentHostPromptContext = {
 			getSetting: key => this._configurationService.getRootValue(copilotCliConfigSchema, key),
 			hasClientTool: name => clientToolNames.has(name),
 			workspaceless: plan.workspaceless === true,
+			toolSearchActive,
 		};
 		// Prompt routing uses the family-aliased selection; the wire model id in
 		// _createSession comes from plan.model and is unaffected.
@@ -602,6 +605,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			skillDirectories,
 			instructionDirectories,
 			systemMessage,
+			...(toolSearchActive ? { toolSearch: { enabled: true, deferThreshold: 1 } } : {}),
 			pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
 				.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),
 			tools: [...shellTools, ...runtime.createClientSdkTools(), ...runtime.createServerSdkTools()],

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -606,7 +606,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			skillDirectories,
 			instructionDirectories,
 			systemMessage,
-toolSearch: toolSearchActive ? { enabled: true, deferThreshold: 1 } : { enabled: false }
+			toolSearch: toolSearchActive ? { enabled: true, deferThreshold: 1 } : { enabled: false },
 			pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
 				.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),
 			tools: [...shellTools, ...runtime.createClientSdkTools(), ...runtime.createServerSdkTools()],

--- a/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
+++ b/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
@@ -73,6 +73,42 @@ default client-tool allowlist is `chat.agentHost.clientTools` (see
 These lines compose with a per-model `tool_instructions` override (see
 `composeToolInstructions`), so Lever 1 and Lever 2 stack.
 
+## Tool search (deferred tool loading)
+
+When `chat.agentHost.copilot.toolSearch.enabled` is on AND the session's model
+supports it (`agentHostModelSupportsToolSearch`), the launcher sets
+`toolSearch: { enabled: true, deferThreshold: 1 }` and the session defers MCP +
+non-core client tools behind the runtime's `tool_search_tool`:
+
+- **The override** (`copilotAgentSession._createClientSdkTools`): the client's
+  forwarded `toolSearch` tool is registered as `tool_search_tool` with
+  `overridesBuiltInTool: true` and `defer: 'never'`, so the runtime routes the
+  model's search to the client's semantic search. The SDK supplies the runtime's
+  live deferred-tool metadata to the override handler; Agent Host carries that
+  corpus as transient tool-call metadata and injects it only into the local
+  `toolSearch` invocation, so embeddings rank the runtime/MCP tools rather than
+  the extension's registry. The corpus is never added to model-facing tool input.
+  Every other client tool gets
+  `defer: 'never'` if it is in `NON_DEFERRED_CLIENT_TOOL_NAMES`
+  (`runTests`, `rename`, `usages`), else `defer: 'auto'`. Built-in runtime tools
+  are never deferred. The renderer (`agentHostSessionHandler._setupClientToolCall`)
+  maps `tool_search_tool` back to `toolSearch` to execute the real VS Code tool.
+- **The prompt** (this folder): `toolSearchInstructionLines(toolSearchActive)`
+  adds a `tool_instructions` line (`toolSearchToolInstructions`) telling the
+  model to load deferred tools via `tool_search_tool` first — gated on
+  `context.toolSearchActive` because the `toolSearch` tool is *always* forwarded,
+  so presence alone can't gate it. The runtime already emits its own
+  deferred-tools reminder (`build_deferred_tools_user_message`) with the accurate
+  deferred set, so this layer intentionally does NOT re-list the deferred tools.
+
+The two identity/count levers are independent: `deferThreshold` is a total
+tool-count gate (1 ⇒ always active), while each tool's `defer` flag decides
+whether *that* tool is deferred.
+
+This B-inject bridge is intentionally interim. A follow-up moves tool-search
+registration and ranking into VS Code core so Agent Host no longer depends on
+the Copilot extension's tool implementation or embeddings plumbing.
+
 ## Lever 2 — per-model contributor (`promptRegistry.ts` + `allPrompts.ts`)
 
 Guidance scoped to a model or family. Implement `IAgentHostPrompt` and register

--- a/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
@@ -8,7 +8,7 @@ import { copilotCliConfigSchema } from '../../../common/copilotCliConfig.js';
 import type { SchemaValue } from '../../../common/agentHostSchema.js';
 import type { ModelSelection } from '../../../common/state/protocol/state.js';
 import { appendSystemMessageContent, COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS, COPILOT_AGENT_HOST_WORKSPACELESS_INSTRUCTIONS, COPILOT_AGENT_HOST_SYSTEM_MESSAGE, fullSystemPrompt, sectionOverrides } from './systemMessage.js';
-import { resolveToolInstructionsOverride } from './toolInstructions.js';
+import { resolveToolInstructionsOverride, toolSearchInstructionLines } from './toolInstructions.js';
 
 type CopilotCliConfigDefinition = typeof copilotCliConfigSchema.definition;
 
@@ -43,6 +43,9 @@ export interface IAgentHostPromptContext {
 	 * is the context-enrichment follow-up.
 	 */
 	hasClientTool(name: string): boolean;
+
+	/** Whether deferred tool search is active for this session. */
+	toolSearchActive: boolean;
 
 	/**
 	 * Whether this is a workspace-less session. When `true`, the
@@ -205,7 +208,7 @@ export class AgentHostPromptRegistry {
 		if (config.mode !== 'customize') {
 			return config;
 		}
-		const toolInstructions = resolveToolInstructionsOverride(name => context.hasClientTool(name), config.sections?.tool_instructions);
+		const toolInstructions = resolveToolInstructionsOverride(name => context.hasClientTool(name), config.sections?.tool_instructions, toolSearchInstructionLines(context.toolSearchActive));
 		if (!toolInstructions) {
 			return config;
 		}

--- a/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
@@ -6,6 +6,7 @@
 import type { SectionOverride } from '@github/copilot-sdk';
 import { coalesce } from '../../../../../base/common/arrays.js';
 import { BrowserChatToolReferenceName, browserChatToolReferenceNames } from '../../../../browserView/common/browserChatToolReferenceNames.js';
+import { CLIENT_TOOL_SEARCH_REFERENCE_NAME, RUNTIME_TOOL_SEARCH_TOOL_NAME } from '../../../common/toolSearchConstants.js';
 
 /**
  * Model-agnostic guidance for the `tool_instructions` system-prompt section.
@@ -64,6 +65,16 @@ const browserToolInstructions: ToolInstructionLine = hasTool => {
  * guidance here.
  */
 const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [browserToolInstructions];
+
+/** Tool-search guidance mirrored from the Copilot extension prompt. */
+const toolSearchToolInstructions: ToolInstructionLine = hasTool =>
+	hasTool(CLIENT_TOOL_SEARCH_REFERENCE_NAME)
+		? `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS call \`${RUNTIME_TOOL_SEARCH_TOOL_NAME}\` first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`
+		: undefined;
+
+export function toolSearchInstructionLines(toolSearchActive: boolean): readonly ToolInstructionLine[] {
+	return toolSearchActive ? [...TOOL_INSTRUCTION_LINES, toolSearchToolInstructions] : TOOL_INSTRUCTION_LINES;
+}
 
 /**
  * Composes the applicable `lines` into a single block (one line each), or

--- a/src/vs/platform/agentHost/node/copilot/toolSearchDeferral.ts
+++ b/src/vs/platform/agentHost/node/copilot/toolSearchDeferral.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export { CLIENT_TOOL_SEARCH_REFERENCE_NAME, RUNTIME_TOOL_SEARCH_TOOL_NAME } from '../../common/toolSearchConstants.js';
+
+/**
+ * Non-deferred client tools, mirroring the Copilot extension allowlist entries
+ * that are actually forwarded to Agent Host.
+ */
+export const NON_DEFERRED_CLIENT_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
+	'runTests',
+	'rename',
+	'usages',
+]);
+
+/** Mirrors the Copilot extension's string-form `modelSupportsToolSearch`. */
+export function agentHostModelSupportsToolSearch(modelId: string | undefined): boolean {
+	if (!modelId) {
+		return false;
+	}
+	const id = modelId.toLowerCase();
+	const normalizedId = id.replace(/\./g, '-');
+	const isGpt56 = id === 'gpt-5.6-sol' || id === 'gpt-5.6-terra' || id === 'gpt-5.6-luna';
+	if (normalizedId === 'gpt-5-4' || normalizedId === 'gpt-5-5' || isGpt56) {
+		return true;
+	}
+	if (!normalizedId.startsWith('claude') || normalizedId.startsWith('claude-haiku')) {
+		return false;
+	}
+	const isPre45 =
+		normalizedId.startsWith('claude-1') ||
+		normalizedId.startsWith('claude-2') ||
+		normalizedId.startsWith('claude-3') ||
+		normalizedId.startsWith('claude-instant') ||
+		normalizedId === 'claude-sonnet-4' || normalizedId.startsWith('claude-sonnet-4-2') ||
+		normalizedId === 'claude-opus-4' || normalizedId.startsWith('claude-opus-4-1') || normalizedId.startsWith('claude-opus-4-2');
+	return !isPre45;
+}

--- a/src/vs/platform/agentHost/node/copilot/toolSearchDeferral.ts
+++ b/src/vs/platform/agentHost/node/copilot/toolSearchDeferral.ts
@@ -22,10 +22,11 @@ export function agentHostModelSupportsToolSearch(modelId: string | undefined): b
 	}
 	const id = modelId.toLowerCase();
 	const normalizedId = id.replace(/\./g, '-');
-	const isGpt56 = id === 'gpt-5.6-sol' || id === 'gpt-5.6-terra' || id === 'gpt-5.6-luna';
-	if (normalizedId === 'gpt-5-4' || normalizedId === 'gpt-5-5' || isGpt56) {
-		return true;
-	}
+	// Disabled due to an SDK issue with the GPT tool search tool.
+	// const isGpt56 = id === 'gpt-5.6-sol' || id === 'gpt-5.6-terra' || id === 'gpt-5.6-luna';
+	// if (normalizedId === 'gpt-5-4' || normalizedId === 'gpt-5-5' || isGpt56) {
+	// 	return true;
+	// }
 	if (!normalizedId.startsWith('claude') || normalizedId.startsWith('claude-haiku')) {
 		return false;
 	}

--- a/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
@@ -71,6 +71,13 @@ suite('Agent host _meta readers', () => {
 			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolArguments: undefined })), {});
 		});
 
+		test('reads valid tool-search candidates and drops malformed corpora', () => {
+			const candidates = [{ name: 'everything-get-sum', description: 'Adds numbers', inputSchema: { type: 'object' } }];
+			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolSearchCandidates: candidates })), { toolSearchCandidates: candidates });
+			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolSearchCandidates: [{ name: 1, description: 'bad' }] })), {});
+			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolSearchCandidates: 'bad' })), {});
+		});
+
 		test('toToolCallMeta round-trips and returns undefined when empty', () => {
 			assert.strictEqual(toToolCallMeta({}), undefined);
 			const wire = toToolCallMeta({ toolKind: 'search', language: undefined });

--- a/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
@@ -72,7 +72,7 @@ suite('Agent host _meta readers', () => {
 		});
 
 		test('reads valid tool-search candidates and drops malformed corpora', () => {
-			const candidates = [{ name: 'everything-get-sum', description: 'Adds numbers', inputSchema: { type: 'object' } }];
+			const candidates = [{ name: 'everything-get-sum', description: 'Adds numbers' }];
 			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolSearchCandidates: candidates })), { toolSearchCandidates: candidates });
 			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolSearchCandidates: [{ name: 1, description: 'bad' }] })), {});
 			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolSearchCandidates: 'bad' })), {});

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -11,6 +11,7 @@ import type { ModelSelection } from '../../common/state/protocol/state.js';
 import { AgentHostPromptRegistry, agentHostPromptRegistry, type IAgentHostPromptContext } from '../../node/copilot/prompts/promptRegistry.js';
 import { COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS, COPILOT_AGENT_HOST_WORKSPACELESS_INSTRUCTIONS, COPILOT_AGENT_HOST_SYSTEM_MESSAGE } from '../../node/copilot/prompts/systemMessage.js';
 import { BrowserChatToolReferenceName } from '../../../browserView/common/browserChatToolReferenceNames.js';
+import { CLIENT_TOOL_SEARCH_REFERENCE_NAME, RUNTIME_TOOL_SEARCH_TOOL_NAME } from '../../common/toolSearchConstants.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import '../../node/copilot/prompts/allPrompts.js';
 
@@ -258,6 +259,58 @@ suite('AgentHostPromptRegistry', () => {
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({}, ['anyTool'])),
 				withFileLinkInstructions({ mode: 'customize', sections: { tool_instructions: { action: 'append', content: 'Always prefer ripgrep.' } } })
+			);
+		});
+	});
+
+	suite('tool search instructions wiring', () => {
+		// End-to-end guard that the registry layers the tool-search line only
+		// when `toolSearchActive` AND the client tool-search tool are both
+		// present; the composition/gating itself is covered in
+		// toolInstructions.test.ts.
+		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS call \`${RUNTIME_TOOL_SEARCH_TOOL_NAME}\` first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`;
+
+		test('layers the tool-search line onto the default config when active and the tool-search tool is present', () => {
+			const registry = new AgentHostPromptRegistry();
+			assert.deepStrictEqual(
+				registry.resolveSystemMessageConfig({ id: 'm' }, context({}, [CLIENT_TOOL_SEARCH_REFERENCE_NAME], false, true)),
+				withFileLinkInstructions({
+					mode: 'customize',
+					sections: {
+						identity: COPILOT_AGENT_HOST_SYSTEM_MESSAGE.sections.identity,
+						tool_instructions: { action: 'append', content: `\n${TOOL_SEARCH_LINE}` },
+					},
+				})
+			);
+		});
+
+		test('is a no-op when tool search is inactive even if the tool-search tool is present', () => {
+			const registry = new AgentHostPromptRegistry();
+			assert.deepStrictEqual(
+				registry.resolveSystemMessageConfig({ id: 'm' }, context({}, [CLIENT_TOOL_SEARCH_REFERENCE_NAME], false, false)),
+				withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
+			);
+		});
+
+		test('is a no-op when active but the client does not expose the tool-search tool', () => {
+			const registry = new AgentHostPromptRegistry();
+			assert.deepStrictEqual(
+				registry.resolveSystemMessageConfig({ id: 'm' }, context({}, ['anyTool'], false, true)),
+				withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
+			);
+		});
+
+		test('composes the tool-search line with a per-model tool_instructions override', () => {
+			const registry = new AgentHostPromptRegistry();
+			registry.registerPrompt(class {
+				static readonly familyPrefixes = ['claude'];
+				resolveSectionOverrides(): Partial<Record<SystemMessageSection, SectionOverride>> {
+					return { tool_instructions: { action: 'append', content: 'Always prefer ripgrep.' } };
+				}
+			});
+			assert.deepStrictEqual(
+				registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({}, [CLIENT_TOOL_SEARCH_REFERENCE_NAME], false, true)),
+				withFileLinkInstructions({ mode: 'customize', sections: { tool_instructions: { action: 'append', content: `\nAlways prefer ripgrep.\n${TOOL_SEARCH_LINE}` } } })
 			);
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -18,12 +18,13 @@ import '../../node/copilot/prompts/allPrompts.js';
  * Builds a prompt context backed by an in-memory bag of customization settings
  * and an optional set of available tool names.
  */
-function context(settings: SchemaValues<typeof copilotCliConfigSchema.definition> = {}, tools: readonly string[] = [], workspaceless = false): IAgentHostPromptContext {
+function context(settings: SchemaValues<typeof copilotCliConfigSchema.definition> = {}, tools: readonly string[] = [], workspaceless = false, toolSearchActive = false): IAgentHostPromptContext {
 	const toolNames = new Set(tools);
 	return {
 		getSetting: key => settings[key],
 		hasClientTool: name => toolNames.has(name),
 		workspaceless,
+		toolSearchActive,
 	};
 }
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -5458,6 +5458,10 @@ suite('CopilotAgentSession', () => {
 
 			const tools = runtime.createServerSdkTools();
 			assert.deepStrictEqual(tools.map(t => t.name).sort(), [...serverToolHost.toolNames].sort());
+			// Server tools are always-available internal tools; they must be
+			// eager (`defer: 'never'`) so tool search never hides them behind
+			// `tool_search_tool`.
+			assert.deepStrictEqual(tools.map(t => t.defer), tools.map(() => 'never'));
 		});
 
 		test('server tool handler routes to the host and returns a success result', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type Anthropic from '@anthropic-ai/sdk';
-import type { CopilotSession, PermissionAllowAllMode, SessionEvent, SessionEventHandler, SessionEventPayload, SessionEventType, Tool, ToolResultObject, TypedSessionEventHandler } from '@github/copilot-sdk';
+import type { CopilotSession, CurrentToolMetadata, PermissionAllowAllMode, SessionEvent, SessionEventHandler, SessionEventPayload, SessionEventType, Tool, ToolResultObject, TypedSessionEventHandler } from '@github/copilot-sdk';
 import type { CCAModel } from '@vscode/copilot-api';
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
@@ -294,12 +294,13 @@ class CapturingLogService extends NullLogService {
  * {@link ToolResultObject} — which is what {@link CopilotAgentSession}'s
  * handler implementation actually returns.
  */
-function invokeClientToolHandler(tool: Pick<Tool, 'name' | 'handler'>, toolCallId: string, args: Record<string, unknown> = {}): Promise<ToolResultObject> {
+function invokeClientToolHandler(tool: Pick<Tool, 'name' | 'handler'>, toolCallId: string, args: Record<string, unknown> = {}, availableTools?: CurrentToolMetadata[]): Promise<ToolResultObject> {
 	return Promise.resolve(tool.handler!(args, {
 		sessionId: 'test-session-1',
 		toolCallId,
 		toolName: tool.name,
 		arguments: args,
+		availableTools,
 	})) as Promise<ToolResultObject>;
 }
 
@@ -365,6 +366,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	restrictedTelemetryContext?: IRestrictedTelemetryContext;
 	restrictedTelemetryContextError?: Error;
 	isLaunchTokenCurrent?: () => boolean;
+	modelId?: string;
 }): Promise<{
 	session: CopilotAgentSession;
 	runtime: ICopilotSessionRuntime;
@@ -422,7 +424,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 		snapshot: options?.clientSnapshot ?? { tools: [], plugins: [], mcpServers: {} },
 		shellManager: undefined,
 		githubToken: options?.githubToken,
-		model: undefined,
+		model: options?.modelId ? { id: options.modelId } : undefined,
 	};
 	let launchedRuntime: ICopilotSessionRuntime | undefined;
 	const sessionLauncher: ICopilotSessionLauncher = {
@@ -4876,6 +4878,84 @@ suite('CopilotAgentSession', () => {
 					},
 				},
 			});
+		});
+
+		test('tool-search override routes to the client and injects deferred candidates', async () => {
+			const toolSearchSnapshot: IActiveClientSnapshot = {
+				tools: [{ name: 'toolSearch', description: 'Search tools', inputSchema: { type: 'object', properties: { query: { type: 'string' } } } }],
+				plugins: [],
+				mcpServers: {},
+			};
+			const activeClientToolSet = new ActiveClientToolSet();
+			activeClientToolSet.set('tool-search-client', toolSearchSnapshot.tools);
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, {
+				clientSnapshot: toolSearchSnapshot,
+				activeClientToolSet,
+				modelId: 'claude-opus-4.8',
+				rootValues: { [CopilotCliConfigKey.ToolSearchEnabled]: true },
+			});
+
+			const [override] = runtime.createClientSdkTools();
+			assert.strictEqual(override.name, 'tool_search_tool');
+			assert.strictEqual(override.overridesBuiltInTool, true);
+			assert.strictEqual(override.defer, 'never');
+			assert.strictEqual(override.skipPermission, true);
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-tool-search',
+				toolName: 'tool_search_tool',
+				arguments: { query: 'add numbers' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			const start = signals.find(s => isAction(s, ActionType.ChatToolCallStart));
+			assert.ok(start && isAction(start, ActionType.ChatToolCallStart));
+			assert.deepStrictEqual((start.action as ChatToolCallStartAction).contributor, { kind: ToolCallContributorKind.Client, clientId: 'tool-search-client' });
+
+			const handlerPromise = invokeClientToolHandler(override, 'tc-tool-search', { query: 'add numbers' }, [
+				{ name: 'everything-get-sum', description: 'Adds numbers', deferLoading: true },
+				{ name: 'read_file', description: 'Reads a file', deferLoading: false },
+			]);
+
+			const readySignal = await waitForSignal(s => isAction(s, ActionType.ChatToolCallReady));
+			assert.ok(isAction(readySignal, ActionType.ChatToolCallReady));
+			const ready = readySignal.action as ChatToolCallReadyAction;
+			assert.strictEqual(ready.confirmed, ToolCallConfirmationReason.NotNeeded);
+			assert.deepStrictEqual(ready._meta?.['toolSearchCandidates'], [{ name: 'everything-get-sum', description: 'Adds numbers' }]);
+
+			session.handleClientToolCallComplete('tc-tool-search', {
+				success: true,
+				pastTenseMessage: 'Searched tools',
+				content: [{ type: ToolResultContentType.Text, text: '["everything-get-sum"]' }],
+			});
+
+			const result = await handlerPromise;
+			assert.strictEqual(result.resultType, 'success');
+			assert.deepStrictEqual(result.toolReferences, ['everything-get-sum']);
+		});
+
+		test('toolSearch is omitted when the flag is off or the model is unsupported', async () => {
+			const toolSearchSnapshot: IActiveClientSnapshot = {
+				tools: [
+					{ name: 'toolSearch', description: 'Search tools', inputSchema: { type: 'object', properties: {} } },
+					{ name: 'my_tool', description: 'Regular tool', inputSchema: { type: 'object', properties: {} } },
+				],
+				plugins: [],
+				mcpServers: {},
+			};
+
+			const flagOff = await createAgentSession(disposables, {
+				clientSnapshot: toolSearchSnapshot,
+				modelId: 'claude-opus-4.8',
+				rootValues: { [CopilotCliConfigKey.ToolSearchEnabled]: false },
+			});
+			assert.deepStrictEqual(flagOff.runtime.createClientSdkTools().map(tool => tool.name), ['my_tool']);
+
+			const unsupported = await createAgentSession(disposables, {
+				clientSnapshot: toolSearchSnapshot,
+				modelId: 'claude-haiku-4.5',
+				rootValues: { [CopilotCliConfigKey.ToolSearchEnabled]: true },
+			});
+			assert.deepStrictEqual(unsupported.runtime.createClientSdkTools().map(tool => tool.name), ['my_tool']);
 		});
 
 		test('agent-coordination client tools auto-ready with a tailored invocation message', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -4958,6 +4958,37 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual(unsupported.runtime.createClientSdkTools().map(tool => tool.name), ['my_tool']);
 		});
 
+		test('toolSearch honors a model-family alias so an aliased preview model is treated as supported', async () => {
+			const toolSearchSnapshot: IActiveClientSnapshot = {
+				tools: [
+					{ name: 'toolSearch', description: 'Search tools', inputSchema: { type: 'object', properties: {} } },
+					{ name: 'my_tool', description: 'Regular tool', inputSchema: { type: 'object', properties: {} } },
+				],
+				plugins: [],
+				mcpServers: {},
+			};
+
+			// The raw preview id is unsupported on its own, so tool search stays off.
+			const withoutAlias = await createAgentSession(disposables, {
+				clientSnapshot: toolSearchSnapshot,
+				modelId: 'preview-model-x',
+				rootValues: { [CopilotCliConfigKey.ToolSearchEnabled]: true },
+			});
+			assert.deepStrictEqual(withoutAlias.runtime.createClientSdkTools().map(tool => tool.name), ['my_tool']);
+
+			// Aliasing it to a tool-search-capable family enables tool search, matching
+			// the prompt/capability routing the launcher applies from the same override.
+			const withAlias = await createAgentSession(disposables, {
+				clientSnapshot: toolSearchSnapshot,
+				modelId: 'preview-model-x',
+				rootValues: {
+					[CopilotCliConfigKey.ToolSearchEnabled]: true,
+					[CopilotCliConfigKey.ModelCapabilityOverrides]: { 'preview-model-x': { family: 'claude-opus-4.8' } },
+				},
+			});
+			assert.deepStrictEqual(withAlias.runtime.createClientSdkTools().map(tool => tool.name), ['tool_search_tool', 'my_tool']);
+		});
+
 		test('agent-coordination client tools auto-ready with a tailored invocation message', async () => {
 			const agentSnapshot: IActiveClientSnapshot = {
 				tools: [{ name: 'list_agents', description: 'List agents', inputSchema: { type: 'object', properties: {} } }],

--- a/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
@@ -5,7 +5,8 @@
 
 import assert from 'assert';
 import type { SectionOverride } from '@github/copilot-sdk';
-import { resolveToolInstructionsOverride, universalToolInstructions } from '../../node/copilot/prompts/toolInstructions.js';
+import { resolveToolInstructionsOverride, toolSearchInstructionLines, universalToolInstructions } from '../../node/copilot/prompts/toolInstructions.js';
+import { CLIENT_TOOL_SEARCH_REFERENCE_NAME, RUNTIME_TOOL_SEARCH_TOOL_NAME } from '../../common/toolSearchConstants.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 /** Builds a `hasTool` predicate backed by the given available tool names. */
@@ -80,6 +81,43 @@ suite('toolInstructions', () => {
 			const transform = (s: string) => s;
 			assert.deepStrictEqual(resolveToolInstructionsOverride(hasTools('a'), { action: 'remove' }, [lineFor('a')]), { action: 'remove' });
 			assert.deepStrictEqual(resolveToolInstructionsOverride(hasTools('a'), { action: transform }, [lineFor('a')]), { action: transform });
+		});
+	});
+
+	// The tool-search line is the model-facing instruction gated on BOTH
+	// `toolSearchActive` (via `toolSearchInstructionLines`) and the client
+	// exposing the tool-search tool. These lock its content, gating, and
+	// composition so neither the instruction nor its gate can silently regress.
+	suite('toolSearchInstructionLines', () => {
+		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS call \`${RUNTIME_TOOL_SEARCH_TOOL_NAME}\` first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`;
+
+		test('active tool search contributes the tool-search line only when the client exposes the tool-search tool', () => {
+			assert.strictEqual(universalToolInstructions(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(true)), TOOL_SEARCH_LINE);
+			// Active, but the client didn't expose the tool-search tool → gated out.
+			assert.strictEqual(universalToolInstructions(hasTools('other'), toolSearchInstructionLines(true)), undefined);
+		});
+
+		test('inactive tool search never contributes the tool-search line', () => {
+			assert.strictEqual(universalToolInstructions(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(false)), undefined);
+		});
+
+		test('composes the tool-search line after the registered browser line', () => {
+			assert.strictEqual(
+				universalToolInstructions(hasTools('openBrowserPage', 'readPage', CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(true)),
+				`Use the browser tools (openBrowserPage, readPage, etc.) when beneficial for front-end tasks, such as when visualizing or validating UI changes.\n${TOOL_SEARCH_LINE}`
+			);
+		});
+
+		test('folds the tool-search line into an existing per-model override only while active', () => {
+			assert.deepStrictEqual(
+				resolveToolInstructionsOverride(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), { action: 'append', content: 'A' }, toolSearchInstructionLines(true)),
+				{ action: 'append', content: `\nA\n${TOOL_SEARCH_LINE}` }
+			);
+			// Inactive with no other applicable line → keep the existing override (undefined).
+			assert.strictEqual(
+				resolveToolInstructionsOverride(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), { action: 'append', content: 'A' }, toolSearchInstructionLines(false)),
+				undefined
+			);
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/toolSearchDeferral.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolSearchDeferral.test.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { agentHostModelSupportsToolSearch, NON_DEFERRED_CLIENT_TOOL_NAMES } from '../../node/copilot/toolSearchDeferral.js';
+import { CLIENT_TOOL_SEARCH_REFERENCE_NAME, RUNTIME_TOOL_SEARCH_TOOL_NAME } from '../../common/toolSearchConstants.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+
+suite('toolSearchDeferral', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('agentHostModelSupportsToolSearch', () => {
+		test('supports Claude Sonnet/Opus 4.5 and up, including future families', () => {
+			for (const id of [
+				'claude-sonnet-4-5', 'claude-sonnet-4.5', 'claude-sonnet-4-5-20250929',
+				'claude-sonnet-4-6', 'claude-sonnet-4.6', 'claude-sonnet-4-6@1.0.0',
+				'claude-opus-4-5', 'claude-opus-4.5', 'claude-opus-4-5-20251101',
+				'claude-opus-4-6', 'claude-opus-4.6', 'claude-opus-4.7',
+				'claude-opus-4-7@1.0.0', 'claude-opus-4-8', 'claude-opus-4.8', 'claude-opus-5',
+				'claude-future-version',
+			]) {
+				assert.strictEqual(agentHostModelSupportsToolSearch(id), true, id);
+			}
+		});
+
+		test('rejects pre-4.5 models, including date-suffixed ones', () => {
+			for (const id of [
+				'claude-sonnet-4-20250514', 'claude-sonnet-4',
+				'claude-opus-4', 'claude-opus-4-20250514',
+				'claude-opus-4-1', 'claude-opus-4.1', 'claude-opus-4-1-20250805',
+			]) {
+				assert.strictEqual(agentHostModelSupportsToolSearch(id), false, id);
+			}
+		});
+
+		test('rejects Haiku and legacy Claude families', () => {
+			for (const id of ['claude-haiku-4-5', 'claude-haiku-4.5', 'claude-3-5-sonnet-20241022', 'claude-3-opus']) {
+				assert.strictEqual(agentHostModelSupportsToolSearch(id), false, id);
+			}
+		});
+
+		test('supports the same OpenAI model families as the extension', () => {
+			for (const id of ['gpt-5.4', 'gpt-5.5', 'gpt-5-4', 'gpt-5-5', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+				assert.strictEqual(agentHostModelSupportsToolSearch(id), true, id);
+			}
+		});
+
+		test('rejects suffixed GPT variants and other non-Claude models', () => {
+			for (const id of ['gpt-5', 'gpt-5.3', 'gpt-5.4-mini', 'gpt-5.4-preview', 'gpt-5.5-preview', 'gpt5.5-preview', 'gpt-5-6-luna', 'gpt-6', 'gemini-2.5-pro', '']) {
+				assert.strictEqual(agentHostModelSupportsToolSearch(id), false, id);
+			}
+			assert.strictEqual(agentHostModelSupportsToolSearch(undefined), false);
+		});
+	});
+
+	suite('constants', () => {
+		test('runtime / client tool-search names are distinct and stable', () => {
+			assert.strictEqual(RUNTIME_TOOL_SEARCH_TOOL_NAME, 'tool_search_tool');
+			assert.strictEqual(CLIENT_TOOL_SEARCH_REFERENCE_NAME, 'toolSearch');
+			assert.notStrictEqual(RUNTIME_TOOL_SEARCH_TOOL_NAME, CLIENT_TOOL_SEARCH_REFERENCE_NAME);
+		});
+
+		test('non-deferred client allowlist holds the core VS Code tools, not the search tool', () => {
+			assert.ok(NON_DEFERRED_CLIENT_TOOL_NAMES.has('runTests'));
+			assert.ok(NON_DEFERRED_CLIENT_TOOL_NAMES.has('rename'));
+			assert.ok(NON_DEFERRED_CLIENT_TOOL_NAMES.has('usages'));
+			assert.strictEqual(NON_DEFERRED_CLIENT_TOOL_NAMES.has(CLIENT_TOOL_SEARCH_REFERENCE_NAME), false);
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/toolSearchDeferral.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolSearchDeferral.test.ts
@@ -42,9 +42,9 @@ suite('toolSearchDeferral', () => {
 			}
 		});
 
-		test('supports the same OpenAI model families as the extension', () => {
+		test('rejects OpenAI model families due to an SDK issue', () => {
 			for (const id of ['gpt-5.4', 'gpt-5.5', 'gpt-5-4', 'gpt-5-5', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
-				assert.strictEqual(agentHostModelSupportsToolSearch(id), true, id);
+				assert.strictEqual(agentHostModelSupportsToolSearch(id), false, id);
 			}
 		});
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCopilotCliSettingsContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCopilotCliSettingsContribution.ts
@@ -7,7 +7,7 @@ import { Disposable, DisposableStore } from '../../../../../../base/common/lifec
 import { isObject } from '../../../../../../base/common/types.js';
 import { IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
 import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
-import { AgentHostCopilotSdkLogLevelSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, CopilotCliConfigKey, type CopilotCliModelCapabilityOverrides, type CopilotSdkLogLevelSetting } from '../../../../../../platform/agentHost/common/copilotCliConfig.js';
+import { AgentHostCopilotSdkLogLevelSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, AgentHostToolSearchEnabledSettingId, CopilotCliConfigKey, type CopilotCliModelCapabilityOverrides, type CopilotSdkLogLevelSetting } from '../../../../../../platform/agentHost/common/copilotCliConfig.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IWorkbenchContribution } from '../../../../../../workbench/common/contributions.js';
 import { AgentHostRootConfigForwarder, type IForwardedRootConfigKey } from './agentHostRootConfigForwarder.js';
@@ -41,6 +41,11 @@ export class AgentHostCopilotCliSettingsContribution extends Disposable implemen
 				key: CopilotCliConfigKey.Opus48Prompt,
 				computeValue: () => this._configurationService.getValue<boolean>(AgentHostOpus48PromptEnabledSettingId) === true,
 				registerTriggers: (store, push) => this._pushOnSettingChange(store, push, AgentHostOpus48PromptEnabledSettingId),
+			},
+			{
+				key: CopilotCliConfigKey.ToolSearchEnabled,
+				computeValue: () => this._configurationService.getValue<boolean>(AgentHostToolSearchEnabledSettingId) === true,
+				registerTriggers: (store, push) => this._pushOnSettingChange(store, push, AgentHostToolSearchEnabledSettingId),
 			},
 			{
 				key: CopilotCliConfigKey.ReasoningEffortOverride,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -30,7 +30,7 @@ import { AgentProvider, AgentSession, CODEX_AGENT_PROVIDER_ID, type IAgentConnec
 import { agentHostAuthority } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
 import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
-import { readToolCallMeta, toToolCallMeta } from '../../../../../../platform/agentHost/common/meta/agentToolCallMeta.js';
+import { readToolCallMeta } from '../../../../../../platform/agentHost/common/meta/agentToolCallMeta.js';
 import { readCompletionAttachmentMeta } from '../../../../../../platform/agentHost/common/meta/agentCompletionAttachmentMeta.js';
 import { IRemoteAgentHostService } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
@@ -372,7 +372,7 @@ function getClientToolPreApproval(toolCall: ToolCallState): ConfirmedReason | un
  * explicit empty replacement is what actually drops the candidates.
  */
 function metaWithoutToolSearchCandidates(source: { readonly _meta?: Record<string, unknown> }): Record<string, unknown> {
-	const meta = toToolCallMeta(readToolCallMeta(source)) ?? {};
+	const meta = { ...source._meta };
 	delete meta['toolSearchCandidates'];
 	return meta;
 }
@@ -3079,6 +3079,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				parameters = parsed as Record<string, unknown>;
 			} catch {
 				this._logService.warn(`[AgentHost] Failed to parse tool input for ${toolName}`);
+				const clearedMeta = toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME
+					? metaWithoutToolSearchCandidates(tc)
+					: undefined;
 				this._dispatchAction(opts.backendSession, {
 					type: ActionType.ChatToolCallComplete,
 					turnId: opts.turnId,
@@ -3088,6 +3091,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 						pastTenseMessage: `Failed to execute ${toolName}`,
 						error: { message: `Invalid tool input for "${toolName}": expected JSON object parameters` },
 					},
+					...(clearedMeta !== undefined ? { _meta: clearedMeta } : {}),
 				}, opts.chatURI);
 				return;
 			}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -30,7 +30,7 @@ import { AgentProvider, AgentSession, CODEX_AGENT_PROVIDER_ID, type IAgentConnec
 import { agentHostAuthority } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
 import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
-import { readToolCallMeta } from '../../../../../../platform/agentHost/common/meta/agentToolCallMeta.js';
+import { readToolCallMeta, toToolCallMeta } from '../../../../../../platform/agentHost/common/meta/agentToolCallMeta.js';
 import { readCompletionAttachmentMeta } from '../../../../../../platform/agentHost/common/meta/agentCompletionAttachmentMeta.js';
 import { IRemoteAgentHostService } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
@@ -362,6 +362,19 @@ function getClientToolPreApproval(toolCall: ToolCallState): ConfirmedReason | un
 	}
 
 	return undefined;
+}
+
+/**
+ * Returns the tool call's `_meta` with the transient
+ * {@link IToolCallMeta.toolSearchCandidates} corpus removed. Always returns an
+ * object (never `undefined`) so a completion action can force-replace the prior
+ * `_meta` — the reducer keeps the existing bag when an action omits one, so an
+ * explicit empty replacement is what actually drops the candidates.
+ */
+function metaWithoutToolSearchCandidates(source: { readonly _meta?: Record<string, unknown> }): Record<string, unknown> {
+	const meta = toToolCallMeta(readToolCallMeta(source)) ?? {};
+	delete meta['toolSearchCandidates'];
+	return meta;
 }
 
 /**
@@ -2983,11 +2996,22 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			const protocolToolCall = part$.get().toolCall;
 			const isProtocolToolCallComplete = protocolToolCall.status === ToolCallStatus.Completed || protocolToolCall.status === ToolCallStatus.Cancelled;
 			if (!isProtocolToolCallComplete) {
+				// The tool-search ready action stashes the (potentially large)
+				// deferred-tool corpus in `_meta.toolSearchCandidates` purely to
+				// seed this invocation. The completion reducer keeps the prior
+				// `_meta` when the action omits one, so without an explicit
+				// replacement the corpus would persist on the completed call and
+				// across reconnects. Carry a candidate-stripped `_meta` on the
+				// tool-search completion to drop it once the search has run.
+				const clearedMeta = toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME
+					? metaWithoutToolSearchCandidates(protocolToolCall)
+					: undefined;
 				this._dispatchAction(opts.backendSession, {
 					type: ActionType.ChatToolCallComplete,
 					turnId: opts.turnId,
 					toolCallId,
 					result: toolResultToProtocol(result ?? { content: [] }, toolName),
+					...(clearedMeta !== undefined ? { _meta: clearedMeta } : {}),
 				}, opts.chatURI);
 			}
 		};

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -34,6 +34,7 @@ import { readToolCallMeta } from '../../../../../../platform/agentHost/common/me
 import { readCompletionAttachmentMeta } from '../../../../../../platform/agentHost/common/meta/agentCompletionAttachmentMeta.js';
 import { IRemoteAgentHostService } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
+import { CLIENT_TOOL_SEARCH_REFERENCE_NAME, RUNTIME_TOOL_SEARCH_TOOL_NAME } from '../../../../../../platform/agentHost/common/toolSearchConstants.js';
 import type { ChatInputRequestWithPlanReview, IAgentHostPlanReview } from '../../../../../../platform/agentHost/common/agentHostPlanReview.js';
 import { IAgentSubscription, observableFromSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { ChatTruncatedAction } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
@@ -2862,7 +2863,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			adopted.didExecuteTool(undefined);
 		}
 
-		const toolData = this._toolsService.getToolByName(toolName);
+		const clientToolName = toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME ? CLIENT_TOOL_SEARCH_REFERENCE_NAME : toolName;
+		const toolData = this._toolsService.getToolByName(clientToolName);
 		if (!toolData) {
 			this._logService.warn(`[AgentHost] Client tool call for unknown tool: ${toolName}`);
 			this._dispatchAction(opts.backendSession, {
@@ -3025,6 +3027,12 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			if (invoked || cts.token.isCancellationRequested) {
 				return;
 			}
+			const toolSearchCandidates = toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME
+				? readToolCallMeta(tc).toolSearchCandidates
+				: undefined;
+			if (toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME && toolSearchCandidates === undefined) {
+				return;
+			}
 			// eslint-disable-next-line local/code-no-in-operator
 			let toolInput = 'toolInput' in tc ? tc.toolInput : undefined;
 			if (toolInput === undefined) {
@@ -3058,6 +3066,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					},
 				}, opts.chatURI);
 				return;
+			}
+			if (toolSearchCandidates !== undefined) {
+				parameters = { ...parameters, candidateTools: toolSearchCandidates };
 			}
 
 			const inv: IToolInvocation = {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -13,7 +13,7 @@ import '../../../../platform/agentHost/common/agentHostEnablementService.js';
 import '../../../../platform/agentHost/browser/agentHostEnablementService.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId, CodexPreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
-import { AgentHostCopilotSdkLogLevelSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, copilotSdkLogLevelSettingValues } from '../../../../platform/agentHost/common/copilotCliConfig.js';
+import { AgentHostCopilotSdkLogLevelSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, AgentHostToolSearchEnabledSettingId, copilotSdkLogLevelSettingValues } from '../../../../platform/agentHost/common/copilotCliConfig.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
 import { COPILOT_ALLOWED_MCP_SERVERS_KEY, COPILOT_DENIED_MCP_SERVERS_KEY, COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, COPILOT_STRICT_MARKETPLACES_KEY, managedModelValue, managedSettingValue } from '../../../../platform/policy/common/copilotManagedSettings.js';
@@ -1432,6 +1432,12 @@ configurationRegistry.registerConfiguration({
 		[AgentHostOpus48PromptEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.opus48Prompt.enabled', "When enabled, Copilot SDK sessions running a Claude Opus 4.8 model apply Opus 4.8-tuned system-prompt section overrides on top of the default system message."),
+			default: false,
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostToolSearchEnabledSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.copilot.toolSearch.enabled', "When enabled, Copilot SDK sessions defer MCP and non-core VS Code tools behind a tool-search tool so the model discovers them on demand instead of loading every tool definition up front."),
 			default: false,
 			tags: ['experimental', 'advanced'],
 		},

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -18,6 +18,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { AgentSession, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { CLIENT_TOOL_SEARCH_REFERENCE_NAME, RUNTIME_TOOL_SEARCH_TOOL_NAME } from '../../../../../../platform/agentHost/common/toolSearchConstants.js';
 import { isChatAction, isSessionAction, type ActionEnvelope, type ChatAction, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type INotification, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { buildDefaultChatUri, buildSubagentChatUri, createChatState, createDefaultChatSummary, MessageKind, SessionLifecycle, SessionStatus, createSessionState, StateComponents, parseDefaultChatUri, type ChatState, type SessionState, type SessionSummary, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { chatReducer, sessionReducer } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
@@ -624,6 +625,15 @@ suite('AgentHostClientTools', () => {
 			source: ToolDataSource.Internal,
 		};
 
+		const testToolSearchTool: IToolData = {
+			id: 'vscode.toolSearch',
+			toolReferenceName: CLIENT_TOOL_SEARCH_REFERENCE_NAME,
+			displayName: 'Search Tools',
+			modelDescription: 'Searches for tools',
+			source: ToolDataSource.Internal,
+			inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+		};
+
 		async function provideSessionWithReadyRunTaskTool(handler: AgentHostSessionHandler, connection: MockAgentHostConnection): Promise<void> {
 			const sessionResource = URI.parse('agent-host-copilot:/session-1');
 			const backendSession = AgentSession.uri('copilot', 'session-1').toString();
@@ -754,6 +764,111 @@ suite('AgentHostClientTools', () => {
 			assert.ok(connection.dispatchedActions.some(entry => isChatAction(entry.action)
 				&& entry.action.type === ActionType.ChatToolCallComplete
 				&& entry.action.toolCallId === 'tool-call-1'));
+		});
+
+		test('tool-search completion drops candidates while preserving unknown metadata', async () => {
+			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testToolSearchTool]);
+			const sessionResource = URI.parse('agent-host-copilot:/session-1');
+			const backendSession = AgentSession.uri('copilot', 'session-1').toString();
+			const chatURI = URI.parse(buildDefaultChatUri(backendSession));
+
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text: 'find a calculator', origin: { kind: MessageKind.User } },
+			} as ChatAction);
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-search-call-1',
+				toolName: RUNTIME_TOOL_SEARCH_TOOL_NAME,
+				displayName: 'Search Tools',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: connection.clientId },
+			} as ChatAction);
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tool-search-call-1',
+				invocationMessage: 'Search Tools',
+				toolInput: '{"query":"calculator"}',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				_meta: {
+					toolSearchCandidates: [{ name: 'calculator', description: 'Adds numbers' }],
+					futureMetadata: { preserve: true },
+				},
+			} as ChatAction);
+
+			await handler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			await timeout(0);
+			await timeout(0);
+
+			const completion = connection.dispatchedActions.find(entry => isChatAction(entry.action)
+				&& entry.action.type === ActionType.ChatToolCallComplete
+				&& entry.action.toolCallId === 'tool-search-call-1');
+			assert.ok(completion && isChatAction(completion.action) && completion.action.type === ActionType.ChatToolCallComplete);
+			assert.deepStrictEqual({
+				parameters: toolsService.invokedToolCalls[0]?.parameters,
+				meta: completion.action._meta,
+			}, {
+				parameters: {
+					query: 'calculator',
+					candidateTools: [{ name: 'calculator', description: 'Adds numbers' }],
+				},
+				meta: { futureMetadata: { preserve: true } },
+			});
+		});
+
+		test('invalid tool-search input drops candidates while preserving unknown metadata', async () => {
+			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testToolSearchTool]);
+			const sessionResource = URI.parse('agent-host-copilot:/session-1');
+			const backendSession = AgentSession.uri('copilot', 'session-1').toString();
+			const chatURI = URI.parse(buildDefaultChatUri(backendSession));
+
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text: 'find a calculator', origin: { kind: MessageKind.User } },
+			} as ChatAction);
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-search-call-invalid',
+				toolName: RUNTIME_TOOL_SEARCH_TOOL_NAME,
+				displayName: 'Search Tools',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: connection.clientId },
+			} as ChatAction);
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tool-search-call-invalid',
+				invocationMessage: 'Search Tools',
+				toolInput: '{invalid',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				_meta: {
+					toolSearchCandidates: [{ name: 'calculator', description: 'Adds numbers' }],
+					futureMetadata: { preserve: true },
+				},
+			} as ChatAction);
+
+			await handler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			await timeout(0);
+			await timeout(0);
+
+			const completion = connection.dispatchedActions.find(entry => isChatAction(entry.action)
+				&& entry.action.type === ActionType.ChatToolCallComplete
+				&& entry.action.toolCallId === 'tool-search-call-invalid');
+			assert.ok(completion && isChatAction(completion.action) && completion.action.type === ActionType.ChatToolCallComplete);
+			assert.deepStrictEqual({
+				invokedToolCalls: toolsService.invokedToolCalls.length,
+				success: completion.action.result.success,
+				meta: completion.action._meta,
+			}, {
+				invokedToolCalls: 0,
+				success: false,
+				meta: { futureMetadata: { preserve: true } },
+			});
 		});
 
 		test('shows another client tool as cancellable progress without invoking or confirming it', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCopilotCliSettingsContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCopilotCliSettingsContribution.test.ts
@@ -13,7 +13,7 @@ import { IConfigurationService } from '../../../../../../platform/configuration/
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
-import { AgentHostCopilotSdkLogLevelSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, CopilotCliConfigKey } from '../../../../../../platform/agentHost/common/copilotCliConfig.js';
+import { AgentHostCopilotSdkLogLevelSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, AgentHostToolSearchEnabledSettingId, CopilotCliConfigKey } from '../../../../../../platform/agentHost/common/copilotCliConfig.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import type { ClientAnnotationsAction, INotification, IRootConfigChangedAction, SessionAction, TerminalAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import type { ConfigPropertySchema, RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
@@ -72,6 +72,7 @@ function makeRootStateWithSchema(properties: Record<string, ConfigPropertySchema
 const fullSchema: Record<string, ConfigPropertySchema> = {
 	[CopilotCliConfigKey.CopilotSdkLogLevel]: { type: 'string', title: 'Copilot SDK Log Level' },
 	[CopilotCliConfigKey.Opus48Prompt]: { type: 'boolean', title: 'Opus 4.8 Agent Prompt' },
+	[CopilotCliConfigKey.ToolSearchEnabled]: { type: 'boolean', title: 'Agent Host Tool Search' },
 	[CopilotCliConfigKey.ReasoningEffortOverride]: { type: 'string', title: 'Reasoning Effort Override' },
 	[CopilotCliConfigKey.ModelCapabilityOverrides]: { type: 'object', title: 'Model Capability Overrides' },
 };
@@ -105,6 +106,7 @@ suite('AgentHostCopilotCliSettingsContribution', () => {
 		const { agentHostService } = setup(disposables, {
 			[AgentHostCopilotSdkLogLevelSettingId]: 'trace',
 			[AgentHostOpus48PromptEnabledSettingId]: true,
+			[AgentHostToolSearchEnabledSettingId]: true,
 			[AgentHostReasoningEffortOverrideSettingId]: 'xhigh',
 			[AgentHostModelCapabilityOverridesSettingId]: { 'preview-model-x': { family: 'claude-opus-4-8' } },
 		});
@@ -113,11 +115,12 @@ suite('AgentHostCopilotCliSettingsContribution', () => {
 
 		// The shared forwarder dispatches one RootConfigChanged per key; merge them
 		// and assert the full forwarded set (order-independent).
-		assert.strictEqual(agentHostService.dispatchedActions.length, 4);
+		assert.strictEqual(agentHostService.dispatchedActions.length, 5);
 		const merged = Object.assign({}, ...agentHostService.dispatchedActions.map(a => (a.action as IRootConfigChangedAction).config));
 		assert.deepStrictEqual(merged, {
 			[CopilotCliConfigKey.CopilotSdkLogLevel]: 'trace',
 			[CopilotCliConfigKey.Opus48Prompt]: true,
+			[CopilotCliConfigKey.ToolSearchEnabled]: true,
 			[CopilotCliConfigKey.ReasoningEffortOverride]: 'xhigh',
 			[CopilotCliConfigKey.ModelCapabilityOverrides]: { 'preview-model-x': { family: 'claude-opus-4-8' } },
 		});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCopilotCliSettingsContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCopilotCliSettingsContribution.test.ts
@@ -164,6 +164,7 @@ suite('AgentHostCopilotCliSettingsContribution', () => {
 		agentHostService.setRootState(makeRootStateWithSchema(fullSchema, {
 			[CopilotCliConfigKey.CopilotSdkLogLevel]: 'trace',
 			[CopilotCliConfigKey.Opus48Prompt]: true,
+			[CopilotCliConfigKey.ToolSearchEnabled]: false,
 			[CopilotCliConfigKey.ReasoningEffortOverride]: 'xhigh',
 			[CopilotCliConfigKey.ModelCapabilityOverrides]: { 'preview-model-x': { family: 'claude-opus-4-8' } },
 		}));


### PR DESCRIPTION
Adds deferred tool search support to the Copilot agent host using the existing client-side semantic search.

Draft until VS Code bumps to `@github/copilot-sdk@1.0.7` and `@github/copilot@1.0.71`.