### PR TITLE
Bump Copilot CLI package to 1.0.71

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -13,7 +13,7 @@
         "@anthropic-ai/claude-agent-sdk": "0.2.112",
         "@anthropic-ai/sdk": "^0.82.0",
         "@github/blackbird-external-ingest-utils": "^0.3.0",
-        "@github/copilot": "^1.0.70-0",
+        "@github/copilot": "^1.0.71",
         "@google/genai": "^1.22.0",
         "@humanwhocodes/gitignore-to-minimatch": "1.0.2",
         "@microsoft/tiktokenizer": "^1.0.10",
@@ -2969,9 +2969,9 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.70-0.tgz",
-      "integrity": "sha512-GPLiKXpwFR11ZISSmTVmVoXj+dwKpQq1foz1rLvSjtzbO/IHQLMJ11CN+o5lkDiERAFtYd70mZf3P/xM05/nQg==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.71.tgz",
+      "integrity": "sha512-F3axBi+sXSLYDJbxCBW36bM6MYKNC2rlyAf3Ivo/MjiHKKJW7j5AmaR1IRYS9Gt8r9mxOwWFM1cJFA+CuLaR8g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -2980,20 +2980,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.70-0",
-        "@github/copilot-darwin-x64": "1.0.70-0",
-        "@github/copilot-linux-arm64": "1.0.70-0",
-        "@github/copilot-linux-x64": "1.0.70-0",
-        "@github/copilot-linuxmusl-arm64": "1.0.70-0",
-        "@github/copilot-linuxmusl-x64": "1.0.70-0",
-        "@github/copilot-win32-arm64": "1.0.70-0",
-        "@github/copilot-win32-x64": "1.0.70-0"
+        "@github/copilot-darwin-arm64": "1.0.71",
+        "@github/copilot-darwin-x64": "1.0.71",
+        "@github/copilot-linux-arm64": "1.0.71",
+        "@github/copilot-linux-x64": "1.0.71",
+        "@github/copilot-linuxmusl-arm64": "1.0.71",
+        "@github/copilot-linuxmusl-x64": "1.0.71",
+        "@github/copilot-win32-arm64": "1.0.71",
+        "@github/copilot-win32-x64": "1.0.71"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-63jLqlVNsX7XMKgEMH4J+lY1zwHCnqapzK1BFEMXgplqvQAJ9q29B83Kskl+i8AGXFpVx+uHRNJIImlkuK3a/g==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.71.tgz",
+      "integrity": "sha512-mEWzyqbqRAWgyU7i2uuSRoVPx/TwaFQX0nZmw0bc30aJ0BnO7cy2kYQyCHw8ykmf/tfxT0xauZ6k0BOFmWizzQ==",
       "cpu": [
         "arm64"
       ],
@@ -3007,9 +3007,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.70-0.tgz",
-      "integrity": "sha512-uIWb54gh64p0sdaCOv8HZlKjAlrNLiQO3jE6VqbxatZniJ5y3bkWkba/ULuBKgwSLRnZKLSHBhP597JwXsamoQ==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.71.tgz",
+      "integrity": "sha512-Md9yEg406OBVBx3w4PeEj62TubulVLBcHleqmCoOoUmPgUxPZotUbrqz3rtbzADbXfrrD7JWvVsbd2UiNL194w==",
       "cpu": [
         "x64"
       ],
@@ -3023,9 +3023,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-+wa9MDl1a3j1/sTAI1I5UHw9PXwwao0SNczml8pCV78gYqmv6YNaCg2ZKvaajv9vinXkFOH+20VDT5HQk1zhlQ==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.71.tgz",
+      "integrity": "sha512-ykLJYOqBj3jRB5IJCDugLClAqbr7DmtTbUjlNY7+Jdq/n6i+d7xUQGclf1IWL5gnxbGQVAf+zkToD+sRM389Kg==",
       "cpu": [
         "arm64"
       ],
@@ -3042,9 +3042,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.70-0.tgz",
-      "integrity": "sha512-oUy+q4ZgH4lrs0Jsnkf8sQDWEwOPxLNRTGqw3RJ+Cf0hHVxVm4F5mIvO+plmJxe3N70rNDrhxQFQXhboRKqf7w==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.71.tgz",
+      "integrity": "sha512-pC0FNHG+BBwZd6yZlM85kkAGN+uJhM6o+THi76N2GnnSxmw7+remb1mvYxdgRVbdCm+LBUIbCKRWJLuMwrfb6A==",
       "cpu": [
         "x64"
       ],
@@ -3061,9 +3061,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-YLtR5MQoORGy82QjrYvtNPDt9FH4XkoVYbMQ2HMYvQrbVghQ+k5FZU3Mx4rnIJR+8qDnE3AGH7JMEgeK87dkQA==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.71.tgz",
+      "integrity": "sha512-hBmDljFTjacxqZTasCEy43H8EIzuXB/hHEBBCMFjhB9J00nIxsO6Dh0woTifKpx7knTYZdpTjjca3D0pAoZlUA==",
       "cpu": [
         "arm64"
       ],
@@ -3080,9 +3080,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.70-0.tgz",
-      "integrity": "sha512-faqw21lOIPmqyLwfYRUeCZ4+TvuvUPsOEb0qh0LI2NL98AtQX123RxBbFMDDC9bnRZ7S/5lZXnpPpn19v+5Vvw==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.71.tgz",
+      "integrity": "sha512-CfTXU8pa5dxRz22xQzoi3TiG1PJo9+WR8PRDiPSdkIBSyPJ1NvX87DJmfXjTgeAfR+wkjt/p0keDCaBBVhNmUA==",
       "cpu": [
         "x64"
       ],
@@ -3099,9 +3099,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-/Wk+jrK/ogAXs/AIjW60f3pIRj3UHEFRXgbrIoc1R0wIDbVas9/GGrpgrRFf5ldyvvVljedxuuvqvaEe2aFtsA==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.71.tgz",
+      "integrity": "sha512-+HI1DokixXhHUahj06Fw67ZAigBuXKC58BFma4UJOGrQsDgwOSbqeTQHCw6vuymzjKlg3sactfsCUTaefkjscQ==",
       "cpu": [
         "arm64"
       ],
@@ -3115,9 +3115,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.70-0.tgz",
-      "integrity": "sha512-3fgEEDeswN9Db4qu4NsGe3BAtHHylfFh+jcwlBscSbI4KGEI3cvXcDFoxPcXWi/cajcvt0Tec5/jAJskJI0SNg==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.71.tgz",
+      "integrity": "sha512-02kXOBd9CwBbCaztuf71WYWn+uGapCuiaasomN4tcMH3HBVZ4gi3J0ZUoRcgcS80xh81uQyeBHbnUKzb/RE/9A==",
       "cpu": [
         "x64"
       ],

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -7261,7 +7261,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.2.112",
     "@anthropic-ai/sdk": "^0.82.0",
     "@github/blackbird-external-ingest-utils": "^0.3.0",
-    "@github/copilot": "^1.0.70-0",
+    "@github/copilot": "^1.0.71",
     "@google/genai": "^1.22.0",
     "@humanwhocodes/gitignore-to-minimatch": "1.0.2",
     "@microsoft/tiktokenizer": "^1.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
-        "@github/copilot": "^1.0.70-0",
+        "@github/copilot": "^1.0.71",
         "@github/copilot-sdk": "^1.0.7-preview.0",
         "@huggingface/transformers": "4.2.0",
         "@microsoft/1ds-core-js": "^3.2.13",
@@ -1112,9 +1112,9 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.70-0.tgz",
-      "integrity": "sha512-GPLiKXpwFR11ZISSmTVmVoXj+dwKpQq1foz1rLvSjtzbO/IHQLMJ11CN+o5lkDiERAFtYd70mZf3P/xM05/nQg==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.71.tgz",
+      "integrity": "sha512-F3axBi+sXSLYDJbxCBW36bM6MYKNC2rlyAf3Ivo/MjiHKKJW7j5AmaR1IRYS9Gt8r9mxOwWFM1cJFA+CuLaR8g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -1123,20 +1123,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.70-0",
-        "@github/copilot-darwin-x64": "1.0.70-0",
-        "@github/copilot-linux-arm64": "1.0.70-0",
-        "@github/copilot-linux-x64": "1.0.70-0",
-        "@github/copilot-linuxmusl-arm64": "1.0.70-0",
-        "@github/copilot-linuxmusl-x64": "1.0.70-0",
-        "@github/copilot-win32-arm64": "1.0.70-0",
-        "@github/copilot-win32-x64": "1.0.70-0"
+        "@github/copilot-darwin-arm64": "1.0.71",
+        "@github/copilot-darwin-x64": "1.0.71",
+        "@github/copilot-linux-arm64": "1.0.71",
+        "@github/copilot-linux-x64": "1.0.71",
+        "@github/copilot-linuxmusl-arm64": "1.0.71",
+        "@github/copilot-linuxmusl-x64": "1.0.71",
+        "@github/copilot-win32-arm64": "1.0.71",
+        "@github/copilot-win32-x64": "1.0.71"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-63jLqlVNsX7XMKgEMH4J+lY1zwHCnqapzK1BFEMXgplqvQAJ9q29B83Kskl+i8AGXFpVx+uHRNJIImlkuK3a/g==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.71.tgz",
+      "integrity": "sha512-mEWzyqbqRAWgyU7i2uuSRoVPx/TwaFQX0nZmw0bc30aJ0BnO7cy2kYQyCHw8ykmf/tfxT0xauZ6k0BOFmWizzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1150,9 +1150,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.70-0.tgz",
-      "integrity": "sha512-uIWb54gh64p0sdaCOv8HZlKjAlrNLiQO3jE6VqbxatZniJ5y3bkWkba/ULuBKgwSLRnZKLSHBhP597JwXsamoQ==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.71.tgz",
+      "integrity": "sha512-Md9yEg406OBVBx3w4PeEj62TubulVLBcHleqmCoOoUmPgUxPZotUbrqz3rtbzADbXfrrD7JWvVsbd2UiNL194w==",
       "cpu": [
         "x64"
       ],
@@ -1166,9 +1166,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-+wa9MDl1a3j1/sTAI1I5UHw9PXwwao0SNczml8pCV78gYqmv6YNaCg2ZKvaajv9vinXkFOH+20VDT5HQk1zhlQ==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.71.tgz",
+      "integrity": "sha512-ykLJYOqBj3jRB5IJCDugLClAqbr7DmtTbUjlNY7+Jdq/n6i+d7xUQGclf1IWL5gnxbGQVAf+zkToD+sRM389Kg==",
       "cpu": [
         "arm64"
       ],
@@ -1185,9 +1185,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.70-0.tgz",
-      "integrity": "sha512-oUy+q4ZgH4lrs0Jsnkf8sQDWEwOPxLNRTGqw3RJ+Cf0hHVxVm4F5mIvO+plmJxe3N70rNDrhxQFQXhboRKqf7w==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.71.tgz",
+      "integrity": "sha512-pC0FNHG+BBwZd6yZlM85kkAGN+uJhM6o+THi76N2GnnSxmw7+remb1mvYxdgRVbdCm+LBUIbCKRWJLuMwrfb6A==",
       "cpu": [
         "x64"
       ],
@@ -1204,9 +1204,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-YLtR5MQoORGy82QjrYvtNPDt9FH4XkoVYbMQ2HMYvQrbVghQ+k5FZU3Mx4rnIJR+8qDnE3AGH7JMEgeK87dkQA==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.71.tgz",
+      "integrity": "sha512-hBmDljFTjacxqZTasCEy43H8EIzuXB/hHEBBCMFjhB9J00nIxsO6Dh0woTifKpx7knTYZdpTjjca3D0pAoZlUA==",
       "cpu": [
         "arm64"
       ],
@@ -1223,9 +1223,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.70-0.tgz",
-      "integrity": "sha512-faqw21lOIPmqyLwfYRUeCZ4+TvuvUPsOEb0qh0LI2NL98AtQX123RxBbFMDDC9bnRZ7S/5lZXnpPpn19v+5Vvw==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.71.tgz",
+      "integrity": "sha512-CfTXU8pa5dxRz22xQzoi3TiG1PJo9+WR8PRDiPSdkIBSyPJ1NvX87DJmfXjTgeAfR+wkjt/p0keDCaBBVhNmUA==",
       "cpu": [
         "x64"
       ],
@@ -1265,9 +1265,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-/Wk+jrK/ogAXs/AIjW60f3pIRj3UHEFRXgbrIoc1R0wIDbVas9/GGrpgrRFf5ldyvvVljedxuuvqvaEe2aFtsA==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.71.tgz",
+      "integrity": "sha512-+HI1DokixXhHUahj06Fw67ZAigBuXKC58BFma4UJOGrQsDgwOSbqeTQHCw6vuymzjKlg3sactfsCUTaefkjscQ==",
       "cpu": [
         "arm64"
       ],
@@ -1281,9 +1281,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.70-0.tgz",
-      "integrity": "sha512-3fgEEDeswN9Db4qu4NsGe3BAtHHylfFh+jcwlBscSbI4KGEI3cvXcDFoxPcXWi/cajcvt0Tec5/jAJskJI0SNg==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.71.tgz",
+      "integrity": "sha512-02kXOBd9CwBbCaztuf71WYWn+uGapCuiaasomN4tcMH3HBVZ4gi3J0ZUoRcgcS80xh81uQyeBHbnUKzb/RE/9A==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
-    "@github/copilot": "^1.0.70-0",
+    "@github/copilot": "^1.0.71",
     "@github/copilot-sdk": "^1.0.7-preview.0",
     "@huggingface/transformers": "4.2.0",
     "@microsoft/1ds-core-js": "^3.2.13",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vscode-reh",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "^1.0.70-0",
+        "@github/copilot": "^1.0.71",
         "@github/copilot-sdk": "^1.0.7-preview.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.70-0.tgz",
-      "integrity": "sha512-GPLiKXpwFR11ZISSmTVmVoXj+dwKpQq1foz1rLvSjtzbO/IHQLMJ11CN+o5lkDiERAFtYd70mZf3P/xM05/nQg==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.71.tgz",
+      "integrity": "sha512-F3axBi+sXSLYDJbxCBW36bM6MYKNC2rlyAf3Ivo/MjiHKKJW7j5AmaR1IRYS9Gt8r9mxOwWFM1cJFA+CuLaR8g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -72,20 +72,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.70-0",
-        "@github/copilot-darwin-x64": "1.0.70-0",
-        "@github/copilot-linux-arm64": "1.0.70-0",
-        "@github/copilot-linux-x64": "1.0.70-0",
-        "@github/copilot-linuxmusl-arm64": "1.0.70-0",
-        "@github/copilot-linuxmusl-x64": "1.0.70-0",
-        "@github/copilot-win32-arm64": "1.0.70-0",
-        "@github/copilot-win32-x64": "1.0.70-0"
+        "@github/copilot-darwin-arm64": "1.0.71",
+        "@github/copilot-darwin-x64": "1.0.71",
+        "@github/copilot-linux-arm64": "1.0.71",
+        "@github/copilot-linux-x64": "1.0.71",
+        "@github/copilot-linuxmusl-arm64": "1.0.71",
+        "@github/copilot-linuxmusl-x64": "1.0.71",
+        "@github/copilot-win32-arm64": "1.0.71",
+        "@github/copilot-win32-x64": "1.0.71"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-63jLqlVNsX7XMKgEMH4J+lY1zwHCnqapzK1BFEMXgplqvQAJ9q29B83Kskl+i8AGXFpVx+uHRNJIImlkuK3a/g==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.71.tgz",
+      "integrity": "sha512-mEWzyqbqRAWgyU7i2uuSRoVPx/TwaFQX0nZmw0bc30aJ0BnO7cy2kYQyCHw8ykmf/tfxT0xauZ6k0BOFmWizzQ==",
       "cpu": [
         "arm64"
       ],
@@ -99,9 +99,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.70-0.tgz",
-      "integrity": "sha512-uIWb54gh64p0sdaCOv8HZlKjAlrNLiQO3jE6VqbxatZniJ5y3bkWkba/ULuBKgwSLRnZKLSHBhP597JwXsamoQ==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.71.tgz",
+      "integrity": "sha512-Md9yEg406OBVBx3w4PeEj62TubulVLBcHleqmCoOoUmPgUxPZotUbrqz3rtbzADbXfrrD7JWvVsbd2UiNL194w==",
       "cpu": [
         "x64"
       ],
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-+wa9MDl1a3j1/sTAI1I5UHw9PXwwao0SNczml8pCV78gYqmv6YNaCg2ZKvaajv9vinXkFOH+20VDT5HQk1zhlQ==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.71.tgz",
+      "integrity": "sha512-ykLJYOqBj3jRB5IJCDugLClAqbr7DmtTbUjlNY7+Jdq/n6i+d7xUQGclf1IWL5gnxbGQVAf+zkToD+sRM389Kg==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.70-0.tgz",
-      "integrity": "sha512-oUy+q4ZgH4lrs0Jsnkf8sQDWEwOPxLNRTGqw3RJ+Cf0hHVxVm4F5mIvO+plmJxe3N70rNDrhxQFQXhboRKqf7w==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.71.tgz",
+      "integrity": "sha512-pC0FNHG+BBwZd6yZlM85kkAGN+uJhM6o+THi76N2GnnSxmw7+remb1mvYxdgRVbdCm+LBUIbCKRWJLuMwrfb6A==",
       "cpu": [
         "x64"
       ],
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-YLtR5MQoORGy82QjrYvtNPDt9FH4XkoVYbMQ2HMYvQrbVghQ+k5FZU3Mx4rnIJR+8qDnE3AGH7JMEgeK87dkQA==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.71.tgz",
+      "integrity": "sha512-hBmDljFTjacxqZTasCEy43H8EIzuXB/hHEBBCMFjhB9J00nIxsO6Dh0woTifKpx7knTYZdpTjjca3D0pAoZlUA==",
       "cpu": [
         "arm64"
       ],
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.70-0.tgz",
-      "integrity": "sha512-faqw21lOIPmqyLwfYRUeCZ4+TvuvUPsOEb0qh0LI2NL98AtQX123RxBbFMDDC9bnRZ7S/5lZXnpPpn19v+5Vvw==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.71.tgz",
+      "integrity": "sha512-CfTXU8pa5dxRz22xQzoi3TiG1PJo9+WR8PRDiPSdkIBSyPJ1NvX87DJmfXjTgeAfR+wkjt/p0keDCaBBVhNmUA==",
       "cpu": [
         "x64"
       ],
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.70-0.tgz",
-      "integrity": "sha512-/Wk+jrK/ogAXs/AIjW60f3pIRj3UHEFRXgbrIoc1R0wIDbVas9/GGrpgrRFf5ldyvvVljedxuuvqvaEe2aFtsA==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.71.tgz",
+      "integrity": "sha512-+HI1DokixXhHUahj06Fw67ZAigBuXKC58BFma4UJOGrQsDgwOSbqeTQHCw6vuymzjKlg3sactfsCUTaefkjscQ==",
       "cpu": [
         "arm64"
       ],
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.70-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.70-0.tgz",
-      "integrity": "sha512-3fgEEDeswN9Db4qu4NsGe3BAtHHylfFh+jcwlBscSbI4KGEI3cvXcDFoxPcXWi/cajcvt0Tec5/jAJskJI0SNg==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.71.tgz",
+      "integrity": "sha512-02kXOBd9CwBbCaztuf71WYWn+uGapCuiaasomN4tcMH3HBVZ4gi3J0ZUoRcgcS80xh81uQyeBHbnUKzb/RE/9A==",
       "cpu": [
         "x64"
       ],

--- a/remote/package.json
+++ b/remote/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@github/copilot": "^1.0.70-0",
+    "@github/copilot": "^1.0.71",
     "@github/copilot-sdk": "^1.0.7-preview.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",

--- a/src/vs/platform/agentHost/test/node/protocol/__snapshots__/Agent_Host_E2E___Copilot__Copilot-specific__client_tool_reaches_ready_after_start_and_completes.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/protocol/__snapshots__/Agent_Host_E2E___Copilot__Copilot-specific__client_tool_reaches_ready_after_start_and_completes.traffic.ahp.yaml
@@ -67,6 +67,7 @@ rounds:
       - channel: ${session_0}
         action:
           type: session/changesetsChanged
+      - method: notifications/tools/list_changed
       - channel: ${chat_0}
         action:
           type: chat/usage


### PR DESCRIPTION
- Bump `@github/copilot` from `^1.0.70-0` to stable `^1.0.71` in the root, remote, and built-in Copilot extension manifests.
- Refresh the corresponding lockfiles so all `@github/copilot-*` platform packages resolve to `1.0.71`.
- Keep `@github/copilot-sdk` unchanged at `^1.0.7-preview.0`; this is a CLI runtime-only update.
- Refresh the Agent Host Copilot traffic snapshot for the new `notifications/tools/list_changed` notification.

<details>
<summary>Validation</summary>

- `npm run typecheck-client`
- `cd extensions/copilot && npx vitest run --pool=forks src/extension/chatSessions/copilotcli/vscode-node/test/copilotCLISDKUpgrade.spec.ts` — 3 passing
- Agent Host Copilot replay E2E — 15 passing, 1 skipped
- `AGENT_HOST_REAL_SDK=1 AGENT_HOST_REPLAY_RECORD=1 ./scripts/test-integration.sh --run src/vs/platform/agentHost/test/node/protocol/copilotImportSession.integrationTest.ts` — 3 passing
- Product/insider pipeline: [build 456427](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=456427). Dependency installation is currently blocked because Monaco's npm feed contains `@github/copilot@1.0.71` but not the stable `@github/copilot-<platform>@1.0.71` artifacts.

</details>

-----------------------------------------
Inspirations from:

- The CLI version is kept aligned across the root [`package.json`](https://github.com/microsoft/vscode/blob/3435a9a2f93bb5a59ba01f8d61aa938e55c8ec42/package.json#L98-L100), [`remote/package.json`](https://github.com/microsoft/vscode/blob/3435a9a2f93bb5a59ba01f8d61aa938e55c8ec42/remote/package.json#L5-L8), and the built-in Copilot extension [`package.json`](https://github.com/microsoft/vscode/blob/3435a9a2f93bb5a59ba01f8d61aa938e55c8ec42/extensions/copilot/package.json#L7261-L7267), following the existing VS Code package-bump layout.
- Platform-specific CLI packages continue to be selected and materialized by [`resolveCopilotCliSourceDir`](https://github.com/microsoft/vscode/blob/3435a9a2f93bb5a59ba01f8d61aa938e55c8ec42/extensions/copilot/script/postinstall.ts#L95-L120).
