### PR TITLE
Return Agent Host terminal instance from revival helper

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -51,7 +51,7 @@ import { IPathService } from '../../../../../services/path/common/pathService.js
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceTrustRequestService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 import { IAgentHostTerminalService } from '../../../../terminal/browser/agentHostTerminalService.js';
-import { ITerminalChatService } from '../../../../terminal/browser/terminal.js';
+import { ITerminalChatService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import {
 	AgentHostCompletionReferenceKind,
 	getAgentHostCompletionReferenceKind,
@@ -3139,7 +3139,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const toolInput = tc.toolInput;
 		const sessionId = makeAhpTerminalToolSessionId(terminalUri, backendSession);
 		const terminalCommandUri = URI.parse(terminalUri);
-		const terminalInstance = this._ensureTerminalInstance(terminalUri, backendSession);
+		const terminalInstance = this._ensureTerminalInstance(terminalUri, sessionId);
 		const existing = invocation.toolSpecificData?.kind === 'terminal'
 			? invocation.toolSpecificData as IChatTerminalToolInvocationData
 			: undefined;
@@ -3555,18 +3555,14 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	 * Attaches to an existing server-side terminal via the agent host
 	 * terminal service and registers it with the terminal chat service.
 	 *
-	 * Returns the `terminalToolSessionId` to use for the tool invocation.
+	 * Returns the local terminal instance attached to the server-side terminal.
 	 */
-	private async _ensureTerminalInstance(terminalUri: string, backendSession: URI): Promise<string> {
-		const terminalToolSessionId = makeAhpTerminalToolSessionId(terminalUri, backendSession);
-		const parsedUri = URI.parse(terminalUri);
-		await this._agentHostTerminalService.reviveTerminal(
+	private _ensureTerminalInstance(terminalUri: string, terminalToolSessionId: string): Promise<ITerminalInstance> {
+		return this._agentHostTerminalService.reviveTerminal(
 			this._config.connection,
-			parsedUri,
+			URI.parse(terminalUri),
 			terminalToolSessionId
 		);
-
-		return terminalToolSessionId;
 	}
 
 	/** Maps a UI session resource to a backend provider URI. */

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -3555,7 +3555,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	 * Attaches to an existing server-side terminal via the agent host
 	 * terminal service and registers it with the terminal chat service.
 	 *
-	 * Returns the local terminal instance attached to the server-side terminal.
+	 * Returns the terminal instance created or reused by the terminal service.
 	 */
 	private _ensureTerminalInstance(terminalUri: string, terminalToolSessionId: string): Promise<ITerminalInstance> {
 		return this._agentHostTerminalService.reviveTerminal(

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -4965,10 +4965,12 @@ suite('AgentHostChatContribution', () => {
 		test('terminal metadata is observable before terminal revival completes', async () => {
 			const terminalRevival = new DeferredPromise<ITerminalInstance>();
 			let revivalStarted = false;
+			let revivalCall: { terminalUri: URI; terminalToolSessionId: string } | undefined;
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
 				agentHostTerminalServiceOverride: {
-					reviveTerminal: () => {
+					reviveTerminal: (_connection, terminalUri, terminalToolSessionId) => {
 						revivalStarted = true;
+						revivalCall = { terminalUri, terminalToolSessionId };
 						return terminalRevival.p;
 					},
 				},
@@ -5008,7 +5010,9 @@ suite('AgentHostChatContribution', () => {
 				kind: terminalData.kind,
 				commandLine: terminalData.commandLine.original,
 				terminalCommandUri: terminalData.terminalCommandUri?.toString(),
-				hasTerminalToolSessionId: !!terminalData.terminalToolSessionId,
+				terminalToolSessionId: terminalData.terminalToolSessionId,
+				revivedTerminalUri: revivalCall?.terminalUri.toString(),
+				revivedTerminalToolSessionId: revivalCall?.terminalToolSessionId,
 				terminalCommandId: terminalData.terminalCommandId,
 				terminalCommandOutput: terminalData.terminalCommandOutput,
 				terminalCommandState: terminalData.terminalCommandState,
@@ -5020,7 +5024,9 @@ suite('AgentHostChatContribution', () => {
 				kind: 'terminal',
 				commandLine: 'long-running-command',
 				terminalCommandUri: 'agenthost-terminal://bang/live-shell',
-				hasTerminalToolSessionId: true,
+				terminalToolSessionId: JSON.stringify({ terminal: 'agenthost-terminal://bang/live-shell', session: 'copilot:/new-turntest' }),
+				revivedTerminalUri: 'agenthost-terminal://bang/live-shell',
+				revivedTerminalToolSessionId: JSON.stringify({ terminal: 'agenthost-terminal://bang/live-shell', session: 'copilot:/new-turntest' }),
 				terminalCommandId: undefined,
 				terminalCommandOutput: undefined,
 				terminalCommandState: undefined,


### PR DESCRIPTION
Follow-up to: https://github.com/microsoft/vscode/pull/325866

- Update `_ensureTerminalInstance` to return the `ITerminalInstance` produced by `reviveTerminal` instead of discarding it and returning the already-known terminal tool session ID.
- Pass the previously computed terminal tool session ID into the helper rather than rebuilding it from `backendSession`.
- Preserve the existing non-blocking flow: publish terminal metadata while revival is pending, then resolve the terminal command after revival completes.
- Extend test coverage to verify the terminal URI and complete tool session identity passed into terminal revival.

-----------------------------------------
Inspirations from:

- The helper’s return contract follows [`IAgentHostTerminalService.reviveTerminal`](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/workbench/contrib/terminal/browser/agentHostTerminalService.ts#L87-L91), which returns `Promise<ITerminalInstance>`.
- The existing metadata-before-revival ordering comes from [`_reviveTerminalIfNeeded`](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts#L3140-L3184).
- The regression test extends the existing deferred-revival coverage in [`agentHostChatContribution.test.ts`](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts#L4965-L5033).