### PR TITLE
Fix deprecation warnings for internal Copilot settings

### DIFF
--- a/extensions/copilot/src/extension/settingsSchema/common/settingsSchema.ts
+++ b/extensions/copilot/src/extension/settingsSchema/common/settingsSchema.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { BaseConfig } from '../../../platform/configuration/common/configurationService';
+import type { EmptyJsonSchema, JsonSchema, ObjectJsonSchema } from '../../../platform/configuration/common/jsonSchema';
+import { escapeRegExpCharacters } from '../../../util/vs/base/common/strings';
+
+const advancedSettingPrefixPattern = String.raw`github\.copilot(?:\.chat)?\.advanced\.`;
+const advancedSettingPrefixRegex = new RegExp(`^${advancedSettingPrefixPattern}`);
+
+type SettingsSchemaConfig = Pick<BaseConfig<unknown>, 'fullyQualifiedId' | 'validator'>;
+
+export function buildSettingsSchema(isInternal: false, configs: Iterable<SettingsSchemaConfig>): EmptyJsonSchema;
+export function buildSettingsSchema(isInternal: true, configs: Iterable<SettingsSchemaConfig>): ObjectJsonSchema;
+export function buildSettingsSchema(isInternal: boolean, configs: Iterable<SettingsSchemaConfig>): JsonSchema;
+export function buildSettingsSchema(isInternal: boolean, configs: Iterable<SettingsSchemaConfig>): JsonSchema {
+	if (!isInternal) {
+		return {};
+	}
+
+	const properties: Record<string, JsonSchema> = {};
+	const registeredAdvancedSettingIds = new Set<string>();
+
+	for (const config of configs) {
+		properties[config.fullyQualifiedId] = {
+			description: 'Recognized Advanced Setting.\nIgnore the warning "Unknown Configuration Setting", which cannot be suppressed.',
+			...(config.validator?.toSchema() ?? {}),
+		};
+
+		if (advancedSettingPrefixRegex.test(config.fullyQualifiedId)) {
+			registeredAdvancedSettingIds.add(config.fullyQualifiedId);
+		}
+	}
+
+	const escapedRegisteredSettingIds = [...registeredAdvancedSettingIds]
+		.sort()
+		.map(escapeRegExpCharacters);
+	const registeredSettingExclusion = escapedRegisteredSettingIds.length > 0
+		? `(?!(?:${escapedRegisteredSettingIds.join('|')})$)`
+		: '';
+	const unknownAdvancedSettingPattern = `^${registeredSettingExclusion}${advancedSettingPrefixPattern}.*$`;
+
+	return {
+		type: 'object',
+		properties,
+		patternProperties: {
+			[unknownAdvancedSettingPattern]: {
+				deprecated: true,
+				description: 'Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.',
+			}
+		}
+	};
+}

--- a/extensions/copilot/src/extension/settingsSchema/test/common/settingsSchema.spec.ts
+++ b/extensions/copilot/src/extension/settingsSchema/test/common/settingsSchema.spec.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, test } from 'vitest';
+import { ConfigKey, globalConfigRegistry } from '../../../../platform/configuration/common/configurationService';
+import type { JsonSchema, ObjectJsonSchema } from '../../../../platform/configuration/common/jsonSchema';
+import { buildSettingsSchema } from '../../common/settingsSchema';
+
+function getUnknownAdvancedSettingSchema(schema: ObjectJsonSchema): [string, JsonSchema] {
+	const entries = Object.entries(schema.patternProperties ?? {});
+	if (entries.length !== 1) {
+		throw new Error(`Expected one unknown advanced setting schema, got ${entries.length}`);
+	}
+	return entries[0];
+}
+
+describe('SettingsSchema', () => {
+	test('returns an empty schema for external users', () => {
+		expect(buildSettingsSchema(false, globalConfigRegistry.configs.values())).toEqual({});
+	});
+
+	test('does not deprecate registered advanced settings', () => {
+		const schema: ObjectJsonSchema = JSON.parse(JSON.stringify(buildSettingsSchema(true, globalConfigRegistry.configs.values())));
+		const [patternSource, fallbackSchema] = getUnknownAdvancedSettingSchema(schema);
+		const unknownAdvancedSettingRegex = new RegExp(patternSource);
+		const issueSettingId = ConfigKey.TeamInternal.InlineEditsXtabSplitPatchOnDiff.fullyQualifiedId;
+
+		expect({
+			registeredSettingsMatchingFallback: Object.keys(schema.properties ?? {}).filter(id => unknownAdvancedSettingRegex.test(id)),
+			issueSettingSchema: schema.properties?.[issueSettingId],
+			fallbackSchema,
+		}).toEqual({
+			registeredSettingsMatchingFallback: [],
+			issueSettingSchema: {
+				description: 'Recognized Advanced Setting.\nIgnore the warning "Unknown Configuration Setting", which cannot be suppressed.',
+				type: 'boolean',
+			},
+			fallbackSchema: {
+				deprecated: true,
+				description: 'Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.',
+			},
+		});
+	});
+
+	test('only deprecates unknown advanced settings', () => {
+		const registeredChatSetting = 'github.copilot.chat.advanced.feature[preview].enabled';
+		const registeredSharedSetting = 'github.copilot.advanced.sharedFeature';
+		const originalSchema = buildSettingsSchema(true, [
+			{ fullyQualifiedId: registeredChatSetting },
+			{ fullyQualifiedId: registeredSharedSetting },
+		]);
+		const [originalPatternSource] = getUnknownAdvancedSettingSchema(originalSchema);
+		const schema: ObjectJsonSchema = JSON.parse(JSON.stringify(originalSchema));
+		const [patternSource] = getUnknownAdvancedSettingSchema(schema);
+		const unknownAdvancedSettingRegex = new RegExp(patternSource);
+		const [emptyRegistryPatternSource] = getUnknownAdvancedSettingSchema(buildSettingsSchema(true, []));
+
+		expect({
+			serializedPatternPreserved: patternSource === originalPatternSource,
+			registeredChatSetting: unknownAdvancedSettingRegex.test(registeredChatSetting),
+			registeredSharedSetting: unknownAdvancedSettingRegex.test(registeredSharedSetting),
+			knownSettingWithSuffix: unknownAdvancedSettingRegex.test(`${registeredChatSetting}.extra`),
+			unknownChatSetting: unknownAdvancedSettingRegex.test('github.copilot.chat.advanced.unknown'),
+			unknownSharedSetting: unknownAdvancedSettingRegex.test('github.copilot.advanced.unknown'),
+			emptyRegistryUnknownSetting: new RegExp(emptyRegistryPatternSource).test('github.copilot.chat.advanced.unknown'),
+			emptyAdvancedSuffix: unknownAdvancedSettingRegex.test('github.copilot.chat.advanced.'),
+			unrelatedSetting: unknownAdvancedSettingRegex.test('editor.fontSize'),
+			wrongSeparators: unknownAdvancedSettingRegex.test('githubXcopilotXchatXadvancedXunknown'),
+			leadingJunk: unknownAdvancedSettingRegex.test(`prefix.${registeredChatSetting}`),
+		}).toEqual({
+			serializedPatternPreserved: true,
+			registeredChatSetting: false,
+			registeredSharedSetting: false,
+			knownSettingWithSuffix: true,
+			unknownChatSetting: true,
+			unknownSharedSetting: true,
+			emptyRegistryUnknownSetting: true,
+			emptyAdvancedSuffix: true,
+			unrelatedSetting: false,
+			wrongSeparators: false,
+			leadingJunk: false,
+		});
+	});
+});

--- a/extensions/copilot/src/extension/settingsSchema/vscode-node/settingsSchemaFeature.ts
+++ b/extensions/copilot/src/extension/settingsSchema/vscode-node/settingsSchemaFeature.ts
@@ -6,10 +6,10 @@
 import { Uri } from 'vscode';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { globalConfigRegistry } from '../../../platform/configuration/common/configurationService';
-import { JsonSchema } from '../../../platform/configuration/common/jsonSchema';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
-import { autorunWithStore, IReader, observableFromEvent } from '../../../util/vs/base/common/observable';
+import { autorunWithStore, observableFromEvent } from '../../../util/vs/base/common/observable';
 import { VirtualTextDocumentProvider } from '../../inlineEdits/vscode-node/utils/virtualTextDocumentProvider';
+import { buildSettingsSchema } from '../common/settingsSchema';
 
 export class SettingsSchemaFeature extends Disposable {
 	private readonly _copilotToken = observableFromEvent(this, this._authenticationService.onDidCopilotTokenChange, () => this._authenticationService.copilotToken);
@@ -23,33 +23,8 @@ export class SettingsSchemaFeature extends Disposable {
 		this._register(autorunWithStore((reader, store) => {
 			const p = store.add(new VirtualTextDocumentProvider('ccsettings'));
 			const doc = p.createDocumentForUri(Uri.parse('ccsettings://root/schema.json'));
-			const schema = this._getSchema(reader);
+			const schema = buildSettingsSchema(this._isInternal.read(reader), globalConfigRegistry.configs.values());
 			doc.setContent(JSON.stringify(schema));
 		}));
-	}
-
-	private _getSchema(reader: IReader): JsonSchema {
-		const props: Record<string, JsonSchema> = {};
-
-		if (!this._isInternal.read(reader)) {
-			return {};
-		} else {
-			// JSON Schema only for internal users!
-			for (const c of globalConfigRegistry.configs.values()) {
-				props[c.fullyQualifiedId] = { description: 'Recognized Advanced Setting.\nIgnore the warning "Unknown Configuration Setting", which cannot be surpressed.', ... (c.validator ? c.validator.toSchema() : {}) };
-			}
-
-			const schema: JsonSchema = {
-				type: 'object',
-				properties: props,
-				patternProperties: {
-					'github\.copilot(\.chat)?\.advanced\..*': {
-						deprecated: true,
-						description: 'Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.',
-					}
-				}
-			};
-			return schema;
-		}
 	}
 }

--- a/extensions/copilot/src/platform/configuration/common/jsonSchema.ts
+++ b/extensions/copilot/src/platform/configuration/common/jsonSchema.ts
@@ -22,6 +22,7 @@ export interface BaseJsonSchema {
 	$schema?: string;
 	title?: string;
 	description?: string;
+	deprecated?: boolean;
 
 	definitions?: {
 		[name: string]: JsonSchema;


### PR DESCRIPTION
Exclude registered advanced Copilot settings from the deprecated fallback schema while continuing to flag unknown advanced settings. Add focused schema regression coverage for internal and external users.

Fixes #326296

## Testing
- npm run precommit
- Focused settings schema unit tests
- Copilot TypeScript type-check
- Targeted ESLint
- JSON language-service diagnostic probe

cc @aeschli 