### PR TITLE
refactor(claude): immutable pipeline + session-orchestrated rebuild (C9)

### DIFF
--- a/src/vs/platform/agentHost/node/claude/CONTEXT.md
+++ b/src/vs/platform/agentHost/node/claude/CONTEXT.md
@@ -769,17 +769,18 @@ UI `'max'` is clamped to SDK `'xhigh'` at the seam. Effort levels
 above the model's `max_thinking_tokens` ceiling are clamped by the
 SDK; the host does not need to gate.
 
-**Config-state ownership and timing (target — the C9 end-state; see ROADMAP).**
-Runtime SDK config splits into two states with two owners. **Interim (today):**
-`ClaudeSdkPipeline` also holds the *desired* values as `_currentModel` /
-`_currentEffort` / `_currentPermissionMode` and replays them onto a fresh `Query`
-on rebind — a duplicate of the session's desired state that C9 removes once the
-pipeline is immutable and seeded once per build. Target ownership:
+**Config-state ownership and timing (C9 — shipped).**
+Runtime SDK config splits into two states with two owners. The pipeline is
+immutable: it never rebinds or replays config onto a fresh `Query` — a rebuild
+mints a *new* pipeline seeded once, so there is no desired-state duplication in
+the pipeline. Ownership:
 - **Desired** — owned by `ClaudeAgentSession` (`_provisionalModel` /
   `_provisionalAgent`; `permissionMode` read live from `IAgentConfigurationService`).
-  The user's intent; survives a pipeline rebuild; seeds every freshly built `Query`.
+  The user's intent; survives a pipeline rebuild; seeds every freshly built `Query`
+  via `Options` (model/effort/permissionMode baked at build, not replayed at runtime).
 - **Applied** — owned by `ClaudeSdkPipeline` (`_applied{Model,Effort,PermissionMode}`),
-  purely to dedup runtime setter calls. Ephemeral: dies with the `WarmQuery`.
+  purely to dedup runtime setter calls; seeded once at construction from the
+  `Options` the pipeline was built with. Ephemeral: dies with the `WarmQuery`.
 
 There is deliberately **no host-side "staged" state**: the SDK's own deferral is
 the staging. Per-axis timing (SDK `applyFlagSettings` docs + Anthropic

--- a/src/vs/platform/agentHost/node/claude/architecture-analysis/ROADMAP.md
+++ b/src/vs/platform/agentHost/node/claude/architecture-analysis/ROADMAP.md
@@ -55,13 +55,15 @@ The target end-state is **focused, legible, testable modules** where:
 ## Execution order (dependency-sequenced)
 
 ```
-  Tier 0 ✅ → C1 ✅ → C2 → C9 → C5 → { C6, C7 }
+  Tier 0 ✅ → C1 ✅ → C9 ✅ → C5 → { C6, C7 }
                   └→ C3 · C4 · C8   (independent; any time after C1)
 
   C2 = one owner for live config (desired-on-session vs applied-on-pipeline)
-  C9 = immutable pipeline / session-orchestrated rebind:
-       deletes the rematerializer pass-in (claudeAgentSession.ts:476)
-       + the whole in-place swap machinery; supersedes most of C2
+       — folded into C9 (shipped): the immutable pipeline holds only the
+       ephemeral `_applied*` dedup, seeded once per build.
+  C9 = immutable pipeline / session-orchestrated rebuild (shipped):
+       deleted the rematerializer pass-in (claudeAgentSession.ts)
+       + the whole in-place swap machinery; superseded C2
 ```
 
 **Rationale.** Tier 0 first — free interface-shrink, unblocks nothing but clears
@@ -259,7 +261,7 @@ Legend — **Serves:** `dup` duplication/rematerializer · `cyc` overlap/circula
 - **Risk:** low-medium — must still await real subprocess exit on the remove-all
   path (the CLI rejects a fresh spawn while `<id>.jsonl` exists).
 
-### C9 — Immutable pipeline / session-orchestrated rebind  ·  Serves: cyc, life  ·  ★ removes the rematerializer  ·  ⬜ proposed
+### C9 — Immutable pipeline / session-orchestrated rebuild  ·  Serves: cyc, life  ·  ★ removes the rematerializer  ·  ✅ shipped
 - **Source:** the "Option B" design conversation (2026-07-16). Enabled by C1's
   `_startSdkQuery` extraction; explicitly requested.
 - **Goal:** `ClaudeSdkPipeline` owns exactly ONE `WarmQuery` for its whole life

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -7,7 +7,7 @@ import type { McpSdkServerConfigWithInstance, OnElicitation, Options, Permission
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { INativeEnvironmentService } from '../../../environment/common/environment.js';
@@ -43,7 +43,7 @@ import { scanClaudeNativePlugins } from './customizations/scan/claudeNativePlugi
 import { scanClaudeRules } from './customizations/scan/claudeRuleScan.js';
 import { resolvePromptToContentBlocks } from './claudePromptResolver.js';
 import type { ClaudeTransport } from './claudeProxyService.js';
-import { ClaudeSdkPipeline, type IRematerializer, type ISdkResolvedCustomizations } from './claudeSdkPipeline.js';
+import { ClaudeSdkPipeline, type ISdkResolvedCustomizations } from './claudeSdkPipeline.js';
 import { SubagentRegistry } from './claudeSubagentRegistry.js';
 import { ClaudePermissionKind } from './claudeToolDisplay.js';
 
@@ -97,6 +97,12 @@ function resolveCurrentPermissionMode(
 export class ClaudeAgentSession extends Disposable {
 
 	private _pipeline: ClaudeSdkPipeline | undefined;
+	/**
+	 * Owns the current {@link ClaudeSdkPipeline} plus its signal subscription.
+	 * Installing a fresh pipeline on a rebuild sets a new store here, disposing
+	 * the previous pipeline (and its transitively-owned dbRef).
+	 */
+	private readonly _pipelineStore = this._register(new MutableDisposable<DisposableStore>());
 	/** Session-lifetime SDK-start inputs captured at {@link materialize}; `undefined` until then. */
 	private _sdkStart: {
 		readonly transport: ClaudeTransport;
@@ -134,8 +140,12 @@ export class ClaudeAgentSession extends Disposable {
 	readonly provisionalConfig: Record<string, unknown> | undefined;
 	/** Resolved project metadata captured at create time (if any). */
 	readonly project: IAgentSessionProjectInfo | undefined;
-	/** Always-present abort controller; wired into `Options.abortController` at materialize time. */
-	readonly abortController: AbortController;
+	/**
+	 * Session-owned abort controller, reassigned per pipeline build so it always
+	 * aliases the live pipeline's controller — and is the abort target during an
+	 * in-flight rebuild (replacing the pipeline's old placeholder-controller dance).
+	 */
+	abortController: AbortController;
 
 	/**
 	 * The actual directory work is done in. Defaults to {@link workspace} until
@@ -446,48 +456,7 @@ export class ClaudeAgentSession extends Disposable {
 			serverToolHost: ctx.serverToolHost,
 		};
 
-		const { warm, permissionMode } = await this._startSdkQuery(ctx.isResume, this.abortController);
-
-		if (this.abortController.signal.aborted) {
-			await warm[Symbol.asyncDispose]();
-			throw new CancellationError();
-		}
-
-		const dbRef = this._sessionDataService.openDatabase(this._storageUri);
-		let pipeline: ClaudeSdkPipeline;
-		try {
-			pipeline = this._register(this._instantiationService.createInstance(
-				ClaudeSdkPipeline,
-				this.sessionId,
-				this.sessionUri,
-				this._chatChannelUri,
-				warm,
-				this.abortController,
-				dbRef,
-				this.subagents,
-				(toolName: string) => this.toolDiff.model.ownerOf(toolName),
-				() => this._rebuildSdkQuery(),
-			));
-		} catch (err) {
-			dbRef.dispose();
-			await warm[Symbol.asyncDispose]();
-			throw err;
-		}
-		this._register(pipeline.onDidProduceSignal(s => this._onDidSessionProgress.fire(this._enrichSignalWithMcpContributor(this._enrichSignalWithCredits(s)))));
-		this._pipeline = pipeline;
-		// The materialize succeeded with the staged anchor applied to `Options`
-		// — clear it now so it isn't re-applied. A throw before this point (e.g.
-		// `startup` / pipeline-create) leaves it staged for the next retry.
-		this._pendingResumeSessionAt = undefined;
-
-		// Seed the pipeline's bijective config cache so a rebuild re-applies
-		// the user's last-chosen model / effort without losing the picker
-		// config. Read provisional state directly off the session.
-		pipeline.seedCurrentConfig(
-			toSdkModelId(this._provisionalModel?.id),
-			toRuntimeEffortLevel(resolveClaudeEffort(this._provisionalModel)),
-			permissionMode,
-		);
+		const permissionMode = await this._installPipeline(ctx.isResume, false);
 
 		// Fresh sessions persist their customization-directory / model /
 		// permissionMode overlay so a later resume re-reads them. Resume
@@ -529,6 +498,63 @@ export class ClaudeAgentSession extends Disposable {
 	}
 
 	/**
+	 * Build a fresh SDK subprocess for the current session state and install it as
+	 * the live pipeline, disposing the previous one. Shared by {@link materialize}
+	 * (first install; `freshController: false` keeps the provisional controller so
+	 * a pre-materialize abort is honored) and the `send` rebuild path
+	 * (`freshController: true` mints a controller for the new subprocess). Returns
+	 * the permission mode the `Options` were built with.
+	 *
+	 * An abort or session-dispose landing during the `startup()` await is honored
+	 * by the post-await gate on {@link abortController} — the session-owned abort
+	 * target that replaces the pipeline's old placeholder-controller dance.
+	 */
+	private async _installPipeline(isResume: boolean, freshController: boolean): Promise<ClaudePermissionMode> {
+		if (freshController) {
+			this.abortController = new AbortController();
+		}
+		const { warm, permissionMode } = await this._startSdkQuery(isResume, this.abortController);
+		if (this.abortController.signal.aborted || this._store.isDisposed) {
+			await warm[Symbol.asyncDispose]();
+			throw new CancellationError();
+		}
+		const dbRef = this._sessionDataService.openDatabase(this._storageUri);
+		const store = new DisposableStore();
+		let pipeline: ClaudeSdkPipeline;
+		try {
+			pipeline = store.add(this._instantiationService.createInstance(
+				ClaudeSdkPipeline,
+				this.sessionId,
+				this.sessionUri,
+				this._chatChannelUri,
+				warm,
+				this.abortController,
+				dbRef,
+				this.subagents,
+				(toolName: string) => this.toolDiff.model.ownerOf(toolName),
+				{
+					model: toSdkModelId(this._provisionalModel?.id),
+					effort: toRuntimeEffortLevel(resolveClaudeEffort(this._provisionalModel)),
+					permissionMode,
+				},
+			));
+		} catch (err) {
+			dbRef.dispose();
+			await warm[Symbol.asyncDispose]();
+			throw err;
+		}
+		store.add(pipeline.onDidProduceSignal(s => this._onDidSessionProgress.fire(this._enrichSignalWithMcpContributor(this._enrichSignalWithCredits(s)))));
+		// Swap in the new pipeline, disposing the previous (pipeline + its signal
+		// subscription + the dbRef it transitively owns) via the store.
+		this._pipelineStore.value = store;
+		this._pipeline = pipeline;
+		// The build succeeded with the staged anchor applied to `Options`; clear
+		// it so it isn't re-applied. A throw above keeps it staged for the retry.
+		this._pendingResumeSessionAt = undefined;
+		return permissionMode;
+	}
+
+	/**
 	 * Build the SDK `Options` from live session state and start the subprocess —
 	 * the single source of truth for creating a `WarmQuery` (materialize and every
 	 * rebuild). Returns the permission mode it built with.
@@ -567,23 +593,6 @@ export class ClaudeAgentSession extends Disposable {
 		this._logService.info(`[Claude] session ${this.sessionId}: startup isResume=${isResume} agent=${options.agent ?? '(none)'}`);
 		const warm = await this._sdkService.startup({ options });
 		return { warm, permissionMode };
-	}
-
-	/**
-	 * The pipeline's rebuild hook ({@link IRematerializer}), passed at construction.
-	 * On failure re-marks the tool / customization diffs dirty and rethrows.
-	 */
-	private async _rebuildSdkQuery(): Promise<{ readonly warm: WarmQuery; readonly abortController: AbortController }> {
-		const abortController = new AbortController();
-		try {
-			const { warm } = await this._startSdkQuery(true, abortController);
-			this._pendingResumeSessionAt = undefined;
-			return { warm, abortController };
-		} catch (err) {
-			this.toolDiff.markDirty();
-			this.clientCustomizationsDiff.markDirty();
-			throw err;
-		}
 	}
 
 	/**
@@ -659,67 +668,65 @@ export class ClaudeAgentSession extends Disposable {
 	}
 
 	/**
-	 * Send a user prompt. Performs the per-turn pre-flight before
-	 * yielding to the pipeline:
-	 *
-	 * - If {@link toolDiff} or {@link clientCustomizationsDiff} reports the
-	 *   live `Query` is out of sync with the workbench's view, yield-restart
-	 *   so the SDK picks up the new `Options.mcpServers` / `Options.plugins`.
-	 *   `Query.reloadPlugins()` cannot help here — the SDK's plugin URI set
-	 *   is captured at startup, so any add / remove / nonce-bump must go
-	 *   through a full rebuild. The rebind itself re-applies the live
-	 *   `permissionMode` via the rematerializer.
-	 * - Otherwise forward the live `permissionMode` to the bound `Query` so
-	 *   a `SessionConfigChanged` action that arrived between turns wins.
-	 *   The pipeline's bijective cache dedupes a no-op `setPermissionMode`,
-	 *   so this is free when nothing changed.
-	 *
-	 * Model / effort are not threaded through here — the pipeline's current
-	 * model / effort (set eagerly via {@link setModel}) is whatever
-	 * the SDK has been told.
+	 * Send a user prompt. The pre-flight decides reuse-vs-rebuild: rebuild the
+	 * pipeline (dispose old, install fresh via {@link _installPipeline}) when it
+	 * has died, when the tool / customization set diverged, or when a Restore
+	 * Checkpoint anchor is staged; otherwise forward the live `permissionMode`.
 	 */
 	async send(prompt: SDKUserMessage, turnId: string): Promise<void> {
-		const pipeline = this._requirePipeline();
 		// New turn: reset the per-turn credit accumulator so proxy reports
 		// for this turn's `/v1/messages` calls sum from zero.
 		this._currentTurnNanoAiu = 0;
-		if (this.toolDiff.hasDifference || this.clientCustomizationsDiff.hasDifference || this._pendingResumeSessionAt !== undefined) {
-			await this._rebindForSyncedState();
+		const pipeline = this._requirePipeline();
+		const needsRebuild = pipeline.isDead
+			|| this.toolDiff.hasDifference
+			|| this.clientCustomizationsDiff.hasDifference
+			|| this._pendingResumeSessionAt !== undefined;
+		if (needsRebuild) {
+			await this._rebuildPipeline();
 		} else {
 			await pipeline.setPermissionMode(resolveCurrentPermissionMode(this._configurationService, this._storageUri, this._permissionModeFallback));
 		}
-		return pipeline.send(prompt, turnId);
+		// Re-read `_pipeline` — a rebuild replaced it.
+		return this._requirePipeline().send(prompt, turnId);
 	}
 
 	/**
-	 * Single yield-restart that covers both client-tool and
-	 * customization divergence in one trip. Drains the parked
-	 * client-tool MCP handlers (same as the original tool-only
-	 * rebind), then triggers the pipeline rebind — the rematerializer
-	 * reads `toolDiff` and `clientCustomizationsDiff.consume()` while
-	 * building the new `Options`, so the bit on each diff clears in
-	 * lockstep with the SDK actually receiving the new values. Fires
-	 * `_onDidCustomizationsChange` afterwards so the workbench
-	 * refetches `getSessionCustomizations` and picks up any newly
-	 * resolved server-side entries from the rebuilt `Query`.
+	 * Dispose the live pipeline and install a fresh one (in `resume` mode) for the
+	 * current session state — the yield-restart / crash-recovery path. Awaits the
+	 * old subprocess's real exit before the resume spawn so there is no two-writer
+	 * window on `<id>.jsonl`. On failure re-marks the tool / customization diffs
+	 * dirty (they were consumed while building) and keeps the resume anchor staged
+	 * so the next send retries rather than proceeding out of sync.
 	 */
-	private async _rebindForSyncedState(): Promise<void> {
+	private async _rebuildPipeline(): Promise<void> {
+		// Drain parked client-tool MCP handlers before the rebuild swaps Options.
 		this._pendingClientToolCalls.rejectAll(new CancellationError());
-		await this._requirePipeline().rebindForRestart();
+		if (this._pipeline) {
+			await this._pipeline.shutdownAndWait();
+		}
+		try {
+			await this._installPipeline(true, true);
+		} catch (err) {
+			this.toolDiff.markDirty();
+			this.clientCustomizationsDiff.markDirty();
+			throw err;
+		}
+		// The rebuilt Query's resolved customization set may differ; refetch.
 		this._onDidCustomizationsChange.fire();
 	}
 
 	/**
-	 * Cancel the in-flight SDK turn. Mirrors the production reference;
-	 * see {@link ClaudeSdkPipeline.abort}. Also denies any parked
-	 * permission / user-input requests so the SDK's `canUseTool`
-	 * callback (and any interactive tool waiting on user input) unwinds
-	 * with a deny / cancel result instead of leaving stale UI behind.
+	 * Cancel the in-flight SDK turn: abort the session-owned controller (also the
+	 * abort target during an in-flight rebuild) and the live pipeline, and deny any
+	 * parked permission / user-input requests so the SDK's `canUseTool` callback
+	 * unwinds with a deny / cancel instead of leaving stale UI behind.
 	 */
 	abort(): void {
 		this._pendingPermissions.denyAll(false);
 		this._pendingUserInputs.denyAll({ response: ChatInputResponseKind.Cancel });
-		this._requirePipeline().abort();
+		this.abortController.abort();
+		this._pipeline?.abort();
 	}
 
 	/**
@@ -1035,7 +1042,7 @@ export class ClaudeAgentSession extends Disposable {
 		}
 		const handled = await this._requirePipeline().startMcpServer(serverName);
 		if (!handled) {
-			await this._rebindForSyncedState();
+			await this._rebuildPipeline();
 		}
 		this._onDidCustomizationsChange.fire();
 	}
@@ -1061,6 +1068,9 @@ export class ClaudeAgentSession extends Disposable {
 	// #endregion
 
 	override dispose(): void {
+		// Abort the session-owned controller first so an in-flight rebuild's
+		// `startup()` await unwinds and its post-await gate discards the fresh warm.
+		this.abortController.abort();
 		// Resolve parked deferreds before tearing the pipeline down so the
 		// SDK's canUseTool callback unwinds with a deny and the loop exits.
 		this._pendingPermissions.denyAll(false);

--- a/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
@@ -21,46 +21,16 @@ import { ClaudeSdkMessageRouter } from './claudeSdkMessageRouter.js';
 import type { SubagentRegistry } from './claudeSubagentRegistry.js';
 
 /**
- * Callback the agent supplies to the {@link ClaudeSdkPipeline} constructor
- * so the pipeline can rebuild its underlying {@link WarmQuery} /
- * {@link AbortController} on abort or crash recovery without depending on
- * the materializer service directly. The callback MUST start the SDK in
- * `resume` mode (i.e. pass `Options.resume = sessionId` instead of
- * `Options.sessionId`) and MUST NOT re-fire the agent's
- * `onDidMaterializeSession` event — that event is once-per-provisional
- * promotion (see `claudeAgent.ts` materialize path).
+ * The model / effort / permissionMode the SDK `Options` were built with, seeded
+ * into the pipeline's applied-config cache so the first runtime {@link ClaudeSdkPipeline.setModel}
+ * / {@link ClaudeSdkPipeline.setPermissionMode} skips a redundant SDK call.
  */
-export interface IRematerializer {
-	(reason: 'restart' | 'recover'): Promise<{ readonly warm: WarmQuery; readonly abortController: AbortController }>;
+export interface ISdkAppliedConfig {
+	readonly model: string | undefined;
+	readonly effort: ClaudeRuntimeEffortLevel | undefined;
+	readonly permissionMode: PermissionMode | undefined;
 }
 
-/**
- * Owns one SDK Query lifecycle for a Claude session. Knows nothing about
- * protocol turns, the workbench mapper, file-edit observers, or
- * permission registries — the consuming session subscribes to
- * {@link onDidProduceSignal} and fans out to its own collaborators.
- *
- * Responsibilities:
- *   • Hold the {@link WarmQuery} + {@link AbortController} for the
- *     active SDK subprocess. Both are mutable: rebind on abort/crash
- *     recovery via the supplied {@link IRematerializer}.
- *   • Drive a {@link ClaudePromptQueue} whose iterable is handed to
- *     `WarmQuery.query()`.
- *   • Apply the current model / effort / permissionMode to the SDK
- *     eagerly when the consumer calls {@link setModel} /
- *     {@link setEffort} / {@link setPermissionMode}. The SDK only takes
- *     these into account on the NEXT user request, so mid-turn calls
- *     are safe — no need to align the SDK setter with the prompt yield.
- *     Re-applied to a fresh Query on rebind.
- *   • Drain the SDK message stream, dispatch each message to the
- *     {@link ClaudeSdkMessageRouter}, settle the matching entry's
- *     deferred on `result`, and emit `ChatTurnComplete` only when
- *     the queue fully drains (intermediate results during steering
- *     preemption do NOT fire turn-complete — CONTEXT.md M10).
- *
- * Disposing the pipeline aborts the controller (terminating the SDK
- * subprocess per `sdk.d.ts:982`) and async-disposes the WarmQuery.
- */
 /**
  * Snapshot of everything the SDK has currently resolved for this
  * session. Returned by {@link ClaudeSdkPipeline.snapshotResolvedCustomizations}.
@@ -84,7 +54,24 @@ export interface ISdkResolvedCustomizations {
 	readonly plugins: readonly { readonly name: string; readonly path: string; readonly source?: string }[];
 }
 
+/**
+ * Owns ONE immutable SDK Query lifecycle for a Claude session. Knows nothing
+ * about protocol turns, the workbench mapper, file-edit observers, or permission
+ * registries — the consuming session subscribes to {@link onDidProduceSignal}.
+ *
+ * The {@link WarmQuery} / {@link AbortController} are fixed for the pipeline's
+ * whole life (never swapped): a rebuild is the session disposing this pipeline
+ * and constructing a fresh one. When the consumer loop ends abnormally
+ * (abort / crash / stream-end) the pipeline reports {@link isDead} and stops; it
+ * does NOT self-heal. Config is applied eagerly via {@link setModel} /
+ * {@link setEffort} / {@link setPermissionMode} (the SDK takes these into account
+ * on the next user request), deduped against the seeded {@link ISdkAppliedConfig}.
+ *
+ * Disposing the pipeline aborts the controller (terminating the SDK subprocess)
+ * and async-disposes the WarmQuery.
+ */
 export class ClaudeSdkPipeline extends Disposable {
+
 	/**
 	 * Phase 11 — snapshot the SDK's currently-resolved customization
 	 * surface (slash commands / skills, subagents, MCP servers). This
@@ -95,7 +82,7 @@ export class ClaudeSdkPipeline extends Disposable {
 	 * client-side enablement separately.
 	 */
 	async snapshotResolvedCustomizations(): Promise<ISdkResolvedCustomizations> {
-		const query = await this._ensureQueryBound();
+		const query = this._liveQuery();
 		const [commands, agents, mcpServers] = await Promise.all([
 			query.supportedCommands(),
 			query.supportedAgents(),
@@ -105,8 +92,7 @@ export class ClaudeSdkPipeline extends Disposable {
 	}
 
 	async startMcpServer(serverName: string): Promise<boolean> {
-		const query = await this._ensureQueryBound();
-		const lifecycle = query;
+		const lifecycle = this._liveQuery();
 		if (lifecycle.toggleMcpServer && lifecycle.reconnectMcpServer) {
 			await lifecycle.toggleMcpServer(serverName, true);
 			await lifecycle.reconnectMcpServer(serverName);
@@ -116,8 +102,7 @@ export class ClaudeSdkPipeline extends Disposable {
 	}
 
 	async stopMcpServer(serverName: string): Promise<boolean> {
-		const query = await this._ensureQueryBound();
-		const lifecycle = query;
+		const lifecycle = this._liveQuery();
 		if (!lifecycle.toggleMcpServer) {
 			return false;
 		}
@@ -125,49 +110,25 @@ export class ClaudeSdkPipeline extends Disposable {
 		return true;
 	}
 
-	/**
-	 * Bind the SDK Query if needed, recovering a dead one first. Mirrors the
-	 * gate in {@link send}: if the pipeline is marked for rebind (after an
-	 * abort/crash the `_query` handle is retained for teardown but its stream
-	 * is dead), rebuild via the rematerializer so pre-flight helpers never
-	 * operate on a disposed stream. Then lazily bind if nothing is bound yet.
-	 */
-	private async _ensureQueryBound(): Promise<Query> {
-		if (this._needsRebind) {
-			await this._rebindQuery('recover');
+	/** The live SDK stream, or throw if the pipeline has died (the session rebuilds a fresh one). */
+	private _liveQuery(): Query {
+		if (this._dead) {
+			throw new Error(`ClaudeSdkPipeline:${this.sessionId}: query is dead`);
 		}
-		if (!this._query) {
-			this._bindWarmQuery();
-			await this._replayCurrentConfig();
-		}
-		return this._query!;
+		return this._query;
 	}
 
 	/**
-	 * Bind a fresh SDK stream off the current warm subprocess. The stream is
-	 * long-lived: it spans every turn until a rebind swaps the subprocess (the
-	 * prompt iterable parks between turns rather than ending), so {@link _query}
-	 * tracks the lifetime of {@link _warm} and is only swapped here.
+	 * The SDK stream, bound once off {@link _warm} in the constructor and never
+	 * re-bound (the prompt iterable parks between turns rather than ending).
 	 */
-	private _bindWarmQuery(): Query {
-		const query = this._warm.query(this._queue.iterable);
-		this._query = query;
-		return query;
-	}
-
-	/**
-	 * The SDK stream bound to the current {@link _warm} subprocess, or
-	 * `undefined` before the first bind. Health is tracked separately by
-	 * {@link _needsRebind}: a non-`undefined` `_query` with `_needsRebind`
-	 * set is a *dead* stream awaiting rebuild. Cleared only on dispose.
-	 */
-	private _query: Query | undefined;
-	private _warm: WarmQuery;
-	private _abortController: AbortController;
+	private readonly _query: Query;
+	private readonly _warm: WarmQuery;
+	private readonly _abortController: AbortController;
 
 	private readonly _queue: ClaudePromptQueue;
 
-	/** Flips to `true` on the first `system:init` SDK message. Drives `Options.resume` decisions for downstream phases. */
+	/** Flips to `true` on the first `system:init` SDK message. */
 	private _isResumed = false;
 
 	/**
@@ -178,22 +139,19 @@ export class ClaudeSdkPipeline extends Disposable {
 	 */
 	private _initPlugins: readonly { readonly name: string; readonly path: string; readonly source?: string }[] = [];
 
-	/** Last model / effort / permission mode applied to the SDK via the runtime setters. Reset on rebind. */
+	/** Last model / effort / permission mode applied to the live Query (dedup only). Seeded at construction. */
 	private _appliedModel: string | undefined;
 	private _appliedEffort: ClaudeRuntimeEffortLevel | undefined;
 	private _appliedPermissionMode: PermissionMode | undefined;
 
-	/** Current values the consumer has asked for. Replayed to a fresh Query on bind / rebind. */
-	private _currentModel: string | undefined;
-	private _currentEffort: ClaudeRuntimeEffortLevel | undefined;
-	private _currentPermissionMode: PermissionMode | undefined;
+	/**
+	 * Terminal health flag. Set synchronously by {@link abort} and when the
+	 * consumer loop ends abnormally (crash / stream-end). Read by the session's
+	 * `send` pre-flight to rebuild a fresh pipeline; the pipeline never revives.
+	 */
+	private _dead = false;
 
-	private readonly _rematerializer: IRematerializer;
-
-	/** Set when the consumer loop ends in error (cancellation OR crash). Read by {@link send} to trigger rebind. */
-	private _needsRebind = false;
-
-	/** Tracks whether the consumer loop is currently draining {@link _query}. */
+	/** Tracks whether the (single) consumer loop has been started. */
 	private _consumerLoopRunning = false;
 
 	private readonly _onDidProduceSignal = this._register(new Emitter<AgentSignal>());
@@ -220,14 +178,16 @@ export class ClaudeSdkPipeline extends Disposable {
 		dbRef: IReference<ISessionDatabase>,
 		subagents: SubagentRegistry,
 		clientToolOwner: ((toolName: string) => string | undefined) | undefined,
-		rematerialize: IRematerializer,
+		appliedConfig: ISdkAppliedConfig,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 		this._warm = warm;
-		this._rematerializer = rematerialize;
 		this._abortController = abortController;
+		this._appliedModel = appliedConfig.model;
+		this._appliedEffort = appliedConfig.effort;
+		this._appliedPermissionMode = appliedConfig.permissionMode;
 		this._wireAbortHandler(abortController);
 		this._queue = this._register(instantiationService.createInstance(
 			ClaudePromptQueue,
@@ -243,8 +203,13 @@ export class ClaudeSdkPipeline extends Disposable {
 			ClaudeSdkMessageRouter, sessionUri, chatChannelUri, dbRef, subagents, clientToolOwner,
 		));
 		this._register(this._router.onDidProduceSignal(s => this._onDidProduceSignal.fire(s)));
-		// Dispose chain → abort → SDK cleanup. Reads the *current*
-		// `_abortController` so a swap aborts the live subprocess.
+		// Bind the SDK stream eagerly. The pipeline is immutable (never re-binds),
+		// and binding here — before the session assigns `_pipeline` — guarantees a
+		// runtime `setPermissionMode` that races the first send can never be lost
+		// to an unbound query. The iterable parks until the first prompt is pushed,
+		// so no turn runs until `send`.
+		this._query = this._warm.query(this._queue.iterable);
+		// Dispose chain → abort → SDK cleanup.
 		this._register(toDisposable(() => this._abortController.abort()));
 		this._register(toDisposable(() => {
 			void Promise.resolve(this._warm[Symbol.asyncDispose]()).catch((err: unknown) =>
@@ -255,6 +220,9 @@ export class ClaudeSdkPipeline extends Disposable {
 	get isResumed(): boolean { return this._isResumed; }
 
 	get isAborted(): boolean { return this._abortController.signal.aborted; }
+
+	/** Terminal: the consumer loop ended (abort / crash / stream-end). The session rebuilds. */
+	get isDead(): boolean { return this._dead; }
 
 	/**
 	 * Whether a turn is currently in flight or queued. False between turns (the
@@ -277,48 +245,22 @@ export class ClaudeSdkPipeline extends Disposable {
 	 */
 	async shutdownAndWait(): Promise<void> {
 		this._abortController.abort();
+		this._dead = true;
 		try {
 			await this._warm[Symbol.asyncDispose]();
-			await this._query?.return(undefined);
+			await this._query.return(undefined);
 		} catch (err) {
 			this._logService.warn(`[ClaudeSdkPipeline:${this.sessionId}] shutdownAndWait: teardown failed`, err);
 		}
 	}
 
 	/**
-	 * Phase 10 \u2014 narrow public wrapper around the internal
-	 * {@link _rebindQuery} so the session's synced-state rebind
-	 * can drive a yield-restart without exposing the private rebind
-	 * machinery to every collaborator.
-	 */
-	rebindForRestart(): Promise<void> {
-		return this._rebindQuery('restart');
-	}
-
-	/**
-	 * Seed the current + applied config from materialize-time `Options`.
-	 * The SDK already starts with these values, so we mark them as both
-	 * "current" (what the consumer wants) and "applied" (what the SDK has)
-	 * to avoid a redundant `setModel` / `applyFlagSettings` on first use.
-	 */
-	seedCurrentConfig(model: string | undefined, effort: ClaudeRuntimeEffortLevel | undefined, permissionMode: PermissionMode | undefined): void {
-		this._currentModel = model;
-		this._currentEffort = effort;
-		this._currentPermissionMode = permissionMode;
-		this._appliedModel = model;
-		this._appliedEffort = effort;
-		this._appliedPermissionMode = permissionMode;
-	}
-
-	/**
 	 * Eagerly push a model change to the SDK. Safe to call mid-turn:
-	 * `Query.setModel` only takes effect on the NEXT user request. No-op
-	 * if the value is unchanged. Buffered as `_currentModel` until the
-	 * Query is bound (and replayed on rebind).
+	 * `Query.setModel` only takes effect on the NEXT user request. No-op if the
+	 * value is unchanged or the pipeline has died.
 	 */
 	async setModel(model: string): Promise<void> {
-		this._currentModel = model;
-		if (this._query && !this._needsRebind && model !== this._appliedModel) {
+		if (!this._dead && model !== this._appliedModel) {
 			try {
 				await this._query.setModel(model);
 				this._appliedModel = model;
@@ -341,8 +283,7 @@ export class ClaudeSdkPipeline extends Disposable {
 	 * replaying it onto a model the API will 400 on.
 	 */
 	async setEffort(effort: ClaudeRuntimeEffortLevel | undefined): Promise<void> {
-		this._currentEffort = effort;
-		if (this._query && !this._needsRebind && effort !== this._appliedEffort) {
+		if (!this._dead && effort !== this._appliedEffort) {
 			try {
 				await this._query.applyFlagSettings({ effortLevel: effort ?? null });
 				this._appliedEffort = effort;
@@ -353,22 +294,24 @@ export class ClaudeSdkPipeline extends Disposable {
 	}
 
 	/**
-	 * Queue a user prompt for the SDK. Resolves when the matching
-	 * `result` message arrives.
-	 *
-	 * If a previous turn aborted or crashed, this triggers a rebind via
-	 * the attached rematerializer before queueing.
+	 * Forwards to {@link Query.setPermissionMode}. No-op if unchanged or dead.
+	 * Permission mode is whole-session (not per-entry).
+	 */
+	async setPermissionMode(mode: PermissionMode): Promise<void> {
+		if (!this._dead && mode !== this._appliedPermissionMode) {
+			await this._query.setPermissionMode(mode);
+			this._appliedPermissionMode = mode;
+		}
+	}
+
+	/**
+	 * Queue a user prompt for the SDK. Resolves when the matching `result`
+	 * message arrives. The session's `send` pre-flight has already rebuilt a
+	 * fresh pipeline if this one was dead, so this only runs on a live query.
 	 */
 	async send(prompt: SDKUserMessage, turnId: string): Promise<void> {
-		if (this._needsRebind) {
-			await this._rebindQuery('recover');
-		}
 		if (this._abortController.signal.aborted) {
 			throw new CancellationError();
-		}
-		if (!this._query) {
-			this._bindWarmQuery();
-			await this._replayCurrentConfig();
 		}
 		this._ensureConsumerLoop();
 		const entry: IPendingSdkMessage = {
@@ -419,39 +362,23 @@ export class ClaudeSdkPipeline extends Disposable {
 	}
 
 	/**
-	 * Cancel the in-flight SDK turn via the abort controller. Mirrors
-	 * the production reference (`claudeCodeAgent.ts:719`). Drops every
-	 * pending entry's deferred (rejected with `CancellationError`),
-	 * marks the pipeline for rebind on next {@link send}. Idempotent.
+	 * Cancel the in-flight SDK turn via the abort controller. Drops every
+	 * pending entry's deferred (rejected with `CancellationError`) and marks the
+	 * pipeline {@link isDead} synchronously so the next `send` rebuilds a fresh
+	 * pipeline rather than reusing this one.
 	 *
-	 * Safe to call during rebind: {@link _rebindQuery} swaps in a fresh
-	 * placeholder {@link AbortController} before awaiting the
-	 * rematerializer, so an abort issued during recovery lands on that
-	 * placeholder and is honored when the freshly-built pair arrives
-	 * (the rebind discards the new pair and surfaces a cancellation).
+	 * Idempotent on the pipeline's own terminal state ({@link isDead}), NOT on the
+	 * shared `AbortController` signal: the session aborts the controller it shares
+	 * with this pipeline *before* calling here, so a `signal.aborted` guard would
+	 * skip `failAll` and strand the in-flight `send` deferred.
 	 */
 	abort(): void {
-		if (this._abortController.signal.aborted) {
+		if (this._dead) {
 			return;
 		}
 		this._abortController.abort();
 		this._queue.failAll(new CancellationError());
-		// Mark unhealthy but keep the `_query` handle: the next `send` rebinds,
-		// and `shutdownAndWait` still needs it to await the subprocess exit.
-		this._needsRebind = true;
-	}
-
-	/**
-	 * Forwards to {@link Query.setPermissionMode} once the query is
-	 * bound; the value is also remembered so it's re-applied after a
-	 * rebind. Permission mode is whole-session (not per-entry).
-	 */
-	async setPermissionMode(mode: PermissionMode): Promise<void> {
-		this._currentPermissionMode = mode;
-		if (this._query && !this._needsRebind && mode !== this._appliedPermissionMode) {
-			await this._query.setPermissionMode(mode);
-			this._appliedPermissionMode = mode;
-		}
+		this._dead = true;
 	}
 
 	private _wireAbortHandler(controller: AbortController): void {
@@ -460,118 +387,20 @@ export class ClaudeSdkPipeline extends Disposable {
 		}, { once: true });
 	}
 
+	/**
+	 * Start the single consumer loop for this pipeline's query if it isn't
+	 * running. The loop runs for the pipeline's whole life (the iterable parks
+	 * between turns); when it ends the query stream is over and the pipeline is
+	 * dead — there is no hand-off to a fresh pass (rebuild mints a new pipeline).
+	 */
 	private _ensureConsumerLoop(): void {
 		if (this._consumerLoopRunning) {
 			return;
 		}
 		this._consumerLoopRunning = true;
-		this._runConsumerLoop();
-	}
-
-	/**
-	 * Runs one {@link _processMessages} pass over the live {@link _query} and,
-	 * when it ends, decides whether to hand off to a fresh pass.
-	 *
-	 * A rebind ({@link _rebindQuery}) swaps in a new `_query` while the loop is
-	 * still draining the OLD (now-disposed) one; that old pass then ends with
-	 * the "stream ended without a result" guard. Because `_consumerLoopRunning`
-	 * stays `true` for the whole handoff, the {@link send} that queued the
-	 * post-rebind prompt already saw {@link _ensureConsumerLoop} no-op — so if
-	 * this pass just stopped, nothing would ever read the new query and `send`
-	 * would hang. Detect the swap (current `_query` differs from the one this
-	 * pass bound) and re-arm for it instead. Abort / crash / dispose leave
-	 * `_query` cleared (or the store disposed), so they fall through to stop.
-	 */
-	private _runConsumerLoop(): void {
-		const boundQuery = this._query;
 		void this._processMessages()
 			.catch(err => this._logService.error(`[ClaudeSdkPipeline:${this.sessionId}] _processMessages crashed: ${err}`))
-			.finally(() => {
-				if (!this._store.isDisposed && this._query && this._query !== boundQuery) {
-					this._runConsumerLoop();
-				} else {
-					this._consumerLoopRunning = false;
-				}
-			});
-	}
-
-	/**
-	 * Push the current model / effort / permissionMode to the SDK if they
-	 * diverge from what was last applied. Called after binding a fresh
-	 * Query (initial first-send and after rebind). Failures are logged.
-	 */
-	private async _replayCurrentConfig(): Promise<void> {
-		try {
-			if (this._currentModel !== undefined && this._currentModel !== this._appliedModel) {
-				await this._query?.setModel(this._currentModel);
-				this._appliedModel = this._currentModel;
-			}
-			if (this._currentEffort !== undefined && this._currentEffort !== this._appliedEffort) {
-				await this._query?.applyFlagSettings({ effortLevel: this._currentEffort });
-				this._appliedEffort = this._currentEffort;
-			}
-			if (this._currentPermissionMode !== undefined && this._currentPermissionMode !== this._appliedPermissionMode) {
-				await this._query?.setPermissionMode(this._currentPermissionMode);
-				this._appliedPermissionMode = this._currentPermissionMode;
-			}
-		} catch (err) {
-			this._logService.warn(`[ClaudeSdkPipeline:${this.sessionId}] _replayCurrentConfig failed: ${err}`);
-		}
-	}
-
-	/**
-	 * Dispose the dead SDK plumbing and rebuild via the agent-supplied
-	 * rematerializer in `resume` mode. Re-applies the current model /
-	 * effort / permission mode to the fresh Query.
-	 */
-	private async _rebindQuery(reason: 'restart' | 'recover'): Promise<void> {
-		const oldWarm = this._warm;
-		// Install a placeholder controller BEFORE awaiting the
-		// rematerializer so a concurrent {@link abort} has a live target
-		// instead of returning early as idempotent against the already-
-		// aborted old controller.
-		const placeholder = new AbortController();
-		this._abortController = placeholder;
-		const built = await this._rematerializer(reason);
-		// Dispose may have run while we were awaiting the rematerializer.
-		// The dispose chain has already torn down the OLD warm/controller;
-		// the freshly-built pair would otherwise leak its subprocess. Mirror
-		// the post-await abort gate in `_materializeProvisional`.
-		if (this._store.isDisposed) {
-			built.abortController.abort();
-			void Promise.resolve(built.warm[Symbol.asyncDispose]()).catch((err: unknown) =>
-				this._logService.warn(`[ClaudeSdkPipeline:${this.sessionId}] rebind-after-dispose: warm dispose failed: ${err}`));
-			throw new CancellationError();
-		}
-		// Abort issued while we were awaiting the rematerializer landed on
-		// the placeholder. Discard the freshly-built pair and surface a
-		// cancellation to the in-flight `send`.
-		if (placeholder.signal.aborted) {
-			built.abortController.abort();
-			void Promise.resolve(built.warm[Symbol.asyncDispose]()).catch((err: unknown) =>
-				this._logService.warn(`[ClaudeSdkPipeline:${this.sessionId}] rebind-aborted: warm dispose failed: ${err}`));
-			void Promise.resolve(oldWarm[Symbol.asyncDispose]()).catch((err: unknown) =>
-				this._logService.warn(`[ClaudeSdkPipeline:${this.sessionId}] previous WarmQuery dispose failed during aborted rebind: ${err}`));
-			this._queue.failAll(new CancellationError());
-			this._needsRebind = true;
-			throw new CancellationError();
-		}
-		void Promise.resolve(oldWarm[Symbol.asyncDispose]()).catch((err: unknown) =>
-			this._logService.warn(`[ClaudeSdkPipeline:${this.sessionId}] previous WarmQuery dispose failed during rebind: ${err}`));
-		this._warm = built.warm;
-		this._abortController = built.abortController;
-		this._wireAbortHandler(built.abortController);
-		this._queue.resetForRebind();
-		this._needsRebind = false;
-		// New SDK starts with the materializer's `Options.model` / effort /
-		// permissionMode but we don't trust that to match `_currentModel`
-		// etc. — reset the applied cache and let `_replayCurrentConfig`
-		// push whatever the consumer last set.
-		this._appliedModel = undefined;
-		this._appliedEffort = undefined;
-		this._appliedPermissionMode = undefined;
-		this._bindWarmQuery();
-		await this._replayCurrentConfig();
+			.finally(() => { this._consumerLoopRunning = false; });
 	}
 
 	/**
@@ -582,17 +411,14 @@ export class ClaudeSdkPipeline extends Disposable {
 	 * when the queue fully drains.
 	 *
 	 * On any uncaught error (cancellation, transport failure, or the
-	 * post-loop "stream ended without result" guard) the catch block
-	 * rejects every pending entry's deferred with the same error and
-	 * marks `_needsRebind=true`. Cancellation is swallowed (don't
-	 * rethrow); other errors propagate to the void caller's `.catch` for
-	 * logging.
+	 * "stream ended without result" guard — the stream only ends on
+	 * abort/crash/dispose since the iterable parks between turns) the catch
+	 * rejects every pending entry's deferred and marks the pipeline
+	 * {@link isDead}. Cancellation is swallowed; other errors propagate to the
+	 * void caller's `.catch` for logging.
 	 */
 	private async _processMessages(): Promise<void> {
 		const query = this._query;
-		if (!query) {
-			throw new Error('ClaudeSdkPipeline._processMessages called before query was bound');
-		}
 		try {
 			for await (const message of query) {
 				if (this._abortController.signal.aborted) {
@@ -600,7 +426,7 @@ export class ClaudeSdkPipeline extends Disposable {
 				}
 				if (message.type === 'system' && message.subtype === 'init') {
 					// Capture the loaded native-plugin list on every init (incl.
-					// resume / post-rebind) so the post-materialize filter is fresh.
+					// resume) so the post-materialize filter is fresh.
 					this._initPlugins = message.plugins ?? [];
 					if (!this._isResumed) {
 						this._isResumed = true;
@@ -635,26 +461,13 @@ export class ClaudeSdkPipeline extends Disposable {
 			if (this._abortController.signal.aborted) {
 				throw new CancellationError();
 			}
-			// A rebind ({@link _rebindQuery}) swaps in a fresh `_query` and
-			// disposes the old one, ending THIS pass's stream cleanly. That is
-			// expected — return quietly and let {@link _runConsumerLoop} hand
-			// off to the new query. Only an unexpected end of the *current*
-			// query (no swap) is the real "stream ended without a result"
-			// failure that should mark the pipeline for recovery.
-			if (this._query !== query) {
-				return;
-			}
+			// The parked iterable only ends on abort / crash / dispose, so an end
+			// without a result is a dead subprocess — mark the pipeline for rebuild.
 			throw new Error('Claude SDK stream ended without a result message');
 		} catch (err) {
 			const fatal = err instanceof Error ? err : new Error(String(err));
-			// Only the loop that still owns the live query reacts: a later
-			// unwinding pass whose query was already swapped by a rebind must
-			// not clobber the fresh one. Mark unhealthy (keep the handle for
-			// teardown); the next `send` rebinds.
-			if (this._query === query) {
-				this._queue.failAll(fatal);
-				this._needsRebind = true;
-			}
+			this._queue.failAll(fatal);
+			this._dead = true;
 			if (!isCancellationError(fatal)) {
 				throw fatal;
 			}

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -3169,15 +3169,17 @@ suite('ClaudeAgent', () => {
 		// fallback `'default'` won, and a plan-mode session silently
 		// downgraded to default mode mid-chat.
 		//
-		// The fix: only forward `setPermissionMode` when the live config
-		// actually carries a value, leaving the session's seeded
-		// bijective state (seeded into the pipeline at materialize time)
-		// authoritative otherwise.
+		// The C9 mechanism: the pipeline is seeded at materialize with the
+		// resolved permissionMode ('plan') as its applied-config baseline, and
+		// `setPermissionMode` dedups against it. Turn 2 reuses the live pipeline,
+		// resolves 'plan' again, matches the seed, and issues NO runtime call —
+		// the seeded mode stays authoritative and 'default' is never pushed.
 		//
 		// Setup: stage the per-session DB with `claude.permissionMode='plan'`,
-		// then run two turns. Turn 1 picks up the mode via
-		// `Options.permissionMode` at materialize. Turn 2 must NOT
-		// record an extra `setPermissionMode` call.
+		// then run two turns on ONE subprocess (park at the turn boundary so the
+		// pipeline stays live for turn 2). Turn 1 picks up the mode via
+		// `Options.permissionMode` at materialize; turn 2 records no
+		// `setPermissionMode` call.
 		const sessionId = 'cross-window-mode-session';
 		const sessionUri = AgentSession.uri('claude', sessionId);
 
@@ -3194,19 +3196,28 @@ suite('ClaudeAgent', () => {
 			createdAt: 4900,
 			cwd: URI.file('/work').fsPath,
 		}];
+		// Park the consumer loop at the turn boundary so the pipeline stays live
+		// across both turns on a single subprocess (production reuse).
+		const advance = new DeferredPromise<void>();
+		sdk.queryAdvance = async (i: number) => { if (i === 2) { await advance.p; } };
 		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
 		await agent.chats.sendMessage(defaultChatUri(sessionUri), 'turn-1', undefined, undefined, 't1');
 
-		sdk.nextQueryMessages = [makeResultSuccess(sessionId)];
-		await agent.chats.sendMessage(defaultChatUri(sessionUri), 'turn-2', undefined, undefined, 't2');
+		// Turn 2 reuses the live pipeline; its result drains at the parked boundary.
+		sdk.nextQueryMessages.push(makeResultSuccess(sessionId));
+		const turn2 = agent.chats.sendMessage(defaultChatUri(sessionUri), 'turn-2', undefined, undefined, 't2');
+		advance.complete();
+		await turn2;
 
 		const fakeQuery = sdk.warmQueries.at(-1)?.produced;
 		assert.deepStrictEqual({
+			startupCount: sdk.startupCallCount,
 			optionsPermissionMode: sdk.capturedStartupOptions[0]?.permissionMode,
 			recordedModes: fakeQuery?.recordedPermissionModes ?? [],
 		}, {
+			startupCount: 1,
 			optionsPermissionMode: 'plan',
-			recordedModes: ['plan'],
+			recordedModes: [],
 		});
 	});
 
@@ -5811,7 +5822,7 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 		assert.strictEqual(resumeOpts.resume, sid);
 	});
 
-	test('rebind re-applies bijective state (model + effort) on the new Query', async () => {
+	test('rebuild carries bijective state (model + effort) into the new Query via Options', async () => {
 		const { ctx, sessionUri, sessionId, query: firstQuery, advance } = await materialize();
 
 		// Hot-swap model + effort on the live query so the bijective
@@ -5823,18 +5834,19 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 		await p2;
 		assert.deepStrictEqual({ models: firstQuery.recordedModels, efforts: firstQuery.recordedFlagSettings.map(s => s.effortLevel) }, { models: ['claude-sonnet-4-6'], efforts: ['high'] });
 
-		// Now abort and resend; the rebound query MUST receive the same
-		// model + effort via the rebind's re-apply pass.
+		// Now abort and resend; the rebuilt query MUST carry the same model +
+		// effort — under C9 delivered via the rebuild's `Options` (baked from the
+		// provisional model), NOT a runtime `setModel`/`applyFlagSettings` replay.
 		await ctx.agent.chats.abort(defaultChatUri(sessionUri));
 		ctx.sdk.queryAdvance = undefined;
 		ctx.sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
 		await ctx.agent.chats.sendMessage(defaultChatUri(sessionUri), 'after-abort', undefined, undefined, 'turn-3');
 
-		const reboundQuery = ctx.sdk.warmQueries[1].produced!;
+		const rebuildOpts = ctx.sdk.capturedStartupOptions[1];
 		assert.deepStrictEqual({
-			models: reboundQuery.recordedModels,
-			efforts: reboundQuery.recordedFlagSettings.map(s => s.effortLevel),
-		}, { models: ['claude-sonnet-4-6'], efforts: ['high'] });
+			model: rebuildOpts.model,
+			effort: rebuildOpts.effort,
+		}, { model: 'claude-sonnet-4-6', effort: 'high' });
 	});
 
 	test('intermediate result during steering does NOT complete the in-flight sendMessage or fire ChatTurnComplete', async () => {
@@ -6415,6 +6427,12 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 
 		// A successful snapshot: one SDK-only command, no agents/MCP. (No disk
 		// skills exist under /work, so the command becomes a built-in.)
+		// Park the consumer loop at the turn boundary (index 2) so the pipeline
+		// stays live for the post-turn snapshot — the real SDK iterable parks
+		// between turns; the fake would otherwise end the stream and mark the
+		// pipeline dead, collapsing the snapshot to the disk-only fallback.
+		const advance = new DeferredPromise<void>();
+		sdk.queryAdvance = async (i: number) => { if (i === 2) { await advance.p; } };
 		sdk.supportedCommandsResult = [{ name: 'sdkcmd', description: 'Provided by the runtime.', argumentHint: '' }];
 		sdk.supportedAgentsResult = [];
 		sdk.mcpServerStatusResult = [];
@@ -6437,6 +6455,7 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 			{ count: container.children?.length, name: child.name, description: child.description },
 			{ count: 1, name: 'sdkcmd', description: 'Provided by the runtime.' }
 		);
+		advance.complete();
 	});
 
 	test('getSessionCustomizations surfaces a native plugin captured from the live SDK init.plugins (path filter)', async () => {

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -5849,6 +5849,122 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 		}, { model: 'claude-sonnet-4-6', effort: 'high' });
 	});
 
+	// C9 adversarial edge cases — races the immutable-pipeline / session-orchestrated
+	// rebuild opens up that a happy-path E2E can't hold open. Driven deterministically
+	// against the real ClaudeAgentSession + ClaudeSdkPipeline via the controllable SDK
+	// fake (park a turn / park inside startup, then fire a concurrent abort).
+
+	test('double abort (two aborts back-to-back) is idempotent, rejects the in-flight turn once, and the session still rebuilds on the next send', async () => {
+		const ctx = createTestContext(disposables);
+		await ctx.agent.authenticate('https://api.github.com', 'tok');
+		await tick();
+		const created = await ctx.agent.createSession({ workingDirectory: URI.file('/workspace'), model: { id: 'claude-opus-4.6' } });
+		const sid = AgentSession.id(created.session);
+
+		// Park the first turn so it is genuinely in flight when we abort.
+		const stall = new DeferredPromise<void>();
+		ctx.sdk.queryAdvance = async (i) => { if (i === 0) { await stall.p; } };
+		ctx.sdk.nextQueryMessages = [makeSystemInitMessage(sid), makeResultSuccess(sid)];
+		const inFlight = ctx.agent.chats.sendMessage(defaultChatUri(created.session), 'hi', undefined, undefined, 'turn-1');
+		await tick();
+
+		// Abort twice — the second must be a no-op (the shared-controller signal is
+		// already aborted), NOT a throw or a double-settle of the same deferred.
+		await ctx.agent.chats.abort(defaultChatUri(created.session));
+		await ctx.agent.chats.abort(defaultChatUri(created.session));
+		await assert.rejects(inFlight, (err: unknown) => isCancellationError(err));
+
+		// The session survives the double abort: the next send recover-rebuilds cleanly.
+		ctx.sdk.queryAdvance = undefined;
+		stall.complete();
+		await tick();
+		const startupBefore = ctx.sdk.startupCallCount;
+		ctx.sdk.nextQueryMessages = [makeSystemInitMessage(sid), makeResultSuccess(sid)];
+		await ctx.agent.chats.sendMessage(defaultChatUri(created.session), 'again', undefined, undefined, 'turn-2');
+		assert.strictEqual(ctx.sdk.startupCallCount, startupBefore + 1, 'double-abort still allows exactly one clean rebuild');
+	});
+
+	test('abort landing inside a rebuild\'s startup() await is caught by the post-await gate: the half-built WarmQuery is disposed and the send rejects', async () => {
+		const ctx = createTestContext(disposables);
+		await ctx.agent.authenticate('https://api.github.com', 'tok');
+		await tick();
+		const created = await ctx.agent.createSession({ workingDirectory: URI.file('/workspace'), model: { id: 'claude-opus-4.6' } });
+		const sid = AgentSession.id(created.session);
+
+		// Turn 1 materializes (startup #1).
+		ctx.sdk.nextQueryMessages = [makeSystemInitMessage(sid), makeResultSuccess(sid)];
+		await ctx.agent.chats.sendMessage(defaultChatUri(created.session), 'hi', undefined, undefined, 'turn-1');
+		// Kill the pipeline so the next send must rebuild.
+		await ctx.agent.chats.abort(defaultChatUri(created.session));
+		await tick();
+
+		// Park INSIDE the rebuild's startup() (startup #2), then abort mid-await. This
+		// exercises `_installPipeline`'s post-await gate on the rebuild path (not just
+		// the materialize path): an abort that lands while the subprocess is spawning
+		// must dispose the freshly-spawned WarmQuery and NOT install a dead pipeline.
+		const inStartup = new DeferredPromise<void>();
+		const releaseStartup = new DeferredPromise<void>();
+		ctx.sdk.startupAdvance = async (callIndex) => {
+			if (callIndex === 2) { inStartup.complete(); await releaseStartup.p; }
+		};
+		const warmsBeforeRebuild = ctx.sdk.warmQueries.length;
+		ctx.sdk.nextQueryMessages = [makeSystemInitMessage(sid), makeResultSuccess(sid)];
+		const rebuildSend = ctx.agent.chats.sendMessage(defaultChatUri(created.session), 'rebuild', undefined, undefined, 'turn-2');
+		await inStartup.p;
+
+		await ctx.agent.chats.abort(defaultChatUri(created.session));
+		releaseStartup.complete();
+		await assert.rejects(rebuildSend, (err: unknown) => isCancellationError(err));
+
+		const rebuildWarm = ctx.sdk.warmQueries[warmsBeforeRebuild];
+		assert.deepStrictEqual({
+			spawnedRebuildWarm: !!rebuildWarm,
+			rebuildWarmDisposed: rebuildWarm?.asyncDisposeCount,
+			startups: ctx.sdk.startupCallCount,
+		}, {
+			spawnedRebuildWarm: true,
+			rebuildWarmDisposed: 1,
+			startups: 2,
+		});
+	});
+
+	test('abort→resend churn: every retired WarmQuery is disposed (no leaked subprocess handle across repeated recover-rebuilds), one startup per cycle', async () => {
+		const ctx = createTestContext(disposables);
+		await ctx.agent.authenticate('https://api.github.com', 'tok');
+		await tick();
+		const created = await ctx.agent.createSession({ workingDirectory: URI.file('/workspace'), model: { id: 'claude-opus-4.6' } });
+		const sid = AgentSession.id(created.session);
+
+		const CYCLES = 4;
+		for (let n = 0; n < CYCLES; n++) {
+			const stall = new DeferredPromise<void>();
+			ctx.sdk.queryAdvance = async (i) => { if (i === 0) { await stall.p; } };
+			ctx.sdk.nextQueryMessages = [makeSystemInitMessage(sid), makeResultSuccess(sid)];
+			const inFlight = ctx.agent.chats.sendMessage(defaultChatUri(created.session), `msg-${n}`, undefined, undefined, `turn-${n}`);
+			await tick();
+			await ctx.agent.chats.abort(defaultChatUri(created.session));
+			await assert.rejects(inFlight, (err: unknown) => isCancellationError(err));
+			ctx.sdk.queryAdvance = undefined;
+			stall.complete();
+			await tick();
+		}
+
+		// One SDK startup per cycle (materialize on cycle 0, recover-rebuild thereafter),
+		// and every WarmQuery except the still-live last one was async-disposed at least
+		// once — the deterministic analog of "no orphan subprocess accumulates".
+		const retired = ctx.sdk.warmQueries.slice(0, -1);
+		assert.deepStrictEqual({
+			startups: ctx.sdk.startupCallCount,
+			warmCount: ctx.sdk.warmQueries.length,
+			leakedRetiredWarms: retired.filter(w => w.asyncDisposeCount === 0).length,
+		}, {
+			startups: CYCLES,
+			warmCount: CYCLES,
+			leakedRetiredWarms: 0,
+		});
+	});
+
+
 	test('intermediate result during steering does NOT complete the in-flight sendMessage or fire ChatTurnComplete', async () => {
 		// CONTEXT.md M10: when the SDK preempts via `'now'`-priority, it
 		// emits one `result` message per turn it ran (the aborted

--- a/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Query, SDKMessage, SDKUserMessage, WarmQuery } from '@anthropic-ai/claude-agent-sdk';
+import type { Query, SDKUserMessage, WarmQuery } from '@anthropic-ai/claude-agent-sdk';
 
 import assert from 'assert';
-import { DeferredPromise } from '../../../../base/common/async.js';
 import { isCancellationError } from '../../../../base/common/errors.js';
 import { DisposableStore, IReference } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -21,7 +20,7 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ISessionDatabase } from '../../common/sessionDataService.js';
 import { buildDefaultChatUri } from '../../common/state/sessionState.js';
-import { ClaudeSdkPipeline, IRematerializer } from '../../node/claude/claudeSdkPipeline.js';
+import { ClaudeSdkPipeline, ISdkAppliedConfig } from '../../node/claude/claudeSdkPipeline.js';
 import { SubagentRegistry } from '../../node/claude/claudeSubagentRegistry.js';
 import { createZeroDiffComputeService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 
@@ -133,51 +132,6 @@ class RecordingWarmQuery extends FakeWarmQuery {
 	}
 }
 
-/** A {@link Query}-shaped stub whose async stream the test ends on demand. */
-type IControllableQuery = Query & {
-	/** Ends the stream (models a dispose-driven close of the underlying query). */
-	end(): void;
-	/** How many times the consumer loop has pulled from this query's iterator. */
-	readonly nextCallCount: number;
-};
-
-/**
- * Builds a {@link Query} whose async iterator blocks (modelling a live turn)
- * until {@link IControllableQuery.end}, and records how many times the consumer
- * loop pulled from it. Lets a test hold the consumer loop on one query while a
- * rebind swaps in the next, then observe whether the new query gets drained.
- */
-function makeControllableQuery(): IControllableQuery {
-	let ended = false;
-	let wake: (() => void) | undefined;
-	const q = Object.assign(new ImmediatelyDoneQuery(), {
-		nextCallCount: 0,
-		end(): void { ended = true; wake?.(); wake = undefined; },
-		[Symbol.asyncIterator]() { return this; },
-		async next(this: { nextCallCount: number }): Promise<IteratorResult<SDKMessage, void>> {
-			this.nextCallCount++;
-			while (!ended) {
-				await new Promise<void>(resolve => { wake = resolve; });
-			}
-			return { done: true, value: undefined };
-		},
-		async return() { return { done: true, value: undefined }; },
-		async throw(err: unknown) { throw err; },
-	});
-	return q as unknown as IControllableQuery;
-}
-
-/** {@link WarmQuery} that hands out {@link makeControllableQuery} instances and records them. */
-class ControllableWarmQuery extends FakeWarmQuery {
-	readonly queries: IControllableQuery[] = [];
-
-	override query(_prompt: string | AsyncIterable<SDKUserMessage>): Query {
-		this.queryCallCount++;
-		const q = makeControllableQuery();
-		this.queries.push(q);
-		return q;
-	}
-}
 
 // ===== Harness =====
 
@@ -185,13 +139,12 @@ interface IPipelineHarness {
 	readonly pipeline: ClaudeSdkPipeline;
 	readonly warm: FakeWarmQuery;
 	readonly controller: AbortController;
-	/** Swap the rematerializer the pipeline was constructed with (test-only seam). */
-	setRematerializer(rematerialize: IRematerializer): void;
 }
 
 function createPipeline(
 	disposables: Pick<DisposableStore, 'add'>,
 	warmOrFactory: FakeWarmQuery | ((signal: AbortSignal) => FakeWarmQuery) = new FakeWarmQuery(),
+	appliedConfig: ISdkAppliedConfig = { model: undefined, effort: undefined, permissionMode: undefined },
 ): IPipelineHarness {
 	const controller = new AbortController();
 	const warm = typeof warmOrFactory === 'function' ? warmOrFactory(controller.signal) : warmOrFactory;
@@ -209,10 +162,6 @@ function createPipeline(
 	);
 	const inst: IInstantiationService = disposables.add(new InstantiationService(services));
 	const subagents = disposables.add(new SubagentRegistry());
-	// Pipeline requires a rematerializer at construction; tests swap theirs via `setRematerializer` (default throws).
-	let rematerialize: IRematerializer = async () => {
-		throw new Error('test rematerializer not set via setRematerializer');
-	};
 	const pipeline = disposables.add(inst.createInstance(
 		ClaudeSdkPipeline,
 		'sess-1',
@@ -223,9 +172,9 @@ function createPipeline(
 		dbRef,
 		subagents,
 		undefined,
-		(reason: 'restart' | 'recover') => rematerialize(reason),
+		appliedConfig,
 	));
-	return { pipeline, warm, controller, setRematerializer: r => { rematerialize = r; } };
+	return { pipeline, warm, controller };
 }
 
 function makePrompt(uuid: string, text: string = uuid): SDKUserMessage {
@@ -241,18 +190,6 @@ function makePrompt(uuid: string, text: string = uuid): SDKUserMessage {
 function makeUuid(label: string): `${string}-${string}-${string}-${string}-${string}` {
 	const pad = (s: string, n: number) => s.padEnd(n, '0').slice(0, n);
 	return `${pad(label, 8)}-0000-0000-0000-000000000000`;
-}
-
-/**
- * Let the pipeline's fire-and-forget `send()` run far enough to bind the
- * Query and finish its synchronous `_replayCurrentConfig` (a no-op when the
- * seeded config already matches). A few microtask turns is enough; the stub
- * Query never awaits real I/O.
- */
-async function flushMicrotasks(): Promise<void> {
-	for (let i = 0; i < 5; i++) {
-		await Promise.resolve();
-	}
 }
 
 suite('ClaudeSdkPipeline', () => {
@@ -285,209 +222,69 @@ suite('ClaudeSdkPipeline', () => {
 		});
 	});
 
-	suite('rematerializer wiring', () => {
+	suite('isDead', () => {
 
-		test('after abort, send invokes the attached rematerializer in "recover" mode and clears the rebind flag', async () => {
-			const { pipeline, setRematerializer } = createPipeline(disposables);
-			const reasons: Array<'restart' | 'recover'> = [];
-			const built: { warm: FakeWarmQuery; controller: AbortController }[] = [];
-			const rematerializer: IRematerializer = async (reason) => {
-				reasons.push(reason);
-				const ctl = new AbortController();
-				const warm = new FakeWarmQuery();
-				built.push({ warm, controller: ctl });
-				return { warm, abortController: ctl };
-			};
-			setRematerializer(rematerializer);
-
+		test('abort sets isDead synchronously', () => {
+			const { pipeline } = createPipeline(disposables);
+			assert.strictEqual(pipeline.isDead, false);
 			pipeline.abort();
-			// Don't await — the consumer loop on the rebound query will end
-			// almost immediately, but the matching SDK `result` never
-			// arrives (FakeWarmQuery's iterator just closes), so the
-			// deferred ends up failed with the "stream ended without
-			// result" guard. We only care that the rematerializer ran.
-			pipeline.send(makePrompt('p1'), 'turn-A').catch(() => { /* expected */ });
-			// Yield a microtask for the async rebind to call the callback.
-			await Promise.resolve();
-			await Promise.resolve();
-
-			assert.deepStrictEqual(reasons, ['recover']);
-			assert.strictEqual(built.length, 1);
-			assert.strictEqual(pipeline.isAborted, false, 'rebind installed a fresh, non-aborted controller');
-		});
-
-		test('rematerializer rejection propagates from send', async () => {
-			const { pipeline, setRematerializer } = createPipeline(disposables);
-			const rebuildErr = new Error('rematerialize failed');
-			let calls = 0;
-			setRematerializer(async () => {
-				calls++;
-				throw rebuildErr;
-			});
-
-			pipeline.abort();
-			await pipeline.send(makePrompt('p1'), 'turn-A').then(
-				() => assert.fail('expected rejection'),
-				err => assert.strictEqual(err, rebuildErr),
-			);
-			assert.strictEqual(calls, 1);
-		});
-
-		test('abort issued while the rematerializer is still resolving cancels the freshly-built controller (rebind-window race)', async () => {
-			const { pipeline, setRematerializer } = createPipeline(disposables);
-			const releaseRebuild = new DeferredPromise<{ warm: FakeWarmQuery; controller: AbortController }>();
-			const built: { warm: FakeWarmQuery; controller: AbortController }[] = [];
-			setRematerializer(async () => {
-				const pair = await releaseRebuild.p;
-				built.push(pair);
-				return { warm: pair.warm, abortController: pair.controller };
-			});
-
-			// Trigger rebind by aborting the seed controller and starting a send.
-			// The send awaits _rebindQuery, which awaits releaseRebuild.
-			pipeline.abort();
-			const sendPromise = pipeline.send(makePrompt('p1'), 'turn-A');
-			await Promise.resolve(); // let _rebindQuery start its await
-
-			// Issue a SECOND abort while rebind is in-flight. This must
-			// land on the not-yet-installed controller — abort returning
-			// early as idempotent here would silently drop the user's
-			// cancel.
-			pipeline.abort();
-
-			// Now release the rematerializer with a fresh, non-aborted controller.
-			const freshController = new AbortController();
-			releaseRebuild.complete({ warm: new FakeWarmQuery(), controller: freshController });
-
-			await sendPromise.then(
-				() => assert.fail('expected cancellation after rebind-window abort'),
-				err => assert.ok(isCancellationError(err), `expected CancellationError, got ${err}`),
-			);
-			assert.strictEqual(built.length, 1);
-			assert.strictEqual(built[0].controller.signal.aborted, true, 'fresh controller cancelled before being installed');
-			assert.strictEqual(pipeline.isAborted, true);
-		});
-
-		test('a rebind hands the consumer loop off to the new query so the post-rebind turn is not lost', async () => {
-			// Regression: a rebind swaps in a fresh `_query` while the consumer
-			// loop is still draining the OLD one. The post-rebind `send` queues
-			// its prompt while the old loop is still marked running, so
-			// `_ensureConsumerLoop` no-ops. If the old loop then just stopped,
-			// nothing would ever read the new query and `send` would hang
-			// ("Restore Checkpoint then send" never responds).
-			const warm1 = new ControllableWarmQuery();
-			const { pipeline, setRematerializer } = createPipeline(disposables, warm1);
-
-			// Bind Q1 and start the consumer loop draining it. No result is
-			// pushed, so this send never resolves — we only need the live loop.
-			pipeline.send(makePrompt('p1'), 'turn-1').catch(() => { /* unwound on teardown */ });
-			await flushMicrotasks();
-			const q1 = warm1.queries[0];
-			assert.ok(q1.nextCallCount > 0, 'consumer loop drains Q1');
-
-			// Rebind to a fresh warm/Q2 while Q1's loop is still parked.
-			const warm2 = new ControllableWarmQuery();
-			setRematerializer(async () => ({ warm: warm2, abortController: new AbortController() }));
-			await pipeline.rebindForRestart();
-			const q2 = warm2.queries[0];
-			assert.strictEqual(q2.nextCallCount, 0, 'new query not drained yet — the old loop is still running');
-
-			// The old query's stream now ends (as a real dispose would). The
-			// loop must hand off to Q2 rather than stopping.
-			q1.end();
-			await flushMicrotasks();
-
-			assert.ok(q2.nextCallCount > 0, 'consumer loop handed off to the new query after the old one ended');
-
-			// Clean teardown: let the re-armed loop unwind before dispose.
-			q2.end();
-			await flushMicrotasks();
+			assert.strictEqual(pipeline.isDead, true);
 		});
 	});
 
-	suite('seedCurrentConfig', () => {
+	suite('applied config seed', () => {
 
-		test('seeded values match the post-materialize SDK state, so first send does NOT push a redundant setModel/applyFlagSettings/setPermissionMode', async () => {
-			// We can't observe the SDK calls without driving the consumer
-			// loop, but we CAN observe that send does not throw and that
-			// the warm query is bound exactly once.
-			const { pipeline, warm } = createPipeline(disposables);
-			pipeline.seedCurrentConfig('claude-sonnet-4-5', 'high', 'default');
-			pipeline.send(makePrompt('p1'), 'turn-A').catch(() => { /* expected: stream ends without result */ });
-			await Promise.resolve();
+		test('the query is bound once at construction (eager bind) with the seeded config', () => {
+			const { warm } = createPipeline(disposables, new FakeWarmQuery(), { model: 'claude-sonnet-4-5', effort: 'high', permissionMode: 'default' });
 			assert.strictEqual(warm.queryCallCount, 1);
 		});
 	});
 
 	suite('setEffort', () => {
 
-		// Bind a live Query (send() lazily binds it) seeded as if the session
-		// materialized on an effort-capable model. Returns the recorder so each
-		// test asserts the exact applyFlagSettings payloads pushed afterwards.
-		async function seededHighThenBind(disposables: Pick<DisposableStore, 'add'>): Promise<{ pipeline: ClaudeSdkPipeline; warm: RecordingWarmQuery; setRematerializer(rematerialize: IRematerializer): void }> {
+		// Construct a pipeline seeded as if the session materialized on an
+		// effort-capable model. The query is bound eagerly at construction, so
+		// runtime setEffort pushes are recorded without needing a send.
+		function seededHigh(disposables: Pick<DisposableStore, 'add'>): { pipeline: ClaudeSdkPipeline; warm: RecordingWarmQuery } {
 			let warm!: RecordingWarmQuery;
-			const { pipeline, setRematerializer } = createPipeline(disposables, signal => (warm = new RecordingWarmQuery(signal)));
-			pipeline.seedCurrentConfig('claude-opus-4-7', 'high', 'default');
-			pipeline.send(makePrompt('p1'), 'turn-A').catch(() => { /* stream ends without result */ });
-			await flushMicrotasks();
-			assert.strictEqual(warm.queryCallCount, 1, 'query should be bound after send');
-			warm.flagSettings.length = 0; // drop any replay from bind; isolate the switch
-			return { pipeline, warm, setRematerializer };
+			const { pipeline } = createPipeline(
+				disposables,
+				signal => (warm = new RecordingWarmQuery(signal)),
+				{ model: 'claude-opus-4-7', effort: 'high', permissionMode: 'default' },
+			);
+			return { pipeline, warm };
 		}
 
 		test('switching to a model with no effort clears the stale effort via applyFlagSettings({ effortLevel: null })', async () => {
 			// Repro of the Haiku 400: a session materialized on Opus applies
 			// effort 'high' at SDK startup; switching to Haiku must CLEAR it, not
 			// leave 'high' to be replayed onto a model the API 400s on.
-			const { pipeline, warm } = await seededHighThenBind(disposables);
+			const { pipeline, warm } = seededHigh(disposables);
 			await pipeline.setEffort(undefined);
 			assert.deepStrictEqual(warm.flagSettings, [{ effortLevel: null }]);
 		});
 
 		test('switching between two effort-capable levels pushes the new value', async () => {
-			const { pipeline, warm } = await seededHighThenBind(disposables);
+			const { pipeline, warm } = seededHigh(disposables);
 			await pipeline.setEffort('low');
 			assert.deepStrictEqual(warm.flagSettings, [{ effortLevel: 'low' }]);
 		});
 
 		test('re-applying the already-applied effort is a no-op (no redundant SDK call)', async () => {
-			const { pipeline, warm } = await seededHighThenBind(disposables);
+			const { pipeline, warm } = seededHigh(disposables);
 			await pipeline.setEffort('high');
 			assert.deepStrictEqual(warm.flagSettings, []);
 		});
 
 		test('clearing an already-clear effort is a no-op', async () => {
 			let warm!: RecordingWarmQuery;
-			const { pipeline } = createPipeline(disposables, signal => (warm = new RecordingWarmQuery(signal)));
-			pipeline.seedCurrentConfig('claude-haiku-4-5', undefined, 'default');
-			pipeline.send(makePrompt('p1'), 'turn-A').catch(() => { /* stream ends without result */ });
-			await flushMicrotasks();
-			warm.flagSettings.length = 0;
+			const { pipeline } = createPipeline(
+				disposables,
+				signal => (warm = new RecordingWarmQuery(signal)),
+				{ model: 'claude-haiku-4-5', effort: undefined, permissionMode: 'default' },
+			);
 			await pipeline.setEffort(undefined);
 			assert.deepStrictEqual(warm.flagSettings, []);
-		});
-
-		test('setEffort while awaiting rebind (post-abort) is buffered, not pushed to the dead query, then replayed on rebind', async () => {
-			// After an abort the `_query` handle is intentionally retained (it is
-			// what teardown awaits) but the stream is dead; `_needsRebind` is the
-			// health signal. setEffort must NOT steer that dead query — it should
-			// buffer the value and let `_replayCurrentConfig` push it onto the
-			// freshly-bound query after the rebind.
-			const { pipeline, warm, setRematerializer } = await seededHighThenBind(disposables);
-			pipeline.abort();
-			warm.flagSettings.length = 0; // isolate: ignore anything from the dead query
-			await pipeline.setEffort('low');
-			assert.deepStrictEqual(warm.flagSettings, [], 'effort must not be pushed while needsRebind');
-
-			let warm2!: RecordingWarmQuery;
-			setRematerializer(async () => {
-				const ctl = new AbortController();
-				warm2 = new RecordingWarmQuery(ctl.signal);
-				return { warm: warm2, abortController: ctl };
-			});
-			pipeline.send(makePrompt('p2'), 'turn-B').catch(() => { /* stream ends without result */ });
-			await flushMicrotasks();
-			assert.deepStrictEqual(warm2.flagSettings, [{ effortLevel: 'low' }], 'buffered effort replayed on the rebound query');
 		});
 	});
 
@@ -511,13 +308,8 @@ suite('ClaudeSdkPipeline', () => {
 
 	suite('CancellationError plumbing', () => {
 
-		test('abort + send rejects with a CancellationError-shaped error after the rematerializer runs (when rematerializer rejects with one)', async () => {
-			const { pipeline, setRematerializer } = createPipeline(disposables);
-			setRematerializer(async () => {
-				const err = new Error('Canceled');
-				err.name = 'Canceled';
-				throw err;
-			});
+		test('send after abort rejects with a CancellationError', async () => {
+			const { pipeline } = createPipeline(disposables);
 			pipeline.abort();
 			await pipeline.send(makePrompt('p1'), 'turn-A').then(
 				() => assert.fail('expected rejection'),

--- a/test/agent-host-e2e/README.md
+++ b/test/agent-host-e2e/README.md
@@ -1,0 +1,74 @@
+# Claude Agent Host — live E2E smoke tests
+
+Assertion-driven **live** smoke tests for the Claude agent host session lifecycle. Unlike the
+node unit suites under `src/vs/platform/agentHost/test/node/` (which drive the code with an SDK
+_fake_), these launch a **real, authenticated Agents window** and a **real Claude SDK subprocess**,
+then assert on ground truth pulled from `agenthost.log` and `ps`.
+
+They exist to catch regressions in the **C9 immutable-pipeline / session-orchestrated-rebuild**
+work ([PR #326270](https://github.com/microsoft/vscode/pull/326270)) that a fake can't fully
+prove — most importantly that the OS subprocess is actually **reaped** and that rapid
+abort→rebuild churn never leaks a process or hits a `<id>.jsonl` two-writer conflict.
+
+## Why this isn't a normal test yet
+
+These need **authentication** (a signed-in Copilot/Claude profile) and a **GUI window driven over
+CDP**, so there is no clean CI slot for them today. For now they're a script you run by hand
+before/after touching the agent-host session lifecycle. The assertions are structured so this can
+graduate into a real gated smoke suite once we have an authenticated headless runner.
+
+## Requirements
+
+- An authenticated `~/.vscode-oss-dev` profile (sign in to Copilot once in a dev build).
+- Full product build (`npm run compile` or a running watch) — the launcher builds if missing.
+- `@playwright/cli` (already a devDependency), `jq`, and macOS/Linux.
+- The **launch skill** at `.claude/skills/launch/scripts/launch.sh` (override with
+  `$CLAUDE_LAUNCH_SH` or `--launch`). It clones the authed profile into a throwaway dir and prints
+  the CDP port.
+
+## Usage
+
+```bash
+# launch a throwaway authed window, run all scenarios, tear it down:
+test/agent-host-e2e/claude-agenthost-smoke.sh
+
+# more churn cycles + verbose per-phase counters:
+test/agent-host-e2e/claude-agenthost-smoke.sh --cycles 6 -v
+
+# drive an already-open window instead of launching one:
+SMOKE_RUN=/tmp/code-oss-dev/<run-dir> \
+  test/agent-host-e2e/claude-agenthost-smoke.sh --cdp 59123 --keep
+```
+
+Exit code is the number of failed assertions (`0` = all green). The tail prints
+`=== summary: N passed, M failed ===`.
+
+## Scenarios & invariants
+
+| # | Scenario | Key assertions (ground truth) |
+|---|----------|-------------------------------|
+| 1 | **materialize** | first turn ⇒ exactly **one** `startup isResume=false`, ≥1 `result`, exactly **1** SDK subprocess |
+| 2 | **multi-turn reuse** | 2 more turns ⇒ startup count **unchanged**, subprocess **PID unchanged** (warm reuse) |
+| 3 | **recover-rebuild** | abort → next send ⇒ **+1** startup, that startup is `isResume=true`, back to 1 subprocess, session usable |
+| 4 | **abort-churn × N** | every cycle: subprocess count **≤ 1** in-flight and post-abort; overall **peak ≤ 1**, **0** `<id>.jsonl`/spawn-conflict/leak errors, session usable afterward (recover-rebuilds exercised are reported informationally — the deterministic proof lives in scenario 3) |
+
+## How it stays reliable
+
+The workbench composer churns element refs on every render and reveals some actions only on real
+hover, which makes snapshot-ref automation flaky. This harness sidesteps that:
+
+- **Send / Cancel are clicked via in-page `eval`** (find the button by accessible name + enabled
+  state, `.click()` it) rather than by snapshot ref.
+- **Truth comes from `agenthost.log` + `ps`**, never from asserting on UI state.
+- Sends **verify-and-retry** (paste, nudge, re-check that Send enabled); aborts **retry until a
+  cancel is actually logged** (or the turn is detected to have completed first).
+- Turns are held open with a long, tool-free enumeration prompt so there's a wide abort window.
+
+## Known soft spots
+
+- If the model finishes a "held-open" turn before the abort lands, that cycle becomes a normal
+  completion (the harness detects it and retries once); the orphan/conflict invariants still hold.
+- Model/agent/customization **pickers** (hover- or flyout-gated) are intentionally **not** driven
+  here — those rebuild triggers are covered deterministically by the node suite
+  (`claudeAgent.test.ts`: `changeAgent … triggers a rebind`, `dirty customizations triggers a
+  rebind`, and the C9 abort/rebuild-race edge tests).

--- a/test/agent-host-e2e/claude-agenthost-smoke.sh
+++ b/test/agent-host-e2e/claude-agenthost-smoke.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+#
+# Claude Agent Host — live E2E smoke tests	 (AUTH REQUIRED)
+#
+# Validates the C9 immutable-pipeline / session-orchestrated-rebuild lifecycle against a REAL
+# authenticated Agents window. Unlike the node unit suites (which use an SDK fake), this drives
+# the real workbench + a real Claude SDK subprocess and asserts on ground truth:
+#		* agenthost.log		— `startup isResume=<bool>` / `result` / abort markers
+#		* `ps`						— the number of live SDK subprocesses for THIS instance
+#
+# Scenarios:
+#		1. materialize						— first turn spawns exactly one subprocess (isResume=false)
+#		2. multi-turn reuse				— more turns reuse the SAME subprocess (no new startup)
+#		3. recover-rebuild				— abort → next send rebuilds in resume mode (isResume=true)
+#		4. abort-churn / orphans	— rapid abort→rebuild cycles never leak a subprocess (count<=1),
+#																reap on abort, hit no <id>.jsonl two-writer conflict, stay usable
+#
+# Requirements: an authenticated ~/.vscode-oss-dev profile, `@playwright/cli` (devDependency),
+#								`jq`, and the launch skill (see --launch / $CLAUDE_LAUNCH_SH).
+#
+# Usage:
+#		test/agent-host-e2e/claude-agenthost-smoke.sh [--cycles N] [--cdp PORT] [--keep] [-v]
+#			--cycles N	 abort-churn cycles (default 4)
+#			--cdp PORT	 attach to an already-running Agents window instead of launching one
+#			--keep			 do not kill the launched window / leave it open on exit
+#			-v					 verbose (echo every phase's counters)
+#
+# Exit code is the number of failed assertions (0 = all green).
+
+set -uo pipefail
+
+# ── config / args ────────────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LAUNCH_SH="${CLAUDE_LAUNCH_SH:-$REPO_ROOT/.claude/skills/launch/scripts/launch.sh}"
+SDKPAT="$(basename "$REPO_ROOT")/node_modules/@anthropic-ai/claude-agent-sdk"
+S="claude-smoke-$$"												# unique playwright-cli daemon session
+CYCLES=4 ; CDP="" ; KEEP=0 ; VERBOSE=0 ; APP_PID="" ; RUN=""
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--cycles) CYCLES="$2"; shift 2;;
+		--cdp) CDP="$2"; shift 2;;
+		--keep) KEEP=1; shift;;
+		-v|--verbose) VERBOSE=1; shift;;
+		*) echo "unknown arg: $1"; exit 2;;
+	esac
+done
+cd "$REPO_ROOT"
+
+# ── assertion framework ──────────────────────────────────────────────────────
+PASS=0 ; FAIL=0 ; declare -a FAILURES=()
+ok()	{ echo "		✓ $1"; PASS=$((PASS+1)); }
+bad() { echo "		✗ $1"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
+assert_eq() { if [ "$2" = "$3" ]; then ok "$1 (= $2)"; else bad "$1: expected '$3', got '$2'"; fi; }
+assert_le() { if [ "$2" -le "$3" ] 2>/dev/null; then ok "$1 ($2 <= $3)"; else bad "$1: $2 > $3"; fi; }
+assert_ge() { if [ "$2" -ge "$3" ] 2>/dev/null; then ok "$1 ($2 >= $3)"; else bad "$1: $2 < $3"; fi; }
+
+# ── ground-truth getters ─────────────────────────────────────────────────────
+logf()		 { find "$RUN/user-data/logs" -iname agenthost.log 2>/dev/null | head -1; }
+# Only count SDK subprocesses NEW since script start, so a prior run's process still
+# flushing its transcript (they linger a few seconds after the window is killed) can't
+# pollute this run's orphan accounting.
+BASELINE_SDK=""
+_sdk_all() { pgrep -f "$SDKPAT" 2>/dev/null | sort -u; }
+sdkcount() { comm -23 <(_sdk_all) <(printf '%s\n' "$BASELINE_SDK" | sort -u) | grep -c . | tr -d ' '; }
+sdkpids()	 { comm -23 <(_sdk_all) <(printf '%s\n' "$BASELINE_SDK" | sort -u) | tr '\n' ' '; }
+g_startups() { local L; L=$(logf); { [ -n "$L" ] && grep -c 'startup isResume=' "$L"; } 2>/dev/null | head -1; }
+g_results()	 { local L; L=$(logf); { [ -n "$L" ] && grep -c 'result for sdkUuid' "$L"; } 2>/dev/null | head -1; }
+g_cancels()	 { local L; L=$(logf); { [ -n "$L" ] && grep -cE 'turnCancelled|aborted by user' "$L"; } 2>/dev/null | head -1; }
+g_resumes()	 { local L; L=$(logf); { [ -n "$L" ] && grep -c 'startup isResume=true' "$L"; } 2>/dev/null | head -1; }
+g_conflicts(){ local L; L=$(logf); [ -z "$L" ] && { echo 0; return; }; grep -icE "EEXIST|\.jsonl.{0,15}(already|exist|lock)|failed to spawn|leaked disposable|double dispose" "$L" 2>/dev/null | head -1; }
+
+# ── playwright primitives (eval-based DOM clicks — robust to ref churn) ───────
+PW() { npx @playwright/cli -s="$S" "$@" 2>/dev/null; }
+click_send() {
+	PW eval '() => { const b=[...document.querySelectorAll("a,button,[role=button]")].find(x=>{const n=(x.getAttribute("aria-label")||x.textContent||"").trim(); const dis=x.getAttribute("aria-disabled")==="true"||x.disabled||x.classList.contains("disabled"); return /^send/i.test(n)&&!dis;}); if(!b)return "NO"; b.click(); return "OK"; }' 2>/dev/null | grep -oE "OK|NO" | head -1
+}
+click_cancel() {
+	PW eval '() => { const b=[...document.querySelectorAll("a,button,[role=button]")].find(x=>/cancel/i.test((x.getAttribute("aria-label")||x.textContent||"").trim())); if(!b)return "NO"; b.click(); return "OK"; }' 2>/dev/null | grep -oE "OK|NO" | head -1
+}
+# focus the composer's monaco input (by its a11y label, else the lowest visible editor).
+focus_editor() {
+	PW eval '() => {
+		const all=[...document.querySelectorAll("textarea, .native-edit-context, [contenteditable=true]")].filter(e=>e.offsetParent!==null);
+		let el=all.find(e=>/editor is not accessible/i.test(e.getAttribute("aria-label")||""));
+		if(!el && all.length){ all.sort((a,b)=>b.getBoundingClientRect().top-a.getBoundingClientRect().top); el=all[0]; }
+		if(!el) return "NO"; el.focus(); return "OK";
+	}' 2>/dev/null | grep -oE "OK|NO" | head -1
+}
+# send <text>: focus + clear + real-clipboard paste, then click Send (retry the whole thing).
+send() {
+	local i
+	printf '%s' "$1" | pbcopy
+	for i in $(seq 1 8); do
+		focus_editor >/dev/null
+		PW press Meta+a >/dev/null 2>&1 ; PW press Backspace >/dev/null 2>&1	 # clear any stale text
+		PW press Meta+v >/dev/null 2>&1
+		sleep 0.5
+		[ "$(click_send)" = "OK" ] && return 0
+		sleep 0.3
+	done
+	return 1
+}
+# wait_inc <getter-fn> <baseline> <timeout-s>: succeed when getter exceeds baseline.
+wait_inc() { local g="$1" base="$2" t="$3" i; for i in $(seq 1 $((t*2))); do [ "$($g)" -gt "$base" ] 2>/dev/null && return 0; sleep 0.5; done; return 1; }
+
+MAX_SDK=0
+track() { [ "$1" -gt "$MAX_SDK" ] 2>/dev/null && MAX_SDK="$1"; [ "$VERBOSE" = 1 ] && echo "			 · sdk=$1 startups=$(g_startups) results=$(g_results) cancels=$(g_cancels)" >&2; return 0; }
+
+LONG='List every integer from 1 to 500, one number on each line, and output nothing else.'
+
+# ── lifecycle ────────────────────────────────────────────────────────────────
+cleanup() {
+	PW close >/dev/null 2>&1 || true
+	if [ "$KEEP" = 0 ] && [ -n "$APP_PID" ]; then kill "$APP_PID" 2>/dev/null || true; fi
+}
+trap cleanup EXIT
+
+launch_or_attach() {
+	if [ -n "$CDP" ]; then
+		echo "▸ attaching to existing Agents window on CDP $CDP"
+		# caller must also export RUN via $SMOKE_RUN when attaching
+		RUN="${SMOKE_RUN:?--cdp requires SMOKE_RUN=<runDir> so the log can be found}"
+	else
+		echo "▸ launching authenticated Agents window …"
+		local json; json="$("$LAUNCH_SH" --agents 2>/dev/null | tail -n1)"
+		CDP="$(jq -r .cdpPort <<<"$json")"; APP_PID="$(jq -r .pid <<<"$json")"; RUN="$(jq -r .runDir <<<"$json")"
+		[ -n "$CDP" ] && [ "$CDP" != null ] || { echo "launch failed"; exit 3; }
+		echo "	cdp=$CDP pid=$APP_PID"
+	fi
+	PW attach --cdp="http://127.0.0.1:$CDP" >/dev/null 2>&1
+	sleep 1
+}
+
+# ── scenarios ────────────────────────────────────────────────────────────────
+scenario_materialize() {
+	echo "▸ [1] materialize"
+	send 'Reply with exactly one word: ready' || { bad "materialize: could not submit prompt"; return; }
+	wait_inc g_results 0 40 || { bad "materialize: no result within 40s"; return; }
+	assert_eq	 "one startup"							"$(g_startups)" "1"
+	assert_ge	 "at least one result"			"$(g_results)"	"1"
+	assert_eq	 "exactly one subprocess"		"$(sdkcount)"		"1"
+	local L; L=$(logf)
+	assert_eq	 "first startup is fresh (isResume=false)" "$(grep -m1 -oE 'isResume=(true|false)' "$L")" "isResume=false"
+}
+
+scenario_reuse() {
+	echo "▸ [2] multi-turn reuse (warm subprocess reused when nothing changed)"
+	# The workbench can push a background client-tool / customization sync mid-session, which
+	# legitimately dirties the diff and rebuilds on the next send (a correct C9 trigger). So we
+	# don't assert "startup never grows" — we prove reuse is achievable: at least one turn runs
+	# with NO new startup and the SAME subprocess PID.
+	local proven=0 attempt
+	for attempt in 1 2 3 4; do
+		local st0 pid0 r0; st0="$(g_startups)"; pid0="$(sdkpids)"; r0="$(g_results)"
+		send "Reply with exactly one word: reuse$attempt" || { bad "reuse: submit failed"; return; }
+		wait_inc g_results "$r0" 40 || { bad "reuse: no result on turn $attempt"; return; }
+		if [ "$(g_startups)" = "$st0" ] && [ "$(sdkpids)" = "$pid0" ]; then proven=1; break; fi
+	done
+	if [ "$proven" = 1 ]; then ok "a turn reused the warm subprocess (no new startup, same PID)"
+	else bad "no clean reuse observed across 4 turns"; fi
+	assert_le "still at most one subprocess" "$(sdkcount)" "1"
+}
+
+# hold a turn open, abort it (retry until a cancel is logged or the turn completes).
+_abort_inflight() {
+	local c0; c0="$(g_cancels)"; local r0="$1" a
+	for a in $(seq 1 6); do
+		click_cancel >/dev/null
+		sleep 1.5
+		[ "$(g_cancels)" -gt "$c0" ] 2>/dev/null && return 0		# abort landed
+		[ "$(g_results)" -gt "$r0" ] 2>/dev/null && return 1		# model finished first
+	done
+	return 2
+}
+
+scenario_recover_rebuild() {
+	echo "▸ [3] recover-rebuild (abort → resume-mode rebuild)"
+	local st0 res0 r0; st0="$(g_startups)"; res0="$(g_resumes)"; r0="$(g_results)"
+	send "$LONG" || { bad "recover: submit failed"; return; }
+	sleep 2; track "$(sdkcount)"
+	_abort_inflight "$r0"
+	case $? in
+		0) ok "abort landed (cancel logged)";;
+		1) echo "		 ~ model completed before abort — retrying once with a longer hold";
+				r0="$(g_results)"; send "$LONG" && { sleep 1; _abort_inflight "$r0" && ok "abort landed on retry" || bad "recover: could not abort a turn"; } || bad "recover: resend failed";;
+		*) bad "recover: no cancel button appeared";;
+	esac
+	sleep 2
+	# next send must rebuild in resume mode
+	local rr0; rr0="$(g_results)"
+	send 'Reply with exactly one word: recovered' || { bad "recover: post-abort submit failed"; return; }
+	wait_inc g_results "$rr0" 40 || { bad "recover: session not usable after abort"; return; }
+	assert_ge "a new startup happened (rebuild)"		 "$(g_startups)" "$((st0+1))"
+	assert_ge "the rebuild used resume mode (isResume=true)" "$(g_resumes)" "$((res0+1))"
+	assert_eq "one subprocess after recovery"				 "$(sdkcount)"	 "1"
+}
+
+scenario_abort_churn() {
+	echo "▸ [4] abort-churn × $CYCLES (orphan / two-writer invariants)"
+	local res0 n; res0="$(g_resumes)"
+	for n in $(seq 1 "$CYCLES"); do
+		[ "$VERBOSE" = 1 ] && echo "		cycle $n"
+		local r0; r0="$(g_results)"
+		send "$LONG" || { echo "		~ cycle $n submit failed, skipping"; continue; }
+		sleep 1.5
+		local cif; cif="$(sdkcount)"; track "$cif"
+		assert_le "cycle $n in-flight: subprocess count" "$cif" "1"
+		_abort_inflight "$r0" >/dev/null
+		sleep 3
+		local cpa; cpa="$(sdkcount)"; track "$cpa"
+		assert_le "cycle $n post-abort: subprocess count" "$cpa" "1"
+	done
+	# final invariants across the whole churn
+	assert_le "peak concurrent subprocesses never exceeded 1" "$MAX_SDK" "1"
+	assert_eq "zero <id>.jsonl / spawn-conflict / leak errors" "$(g_conflicts)" "0"
+	# Recover-rebuilds under churn are informational: whether a given cycle's abort wins the
+	# race with the model is timing-dependent, and scenario [3] already proves resume-mode
+	# rebuild deterministically. Here we just report how many the churn happened to exercise.
+	echo "		· recover-rebuilds exercised during churn: $(( $(g_resumes) - res0 ))"
+	# session still usable
+	local r0; r0="$(g_results)"
+	send 'Reply with exactly one word: survived' && wait_inc g_results "$r0" 40 \
+		&& ok "session still usable after churn" || bad "session unusable after churn"
+}
+
+# ── run ──────────────────────────────────────────────────────────────────────
+echo "=== Claude Agent Host — live E2E smoke ($(date +%H:%M:%S)) ==="
+BASELINE_SDK="$(_sdk_all)"				# exclude any pre-existing (other-run) SDK subprocesses
+launch_or_attach
+scenario_materialize
+scenario_reuse
+scenario_recover_rebuild
+scenario_abort_churn
+
+echo ""
+echo "=== summary: $PASS passed, $FAIL failed	 (peak subprocs=$MAX_SDK) ==="
+if [ "$FAIL" -gt 0 ]; then printf '	 FAILED: %s\n' "${FAILURES[@]}"; fi
+exit "$FAIL"


### PR DESCRIPTION
> **Stacked on #326256** (Tier 0 + C1). Review that first; this PR's diff is the single commit on top. Base will retarget to `main` once #326256 lands.

## What

**C9 — remove the rematerializer.** Today one SDK session is split across two objects: `ClaudeSdkPipeline` owns the `WarmQuery` *lifetime*, `ClaudeAgentSession` owns Query *construction* (`Options`). Because the SDK bakes startup-only `Options` into the subprocess, any tool/customization/agent change — or crash recovery — needed a fresh `WarmQuery`, which the pipeline obtained by calling a `rematerializer` closure back up into the session and rebinding **in place**, carrying a large amount of swap machinery and a `_current*` config duplicate.

This PR makes the pipeline **immutable** and moves rebuild orchestration to the session:

- **`ClaudeSdkPipeline`** owns exactly ONE `WarmQuery` for its whole life. `_query` is bound **eagerly in the constructor** and never re-bound (the prompt iterable parks between turns rather than ending). The pipeline reports a terminal `isDead` (set synchronously by `abort()` and when the consumer loop ends abnormally) and never self-heals.
- **`ClaudeAgentSession`** orchestrates rebuild. `_installPipeline(isResume, freshController)` builds+installs a pipeline into a `MutableDisposable`, with a per-pipeline signal-wiring `DisposableStore`. `send()`'s pre-flight is the single reuse-vs-rebuild decision (`isDead` / tool diff / customization diff / resume anchor). A rebuild = dispose the old pipeline + build a fresh one; there is no in-place swap.
- **Config (folds in C2):** *desired* lives on the session (`_provisionalModel` / `_provisionalAgent`; `permissionMode` read live) and seeds each build's `Options`; *applied* lives on the pipeline (`_applied{Model,Effort,PermissionMode}`) purely to dedup runtime setters, seeded once at construction. The `_current*` desired-state duplicate is gone.

Net **−366 lines**.

## Behavior changes (not a pure refactor)

1. **`shutdownAndWait` before a rebuild's resume spawn.** The tool/customization restart path now *awaits* the old subprocess's real exit before the resume spawn (matches `_removeAllTurns`' existing discipline; closes a latent two-writer window on `<id>.jsonl`).
2. **Bijective model/effort survives a rebuild via `Options`, not runtime replay.** The rebuilt Query gets model/effort from `Options` (baked from `_provisionalModel`), not a `Query.setModel` replay pass.

Also fixes a **shared-controller idempotency bug** surfaced while writing the tests: since the session now shares its `AbortController` with the live pipeline and aborts it *before* calling `pipeline.abort()`, the pipeline's old `if (signal.aborted) return` guard skipped `failAll` and stranded the in-flight `send` deferred. `abort()` now guards on its own terminal `_dead` flag.

## Validation

- `typecheck-client` / `eslint` / `valid-layers-check` clean.
- All agent-host node suites pass — `claudeAgent` **194**, plus `claudeSdkPipeline` / `claudePromptQueue` / `claudeSdkMessageRouter` green.
- **Live E2E** (authenticated Agents window, watching `agenthost.log`):

  | Time | Event | C9 behavior |
  |---|---|---|
  | t0 | `startup isResume=false` | materialize (1 startup) |
  | t1–t3 | 3 results | multi-turn **reuse — no new startup** |
  | t4 | turnCancelled → consumer loop dies | abort → `isDead` |
  | t5 | **`startup isResume=true`** | **recover-rebuild** |
  | t6 | result | rebuilt pipeline works |

  Confirmed: no orphan subprocesses, single clean abort, clean recovery.

## Follow-up (not in this PR)

- **Agent as a live setter** (empirical gate): verify `applyFlagSettings({ agent })` swaps the live agent; if confirmed, drop agent from the rebuild triggers. Gated on a ~15-min live E2E; kept as a rebuild trigger for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)