### PR TITLE
sessions: hide worktree/branch config when folder has no usable git repo

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -17,7 +17,7 @@ This document covers the shared base and the **local** concrete provider. For th
 Agent host providers implement `IAgentHostSessionsProvider` (defined in sessions core at `src/vs/sessions/common/agentHostSessionsProvider.ts`), which extends `ISessionsProvider` with:
 
 - **Remote connection members** (optional, populated only by remote providers): `connectionStatus`, `remoteAddress`, `connect()`, `disconnect()`, `canConnectOnDemand`.
-- **Dynamic session config**: `onDidChangeSessionConfig`, `getSessionConfig`, `isSessionConfigResolving`, `setSessionConfigValue`, `replaceSessionConfig`, `getSessionConfigCompletions`. These power the per-session configuration picker (isolation, branch, and other host-declared properties resolved live from the backend schema).
+- **Dynamic session config**: `onDidChangeSessionConfig`, `getSessionConfig`, `isSessionConfigResolving`, `setSessionConfigValue`, `replaceSessionConfig`, `getSessionConfigCompletions`. These power the per-session configuration picker (isolation, branch, and other host-declared properties resolved live from the backend schema). When the host reports only read-only `folder` isolation because the workspace has no usable Git repository, the picker omits the isolation control rather than showing a disabled `Folder` label. This availability filter runs before presentation-specific `_shouldRenderProperty` overrides so the mobile-aware picker cannot reintroduce the unavailable control on desktop.
 
 `isAgentHostProvider(provider: ISessionsProvider)` (same file) is a type guard returning `true` for the local and remote agent host providers; `isAgentHostProviderId(providerId: string)` is the id-only variant, `true` for `local-agent-host` and any `agenthost-*` (remote) provider id.
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -314,6 +314,9 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			if (!this._isPickable(schema)) {
 				continue;
 			}
+			if (property === SessionConfigKey.Isolation && !schema.enum?.includes('worktree')) {
+				continue;
+			}
 			if (!this._shouldRenderProperty(property, schema, isNewSession)) {
 				continue;
 			}

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHost/agentHostSessionConfigPicker.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHost/agentHostSessionConfigPicker.test.ts
@@ -11,7 +11,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../ba
 import { isIMenuItem, MenuId, MenuRegistry } from '../../../../../../../platform/actions/common/actions.js';
 import { IActionWidgetService } from '../../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { SessionConfigKey } from '../../../../../../../platform/agentHost/common/sessionConfigKeys.js';
-import { ResolveSessionConfigResult } from '../../../../../../../platform/agentHost/common/state/protocol/commands.js';
+import { ResolveSessionConfigResult, SessionConfigPropertySchema } from '../../../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../../../../platform/dialogs/common/dialogs.js';
@@ -52,6 +52,22 @@ function makeRepoConfig(branchValue?: string): ResolveSessionConfigResult {
 	} as ResolveSessionConfigResult;
 }
 
+function makeNoGitConfig(): ResolveSessionConfigResult {
+	return {
+		schema: {
+			type: 'object',
+			properties: {
+				[SessionConfigKey.Isolation]: {
+					title: 'Isolation', description: '', type: 'string',
+					enum: ['folder'], enumLabels: ['Folder'],
+					default: 'folder', readOnly: true,
+				},
+			},
+		},
+		values: { [SessionConfigKey.Isolation]: 'folder' },
+	} as ResolveSessionConfigResult;
+}
+
 /**
  * Fake provider whose `getSessionConfig` returns whatever config is set. The
  * provider (not the picker) owns the seeded schema, so a picker recreated by a
@@ -78,6 +94,12 @@ class FakeProvider implements Pick<IAgentHostSessionsProvider, 'id' | 'onDidChan
 		this.config = config;
 		this.resolving.set(resolving, undefined);
 		this._emitter.fire(SESSION_ID);
+	}
+}
+
+class AlwaysRenderConfigPicker extends AgentHostSessionConfigPicker {
+	protected override _shouldRenderProperty(_property: string, _schema: SessionConfigPropertySchema, _isNewSession: boolean): boolean {
+		return true;
 	}
 }
 
@@ -205,5 +227,15 @@ suite('Agent Host Session Config Picker', () => {
 		assert.strictEqual(isolationSlot(second.container)!.classList.contains('disabled'), false, 'isolation re-enables after resolve');
 		assert.strictEqual(branchSlot(second.container)!.classList.contains('disabled'), false, 'branch re-enables after resolve');
 		assert.strictEqual(branchLabel(second.container), 'dev', 'branch label reflects the resolved value');
+	});
+
+	test('does not render folder isolation when the workspace has no Git repository', () => {
+		const services = setupServices(store);
+		services.provider.config = makeNoGitConfig();
+		const picker = store.add(services.instantiationService.createInstance(AlwaysRenderConfigPicker, services.sessionObs));
+		const container = document.createElement('div');
+		picker.render(container);
+
+		assert.strictEqual(isolationSlot(container), null);
 	});
 });

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -51,6 +51,7 @@ registerAction2(class extends Action2 {
 				when: ContextKeyExpr.and(
 					IsNewChatSessionContext,
 					IsActiveSessionCopilotChatCLI,
+					SessionHasGitRepositoryContext,
 					ContextKeyExpr.equals('config.github.copilot.chat.cli.isolationOption.enabled', true),
 				),
 			}],
@@ -65,12 +66,11 @@ registerAction2(class extends Action2 {
 			id: 'sessions.defaultCopilot.branchPicker',
 			title: localize2('branchPicker', "Branch"),
 			f1: false,
-			precondition: SessionHasGitRepositoryContext,
 			menu: [{
 				id: Menus.NewSessionRepositoryConfig,
 				group: 'navigation',
 				order: 2,
-				when: ContextKeyExpr.and(IsNewChatSessionContext, IsActiveSessionCopilotChatCLI),
+				when: ContextKeyExpr.and(IsNewChatSessionContext, IsActiveSessionCopilotChatCLI, SessionHasGitRepositoryContext),
 			}],
 		});
 	}
@@ -269,7 +269,12 @@ class CopilotActiveSessionContribution extends Disposable implements IWorkbenchC
 				const provider = sessionsProvidersService.getProvider(session.providerId);
 				const providerSession = provider instanceof CopilotChatSessionsProvider ? provider.getSession(session.sessionId) : undefined;
 				const isLoading = providerSession?.loading.read(reader);
-				hasRepositoryKey.set(!isLoading && !!providerSession?.gitRepository);
+				const gitRepository = providerSession?.gitRepository;
+				// An empty repository (no HEAD commit) cannot run worktree
+				// isolation, so treat it as having no usable git repository —
+				// mirrors CopilotCLISession's own worktree gating.
+				const hasHeadCommit = !!gitRepository?.state.read(reader).HEAD?.commit;
+				hasRepositoryKey.set(!isLoading && !!gitRepository && hasHeadCommit);
 			} else if (session?.providerId === LOCAL_AGENT_HOST_PROVIDER_ID) {
 				const provider = sessionsProvidersService.getProvider(session.providerId);
 				const providerSession = provider instanceof BaseAgentHostSessionsProvider


### PR DESCRIPTION
## What

In the Agents window new-session view, the repository configuration controls (isolation **New Worktree** and **Branch**) were rendered but **disabled/greyed** when the selected folder had no usable git repository. Now they are hidden instead of shown as dead controls.

## Changes

**Agent Host provider** (`agentHostSessionConfigPicker.ts`)
- Skip the isolation control at render time when the resolved schema offers no `worktree` option (a non-git folder resolves to read-only `folder`).
- The filter runs **before** the desktop/mobile `_shouldRenderProperty` overrides, so the mobile-aware subclass (also instantiated on desktop) cannot reintroduce the control.

**Copilot Chat provider** (`copilotChatSessionsActions.ts`)
- `SessionHasGitRepositoryContext` is now **HEAD-commit aware and reactive**: an empty repository (repo object exists but no commits) counts as "no usable git repo", matching `CopilotCLISession`'s own worktree gating (`_hasGitRepo`). Previously the key was `!!gitRepository`, which was true for empty repos.
- Gate both new-session actions on that key via `when`:
  - **Isolation** - added `SessionHasGitRepositoryContext` to the `when`.
  - **Branch** - moved the git gate from `precondition` (which only disabled it) to `when` (which hides it).

## Reviewer notes

- Because the Copilot context key is now HEAD-aware, **Sync Changes** (which shares this key) is also hidden for empty repositories - correct, since there is nothing to sync without commits.
- Normal repositories with commits are unaffected: the controls still render enabled.
- Spec + regression tests updated (`AGENT_HOST_SESSIONS_PROVIDER.md`, `agentHostSessionConfigPicker.test.ts`).

Validated locally: `typecheck-client`, `valid-layers-check`, hygiene, and the Agent Host config picker test suite all pass.
