### PR TITLE
AH: fix stalled client tool calls

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1938,6 +1938,36 @@ export class CopilotAgentSession extends Disposable {
 				: undefined;
 			const recommendation = autoApproval?.recommendation;
 			if (recommendation === 'approve' && !request.requestSandboxBypass) {
+				if (request.kind === 'custom-tool'
+					&& typeof request.toolName === 'string'
+					&& this._clientToolNames.has(request.toolName)
+				) {
+					const { invocationMessage, toolInput, permissionKind, permissionPath } = getPermissionDisplay(request, this._workingDirectory);
+					const parentToolCallId = this._activeToolCalls.get(toolCallId)?.parentToolCallId;
+					this._onDidSessionProgress.fire({
+						kind: 'pending_confirmation',
+						chat: this._chatChannelUri,
+						state: {
+							status: ToolCallStatus.PendingConfirmation,
+							toolCallId,
+							toolName: request.toolName,
+							displayName: getToolDisplayName(request.toolName),
+							invocationMessage,
+							toolInput,
+							riskAssessment: autoApproval?.reason
+								? {
+									kind: ToolCallRiskAssessmentKind.Judge,
+									status: ToolCallRiskAssessmentStatus.Complete,
+									reason: autoApproval.reason,
+									safety: 1,
+								}
+								: undefined,
+						},
+						permissionKind,
+						permissionPath,
+						parentToolCallId,
+					});
+				}
 				return { kind: 'approve-once' };
 			}
 
@@ -3025,7 +3055,9 @@ export class CopilotAgentSession extends Disposable {
 				return;
 			}
 
-			const shouldWaitForClientToolReady = contributor?.kind === ToolCallContributorKind.Client && !isAgentCoordinationTool(e.data.toolName);
+			const shouldWaitForClientToolReady = contributor?.kind === ToolCallContributorKind.Client
+				&& !isAgentCoordinationTool(e.data.toolName)
+				&& this._lastAppliedPermissionMode !== 'on';
 			if (shouldWaitForClientToolReady) {
 				return;
 			}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1942,8 +1942,10 @@ export class CopilotAgentSession extends Disposable {
 					&& typeof request.toolName === 'string'
 					&& this._clientToolNames.has(request.toolName)
 				) {
-					const { invocationMessage, toolInput, permissionKind, permissionPath } = getPermissionDisplay(request, this._workingDirectory);
-					const parentToolCallId = this._activeToolCalls.get(toolCallId)?.parentToolCallId;
+					const trackedToolCall = this._activeToolCalls.get(toolCallId);
+					const displayName = trackedToolCall?.displayName ?? getToolDisplayName(request.toolName);
+					const parameters = trackedToolCall?.parameters;
+					const parentToolCallId = trackedToolCall?.parentToolCallId;
 					this._onDidSessionProgress.fire({
 						kind: 'pending_confirmation',
 						chat: this._chatChannelUri,
@@ -1951,9 +1953,9 @@ export class CopilotAgentSession extends Disposable {
 							status: ToolCallStatus.PendingConfirmation,
 							toolCallId,
 							toolName: request.toolName,
-							displayName: getToolDisplayName(request.toolName),
-							invocationMessage,
-							toolInput,
+							displayName,
+							invocationMessage: getInvocationMessage(request.toolName, displayName, parameters),
+							toolInput: getToolInputString(request.toolName, parameters, tryStringify(parameters)),
 							riskAssessment: autoApproval?.reason
 								? {
 									kind: ToolCallRiskAssessmentKind.Judge,
@@ -1963,8 +1965,6 @@ export class CopilotAgentSession extends Disposable {
 								}
 								: undefined,
 						},
-						permissionKind,
-						permissionPath,
 						parentToolCallId,
 					});
 				}

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -4345,6 +4345,106 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result.textResultForLlm, 'result text');
 		});
 
+		test('client tool auto-readies when SDK allow-all mode is on', async () => {
+			const { session, runtime, mockSession, signals } = await createAgentSession(disposables, {
+				clientSnapshot: snapshot,
+				activeClientToolSet: activeClientToolSetWith('test-client'),
+				configValues: { [SessionConfigKey.AutoApprove]: 'autoApprove' },
+			});
+			await session.syncPermissionMode('turn-start');
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-allow-all',
+				toolName: 'my_tool',
+				arguments: { file: 'test.ts' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			const readySignal = signals.find(s => isAction(s, ActionType.ChatToolCallReady));
+			assert.ok(readySignal && isAction(readySignal, ActionType.ChatToolCallReady));
+			const readyAction = readySignal.action as ChatToolCallReadyAction;
+			assert.deepStrictEqual({
+				permissionModeSetCalls: mockSession.permissionModeSetCalls,
+				toolCallId: readyAction.toolCallId,
+				toolInput: readyAction.toolInput,
+				confirmed: readyAction.confirmed,
+			}, {
+				permissionModeSetCalls: ['on'],
+				toolCallId: 'tc-allow-all',
+				toolInput: '{"file":"test.ts"}',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			});
+
+			const handlerPromise = invokeClientToolHandler(runtime.createClientSdkTools()[0], 'tc-allow-all', { file: 'test.ts' });
+			session.handleClientToolCallComplete('tc-allow-all', {
+				success: true,
+				pastTenseMessage: 'did it',
+				content: [{ type: ToolResultContentType.Text, text: 'result text' }],
+			});
+			assert.strictEqual((await handlerPromise).textResultForLlm, 'result text');
+		});
+
+		test('SDK-approved client tool auto-readies in assisted mode', async () => {
+			const { session, runtime, mockSession, signals } = await createAgentSession(disposables, {
+				clientSnapshot: snapshot,
+				activeClientToolSet: activeClientToolSetWith('test-client'),
+				configValues: { [SessionConfigKey.AutoApprove]: 'assisted' },
+			});
+			await session.syncPermissionMode('turn-start');
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-assisted',
+				toolName: 'my_tool',
+				arguments: {},
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			mockSession.fire('permission.requested', {
+				requestId: 'permission-assisted',
+				permissionRequest: {
+					kind: 'custom-tool',
+					toolCallId: 'tc-assisted',
+					toolName: 'my_tool',
+				},
+				promptRequest: {
+					kind: 'custom-tool',
+					toolCallId: 'tc-assisted',
+					toolName: 'my_tool',
+					autoApproval: {
+						recommendation: 'approve',
+						reason: 'The requested browser navigation is safe.',
+					},
+				},
+			} as SessionEventPayload<'permission.requested'>['data']);
+			const permissionResult = await runtime.handlePermissionRequest({
+				kind: 'custom-tool',
+				toolCallId: 'tc-assisted',
+				toolName: 'my_tool',
+			});
+			const readySignal = signals.find((s): s is IAgentToolPendingConfirmationSignal => s.kind === 'pending_confirmation');
+
+			assert.deepStrictEqual({
+				permissionModeSetCalls: mockSession.permissionModeSetCalls,
+				permissionResult,
+				ready: readySignal?.state,
+			}, {
+				permissionModeSetCalls: ['auto'],
+				permissionResult: { kind: 'approve-once' },
+				ready: {
+					status: ToolCallStatus.PendingConfirmation,
+					toolCallId: 'tc-assisted',
+					toolName: 'my_tool',
+					displayName: 'my_tool',
+					invocationMessage: 'Running my_tool...',
+					toolInput: undefined,
+					riskAssessment: {
+						kind: ToolCallRiskAssessmentKind.Judge,
+						status: ToolCallRiskAssessmentStatus.Complete,
+						reason: 'The requested browser navigation is safe.',
+						safety: 1,
+					},
+				},
+			});
+		});
+
 		test('agent-coordination client tools auto-ready with a tailored invocation message', async () => {
 			const agentSnapshot: IActiveClientSnapshot = {
 				tools: [{ name: 'list_agents', description: 'List agents', inputSchema: { type: 'object', properties: {} } }],

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -4437,7 +4437,7 @@ suite('CopilotAgentSession', () => {
 					toolCallId: 'tc-assisted',
 					toolName: 'my_tool',
 					displayName: 'my_tool',
-					invocationMessage: 'Running my_tool...',
+					invocationMessage: 'my_tool',
 					toolInput: { file: 'test.ts' },
 					riskAssessment: {
 						kind: ToolCallRiskAssessmentKind.Judge,

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -4365,12 +4365,12 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual({
 				permissionModeSetCalls: mockSession.permissionModeSetCalls,
 				toolCallId: readyAction.toolCallId,
-				toolInput: readyAction.toolInput,
+				toolInput: readyAction.toolInput === undefined ? undefined : JSON.parse(readyAction.toolInput),
 				confirmed: readyAction.confirmed,
 			}, {
 				permissionModeSetCalls: ['on'],
 				toolCallId: 'tc-allow-all',
-				toolInput: '{"file":"test.ts"}',
+				toolInput: { file: 'test.ts' },
 				confirmed: ToolCallConfirmationReason.NotNeeded,
 			});
 
@@ -4394,7 +4394,7 @@ suite('CopilotAgentSession', () => {
 			mockSession.fire('tool.execution_start', {
 				toolCallId: 'tc-assisted',
 				toolName: 'my_tool',
-				arguments: {},
+				arguments: { file: 'test.ts' },
 			} as SessionEventPayload<'tool.execution_start'>['data']);
 
 			mockSession.fire('permission.requested', {
@@ -4420,11 +4420,15 @@ suite('CopilotAgentSession', () => {
 				toolName: 'my_tool',
 			});
 			const readySignal = signals.find((s): s is IAgentToolPendingConfirmationSignal => s.kind === 'pending_confirmation');
+			const readyState = readySignal?.state;
 
 			assert.deepStrictEqual({
 				permissionModeSetCalls: mockSession.permissionModeSetCalls,
 				permissionResult,
-				ready: readySignal?.state,
+				ready: readyState ? {
+					...readyState,
+					toolInput: readyState.toolInput === undefined ? undefined : JSON.parse(readyState.toolInput),
+				} : undefined,
 			}, {
 				permissionModeSetCalls: ['auto'],
 				permissionResult: { kind: 'approve-once' },
@@ -4434,7 +4438,7 @@ suite('CopilotAgentSession', () => {
 					toolName: 'my_tool',
 					displayName: 'my_tool',
 					invocationMessage: 'Running my_tool...',
-					toolInput: undefined,
+					toolInput: { file: 'test.ts' },
 					riskAssessment: {
 						kind: ToolCallRiskAssessmentKind.Judge,
 						status: ToolCallRiskAssessmentStatus.Complete,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Client tools could stall because Agent Host relied on the SDK permission callback to emit ChatToolCallReady, which tells the client to execute the tool.
- Allow All: The SDK bypasses the permission callback entirely, so readiness was never emitted.
- Assisted Approvals: When the SDK judged a tool safe, Agent Host returned approval before emitting readiness, causing the same stall.


### Fix
- In Allow All, emit readiness directly from tool.execution_start.
- In Assisted Approvals, emit readiness when the SDK explicitly recommends approval.
Tools requiring approval continue through the existing confirmation flow.