### PR TITLE
Fix agent host MCP server state and add per-server diagnostics

### DIFF
--- a/src/vs/platform/agentHost/node/claude/customizations/scan/claudeMcpScan.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/scan/claudeMcpScan.ts
@@ -45,7 +45,7 @@ function extractMcpServerMap(uri: URI, raw: unknown): Record<string, unknown> | 
  * user scope) for declared MCP servers and returns them as
  * {@link McpServerCustomization} entries pointing at the real source file.
  *
- * Pre-materialize, the state is {@link McpServerStatus.Starting} (declared
+ * Pre-materialize, the state is {@link McpServerStatus.Stopped} (declared
  * but not yet connected). Post-materialize, the live connection status is
  * enriched from the SDK's `mcpServerStatus()` by the projector.
  */

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -3665,7 +3665,7 @@ class SessionPluginController extends Disposable {
 	 * kept up to date by the owning session from its MCP controller. Overlaid
 	 * onto published customizations by {@link _overlayMcpState} so a re-sync
 	 * preserves the live state of otherwise-unchanged MCP servers instead of
-	 * resetting them to the `Starting` default baked into
+	 * resetting them to the `Stopped` default baked into
 	 * `makeMcpServerCustomization`. Exposed (not injected) so the session can
 	 * write to it once it holds this controller.
 	 */

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -415,6 +415,24 @@ interface UsageContext {
 	cost?: number;
 }
 
+/** Which SDK source produced an MCP lifecycle log record. */
+type McpLifecycleOrigin = 'loaded' | 'statusChanged' | 'inventory';
+
+/**
+ * SDK-neutral fields carried into a single MCP lifecycle log record. The
+ * `session.mcp_servers_loaded` event, the `session.mcp_server_status_changed`
+ * event, and the `rpc.mcp.list` inventory each populate the subset they carry.
+ */
+interface IMcpLifecycleLogInfo {
+	readonly name: string;
+	readonly status: SdkMcpServerStatus;
+	readonly error?: string;
+	readonly source?: string;
+	readonly transport?: string;
+	readonly pluginName?: string;
+	readonly pluginVersion?: string;
+}
+
 class CopilotTurn {
 
 	private _state: CopilotTurnState = 'pending';
@@ -662,6 +680,14 @@ export class CopilotAgentSession extends Disposable {
 
 	/** Tracks whether a non-empty activity has been published, so we only emit a clear when needed. */
 	private _hasActivity = false;
+
+	/**
+	 * Last SDK-reported MCP status logged for each server (keyed by server
+	 * name). Used to suppress duplicate lifecycle log records when the SDK
+	 * re-reports an unchanged status — the `rpc.mcp.list` seed and the
+	 * `session.mcp_servers_loaded` event routinely carry the same snapshot.
+	 */
+	private readonly _lastLoggedMcpStatus = new Map<string, SdkMcpServerStatus>();
 
 	/** Platform used to compute the SDK sandbox policy (injectable for tests). */
 	private readonly _platform: NodeJS.Platform;
@@ -1459,6 +1485,7 @@ export class CopilotAgentSession extends Disposable {
 		await this.syncPermissionMode('turn-start');
 		await this._applyEffectiveSandboxConfig();
 		await this._reconcileMcpServerEnablement();
+		this._markEnabledMcpServersStarting();
 		await this._wrapper.session.send({ prompt, attachments: sdkAttachments?.length ? sdkAttachments : undefined });
 		this._logService.info(`[Copilot:${this.sessionId}] session.send() returned`);
 	}
@@ -1823,6 +1850,10 @@ export class CopilotAgentSession extends Disposable {
 			}
 			try {
 				if (desired) {
+					// Re-enabling restarts the server. The SDK connects it in the
+					// background with no live "starting" event, so surface Starting
+					// optimistically until the trailing refresh settles it.
+					this._mcpCustomizations.markStarting([server.serverName]);
 					await this._wrapper.session.rpc.mcp.enable({ serverName: server.serverName });
 				} else {
 					await this._disableMcpServer(server.serverName);
@@ -1834,6 +1865,23 @@ export class CopilotAgentSession extends Disposable {
 		}
 		if (changed) {
 			await this._refreshMcpServersFromRpc();
+		}
+	}
+
+	/**
+	 * Optimistically marks the session's enabled MCP servers as Starting for the
+	 * turn that is about to begin. Sending a message makes the SDK connect
+	 * enabled servers in the background with no live "starting" event, so without
+	 * this a connecting server would read as its last settled state (e.g. the
+	 * seeded Stopped) until the connection resolves. Already-running servers are
+	 * left untouched by the controller; the subsequent SDK status settles each
+	 * server.
+	 */
+	private _markEnabledMcpServersStarting(): void {
+		const customizations = this._stateManager.getSessionState(this.sessionUri.toString())?.customizations ?? [];
+		const enabled = getEffectiveMcpServerCustomizations(customizations).filter(server => server.enabled);
+		if (enabled.length > 0) {
+			this._mcpCustomizations.markStarting(enabled.map(server => server.name));
 		}
 	}
 
@@ -3501,11 +3549,23 @@ export class CopilotAgentSession extends Disposable {
 		// Translate SDK-reported MCP server lifecycle into AHP customization
 		// actions. The controller decides whether each server is a
 		// plugin-derived child (narrow `SessionMcpServerStateChanged`) or a
-		// bare top-level entry (`SessionCustomizationUpdated`).
+		// bare top-level entry (`SessionCustomizationUpdated`). Each state
+		// change is also logged (with structured metadata) so it flows to the
+		// agent host's OTLP log stream and the per-server Output channels.
 		this._register(wrapper.onMcpServersLoaded(e => {
+			this._logMcpServersSnapshot(e.data.servers.map(s => ({
+				name: s.name,
+				status: s.status,
+				error: s.error,
+				source: s.source,
+				transport: s.transport,
+				pluginName: s.pluginName,
+				pluginVersion: s.pluginVersion,
+			})), 'loaded');
 			this._applyMcpServerList(e.data.servers);
 		}));
 		this._register(wrapper.onMcpServerStatusChanged(e => {
+			this._logMcpServerLifecycle({ name: e.data.serverName, status: e.data.status, error: e.data.error, origin: 'statusChanged' });
 			const server = this._toSdkMcpServer(e.data.serverName, e.data.status, e.data.error);
 			if (!server) {
 				this._mcpCustomizations.remove(e.data.serverName);
@@ -3549,6 +3609,14 @@ export class CopilotAgentSession extends Disposable {
 		}
 		const result = await mcpRpc.list();
 		if (!this._store.isDisposed) {
+			this._logMcpServersSnapshot(result.servers.map(s => ({
+				name: s.name,
+				status: s.status,
+				error: s.error,
+				source: s.source,
+				pluginName: s.sourcePlugin,
+				pluginVersion: s.sourcePluginVersion,
+			})), 'inventory');
 			this._applyMcpServerList(result.servers);
 		}
 	}
@@ -3557,6 +3625,59 @@ export class CopilotAgentSession extends Disposable {
 		const sdkServers = servers
 			.map(s => this._toSdkMcpServer(s.name, s.status, s.error));
 		this._mcpCustomizations.applyAll(sdkServers);
+	}
+
+	/**
+	 * Logs a full MCP inventory snapshot ({@link _logMcpServerLifecycle} per
+	 * server), then forgets the dedup entry for any server that dropped out of
+	 * the snapshot so a later re-add re-logs its arrival.
+	 */
+	private _logMcpServersSnapshot(servers: readonly IMcpLifecycleLogInfo[], origin: McpLifecycleOrigin): void {
+		const seen = new Set<string>();
+		for (const server of servers) {
+			seen.add(server.name);
+			this._logMcpServerLifecycle({ ...server, origin });
+		}
+		for (const name of [...this._lastLoggedMcpStatus.keys()]) {
+			if (!seen.has(name)) {
+				this._lastLoggedMcpStatus.delete(name);
+			}
+		}
+	}
+
+	/**
+	 * Emits a single structured MCP lifecycle log record for `server`,
+	 * deduplicated by SDK status so an unchanged re-report stays quiet. Failed
+	 * servers log at `error` (carrying the failure text in the body and an
+	 * `errorType` attribute); every other transition logs at `info`. Records
+	 * flow through {@link ILogService} to the agent host's OTLP log stream.
+	 */
+	private _logMcpServerLifecycle(server: IMcpLifecycleLogInfo & { readonly origin: McpLifecycleOrigin }): void {
+		if (this._lastLoggedMcpStatus.get(server.name) === server.status) {
+			return;
+		}
+		this._lastLoggedMcpStatus.set(server.name, server.status);
+
+		const state = this._translateSdkMcpStatus(server.name, server.status, server.error);
+		const attributes: Record<string, OtelAttributeValue> = {
+			mcpEvent: server.origin,
+			mcpServer: server.name,
+			mcpStatus: server.status,
+			mcpState: state.kind,
+		};
+		if (server.source) { attributes.mcpSource = server.source; }
+		if (server.transport) { attributes.mcpTransport = server.transport; }
+		if (server.pluginName) { attributes.mcpPlugin = server.pluginName; }
+		if (server.pluginVersion) { attributes.mcpPluginVersion = server.pluginVersion; }
+		if (state.kind === McpServerStatus.Error) { attributes.errorType = state.error.errorType; }
+
+		const detail = server.error ? `: ${server.error}` : '';
+		const message = `[Copilot:${this.sessionId}] MCP server '${server.name}' ${server.status} (${state.kind})${detail}`;
+		if (server.status === 'failed') {
+			this._logService.error(message, new OtelData(attributes));
+		} else {
+			this._logService.info(message, new OtelData(attributes));
+		}
 	}
 
 	private _setToolCallUiMeta(meta: Mutable<IToolCallMeta>, resourceUri: string | undefined, mcpServerName: string | undefined): void {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1830,9 +1830,18 @@ export class CopilotAgentSession extends Disposable {
 		}
 		// stopServer leaves inline session MCP servers not_configured; disable->enable is the validated restart path.
 		await this._disableMcpServer(serverName);
-		await this._wrapper.session.rpc.mcp.enable({ serverName });
-		await this._wrapper.session.rpc.mcp.listTools({ serverName });
-		this._seedMcpServersFromRpc();
+		// The SDK reconnects in the background on enable with no live "starting"
+		// event, so surface Starting optimistically until the seed below settles it.
+		this._mcpCustomizations.markStarting([serverName]);
+		try {
+			await this._wrapper.session.rpc.mcp.enable({ serverName });
+			await this._wrapper.session.rpc.mcp.listTools({ serverName });
+		} finally {
+			// Always reconcile against the SDK's real state -- on success this
+			// settles Starting -> Ready/AuthRequired, and on failure it clears the
+			// optimistic Starting instead of leaving the UI stuck.
+			this._seedMcpServersFromRpc();
+		}
 	}
 
 	private async _reconcileMcpServerEnablement(): Promise<void> {
@@ -1852,13 +1861,16 @@ export class CopilotAgentSession extends Disposable {
 				if (desired) {
 					// Re-enabling restarts the server. The SDK connects it in the
 					// background with no live "starting" event, so surface Starting
-					// optimistically until the trailing refresh settles it.
+					// optimistically. Mark `changed` now (before the enable) so the
+					// trailing refresh always runs and settles/clears this optimistic
+					// Starting even if the enable rejects.
 					this._mcpCustomizations.markStarting([server.serverName]);
+					changed = true;
 					await this._wrapper.session.rpc.mcp.enable({ serverName: server.serverName });
 				} else {
 					await this._disableMcpServer(server.serverName);
+					changed = true;
 				}
-				changed = true;
 			} catch (e) {
 				this._logService.error(e, `[Copilot:${this.sessionId}] Failed to ${desired ? 'enable' : 'disable'} MCP server ${server.serverName}`);
 			}

--- a/src/vs/platform/agentHost/node/shared/mcpCustomizationController.ts
+++ b/src/vs/platform/agentHost/node/shared/mcpCustomizationController.ts
@@ -32,7 +32,7 @@ export interface ISdkMcpServer {
  * owns — the high-frequency `state`/`channel` pair. Consumers overlay
  * these onto their published customizations (keyed by customization id)
  * so a wholesale customization republish preserves live MCP status
- * rather than resetting it to the `Starting` default baked into
+ * rather than resetting it to the `Stopped` default baked into
  * `makeMcpServerCustomization`.
  */
 export type IMcpServerRuntimeState = Pick<McpServerCustomization, 'state' | 'channel'>;
@@ -274,6 +274,33 @@ export class McpCustomizationController extends Disposable {
 	/** Upserts a single server. */
 	applyOne(server: ISdkMcpServer): void {
 		transaction(tx => this._applyOne(server, tx));
+	}
+
+	/**
+	 * Optimistically transitions the named servers to
+	 * {@link McpServerStatus.Starting}, skipping any that are already
+	 * {@link McpServerStatus.Ready} (nothing to (re)start), blocked on
+	 * {@link McpServerStatus.AuthRequired} (needs the user, not a background
+	 * start), or already {@link McpServerStatus.Starting}.
+	 *
+	 * The SDK connects enabled servers in the background — on an explicit
+	 * start or when a turn begins — but emits no live "starting" event, so
+	 * without this a connecting server would read as its last settled state
+	 * (e.g. `Stopped`) until it resolves. Callers invoke this immediately
+	 * before the (blocking) connect so clients see the transient `Starting`
+	 * state; the subsequent SDK status settles each server. Batched in a
+	 * single transaction so {@link runtimeStates} observers see one update.
+	 */
+	markStarting(serverNames: Iterable<string>): void {
+		transaction(tx => {
+			for (const name of serverNames) {
+				const previous = this._live.get().get(name)?.state.kind;
+				if (previous === McpServerStatus.Ready || previous === McpServerStatus.AuthRequired || previous === McpServerStatus.Starting) {
+					continue;
+				}
+				this._applyOne({ name, state: { kind: McpServerStatus.Starting } }, tx);
+			}
+		});
 	}
 
 	private _applyOne(server: ISdkMcpServer, tx: ITransaction): void {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -187,6 +187,9 @@ class MockCopilotSession {
 					servers: this.mcpListResult.servers.map(server => server.name === params.serverName ? { ...server, status: 'pending' } : server),
 				};
 			},
+			listTools: async (_params: { serverName: string }) => {
+				return { tools: [] };
+			},
 			disable: async (params: { serverName: string }) => {
 				this.mcpDisableCalls.push(params);
 				await this.mcpDisableGate;
@@ -5515,6 +5518,35 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual({ beforeSend, afterSend }, {
 				beforeSend: { kind: McpServerStatus.Error, error: { errorType: 'mcp-server-failed', message: 'boom' } },
 				afterSend: { kind: McpServerStatus.Starting },
+			});
+		});
+
+		test('startMcpServer optimistically marks the server Starting before the blocking reconnect', async () => {
+			const serverName = 'db';
+			const id = 'mcp-top-level:copilot:test-session-1:db';
+			const { session } = await createAgentSession(disposables, {
+				sessionCustomizations: () => [{
+					type: CustomizationType.McpServer,
+					id,
+					uri: id,
+					name: serverName,
+					enabled: true,
+					state: { kind: McpServerStatus.Stopped },
+				}],
+				// Settled (failed) before the explicit restart; the disable->enable
+				// reconnect is a background SDK operation with no live "starting" event.
+				configureMockSession: mock => { mock.mcpListResult = { servers: [{ name: serverName, status: 'failed', error: 'boom' }] }; },
+			});
+
+			const beforeStart = session.topLevelMcpCustomizations()[0]?.state;
+			await session.startMcpServer(id);
+			// The trailing inventory refresh is fire-and-forget, so right after the
+			// awaited enable the optimistic Starting is observable.
+			const afterStart = session.topLevelMcpCustomizations()[0]?.state;
+
+			assert.deepStrictEqual({ beforeStart, afterStart }, {
+				beforeStart: { kind: McpServerStatus.Error, error: { errorType: 'mcp-server-failed', message: 'boom' } },
+				afterStart: { kind: McpServerStatus.Starting },
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -43,6 +43,7 @@ import { CopilotCliConfigKey } from '../../common/copilotCliConfig.js';
 import { AgentHostSandboxConfigKey, AgentHostSandboxKey } from '../../common/sandboxConfigSchema.js';
 import { AgentSandboxEnabledValue } from '../../../sandbox/common/settings.js';
 import { createSessionDataService, createZeroDiffComputeService } from '../common/sessionTestHelpers.js';
+import { OtelData } from '../../common/otlp/otlpLogEmitter.js';
 import { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
 
@@ -5490,6 +5491,33 @@ suite('CopilotAgentSession', () => {
 			});
 		});
 
+		test('sending a message optimistically marks an enabled server as Starting', async () => {
+			const serverName = 'db';
+			const id = 'mcp-top-level:copilot:test-session-1:db';
+			const { session } = await createAgentSession(disposables, {
+				sessionCustomizations: () => [{
+					type: CustomizationType.McpServer,
+					id,
+					uri: id,
+					name: serverName,
+					enabled: true,
+					state: { kind: McpServerStatus.Stopped },
+				}],
+				// The server is settled (failed) before the turn; the SDK reconnects
+				// enabled servers in the background on send without a live event.
+				configureMockSession: mock => { mock.mcpListResult = { servers: [{ name: serverName, status: 'failed', error: 'boom' }] }; },
+			});
+
+			const beforeSend = session.topLevelMcpCustomizations()[0]?.state;
+			await session.send('hello');
+			const afterSend = session.topLevelMcpCustomizations()[0]?.state;
+
+			assert.deepStrictEqual({ beforeSend, afterSend }, {
+				beforeSend: { kind: McpServerStatus.Error, error: { errorType: 'mcp-server-failed', message: 'boom' } },
+				afterSend: { kind: McpServerStatus.Starting },
+			});
+		});
+
 		test('peer chat MCP desired enablement uses parent session customizations', async () => {
 			const parentSessionUri = AgentSession.uri('copilot', 'parent-session');
 			const peerChatUri = URI.parse(buildChatUri(parentSessionUri, 'peer-1'));
@@ -5926,6 +5954,71 @@ suite('CopilotAgentSession', () => {
 				servers: [{ name: 'late', status: 'connected' }],
 			} as SessionEventPayload<'session.mcp_servers_loaded'>['data']);
 			await waitForSignal(s => isAction(s, ActionType.SessionCustomizationUpdated));
+		});
+
+		test('a failed MCP server logs at error with structured attributes and preserves the failure detail', async () => {
+			const logService = new CapturingLogService();
+			const { mockSession, waitForSignal } = await createAgentSession(disposables, { logService });
+
+			mockSession.fire('session.mcp_server_status_changed', {
+				serverName: 'db',
+				status: 'failed',
+				error: 'connection refused',
+			} as SessionEventPayload<'session.mcp_server_status_changed'>['data']);
+
+			const signal = await waitForSignal(s => isAction(s, ActionType.SessionCustomizationUpdated)) as IAgentActionSignal;
+			const action = signal.action as Extract<SessionAction, { type: ActionType.SessionCustomizationUpdated }>;
+			const record = logService.errors.find(e => String(e.first).includes('MCP server \'db\''));
+
+			assert.deepStrictEqual({
+				state: action.customization.type === 'mcpServer' ? action.customization.state : undefined,
+				body: record ? String(record.first).replace(/^\[Copilot:[^\]]*\]\s*/, '') : undefined,
+				attributes: record?.args[0] instanceof OtelData ? record.args[0].attributes : undefined,
+			}, {
+				state: { kind: McpServerStatus.Error, error: { errorType: 'mcp-server-failed', message: 'connection refused' } },
+				body: 'MCP server \'db\' failed (error): connection refused',
+				attributes: { mcpEvent: 'statusChanged', mcpServer: 'db', mcpStatus: 'failed', mcpState: 'error', errorType: 'mcp-server-failed' },
+			});
+		});
+
+		test('an MCP lifecycle change logs at info with the SDK-reported metadata', async () => {
+			const logService = new CapturingLogService();
+			const { mockSession, waitForSignal } = await createAgentSession(disposables, { logService });
+
+			mockSession.fire('session.mcp_servers_loaded', {
+				servers: [{ name: 'docs', status: 'connected', source: 'plugin', transport: 'stdio', pluginName: 'acme', pluginVersion: '1.2.3' }],
+			} as SessionEventPayload<'session.mcp_servers_loaded'>['data']);
+			await waitForSignal(s => isAction(s, ActionType.SessionCustomizationUpdated));
+
+			const record = logService.infos.find(i => i.message.includes('MCP server \'docs\''));
+			assert.deepStrictEqual(record?.args[0] instanceof OtelData ? record.args[0].attributes : undefined, {
+				mcpEvent: 'loaded',
+				mcpServer: 'docs',
+				mcpStatus: 'connected',
+				mcpState: 'ready',
+				mcpSource: 'plugin',
+				mcpTransport: 'stdio',
+				mcpPlugin: 'acme',
+				mcpPluginVersion: '1.2.3',
+			});
+		});
+
+		test('an unchanged MCP status is not logged twice', async () => {
+			const logService = new CapturingLogService();
+			// Seeding the same server keeps the first log deterministic regardless
+			// of when the rpc seed and the live events interleave.
+			const { mockSession, waitForSignal } = await createAgentSession(disposables, {
+				logService,
+				configureMockSession: m => { m.mcpListResult = { servers: [{ name: 'docs', status: 'connected' }] }; },
+			});
+
+			mockSession.fire('session.mcp_servers_loaded', { servers: [{ name: 'docs', status: 'connected' }] } as SessionEventPayload<'session.mcp_servers_loaded'>['data']);
+			await waitForSignal(s => isAction(s, ActionType.SessionCustomizationUpdated));
+			mockSession.fire('session.mcp_servers_loaded', { servers: [{ name: 'docs', status: 'connected' }] } as SessionEventPayload<'session.mcp_servers_loaded'>['data']);
+			await timeout(0);
+
+			const docsLogs = logService.infos.filter(i => i.message.includes('MCP server \'docs\''));
+			assert.strictEqual(docsLogs.length, 1);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/customizations/scan/claudeMcpScan.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/scan/claudeMcpScan.test.ts
@@ -37,7 +37,7 @@ suite('claudeMcpScan', () => {
 
 		assert.deepStrictEqual(
 			servers.map(s => ({ type: s.type, uri: s.uri, name: s.name, enabled: s.enabled, state: s.state })),
-			[{ type: CustomizationType.McpServer, uri: settings.toString(), name: 'srv', enabled: true, state: { kind: McpServerStatus.Starting } }],
+			[{ type: CustomizationType.McpServer, uri: settings.toString(), name: 'srv', enabled: true, state: { kind: McpServerStatus.Stopped } }],
 		);
 	});
 

--- a/src/vs/platform/agentHost/test/node/shared/mcpCustomizationController.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/mcpCustomizationController.test.ts
@@ -313,6 +313,35 @@ suite('McpCustomizationController', () => {
 		]);
 	});
 
+	test('markStarting transitions non-ready servers to Starting, skipping ready/auth-required/starting', () => {
+		const { controller, actions } = harness(store, { customizations: PLUGIN_CUSTOMIZATIONS });
+		store.add(controller);
+
+		controller.applyOne(server('fs', stopped()));
+		controller.applyOne(server('search', ready()));
+		controller.applyOne(server('mail', authRequired()));
+		const before = actions.length;
+
+		// `unknown` has no live entry yet; it should be created as Starting.
+		controller.markStarting(['fs', 'search', 'mail', 'unknown']);
+
+		const summarized = actions.slice(before).map(a => {
+			if (a.type === ActionType.SessionMcpServerStateChanged) {
+				return { type: a.type, id: a.id, state: a.state };
+			}
+			if (a.type === ActionType.SessionCustomizationUpdated && a.customization.type === CustomizationType.McpServer) {
+				return { type: a.type, id: a.customization.id, state: a.customization.state };
+			}
+			return { type: a.type, id: undefined, state: undefined };
+		});
+		assert.deepStrictEqual(summarized, [
+			// fs (Stopped) -> Starting via its plugin child id
+			{ type: ActionType.SessionMcpServerStateChanged, id: 'mcp-child:demo:fs', state: { kind: McpServerStatus.Starting } },
+			// unknown (no entry) -> Starting as a bare top-level customization
+			{ type: ActionType.SessionCustomizationUpdated, id: 'mcp-top-level:copilot:session-1:unknown', state: { kind: McpServerStatus.Starting } },
+		]);
+	});
+
 	test('parseMcpChannelUri round-trips the controller-minted channel URI', () => {
 		const channel = 'mcp://copilot/session-1/fs';
 		assert.deepStrictEqual(parseMcpChannelUri(channel), {

--- a/src/vs/platform/agentPlugins/common/pluginParsers.ts
+++ b/src/vs/platform/agentPlugins/common/pluginParsers.ts
@@ -258,6 +258,11 @@ function makeHookCustomization(hookUri: URI): HookCustomization {
  * multiple servers declared in one file get distinct ids, and the entry
  * carries {@link DEFAULT_MCP_APP} so MCP App support is advertised
  * consistently with every other MCP customization.
+ *
+ * The seed state is {@link McpServerStatus.Stopped}: a declared-but-not-yet
+ * connected server has not been started by any SDK, so it must not claim to
+ * be {@link McpServerStatus.Starting}. The live state is enriched from the
+ * SDK's reported status once a session materializes.
  */
 export function makeMcpServerCustomization(definitionUri: URI, name: string): McpServerCustomization {
 	return {
@@ -266,7 +271,7 @@ export function makeMcpServerCustomization(definitionUri: URI, name: string): Mc
 		uri: definitionUri.toString(),
 		name,
 		enabled: true,
-		state: { kind: McpServerStatus.Starting },
+		state: { kind: McpServerStatus.Stopped },
 		mcpApp: DEFAULT_MCP_APP,
 	};
 }

--- a/src/vs/platform/agentPlugins/test/common/pluginParsers.test.ts
+++ b/src/vs/platform/agentPlugins/test/common/pluginParsers.test.ts
@@ -398,7 +398,7 @@ suite('pluginParsers', () => {
 
 	suite('makeMcpServerCustomization', () => {
 
-		test('builds a Starting server with DEFAULT_MCP_APP and a name-disambiguated id', () => {
+		test('builds a Stopped server with DEFAULT_MCP_APP and a name-disambiguated id', () => {
 			const uri = URI.file('/workspace/.mcp.json');
 			const customization = makeMcpServerCustomization(uri, 'fs server');
 			assert.deepStrictEqual(customization, {
@@ -407,7 +407,7 @@ suite('pluginParsers', () => {
 				uri: uri.toString(),
 				name: 'fs server',
 				enabled: true,
-				state: { kind: McpServerStatus.Starting },
+				state: { kind: McpServerStatus.Stopped },
 				mcpApp: DEFAULT_MCP_APP,
 			});
 		});

--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -33,7 +33,6 @@ export interface IAgentHostMcpServer {
 	readonly enabled: boolean;
 	readonly status: McpServerStatus;
 	readonly state: McpServerState;
-	readonly logOutputChannelId?: string;
 	/** Starts or restarts the server. Providers that cannot control lifecycle may no-op. */
 	start(): Promise<void>;
 	/** Stops the server. Providers that cannot control lifecycle may no-op. */

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1751,9 +1751,6 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	abstract readonly icon: ThemeIcon;
 	abstract readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 
-	/** The workbench Output channel id carrying this host's agent host logs. */
-	protected abstract getLogOutputChannelId(): string | undefined;
-
 	get order(): number { return 0; }
 
 	get sessionTypes(): readonly ISessionType[] { return this._sessionTypes; }
@@ -2951,7 +2948,6 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			return [];
 		}
 		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
-		const logOutputChannelId = this.getLogOutputChannelId();
 		return (sessionState.customizations ?? [])
 			.flatMap(c => c.type === CustomizationType.McpServer
 				? [c]
@@ -2964,7 +2960,6 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 				enabled: c.enabled,
 				status: c.state.kind,
 				state: c.state,
-				logOutputChannelId,
 				setEnabled: (enabled: boolean) => {
 					const connection = this.connection;
 					if (!connection) {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -28,7 +28,6 @@ import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/co
 import { IWorkbenchEnvironmentService } from '../../../../../workbench/services/environment/common/environmentService.js';
 import { LOCAL_AGENT_HOST_PROVIDER_ID, LocalAgentHostDefaultProviderSettingId } from '../../../../common/agentHostSessionsProvider.js';
 import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
-import { AGENT_HOST_LOG_OUTPUT_CHANNEL_ID } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { buildAgentHostSessionWorkspace, readBranchProtectionPatterns } from '../../../../common/agentHostSessionWorkspace.js';
 import { IGitHubInfo, ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL } from '../../../../services/sessions/common/session.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
@@ -69,10 +68,6 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 	/** `true` when running in the dedicated Agents window vs. a regular editor window. */
 	private readonly _isSessionsWindow: boolean;
-
-	protected override getLogOutputChannelId(): string | undefined {
-		return AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
-	}
 
 	/**
 	 * When the experimental {@link LocalAgentHostDefaultProviderSettingId}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -17,7 +17,7 @@ import { localize } from '../../../../../nls.js';
 import { agentHostUri } from '../../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
 import { AGENT_HOST_SCHEME, agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { type IAgentConnection, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
-import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, remoteAgentHostLogOutputChannelId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import type { ISessionGitState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IDialogService, IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
@@ -88,10 +88,6 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 	readonly canConnectOnDemand: boolean;
 	readonly onDidReportConnectProgress: Event<IAgentHostConnectProgress> | undefined;
-
-	protected override getLogOutputChannelId(): string | undefined {
-		return remoteAgentHostLogOutputChannelId(this.remoteAddress);
-	}
 
 	private readonly _connectionStatus = observableValue<RemoteAgentHostConnectionStatus>('connectionStatus', RemoteAgentHostConnectionStatus.disconnected);
 	readonly connectionStatus: IObservable<RemoteAgentHostConnectionStatus> = this._connectionStatus;

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
@@ -167,6 +167,9 @@ function createTestCustomAgentsService(connection: MockAgentConnection, rootCust
 		},
 		setMcpServerEnablement() { },
 		prepareMcpServersForTurn() { },
+		showMcpServerLog(_sessionResource: URI, _serverId: string) {
+			// no-op
+		},
 	};
 }
 

--- a/src/vs/sessions/services/agentHost/browser/agentHostCustomizationService.ts
+++ b/src/vs/sessions/services/agentHost/browser/agentHostCustomizationService.ts
@@ -70,7 +70,6 @@ export class AgentHostCustomizationService extends AbstractAgentHostCustomizatio
 		return {
 			customizations: provider.getCustomizations(session.sessionId),
 			workingDirectory: provider.getWorkingDirectory(session.sessionId),
-			logOutputChannelId: servers[0]?.logOutputChannelId,
 			rootConfig: provider.getRootConfig(),
 			authenticate: request => provider.authenticate(request),
 			setCustomizationEnabled: (rawId, enabled) => {

--- a/src/vs/sessions/services/agentHost/browser/agentHostCustomizationService.ts
+++ b/src/vs/sessions/services/agentHost/browser/agentHostCustomizationService.ts
@@ -34,6 +34,7 @@ export class AgentHostCustomizationService extends AbstractAgentHostCustomizatio
 		this._register(this._sessionsManagementService.onDidChangeSessions(e => {
 			for (const session of e.removed) {
 				this._clearMcpServerTracking(session.resource);
+				this._disposeMcpDiagnostics(session.resource);
 			}
 			this._fireCustomAgentsChanged();
 			this._fireCustomizationsChanged();

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
@@ -6,7 +6,8 @@
 import { URI } from '../../../../../../base/common/uri.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableResourceMap, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
-import { NKeyMap } from '../../../../../../base/common/map.js';
+import { NKeyMap, ResourceSet } from '../../../../../../base/common/map.js';
+import { StringSHA1 } from '../../../../../../base/common/hash.js';
 import { IReader } from '../../../../../../base/common/observable.js';
 import { AgentHostMcpServers, AgentHostMcpServersConfigKey } from '../../../../../../platform/agentHost/common/agentHostSchema.js';
 import { IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
@@ -154,6 +155,14 @@ export abstract class AbstractAgentHostCustomizationService extends Disposable i
 	private readonly _mcpEnablementModel: EnablementModel;
 	private readonly _mcpServerTracking = new NKeyMap<IMcpServerTrackingEntry, [string, string]>();
 	private readonly _mcpLogRegistry: AgentHostMcpServerLogRegistry;
+	/**
+	 * Sessions whose MCP diagnostics we mirror into per-server Output channels.
+	 * A session is tracked once the UI first queries its MCP servers; from then
+	 * on every state change is recorded via {@link onDidChangeCustomizations},
+	 * independent of whether the UI re-queries -- so a failure and a later
+	 * recovery both land in the channel history.
+	 */
+	private readonly _mcpDiagnosticSessions = new ResourceSet();
 
 	protected constructor(
 		protected readonly _instantiationService: IInstantiationService,
@@ -163,6 +172,7 @@ export abstract class AbstractAgentHostCustomizationService extends Disposable i
 		super();
 		this._mcpEnablementModel = this._register(new EnablementModel(MCP_SERVER_ENABLEMENT_STORAGE_KEY, storageService));
 		this._mcpLogRegistry = this._register(this._instantiationService.createInstance(AgentHostMcpServerLogRegistry));
+		this._register(this.onDidChangeCustomizations(() => this._recordMcpDiagnostics()));
 	}
 
 	protected abstract _resolveTarget(sessionResource: URI): IAgentHostCustomizationTarget | undefined;
@@ -184,26 +194,21 @@ export abstract class AbstractAgentHostCustomizationService extends Disposable i
 		if (!target) {
 			return [];
 		}
+		// Start mirroring this session's MCP diagnostics (idempotent). Recording
+		// itself is driven by state-change events, not this getter, so a later
+		// failure/recovery is captured even without a re-query.
+		this._trackMcpDiagnostics(sessionResource, target);
 		return this._flattenMcpServers(target.customizations)
-			.map((c): IAgentHostMcpServer => {
-				const id = this._scopedMcpServerId(sessionResource, c.id);
-				// Record into the per-server diagnostics channel on every
-				// projection (which fires on each state change the UI observes)
-				// so the channel captures the observable transition history. The
-				// channel id itself stays internal -- reveal it via
-				// {@link showMcpServerLog}.
-				this._mcpLogRegistry.record({ id, name: c.name, enabled: c.enabled, state: c.state });
-				return {
-					id,
-					name: c.name,
-					enabled: c.enabled,
-					status: c.state.kind,
-					state: c.state,
-					setEnabled: (enabled: boolean) => target.setCustomizationEnabled(c.id, enabled),
-					start: () => target.startMcpServer(c.id),
-					stop: () => target.stopMcpServer(c.id),
-				};
-			});
+			.map((c): IAgentHostMcpServer => ({
+				id: this._scopedMcpServerId(sessionResource, c.id),
+				name: c.name,
+				enabled: c.enabled,
+				status: c.state.kind,
+				state: c.state,
+				setEnabled: (enabled: boolean) => target.setCustomizationEnabled(c.id, enabled),
+				start: () => target.startMcpServer(c.id),
+				stop: () => target.stopMcpServer(c.id),
+			}));
 	}
 
 	showMcpServerLog(sessionResource: URI, serverId: string): void {
@@ -215,10 +220,41 @@ export abstract class AbstractAgentHostCustomizationService extends Disposable i
 		if (!server) {
 			return;
 		}
-		// Record (idempotent -- dedup'd by state signature) so the channel exists
-		// even if `getMcpServers` was never called for this session, then reveal it.
-		const channelId = this._mcpLogRegistry.record({ id: serverId, name: server.name, enabled: server.enabled, state: server.state });
+		// Ensure the session is tracked and its channels exist, then reveal.
+		this._trackMcpDiagnostics(sessionResource, target);
+		const channelId = this._mcpLogRegistry.record({ sessionResource, rawId: server.id, name: server.name, enabled: server.enabled, state: server.state });
 		this._mcpLogRegistry.show(channelId);
+	}
+
+	/**
+	 * Registers `sessionResource` for MCP diagnostics mirroring and records the
+	 * currently-observed state of each of its servers. Idempotent: registering
+	 * an already-tracked session simply re-records (dedup'd by state signature).
+	 */
+	private _trackMcpDiagnostics(sessionResource: URI, target: IAgentHostCustomizationTarget): void {
+		this._mcpDiagnosticSessions.add(sessionResource);
+		for (const server of this._flattenMcpServers(target.customizations)) {
+			this._mcpLogRegistry.record({ sessionResource, rawId: server.id, name: server.name, enabled: server.enabled, state: server.state });
+		}
+	}
+
+	/** Re-records every tracked session's MCP server states (on any customizations change). */
+	private _recordMcpDiagnostics(): void {
+		for (const sessionResource of this._mcpDiagnosticSessions) {
+			const target = this._resolveTarget(sessionResource);
+			if (!target) {
+				continue;
+			}
+			for (const server of this._flattenMcpServers(target.customizations)) {
+				this._mcpLogRegistry.record({ sessionResource, rawId: server.id, name: server.name, enabled: server.enabled, state: server.state });
+			}
+		}
+	}
+
+	/** Stops mirroring and disposes all MCP diagnostics channels for a session that is going away. */
+	protected _disposeMcpDiagnostics(sessionResource: URI): void {
+		this._mcpDiagnosticSessions.delete(sessionResource);
+		this._mcpLogRegistry.disposeForSession(sessionResource);
 	}
 
 	addMcpServer(sessionResource: URI, name: string, config: IMcpServerConfiguration): void {
@@ -390,6 +426,7 @@ class WorkbenchAgentHostCustomizationService extends AbstractAgentHostCustomizat
 			const currentBackend = this._provisionalSessionService.get(sessionResource);
 			if (existing && existing.backendSession.toString() !== currentBackend?.toString()) {
 				this._clearMcpServerTracking(sessionResource);
+				this._disposeMcpDiagnostics(sessionResource);
 			}
 			this._sessionStateSubscriptions.deleteAndDispose(sessionResource);
 			this._fireCustomizationsChanged();
@@ -399,6 +436,7 @@ class WorkbenchAgentHostCustomizationService extends AbstractAgentHostCustomizat
 			for (const sessionResource of e.sessionResources) {
 				this._sessionStateSubscriptions.deleteAndDispose(sessionResource);
 				this._clearMcpServerTracking(sessionResource);
+				this._disposeMcpDiagnostics(sessionResource);
 			}
 			this._fireCustomizationsChanged();
 			this._fireCustomAgentsChanged();
@@ -502,43 +540,60 @@ class WorkbenchAgentHostCustomizationService extends AbstractAgentHostCustomizat
 registerSingleton(IAgentHostCustomizationService, WorkbenchAgentHostCustomizationService, InstantiationType.Delayed);
 
 /**
- * Owns one hidden Output channel per agent-host MCP server (keyed by the
- * scoped server id, so same-named servers in different sessions stay
- * separate). {@link record} appends a line whenever a server's observable
- * state changes — its lifecycle kind, error, or enablement — so opening the
- * channel shows the server's history including any failure detail. {@link show}
- * reveals the (otherwise hidden) channel.
+ * Owns one hidden Output channel per (agent-host session, MCP server) pair.
+ * {@link record} appends a line whenever a server's observable state changes
+ * (its lifecycle kind, error, or enablement) so opening the channel shows the
+ * server's history including any failure detail. {@link show} reveals the
+ * (otherwise hidden) channel, and {@link disposeForSession} tears down every
+ * channel belonging to a session that is going away.
  */
 class AgentHostMcpServerLogRegistry extends Disposable {
 
-	private readonly _entries = new Map<string, { readonly logger: ILogger; lastSignature: string | undefined }>();
+	private readonly _entries = new Map<string, { readonly logger: ILogger; readonly dispose: () => void; lastSignature: string | undefined }>();
+	/** Channel ids grouped by owning session key, so a session teardown can dispose them all. */
+	private readonly _bySession = new Map<string, Set<string>>();
 
 	constructor(
 		@ILoggerService private readonly _loggerService: ILoggerService,
 		@IOutputService private readonly _outputService: IOutputService,
 	) {
 		super();
+		this._register(toDisposable(() => {
+			for (const key of [...this._bySession.keys()]) {
+				this._disposeSessionKey(key);
+			}
+		}));
 	}
 
 	/**
-	 * Ensures a hidden diagnostics channel exists for the MCP server and
-	 * records a line whenever its state changes (including the first observed
-	 * state). Returns the stable channel id for the service to reveal via
-	 * {@link show} — the id is not exposed outside the service.
+	 * Ensures a hidden diagnostics channel exists for the MCP server identified
+	 * by `(sessionResource, rawId)` and records a line whenever its state
+	 * changes (including the first observed state). Returns the stable channel
+	 * id for the service to reveal via {@link show} -- the id is internal.
 	 */
-	record(server: { readonly id: string; readonly name: string; readonly enabled: boolean; readonly state: McpServerState }): string {
-		const channelId = channelIdForMcpServer(server.id);
+	record(server: { readonly sessionResource: URI; readonly rawId: string; readonly name: string; readonly enabled: boolean; readonly state: McpServerState }): string {
+		const sessionKey = server.sessionResource.toString();
+		const channelId = channelIdForMcpServer(sessionKey, server.rawId);
 		let entry = this._entries.get(channelId);
 		if (!entry) {
-			const logger = this._register(this._loggerService.createLogger(channelId, {
+			const logger = this._loggerService.createLogger(channelId, {
 				hidden: true,
 				name: localize('agentHost.mcpServer.outputChannel', "MCP: {0}", server.name),
-			}));
+			});
 			// Mirror the workbench MCP server pattern: a logger disposed but not
 			// deregistered is reused as a no-op instance, so deregister on dispose.
-			this._register(toDisposable(() => this._loggerService.deregisterLogger(channelId)));
-			entry = { logger, lastSignature: undefined };
+			const dispose = () => {
+				logger.dispose();
+				this._loggerService.deregisterLogger(channelId);
+			};
+			entry = { logger, dispose, lastSignature: undefined };
 			this._entries.set(channelId, entry);
+			let group = this._bySession.get(sessionKey);
+			if (!group) {
+				group = new Set();
+				this._bySession.set(sessionKey, group);
+			}
+			group.add(channelId);
 		}
 
 		const { signature, message, isError } = describeMcpServerState(server.name, server.enabled, server.state);
@@ -561,16 +616,39 @@ class AgentHostMcpServerLogRegistry extends Disposable {
 		this._loggerService.setVisibility(channelId, true);
 		void this._outputService.showChannel(channelId);
 	}
+
+	/** Disposes every channel/logger owned by `sessionResource` (session teardown). */
+	disposeForSession(sessionResource: URI): void {
+		this._disposeSessionKey(sessionResource.toString());
+	}
+
+	private _disposeSessionKey(sessionKey: string): void {
+		const group = this._bySession.get(sessionKey);
+		if (!group) {
+			return;
+		}
+		this._bySession.delete(sessionKey);
+		for (const channelId of group) {
+			this._entries.get(channelId)?.dispose();
+			this._entries.delete(channelId);
+		}
+	}
 }
 
 /**
- * Stable, filesystem-safe Output/logger id for the MCP server whose scoped id
- * is `serverId`. Reserved logger-id characters are replaced (rather than
- * stripped, which the logger service would otherwise do and could collide two
- * distinct ids) so each server keeps a distinct channel.
+ * Stable, injective, filesystem-safe Output/logger id for the MCP server
+ * `rawId` in the session keyed by `sessionKey`. The composite key is SHA1-hashed
+ * to hex: hex characters are never touched by the logger service's own reserved-
+ * character stripping (so distinct servers can't collapse onto one channel), and
+ * hashing keeps the id bounded regardless of how long the session URI or raw id
+ * is.
  */
-function channelIdForMcpServer(serverId: string): string {
-	return `agentHostMcpServer.${serverId.replace(/[\\/:*?"<>|]/g, '-')}`;
+function channelIdForMcpServer(sessionKey: string, rawId: string): string {
+	const sha = new StringSHA1();
+	sha.update(sessionKey);
+	sha.update('\0');
+	sha.update(rawId);
+	return `agentHostMcpServer.${sha.digest()}`;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
@@ -5,30 +5,30 @@
 
 import { URI } from '../../../../../../base/common/uri.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
-import { Disposable, DisposableResourceMap, IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableResourceMap, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { NKeyMap } from '../../../../../../base/common/map.js';
 import { IReader } from '../../../../../../base/common/observable.js';
 import { AgentHostMcpServers, AgentHostMcpServersConfigKey } from '../../../../../../platform/agentHost/common/agentHostSchema.js';
-import { AgentSession, IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
-import { isRemoteAgentHostSessionType, remoteAgentHostSessionTypeId } from '../../../../../../platform/agentHost/common/agentHostSessionType.js';
-import { AGENT_HOST_LOG_OUTPUT_CHANNEL_ID, remoteAgentHostLogOutputChannelId } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
-import { IAgentHostConnectionsService, IAgentHostSessionResolution, LOCAL_AGENT_HOST_SCHEME_PREFIX } from '../../../../../../platform/agentHost/common/agentHostConnectionsService.js';
+import { IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
+import { IAgentHostConnectionsService, IAgentHostSessionResolution } from '../../../../../../platform/agentHost/common/agentHostConnectionsService.js';
 import { getEffectiveAgents } from '../../../../../../platform/agentHost/common/customAgents.js';
 import { type IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
-import { CustomizationType, McpServerCustomization, McpServerStatus, type Customization, type RootConfigState, type SessionState } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { CustomizationType, McpServerCustomization, McpServerStatus, type Customization, type McpServerState, type RootConfigState, type SessionState } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { AgentCustomization, ROOT_STATE_URI, StateComponents } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
 import { createDecorator, IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IMcpServerConfiguration } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
-import { ILogService } from '../../../../../../platform/log/common/log.js';
+import { ILogger, ILoggerService, ILogService } from '../../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ContributionEnablementState, EnablementModel, isContributionEnabled } from '../../../common/enablement.js';
+import { localize } from '../../../../../../nls.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { isUntitledChatSession } from '../../../common/model/chatUri.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
 import { IAgentHostMcpServer } from '../../../../../../sessions/common/agentHostSessionsProvider.js';
 import { resolveMcpServerAuthentication, agentHostMcpServerId } from './agentHostAuth.js';
+import { IOutputService } from '../../../../../services/output/common/output.js';
 
 const MCP_SERVER_ENABLEMENT_STORAGE_KEY = 'chat.agentHost.mcpServerEnablement';
 
@@ -55,9 +55,8 @@ export interface IAgentHostCustomizationService {
 	 * Returns the MCP servers exposed by an agent-host session. Each entry
 	 * carries the current status, a {@link IAgentHostMcpServer.setEnabled}
 	 * method that dispatches the protocol-level toggle on behalf of the
-	 * caller, lifecycle actions, and the
-	 * {@link IAgentHostMcpServer.logOutputChannelId} of the host backing the
-	 * session. Returns an empty array for sessions not
+	 * caller, and lifecycle actions. Per-server diagnostics are revealed via
+	 * {@link showMcpServerLog}. Returns an empty array for sessions not
 	 * backed by an agent host, or that don't expose any MCP servers.
 	 */
 	getMcpServers(sessionResource: URI): readonly IAgentHostMcpServer[];
@@ -85,6 +84,16 @@ export interface IAgentHostCustomizationService {
 
 	/** Applies durable MCP preferences that changed since this session's previous turn. */
 	prepareMcpServersForTurn(sessionResource: URI): void;
+
+	/**
+	 * Reveals the per-server MCP diagnostics Output channel for the server
+	 * `serverId` in the agent-host session `sessionResource`, making its hidden
+	 * logger visible first. The channel is an internal detail of this service --
+	 * callers identify the server the same way they do for
+	 * {@link authenticateMcpServer}. No-op when the session/server cannot be
+	 * resolved.
+	 */
+	showMcpServerLog(sessionResource: URI, serverId: string): void;
 }
 
 export class NullAgentHostCustomizationService implements IAgentHostCustomizationService {
@@ -118,12 +127,14 @@ export class NullAgentHostCustomizationService implements IAgentHostCustomizatio
 	prepareMcpServersForTurn(_sessionResource: URI): void {
 		// no-op
 	}
+	showMcpServerLog(_sessionResource: URI, _serverId: string): void {
+		// no-op
+	}
 }
 
 export interface IAgentHostCustomizationTarget {
 	readonly customizations: readonly Customization[];
 	readonly workingDirectory?: string;
-	readonly logOutputChannelId?: string;
 	readonly rootConfig?: RootConfigState;
 	authenticate(request: { resource: string; scopes?: readonly string[]; token: string }): Promise<unknown>;
 	setCustomizationEnabled(rawId: string, enabled: boolean): void;
@@ -142,6 +153,7 @@ export abstract class AbstractAgentHostCustomizationService extends Disposable i
 
 	private readonly _mcpEnablementModel: EnablementModel;
 	private readonly _mcpServerTracking = new NKeyMap<IMcpServerTrackingEntry, [string, string]>();
+	private readonly _mcpLogRegistry: AgentHostMcpServerLogRegistry;
 
 	protected constructor(
 		protected readonly _instantiationService: IInstantiationService,
@@ -150,6 +162,7 @@ export abstract class AbstractAgentHostCustomizationService extends Disposable i
 	) {
 		super();
 		this._mcpEnablementModel = this._register(new EnablementModel(MCP_SERVER_ENABLEMENT_STORAGE_KEY, storageService));
+		this._mcpLogRegistry = this._register(this._instantiationService.createInstance(AgentHostMcpServerLogRegistry));
 	}
 
 	protected abstract _resolveTarget(sessionResource: URI): IAgentHostCustomizationTarget | undefined;
@@ -171,18 +184,41 @@ export abstract class AbstractAgentHostCustomizationService extends Disposable i
 		if (!target) {
 			return [];
 		}
-		const servers = this._flattenMcpServers(target.customizations);
-		return servers.map((c): IAgentHostMcpServer => ({
-			id: this._scopedMcpServerId(sessionResource, c.id),
-			name: c.name,
-			enabled: c.enabled,
-			status: c.state.kind,
-			state: c.state,
-			logOutputChannelId: target.logOutputChannelId,
-			setEnabled: (enabled: boolean) => target.setCustomizationEnabled(c.id, enabled),
-			start: () => target.startMcpServer(c.id),
-			stop: () => target.stopMcpServer(c.id),
-		}));
+		return this._flattenMcpServers(target.customizations)
+			.map((c): IAgentHostMcpServer => {
+				const id = this._scopedMcpServerId(sessionResource, c.id);
+				// Record into the per-server diagnostics channel on every
+				// projection (which fires on each state change the UI observes)
+				// so the channel captures the observable transition history. The
+				// channel id itself stays internal -- reveal it via
+				// {@link showMcpServerLog}.
+				this._mcpLogRegistry.record({ id, name: c.name, enabled: c.enabled, state: c.state });
+				return {
+					id,
+					name: c.name,
+					enabled: c.enabled,
+					status: c.state.kind,
+					state: c.state,
+					setEnabled: (enabled: boolean) => target.setCustomizationEnabled(c.id, enabled),
+					start: () => target.startMcpServer(c.id),
+					stop: () => target.stopMcpServer(c.id),
+				};
+			});
+	}
+
+	showMcpServerLog(sessionResource: URI, serverId: string): void {
+		const target = this._resolveTarget(sessionResource);
+		if (!target) {
+			return;
+		}
+		const server = this._flattenMcpServers(target.customizations).find(c => this._scopedMcpServerId(sessionResource, c.id) === serverId);
+		if (!server) {
+			return;
+		}
+		// Record (idempotent -- dedup'd by state signature) so the channel exists
+		// even if `getMcpServers` was never called for this session, then reveal it.
+		const channelId = this._mcpLogRegistry.record({ id: serverId, name: server.name, enabled: server.enabled, state: server.state });
+		this._mcpLogRegistry.show(channelId);
 	}
 
 	addMcpServer(sessionResource: URI, name: string, config: IMcpServerConfiguration): void {
@@ -380,7 +416,6 @@ class WorkbenchAgentHostCustomizationService extends AbstractAgentHostCustomizat
 		return {
 			customizations: sessionState?.customizations ?? [],
 			workingDirectory: sessionState?.workingDirectory,
-			logOutputChannelId: this._resolveLogOutputChannelId(sessionResource, target.backendSession),
 			rootConfig: rootState && !(rootState instanceof Error) ? rootState.config : undefined,
 			authenticate: request => target.connection.authenticate(request),
 			setCustomizationEnabled: (rawId, enabled) => {
@@ -411,24 +446,6 @@ class WorkbenchAgentHostCustomizationService extends AbstractAgentHostCustomizat
 				});
 			}
 		};
-	}
-
-	private _resolveLogOutputChannelId(sessionResource: URI, backendSession: URI): string | undefined {
-		if (sessionResource.scheme.startsWith(LOCAL_AGENT_HOST_SCHEME_PREFIX)) {
-			return AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
-		}
-
-		if (isRemoteAgentHostSessionType(sessionResource.scheme)) {
-			const backendProvider = AgentSession.provider(backendSession);
-			// The facade descriptor already exposes the sanitized authority, so
-			// we match the session scheme against `remote-<authority>-<provider>`.
-			const info = backendProvider
-				? this._connectionsService.connections.find(c => !c.isAmbient && c.address !== undefined && sessionResource.scheme === remoteAgentHostSessionTypeId(c.authority, backendProvider))
-				: undefined;
-			return info?.address ? remoteAgentHostLogOutputChannelId(info.address) : undefined;
-		}
-
-		return undefined;
 	}
 
 	private _readSessionState(sessionResource: URI): SessionState | undefined {
@@ -483,3 +500,98 @@ class WorkbenchAgentHostCustomizationService extends AbstractAgentHostCustomizat
 }
 
 registerSingleton(IAgentHostCustomizationService, WorkbenchAgentHostCustomizationService, InstantiationType.Delayed);
+
+/**
+ * Owns one hidden Output channel per agent-host MCP server (keyed by the
+ * scoped server id, so same-named servers in different sessions stay
+ * separate). {@link record} appends a line whenever a server's observable
+ * state changes — its lifecycle kind, error, or enablement — so opening the
+ * channel shows the server's history including any failure detail. {@link show}
+ * reveals the (otherwise hidden) channel.
+ */
+class AgentHostMcpServerLogRegistry extends Disposable {
+
+	private readonly _entries = new Map<string, { readonly logger: ILogger; lastSignature: string | undefined }>();
+
+	constructor(
+		@ILoggerService private readonly _loggerService: ILoggerService,
+		@IOutputService private readonly _outputService: IOutputService,
+	) {
+		super();
+	}
+
+	/**
+	 * Ensures a hidden diagnostics channel exists for the MCP server and
+	 * records a line whenever its state changes (including the first observed
+	 * state). Returns the stable channel id for the service to reveal via
+	 * {@link show} — the id is not exposed outside the service.
+	 */
+	record(server: { readonly id: string; readonly name: string; readonly enabled: boolean; readonly state: McpServerState }): string {
+		const channelId = channelIdForMcpServer(server.id);
+		let entry = this._entries.get(channelId);
+		if (!entry) {
+			const logger = this._register(this._loggerService.createLogger(channelId, {
+				hidden: true,
+				name: localize('agentHost.mcpServer.outputChannel', "MCP: {0}", server.name),
+			}));
+			// Mirror the workbench MCP server pattern: a logger disposed but not
+			// deregistered is reused as a no-op instance, so deregister on dispose.
+			this._register(toDisposable(() => this._loggerService.deregisterLogger(channelId)));
+			entry = { logger, lastSignature: undefined };
+			this._entries.set(channelId, entry);
+		}
+
+		const { signature, message, isError } = describeMcpServerState(server.name, server.enabled, server.state);
+		if (entry.lastSignature !== signature) {
+			entry.lastSignature = signature;
+			if (isError) {
+				entry.logger.error(message);
+			} else {
+				entry.logger.info(message);
+			}
+		}
+		return channelId;
+	}
+
+	/** Reveals the diagnostics channel `channelId`, making its hidden logger visible. */
+	show(channelId: string): void {
+		if (!this._entries.has(channelId)) {
+			return;
+		}
+		this._loggerService.setVisibility(channelId, true);
+		void this._outputService.showChannel(channelId);
+	}
+}
+
+/**
+ * Stable, filesystem-safe Output/logger id for the MCP server whose scoped id
+ * is `serverId`. Reserved logger-id characters are replaced (rather than
+ * stripped, which the logger service would otherwise do and could collide two
+ * distinct ids) so each server keeps a distinct channel.
+ */
+function channelIdForMcpServer(serverId: string): string {
+	return `agentHostMcpServer.${serverId.replace(/[\\/:*?"<>|]/g, '-')}`;
+}
+
+/**
+ * Renders an MCP server's current state into a diagnostics log line, a change
+ * signature (used to suppress duplicate records), and whether it is an error.
+ */
+function describeMcpServerState(name: string, enabled: boolean, state: McpServerState): { signature: string; message: string; isError: boolean } {
+	if (!enabled) {
+		return { signature: 'disabled', message: localize('agentHost.mcpServer.disabled', "Server '{0}' is disabled", name), isError: false };
+	}
+	switch (state.kind) {
+		case McpServerStatus.Ready:
+			return { signature: 'ready', message: localize('agentHost.mcpServer.ready', "Server '{0}' is running", name), isError: false };
+		case McpServerStatus.Starting:
+			return { signature: 'starting', message: localize('agentHost.mcpServer.starting', "Server '{0}' is starting", name), isError: false };
+		case McpServerStatus.AuthRequired:
+			return { signature: `authRequired:${state.resource.resource}`, message: localize('agentHost.mcpServer.authRequired', "Server '{0}' requires authentication ({1})", name, state.resource.resource), isError: false };
+		case McpServerStatus.Error:
+			return { signature: `error:${state.error.errorType}:${state.error.message}`, message: localize('agentHost.mcpServer.error', "Server '{0}' failed: {1}", name, state.error.message), isError: true };
+		case McpServerStatus.Stopped:
+		default:
+			return { signature: 'stopped', message: localize('agentHost.mcpServer.stopped', "Server '{0}' is stopped", name), isError: false };
+	}
+}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCustomizationService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCustomizationService.test.ts
@@ -8,11 +8,12 @@ import { ResourceMap } from '../../../../../../base/common/map.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { ILogService, NullLogService, ILoggerService, NullLoggerService } from '../../../../../../platform/log/common/log.js';
 import { InMemoryStorageService, IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { CustomizationType, McpServerCustomization, McpServerStatus } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ContributionEnablementState } from '../../../common/enablement.js';
 import { AbstractAgentHostCustomizationService, IAgentHostCustomizationTarget } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
+import { IOutputService } from '../../../../../services/output/common/output.js';
 
 /** A dispatched `setCustomizationEnabled(rawId, enabled)` call recorded by a {@link FakeTarget}. */
 interface IDispatchedToggle {
@@ -92,6 +93,8 @@ suite('AbstractAgentHostCustomizationService - MCP server enablement', () => {
 
 	function createSut() {
 		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(ILoggerService, store.add(new NullLoggerService()));
+		instantiationService.stub(IOutputService, { showChannel: async () => { } });
 		const sut = store.add(new TestAgentHostCustomizationService(instantiationService, new NullLogService(), store.add(new InMemoryStorageService())));
 		return sut;
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/mcpListWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/mcpListWidget.test.ts
@@ -28,7 +28,6 @@ function createAgentHostServer(overrides: Partial<AgentHostMcpServer> = {}): Age
 		enabled: true,
 		status: McpServerStatus.Ready,
 		state: { kind: McpServerStatus.Ready },
-		logOutputChannelId: undefined,
 		setEnabled: () => { },
 		start: () => { },
 		stop: () => { },

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -49,7 +49,6 @@ import { IAuthenticationService } from '../../../services/authentication/common/
 import { IAccountQuery, IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
 import { MCP_CONFIGURATION_KEY, WORKSPACE_STANDALONE_CONFIGURATIONS } from '../../../services/configuration/common/configuration.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { IOutputService } from '../../../services/output/common/output.js';
 import { IRemoteUserDataProfilesService } from '../../../services/userDataProfile/common/remoteUserDataProfiles.js';
 import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
@@ -456,7 +455,6 @@ export class McpAgentHostServerOptionsCommand extends Action2 {
 	override async run(accessor: ServicesAccessor, agentHostSession: URI, customizationId: string): Promise<void> {
 		const agentHostCustomizations = accessor.get(IAgentHostCustomizationService);
 		const quickInputService = accessor.get(IQuickInputService);
-		const outputService = accessor.get(IOutputService);
 		const notificationService = accessor.get(INotificationService);
 		const logService = accessor.get(ILogService);
 		const aiCustomizationWorkspaceService = accessor.get(IAICustomizationWorkspaceService);
@@ -466,8 +464,6 @@ export class McpAgentHostServerOptionsCommand extends Action2 {
 		if (!server) {
 			return;
 		}
-
-		const logOutputChannelId = server.logOutputChannelId;
 
 		type ItemType = { action: 'toggleSession' | 'showOutput' | 'authenticate' | AgentHostMcpServerLifecycleAction | AgentHostMcpServerEnablementAction } & IQuickPickItem;
 
@@ -516,12 +512,11 @@ export class McpAgentHostServerOptionsCommand extends Action2 {
 			});
 		}
 
-		if (logOutputChannelId) {
-			items.push({
-				label: localize('mcp.showOutput', 'Show Output'),
-				action: 'showOutput',
-			});
-		}
+		// Every agent-host MCP server has a per-server diagnostics channel.
+		items.push({
+			label: localize('mcp.showOutput', 'Show Output'),
+			action: 'showOutput',
+		});
 
 		const picked = await quickInputService.pick(items, {
 			placeHolder: server.name,
@@ -532,9 +527,7 @@ export class McpAgentHostServerOptionsCommand extends Action2 {
 		}
 
 		if (picked.action === 'showOutput') {
-			if (logOutputChannelId) {
-				await outputService.showChannel(logOutputChannelId);
-			}
+			agentHostCustomizations.showMcpServerLog(agentHostSession, server.id);
 			return;
 		}
 


### PR DESCRIPTION
## Problem

Agent-host MCP servers were seeded as `Starting` before any SDK had attempted to start them, and connection failures were only visible as a coarse status badge with no detail.

## Changes

- **Correct the seed state.** `makeMcpServerCustomization` now produces `Stopped` instead of `Starting` -- a declared-but-unstarted server has not begun connecting. Comments and parser/scan/provider tests updated accordingly.
- **Optimistic `Starting` at the real triggers.** The Copilot SDK gives no live "starting" signal on initial connect (servers settle inside a blocking init phase, and `rpc.mcp.list` blocks until settled -- confirmed by an SDK probe and the runtime source). So the workbench drives `Starting` itself at the two moments the SDK actually (re)starts a server:
  - sending a message (turn start) via `_markEnabledMcpServersStarting()`, and
  - the explicit disable->enable flip.

  Added `McpCustomizationController.markStarting(names)` which skips servers already `Ready`/`AuthRequired`/`Starting`. It is **not** run on every `_reconcileMcpServerEnablement` pass (that only syncs enablement).
- **Structured lifecycle logging.** MCP `loaded` / `statusChanged` / `inventory` events are logged through the agent host's existing OTLP log stream with `OtelData` attributes (server, status, state, source/transport/plugin metadata, error type), deduplicated by SDK status. Failures log at `error` with the failure text, which is also preserved in `McpServerErrorState`.
- **Per-server diagnostics channel.** Each `(session, MCP server)` gets its own hidden Output channel recording lifecycle transitions (deduplicated). "Show Output" reveals it.
- **Encapsulated the channel.** `showMcpServerLog(sessionResource, serverId)` resolves and reveals the channel internally (mirroring `authenticateMcpServer`); `logOutputChannelId` was removed from the public `IAgentHostMcpServer` surface, along with the now-dead `getLogOutputChannelId` provider plumbing.

No AHP schema/version change: errored state already carries structured `ErrorInfo`.

## Testing

- `npm run typecheck-client`, `npm run valid-layers-check`, and hygiene all clean.
- New/updated unit tests: `markStarting` (controller), optimistic-Starting on send (session), the three lifecycle-log tests, the `Stopped` seed assertions (parser + claude scan), plus existing reconcile/auth-preservation coverage still green.
