### PR TITLE
Add dictation mode and model-download telemetry

### DIFF
--- a/src/vs/platform/localTranscription/common/localTranscription.ts
+++ b/src/vs/platform/localTranscription/common/localTranscription.ts
@@ -30,8 +30,19 @@ export interface ILocalTranscriptionModelStatus {
 	readonly state: LocalTranscriptionModelState;
 	/** Overall download progress in [0, 1] while `Downloading`. */
 	readonly progress?: number;
-	/** Short error identifier when `state === Error`. */
+	/**
+	 * Whether model files were actually fetched from the network (a cache miss)
+	 * during this preparation, as opposed to loaded from the on-disk cache. Set
+	 * on the `Ready` status. Used for download telemetry.
+	 */
+	readonly downloaded?: boolean;
+	/** Human-readable error message when `state === Error` (for UI/logging). */
 	readonly error?: string;
+	/**
+	 * Allowlisted, low-cardinality error identifier when `state === Error`
+	 * (e.g. `network`, `notFound`, `memory`), safe to send as telemetry.
+	 */
+	readonly errorCode?: string;
 }
 
 export interface ILocalTranscriptionResult {

--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -67,6 +67,31 @@ type Transformers = typeof import('@huggingface/transformers');
 type ASRResult = { text?: string } | Array<{ text?: string }>;
 type ASRPipeline = (audio: Float32Array, options?: Record<string, unknown>) => Promise<ASRResult>;
 
+/**
+ * Map a raw model download/load error message to a fixed, low-cardinality code
+ * safe to emit as telemetry. The raw message can contain paths, URLs, or other
+ * dynamic detail, so only the returned allowlisted code should be reported.
+ */
+function classifyModelError(message: string): string {
+	const text = message.toLowerCase();
+	if (/\b(404|not found|no such file|does not exist|could not locate|repository not found)\b/.test(text)) {
+		return 'notFound';
+	}
+	if (/\b(network|fetch|econn|enotfound|etimedout|socket|dns|offline|proxy|tls|certificate|getaddrinfo)\b/.test(text)) {
+		return 'network';
+	}
+	if (/\b(out of memory|oom|enomem|allocation failed|cannot allocate)\b/.test(text)) {
+		return 'memory';
+	}
+	if (/\b(enospc|no space left|disk)\b/.test(text)) {
+		return 'disk';
+	}
+	if (/\b(eacces|eperm|permission denied|access is denied)\b/.test(text)) {
+		return 'permission';
+	}
+	return 'unknown';
+}
+
 export class LocalTranscriptionService extends Disposable implements ILocalTranscriptionService {
 
 	declare readonly _serviceBrand: undefined;
@@ -140,10 +165,20 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 				env.cacheDir = cacheDir;
 				env.allowRemoteModels = true;
 
+				// transformers.js only emits `initiate`/`download`/`progress`
+				// callbacks for files it actually fetches from the network; a
+				// fully-cached model loads without any of them. Track that so we
+				// can distinguish a first-use download from a cache hit (the
+				// unconditional `Downloading` state below is a UI signal only and
+				// fires even for cached loads, so it cannot be used for this).
+				let didDownload = false;
 				this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: 0 });
 				const pipe = await pipeline('automatic-speech-recognition', model, {
 					dtype: DEFAULT_DTYPE,
 					progress_callback: (p: { status?: string; progress?: number }) => {
+						if (p.status === 'initiate' || p.status === 'download' || p.status === 'progress') {
+							didDownload = true;
+						}
 						if (p.status === 'progress' && typeof p.progress === 'number') {
 							this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: Math.min(1, p.progress / 100) });
 						} else if (p.status === 'ready') {
@@ -154,13 +189,14 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 				// The transformers.js pipeline() return type is a broad union that
 				// isn't directly callable; narrow it to our ASR call signature.
 				this._pipeline = pipe as unknown as ASRPipeline;
-				this._setStatus({ state: LocalTranscriptionModelState.Ready });
+				this._setStatus({ state: LocalTranscriptionModelState.Ready, downloaded: didDownload });
 				return this._pipeline;
 			} catch (err) {
 				this._pipeline = undefined;
 				this._pipelinePromise = undefined;
 				this._loadedModel = undefined;
-				this._setStatus({ state: LocalTranscriptionModelState.Error, error: String(err instanceof Error ? err.message : err) });
+				const message = String(err instanceof Error ? err.message : err);
+				this._setStatus({ state: LocalTranscriptionModelState.Error, error: message, errorCode: classifyModelError(message) });
 				throw err;
 			}
 		})();

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -185,11 +185,10 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	private _sessionSegments = 0;
 	private _sessionErrorCode = '';
 
-	// Model-preparation telemetry accumulators. `_prepareStartMs` is non-zero
-	// while a preparation is being tracked; `_prepareDownloadObserved` records
-	// whether a first-use download to disk was seen (vs loading a cached model).
+	// Model-preparation telemetry accumulator. `_prepareStartMs` is non-zero
+	// while a preparation is being tracked, so the terminal Ready/Error status
+	// can report the elapsed download/load time exactly once.
 	private _prepareStartMs = 0;
-	private _prepareDownloadObserved = false;
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -258,16 +257,17 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	 * reaches a terminal state (ready or error). `_prepareStartMs` guards against
 	 * duplicate emission, since `_handleModelStatus` can fire repeatedly.
 	 */
-	private _logModelPrepareTelemetry(outcome: 'ready' | 'error', error?: string): void {
+	private _logModelPrepareTelemetry(status: ILocalTranscriptionModelStatus): void {
 		if (this._prepareStartMs === 0) {
 			return;
 		}
+		const outcome = status.state === LocalTranscriptionModelState.Ready ? 'ready' : 'error';
 		const durationMs = Date.now() - this._prepareStartMs;
 		this._telemetryService.publicLog2<SpeechToTextModelPrepareEvent, SpeechToTextModelPrepareClassification>('chatSpeechToText.modelPrepare', {
 			outcome,
-			downloaded: this._prepareDownloadObserved,
+			downloaded: status.downloaded === true,
 			durationMs,
-			errorCode: outcome === 'error' ? (error || 'unknown') : '',
+			errorCode: outcome === 'error' ? (status.errorCode || 'unknown') : '',
 		});
 		this._prepareStartMs = 0;
 	}
@@ -397,7 +397,6 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		// Start timing preparation (download + load) for the model-prepare
 		// telemetry event, emitted once the model reaches Ready or Error.
 		this._prepareStartMs = Date.now();
-		this._prepareDownloadObserved = false;
 		// Guarantee the download notification is dismissed no matter how the
 		// session ends (teardown, cancel, or the service being disposed).
 		this._localSessionDisposables.add(toDisposable(() => this._completeDownloadNotification()));
@@ -420,13 +419,11 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	 */
 	private _handleModelStatus(status: ILocalTranscriptionModelStatus): void {
 		this._updateDownloadNotification(status);
-		if (status.state === LocalTranscriptionModelState.Downloading) {
-			this._prepareDownloadObserved = true;
-		} else if (status.state === LocalTranscriptionModelState.Ready) {
-			this._logModelPrepareTelemetry('ready');
+		if (status.state === LocalTranscriptionModelState.Ready) {
+			this._logModelPrepareTelemetry(status);
 			this._setPreparingModel(false);
 		} else if (status.state === LocalTranscriptionModelState.Error) {
-			this._logModelPrepareTelemetry('error', status.error);
+			this._logModelPrepareTelemetry(status);
 			this._setPreparingModel(false);
 			this._failSession('model', localize('chatStt.modelError', "On-device speech-to-text model failed to load: {0}", status.error ?? ''));
 		}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -32,9 +32,12 @@ const SAMPLE_RATE = 16000;
 const ENABLED_SETTING = 'chat.speechToText.enabled';
 /** On-device Whisper model to use for dictation. */
 const MODEL_SETTING = 'chat.speechToText.model';
+/** Setting that controls the tap-vs-hold behavior of the dictation shortcut. */
+const MODE_SETTING = 'chat.speechToText.mode';
 
 type SpeechToTextSessionEvent = {
 	outcome: 'completed' | 'cancelled' | 'error';
+	mode: string;
 	durationMs: number;
 	segments: number;
 	transcriptLength: number;
@@ -44,10 +47,26 @@ type SpeechToTextSessionClassification = {
 	owner: 'meganrogge';
 	comment: 'Tracks usage and reliability of chat-input dictation (speech-to-text).';
 	outcome: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How the dictation session ended.' };
-	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Recording duration in milliseconds.' };
-	segments: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of transcript segments returned.' };
-	transcriptLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Character length of the final transcript.' };
+	mode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Configured dictation shortcut mode (auto, toggle, or pushToTalk).' };
+	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Recording duration in milliseconds.' };
+	segments: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of transcript segments returned.' };
+	transcriptLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Character length of the final transcript.' };
 	errorCode: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Short error identifier when the session failed, else empty.' };
+};
+
+type SpeechToTextModelPrepareEvent = {
+	outcome: 'ready' | 'error';
+	downloaded: boolean;
+	durationMs: number;
+	errorCode: string;
+};
+type SpeechToTextModelPrepareClassification = {
+	owner: 'meganrogge';
+	comment: 'Tracks download/load success and duration of the on-device dictation (speech-to-text) model.';
+	outcome: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the model became ready or failed to prepare.' };
+	downloaded: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether a download to disk was observed (first use) versus loading an already-cached model.' };
+	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds from starting preparation until the model became ready or errored.' };
+	errorCode: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Short error identifier when preparation failed, else empty.' };
 };
 
 export const enum ChatSpeechToTextState {
@@ -166,6 +185,12 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	private _sessionSegments = 0;
 	private _sessionErrorCode = '';
 
+	// Model-preparation telemetry accumulators. `_prepareStartMs` is non-zero
+	// while a preparation is being tracked; `_prepareDownloadObserved` records
+	// whether a first-use download to disk was seen (vs loading a cached model).
+	private _prepareStartMs = 0;
+	private _prepareDownloadObserved = false;
+
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@INotificationService private readonly _notificationService: INotificationService,
@@ -210,12 +235,41 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		const durationMs = Date.now() - this._sessionStartMs;
 		this._telemetryService.publicLog2<SpeechToTextSessionEvent, SpeechToTextSessionClassification>('chatSpeechToText.session', {
 			outcome,
+			mode: this._getDictationMode(),
 			durationMs,
 			segments: this._sessionSegments,
 			transcriptLength: this._transcript.length,
 			errorCode: this._sessionErrorCode,
 		});
 		this._sessionStartMs = 0;
+	}
+
+	/**
+	 * Read the configured dictation shortcut mode for telemetry, normalizing any
+	 * unexpected value to the `auto` default so the event stays low-cardinality.
+	 */
+	private _getDictationMode(): string {
+		const value = this._configurationService.getValue<string>(MODE_SETTING);
+		return value === 'toggle' || value === 'pushToTalk' ? value : 'auto';
+	}
+
+	/**
+	 * Emit the model-preparation telemetry event once, when the on-device model
+	 * reaches a terminal state (ready or error). `_prepareStartMs` guards against
+	 * duplicate emission, since `_handleModelStatus` can fire repeatedly.
+	 */
+	private _logModelPrepareTelemetry(outcome: 'ready' | 'error', error?: string): void {
+		if (this._prepareStartMs === 0) {
+			return;
+		}
+		const durationMs = Date.now() - this._prepareStartMs;
+		this._telemetryService.publicLog2<SpeechToTextModelPrepareEvent, SpeechToTextModelPrepareClassification>('chatSpeechToText.modelPrepare', {
+			outcome,
+			downloaded: this._prepareDownloadObserved,
+			durationMs,
+			errorCode: outcome === 'error' ? (error || 'unknown') : '',
+		});
+		this._prepareStartMs = 0;
 	}
 
 	private _setState(state: ChatSpeechToTextState): void {
@@ -340,6 +394,10 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	 */
 	private _trackModelPreparation(): void {
 		this._setPreparingModel(true);
+		// Start timing preparation (download + load) for the model-prepare
+		// telemetry event, emitted once the model reaches Ready or Error.
+		this._prepareStartMs = Date.now();
+		this._prepareDownloadObserved = false;
 		// Guarantee the download notification is dismissed no matter how the
 		// session ends (teardown, cancel, or the service being disposed).
 		this._localSessionDisposables.add(toDisposable(() => this._completeDownloadNotification()));
@@ -362,9 +420,13 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	 */
 	private _handleModelStatus(status: ILocalTranscriptionModelStatus): void {
 		this._updateDownloadNotification(status);
-		if (status.state === LocalTranscriptionModelState.Ready) {
+		if (status.state === LocalTranscriptionModelState.Downloading) {
+			this._prepareDownloadObserved = true;
+		} else if (status.state === LocalTranscriptionModelState.Ready) {
+			this._logModelPrepareTelemetry('ready');
 			this._setPreparingModel(false);
 		} else if (status.state === LocalTranscriptionModelState.Error) {
+			this._logModelPrepareTelemetry('error', status.error);
 			this._setPreparingModel(false);
 			this._failSession('model', localize('chatStt.modelError', "On-device speech-to-text model failed to load: {0}", status.error ?? ''));
 		}
@@ -518,6 +580,9 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		this._stopCapture();
 		this._setPreparingModel(false);
 		this._completeDownloadNotification();
+		// Drop any in-progress preparation timing; a session torn down before the
+		// model reached a terminal state does not emit a model-prepare event.
+		this._prepareStartMs = 0;
 		this._localSessionDisposables.clear();
 	}
 


### PR DESCRIPTION
## Summary

Fills two telemetry gaps for chat-input dictation (speech-to-text):

- **Dictation mode**: adds a `mode` dimension (`auto` / `toggle` / `pushToTalk`) to the existing `chatSpeechToText.session` event, read from `chat.speechToText.mode` when the session ends. Lets us see which shortcut behavior people actually use.
- **Model download/load**: adds a new `chatSpeechToText.modelPrepare` event, emitted once the on-device model reaches a terminal state, capturing:
  - `outcome`: `ready` | `error`
  - `downloaded`: whether a first-use download to disk was observed (vs loading an already-cached model)
  - `durationMs`: time from starting preparation until ready/error
  - `errorCode`: short error identifier on failure

The event only fires when preparation was actually needed (the model wasn't already `Ready`/`Error` at session start), so an already-cached, instantly-ready model produces no event. `_prepareStartMs` guards against duplicate emission since `_handleModelStatus` can fire repeatedly, and it's reset on teardown so a session cancelled mid-download emits nothing.

Also marks the numeric `chatSpeechToText.session` fields (`durationMs`, `segments`, `transcriptLength`) as `isMeasurement: true`, per the telemetry guidelines.

## Validation

- `npm run typecheck-client` passes
- pre-commit hygiene hook passed

No existing unit tests cover `ChatSpeechToTextService`; adding a mocking harness is out of scope for this telemetry-only change.