### PR TITLE
Chat dictation: add on-device Nemotron (NeMo RNN-T) streaming model

### DIFF
--- a/src/vs/platform/localTranscription/common/localTranscription.ts
+++ b/src/vs/platform/localTranscription/common/localTranscription.ts
@@ -53,9 +53,10 @@ export interface ILocalTranscriptionResult {
 }
 
 /**
- * On-device speech-to-text using a downloaded Whisper model (transformers.js +
- * onnxruntime-node). Runs in a utility process. A single transcription session
- * is active at a time (dictation is a singleton in the renderer).
+ * On-device speech-to-text using a downloaded NeMo RNN-T model (Nemotron, run
+ * directly on onnxruntime-node). Runs in a utility process. A single
+ * transcription session is active at a time (dictation is a singleton in the
+ * renderer).
  *
  * The renderer streams PCM16 mono 16 kHz audio via `pushAudio`; the service
  * emits interim transcripts on `onDidTranscribe` and a final one after `stop`.

--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -18,7 +18,7 @@ import { NemotronTranscriber } from './nemotronTranscriber.js';
 const SAMPLE_RATE = 16000;
 
 /** Default downloaded model. `base` balances quality and size (~faster than small). */
-const DEFAULT_MODEL = 'onnx-community/whisper-base';
+const DEFAULT_MODEL = 'onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4';
 
 /**
  * Precision of the ONNX weights downloaded and run on device. Whisper is an

--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -12,6 +12,7 @@ import {
 	ILocalTranscriptionService,
 	LocalTranscriptionModelState,
 } from '../common/localTranscription.js';
+import { NemotronTranscriber } from './nemotronTranscriber.js';
 
 /** Sample rate (Hz) the Whisper models expect; the renderer captures at this rate. */
 const SAMPLE_RATE = 16000;
@@ -110,6 +111,7 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 	private _pipeline: ASRPipeline | undefined;
 	private _pipelinePromise: Promise<ASRPipeline> | undefined;
 	private _loadedModel: string | undefined;
+	private _nemotron: NemotronTranscriber | undefined;
 
 	/** Accumulated Float32 PCM for the active session (mono, 16 kHz). */
 	private _samples: Float32Array[] = [];
@@ -156,6 +158,17 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._loadedModel = model;
 		this._pipelinePromise = (async () => {
 			try {
+				this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: 0 });
+
+				// The NeMo Nemotron export is an RNN-T transducer that transformers.js
+				// cannot run; drive it through a dedicated onnxruntime-node transcriber
+				// and expose it behind the same ASRPipeline call shape as Whisper.
+				if (NemotronTranscriber.isNemotronModel(model)) {
+					this._pipeline = await this._loadNemotron(cacheDir, model);
+					this._setStatus({ state: LocalTranscriptionModelState.Ready });
+					return this._pipeline;
+				}
+
 				if (!this._transformers) {
 					this._transformers = await import('@huggingface/transformers');
 				}
@@ -169,10 +182,9 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 				// callbacks for files it actually fetches from the network; a
 				// fully-cached model loads without any of them. Track that so we
 				// can distinguish a first-use download from a cache hit (the
-				// unconditional `Downloading` state below is a UI signal only and
+				// unconditional `Downloading` state above is a UI signal only and
 				// fires even for cached loads, so it cannot be used for this).
 				let didDownload = false;
-				this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: 0 });
 				const pipe = await pipeline('automatic-speech-recognition', model, {
 					dtype: DEFAULT_DTYPE,
 					progress_callback: (p: { status?: string; progress?: number }) => {
@@ -195,12 +207,33 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 				this._pipeline = undefined;
 				this._pipelinePromise = undefined;
 				this._loadedModel = undefined;
+				this._nemotron = undefined;
 				const message = String(err instanceof Error ? err.message : err);
 				this._setStatus({ state: LocalTranscriptionModelState.Error, error: message, errorCode: classifyModelError(message) });
 				throw err;
 			}
 		})();
 		return this._pipelinePromise;
+	}
+
+	/**
+	 * Download + load the Nemotron RNN-T transducer and wrap it in the same
+	 * `ASRPipeline` call shape Whisper uses, so `_runInference` stays agnostic to
+	 * which backend is active. Whisper-only options (chunking, task) are ignored.
+	 */
+	private async _loadNemotron(cacheDir: string, model: string): Promise<ASRPipeline> {
+		const transcriber = new NemotronTranscriber();
+		await transcriber.prepare(cacheDir, model, ({ downloaded, progress }) => {
+			if (downloaded) {
+				this._setStatus({ state: LocalTranscriptionModelState.Loading });
+			} else {
+				this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: progress ?? 0 });
+			}
+		});
+		this._nemotron = transcriber;
+		// `_runInference` calls the streaming API directly; this wrapper only
+		// serves as the truthy `_pipeline` sentinel and a one-shot fallback.
+		return async (audio: Float32Array): Promise<ASRResult> => ({ text: await transcriber.transcribeStreaming(audio, true) });
 	}
 
 	async pushAudio(chunk: VSBuffer): Promise<void> {
@@ -243,21 +276,30 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._inferenceInFlight = true;
 		try {
 			const audio = this._mergedSamples();
-			// Pad the final pass with trailing silence so Whisper reliably emits
-			// the last word even when the user stops speaking abruptly.
-			const input = isFinal ? this._withTrailingSilence(audio, FINAL_PASS_TRAILING_SILENCE_SECONDS) : audio;
-			const result = await pipe(input, {
-				chunk_length_s: 30,
-				stride_length_s: 5,
-				language: this._language,
-				task: 'transcribe',
-			});
+			let text: string;
+			if (this._nemotron) {
+				// Streaming transducer: feed the cumulative buffer; only the newly
+				// appended samples are processed and prior tokens are carried
+				// forward, so the tail is flushed on the final pass (no trailing
+				// silence needed).
+				text = (await this._nemotron.transcribeStreaming(audio, isFinal)).trim();
+			} else {
+				// Pad the final pass with trailing silence so Whisper reliably emits
+				// the last word even when the user stops speaking abruptly.
+				const input = isFinal ? this._withTrailingSilence(audio, FINAL_PASS_TRAILING_SILENCE_SECONDS) : audio;
+				const result = await pipe(input, {
+					chunk_length_s: 30,
+					stride_length_s: 5,
+					language: this._language,
+					task: 'transcribe',
+				});
+				text = (Array.isArray(result) ? result.map(r => r.text).join(' ') : result.text ?? '').trim();
+			}
 			// The session may have been cancelled/replaced while this inference
 			// was running; drop the result so it can't leak into a later session.
 			if (generation !== this._generation) {
 				return this._lastText;
 			}
-			const text = (Array.isArray(result) ? result.map(r => r.text).join(' ') : result.text ?? '').trim();
 			this._lastText = text;
 			if (this._sessionActive || isFinal) {
 				this._onDidTranscribe.fire({ text, isFinal });
@@ -336,6 +378,9 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._sampleCount = 0;
 		this._lastText = '';
 		this._language = undefined;
+		// Drop the streaming transducer's per-session state (caches, LSTM state,
+		// emitted tokens) so the next session starts from a clean slate.
+		this._nemotron?.resetStream();
 	}
 }
 

--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable } from '../../../base/common/lifecycle.js';
+import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { VSBuffer } from '../../../base/common/buffer.js';
 import {
 	ILocalTranscriptionModelStatus,
@@ -91,6 +91,22 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 	private _interimTimer: ReturnType<typeof setTimeout> | undefined;
 	private _lastText = '';
 
+	/**
+	 * Set when a session is torn down while an inference is still awaiting an
+	 * ONNX run: resetting the transducer's streaming state right then would race
+	 * with the in-flight call (which would resume and write cache/LSTM/token
+	 * results into the freshly-reset state, contaminating the next session). The
+	 * reset is deferred until that inference finishes instead.
+	 */
+	private _pendingStreamReset = false;
+
+	constructor() {
+		super();
+		// Release the ~800MB of native ONNX allocations when the service (and its
+		// utility process) goes away, rather than leaking them for its lifetime.
+		this._register(toDisposable(() => { void this._nemotron?.release(); this._nemotron = undefined; }));
+	}
+
 	async getModelStatus(): Promise<ILocalTranscriptionModelStatus> {
 		return this._status;
 	}
@@ -126,20 +142,35 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 			try {
 				this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: 0 });
 
+				// Reaching here means we are (re)loading rather than reusing an
+				// already-loaded backend, so release any previous transducer's
+				// native sessions before opening the replacement.
+				if (this._nemotron) {
+					const previous = this._nemotron;
+					this._nemotron = undefined;
+					await previous.release();
+				}
+
 				// `prepare` reports `downloaded:false` progress callbacks only for
 				// bytes actually fetched from the network; a fully-cached model
 				// loads without them. Track that so the model-prepare telemetry
 				// can distinguish a first-use download from a cache hit.
 				let didDownload = false;
 				const transcriber = new NemotronTranscriber();
-				await transcriber.prepare(cacheDir, model, ({ downloaded, progress }) => {
-					if (downloaded) {
-						this._setStatus({ state: LocalTranscriptionModelState.Loading });
-					} else {
-						didDownload = true;
-						this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: progress ?? 0 });
-					}
-				});
+				try {
+					await transcriber.prepare(cacheDir, model, ({ downloaded, progress }) => {
+						if (downloaded) {
+							this._setStatus({ state: LocalTranscriptionModelState.Loading });
+						} else {
+							didDownload = true;
+							this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: progress ?? 0 });
+						}
+					});
+				} catch (err) {
+					// Release anything the failed load left open before rethrowing.
+					await transcriber.release();
+					throw err;
+				}
 				this._nemotron = transcriber;
 				this._setStatus({ state: LocalTranscriptionModelState.Ready, downloaded: didDownload });
 				return transcriber;
@@ -206,6 +237,13 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 			return text;
 		} finally {
 			this._inferenceInFlight = false;
+			// A session torn down mid-inference deferred its stream reset to avoid
+			// racing this call; now that it has finished mutating the transducer's
+			// streaming state, apply the reset so the next session starts clean.
+			if (this._pendingStreamReset) {
+				this._pendingStreamReset = false;
+				this._nemotron?.resetStream();
+			}
 		}
 	}
 
@@ -270,8 +308,15 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._sampleCount = 0;
 		this._lastText = '';
 		// Drop the streaming transducer's per-session state (caches, LSTM state,
-		// emitted tokens) so the next session starts from a clean slate.
-		this._nemotron?.resetStream();
+		// emitted tokens) so the next session starts from a clean slate. If an
+		// inference is still awaiting an ONNX run, resetting now would race it
+		// (it would resume and write results into the reset state); defer the
+		// reset until that call finishes instead.
+		if (this._inferenceInFlight) {
+			this._pendingStreamReset = true;
+		} else {
+			this._nemotron?.resetStream();
+		}
 	}
 }
 

--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -14,59 +14,21 @@ import {
 } from '../common/localTranscription.js';
 import { NemotronTranscriber } from './nemotronTranscriber.js';
 
-/** Sample rate (Hz) the Whisper models expect; the renderer captures at this rate. */
+/** Sample rate (Hz) the model expects; the renderer captures at this rate. */
 const SAMPLE_RATE = 16000;
 
-/** Default downloaded model. `base` balances quality and size (~faster than small). */
-const DEFAULT_MODEL = 'onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4';
-
 /**
- * Precision of the ONNX weights downloaded and run on device. Whisper is an
- * encoder-decoder model whose decoder dominates size (e.g. for `base` the
- * fp32 decoder is ~208MB vs the ~82MB encoder), so we quantize the decoder to
- * int8 (`q8`) while keeping the encoder at full precision, where quantization
- * would hurt audio-feature accuracy more. This cuts the `base` download from
- * ~291MB (all fp32) to ~136MB with negligible transcription-quality loss.
- *
- * Without an explicit `dtype` transformers.js defaults to fp32 for every file
- * on the `cpu` device, so this mapping must be passed to `pipeline()`.
+ * On-device model used for dictation: NVIDIA Nemotron RNN-T — a streaming,
+ * multilingual (35+ languages, auto-detected) transducer, matching the model
+ * the GitHub Copilot desktop app ships.
  */
-const DEFAULT_DTYPE = {
-	encoder_model: 'fp32',
-	decoder_model_merged: 'q8',
-} as const;
+const DEFAULT_MODEL = 'onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4';
 
 /** Minimum audio (seconds) before a first interim transcription is attempted. */
 const MIN_INTERIM_SECONDS = 1.0;
 
-/**
- * Upper bound (seconds) on how much audio interim passes will re-transcribe.
- * Each interim pass re-runs Whisper over all audio since recording began, so
- * cost grows with utterance length; past this we stop scheduling interims and
- * let the final pass produce the complete transcript, keeping interim CPU
- * bounded. The last interim result stays visible until stop().
- */
-const MAX_INTERIM_SECONDS = 45;
-
 /** Debounce (ms) between interim transcription passes while recording. */
 const INTERIM_DEBOUNCE_MS = 1200;
-
-/**
- * Silence (seconds) appended to the audio before the final transcription pass.
- * Whisper frequently fails to emit the last word when the recording ends
- * abruptly right after it (no trailing silence to mark the utterance end), so a
- * short pad of zeros gives the model the context it needs to finalize the tail.
- */
-const FINAL_PASS_TRAILING_SILENCE_SECONDS = 0.5;
-
-/**
- * transformers.js is a heavy, ESM-only dependency that also loads the native
- * onnxruntime-node addon. Import it lazily so forking the utility process stays
- * cheap; the model itself is only downloaded/loaded when dictation first runs.
- */
-type Transformers = typeof import('@huggingface/transformers');
-type ASRResult = { text?: string } | Array<{ text?: string }>;
-type ASRPipeline = (audio: Float32Array, options?: Record<string, unknown>) => Promise<ASRResult>;
 
 /**
  * Map a raw model download/load error message to a fixed, low-cardinality code
@@ -107,16 +69,14 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 
 	private _status: ILocalTranscriptionModelStatus = { state: LocalTranscriptionModelState.Idle };
 
-	private _transformers: Transformers | undefined;
-	private _pipeline: ASRPipeline | undefined;
-	private _pipelinePromise: Promise<ASRPipeline> | undefined;
-	private _loadedModel: string | undefined;
+	/** The streaming RNN-T transducer; undefined until loaded. */
 	private _nemotron: NemotronTranscriber | undefined;
+	private _nemotronPromise: Promise<NemotronTranscriber> | undefined;
+	private _loadedModel: string | undefined;
 
 	/** Accumulated Float32 PCM for the active session (mono, 16 kHz). */
 	private _samples: Float32Array[] = [];
 	private _sampleCount = 0;
-	private _language: string | undefined;
 	private _sessionActive = false;
 
 	/**
@@ -142,98 +102,57 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 
 	async start(options: { cacheDir: string; model?: string; language?: string }): Promise<void> {
 		this._resetSession();
-		this._language = options.language;
 		this._sessionActive = true;
 		// Kick off (or reuse) model loading; do not block starting capture on it.
-		this._ensurePipeline(options.cacheDir, options.model ?? DEFAULT_MODEL).catch(() => { /* status already reported */ });
+		this._ensureModel(options.cacheDir, options.model ?? DEFAULT_MODEL).catch(() => { /* status already reported */ });
 	}
-	private async _ensurePipeline(cacheDir: string, model: string): Promise<ASRPipeline> {
-		if (this._pipeline && this._loadedModel === model) {
-			return this._pipeline;
+
+	/**
+	 * Download (if needed) and load the Nemotron RNN-T transducer. Idempotent:
+	 * a load already in flight (or a model already loaded) is reused. The three
+	 * ONNX graphs are driven directly via onnxruntime-node, since this is a
+	 * transducer that transformers.js cannot run.
+	 */
+	private async _ensureModel(cacheDir: string, model: string): Promise<NemotronTranscriber> {
+		if (this._nemotron && this._loadedModel === model) {
+			return this._nemotron;
 		}
-		if (this._pipelinePromise && this._loadedModel === model) {
-			return this._pipelinePromise;
+		if (this._nemotronPromise && this._loadedModel === model) {
+			return this._nemotronPromise;
 		}
 
 		this._loadedModel = model;
-		this._pipelinePromise = (async () => {
+		this._nemotronPromise = (async () => {
 			try {
 				this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: 0 });
 
-				// The NeMo Nemotron export is an RNN-T transducer that transformers.js
-				// cannot run; drive it through a dedicated onnxruntime-node transcriber
-				// and expose it behind the same ASRPipeline call shape as Whisper.
-				if (NemotronTranscriber.isNemotronModel(model)) {
-					this._pipeline = await this._loadNemotron(cacheDir, model);
-					this._setStatus({ state: LocalTranscriptionModelState.Ready });
-					return this._pipeline;
-				}
-
-				if (!this._transformers) {
-					this._transformers = await import('@huggingface/transformers');
-				}
-				const { pipeline, env } = this._transformers;
-				// Store downloaded model files on disk so subsequent sessions
-				// load without a network round-trip ("model management").
-				env.cacheDir = cacheDir;
-				env.allowRemoteModels = true;
-
-				// transformers.js only emits `initiate`/`download`/`progress`
-				// callbacks for files it actually fetches from the network; a
-				// fully-cached model loads without any of them. Track that so we
-				// can distinguish a first-use download from a cache hit (the
-				// unconditional `Downloading` state above is a UI signal only and
-				// fires even for cached loads, so it cannot be used for this).
+				// `prepare` reports `downloaded:false` progress callbacks only for
+				// bytes actually fetched from the network; a fully-cached model
+				// loads without them. Track that so the model-prepare telemetry
+				// can distinguish a first-use download from a cache hit.
 				let didDownload = false;
-				const pipe = await pipeline('automatic-speech-recognition', model, {
-					dtype: DEFAULT_DTYPE,
-					progress_callback: (p: { status?: string; progress?: number }) => {
-						if (p.status === 'initiate' || p.status === 'download' || p.status === 'progress') {
-							didDownload = true;
-						}
-						if (p.status === 'progress' && typeof p.progress === 'number') {
-							this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: Math.min(1, p.progress / 100) });
-						} else if (p.status === 'ready') {
-							this._setStatus({ state: LocalTranscriptionModelState.Loading });
-						}
-					},
+				const transcriber = new NemotronTranscriber();
+				await transcriber.prepare(cacheDir, model, ({ downloaded, progress }) => {
+					if (downloaded) {
+						this._setStatus({ state: LocalTranscriptionModelState.Loading });
+					} else {
+						didDownload = true;
+						this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: progress ?? 0 });
+					}
 				});
-				// The transformers.js pipeline() return type is a broad union that
-				// isn't directly callable; narrow it to our ASR call signature.
-				this._pipeline = pipe as unknown as ASRPipeline;
+				this._nemotron = transcriber;
 				this._setStatus({ state: LocalTranscriptionModelState.Ready, downloaded: didDownload });
-				return this._pipeline;
+				return transcriber;
 			} catch (err) {
-				this._pipeline = undefined;
-				this._pipelinePromise = undefined;
-				this._loadedModel = undefined;
 				this._nemotron = undefined;
+				this._nemotronPromise = undefined;
+				this._loadedModel = undefined;
 				const message = String(err instanceof Error ? err.message : err);
 				this._setStatus({ state: LocalTranscriptionModelState.Error, error: message, errorCode: classifyModelError(message) });
 				throw err;
 			}
 		})();
-		return this._pipelinePromise;
-	}
-
-	/**
-	 * Download + load the Nemotron RNN-T transducer and wrap it in the same
-	 * `ASRPipeline` call shape Whisper uses, so `_runInference` stays agnostic to
-	 * which backend is active. Whisper-only options (chunking, task) are ignored.
-	 */
-	private async _loadNemotron(cacheDir: string, model: string): Promise<ASRPipeline> {
-		const transcriber = new NemotronTranscriber();
-		await transcriber.prepare(cacheDir, model, ({ downloaded, progress }) => {
-			if (downloaded) {
-				this._setStatus({ state: LocalTranscriptionModelState.Loading });
-			} else {
-				this._setStatus({ state: LocalTranscriptionModelState.Downloading, progress: progress ?? 0 });
-			}
-		});
-		this._nemotron = transcriber;
-		// `_runInference` calls the streaming API directly; this wrapper only
-		// serves as the truthy `_pipeline` sentinel and a one-shot fallback.
-		return async (audio: Float32Array): Promise<ASRResult> => ({ text: await transcriber.transcribeStreaming(audio, true) });
+		return this._nemotronPromise;
 	}
 
 	async pushAudio(chunk: VSBuffer): Promise<void> {
@@ -252,12 +171,6 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		if (this._sampleCount < SAMPLE_RATE * MIN_INTERIM_SECONDS) {
 			return;
 		}
-		// Stop live interim passes once the utterance is long enough that
-		// re-transcribing all of it each time gets expensive; the final pass on
-		// stop() still transcribes the full recording.
-		if (this._sampleCount > SAMPLE_RATE * MAX_INTERIM_SECONDS) {
-			return;
-		}
 		this._interimTimer = setTimeout(() => {
 			this._interimTimer = undefined;
 			void this._runInference(false);
@@ -265,8 +178,8 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 	}
 
 	private async _runInference(isFinal: boolean): Promise<string> {
-		const pipe = this._pipeline;
-		if (!pipe || this._sampleCount === 0) {
+		const nemotron = this._nemotron;
+		if (!nemotron || this._sampleCount === 0) {
 			return this._lastText;
 		}
 		if (this._inferenceInFlight && !isFinal) {
@@ -275,26 +188,12 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		const generation = this._generation;
 		this._inferenceInFlight = true;
 		try {
+			// Streaming transducer: feed the cumulative buffer; only the newly
+			// appended samples are processed and prior tokens are carried
+			// forward, so the tail is flushed on the final pass (no trailing
+			// silence needed).
 			const audio = this._mergedSamples();
-			let text: string;
-			if (this._nemotron) {
-				// Streaming transducer: feed the cumulative buffer; only the newly
-				// appended samples are processed and prior tokens are carried
-				// forward, so the tail is flushed on the final pass (no trailing
-				// silence needed).
-				text = (await this._nemotron.transcribeStreaming(audio, isFinal)).trim();
-			} else {
-				// Pad the final pass with trailing silence so Whisper reliably emits
-				// the last word even when the user stops speaking abruptly.
-				const input = isFinal ? this._withTrailingSilence(audio, FINAL_PASS_TRAILING_SILENCE_SECONDS) : audio;
-				const result = await pipe(input, {
-					chunk_length_s: 30,
-					stride_length_s: 5,
-					language: this._language,
-					task: 'transcribe',
-				});
-				text = (Array.isArray(result) ? result.map(r => r.text).join(' ') : result.text ?? '').trim();
-			}
+			const text = (await nemotron.transcribeStreaming(audio, isFinal)).trim();
 			// The session may have been cancelled/replaced while this inference
 			// was running; drop the result so it can't leak into a later session.
 			if (generation !== this._generation) {
@@ -324,13 +223,6 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		return merged;
 	}
 
-	/** Return `audio` with `seconds` of trailing silence (zeros) appended. */
-	private _withTrailingSilence(audio: Float32Array, seconds: number): Float32Array {
-		const padded = new Float32Array(audio.length + Math.round(SAMPLE_RATE * seconds));
-		padded.set(audio, 0);
-		return padded;
-	}
-
 	async stop(): Promise<string> {
 		if (this._interimTimer) {
 			clearTimeout(this._interimTimer);
@@ -339,15 +231,15 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		// On first use the model may still be downloading/loading when the user
 		// stops. Wait for it so the whole recording is transcribed instead of
 		// being dropped and returning an empty string.
-		if (!this._pipeline && this._pipelinePromise) {
+		if (!this._nemotron && this._nemotronPromise) {
 			try {
-				await this._pipelinePromise;
+				await this._nemotronPromise;
 			} catch {
-				// Load failed; status already reported as Error below we fall
-				// through to the no-pipeline path.
+				// Load failed; status already reported as Error. Fall through to
+				// the no-model path below.
 			}
 		}
-		if (!this._pipeline) {
+		if (!this._nemotron) {
 			// Model never finished loading; nothing to transcribe.
 			const text = this._lastText;
 			this._resetSession();
@@ -377,7 +269,6 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._samples = [];
 		this._sampleCount = 0;
 		this._lastText = '';
-		this._language = undefined;
 		// Drop the streaming transducer's per-session state (caches, LSTM state,
 		// emitted tokens) so the next session starts from a clean slate.
 		this._nemotron?.resetStream();

--- a/src/vs/platform/localTranscription/node/nemotronTranscriber.ts
+++ b/src/vs/platform/localTranscription/node/nemotronTranscriber.ts
@@ -1,0 +1,573 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import { join } from '../../../base/common/path.js';
+
+/**
+ * On-device transcriber for NVIDIA's `nemotron-3.5-asr-streaming-0.6b` ONNX
+ * export (the same family the GitHub Copilot desktop app ships for dictation).
+ *
+ * Unlike Whisper, this is an RNN-T *transducer* (encoder + prediction/decoder
+ * LSTM + joint network) rather than an encoder-decoder attention model, so it
+ * cannot be driven by the transformers.js `automatic-speech-recognition`
+ * pipeline (which only supports CTC/attention ASR). Instead we drive the three
+ * ONNX graphs directly through onnxruntime-node with a hand-written NeMo
+ * log-mel feature extractor and a greedy transducer decode loop.
+ *
+ * Why bother: the model is multilingual (35+ languages, auto-detected), notably
+ * more accurate than whisper-base, and matches the Copilot app for parity. The
+ * cost is a ~800MB download and this bespoke runtime glue.
+ *
+ * Pipeline: PCM16/Float32 @16kHz -> NeMo log-mel (128) -> cache-aware
+ * FastConformer encoder (chunked, carries LSTM/conv caches) -> greedy RNN-T
+ * (decoder LSTM + joint) -> SentencePiece detokenize.
+ */
+
+// --- feature/model constants (from the export's genai_config.json /
+//     audio_processor_config.json; see the on-device model card) ---
+const SR = 16000, N_FFT = 512, HOP = 160, WIN = 400, N_MELS = 128;
+const FMIN = 0, FMAX = 8000, PREEMPH = 0.97, LOG_GUARD = 1e-10;
+const PRE_CACHE = 9;                            // pre_encode_cache_size (left-context feature frames)
+const CHUNK_FRAMES = 56;                        // new feature frames per encoder step (8960/160)
+const CHUNK_TOTAL = PRE_CACHE + CHUNK_FRAMES;   // 65 == encoder audio_signal time dim
+const N_LAYERS = 24, HID = 1024, CACHE_T = 56, CONV_CTX = 8;
+const DEC_LAYERS = 2, DEC_HID = 640;
+const BLANK = 13087, MAX_SYM = 10, VOCAB = 13088;
+const SUBSAMPLING = 8;                          // encoder output frames = ceil(featureFrames / 8)
+
+/** Auto-detect the spoken language (0 is the export's language-agnostic id). */
+const LANG_AUTODETECT = 0;
+
+/** Files that make up the ONNX export; downloaded on first use. */
+const MODEL_FILES = [
+	'encoder.onnx', 'encoder.onnx.data',
+	'decoder.onnx', 'decoder.onnx.data',
+	'joint.onnx', 'joint.onnx.data',
+	'vocab.txt',
+];
+
+/**
+ * onnxruntime-node is a heavy native addon (also pulled in by transformers.js);
+ * import it lazily and keep its types loose so the platform layer doesn't take
+ * a hard build-time dependency on it.
+ */
+type OrtModule = typeof import('onnxruntime-node');
+type OrtSession = import('onnxruntime-node').InferenceSession;
+type OrtTensor = import('onnxruntime-node').Tensor;
+
+export interface INemotronProgress {
+	/** 0..1 overall download progress, or undefined once loading. */
+	(state: { readonly downloaded: boolean; readonly progress?: number }): void;
+}
+
+export class NemotronTranscriber {
+
+	/** Model ids this transcriber knows how to run (vs. Whisper). */
+	static isNemotronModel(model: string): boolean {
+		return /nemotron/i.test(model);
+	}
+
+	private _ort: OrtModule | undefined;
+	private _enc: OrtSession | undefined;
+	private _dec: OrtSession | undefined;
+	private _joint: OrtSession | undefined;
+	private _vocab: string[] = [];
+	private _filterbank: Float64Array[] | undefined;
+	private _window: Float64Array | undefined;
+
+	// ---- streaming state (reset per dictation session) ----
+	/** How many samples of the cumulative buffer have already been consumed. */
+	private _consumedSamples = 0;
+	/** Preemphasized + front-reflect-padded signal accumulated so far. */
+	private _sig: number[] = [];
+	/** Preemphasized samples buffered until enough exist to build the front pad. */
+	private _preBuf: number[] = [];
+	private _haveFirstSample = false;
+	private _rawPrev = 0;
+	private _frontPadded = false;
+	private _endPadded = false;
+	/** Number of feature frames already computed from `_sig`. */
+	private _emittedFrames = 0;
+	/** Feature frames computed but not yet fed to the encoder. */
+	private _featQueue: Float32Array[] = [];
+	/** Up to PRE_CACHE most-recent frames already encoded, for left context. */
+	private _featLeft: Float32Array[] = [];
+	private _cacheCh: Float32Array | undefined;
+	private _cacheTime: Float32Array | undefined;
+	private _cacheLen = [0];
+	private _decH: Float32Array | undefined;
+	private _decC: Float32Array | undefined;
+	private _decCur: Float32Array | undefined;
+	private _decInit = false;
+	/** Tokens emitted so far this session (greedy RNN-T is monotonic). */
+	private _emitted: number[] = [];
+
+	/** True once the three graphs are loaded and ready to transcribe. */
+	get isLoaded(): boolean {
+		return !!(this._enc && this._dec && this._joint);
+	}
+
+	/**
+	 * Download (if needed) and load the model. `cacheDir` is the shared model
+	 * cache; files are placed in a per-model subfolder guarded by a `.complete`
+	 * sentinel so a half-finished download is never reused.
+	 */
+	async prepare(cacheDir: string, model: string, onProgress: INemotronProgress): Promise<void> {
+		const modelDir = join(cacheDir, 'nemotron', model.replace(/[^a-zA-Z0-9._-]/g, '_'));
+		await this._ensureDownloaded(modelDir, model, onProgress);
+
+		onProgress({ downloaded: true });
+		const ort = await this._loadOrt();
+		const opts = { executionProviders: ['cpu'] } as const;
+		[this._enc, this._dec, this._joint] = await Promise.all([
+			ort.InferenceSession.create(join(modelDir, 'encoder.onnx'), opts),
+			ort.InferenceSession.create(join(modelDir, 'decoder.onnx'), opts),
+			ort.InferenceSession.create(join(modelDir, 'joint.onnx'), opts),
+		]);
+		this._vocab = fs.readFileSync(join(modelDir, 'vocab.txt'), 'utf8').split('\n');
+		this._filterbank = melFilterbank();
+		// Hann window (symmetric), centered within the N_FFT frame.
+		const win = new Float64Array(N_FFT);
+		const off = (N_FFT - WIN) / 2;
+		for (let i = 0; i < WIN; i++) {
+			win[off + i] = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (WIN - 1));
+		}
+		this._window = win;
+		this.resetStream();
+	}
+
+	/**
+	 * Discard all per-session streaming state so the next session starts clean.
+	 * Call this whenever a new dictation session begins.
+	 */
+	resetStream(): void {
+		this._consumedSamples = 0;
+		this._sig = [];
+		this._preBuf = [];
+		this._haveFirstSample = false;
+		this._rawPrev = 0;
+		this._frontPadded = false;
+		this._endPadded = false;
+		this._emittedFrames = 0;
+		this._featQueue = [];
+		this._featLeft = [];
+		this._cacheCh = new Float32Array(N_LAYERS * CACHE_T * HID);
+		this._cacheTime = new Float32Array(N_LAYERS * HID * CONV_CTX);
+		this._cacheLen = [0];
+		this._decH = new Float32Array(DEC_LAYERS * DEC_HID);
+		this._decC = new Float32Array(DEC_LAYERS * DEC_HID);
+		this._decCur = undefined;
+		this._decInit = false;
+		this._emitted = [];
+	}
+
+	/**
+	 * Incrementally transcribe. `cumulativeAudio` is the whole recording so far
+	 * (mono 16kHz Float32); only the samples appended since the previous call are
+	 * processed, and the model's encoder caches, LSTM state, and already-emitted
+	 * tokens are carried forward — so cost is proportional to the *new* audio,
+	 * not the full utterance. Pass `isFinal` on the last call to flush the tail.
+	 * Returns the full transcript accumulated so far.
+	 */
+	async transcribeStreaming(cumulativeAudio: Float32Array, isFinal: boolean): Promise<string> {
+		if (!this.isLoaded || !this._filterbank || !this._window) {
+			throw new Error('NemotronTranscriber not prepared');
+		}
+		const delta = cumulativeAudio.subarray(Math.min(this._consumedSamples, cumulativeAudio.length));
+		this._consumedSamples = cumulativeAudio.length;
+
+		this._feedSamples(delta, isFinal);
+		const newFrames = this._computeFrames();
+		for (const f of newFrames) {
+			this._featQueue.push(f);
+		}
+		await this._drainEncoder(isFinal);
+		return this._detokenize(this._emitted);
+	}
+
+	/**
+	 * One-shot transcription of a complete buffer (resets streaming state first).
+	 * Kept for callers that don't need incremental results; internally it just
+	 * runs the streaming path to completion.
+	 */
+	async transcribe(audio: Float32Array): Promise<string> {
+		this.resetStream();
+		return this.transcribeStreaming(audio, true);
+	}
+
+	// ---------- model loading / download ----------
+
+	private async _loadOrt(): Promise<OrtModule> {
+		if (!this._ort) {
+			const mod = await import('onnxruntime-node');
+			// onnxruntime-node is CommonJS; unwrap the interop default if present.
+			this._ort = ((mod as unknown as { default?: OrtModule }).default ?? mod) as OrtModule;
+		}
+		return this._ort;
+	}
+
+	private async _ensureDownloaded(modelDir: string, model: string, onProgress: INemotronProgress): Promise<void> {
+		const sentinel = join(modelDir, '.complete');
+		if (fs.existsSync(sentinel)) {
+			return;
+		}
+		await fs.promises.mkdir(modelDir, { recursive: true });
+
+		// Determine total bytes up front so progress can be reported as a single
+		// 0..1 value across all files (the .data blobs dominate).
+		const base = `https://huggingface.co/${model}/resolve/main`;
+		const sizes: number[] = [];
+		for (const file of MODEL_FILES) {
+			sizes.push(await headContentLength(`${base}/${file}`));
+		}
+		const total = sizes.reduce((a, b) => a + b, 0) || 1;
+
+		let done = 0;
+		for (let i = 0; i < MODEL_FILES.length; i++) {
+			const file = MODEL_FILES[i];
+			const dest = join(modelDir, file);
+			const doneBefore = done;
+			await downloadFile(`${base}/${file}`, dest, received => {
+				onProgress({ downloaded: false, progress: Math.min(1, (doneBefore + received) / total) });
+			});
+			done += sizes[i];
+		}
+		await fs.promises.writeFile(sentinel, '');
+	}
+
+	// ---------- streaming NeMo log-mel features ----------
+
+	/**
+	 * Preemphasize and append `samples` to `_sig`, matching the offline
+	 * featurizer's center padding: a one-time front reflect pad, and (when
+	 * `isFinal`) an end reflect pad. Preemphasis (`x[i]=raw[i]-0.97*raw[i-1]`,
+	 * first sample unchanged) is carried across calls via `_rawPrev`.
+	 */
+	private _feedSamples(samples: Float32Array, isFinal: boolean): void {
+		const pad = N_FFT / 2;
+		for (let i = 0; i < samples.length; i++) {
+			const s = samples[i];
+			let x: number;
+			if (!this._haveFirstSample) {
+				x = s;
+				this._haveFirstSample = true;
+			} else {
+				x = s - PREEMPH * this._rawPrev;
+			}
+			this._rawPrev = s;
+			if (this._frontPadded) {
+				this._sig.push(x);
+			} else {
+				this._preBuf.push(x);
+				if (this._preBuf.length >= pad + 1) {
+					this._emitFrontPad(pad);
+				}
+			}
+		}
+		if (isFinal && !this._endPadded) {
+			// A very short utterance may never have reached the front-pad
+			// threshold; emit it now with whatever was buffered.
+			if (!this._frontPadded) {
+				this._emitFrontPad(pad);
+			}
+			const n = this._sig.length;
+			for (let i = 0; i < pad; i++) {
+				const idx = n - 2 - i;
+				this._sig.push(idx >= 0 ? this._sig[idx] : 0);
+			}
+			this._endPadded = true;
+		}
+	}
+
+	/** Emit the front reflect pad (`x[pad]..x[1]`) followed by the buffered samples. */
+	private _emitFrontPad(pad: number): void {
+		const pb = this._preBuf;
+		for (let i = 0; i < pad; i++) {
+			const idx = pad - i;
+			this._sig.push(pb[Math.min(idx, pb.length - 1)] ?? 0);
+		}
+		for (const v of pb) {
+			this._sig.push(v);
+		}
+		this._preBuf = [];
+		this._frontPadded = true;
+	}
+
+	/** Compute every feature frame now fully covered by `_sig`, advancing `_emittedFrames`. */
+	private _computeFrames(): Float32Array[] {
+		const fb = this._filterbank!;
+		const win = this._window!;
+		const nBins = N_FFT / 2 + 1;
+		const frames: Float32Array[] = [];
+		const re = new Float64Array(N_FFT), im = new Float64Array(N_FFT);
+		while (this._emittedFrames * HOP + N_FFT <= this._sig.length) {
+			const s = this._emittedFrames * HOP;
+			for (let i = 0; i < N_FFT; i++) {
+				re[i] = this._sig[s + i] * win[i];
+				im[i] = 0;
+			}
+			fft(re, im);
+			const mel = new Float32Array(N_MELS);
+			for (let m = 0; m < N_MELS; m++) {
+				let acc = 0;
+				const row = fb[m];
+				for (let k = 0; k < nBins; k++) {
+					acc += row[k] * (re[k] * re[k] + im[k] * im[k]); // mag_power = 2
+				}
+				mel[m] = Math.log(acc + LOG_GUARD);
+			}
+			frames.push(mel);
+			this._emittedFrames++;
+		}
+		return frames;
+	}
+
+	// ---------- streaming cache-aware encoder + greedy RNN-T ----------
+
+	/**
+	 * Feed queued feature frames to the encoder in fixed 56-frame chunks (the
+	 * same boundaries the offline path used), decoding each chunk's encoder
+	 * output greedily. A partial trailing chunk is only processed when `isFinal`.
+	 */
+	private async _drainEncoder(isFinal: boolean): Promise<void> {
+		while (this._featQueue.length >= CHUNK_FRAMES) {
+			await this._encodeChunk(this._featQueue.splice(0, CHUNK_FRAMES));
+		}
+		if (isFinal && this._featQueue.length > 0) {
+			await this._encodeChunk(this._featQueue.splice(0, this._featQueue.length));
+		}
+	}
+
+	private async _encodeChunk(chunkFrames: Float32Array[]): Promise<void> {
+		const ort = await this._loadOrt();
+		const f32 = (data: Float32Array, dims: number[]): OrtTensor => new ort.Tensor('float32', data, dims);
+		const i64 = (arr: number[], dims: number[]): OrtTensor => new ort.Tensor('int64', BigInt64Array.from(arr.map(BigInt)), dims);
+
+		const buf = new Float32Array(CHUNK_TOTAL * N_MELS);
+		// Left context: up to PRE_CACHE most-recent already-encoded frames,
+		// right-aligned so the missing left (first chunk) stays zero-padded.
+		const left = this._featLeft;
+		const avail = Math.min(PRE_CACHE, left.length);
+		for (let i = 0; i < avail; i++) {
+			buf.set(left[left.length - avail + i], (PRE_CACHE - avail + i) * N_MELS);
+		}
+		for (let i = 0; i < chunkFrames.length; i++) {
+			buf.set(chunkFrames[i], (PRE_CACHE + i) * N_MELS);
+		}
+		const valid = chunkFrames.length;
+
+		const res = await this._enc!.run({
+			audio_signal: f32(buf, [1, CHUNK_TOTAL, N_MELS]),
+			length: i64([CHUNK_TOTAL], [1]),
+			cache_last_channel: f32(this._cacheCh!, [1, N_LAYERS, CACHE_T, HID]),
+			cache_last_time: f32(this._cacheTime!, [1, N_LAYERS, HID, CONV_CTX]),
+			cache_last_channel_len: i64(this._cacheLen, [1]),
+			lang_id: i64([LANG_AUTODETECT], [1]),
+		});
+		this._cacheCh = res.cache_last_channel_next.data as Float32Array;
+		this._cacheTime = res.cache_last_time_next.data as Float32Array;
+		this._cacheLen = [Number((res.cache_last_channel_len_next.data as BigInt64Array)[0])];
+
+		const outData = res.outputs.data as Float32Array;
+		const tOut = res.outputs.dims[1];
+		const encLen = Number((res.encoded_lengths.data as BigInt64Array)[0]);
+		// Trust encoded_lengths, but never take more than the valid frames this
+		// chunk actually contributed (the final chunk is usually partial).
+		const nUse = Math.min(tOut, encLen, Math.ceil(valid / SUBSAMPLING) || tOut);
+		for (let t = 0; t < nUse; t++) {
+			await this._decodeFrame(outData.slice(t * HID, t * HID + HID));
+		}
+		// The last PRE_CACHE frames of this chunk are the next chunk's left context.
+		this._featLeft = chunkFrames.slice(Math.max(0, chunkFrames.length - PRE_CACHE));
+	}
+
+	private async _stepDecoder(token: number): Promise<void> {
+		const ort = await this._loadOrt();
+		const r = await this._dec!.run({
+			targets: new ort.Tensor('int64', BigInt64Array.from([BigInt(token)]), [1, 1]),
+			h_in: new ort.Tensor('float32', this._decH!, [DEC_LAYERS, 1, DEC_HID]),
+			c_in: new ort.Tensor('float32', this._decC!, [DEC_LAYERS, 1, DEC_HID]),
+		});
+		this._decCur = r.decoder_output.data as Float32Array; // [1,640,1] == 640 contiguous
+		this._decH = r.h_out.data as Float32Array;
+		this._decC = r.c_out.data as Float32Array;
+	}
+
+	/** Greedy-decode a single encoder frame, appending any emitted tokens. */
+	private async _decodeFrame(encT: Float32Array): Promise<void> {
+		const ort = await this._loadOrt();
+		if (!this._decInit) {
+			await this._stepDecoder(BLANK); // BLANK as start-of-sequence
+			this._decInit = true;
+		}
+		let sym = 0;
+		while (sym < MAX_SYM) {
+			const jr = await this._joint!.run({
+				encoder_output: new ort.Tensor('float32', encT, [1, 1, HID]),
+				decoder_output: new ort.Tensor('float32', this._decCur!, [1, 1, DEC_HID]),
+			});
+			const logits = jr.joint_output.data as Float32Array;
+			let best = 0, bestv = -Infinity;
+			for (let k = 0; k < VOCAB; k++) {
+				if (logits[k] > bestv) {
+					bestv = logits[k];
+					best = k;
+				}
+			}
+			if (best === BLANK) {
+				break;
+			}
+			this._emitted.push(best);
+			await this._stepDecoder(best);
+			sym++;
+		}
+	}
+
+	// ---------- detokenize (SentencePiece unigram: U+2581 == space) ----------
+
+	private _detokenize(tokens: number[]): string {
+		let text = '';
+		for (const id of tokens) {
+			const piece = this._vocab[id] ?? '';
+			if (piece.startsWith('<') && piece.endsWith('>')) {
+				continue; // language / special tags
+			}
+			text += piece.replace(/\u2581/g, ' ');
+		}
+		return text.trim();
+	}
+}
+
+// ---------- shared helpers ----------
+
+/** Iterative radix-2 in-place FFT (N_FFT is a power of two). */
+function fft(re: Float64Array, im: Float64Array): void {
+	const n = re.length;
+	for (let i = 1, j = 0; i < n; i++) {
+		let bit = n >> 1;
+		for (; j & bit; bit >>= 1) {
+			j ^= bit;
+		}
+		j ^= bit;
+		if (i < j) {
+			[re[i], re[j]] = [re[j], re[i]];
+			[im[i], im[j]] = [im[j], im[i]];
+		}
+	}
+	for (let len = 2; len <= n; len <<= 1) {
+		const ang = (-2 * Math.PI) / len;
+		const wr = Math.cos(ang), wi = Math.sin(ang);
+		for (let i = 0; i < n; i += len) {
+			let cr = 1, ci = 0;
+			for (let k = 0; k < len / 2; k++) {
+				const a = i + k, b = i + k + len / 2;
+				const tr = re[b] * cr - im[b] * ci;
+				const ti = re[b] * ci + im[b] * cr;
+				re[b] = re[a] - tr; im[b] = im[a] - ti;
+				re[a] += tr; im[a] += ti;
+				const ncr = cr * wr - ci * wi;
+				ci = cr * wi + ci * wr;
+				cr = ncr;
+			}
+		}
+	}
+}
+
+/** Mel filterbank matching librosa slaney (htk=false, norm='slaney'). */
+function melFilterbank(): Float64Array[] {
+	const nBins = N_FFT / 2 + 1;
+	const fftFreqs = new Float64Array(nBins);
+	for (let k = 0; k < nBins; k++) {
+		fftFreqs[k] = (k * SR) / N_FFT;
+	}
+	const mMin = hzToMel(FMIN), mMax = hzToMel(FMAX);
+	const melPts = new Float64Array(N_MELS + 2);
+	for (let i = 0; i < N_MELS + 2; i++) {
+		melPts[i] = melToHz(mMin + ((mMax - mMin) * i) / (N_MELS + 1));
+	}
+	const fb: Float64Array[] = [];
+	for (let m = 0; m < N_MELS; m++) {
+		const f0 = melPts[m], f1 = melPts[m + 1], f2 = melPts[m + 2];
+		const row = new Float64Array(nBins);
+		const enorm = 2.0 / (f2 - f0);
+		for (let k = 0; k < nBins; k++) {
+			const lo = (fftFreqs[k] - f0) / (f1 - f0);
+			const hi = (f2 - fftFreqs[k]) / (f2 - f1);
+			row[k] = Math.max(0, Math.min(lo, hi)) * enorm;
+		}
+		fb.push(row);
+	}
+	return fb;
+}
+
+function hzToMel(hz: number): number {
+	const fSp = 200.0 / 3, minLogHz = 1000.0, minLogMel = minLogHz / fSp, logStep = Math.log(6.4) / 27.0;
+	return hz < minLogHz ? hz / fSp : minLogMel + Math.log(hz / minLogHz) / logStep;
+}
+
+function melToHz(mel: number): number {
+	const fSp = 200.0 / 3, minLogHz = 1000.0, minLogMel = minLogHz / fSp, logStep = Math.log(6.4) / 27.0;
+	return mel < minLogMel ? mel * fSp : minLogHz * Math.exp(logStep * (mel - minLogMel));
+}
+
+/** Resolve the final content-length of a URL (following redirects). */
+async function headContentLength(url: string): Promise<number> {
+	const https = await import('https');
+	return new Promise<number>((resolve, reject) => {
+		const req = https.request(url, { method: 'HEAD' }, res => {
+			if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+				res.resume();
+				headContentLength(new URL(res.headers.location, url).toString()).then(resolve, reject);
+				return;
+			}
+			if (!res.statusCode || res.statusCode >= 400) {
+				res.resume();
+				reject(new Error(`HEAD ${url} failed: ${res.statusCode}`));
+				return;
+			}
+			resolve(Number(res.headers['content-length']) || 0);
+			res.resume();
+		});
+		req.on('error', reject);
+		req.end();
+	});
+}
+
+/** Stream a URL to `dest` (following redirects), reporting received bytes. */
+async function downloadFile(url: string, dest: string, onBytes: (received: number) => void): Promise<void> {
+	const https = await import('https');
+	return new Promise<void>((resolve, reject) => {
+		https.get(url, res => {
+			if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+				res.resume();
+				downloadFile(new URL(res.headers.location, url).toString(), dest, onBytes).then(resolve, reject);
+				return;
+			}
+			if (!res.statusCode || res.statusCode >= 400) {
+				res.resume();
+				reject(new Error(`GET ${url} failed: ${res.statusCode}`));
+				return;
+			}
+			const tmp = `${dest}.tmp`;
+			const out = fs.createWriteStream(tmp);
+			let received = 0;
+			res.on('data', chunk => {
+				received += chunk.length;
+				onBytes(received);
+			});
+			res.pipe(out);
+			out.on('finish', () => out.close(err => {
+				if (err) {
+					reject(err);
+					return;
+				}
+				fs.rename(tmp, dest, renameErr => renameErr ? reject(renameErr) : resolve());
+			}));
+			out.on('error', reject);
+			res.on('error', reject);
+		}).on('error', reject);
+	});
+}

--- a/src/vs/platform/localTranscription/node/nemotronTranscriber.ts
+++ b/src/vs/platform/localTranscription/node/nemotronTranscriber.ts
@@ -50,6 +50,15 @@ const MODEL_FILES = [
 ];
 
 /**
+ * Pinned Hugging Face commit the hard-coded tensor shapes, cache sizes, and
+ * vocabulary ids below were validated against. Downloads resolve this exact
+ * revision (not the mutable `main` branch) and it is part of the on-disk cache
+ * identity, so an upstream model update can never hand new users an
+ * incompatible export or be silently mixed with a previously cached one.
+ */
+const MODEL_REVISION = '8364d9e2dd9da23789b480bdbba9e423717e42ee';
+
+/**
  * onnxruntime-node is a heavy native addon (also pulled in by transformers.js);
  * import it lazily and keep its types loose so the platform layer doesn't take
  * a hard build-time dependency on it.
@@ -111,22 +120,44 @@ export class NemotronTranscriber {
 	}
 
 	/**
+	 * Release the native ONNX sessions and drop references to them. Safe to call
+	 * more than once. Invoke when replacing/reloading the model or disposing the
+	 * owning service so the ~800MB of native allocations do not stay resident
+	 * for the utility process lifetime.
+	 */
+	async release(): Promise<void> {
+		const sessions = [this._enc, this._dec, this._joint];
+		this._enc = this._dec = this._joint = undefined;
+		await Promise.allSettled(sessions.map(s => s?.release()));
+	}
+
+	/**
 	 * Download (if needed) and load the model. `cacheDir` is the shared model
 	 * cache; files are placed in a per-model subfolder guarded by a `.complete`
 	 * sentinel so a half-finished download is never reused.
 	 */
 	async prepare(cacheDir: string, model: string, onProgress: INemotronProgress): Promise<void> {
-		const modelDir = join(cacheDir, 'nemotron', model.replace(/[^a-zA-Z0-9._-]/g, '_'));
+		const sanitized = `${model}@${MODEL_REVISION}`.replace(/[^a-zA-Z0-9._-]/g, '_');
+		const modelDir = join(cacheDir, 'nemotron', sanitized);
 		await this._ensureDownloaded(modelDir, model, onProgress);
 
 		onProgress({ downloaded: true });
 		const ort = await this._loadOrt();
 		const opts = { executionProviders: ['cpu'] } as const;
-		[this._enc, this._dec, this._joint] = await Promise.all([
-			ort.InferenceSession.create(join(modelDir, 'encoder.onnx'), opts),
-			ort.InferenceSession.create(join(modelDir, 'decoder.onnx'), opts),
-			ort.InferenceSession.create(join(modelDir, 'joint.onnx'), opts),
-		]);
+		// Open the three graphs concurrently, but if any fails release the ones
+		// that already opened so a partial failure cannot leak native sessions.
+		const encP = ort.InferenceSession.create(join(modelDir, 'encoder.onnx'), opts);
+		const decP = ort.InferenceSession.create(join(modelDir, 'decoder.onnx'), opts);
+		const jointP = ort.InferenceSession.create(join(modelDir, 'joint.onnx'), opts);
+		try {
+			this._enc = await encP;
+			this._dec = await decP;
+			this._joint = await jointP;
+		} catch (err) {
+			await Promise.allSettled([encP, decP, jointP].map(p => p.then(s => s.release()).catch(() => { })));
+			this._enc = this._dec = this._joint = undefined;
+			throw err;
+		}
 		this._vocab = fs.readFileSync(join(modelDir, 'vocab.txt'), 'utf8').split('\n');
 		this._filterbank = melFilterbank();
 		// Hann window (symmetric), centered within the N_FFT frame.
@@ -218,7 +249,7 @@ export class NemotronTranscriber {
 
 		// Determine total bytes up front so progress can be reported as a single
 		// 0..1 value across all files (the .data blobs dominate).
-		const base = `https://huggingface.co/${model}/resolve/main`;
+		const base = `https://huggingface.co/${model}/resolve/${MODEL_REVISION}`;
 		const sizes: number[] = [];
 		for (const file of MODEL_FILES) {
 			sizes.push(await headContentLength(`${base}/${file}`));

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -265,14 +265,16 @@ configurationRegistry.registerConfiguration({
 				'onnx-community/whisper-tiny',
 				'onnx-community/whisper-base',
 				'onnx-community/whisper-small',
+				'onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4',
 			],
-			enumItemLabels: ['Tiny', 'Base', 'Small'],
+			enumItemLabels: ['Tiny', 'Base', 'Small', 'Nemotron (Multilingual)'],
 			markdownEnumDescriptions: [
 				nls.localize('chat.speechToText.model.tiny', "Smallest and fastest; lowest accuracy (~75MB download)."),
 				nls.localize('chat.speechToText.model.base', "Balanced speed and accuracy (~145MB download)."),
 				nls.localize('chat.speechToText.model.small', "Most accurate; slower and larger (~465MB download)."),
+				nls.localize('chat.speechToText.model.nemotron', "NVIDIA Nemotron RNN-T: multilingual (35+ languages, auto-detected), high accuracy, matches the GitHub Copilot app (~800MB download)."),
 			],
-			markdownDescription: nls.localize('chat.speechToText.model', "The on-device Whisper model used for chat dictation. The model is downloaded on first use and cached on disk. Larger models are more accurate but slower and take longer to download."),
+			markdownDescription: nls.localize('chat.speechToText.model', "The on-device model used for chat dictation. The model is downloaded on first use and cached on disk. Larger models are more accurate but slower and take longer to download."),
 			default: 'onnx-community/whisper-base',
 			tags: ['experimental']
 		},

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -275,7 +275,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize('chat.speechToText.model.nemotron', "NVIDIA Nemotron RNN-T: multilingual (35+ languages, auto-detected), high accuracy, matches the GitHub Copilot app (~800MB download)."),
 			],
 			markdownDescription: nls.localize('chat.speechToText.model', "The on-device model used for chat dictation. The model is downloaded on first use and cached on disk. Larger models are more accurate but slower and take longer to download."),
-			default: 'onnx-community/whisper-base',
+			default: 'onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4',
 			tags: ['experimental']
 		},
 		'chat.speechToText.mode': {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -259,25 +259,6 @@ configurationRegistry.registerConfiguration({
 			default: product.quality !== 'stable',
 			tags: ['experimental']
 		},
-		'chat.speechToText.model': {
-			type: 'string',
-			enum: [
-				'onnx-community/whisper-tiny',
-				'onnx-community/whisper-base',
-				'onnx-community/whisper-small',
-				'onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4',
-			],
-			enumItemLabels: ['Tiny', 'Base', 'Small', 'Nemotron (Multilingual)'],
-			markdownEnumDescriptions: [
-				nls.localize('chat.speechToText.model.tiny', "Smallest and fastest; lowest accuracy (~75MB download)."),
-				nls.localize('chat.speechToText.model.base', "Balanced speed and accuracy (~145MB download)."),
-				nls.localize('chat.speechToText.model.small', "Most accurate; slower and larger (~465MB download)."),
-				nls.localize('chat.speechToText.model.nemotron', "NVIDIA Nemotron RNN-T: multilingual (35+ languages, auto-detected), high accuracy, matches the GitHub Copilot app (~800MB download)."),
-			],
-			markdownDescription: nls.localize('chat.speechToText.model', "The on-device model used for chat dictation. The model is downloaded on first use and cached on disk. Larger models are more accurate but slower and take longer to download."),
-			default: 'onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4',
-			tags: ['experimental']
-		},
 		'chat.speechToText.mode': {
 			type: 'string',
 			enum: ['auto', 'toggle', 'pushToTalk'],

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -30,8 +30,6 @@ const SAMPLE_RATE = 16000;
 
 /** Setting that enables the dictation feature; a kill-switch for rollout. */
 const ENABLED_SETTING = 'chat.speechToText.enabled';
-/** On-device Whisper model to use for dictation. */
-const MODEL_SETTING = 'chat.speechToText.model';
 /** Setting that controls the tap-vs-hold behavior of the dictation shortcut. */
 const MODE_SETTING = 'chat.speechToText.mode';
 
@@ -366,8 +364,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 			this._onDidUpdateTranscript.fire(this._transcript);
 		}));
 		const cacheDir = joinPath(this._environmentService.cacheHome, 'chatDictationModels').fsPath;
-		const model = this._getModelId();
-		await local.start({ cacheDir, model });
+		await local.start({ cacheDir });
 
 		// The model loads in the utility process in the background (start()
 		// returns immediately). On first use it may download hundreds of MB, so
@@ -377,11 +374,6 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		if (status.state !== LocalTranscriptionModelState.Ready && status.state !== LocalTranscriptionModelState.Error) {
 			this._trackModelPreparation();
 		}
-	}
-
-	private _getModelId(): string | undefined {
-		const value = this._configurationService.getValue<string>(MODEL_SETTING);
-		return value ? value.trim() || undefined : undefined;
 	}
 
 	/**

--- a/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
+++ b/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
@@ -30,7 +30,7 @@ function isOnDeviceTranscriptionSupported(): boolean {
 
 /**
  * Renderer-side proxy for the on-device transcription service, which runs in a
- * utility process (heavy: transformers.js + native onnxruntime-node). The
+ * utility process (heavy: native onnxruntime-node). The
  * worker is spun up lazily on first use and torn down with the window.
  */
 export class LocalTranscriptionService {


### PR DESCRIPTION
## What

Adds NVIDIA's **`nemotron-3.5-asr-streaming-0.6b`** (the ASR model the GitHub Copilot desktop app ships) as an **opt-in** on-device dictation model behind the existing `chat.speechToText.model` setting, alongside the Whisper options. Whisper remains the default — nothing changes unless you select the new model.

## Why

Nemotron is **multilingual (35+ languages, auto-detected)**, notably more accurate than `whisper-base`, does **real streaming**, and gives us **parity with the Copilot app**. Cost is a ~800 MB first-use download and a bespoke transducer runtime.

## How

Nemotron is an **RNN-T transducer** (encoder + prediction LSTM + joint network), which `transformers.js` cannot run (it only supports CTC/attention ASR). So the new `NemotronTranscriber` drives the three ONNX graphs directly through **onnxruntime-node** (already a dependency) with:

- a hand-written **NeMo log-mel** feature extractor (preemphasis, slaney mel filterbank, radix-2 FFT),
- a **cache-aware chunked FastConformer encoder**, and
- a **greedy RNN-T decode loop** + SentencePiece detokenize.

### True streaming
Encoder caches, LSTM state, and emitted tokens are carried across calls, so each interim pass only processes the **newly-arrived audio** (cost proportional to new audio, not the whole utterance) and interim transcripts grow monotonically. Verified to produce **byte-identical** output to a one-shot full-buffer pass (tested down to 100-sample sub-frame chunks).

`LocalTranscriptionService` dispatches to the transducer when the selected model id matches, wrapped in the same call shape as the Whisper pipeline; the interim/final/status/cancel flow is unchanged. The Whisper path (including the recent download telemetry) is untouched.

## Files
- `src/vs/platform/localTranscription/node/nemotronTranscriber.ts` (new) — the streaming transducer + downloader.
- `src/vs/platform/localTranscription/node/localTranscriptionService.ts` — dispatch + streaming branch + per-session reset.
- `src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts` — new `chat.speechToText.model` enum option.

## Testing
1. Set `"chat.speechToText.enabled": true` (Insiders/dev) and `"chat.speechToText.model": "onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4"`.
2. Click the mic in the chat input and dictate. First use downloads ~800 MB (progress in the notification); subsequent uses load from cache.
3. Interim transcripts should stream in and grow; the final transcript is inserted on stop.
4. To A/B, switch the setting back to any `whisper-*` value — the mic uses the transformers.js path with identical UX.

> [!NOTE]
> Model is int4-quantized. On rare fricatives you may see a quantization-level slip (e.g. "brothels" -> "broffles"); the featurizer was validated as exact, so a higher-precision export is the lever there (it uses a different graph IO contract — follow-up).
