### PR TITLE
fix: mitigate Linux webview renderer FD exhaustion during resource loading

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
@@ -1,0 +1,126 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { asPromise } from '../utils';
+
+suite('vscode API - webview', () => {
+	const disposables: vscode.Disposable[] = [];
+	const webviewViewType = 'webview-resource-load-test';
+	const resourceCount = 625;
+	const resourceSize = 128 * 1024;
+
+	suiteSetup(async () => {
+		await vscode.extensions.getExtension('vscode.vscode-api-tests')?.activate();
+	});
+
+	teardown(() => {
+		vscode.Disposable.from(...disposables).dispose();
+		disposables.length = 0;
+	});
+
+	test('loads many local resources concurrently without crashing', async function () {
+		if (vscode.env.uiKind !== vscode.UIKind.Desktop) {
+			this.skip();
+		}
+
+		const timeout = 60_000;
+		this.timeout(timeout);
+
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), 'vscode-webview-resource-load-'));
+		try {
+			const panel = vscode.window.createWebviewPanel(webviewViewType, 'Webview Resource Load Test', vscode.ViewColumn.Active, {
+				enableScripts: true,
+				localResourceRoots: [vscode.Uri.file(tempDir)],
+			});
+			disposables.push(panel);
+
+			const didDispose = asPromise(panel.onDidDispose, timeout);
+			const didReceiveMessage = new Promise<{
+				readonly type: 'done';
+				readonly count: number;
+				readonly totalBytes: number;
+			}>((resolve, reject) => {
+				disposables.push(panel.webview.onDidReceiveMessage(message => {
+					if (message?.type === 'done') {
+						resolve(message);
+					} else if (message?.type === 'error') {
+						reject(new Error(message.message));
+					}
+				}));
+			});
+
+			const expectedTotalBytes = resourceCount * resourceSize;
+			const resources: string[] = [];
+			for (let index = 0; index < resourceCount; index++) {
+				const filePath = path.join(tempDir, `resource-${index}.bin`);
+				await writeFile(filePath, Buffer.alloc(resourceSize, index));
+				resources.push(panel.webview.asWebviewUri(vscode.Uri.file(filePath)).toString());
+			}
+
+			const nonce = String(Date.now());
+			panel.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src ${panel.webview.cspSource}; script-src 'nonce-${nonce}';">
+</head>
+<body>
+	<script nonce="${nonce}">
+		const vscode = acquireVsCodeApi();
+		const resources = ${JSON.stringify(resources)};
+		const loadResources = async () => {
+			try {
+				const lengths = await Promise.all(resources.map(async resource => {
+					const response = await fetch(resource);
+					if (!response.ok) {
+						throw new Error(\`Unexpected status \${response.status} for \${resource}\`);
+					}
+					const bytes = await response.arrayBuffer();
+					return bytes.byteLength;
+				}));
+				vscode.postMessage({
+					type: 'done',
+					count: lengths.length,
+					totalBytes: lengths.reduce((total, value) => total + value, 0),
+				});
+			} catch (error) {
+				vscode.postMessage({
+					type: 'error',
+					message: error instanceof Error ? error.message : String(error),
+				});
+			}
+		};
+		window.addEventListener('error', event => {
+			vscode.postMessage({ type: 'error', message: event.message });
+		});
+		window.addEventListener('unhandledrejection', event => {
+			const reason = event.reason instanceof Error ? event.reason.message : String(event.reason);
+			vscode.postMessage({ type: 'error', message: reason });
+		});
+		void loadResources();
+	</script>
+</body>
+</html>`;
+
+			const result = await Promise.race([
+				didReceiveMessage,
+				didDispose.then(() => Promise.reject(new Error('Webview disposed before resources finished loading'))),
+			]);
+
+			assert.deepStrictEqual(result, {
+				type: 'done',
+				count: resourceCount,
+				totalBytes: expectedTotalBytes,
+			});
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-nXjtuhBilO++r8hfxl5VjEScSmdm07wDAk6jw228DgM=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-FFQoOVVa2tOE3uqUvirwaMNT20TZmrHcL2aaOjJ8BUo=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -252,7 +252,7 @@
 				return reject(new Error('Service Workers are not enabled. Webviews will not work. Try disabling private/incognito mode.'));
 			}
 
-			const swPath = encodeURI(`service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`);
+			const swPath = encodeURI(`service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}&platform=${searchParams.get('platform')}`);
 			navigator.serviceWorker.register(swPath, { type: 'module', updateViaCache: 'none' })
 				.then(async registration => {
 					if (navigator.serviceWorker.controller) {

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -8,7 +8,9 @@
 /** @type {ServiceWorkerGlobalScope} */
 const sw = /** @type {any} */ (self);
 
-const VERSION = 5;
+const VERSION = 6;
+
+const maxActiveHostResourceResponseBodies = 32;
 
 const resourceCacheName = `vscode-resource-cache-${VERSION}`;
 
@@ -17,6 +19,7 @@ const rootPath = sw.location.pathname.replace(/\/service-worker.js$/, '');
 const searchParams = new URL(location.toString()).searchParams;
 
 const remoteAuthority = searchParams.get('remoteAuthority');
+const shouldLimitHostResourceResponseBodies = searchParams.get('platform') === 'electron';
 
 /**
  * Origin used for resources
@@ -106,11 +109,121 @@ class RequestStore {
 	}
 }
 
+class AsyncSemaphore {
+	/**
+	 * @param {number} maxConcurrency
+	 */
+	constructor(maxConcurrency) {
+		this.maxConcurrency = maxConcurrency;
+		this.activeCount = 0;
+		/** @type {Array<(release: () => void) => void>} */
+		this.waiters = [];
+	}
+
+	/**
+	 * @returns {Promise<() => void>}
+	 */
+	acquire() {
+		if (this.activeCount < this.maxConcurrency && this.waiters.length === 0) {
+			this.activeCount++;
+			return Promise.resolve(this.createReleaser());
+		}
+
+		return new Promise(resolve => this.waiters.push(resolve));
+	}
+
+	/**
+	 * @returns {() => void}
+	 */
+	createReleaser() {
+		let released = false;
+		return () => {
+			if (released) {
+				return;
+			}
+			released = true;
+
+			const waiter = this.waiters.shift();
+			if (waiter) {
+				waiter(this.createReleaser());
+			} else {
+				this.activeCount--;
+			}
+		};
+	}
+}
+
+/**
+ * @param {() => void} release
+ * @param {number} pendingCount
+ * @returns {() => void}
+ */
+function createJoinedFinalizer(release, pendingCount) {
+	let remaining = pendingCount;
+	let finished = false;
+	return () => {
+		if (finished) {
+			return;
+		}
+
+		remaining--;
+		if (remaining === 0) {
+			finished = true;
+			release();
+		}
+	};
+}
+
+/**
+ * @param {ReadableStream<Uint8Array>} stream
+ * @param {() => void} onDidFinish
+ * @returns {ReadableStream<Uint8Array>}
+ */
+function trackReadableStreamLifetime(stream, onDidFinish) {
+	const reader = stream.getReader();
+	let finished = false;
+	const finish = () => {
+		if (finished) {
+			return;
+		}
+		finished = true;
+		onDidFinish();
+	};
+
+	return new ReadableStream({
+		async pull(controller) {
+			try {
+				const { done, value } = await reader.read();
+				if (done) {
+					finish();
+					controller.close();
+					return;
+				}
+
+				controller.enqueue(value);
+			} catch (error) {
+				finish();
+				throw error;
+			}
+		},
+		cancel(reason) {
+			const cancellation = reader.cancel(reason).catch(() => undefined);
+			if (shouldLimitHostResourceResponseBodies) {
+				return cancellation.finally(finish);
+			}
+			finish();
+			return cancellation;
+		}
+	});
+}
+
 /**
  * Map of requested paths to responses.
  */
 /** @type {RequestStore<ResourceResponse>} */
 const resourceRequestStore = new RequestStore();
+
+const hostResourceResponseBodySemaphore = new AsyncSemaphore(maxActiveHostResourceResponseBodies);
 
 /**
  * Safari fallback: map of active chunk-based streaming responses.
@@ -165,16 +278,31 @@ sw.addEventListener('message', async (event) => {
 					);
 					stream = transform.readable;
 				}
-				resourceRequestStore.resolve(response.id, {
-					status: response.status,
-					id: response.id,
-					path: response.path,
-					mime: response.mime,
-					etag: response.etag,
-					mtime: response.mtime,
-					stream,
-					range: response.range,
-				});
+				if (response.stream) {
+					if (!resourceRequestStore.resolve(response.id, {
+						status: response.status,
+						id: response.id,
+						path: response.path,
+						mime: response.mime,
+						etag: response.etag,
+						mtime: response.mtime,
+						stream,
+						range: response.range,
+					})) {
+						event.waitUntil(stream.cancel().catch(() => undefined));
+					}
+				} else {
+					resourceRequestStore.resolve(response.id, {
+						status: response.status,
+						id: response.id,
+						path: response.path,
+						mime: response.mime,
+						etag: response.etag,
+						mtime: response.mtime,
+						stream,
+						range: response.range,
+					});
+				}
 			} else if (!resourceRequestStore.resolve(response.id, response)) {
 				console.log('Could not resolve unknown resource', response.path);
 			}
@@ -319,8 +447,9 @@ async function processResourceRequest(
 	 * @param {Response|undefined} cachedResponse
 	 * @returns {Response}
 	 */
-	const resolveResourceEntry = (result, cachedResponse) => {
+	const resolveResourceEntry = (result, cachedResponse, releaseHostResourceResponseBody) => {
 		if (result.status === 'timeout') {
+			releaseHostResourceResponseBody();
 			return requestTimeout();
 		}
 
@@ -333,6 +462,7 @@ async function processResourceRequest(
 		const entry = result.value;
 		if (entry.status === 304) { // Not modified
 			if (cachedResponse) {
+				releaseHostResourceResponseBody();
 				const r = cachedResponse.clone();
 				for (const [key, value] of Object.entries(accessControlHeaders)) {
 					r.headers.set(key, value);
@@ -344,10 +474,12 @@ async function processResourceRequest(
 		}
 
 		if (entry.status === 401) {
+			releaseHostResourceResponseBody();
 			return unauthorized();
 		}
 
 		if (entry.status !== 200 && entry.status !== 206) {
+			releaseHostResourceResponseBody();
 			return notFound();
 		}
 
@@ -382,18 +514,22 @@ async function processResourceRequest(
 			if (entry.status === 206 && entry.range) {
 				headers['Content-Range'] = entry.range;
 				headers['Cache-Control'] = 'no-store';
-				return new Response(entry.stream, { status: 206, headers });
+				return new Response(trackReadableStreamLifetime(entry.stream, releaseHostResourceResponseBody), { status: 206, headers });
 			}
-
-			const response = new Response(entry.stream, { status: 200, headers });
 
 			if (shouldTryCaching && entry.etag) {
-				const responseForCache = response.clone();
-				caches.open(resourceCacheName).then(cache => {
-					return cache.put(event.request, responseForCache);
-				});
+				const [responseStream, cacheStream] = entry.stream.tee();
+				const releaseAfterResponseAndCache = createJoinedFinalizer(releaseHostResourceResponseBody, 2);
+				const response = new Response(trackReadableStreamLifetime(responseStream, releaseAfterResponseAndCache), { status: 200, headers });
+				const responseForCache = new Response(cacheStream, { status: 200, headers });
+				void caches.open(resourceCacheName)
+					.then(cache => cache.put(event.request, responseForCache))
+					.then(undefined, () => undefined)
+					.finally(releaseAfterResponseAndCache);
+				return response;
 			}
-			return response;
+
+			return new Response(trackReadableStreamLifetime(entry.stream, releaseHostResourceResponseBody), { status: 200, headers });
 		}
 	};
 
@@ -403,8 +539,6 @@ async function processResourceRequest(
 		const cache = await caches.open(resourceCacheName);
 		cached = await cache.match(event.request);
 	}
-
-	const { requestId, promise } = resourceRequestStore.create();
 
 	// Parse range header to forward to the host so it can read only the needed bytes
 	/** @type {{ start: number, end?: number } | undefined} */
@@ -428,28 +562,48 @@ async function processResourceRequest(
 		}
 	}
 
+	/** @type {Client[] | undefined} */
+	let parentClients;
 	if (webviewId) {
-		const parentClients = await getOuterIframeClient(webviewId);
+		parentClients = await getOuterIframeClient(webviewId);
 		if (!parentClients.length) {
 			console.log('Could not find parent client for request');
 			return notFound();
 		}
-
-		for (const parentClient of parentClients) {
-			parentClient.postMessage({
-				channel: 'load-resource',
-				id: requestId,
-				scheme: requestUrlComponents.scheme,
-				authority: requestUrlComponents.authority,
-				path: requestUrlComponents.path,
-				query: requestUrlComponents.query,
-				ifNoneMatch: cached?.headers.get('ETag'),
-				range,
-			});
-		}
 	}
 
-	return promise.then(entry => resolveResourceEntry(entry, cached));
+	const releaseHostResourceResponseBody = shouldLimitHostResourceResponseBodies && webviewId
+		? await hostResourceResponseBodySemaphore.acquire()
+		: () => { };
+
+	const { requestId, promise } = resourceRequestStore.create();
+	try {
+		if (parentClients) {
+			for (const parentClient of parentClients) {
+				parentClient.postMessage({
+					channel: 'load-resource',
+					id: requestId,
+					scheme: requestUrlComponents.scheme,
+					authority: requestUrlComponents.authority,
+					path: requestUrlComponents.path,
+					query: requestUrlComponents.query,
+					ifNoneMatch: cached?.headers.get('ETag'),
+					range,
+				});
+			}
+		}
+
+		const entry = await promise;
+		try {
+			return resolveResourceEntry(entry, cached, releaseHostResourceResponseBody);
+		} catch (error) {
+			releaseHostResourceResponseBody();
+			throw error;
+		}
+	} catch (error) {
+		releaseHostResourceResponseBody();
+		throw error;
+	}
 }
 
 /**

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -109,7 +109,7 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 		}
 	});
 
-	private readonly _expectedServiceWorkerVersion = 5; // Keep this in sync with the version in service-worker.js
+	private readonly _expectedServiceWorkerVersion = 6; // Keep this in sync with the version in service-worker.js
 
 	private _element: HTMLIFrameElement | undefined;
 	protected get element(): HTMLIFrameElement | undefined { return this._element; }
@@ -816,42 +816,56 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 						? `bytes ${range.start}-${rangeEnd}/${result.size}`
 						: undefined;
 					if (WebviewElement._supportsTransferableStreams.value) {
+						const streamCts = this.platform === 'electron' ? new CancellationTokenSource(token) : undefined;
+						let controller: ReadableStreamDefaultController<Uint8Array<ArrayBuffer>> | undefined;
+						let closed = false;
+						const close = () => {
+							if (!closed) {
+								closed = true;
+								streamCts?.dispose();
+								if (controller) {
+									this._activeStreamControllers.delete(controller);
+									try { controller.close(); } catch { /* already closed */ }
+								}
+							}
+						};
 						const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
-							start: (controller) => {
+							start: (newController) => {
 								// Track this controller so that the single
 								// cancellation handler in dispose() can close
 								// all active streams without per-stream listeners.
+								controller = newController;
 								this._activeStreamControllers.add(controller);
-								let closed = false;
-								const close = () => {
-									if (!closed) {
-										closed = true;
-										this._activeStreamControllers.delete(controller);
-										try { controller.close(); } catch { /* already closed */ }
-									}
-								};
 
 								listenStream(result.stream, {
 									onData: (chunk) => {
 										if (!closed) {
 											try {
-												controller.enqueue(new Uint8Array<ArrayBuffer>(chunk.buffer.buffer as ArrayBuffer, chunk.buffer.byteOffset, chunk.buffer.byteLength));
+												controller?.enqueue(new Uint8Array<ArrayBuffer>(chunk.buffer.buffer as ArrayBuffer, chunk.buffer.byteOffset, chunk.buffer.byteLength));
 											} catch {
-												closed = true;
-												this._activeStreamControllers.delete(controller);
+												close();
 											}
 										}
 									},
 									onError: (err) => {
 										if (!closed) {
 											closed = true;
-											this._activeStreamControllers.delete(controller);
-											try { controller.error(err); } catch { /* already closed */ }
+											streamCts?.dispose();
+											const currentController = controller;
+											if (currentController) {
+												this._activeStreamControllers.delete(currentController);
+												try { currentController.error(err); } catch { /* already closed */ }
+											}
 										}
 									},
 									onEnd: () => close()
-								}, token);
-							}
+								}, streamCts?.token ?? token);
+							},
+							cancel: streamCts ? () => {
+								streamCts.dispose(true);
+								result.stream.destroy();
+								close();
+							} : undefined,
 						});
 						this._send('did-load-resource', {
 							id,


### PR DESCRIPTION
Followup improvement for https://github.com/microsoft/vscode/issues/326092

The issue surfaced a renderer forced exit after hitting EMFILE on Linux when a webview issued very large number of concurrent local resource fetches.

- Codex extension can trigger roughly 625 concurrent webview resource requests.
- Webview resource loading currently forwards each request to the host and begins transferring the returned body immediately.
- Disk reads are chunked at 256 KiB, and Mojo uses shared-memory FDs for payloads above 64 KiB, so each in-flight resource body can consume file descriptors in the renderer while it is being streamed.
- The sandboxed renderer runs with RLIMIT_NOFILE=1024 on Linux.
- This is not specific to codex extension, any extension with enough concurrent resource bodies can accumulate to exhaust the renderer FD budget.

This makes the problem specifically about the number of simultaneously active host-backed response bodies. A naive limiter around `WebviewElement.loadResource()` would not address the root cause because `loadResource` returns as soon as the stream is transferred, while the FD pressure persists for the lifetime of the stream in the renderer.

Introduce a service-worker-side global concurrency limit for host-backed webview resource response bodies.

- Add a global limit of 32 active host-backed resource bodies in the webview service worker.
- Acquire a permit before creating/posting the load-resource request so time spent waiting for a slot does not consume the existing 30 second RequestStore timeout.
- Hold the permit for the full lifetime of the returned ReadableStream, and release it only when the stream reaches EOF, errors, or is cancelled.
- Release exactly once on all non-stream results and on every early/error path, including timeout handling.
- Preserve existing range request behavior, ETag/304 handling, CacheStorage behavior, Safari fallback streaming, and cancellation semantics.
- For cacheable responses, keep the permit until both source transfer and the associated cache write complete, without delaying delivery of the response back to the webview.
- Bump the service worker version and WebviewElement expected version together so clients pick up the updated worker.

Tests
- Add an API integration regression test that creates a webview, materializes many local resources, fetches them concurrently from inside the webview, and verifies the webview stays alive and all loads complete.
