### PR TITLE
Stream output for SDK built-in shell tool in agent host Copilot

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3994,9 +3994,7 @@ export class CopilotAgentSession extends Disposable {
 			if (!tracked || !isShellTool(tracked.toolName)) {
 				return;
 			}
-			// TODO: Replace this text snapshot bridge with an output-only AHP terminal once AHP defines
-			// that capability and SDK shell events expose a live shell identity. Then attach terminal
-			// content to the tool call and stream its output through the terminal channel.
+			// TODO: Use terminal-specific AHP content once live shell output is modeled separately from terminalComplete.preview.
 			this._emitAction({
 				type: ActionType.ChatToolCallContentChanged,
 				turnId: this._turnId,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3990,6 +3990,22 @@ export class CopilotAgentSession extends Disposable {
 
 		this._register(wrapper.onToolPartialResult(e => {
 			this._logService.trace(`[Copilot:${sessionId}] Tool partial result: ${e.data.toolCallId} (${e.data.partialOutput.length} chars)`);
+			const tracked = this._activeToolCalls.get(e.data.toolCallId);
+			if (!tracked || !isShellTool(tracked.toolName)) {
+				return;
+			}
+			// TODO: Replace this text snapshot bridge with an output-only AHP terminal once AHP defines
+			// that capability and SDK shell events expose a live shell identity. Then attach terminal
+			// content to the tool call and stream its output through the terminal channel.
+			this._emitAction({
+				type: ActionType.ChatToolCallContentChanged,
+				turnId: this._turnId,
+				toolCallId: e.data.toolCallId,
+				content: [
+					...tracked.content.filter(content => content.type !== ToolResultContentType.Text),
+					{ type: ToolResultContentType.Text, text: e.data.partialOutput },
+				],
+			}, tracked.parentToolCallId);
 		}));
 
 		this._register(wrapper.onToolProgress(e => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -2867,6 +2867,82 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual((toolStart.action as ChatToolCallStartAction).intention, 'List files in the repo root');
 		});
 
+		test('tool partial results stream cumulative output as running content', async () => {
+			const { session, mockSession, signals, waitForSignal } = await createAgentSession(disposables);
+			session.resetTurnState('turn-stream');
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-stream',
+				toolName: 'bash',
+				arguments: { command: 'print ticks', description: 'Print ticks' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+			mockSession.fire('tool.execution_partial_result', {
+				toolCallId: 'tc-stream',
+				partialOutput: 'tick 1\n',
+			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
+			mockSession.fire('tool.execution_partial_result', {
+				toolCallId: 'tc-stream',
+				partialOutput: 'tick 1\ntick 2\n',
+			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
+			mockSession.fire('tool.execution_complete', {
+				toolCallId: 'tc-stream',
+				success: true,
+				result: { content: 'tick 1\ntick 2\n' },
+			} as SessionEventPayload<'tool.execution_complete'>['data']);
+			await waitForSignal(signal => isAction(signal, ActionType.ChatToolCallComplete));
+
+			assert.deepStrictEqual(getActions(signals)
+				.filter(action => action.type === ActionType.ChatToolCallContentChanged)
+				.map(action => ({
+					turnId: action.turnId,
+					toolCallId: action.toolCallId,
+					content: action.content,
+				})), [
+				{
+					turnId: 'turn-stream',
+					toolCallId: 'tc-stream',
+					content: [{ type: ToolResultContentType.Text, text: 'tick 1\n' }],
+				},
+				{
+					turnId: 'turn-stream',
+					toolCallId: 'tc-stream',
+					content: [{ type: ToolResultContentType.Text, text: 'tick 1\ntick 2\n' }],
+				},
+			]);
+			const completed = getActions(signals).find(action => action.type === ActionType.ChatToolCallComplete) as ChatToolCallCompleteAction;
+			assert.deepStrictEqual(completed.result.content, [
+				{ type: ToolResultContentType.Text, text: 'tick 1\ntick 2\n' },
+			]);
+		});
+
+		test('tool partial results for untracked tools are ignored', async () => {
+			const { mockSession, signals } = await createAgentSession(disposables);
+
+			mockSession.fire('tool.execution_partial_result', {
+				toolCallId: 'tc-untracked',
+				partialOutput: 'orphaned output',
+			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
+
+			assert.deepStrictEqual(getActions(signals), []);
+		});
+
+		test('tool partial results for tracked non-shell tools are ignored', async () => {
+			const { mockSession, signals } = await createAgentSession(disposables);
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-non-shell',
+				toolName: 'grep',
+				arguments: { pattern: 'needle' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+			mockSession.fire('tool.execution_partial_result', {
+				toolCallId: 'tc-non-shell',
+				partialOutput: 'unexpected partial output',
+			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
+
+			assert.deepStrictEqual(getActions(signals)
+				.filter(action => action.type === ActionType.ChatToolCallContentChanged), []);
+		});
+
 		test('live tool_start strips redundant cd prefix matching workingDirectory', async () => {
 			const wd = URI.file('/repo/project');
 			const { mockSession, signals } = await createAgentSession(disposables, { workingDirectory: wd });


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/324825
Part of: https://github.com/microsoft/vscode/issues/323399

- Forward cumulative `tool.execution_partial_result` output from Copilot SDK `bash` and `powershell` calls into the running Agent Host tool call.
- Refresh the inline terminal preview as output arrives instead of waiting for command completion.
- Limit partial-result updates to tracked shell calls, ignoring untracked and non-shell tool output.
- Preserve existing non-text tool content while replacing the previous text snapshot with the latest cumulative output.
- Keep the existing AHP terminal resource and `terminal/data` path unchanged, documenting the future move to an output-only AHP terminal when the protocol and SDK expose the required capabilities.
- Add coverage for cumulative output snapshots, untracked calls, and non-shell calls.

-----------------------------------------
Inspirations from:

- The SDK partial-result event comes from [`CopilotSessionWrapper.onToolPartialResult`](https://github.com/microsoft/vscode/blob/d5862406ee909d95ad04d8dac35c3a8646b886a6/src/vs/platform/agentHost/node/copilot/copilotSerssionWrapper.ts#L186-L189).
- Updating a running tool call through `ChatToolCallContentChanged` follows the existing [`onDidAssociateTerminal` handler](https://github.com/microsoft/vscode/blob/d5862406ee909d95ad04d8dac35c3a8646b886a6/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts#L734-L755).
- Rendering text content as an inline terminal snapshot follows the compatibility fallback in [`getTerminalOutput`](https://github.com/microsoft/vscode/blob/d5862406ee909d95ad04d8dac35c3a8646b886a6/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts#L1162-L1187).
- Shell-only scoping uses the existing [`isShellTool`](https://github.com/microsoft/vscode/blob/d5862406ee909d95ad04d8dac35c3a8646b886a6/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts#L469-L474) classification.