### PR TITLE
Polish MCP server list status actions

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -222,7 +222,7 @@ AHP Remote Server ────────────────────�
 
 ### MCP server list active-session controls
 
-The MCP Servers tab merges local/workspace MCP configuration with MCP servers reported by the active agent-host session. When a listed server also exists in the active session, row status follows the session-backed server and lifecycle controls (start/stop) target the agent host. Model-access and sampling-log actions are hidden for session-backed rows because those are not inline session controls.
+The MCP Servers tab merges local/workspace MCP configuration with MCP servers reported by the active agent-host session. When a listed server also exists in the active session, row status follows the session-backed server and lifecycle controls (start/stop) target the agent host. Model-access and sampling-log actions are hidden for session-backed rows because those are not inline session controls. Runtime states render as semantic colored icons rather than text badges: running uses a green check, while stopped has no visual icon. Authentication-required rows expose an inline **Sign In** button, and an actionable error icon opens that server's local or agent-host output.
 
 Enablement has three explicit scopes. `Enable` / `Disable` persists at profile scope, `Enable (Workspace)` / `Disable (Workspace)` persists for the active project, and `Enable (Session)` / `Disable (Session)` dispatches only to the active agent-host session. Servers with an exact, unambiguous identifier or name match to an `IMcpService` entry, including extension-provided servers, use the existing local enablement model for profile/workspace state. Ambiguous matches remain agent-host-only so an action cannot target the wrong local server. Agent-host-only profile state is keyed by agent-host resource scheme (which includes local/remote host and provider identity) plus exact server name; workspace state additionally includes the session working directory so repositories inside the shared Agents window storage workspace remain independent. Workspace actions are hidden when the Sessions-aware active project root is absent, including workspace-less quick chats.
 
@@ -272,7 +272,9 @@ Provider-supplied customization rows that include an explicit storage origin are
 
 ### MCP Active Session Status
 
-The MCP Servers section combines locally known MCP servers with MCP servers reported by the active agent-host session (`IAgentHostCustomizationService.getMcpServers(activeSessionResource)`). Active-session servers are matched to known workspace, user, extension, plugin, or built-in rows by stable identifiers and display names so the row can show the active session's status, matching `MCP: List Servers`. Active-session servers that do not match any known local/runtime server are appended under an **Active Session** group and counted with the rest of the section.
+The MCP Servers section combines locally known MCP servers with MCP servers reported by the active agent-host session (`IAgentHostCustomizationService.getMcpServers(activeSessionResource)`). Active-session servers are matched to known workspace, user, extension, plugin, or built-in rows by stable identifiers and display names so the row can show the active session's status, matching `MCP: List Servers`. Active-session servers that do not match any known local/runtime server are appended to the **Workspace** group and counted with the rest of the section.
+
+The MCP list uses `WorkbenchList` as its sole scroll owner. Layout uses the widget's rendered content-box dimensions rather than the padded panel's outer dimensions, and the virtual delegate height matches each rendered row variant, including the taller two-line description row. These invariants keep the final row fully reachable at the bottom of the list.
 
 ### Sidebar Customizations Section
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -47,10 +47,12 @@ import { ICustomizationHarnessService } from '../../common/customizationHarnessS
 import { IAgentHostCustomizationService } from '../agentSessions/agentHost/agentHostCustomizationService.js';
 import { McpServerStatus } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { GalleryItemInstallState, GalleryItemRenderer, IGalleryItemProvider } from './galleryItemRenderer.js';
+import { IOutputService } from '../../../../services/output/common/output.js';
 
 const $ = DOM.$;
 
 const MCP_ITEM_HEIGHT = 36;
+const MCP_ITEM_WITH_DESCRIPTION_HEIGHT = 44;
 
 const PLUGIN_COLLECTION_PREFIX = MCP_PLUGIN_COLLECTION_ID_PREFIX;
 
@@ -68,7 +70,7 @@ function getPluginUriFromCollectionId(collectionId: string | undefined): string 
  * Represents a collapsible group header in the MCP server list.
  */
 interface IMcpGroupHeaderEntry extends ICustomizationGroupHeaderEntry {
-	readonly scope: LocalMcpServerScope | 'builtin' | 'plugin' | 'extension' | 'active-session';
+	readonly scope: LocalMcpServerScope | 'builtin' | 'plugin' | 'extension';
 }
 
 /**
@@ -122,6 +124,12 @@ class McpServerItemDelegate implements IListVirtualDelegate<IMcpListEntry> {
 		if (element.type === 'server-item' && element.server.gallery && (element.marketplace || !element.server.local)) {
 			return 62;
 		}
+		if (element.type === 'server-item' && element.server.description?.trim()) {
+			return MCP_ITEM_WITH_DESCRIPTION_HEIGHT;
+		}
+		if (element.type === 'builtin-item' && element.description) {
+			return MCP_ITEM_WITH_DESCRIPTION_HEIGHT;
+		}
 		return MCP_ITEM_HEIGHT;
 	}
 
@@ -145,8 +153,9 @@ interface IMcpServerItemTemplateData {
 	readonly typeIcon: HTMLElement;
 	readonly name: HTMLElement;
 	readonly description: HTMLElement;
-	readonly status: HTMLElement;
-	readonly disposables: DisposableStore;
+	readonly actions: HTMLElement;
+	readonly elementDisposables: DisposableStore;
+	readonly actionDisposables: DisposableStore;
 }
 
 /**
@@ -159,6 +168,9 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpS
 		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
 		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
 		@IHoverService private readonly hoverService: IHoverService,
+		@IAgentHostCustomizationService private readonly agentHostCustomizationService: IAgentHostCustomizationService,
+		@ICustomizationHarnessService private readonly customizationHarnessService: ICustomizationHarnessService,
+		@IOutputService private readonly outputService: IOutputService,
 	) { }
 
 	renderTemplate(container: HTMLElement): IMcpServerItemTemplateData {
@@ -173,13 +185,22 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpS
 
 		const description = DOM.append(details, $('.mcp-server-description'));
 
-		const status = DOM.append(container, $('.mcp-server-status'));
+		const actions = DOM.append(container, $('.mcp-server-actions'));
 
-		return { container, typeIcon, name, description, status, disposables: new DisposableStore() };
+		return {
+			container,
+			typeIcon,
+			name,
+			description,
+			actions,
+			elementDisposables: new DisposableStore(),
+			actionDisposables: new DisposableStore(),
+		};
 	}
 
 	renderElement(element: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry, index: number, templateData: IMcpServerItemTemplateData): void {
-		templateData.disposables.clear();
+		templateData.elementDisposables.clear();
+		templateData.actionDisposables.clear();
 
 		if (element.type === 'builtin-item') {
 			templateData.container.classList.add('builtin');
@@ -189,14 +210,15 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpS
 				templateData.description.textContent = truncateToFirstLine(element.description);
 				templateData.description.style.display = '';
 			} else {
+				templateData.description.textContent = '';
 				templateData.description.style.display = 'none';
 			}
-			this.updateKnownServerStatus(templateData, element.localServer, element.activeSessionServer);
+			this.updateKnownServerStatus(templateData, element);
 
 			// Add hover with plugin provenance for plugin-sourced builtin items
 			const pluginUriStr = getPluginUriFromCollectionId(element.collectionId);
 			if (pluginUriStr) {
-				templateData.disposables.add(this.hoverService.setupDelayedHover(templateData.container, () => {
+				templateData.elementDisposables.add(this.hoverService.setupDelayedHover(templateData.container, () => {
 					const plugin = this.agentPluginService.plugins.get().find(p => p.uri.toString() === pluginUriStr);
 					if (plugin) {
 						return {
@@ -214,8 +236,9 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpS
 			templateData.container.classList.remove('builtin');
 			templateData.container.classList.toggle('has-detail', false);
 			templateData.name.textContent = formatDisplayName(element.server.name);
+			templateData.description.textContent = '';
 			templateData.description.style.display = 'none';
-			this.updateActiveSessionStatus(templateData, element.server);
+			this.updateActiveSessionStatus(templateData, element);
 			return;
 		}
 
@@ -232,80 +255,165 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpS
 			templateData.description.textContent = truncateToFirstLine(description);
 			templateData.description.style.display = '';
 		} else {
+			templateData.description.textContent = '';
 			templateData.description.style.display = 'none';
 		}
 
 		if (element.activeSessionServer) {
-			this.updateKnownServerStatus(templateData, element.localServer, element.activeSessionServer);
+			this.updateKnownServerStatus(templateData, element);
 		} else if (this.workspaceService.isSessionsWindow) {
-			this.updateKnownServerStatus(templateData, element.localServer, undefined);
+			this.updateKnownServerStatus(templateData, element);
 		} else {
-			templateData.disposables.add(autorun(reader => {
+			templateData.elementDisposables.add(autorun(reader => {
 				const disabled = element.localServer ? isContributionDisabled(element.localServer.enablement.read(reader)) : false;
 				const connectionState = element.localServer?.connectionState.read(reader);
 				templateData.container.classList.toggle('disabled', disabled);
-				this.updateStatus(templateData.status, disabled ? 'disabled' : connectionState?.state);
+				this.updateStatus(templateData, element, disabled ? 'disabled' : connectionState?.state);
 			}));
 		}
 	}
 
-	private updateKnownServerStatus(templateData: IMcpServerItemTemplateData, localServer: IMcpServer | undefined, activeSessionServer: AgentHostMcpServer | undefined): void {
-		templateData.disposables.add(autorun(reader => {
-			const localDisabled = localServer ? isContributionDisabled(localServer.enablement.read(reader)) : false;
+	private updateKnownServerStatus(templateData: IMcpServerItemTemplateData, element: IMcpServerItemEntry | IMcpBuiltinItemEntry): void {
+		templateData.elementDisposables.add(autorun(reader => {
+			const localDisabled = element.localServer ? isContributionDisabled(element.localServer.enablement.read(reader)) : false;
+			const activeSessionServer = element.activeSessionServer;
 			templateData.container.classList.toggle('disabled', localDisabled || activeSessionServer?.enabled === false);
-			this.updateStatus(templateData.status, localDisabled ? 'disabled' : activeSessionServer ? (activeSessionServer.enabled ? activeSessionServer.status : 'disabled') : undefined);
+			this.updateStatus(templateData, element, localDisabled ? 'disabled' : activeSessionServer ? (activeSessionServer.enabled ? activeSessionServer.status : 'disabled') : undefined);
 		}));
 	}
 
-	private updateActiveSessionStatus(templateData: IMcpServerItemTemplateData, server: AgentHostMcpServer | undefined): void {
-		const disabled = server?.enabled === false;
+	private updateActiveSessionStatus(templateData: IMcpServerItemTemplateData, element: IMcpSessionServerItemEntry): void {
+		const disabled = element.server.enabled === false;
 		templateData.container.classList.toggle('disabled', disabled);
-		this.updateStatus(templateData.status, disabled ? 'disabled' : server?.status);
+		this.updateStatus(templateData, element, disabled ? 'disabled' : element.server.status);
 	}
 
-	private updateStatus(statusElement: HTMLElement, state: McpStatusKind | undefined): void {
-		statusElement.className = 'mcp-server-status';
+	private updateStatus(templateData: IMcpServerItemTemplateData, element: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry, state: McpStatusKind | undefined): void {
+		templateData.actionDisposables.clear();
+		DOM.clearNode(templateData.actions);
 
 		const presentation = getMcpStatusPresentation(state);
 		if (!presentation) {
-			statusElement.style.display = 'none';
 			return;
 		}
 
-		statusElement.style.display = '';
-		statusElement.textContent = presentation.label;
-		statusElement.classList.add(presentation.className);
+		const activeSessionServer = getActiveSessionServer(element);
+		const label = getMcpEntryLabel(element);
+		if (state === McpServerStatus.AuthRequired && activeSessionServer) {
+			const signInLabel = localize('signInToMcpServer', "Sign in to {0}", label);
+			const signInButton = templateData.actionDisposables.add(new Button(templateData.actions, {
+				...defaultButtonStyles,
+				secondary: true,
+				small: true,
+				title: signInLabel,
+				ariaLabel: signInLabel,
+			}));
+			signInButton.label = localize('signIn', "Sign In");
+			signInButton.element.classList.add('mcp-server-sign-in');
+			templateData.actionDisposables.add(DOM.addDisposableListener(signInButton.element, DOM.EventType.MOUSE_DOWN, event => DOM.EventHelper.stop(event, true)));
+			templateData.actionDisposables.add(signInButton.onDidClick(async event => {
+				DOM.EventHelper.stop(event, true);
+				signInButton.enabled = false;
+				try {
+					await this.agentHostCustomizationService.authenticateMcpServer(this.customizationHarnessService.activeSessionResource.get(), activeSessionServer.id);
+				} finally {
+					signInButton.enabled = true;
+				}
+			}));
+		}
+
+		if (!presentation.icon) {
+			return;
+		}
+
+		const showOutput = state === McpServerStatus.Error || state === McpConnectionState.Kind.Error
+			? this.getShowOutputHandler(element)
+			: undefined;
+		if (showOutput) {
+			const showOutputLabel = localize('showMcpServerOutput', "Show output for {0}", label);
+			const statusButton = templateData.actionDisposables.add(new Button(templateData.actions, {
+				title: showOutputLabel,
+				ariaLabel: showOutputLabel,
+			}));
+			statusButton.icon = presentation.icon;
+			statusButton.element.classList.add('mcp-server-status', 'mcp-server-status-action', presentation.className);
+			templateData.actionDisposables.add(DOM.addDisposableListener(statusButton.element, DOM.EventType.MOUSE_DOWN, event => DOM.EventHelper.stop(event, true)));
+			templateData.actionDisposables.add(statusButton.onDidClick(event => {
+				DOM.EventHelper.stop(event, true);
+				showOutput();
+			}));
+			return;
+		}
+
+		const statusElement = DOM.append(templateData.actions, $('.mcp-server-status'));
+		statusElement.classList.add(presentation.className, ...ThemeIcon.asClassNameArray(presentation.icon));
+		statusElement.setAttribute('aria-hidden', 'true');
+		templateData.actionDisposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), statusElement, presentation.label));
+	}
+
+	private getShowOutputHandler(element: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry): (() => void) | undefined {
+		const activeSessionServer = getActiveSessionServer(element);
+		const outputChannelId = activeSessionServer?.logOutputChannelId;
+		if (outputChannelId) {
+			return () => {
+				void this.outputService.showChannel(outputChannelId);
+			};
+		}
+		const localServer = element.type !== 'session-server-item' ? element.localServer : undefined;
+		if (localServer) {
+			return () => localServer.showOutput();
+		}
+		return undefined;
 	}
 
 	disposeTemplate(templateData: IMcpServerItemTemplateData): void {
-		templateData.disposables.dispose();
+		templateData.elementDisposables.dispose();
+		templateData.actionDisposables.dispose();
 	}
 }
 
-function getMcpStatusPresentation(state: McpStatusKind | undefined): { label: string; className: string } | undefined {
+interface IMcpStatusPresentation {
+	readonly label: string;
+	readonly className: string;
+	readonly icon?: ThemeIcon;
+}
+
+function getMcpStatusPresentation(state: McpStatusKind | undefined): IMcpStatusPresentation | undefined {
 	if (state === undefined) {
 		return undefined;
 	}
 	if (state === 'disabled') {
-		return { label: localize('disabled', "Disabled"), className: 'disabled' };
+		return { label: localize('disabled', "Disabled"), className: 'disabled', icon: Codicon.circleSlash };
 	}
 	switch (state) {
 		case McpConnectionState.Kind.Running:
 		case McpServerStatus.Ready:
-			return { label: localize('running', "Running"), className: 'running' };
+			return { label: localize('running', "Running"), className: 'running', icon: Codicon.check };
 		case McpConnectionState.Kind.Starting:
 		case McpServerStatus.Starting:
-			return { label: localize('starting', "Starting"), className: 'starting' };
+			return { label: localize('starting', "Starting"), className: 'starting', icon: ThemeIcon.modify(Codicon.loading, 'spin') };
 		case McpServerStatus.AuthRequired:
-			return { label: localize('authRequired', "Authentication required"), className: 'auth-required' };
+			return { label: localize('authRequired', "Authentication required"), className: 'auth-required', icon: Codicon.account };
 		case McpConnectionState.Kind.Error:
 		case McpServerStatus.Error:
-			return { label: localize('error', "Error"), className: 'error' };
+			return { label: localize('error', "Error"), className: 'error', icon: Codicon.error };
 		case McpConnectionState.Kind.Stopped:
 		case McpServerStatus.Stopped:
 		default:
 			return { label: localize('stopped', "Stopped"), className: 'stopped' };
 	}
+}
+
+function getActiveSessionServer(entry: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry): AgentHostMcpServer | undefined {
+	return entry.type === 'session-server-item' ? entry.server : entry.activeSessionServer;
+}
+
+function getMcpEntryLabel(element: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry): string {
+	return element.type === 'session-server-item'
+		? element.server.name
+		: element.type === 'builtin-item'
+			? element.label
+			: element.server.label;
 }
 
 function getMcpStatusKind(entry: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry, isSessionsWindow: boolean): McpStatusKind | undefined {
@@ -328,11 +436,7 @@ function getMcpEntryAriaLabel(element: IMcpListEntry, isSessionsWindow: boolean)
 	if (element.type === 'group-header') {
 		return localize('mcpGroupAriaLabel', "{0}, {1} items, {2}", element.label, element.count, element.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 	}
-	const label = element.type === 'session-server-item'
-		? element.server.name
-		: element.type === 'builtin-item'
-			? element.label
-			: element.server.label;
+	const label = getMcpEntryLabel(element);
 	const status = getMcpStatusPresentation(getMcpStatusKind(element, isSessionsWindow));
 	return status
 		? localize('mcpServerAriaLabelWithStatus', "{0}, {1}", label, status.label)
@@ -1063,52 +1167,25 @@ export class McpListWidget extends Disposable {
 			.filter(s => !localIds.has(s.definition.id))
 			.filter(s => !query || s.definition.label.toLowerCase().includes(query));
 
-		// Group servers by scope
-		const groups: { scope: LocalMcpServerScope; label: string; icon: ThemeIcon; description: string; servers: Array<{ server: IWorkbenchMcpServer; activeSessionServer?: AgentHostMcpServer; localServer?: IMcpServer }> }[] = [
-			{ scope: LocalMcpServerScope.Workspace, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "MCP servers configured in your workspace settings, shared with your team via version control."), servers: [] },
-			{ scope: LocalMcpServerScope.User, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "MCP servers configured in your user settings. Private to you and available across all projects."), servers: [] },
+		const groups: { scope: LocalMcpServerScope; label: string; icon: ThemeIcon; description: string; entries: Array<IMcpServerItemEntry | IMcpSessionServerItemEntry> }[] = [
+			{ scope: LocalMcpServerScope.Workspace, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "MCP servers configured in your workspace or reported by the active session."), entries: [] },
+			{ scope: LocalMcpServerScope.User, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "MCP servers configured in your user settings. Private to you and available across all projects."), entries: [] },
 		];
 
 		for (const server of this.filteredServers) {
-			const entry = {
+			const entry: IMcpServerItemEntry = {
+				type: 'server-item',
 				server,
 				activeSessionServer: activeSessionMatcher.take(getWorkbenchServerMatchKeys(server)),
 				localServer: localServerMatcher.find(getWorkbenchServerMatchKeys(server)),
 			};
 			const scope = server.local?.scope;
 			if (scope === LocalMcpServerScope.Workspace) {
-				groups[0].servers.push(entry);
+				groups[0].entries.push(entry);
 			} else {
 				// User, RemoteUser, or unknown → group under User
-				groups[1].servers.push(entry);
+				groups[1].entries.push(entry);
 			}
-		}
-
-		// Build display entries with group headers
-		const entries: IMcpListEntry[] = [];
-		let isFirst = true;
-		for (const group of groups) {
-			if (group.servers.length === 0) {
-				continue;
-			}
-			const collapsed = this.collapsedGroups.has(group.scope);
-			entries.push({
-				type: 'group-header',
-				id: `mcp-group-${group.scope}`,
-				scope: group.scope,
-				label: group.label,
-				icon: group.icon,
-				count: group.servers.length,
-				isFirst,
-				description: group.description,
-				collapsed,
-			});
-			if (!collapsed) {
-				for (const { server, activeSessionServer, localServer } of group.servers) {
-					entries.push({ type: 'server-item', server, activeSessionServer, localServer });
-				}
-			}
-			isFirst = false;
 		}
 
 		// Add plugin-provided, extension-provided, and built-in servers.
@@ -1130,6 +1207,9 @@ export class McpListWidget extends Disposable {
 			}
 		}
 		const activeSessionOnlyServers = activeSessionMatcher.unmatched(query);
+		for (const server of activeSessionOnlyServers) {
+			groups[0].entries.push({ type: 'session-server-item', server });
+		}
 
 		// Show empty state only when there are no servers at all (not when filtered to empty)
 		if (this.filteredServers.length === 0 && builtinServers.length === 0 && activeSessionOnlyServers.length === 0) {
@@ -1150,23 +1230,26 @@ export class McpListWidget extends Disposable {
 			this.listContainer.style.display = '';
 		}
 
-		if (activeSessionOnlyServers.length > 0) {
-			const collapsed = this.collapsedGroups.has('active-session');
+		const entries: IMcpListEntry[] = [];
+		let isFirst = true;
+		for (const group of groups) {
+			if (group.entries.length === 0) {
+				continue;
+			}
+			const collapsed = this.collapsedGroups.has(group.scope);
 			entries.push({
 				type: 'group-header',
-				id: 'mcp-group-active-session',
-				scope: 'active-session',
-				label: localize('activeSessionGroup', "Active Session"),
-				icon: mcpServerIcon,
-				count: activeSessionOnlyServers.length,
+				id: `mcp-group-${group.scope}`,
+				scope: group.scope,
+				label: group.label,
+				icon: group.icon,
+				count: group.entries.length,
 				isFirst,
-				description: localize('activeSessionGroupDescription', "MCP servers reported by the active session."),
+				description: group.description,
 				collapsed,
 			});
 			if (!collapsed) {
-				for (const server of activeSessionOnlyServers) {
-					entries.push({ type: 'session-server-item', server });
-				}
+				entries.push(...group.entries);
 			}
 			isFirst = false;
 		}
@@ -1294,7 +1377,9 @@ export class McpListWidget extends Disposable {
 		this.lastHeight = height;
 		this.lastWidth = width;
 
-		this.element.style.height = `${height}px`;
+		this.element.style.height = '';
+		const availableHeight = this.element.clientHeight || height;
+		const availableWidth = this.element.clientWidth || width;
 
 		// Measure sibling elements to calculate the list height.
 		// When offsetHeight returns 0 the container may have just become visible
@@ -1315,10 +1400,10 @@ export class McpListWidget extends Disposable {
 		}
 		const headerHeight = this.sectionTitleHeader.offsetHeight;
 		this.lastHeaderHeight = headerHeight;
-		const listHeight = Math.max(0, height - searchBarHeight - headerHeight);
+		const listHeight = Math.max(0, availableHeight - searchBarHeight - headerHeight);
 
 		this.listContainer.style.height = `${listHeight}px`;
-		this.list.layout(listHeight, width);
+		this.list.layout(listHeight, availableWidth);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -310,16 +310,14 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpS
 			}));
 			signInButton.label = localize('signIn', "Sign In");
 			signInButton.element.classList.add('mcp-server-sign-in');
-			templateData.actionDisposables.add(DOM.addDisposableListener(signInButton.element, DOM.EventType.MOUSE_DOWN, event => DOM.EventHelper.stop(event, true)));
-			templateData.actionDisposables.add(signInButton.onDidClick(async event => {
-				DOM.EventHelper.stop(event, true);
+			registerMcpInlineButtonAction(templateData.actionDisposables, signInButton, async () => {
 				signInButton.enabled = false;
 				try {
-					await this.agentHostCustomizationService.authenticateMcpServer(this.customizationHarnessService.activeSessionResource.get(), activeSessionServer.id);
+					await authenticateMcpServer(this.agentHostCustomizationService, this.customizationHarnessService.activeSessionResource.get(), activeSessionServer.id);
 				} finally {
 					signInButton.enabled = true;
 				}
-			}));
+			});
 		}
 
 		if (!presentation.icon) {
@@ -327,7 +325,7 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpS
 		}
 
 		const showOutput = state === McpServerStatus.Error || state === McpConnectionState.Kind.Error
-			? this.getShowOutputHandler(element)
+			? getMcpServerOutputHandler(this.outputService, element.type === 'session-server-item' ? undefined : element.localServer, activeSessionServer)
 			: undefined;
 		if (showOutput) {
 			const showOutputLabel = localize('showMcpServerOutput', "Show output for {0}", label);
@@ -337,11 +335,9 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpS
 			}));
 			statusButton.icon = presentation.icon;
 			statusButton.element.classList.add('mcp-server-status', 'mcp-server-status-action', presentation.className);
-			templateData.actionDisposables.add(DOM.addDisposableListener(statusButton.element, DOM.EventType.MOUSE_DOWN, event => DOM.EventHelper.stop(event, true)));
-			templateData.actionDisposables.add(statusButton.onDidClick(event => {
-				DOM.EventHelper.stop(event, true);
+			registerMcpInlineButtonAction(templateData.actionDisposables, statusButton, () => {
 				showOutput();
-			}));
+			});
 			return;
 		}
 
@@ -351,25 +347,38 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpS
 		templateData.actionDisposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), statusElement, presentation.label));
 	}
 
-	private getShowOutputHandler(element: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry): (() => void) | undefined {
-		const activeSessionServer = getActiveSessionServer(element);
-		const outputChannelId = activeSessionServer?.logOutputChannelId;
-		if (outputChannelId) {
-			return () => {
-				void this.outputService.showChannel(outputChannelId);
-			};
-		}
-		const localServer = element.type !== 'session-server-item' ? element.localServer : undefined;
-		if (localServer) {
-			return () => localServer.showOutput();
-		}
-		return undefined;
-	}
-
 	disposeTemplate(templateData: IMcpServerItemTemplateData): void {
 		templateData.elementDisposables.dispose();
 		templateData.actionDisposables.dispose();
 	}
+}
+
+/** Registers an inline MCP button without allowing its pointer or click events to open the containing list row. */
+export function registerMcpInlineButtonAction(store: Pick<DisposableStore, 'add'>, button: Button, action: () => void | Promise<void>): void {
+	store.add(DOM.addDisposableGenericMouseDownListener(button.element, event => DOM.EventHelper.stop(event, true)));
+	store.add(button.onDidClick(event => {
+		DOM.EventHelper.stop(event, true);
+		void action();
+	}));
+}
+
+/** Runs authentication for one active-session MCP server. */
+export function authenticateMcpServer(agentHostCustomizationService: IAgentHostCustomizationService, sessionResource: URI, serverId: string): Promise<boolean> {
+	return agentHostCustomizationService.authenticateMcpServer(sessionResource, serverId);
+}
+
+/** Resolves the output action for an MCP server, preferring its active agent-host output. */
+export function getMcpServerOutputHandler(outputService: Pick<IOutputService, 'showChannel'>, localServer: Pick<IMcpServer, 'showOutput'> | undefined, activeSessionServer: AgentHostMcpServer | undefined): (() => void) | undefined {
+	const outputChannelId = activeSessionServer?.logOutputChannelId;
+	if (outputChannelId) {
+		return () => {
+			void outputService.showChannel(outputChannelId);
+		};
+	}
+	if (localServer) {
+		return () => localServer.showOutput();
+	}
+	return undefined;
 }
 
 interface IMcpStatusPresentation {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -1409,13 +1409,14 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	min-height: 0;
 	overflow: hidden;
 }
 
 .mcp-list-widget .mcp-list-container {
 	flex: 1;
 	min-height: 0;
-	overflow: auto;
+	overflow: hidden;
 }
 
 /* MCP Empty State */
@@ -1534,9 +1535,10 @@
 	align-items: center;
 	padding: 6px 8px 6px 30px;
 	cursor: pointer;
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-small);
 	min-height: 32px;
 	gap: 10px;
+	box-sizing: border-box;
 }
 
 .mcp-server-item:not(.has-detail):not(.builtin) {
@@ -1581,37 +1583,58 @@
 	line-height: 14px;
 }
 
+.mcp-server-item .mcp-server-actions {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	gap: var(--vscode-spacing-size40);
+}
+
+.mcp-server-item .mcp-server-sign-in.monaco-button {
+	min-width: 0;
+	min-height: var(--vscode-spacing-size240);
+	padding: 0 var(--vscode-spacing-size80);
+	font-size: var(--vscode-agents-fontSize-label1);
+	border-radius: var(--vscode-cornerRadius-small);
+}
+
 .mcp-server-item .mcp-server-status {
 	flex-shrink: 0;
-	font-size: var(--vscode-agents-fontSize-label2);
-	padding: 2px 8px;
-	border-radius: 4px;
-	font-weight: var(--vscode-agents-fontWeight-semiBold);
+	width: var(--vscode-spacing-size240);
+	height: var(--vscode-spacing-size240);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: var(--vscode-codiconFontSize);
+}
+
+.mcp-server-item .mcp-server-status-action.monaco-button {
+	min-width: var(--vscode-spacing-size240);
+	min-height: var(--vscode-spacing-size240);
+	padding: var(--vscode-spacing-size40);
+	border: 0;
+	border-radius: var(--vscode-cornerRadius-small);
+	background-color: transparent;
+}
+
+.mcp-server-item .mcp-server-status-action.monaco-button:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .mcp-server-item .mcp-server-status.running {
-	background-color: color-mix(in srgb, var(--vscode-terminal-ansiGreen) 50%, transparent);
-	color: var(--vscode-editor-background);
+	color: var(--vscode-charts-green);
 }
 
 .mcp-server-item .mcp-server-status.starting {
-	background-color: color-mix(in srgb, var(--vscode-terminal-ansiYellow) 50%, transparent);
-	color: var(--vscode-editor-background);
+	color: var(--vscode-progressBar-background, var(--vscode-icon-foreground));
 }
 
 .mcp-server-item .mcp-server-status.auth-required {
-	background-color: color-mix(in srgb, var(--vscode-terminal-ansiYellow) 50%, transparent);
-	color: var(--vscode-editor-background);
+	color: var(--vscode-list-warningForeground, var(--vscode-editorWarning-foreground));
 }
 
 .mcp-server-item .mcp-server-status.error {
-	background-color: color-mix(in srgb, var(--vscode-terminal-ansiRed) 50%, transparent);
-	color: var(--vscode-editor-background);
-}
-
-.mcp-server-item .mcp-server-status.stopped {
-	background-color: color-mix(in srgb, var(--vscode-badge-background) 50%, transparent);
-	color: var(--vscode-badge-foreground);
+	color: var(--vscode-testing-iconFailed, var(--vscode-errorForeground));
 }
 
 .mcp-server-item.disabled {
@@ -1619,8 +1642,7 @@
 }
 
 .mcp-server-item .mcp-server-status.disabled {
-	background-color: color-mix(in srgb, var(--vscode-badge-background) 50%, transparent);
-	color: var(--vscode-badge-foreground);
+	color: var(--vscode-disabledForeground);
 }
 
 /* Button group for Add Server + Browse Marketplace */

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/mcpListWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/mcpListWidget.test.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import * as DOM from '../../../../../../base/browser/dom.js';
+import { Button, unthemedButtonStyles } from '../../../../../../base/browser/ui/button/button.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IAction, Separator } from '../../../../../../base/common/actions.js';
 import { DisposableStore, isDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -15,10 +17,13 @@ import { IAgentHostCustomizationService } from '../../../browser/agentSessions/a
 import { IMcpService } from '../../../../mcp/common/mcpTypes.js';
 import {
 	AgentHostMcpServer,
+	authenticateMcpServer,
 	getActiveSessionServerOptionsActions,
 	getAgentHostMcpServerEnablementActions,
 	getLocalMcpServerEnablementActions,
+	getMcpServerOutputHandler,
 	getSessionEnablementAction,
+	registerMcpInlineButtonAction,
 } from '../../../browser/aiCustomization/mcpListWidget.js';
 
 function createAgentHostServer(overrides: Partial<AgentHostMcpServer> = {}): AgentHostMcpServer {
@@ -158,6 +163,89 @@ suite('mcpListWidget', () => {
 				'(separator)',
 				'Server Options',
 			]);
+		});
+	});
+
+	suite('inline actions', () => {
+		test('authentication receives the active session and server without opening the row', () => {
+			const sessionResource = URI.parse('vscode-agent-session:///session-1');
+			const calls: [URI, string][] = [];
+			const service = {
+				authenticateMcpServer: (resource: URI, serverId: string) => {
+					calls.push([resource, serverId]);
+					return Promise.resolve(true);
+				},
+			} as IAgentHostCustomizationService;
+			const row = document.createElement('div');
+			let rowPointerDowns = 0;
+			let rowClicks = 0;
+			disposables.add(DOM.addDisposableGenericMouseDownListener(row, () => rowPointerDowns++));
+			disposables.add(DOM.addDisposableListener(row, DOM.EventType.CLICK, () => rowClicks++));
+			const button = disposables.add(new Button(row, unthemedButtonStyles));
+			registerMcpInlineButtonAction(disposables, button, async () => {
+				await authenticateMcpServer(service, sessionResource, 'server-1');
+			});
+
+			button.element.dispatchEvent(new MouseEvent(DOM.EventType.MOUSE_DOWN, { bubbles: true }));
+			button.element.click();
+
+			assert.deepStrictEqual({
+				calls,
+				rowPointerDowns,
+				rowClicks,
+			}, {
+				calls: [[sessionResource, 'server-1']],
+				rowPointerDowns: 0,
+				rowClicks: 0,
+			});
+		});
+
+		test('active-session error opens the agent-host output without opening the row', () => {
+			const shownChannels: string[] = [];
+			let localOutputCount = 0;
+			const outputHandler = getMcpServerOutputHandler(
+				{ showChannel: async channelId => { shownChannels.push(channelId); } },
+				{ showOutput: async () => { localOutputCount++; } },
+				createAgentHostServer({ logOutputChannelId: 'agent-host-output' }),
+			);
+			assert.ok(outputHandler);
+			const row = document.createElement('div');
+			let rowClicks = 0;
+			disposables.add(DOM.addDisposableListener(row, DOM.EventType.CLICK, () => rowClicks++));
+			const button = disposables.add(new Button(row, unthemedButtonStyles));
+			registerMcpInlineButtonAction(disposables, button, outputHandler);
+
+			button.element.click();
+
+			assert.deepStrictEqual({
+				shownChannels,
+				localOutputCount,
+				rowClicks,
+			}, {
+				shownChannels: ['agent-host-output'],
+				localOutputCount: 0,
+				rowClicks: 0,
+			});
+		});
+
+		test('local error opens local output when no agent-host output exists', () => {
+			const shownChannels: string[] = [];
+			let localOutputCount = 0;
+			const outputHandler = getMcpServerOutputHandler(
+				{ showChannel: async channelId => { shownChannels.push(channelId); } },
+				{ showOutput: async () => { localOutputCount++; } },
+				undefined,
+			);
+
+			outputHandler?.();
+
+			assert.deepStrictEqual({
+				shownChannels,
+				localOutputCount,
+			}, {
+				shownChannels: [],
+				localOutputCount: 1,
+			});
 		});
 	});
 });

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -1248,6 +1248,9 @@ function renderMcpDisabled(ctx: ComponentFixtureContext, byPolicy: boolean): voi
 				override registerExternalHarness() { return { dispose() { } }; }
 			}());
 			reg.defineInstance(IAgentHostCustomizationService, createMockAgentHostCustomizationService());
+			reg.defineInstance(IOutputService, new class extends mock<IOutputService>() {
+				override async showChannel() { }
+			}());
 		},
 	});
 

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -35,6 +35,7 @@ import { IProductService } from '../../../../../platform/product/common/productS
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
+import { IOutputService } from '../../../../services/output/common/output.js';
 import { IWorkingCopyService } from '../../../../services/workingCopy/common/workingCopyService.js';
 import { IWebviewService } from '../../../../contrib/webview/browser/webview.js';
 import { IAICustomizationWorkspaceService, AICustomizationManagementSection, AICustomizationSource } from '../../../../contrib/chat/common/aiCustomizationWorkspaceService.js';
@@ -142,6 +143,7 @@ function createMockAgentHostCustomizationService(mcpServers: readonly FixtureAge
 		override getWorkingDirectory() { return undefined; }
 		override getMcpServers() { return mcpServers; }
 		override addMcpServer() { }
+		override async authenticateMcpServer() { return true; }
 	}();
 }
 
@@ -544,14 +546,16 @@ const mcpUserServers = [
 	makeLocalMcpServer('mcp-puppeteer', 'Puppeteer', LocalMcpServerScope.User, 'Browser automation'),
 ];
 const mcpRuntimeServers = [
-	{ definition: { id: 'github-copilot-mcp', label: 'GitHub Copilot' }, collection: { id: 'ext.github.copilot/mcp', label: 'ext.github.copilot/mcp' }, enablement: constObservable(ContributionEnablementState.EnabledProfile), connectionState: constObservable({ state: McpConnectionState.Kind.Running }) },
-	{ definition: { id: 'mcp-web-search', label: 'Web Search' }, collection: { id: 'user-mcp', label: 'User MCP' }, enablement: constObservable(ContributionEnablementState.DisabledProfile), connectionState: constObservable({ state: McpConnectionState.Kind.Stopped }) },
+	{ definition: { id: 'github-copilot-mcp', label: 'GitHub Copilot' }, collection: { id: 'ext.github.copilot/mcp', label: 'ext.github.copilot/mcp' }, enablement: constObservable(ContributionEnablementState.EnabledProfile), connectionState: constObservable({ state: McpConnectionState.Kind.Starting }), showOutput() { } },
+	{ definition: { id: 'mcp-postgres', label: 'PostgreSQL' }, collection: { id: 'workspace-mcp', label: 'Workspace MCP' }, enablement: constObservable(ContributionEnablementState.EnabledProfile), connectionState: constObservable({ state: McpConnectionState.Kind.Error }), showOutput() { } },
+	{ definition: { id: 'mcp-web-search', label: 'Web Search' }, collection: { id: 'user-mcp', label: 'User MCP' }, enablement: constObservable(ContributionEnablementState.DisabledProfile), connectionState: constObservable({ state: McpConnectionState.Kind.Stopped }), showOutput() { } },
+	{ definition: { id: 'mcp-filesystem', label: 'Filesystem' }, collection: { id: 'user-mcp', label: 'User MCP' }, enablement: constObservable(ContributionEnablementState.EnabledProfile), connectionState: constObservable({ state: McpConnectionState.Kind.Stopped }), showOutput() { } },
 ];
 
 const activeSessionMcpServers: FixtureAgentHostMcpServer[] = [
-	{ id: 'mcp-top-level:fixture:session:component-explorer', name: 'component-explorer', enabled: true, status: McpServerStatus.Ready, state: { kind: McpServerStatus.Ready }, start: mcpLifecycleNoop, stop: mcpLifecycleNoop, setEnabled() { } },
-	{ id: 'mcp-top-level:fixture:session:Remote Browser', name: 'Remote Browser', enabled: true, status: McpServerStatus.AuthRequired, state: { kind: McpServerStatus.AuthRequired, reason: McpAuthRequiredReason.Required, resource: { resource: 'https://mcp.example.com' } }, start: mcpLifecycleNoop, stop: mcpLifecycleNoop, setEnabled() { } },
-	{ id: 'mcp-top-level:fixture:session:Remote Search', name: 'Remote Search', enabled: true, status: McpServerStatus.Error, state: { kind: McpServerStatus.Error, error: { errorType: 'fixture', message: 'Fixture error' } }, start: mcpLifecycleNoop, stop: mcpLifecycleNoop, setEnabled() { } },
+	{ id: 'mcp-top-level:fixture:session:component-explorer', name: 'component-explorer', enabled: true, status: McpServerStatus.Ready, state: { kind: McpServerStatus.Ready }, logOutputChannelId: 'fixture-agent-host', start: mcpLifecycleNoop, stop: mcpLifecycleNoop, setEnabled() { } },
+	{ id: 'mcp-top-level:fixture:session:Remote Browser', name: 'Remote Browser', enabled: true, status: McpServerStatus.AuthRequired, state: { kind: McpServerStatus.AuthRequired, reason: McpAuthRequiredReason.Required, resource: { resource: 'https://mcp.example.com' } }, logOutputChannelId: 'fixture-agent-host', start: mcpLifecycleNoop, stop: mcpLifecycleNoop, setEnabled() { } },
+	{ id: 'mcp-top-level:fixture:session:Remote Search', name: 'Remote Search', enabled: true, status: McpServerStatus.Error, state: { kind: McpServerStatus.Error, error: { errorType: 'fixture', message: 'Fixture error' } }, logOutputChannelId: 'fixture-agent-host', start: mcpLifecycleNoop, stop: mcpLifecycleNoop, setEnabled() { } },
 ];
 
 interface IRenderEditorOptions {
@@ -837,6 +841,9 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 			reg.defineInstance(IQuickInputService, new class extends mock<IQuickInputService>() { }());
 			reg.defineInstance(IViewsService, new class extends mock<IViewsService>() {
 				override async openView<T extends {}>(_id: string, _focus?: boolean) { return null as T | null; }
+			}());
+			reg.defineInstance(IOutputService, new class extends mock<IOutputService>() {
+				override async showChannel() { }
 			}());
 			reg.defineInstance(IChatWidgetService, new class extends mock<IChatWidgetService>() {
 				override get lastFocusedWidget() { return undefined; }

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -1028,6 +1028,9 @@ async function renderMcpBrowseMode(ctx: ComponentFixtureContext): Promise<void> 
 				override registerExternalHarness() { return { dispose() { } }; }
 			}());
 			reg.defineInstance(IAgentHostCustomizationService, createMockAgentHostCustomizationService());
+			reg.defineInstance(IOutputService, new class extends mock<IOutputService>() {
+				override async showChannel() { }
+			}());
 		},
 	});
 


### PR DESCRIPTION
## Summary
- replace MCP status badges with semantic icons and inline authentication/output actions
- group active-session-only MCP servers under Workspace
- fix virtual list sizing so the final server remains fully scrollable

## Validation
- `npm run typecheck-client`
- `.\scripts\test.bat --run src\vs\workbench\contrib\chat\test\browser\aiCustomization\mcpListWidget.test.ts`
- `npm run valid-layers-check`
- targeted hygiene and `git diff --check`
- dark/light component fixture inspection, including scrolled and active-session states