### PR TITLE
Fix sandbox dependency installation on Linux

### DIFF
--- a/src/vs/platform/sandbox/common/sandboxHelperService.ts
+++ b/src/vs/platform/sandbox/common/sandboxHelperService.ts
@@ -12,6 +12,7 @@ export interface ISandboxDependencyStatus {
 	readonly bubblewrapUsable: boolean;
 	readonly socatInstalled: boolean;
 	readonly bubblewrapError?: string;
+	readonly dependencyInstallCommand?: string;
 }
 
 export interface IWindowsMxcFilesystemPolicy {

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -345,6 +345,7 @@ export class TerminalSandboxEngine extends Disposable {
 				sandboxConfigPath,
 				failedCheck: TerminalSandboxPrerequisiteCheck.Dependencies,
 				missingDependencies,
+				canInstallMissingDependencies: !!this._sandboxDependencyStatus?.dependencyInstallCommand,
 			};
 		}
 

--- a/src/vs/platform/sandbox/common/terminalSandboxService.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxService.ts
@@ -32,6 +32,7 @@ export interface ITerminalSandboxPrerequisiteCheckResult {
 	sandboxConfigPath: string | undefined;
 	failedCheck: TerminalSandboxPrerequisiteCheck | undefined;
 	missingDependencies?: string[];
+	canInstallMissingDependencies?: boolean;
 	remediations?: readonly TerminalSandboxPreCheckRemediation[];
 	detail?: string;
 }

--- a/src/vs/platform/sandbox/node/sandboxHelper.ts
+++ b/src/vs/platform/sandbox/node/sandboxHelper.ts
@@ -7,16 +7,26 @@ import { execFile } from 'child_process';
 import { getCaseInsensitive } from '../../../base/common/objects.js';
 import { win32 } from '../../../base/common/path.js';
 import { isLinux, isWindows } from '../../../base/common/platform.js';
+import { getOSReleaseInfo } from '../../../base/node/osReleaseInfo.js';
 import { findExecutable } from '../../../base/node/processes.js';
 import { ISandboxDependencyStatus, ISandboxHelperService, type IWindowsMxcConfig, IWindowsMxcFilesystemPolicy, type IWindowsMxcPolicyContainment, type IWindowsMxcSandboxPolicy } from '../common/sandboxHelperService.js';
 
 type FindCommand = (command: string) => Promise<string | undefined>;
 type BubblewrapProbe = (command: string) => Promise<{ usable: boolean; error?: string }>;
+type ResolveLinuxInstallEnvironment = () => Promise<{ distributionIds: readonly string[]; isRoot: boolean }>;
+
+const linuxDependencyInstallCommands: readonly { distributionIds: readonly string[]; commands: readonly [executable: string, command: string][] }[] = [
+	{ distributionIds: ['debian', 'ubuntu', 'linuxmint', 'pop', 'elementary', 'kali', 'raspbian'], commands: [['apt-get', 'apt-get install -y'], ['apt', 'apt install -y']] },
+	{ distributionIds: ['fedora', 'rhel', 'centos', 'rocky', 'almalinux'], commands: [['dnf', 'dnf install -y'], ['yum', 'yum install -y']] },
+	{ distributionIds: ['arch', 'manjaro', 'endeavouros'], commands: [['pacman', 'pacman -S --needed --noconfirm']] },
+	{ distributionIds: ['suse', 'opensuse', 'opensuse-leap', 'opensuse-tumbleweed'], commands: [['zypper', 'zypper --non-interactive install']] },
+	{ distributionIds: ['alpine'], commands: [['apk', 'apk add']] },
+];
 
 export class SandboxHelperService implements ISandboxHelperService {
 	declare readonly _serviceBrand: undefined;
 
-	static async checkSandboxDependenciesWith(findCommand: FindCommand, linux: boolean = isLinux, probeBubblewrap: BubblewrapProbe = command => SandboxHelperService._probeBubblewrap(command)): Promise<ISandboxDependencyStatus | undefined> {
+	static async checkSandboxDependenciesWith(findCommand: FindCommand, linux: boolean = isLinux, probeBubblewrap: BubblewrapProbe = command => SandboxHelperService._probeBubblewrap(command), resolveInstallEnvironment: ResolveLinuxInstallEnvironment = () => SandboxHelperService._resolveLinuxInstallEnvironment()): Promise<ISandboxDependencyStatus | undefined> {
 		if (!linux) {
 			return undefined;
 		}
@@ -26,12 +36,42 @@ export class SandboxHelperService implements ISandboxHelperService {
 			findCommand('socat'),
 		]);
 		const bubblewrapProbe = bubblewrapPath ? await probeBubblewrap(bubblewrapPath) : { usable: false };
+		const dependencyInstallCommand = !bubblewrapPath || !socatPath
+			? await SandboxHelperService._findDependencyInstallCommand(findCommand, resolveInstallEnvironment)
+			: undefined;
 
 		return {
 			bubblewrapInstalled: !!bubblewrapPath,
 			bubblewrapUsable: bubblewrapProbe.usable,
 			bubblewrapError: bubblewrapProbe.error,
 			socatInstalled: !!socatPath,
+			dependencyInstallCommand,
+		};
+	}
+
+	private static async _findDependencyInstallCommand(findCommand: FindCommand, resolveInstallEnvironment: ResolveLinuxInstallEnvironment): Promise<string | undefined> {
+		const environment = await resolveInstallEnvironment();
+		const installer = linuxDependencyInstallCommands.find(candidate => candidate.distributionIds.some(id => environment.distributionIds.includes(id)));
+		if (!installer) {
+			return undefined;
+		}
+		const elevation = environment.isRoot ? '' : await findCommand('sudo') ? 'sudo ' : undefined;
+		if (elevation === undefined) {
+			return undefined;
+		}
+		for (const [executable, command] of installer.commands) {
+			if (await findCommand(executable)) {
+				return `${elevation}${command}`;
+			}
+		}
+		return undefined;
+	}
+
+	private static async _resolveLinuxInstallEnvironment(): Promise<{ distributionIds: readonly string[]; isRoot: boolean }> {
+		const releaseInfo = await getOSReleaseInfo(() => { });
+		return {
+			distributionIds: [releaseInfo?.id, ...releaseInfo?.id_like?.split(/\s+/) ?? []].filter((id): id is string => !!id),
+			isRoot: process.getuid?.() === 0,
 		};
 	}
 

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -787,7 +787,7 @@ suite('TerminalSandboxEngine', () => {
 	});
 
 	test('checkForSandboxingPrereqs reports missing dependencies', async () => {
-		let status: ISandboxDependencyStatus = { bubblewrapInstalled: false, bubblewrapUsable: false, socatInstalled: true };
+		let status: ISandboxDependencyStatus = { bubblewrapInstalled: false, bubblewrapUsable: false, socatInstalled: true, dependencyInstallCommand: 'sudo pacman -S --needed --noconfirm' };
 		const host = createHost({
 			checkSandboxDependencies: () => Promise.resolve(status),
 		});
@@ -797,6 +797,7 @@ suite('TerminalSandboxEngine', () => {
 		strictEqual(result.enabled, true);
 		strictEqual(result.failedCheck, 'dependencies');
 		strictEqual(result.missingDependencies?.[0], 'bubblewrap');
+		strictEqual(result.canInstallMissingDependencies, true);
 
 		status = { bubblewrapInstalled: true, bubblewrapUsable: true, socatInstalled: true };
 		const result2 = await engine.checkForSandboxingPrereqs(true);

--- a/src/vs/platform/sandbox/test/node/sandboxHelper.test.ts
+++ b/src/vs/platform/sandbox/test/node/sandboxHelper.test.ts
@@ -55,6 +55,7 @@ suite('SandboxHelperService', () => {
 			bubblewrapUsable: true,
 			bubblewrapError: undefined,
 			socatInstalled: true,
+			dependencyInstallCommand: undefined,
 		});
 	});
 
@@ -70,6 +71,83 @@ suite('SandboxHelperService', () => {
 			bubblewrapUsable: false,
 			bubblewrapError: 'No permissions to create namespace',
 			socatInstalled: true,
+			dependencyInstallCommand: undefined,
 		});
+	});
+
+	for (const [distributionId, packageManager, expectedCommand] of [
+		['debian', 'apt-get', 'sudo apt-get install -y'],
+		['ubuntu', 'apt', 'sudo apt install -y'],
+		['fedora', 'dnf', 'sudo dnf install -y'],
+		['centos', 'yum', 'sudo yum install -y'],
+		['arch', 'pacman', 'sudo pacman -S --needed --noconfirm'],
+		['opensuse', 'zypper', 'sudo zypper --non-interactive install'],
+		['alpine', 'apk', 'sudo apk add'],
+	] as const) {
+		test(`detects ${packageManager} for dependency installation`, async () => {
+			const result = await SandboxHelperService.checkSandboxDependenciesWith(
+				async command => command === 'socat' || command === 'sudo' || command === packageManager ? `/usr/bin/${command}` : undefined,
+				true,
+				undefined,
+				async () => ({ distributionIds: [distributionId], isRoot: false }),
+			);
+
+			strictEqual(result?.dependencyInstallCommand, expectedCommand);
+		});
+	}
+
+	test('uses ID_LIKE to detect a derivative distribution', async () => {
+		const result = await SandboxHelperService.checkSandboxDependenciesWith(
+			async command => ['socat', 'sudo', 'dnf'].includes(command) ? `/usr/bin/${command}` : undefined,
+			true,
+			undefined,
+			async () => ({ distributionIds: ['custom-linux', 'fedora'], isRoot: false }),
+		);
+
+		strictEqual(result?.dependencyInstallCommand, 'sudo dnf install -y');
+	});
+
+	test('uses the native package manager when multiple managers are available', async () => {
+		const result = await SandboxHelperService.checkSandboxDependenciesWith(
+			async command => ['socat', 'sudo', 'apt-get', 'pacman'].includes(command) ? `/usr/bin/${command}` : undefined,
+			true,
+			undefined,
+			async () => ({ distributionIds: ['arch'], isRoot: false }),
+		);
+
+		strictEqual(result?.dependencyInstallCommand, 'sudo pacman -S --needed --noconfirm');
+	});
+
+	test('does not use sudo when running as root', async () => {
+		const result = await SandboxHelperService.checkSandboxDependenciesWith(
+			async command => ['socat', 'apk'].includes(command) ? `/usr/bin/${command}` : undefined,
+			true,
+			undefined,
+			async () => ({ distributionIds: ['alpine'], isRoot: true }),
+		);
+
+		strictEqual(result?.dependencyInstallCommand, 'apk add');
+	});
+
+	test('does not offer dependency installation to a non-root user without sudo', async () => {
+		const result = await SandboxHelperService.checkSandboxDependenciesWith(
+			async command => ['socat', 'pacman'].includes(command) ? `/usr/bin/${command}` : undefined,
+			true,
+			undefined,
+			async () => ({ distributionIds: ['arch'], isRoot: false }),
+		);
+
+		strictEqual(result?.dependencyInstallCommand, undefined);
+	});
+
+	test('does not offer dependency installation without a supported package manager', async () => {
+		const result = await SandboxHelperService.checkSandboxDependenciesWith(
+			async command => command === 'socat' ? '/usr/bin/socat' : undefined,
+			true,
+			undefined,
+			async () => ({ distributionIds: ['unknown'], isRoot: false }),
+		);
+
+		strictEqual(result?.dependencyInstallCommand, undefined);
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -991,12 +991,15 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		const missingDependencies = sandboxPrereqs.failedCheck === TerminalSandboxPrerequisiteCheck.Dependencies && sandboxPrereqs.missingDependencies?.length
 			? sandboxPrereqs.missingDependencies
 			: undefined;
+		const canInstallMissingDependencies = !!missingDependencies && sandboxPrereqs.canInstallMissingDependencies === true;
 		const sandboxRemediations = sandboxPrereqs.failedCheck === TerminalSandboxPrerequisiteCheck.Bubblewrap && sandboxPrereqs.remediations?.length
 			? [...sandboxPrereqs.remediations]
 			: undefined;
 		const sandboxPrerequisiteFailure = sandboxPrereqs.failedCheck === TerminalSandboxPrerequisiteCheck.Bubblewrap && !sandboxRemediations
 			? localize('runInTerminal.bubblewrap.unusable', "Bubblewrap is installed but cannot create the required sandbox namespace on this system. The command was not executed.")
-			: undefined;
+			: missingDependencies && !canInstallMissingDependencies
+				? localize('runInTerminal.missingDeps.unsupportedInstaller', "The following dependencies required for sandboxed execution are not installed: {0}. Install them using your system package manager, then run the command again.", missingDependencies.join(', '))
+				: undefined;
 
 		const terminalToolSessionId = generateUuid();
 		// Generate a custom command ID to link the command between renderer and pty host
@@ -1093,7 +1096,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		let sandboxPrerequisiteConfirmation: IToolConfirmationMessages | undefined = undefined;
 		// If sandbox dependencies are missing, show a confirmation asking the user to install them.
 		// This is handled before the tool is invoked so the model never sees the dependency error.
-		if (missingDependencies) {
+		if (missingDependencies && canInstallMissingDependencies) {
 			const depsList = missingDependencies.join(', ');
 			sandboxPrerequisiteConfirmation = {
 				title: localize('runInTerminal.missingDeps.title', "Missing Sandbox Dependencies"),

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -287,8 +287,12 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 	// ---- workbench-only flows -----------------------------------------------
 
 	async installMissingSandboxDependencies(missingDependencies: string[], sessionResource: URI | undefined, token: CancellationToken, options: ISandboxDependencyInstallOptions): Promise<ISandboxDependencyInstallResult> {
-		const depsList = missingDependencies.join(' ');
-		return this._runSandboxPrerequisiteCommand(`sudo apt install -y ${depsList}`, sessionResource, token, options);
+		const status = await this._resolveSandboxDependencyStatus();
+		if (!status?.dependencyInstallCommand) {
+			return { exitCode: undefined };
+		}
+		const depsList = missingDependencies.map(dependency => this._quoteShellArgument(dependency)).join(' ');
+		return this._runSandboxPrerequisiteCommand(`${status.dependencyInstallCommand} ${depsList}`, sessionResource, token, options);
 	}
 
 	async runSandboxRemediation(remediation: TerminalSandboxPreCheckRemediation, sessionResource: URI | undefined, token: CancellationToken, options: ISandboxDependencyInstallOptions): Promise<ISandboxDependencyInstallResult> {
@@ -362,6 +366,10 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		installCommandSent = true;
 
 		return { exitCode: await completionPromise };
+	}
+
+	private _quoteShellArgument(value: string): string {
+		return `'${value.replace(/'/g, `'\\''`)}'`;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -5,6 +5,7 @@
 
 import { deepStrictEqual, strictEqual, ok } from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { IChannel } from '../../../../../../base/parts/ipc/common/ipc.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { TestLifecycleService, workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
@@ -15,7 +16,7 @@ import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { IEnvironmentService } from '../../../../../../platform/environment/common/environment.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
-import { IRemoteAgentService } from '../../../../../services/remote/common/remoteAgentService.js';
+import { IRemoteAgentConnection, IRemoteAgentService } from '../../../../../services/remote/common/remoteAgentService.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 import { AgentNetworkDomainSettingId } from '../../../../../../platform/networkFilter/common/settings.js';
@@ -72,6 +73,7 @@ suite('TerminalSandboxService - network domains', () => {
 	}
 
 	class MockRemoteAgentService {
+		connection: IRemoteAgentConnection | null = null;
 		remoteEnvironment: IRemoteAgentEnvironment | null = {
 			os: OperatingSystem.Linux,
 			tmpDir: URI.file('/tmp'),
@@ -97,8 +99,8 @@ suite('TerminalSandboxService - network domains', () => {
 			isUnsupportedGlibc: false
 		};
 
-		getConnection() {
-			return null;
+		getConnection(): IRemoteAgentConnection | null {
+			return this.connection;
 		}
 
 		async getEnvironment(): Promise<IRemoteAgentEnvironment | null> {
@@ -330,6 +332,109 @@ suite('TerminalSandboxService - network domains', () => {
 		strictEqual(result.failedCheck, TerminalSandboxPrerequisiteCheck.Bubblewrap);
 		deepStrictEqual(result.remediations, [TerminalSandboxPreCheckRemediation.DisableUnprivilagedusernamespaceRestriction]);
 		strictEqual(result.detail, 'No permissions to create namespace');
+	});
+
+	test('should install sandbox dependencies with the detected package manager', async () => {
+		sandboxHelperService.status = {
+			bubblewrapInstalled: false,
+			bubblewrapUsable: false,
+			socatInstalled: false,
+			dependencyInstallCommand: 'sudo pacman -S --needed --noconfirm',
+		};
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		let sentCommand: string | undefined;
+		const commandFinishedEmitter = store.add(new Emitter<{ exitCode: number | undefined }>());
+		const terminal: ISandboxDependencyInstallTerminal = {
+			sendText: async command => {
+				sentCommand = command;
+				commandFinishedEmitter.fire({ exitCode: 0 });
+			},
+			focus: () => { },
+			capabilities: {
+				get: () => ({ onCommandFinished: commandFinishedEmitter.event }),
+				onDidAddCapability: Event.None,
+			},
+			onDidInputData: Event.None,
+			onDisposed: Event.None,
+		};
+
+		const result = await sandboxService.installMissingSandboxDependencies(['bubblewrap', 'socat'], undefined, CancellationToken.None, {
+			createTerminal: async () => terminal,
+			focusTerminal: async () => { },
+		});
+
+		strictEqual(result.exitCode, 0);
+		strictEqual(sentCommand, `sudo pacman -S --needed --noconfirm 'bubblewrap' 'socat'`);
+	});
+
+	test('should install sandbox dependencies with the remote host package manager', async () => {
+		sandboxHelperService.status = {
+			bubblewrapInstalled: false,
+			bubblewrapUsable: false,
+			socatInstalled: false,
+			dependencyInstallCommand: 'sudo apt-get install -y',
+		};
+		const remoteStatus: ISandboxDependencyStatus = {
+			bubblewrapInstalled: false,
+			bubblewrapUsable: false,
+			socatInstalled: false,
+			dependencyInstallCommand: 'sudo pacman -S --needed --noconfirm',
+		};
+		const channel: IChannel = {
+			call: async <T>(command: string): Promise<T> => {
+				strictEqual(command, 'checkSandboxDependencies');
+				return remoteStatus as T;
+			},
+			listen: () => Event.None,
+		};
+		remoteAgentService.connection = {
+			withChannel: async <T extends IChannel, R>(_channelName: string, callback: (channel: T) => Promise<R>): Promise<R> => callback(channel as T),
+		} as IRemoteAgentConnection;
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		let sentCommand: string | undefined;
+		const commandFinishedEmitter = store.add(new Emitter<{ exitCode: number | undefined }>());
+		const terminal: ISandboxDependencyInstallTerminal = {
+			sendText: async command => {
+				sentCommand = command;
+				commandFinishedEmitter.fire({ exitCode: 0 });
+			},
+			focus: () => { },
+			capabilities: {
+				get: () => ({ onCommandFinished: commandFinishedEmitter.event }),
+				onDidAddCapability: Event.None,
+			},
+			onDidInputData: Event.None,
+			onDisposed: Event.None,
+		};
+
+		const result = await sandboxService.installMissingSandboxDependencies(['bubblewrap'], undefined, CancellationToken.None, {
+			createTerminal: async () => terminal,
+			focusTerminal: async () => { },
+		});
+
+		strictEqual(result.exitCode, 0);
+		strictEqual(sentCommand, `sudo pacman -S --needed --noconfirm 'bubblewrap'`);
+	});
+
+	test('should not create a terminal without a supported package manager', async () => {
+		sandboxHelperService.status = {
+			bubblewrapInstalled: false,
+			bubblewrapUsable: false,
+			socatInstalled: true,
+		};
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		let terminalCreated = false;
+
+		const result = await sandboxService.installMissingSandboxDependencies(['bubblewrap'], undefined, CancellationToken.None, {
+			createTerminal: async () => {
+				terminalCreated = true;
+				throw new Error('Unexpected terminal creation');
+			},
+			focusTerminal: async () => { },
+		});
+
+		strictEqual(result.exitCode, undefined);
+		strictEqual(terminalCreated, false);
 	});
 
 	test('should run the approved bubblewrap remediation command', async () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -548,7 +548,7 @@ suite('RunInTerminalTool', () => {
 			const prepared = await executeToolTest({ command: 'echo hello' });
 			const result = await invokeToolTest({ command: 'echo hello' });
 
-			strictEqual(prepared?.confirmationMessages, undefined);
+			strictEqual(prepared?.confirmationMessages?.customOptions, undefined);
 			ok((result.content[0] as { value?: string }).value?.includes('system package manager'));
 			strictEqual(createTerminalCallCount, 0);
 		});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -518,6 +518,7 @@ suite('RunInTerminalTool', () => {
 				sandboxConfigPath: '/tmp/sandbox.json',
 				failedCheck: TerminalSandboxPrerequisiteCheck.Dependencies,
 				missingDependencies: ['bubblewrap'],
+				canInstallMissingDependencies: true,
 			};
 
 			const result = await executeToolTest({
@@ -532,6 +533,24 @@ suite('RunInTerminalTool', () => {
 			ok(result?.confirmationMessages?.customOptions?.length === 2, 'Expected two custom options');
 			// missingDependencies should be in toolSpecificData so invoke can handle it
 			strictEqual((result?.toolSpecificData as IChatTerminalToolInvocationData | undefined)?.missingSandboxDependencies?.length, 1);
+		});
+
+		test('should request manual installation when no supported package manager is available', async () => {
+			sandboxEnabled = false;
+			sandboxPrereqResult = {
+				enabled: false,
+				sandboxConfigPath: '/tmp/sandbox.json',
+				failedCheck: TerminalSandboxPrerequisiteCheck.Dependencies,
+				missingDependencies: ['bubblewrap'],
+				canInstallMissingDependencies: false,
+			};
+
+			const prepared = await executeToolTest({ command: 'echo hello' });
+			const result = await invokeToolTest({ command: 'echo hello' });
+
+			strictEqual(prepared?.confirmationMessages, undefined);
+			ok((result.content[0] as { value?: string }).value?.includes('system package manager'));
+			strictEqual(createTerminalCallCount, 0);
 		});
 
 		test('should show repair choices when bubblewrap is installed but unusable on Linux', async () => {
@@ -568,6 +587,7 @@ suite('RunInTerminalTool', () => {
 					sandboxConfigPath: '/tmp/sandbox.json',
 					failedCheck: TerminalSandboxPrerequisiteCheck.Dependencies,
 					missingDependencies: ['bubblewrap'],
+					canInstallMissingDependencies: true,
 				};
 			};
 


### PR DESCRIPTION
## Summary

- detect the Linux distribution and select a supported native package manager for sandbox dependencies
- propagate whether missing sandbox dependencies can be installed automatically and use the detected install command
- fall back to manual installation guidance when no supported installer is available
- quote dependency names passed to the shell and add coverage for local and remote hosts

## Testing

Not run (per request).