### PR TITLE
Add aria-label to suggest widget details close button

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestWidgetDetails.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidgetDetails.ts
@@ -64,6 +64,7 @@ export class SuggestDetailsWidget {
 		this._header = dom.append(this._body, dom.$('.header'));
 		this._close = dom.append(this._header, dom.$('span' + ThemeIcon.asCSSSelector(Codicon.close)));
 		this._close.title = nls.localize('details.close', "Close");
+		this._close.ariaLabel = nls.localize('details.close', "Close");
 		this._close.role = 'button';
 		this._close.tabIndex = -1;
 		this._type = dom.append(this._header, dom.$('p.type'));


### PR DESCRIPTION
Fixes https://github.com/microsoft/monaco-editor/issues/5389

## Problem

The close button in the suggest widget details header is an icon-only `<span>` with `role="button"` and a `title`, but it has no `aria-label`. A `title` is not a reliable accessible name for screen readers, so the button was announced without a meaningful label.

## Fix

Add an `ariaLabel` (reusing the existing localized `"Close"` string) to `this._close` in `suggestWidgetDetails.ts` so screen readers announce "Close" for the button. Uses the `.ariaLabel` DOM property, consistent with existing usage elsewhere in the codebase (comments, search view, etc.).

Relates to §7 (ARIA Labels and Roles) of the accessibility guidelines: every interactive element without visible text must have a descriptive, localized `aria-label`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>