### PR TITLE
Add enterprise allowedMcpServers / deniedMcpServers governance policies for MCP servers

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -457,6 +457,42 @@
             "included": true
         },
         {
+            "key": "chat.mcp.allowedServers",
+            "name": "ChatAllowedMcpServers",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.130",
+            "localization": {
+                "description": {
+                    "key": "chat.mcp.allowedServers.policy",
+                    "value": "Allowlist of Model Context Protocol servers. When set, only servers matching an entry may be installed or run; omit entirely to allow all servers (subject to the deny list)."
+                }
+            },
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "included": false
+        },
+        {
+            "key": "chat.mcp.deniedServers",
+            "name": "ChatDeniedMcpServers",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.130",
+            "localization": {
+                "description": {
+                    "key": "chat.mcp.deniedServers.policy",
+                    "value": "Denylist of Model Context Protocol servers. Servers matching any entry are blocked from being installed or run, even if they also match the allow list; deny rules always take precedence."
+                }
+            },
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "included": false
+        },
+        {
             "key": "chat.extensionTools.enabled",
             "name": "ChatAgentExtensionTools",
             "category": "InteractiveSession",

--- a/src/vs/platform/mcp/common/allowedMcpServers.ts
+++ b/src/vs/platform/mcp/common/allowedMcpServers.ts
@@ -106,15 +106,40 @@ function matchesMatcher(matcher: IMcpServerMatcher, identity: IMcpServerIdentity
 }
 
 /**
- * Matches a URL against a pattern that may contain `*` wildcards (each `*` matches any run of
- * characters). Matching is case-insensitive, anchored to the whole string, and every other
- * character is matched literally.
+ * Matches a URL against a pattern that may contain `*` wildcards. Matching is case-insensitive,
+ * anchored to the whole string, and every non-wildcard character is matched literally.
+ *
+ * Wildcard reach is region-aware so an authority wildcard cannot swallow the path: a `*` inside
+ * the authority region (scheme + `//` + host/port, i.e. everything before the first `/` of the
+ * path) matches any run of non-`/` characters, while a `*` in the path/query region matches any
+ * run of characters. This prevents patterns like `https://*.example.com/*` from matching a URL
+ * whose real host is untrusted, e.g. `https://evil.test/.example.com/tool`.
  */
 function matchesUrlPattern(pattern: string, url: string): boolean {
-	const regexSource = `^${pattern.split('*').map(escapeRegExpCharacters).join('.*')}$`;
+	const regexSource = buildUrlPatternRegexSource(pattern);
 	try {
 		return new RegExp(regexSource, 'i').test(url);
 	} catch {
 		return false;
 	}
+}
+
+function buildUrlPatternRegexSource(pattern: string): string {
+	// The authority region spans from the start of the pattern up to (but not including) the first
+	// `/` of the path. Wildcards there must not cross a `/` so they cannot consume path segments.
+	const schemeSeparator = pattern.indexOf('://');
+	const authorityStart = schemeSeparator >= 0 ? schemeSeparator + 3 : 0;
+	const pathStart = pattern.indexOf('/', authorityStart);
+	const authorityEnd = pathStart >= 0 ? pathStart : pattern.length;
+
+	let source = '^';
+	for (let i = 0; i < pattern.length; i++) {
+		const char = pattern[i];
+		if (char === '*') {
+			source += i < authorityEnd ? '[^/]*' : '.*';
+		} else {
+			source += escapeRegExpCharacters(char);
+		}
+	}
+	return source + '$';
 }

--- a/src/vs/platform/mcp/common/allowedMcpServers.ts
+++ b/src/vs/platform/mcp/common/allowedMcpServers.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { equals } from '../../../base/common/arrays.js';
+import { escapeRegExpCharacters } from '../../../base/common/strings.js';
+import { isObject, isString } from '../../../base/common/types.js';
+
+/**
+ * A single entry in the `chat.mcp.allowedServers` allowlist. Identifies an MCP server by exactly
+ * one strategy: its configured name, a remote server URL pattern (supporting `*` wildcards), or a
+ * local stdio command invocation (matched as an ordered argument list). Delivered as JSON via user
+ * settings or enterprise managed settings and validated at match time, so only the field matching
+ * the intended strategy is meaningful.
+ */
+export interface IMcpServerMatcher {
+	readonly serverName?: string;
+	readonly serverUrl?: string;
+	readonly serverCommand?: readonly string[];
+}
+
+/**
+ * Normalized identity of an MCP server used for allowlist matching. Both the install-time and the
+ * runtime enforcement paths reduce their server representation to this shape: `url` is set for
+ * remote (HTTP/SSE) servers and `command` (the full `[command, ...args]` invocation) for local
+ * stdio servers.
+ */
+export interface IMcpServerIdentity {
+	readonly name: string;
+	readonly url?: string;
+	readonly command?: readonly string[];
+}
+
+/**
+ * The result of evaluating an MCP server against the allow/deny lists.
+ */
+export const enum McpServerAllowResult {
+	/** Permitted: not denied, and either no allowlist is configured or it matches one. */
+	Allowed,
+	/** Blocked because it matches a deny entry (deny always wins). */
+	Denied,
+	/** Blocked because an allowlist is configured and it matches no entry. */
+	NotAllowed,
+}
+
+/**
+ * Coerces a resolved `chat.mcp.allowedServers` / `chat.mcp.deniedServers` configuration value into a
+ * list of matchers. Returns `undefined` (meaning "not configured") when the value is not an array —
+ * which is also how an unset setting surfaces (the registered `null` default). Malformed matcher
+ * entries (non-objects, or entries that do not carry exactly one valid matching field) are dropped
+ * so a bad payload degrades to "no match" rather than throwing during matching.
+ */
+export function getMcpServerMatchers(value: unknown): readonly IMcpServerMatcher[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	return value.filter(isValidMatcher);
+}
+
+function isValidMatcher(entry: unknown): entry is IMcpServerMatcher {
+	if (!isObject(entry)) {
+		return false;
+	}
+	const { serverName, serverUrl, serverCommand } = entry as IMcpServerMatcher;
+	const hasName = isString(serverName) && serverName.length > 0;
+	const hasUrl = isString(serverUrl) && serverUrl.length > 0;
+	const hasCommand = Array.isArray(serverCommand) && serverCommand.length > 0 && serverCommand.every(isString);
+	// Exactly one matching strategy per the canonical schema's `oneOf`.
+	return (hasName ? 1 : 0) + (hasUrl ? 1 : 0) + (hasCommand ? 1 : 0) === 1;
+}
+
+/**
+ * Whether the server identity matches at least one of the given matchers. A `undefined` or empty
+ * matcher list matches nothing.
+ */
+export function isMcpServerMatched(matchers: readonly IMcpServerMatcher[] | undefined, identity: IMcpServerIdentity): boolean {
+	return !!matchers && matchers.some(matcher => matchesMatcher(matcher, identity));
+}
+
+/**
+ * Evaluates an MCP server against the allow and deny lists. Deny always takes precedence; an unset
+ * (`undefined`) allowlist imposes no restriction, while a configured allowlist requires a match.
+ */
+export function checkMcpServerAllowed(allowlist: readonly IMcpServerMatcher[] | undefined, denylist: readonly IMcpServerMatcher[] | undefined, identity: IMcpServerIdentity): McpServerAllowResult {
+	if (isMcpServerMatched(denylist, identity)) {
+		return McpServerAllowResult.Denied;
+	}
+	if (allowlist !== undefined && !isMcpServerMatched(allowlist, identity)) {
+		return McpServerAllowResult.NotAllowed;
+	}
+	return McpServerAllowResult.Allowed;
+}
+
+function matchesMatcher(matcher: IMcpServerMatcher, identity: IMcpServerIdentity): boolean {
+	if (isString(matcher.serverName)) {
+		return matcher.serverName === identity.name;
+	}
+	if (isString(matcher.serverUrl)) {
+		return identity.url !== undefined && matchesUrlPattern(matcher.serverUrl, identity.url);
+	}
+	if (Array.isArray(matcher.serverCommand)) {
+		return identity.command !== undefined && equals(matcher.serverCommand, identity.command);
+	}
+	return false;
+}
+
+/**
+ * Matches a URL against a pattern that may contain `*` wildcards (each `*` matches any run of
+ * characters). Matching is case-insensitive, anchored to the whole string, and every other
+ * character is matched literally.
+ */
+function matchesUrlPattern(pattern: string, url: string): boolean {
+	const regexSource = `^${pattern.split('*').map(escapeRegExpCharacters).join('.*')}$`;
+	try {
+		return new RegExp(regexSource, 'i').test(url);
+	} catch {
+		return false;
+	}
+}

--- a/src/vs/platform/mcp/common/allowedMcpServersService.ts
+++ b/src/vs/platform/mcp/common/allowedMcpServersService.ts
@@ -44,14 +44,10 @@ export class AllowedMcpServersService extends Disposable implements IAllowedMcpS
 		const allowlist = getMcpServerMatchers(this.configurationService.getValue(mcpAllowedServersConfig));
 		const denylist = getMcpServerMatchers(this.configurationService.getValue(mcpDeniedServersConfig));
 		switch (checkMcpServerAllowed(allowlist, denylist, identity)) {
-			case McpServerAllowResult.Denied: {
-				const settingsCommandLink = createCommandUri('workbench.action.openSettings', { query: `@id:${mcpDeniedServersConfig}` }).toString();
-				return new MarkdownString(nls.localize('mcp server is denied', "This Model Context Protocol server is blocked by your organization's policy. Please check your [settings]({0}).", settingsCommandLink));
-			}
-			case McpServerAllowResult.NotAllowed: {
-				const settingsCommandLink = createCommandUri('workbench.action.openSettings', { query: `@id:${mcpAllowedServersConfig}` }).toString();
-				return new MarkdownString(nls.localize('mcp server not in allowlist', "This Model Context Protocol server is not in the list of allowed servers. Please check your [settings]({0}).", settingsCommandLink));
-			}
+			case McpServerAllowResult.Denied:
+				return new MarkdownString(nls.localize('mcp server is denied', "This Model Context Protocol server is blocked by your organization's policy. Please contact your administrator for more information."));
+			case McpServerAllowResult.NotAllowed:
+				return new MarkdownString(nls.localize('mcp server not in allowlist', "This Model Context Protocol server is not in the list of servers allowed by your organization. Please contact your administrator for more information."));
 		}
 
 		return true;

--- a/src/vs/platform/mcp/common/allowedMcpServersService.ts
+++ b/src/vs/platform/mcp/common/allowedMcpServersService.ts
@@ -8,7 +8,10 @@ import * as nls from '../../../nls.js';
 import { createCommandUri, IMarkdownString, MarkdownString } from '../../../base/common/htmlContent.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { Emitter } from '../../../base/common/event.js';
-import { IAllowedMcpServersService, IGalleryMcpServer, IInstallableMcpServer, ILocalMcpServer, mcpAccessConfig, McpAccessValue } from './mcpManagement.js';
+import { hasKey } from '../../../base/common/types.js';
+import { checkMcpServerAllowed, getMcpServerMatchers, IMcpServerIdentity, McpServerAllowResult } from './allowedMcpServers.js';
+import { IAllowedMcpServersService, IGalleryMcpServer, IInstallableMcpServer, ILocalMcpServer, mcpAccessConfig, mcpAllowedServersConfig, mcpDeniedServersConfig, McpAccessValue } from './mcpManagement.js';
+import { McpServerType } from './mcpPlatformTypes.js';
 
 export class AllowedMcpServersService extends Disposable implements IAllowedMcpServersService {
 
@@ -22,18 +25,49 @@ export class AllowedMcpServersService extends Disposable implements IAllowedMcpS
 	) {
 		super();
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(mcpAccessConfig)) {
+			if (e.affectsConfiguration(mcpAccessConfig) || e.affectsConfiguration(mcpAllowedServersConfig) || e.affectsConfiguration(mcpDeniedServersConfig)) {
 				this._onDidChangeAllowedMcpServers.fire();
 			}
 		}));
 	}
 
 	isAllowed(mcpServer: IGalleryMcpServer | ILocalMcpServer | IInstallableMcpServer): true | IMarkdownString {
-		if (this.configurationService.getValue(mcpAccessConfig) !== McpAccessValue.None) {
-			return true;
+		return this.isServerAllowed(this.toIdentity(mcpServer));
+	}
+
+	isServerAllowed(identity: IMcpServerIdentity): true | IMarkdownString {
+		if (this.configurationService.getValue(mcpAccessConfig) === McpAccessValue.None) {
+			const settingsCommandLink = createCommandUri('workbench.action.openSettings', { query: `@id:${mcpAccessConfig}` }).toString();
+			return new MarkdownString(nls.localize('mcp servers are not allowed', "Model Context Protocol servers are disabled in the Editor. Please check your [settings]({0}).", settingsCommandLink));
 		}
 
-		const settingsCommandLink = createCommandUri('workbench.action.openSettings', { query: `@id:${mcpAccessConfig}` }).toString();
-		return new MarkdownString(nls.localize('mcp servers are not allowed', "Model Context Protocol servers are disabled in the Editor. Please check your [settings]({0}).", settingsCommandLink));
+		const allowlist = getMcpServerMatchers(this.configurationService.getValue(mcpAllowedServersConfig));
+		const denylist = getMcpServerMatchers(this.configurationService.getValue(mcpDeniedServersConfig));
+		switch (checkMcpServerAllowed(allowlist, denylist, identity)) {
+			case McpServerAllowResult.Denied: {
+				const settingsCommandLink = createCommandUri('workbench.action.openSettings', { query: `@id:${mcpDeniedServersConfig}` }).toString();
+				return new MarkdownString(nls.localize('mcp server is denied', "This Model Context Protocol server is blocked by your organization's policy. Please check your [settings]({0}).", settingsCommandLink));
+			}
+			case McpServerAllowResult.NotAllowed: {
+				const settingsCommandLink = createCommandUri('workbench.action.openSettings', { query: `@id:${mcpAllowedServersConfig}` }).toString();
+				return new MarkdownString(nls.localize('mcp server not in allowlist', "This Model Context Protocol server is not in the list of allowed servers. Please check your [settings]({0}).", settingsCommandLink));
+			}
+		}
+
+		return true;
+	}
+
+	private toIdentity(mcpServer: IGalleryMcpServer | ILocalMcpServer | IInstallableMcpServer): IMcpServerIdentity {
+		if (hasKey(mcpServer, { config: true })) {
+			const config = mcpServer.config;
+			if (config.type === McpServerType.REMOTE) {
+				return { name: mcpServer.name, url: config.url };
+			}
+			return { name: mcpServer.name, command: [config.command, ...(config.args ?? [])] };
+		}
+
+		// Gallery server: match by name or a remote URL; the local command invocation is only
+		// known once the server is installed with a resolved configuration.
+		return { name: mcpServer.name, url: mcpServer.configuration.remotes?.[0]?.url };
 	}
 }

--- a/src/vs/platform/mcp/common/mcpManagement.ts
+++ b/src/vs/platform/mcp/common/mcpManagement.ts
@@ -10,6 +10,7 @@ import { IIterativePager } from '../../../base/common/paging.js';
 import { URI } from '../../../base/common/uri.js';
 import { SortBy, SortOrder } from '../../extensionManagement/common/extensionManagement.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { IMcpServerIdentity } from './allowedMcpServers.js';
 import { IMcpSandboxConfiguration, IMcpServerConfiguration, IMcpServerVariable } from './mcpPlatformTypes.js';
 
 export type InstallSource = 'gallery' | 'local';
@@ -244,9 +245,18 @@ export interface IAllowedMcpServersService {
 
 	readonly onDidChangeAllowedMcpServers: Event<void>;
 	isAllowed(mcpServer: IGalleryMcpServer | ILocalMcpServer | IInstallableMcpServer): true | IMarkdownString;
+
+	/**
+	 * Checks whether an MCP server identified by name / remote URL / local command is permitted by
+	 * the `chat.mcp.allowedServers` allowlist (in addition to the `chat.mcp.access` gate). Used by
+	 * the runtime enforcement path, which does not have a gallery/local/installable representation.
+	 */
+	isServerAllowed(identity: IMcpServerIdentity): true | IMarkdownString;
 }
 
 export const mcpAccessConfig = 'chat.mcp.access';
+export const mcpAllowedServersConfig = 'chat.mcp.allowedServers';
+export const mcpDeniedServersConfig = 'chat.mcp.deniedServers';
 export const mcpGalleryServiceUrlConfig = 'chat.mcp.gallery.serviceUrl';
 export const mcpGalleryServiceEnablementConfig = 'chat.mcp.gallery.enabled';
 export const mcpAutoStartConfig = 'chat.mcp.autostart';

--- a/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -333,9 +333,24 @@ export abstract class AbstractMcpResourceManagementService extends AbstractCommo
 		@IUriIdentityService protected readonly uriIdentityService: IUriIdentityService,
 		@ILogService logService: ILogService,
 		@IMcpResourceScannerService protected readonly mcpResourceScannerService: IMcpResourceScannerService,
+		@IAllowedMcpServersService protected readonly allowedMcpServersService: IAllowedMcpServersService,
 	) {
 		super(logService);
 		this.reloadConfigurationScheduler = this._register(new RunOnceScheduler(() => this.updateLocal(), 50));
+	}
+
+	/**
+	 * Enforces the enterprise allow/deny policy at the point of persistence. Called by every
+	 * install path (installable and each gallery override) against the fully resolved server
+	 * configuration, so a caller that goes straight to the management API cannot bypass the
+	 * `canInstall` UI check, and a gallery entry cannot slip through if its resolved command/URL
+	 * differs from the pre-resolution metadata.
+	 */
+	protected ensureServerAllowed(server: IGalleryMcpServer | IInstallableMcpServer): void {
+		const result = this.allowedMcpServersService.isAllowed(server);
+		if (result !== true) {
+			throw new Error(result.value);
+		}
 	}
 
 	private initialize(): Promise<void> {
@@ -456,6 +471,7 @@ export abstract class AbstractMcpResourceManagementService extends AbstractCommo
 
 	async install(server: IInstallableMcpServer, options?: Omit<InstallOptions, 'mcpResource'>): Promise<ILocalMcpServer> {
 		this.logService.trace('MCP Management Service: install', server.name);
+		this.ensureServerAllowed(server);
 
 		this._onInstallMcpServer.fire({ name: server.name, mcpResource: this.mcpResource });
 		try {
@@ -507,9 +523,10 @@ export class McpUserResourceManagementService extends AbstractMcpResourceManagem
 		@IUriIdentityService uriIdentityService: IUriIdentityService,
 		@ILogService logService: ILogService,
 		@IMcpResourceScannerService mcpResourceScannerService: IMcpResourceScannerService,
+		@IAllowedMcpServersService allowedMcpServersService: IAllowedMcpServersService,
 		@IEnvironmentService environmentService: IEnvironmentService
 	) {
-		super(mcpResource, ConfigurationTarget.USER, mcpGalleryService, fileService, uriIdentityService, logService, mcpResourceScannerService);
+		super(mcpResource, ConfigurationTarget.USER, mcpGalleryService, fileService, uriIdentityService, logService, mcpResourceScannerService, allowedMcpServersService);
 		this.mcpLocation = uriIdentityService.extUri.joinPath(environmentService.userRoamingDataHome, 'mcp');
 	}
 

--- a/src/vs/platform/mcp/node/mcpManagementService.ts
+++ b/src/vs/platform/mcp/node/mcpManagementService.ts
@@ -8,7 +8,7 @@ import { IEnvironmentService } from '../../environment/common/environment.js';
 import { IFileService } from '../../files/common/files.js';
 import { ILogService } from '../../log/common/log.js';
 import { IUriIdentityService } from '../../uriIdentity/common/uriIdentity.js';
-import { IGalleryMcpServer, IMcpGalleryService, IMcpManagementService, InstallOptions, ILocalMcpServer, RegistryType, IInstallableMcpServer } from '../common/mcpManagement.js';
+import { IGalleryMcpServer, IMcpGalleryService, IMcpManagementService, InstallOptions, ILocalMcpServer, RegistryType, IInstallableMcpServer, IAllowedMcpServersService } from '../common/mcpManagement.js';
 import { McpUserResourceManagementService as CommonMcpUserResourceManagementService, McpManagementService as CommonMcpManagementService } from '../common/mcpManagementService.js';
 import { IMcpResourceScannerService } from '../common/mcpResourceScannerService.js';
 
@@ -20,9 +20,10 @@ export class McpUserResourceManagementService extends CommonMcpUserResourceManag
 		@IUriIdentityService uriIdentityService: IUriIdentityService,
 		@ILogService logService: ILogService,
 		@IMcpResourceScannerService mcpResourceScannerService: IMcpResourceScannerService,
+		@IAllowedMcpServersService allowedMcpServersService: IAllowedMcpServersService,
 		@IEnvironmentService environmentService: IEnvironmentService,
 	) {
-		super(mcpResource, mcpGalleryService, fileService, uriIdentityService, logService, mcpResourceScannerService, environmentService);
+		super(mcpResource, mcpGalleryService, fileService, uriIdentityService, logService, mcpResourceScannerService, allowedMcpServersService, environmentService);
 	}
 
 	override async installFromGallery(server: IGalleryMcpServer, options?: InstallOptions): Promise<ILocalMcpServer> {
@@ -53,6 +54,8 @@ export class McpUserResourceManagementService extends CommonMcpUserResourceManag
 				},
 				inputs: mcpServerConfiguration.inputs
 			};
+
+			this.ensureServerAllowed(installable);
 
 			await this.mcpResourceScannerService.addMcpServers([installable], this.mcpResource, this.target);
 

--- a/src/vs/platform/mcp/test/common/allowedMcpServers.test.ts
+++ b/src/vs/platform/mcp/test/common/allowedMcpServers.test.ts
@@ -1,0 +1,113 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { checkMcpServerAllowed, getMcpServerMatchers, IMcpServerMatcher, isMcpServerMatched, McpServerAllowResult } from '../../common/allowedMcpServers.js';
+
+suite('AllowedMcpServers', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('getMcpServerMatchers', () => {
+
+		test('coerces non-arrays to undefined', () => {
+			assert.strictEqual(getMcpServerMatchers(null), undefined);
+			assert.strictEqual(getMcpServerMatchers(undefined), undefined);
+			assert.strictEqual(getMcpServerMatchers(true), undefined);
+			assert.strictEqual(getMcpServerMatchers('[]'), undefined);
+			assert.strictEqual(getMcpServerMatchers({ allowed: [] }), undefined);
+		});
+
+		test('empty array is preserved', () => {
+			assert.deepStrictEqual(getMcpServerMatchers([]), []);
+		});
+
+		test('drops malformed and multi-field matcher entries', () => {
+			const value = [
+				{ serverName: 'github' },
+				{ serverUrl: 'https://mcp.example.com/*' },
+				{ serverCommand: ['npx', '-y', 'server'] },
+				{ serverName: '' }, // empty string dropped
+				{ serverCommand: [] }, // empty array dropped
+				{ serverCommand: ['ok', 5] }, // non-string element dropped
+				{ serverName: 'a', serverUrl: 'b' }, // more than one field dropped
+				{}, // no field dropped
+				'string-entry', // non-object dropped
+			];
+			assert.deepStrictEqual(getMcpServerMatchers(value), [
+				{ serverName: 'github' },
+				{ serverUrl: 'https://mcp.example.com/*' },
+				{ serverCommand: ['npx', '-y', 'server'] },
+			]);
+		});
+	});
+
+	suite('isMcpServerMatched', () => {
+
+		test('undefined and empty match nothing', () => {
+			assert.strictEqual(isMcpServerMatched(undefined, { name: 'x' }), false);
+			assert.strictEqual(isMcpServerMatched([], { name: 'x' }), false);
+		});
+
+		test('matches by server name', () => {
+			const matchers: IMcpServerMatcher[] = [{ serverName: 'github' }];
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 'github' }), true);
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 'gitlab' }), false);
+		});
+
+		test('matches by remote URL with wildcards, case-insensitively', () => {
+			const matchers: IMcpServerMatcher[] = [{ serverUrl: 'https://*.example.com/*' }];
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://mcp.example.com/api' }), true);
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://MCP.EXAMPLE.COM/api' }), true);
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://example.com/api' }), false);
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://mcp.evil.com/api' }), false);
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', command: ['node', 'x.js'] }), false);
+		});
+
+		test('exact URL pattern matches only that URL', () => {
+			const matchers: IMcpServerMatcher[] = [{ serverUrl: 'https://mcp.example.com/mcp' }];
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://mcp.example.com/mcp' }), true);
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://mcp.example.com/mcp/extra' }), false);
+		});
+
+		test('matches by local command as an ordered argument list', () => {
+			const matchers: IMcpServerMatcher[] = [{ serverCommand: ['npx', '-y', 'server'] }];
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', command: ['npx', '-y', 'server'] }), true);
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', command: ['npx', 'server'] }), false);
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', command: ['npx', '-y', 'server', '--flag'] }), false);
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://mcp.example.com' }), false);
+		});
+	});
+
+	suite('checkMcpServerAllowed', () => {
+
+		test('no lists configured allows everything', () => {
+			assert.strictEqual(checkMcpServerAllowed(undefined, undefined, { name: 'x' }), McpServerAllowResult.Allowed);
+		});
+
+		test('empty allowlist blocks everything as NotAllowed', () => {
+			assert.strictEqual(checkMcpServerAllowed([], undefined, { name: 'x' }), McpServerAllowResult.NotAllowed);
+		});
+
+		test('allowlist permits only matching servers', () => {
+			const allow: IMcpServerMatcher[] = [{ serverName: 'github' }];
+			assert.strictEqual(checkMcpServerAllowed(allow, undefined, { name: 'github' }), McpServerAllowResult.Allowed);
+			assert.strictEqual(checkMcpServerAllowed(allow, undefined, { name: 'other' }), McpServerAllowResult.NotAllowed);
+		});
+
+		test('deny takes precedence over allow', () => {
+			const allow: IMcpServerMatcher[] = [{ serverName: 'github' }];
+			const deny: IMcpServerMatcher[] = [{ serverName: 'github' }];
+			assert.strictEqual(checkMcpServerAllowed(allow, deny, { name: 'github' }), McpServerAllowResult.Denied);
+		});
+
+		test('deny blocks even when no allowlist is configured', () => {
+			const deny: IMcpServerMatcher[] = [{ serverUrl: 'https://*.untrusted.example.com/*' }];
+			assert.strictEqual(checkMcpServerAllowed(undefined, deny, { name: 's', url: 'https://api.untrusted.example.com/mcp' }), McpServerAllowResult.Denied);
+			assert.strictEqual(checkMcpServerAllowed(undefined, deny, { name: 's', url: 'https://api.trusted.example.com/mcp' }), McpServerAllowResult.Allowed);
+		});
+	});
+});

--- a/src/vs/platform/mcp/test/common/allowedMcpServers.test.ts
+++ b/src/vs/platform/mcp/test/common/allowedMcpServers.test.ts
@@ -64,6 +64,8 @@ suite('AllowedMcpServers', () => {
 			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://MCP.EXAMPLE.COM/api' }), true);
 			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://example.com/api' }), false);
 			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://mcp.evil.com/api' }), false);
+			// An authority wildcard must not swallow the path separator and let an untrusted host through.
+			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', url: 'https://evil.test/.example.com/tool' }), false);
 			assert.strictEqual(isMcpServerMatched(matchers, { name: 's', command: ['node', 'x.js'] }), false);
 		});
 

--- a/src/vs/platform/mcp/test/common/allowedMcpServersService.test.ts
+++ b/src/vs/platform/mcp/test/common/allowedMcpServersService.test.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
+import { AllowedMcpServersService } from '../../common/allowedMcpServersService.js';
+import { IInstallableMcpServer, mcpAccessConfig, mcpAllowedServersConfig, mcpDeniedServersConfig, McpAccessValue } from '../../common/mcpManagement.js';
+import { McpServerType } from '../../common/mcpPlatformTypes.js';
+
+suite('AllowedMcpServersService', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createService(config: Record<string, unknown>): AllowedMcpServersService {
+		const configurationService = new TestConfigurationService(config);
+		return disposables.add(new AllowedMcpServersService(configurationService));
+	}
+
+	test('allows any server when nothing is configured', () => {
+		const service = createService({});
+		assert.strictEqual(service.isServerAllowed({ name: 'github' }), true);
+	});
+
+	test('blocks all servers when access is None', () => {
+		const service = createService({ [mcpAccessConfig]: McpAccessValue.None });
+		const result = service.isServerAllowed({ name: 'github' });
+		assert.notStrictEqual(result, true);
+	});
+
+	test('allowlist permits only matching servers', () => {
+		const service = createService({ [mcpAllowedServersConfig]: [{ serverName: 'github' }] });
+		assert.strictEqual(service.isServerAllowed({ name: 'github' }), true);
+
+		const result = service.isServerAllowed({ name: 'gitlab' });
+		assert.notStrictEqual(result, true);
+		assert.ok(result !== true && result.value.includes('not in the list of allowed servers'));
+	});
+
+	test('denylist blocks a matching server even when it is also allowed', () => {
+		const service = createService({
+			[mcpAllowedServersConfig]: [{ serverName: 'github' }],
+			[mcpDeniedServersConfig]: [{ serverName: 'github' }],
+		});
+
+		const result = service.isServerAllowed({ name: 'github' });
+		assert.notStrictEqual(result, true);
+		assert.ok(result !== true && result.value.includes('blocked by your organization'));
+	});
+
+	test('denylist blocks by remote URL wildcard even without an allowlist', () => {
+		const service = createService({ [mcpDeniedServersConfig]: [{ serverUrl: 'https://*.untrusted.example.com/*' }] });
+
+		const denied = service.isServerAllowed({ name: 's', url: 'https://api.untrusted.example.com/mcp' });
+		assert.notStrictEqual(denied, true);
+		assert.strictEqual(service.isServerAllowed({ name: 's', url: 'https://api.trusted.example.com/mcp' }), true);
+	});
+
+	test('isAllowed matches an installable stdio server by its command', () => {
+		const service = createService({ [mcpAllowedServersConfig]: [{ serverCommand: ['npx', '-y', 'server'] }] });
+
+		const allowed: IInstallableMcpServer = { name: 'anything', config: { type: McpServerType.LOCAL, command: 'npx', args: ['-y', 'server'] } };
+		assert.strictEqual(service.isAllowed(allowed), true);
+
+		const blocked: IInstallableMcpServer = { name: 'anything', config: { type: McpServerType.LOCAL, command: 'npx', args: ['other'] } };
+		assert.notStrictEqual(service.isAllowed(blocked), true);
+	});
+
+	test('isAllowed matches an installable remote server by its URL', () => {
+		const service = createService({ [mcpAllowedServersConfig]: [{ serverUrl: 'https://mcp.example.com/*' }] });
+
+		const allowed: IInstallableMcpServer = { name: 'anything', config: { type: McpServerType.REMOTE, url: 'https://mcp.example.com/api' } };
+		assert.strictEqual(service.isAllowed(allowed), true);
+
+		const blocked: IInstallableMcpServer = { name: 'anything', config: { type: McpServerType.REMOTE, url: 'https://other.example.org/api' } };
+		assert.notStrictEqual(service.isAllowed(blocked), true);
+	});
+});

--- a/src/vs/platform/mcp/test/common/allowedMcpServersService.test.ts
+++ b/src/vs/platform/mcp/test/common/allowedMcpServersService.test.ts
@@ -36,7 +36,7 @@ suite('AllowedMcpServersService', () => {
 
 		const result = service.isServerAllowed({ name: 'gitlab' });
 		assert.notStrictEqual(result, true);
-		assert.ok(result !== true && result.value.includes('not in the list of allowed servers'));
+		assert.ok(result !== true && result.value.includes('not in the list of servers allowed by your organization'));
 	});
 
 	test('denylist blocks a matching server even when it is also allowed', () => {

--- a/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
+++ b/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
@@ -9,9 +9,9 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { AbstractCommonMcpManagementService, AbstractMcpResourceManagementService } from '../../common/mcpManagementService.js';
-import { IGalleryMcpServer, IGalleryMcpServerConfiguration, IInstallableMcpServer, ILocalMcpServer, IMcpGalleryService, InstallOptions, RegistryType, TransportType, UninstallOptions } from '../../common/mcpManagement.js';
+import { IAllowedMcpServersService, IGalleryMcpServer, IGalleryMcpServerConfiguration, IInstallableMcpServer, ILocalMcpServer, IMcpGalleryService, InstallOptions, RegistryType, TransportType, UninstallOptions } from '../../common/mcpManagement.js';
 import { IMcpSandboxConfiguration, McpServerType, McpServerVariableType, IMcpServerConfiguration, IMcpServerVariable } from '../../common/mcpPlatformTypes.js';
-import { IMarkdownString } from '../../../../base/common/htmlContent.js';
+import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Event } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ConfigurationTarget } from '../../../configuration/common/configuration.js';
@@ -51,7 +51,7 @@ class TestMcpManagementService extends AbstractCommonMcpManagementService {
 }
 
 class TestMcpResourceManagementService extends AbstractMcpResourceManagementService {
-	constructor(mcpResource: URI, fileService: FileService, uriIdentityService: UriIdentityService, mcpResourceScannerService: McpResourceScannerService) {
+	constructor(mcpResource: URI, fileService: FileService, uriIdentityService: UriIdentityService, mcpResourceScannerService: McpResourceScannerService, allowedMcpServersService: IAllowedMcpServersService = { _serviceBrand: undefined, onDidChangeAllowedMcpServers: Event.None, isAllowed: () => true, isServerAllowed: () => true }) {
 		super(
 			mcpResource,
 			ConfigurationTarget.USER,
@@ -60,7 +60,7 @@ class TestMcpResourceManagementService extends AbstractMcpResourceManagementServ
 			uriIdentityService,
 			new NullLogService(),
 			mcpResourceScannerService,
-			{ _serviceBrand: undefined, onDidChangeAllowedMcpServers: Event.None, isAllowed: () => true, isServerAllowed: () => true },
+			allowedMcpServersService,
 		);
 	}
 
@@ -1191,3 +1191,48 @@ suite('McpResourceManagementService', () => {
 		assert.deepStrictEqual(updated[0].rootSandbox, updatedSandbox);
 	});
 });
+
+suite('McpResourceManagementService - install policy enforcement', () => {
+	const mcpResource = URI.from({ scheme: Schemas.inMemory, path: '/mcp-policy.json' });
+	let disposables: DisposableStore;
+	let fileService: FileService;
+	let uriIdentityService: UriIdentityService;
+	let scannerService: McpResourceScannerService;
+
+	const server: IInstallableMcpServer = { name: 'my-server', config: { type: McpServerType.LOCAL, command: 'node', args: [] } };
+
+	function createService(isAllowed: IAllowedMcpServersService['isAllowed']): TestMcpResourceManagementService {
+		const allowedMcpServersService: IAllowedMcpServersService = { _serviceBrand: undefined, onDidChangeAllowedMcpServers: Event.None, isAllowed, isServerAllowed: () => true };
+		return disposables.add(new TestMcpResourceManagementService(mcpResource, fileService, uriIdentityService, scannerService, allowedMcpServersService));
+	}
+
+	setup(() => {
+		disposables = new DisposableStore();
+		fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+		uriIdentityService = disposables.add(new UriIdentityService(fileService));
+		scannerService = disposables.add(new McpResourceScannerService(fileService, uriIdentityService));
+	});
+
+	teardown(() => {
+		disposables.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('install throws and does not persist a server blocked by policy', async () => {
+		const service = createService(() => new MarkdownString('This mcp server is blocked by your organization.'));
+
+		await assert.rejects(() => service.install(server), /blocked by your organization/);
+		assert.strictEqual((await service.getInstalled()).find(s => s.name === server.name), undefined);
+	});
+
+	test('install persists a server allowed by policy', async () => {
+		const service = createService(() => true);
+
+		const local = await service.install(server);
+		assert.strictEqual(local.name, server.name);
+		assert.ok((await service.getInstalled()).some(s => s.name === server.name));
+	});
+});
+

--- a/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
+++ b/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
@@ -60,6 +60,7 @@ class TestMcpResourceManagementService extends AbstractMcpResourceManagementServ
 			uriIdentityService,
 			new NullLogService(),
 			mcpResourceScannerService,
+			{ _serviceBrand: undefined, onDidChangeAllowedMcpServers: Event.None, isAllowed: () => true, isServerAllowed: () => true },
 		);
 	}
 

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -35,6 +35,12 @@ export const COPILOT_EXTRA_MARKETPLACES_KEY = 'extraKnownMarketplaces';
 /** Managed-settings key for the strict-marketplace allowlist (carried as a JSON-encoded array of source entries; absent = no restrictions, `[]` = lockdown). */
 export const COPILOT_STRICT_MARKETPLACES_KEY = 'strictKnownMarketplaces';
 
+/** Managed-settings key for the per-server MCP allowlist (carried as a JSON-encoded array of matcher entries; absent = no allow restriction, `[]` = only servers matching an entry, i.e. block all). */
+export const COPILOT_ALLOWED_MCP_SERVERS_KEY = 'allowedMcpServers';
+
+/** Managed-settings key for the per-server MCP denylist (carried as a JSON-encoded array of matcher entries; deny always takes precedence over allow). */
+export const COPILOT_DENIED_MCP_SERVERS_KEY = 'deniedMcpServers';
+
 /**
  * Managed-settings key for the default chat model (carried as a plain string: `auto`, a model
  * family name, or a full model id). Nested under `permissions` in the managed-settings schema
@@ -426,6 +432,14 @@ const STRUCTURED_MANAGED_SETTINGS: readonly IStructuredManagedSetting[] = [
 	},
 	{
 		key: COPILOT_STRICT_MARKETPLACES_KEY,
+		encode: encodeArray,
+	},
+	{
+		key: COPILOT_ALLOWED_MCP_SERVERS_KEY,
+		encode: encodeArray,
+	},
+	{
+		key: COPILOT_DENIED_MCP_SERVERS_KEY,
 		encode: encodeArray,
 	},
 	{

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -16,7 +16,7 @@ import { AgentHostAhpJsonlLoggingSettingId, AgentHostSdkSandboxEnabledSettingId,
 import { AgentHostCopilotSdkLogLevelSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, copilotSdkLogLevelSettingValues } from '../../../../platform/agentHost/common/copilotCliConfig.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
-import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, COPILOT_STRICT_MARKETPLACES_KEY, managedModelValue, managedSettingValue } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_ALLOWED_MCP_SERVERS_KEY, COPILOT_DENIED_MCP_SERVERS_KEY, COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, COPILOT_STRICT_MARKETPLACES_KEY, managedModelValue, managedSettingValue } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../platform/sandbox/common/settings.js';
 import { registerEditorFeature } from '../../../../editor/common/editorFeatures.js';
 import * as nls from '../../../../nls.js';
@@ -28,7 +28,7 @@ import { SyncDescriptor } from '../../../../platform/instantiation/common/descri
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { McpAccessValue, McpAutoStartValue, mcpAccessConfig, mcpAutoStartConfig, mcpGalleryServiceEnablementConfig, mcpGalleryServiceUrlConfig, mcpAppsEnabledConfig } from '../../../../platform/mcp/common/mcpManagement.js';
+import { McpAccessValue, McpAutoStartValue, mcpAccessConfig, mcpAllowedServersConfig, mcpAutoStartConfig, mcpDeniedServersConfig, mcpGalleryServiceEnablementConfig, mcpGalleryServiceUrlConfig, mcpAppsEnabledConfig } from '../../../../platform/mcp/common/mcpManagement.js';
 import product from '../../../../platform/product/common/product.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
@@ -914,6 +914,82 @@ configurationRegistry.registerConfiguration({
 							key: 'chat.mcp.access.any', value: nls.localize('chat.mcp.access.any', "Allow access to any installed MCP server.")
 						}
 					]
+				},
+			}
+		},
+		[mcpAllowedServersConfig]: {
+			type: ['array', 'null'],
+			items: {
+				type: 'object',
+				additionalProperties: false,
+				properties: {
+					serverName: { type: 'string', minLength: 1, description: nls.localize('chat.mcp.allowedServers.serverName', "Match a server by its configured name.") },
+					serverUrl: { type: 'string', minLength: 1, description: nls.localize('chat.mcp.allowedServers.serverUrl', "Match a remote server by its URL. Supports `*` wildcards, for example `https://*.example.com/*`.") },
+					serverCommand: { type: 'array', minItems: 1, items: { type: 'string' }, description: nls.localize('chat.mcp.allowedServers.serverCommand', "Match a local server by its exact command invocation, given as the command followed by its arguments.") },
+				},
+				oneOf: [
+					{ required: ['serverName'] },
+					{ required: ['serverUrl'] },
+					{ required: ['serverCommand'] },
+				],
+			},
+			markdownDescription: nls.localize('chat.mcp.allowedServers', "Enterprise-managed allowlist that controls which Model Context Protocol servers may be installed and run. When set, only servers matching an entry are permitted; any other server is blocked. Servers can be matched by name, remote URL pattern (with `*` wildcards), or local command invocation. Omit entirely to allow all servers (subject to the deny list). Delivered via enterprise policy for governance; this setting is not surfaced to end users."),
+			default: null,
+			scope: ConfigurationScope.APPLICATION,
+			// Governance-only: delivered via the `ChatAllowedMcpServers` enterprise policy and hidden
+			// from the Settings UI so it is not configurable by end users.
+			included: false,
+			policy: {
+				name: 'ChatAllowedMcpServers',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.130',
+				value: managedSettingValue(COPILOT_ALLOWED_MCP_SERVERS_KEY),
+				managedSettings: {
+					[COPILOT_ALLOWED_MCP_SERVERS_KEY]: { type: 'string' },
+				},
+				localization: {
+					description: {
+						key: 'chat.mcp.allowedServers.policy',
+						value: nls.localize('chat.mcp.allowedServers.policy', "Allowlist of Model Context Protocol servers. When set, only servers matching an entry may be installed or run; omit entirely to allow all servers (subject to the deny list).")
+					}
+				},
+			}
+		},
+		[mcpDeniedServersConfig]: {
+			type: ['array', 'null'],
+			items: {
+				type: 'object',
+				additionalProperties: false,
+				properties: {
+					serverName: { type: 'string', minLength: 1, description: nls.localize('chat.mcp.deniedServers.serverName', "Match a server by its configured name.") },
+					serverUrl: { type: 'string', minLength: 1, description: nls.localize('chat.mcp.deniedServers.serverUrl', "Match a remote server by its URL. Supports `*` wildcards, for example `https://*.example.com/*`.") },
+					serverCommand: { type: 'array', minItems: 1, items: { type: 'string' }, description: nls.localize('chat.mcp.deniedServers.serverCommand', "Match a local server by its exact command invocation, given as the command followed by its arguments.") },
+				},
+				oneOf: [
+					{ required: ['serverName'] },
+					{ required: ['serverUrl'] },
+					{ required: ['serverCommand'] },
+				],
+			},
+			markdownDescription: nls.localize('chat.mcp.deniedServers', "Enterprise-managed denylist of Model Context Protocol servers. Servers matching any entry are unconditionally blocked from being installed or run, even if they also match the allow list — deny rules always take precedence. Servers can be matched by name, remote URL pattern (with `*` wildcards), or local command invocation. Delivered via enterprise policy for governance; this setting is not surfaced to end users."),
+			default: null,
+			scope: ConfigurationScope.APPLICATION,
+			// Governance-only: delivered via the `ChatDeniedMcpServers` enterprise policy and hidden
+			// from the Settings UI so it is not configurable by end users.
+			included: false,
+			policy: {
+				name: 'ChatDeniedMcpServers',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.130',
+				value: managedSettingValue(COPILOT_DENIED_MCP_SERVERS_KEY),
+				managedSettings: {
+					[COPILOT_DENIED_MCP_SERVERS_KEY]: { type: 'string' },
+				},
+				localization: {
+					description: {
+						key: 'chat.mcp.deniedServers.policy',
+						value: nls.localize('chat.mcp.deniedServers.policy', "Denylist of Model Context Protocol servers. Servers matching any entry are blocked from being installed or run, even if they also match the allow list; deny rules always take precedence.")
+					}
 				},
 			}
 		},

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -29,6 +29,7 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { ConfigurationResolverExpression } from '../../../services/configurationResolver/common/configurationResolverExpression.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
@@ -42,7 +43,7 @@ import { IMcpRegistry } from './mcpRegistryTypes.js';
 import { IMcpSandboxService } from './mcpSandboxService.js';
 import { McpServerRequestHandler } from './mcpServerRequestHandler.js';
 import { McpTaskManager } from './mcpTaskManager.js';
-import { ElicitationKind, extensionMcpCollectionPrefix, IMcpElicitationService, IMcpIcons, IMcpPotentialSandboxBlock, IMcpPrompt, IMcpPromptMessage, IMcpResource, IMcpResourceTemplate, IMcpSamplingService, IMcpServer, IMcpServerConnection, IMcpServerStartOpts, IMcpTool, IMcpToolCallContext, McpCapability, McpCollectionDefinition, McpCollectionReference, McpConnectionFailedError, McpConnectionState, McpDefinitionReference, mcpPromptReplaceSpecialChars, McpResourceURI, McpServerCacheState, McpServerDefinition, McpServerStaticToolAvailability, McpServerTransportType, McpToolName, McpToolVisibility, MpcResponseError, UserInteractionRequiredError } from './mcpTypes.js';
+import { ElicitationKind, extensionMcpCollectionPrefix, IMcpElicitationService, IMcpIcons, IMcpPotentialSandboxBlock, IMcpPrompt, IMcpPromptMessage, IMcpResource, IMcpResourceTemplate, IMcpSamplingService, IMcpServer, IMcpServerConnection, IMcpServerStartOpts, IMcpTool, IMcpToolCallContext, McpCapability, McpCollectionDefinition, McpCollectionReference, McpConnectionFailedError, McpConnectionState, McpDefinitionReference, mcpPromptReplaceSpecialChars, McpResourceURI, McpServerCacheState, McpServerDefinition, McpServerLaunch, McpServerStaticToolAvailability, McpServerTransportType, McpToolName, McpToolVisibility, MpcResponseError, UserInteractionRequiredError } from './mcpTypes.js';
 import { ContributionEnablementState, IEnablementModel } from '../../chat/common/enablement.js';
 import { MCP } from './modelContextProtocol.js';
 import { McpApps } from './modelContextProtocolApps.js';
@@ -358,8 +359,20 @@ export class McpServer extends Disposable implements IMcpServer {
 		const callPromise = new Promise<R>((resolve, reject) => {
 
 			d = autorun(reader => {
+				if (ranOnce) {
+					return;
+				}
+
 				const connection = server.connection.read(reader);
-				if (!connection || ranOnce) {
+				if (!connection) {
+					// No live connection: the server may be blocked by policy (its connection is torn
+					// down while blocked) or stopped. Surface the terminal state instead of waiting forever.
+					const state = server.connectionState.read(reader);
+					if (state.state === McpConnectionState.Kind.Error) {
+						reject(new McpConnectionFailedError(`MCP server could not be started: ${state.message}`));
+					} else if (state.state === McpConnectionState.Kind.Stopped) {
+						reject(new McpConnectionFailedError('MCP server has stopped'));
+					}
 					return;
 				}
 
@@ -391,9 +404,22 @@ export class McpServer extends Disposable implements IMcpServer {
 	private readonly _connection = this._register(disposableObservableValue<IMcpServerConnection | undefined>(this, undefined));
 
 	public readonly connection = this._connection;
-	/** Holds an error state when the server is blocked by the `chat.mcp.allowedServers` policy, so the block surfaces in the UI without a real connection. */
-	private readonly _policyBlockState = observableValue<McpConnectionState.Error | undefined>(this, undefined);
-	public readonly connectionState: IObservable<McpConnectionState> = derived(reader => this._connection.read(reader)?.state.read(reader) ?? this._policyBlockState.read(reader) ?? { state: McpConnectionState.Kind.Stopped });
+
+	/**
+	 * Reactively evaluates the `chat.mcp.allowedServers` / `chat.mcp.deniedServers` policy against
+	 * this server's identity. Holds an error state while blocked, `undefined` while allowed.
+	 *
+	 * Being a derived, it recomputes whenever the policy changes (via {@link _policyEpoch}), the
+	 * server definition changes, or a connection resolves — so it always evaluates the *resolved*
+	 * launch of a live connection and falls back to the definition otherwise. This also means a
+	 * blocked server surfaces the block at rest (before any start), which hides its cached tools
+	 * and prompts and lets the UI show the reason.
+	 *
+	 * Initialized in the constructor because it depends on the injected allowed-servers service.
+	 */
+	private readonly _policyEpoch: IObservable<void>;
+	private readonly _policyBlock: IObservable<McpConnectionState.Error | undefined>;
+	public readonly connectionState: IObservable<McpConnectionState> = derived(reader => this._policyBlock.read(reader) ?? this._connection.read(reader)?.state.read(reader) ?? { state: McpConnectionState.Kind.Stopped });
 
 
 	private readonly _capabilities: CachedPrimitive<number | undefined, number | undefined>;
@@ -402,13 +428,17 @@ export class McpServer extends Disposable implements IMcpServer {
 	}
 
 	private readonly _tools: CachedPrimitive<readonly IMcpTool[], readonly ValidatedMcpTool[]>;
+	/** Cached tools are suppressed while the server is blocked by policy so they cannot be listed, referenced, or executed. */
+	private readonly _gatedTools: IObservable<readonly IMcpTool[]> = derived(reader => this._policyBlock.read(reader) ? [] : this._tools.value.read(reader));
 	public get tools() {
-		return this._tools.value;
+		return this._gatedTools;
 	}
 
 	private readonly _prompts: CachedPrimitive<readonly IMcpPrompt[], readonly StoredMcpPrompt[]>;
+	/** Cached prompts are suppressed while the server is blocked by policy. */
+	private readonly _gatedPrompts: IObservable<readonly IMcpPrompt[]> = derived(reader => this._policyBlock.read(reader) ? [] : this._prompts.value.read(reader));
 	public get prompts() {
-		return this._prompts.value;
+		return this._gatedPrompts;
 	}
 
 	private readonly _serverMetadata: CachedPrimitive<ServerMetadata, StoredServerMetadata | undefined>;
@@ -508,6 +538,42 @@ export class McpServer extends Disposable implements IMcpServer {
 		this.collection = initialCollection;
 		this._fullDefinitions = this._mcpRegistry.getServerDefinition(this.collection, this.definition);
 		this.enablement = derived(r => enablementModel.readEnabled(definition.id, r));
+
+		this._policyEpoch = observableFromEvent(this, this._allowedMcpServersService.onDidChangeAllowedMcpServers, () => undefined);
+		this._policyBlock = derived<McpConnectionState.Error | undefined>(this, reader => {
+			this._policyEpoch.read(reader);
+			const connection = this._connection.read(reader);
+			if (connection) {
+				// Authoritative: the connection carries the fully resolved launch.
+				return this._evaluatePolicy(this._identityFromLaunch(connection.launchDefinition));
+			}
+			// At rest, only decide when we have a concrete, fully-resolved launch. If the definition
+			// has not been provided yet (e.g. a lazy/extension server before activation) or the launch
+			// still contains unresolved `${...}` variables (inputs, workspace or env vars), a
+			// URL/command allow/deny rule cannot be matched reliably, so defer the decision to start()
+			// — which re-checks the fully resolved launch — to avoid over-eagerly blocking (and hiding
+			// the cached tools of) a server that will actually be allowed once resolved. `chat.mcp.access`
+			// and deny-by-name are still enforced at start(), and access also by the enablement layer.
+			const launch = this._fullDefinitions.read(reader).server?.launch;
+			if (!launch) {
+				return undefined;
+			}
+			const identity = this._identityFromLaunch(launch);
+			if (McpServer._hasUnresolvedVariables(identity)) {
+				return undefined;
+			}
+			return this._evaluatePolicy(identity);
+		});
+
+		// Stop a live connection when the policy blocks it (e.g. the policy was tightened while the
+		// server was running). The block itself is evaluated reactively by `_policyBlock`, which also
+		// hides cached tools/prompts and surfaces the reason in the UI.
+		this._register(autorun(reader => {
+			if (this._policyBlock.read(reader) && this._connection.read(undefined)) {
+				this._connection.set(undefined, undefined); // disposes and stops the connection
+			}
+		}));
+
 		this._loggerId = `mcpServer.${definition.id}`;
 		this._logger = this._register(_loggerService.createLogger(this._loggerId, { hidden: true, name: `MCP: ${definition.label}` }));
 
@@ -653,8 +719,7 @@ export class McpServer extends Disposable implements IMcpServer {
 		}, token);
 	}
 
-	private _getIdentity(): IMcpServerIdentity {
-		const launch = this._fullDefinitions.get().server?.launch;
+	private _identityFromLaunch(launch: McpServerLaunch | undefined): IMcpServerIdentity {
 		if (launch?.type === McpServerTransportType.HTTP) {
 			return { name: this.definition.label, url: launch.uri.toString(true) };
 		}
@@ -664,17 +729,32 @@ export class McpServer extends Disposable implements IMcpServer {
 		return { name: this.definition.label };
 	}
 
+	private _evaluatePolicy(identity: IMcpServerIdentity): McpConnectionState.Error | undefined {
+		const allowed = this._allowedMcpServersService.isServerAllowed(identity);
+		return allowed === true ? undefined : { state: McpConnectionState.Kind.Error, message: allowed.value };
+	}
+
+	/**
+	 * Whether the URL/command fields matched by the policy still contain unresolved `${...}`
+	 * configuration variables. When they do, matching against allow/deny URL or command rules is
+	 * unreliable, so the block is deferred until the launch is resolved. The server name is used
+	 * verbatim and is not considered here.
+	 */
+	private static _hasUnresolvedVariables(identity: IMcpServerIdentity): boolean {
+		const variableMarker = ConfigurationResolverExpression.VARIABLE_LHS;
+		return !!identity.url?.includes(variableMarker) || !!identity.command?.some(arg => arg.includes(variableMarker));
+	}
+
 	public start({ interaction, autoTrustChanges, promptType, debug, errorOnUserInteraction }: IMcpServerStartOpts = {}): Promise<McpConnectionState> {
 		interaction?.participants.set(this.definition.id, { s: 'unknown' });
 
 		return this._connectionSequencer.queue<McpConnectionState>(async () => {
-			const allowed = this._allowedMcpServersService.isServerAllowed(this._getIdentity());
-			if (allowed !== true) {
-				const blocked: McpConnectionState = { state: McpConnectionState.Kind.Error, message: allowed.value };
-				this._policyBlockState.set(blocked, undefined);
-				return blocked;
+			// Evaluated against the definition here (no connection yet). `_policyBlock` re-evaluates
+			// against the resolved launch once the connection exists (checked again below).
+			const preStartBlock = this._policyBlock.get();
+			if (preStartBlock) {
+				return preStartBlock;
 			}
-			this._policyBlockState.set(undefined, undefined);
 
 			const activationEvent = mcpActivationEvent(this.collection.id.slice(extensionMcpCollectionPrefix.length));
 			if (this._requiresExtensionActivation && !this._extensionService.activationEventIsDone(activationEvent)) {
@@ -728,6 +808,16 @@ export class McpServer extends Disposable implements IMcpServer {
 				if (connection.definition.devMode) {
 					this.showOutput();
 				}
+			}
+
+			// Re-evaluate the policy against the *resolved* launch definition. Extension activation and
+			// variable/input substitution during resolution can change the URL or command, so the
+			// identity that actually launches may differ from the one checked before resolution.
+			// `_policyBlock` now sees the live connection and uses its resolved launch.
+			const resolvedBlock = this._policyBlock.get();
+			if (resolvedBlock) {
+				this._connection.set(undefined, undefined); // dispose the just-resolved connection
+				return resolvedBlock;
 			}
 
 			this._potentialSandboxBlocks.length = 0;

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -21,6 +21,8 @@ import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IMcpServerIdentity } from '../../../../platform/mcp/common/allowedMcpServers.js';
+import { IAllowedMcpServersService } from '../../../../platform/mcp/common/mcpManagement.js';
 import { ILogger, ILoggerService } from '../../../../platform/log/common/log.js';
 import { INotificationService, IPromptChoice, Severity } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
@@ -389,7 +391,9 @@ export class McpServer extends Disposable implements IMcpServer {
 	private readonly _connection = this._register(disposableObservableValue<IMcpServerConnection | undefined>(this, undefined));
 
 	public readonly connection = this._connection;
-	public readonly connectionState: IObservable<McpConnectionState> = derived(reader => this._connection.read(reader)?.state.read(reader) ?? { state: McpConnectionState.Kind.Stopped });
+	/** Holds an error state when the server is blocked by the `chat.mcp.allowedServers` policy, so the block surfaces in the UI without a real connection. */
+	private readonly _policyBlockState = observableValue<McpConnectionState.Error | undefined>(this, undefined);
+	public readonly connectionState: IObservable<McpConnectionState> = derived(reader => this._connection.read(reader)?.state.read(reader) ?? this._policyBlockState.read(reader) ?? { state: McpConnectionState.Kind.Stopped });
 
 
 	private readonly _capabilities: CachedPrimitive<number | undefined, number | undefined>;
@@ -483,6 +487,7 @@ export class McpServer extends Disposable implements IMcpServer {
 		prefixGenerator: McpPrefixGenerator,
 		enablementModel: IEnablementModel,
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
+		@IAllowedMcpServersService private readonly _allowedMcpServersService: IAllowedMcpServersService,
 		@IWorkspaceContextService workspacesService: IWorkspaceContextService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@ILoggerService private readonly _loggerService: ILoggerService,
@@ -648,10 +653,29 @@ export class McpServer extends Disposable implements IMcpServer {
 		}, token);
 	}
 
+	private _getIdentity(): IMcpServerIdentity {
+		const launch = this._fullDefinitions.get().server?.launch;
+		if (launch?.type === McpServerTransportType.HTTP) {
+			return { name: this.definition.label, url: launch.uri.toString(true) };
+		}
+		if (launch?.type === McpServerTransportType.Stdio) {
+			return { name: this.definition.label, command: [launch.command, ...launch.args] };
+		}
+		return { name: this.definition.label };
+	}
+
 	public start({ interaction, autoTrustChanges, promptType, debug, errorOnUserInteraction }: IMcpServerStartOpts = {}): Promise<McpConnectionState> {
 		interaction?.participants.set(this.definition.id, { s: 'unknown' });
 
 		return this._connectionSequencer.queue<McpConnectionState>(async () => {
+			const allowed = this._allowedMcpServersService.isServerAllowed(this._getIdentity());
+			if (allowed !== true) {
+				const blocked: McpConnectionState = { state: McpConnectionState.Kind.Error, message: allowed.value };
+				this._policyBlockState.set(blocked, undefined);
+				return blocked;
+			}
+			this._policyBlockState.set(undefined, undefined);
+
 			const activationEvent = mcpActivationEvent(this.collection.id.slice(extensionMcpCollectionPrefix.length));
 			if (this._requiresExtensionActivation && !this._extensionService.activationEventIsDone(activationEvent)) {
 				await this._extensionService.activateByEvent(activationEvent);

--- a/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import { Barrier, timeout } from '../../../../../base/common/async.js';
+import { Event } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -12,6 +13,7 @@ import { FileChangeType, FileSystemProviderErrorCode, FileType, IFileChange, IFi
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILoggerService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IAllowedMcpServersService } from '../../../../../platform/mcp/common/mcpManagement.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -44,6 +46,7 @@ suite('Workbench - MCP - ResourceFilesystem', () => {
 			[IWorkbenchEnvironmentService, {}],
 			[ITelemetryService, NullTelemetryService],
 			[IProductService, TestProductService],
+			[IAllowedMcpServersService, { _serviceBrand: undefined, onDidChangeAllowedMcpServers: Event.None, isAllowed: () => true, isServerAllowed: () => true }],
 		);
 
 		const parentInsta1 = ds.add(new TestInstantiationService(services));

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -17,6 +17,16 @@ import { normalizeManagedSettings } from '../../../../platform/policy/common/cop
  *
  * Exported for unit-testing the {@link adaptManagedSettings} shape transformation.
  */
+/**
+ * A single MCP server matcher entry in the `allowedMcpServers` / `deniedMcpServers` managed
+ * settings, identifying a server by exactly one strategy: name, remote URL pattern, or local
+ * command invocation.
+ */
+export type IManagedMcpServerMatcher =
+	| { readonly serverName: string }
+	| { readonly serverUrl: string }
+	| { readonly serverCommand: readonly string[] };
+
 export interface IManagedSettingsResponse {
 	readonly permissions?: {
 		readonly disableBypassPermissionsMode?: string;
@@ -28,6 +38,8 @@ export interface IManagedSettingsResponse {
 		| { readonly source: 'git'; readonly url: string; readonly ref?: string };
 	}>;
 	readonly strictKnownMarketplaces?: readonly unknown[];
+	readonly allowedMcpServers?: ReadonlyArray<IManagedMcpServerMatcher>;
+	readonly deniedMcpServers?: ReadonlyArray<IManagedMcpServerMatcher>;
 	readonly telemetry?: {
 		readonly enabled?: boolean;
 		readonly endpoint?: string;

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -7,6 +7,16 @@ import { IPolicyData } from '../../../../base/common/defaultAccount.js';
 import { normalizeManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
 
 /**
+ * A single MCP server matcher entry in the `allowedMcpServers` / `deniedMcpServers` managed
+ * settings, identifying a server by exactly one strategy: name, remote URL pattern, or local
+ * command invocation.
+ */
+export type IManagedMcpServerMatcher =
+	| { readonly serverName: string }
+	| { readonly serverUrl: string }
+	| { readonly serverCommand: readonly string[] };
+
+/**
  * Response shape from the Copilot `/copilot_internal/managed_settings` endpoint.
  * The endpoint returns `.github/copilot/settings.json` content from the
  * enterprise's source org. An empty response (`{}`) is success and means
@@ -17,16 +27,6 @@ import { normalizeManagedSettings } from '../../../../platform/policy/common/cop
  *
  * Exported for unit-testing the {@link adaptManagedSettings} shape transformation.
  */
-/**
- * A single MCP server matcher entry in the `allowedMcpServers` / `deniedMcpServers` managed
- * settings, identifying a server by exactly one strategy: name, remote URL pattern, or local
- * command invocation.
- */
-export type IManagedMcpServerMatcher =
-	| { readonly serverName: string }
-	| { readonly serverUrl: string }
-	| { readonly serverCommand: readonly string[] };
-
 export interface IManagedSettingsResponse {
 	readonly permissions?: {
 		readonly disableBypassPermissionsMode?: string;

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -57,6 +57,39 @@ suite('adaptManagedSettings', () => {
 		});
 	});
 
+	test('carries allowedMcpServers as a canonical JSON string under a single key', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
+			allowedMcpServers: [
+				{ serverName: 'github' },
+				{ serverUrl: 'https://mcp.example.com/*' },
+				{ serverCommand: ['npx', '-y', 'server'] },
+			],
+		}), {
+			managedSettings: {
+				allowedMcpServers: '[{"serverName":"github"},{"serverUrl":"https://mcp.example.com/*"},{"serverCommand":["npx","-y","server"]}]',
+			},
+		});
+	});
+
+	test('carries an empty allowedMcpServers array as a JSON string', () => {
+		assert.deepStrictEqual(adaptManagedSettings({ allowedMcpServers: [] }), {
+			managedSettings: { allowedMcpServers: '[]' },
+		});
+	});
+
+	test('carries deniedMcpServers as a canonical JSON string under a single key', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
+			deniedMcpServers: [
+				{ serverName: 'blocked' },
+				{ serverUrl: 'https://*.untrusted.example.com/*' },
+			],
+		}), {
+			managedSettings: {
+				deniedMcpServers: '[{"serverName":"blocked"},{"serverUrl":"https://*.untrusted.example.com/*"}]',
+			},
+		});
+	});
+
 	test('flattens scalar telemetry leaves and carries resourceAttributes and headers as single JSON keys', () => {
 		assert.deepStrictEqual(adaptManagedSettings({
 			telemetry: {

--- a/src/vs/workbench/services/mcp/common/mcpWorkbenchManagementService.ts
+++ b/src/vs/workbench/services/mcp/common/mcpWorkbenchManagementService.ts
@@ -448,8 +448,9 @@ class WorkspaceMcpResourceManagementService extends AbstractMcpResourceManagemen
 		@IUriIdentityService uriIdentityService: IUriIdentityService,
 		@ILogService logService: ILogService,
 		@IMcpResourceScannerService mcpResourceScannerService: IMcpResourceScannerService,
+		@IAllowedMcpServersService allowedMcpServersService: IAllowedMcpServersService,
 	) {
-		super(mcpResource, target, mcpGalleryService, fileService, uriIdentityService, logService, mcpResourceScannerService);
+		super(mcpResource, target, mcpGalleryService, fileService, uriIdentityService, logService, mcpResourceScannerService, allowedMcpServersService);
 	}
 
 	override async installFromGallery(server: IGalleryMcpServer, options?: InstallOptions): Promise<ILocalMcpServer> {
@@ -475,6 +476,8 @@ class WorkspaceMcpResourceManagementService extends AbstractMcpResourceManagemen
 				},
 				inputs: mcpServerConfiguration.inputs
 			};
+
+			this.ensureServerAllowed(installable);
 
 			await this.mcpResourceScannerService.addMcpServers([installable], this.mcpResource, this.target);
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/7930

**Summary**

Adds enterprise-managed per-server MCP allow/deny lists so administrators can control which MCP servers may be installed and run. Servers are matched by name, remote URL pattern (with * wildcards), or exact local command invocation. Enforced at both install time and runtime, and delivered via enterprise policy (governance-only; not surfaced in the Settings UI).

**Settings / policies**

- chat.mcp.allowedServers (policy ChatAllowedMcpServers) — when set, only matching servers are permitted; omit to allow all.
- chat.mcp.deniedServers (policy ChatDeniedMcpServers) — matching servers are always blocked; deny takes precedence over allow.
- Both are arrays of { serverName } | { serverUrl } | { serverCommand } matchers, included: false (policy-only), delivered through the managed-settings pipeline (server managed_settings, native MDM, or file).

**Behavior**

- Composes with the existing coarse `chat.mcp.access` gate — controls are ANDed; the most restrictive wins. `chat.mcp.access: none` still blocks everything, and `registry` continues to be enforced independently.
- allowedServers unset ⇒ no allow restriction; [] ⇒ block all. deniedServers [] ⇒ no-op.
- URL matching is host-aware: `*` wildcards in the authority (scheme/host/port) never cross `/` into the path, so an authority wildcard cannot admit an untrusted host.
- Install-time enforcement runs inside the install operation itself (both direct install and gallery install), evaluated against the fully resolved server configuration — not only the `canInstall` UI check — so the management APIs can't be used to bypass it.
- Runtime enforcement is reactive: tightening the policy stops an already-running server, and a blocked server never connects, its cached tools/prompts are suppressed, and tool execution is rejected.
- To avoid over-eager blocking, evaluation is deferred while a server's launch is unresolved (definition not yet loaded, or unresolved `${...}` variables) and decided authoritatively once resolved.
- Blocked servers surface a clear error state in the MCP UI (distinct messages for "not allowed" vs "blocked by policy") directing the user to their administrator; they never connect or expose tools.