### PR TITLE
Voice: add connected idle barge-in hint and glow

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -13,6 +13,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IMicCaptureService } from '../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
@@ -150,6 +151,7 @@ export class ChatView extends AbstractChatView {
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ILogService private readonly logService: ILogService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
 		@IMicCaptureService private readonly micCaptureService: IMicCaptureService,
 		@ITtsPlaybackService private readonly ttsPlaybackService: ITtsPlaybackService,
@@ -376,6 +378,7 @@ export class ChatView extends AbstractChatView {
 			micCaptureService: this.micCaptureService,
 			configurationService: this.configurationService,
 			keybindingService: this.keybindingService,
+			accessibilityService: this.accessibilityService,
 		}, {
 			inputContainer: inputContainerEl,
 			isActive: this._isActiveObs,

--- a/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
+++ b/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
@@ -131,12 +131,23 @@ so mirror the blue-listening / purple-speaking glow here. `voice-active` /
 }
 
 /* Purple when speaking */
-.new-chat-input-area.voice-active:not(.voice-listening) .action-label.codicon-voice-mode {
+.new-chat-input-area.voice-active.voice-speaking .action-label.codicon-voice-mode {
 	--sessions-voice-icon-glow-color: rgba(163, 113, 247, 0.65);
 	color: var(--vscode-charts-purple, #a371f7) !important;
 	border-radius: 50%;
 }
 
-.monaco-workbench.monaco-enable-motion .new-chat-input-area.voice-active:not(.voice-listening) .action-label.codicon-voice-mode {
+.monaco-workbench.monaco-enable-motion .new-chat-input-area.voice-active.voice-speaking .action-label.codicon-voice-mode {
+	animation: sessionsVoiceIconGlow 1.4s ease-in-out infinite;
+}
+
+/* White breathing glow while connected-idle (armed) */
+.new-chat-input-area.voice-active.voice-idle .action-label.codicon-voice-mode {
+	--sessions-voice-icon-glow-color: rgba(255, 255, 255, 0.7);
+	color: var(--vscode-foreground) !important;
+	border-radius: 50%;
+}
+
+.monaco-workbench.monaco-enable-motion .new-chat-input-area.voice-active.voice-idle .action-label.codicon-voice-mode {
 	animation: sessionsVoiceIconGlow 1.4s ease-in-out infinite;
 }

--- a/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
+++ b/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
@@ -141,9 +141,9 @@ so mirror the blue-listening / purple-speaking glow here. `voice-active` /
 	animation: sessionsVoiceIconGlow 1.4s ease-in-out infinite;
 }
 
-/* White breathing glow while connected-idle (armed) */
+/* Themed breathing glow while connected-idle (armed) */
 .new-chat-input-area.voice-active.voice-idle .action-label.codicon-voice-mode {
-	--sessions-voice-icon-glow-color: rgba(255, 255, 255, 0.7);
+	--sessions-voice-icon-glow-color: color-mix(in srgb, var(--vscode-foreground) 70%, transparent);
 	color: var(--vscode-foreground) !important;
 	border-radius: 50%;
 }

--- a/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
@@ -17,6 +17,7 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { IInstantiationService, createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { IMicCaptureService } from '../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
 import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
@@ -164,6 +165,7 @@ export class NewChatVoiceController extends Disposable {
 		@IMicCaptureService micCaptureService: IMicCaptureService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IKeybindingService keybindingService: IKeybindingService,
+		@IAccessibilityService accessibilityService: IAccessibilityService,
 	) {
 		super();
 
@@ -205,6 +207,7 @@ export class NewChatVoiceController extends Disposable {
 			micCaptureService,
 			configurationService,
 			keybindingService,
+			accessibilityService,
 		}, {
 			inputContainer: options.inputContainer,
 			isActive: isVoiceTarget,

--- a/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
@@ -14,6 +14,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { IMicCaptureService } from '../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
 import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
@@ -25,6 +26,7 @@ export interface IVoiceInputDecorationsServices {
 	readonly micCaptureService: IMicCaptureService;
 	readonly configurationService: IConfigurationService;
 	readonly keybindingService: IKeybindingService;
+	readonly accessibilityService: IAccessibilityService;
 }
 
 export interface IVoiceInputDecorationsOptions {
@@ -43,7 +45,7 @@ export interface IVoiceInputDecorationsOptions {
  * Decorations show only while this surface is active and voice targets it.
  */
 export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServices, options: IVoiceInputDecorationsOptions): IDisposable {
-	const { voiceSessionController, ttsPlaybackService, micCaptureService, configurationService, keybindingService } = services;
+	const { voiceSessionController, ttsPlaybackService, micCaptureService, configurationService, keybindingService, accessibilityService } = services;
 	const { inputContainer: inputContainerEl, isActive, getCurrentResource } = options;
 
 	const store = new DisposableStore();
@@ -76,7 +78,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 				?? (voiceState === 'listening' ? micCaptureService.analyserNode : null)
 				?? null;
 			const intensity = voiceState === 'idle'
-				? readIdleVoiceGlowIntensity(win.performance.now())
+				? readIdleVoiceGlowIntensity(win.performance.now(), accessibilityService.isMotionReduced())
 				: readVoiceGlowIntensity(analyser, glowDataArrayRef);
 
 			const transcriptHidden = configurationService.getValue<boolean>('agents.voice.showTranscript') === false;

--- a/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
@@ -85,6 +85,8 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 			inputContainerEl.style.boxShadow = boxShadow;
 			inputContainerEl.classList.add('voice-active');
 			inputContainerEl.classList.toggle('voice-listening', voiceState === 'listening');
+			inputContainerEl.classList.toggle('voice-speaking', voiceState === 'speaking');
+			inputContainerEl.classList.toggle('voice-idle', voiceState === 'idle');
 		};
 		animFrameId = win.requestAnimationFrame(animate);
 	};
@@ -95,7 +97,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 		}
 		inputContainerEl.style.borderColor = '';
 		inputContainerEl.style.boxShadow = '';
-		inputContainerEl.classList.remove('voice-active', 'voice-listening');
+		inputContainerEl.classList.remove('voice-active', 'voice-listening', 'voice-speaking', 'voice-idle');
 	};
 
 	store.add(autorun(reader => {
@@ -144,6 +146,19 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 				const listening = dom.$('span.listening');
 				listening.textContent = localize('voiceMode.listening', "Listening...");
 				transcriptOverlay.append(listening);
+				transcriptScrollable.scanDomNode();
+			} else if (!showTranscript && voiceState === 'speaking') {
+				// Transcript is disabled: hint that the user can interrupt playback.
+				transcriptOverlayNode.style.display = '';
+				transcriptOverlayNode.classList.remove('has-transcript');
+				transcriptOverlay.replaceChildren();
+				const hint = dom.$('span.partial');
+				const kb = keybindingService.lookupKeybinding('agentsVoice.pushToTalk');
+				const kbLabel = kb?.getLabel();
+				hint.textContent = kbLabel
+					? localize('voiceMode.bargeInHint', "Press {0} to barge in", kbLabel)
+					: localize('voiceMode.bargeInHintNoKb', "Speak to barge in");
+				transcriptOverlay.append(hint);
 				transcriptScrollable.scanDomNode();
 			} else if (voiceState === 'idle' && visible.length === 0 && showTranscript && !handsFree) {
 				transcriptOverlayNode.style.display = '';

--- a/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceInputDecorations.ts
@@ -17,7 +17,7 @@ import { IKeybindingService } from '../../../../platform/keybinding/common/keybi
 import { IMicCaptureService } from '../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
 import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
-import { computeVoiceGlowStyle, readVoiceGlowIntensity } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceGlow.js';
+import { computeVoiceGlowStyle, readIdleVoiceGlowIntensity, readVoiceGlowIntensity } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceGlow.js';
 
 export interface IVoiceInputDecorationsServices {
 	readonly voiceSessionController: IVoiceSessionController;
@@ -75,7 +75,9 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 			const analyser = ttsPlaybackService.analyserNode
 				?? (voiceState === 'listening' ? micCaptureService.analyserNode : null)
 				?? null;
-			const intensity = readVoiceGlowIntensity(analyser, glowDataArrayRef);
+			const intensity = voiceState === 'idle'
+				? readIdleVoiceGlowIntensity(win.performance.now())
+				: readVoiceGlowIntensity(analyser, glowDataArrayRef);
 
 			const transcriptHidden = configurationService.getValue<boolean>('agents.voice.showTranscript') === false;
 			const { borderColor, boxShadow } = computeVoiceGlowStyle(voiceState, intensity, transcriptHidden);
@@ -104,7 +106,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 		const current = getCurrentResource();
 		// Glow only the active slot targeted by the backend.
 		const targetedElsewhere = !!targetSession && !!current && !isEqual(targetSession, current);
-		if (connected && active && !targetedElsewhere && (voiceState === 'listening' || voiceState === 'speaking')) {
+		if (connected && active && !targetedElsewhere && (voiceState === 'idle' || voiceState === 'listening' || voiceState === 'speaking')) {
 			startGlowAnimation();
 		} else {
 			stopGlowAnimation();
@@ -151,8 +153,8 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 				const kb = keybindingService.lookupKeybinding('agentsVoice.pushToTalk');
 				const kbLabel = kb?.getLabel();
 				hint.textContent = kbLabel
-					? localize('voiceMode.pttHint', "Press {0} to talk", kbLabel)
-					: localize('voiceMode.clickMicHint', "Click voice mode to talk");
+					? localize('voiceMode.pttOrBargeInHint', "Press {0} to talk or barge in", kbLabel)
+					: localize('voiceMode.clickMicOrBargeInHint', "Click voice mode to talk or barge in");
 				transcriptOverlay.append(hint);
 				transcriptScrollable.scanDomNode();
 			} else {

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
@@ -639,6 +639,10 @@ export class AgentsVoiceWidget extends Disposable {
 				this._inputBoxPlaceholder!.textContent = localize('agentsVoice.connecting', "Connecting...");
 			} else if (isConnected && voiceState === 'listening') {
 				this._inputBoxPlaceholder!.textContent = localize('agentsVoice.listening', "Listening");
+			} else if (isConnected && voiceState === 'speaking') {
+				this._inputBoxPlaceholder!.textContent = keyLabel
+					? localize('agentsVoice.pressToBargeIn', "Press {0} to barge in", keyLabel)
+					: localize('agentsVoice.speakToBargeIn', "Speak to barge in");
 			} else if (isConnected) {
 				this._inputBoxPlaceholder!.textContent = keyLabel
 					? localize('agentsVoice.holdToTalkOrBargeIn', "Hold {0} to talk or barge in", keyLabel)

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
@@ -19,6 +19,7 @@ import { createOnboarding } from './components/onboardingComponent.js';
 import { createVoiceBar } from './components/voiceBarComponent.js';
 import { FONT_SIZE, addKeyboardActivation } from './components/tokens.js';
 import type { VoiceState, IPendingToolConfirmation, ITranscriptTurn } from '../../chat/browser/voiceClient/voiceSessionController.js';
+import { computeVoiceGlowStyle, readIdleVoiceGlowIntensity } from '../../chat/browser/voiceClient/voiceGlow.js';
 
 export interface VoiceWidgetCallbacks {
 	readonly copilotIconSrc: string;
@@ -600,7 +601,8 @@ export class AgentsVoiceWidget extends Disposable {
 		const hasTranscript = transcriptTurns.some(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
 
 		// Toggle voice-active glow on the input container (base state; wave animation overrides dynamically)
-		if (!showConnected || (voiceState !== 'listening' && voiceState !== 'speaking')) {
+		const shouldShowInputGlow = (isConnected && voiceState === 'idle') || (showConnected && (voiceState === 'listening' || voiceState === 'speaking'));
+		if (!shouldShowInputGlow) {
 			this._inputBoxContainer!.style.borderColor = 'var(--vscode-input-border, transparent)';
 			this._inputBoxContainer!.style.boxShadow = 'none';
 		}
@@ -631,8 +633,16 @@ export class AgentsVoiceWidget extends Disposable {
 			this._inputBoxTranscriptComponent.element.style.display = 'none';
 			this._transcriptComponent.element.style.display = 'none';
 			const keyLabel = this._pttKeyLabel.read(reader);
-			if (showConnected) {
+			if (isReconnecting) {
+				this._inputBoxPlaceholder!.textContent = localize('agentsVoice.reconnecting', "Reconnecting...");
+			} else if (isConnecting) {
+				this._inputBoxPlaceholder!.textContent = localize('agentsVoice.connecting', "Connecting...");
+			} else if (isConnected && voiceState === 'listening') {
 				this._inputBoxPlaceholder!.textContent = localize('agentsVoice.listening', "Listening");
+			} else if (isConnected) {
+				this._inputBoxPlaceholder!.textContent = keyLabel
+					? localize('agentsVoice.holdToTalkOrBargeIn', "Hold {0} to talk or barge in", keyLabel)
+					: localize('agentsVoice.holdMicToTalkOrBargeIn', "Hold the mic to talk or barge in");
 			} else if (keyLabel) {
 				this._inputBoxPlaceholder!.textContent = localize('agentsVoice.holdToTalk', "Hold {0} to talk", keyLabel);
 			} else {
@@ -985,8 +995,10 @@ export class AgentsVoiceWidget extends Disposable {
 		const animate = () => {
 			this._animationFrameId = getWindow(this.container).requestAnimationFrame(animate);
 			const onboarding = this._showOnboarding.get();
+			const connected = this._isConnected.get();
 			const voiceState = this._voiceState.get();
-			const glowActive = onboarding || voiceState === 'speaking' || voiceState === 'listening';
+			const connectedIdle = connected && voiceState === 'idle';
+			const glowActive = onboarding || connectedIdle || voiceState === 'speaking' || voiceState === 'listening';
 
 			if (!glowActive) {
 				this._glowDiv.style.display = 'none';
@@ -1004,6 +1016,8 @@ export class AgentsVoiceWidget extends Disposable {
 			let intensity: number;
 			if (onboarding) {
 				intensity = 0.6;
+			} else if (connectedIdle) {
+				intensity = readIdleVoiceGlowIntensity(getWindow(this.container).performance.now());
 			} else if (!analyser) {
 				intensity = 0.3;
 			} else {
@@ -1018,20 +1032,20 @@ export class AgentsVoiceWidget extends Disposable {
 
 			// Animate input box container border/shadow (inputBoxLayout)
 			if (this._inputBoxContainer) {
-				const r = (voiceState === 'speaking') ? '163,113,247' : '88,166,255';
-				const borderAlpha = 0.4 + intensity * 0.5;
-				const shadowSpread = 4 + intensity * 12;
-				const shadowAlpha = 0.15 + intensity * 0.35;
-				this._inputBoxContainer.style.borderColor = `rgba(${r},${borderAlpha})`;
-				this._inputBoxContainer.style.boxShadow = `0 0 ${shadowSpread}px rgba(${r},${shadowAlpha}), inset 0 0 ${shadowSpread * 0.4}px rgba(${r},${shadowAlpha * 0.3})`;
+				const inputGlowState = connectedIdle ? 'idle' : voiceState;
+				if (inputGlowState === 'idle' || inputGlowState === 'listening' || inputGlowState === 'speaking') {
+					const { borderColor, boxShadow } = computeVoiceGlowStyle(inputGlowState, intensity, false);
+					this._inputBoxContainer.style.borderColor = borderColor;
+					this._inputBoxContainer.style.boxShadow = boxShadow;
+				}
 			}
 
 			if (this._inputBoxMicBtn) {
-				const iconGlowActive = voiceState === 'listening' || voiceState === 'speaking';
+				const iconGlowActive = connectedIdle || voiceState === 'listening' || voiceState === 'speaking';
 				if (iconGlowActive) {
-					const r = voiceState === 'speaking' ? '163,113,247' : '88,166,255';
-					const shadowSpread = 3 + intensity * 8;
-					const shadowAlpha = 0.2 + intensity * 0.45;
+					const r = connectedIdle ? '255,255,255' : voiceState === 'speaking' ? '163,113,247' : '88,166,255';
+					const shadowSpread = connectedIdle ? 2 + intensity * 8 : 3 + intensity * 8;
+					const shadowAlpha = connectedIdle ? 0.08 + intensity * 0.18 : 0.2 + intensity * 0.45;
 					this._inputBoxMicBtn.style.boxShadow = `0 0 ${shadowSpread}px rgba(${r},${shadowAlpha})`;
 				} else {
 					this._inputBoxMicBtn.style.boxShadow = 'none';
@@ -1040,8 +1054,8 @@ export class AgentsVoiceWidget extends Disposable {
 
 			// Classic layout glow div
 			this._glowDiv.style.display = '';
-			const baseOpacity = 0.15 + intensity * 0.4;
-			const r = (onboarding || voiceState === 'speaking') ? '163,113,247' : '88,166,255';
+			const baseOpacity = connectedIdle ? 0.06 + intensity * 0.18 : 0.15 + intensity * 0.4;
+			const r = connectedIdle ? '255,255,255' : (onboarding || voiceState === 'speaking') ? '163,113,247' : '88,166,255';
 			this._glowDiv.style.background = `radial-gradient(ellipse 40% 70% at 50% 0%, rgba(${r},${baseOpacity}) 0%, transparent 100%), radial-gradient(ellipse 70% 100% at 50% 0%, rgba(${r},${baseOpacity * 0.4}) 0%, transparent 100%)`;
 		};
 		this._animationFrameId = getWindow(this.container).requestAnimationFrame(animate);

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
@@ -19,7 +19,7 @@ import { createOnboarding } from './components/onboardingComponent.js';
 import { createVoiceBar } from './components/voiceBarComponent.js';
 import { FONT_SIZE, addKeyboardActivation } from './components/tokens.js';
 import type { VoiceState, IPendingToolConfirmation, ITranscriptTurn } from '../../chat/browser/voiceClient/voiceSessionController.js';
-import { computeVoiceGlowStyle, readIdleVoiceGlowIntensity } from '../../chat/browser/voiceClient/voiceGlow.js';
+import { computeVoiceGlowStyle, readIdleVoiceGlowIntensity, IDLE_VOICE_GLOW_COLOR } from '../../chat/browser/voiceClient/voiceGlow.js';
 
 export interface VoiceWidgetCallbacks {
 	readonly copilotIconSrc: string;
@@ -38,6 +38,8 @@ export interface VoiceWidgetCallbacks {
 	/** Create a new session and set it as transcription target. */
 	newSessionAsTarget(): void;
 	getAnalyserNode(): AnalyserNode | null;
+	/** Reduced-motion state (honors OS + `workbench.reduceMotion`). */
+	isMotionReduced(): boolean;
 	onResize(): void;
 	openPttKeySettings(): void;
 	/** Optional — when provided, header renders a "popout" button. */
@@ -1021,7 +1023,7 @@ export class AgentsVoiceWidget extends Disposable {
 			if (onboarding) {
 				intensity = 0.6;
 			} else if (connectedIdle) {
-				intensity = readIdleVoiceGlowIntensity(getWindow(this.container).performance.now());
+				intensity = readIdleVoiceGlowIntensity(getWindow(this.container).performance.now(), this.callbacks.isMotionReduced());
 			} else if (!analyser) {
 				intensity = 0.3;
 			} else {
@@ -1047,10 +1049,13 @@ export class AgentsVoiceWidget extends Disposable {
 			if (this._inputBoxMicBtn) {
 				const iconGlowActive = connectedIdle || voiceState === 'listening' || voiceState === 'speaking';
 				if (iconGlowActive) {
-					const r = connectedIdle ? '255,255,255' : voiceState === 'speaking' ? '163,113,247' : '88,166,255';
 					const shadowSpread = connectedIdle ? 2 + intensity * 8 : 3 + intensity * 8;
 					const shadowAlpha = connectedIdle ? 0.08 + intensity * 0.18 : 0.2 + intensity * 0.45;
-					this._inputBoxMicBtn.style.boxShadow = `0 0 ${shadowSpread}px rgba(${r},${shadowAlpha})`;
+					// Themed idle color stays visible on light input backgrounds; saturated blue/purple for listening/speaking.
+					const glowColor = connectedIdle
+						? `color-mix(in srgb, ${IDLE_VOICE_GLOW_COLOR} ${+(shadowAlpha * 100).toFixed(2)}%, transparent)`
+						: `rgba(${voiceState === 'speaking' ? '163,113,247' : '88,166,255'},${shadowAlpha})`;
+					this._inputBoxMicBtn.style.boxShadow = `0 0 ${shadowSpread}px ${glowColor}`;
 				} else {
 					this._inputBoxMicBtn.style.boxShadow = 'none';
 				}
@@ -1059,8 +1064,14 @@ export class AgentsVoiceWidget extends Disposable {
 			// Classic layout glow div
 			this._glowDiv.style.display = '';
 			const baseOpacity = connectedIdle ? 0.06 + intensity * 0.18 : 0.15 + intensity * 0.4;
-			const r = connectedIdle ? '255,255,255' : (onboarding || voiceState === 'speaking') ? '163,113,247' : '88,166,255';
-			this._glowDiv.style.background = `radial-gradient(ellipse 40% 70% at 50% 0%, rgba(${r},${baseOpacity}) 0%, transparent 100%), radial-gradient(ellipse 70% 100% at 50% 0%, rgba(${r},${baseOpacity * 0.4}) 0%, transparent 100%)`;
+			if (connectedIdle) {
+				// Themed idle color so the gradient stays visible on light (white) input backgrounds.
+				const c = (a: number) => `color-mix(in srgb, ${IDLE_VOICE_GLOW_COLOR} ${+(a * 100).toFixed(2)}%, transparent)`;
+				this._glowDiv.style.background = `radial-gradient(ellipse 40% 70% at 50% 0%, ${c(baseOpacity)} 0%, transparent 100%), radial-gradient(ellipse 70% 100% at 50% 0%, ${c(baseOpacity * 0.4)} 0%, transparent 100%)`;
+			} else {
+				const r = (onboarding || voiceState === 'speaking') ? '163,113,247' : '88,166,255';
+				this._glowDiv.style.background = `radial-gradient(ellipse 40% 70% at 50% 0%, rgba(${r},${baseOpacity}) 0%, transparent 100%), radial-gradient(ellipse 70% 100% at 50% 0%, rgba(${r},${baseOpacity * 0.4}) 0%, transparent 100%)`;
+			}
 		};
 		this._animationFrameId = getWindow(this.container).requestAnimationFrame(animate);
 	}

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
@@ -27,6 +27,7 @@ import { IChatService } from '../../chat/common/chatService/chatService.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { editorBackground } from '../../../../platform/theme/common/colorRegistry.js';
 import { inputBackground, inputBorder } from '../../../../platform/theme/common/colors/inputColors.js';
 import { AgentsVoiceWidget } from './agentsVoiceWidget.js';
@@ -72,6 +73,7 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@IThemeService private readonly themeService: IThemeService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
@@ -204,6 +206,7 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 					?? (state === 'listening' ? this.micCaptureService.analyserNode : null)
 					?? null;
 			},
+			isMotionReduced: () => this.accessibilityService.isMotionReduced(),
 			onResize: () => this._resizeWindow(auxiliaryWindow),
 			openPttKeySettings: () => this.commandService.executeCommand('workbench.action.openGlobalKeybindings', 'agentsVoice.pushToTalk'),
 			submitFeedback: (text) => this.voiceSessionController.submitFeedback(text),

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
@@ -34,9 +34,13 @@ export function readVoiceGlowIntensity(analyser: AnalyserNode | null, dataArray:
 
 /**
  * A subtle breathing intensity for connected-idle voice mode, used to show that
- * the surface is still armed even when no audio is flowing.
+ * the surface is still armed even when no audio is flowing. Returns a static
+ * midpoint when motion is reduced so the glow renders without animating.
  */
-export function readIdleVoiceGlowIntensity(timestampMs: number): number {
+export function readIdleVoiceGlowIntensity(timestampMs: number, reducedMotion = false): number {
+	if (reducedMotion) {
+		return 0.4;
+	}
 	return 0.25 + ((Math.sin(timestampMs / 600) + 1) * 0.5) * 0.3;
 }
 
@@ -46,19 +50,25 @@ export interface IVoiceGlowStyle {
 }
 
 /**
- * Compute the glow border color and box-shadow. White while connected-idle,
- * blue while listening (flashier when the transcript is hidden), and purple
- * while speaking.
+ * The theme-aware base color for the connected-idle glow. Derived from the themed
+ * foreground so it stays visible against the input background in every theme
+ * (a fixed white would vanish on light themes whose input background is white).
+ */
+export const IDLE_VOICE_GLOW_COLOR = 'var(--vscode-foreground)';
+
+/**
+ * Compute the glow border color and box-shadow. Themed foreground while
+ * connected-idle, blue while listening (flashier when the transcript is hidden),
+ * and purple while speaking.
  */
 export function computeVoiceGlowStyle(voiceState: VoiceGlowState, intensity: number, transcriptHidden: boolean): IVoiceGlowStyle {
 	if (voiceState === 'idle') {
-		const borderAlpha = 0.3 + intensity * 0.3;
 		const shadowSpread = 7 + intensity * 14;
 		const shadowAlpha = 0.16 + intensity * 0.22;
-		const rgb = '255,255,255';
+		const mix = (alpha: number) => `color-mix(in srgb, ${IDLE_VOICE_GLOW_COLOR} ${+(alpha * 100).toFixed(2)}%, transparent)`;
 		return {
-			borderColor: `rgba(${rgb},${borderAlpha})`,
-			boxShadow: `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), inset 0 0 ${shadowSpread * 0.35}px rgba(${rgb},${shadowAlpha * 0.5})`
+			borderColor: mix(0.3 + intensity * 0.3),
+			boxShadow: `0 0 ${shadowSpread}px ${mix(shadowAlpha)}, inset 0 0 ${shadowSpread * 0.35}px ${mix(shadowAlpha * 0.5)}`
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
@@ -37,7 +37,7 @@ export function readVoiceGlowIntensity(analyser: AnalyserNode | null, dataArray:
  * the surface is still armed even when no audio is flowing.
  */
 export function readIdleVoiceGlowIntensity(timestampMs: number): number {
-	return 0.2 + ((Math.sin(timestampMs / 600) + 1) * 0.5) * 0.2;
+	return 0.25 + ((Math.sin(timestampMs / 600) + 1) * 0.5) * 0.3;
 }
 
 export interface IVoiceGlowStyle {
@@ -52,9 +52,9 @@ export interface IVoiceGlowStyle {
  */
 export function computeVoiceGlowStyle(voiceState: VoiceGlowState, intensity: number, transcriptHidden: boolean): IVoiceGlowStyle {
 	if (voiceState === 'idle') {
-		const borderAlpha = 0.16 + intensity * 0.18;
-		const shadowSpread = 5 + intensity * 10;
-		const shadowAlpha = 0.08 + intensity * 0.14;
+		const borderAlpha = 0.3 + intensity * 0.3;
+		const shadowSpread = 7 + intensity * 14;
+		const shadowAlpha = 0.16 + intensity * 0.22;
 		const rgb = '255,255,255';
 		return {
 			borderColor: `rgba(${rgb},${borderAlpha})`,

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
@@ -32,16 +32,36 @@ export function readVoiceGlowIntensity(analyser: AnalyserNode | null, dataArray:
 	return Math.min(1, (sum / dataArray.value.length) / 80);
 }
 
+/**
+ * A subtle breathing intensity for connected-idle voice mode, used to show that
+ * the surface is still armed even when no audio is flowing.
+ */
+export function readIdleVoiceGlowIntensity(timestampMs: number): number {
+	return 0.2 + ((Math.sin(timestampMs / 600) + 1) * 0.5) * 0.2;
+}
+
 export interface IVoiceGlowStyle {
 	readonly borderColor: string;
 	readonly boxShadow: string;
 }
 
 /**
- * Compute the glow border color and box-shadow. Blue while listening (flashier
- * when the transcript is hidden), purple while speaking.
+ * Compute the glow border color and box-shadow. White while connected-idle,
+ * blue while listening (flashier when the transcript is hidden), and purple
+ * while speaking.
  */
 export function computeVoiceGlowStyle(voiceState: VoiceGlowState, intensity: number, transcriptHidden: boolean): IVoiceGlowStyle {
+	if (voiceState === 'idle') {
+		const borderAlpha = 0.16 + intensity * 0.18;
+		const shadowSpread = 5 + intensity * 10;
+		const shadowAlpha = 0.08 + intensity * 0.14;
+		const rgb = '255,255,255';
+		return {
+			borderColor: `rgba(${rgb},${borderAlpha})`,
+			boxShadow: `0 0 ${shadowSpread}px rgba(${rgb},${shadowAlpha}), inset 0 0 ${shadowSpread * 0.35}px rgba(${rgb},${shadowAlpha * 0.5})`
+		};
+	}
+
 	// Blue when listening, purple when speaking.
 	const rgb = voiceState === 'speaking' ? '163,113,247' : '88,166,255';
 	const flashy = voiceState === 'listening' && transcriptHidden;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -4595,9 +4595,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	animation: chat-voice-icon-glow 1.4s ease-in-out infinite;
 }
 
-/* Voice mode: white breathing glow while connected-idle (armed) */
+/* Voice mode: themed breathing glow while connected-idle (armed) */
 .chat-input-container.voice-active.voice-idle .chat-input-toolbars .action-label.codicon-voice-mode {
-	--chat-voice-icon-glow-color: rgba(255, 255, 255, 0.7);
+	--chat-voice-icon-glow-color: color-mix(in srgb, var(--vscode-foreground) 70%, transparent);
 	color: var(--vscode-foreground) !important;
 	border-radius: 50%;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -4585,13 +4585,24 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 /* Voice mode: purple when speaking */
-.chat-input-container.voice-active:not(.voice-listening) .chat-input-toolbars .action-label.codicon-voice-mode {
+.chat-input-container.voice-active.voice-speaking .chat-input-toolbars .action-label.codicon-voice-mode {
 	--chat-voice-icon-glow-color: rgba(163, 113, 247, 0.65);
 	color: var(--vscode-charts-purple, #a371f7) !important;
 	border-radius: 50%;
 }
 
-.monaco-workbench.monaco-enable-motion .chat-input-container.voice-active:not(.voice-listening) .chat-input-toolbars .action-label.codicon-voice-mode {
+.monaco-workbench.monaco-enable-motion .chat-input-container.voice-active.voice-speaking .chat-input-toolbars .action-label.codicon-voice-mode {
+	animation: chat-voice-icon-glow 1.4s ease-in-out infinite;
+}
+
+/* Voice mode: white breathing glow while connected-idle (armed) */
+.chat-input-container.voice-active.voice-idle .chat-input-toolbars .action-label.codicon-voice-mode {
+	--chat-voice-icon-glow-color: rgba(255, 255, 255, 0.7);
+	color: var(--vscode-foreground) !important;
+	border-radius: 50%;
+}
+
+.monaco-workbench.monaco-enable-motion .chat-input-container.voice-active.voice-idle .chat-input-toolbars .action-label.codicon-voice-mode {
 	animation: chat-voice-icon-glow 1.4s ease-in-out infinite;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -39,6 +39,7 @@ import { defaultButtonStyles } from '../../../../../../platform/theme/browser/de
 import { editorBackground } from '../../../../../../platform/theme/common/colorRegistry.js';
 import { ChatViewTitleControl } from './chatViewTitleControl.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
+import { IAccessibilityService } from '../../../../../../platform/accessibility/common/accessibility.js';
 import { IViewPaneOptions, ViewPane } from '../../../../../browser/parts/views/viewPane.js';
 import { Memento } from '../../../../../common/memento.js';
 import { SIDE_BAR_FOREGROUND } from '../../../../../common/theme.js';
@@ -147,6 +148,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		@IMicCaptureService private readonly micCaptureService: IMicCaptureService,
 		@ITtsPlaybackService private readonly ttsPlaybackService: ITtsPlaybackService,
 		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IAgentTitleBarStatusService _agentTitleBarStatusService: IAgentTitleBarStatusService,
 		@IVoicePlaybackService _voicePlaybackService: IVoicePlaybackService,
@@ -482,7 +484,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 					?? (voiceState === 'listening' ? this.micCaptureService.analyserNode : null)
 					?? null;
 				const intensity = voiceState === 'idle'
-					? readIdleVoiceGlowIntensity(win.performance.now())
+					? readIdleVoiceGlowIntensity(win.performance.now(), this.accessibilityService.isMotionReduced())
 					: readVoiceGlowIntensity(analyser, glowDataArrayRef);
 
 				const transcriptHidden = this.configurationService.getValue<boolean>('agents.voice.showTranscript') === false;

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -466,14 +466,14 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				if (lastGlowTarget && lastGlowTarget !== target) {
 					lastGlowTarget.style.borderColor = '';
 					lastGlowTarget.style.boxShadow = '';
-					lastGlowTarget.classList.remove('voice-active', 'voice-listening');
+					lastGlowTarget.classList.remove('voice-active', 'voice-listening', 'voice-speaking', 'voice-idle');
 				}
 				lastGlowTarget = target;
 
 				if (!glowActive) {
 					target.style.borderColor = '';
 					target.style.boxShadow = '';
-					target.classList.remove('voice-active', 'voice-listening');
+					target.classList.remove('voice-active', 'voice-listening', 'voice-speaking', 'voice-idle');
 					return;
 				}
 
@@ -491,6 +491,8 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				target.style.boxShadow = boxShadow;
 				target.classList.add('voice-active');
 				target.classList.toggle('voice-listening', voiceState === 'listening');
+				target.classList.toggle('voice-speaking', voiceState === 'speaking');
+				target.classList.toggle('voice-idle', voiceState === 'idle');
 			};
 			animFrameId = win.requestAnimationFrame(animate);
 		};
@@ -502,7 +504,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			const target = lastGlowTarget ?? inputContainerEl;
 			target.style.borderColor = '';
 			target.style.boxShadow = '';
-			target.classList.remove('voice-active', 'voice-listening');
+			target.classList.remove('voice-active', 'voice-listening', 'voice-speaking', 'voice-idle');
 			lastGlowTarget = undefined;
 		};
 
@@ -597,6 +599,19 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 					const listening = $('span.listening');
 					listening.textContent = localize('voiceMode.listening', "Listening...");
 					transcriptOverlay.append(listening);
+					transcriptScrollable.scanDomNode();
+				} else if (!showTranscript && voiceState === 'speaking') {
+					// Transcript is disabled: hint that the user can interrupt playback.
+					transcriptOverlayNode.style.display = '';
+					transcriptOverlayNode.classList.remove('has-transcript');
+					transcriptOverlay.replaceChildren();
+					const hint = $('span.partial');
+					const kb = this.keybindingService.lookupKeybinding('agentsVoice.pushToTalk');
+					const kbLabel = kb?.getLabel();
+					hint.textContent = kbLabel
+						? localize('voiceMode.bargeInHint', "Press {0} to barge in", kbLabel)
+						: localize('voiceMode.bargeInHintNoKb', "Speak to barge in");
+					transcriptOverlay.append(hint);
 					transcriptScrollable.scanDomNode();
 				} else if (voiceState === 'idle' && visible.length === 0 && showTranscript && !handsFree) {
 					transcriptOverlayNode.style.display = '';

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -75,7 +75,7 @@ import { IHostService } from '../../../../../services/host/browser/host.js';
 import { IMicCaptureService } from '../../voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../voiceClient/ttsPlaybackService.js';
 import { IVoiceSessionController } from '../../voiceClient/voiceSessionController.js';
-import { computeVoiceGlowStyle, readVoiceGlowIntensity } from '../../voiceClient/voiceGlow.js';
+import { computeVoiceGlowStyle, readIdleVoiceGlowIntensity, readVoiceGlowIntensity } from '../../voiceClient/voiceGlow.js';
 import { IAgentTitleBarStatusService } from '../../agentSessions/experiments/agentTitleBarStatusService.js';
 import { IVoicePlaybackService } from '../../../common/voicePlaybackService.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
@@ -459,7 +459,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				animFrameId = win.requestAnimationFrame(animate);
 				const connected = this.voiceSessionController.isConnected.get();
 				const voiceState = this.voiceSessionController.voiceState.get();
-				const glowActive = connected && (voiceState === 'listening' || voiceState === 'speaking');
+				const glowActive = connected && (voiceState === 'idle' || voiceState === 'listening' || voiceState === 'speaking');
 				const target = getActiveInputContainer();
 
 				// If the target changed, clear styling on the old one
@@ -481,7 +481,9 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				const analyser = this.ttsPlaybackService.analyserNode
 					?? (voiceState === 'listening' ? this.micCaptureService.analyserNode : null)
 					?? null;
-				const intensity = readVoiceGlowIntensity(analyser, glowDataArrayRef);
+				const intensity = voiceState === 'idle'
+					? readIdleVoiceGlowIntensity(win.performance.now())
+					: readVoiceGlowIntensity(analyser, glowDataArrayRef);
 
 				const transcriptHidden = this.configurationService.getValue<boolean>('agents.voice.showTranscript') === false;
 				const { borderColor, boxShadow } = computeVoiceGlowStyle(voiceState, intensity, transcriptHidden);
@@ -517,7 +519,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		this._register(autorun(reader => {
 			const connected = this.voiceSessionController.isConnected.read(reader);
 			const voiceState = this.voiceSessionController.voiceState.read(reader);
-			if (connected && (voiceState === 'listening' || voiceState === 'speaking')) {
+			if (connected && (voiceState === 'idle' || voiceState === 'listening' || voiceState === 'speaking')) {
 				startGlowAnimation();
 			} else {
 				stopGlowAnimation();
@@ -604,8 +606,8 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 					const kb = this.keybindingService.lookupKeybinding('agentsVoice.pushToTalk');
 					const kbLabel = kb?.getLabel();
 					hint.textContent = kbLabel
-						? localize('voiceMode.pttHint', "Press {0} to talk", kbLabel)
-						: localize('voiceMode.clickMicHint', "Click voice mode to talk");
+						? localize('voiceMode.pttOrBargeInHint', "Press {0} to talk or barge in", kbLabel)
+						: localize('voiceMode.clickMicOrBargeInHint', "Click voice mode to talk or barge in");
 					transcriptOverlay.append(hint);
 					transcriptScrollable.scanDomNode();
 				} else {

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceGlow.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceGlow.test.ts
@@ -10,7 +10,7 @@ import { computeVoiceGlowStyle, readIdleVoiceGlowIntensity } from '../../../brow
 suite('VoiceGlow', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('renders a subtle white glow for connected idle voice mode', () => {
+	test('renders a themed subtle glow for connected idle voice mode', () => {
 		const idleStyle = computeVoiceGlowStyle('idle', 0.4, false);
 		assert.deepStrictEqual(
 			{
@@ -18,8 +18,8 @@ suite('VoiceGlow', () => {
 				boxShadow: idleStyle.boxShadow.replace('12.600000000000001', '12.6'),
 			},
 			{
-				borderColor: 'rgba(255,255,255,0.42)',
-				boxShadow: '0 0 12.6px rgba(255,255,255,0.248), inset 0 0 4.41px rgba(255,255,255,0.124)'
+				borderColor: 'color-mix(in srgb, var(--vscode-foreground) 42%, transparent)',
+				boxShadow: '0 0 12.6px color-mix(in srgb, var(--vscode-foreground) 24.8%, transparent), inset 0 0 4.41px color-mix(in srgb, var(--vscode-foreground) 12.4%, transparent)'
 			}
 		);
 	});
@@ -28,6 +28,13 @@ suite('VoiceGlow', () => {
 		assert.deepStrictEqual(
 			[0, 300 * Math.PI, 900 * Math.PI].map(timestamp => Number(readIdleVoiceGlowIntensity(timestamp).toFixed(3))),
 			[0.4, 0.55, 0.25]
+		);
+	});
+
+	test('renders a static idle glow midpoint when motion is reduced', () => {
+		assert.deepStrictEqual(
+			[0, 300 * Math.PI, 900 * Math.PI].map(timestamp => readIdleVoiceGlowIntensity(timestamp, true)),
+			[0.4, 0.4, 0.4]
 		);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceGlow.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceGlow.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { computeVoiceGlowStyle, readIdleVoiceGlowIntensity } from '../../../browser/voiceClient/voiceGlow.js';
+
+suite('VoiceGlow', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('renders a subtle white glow for connected idle voice mode', () => {
+		const idleStyle = computeVoiceGlowStyle('idle', 0.4, false);
+		assert.deepStrictEqual(
+			{
+				borderColor: idleStyle.borderColor.replace('0.23199999999999998', '0.232'),
+				boxShadow: idleStyle.boxShadow,
+			},
+			{
+				borderColor: 'rgba(255,255,255,0.232)',
+				boxShadow: '0 0 9px rgba(255,255,255,0.136), inset 0 0 3.15px rgba(255,255,255,0.068)'
+			}
+		);
+	});
+
+	test('breathes the idle glow intensity over time', () => {
+		assert.deepStrictEqual(
+			[0, 300 * Math.PI, 900 * Math.PI].map(timestamp => Number(readIdleVoiceGlowIntensity(timestamp).toFixed(3))),
+			[0.3, 0.4, 0.2]
+		);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceGlow.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceGlow.test.ts
@@ -14,12 +14,12 @@ suite('VoiceGlow', () => {
 		const idleStyle = computeVoiceGlowStyle('idle', 0.4, false);
 		assert.deepStrictEqual(
 			{
-				borderColor: idleStyle.borderColor.replace('0.23199999999999998', '0.232'),
-				boxShadow: idleStyle.boxShadow,
+				borderColor: idleStyle.borderColor,
+				boxShadow: idleStyle.boxShadow.replace('12.600000000000001', '12.6'),
 			},
 			{
-				borderColor: 'rgba(255,255,255,0.232)',
-				boxShadow: '0 0 9px rgba(255,255,255,0.136), inset 0 0 3.15px rgba(255,255,255,0.068)'
+				borderColor: 'rgba(255,255,255,0.42)',
+				boxShadow: '0 0 12.6px rgba(255,255,255,0.248), inset 0 0 4.41px rgba(255,255,255,0.124)'
 			}
 		);
 	});
@@ -27,7 +27,7 @@ suite('VoiceGlow', () => {
 	test('breathes the idle glow intensity over time', () => {
 		assert.deepStrictEqual(
 			[0, 300 * Math.PI, 900 * Math.PI].map(timestamp => Number(readIdleVoiceGlowIntensity(timestamp).toFixed(3))),
-			[0.3, 0.4, 0.2]
+			[0.4, 0.55, 0.25]
 		);
 	});
 });


### PR DESCRIPTION
Update the connected idle voice UI to make barge-in discoverable and add a subtle white breathing glow while the session stays armed.

Also centralize the idle glow styling in the shared helper and cover it with focused VoiceGlow tests.


https://github.com/user-attachments/assets/fe89e17b-ae6f-445c-ab06-6f2e2fa7d06b


