### PR TITLE
Settings editor - add focus next/previous setting commands

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -59,6 +59,8 @@ const SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH = 'settings.action.focu
 const SETTINGS_EDITOR_COMMAND_SHOW_PREVIOUS_SEARCH = 'settings.action.showPreviousSearch';
 const SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH_ON_ENTER = 'settings.action.focusSettingsFromSearchOnEnter';
 const SETTINGS_EDITOR_COMMAND_FOCUS_SEARCH_FROM_SETTINGS = 'settings.action.focusSearchFromSettings';
+const SETTINGS_EDITOR_COMMAND_FOCUS_NEXT_SETTING = 'settings.action.focusNextSetting';
+const SETTINGS_EDITOR_COMMAND_FOCUS_PREVIOUS_SETTING = 'settings.action.focusPreviousSetting';
 const SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_LIST = 'settings.action.focusSettingsList';
 const SETTINGS_EDITOR_COMMAND_FOCUS_TOC = 'settings.action.focusTOC';
 const SETTINGS_EDITOR_COMMAND_FOCUS_CONTROL = 'settings.action.focusSettingControl';
@@ -739,6 +741,50 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			run(accessor: ServicesAccessor): void {
 				const preferencesEditor = getPreferencesEditor(accessor);
 				preferencesEditor?.focusSearch();
+			}
+		}));
+
+		this._register(registerAction2(class extends Action2 {
+			constructor() {
+				super({
+					id: SETTINGS_EDITOR_COMMAND_FOCUS_NEXT_SETTING,
+					precondition: CONTEXT_SETTINGS_EDITOR,
+					keybinding: {
+						primary: KeyCode.F7,
+						weight: KeybindingWeight.WorkbenchContrib,
+						when: null
+					},
+					f1: true,
+					category,
+					title: nls.localize2('settings.focusNextSetting', "Focus Next Setting")
+				});
+			}
+
+			run(accessor: ServicesAccessor): void {
+				const preferencesEditor = getPreferencesEditor(accessor);
+				preferencesEditor?.focusNextSetting();
+			}
+		}));
+
+		this._register(registerAction2(class extends Action2 {
+			constructor() {
+				super({
+					id: SETTINGS_EDITOR_COMMAND_FOCUS_PREVIOUS_SETTING,
+					precondition: CONTEXT_SETTINGS_EDITOR,
+					keybinding: {
+						primary: KeyMod.Shift | KeyCode.F7,
+						weight: KeybindingWeight.WorkbenchContrib,
+						when: null
+					},
+					f1: true,
+					category,
+					title: nls.localize2('settings.focusPreviousSetting', "Focus Previous Setting")
+				});
+			}
+
+			run(accessor: ServicesAccessor): void {
+				const preferencesEditor = getPreferencesEditor(accessor);
+				preferencesEditor?.focusPreviousSetting();
 			}
 		}));
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -679,6 +679,48 @@ export class SettingsEditor2 extends EditorPane {
 	}
 
 	/**
+	 * Moves focus to the next setting's control, skipping group headers. Works no matter
+	 * whether focus is currently in the search input, on a tree row, or inside a setting's
+	 * control. Stops at the last setting.
+	 */
+	focusNextSetting(): void {
+		this.focusAdjacentSetting(true);
+	}
+
+	/**
+	 * Like {@link focusNextSetting}, but backwards. Stops at the first setting.
+	 */
+	focusPreviousSetting(): void {
+		this.focusAdjacentSetting(false);
+	}
+
+	private focusAdjacentSetting(next: boolean): void {
+		// The tree's focus tracks the setting whose control contains DOM focus, so this
+		// anchor is correct even while focus is inside a control. It is empty when no
+		// setting has been focused yet, in which case navigation starts from the top,
+		// or from the bottom when navigating backwards.
+		const anchor = this.settingsTree.getFocus()[0];
+		const navigator = this.settingsTree.navigate(anchor);
+		let target = !anchor && !next ? navigator.last() : next ? navigator.next() : navigator.previous();
+		while (target && !(target instanceof SettingsTreeSettingElement)) {
+			target = next ? navigator.next() : navigator.previous();
+		}
+		if (!(target instanceof SettingsTreeSettingElement)) {
+			return;
+		}
+
+		// Reveal renders the row synchronously so its control can be queried below.
+		this.settingsTree.reveal(target);
+		this.settingsTree.setFocus([target]);
+		const domElements = this.settingRenderers.getDOMElementsForSettingKey(this.settingsTree.getHTMLElement(), target.setting.key);
+		// eslint-disable-next-line no-restricted-syntax
+		const control = domElements[0]?.querySelector(AbstractSettingRenderer.CONTROL_SELECTOR);
+		if (control) {
+			(<HTMLElement>control).focus();
+		}
+	}
+
+	/**
 	 * Invoked when the user presses the down arrow while the search input is focused.
 	 * Navigates forward through the search history first; only once there are no more
 	 * recent history entries does focus move down into the settings results.

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -715,8 +715,10 @@ export class SettingsEditor2 extends EditorPane {
 		// Reveal renders the row synchronously so its control can be focused below.
 		this.settingsTree.reveal(target);
 		this.settingsTree.setFocus([target]);
+		// The row selector avoids matching the previously focused setting, whose container
+		// keeps a stale focused class until DOM focus moves away from its control.
 		// eslint-disable-next-line no-restricted-syntax
-		const control = this.settingsTree.getHTMLElement().querySelector(`[${AbstractSettingRenderer.SETTING_ID_ATTR}="${target.id}"] ${AbstractSettingRenderer.CONTROL_SELECTOR}`);
+		const control = this.settingsTree.getHTMLElement().querySelector(`.monaco-list-row.focused ${AbstractSettingRenderer.CONTROL_SELECTOR}`);
 		if (control) {
 			(<HTMLElement>control).focus();
 		}

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -747,7 +747,7 @@ export class SettingsEditor2 extends EditorPane {
 	 * focus is not moved into stale results.
 	 */
 	private isSearchUpToDate(): boolean {
-		return !this.searchInputDelayer.isTriggered && this.renderedSearchQuery === this.searchWidget.getValue().trim();
+		return !this.searchInputDelayer.isTriggered() && this.renderedSearchQuery === this.searchWidget.getValue().trim();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -695,10 +695,11 @@ export class SettingsEditor2 extends EditorPane {
 	}
 
 	private focusAdjacentSetting(next: boolean): void {
-		// The tree's focus tracks the setting whose control contains DOM focus, so this
-		// anchor is correct even while focus is inside a control. It is empty when no
-		// setting has been focused yet, in which case navigation starts from the top,
-		// or from the bottom when navigating backwards.
+		if (!this.isSearchUpToDate()) {
+			return;
+		}
+
+		// The tree's focus tracks the setting whose control contains DOM focus, so the anchor is valid even while a control is focused.
 		const anchor = this.settingsTree.getFocus()[0];
 		const navigator = this.settingsTree.navigate(anchor);
 		let target = !anchor && !next ? navigator.last() : next ? navigator.next() : navigator.previous();
@@ -709,12 +710,11 @@ export class SettingsEditor2 extends EditorPane {
 			return;
 		}
 
-		// Reveal renders the row synchronously so its control can be queried below.
+		// Reveal renders the row synchronously so its control can be focused below.
 		this.settingsTree.reveal(target);
 		this.settingsTree.setFocus([target]);
-		const domElements = this.settingRenderers.getDOMElementsForSettingKey(this.settingsTree.getHTMLElement(), target.setting.key);
 		// eslint-disable-next-line no-restricted-syntax
-		const control = domElements[0]?.querySelector(AbstractSettingRenderer.CONTROL_SELECTOR);
+		const control = this.settingsTree.getHTMLElement().querySelector(`.focused ${AbstractSettingRenderer.CONTROL_SELECTOR}`);
 		if (control) {
 			(<HTMLElement>control).focus();
 		}

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -700,7 +700,9 @@ export class SettingsEditor2 extends EditorPane {
 		}
 
 		// The tree's focus tracks the setting whose control contains DOM focus, so the anchor is valid even while a control is focused.
-		const anchor = this.settingsTree.getFocus()[0];
+		const anchor = this._currentFocusContext === SettingsFocusContext.SettingTree || this._currentFocusContext === SettingsFocusContext.SettingControl
+			? this.settingsTree.getFocus()[0]
+			: undefined;
 		const navigator = this.settingsTree.navigate(anchor);
 		let target = !anchor && !next ? navigator.last() : next ? navigator.next() : navigator.previous();
 		while (target && !(target instanceof SettingsTreeSettingElement)) {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -714,7 +714,7 @@ export class SettingsEditor2 extends EditorPane {
 		this.settingsTree.reveal(target);
 		this.settingsTree.setFocus([target]);
 		// eslint-disable-next-line no-restricted-syntax
-		const control = this.settingsTree.getHTMLElement().querySelector(`.focused ${AbstractSettingRenderer.CONTROL_SELECTOR}`);
+		const control = this.settingsTree.getHTMLElement().querySelector(`[${AbstractSettingRenderer.SETTING_ID_ATTR}="${target.id}"] ${AbstractSettingRenderer.CONTROL_SELECTOR}`);
 		if (control) {
 			(<HTMLElement>control).focus();
 		}


### PR DESCRIPTION
This implements the two commands @roblourens specced in https://github.com/microsoft/vscode/issues/52815#issuecomment-427514043: `settings.action.focusNextSetting` and `settings.action.focusPreviousSetting`. They move focus directly to the next/previous setting's value control (input, checkbox, dropdown), skipping group headers, and they work no matter whether focus is currently in the search input, on a tree row, or inside a setting's control — so pressing the shortcut exactly N times from the top reaches the Nth setting's control, which was the acceptance test in that comment. With nothing focused yet, the backwards command starts from the last setting; at the first/last setting the commands are a no-op (no wrap), matching the tree's own navigation.

Implementation notes. Navigation walks the tree model (`settingsTree.navigate`) instead of the DOM the 2018 comment described, because the tree is virtualized and off-screen settings have no DOM; the target is revealed first and then its control is focused via the same `data-key` + `CONTROL_SELECTOR` pattern `onDidClickSetting` uses. Focusing the control directly announces the control's own label, the same as the existing Enter → `focusSettingControl` path. The commands are in the palette (`f1`) like `focusLevelUp` and the accessible diff viewer commands, since they're meant to be discoverable and rebindable.

On the keybinding: the spec suggested cmd+down/up, but that can't work — the settings dropdowns swallow every up/down keydown regardless of modifiers before the keybinding service sees them (`SelectBoxList` on desktop, `selectBoxCustom.ts` keydown handler stops arrow/Space/Enter with `EventHelper.stop`; `SelectBoxNative` on iOS web does the same), so stepping would break at every enum setting. Cmd+arrows are also already taken inside the settings editor by widget navigation (search ↔ TOC) and list scrolling. F7 / Shift+F7 follows the accessible diff viewer / `wordHighlight.next` "go to next item" precedent and passes through the search box, text inputs, checkboxes, and dropdowns (verified on macOS). Can change the default or ship the commands unbound if you'd rather.

Verified in a dev build on macOS: from a fresh editor the first press lands on the first setting (skipping the Commonly Used header), six presses reach the sixth setting stepping through two dropdowns with the list auto-scrolling, Shift+F7 steps back, Shift+F7 with nothing focused lands on the last setting, and the commands stop at the ends. Consistent with the sibling settings focus commands (#106897, #321571), no automated test is added — the navigation runs entirely through the existing tree model.

Fixes #52815
