### PR TITLE
Don't leak internal cache_control sentinel to BYOK providers

### DIFF
--- a/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
@@ -13,3 +13,18 @@ export namespace CustomDataPartMimeTypes {
 }
 
 export const CacheType = 'ephemeral';
+
+/**
+ * Vendors of Copilot's built-in BYOK providers whose converters handle the internal
+ * {@link CustomDataPartMimeTypes.CacheControl} sentinel (Anthropic uses it, Gemini strips it).
+ * The sentinel is only emitted to these providers; others would serialize it verbatim into
+ * their upstream request (issue #313920). Stopgap until a public opt-in capability exists.
+ *
+ * TODO @vritant24: replace this vendor allow-list with an externally exposed API so any
+ * `LanguageModelChatProvider` can opt in to receiving cache breakpoints (issue #313920).
+ */
+export const CacheBreakpointAwareModelVendors: ReadonlySet<string> = new Set(['anthropic', 'gemini', 'openrouter']);
+
+export function modelVendorHandlesCacheBreakpoints(vendor: string | undefined): boolean {
+	return !!vendor && CacheBreakpointAwareModelVendors.has(vendor.toLowerCase());
+}

--- a/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
@@ -16,12 +16,9 @@ export const CacheType = 'ephemeral';
 
 /**
  * Vendors of Copilot's built-in BYOK providers whose converters handle the internal
- * {@link CustomDataPartMimeTypes.CacheControl} sentinel (Anthropic uses it, Gemini strips it).
- * The sentinel is only emitted to these providers; others would serialize it verbatim into
- * their upstream request (issue #313920). Stopgap until a public opt-in capability exists.
+ * {@link CustomDataPartMimeTypes.CacheControl} sentinel. Others would leak it upstream (#313920).
  *
- * TODO @vritant24: replace this vendor allow-list with an externally exposed API so any
- * `LanguageModelChatProvider` can opt in to receiving cache breakpoints (issue #313920).
+ * TODO @vritant24: replace with an externally exposed opt-in API (#313920).
  */
 export const CacheBreakpointAwareModelVendors: ReadonlySet<string> = new Set(['anthropic', 'gemini', 'openrouter']);
 

--- a/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
@@ -26,5 +26,5 @@ export const CacheType = 'ephemeral';
 export const CacheBreakpointAwareModelVendors: ReadonlySet<string> = new Set(['anthropic', 'gemini', 'openrouter']);
 
 export function modelVendorHandlesCacheBreakpoints(vendor: string | undefined): boolean {
-	return !!vendor && CacheBreakpointAwareModelVendors.has(vendor.toLowerCase());
+	return vendor !== undefined && CacheBreakpointAwareModelVendors.has(vendor);
 }

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -24,7 +24,7 @@ import { retrieveCapturingTokenByCorrelation, storeCapturingTokenForCorrelation 
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { TelemetryData } from '../../telemetry/common/telemetryData';
 import { EndpointEditToolName, isEndpointEditToolName } from '../common/endpointProvider';
-import { CustomDataPartMimeTypes } from '../common/endpointTypes';
+import { CustomDataPartMimeTypes, modelVendorHandlesCacheBreakpoints } from '../common/endpointTypes';
 import { decodeStatefulMarker, encodeStatefulMarker, rawPartAsStatefulMarker } from '../common/statefulMarkerContainer';
 import { rawPartAsThinkingData } from '../common/thinkingDataContainer';
 import { ExtensionContributedChatTokenizer } from './extChatTokenizer';
@@ -174,6 +174,7 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 		const vscodeMessages = convertToApiChatMessage(messages, {
 			ignoreStatefulMarker,
 			summarizedAtRoundId,
+			emitCacheBreakpoints: modelVendorHandlesCacheBreakpoints(this.languageModel.vendor),
 		});
 		const ourRequestId = generateUuid();
 
@@ -331,6 +332,8 @@ function getTelemetryTurnFromProperties(telemetryProperties: IMakeChatRequestOpt
 interface ConvertToApiChatMessageOptions {
 	readonly ignoreStatefulMarker?: boolean;
 	readonly summarizedAtRoundId?: string;
+	/** Emit the {@link CustomDataPartMimeTypes.CacheControl} sentinel for cache breakpoints. Defaults to `true`. */
+	readonly emitCacheBreakpoints?: boolean;
 }
 
 export function convertToApiChatMessage(messages: Raw.ChatMessage[], options: ConvertToApiChatMessageOptions = {}): Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2> {
@@ -356,7 +359,9 @@ export function convertToApiChatMessage(messages: Raw.ChatMessage[], options: Co
 					continue;
 				}
 			} else if (contentPart.type === Raw.ChatCompletionContentPartKind.CacheBreakpoint) {
-				apiContent.push(new vscode.LanguageModelDataPart(new TextEncoder().encode('ephemeral'), CustomDataPartMimeTypes.CacheControl));
+				if (options.emitCacheBreakpoints !== false) {
+					apiContent.push(new vscode.LanguageModelDataPart(new TextEncoder().encode('ephemeral'), CustomDataPartMimeTypes.CacheControl));
+				}
 			} else if (contentPart.type === Raw.ChatCompletionContentPartKind.Opaque) {
 				const statefulMarker = rawPartAsStatefulMarker(contentPart);
 				// A marker created under a different local summary generation points at

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -332,7 +332,7 @@ function getTelemetryTurnFromProperties(telemetryProperties: IMakeChatRequestOpt
 interface ConvertToApiChatMessageOptions {
 	readonly ignoreStatefulMarker?: boolean;
 	readonly summarizedAtRoundId?: string;
-	/** Emit the {@link CustomDataPartMimeTypes.CacheControl} sentinel for cache breakpoints. Defaults to `true`. */
+	/** Emit the {@link CustomDataPartMimeTypes.CacheControl} sentinel for cache breakpoints. Defaults to `false` (fail closed) so it never reaches a provider that can't consume it (#313920). */
 	readonly emitCacheBreakpoints?: boolean;
 }
 
@@ -359,7 +359,7 @@ export function convertToApiChatMessage(messages: Raw.ChatMessage[], options: Co
 					continue;
 				}
 			} else if (contentPart.type === Raw.ChatCompletionContentPartKind.CacheBreakpoint) {
-				if (options.emitCacheBreakpoints !== false) {
+				if (options.emitCacheBreakpoints) {
 					apiContent.push(new vscode.LanguageModelDataPart(new TextEncoder().encode('ephemeral'), CustomDataPartMimeTypes.CacheControl));
 				}
 			} else if (contentPart.type === Raw.ChatCompletionContentPartKind.Opaque) {

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatTokenizer.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatTokenizer.ts
@@ -8,6 +8,7 @@ import { LanguageModelChat, LanguageModelChatTool } from 'vscode';
 import { ITokenizer } from '../../../util/common/tokenizer';
 import { assertNever } from '../../../util/vs/base/common/assert';
 import { calculateImageTokenCost, estimateDocumentTokenCost } from '../../tokenizer/node/tokenizer';
+import { modelVendorHandlesCacheBreakpoints } from '../common/endpointTypes';
 import { convertToApiChatMessage } from './extChatEndpoint';
 
 /**
@@ -65,8 +66,11 @@ export class ExtensionContributedChatTokenizer implements ITokenizer {
 	}
 
 	async countMessageTokens(message: Raw.ChatMessage): Promise<number> {
-		// Convert to VS Code message format and use the language model's countTokens
-		const apiMessages = convertToApiChatMessage([message]);
+		// Convert to VS Code message format and use the language model's countTokens.
+		// Mirror the request path so only cache-aware providers ever see the internal sentinel (#313920).
+		const apiMessages = convertToApiChatMessage([message], {
+			emitCacheBreakpoints: modelVendorHandlesCacheBreakpoints(this.languageModel.vendor),
+		});
 		if (apiMessages.length === 0) {
 			return 0;
 		}

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -128,7 +128,72 @@ describe('ExtensionContributedChatEndpoint', () => {
 
 		expect(decodeStatefulMarker(getStatefulMarkerPart(converted[0])!.data).marker).toBe('resp-legacy');
 	});
+
+	// https://github.com/microsoft/vscode/issues/313920: the internal cache_control sentinel
+	// must only reach providers that handle it, or a naive serializer leaks it upstream.
+	it('omits the internal cache_control sentinel for providers that do not handle it, keeps it for those that do', () => {
+		const toolMessage: Raw.ChatMessage = {
+			role: Raw.ChatRole.Tool,
+			toolCallId: 'call-1',
+			content: [
+				{ type: Raw.ChatCompletionContentPartKind.Text, text: 'the tool output' },
+				{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
+			],
+		};
+
+		const withoutBreakpoints = convertToApiChatMessage([toolMessage], { emitCacheBreakpoints: false });
+		const withBreakpoints = convertToApiChatMessage([toolMessage], { emitCacheBreakpoints: true });
+
+		expect({
+			omitted: describeToolResult(withoutBreakpoints[0]),
+			emitted: describeToolResult(withBreakpoints[0]),
+		}).toEqual({
+			omitted: { text: 'the tool output', cacheControl: false },
+			emitted: { text: 'the tool output', cacheControl: true },
+		});
+	});
+
+	it('gates the cache_control sentinel on the model vendor end-to-end', async () => {
+		const capture = async (vendor: string) => {
+			let capturedMessages: readonly vscode.LanguageModelChatMessage[] | undefined;
+			const languageModel = createLanguageModel(() => { }, messages => capturedMessages = messages, vendor);
+			const endpoint = new ExtensionContributedChatEndpoint(
+				languageModel,
+				createInstantiationService(),
+				new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '1.0.0', sessionId: 'test' })),
+			);
+
+			await endpoint.makeChatRequest2({
+				debugName: 'test',
+				messages: [{
+					role: Raw.ChatRole.Tool,
+					toolCallId: 'call-1',
+					content: [
+						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'the tool output' },
+						{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
+					],
+				}],
+				finishedCb: undefined,
+				location: ChatLocation.Agent,
+				requestOptions: {},
+			}, new vscode.CancellationTokenSource().token);
+
+			return describeToolResult(capturedMessages![0]);
+		};
+
+		expect({ anthropic: await capture('anthropic'), ollama: await capture('ollama') }).toEqual({
+			anthropic: { text: 'the tool output', cacheControl: true },
+			ollama: { text: 'the tool output', cacheControl: false },
+		});
+	});
 });
+
+function describeToolResult(message: vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2): { text: string | undefined; cacheControl: boolean } {
+	const toolResult = message.content[0] as vscode.LanguageModelToolResultPart2;
+	const text = toolResult.content.find((part): part is vscode.LanguageModelTextPart => part instanceof vscode.LanguageModelTextPart)?.value;
+	const cacheControl = toolResult.content.some(part => part instanceof vscode.LanguageModelDataPart && part.mimeType === CustomDataPartMimeTypes.CacheControl);
+	return { text, cacheControl };
+}
 
 function createMarkerMessage(marker: string, summarizedAtRoundId: string | undefined): Raw.ChatMessage {
 	return {
@@ -153,11 +218,12 @@ function getStatefulMarkerPart(message: vscode.LanguageModelChatMessage | vscode
 function createLanguageModel(
 	captureOptions: (options: vscode.LanguageModelChatRequestOptions) => void,
 	captureMessages?: (messages: readonly vscode.LanguageModelChatMessage[]) => void,
+	vendor: string = 'test-vendor',
 ): vscode.LanguageModelChat {
 	return {
 		id: 'test-model',
 		name: 'Test Model',
-		vendor: 'test-vendor',
+		vendor,
 		family: 'test-family',
 		version: '1.0.0',
 		maxInputTokens: 1000,

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatTokenizer.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatTokenizer.spec.ts
@@ -132,6 +132,40 @@ describe('ExtensionContributedChatTokenizer', () => {
 			const result = await tokenizer.countMessageTokens(message);
 			expect(result).toBeGreaterThanOrEqual(3);
 		});
+
+		// https://github.com/microsoft/vscode/issues/313920: the token-count path must not hand the
+		// internal cache_control sentinel to providers that can't consume it.
+		it('gates the cache_control sentinel on the model vendor', async () => {
+			const toolMessage: Raw.ChatMessage = {
+				role: Raw.ChatRole.Tool,
+				toolCallId: 'call-1',
+				content: [
+					{ type: Raw.ChatCompletionContentPartKind.Text, text: 'the tool output' },
+					{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
+				],
+			};
+
+			const countedForVendor = async (vendor: string) => {
+				let captured: LanguageModelChatMessage | LanguageModelChatMessage2 | undefined;
+				const model = {
+					vendor,
+					countTokens: (input: string | LanguageModelChatMessage | LanguageModelChatMessage2) => {
+						if (typeof input !== 'string') {
+							captured = input;
+						}
+						return Promise.resolve(0);
+					},
+				} as unknown as LanguageModelChat;
+				await new ExtensionContributedChatTokenizer(model).countMessageTokens(toolMessage);
+				const toolResult = captured!.content[0] as { content: { mimeType?: string }[] };
+				return toolResult.content.some(part => part.mimeType === 'cache_control');
+			};
+
+			expect({ anthropic: await countedForVendor('anthropic'), ollama: await countedForVendor('ollama') }).toEqual({
+				anthropic: true,
+				ollama: false,
+			});
+		});
 	});
 
 	describe('countMessagesTokens', () => {

--- a/src/vs/workbench/api/test/browser/extHostTypeConverter.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTypeConverter.test.ts
@@ -75,9 +75,7 @@ suite('ExtHostTypeConverter', function () {
 
 	test('LanguageModelChatMessage2 converters preserve tool-result data parts across the provider boundary #313920', function () {
 
-		// Platform converters faithfully round-trip data parts and don't strip unknown mime types,
-		// so the producer (the Copilot host) must avoid emitting internal sentinels to providers
-		// that can't consume them — otherwise a naive `JSON.stringify(part)` leaks them upstream.
+		// Platform converters round-trip data parts unchanged (unknown mime types aren't stripped), so the producer must gate emission (#313920).
 		const CACHE_CONTROL_MIME = 'cache_control';
 
 		const toolResult = new extHostTypes.LanguageModelToolResultPart('call-1', [

--- a/src/vs/workbench/api/test/browser/extHostTypeConverter.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTypeConverter.test.ts
@@ -6,7 +6,7 @@
 
 import assert from 'assert';
 import * as extHostTypes from '../../common/extHostTypes.js';
-import { ChatAgentResult, MarkdownString, NotebookCellOutputItem, NotebookData, LanguageSelector, WorkspaceEdit } from '../../common/extHostTypeConverters.js';
+import { ChatAgentResult, LanguageModelChatMessage2, MarkdownString, NotebookCellOutputItem, NotebookData, LanguageSelector, WorkspaceEdit } from '../../common/extHostTypeConverters.js';
 import { isEmptyObject } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IWorkspaceTextEditDto } from '../../common/extHost.protocol.js';
@@ -71,6 +71,41 @@ suite('ExtHostTypeConverter', function () {
 		assert.strictEqual(size(data.uris!), 2);
 		assert.ok(!!data.uris!['file:///somepath/here']);
 		assert.ok(!!data.uris!['file:///somepath/here2']);
+	});
+
+	test('LanguageModelChatMessage2 converters preserve tool-result data parts across the provider boundary #313920', function () {
+
+		// Platform converters faithfully round-trip data parts and don't strip unknown mime types,
+		// so the producer (the Copilot host) must avoid emitting internal sentinels to providers
+		// that can't consume them — otherwise a naive `JSON.stringify(part)` leaks them upstream.
+		const CACHE_CONTROL_MIME = 'cache_control';
+
+		const toolResult = new extHostTypes.LanguageModelToolResultPart('call-1', [
+			new extHostTypes.LanguageModelTextPart('the tool output'),
+			new extHostTypes.LanguageModelDataPart(new TextEncoder().encode('ephemeral'), CACHE_CONTROL_MIME),
+		]);
+		const hostMessage = extHostTypes.LanguageModelChatMessage2.User([toolResult]);
+
+		const providerMessage = LanguageModelChatMessage2.to(LanguageModelChatMessage2.from(hostMessage));
+		const providerToolResult = providerMessage.content[0] as extHostTypes.LanguageModelToolResultPart;
+		const roundTrippedPart = providerToolResult.content[1] as extHostTypes.LanguageModelDataPart;
+
+		assert.deepStrictEqual({
+			mimeType: roundTrippedPart.mimeType,
+			decodedData: new TextDecoder().decode(roundTrippedPart.data),
+			marshalled: roundTrippedPart.toJSON(),
+			naiveSerialization: JSON.stringify(roundTrippedPart),
+		}, {
+			mimeType: 'cache_control',
+			decodedData: 'ephemeral',
+			marshalled: {
+				$mid: MarshalledId.LanguageModelDataPart,
+				mimeType: 'cache_control',
+				data: 'ZXBoZW1lcmFs', // base64('ephemeral')
+				audience: undefined,
+			},
+			naiveSerialization: '{"$mid":24,"mimeType":"cache_control","data":"ZXBoZW1lcmFs"}',
+		});
 	});
 
 	test('NPM script explorer running a script from the hover does not work #65561', function () {


### PR DESCRIPTION
Fixes #313920

**Problem:** The host injects an Anthropic cache-breakpoint (`cache_control` data part) into tool results for every non-`messages` endpoint — including third-party providers (Ollama, custom) that can't recognize it and serialize it verbatim into their upstream request as `{"$mid":24,"mimeType":"cache_control",...}`, polluting the cache prefix and wasting tokens.

**Fix:** In `convertToApiChatMessage`, only emit the sentinel to vendors whose converters handle it (`anthropic`, `gemini`, `openrouter`). Everyone else no longer receives it — leak gone, no caching lost. Stopgap noted with `TODO @vritant24` for a public opt-in API (Phase 2).

**Tests:** `extChatEndpoint.spec.ts` (sentinel gated by vendor, end-to-end); `extHostTypeConverter.test.ts` (platform round-trips data parts unchanged, so the producer must gate).
