### PR TITLE
Voice: narrate confirmations/responses stranded on the user_speaking latch

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -669,6 +669,10 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 		}
 	}
 
+	get canRequestNarration(): boolean {
+		return this._ws?.readyState === WebSocket.OPEN && this._sessionStartedOnSocket;
+	}
+
 	requestNarration(codingSessionId: string, kind: 'response' | 'confirmation', text: string, narrationId?: string): string | undefined {
 		// Gate on session_context having been sent: the WS preserves send order,
 		// so the backend processes start_session/resume_session before any

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -213,6 +213,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _pttHeld = false;
 	private _pttToggleMode = false;
 	/**
+	 * True from the backend's `speech_started` until the utterance is finalized
+	 * (final transcription / turn ended). Marks a genuinely in-progress user turn
+	 * even before any transcription text has arrived.
+	 */
+	private _userSpeechActive = false;
+	/**
 	 * True while a passive hands-free barge-in listen is streaming during the
 	 * assistant's playback (opened by `_startBargeInListen`). It is NOT toggle
 	 * mode — an explicit `pttDown()` promotes this stream into a user-driven
@@ -1424,6 +1430,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// (same flow as pttDown, but for server-VAD path).
 		this._voiceEventDisposables.add(this.voiceClientService.onSpeechStarted(() => {
 			this._clearAutoListenTimer();
+			this._userSpeechActive = true;
 			this.ttsPlaybackService.stopPlayback();
 			this._audioQueue.length = 0;
 			this._currentPlaybackSessionId = null;
@@ -1440,6 +1447,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._voiceEventDisposables.add(this.voiceClientService.onTurnAutoEnded(e => {
 			if (!this._pttHeld) { return; }
 			if (e.turnId && e.turnId !== this._pttCurrentTurnId) { return; }
+			this._userSpeechActive = false;
 			this._pttToggleMode = false;
 			this._finishPtt('auto');
 		}));
@@ -1461,6 +1469,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 			this._updateUserTurn(text, e.committed ?? '', e.status === 'partial');
 			if (e.status !== 'partial') {
+				this._userSpeechActive = false;
 				if (!this._pttHeld) {
 					this._voiceState.set('processing', undefined);
 					this._statusText.set('Processing...', undefined);
@@ -1727,6 +1736,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this.micCaptureService.stopCapture();
 		this.voiceClientService.disconnect();
 		this._pttHeld = false;
+		this._userSpeechActive = false;
 		this._pttToggleMode = false;
 		this._bargeInListenActive = false;
 		this._isConnected.set(false, undefined);
@@ -1847,6 +1857,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this.ttsPlaybackService.closeContext();
 		this.micCaptureService.stopCapture();
 		this._pttHeld = false;
+		this._userSpeechActive = false;
 		this._pttToggleMode = false;
 		// No reconnect is coming and a later connect() does not reset narration
 		// bookkeeping, so clear the deferred/in-flight narration state and its
@@ -2051,19 +2062,21 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/**
 	 * Finish the current push-to-talk press.
 	 *
-	 * ``reason`` is ``'local'`` for a user-driven end (button release / toggle
-	 * tap / keyword) — the mic drains its tail and the ``onPttEnd`` → ``ptt_end``
-	 * path fires. It is ``'auto'`` when the backend ended the turn itself
-	 * (``turn_auto_ended``): the mic is aborted with no drain and NO ``ptt_end``
-	 * is sent for the turn.
+	 * ``'local'`` is a user-driven end (release / tap / keyword): the mic drains
+	 * its tail and the ``onPttEnd`` → ``ptt_end`` path fires. ``'auto'`` is when
+	 * the backend ended the turn itself (``turn_auto_ended``): the mic is aborted
+	 * with no drain and NO ``ptt_end`` is sent. ``'immediate'`` is for a known-
+	 * silent passive turn: abort with no drain and send ``ptt_end`` synchronously
+	 * so the backend clears its ``user_is_speaking`` latch before the next frame.
 	 */
-	private _finishPtt(reason: 'local' | 'auto' = 'local'): void {
+	private _finishPtt(reason: 'local' | 'auto' | 'immediate' = 'local'): void {
 		// End toggle (hands-free) mode on every turn-ending path — even when not held — so an out-of-band finish can't leave a stale toggle that self-kills the next auto-listen.
 		this._pttToggleMode = false;
 		this._bargeInListenActive = false;
 		if (!this._pttHeld) { return; }
 		this._clearAutoListenTimer();
 		this._pttHeld = false;
+		this._userSpeechActive = false;
 		// End toggle (hands-free) mode on every turn-ending path, so an out-of-band finish can't leave a stale toggle that self-kills the next auto-listen.
 		this._pttToggleMode = false;
 		this._telemetryPttUpMs = Date.now();
@@ -2082,6 +2095,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// Backend already ended the turn — stop capturing without draining
 			// more audio and without emitting our own ptt_end.
 			this.micCaptureService.abortPtt();
+		} else if (reason === 'immediate') {
+			// Silent passive turn: stop now (no drain) and send ptt_end synchronously so a following narration request isn't NACK'd `busy: user_speaking`.
+			this.micCaptureService.abortPtt();
+			this.voiceClientService.sendPttEnd();
 		} else {
 			this.micCaptureService.pttUp();
 		}
@@ -2487,8 +2504,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._transcriptTurns.set([...cur.slice(0, -1), updated], undefined);
 	}
 
-/** Whether the transcript currently contains a non-empty partial user turn. */
+	/** Whether the user is mid-utterance: VAD speech is active, or the transcript tail is a non-empty partial user turn. */
 	private _isActivelyDictating(): boolean {
+		if (this._userSpeechActive) {
+			return true;
+		}
 		const turns = this._transcriptTurns.get();
 		const last = turns[turns.length - 1];
 		return !!last && last.speaker === 'user' && last.isPartial && last.text.trim().length > 0;
@@ -2994,20 +3014,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 		}
 		this.logService.trace(`[voice] narrate kind=${kind} id=${sessionId.slice(-32)}`);
-		// A hands-free auto-listen / barge-in turn keeps the backend's
-		// `user_is_speaking` latch set - it latches on `ptt_start` and is only
-		// cleared by a real `ptt_end` (see `_startBargeInListen`, `_finishPtt`).
-		// Requesting a narration while that latch is set gets NACK'd
-		// `busy: user_speaking` and deferred until a `narration_unblocked` that
-		// never arrives for a SILENT passive turn - so the confirmation/response
-		// is stranded and never spoken. When the user is NOT actively dictating,
-		// end the open turn with a genuine `ptt_end` (WS preserves order, so it
-		// reaches the backend before the request) so the latch clears and the
-		// narration is accepted immediately. Guard on `canRequestNarration` so a
-		// closed-socket path still queues a retry below without tearing down a
-		// freshly-entered listen on connect. When the user IS mid-utterance, leave
-		// the turn open and let the busy/defer + `narration_unblocked` path narrate
-		// once they finish, rather than cutting off their speech.
+		// A silent hands-free auto-listen/barge-in turn keeps the backend's `user_is_speaking` latch set, which NACKs the narration request `busy: user_speaking`; end it first (real `ptt_end`) so the request is accepted. Skip while the user is genuinely mid-utterance (defer instead) or when the socket is closed (retry below).
 		const endPassiveTurnFirst = this._pttHeld && !this._isActivelyDictating() && this.voiceClientService.canRequestNarration;
 		if (endPassiveTurnFirst) {
 			this._prepareForPlayback(true);
@@ -3022,9 +3029,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return false;
 		}
 		if (!endPassiveTurnFirst) {
-			// Not already prepared above. The narration audio is now inbound: get
-			// out of listening/auto-listen so the echoed audio isn't suppressed (or
-			// captured as the user's own turn) while PTT/mic capture is active.
+			// Narration audio is inbound: leave listening/auto-listen so the echoed audio isn't suppressed or captured as the user's turn.
 			this._prepareForPlayback();
 		}
 		this._pendingNarrationRetries.delete(sessionId);
@@ -3588,13 +3593,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._clearAutoListenTimer();
 		this._autoListenSuppressed = false;
 		if (this._pttHeld) {
-			// 'auto' aborts the mic locally and sends NO `ptt_end` (used when the
-			// backend already ended the turn, so the audio can just play). When the
-			// caller needs the backend to learn the turn ended - e.g. a client-driven
-			// narration whose request would otherwise be NACK'd `busy: user_speaking`
-			// because the latch is still set - pass `endOpenTurn` to finish with a
-			// genuine `ptt_end` ('local') instead.
-			this._finishPtt(endOpenTurn ? 'local' : 'auto');
+			// `endOpenTurn` sends a real `ptt_end` (backend clears its latch) vs. a local-only abort.
+			this._finishPtt(endOpenTurn ? 'immediate' : 'auto');
 		}
 		this._pttToggleMode = false;
 		this._pttHeld = false;

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2487,14 +2487,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._transcriptTurns.set([...cur.slice(0, -1), updated], undefined);
 	}
 
-	/**
-	 * True when the user is mid-utterance: the tail of the transcript is a
-	 * still-open (partial) user turn with non-empty recognized text. Used to
-	 * decide whether a client-driven narration may force-end the current
-	 * hands-free listen turn (safe when silent) or must defer to the
-	 * busy/`narration_unblocked` path (when the user is actually speaking, so we
-	 * don't cut off their words).
-	 */
+/** Whether the transcript currently contains a non-empty partial user turn. */
 	private _isActivelyDictating(): boolean {
 		const turns = this._transcriptTurns.get();
 		const last = turns[turns.length - 1];

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2488,6 +2488,20 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	/**
+	 * True when the user is mid-utterance: the tail of the transcript is a
+	 * still-open (partial) user turn with non-empty recognized text. Used to
+	 * decide whether a client-driven narration may force-end the current
+	 * hands-free listen turn (safe when silent) or must defer to the
+	 * busy/`narration_unblocked` path (when the user is actually speaking, so we
+	 * don't cut off their words).
+	 */
+	private _isActivelyDictating(): boolean {
+		const turns = this._transcriptTurns.get();
+		const last = turns[turns.length - 1];
+		return !!last && last.speaker === 'user' && last.isPartial && last.text.trim().length > 0;
+	}
+
+	/**
 	 * Update the assistant turn at the tail of the buffer with `text`.
 	 *
 	 * The streaming TTS pipeline pushes a monotonically-growing transcript
@@ -2987,6 +3001,24 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 		}
 		this.logService.trace(`[voice] narrate kind=${kind} id=${sessionId.slice(-32)}`);
+		// A hands-free auto-listen / barge-in turn keeps the backend's
+		// `user_is_speaking` latch set - it latches on `ptt_start` and is only
+		// cleared by a real `ptt_end` (see `_startBargeInListen`, `_finishPtt`).
+		// Requesting a narration while that latch is set gets NACK'd
+		// `busy: user_speaking` and deferred until a `narration_unblocked` that
+		// never arrives for a SILENT passive turn - so the confirmation/response
+		// is stranded and never spoken. When the user is NOT actively dictating,
+		// end the open turn with a genuine `ptt_end` (WS preserves order, so it
+		// reaches the backend before the request) so the latch clears and the
+		// narration is accepted immediately. Guard on `canRequestNarration` so a
+		// closed-socket path still queues a retry below without tearing down a
+		// freshly-entered listen on connect. When the user IS mid-utterance, leave
+		// the turn open and let the busy/defer + `narration_unblocked` path narrate
+		// once they finish, rather than cutting off their speech.
+		const endPassiveTurnFirst = this._pttHeld && !this._isActivelyDictating() && this.voiceClientService.canRequestNarration;
+		if (endPassiveTurnFirst) {
+			this._prepareForPlayback(true);
+		}
 		const narrationId = this.voiceClientService.requestNarration(sessionId, kind, text, reuseId);
 		if (!narrationId) {
 			// Socket was closed, so nothing was sent: don't touch playback/listening
@@ -2996,12 +3028,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._pendingNarrationRetries.set(sessionId, { kind, text });
 			return false;
 		}
-		// The narration audio is now inbound. Get out of listening/auto-listen so
-		// the echoed audio isn't suppressed (or captured as the user's own turn)
-		// while PTT/mic capture is active. Done here so EVERY narration path
-		// (live, on-focus, on-reconnect retry) is prepared, not just focus - but
-		// only once a request is actually in flight.
-		this._prepareForPlayback();
+		if (!endPassiveTurnFirst) {
+			// Not already prepared above. The narration audio is now inbound: get
+			// out of listening/auto-listen so the echoed audio isn't suppressed (or
+			// captured as the user's own turn) while PTT/mic capture is active.
+			this._prepareForPlayback();
+		}
 		this._pendingNarrationRetries.delete(sessionId);
 		// This newer request supersedes any older busy/interrupted entry deferred
 		// for this session (latest-wins per session). Without this, a later
@@ -3559,11 +3591,17 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * controller can sit in listening and the echoed audio is dropped, leaving the
 	 * user staring at a focused session that never speaks.
 	 */
-	private _prepareForPlayback(): void {
+	private _prepareForPlayback(endOpenTurn = false): void {
 		this._clearAutoListenTimer();
 		this._autoListenSuppressed = false;
 		if (this._pttHeld) {
-			this._finishPtt('auto');
+			// 'auto' aborts the mic locally and sends NO `ptt_end` (used when the
+			// backend already ended the turn, so the audio can just play). When the
+			// caller needs the backend to learn the turn ended - e.g. a client-driven
+			// narration whose request would otherwise be NACK'd `busy: user_speaking`
+			// because the latch is still set - pass `endOpenTurn` to finish with a
+			// genuine `ptt_end` ('local') instead.
+			this._finishPtt(endOpenTurn ? 'local' : 'auto');
 		}
 		this._pttToggleMode = false;
 		this._pttHeld = false;

--- a/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
@@ -234,6 +234,8 @@ export interface IVoiceClientService {
 	sendToolResult(callId: string, result: string): void;
 	/** Ask the backend to speak `text` for a session now; returns the narration id echoed on the resulting `audio_response`, or `undefined` if nothing was sent. Pass `narrationId` to reuse a prior id (a `busy` retry) so the backend can dedup a lost ack; omit it to mint a fresh one. */
 	requestNarration(codingSessionId: string, kind: 'response' | 'confirmation', text: string, narrationId?: string): string | undefined;
+	/** True when a `requestNarration` call would actually send (socket open and the session has started on it). Lets the caller stop the mic before requesting only when the request will really go out. */
+	readonly canRequestNarration: boolean;
 	/**
 	 * Notify the backend of a session state transition.
 	 *


### PR DESCRIPTION
## Problem
In hands-free voice mode, a confirmation (or completed response) is sometimes **never read aloud**. Trace shows:

```
[voice] narrate kind=confirmation id=…
[voice] request_narration kind=confirmation narration_id=…
[voice] narration_ack busy id=… reason=user_speaking; deferring
```

…and no `narration_unblocked` ever follows, so the narration is stranded.

## Root cause
On connect (and for barge-in), the controller opens a **passive auto-listen mic turn** — `ptt_start` is sent and the turn is left open with no `ptt_end`. The backend **latches `user_is_speaking` on `ptt_start`**, so a client-driven `request_narration` issued while that latch is set is NACK'd `busy: user_speaking` and deferred, waiting for a `narration_unblocked` nudge.

For a **silent** passive turn that nudge never arrives: `_prepareForPlayback()` ran *after* the request and used `_finishPtt('auto')` → `abortPtt()`, which stops the mic **locally without emitting `ptt_end`**. The backend never learns the turn ended, never clears the latch, and never unblocks — so the confirmation/response is never spoken.

## Fix
In `_narrate`, when the user is **not actively dictating**, end the open listen turn with a genuine `ptt_end` **before** requesting the narration (the WebSocket preserves send order, so the backend clears the latch and accepts the request immediately). When the user **is** mid-utterance, leave the turn open and keep the existing busy/defer + `narration_unblocked` path so their speech isn't cut off.

- `_prepareForPlayback(endOpenTurn)` — finishes via `_finishPtt('local')` (real `ptt_end`) when `true`, else the prior `'auto'` abort.
- `_isActivelyDictating()` — true only when the transcript tail is a non-empty *partial* user turn.
- `IVoiceClientService.canRequestNarration` — gates the force-end so a closed-socket path still queues a retry without tearing down a freshly-entered listen on connect.

## Behavior
- Silent auto-listen open → confirmation/response narrates **right away**.
- User genuinely mid-utterance → still defers politely and narrates once they finish.

## Validation
- `./node_modules/.bin/tsc --noEmit -p src/tsconfig.json` (clean)
- precommit hygiene hooks

_Note: unit tests were not executed (no build output in the isolated worktree)._
