### PR TITLE
Git - re-read the index base when staging, reverting or unstaging ranges

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1938,8 +1938,8 @@ export class CommandCenter {
 		}
 
 		const originalUri = toGitUri(modifiedUri, '~');
-		const originalDocument = await workspace.openTextDocument(originalUri);
-		const result = applyLineChanges(originalDocument, modifiedDocument, changes);
+		const original = await workspace.decode(await workspace.fs.readFile(originalUri), { encoding: modifiedDocument.encoding });
+		const result = applyLineChanges(original, modifiedDocument.getText(), changes);
 
 		await this.runByRepository(modifiedUri, async (repository, resource) =>
 			await repository.stage(resource, result, modifiedDocument.encoding));
@@ -2009,9 +2009,9 @@ export class CommandCenter {
 		}
 
 		const originalUri = toGitUri(modifiedUri, '~');
-		const originalDocument = await workspace.openTextDocument(originalUri);
+		const original = await workspace.decode(await workspace.fs.readFile(originalUri), { encoding: modifiedDocument.encoding });
 		const visibleRangesBeforeRevert = textEditor.visibleRanges;
-		const result = applyLineChanges(originalDocument, modifiedDocument, changes);
+		const result = applyLineChanges(original, modifiedDocument.getText(), changes);
 
 		const edit = new WorkspaceEdit();
 		edit.replace(modifiedUri, new Range(new Position(0, 0), modifiedDocument.lineAt(modifiedDocument.lineCount - 1).range.end), result);
@@ -2085,7 +2085,7 @@ export class CommandCenter {
 		this.logger.trace(`[CommandCenter][unstageSelectedRanges] diffInformation changes: ${JSON.stringify(indexLineChanges)}`);
 
 		const originalUri = toGitUri(resource.original, 'HEAD');
-		const originalDocument = await workspace.openTextDocument(originalUri);
+		const original = await workspace.decode(await workspace.fs.readFile(originalUri), { encoding: modifiedDocument.encoding });
 		const selectedLines = toLineRanges(textEditor.selections, modifiedDocument);
 
 		const selectedDiffs = indexLineChanges
@@ -2109,7 +2109,7 @@ export class CommandCenter {
 		const selectedDiffsInverted = selectedDiffs.map(invertLineChange);
 		this.logger.trace(`[CommandCenter][unstageSelectedRanges] selectedDiffsInverted: ${JSON.stringify(selectedDiffsInverted)}`);
 
-		const result = applyLineChanges(modifiedDocument, originalDocument, selectedDiffsInverted);
+		const result = applyLineChanges(modifiedDocument.getText(), original, selectedDiffsInverted);
 		await repository.stage(modifiedDocument.uri, result, modifiedDocument.encoding);
 	}
 
@@ -2174,8 +2174,8 @@ export class CommandCenter {
 		const diffsInverted = [...changesInverted, ...workingTreeDiffsInverted].sort(compareLineChanges);
 
 		const originalUri = toGitUri(modifiedUri, 'HEAD');
-		const originalDocument = await workspace.openTextDocument(originalUri);
-		const result = applyLineChanges(modifiedDocument, originalDocument, diffsInverted);
+		const original = await workspace.decode(await workspace.fs.readFile(originalUri), { encoding: modifiedDocument.encoding });
+		const result = applyLineChanges(modifiedDocument.getText(), original, diffsInverted);
 
 		await this.runByRepository(modifiedUri, async (repository, resource) =>
 			await repository.stage(resource, result, modifiedDocument.encoding));

--- a/extensions/git/src/staging.ts
+++ b/extensions/git/src/staging.ts
@@ -13,7 +13,43 @@ export interface LineChange {
 	readonly modifiedEndLineNumber: number;
 }
 
-export function applyLineChanges(original: TextDocument, modified: TextDocument, diffs: LineChange[]): string {
+/**
+ * A line-addressable view over a string, providing the subset of `TextDocument`
+ * behavior that {@link applyLineChanges} relies on. It lets the staged result be
+ * computed from freshly read content rather than a `TextDocument`.
+ */
+class LineIndex {
+	private readonly lineStarts: number[] = [0];
+	private readonly lineEnds: number[] = [];
+
+	constructor(private readonly text: string) {
+		const eol = /\r\n|\r|\n/g;
+		let match: RegExpExecArray | null;
+		while ((match = eol.exec(text))) {
+			this.lineEnds.push(match.index);
+			this.lineStarts.push(match.index + match[0].length);
+		}
+		this.lineEnds.push(text.length);
+	}
+
+	get lineCount(): number {
+		return this.lineStarts.length;
+	}
+
+	lineLength(line: number): number {
+		return this.lineEnds[line] - this.lineStarts[line];
+	}
+
+	getText(startLine: number, startCharacter: number, endLine: number, endCharacter: number): string {
+		// Lines past the end clamp to the end of the content, like TextDocument.getText.
+		const offset = (line: number, character: number) => line < this.lineStarts.length ? this.lineStarts[line] + character : this.text.length;
+		return this.text.slice(offset(startLine, startCharacter), offset(endLine, endCharacter));
+	}
+}
+
+export function applyLineChanges(original: string, modified: string, diffs: LineChange[]): string {
+	const originalContent = new LineIndex(original);
+	const modifiedContent = new LineIndex(modified);
 	const result: string[] = [];
 	let currentLine = 0;
 
@@ -27,12 +63,12 @@ export function applyLineChanges(original: TextDocument, modified: TextDocument,
 		// if this is a deletion at the very end of the document,then we need to account
 		// for a newline at the end of the last line which may have been deleted
 		// https://github.com/microsoft/vscode/issues/59670
-		if (isDeletion && diff.originalEndLineNumber === original.lineCount) {
+		if (isDeletion && diff.originalEndLineNumber === originalContent.lineCount) {
 			endLine -= 1;
-			endCharacter = original.lineAt(endLine).range.end.character;
+			endCharacter = originalContent.lineLength(endLine);
 		}
 
-		result.push(original.getText(new Range(currentLine, 0, endLine, endCharacter)));
+		result.push(originalContent.getText(currentLine, 0, endLine, endCharacter));
 
 		if (!isDeletion) {
 			let fromLine = diff.modifiedStartLineNumber - 1;
@@ -41,18 +77,18 @@ export function applyLineChanges(original: TextDocument, modified: TextDocument,
 			// if this is an insertion at the very end of the document,
 			// then we must start the next range after the last character of the
 			// previous line, in order to take the correct eol
-			if (isInsertion && diff.originalStartLineNumber === original.lineCount) {
+			if (isInsertion && diff.originalStartLineNumber === originalContent.lineCount) {
 				fromLine -= 1;
-				fromCharacter = modified.lineAt(fromLine).range.end.character;
+				fromCharacter = modifiedContent.lineLength(fromLine);
 			}
 
-			result.push(modified.getText(new Range(fromLine, fromCharacter, diff.modifiedEndLineNumber, 0)));
+			result.push(modifiedContent.getText(fromLine, fromCharacter, diff.modifiedEndLineNumber, 0));
 		}
 
 		currentLine = isInsertion ? diff.originalStartLineNumber : diff.originalEndLineNumber;
 	}
 
-	result.push(original.getText(new Range(currentLine, 0, original.lineCount, 0)));
+	result.push(originalContent.getText(currentLine, 0, originalContent.lineCount, 0));
 
 	return result.join('');
 }

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -5,12 +5,13 @@
 
 import 'mocha';
 import assert from 'assert';
-import { workspace, commands, window, Uri, WorkspaceEdit, Range, TextDocument, extensions, TabInputTextDiff } from 'vscode';
+import { workspace, commands, window, Uri, WorkspaceEdit, Range, Selection, TextDocument, TextEditor, extensions, TabInputTextDiff } from 'vscode';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { GitExtension, API, Repository } from '../api/git';
 import { Status } from '../api/git.constants';
+import { fromGitUri, isGitUri } from '../uri';
 import { eventToPromise } from '../util';
 
 suite('git smoke test', function () {
@@ -147,6 +148,39 @@ suite('git smoke test', function () {
 		assert.strictEqual(repository.state.indexChanges.length, 0);
 	});
 
+	test('does not stage a revert of the previous commit (#64027)', async function () {
+		const name = 'stage-range.txt';
+		fs.writeFileSync(file(name), '1\n2\n3\n4\n5\n6\n', 'utf8');
+		cp.execSync(`git add ${name}`, { cwd });
+		cp.execSync('git commit -m "add stage-range.txt"', { cwd });
+
+		const doc = await open(name);
+		const editor = window.activeTextEditor!;
+
+		// Change two separate regions: line 1 and line 6.
+		const edit = new WorkspaceEdit();
+		edit.replace(doc.uri, new Range(0, 0, 0, 1), '1x');
+		edit.replace(doc.uri, new Range(5, 0, 5, 1), '6x');
+		await workspace.applyEdit(edit);
+		await doc.save();
+
+		// Stage the first region and commit it.
+		await waitForWorkingTreeDiff(editor, 2);
+		editor.selection = new Selection(0, 0, 0, 0);
+		await commands.executeCommand('git.stageSelectedRanges');
+		await repository.commit('stage first region');
+
+		// Immediately stage the second region. The index base must be re-read after the
+		// commit, otherwise the just-committed first region is staged as a revert.
+		await waitForWorkingTreeDiff(editor, 1);
+		editor.selection = new Selection(5, 0, 5, 0);
+		await commands.executeCommand('git.stageSelectedRanges');
+
+		assert.strictEqual(cp.execSync(`git show :${name}`, { cwd }).toString(), '1x\n2\n3\n4\n5\n6x\n');
+
+		await repository.commit('stage second region');
+	});
+
 	test('rename/delete conflict', async function () {
 		await commands.executeCommand('workbench.view.scm');
 
@@ -175,4 +209,20 @@ suite('git smoke test', function () {
 		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
 		assert.strictEqual(repository.state.indexChanges.length, 0);
 	});
+
+	function waitForWorkingTreeDiff(editor: TextEditor, changes: number): Promise<void> {
+		// Gate on the same working-tree diff (ref '~'/'') that git.stageSelectedRanges consumes.
+		const ready = () => !!editor.diffInformation?.some(d => d.original && isGitUri(d.original) && ['~', ''].includes(fromGitUri(d.original).ref) && !d.isStale && d.changes.length === changes);
+		if (ready()) {
+			return Promise.resolve();
+		}
+		return new Promise<void>(resolve => {
+			const disposable = window.onDidChangeTextEditorDiffInformation(e => {
+				if (e.textEditor === editor && ready()) {
+					disposable.dispose();
+					resolve();
+				}
+			});
+		});
+	}
 });

--- a/extensions/git/src/test/staging.test.ts
+++ b/extensions/git/src/test/staging.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import assert from 'assert';
+import { applyLineChanges, LineChange } from '../staging';
+
+suite('staging', () => {
+	suite('applyLineChanges', () => {
+		const change = (originalStartLineNumber: number, originalEndLineNumber: number, modifiedStartLineNumber: number, modifiedEndLineNumber: number): LineChange =>
+			({ originalStartLineNumber, originalEndLineNumber, modifiedStartLineNumber, modifiedEndLineNumber });
+
+		test('applies a modification in the middle of the file', () => {
+			assert.strictEqual(
+				applyLineChanges('a\nb\nc\n', 'a\nB\nc\n', [change(2, 2, 2, 2)]),
+				'a\nB\nc\n');
+		});
+
+		test('applies only the selected change, keeping the rest of the base (#64027)', () => {
+			// The base already contains the first region (as if it was committed); staging the
+			// second region must not revert the first.
+			assert.strictEqual(
+				applyLineChanges('1x\n2\n3\n4\n5\n6\n', '1x\n2\n3\n4\n5\n6x\n', [change(6, 6, 6, 6)]),
+				'1x\n2\n3\n4\n5\n6x\n');
+		});
+
+		test('applies an insertion at the end of the file (#59670)', () => {
+			assert.strictEqual(
+				applyLineChanges('a\nb', 'a\nb\nc', [change(2, 0, 3, 3)]),
+				'a\nb\nc');
+		});
+
+		test('applies a deletion at the end of the file (#59670)', () => {
+			// No trailing newline, so the deleted line is the last line and the end-of-file
+			// branch (originalEndLineNumber === lineCount) is exercised.
+			assert.strictEqual(
+				applyLineChanges('a\nb\nc', 'a\nb', [change(3, 3, 2, 0)]),
+				'a\nb');
+		});
+
+		test('preserves CRLF line endings', () => {
+			assert.strictEqual(
+				applyLineChanges('a\r\nb\r\nc\r\n', 'a\r\nB\r\nc\r\n', [change(2, 2, 2, 2)]),
+				'a\r\nB\r\nc\r\n');
+		});
+
+		test('applies multiple selected changes in a single call', () => {
+			assert.strictEqual(
+				applyLineChanges('a\nb\nc\nd\n', 'A\nb\nc\nD\n', [change(1, 1, 1, 1), change(4, 4, 4, 4)]),
+				'A\nb\nc\nD\n');
+		});
+	});
+});


### PR DESCRIPTION
Fixes #64027

### The bug

Stage a selected range, commit, then stage a second range with nothing in between, and the second stage also stages an exact revert of the just-committed region (it shows up in `git diff --cached` and gets committed). Reliably reproducible; @joaomoreno diagnosed the mechanism back in 2018 ("VS Code fails to refresh the index version of the file in time for that second stage").

### Root cause

`_stageChanges`/`_revertChanges`/the two unstage paths build the staged content by applying the selected line changes onto the index/HEAD base, which they obtain via `openTextDocument(toGitUri(uri, '~' | 'HEAD'))`. The git file system provider serves that content fresh (`readFile` runs `git show` every time), but the workbench caches the `TextDocument`, and the provider's invalidation event is `@debounce(1100)`. So within ~1.1s of a commit the cached base is stale — the second stage applies the new hunk onto the pre-commit base and reverts the first commit. `workspace.fs.readFile` on the same `git:` URI bypasses the document cache and is always fresh.

### The fix

Read the base directly with `workspace.fs.readFile` + `workspace.decode({ encoding: modifiedDocument.encoding })` (the inverse of the `workspace.encode({ encoding })` already used on the stage write path), instead of opening a document for it. `applyLineChanges` now takes the two sides as strings, backed by a small `LineIndex` helper that provides the `lineCount`/line-length/`getText` behaviour it relied on — so the freshly read base can be applied without a `TextDocument`. Both parameters became strings because the unstage sites pass the git side as the `modified` argument.

I kept `LineIndex` rather than reaching for `openTextDocument({ content })` deliberately: an untitled document per stage would land in `workspace.textDocuments` and fire `onDidOpenTextDocument` to every extension on a frequently-run command, and slicing the string preserves the base bytes/EOL exactly (an untitled doc infers and can normalize EOL). `LineIndex` is verified byte-identical to the previous `TextDocument`-based algorithm.

### Scope

This changes the four `applyLineChanges`-based range/hunk commands (stage/revert/unstage selected ranges and the gutter stage/revert/unstage-change actions). The diff-editor toolbar's `git.diff.stageHunk`/`stageSelection` path stages a string precomputed by the diff editor and never went through this base read, so it is unaffected.

### Tests

- `extensions/git/src/test/smoke.test.ts` — an end-to-end regression: stage a region, commit, stage a second region, and assert the index contains only the second region. Verified it fails on the current code (stages `1\n…` — line 1 reverted) and passes with the fix.
- `extensions/git/src/test/staging.test.ts` — unit coverage for the `applyLineChanges` string refactor: mid-file, end-of-file insert/delete (#59670), CRLF, and multiple selected changes.

The end-to-end test covers `git.stageSelectedRanges` (the `~`/index base), which is the reliably reproducible case since the working-tree quick diff always keeps that document open. The revert and unstage sites take the identical fresh read against the `HEAD` base, whose staleness is impractical to drive in an end-to-end test, so they lean on the `applyLineChanges` byte-parity units plus the shared read path.
