### PR TITLE
fix: restore 8 KiB Node buffer pool on linux

### DIFF
--- a/src/bootstrap-node.ts
+++ b/src/bootstrap-node.ts
@@ -5,11 +5,17 @@
 
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { Buffer } from 'node:buffer';
 import { createRequire } from 'node:module';
 import type { IProductConfiguration } from './vs/base/common/product.js';
 
 const require = createRequire(import.meta.url);
 const isWindows = process.platform === 'win32';
+
+// Avoid 64 KiB pooled backing stores crossing Mojo's shared-memory threshold.
+if (process.platform === 'linux') {
+	Buffer.poolSize = 8 * 1024;
+}
 
 // increase number of stack frames(from 10, https://github.com/v8/v8/wiki/Stack-Trace-API)
 Error.stackTraceLimit = 100;


### PR DESCRIPTION
Node 24.18 changed Buffer.poolSize from 8 KiB to 64 KiB in https://github.com/nodejs/node/commit/d3ef4122eefb6b293b72b348fc6ea4cb602622a5

Node uses the pool for Buffer allocations smaller than half the pool size. As a result, allocations below 32 KiB can now be views into a shared 64 KiB backing ArrayBuffer.

VS Code's VSBuffer preserves these pooled backing stores. Webview resource streaming then forwards Uint8Array views through transferable streams without copying just the visible byte range. Structured clone consequently serializes the full 64 KiB backing store.

Chromium's mojo_base::BigBuffer has a 64 KiB inline limit. The structured-clone envelope makes these payloads just above that limit, so each message switches from inline storage to writable shared memory.

On POSIX, each writable shared-memory region carries two file descriptors: its writable descriptor and a read-only descriptor used for conversion. Under a renderer RLIMIT_NOFILE of 1024, a burst of webview resource messages therefore consumes two descriptors per chunk.

Instrumentation of VS Code loading the Codex webview showed:

- 1,910 large CommonCloneableMessage serializations
- the dominant payload sizes were 65,556 and 65,557 bytes
- renderer descriptors increasing through 1021, 1022, and 1023..
- recvmsg() returning message bytes with MSG_CTRUNC once descriptors could no longer be installed
- subsequent resource failures and service-worker network errors.

Restoring the previous 8 KiB pool size prevents small VS Code buffers from retaining 64 KiB backing stores. Their structured-clone messages remain below BigBuffer's inline threshold and no longer require shared-memory descriptor pairs.

Instrumentation with this override removed the 65,556/65,557-byte message burst and avoided the clean renderer exit. Larger shared-memory messages can still exhaust descriptors under sufficiently heavy pressure, so this is a targeted mitigation rather than a replacement for the Mojo MSG_CTRUNC fix.

Fixes https://github.com/microsoft/vscode/issues/326092