### PR TITLE
Quantize on-device dictation decoder to shrink model download

### DIFF
--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -19,6 +19,22 @@ const SAMPLE_RATE = 16000;
 /** Default downloaded model. `base` balances quality and size (~faster than small). */
 const DEFAULT_MODEL = 'onnx-community/whisper-base';
 
+/**
+ * Precision of the ONNX weights downloaded and run on device. Whisper is an
+ * encoder-decoder model whose decoder dominates size (e.g. for `base` the
+ * fp32 decoder is ~208MB vs the ~82MB encoder), so we quantize the decoder to
+ * int8 (`q8`) while keeping the encoder at full precision, where quantization
+ * would hurt audio-feature accuracy more. This cuts the `base` download from
+ * ~291MB (all fp32) to ~136MB with negligible transcription-quality loss.
+ *
+ * Without an explicit `dtype` transformers.js defaults to fp32 for every file
+ * on the `cpu` device, so this mapping must be passed to `pipeline()`.
+ */
+const DEFAULT_DTYPE = {
+	encoder_model: 'fp32',
+	decoder_model_merged: 'q8',
+} as const;
+
 /** Minimum audio (seconds) before a first interim transcription is attempted. */
 const MIN_INTERIM_SECONDS = 1.0;
 
@@ -118,6 +134,7 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 
 				this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: 0 });
 				const pipe = await pipeline('automatic-speech-recognition', model, {
+					dtype: DEFAULT_DTYPE,
 					progress_callback: (p: { status?: string; progress?: number }) => {
 						if (p.status === 'progress' && typeof p.progress === 'number') {
 							this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: Math.min(1, p.progress / 100) });


### PR DESCRIPTION
## What

The on-device dictation model (`onnx-community/whisper-*`) is loaded via a transformers.js pipeline **without a `dtype`**. On the `cpu` device transformers.js defaults every ONNX file to **fp32**, so the `base` model downloads **~291MB** (fp32 encoder ~82MB + fp32 decoder ~208MB).

This PR passes an explicit `dtype` that keeps the **encoder at fp32** (quantizing it hurts audio-feature accuracy more) and quantizes the **decoder to int8 (`q8`)**, which dominates model size.

## Impact (download size)

| Model | Before (fp32) | After (fp32 enc + q8 dec) |
|-------|---------------|---------------------------|
| tiny  | ~140MB        | **~64MB** |
| base (default) | ~291MB | **~136MB** |
| small | ~1GB+         | **~510MB** |

Negligible transcription-quality loss for dictation. These sizes also match what the existing `chat.speechToText.model` setting descriptions already advertise (~75 / 145 / 465MB), i.e. the quantized decoder was the intended design but the `dtype` was never passed.

## Change

Single-file change in `localTranscriptionService.ts`: add a `DEFAULT_DTYPE` (`{ encoder_model: 'fp32', decoder_model_merged: 'q8' }`) and pass it to `pipeline()`.

## Testing

- `npm run typecheck-client` passes.
- Manual: first-run dictation downloads the smaller decoder and transcribes as before.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>