### PR TITLE
Gate default-to-Agent-Host-Copilot behind chat.defaultToCopilotHarness

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/common/agentHostEnablementService.ts
@@ -60,6 +60,13 @@ configurationRegistry.registerConfiguration({
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},
+		'chat.defaultToCopilotHarness': {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.defaultToCopilotHarness', "When enabled, new editor and panel chat sessions default to the Agent Host Copilot CLI instead of the local harness. Requires `#{0}#`.", agentHostEnabledSettingId),
+			default: false,
+			tags: ['experimental'],
+			experiment: { mode: 'startup' },
+		},
 		'chat.editor.localAgent.enabled': {
 			type: 'boolean',
 			description: nls.localize('chat.editor.localAgent.enabled', "When enabled, shows the VS Code local chat harness in the chat picker. This setting is ignored in virtual workspaces, where the local chat harness is always available."),

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -155,6 +155,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(ChatConfiguration.EditorPreferCopilotHarness) ||
+				e.affectsConfiguration(ChatConfiguration.DefaultToCopilotHarness) ||
 				e.affectsConfiguration(ChatConfiguration.EditorLocalAgentEnabled) ||
 				e.affectsConfiguration(ChatConfiguration.CopilotCliHideExtensionHostEditor)) {
 				this._updateAgentSessionItems();

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -106,6 +106,7 @@ export enum ChatConfiguration {
 	DefaultNewSessionMode = 'chat.newSession.defaultMode',
 	CopilotCliHideExtensionHostAgents = 'chat.agents.copilotCli.hideExtensionHost',
 	EditorPreferCopilotHarness = 'chat.editor.preferCopilotHarness',
+	DefaultToCopilotHarness = 'chat.defaultToCopilotHarness',
 	EditorLocalAgentEnabled = 'chat.editor.localAgent.enabled',
 	CopilotCliHideExtensionHostEditor = 'chat.editor.copilotCli.hideExtensionHost',
 	AgentsHandoffTipMode = 'chat.agentsHandoffTip.mode',
@@ -263,10 +264,11 @@ export function isSupportedChatFileScheme(accessor: ServicesAccessor, scheme: st
  * Returns the effective default session type for a new chat in the VS Code
  * editor window.
  *
- * When the agent host is enabled, Agent Host Copilot CLI is the default so that
- * first-time users land on Copilot instead of the local harness. Otherwise it
- * falls back to {@link localChatSessionType} when local is enabled, or to the
- * first visible non-local provider.
+ * When the agent host is enabled and `chat.defaultToCopilotHarness` is opted
+ * in, Agent Host Copilot CLI is the default so that first-time users land on
+ * Copilot instead of the local harness. Otherwise it falls back to
+ * {@link localChatSessionType} when local is enabled, or to the first visible
+ * non-local provider.
  */
 export function getComputedDefaultSessionType(
 	configurationService: IConfigurationService,
@@ -274,7 +276,7 @@ export function getComputedDefaultSessionType(
 	workspace: IWorkspace,
 	agentHostEnabled: boolean
 ): string {
-	if (agentHostEnabled) {
+	if (agentHostEnabled && configurationService.getValue<boolean>(ChatConfiguration.DefaultToCopilotHarness)) {
 		return SessionType.AgentHostCopilot;
 	}
 

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -55,7 +55,9 @@ suite('ChatConfiguration defaults', () => {
 	});
 
 	test('editor default prefers agent host Copilot when the agent host is enabled', () => {
-		const configurationService = new TestConfigurationService();
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
+		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
 		const storageService = disposables.add(new TestStorageService());
 
@@ -70,8 +72,25 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
+	test('editor default stays local when the agent host is enabled but the Copilot default is not opted in', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		// The agent host is enabled but `chat.defaultToCopilotHarness` is off (its
+		// default), so the computed default remains the local harness.
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace, true),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true),
+		}, {
+			computed: localChatSessionType,
+			rememberedAware: localChatSessionType,
+		});
+	});
+
 	test('editor default keeps agent host Copilot before contribution registers', () => {
 		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
 			[ChatConfiguration.EditorLocalAgentEnabled]: false,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.CopilotCLI);
@@ -126,7 +145,9 @@ suite('ChatConfiguration defaults', () => {
 	});
 
 	test('remembered non-local selection wins over the agent host default', () => {
-		const configurationService = new TestConfigurationService();
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
+		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
@@ -181,6 +202,7 @@ suite('ChatConfiguration defaults', () => {
 
 	test('preferCopilotHarness resolves the swap without consuming the marker until applied', () => {
 		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
 			[ChatConfiguration.EditorPreferCopilotHarness]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
@@ -234,7 +256,9 @@ suite('ChatConfiguration defaults', () => {
 	});
 
 	test('selecting computed default clears remembered selection', () => {
-		const configurationService = new TestConfigurationService();
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
+		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
@@ -253,7 +277,9 @@ suite('ChatConfiguration defaults', () => {
 	});
 
 	test('selecting local while the agent host default is Copilot remembers local as an opt-out', () => {
-		const configurationService = new TestConfigurationService();
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
+		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
 		const storageService = disposables.add(new TestStorageService());
 
@@ -272,6 +298,7 @@ suite('ChatConfiguration defaults', () => {
 
 	test('one-time Copilot swap overrides a remembered local opt-out and stays redundant when agent host is enabled', () => {
 		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
 			[ChatConfiguration.EditorPreferCopilotHarness]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
@@ -295,7 +322,9 @@ suite('ChatConfiguration defaults', () => {
 	});
 
 	test('new chat from a local session preserves local even when the agent host default is Copilot', () => {
-		const configurationService = new TestConfigurationService();
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
+		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
 		const storageService = disposables.add(new TestStorageService());
 
@@ -311,7 +340,9 @@ suite('ChatConfiguration defaults', () => {
 	});
 
 	test('explicit New Local Chat wins over a non-local current session even when the agent host default is Copilot', () => {
-		const configurationService = new TestConfigurationService();
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
+		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
 		const storageService = disposables.add(new TestStorageService());
 
@@ -326,7 +357,9 @@ suite('ChatConfiguration defaults', () => {
 	});
 
 	test('default session resource follows the agent host default', () => {
-		const configurationService = new TestConfigurationService();
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
+		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
 		const storageService = disposables.add(new TestStorageService());
 
@@ -345,6 +378,7 @@ suite('ChatConfiguration defaults', () => {
 
 	test('agent host default wins over a virtual workspace local override', () => {
 		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
 			[ChatConfiguration.EditorLocalAgentEnabled]: false,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -201,8 +201,10 @@ suite('ChatConfiguration defaults', () => {
 	});
 
 	test('preferCopilotHarness resolves the swap without consuming the marker until applied', () => {
+		// DefaultToCopilotHarness stays unset so this proves the one-time swap
+		// fires solely because EditorPreferCopilotHarness is enabled, independent
+		// of the new default gate.
 		const configurationService = new TestConfigurationService({
-			[ChatConfiguration.DefaultToCopilotHarness]: true,
 			[ChatConfiguration.EditorPreferCopilotHarness]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
@@ -228,8 +230,8 @@ suite('ChatConfiguration defaults', () => {
 			firstResolve: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
 			markerBeforeApply: false,
 			secondResolveBeforeApply: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
-			// After applying, the current local session is preserved (feature-2's
-			// computed default is Copilot, but session preservation keeps local).
+			// Once marked, the one-time swap no longer fires; with no remembered
+			// selection the current local session type is returned.
 			afterApply: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
 			markerAfterApply: true,
 		});


### PR DESCRIPTION
Follow-up to #326086. That PR made Agent Host Copilot the computed default for editor and panel chat unconditionally whenever the agent host is enabled. This adds the experimental setting that should have gated it, mirroring `chat.editor.preferCopilotHarness`.

### What changed
- New setting `chat.defaultToCopilotHarness` (`experimental`, `default: false`), registered next to the other agent-host chat settings in `agentHostEnablementService.ts`.
- `getComputedDefaultSessionType` now returns `SessionType.AgentHostCopilot` only when the agent host is enabled **and** this setting is opted in. Every editor/panel caller routes through this one function, so the gate covers both surfaces. The one-time `chat.editor.preferCopilotHarness` migration swap is intentionally left independent — it stays scoped to the Local→Copilot migration.

### Behavior impact ⚠️
Because the default is `false`, this is opt-in. The agent host is enabled by default in Insiders, so **without the experiment (or an explicit setting), Insiders first-time users now land on Local instead of Copilot** — a deliberate change from #326086, which had it always-on there. Rollout is via an ExP treatment on `config.chat.defaultToCopilotHarness`, which registers the value as a configuration *default* override at startup. Note this means if the experiment is later turned off, users without a persisted Copilot session fall back to Local.

Existing users are unaffected regardless: a Local session with content, or an explicit Local opt-out, always wins over the computed default; only empty auto-created Local sessions are skipped once the default is non-local.

### Testing
Verified locally end-to-end (fresh folder workspace, authed profile). Toggling only this setting:
- `true` → both panel and editor chat default to Agent Host Copilot ("Chat with Copilot").
- unset → panel/editor fall back to Local.

To reproduce: set `chat.agentHost.enabled: true` + `chat.defaultToCopilotHarness: true` in a fresh profile before launch (settings are read before the chat view's first session resolution, so this faithfully emulates the ExP treatment without the startup race). Open a brand-new folder with `--disable-workspace-trust`, since Restricted Mode otherwise suppresses the agent host.

Also covered by unit tests in `constants.test.ts`, including the gated-off case (agent host enabled but setting off → default stays Local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
