### PR TITLE
voice: timeout if narration audio never starts

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -3082,8 +3082,28 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		}
 		this._pendingSolicitedNarrations.delete(narrationId);
 		this._solicitedNarrationIds.delete(narrationId);
+		// Only restore state when this was the last thing we were waiting on. If a
+		// direct chat reply is still expected (`_awaitingReplyAudio`) or another
+		// solicited narration is still waiting for its audio to start, restoring
+		// idle / re-entering the hands-free mic here could suppress that other
+		// response's audio. Leave restoration to whichever watchdog fires last.
+		if (this._awaitingReplyAudio || this._hasNarrationAwaitingAudio()) {
+			this.logService.trace(`[voice] solicited narration ${narrationId.slice(0, 8)} timed out waiting for audio start; another response still expected, deferring state restore`);
+			return;
+		}
 		this.logService.trace(`[voice] solicited narration ${narrationId.slice(0, 8)} timed out waiting for audio start; restoring idle state`);
 		this._restoreVoiceStateAfterNarrationTimeout();
+	}
+
+	/** True while any tracked solicited narration is still waiting for its audio
+	 *  to start (i.e. a no-audio watchdog is still outstanding). */
+	private _hasNarrationAwaitingAudio(): boolean {
+		for (const pending of this._pendingSolicitedNarrations.values()) {
+			if (!pending.hasReceivedAudio) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private _clearPendingSolicitedNarration(narrationId: string, pending: IPendingSolicitedNarration): void {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -75,6 +75,15 @@ interface IDeferredResponse {
 	readonly chunks: IDeferredChunk[];
 }
 
+interface IPendingSolicitedNarration {
+	readonly sessionId: string;
+	readonly kind: 'response' | 'confirmation';
+	readonly text: string;
+	readonly audioStartTimer: ReturnType<typeof setTimeout>;
+	audioFinalizeTimer: ReturnType<typeof setTimeout> | undefined;
+	hasReceivedAudio: boolean;
+}
+
 export interface IPendingToolConfirmation {
 	readonly type: 'approval' | 'input';
 	readonly sessionLabel: string;
@@ -508,7 +517,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * A safety timer releases the in-flight guard if no audio ever comes, so a
 	 * later focus/state event can retry rather than the reply being lost.
 	 */
-	private readonly _pendingSolicitedNarrations = new Map<string, { sessionId: string; kind: 'response' | 'confirmation'; text: string; timer: ReturnType<typeof setTimeout> }>();
+	private readonly _pendingSolicitedNarrations = new Map<string, IPendingSolicitedNarration>();
+	private static readonly _SOLICITED_NARRATION_AUDIO_START_TIMEOUT_MS = 30_000;
 	private static readonly _SOLICITED_NARRATION_TIMEOUT_MS = 30_000;
 
 	/**
@@ -943,8 +953,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				// its timeout) so clicking the session again re-requests immediately.
 				const pending = this._pendingSolicitedNarrations.get(finishedResponseId);
 				if (pending) {
-					clearTimeout(pending.timer);
-					this._pendingSolicitedNarrations.delete(finishedResponseId);
+					this._clearPendingSolicitedNarration(finishedResponseId, pending);
 				}
 			}
 
@@ -1490,6 +1499,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// (otherwise it is stranded and never read). Untagged / non-agent-host
 			// ids pass through unchanged.
 			const codingSessionId = this._canonicalSessionId(e.codingSessionId);
+			if (e.audio) {
+				this._markSolicitedNarrationAudioStarted(e.responseId);
+			}
 			// If this response is for a session the user isn't currently looking
 			// at, don't play it now: buffer it until that session is focused and
 			// notify with a short audio cue instead. When the backend echoes a
@@ -1774,7 +1786,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._lastResponseSummaryById.clear();
 		this._lastNarratedText.clear();
 		this._pendingNarrationRetries.clear();
-		for (const s of this._pendingSolicitedNarrations.values()) { clearTimeout(s.timer); }
+		for (const [narrationId, pending] of this._pendingSolicitedNarrations) {
+			this._clearPendingSolicitedNarration(narrationId, pending);
+		}
 		this._pendingSolicitedNarrations.clear();
 		this._deferredNarrations.clear();
 		this._narratedConfirmation.clear();
@@ -1853,7 +1867,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// timers here (as disconnect() does). Otherwise a narration_unblocked on a
 		// new connection could retry narration from this evicted session, and the
 		// solicited-narration safety timers would linger past teardown.
-		for (const s of this._pendingSolicitedNarrations.values()) { clearTimeout(s.timer); }
+		for (const [narrationId, pending] of this._pendingSolicitedNarrations) {
+			this._clearPendingSolicitedNarration(narrationId, pending);
+		}
 		this._pendingSolicitedNarrations.clear();
 		this._solicitedNarrationIds.clear();
 		this._pendingNarrationRetries.clear();
@@ -3021,18 +3037,73 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		}
 		this._solicitedNarrationIds.add(narrationId);
 		// Do NOT mark the reply narrated / clear its pending indicator yet - a
-		// request being accepted is not the reply being heard. Track it until its
-		// audio finalizes (_markNarrationHeard). A safety timer releases the guard
-		// if no audio ever arrives so a later focus/state event can retry.
-		const timer = setTimeout(() => {
-			// No audio finalized in time: release the in-flight guard but leave
-			// _lastNarratedText/pending untouched so the reply can be retried and
-			// isn't silently lost.
-			this._pendingSolicitedNarrations.delete(narrationId);
-			this.logService.trace(`[voice] solicited narration ${narrationId.slice(0, 8)} timed out with no final audio; releasing guard for retry`);
-		}, VoiceSessionController._SOLICITED_NARRATION_TIMEOUT_MS);
-		this._pendingSolicitedNarrations.set(narrationId, { sessionId, kind, text, timer });
+		// request being accepted is not the reply being heard. First wait for the
+		// backend to send any audio at all; once it does, arm a second timeout for
+		// the stream to finish. This prevents voice mode from getting stuck if the
+		// backend never starts returning audio for a completed response.
+		const audioStartTimer = setTimeout(() => {
+			this._handleSolicitedNarrationAudioStartTimeout(narrationId);
+		}, VoiceSessionController._SOLICITED_NARRATION_AUDIO_START_TIMEOUT_MS);
+		this._pendingSolicitedNarrations.set(narrationId, {
+			sessionId,
+			kind,
+			text,
+			audioStartTimer,
+			audioFinalizeTimer: undefined,
+			hasReceivedAudio: false,
+		});
 		return true;
+	}
+
+	private _markSolicitedNarrationAudioStarted(narrationId: string | undefined): void {
+		if (!narrationId) {
+			return;
+		}
+		const pending = this._pendingSolicitedNarrations.get(narrationId);
+		if (!pending || pending.hasReceivedAudio) {
+			return;
+		}
+		pending.hasReceivedAudio = true;
+		clearTimeout(pending.audioStartTimer);
+		pending.audioFinalizeTimer = setTimeout(() => {
+			if (this._pendingSolicitedNarrations.get(narrationId) !== pending) {
+				return;
+			}
+			this._pendingSolicitedNarrations.delete(narrationId);
+			this._solicitedNarrationIds.delete(narrationId);
+			this.logService.trace(`[voice] solicited narration ${narrationId.slice(0, 8)} timed out before final audio; releasing guard for retry`);
+		}, VoiceSessionController._SOLICITED_NARRATION_TIMEOUT_MS);
+	}
+
+	private _handleSolicitedNarrationAudioStartTimeout(narrationId: string): void {
+		const pending = this._pendingSolicitedNarrations.get(narrationId);
+		if (!pending || pending.hasReceivedAudio) {
+			return;
+		}
+		this._pendingSolicitedNarrations.delete(narrationId);
+		this._solicitedNarrationIds.delete(narrationId);
+		this.logService.trace(`[voice] solicited narration ${narrationId.slice(0, 8)} timed out waiting for audio start; restoring idle state`);
+		this._restoreVoiceStateAfterNarrationTimeout();
+	}
+
+	private _clearPendingSolicitedNarration(narrationId: string, pending: IPendingSolicitedNarration): void {
+		clearTimeout(pending.audioStartTimer);
+		if (pending.audioFinalizeTimer) {
+			clearTimeout(pending.audioFinalizeTimer);
+		}
+		this._pendingSolicitedNarrations.delete(narrationId);
+	}
+
+	private _restoreVoiceStateAfterNarrationTimeout(): void {
+		if (this.ttsPlaybackService.isPlaying || this._audioQueue.length > 0 || this._currentPlaybackSessionId !== null || this._pttHeld) {
+			return;
+		}
+		if (this._isHandsFreeEnabled() && this._window && this._isConnected.get()) {
+			this._enterAutoListen();
+			return;
+		}
+		this._voiceState.set('idle', undefined);
+		this._statusText.set('Hold to speak...', undefined);
 	}
 
 	/** Mark a solicited narration's reply as actually heard once its final audio
@@ -3044,8 +3115,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (!solicited) {
 			return;
 		}
-		clearTimeout(solicited.timer);
-		this._pendingSolicitedNarrations.delete(narrationId);
+		this._clearPendingSolicitedNarration(narrationId, solicited);
 		// Only responses populate the persistent text dedup (and own the pending
 		// indicator). A confirmation is transient actionable state that must be
 		// re-narratable, so heard confirmations leave _lastNarratedText untouched.
@@ -3081,8 +3151,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		const key = this._sessionKey(e.codingSessionId);
 		const solicited = this._pendingSolicitedNarrations.get(e.narrationId);
 		if (solicited) {
-			clearTimeout(solicited.timer);
-			this._pendingSolicitedNarrations.delete(e.narrationId);
+			this._clearPendingSolicitedNarration(e.narrationId, solicited);
 		}
 		this._solicitedNarrationIds.delete(e.narrationId);
 		if (e.disposition === 'invalid') {
@@ -3109,8 +3178,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		const key = this._sessionKey(e.codingSessionId);
 		const solicited = this._pendingSolicitedNarrations.get(e.narrationId);
 		if (solicited) {
-			clearTimeout(solicited.timer);
-			this._pendingSolicitedNarrations.delete(e.narrationId);
+			this._clearPendingSolicitedNarration(e.narrationId, solicited);
 		}
 		this._solicitedNarrationIds.delete(e.narrationId);
 		if (solicited) {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -80,7 +80,6 @@ interface IPendingSolicitedNarration {
 	readonly kind: 'response' | 'confirmation';
 	readonly text: string;
 	readonly audioStartTimer: ReturnType<typeof setTimeout>;
-	audioFinalizeTimer: ReturnType<typeof setTimeout> | undefined;
 	hasReceivedAudio: boolean;
 }
 
@@ -519,7 +518,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 */
 	private readonly _pendingSolicitedNarrations = new Map<string, IPendingSolicitedNarration>();
 	private static readonly _SOLICITED_NARRATION_AUDIO_START_TIMEOUT_MS = 30_000;
-	private static readonly _SOLICITED_NARRATION_TIMEOUT_MS = 30_000;
 
 	/**
 	 * Narrations the backend bounced (`narration_ack` `busy`) or cancelled
@@ -3037,10 +3035,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		}
 		this._solicitedNarrationIds.add(narrationId);
 		// Do NOT mark the reply narrated / clear its pending indicator yet - a
-		// request being accepted is not the reply being heard. First wait for the
-		// backend to send any audio at all; once it does, arm a second timeout for
-		// the stream to finish. This prevents voice mode from getting stuck if the
-		// backend never starts returning audio for a completed response.
+		// request being accepted is not the reply being heard. Wait for the
+		// backend to start returning audio: if it never does, the watchdog below
+		// releases the guard and restores state so voice mode can't get stuck on
+		// a completed response that never produced audio. Once audio starts, the
+		// stream is left to finalize normally (_markNarrationHeard) with no
+		// timeout on the remainder.
 		const audioStartTimer = setTimeout(() => {
 			this._handleSolicitedNarrationAudioStartTimeout(narrationId);
 		}, VoiceSessionController._SOLICITED_NARRATION_AUDIO_START_TIMEOUT_MS);
@@ -3049,7 +3049,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			kind,
 			text,
 			audioStartTimer,
-			audioFinalizeTimer: undefined,
 			hasReceivedAudio: false,
 		});
 		return true;
@@ -3063,16 +3062,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (!pending || pending.hasReceivedAudio) {
 			return;
 		}
+		// Audio has started arriving, so the "no audio at all" watchdog is done.
+		// The rest of the stream is left to finalize normally (_markNarrationHeard);
+		// we don't time out a stream that is actively coming in.
 		pending.hasReceivedAudio = true;
 		clearTimeout(pending.audioStartTimer);
-		pending.audioFinalizeTimer = setTimeout(() => {
-			if (this._pendingSolicitedNarrations.get(narrationId) !== pending) {
-				return;
-			}
-			this._pendingSolicitedNarrations.delete(narrationId);
-			this._solicitedNarrationIds.delete(narrationId);
-			this.logService.trace(`[voice] solicited narration ${narrationId.slice(0, 8)} timed out before final audio; releasing guard for retry`);
-		}, VoiceSessionController._SOLICITED_NARRATION_TIMEOUT_MS);
 	}
 
 	private _handleSolicitedNarrationAudioStartTimeout(narrationId: string): void {
@@ -3108,9 +3102,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 	private _clearPendingSolicitedNarration(narrationId: string, pending: IPendingSolicitedNarration): void {
 		clearTimeout(pending.audioStartTimer);
-		if (pending.audioFinalizeTimer) {
-			clearTimeout(pending.audioFinalizeTimer);
-		}
 		this._pendingSolicitedNarrations.delete(narrationId);
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -1,0 +1,176 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import sinon from 'sinon';
+import { Event } from '../../../../../../base/common/event.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import { NullTelemetryService } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
+import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { ITtsPlaybackService } from '../../../browser/voiceClient/ttsPlaybackService.js';
+import { IVoiceToolDispatchService } from '../../../browser/voiceClient/voiceToolDispatchService.js';
+import { IVoiceSessionController, VoiceSessionController } from '../../../browser/voiceClient/voiceSessionController.js';
+import { IMicCaptureService } from '../../../browser/voiceClient/micCaptureService.js';
+import { IVoicePlaybackService } from '../../../common/voicePlaybackService.js';
+import { IVoiceClientService } from '../../../common/voiceClient/voiceClientService.js';
+import { IAgentSessionsService } from '../../../browser/agentSessions/agentSessionsService.js';
+import { IAgentSessionsModel } from '../../../browser/agentSessions/agentSessionsModel.js';
+import { IChatService } from '../../../common/chatService/chatService.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IVoiceTranscriptStore } from '../../../../agentsVoice/common/voiceTranscriptStore.js';
+import { IAccessibilitySignalService } from '../../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
+import { IAccessibilityService } from '../../../../../../platform/accessibility/common/accessibility.js';
+import { IChatWidgetService } from '../../../browser/chat.js';
+
+class TestVoiceClientService extends mock<IVoiceClientService>() {
+	private narrationCounter = 0;
+	readonly requests: { sessionId: string; kind: 'response' | 'confirmation'; text: string; narrationId: string }[] = [];
+
+	override disconnect(): void { }
+
+	override requestNarration(codingSessionId: string, kind: 'response' | 'confirmation', text: string, narrationId?: string): string | undefined {
+		const id = narrationId ?? `narration-${++this.narrationCounter}`;
+		this.requests.push({ sessionId: codingSessionId, kind, text, narrationId: id });
+		return id;
+	}
+}
+
+class TestTtsPlaybackService extends mock<ITtsPlaybackService>() {
+	override readonly isPlaying = false;
+	override readonly onPlaybackStarted = Event.None;
+	override readonly onPlaybackStopped = Event.None;
+	override readonly analyserNode = undefined;
+	override getLastPlayedSamples(): Float32Array | null { return null; }
+	override closeContext(): void { }
+}
+
+class TestAgentSessionsService extends mock<IAgentSessionsService>() {
+	override readonly onDidChangeSessionArchivedState = Event.None;
+	override readonly model: IAgentSessionsModel = {
+		onWillResolve: Event.None,
+		onDidResolve: Event.None,
+		sessions: [],
+		onDidChangeSessions: Event.None,
+		onDidChangeSessionArchivedState: Event.None,
+		resolved: true,
+		getSession: () => undefined,
+		observeSession: () => observableValue('session', undefined),
+		resolve: async () => { },
+	};
+}
+
+class TestChatService extends mock<IChatService>() {
+	override readonly chatModels = observableValue('chatModels', []);
+	override getSession(): undefined { return undefined; }
+}
+
+class TestChatWidgetService extends mock<IChatWidgetService>() {
+	override readonly onDidChangeFocusedSession = Event.None;
+	override readonly onDidAddWidget = Event.None;
+	override getAllWidgets() { return []; }
+}
+
+suite('VoiceSessionController', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	let clock: sinon.SinonFakeTimers;
+
+	setup(() => {
+		clock = sinon.useFakeTimers();
+	});
+
+	teardown(() => {
+		clock.restore();
+		sinon.restore();
+	});
+
+	function createController(voiceClientService: TestVoiceClientService): IVoiceSessionController {
+		return store.add(new VoiceSessionController(
+			voiceClientService,
+			new class extends mock<IMicCaptureService>() {
+				override readonly onPttStart = Event.None;
+				override readonly onPttAudioChunk = Event.None;
+				override readonly onPttEnd = Event.None;
+				override readonly onPttDiagnostic = Event.None;
+				override readonly analyserNode = undefined;
+				override prepare(): void { }
+				override async startCapture(): Promise<void> { }
+				override stopCapture(): void { }
+			}(),
+			new TestTtsPlaybackService(),
+			new class extends mock<IVoiceToolDispatchService>() {
+				override setDelegate(): void { }
+			}(),
+			new class extends mock<IVoicePlaybackService>() { }(),
+			new TestAgentSessionsService(),
+			new TestChatService(),
+			new class extends mock<ICommandService>() {
+				override async executeCommand(): Promise<undefined> { return undefined; }
+			}(),
+			new class extends mock<IAuthenticationService>() {
+				override async getSessions(): Promise<[]> { return []; }
+			}(),
+			new class extends mock<IVoiceTranscriptStore>() {
+				override async loadTurns(): Promise<[]> { return []; }
+			}(),
+			new NullLogService(),
+			new class extends mock<IWorkbenchEnvironmentService>() { }(),
+			NullTelemetryService,
+			new TestConfigurationService({ 'agents.voice.handsFree': false }),
+			new class extends mock<IAccessibilitySignalService>() { }(),
+			new class extends mock<IAccessibilityService>() { }(),
+			new TestChatWidgetService(),
+			new class extends mock<INotificationService>() { }(),
+		));
+	}
+
+	test('restores idle state when solicited narration never starts returning audio', () => {
+		const voiceClientService = new TestVoiceClientService();
+		const controller = createController(voiceClientService);
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		const pendingSolicitedNarrations = Reflect.get(controller, '_pendingSolicitedNarrations') as Map<string, unknown>;
+
+		assert.strictEqual(narrate.call(controller, 'agent-host-copilot:/session-1', 'response', 'Done'), true);
+		assert.deepStrictEqual(voiceClientService.requests, [{
+			sessionId: 'agent-host-copilot:/session-1',
+			kind: 'response',
+			text: 'Done',
+			narrationId: 'narration-1',
+		}]);
+
+		clock.tick(30_000);
+
+		assert.strictEqual(controller.voiceState.get(), 'idle');
+		assert.strictEqual(controller.statusText.get(), 'Hold to speak...');
+		assert.strictEqual(pendingSolicitedNarrations.size, 0);
+	});
+
+	test('switches to the final-audio timeout only after audio actually arrives', () => {
+		const voiceClientService = new TestVoiceClientService();
+		const controller = createController(voiceClientService);
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		const markAudioStarted = Reflect.get(controller, '_markSolicitedNarrationAudioStarted') as (narrationId: string | undefined) => void;
+		const pendingSolicitedNarrations = Reflect.get(controller, '_pendingSolicitedNarrations') as Map<string, unknown>;
+
+		assert.strictEqual(narrate.call(controller, URI.parse('agent-host-copilot:/session-2').toString(), 'response', 'Ready'), true);
+
+		clock.tick(10_000);
+		markAudioStarted.call(controller, 'narration-1');
+		clock.tick(20_000);
+
+		assert.strictEqual(controller.statusText.get(), 'Tap to start');
+		assert.strictEqual(pendingSolicitedNarrations.size, 1);
+
+		clock.tick(30_000);
+
+		assert.strictEqual(pendingSolicitedNarrations.size, 0);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -173,4 +173,53 @@ suite('VoiceSessionController', () => {
 
 		assert.strictEqual(pendingSolicitedNarrations.size, 0);
 	});
+
+	test('does not restore state while another solicited narration is still awaiting audio', () => {
+		const voiceClientService = new TestVoiceClientService();
+		const controller = createController(voiceClientService);
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		const pendingSolicitedNarrations = Reflect.get(controller, '_pendingSolicitedNarrations') as Map<string, unknown>;
+
+		// First narration armed at t=0 (audio-start watchdog fires at t=30s).
+		assert.strictEqual(narrate.call(controller, 'agent-host-copilot:/session-a', 'response', 'First'), true);
+		// Second narration armed at t=15s (its watchdog fires at t=45s).
+		clock.tick(15_000);
+		assert.strictEqual(narrate.call(controller, 'agent-host-copilot:/session-b', 'response', 'Second'), true);
+		assert.strictEqual(pendingSolicitedNarrations.size, 2);
+
+		// First watchdog fires: the second narration is still awaiting audio, so
+		// state must NOT be restored yet — its own watchdog owns that.
+		clock.tick(15_000);
+		assert.strictEqual(pendingSolicitedNarrations.size, 1);
+		assert.strictEqual(controller.statusText.get(), 'Tap to start');
+
+		// Second (last outstanding) watchdog fires: now state is restored.
+		clock.tick(15_000);
+		assert.strictEqual(pendingSolicitedNarrations.size, 0);
+		assert.strictEqual(controller.voiceState.get(), 'idle');
+		assert.strictEqual(controller.statusText.get(), 'Hold to speak...');
+	});
+
+	test('does not restore state while a direct reply is still awaited', () => {
+		const voiceClientService = new TestVoiceClientService();
+		const controller = createController(voiceClientService);
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		const setAwaitingReply = Reflect.get(controller, '_setAwaitingReply') as () => void;
+		const pendingSolicitedNarrations = Reflect.get(controller, '_pendingSolicitedNarrations') as Map<string, unknown>;
+
+		// Narration armed at t=0 (audio-start watchdog fires at t=30s).
+		assert.strictEqual(narrate.call(controller, 'agent-host-copilot:/session-c', 'response', 'Done'), true);
+		// A direct reply becomes awaited at t=1s (its own watchdog fires at t=31s,
+		// after the narration's), so `_awaitingReplyAudio` is still set when the
+		// narration times out.
+		clock.tick(1_000);
+		setAwaitingReply.call(controller);
+
+		clock.tick(29_000);
+
+		// The narration's audio-start watchdog fired, but a direct reply is still
+		// expected, so it must not clobber that reply's state.
+		assert.strictEqual(pendingSolicitedNarrations.size, 0);
+		assert.strictEqual(controller.statusText.get(), 'Tap to start');
+	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -153,7 +153,7 @@ suite('VoiceSessionController', () => {
 		assert.strictEqual(pendingSolicitedNarrations.size, 0);
 	});
 
-	test('switches to the final-audio timeout only after audio actually arrives', () => {
+	test('stops the audio-start watchdog once audio arrives and does not time out the stream', () => {
 		const voiceClientService = new TestVoiceClientService();
 		const controller = createController(voiceClientService);
 		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
@@ -162,16 +162,16 @@ suite('VoiceSessionController', () => {
 
 		assert.strictEqual(narrate.call(controller, URI.parse('agent-host-copilot:/session-2').toString(), 'response', 'Ready'), true);
 
+		// Audio starts before the audio-start watchdog fires, so it is cancelled.
 		clock.tick(10_000);
 		markAudioStarted.call(controller, 'narration-1');
-		clock.tick(20_000);
 
-		assert.strictEqual(controller.statusText.get(), 'Tap to start');
+		// Well past any timeout: the stream is left to finalize normally, so the
+		// narration stays tracked and state is untouched (no finalize timeout).
+		clock.tick(120_000);
+
 		assert.strictEqual(pendingSolicitedNarrations.size, 1);
-
-		clock.tick(30_000);
-
-		assert.strictEqual(pendingSolicitedNarrations.size, 0);
+		assert.strictEqual(controller.statusText.get(), 'Tap to start');
 	});
 
 	test('does not restore state while another solicited narration is still awaiting audio', () => {


### PR DESCRIPTION
## Summary
Adds a **30-second audio-start watchdog** for solicited narration requests so voice mode recovers instead of getting stuck when the backend finishes the main LLM turn but never begins streaming narration audio.

## Behavior
- When a `request_narration` is accepted, arm a 30s watchdog that waits for the backend to start returning audio.
- **No audio within 30s** → drop the narration, release the in-flight guard, and restore voice state (re-enter the hands-free mic if enabled, else go idle / "Hold to speak…") so the user isn't stuck.
- **Audio starts** → cancel the watchdog and let the stream finalize normally via `_markNarrationHeard`. The remainder of an actively-arriving stream is **not** timed out.
- The 30s value matches the sibling `_awaitingReplyAudio` watchdog for consistency. A timeout is non-destructive: `_lastNarratedText` / the pending indicator are left untouched so the narration can be re-requested on the next focus/state event.

## Concurrency guard
Restoring state on timeout only happens when nothing else is still expected: the timed-out narration is always dropped, but the state restore is deferred while `_awaitingReplyAudio` is set or another solicited narration is still waiting for its first audio chunk. Whichever watchdog fires last performs the restore, so a narration timing out can't clobber state (or start the mic) while another response's audio is still inbound.

## Tests
Controller tests (`voiceSessionController.test.ts`) cover:
- state is restored when a solicited narration never returns audio;
- the audio-start watchdog is cancelled once audio arrives and the stream is not timed out afterward;
- restore is deferred while another solicited narration is still awaiting audio (last watchdog restores);
- restore is deferred while a direct chat reply is still awaited (`_awaitingReplyAudio`).

## Validation
- `./node_modules/.bin/tsc --project ./src/tsconfig.json --noEmit --skipLibCheck`
- `npm run precommit` (hygiene)