### PR TITLE
editTelemetry: unify long-term edit source tracking

### DIFF
--- a/src/vs/editor/common/textModelEditSource.ts
+++ b/src/vs/editor/common/textModelEditSource.ts
@@ -108,12 +108,16 @@ export const EditSources = {
 		mode: string | undefined;
 		extensionId: VersionedExtensionId | undefined;
 		codeBlockSuggestionId: EditSuggestionId | undefined;
+		harness?: string;
+		origin?: string;
 	}) {
 		return createEditSource({
 			source: 'Chat.applyEdits',
 			$modelId: avoidPathRedaction(data.modelId),
 			$extensionId: data.extensionId?.extensionId,
 			$extensionVersion: data.extensionId?.version,
+			$harness: data.harness,
+			$origin: data.origin,
 			$$languageId: data.languageId,
 			$$sessionId: data.sessionId,
 			$$requestId: data.requestId,

--- a/src/vs/workbench/contrib/editTelemetry/browser/editTelemetryContribution.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/editTelemetryContribution.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { autorun, derived } from '../../../../base/common/observable.js';
+import { autorun, derived, observableFromEvent } from '../../../../base/common/observable.js';
+import { Event } from '../../../../base/common/event.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
-import { ITelemetryService, TelemetryLevel, telemetryLevelEnabled } from '../../../../platform/telemetry/common/telemetry.js';
+import { ITelemetryService, TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID, TelemetryLevel, telemetryLevelEnabled } from '../../../../platform/telemetry/common/telemetry.js';
 import { AnnotatedDocuments } from './helpers/annotatedDocuments.js';
 import { EditTrackingFeature } from './telemetry/editSourceTrackingFeature.js';
 import { VSCodeWorkspace } from './helpers/vscodeObservableWorkspace.js';
@@ -31,9 +32,18 @@ export class EditTelemetryContribution extends Disposable {
 		const annotatedDocuments = derived(reader => reader.store.add(instantiationService.createInstance(AnnotatedDocuments, workspace.read(reader))));
 
 		const editSourceTrackingEnabled = observableConfigValue(EDIT_TELEMETRY_SETTING_ID, true, configurationService);
+		const usageTelemetryEnabled = observableFromEvent(
+			this,
+			Event.filter(configurationService.onDidChangeConfiguration, event =>
+				event.affectsConfiguration(TELEMETRY_SETTING_ID) ||
+				event.affectsConfiguration(TELEMETRY_OLD_SETTING_ID) ||
+				event.affectsConfiguration(TELEMETRY_CRASH_REPORTER_SETTING_ID)
+			),
+			() => telemetryLevelEnabled(telemetryService, TelemetryLevel.USAGE)
+		);
 		this._register(autorun(r => {
 			const enabled = editSourceTrackingEnabled.read(r);
-			if (!enabled || !telemetryLevelEnabled(telemetryService, TelemetryLevel.USAGE)) {
+			if (!enabled || !usageTelemetryEnabled.read(r)) {
 				return;
 			}
 			r.store.add(instantiationService.createInstance(EditTrackingFeature, workspace.read(r), annotatedDocuments.read(r)));

--- a/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentAdapters.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentAdapters.ts
@@ -1,0 +1,126 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { runOnChange } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IObservableDocument, StringEditWithReason } from './observableWorkspace.js';
+import {
+	IUnifiedDocumentRegistryResult,
+	UnifiedDocumentRegistry,
+} from './unifiedDocumentRegistry.js';
+import { UnifiedDocumentAgentTransitionKind } from './unifiedDocumentReconciler.js';
+
+export type UnifiedDocumentModelAdapterInputKind = 'connected' | 'edit' | 'reloadFromDisk' | 'disconnected';
+
+export interface IUnifiedDocumentModelAdapterResult<TSource> {
+	readonly inputKind: UnifiedDocumentModelAdapterInputKind;
+	readonly result: IUnifiedDocumentRegistryResult<TSource>;
+}
+
+/**
+ * Translates one observable model into unified registry inputs.
+ */
+export class UnifiedDocumentModelAdapter<TSource> extends Disposable {
+	private _isDisposed = false;
+
+	constructor(
+		private readonly _registry: UnifiedDocumentRegistry<TSource>,
+		private readonly _document: IObservableDocument,
+		initialDiskContent: string,
+		private readonly _isDirty: () => boolean,
+		private readonly _toSource: (change: StringEditWithReason) => TSource,
+		private readonly _onResult: (result: IUnifiedDocumentModelAdapterResult<TSource>) => void,
+	) {
+		super();
+		this._onResult({
+			inputKind: 'connected',
+			result: this._registry.modelConnected(
+				this._document.uri,
+				initialDiskContent,
+				{ content: this._document.value.get().value, dirty: this._isDirty() },
+			),
+		});
+
+		this._register(runOnChange(this._document.value, (value, previousValue, changes) => {
+			let before = previousValue.value;
+			for (const change of changes) {
+				const after = change.apply(before);
+				const inputKind = change.reason.metadata.source === 'reloadFromDisk' ? 'reloadFromDisk' : 'edit';
+				this._onResult({
+					inputKind,
+					result: this._registry.modelEdit(this._document.uri, {
+						before,
+						after,
+						source: this._toSource(change),
+						kind: inputKind === 'reloadFromDisk' ? 'reloadFromDisk' : 'model',
+						dirty: this._isDirty(),
+					}),
+				});
+				before = after;
+			}
+			if (before !== value.value) {
+				throw new Error(`Unified document model adapter produced ${JSON.stringify(before)}, expected ${JSON.stringify(value.value)}`);
+			}
+		}));
+	}
+
+	override dispose(): void {
+		if (this._isDisposed) {
+			return;
+		}
+		this._isDisposed = true;
+		super.dispose();
+		this._onResult({
+			inputKind: 'disconnected',
+			result: this._registry.modelDisconnected(this._document.uri),
+		});
+	}
+}
+
+export interface IUnifiedDocumentAgentEdit<TSource> {
+	readonly resource: URI;
+	readonly previousResource?: URI;
+	readonly before: string;
+	readonly after: string;
+	readonly source: TSource;
+	readonly correlation: string;
+	readonly kind: UnifiedDocumentAgentTransitionKind;
+}
+
+export interface IUnifiedDocumentAgentAdapterResult<TSource> {
+	readonly transitionResult: IUnifiedDocumentRegistryResult<TSource>;
+	readonly transferResult?: IUnifiedDocumentRegistryResult<TSource>;
+}
+
+/**
+ * Applies one normalized Agent Host edit to the unified registry.
+ */
+export function applyUnifiedDocumentAgentEdit<TSource>(
+	registry: UnifiedDocumentRegistry<TSource>,
+	edit: IUnifiedDocumentAgentEdit<TSource>,
+): IUnifiedDocumentAgentAdapterResult<TSource> {
+	const transitionResource = edit.kind === 'rename' && edit.previousResource ? edit.previousResource : edit.resource;
+	const transitionResult = registry.agentTransition(transitionResource, {
+		before: edit.before,
+		after: edit.after,
+		source: edit.source,
+		correlation: edit.correlation,
+		kind: edit.kind,
+	});
+	if (
+		edit.kind !== 'rename' ||
+		!edit.previousResource ||
+		transitionResult.outcome === 'conflict' ||
+		transitionResult.outcome === 'skippedDirty'
+	) {
+		return { transitionResult };
+	}
+
+	return {
+		transitionResult,
+		transferResult: registry.transfer(edit.previousResource, edit.resource),
+	};
+}

--- a/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentAdapters.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentAdapters.ts
@@ -6,6 +6,7 @@
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { runOnChange } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { StringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
 import { IObservableDocument, StringEditWithReason } from './observableWorkspace.js';
 import {
 	IUnifiedDocumentRegistryResult,
@@ -54,6 +55,7 @@ export class UnifiedDocumentModelAdapter<TSource> extends Disposable {
 					result: this._registry.modelEdit(this._document.uri, {
 						before,
 						after,
+						edit: change,
 						source: this._toSource(change),
 						kind: inputKind === 'reloadFromDisk' ? 'reloadFromDisk' : 'model',
 						dirty: this._isDirty(),
@@ -85,6 +87,7 @@ export interface IUnifiedDocumentAgentEdit<TSource> {
 	readonly previousResource?: URI;
 	readonly before: string;
 	readonly after: string;
+	readonly edit: StringEdit;
 	readonly source: TSource;
 	readonly correlation: string;
 	readonly kind: UnifiedDocumentAgentTransitionKind;
@@ -106,6 +109,7 @@ export function applyUnifiedDocumentAgentEdit<TSource>(
 	const transitionResult = registry.agentTransition(transitionResource, {
 		before: edit.before,
 		after: edit.after,
+		edit: edit.edit,
 		source: edit.source,
 		correlation: edit.correlation,
 		kind: edit.kind,

--- a/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentReconciler.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentReconciler.ts
@@ -65,6 +65,7 @@ export interface IUnifiedDocumentSnapshot<TSource> {
 	readonly diskContent: string;
 	readonly model: IUnifiedDocumentModelState | undefined;
 	readonly pendingReload: IUnifiedDocumentPendingReload<TSource> | undefined;
+	readonly pendingAgentTransitions: boolean;
 	readonly transitions: readonly IUnifiedDocumentTransition<TSource>[];
 }
 
@@ -80,6 +81,10 @@ interface IRecentTransition<TSource> {
 	readonly transition: IUnifiedDocumentTransition<TSource>;
 }
 
+interface IRecentExternalTransition<TSource> extends IRecentTransition<TSource> {
+	readonly after: string;
+}
+
 interface IAgentCorrelation {
 	readonly beforeId: string;
 	readonly afterId: string;
@@ -87,6 +92,7 @@ interface IAgentCorrelation {
 }
 
 const MAX_AGENT_CORRELATIONS = 128;
+const MAX_RECENT_AGENT_TRANSITIONS = 128;
 
 /**
  * Reconciles model, Agent Host, and disk observations into one canonical edit sequence.
@@ -100,7 +106,10 @@ export class UnifiedDocumentReconciler<TSource> {
 	private readonly _transitions: IUnifiedDocumentTransition<TSource>[] = [];
 	private readonly _agentCorrelations = new Map<string, IAgentCorrelation>();
 	private _recentAgentTransition: IRecentTransition<TSource> | undefined;
-	private _recentExternalTransition: IRecentTransition<TSource> | undefined;
+	private readonly _recentAgentTransitions: IRecentTransition<TSource>[] = [];
+	private _recentExternalTransition: IRecentExternalTransition<TSource> | undefined;
+	private readonly _recentExternalAgentTransitions: IUnifiedDocumentAgentTransition<TSource>[] = [];
+	private readonly _pendingReloadAgentTransitions: IUnifiedDocumentAgentTransition<TSource>[] = [];
 	private _nextTransitionId = 1;
 
 	constructor(
@@ -118,24 +127,21 @@ export class UnifiedDocumentReconciler<TSource> {
 		}
 
 		this._model = { ...state };
+		const changes = this._commitRecentExternalAgentTransitions();
 		if (state.content === this._content) {
-			return this._result('applied');
+			return this._result('applied', changes);
 		}
 		if (state.dirty) {
-			return this._result('skippedDirty');
+			return this._result('skippedDirty', changes);
 		}
-		if (
-			this._recentAgentTransition?.beforeId === contentId(state.content) &&
-			this._recentAgentTransition.afterId === contentId(this._content) &&
-			this._diskContent === this._content
-		) {
-			return this._result('applied');
+		if (this._isRecentAgentTransition(state.content, this._content) && this._diskContent === this._content) {
+			return this._result('applied', changes);
 		}
 		if (state.content !== this._diskContent) {
-			return this._result('conflict');
+			return this._result('conflict', changes);
 		}
 
-		const changes = this._commitPendingReload();
+		changes.push(...this._commitPendingReload());
 		changes.push(this._appendTransition(
 			this._content,
 			state.content,
@@ -159,26 +165,27 @@ export class UnifiedDocumentReconciler<TSource> {
 		if (!this._model || this._model.content !== edit.before) {
 			return this._result('conflict');
 		}
+		const recentExternalChanges = this._commitRecentExternalAgentTransitions();
 
 		if (edit.kind === 'reloadFromDisk') {
-			if (isSameContentTransition(this._recentAgentTransition, edit) && this._content === edit.after && this._diskContent === edit.after) {
+			if (this._isRecentAgentTransition(edit.before, edit.after) && this._content === edit.after && this._diskContent === edit.after) {
 				this._model = { content: edit.after, dirty: edit.dirty };
 				this._diskContent = edit.after;
-				return this._result('duplicate');
+				return this._result('duplicate', recentExternalChanges);
 			}
 			if (isSameContentTransition(this._recentExternalTransition, edit) && this._content === edit.after && this._diskContent === edit.after) {
 				this._model = { content: edit.after, dirty: edit.dirty };
-				return this._result('duplicate');
+				return this._result('duplicate', recentExternalChanges);
 			}
 			if (isSameContentTransition(this._pendingReload, edit)) {
 				this._model = { content: edit.after, dirty: edit.dirty };
 				this._diskContent = edit.after;
 				this._content = edit.after;
-				return this._result('duplicate');
+				return this._result('duplicate', recentExternalChanges);
 			}
 		}
 
-		const changes = this._commitPendingReload();
+		const changes = [...recentExternalChanges, ...this._commitPendingReload()];
 		if (this._content !== edit.before) {
 			this._model = { content: edit.after, dirty: edit.dirty };
 			if (edit.kind === 'reloadFromDisk') {
@@ -196,6 +203,7 @@ export class UnifiedDocumentReconciler<TSource> {
 				after: edit.after,
 				transition: this._createTransition(edit.edit, edit.source, edit.kind),
 			};
+			this._pendingReloadAgentTransitions.length = 0;
 			return this._result('applied', changes);
 		}
 
@@ -231,31 +239,17 @@ export class UnifiedDocumentReconciler<TSource> {
 				return this._result('applied', [replacement]);
 			}
 		}
-
-		const pendingReload = this._pendingReload;
-		if (pendingReload && isSameContentTransition(pendingReload, transition)) {
-			const appliedTransition: IUnifiedDocumentTransition<TSource> = {
-				...pendingReload.transition,
-				edit: transition.edit,
-				source: transition.source,
-				kind: 'agentHost',
-				correlation: transition.correlation,
-				agentKind: transition.kind,
-			};
-			this._pendingReload = undefined;
-			this._transitions.push(appliedTransition);
-			this._recentAgentTransition = createRecentTransition(transition.before, transition.after, appliedTransition);
-			this._recentExternalTransition = undefined;
-			this._recordAgentCorrelation(transition, 'applied');
-			return this._result('applied', [{
-				kind: 'append',
-				before: transition.before,
-				after: transition.after,
-				transition: appliedTransition,
-			}]);
+		const recentExternalAgentResult = this._applyRecentExternalAgentTransition(transition);
+		if (recentExternalAgentResult) {
+			return recentExternalAgentResult;
 		}
 
-		const changes = this._commitPendingReload();
+		const pendingReloadResult = this._applyPendingReloadAgentTransition(transition);
+		if (pendingReloadResult) {
+			return pendingReloadResult;
+		}
+
+		const changes = [...this._commitRecentExternalAgentTransitions(), ...this._commitPendingReload()];
 		if (this._model?.dirty) {
 			if (this._diskContent === transition.before) {
 				this._diskContent = transition.after;
@@ -278,13 +272,14 @@ export class UnifiedDocumentReconciler<TSource> {
 	}
 
 	diskSnapshot(content: string, edit: StringEdit): IUnifiedDocumentReconcileResult<TSource> {
+		const recentExternalChanges = this._commitRecentExternalAgentTransitions();
 		if (this._pendingReload && content === this._pendingReload.after) {
-			const changes = this._commitPendingReload();
+			const changes = [...recentExternalChanges, ...this._commitPendingReload()];
 			this._diskContent = content;
 			return this._result('applied', changes);
 		}
 
-		const changes = this._commitPendingReload();
+		const changes = [...recentExternalChanges, ...this._commitPendingReload()];
 		if (content === this._diskContent && content === this._content) {
 			return this._result('duplicate', changes);
 		}
@@ -314,6 +309,7 @@ export class UnifiedDocumentReconciler<TSource> {
 		this._initialContent = this._content;
 		this._transitions.length = 0;
 		this._recentExternalTransition = undefined;
+		this._recentExternalAgentTransitions.length = 0;
 	}
 
 	getSnapshot(): IUnifiedDocumentSnapshot<TSource> {
@@ -326,6 +322,7 @@ export class UnifiedDocumentReconciler<TSource> {
 				...this._pendingReload,
 				transition: { ...this._pendingReload.transition },
 			} : undefined,
+			pendingAgentTransitions: this._pendingReloadAgentTransitions.length > 0 || this._recentExternalAgentTransitions.length > 0,
 			transitions: this._transitions.map(transition => ({ ...transition })),
 		};
 	}
@@ -336,8 +333,23 @@ export class UnifiedDocumentReconciler<TSource> {
 		}
 		const pendingReload = this._pendingReload;
 		this._pendingReload = undefined;
+		const agentTransitions = this._pendingReloadAgentTransitions.splice(0);
+		if (agentTransitions.length > 0) {
+			const changes = agentTransitions.map(transition => this._appendAgentTransition(transition));
+			const agentAfter = agentTransitions[agentTransitions.length - 1].after;
+			if (agentAfter !== pendingReload.after) {
+				changes.push(this._appendTransition(
+					agentAfter,
+					pendingReload.after,
+					createMinimalEdit(agentAfter, pendingReload.after),
+					this._externalSource,
+					'reloadFromDisk',
+				));
+			}
+			return changes;
+		}
 		this._transitions.push(pendingReload.transition);
-		this._recentExternalTransition = createRecentTransition(
+		this._recentExternalTransition = createRecentExternalTransition(
 			pendingReload.before,
 			pendingReload.after,
 			pendingReload.transition,
@@ -375,10 +387,12 @@ export class UnifiedDocumentReconciler<TSource> {
 		this._transitions.push(transition);
 		const recent = createRecentTransition(before, after, transition);
 		if (kind === 'agentHost') {
-			this._recentAgentTransition = recent;
+			this._recordRecentAgentTransition(recent);
 			this._recentExternalTransition = undefined;
+			this._recentExternalAgentTransitions.length = 0;
 		} else if (kind === 'reloadFromDisk' || kind === 'diskSnapshot') {
-			this._recentExternalTransition = recent;
+			this._recentExternalTransition = createRecentExternalTransition(before, after, transition);
+			this._recentExternalAgentTransitions.length = 0;
 		}
 		return { kind: 'append', before, after, transition: { ...transition } };
 	}
@@ -417,14 +431,157 @@ export class UnifiedDocumentReconciler<TSource> {
 			agentKind: agentTransition.kind,
 		};
 		this._transitions[index] = replacement;
-		this._recentAgentTransition = createRecentTransition(agentTransition.before, agentTransition.after, replacement);
+		this._recordRecentAgentTransition(createRecentTransition(agentTransition.before, agentTransition.after, replacement));
 		this._recentExternalTransition = undefined;
+		this._recentExternalAgentTransitions.length = 0;
 		return {
 			kind: 'replace',
 			before: agentTransition.before,
 			after: agentTransition.after,
 			transition: { ...replacement },
 		};
+	}
+
+	private _applyPendingReloadAgentTransition(
+		transition: IUnifiedDocumentAgentTransition<TSource>,
+	): IUnifiedDocumentReconcileResult<TSource> | undefined {
+		const pendingReload = this._pendingReload;
+		if (!pendingReload || this._pendingReloadAgentTransitions.length >= MAX_RECENT_AGENT_TRANSITIONS) {
+			return undefined;
+		}
+		const expectedBefore = this._pendingReloadAgentTransitions.length > 0
+			? this._pendingReloadAgentTransitions[this._pendingReloadAgentTransitions.length - 1].after
+			: pendingReload.before;
+		if (transition.before !== expectedBefore) {
+			return undefined;
+		}
+
+		this._pendingReloadAgentTransitions.push(transition);
+		this._recordAgentCorrelation(transition, 'applied');
+		if (transition.after !== pendingReload.after) {
+			return this._result('applied');
+		}
+
+		this._pendingReload = undefined;
+		const agentTransitions = this._pendingReloadAgentTransitions.splice(0);
+		return this._result('applied', agentTransitions.map(agentTransition => this._appendAgentTransition(agentTransition)));
+	}
+
+	private _isRecentAgentTransition(before: string, after: string): boolean {
+		if (isSameContentTransition(this._recentAgentTransition, { before, after })) {
+			return true;
+		}
+		const last = this._recentAgentTransitions[this._recentAgentTransitions.length - 1];
+		if (!last || last.afterId !== contentId(after)) {
+			return false;
+		}
+		const beforeId = contentId(before);
+		return this._recentAgentTransitions.some(transition => transition.beforeId === beforeId);
+	}
+
+	private _recordRecentAgentTransition(transition: IRecentTransition<TSource>): void {
+		const previous = this._recentAgentTransitions[this._recentAgentTransitions.length - 1];
+		if (previous && previous.afterId !== transition.beforeId) {
+			this._recentAgentTransitions.length = 0;
+		}
+		this._recentAgentTransitions.push(transition);
+		if (this._recentAgentTransitions.length > MAX_RECENT_AGENT_TRANSITIONS) {
+			this._recentAgentTransitions.shift();
+		}
+		this._recentAgentTransition = transition;
+	}
+
+	private _applyRecentExternalAgentTransition(
+		transition: IUnifiedDocumentAgentTransition<TSource>,
+	): IUnifiedDocumentReconcileResult<TSource> | undefined {
+		const recentExternalTransition = this._recentExternalTransition;
+		if (!recentExternalTransition || this._recentExternalAgentTransitions.length >= MAX_RECENT_AGENT_TRANSITIONS) {
+			return undefined;
+		}
+		const correlated = this._recentExternalAgentTransitions.find(candidate => candidate.correlation === transition.correlation);
+		if (correlated) {
+			return this._result(isSameContentTransition(correlated, transition) ? 'duplicate' : 'conflict');
+		}
+		const expectedBeforeId = this._recentExternalAgentTransitions.length > 0
+			? contentId(this._recentExternalAgentTransitions[this._recentExternalAgentTransitions.length - 1].after)
+			: recentExternalTransition.beforeId;
+		if (contentId(transition.before) !== expectedBeforeId) {
+			return undefined;
+		}
+
+		this._recentExternalAgentTransitions.push(transition);
+		if (contentId(transition.after) !== recentExternalTransition.afterId) {
+			return this._result('applied');
+		}
+
+		const changes = this._replaceExternalWithAgentTransitions(recentExternalTransition, this._recentExternalAgentTransitions.splice(0));
+		return changes ? this._result('applied', changes) : undefined;
+	}
+
+	private _commitRecentExternalAgentTransitions(): IUnifiedDocumentTransitionChange<TSource>[] {
+		const recentExternalTransition = this._recentExternalTransition;
+		if (!recentExternalTransition) {
+			this._recentExternalAgentTransitions.length = 0;
+			return [];
+		}
+		if (this._recentExternalAgentTransitions.length === 0) {
+			return [];
+		}
+		return this._replaceExternalWithAgentTransitions(recentExternalTransition, this._recentExternalAgentTransitions.splice(0)) ?? [];
+	}
+
+	private _replaceExternalWithAgentTransitions(
+		existing: IRecentExternalTransition<TSource>,
+		agentTransitions: IUnifiedDocumentAgentTransition<TSource>[],
+	): IUnifiedDocumentTransitionChange<TSource>[] | undefined {
+		const index = this._transitions.findIndex(transition => transition.id === existing.transition.id);
+		if (index < 0 || agentTransitions.length === 0) {
+			return undefined;
+		}
+
+		const replacements = agentTransitions.map((agentTransition, agentIndex): IUnifiedDocumentTransition<TSource> => ({
+			...(agentIndex === 0 ? existing.transition : this._createTransition(agentTransition.edit, agentTransition.source, 'agentHost')),
+			edit: agentTransition.edit,
+			source: agentTransition.source,
+			kind: 'agentHost',
+			correlation: agentTransition.correlation,
+			agentKind: agentTransition.kind,
+		}));
+		const changes: IUnifiedDocumentTransitionChange<TSource>[] = replacements.map((replacement, replacementIndex) => ({
+			kind: replacementIndex === 0 ? 'replace' : 'append',
+			before: agentTransitions[replacementIndex].before,
+			after: agentTransitions[replacementIndex].after,
+			transition: { ...replacement },
+		}));
+		const agentAfter = agentTransitions[agentTransitions.length - 1].after;
+		if (contentId(agentAfter) !== existing.afterId) {
+			const externalRemainder = this._createTransition(
+				createMinimalEdit(agentAfter, existing.after),
+				existing.transition.source,
+				existing.transition.kind,
+			);
+			replacements.push(externalRemainder);
+			changes.push({
+				kind: 'append',
+				before: agentAfter,
+				after: existing.after,
+				transition: { ...externalRemainder },
+			});
+			this._recentExternalTransition = createRecentExternalTransition(agentAfter, existing.after, externalRemainder);
+		} else {
+			this._recentExternalTransition = undefined;
+		}
+
+		this._transitions.splice(index, 1, ...replacements);
+		for (let agentIndex = 0; agentIndex < agentTransitions.length; agentIndex++) {
+			this._recordRecentAgentTransition(createRecentTransition(
+				agentTransitions[agentIndex].before,
+				agentTransitions[agentIndex].after,
+				replacements[agentIndex],
+			));
+			this._recordAgentCorrelation(agentTransitions[agentIndex], 'applied');
+		}
+		return changes;
 	}
 
 	private _recordAgentCorrelation(transition: IUnifiedDocumentAgentTransition<TSource>, outcome: UnifiedDocumentReconcileOutcome): void {
@@ -480,6 +637,17 @@ function createRecentTransition<TSource>(
 		beforeId: contentId(before),
 		afterId: contentId(after),
 		transition,
+	};
+}
+
+function createRecentExternalTransition<TSource>(
+	before: string,
+	after: string,
+	transition: IUnifiedDocumentTransition<TSource>,
+): IRecentExternalTransition<TSource> {
+	return {
+		...createRecentTransition(before, after, transition),
+		after,
 	};
 }
 

--- a/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentReconciler.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentReconciler.ts
@@ -1,0 +1,395 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export type UnifiedDocumentReconcileOutcome = 'applied' | 'duplicate' | 'conflict' | 'skippedDirty';
+
+export type UnifiedDocumentTransitionKind = 'model' | 'reloadFromDisk' | 'agentHost' | 'diskSnapshot';
+
+export type UnifiedDocumentAgentTransitionKind = 'create' | 'edit' | 'delete' | 'rename';
+
+export interface IUnifiedDocumentModelState {
+	readonly content: string;
+	readonly dirty: boolean;
+}
+
+export interface IUnifiedDocumentModelEdit<TSource> {
+	readonly before: string;
+	readonly after: string;
+	readonly source: TSource;
+	readonly kind: 'model' | 'reloadFromDisk';
+	readonly dirty: boolean;
+}
+
+export interface IUnifiedDocumentAgentTransition<TSource> {
+	readonly before: string;
+	readonly after: string;
+	readonly source: TSource;
+	readonly correlation: string;
+	readonly kind: UnifiedDocumentAgentTransitionKind;
+}
+
+export interface IUnifiedDocumentTransition<TSource> {
+	readonly id: number;
+	readonly before: string;
+	readonly after: string;
+	readonly source: TSource;
+	readonly kind: UnifiedDocumentTransitionKind;
+	readonly correlation?: string;
+	readonly agentKind?: UnifiedDocumentAgentTransitionKind;
+}
+
+export interface IUnifiedDocumentTransitionChange<TSource> {
+	readonly kind: 'append' | 'replace';
+	readonly transition: IUnifiedDocumentTransition<TSource>;
+}
+
+export interface IUnifiedDocumentSnapshot<TSource> {
+	readonly initialContent: string;
+	readonly content: string;
+	readonly diskContent: string;
+	readonly model: IUnifiedDocumentModelState | undefined;
+	readonly pendingReload: IUnifiedDocumentTransition<TSource> | undefined;
+	readonly transitions: readonly IUnifiedDocumentTransition<TSource>[];
+}
+
+export interface IUnifiedDocumentReconcileResult<TSource> {
+	readonly outcome: UnifiedDocumentReconcileOutcome;
+	readonly changes: readonly IUnifiedDocumentTransitionChange<TSource>[];
+	readonly snapshot: IUnifiedDocumentSnapshot<TSource>;
+}
+
+/**
+ * Reconciles model, Agent Host, and disk observations into one canonical edit sequence.
+ */
+export class UnifiedDocumentReconciler<TSource> {
+	private readonly _initialContent: string;
+	private _content: string;
+	private _diskContent: string;
+	private _model: IUnifiedDocumentModelState | undefined;
+	private _pendingReload: IUnifiedDocumentTransition<TSource> | undefined;
+	private readonly _transitions: IUnifiedDocumentTransition<TSource>[] = [];
+	private readonly _agentCorrelations = new Map<string, { readonly before: string; readonly after: string; readonly outcome: UnifiedDocumentReconcileOutcome }>();
+	private _nextTransitionId = 1;
+
+	constructor(
+		initialContent: string,
+		private readonly _externalSource: TSource,
+	) {
+		this._initialContent = initialContent;
+		this._content = initialContent;
+		this._diskContent = initialContent;
+	}
+
+	modelConnected(state: IUnifiedDocumentModelState): IUnifiedDocumentReconcileResult<TSource> {
+		if (this._model) {
+			return this._result('conflict');
+		}
+
+		this._model = { ...state };
+		if (state.content === this._content) {
+			return this._result('applied');
+		}
+		if (state.dirty) {
+			return this._result('skippedDirty');
+		}
+		const latestAgentTransition = this._findLatestTransition('agentHost');
+		if (
+			latestAgentTransition?.before === state.content &&
+			latestAgentTransition.after === this._content &&
+			this._diskContent === this._content
+		) {
+			return this._result('applied');
+		}
+		if (state.content !== this._diskContent) {
+			return this._result('conflict');
+		}
+
+		const changes = this._commitPendingReload();
+		changes.push(this._appendTransition(this._content, state.content, this._externalSource, 'diskSnapshot'));
+		this._content = state.content;
+		return this._result('applied', changes);
+	}
+
+	modelDisconnected(): IUnifiedDocumentReconcileResult<TSource> {
+		if (!this._model) {
+			return this._result('duplicate');
+		}
+		this._model = undefined;
+		return this._result('applied');
+	}
+
+	modelEdit(edit: IUnifiedDocumentModelEdit<TSource>): IUnifiedDocumentReconcileResult<TSource> {
+		if (!this._model || this._model.content !== edit.before) {
+			return this._result('conflict');
+		}
+
+		if (edit.kind === 'reloadFromDisk') {
+			const matchingAgentTransition = this._findTransition(edit.before, edit.after, 'agentHost');
+			if (matchingAgentTransition && this._content === edit.after && this._diskContent === edit.after) {
+				this._model = { content: edit.after, dirty: edit.dirty };
+				this._diskContent = edit.after;
+				return this._result('duplicate');
+			}
+			const matchingExternalTransition = this._findExternalTransition(edit.before, edit.after);
+			if (matchingExternalTransition && this._content === edit.after && this._diskContent === edit.after) {
+				this._model = { content: edit.after, dirty: edit.dirty };
+				return this._result('duplicate');
+			}
+			if (this._pendingReload && isSameContentTransition(this._pendingReload, edit)) {
+				this._model = { content: edit.after, dirty: edit.dirty };
+				this._diskContent = edit.after;
+				this._content = edit.after;
+				return this._result('duplicate');
+			}
+		}
+
+		const changes = this._commitPendingReload();
+		if (this._content !== edit.before) {
+			this._model = { content: edit.after, dirty: edit.dirty };
+			if (edit.kind === 'reloadFromDisk') {
+				this._diskContent = edit.after;
+			}
+			return this._result('conflict', changes);
+		}
+
+		this._model = { content: edit.after, dirty: edit.dirty };
+		this._content = edit.after;
+		if (edit.kind === 'reloadFromDisk') {
+			this._diskContent = edit.after;
+			this._pendingReload = this._createTransition(edit.before, edit.after, edit.source, edit.kind);
+			return this._result('applied', changes);
+		}
+
+		if (edit.before === edit.after) {
+			return this._result('duplicate', changes);
+		}
+		changes.push(this._appendTransition(edit.before, edit.after, edit.source, edit.kind));
+		return this._result('applied', changes);
+	}
+
+	agentTransition(transition: IUnifiedDocumentAgentTransition<TSource>): IUnifiedDocumentReconcileResult<TSource> {
+		const correlated = this._agentCorrelations.get(transition.correlation);
+		if (correlated) {
+			return this._result(
+				correlated.before === transition.before && correlated.after === transition.after ? 'duplicate' : 'conflict'
+			);
+		}
+
+		const existingAgentTransition = this._findTransition(transition.before, transition.after, 'agentHost');
+		if (existingAgentTransition && this._content === transition.after && this._diskContent === transition.after) {
+			this._recordAgentCorrelation(transition, 'duplicate');
+			return this._result('duplicate');
+		}
+
+		const matchingExternalTransition = this._findExternalTransition(transition.before, transition.after);
+		if (matchingExternalTransition && this._diskContent === transition.after) {
+			const replacement = this._replaceWithAgentTransition(matchingExternalTransition, transition);
+			this._recordAgentCorrelation(transition, 'applied');
+			return this._result('applied', [{ kind: 'replace', transition: replacement }]);
+		}
+
+		if (this._pendingReload && isSameContentTransition(this._pendingReload, transition)) {
+			const pendingReload = this._pendingReload;
+			const appliedTransition: IUnifiedDocumentTransition<TSource> = {
+				...pendingReload,
+				source: transition.source,
+				kind: 'agentHost',
+				correlation: transition.correlation,
+				agentKind: transition.kind,
+			};
+			this._pendingReload = undefined;
+			this._transitions.push(appliedTransition);
+			this._recordAgentCorrelation(transition, 'applied');
+			return this._result('applied', [{ kind: 'append', transition: { ...appliedTransition } }]);
+		}
+
+		const changes = this._commitPendingReload();
+		if (this._model?.dirty) {
+			if (this._diskContent === transition.before) {
+				this._diskContent = transition.after;
+			}
+			this._recordAgentCorrelation(transition, 'skippedDirty');
+			return this._result('skippedDirty', changes);
+		}
+		if (this._diskContent !== transition.before || this._content !== transition.before) {
+			return this._result('conflict', changes);
+		}
+
+		this._diskContent = transition.after;
+		this._content = transition.after;
+		this._recordAgentCorrelation(transition, 'applied');
+		if (transition.before === transition.after) {
+			return this._result('applied', changes);
+		}
+		changes.push(this._appendAgentTransition(transition));
+		return this._result('applied', changes);
+	}
+
+	diskSnapshot(content: string): IUnifiedDocumentReconcileResult<TSource> {
+		if (this._pendingReload && content === this._pendingReload.after) {
+			const changes = this._commitPendingReload();
+			this._diskContent = content;
+			return this._result('applied', changes);
+		}
+
+		const changes = this._commitPendingReload();
+		if (content === this._diskContent && content === this._content) {
+			return this._result('duplicate', changes);
+		}
+
+		const previousDiskContent = this._diskContent;
+		this._diskContent = content;
+		const isModelSave = this._model?.dirty === true && content === this._model.content;
+		if (isModelSave && this._model) {
+			this._model = { content: this._model.content, dirty: false };
+		}
+		if (this._model?.dirty && content !== this._model.content) {
+			return this._result('conflict', changes);
+		}
+		if (content === this._content) {
+			return this._result('duplicate', changes);
+		}
+		if (!isModelSave && this._content !== previousDiskContent) {
+			return this._result('conflict', changes);
+		}
+
+		changes.push(this._appendTransition(this._content, content, this._externalSource, 'diskSnapshot'));
+		this._content = content;
+		return this._result('applied', changes);
+	}
+
+	getSnapshot(): IUnifiedDocumentSnapshot<TSource> {
+		return {
+			initialContent: this._initialContent,
+			content: this._content,
+			diskContent: this._diskContent,
+			model: this._model ? { ...this._model } : undefined,
+			pendingReload: this._pendingReload ? { ...this._pendingReload } : undefined,
+			transitions: this._transitions.map(transition => ({ ...transition })),
+		};
+	}
+
+	private _commitPendingReload(): IUnifiedDocumentTransitionChange<TSource>[] {
+		if (!this._pendingReload) {
+			return [];
+		}
+		const transition = this._pendingReload;
+		this._pendingReload = undefined;
+		this._transitions.push(transition);
+		return [{ kind: 'append', transition: { ...transition } }];
+	}
+
+	private _appendAgentTransition(transition: IUnifiedDocumentAgentTransition<TSource>): IUnifiedDocumentTransitionChange<TSource> {
+		return this._appendTransition(transition.before, transition.after, transition.source, 'agentHost', transition.correlation, transition.kind);
+	}
+
+	private _appendTransition(
+		before: string,
+		after: string,
+		source: TSource,
+		kind: UnifiedDocumentTransitionKind,
+		correlation?: string,
+		agentKind?: UnifiedDocumentAgentTransitionKind,
+	): IUnifiedDocumentTransitionChange<TSource> {
+		const transition = this._createTransition(before, after, source, kind, correlation, agentKind);
+		this._transitions.push(transition);
+		return { kind: 'append', transition: { ...transition } };
+	}
+
+	private _createTransition(
+		before: string,
+		after: string,
+		source: TSource,
+		kind: UnifiedDocumentTransitionKind,
+		correlation?: string,
+		agentKind?: UnifiedDocumentAgentTransitionKind,
+	): IUnifiedDocumentTransition<TSource> {
+		return {
+			id: this._nextTransitionId++,
+			before,
+			after,
+			source,
+			kind,
+			correlation,
+			agentKind,
+		};
+	}
+
+	private _findTransition(before: string, after: string, kind: UnifiedDocumentTransitionKind): IUnifiedDocumentTransition<TSource> | undefined {
+		for (let index = this._transitions.length - 1; index >= 0; index--) {
+			const transition = this._transitions[index];
+			if (transition.kind === kind && transition.before === before && transition.after === after) {
+				return transition;
+			}
+		}
+		return undefined;
+	}
+
+	private _findLatestTransition(kind: UnifiedDocumentTransitionKind): IUnifiedDocumentTransition<TSource> | undefined {
+		for (let index = this._transitions.length - 1; index >= 0; index--) {
+			const transition = this._transitions[index];
+			if (transition.kind === kind) {
+				return transition;
+			}
+		}
+		return undefined;
+	}
+
+	private _findExternalTransition(before: string, after: string): IUnifiedDocumentTransition<TSource> | undefined {
+		for (let index = this._transitions.length - 1; index >= 0; index--) {
+			const transition = this._transitions[index];
+			if (
+				(transition.kind === 'reloadFromDisk' || transition.kind === 'diskSnapshot') &&
+				transition.before === before &&
+				transition.after === after
+			) {
+				return transition;
+			}
+		}
+		return undefined;
+	}
+
+	private _replaceWithAgentTransition(
+		existing: IUnifiedDocumentTransition<TSource>,
+		agentTransition: IUnifiedDocumentAgentTransition<TSource>,
+	): IUnifiedDocumentTransition<TSource> {
+		const replacement: IUnifiedDocumentTransition<TSource> = {
+			...existing,
+			source: agentTransition.source,
+			kind: 'agentHost',
+			correlation: agentTransition.correlation,
+			agentKind: agentTransition.kind,
+		};
+		const index = this._transitions.findIndex(transition => transition.id === existing.id);
+		this._transitions[index] = replacement;
+		return replacement;
+	}
+
+	private _recordAgentCorrelation(transition: IUnifiedDocumentAgentTransition<TSource>, outcome: UnifiedDocumentReconcileOutcome): void {
+		this._agentCorrelations.set(transition.correlation, {
+			before: transition.before,
+			after: transition.after,
+			outcome,
+		});
+	}
+
+	private _result(
+		outcome: UnifiedDocumentReconcileOutcome,
+		changes: readonly IUnifiedDocumentTransitionChange<TSource>[] = [],
+	): IUnifiedDocumentReconcileResult<TSource> {
+		return {
+			outcome,
+			changes,
+			snapshot: this.getSnapshot(),
+		};
+	}
+}
+
+function isSameContentTransition(
+	first: { readonly before: string; readonly after: string },
+	second: { readonly before: string; readonly after: string },
+): boolean {
+	return first.before === second.before && first.after === second.after;
+}

--- a/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentReconciler.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentReconciler.ts
@@ -3,6 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { stringHash } from '../../../../../base/common/hash.js';
+import { hasKey } from '../../../../../base/common/types.js';
+import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
+import { StringEdit, StringReplacement } from '../../../../../editor/common/core/edits/stringEdit.js';
+
 export type UnifiedDocumentReconcileOutcome = 'applied' | 'duplicate' | 'conflict' | 'skippedDirty';
 
 export type UnifiedDocumentTransitionKind = 'model' | 'reloadFromDisk' | 'agentHost' | 'diskSnapshot';
@@ -17,6 +22,7 @@ export interface IUnifiedDocumentModelState {
 export interface IUnifiedDocumentModelEdit<TSource> {
 	readonly before: string;
 	readonly after: string;
+	readonly edit: StringEdit;
 	readonly source: TSource;
 	readonly kind: 'model' | 'reloadFromDisk';
 	readonly dirty: boolean;
@@ -25,6 +31,7 @@ export interface IUnifiedDocumentModelEdit<TSource> {
 export interface IUnifiedDocumentAgentTransition<TSource> {
 	readonly before: string;
 	readonly after: string;
+	readonly edit: StringEdit;
 	readonly source: TSource;
 	readonly correlation: string;
 	readonly kind: UnifiedDocumentAgentTransitionKind;
@@ -32,8 +39,7 @@ export interface IUnifiedDocumentAgentTransition<TSource> {
 
 export interface IUnifiedDocumentTransition<TSource> {
 	readonly id: number;
-	readonly before: string;
-	readonly after: string;
+	readonly edit: StringEdit;
 	readonly source: TSource;
 	readonly kind: UnifiedDocumentTransitionKind;
 	readonly correlation?: string;
@@ -42,6 +48,14 @@ export interface IUnifiedDocumentTransition<TSource> {
 
 export interface IUnifiedDocumentTransitionChange<TSource> {
 	readonly kind: 'append' | 'replace';
+	readonly before: string;
+	readonly after: string;
+	readonly transition: IUnifiedDocumentTransition<TSource>;
+}
+
+export interface IUnifiedDocumentPendingReload<TSource> {
+	readonly before: string;
+	readonly after: string;
 	readonly transition: IUnifiedDocumentTransition<TSource>;
 }
 
@@ -50,7 +64,7 @@ export interface IUnifiedDocumentSnapshot<TSource> {
 	readonly content: string;
 	readonly diskContent: string;
 	readonly model: IUnifiedDocumentModelState | undefined;
-	readonly pendingReload: IUnifiedDocumentTransition<TSource> | undefined;
+	readonly pendingReload: IUnifiedDocumentPendingReload<TSource> | undefined;
 	readonly transitions: readonly IUnifiedDocumentTransition<TSource>[];
 }
 
@@ -60,17 +74,33 @@ export interface IUnifiedDocumentReconcileResult<TSource> {
 	readonly snapshot: IUnifiedDocumentSnapshot<TSource>;
 }
 
+interface IRecentTransition<TSource> {
+	readonly beforeId: string;
+	readonly afterId: string;
+	readonly transition: IUnifiedDocumentTransition<TSource>;
+}
+
+interface IAgentCorrelation {
+	readonly beforeId: string;
+	readonly afterId: string;
+	readonly outcome: UnifiedDocumentReconcileOutcome;
+}
+
+const MAX_AGENT_CORRELATIONS = 128;
+
 /**
  * Reconciles model, Agent Host, and disk observations into one canonical edit sequence.
  */
 export class UnifiedDocumentReconciler<TSource> {
-	private readonly _initialContent: string;
+	private _initialContent: string;
 	private _content: string;
 	private _diskContent: string;
 	private _model: IUnifiedDocumentModelState | undefined;
-	private _pendingReload: IUnifiedDocumentTransition<TSource> | undefined;
+	private _pendingReload: IUnifiedDocumentPendingReload<TSource> | undefined;
 	private readonly _transitions: IUnifiedDocumentTransition<TSource>[] = [];
-	private readonly _agentCorrelations = new Map<string, { readonly before: string; readonly after: string; readonly outcome: UnifiedDocumentReconcileOutcome }>();
+	private readonly _agentCorrelations = new Map<string, IAgentCorrelation>();
+	private _recentAgentTransition: IRecentTransition<TSource> | undefined;
+	private _recentExternalTransition: IRecentTransition<TSource> | undefined;
 	private _nextTransitionId = 1;
 
 	constructor(
@@ -94,10 +124,9 @@ export class UnifiedDocumentReconciler<TSource> {
 		if (state.dirty) {
 			return this._result('skippedDirty');
 		}
-		const latestAgentTransition = this._findLatestTransition('agentHost');
 		if (
-			latestAgentTransition?.before === state.content &&
-			latestAgentTransition.after === this._content &&
+			this._recentAgentTransition?.beforeId === contentId(state.content) &&
+			this._recentAgentTransition.afterId === contentId(this._content) &&
 			this._diskContent === this._content
 		) {
 			return this._result('applied');
@@ -107,7 +136,13 @@ export class UnifiedDocumentReconciler<TSource> {
 		}
 
 		const changes = this._commitPendingReload();
-		changes.push(this._appendTransition(this._content, state.content, this._externalSource, 'diskSnapshot'));
+		changes.push(this._appendTransition(
+			this._content,
+			state.content,
+			createMinimalEdit(this._content, state.content),
+			this._externalSource,
+			'diskSnapshot',
+		));
 		this._content = state.content;
 		return this._result('applied', changes);
 	}
@@ -126,18 +161,16 @@ export class UnifiedDocumentReconciler<TSource> {
 		}
 
 		if (edit.kind === 'reloadFromDisk') {
-			const matchingAgentTransition = this._findTransition(edit.before, edit.after, 'agentHost');
-			if (matchingAgentTransition && this._content === edit.after && this._diskContent === edit.after) {
+			if (isSameContentTransition(this._recentAgentTransition, edit) && this._content === edit.after && this._diskContent === edit.after) {
 				this._model = { content: edit.after, dirty: edit.dirty };
 				this._diskContent = edit.after;
 				return this._result('duplicate');
 			}
-			const matchingExternalTransition = this._findExternalTransition(edit.before, edit.after);
-			if (matchingExternalTransition && this._content === edit.after && this._diskContent === edit.after) {
+			if (isSameContentTransition(this._recentExternalTransition, edit) && this._content === edit.after && this._diskContent === edit.after) {
 				this._model = { content: edit.after, dirty: edit.dirty };
 				return this._result('duplicate');
 			}
-			if (this._pendingReload && isSameContentTransition(this._pendingReload, edit)) {
+			if (isSameContentTransition(this._pendingReload, edit)) {
 				this._model = { content: edit.after, dirty: edit.dirty };
 				this._diskContent = edit.after;
 				this._content = edit.after;
@@ -158,14 +191,18 @@ export class UnifiedDocumentReconciler<TSource> {
 		this._content = edit.after;
 		if (edit.kind === 'reloadFromDisk') {
 			this._diskContent = edit.after;
-			this._pendingReload = this._createTransition(edit.before, edit.after, edit.source, edit.kind);
+			this._pendingReload = {
+				before: edit.before,
+				after: edit.after,
+				transition: this._createTransition(edit.edit, edit.source, edit.kind),
+			};
 			return this._result('applied', changes);
 		}
 
 		if (edit.before === edit.after) {
 			return this._result('duplicate', changes);
 		}
-		changes.push(this._appendTransition(edit.before, edit.after, edit.source, edit.kind));
+		changes.push(this._appendTransition(edit.before, edit.after, edit.edit, edit.source, edit.kind));
 		return this._result('applied', changes);
 	}
 
@@ -173,27 +210,33 @@ export class UnifiedDocumentReconciler<TSource> {
 		const correlated = this._agentCorrelations.get(transition.correlation);
 		if (correlated) {
 			return this._result(
-				correlated.before === transition.before && correlated.after === transition.after ? 'duplicate' : 'conflict'
+				correlated.beforeId === contentId(transition.before) && correlated.afterId === contentId(transition.after) ? 'duplicate' : 'conflict'
 			);
 		}
 
-		const existingAgentTransition = this._findTransition(transition.before, transition.after, 'agentHost');
-		if (existingAgentTransition && this._content === transition.after && this._diskContent === transition.after) {
+		if (
+			isSameContentTransition(this._recentAgentTransition, transition) &&
+			this._content === transition.after &&
+			this._diskContent === transition.after
+		) {
 			this._recordAgentCorrelation(transition, 'duplicate');
 			return this._result('duplicate');
 		}
 
-		const matchingExternalTransition = this._findExternalTransition(transition.before, transition.after);
-		if (matchingExternalTransition && this._diskContent === transition.after) {
-			const replacement = this._replaceWithAgentTransition(matchingExternalTransition, transition);
-			this._recordAgentCorrelation(transition, 'applied');
-			return this._result('applied', [{ kind: 'replace', transition: replacement }]);
+		const recentExternalTransition = this._recentExternalTransition;
+		if (recentExternalTransition && isSameContentTransition(recentExternalTransition, transition) && this._diskContent === transition.after) {
+			const replacement = this._replaceWithAgentTransition(recentExternalTransition, transition);
+			if (replacement) {
+				this._recordAgentCorrelation(transition, 'applied');
+				return this._result('applied', [replacement]);
+			}
 		}
 
-		if (this._pendingReload && isSameContentTransition(this._pendingReload, transition)) {
-			const pendingReload = this._pendingReload;
+		const pendingReload = this._pendingReload;
+		if (pendingReload && isSameContentTransition(pendingReload, transition)) {
 			const appliedTransition: IUnifiedDocumentTransition<TSource> = {
-				...pendingReload,
+				...pendingReload.transition,
+				edit: transition.edit,
 				source: transition.source,
 				kind: 'agentHost',
 				correlation: transition.correlation,
@@ -201,8 +244,15 @@ export class UnifiedDocumentReconciler<TSource> {
 			};
 			this._pendingReload = undefined;
 			this._transitions.push(appliedTransition);
+			this._recentAgentTransition = createRecentTransition(transition.before, transition.after, appliedTransition);
+			this._recentExternalTransition = undefined;
 			this._recordAgentCorrelation(transition, 'applied');
-			return this._result('applied', [{ kind: 'append', transition: { ...appliedTransition } }]);
+			return this._result('applied', [{
+				kind: 'append',
+				before: transition.before,
+				after: transition.after,
+				transition: appliedTransition,
+			}]);
 		}
 
 		const changes = this._commitPendingReload();
@@ -227,7 +277,7 @@ export class UnifiedDocumentReconciler<TSource> {
 		return this._result('applied', changes);
 	}
 
-	diskSnapshot(content: string): IUnifiedDocumentReconcileResult<TSource> {
+	diskSnapshot(content: string, edit: StringEdit): IUnifiedDocumentReconcileResult<TSource> {
 		if (this._pendingReload && content === this._pendingReload.after) {
 			const changes = this._commitPendingReload();
 			this._diskContent = content;
@@ -255,9 +305,15 @@ export class UnifiedDocumentReconciler<TSource> {
 			return this._result('conflict', changes);
 		}
 
-		changes.push(this._appendTransition(this._content, content, this._externalSource, 'diskSnapshot'));
+		changes.push(this._appendTransition(this._content, content, edit, this._externalSource, 'diskSnapshot'));
 		this._content = content;
 		return this._result('applied', changes);
+	}
+
+	resetWindow(): void {
+		this._initialContent = this._content;
+		this._transitions.length = 0;
+		this._recentExternalTransition = undefined;
 	}
 
 	getSnapshot(): IUnifiedDocumentSnapshot<TSource> {
@@ -266,7 +322,10 @@ export class UnifiedDocumentReconciler<TSource> {
 			content: this._content,
 			diskContent: this._diskContent,
 			model: this._model ? { ...this._model } : undefined,
-			pendingReload: this._pendingReload ? { ...this._pendingReload } : undefined,
+			pendingReload: this._pendingReload ? {
+				...this._pendingReload,
+				transition: { ...this._pendingReload.transition },
+			} : undefined,
 			transitions: this._transitions.map(transition => ({ ...transition })),
 		};
 	}
@@ -275,32 +334,57 @@ export class UnifiedDocumentReconciler<TSource> {
 		if (!this._pendingReload) {
 			return [];
 		}
-		const transition = this._pendingReload;
+		const pendingReload = this._pendingReload;
 		this._pendingReload = undefined;
-		this._transitions.push(transition);
-		return [{ kind: 'append', transition: { ...transition } }];
+		this._transitions.push(pendingReload.transition);
+		this._recentExternalTransition = createRecentTransition(
+			pendingReload.before,
+			pendingReload.after,
+			pendingReload.transition,
+		);
+		return [{
+			kind: 'append',
+			before: pendingReload.before,
+			after: pendingReload.after,
+			transition: { ...pendingReload.transition },
+		}];
 	}
 
 	private _appendAgentTransition(transition: IUnifiedDocumentAgentTransition<TSource>): IUnifiedDocumentTransitionChange<TSource> {
-		return this._appendTransition(transition.before, transition.after, transition.source, 'agentHost', transition.correlation, transition.kind);
+		return this._appendTransition(
+			transition.before,
+			transition.after,
+			transition.edit,
+			transition.source,
+			'agentHost',
+			transition.correlation,
+			transition.kind,
+		);
 	}
 
 	private _appendTransition(
 		before: string,
 		after: string,
+		edit: StringEdit,
 		source: TSource,
 		kind: UnifiedDocumentTransitionKind,
 		correlation?: string,
 		agentKind?: UnifiedDocumentAgentTransitionKind,
 	): IUnifiedDocumentTransitionChange<TSource> {
-		const transition = this._createTransition(before, after, source, kind, correlation, agentKind);
+		const transition = this._createTransition(edit, source, kind, correlation, agentKind);
 		this._transitions.push(transition);
-		return { kind: 'append', transition: { ...transition } };
+		const recent = createRecentTransition(before, after, transition);
+		if (kind === 'agentHost') {
+			this._recentAgentTransition = recent;
+			this._recentExternalTransition = undefined;
+		} else if (kind === 'reloadFromDisk' || kind === 'diskSnapshot') {
+			this._recentExternalTransition = recent;
+		}
+		return { kind: 'append', before, after, transition: { ...transition } };
 	}
 
 	private _createTransition(
-		before: string,
-		after: string,
+		edit: StringEdit,
 		source: TSource,
 		kind: UnifiedDocumentTransitionKind,
 		correlation?: string,
@@ -308,8 +392,7 @@ export class UnifiedDocumentReconciler<TSource> {
 	): IUnifiedDocumentTransition<TSource> {
 		return {
 			id: this._nextTransitionId++,
-			before,
-			after,
+			edit,
 			source,
 			kind,
 			correlation,
@@ -317,62 +400,46 @@ export class UnifiedDocumentReconciler<TSource> {
 		};
 	}
 
-	private _findTransition(before: string, after: string, kind: UnifiedDocumentTransitionKind): IUnifiedDocumentTransition<TSource> | undefined {
-		for (let index = this._transitions.length - 1; index >= 0; index--) {
-			const transition = this._transitions[index];
-			if (transition.kind === kind && transition.before === before && transition.after === after) {
-				return transition;
-			}
-		}
-		return undefined;
-	}
-
-	private _findLatestTransition(kind: UnifiedDocumentTransitionKind): IUnifiedDocumentTransition<TSource> | undefined {
-		for (let index = this._transitions.length - 1; index >= 0; index--) {
-			const transition = this._transitions[index];
-			if (transition.kind === kind) {
-				return transition;
-			}
-		}
-		return undefined;
-	}
-
-	private _findExternalTransition(before: string, after: string): IUnifiedDocumentTransition<TSource> | undefined {
-		for (let index = this._transitions.length - 1; index >= 0; index--) {
-			const transition = this._transitions[index];
-			if (
-				(transition.kind === 'reloadFromDisk' || transition.kind === 'diskSnapshot') &&
-				transition.before === before &&
-				transition.after === after
-			) {
-				return transition;
-			}
-		}
-		return undefined;
-	}
-
 	private _replaceWithAgentTransition(
-		existing: IUnifiedDocumentTransition<TSource>,
+		existing: IRecentTransition<TSource>,
 		agentTransition: IUnifiedDocumentAgentTransition<TSource>,
-	): IUnifiedDocumentTransition<TSource> {
+	): IUnifiedDocumentTransitionChange<TSource> | undefined {
+		const index = this._transitions.findIndex(transition => transition.id === existing.transition.id);
+		if (index < 0) {
+			return undefined;
+		}
 		const replacement: IUnifiedDocumentTransition<TSource> = {
-			...existing,
+			...existing.transition,
+			edit: agentTransition.edit,
 			source: agentTransition.source,
 			kind: 'agentHost',
 			correlation: agentTransition.correlation,
 			agentKind: agentTransition.kind,
 		};
-		const index = this._transitions.findIndex(transition => transition.id === existing.id);
 		this._transitions[index] = replacement;
-		return replacement;
+		this._recentAgentTransition = createRecentTransition(agentTransition.before, agentTransition.after, replacement);
+		this._recentExternalTransition = undefined;
+		return {
+			kind: 'replace',
+			before: agentTransition.before,
+			after: agentTransition.after,
+			transition: { ...replacement },
+		};
 	}
 
 	private _recordAgentCorrelation(transition: IUnifiedDocumentAgentTransition<TSource>, outcome: UnifiedDocumentReconcileOutcome): void {
+		this._agentCorrelations.delete(transition.correlation);
 		this._agentCorrelations.set(transition.correlation, {
-			before: transition.before,
-			after: transition.after,
+			beforeId: contentId(transition.before),
+			afterId: contentId(transition.after),
 			outcome,
 		});
+		if (this._agentCorrelations.size > MAX_AGENT_CORRELATIONS) {
+			const oldestCorrelation = this._agentCorrelations.keys().next().value;
+			if (oldestCorrelation !== undefined) {
+				this._agentCorrelations.delete(oldestCorrelation);
+			}
+		}
 	}
 
 	private _result(
@@ -388,8 +455,39 @@ export class UnifiedDocumentReconciler<TSource> {
 }
 
 function isSameContentTransition(
-	first: { readonly before: string; readonly after: string },
-	second: { readonly before: string; readonly after: string },
+	left: { readonly before: string; readonly after: string } | IRecentTransition<unknown> | undefined,
+	right: { readonly before: string; readonly after: string },
 ): boolean {
-	return first.before === second.before && first.after === second.after;
+	if (!left) {
+		return false;
+	}
+	if (hasKey(left, { beforeId: true })) {
+		return left.beforeId === contentId(right.before) && left.afterId === contentId(right.after);
+	}
+	return left.before === right.before && left.after === right.after;
+}
+
+function contentId(content: string): string {
+	return `${content.length}:${stringHash(content, 0)}:${stringHash(content, 5381)}`;
+}
+
+function createRecentTransition<TSource>(
+	before: string,
+	after: string,
+	transition: IUnifiedDocumentTransition<TSource>,
+): IRecentTransition<TSource> {
+	return {
+		beforeId: contentId(before),
+		afterId: contentId(after),
+		transition,
+	};
+}
+
+export function createMinimalEdit(before: string, after: string): StringEdit {
+	if (before === after) {
+		return StringEdit.empty;
+	}
+	return new StringEdit([
+		StringReplacement.replace(OffsetRange.ofLength(before.length), after).removeCommonSuffixAndPrefix(before),
+	]).normalize();
 }

--- a/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentRegistry.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentRegistry.ts
@@ -12,6 +12,7 @@ import {
 	UnifiedDocumentReconcileOutcome,
 	UnifiedDocumentReconciler,
 } from './unifiedDocumentReconciler.js';
+import { StringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
 
 export interface IUnifiedDocumentRegistryOptions<TSource> {
 	readonly externalSource: TSource;
@@ -85,9 +86,9 @@ export class UnifiedDocumentRegistry<TSource> {
 		return this._wrap(entry, entry.reconciler.agentTransition(transition));
 	}
 
-	diskSnapshot(resource: URI, content: string): IUnifiedDocumentRegistryResult<TSource> {
+	diskSnapshot(resource: URI, content: string, edit: StringEdit): IUnifiedDocumentRegistryResult<TSource> {
 		const entry = this._getOrCreate(resource, content);
-		return this._wrap(entry, entry.reconciler.diskSnapshot(content));
+		return this._wrap(entry, entry.reconciler.diskSnapshot(content, edit));
 	}
 
 	transfer(previousResource: URI, resource: URI): IUnifiedDocumentRegistryResult<TSource> {

--- a/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentRegistry.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/helpers/unifiedDocumentRegistry.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../base/common/uri.js';
+import {
+	IUnifiedDocumentAgentTransition,
+	IUnifiedDocumentModelEdit,
+	IUnifiedDocumentModelState,
+	IUnifiedDocumentReconcileResult,
+	UnifiedDocumentReconcileOutcome,
+	UnifiedDocumentReconciler,
+} from './unifiedDocumentReconciler.js';
+
+export interface IUnifiedDocumentRegistryOptions<TSource> {
+	readonly externalSource: TSource;
+	readonly canonicalize: (resource: URI) => URI;
+	readonly getComparisonKey: (resource: URI) => string;
+}
+
+export interface IUnifiedDocumentRegistryEntry<TSource> {
+	readonly resource: URI;
+	readonly reconciler: UnifiedDocumentReconciler<TSource>;
+}
+
+export interface IUnifiedDocumentRegistryResult<TSource> {
+	readonly outcome: UnifiedDocumentReconcileOutcome;
+	readonly resource: URI;
+	readonly reconcileResult?: IUnifiedDocumentReconcileResult<TSource>;
+}
+
+class UnifiedDocumentRegistryEntry<TSource> implements IUnifiedDocumentRegistryEntry<TSource> {
+	constructor(
+		public resource: URI,
+		readonly reconciler: UnifiedDocumentReconciler<TSource>,
+	) { }
+}
+
+/**
+ * Owns one unified reconciler per canonical resource identity.
+ */
+export class UnifiedDocumentRegistry<TSource> {
+	private readonly _entries = new Map<string, UnifiedDocumentRegistryEntry<TSource>>();
+
+	constructor(private readonly _options: IUnifiedDocumentRegistryOptions<TSource>) { }
+
+	get size(): number {
+		return this._entries.size;
+	}
+
+	get(resource: URI): IUnifiedDocumentRegistryEntry<TSource> | undefined {
+		return this._entries.get(this._key(resource));
+	}
+
+	entries(): readonly IUnifiedDocumentRegistryEntry<TSource>[] {
+		return Array.from(this._entries.values());
+	}
+
+	modelConnected(resource: URI, initialContent: string, state: IUnifiedDocumentModelState): IUnifiedDocumentRegistryResult<TSource> {
+		const entry = this._getOrCreate(resource, initialContent);
+		return this._wrap(entry, entry.reconciler.modelConnected(state));
+	}
+
+	modelDisconnected(resource: URI): IUnifiedDocumentRegistryResult<TSource> {
+		const canonicalResource = this._canonicalize(resource);
+		const entry = this._entries.get(this._key(canonicalResource));
+		if (!entry) {
+			return { outcome: 'duplicate', resource: canonicalResource };
+		}
+		return this._wrap(entry, entry.reconciler.modelDisconnected());
+	}
+
+	modelEdit(resource: URI, edit: IUnifiedDocumentModelEdit<TSource>): IUnifiedDocumentRegistryResult<TSource> {
+		const canonicalResource = this._canonicalize(resource);
+		const entry = this._entries.get(this._key(canonicalResource));
+		if (!entry) {
+			return { outcome: 'conflict', resource: canonicalResource };
+		}
+		return this._wrap(entry, entry.reconciler.modelEdit(edit));
+	}
+
+	agentTransition(resource: URI, transition: IUnifiedDocumentAgentTransition<TSource>): IUnifiedDocumentRegistryResult<TSource> {
+		const entry = this._getOrCreate(resource, transition.before);
+		return this._wrap(entry, entry.reconciler.agentTransition(transition));
+	}
+
+	diskSnapshot(resource: URI, content: string): IUnifiedDocumentRegistryResult<TSource> {
+		const entry = this._getOrCreate(resource, content);
+		return this._wrap(entry, entry.reconciler.diskSnapshot(content));
+	}
+
+	transfer(previousResource: URI, resource: URI): IUnifiedDocumentRegistryResult<TSource> {
+		const canonicalPreviousResource = this._canonicalize(previousResource);
+		const canonicalResource = this._canonicalize(resource);
+		const previousKey = this._key(canonicalPreviousResource);
+		const key = this._key(canonicalResource);
+		const entry = this._entries.get(previousKey);
+		if (!entry) {
+			return { outcome: 'conflict', resource: canonicalResource };
+		}
+		if (previousKey === key) {
+			entry.resource = canonicalResource;
+			return { outcome: 'duplicate', resource: canonicalResource };
+		}
+		if (this._entries.has(key)) {
+			return { outcome: 'conflict', resource: canonicalResource };
+		}
+
+		this._entries.delete(previousKey);
+		entry.resource = canonicalResource;
+		this._entries.set(key, entry);
+		return { outcome: 'applied', resource: canonicalResource };
+	}
+
+	delete(resource: URI): boolean {
+		return this._entries.delete(this._key(resource));
+	}
+
+	clear(): void {
+		this._entries.clear();
+	}
+
+	private _getOrCreate(resource: URI, initialContent: string): UnifiedDocumentRegistryEntry<TSource> {
+		const canonicalResource = this._canonicalize(resource);
+		const key = this._key(canonicalResource);
+		let entry = this._entries.get(key);
+		if (!entry) {
+			entry = new UnifiedDocumentRegistryEntry(
+				canonicalResource,
+				new UnifiedDocumentReconciler(initialContent, this._options.externalSource),
+			);
+			this._entries.set(key, entry);
+		}
+		return entry;
+	}
+
+	private _canonicalize(resource: URI): URI {
+		return this._options.canonicalize(resource);
+	}
+
+	private _key(resource: URI): string {
+		return this._options.getComparisonKey(this._canonicalize(resource));
+	}
+
+	private _wrap(
+		entry: UnifiedDocumentRegistryEntry<TSource>,
+		reconcileResult: IUnifiedDocumentReconcileResult<TSource>,
+	): IUnifiedDocumentRegistryResult<TSource> {
+		return {
+			outcome: reconcileResult.outcome,
+			resource: entry.resource,
+			reconcileResult,
+		};
+	}
+}

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditSourceTracking.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditSourceTracking.ts
@@ -235,14 +235,10 @@ export class AgentHostEditSourceTracking extends Disposable {
 			correlation: `${session.toString()}:${toolCallId}:${contentIndex}`,
 			kind: normalized.kind,
 		});
-		if (!shouldTrackAgentEdit(reconcileResult)) {
+		if (!shouldTrackAgentEdit(reconcileResult) || dirtyResource) {
 			if (dirtyResource) {
 				this._logService.trace(`[AgentHostEditSourceTracking] Skipping attribution for dirty open file ${dirtyResource.toString()}`);
 			}
-			return;
-		}
-		if (dirtyResource) {
-			this._logService.trace(`[AgentHostEditSourceTracking] Skipping attribution for dirty open file ${dirtyResource.toString()}`);
 			return;
 		}
 

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditSourceTracking.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditSourceTracking.ts
@@ -22,6 +22,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ISCMService } from '../../../scm/common/scm.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { IUnifiedDocumentAgentAdapterResult } from '../helpers/unifiedDocumentAdapters.js';
 import { EditTelemetryTrigger } from './editSourceTelemetry.js';
 import { IScmRepoAdapter, ScmAdapter } from './scmAdapter.js';
 import { UnifiedEditSourceTracking } from './unifiedEditSourceTracking.js';
@@ -225,7 +226,7 @@ export class AgentHostEditSourceTracking extends Disposable {
 			origin: 'agentHost',
 		});
 		const beforeResource = normalized.beforeUri ? toAgentHostUri(normalized.beforeUri, connectionAuthority) : undefined;
-		this._unifiedTracking.applyAgentEdit({
+		const reconcileResult = await this._unifiedTracking.applyAgentEdit({
 			resource,
 			previousResource: beforeResource,
 			before: beforeText,
@@ -234,6 +235,12 @@ export class AgentHostEditSourceTracking extends Disposable {
 			correlation: `${session.toString()}:${toolCallId}:${contentIndex}`,
 			kind: normalized.kind,
 		});
+		if (!shouldTrackAgentEdit(reconcileResult)) {
+			if (dirtyResource) {
+				this._logService.trace(`[AgentHostEditSourceTracking] Skipping attribution for dirty open file ${dirtyResource.toString()}`);
+			}
+			return;
+		}
 		if (dirtyResource) {
 			this._logService.trace(`[AgentHostEditSourceTracking] Skipping attribution for dirty open file ${dirtyResource.toString()}`);
 			return;
@@ -346,4 +353,11 @@ function firstLine(text: string): string {
 
 export function isDirtyOpenTextModel(resource: URI, modelService: Pick<IModelService, 'getModel'>, textFileService: Pick<ITextFileService, 'isDirty'>): boolean {
 	return modelService.getModel(resource) !== null && textFileService.isDirty(resource);
+}
+
+export function shouldTrackAgentEdit<TSource>(result: IUnifiedDocumentAgentAdapterResult<TSource>): boolean {
+	return (
+		result.transitionResult.outcome === 'applied' ||
+		result.transitionResult.outcome === 'duplicate'
+	) && result.transferResult?.outcome !== 'conflict';
 }

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditSourceTracking.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditSourceTracking.ts
@@ -1,0 +1,349 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IntervalTimer } from '../../../../../base/common/async.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { extname } from '../../../../../base/common/path.js';
+import { autorun, derived, IObservable, IReader, ISettableObservable, observableValue, runOnChange } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { EditSources } from '../../../../../editor/common/textModelEditSource.js';
+import { AgentSession } from '../../../../../platform/agentHost/common/agentService.js';
+import { IAgentHostConnectionsService } from '../../../../../platform/agentHost/common/agentHostConnectionsService.js';
+import { normalizeFileEdit } from '../../../../../platform/agentHost/common/fileEditDiff.js';
+import { toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { ActionType } from '../../../../../platform/agentHost/common/state/protocol/common/actions.js';
+import { isAhpChatChannel, parseRequiredSessionUriFromChatUri, ToolResultContentType, type ToolResultFileEditContent } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { FileOperationResult, IFileService, toFileOperationResult } from '../../../../../platform/files/common/files.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { ISCMService } from '../../../scm/common/scm.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { EditTelemetryTrigger } from './editSourceTelemetry.js';
+import { IScmRepoAdapter, ScmAdapter } from './scmAdapter.js';
+import { UnifiedEditSourceTracking } from './unifiedEditSourceTracking.js';
+
+const MAX_TRACKED_FILE_SIZE = 5 * 1024 * 1024;
+
+type GetRepo = (resource: URI, reader: IReader) => IScmRepoAdapter | undefined;
+
+/**
+ * Tracks long-term Agent Host AI attribution for one file.
+ */
+export class AgentHostTrackedFile extends Disposable {
+	private readonly _resource: ISettableObservable<URI>;
+	private readonly _repo;
+	private _languageId = 'plaintext';
+	private _operationQueue: Promise<void> = Promise.resolve();
+	private _isDisposed = false;
+
+	constructor(
+		resource: URI,
+		private readonly _readCurrentText: (resource: URI) => Promise<string | undefined>,
+		getRepo: GetRepo,
+		private readonly _logService: ILogService,
+		private readonly _onDidExpire: () => void,
+		private readonly _onDidFlush: (resource: URI, content: string, languageId: string, trigger: EditTelemetryTrigger) => void,
+	) {
+		super();
+		this._resource = observableValue(this, resource);
+		this._repo = derived(this, reader => getRepo(this._resource.read(reader), reader));
+
+		this._register(autorun(reader => {
+			const repo = this._repo.read(reader);
+			if (!repo) {
+				return;
+			}
+			reader.store.add(runOnChange(repo.headCommitHashObs, () => this._flushAndLog('hashChange')));
+			reader.store.add(runOnChange(repo.headBranchNameObs, () => this._flushAndLog('branchChange')));
+		}));
+
+		this._register(new IntervalTimer()).cancelAndSet(() => this._expireAndLog(), 10 * 60 * 60 * 1000);
+	}
+
+	get resource(): URI {
+		return this._resource.get();
+	}
+
+	setResource(resource: URI): void {
+		this._resource.set(resource, undefined);
+	}
+
+	applyEdit(languageId: string): Promise<void> {
+		return this._enqueue(async () => {
+			if (this._isDisposed) {
+				return;
+			}
+			this._languageId = languageId;
+		});
+	}
+
+	flush(trigger: EditTelemetryTrigger): Promise<void> {
+		return this._enqueue(async () => {
+			if (this._isDisposed) {
+				return;
+			}
+			const currentText = await this._readCurrentText(this.resource);
+			if (currentText === undefined || this._isDisposed) {
+				return;
+			}
+			this._onDidFlush(this.resource, currentText, this._languageId, trigger);
+		});
+	}
+
+	private _enqueue(operation: () => Promise<void>): Promise<void> {
+		const result = this._operationQueue.then(operation, operation);
+		this._operationQueue = result.then(() => undefined, () => undefined);
+		return result;
+	}
+
+	private _flushAndLog(trigger: EditTelemetryTrigger): void {
+		this.flush(trigger).catch(error => this._logService.error(`[AgentHostEditSourceTracking] Failed to flush ${this.resource.toString()}: ${error}`));
+	}
+
+	private _expireAndLog(): void {
+		this.flush('10hours').then(() => this._onDidExpire(), error => {
+			this._logService.error(`[AgentHostEditSourceTracking] Failed to flush ${this.resource.toString()}: ${error}`);
+		});
+	}
+
+	override dispose(): void {
+		this._isDisposed = true;
+		super.dispose();
+	}
+}
+
+/**
+ * Converts Agent Host file-edit actions into workbench edit-source telemetry.
+ */
+export class AgentHostEditSourceTracking extends Disposable {
+	private readonly _connectionListeners = this._register(new MutableDisposable<DisposableStore>());
+	private readonly _trackedFiles = new Map<string, AgentHostTrackedFile>();
+	private readonly _scmAdapter: ScmAdapter;
+	private _operationQueue: Promise<void> = Promise.resolve();
+	private _isDisposed = false;
+
+	constructor(
+		private readonly _detailsEnabled: IObservable<boolean>,
+		private readonly _unifiedTracking: UnifiedEditSourceTracking,
+		@IAgentHostConnectionsService private readonly _connectionsService: IAgentHostConnectionsService,
+		@IFileService private readonly _fileService: IFileService,
+		@IModelService private readonly _modelService: IModelService,
+		@ILanguageService private readonly _languageService: ILanguageService,
+		@ITextFileService private readonly _textFileService: ITextFileService,
+		@ISCMService scmService: ISCMService,
+		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+		this._scmAdapter = new ScmAdapter(scmService);
+		this._syncConnectionListeners();
+		this._register(this._connectionsService.onDidChangeConnections(() => this._syncConnectionListeners()));
+		this._register(autorun(reader => {
+			if (!this._detailsEnabled.read(reader)) {
+				this._clearTrackedFiles();
+			}
+		}));
+	}
+
+	private _syncConnectionListeners(): void {
+		const store = new DisposableStore();
+		for (const connectionInfo of this._connectionsService.connections) {
+			const connection = connectionInfo.connection;
+			if (!connection) {
+				continue;
+			}
+			store.add(connection.onDidAction(envelope => {
+				const action = envelope.action;
+				if (!this._detailsEnabled.get() || action.type !== ActionType.ChatToolCallComplete || !isAhpChatChannel(envelope.channel.toString())) {
+					return;
+				}
+				this._enqueue(async () => {
+					if (!this._detailsEnabled.get()) {
+						return;
+					}
+					const session = URI.parse(parseRequiredSessionUriFromChatUri(envelope.channel));
+					const provider = AgentSession.provider(session);
+					if (!provider) {
+						return;
+					}
+					for (const [contentIndex, content] of (action.result.content ?? []).entries()) {
+						if (content.type === ToolResultContentType.FileEdit) {
+							await this._processFileEdit(connectionInfo.authority, session, provider, action.turnId, action.toolCallId, contentIndex, content);
+						}
+					}
+				});
+			}));
+		}
+		this._connectionListeners.value = store;
+	}
+
+	private async _processFileEdit(
+		connectionAuthority: string,
+		session: URI,
+		provider: string,
+		turnId: string,
+		toolCallId: string,
+		contentIndex: number,
+		fileEdit: ToolResultFileEditContent,
+	): Promise<void> {
+		const normalized = normalizeFileEdit(fileEdit);
+		if (!normalized) {
+			return;
+		}
+
+		const resource = toAgentHostUri(normalized.resource, connectionAuthority);
+		if (extname(resource.path).toLowerCase() === '.ipynb') {
+			return;
+		}
+		const editedResources = [normalized.beforeUri, normalized.afterUri]
+			.filter(resource => resource !== undefined)
+			.map(resource => toAgentHostUri(resource, connectionAuthority));
+		const dirtyResource = editedResources.find(resource => isDirtyOpenTextModel(resource, this._modelService, this._textFileService));
+
+		const beforeText = normalized.beforeContentUri ? await this._readSnapshot(normalized.beforeContentUri, connectionAuthority) : '';
+		const afterText = normalized.afterContentUri ? await this._readSnapshot(normalized.afterContentUri, connectionAuthority) : '';
+		if (this._isDisposed || !this._detailsEnabled.get() || beforeText === undefined || afterText === undefined || Math.max(beforeText.length, afterText.length) > MAX_TRACKED_FILE_SIZE) {
+			return;
+		}
+
+		const harness = provider;
+		const agentSessionId = AgentSession.id(session);
+		const languageId = this._languageService.guessLanguageIdByFilepathOrFirstLine(resource, firstLine(afterText || beforeText)) ?? 'plaintext';
+		const source = EditSources.chatApplyEdits({
+			modelId: undefined,
+			sessionId: agentSessionId,
+			requestId: turnId,
+			languageId,
+			mode: undefined,
+			extensionId: undefined,
+			codeBlockSuggestionId: undefined,
+			harness,
+			origin: 'agentHost',
+		});
+		const beforeResource = normalized.beforeUri ? toAgentHostUri(normalized.beforeUri, connectionAuthority) : undefined;
+		this._unifiedTracking.applyAgentEdit({
+			resource,
+			previousResource: beforeResource,
+			before: beforeText,
+			after: afterText,
+			source,
+			correlation: `${session.toString()}:${toolCallId}:${contentIndex}`,
+			kind: normalized.kind,
+		});
+		if (dirtyResource) {
+			this._logService.trace(`[AgentHostEditSourceTracking] Skipping attribution for dirty open file ${dirtyResource.toString()}`);
+			return;
+		}
+
+		const resourceKey = this._uriIdentityService.extUri.getComparisonKey(resource);
+		const beforeResourceKey = beforeResource ? this._uriIdentityService.extUri.getComparisonKey(beforeResource) : undefined;
+		let trackedFile = this._trackedFiles.get(resourceKey);
+		if (!trackedFile && beforeResourceKey && beforeResourceKey !== resourceKey) {
+			trackedFile = this._trackedFiles.get(beforeResourceKey);
+			if (trackedFile) {
+				this._trackedFiles.delete(beforeResourceKey);
+				this._trackedFiles.set(resourceKey, trackedFile);
+				trackedFile.setResource(resource);
+			}
+		}
+		if (!trackedFile) {
+			const createdTrackedFile = new AgentHostTrackedFile(
+				resource,
+				currentResource => this._readCurrentText(currentResource),
+				(repoResource, reader) => this._scmAdapter.getRepo(repoResource, reader),
+				this._logService,
+				() => this._removeTrackedFile(createdTrackedFile),
+				(currentResource, content, currentLanguageId, trigger) => this._flushAgentHostResource(currentResource, content, currentLanguageId, trigger),
+			);
+			trackedFile = createdTrackedFile;
+			this._trackedFiles.set(resourceKey, trackedFile);
+		}
+		this._unifiedTracking.retainAgentResource(resource);
+
+		await trackedFile.applyEdit(languageId);
+	}
+
+	private _flushAgentHostResource(resource: URI, content: string, languageId: string, trigger: EditTelemetryTrigger): void {
+		this._unifiedTracking.applyDiskSnapshot(resource, content);
+		if (this._unifiedTracking.hasLocalLongTermResource(resource)) {
+			return;
+		}
+		this._unifiedTracking.flushLongTermDetails(resource, trigger, languageId).catch(error => {
+			this._logService.error(`[AgentHostEditSourceTracking] Failed to flush unified long-term details: ${error}`);
+		});
+	}
+
+	private async _readSnapshot(resource: URI, connectionAuthority: string): Promise<string | undefined> {
+		return this._readText(toAgentHostUri(resource, connectionAuthority), false);
+	}
+
+	private async _readCurrentText(resource: URI): Promise<string | undefined> {
+		return this._readText(resource, true);
+	}
+
+	private async _readText(resource: URI, missingAsEmpty: boolean): Promise<string | undefined> {
+		try {
+			const value = (await this._fileService.readFile(resource)).value.toString();
+			if (value.includes('\0')) {
+				this._logService.trace(`[AgentHostEditSourceTracking] Skipping binary file ${resource.toString()}`);
+				return undefined;
+			}
+			return value;
+		} catch (error) {
+			if (missingAsEmpty && toFileOperationResult(error) === FileOperationResult.FILE_NOT_FOUND) {
+				return '';
+			}
+			throw error;
+		}
+	}
+
+	private _enqueue(operation: () => Promise<void>): void {
+		const run = async () => {
+			if (!this._isDisposed) {
+				await operation();
+			}
+		};
+		const result = this._operationQueue.then(run, run);
+		this._operationQueue = result.catch(error => {
+			this._logService.error(`[AgentHostEditSourceTracking] Failed to process Agent Host edit: ${error}`);
+		});
+	}
+
+	private _removeTrackedFile(trackedFile: AgentHostTrackedFile): void {
+		for (const [key, value] of this._trackedFiles) {
+			if (value === trackedFile) {
+				this._trackedFiles.delete(key);
+				this._unifiedTracking.releaseAgentResource(trackedFile.resource);
+				trackedFile.dispose();
+				return;
+			}
+		}
+	}
+
+	private _clearTrackedFiles(): void {
+		for (const trackedFile of this._trackedFiles.values()) {
+			this._unifiedTracking.releaseAgentResource(trackedFile.resource);
+			trackedFile.dispose();
+		}
+		this._trackedFiles.clear();
+	}
+
+	override dispose(): void {
+		this._isDisposed = true;
+		this._clearTrackedFiles();
+		super.dispose();
+	}
+}
+
+function firstLine(text: string): string {
+	const lineBreak = text.search(/\r\n|\r|\n/);
+	return lineBreak === -1 ? text : text.substring(0, lineBreak);
+}
+
+export function isDirtyOpenTextModel(resource: URI, modelService: Pick<IModelService, 'getModel'>, textFileService: Pick<ITextFileService, 'isDirty'>): boolean {
+	return modelService.getModel(resource) !== null && textFileService.isDirty(resource);
+}

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTelemetry.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTelemetry.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { forwardToChannelIf } from '../../../../../platform/dataChannel/browser/forwardingTelemetryService.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+
+export type EditTelemetryMode = 'longterm' | '10minFocusWindow' | '20minFocusWindow';
+export type EditTelemetryTrigger = '10hours' | 'hashChange' | 'branchChange' | 'closed' | 'time';
+
+export interface IEditSourcesDetailsTelemetryData {
+	mode: EditTelemetryMode;
+	sourceKey: string;
+	sourceKeyCleaned: string;
+	extensionId: string | undefined;
+	extensionVersion: string | undefined;
+	modelId: string | undefined;
+	trigger: EditTelemetryTrigger;
+	languageId: string;
+	statsUuid: string;
+	conversationId: string | undefined;
+	requestId: string | undefined;
+	origin: string | undefined;
+	harness: string | undefined;
+	modifiedCount: number;
+	deltaModifiedCount: number;
+	totalModifiedCount: number;
+}
+
+type EditSourcesDetailsTelemetryClassification = {
+	owner: 'hediet';
+	comment: 'Provides detailed character count breakdown for individual edit sources (typing, paste, inline completions, NES, etc.) within a session. Reports the top 10-30 sources per session with granular metadata including extension IDs and model IDs for AI edits. Sessions are scoped to either 10-minute or 20-minute focus time windows for visible documents, or longer periods ending on branch changes, commits, or 10-hour intervals. Focus time is computed as the accumulated time where VS Code has focus and there was recent user activity (within the last minute). This event complements editSources.stats by providing source-specific details. @sentToGitHub';
+	mode: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Describes the session mode. Is either \'longterm\', \'10minFocusWindow\', or \'20minFocusWindow\'.' };
+	sourceKey: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'A description of the source of the edit.' };
+	sourceKeyCleaned: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The source of the edit with some properties (such as extensionId, extensionVersion and modelId) removed.' };
+	extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension id.' };
+	extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension.' };
+	modelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The LLM id.' };
+	languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language id of the document.' };
+	statsUuid: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The unique identifier of the session for which stats are reported. The sourceKey is unique in this session.' };
+	conversationId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat conversation identifier when the edit source comes from chat. Sourced from the chat edit session id.' };
+	requestId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat request identifier when the edit source comes from chat.' };
+	origin: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The system that observed and attributed the edit.' };
+	harness: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent harness that produced the edit.' };
+	trigger: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Indicates why the session ended.' };
+	modifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by the given edit source during the session that are still in the text document at the end of the session.'; isMeasurement: true };
+	deltaModifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by the given edit source during the session.'; isMeasurement: true };
+	totalModifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by any edit source during the session that are still in the text document at the end of the session.'; isMeasurement: true };
+};
+
+export function sendEditSourcesDetailsTelemetry(telemetryService: ITelemetryService, data: IEditSourcesDetailsTelemetryData, forwardToGitHub?: boolean): void {
+	telemetryService.publicLog2<IEditSourcesDetailsTelemetryData, EditSourcesDetailsTelemetryClassification>('editTelemetry.editSources.details', {
+		...data,
+		...(forwardToGitHub === undefined ? {} : forwardToChannelIf(forwardToGitHub)),
+	});
+}

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingFeature.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingFeature.ts
@@ -27,6 +27,8 @@ import { DataChannelForwardingTelemetryService } from '../../../../../platform/d
 import { EDIT_TELEMETRY_DETAILS_SETTING_ID, EDIT_TELEMETRY_SHOW_DECORATIONS, EDIT_TELEMETRY_SHOW_STATUS_BAR } from '../settings.js';
 import { VSCodeWorkspace } from '../helpers/vscodeObservableWorkspace.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { AgentHostEditSourceTracking } from './agentHostEditSourceTracking.js';
+import { UnifiedEditSourceTracking } from './unifiedEditSourceTracking.js';
 
 export class EditTrackingFeature extends Disposable {
 
@@ -68,7 +70,9 @@ export class EditTrackingFeature extends Disposable {
 		const instantiationServiceWithInterceptedTelemetry = this._instantiationService.createChild(new ServiceCollection(
 			[ITelemetryService, this._instantiationService.createInstance(DataChannelForwardingTelemetryService)]
 		));
-		const impl = this._register(instantiationServiceWithInterceptedTelemetry.createInstance(EditSourceTrackingImpl, shouldSendDetails, this._annotatedDocuments));
+		const unifiedTracking = this._register(instantiationServiceWithInterceptedTelemetry.createInstance(UnifiedEditSourceTracking, this._workspace));
+		const impl = this._register(instantiationServiceWithInterceptedTelemetry.createInstance(EditSourceTrackingImpl, shouldSendDetails, this._annotatedDocuments, unifiedTracking));
+		this._register(instantiationServiceWithInterceptedTelemetry.createInstance(AgentHostEditSourceTracking, shouldSendDetails, unifiedTracking));
 
 		this._register(autorun((reader) => {
 			if (!this._editSourceTrackingShowDecorations.read(reader)) {

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
@@ -17,9 +17,9 @@ import { DocumentEditSourceTracker, TrackedEdit } from './editTracker.js';
 import { sumByCategory } from '../helpers/utils.js';
 import { IScmRepoAdapter, ScmAdapter } from './scmAdapter.js';
 import { IRandomService } from '../randomService.js';
-
-type EditTelemetryMode = 'longterm' | '10minFocusWindow' | '20minFocusWindow';
-type EditTelemetryTrigger = '10hours' | 'hashChange' | 'branchChange' | 'closed' | 'time';
+import { EditTelemetryMode, EditTelemetryTrigger, sendEditSourcesDetailsTelemetry } from './editSourceTelemetry.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { UnifiedEditSourceTracking } from './unifiedEditSourceTracking.js';
 
 export type EditTelemetryCategory = 'nes' | 'inlineCompletionsCopilot' | 'inlineCompletionsNES' | 'inlineCompletionsOther' | 'otherAI' | 'user' | 'ide' | 'external' | 'unknown';
 
@@ -45,13 +45,20 @@ export class EditSourceTrackingImpl extends Disposable {
 	constructor(
 		private readonly _statsEnabled: IObservable<boolean>,
 		private readonly _annotatedDocuments: IAnnotatedDocuments,
+		private readonly _unifiedTracking: UnifiedEditSourceTracking | undefined,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
 
 		const scmBridge = this._instantiationService.createInstance(ScmAdapter);
 		this._states = mapObservableArrayCached(this, this._annotatedDocuments.documents, (doc, store) => {
-			return [doc.document, store.add(this._instantiationService.createInstance(TrackedDocumentInfo, doc, scmBridge, this._statsEnabled))] as const;
+			return [doc.document, store.add(this._instantiationService.createInstance(
+				TrackedDocumentInfo,
+				doc,
+				scmBridge,
+				this._statsEnabled,
+				this._unifiedTracking,
+			))] as const;
 		});
 		this.docsState = this._states.map((entries) => new Map(entries));
 
@@ -70,14 +77,17 @@ class TrackedDocumentInfo extends Disposable {
 		private readonly _doc: AnnotatedDocument,
 		private readonly _scm: ScmAdapter,
 		private readonly _statsEnabled: IObservable<boolean>,
+		private readonly _unifiedTracking: UnifiedEditSourceTracking | undefined,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IRandomService private readonly _randomService: IRandomService,
 		@IUserAttentionService private readonly _userAttentionService: IUserAttentionService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 
 		this._repo = derived(this, reader => this._scm.getRepo(_doc.document.uri, reader));
+		this._unifiedTracking?.retainLocalLongTermResource(this._doc.document.uri);
 
 		const docWithJustReason = createDocWithJustReason(_doc.documentWithAnnotations, this._store);
 
@@ -92,9 +102,11 @@ class TrackedDocumentInfo extends Disposable {
 			const startFocusTime = this._userAttentionService.totalFocusTimeMs;
 			const startTime = Date.now();
 			reader.store.add(toDisposable(() => {
+				const statsUuid = this._randomService.generateUuid();
+				this._flushLongTermDetails(longtermReason, statsUuid);
 				// send long term document telemetry
 				if (!t.isEmpty()) {
-					this.sendTelemetry('longterm', longtermReason, t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
+					this.sendTelemetry('longterm', longtermReason, t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime, statsUuid);
 				}
 				t.dispose();
 			}));
@@ -187,7 +199,29 @@ class TrackedDocumentInfo extends Disposable {
 
 	}
 
-	async sendTelemetry(mode: EditTelemetryMode, trigger: EditTelemetryTrigger, t: DocumentEditSourceTracker, focusTime: number, actualTime: number) {
+	private _flushLongTermDetails(trigger: EditTelemetryTrigger, statsUuid: string): void {
+		const unifiedTracking = this._unifiedTracking;
+		if (!unifiedTracking) {
+			return;
+		}
+		unifiedTracking.flushLongTermDetails(
+			this._doc.document.uri,
+			trigger,
+			this._doc.document.languageId.get(),
+			statsUuid,
+		).catch(error => {
+			this._logService.error(`[EditSourceTrackingImpl] Failed to flush unified long-term details: ${error}`);
+		});
+	}
+
+	async sendTelemetry(
+		mode: EditTelemetryMode,
+		trigger: EditTelemetryTrigger,
+		t: DocumentEditSourceTracker,
+		focusTime: number,
+		actualTime: number,
+		statsUuid = this._randomService.generateUuid(),
+	) {
 		const ranges = t.getTrackedRanges();
 		const keys = t.getAllKeys();
 		if (keys.length === 0) {
@@ -196,81 +230,41 @@ class TrackedDocumentInfo extends Disposable {
 
 		const data = this.getTelemetryData(ranges);
 
-		const statsUuid = this._randomService.generateUuid();
-
-		const sums = sumByCategory(ranges, r => r.range.length, r => r.sourceKey);
-		for (const key of keys) {
-			if (!sums[key]) {
-				sums[key] = 0;
+		if (mode !== 'longterm' || !this._unifiedTracking) {
+			const sums = sumByCategory(ranges, r => r.range.length, r => r.sourceKey);
+			for (const key of keys) {
+				if (!sums[key]) {
+					sums[key] = 0;
+				}
 			}
-		}
-		const entries = Object.entries(sums)
-			.filter((entry): entry is [string, number] => entry[1] !== undefined)
-			.sort(reverseOrder(compareBy(([, value]) => value, numberComparator)))
-			.slice(0, mode === 'longterm' ? 30 : 10);
+			const entries = Object.entries(sums)
+				.filter((entry): entry is [string, number] => entry[1] !== undefined)
+				.sort(reverseOrder(compareBy(([, value]) => value, numberComparator)))
+				.slice(0, mode === 'longterm' ? 30 : 10);
 
-		for (const [key, value] of entries) {
-			const repr = t.getRepresentative(key)!;
-			const deltaModifiedCount = t.getTotalInsertedCharactersCount(key);
+			for (const [key, value] of entries) {
+				const repr = t.getRepresentative(key)!;
+				const deltaModifiedCount = t.getTotalInsertedCharactersCount(key);
 
-			this._telemetryService.publicLog2<{
-				mode: EditTelemetryMode;
-				sourceKey: string;
-
-				sourceKeyCleaned: string;
-				extensionId: string | undefined;
-				extensionVersion: string | undefined;
-				modelId: string | undefined;
-
-				trigger: EditTelemetryTrigger;
-				languageId: string;
-				statsUuid: string;
-				conversationId: string | undefined;
-				requestId: string | undefined;
-				modifiedCount: number;
-				deltaModifiedCount: number;
-				totalModifiedCount: number;
-			}, {
-				owner: 'hediet';
-				comment: 'Provides detailed character count breakdown for individual edit sources (typing, paste, inline completions, NES, etc.) within a session. Reports the top 10-30 sources per session with granular metadata including extension IDs and model IDs for AI edits. Sessions are scoped to either 10-minute or 20-minute focus time windows for visible documents, or longer periods ending on branch changes, commits, or 10-hour intervals. Focus time is computed as the accumulated time where VS Code has focus and there was recent user activity (within the last minute). This event complements editSources.stats by providing source-specific details. @sentToGitHub';
-
-				mode: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Describes the session mode. Is either \'longterm\', \'10minFocusWindow\', or \'20minFocusWindow\'.' };
-				sourceKey: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'A description of the source of the edit.' };
-
-				sourceKeyCleaned: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The source of the edit with some properties (such as extensionId, extensionVersion and modelId) removed.' };
-				extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension id.' };
-				extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension.' };
-				modelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The LLM id.' };
-
-				languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language id of the document.' };
-				statsUuid: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The unique identifier of the session for which stats are reported. The sourceKey is unique in this session.' };
-				conversationId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat conversation identifier when the edit source comes from chat. Sourced from the chat edit session id.' };
-				requestId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat request identifier when the edit source comes from chat.' };
-
-				trigger: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Indicates why the session ended.' };
-
-				modifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by the given edit source during the session that are still in the text document at the end of the session.'; isMeasurement: true };
-				deltaModifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by the given edit source during the session.'; isMeasurement: true };
-				totalModifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by any edit source during the session that are still in the text document at the end of the session.'; isMeasurement: true };
-
-			}>('editTelemetry.editSources.details', {
-				mode,
-				sourceKey: key,
-
-				sourceKeyCleaned: repr.toKey(1, { $extensionId: false, $extensionVersion: false, $modelId: false }),
-				extensionId: repr.props.$extensionId,
-				extensionVersion: repr.props.$extensionVersion,
-				modelId: repr.props.$modelId,
-
-				trigger,
-				languageId: this._doc.document.languageId.get(),
-				statsUuid: statsUuid,
-				conversationId: repr.props.$$sessionId,
-				requestId: repr.props.$$requestId,
-				modifiedCount: value,
-				deltaModifiedCount: deltaModifiedCount,
-				totalModifiedCount: data.totalModifiedCharactersInFinalState,
-			});
+				sendEditSourcesDetailsTelemetry(this._telemetryService, {
+					mode,
+					sourceKey: key,
+					sourceKeyCleaned: repr.toKey(1, { $extensionId: false, $extensionVersion: false, $modelId: false }),
+					extensionId: repr.props.$extensionId,
+					extensionVersion: repr.props.$extensionVersion,
+					modelId: repr.props.$modelId,
+					trigger,
+					languageId: this._doc.document.languageId.get(),
+					statsUuid,
+					conversationId: repr.props.$$sessionId,
+					requestId: repr.props.$$requestId,
+					origin: repr.props.$origin,
+					harness: repr.props.$harness,
+					modifiedCount: value,
+					deltaModifiedCount,
+					totalModifiedCount: data.totalModifiedCharactersInFinalState,
+				});
+			}
 		}
 
 
@@ -331,6 +325,11 @@ class TrackedDocumentInfo extends Disposable {
 			actualTime,
 			trigger,
 		});
+	}
+
+	override dispose(): void {
+		super.dispose();
+		this._unifiedTracking?.releaseLocalLongTermResource(this._doc.document.uri);
 	}
 
 	getTelemetryData(ranges: readonly TrackedEdit[]) {

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editTracker.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editTracker.ts
@@ -80,6 +80,15 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 		return this._representativePerKey.get(key);
 	}
 
+	public applyPendingExternalEdits(): void {
+		if (this._pendingExternalEdits.isEmpty()) {
+			return;
+		}
+		this._applyEdit(this._pendingExternalEdits);
+		this._pendingExternalEdits = AnnotatedStringEdit.empty;
+		this._update.trigger(undefined);
+	}
+
 	public getTrackedRanges(reader?: IReader): TrackedEdit[] {
 		this._update.read(reader);
 		const ranges = this._edits.getNewRanges();

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedDocumentTrackerProjection.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedDocumentTrackerProjection.ts
@@ -1,0 +1,204 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IObservableWithChange, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { AnnotatedStringEdit, StringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
+import { StringText } from '../../../../../editor/common/core/text/abstractText.js';
+import { TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
+import { EditKeySourceData, EditSourceData, IDocumentWithAnnotatedEdits } from '../helpers/documentWithAnnotatedEdits.js';
+import { IUnifiedDocumentSnapshot } from '../helpers/unifiedDocumentReconciler.js';
+import { DocumentEditSourceTracker } from './editTracker.js';
+
+export type UnifiedDocumentComputeDiff = (before: string, after: string) => Promise<StringEdit>;
+
+export interface IEditTrackerSourceSnapshot {
+	readonly sourceKey: string;
+	readonly sourceIndex: number;
+	readonly retainedIndex: number | undefined;
+	readonly representativeKey: string;
+	readonly cleanedSourceKey: string;
+	readonly extensionId: string | undefined;
+	readonly extensionVersion: string | undefined;
+	readonly modelId: string | undefined;
+	readonly conversationId: string | undefined;
+	readonly requestId: string | undefined;
+	readonly origin: string | undefined;
+	readonly harness: string | undefined;
+	readonly insertedCount: number;
+	readonly retainedCount: number;
+}
+
+export interface IEditTrackerRangeSnapshot {
+	readonly start: number;
+	readonly endExclusive: number;
+	readonly sourceKey: string;
+}
+
+export interface IEditTrackerSnapshot {
+	readonly content: string;
+	readonly targetContent: string;
+	readonly hasPendingReload: boolean;
+	readonly totalRetainedCount: number;
+	readonly sources: readonly IEditTrackerSourceSnapshot[];
+	readonly ranges: readonly IEditTrackerRangeSnapshot[];
+}
+
+export interface IEditSourceDetailsRowSnapshot {
+	readonly sourceKey: string;
+	readonly cleanedSourceKey: string;
+	readonly extensionId: string | undefined;
+	readonly extensionVersion: string | undefined;
+	readonly modelId: string | undefined;
+	readonly conversationId: string | undefined;
+	readonly requestId: string | undefined;
+	readonly origin: string | undefined;
+	readonly harness: string | undefined;
+	readonly modifiedCount: number;
+	readonly deltaModifiedCount: number;
+}
+
+export interface IEditSourceDetailsSnapshot {
+	readonly totalModifiedCount: number;
+	readonly rows: readonly IEditSourceDetailsRowSnapshot[];
+}
+
+export type EditSourceDetailsOrder = 'tracker' | 'retained';
+
+/**
+ * Replays a unified transition snapshot through the existing edit-source tracker.
+ */
+export async function projectUnifiedDocumentTracker(
+	snapshot: IUnifiedDocumentSnapshot<TextModelEditSource>,
+	computeDiff: UnifiedDocumentComputeDiff,
+): Promise<IEditTrackerSnapshot> {
+	const store = new DisposableStore();
+	try {
+		const document = store.add(new ProjectionDocument(snapshot.initialContent));
+		const tracker = store.add(new DocumentEditSourceTracker(document, undefined));
+		let content = snapshot.initialContent;
+		for (const transition of snapshot.transitions) {
+			if (transition.before !== content) {
+				throw new Error(`Unified transition ${transition.id} starts from unexpected content`);
+			}
+			if (transition.before !== transition.after) {
+				const edit = await computeDiff(transition.before, transition.after);
+				document.apply(edit, transition.source);
+			}
+			content = transition.after;
+		}
+		await tracker.waitForQueue();
+		tracker.applyPendingExternalEdits();
+
+		if (snapshot.pendingReload) {
+			if (snapshot.pendingReload.before !== content || snapshot.pendingReload.after !== snapshot.content) {
+				throw new Error('Unified pending reload does not connect projected and target content');
+			}
+		} else if (content !== snapshot.content) {
+			throw new Error('Unified transition replay produced unexpected content');
+		}
+
+		return snapshotDocumentEditSourceTracker(tracker, content, snapshot.content, !!snapshot.pendingReload);
+	} finally {
+		store.dispose();
+	}
+}
+
+export function snapshotDocumentEditSourceTracker(
+	tracker: DocumentEditSourceTracker,
+	content: string,
+	targetContent = content,
+	hasPendingReload = false,
+): IEditTrackerSnapshot {
+	const ranges = tracker.getTrackedRanges().map(range => ({
+		start: range.range.start,
+		endExclusive: range.range.endExclusive,
+		sourceKey: range.sourceKey,
+	}));
+	const retainedByKey = new Map<string, number>();
+	const retainedIndexByKey = new Map<string, number>();
+	for (const [rangeIndex, range] of ranges.entries()) {
+		retainedByKey.set(range.sourceKey, (retainedByKey.get(range.sourceKey) ?? 0) + range.endExclusive - range.start);
+		if (!retainedIndexByKey.has(range.sourceKey)) {
+			retainedIndexByKey.set(range.sourceKey, rangeIndex);
+		}
+	}
+	const sources = tracker.getAllKeys().map((sourceKey, sourceIndex) => {
+		const representative = tracker.getRepresentative(sourceKey);
+		return {
+			sourceKey,
+			sourceIndex,
+			retainedIndex: retainedIndexByKey.get(sourceKey),
+			representativeKey: representative?.toKey(Number.MAX_SAFE_INTEGER) ?? '',
+			cleanedSourceKey: representative?.toKey(1, { $extensionId: false, $extensionVersion: false, $modelId: false }) ?? '',
+			extensionId: representative?.props.$extensionId,
+			extensionVersion: representative?.props.$extensionVersion,
+			modelId: representative?.props.$modelId,
+			conversationId: representative?.props.$$sessionId,
+			requestId: representative?.props.$$requestId,
+			origin: representative?.props.$origin,
+			harness: representative?.props.$harness,
+			insertedCount: tracker.getTotalInsertedCharactersCount(sourceKey),
+			retainedCount: retainedByKey.get(sourceKey) ?? 0,
+		};
+	}).sort((left, right) => left.sourceKey.localeCompare(right.sourceKey));
+
+	return {
+		content,
+		targetContent,
+		hasPendingReload,
+		totalRetainedCount: ranges.reduce((sum, range) => sum + range.endExclusive - range.start, 0),
+		sources,
+		ranges,
+	};
+}
+
+export function snapshotEditSourceDetails(
+	snapshot: IEditTrackerSnapshot,
+	limit = 30,
+	order: EditSourceDetailsOrder = 'tracker',
+): IEditSourceDetailsSnapshot {
+	const getOrder = (source: IEditTrackerSourceSnapshot) => order === 'retained'
+		? source.retainedIndex ?? snapshot.ranges.length + source.sourceIndex
+		: source.sourceIndex;
+	const sources = snapshot.sources
+		.toSorted((left, right) => right.retainedCount - left.retainedCount || getOrder(left) - getOrder(right))
+		.slice(0, limit);
+	return {
+		totalModifiedCount: snapshot.sources.reduce((sum, source) => sum + source.retainedCount, 0),
+		rows: sources.map(source => ({
+			sourceKey: source.sourceKey,
+			cleanedSourceKey: source.cleanedSourceKey,
+			extensionId: source.extensionId,
+			extensionVersion: source.extensionVersion,
+			modelId: source.modelId,
+			conversationId: source.conversationId,
+			requestId: source.requestId,
+			origin: source.origin,
+			harness: source.harness,
+			modifiedCount: source.retainedCount,
+			deltaModifiedCount: source.insertedCount,
+		})),
+	};
+}
+
+class ProjectionDocument extends Disposable implements IDocumentWithAnnotatedEdits<EditKeySourceData> {
+	private readonly _value: ISettableObservable<StringText, { edit: AnnotatedStringEdit<EditKeySourceData> }>;
+	readonly value: IObservableWithChange<StringText, { edit: AnnotatedStringEdit<EditKeySourceData> }>;
+
+	constructor(initialContent: string) {
+		super();
+		this.value = this._value = observableValue(this, new StringText(initialContent));
+	}
+
+	apply(edit: StringEdit, source: TextModelEditSource): void {
+		const data = new EditSourceData(source).toEditSourceData();
+		this._value.set(edit.applyOnText(this._value.get()), undefined, { edit: edit.mapData(() => data) });
+	}
+
+	waitForQueue(): Promise<void> {
+		return Promise.resolve();
+	}
+}

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedDocumentTrackerProjection.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedDocumentTrackerProjection.ts
@@ -5,14 +5,12 @@
 
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { IObservableWithChange, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
-import { AnnotatedStringEdit, StringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
+import { AnnotatedStringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
 import { StringText } from '../../../../../editor/common/core/text/abstractText.js';
 import { TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
 import { EditKeySourceData, EditSourceData, IDocumentWithAnnotatedEdits } from '../helpers/documentWithAnnotatedEdits.js';
 import { IUnifiedDocumentSnapshot } from '../helpers/unifiedDocumentReconciler.js';
 import { DocumentEditSourceTracker } from './editTracker.js';
-
-export type UnifiedDocumentComputeDiff = (before: string, after: string) => Promise<StringEdit>;
 
 export interface IEditTrackerSourceSnapshot {
 	readonly sourceKey: string;
@@ -72,7 +70,6 @@ export type EditSourceDetailsOrder = 'tracker' | 'retained';
  */
 export async function projectUnifiedDocumentTracker(
 	snapshot: IUnifiedDocumentSnapshot<TextModelEditSource>,
-	computeDiff: UnifiedDocumentComputeDiff,
 ): Promise<IEditTrackerSnapshot> {
 	const store = new DisposableStore();
 	try {
@@ -80,14 +77,8 @@ export async function projectUnifiedDocumentTracker(
 		const tracker = store.add(new DocumentEditSourceTracker(document, undefined));
 		let content = snapshot.initialContent;
 		for (const transition of snapshot.transitions) {
-			if (transition.before !== content) {
-				throw new Error(`Unified transition ${transition.id} starts from unexpected content`);
-			}
-			if (transition.before !== transition.after) {
-				const edit = await computeDiff(transition.before, transition.after);
-				document.apply(edit, transition.source);
-			}
-			content = transition.after;
+			document.apply(transition);
+			content = document.content;
 		}
 		await tracker.waitForQueue();
 		tracker.applyPendingExternalEdits();
@@ -193,9 +184,13 @@ class ProjectionDocument extends Disposable implements IDocumentWithAnnotatedEdi
 		this.value = this._value = observableValue(this, new StringText(initialContent));
 	}
 
-	apply(edit: StringEdit, source: TextModelEditSource): void {
-		const data = new EditSourceData(source).toEditSourceData();
-		this._value.set(edit.applyOnText(this._value.get()), undefined, { edit: edit.mapData(() => data) });
+	get content(): string {
+		return this._value.get().value;
+	}
+
+	apply(transition: IUnifiedDocumentSnapshot<TextModelEditSource>['transitions'][number]): void {
+		const data = new EditSourceData(transition.source).toEditSourceData();
+		this._value.set(transition.edit.applyOnText(this._value.get()), undefined, { edit: transition.edit.mapData(() => data) });
 	}
 
 	waitForQueue(): Promise<void> {

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedEditSourceTracking.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedEditSourceTracking.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { mapObservableArrayCached } from '../../../../../base/common/observable.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { IObservableWithChange, ISettableObservable, mapObservableArrayCached, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { AnnotatedStringEdit, StringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
+import { StringText } from '../../../../../editor/common/core/text/abstractText.js';
 import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
 import { EditSources, TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
 import { FileOperationResult, IFileService, toFileOperationResult } from '../../../../../platform/files/common/files.js';
@@ -13,7 +15,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
-import { DiffService } from '../helpers/documentWithAnnotatedEdits.js';
+import { DiffService, EditKeySourceData, EditSourceData, IDocumentWithAnnotatedEdits } from '../helpers/documentWithAnnotatedEdits.js';
 import { ObservableWorkspace } from '../helpers/observableWorkspace.js';
 import {
 	applyUnifiedDocumentAgentEdit,
@@ -25,28 +27,28 @@ import {
 	IUnifiedDocumentRegistryResult,
 	UnifiedDocumentRegistry,
 } from '../helpers/unifiedDocumentRegistry.js';
-import { IUnifiedDocumentSnapshot, IUnifiedDocumentTransition } from '../helpers/unifiedDocumentReconciler.js';
+import {
+	IUnifiedDocumentSnapshot,
+	IUnifiedDocumentTransition,
+	IUnifiedDocumentTransitionChange,
+} from '../helpers/unifiedDocumentReconciler.js';
 import { IRandomService } from '../randomService.js';
 import { EditTelemetryTrigger, sendEditSourcesDetailsTelemetry } from './editSourceTelemetry.js';
+import { DocumentEditSourceTracker } from './editTracker.js';
 import {
 	IEditSourceDetailsSnapshot,
 	IEditTrackerSnapshot,
-	projectUnifiedDocumentTracker,
+	snapshotDocumentEditSourceTracker,
 	snapshotEditSourceDetails,
 } from './unifiedDocumentTrackerProjection.js';
-
-interface IUnifiedEditSourceTrackingCheckpoint {
-	readonly content: string;
-	readonly maxTransitionId: number;
-}
 
 /**
  * Owns the canonical edit stream and long-term details windows for each resource.
  */
 export class UnifiedEditSourceTracking extends Disposable {
 	private readonly _registry: UnifiedDocumentRegistry<TextModelEditSource>;
+	private readonly _trackedResources = new Map<string, UnifiedTrackedResource>();
 	private readonly _lastResults = new Map<string, IUnifiedDocumentRegistryResult<TextModelEditSource>>();
-	private readonly _longTermCheckpoints = new Map<string, IUnifiedEditSourceTrackingCheckpoint>();
 	private readonly _flushQueues = new Map<string, Promise<IEditSourceDetailsSnapshot | undefined>>();
 	private readonly _retainedAgentResources = new Set<string>();
 	private readonly _localLongTermResources = new Set<string>();
@@ -78,7 +80,7 @@ export class UnifiedEditSourceTracking extends Disposable {
 				() => this._textFileService.isDirty(document.uri),
 				change => change.reason,
 				result => {
-					this._recordResult(result.result);
+					this._applyResult(result.result);
 					if (result.inputKind === 'disconnected') {
 						this._scheduleCleanup(result.result.resource);
 					}
@@ -87,15 +89,18 @@ export class UnifiedEditSourceTracking extends Disposable {
 		}).recomputeInitiallyAndOnChange(this._store);
 	}
 
-	applyAgentEdit(edit: IUnifiedDocumentAgentEdit<TextModelEditSource>): IUnifiedDocumentAgentAdapterResult<TextModelEditSource> {
-		const result = applyUnifiedDocumentAgentEdit(this._registry, edit);
-		this._recordResult(result.transitionResult);
+	async applyAgentEdit(edit: Omit<IUnifiedDocumentAgentEdit<TextModelEditSource>, 'edit'>): Promise<IUnifiedDocumentAgentAdapterResult<TextModelEditSource>> {
+		const stringEdit = await this._computeSnapshotEdit(edit.before, edit.after);
+		const result = applyUnifiedDocumentAgentEdit(this._registry, { ...edit, edit: stringEdit });
+		this._applyResult(result.transitionResult);
+		if (result.transitionResult.outcome === 'conflict' || result.transitionResult.outcome === 'skippedDirty') {
+			this._scheduleCleanup(result.transitionResult.resource);
+		}
 		if (result.transferResult) {
-			if (edit.previousResource) {
-				this._lastResults.delete(this._key(edit.previousResource));
+			this._recordResult(result.transferResult);
+			if (result.transferResult.outcome === 'applied' && edit.previousResource) {
 				this._transferResourceState(edit.previousResource, edit.resource);
 			}
-			this._recordResult(result.transferResult);
 		}
 		return result;
 	}
@@ -122,9 +127,11 @@ export class UnifiedEditSourceTracking extends Disposable {
 		return this._localLongTermResources.has(this._key(resource));
 	}
 
-	applyDiskSnapshot(resource: URI, content: string): IUnifiedDocumentRegistryResult<TextModelEditSource> {
-		const result = this._registry.diskSnapshot(resource, content);
-		this._recordResult(result);
+	async applyDiskSnapshot(resource: URI, content: string): Promise<IUnifiedDocumentRegistryResult<TextModelEditSource>> {
+		const snapshot = this.getSnapshot(resource);
+		const edit = await this._computeSnapshotEdit(snapshot?.content ?? content, content);
+		const result = this._registry.diskSnapshot(resource, content, edit);
+		this._applyResult(result);
 		return result;
 	}
 
@@ -136,9 +143,8 @@ export class UnifiedEditSourceTracking extends Disposable {
 		return this._registry.get(resource)?.reconciler.getSnapshot();
 	}
 
-	async project(resource: URI): Promise<IEditTrackerSnapshot | undefined> {
-		const snapshot = this.getSnapshot(resource);
-		return snapshot ? projectUnifiedDocumentTracker(snapshot, (before, after) => this._diffService.computeDiff(before, after)) : undefined;
+	project(resource: URI): IEditTrackerSnapshot | undefined {
+		return this._trackedResources.get(this._key(resource))?.snapshot();
 	}
 
 	flushLongTermDetails(
@@ -168,34 +174,14 @@ export class UnifiedEditSourceTracking extends Disposable {
 		statsUuid: string,
 	): Promise<IEditSourceDetailsSnapshot | undefined> {
 		await this._synchronizeDisk(resource);
-		const snapshot = this.getSnapshot(resource);
-		if (!snapshot) {
-			return undefined;
-		}
-		const checkpoint = this._longTermCheckpoints.get(resourceKey);
-		const transitions = checkpoint
-			? snapshot.transitions.filter(transition => transition.id > checkpoint.maxTransitionId)
-			: snapshot.transitions;
-		const pendingReload = snapshot.pendingReload && (!checkpoint || snapshot.pendingReload.id > checkpoint.maxTransitionId)
-			? snapshot.pendingReload
-			: undefined;
-		if (transitions.length === 0) {
-			if (!pendingReload) {
-				this._longTermCheckpoints.set(resourceKey, createCheckpoint(snapshot.content, snapshot.transitions));
-			}
+		const reconciler = this._registry.get(resource)?.reconciler;
+		const snapshot = reconciler?.getSnapshot();
+		const trackedResource = this._trackedResources.get(resourceKey);
+		if (!reconciler || !snapshot || !trackedResource || snapshot.pendingReload || snapshot.transitions.length === 0) {
 			return undefined;
 		}
 
-		const windowSnapshot: IUnifiedDocumentSnapshot<TextModelEditSource> = {
-			...snapshot,
-			initialContent: checkpoint?.content ?? snapshot.initialContent,
-			transitions,
-			pendingReload,
-		};
-		const trackerSnapshot = await projectUnifiedDocumentTracker(
-			windowSnapshot,
-			(before, after) => this._diffService.computeDiff(before, after),
-		);
+		const trackerSnapshot = trackedResource.snapshot();
 		const details = snapshotEditSourceDetails(trackerSnapshot, 30, 'retained');
 		if (details.rows.length > 0) {
 			for (const row of details.rows) {
@@ -219,7 +205,8 @@ export class UnifiedEditSourceTracking extends Disposable {
 				}, row.origin === 'agentHost' ? row.harness === 'copilotcli' : undefined);
 			}
 		}
-		this._longTermCheckpoints.set(resourceKey, createCheckpoint(trackerSnapshot.content, transitions));
+		trackedResource.reset(snapshot.content);
+		reconciler.resetWindow();
 		return details;
 	}
 
@@ -231,14 +218,30 @@ export class UnifiedEditSourceTracking extends Disposable {
 		try {
 			const content = (await this._fileService.readFile(resource)).value.toString();
 			if (!content.includes('\0')) {
-				this.applyDiskSnapshot(resource, content);
+				await this.applyDiskSnapshot(resource, content);
 			}
 		} catch (error) {
 			if (toFileOperationResult(error) === FileOperationResult.FILE_NOT_FOUND) {
-				this.applyDiskSnapshot(resource, '');
+				await this.applyDiskSnapshot(resource, '');
 				return;
 			}
 			throw error;
+		}
+	}
+
+	private _applyResult(result: IUnifiedDocumentRegistryResult<TextModelEditSource>): void {
+		this._recordResult(result);
+		const key = this._key(result.resource);
+		let trackedResource = this._trackedResources.get(key);
+		if (!trackedResource) {
+			trackedResource = new UnifiedTrackedResource(result.reconcileResult?.snapshot.initialContent ?? '');
+			this._trackedResources.set(key, trackedResource);
+		}
+		const changes = result.reconcileResult?.changes ?? [];
+		if (changes.some(change => change.kind === 'replace')) {
+			trackedResource.rebuild(result.reconcileResult!.snapshot);
+		} else {
+			trackedResource.apply(changes);
 		}
 	}
 
@@ -249,10 +252,10 @@ export class UnifiedEditSourceTracking extends Disposable {
 	private _transferResourceState(previousResource: URI, resource: URI): void {
 		const previousKey = this._key(previousResource);
 		const key = this._key(resource);
-		const checkpoint = this._longTermCheckpoints.get(previousKey);
-		if (checkpoint) {
-			this._longTermCheckpoints.delete(previousKey);
-			this._longTermCheckpoints.set(key, checkpoint);
+		const trackedResource = this._trackedResources.get(previousKey);
+		if (trackedResource) {
+			this._trackedResources.delete(previousKey);
+			this._trackedResources.set(key, trackedResource);
 		}
 		if (this._retainedAgentResources.delete(previousKey)) {
 			this._retainedAgentResources.add(key);
@@ -272,24 +275,96 @@ export class UnifiedEditSourceTracking extends Disposable {
 			}
 			this._registry.delete(resource);
 			this._lastResults.delete(resourceKey);
-			this._longTermCheckpoints.delete(resourceKey);
+			this._trackedResources.get(resourceKey)?.dispose();
+			this._trackedResources.delete(resourceKey);
 		}, error => {
 			this._logService.error(`[UnifiedEditSourceTracking] Failed to finish resource cleanup: ${error}`);
 		});
 	}
 
+	private async _computeSnapshotEdit(before: string, after: string): Promise<StringEdit> {
+		if (before === after) {
+			return StringEdit.empty;
+		}
+		return (await this._diffService.computeDiff(before, after)).removeCommonSuffixPrefix(before);
+	}
+
 	private _key(resource: URI): string {
 		return this._uriIdentityService.extUri.getComparisonKey(this._uriIdentityService.asCanonicalUri(resource));
 	}
+
+	override dispose(): void {
+		for (const trackedResource of this._trackedResources.values()) {
+			trackedResource.dispose();
+		}
+		this._trackedResources.clear();
+		super.dispose();
+	}
 }
 
-function createCheckpoint(
-	content: string,
-	transitions: readonly IUnifiedDocumentTransition<TextModelEditSource>[],
-): IUnifiedEditSourceTrackingCheckpoint {
-	let maxTransitionId = 0;
-	for (const transition of transitions) {
-		maxTransitionId = Math.max(maxTransitionId, transition.id);
+class UnifiedTrackedResource extends Disposable {
+	private readonly _active = this._register(new MutableDisposable<DisposableStore>());
+	private _document!: UnifiedTrackingDocument;
+	private _tracker!: DocumentEditSourceTracker;
+
+	constructor(initialContent: string) {
+		super();
+		this.reset(initialContent);
 	}
-	return { content, maxTransitionId };
+
+	apply(changes: readonly IUnifiedDocumentTransitionChange<TextModelEditSource>[]): void {
+		for (const change of changes) {
+			if (change.kind !== 'append') {
+				throw new Error('Replacement changes require a tracker rebuild');
+			}
+			this._document.apply(change.before, change.after, change.transition);
+		}
+	}
+
+	rebuild(snapshot: IUnifiedDocumentSnapshot<TextModelEditSource>): void {
+		this.reset(snapshot.initialContent);
+		for (const transition of snapshot.transitions) {
+			const before = this._document.content;
+			const after = transition.edit.apply(before);
+			this._document.apply(before, after, transition);
+		}
+	}
+
+	snapshot(): IEditTrackerSnapshot {
+		this._tracker.applyPendingExternalEdits();
+		return snapshotDocumentEditSourceTracker(this._tracker, this._document.content);
+	}
+
+	reset(content: string): void {
+		const store = new DisposableStore();
+		this._document = store.add(new UnifiedTrackingDocument(content));
+		this._tracker = store.add(new DocumentEditSourceTracker(this._document, undefined));
+		this._active.value = store;
+	}
+}
+
+class UnifiedTrackingDocument extends Disposable implements IDocumentWithAnnotatedEdits<EditKeySourceData> {
+	private readonly _value: ISettableObservable<StringText, { edit: AnnotatedStringEdit<EditKeySourceData> }>;
+	readonly value: IObservableWithChange<StringText, { edit: AnnotatedStringEdit<EditKeySourceData> }>;
+
+	constructor(initialContent: string) {
+		super();
+		this.value = this._value = observableValue(this, new StringText(initialContent));
+	}
+
+	get content(): string {
+		return this._value.get().value;
+	}
+
+	apply(before: string, after: string, transition: IUnifiedDocumentTransition<TextModelEditSource>): void {
+		if (this.content !== before || transition.edit.apply(before) !== after) {
+			throw new Error('Unified transition does not connect to the tracked document');
+		}
+		const data = new EditSourceData(transition.source).toEditSourceData();
+		this._value.set(new StringText(after), undefined, { edit: transition.edit.mapData(() => data) });
+	}
+
+	waitForQueue(): Promise<void> {
+		return Promise.resolve();
+	}
 }

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedEditSourceTracking.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedEditSourceTracking.ts
@@ -1,0 +1,295 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { mapObservableArrayCached } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
+import { EditSources, TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
+import { FileOperationResult, IFileService, toFileOperationResult } from '../../../../../platform/files/common/files.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { DiffService } from '../helpers/documentWithAnnotatedEdits.js';
+import { ObservableWorkspace } from '../helpers/observableWorkspace.js';
+import {
+	applyUnifiedDocumentAgentEdit,
+	IUnifiedDocumentAgentAdapterResult,
+	IUnifiedDocumentAgentEdit,
+	UnifiedDocumentModelAdapter,
+} from '../helpers/unifiedDocumentAdapters.js';
+import {
+	IUnifiedDocumentRegistryResult,
+	UnifiedDocumentRegistry,
+} from '../helpers/unifiedDocumentRegistry.js';
+import { IUnifiedDocumentSnapshot, IUnifiedDocumentTransition } from '../helpers/unifiedDocumentReconciler.js';
+import { IRandomService } from '../randomService.js';
+import { EditTelemetryTrigger, sendEditSourcesDetailsTelemetry } from './editSourceTelemetry.js';
+import {
+	IEditSourceDetailsSnapshot,
+	IEditTrackerSnapshot,
+	projectUnifiedDocumentTracker,
+	snapshotEditSourceDetails,
+} from './unifiedDocumentTrackerProjection.js';
+
+interface IUnifiedEditSourceTrackingCheckpoint {
+	readonly content: string;
+	readonly maxTransitionId: number;
+}
+
+/**
+ * Owns the canonical edit stream and long-term details windows for each resource.
+ */
+export class UnifiedEditSourceTracking extends Disposable {
+	private readonly _registry: UnifiedDocumentRegistry<TextModelEditSource>;
+	private readonly _lastResults = new Map<string, IUnifiedDocumentRegistryResult<TextModelEditSource>>();
+	private readonly _longTermCheckpoints = new Map<string, IUnifiedEditSourceTrackingCheckpoint>();
+	private readonly _flushQueues = new Map<string, Promise<IEditSourceDetailsSnapshot | undefined>>();
+	private readonly _retainedAgentResources = new Set<string>();
+	private readonly _localLongTermResources = new Set<string>();
+	private readonly _diffService: DiffService;
+
+	constructor(
+		workspace: ObservableWorkspace,
+		@IFileService private readonly _fileService: IFileService,
+		@ITextFileService private readonly _textFileService: ITextFileService,
+		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService,
+		@IEditorWorkerService editorWorkerService: IEditorWorkerService,
+		@IRandomService private readonly _randomService: IRandomService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+		this._diffService = new DiffService(editorWorkerService);
+		this._registry = new UnifiedDocumentRegistry({
+			externalSource: EditSources.reloadFromDisk(),
+			canonicalize: resource => this._uriIdentityService.asCanonicalUri(resource),
+			getComparisonKey: resource => this._uriIdentityService.extUri.getComparisonKey(resource),
+		});
+		mapObservableArrayCached(this, workspace.documents, (document, store) => {
+			const initialContent = document.value.get().value;
+			return store.add(new UnifiedDocumentModelAdapter(
+				this._registry,
+				document,
+				initialContent,
+				() => this._textFileService.isDirty(document.uri),
+				change => change.reason,
+				result => {
+					this._recordResult(result.result);
+					if (result.inputKind === 'disconnected') {
+						this._scheduleCleanup(result.result.resource);
+					}
+				},
+			));
+		}).recomputeInitiallyAndOnChange(this._store);
+	}
+
+	applyAgentEdit(edit: IUnifiedDocumentAgentEdit<TextModelEditSource>): IUnifiedDocumentAgentAdapterResult<TextModelEditSource> {
+		const result = applyUnifiedDocumentAgentEdit(this._registry, edit);
+		this._recordResult(result.transitionResult);
+		if (result.transferResult) {
+			if (edit.previousResource) {
+				this._lastResults.delete(this._key(edit.previousResource));
+				this._transferResourceState(edit.previousResource, edit.resource);
+			}
+			this._recordResult(result.transferResult);
+		}
+		return result;
+	}
+
+	retainAgentResource(resource: URI): void {
+		this._retainedAgentResources.add(this._key(resource));
+	}
+
+	releaseAgentResource(resource: URI): void {
+		this._retainedAgentResources.delete(this._key(resource));
+		this._scheduleCleanup(resource);
+	}
+
+	retainLocalLongTermResource(resource: URI): void {
+		this._localLongTermResources.add(this._key(resource));
+	}
+
+	releaseLocalLongTermResource(resource: URI): void {
+		this._localLongTermResources.delete(this._key(resource));
+		this._scheduleCleanup(resource);
+	}
+
+	hasLocalLongTermResource(resource: URI): boolean {
+		return this._localLongTermResources.has(this._key(resource));
+	}
+
+	applyDiskSnapshot(resource: URI, content: string): IUnifiedDocumentRegistryResult<TextModelEditSource> {
+		const result = this._registry.diskSnapshot(resource, content);
+		this._recordResult(result);
+		return result;
+	}
+
+	getLastResult(resource: URI): IUnifiedDocumentRegistryResult<TextModelEditSource> | undefined {
+		return this._lastResults.get(this._key(resource));
+	}
+
+	getSnapshot(resource: URI): IUnifiedDocumentSnapshot<TextModelEditSource> | undefined {
+		return this._registry.get(resource)?.reconciler.getSnapshot();
+	}
+
+	async project(resource: URI): Promise<IEditTrackerSnapshot | undefined> {
+		const snapshot = this.getSnapshot(resource);
+		return snapshot ? projectUnifiedDocumentTracker(snapshot, (before, after) => this._diffService.computeDiff(before, after)) : undefined;
+	}
+
+	flushLongTermDetails(
+		resource: URI,
+		trigger: EditTelemetryTrigger,
+		languageId: string,
+		statsUuid = this._randomService.generateUuid(),
+	): Promise<IEditSourceDetailsSnapshot | undefined> {
+		const resourceKey = this._key(resource);
+		const run = () => this._flushLongTermDetails(resourceKey, resource, trigger, languageId, statsUuid);
+		const result = (this._flushQueues.get(resourceKey) ?? Promise.resolve(undefined)).then(run, run);
+		this._flushQueues.set(resourceKey, result);
+		const clearQueue = () => {
+			if (this._flushQueues.get(resourceKey) === result) {
+				this._flushQueues.delete(resourceKey);
+			}
+		};
+		result.then(clearQueue, clearQueue);
+		return result;
+	}
+
+	private async _flushLongTermDetails(
+		resourceKey: string,
+		resource: URI,
+		trigger: EditTelemetryTrigger,
+		languageId: string,
+		statsUuid: string,
+	): Promise<IEditSourceDetailsSnapshot | undefined> {
+		await this._synchronizeDisk(resource);
+		const snapshot = this.getSnapshot(resource);
+		if (!snapshot) {
+			return undefined;
+		}
+		const checkpoint = this._longTermCheckpoints.get(resourceKey);
+		const transitions = checkpoint
+			? snapshot.transitions.filter(transition => transition.id > checkpoint.maxTransitionId)
+			: snapshot.transitions;
+		const pendingReload = snapshot.pendingReload && (!checkpoint || snapshot.pendingReload.id > checkpoint.maxTransitionId)
+			? snapshot.pendingReload
+			: undefined;
+		if (transitions.length === 0) {
+			if (!pendingReload) {
+				this._longTermCheckpoints.set(resourceKey, createCheckpoint(snapshot.content, snapshot.transitions));
+			}
+			return undefined;
+		}
+
+		const windowSnapshot: IUnifiedDocumentSnapshot<TextModelEditSource> = {
+			...snapshot,
+			initialContent: checkpoint?.content ?? snapshot.initialContent,
+			transitions,
+			pendingReload,
+		};
+		const trackerSnapshot = await projectUnifiedDocumentTracker(
+			windowSnapshot,
+			(before, after) => this._diffService.computeDiff(before, after),
+		);
+		const details = snapshotEditSourceDetails(trackerSnapshot, 30, 'retained');
+		if (details.rows.length > 0) {
+			for (const row of details.rows) {
+				sendEditSourcesDetailsTelemetry(this._telemetryService, {
+					mode: 'longterm',
+					sourceKey: row.sourceKey,
+					sourceKeyCleaned: row.cleanedSourceKey,
+					extensionId: row.extensionId,
+					extensionVersion: row.extensionVersion,
+					modelId: row.modelId,
+					trigger,
+					languageId,
+					statsUuid,
+					conversationId: row.conversationId,
+					requestId: row.requestId,
+					origin: row.origin,
+					harness: row.harness,
+					modifiedCount: row.modifiedCount,
+					deltaModifiedCount: row.deltaModifiedCount,
+					totalModifiedCount: details.totalModifiedCount,
+				}, row.origin === 'agentHost' ? row.harness === 'copilotcli' : undefined);
+			}
+		}
+		this._longTermCheckpoints.set(resourceKey, createCheckpoint(trackerSnapshot.content, transitions));
+		return details;
+	}
+
+	private async _synchronizeDisk(resource: URI): Promise<void> {
+		const snapshot = this.getSnapshot(resource);
+		if (snapshot?.model?.dirty || snapshot?.pendingReload || !this._fileService.hasProvider(resource)) {
+			return;
+		}
+		try {
+			const content = (await this._fileService.readFile(resource)).value.toString();
+			if (!content.includes('\0')) {
+				this.applyDiskSnapshot(resource, content);
+			}
+		} catch (error) {
+			if (toFileOperationResult(error) === FileOperationResult.FILE_NOT_FOUND) {
+				this.applyDiskSnapshot(resource, '');
+				return;
+			}
+			throw error;
+		}
+	}
+
+	private _recordResult(result: IUnifiedDocumentRegistryResult<TextModelEditSource>): void {
+		this._lastResults.set(this._key(result.resource), result);
+	}
+
+	private _transferResourceState(previousResource: URI, resource: URI): void {
+		const previousKey = this._key(previousResource);
+		const key = this._key(resource);
+		const checkpoint = this._longTermCheckpoints.get(previousKey);
+		if (checkpoint) {
+			this._longTermCheckpoints.delete(previousKey);
+			this._longTermCheckpoints.set(key, checkpoint);
+		}
+		if (this._retainedAgentResources.delete(previousKey)) {
+			this._retainedAgentResources.add(key);
+		}
+		if (this._localLongTermResources.delete(previousKey)) {
+			this._localLongTermResources.add(key);
+		}
+	}
+
+	private _scheduleCleanup(resource: URI): void {
+		const resourceKey = this._key(resource);
+		const pendingFlush = this._flushQueues.get(resourceKey);
+		(pendingFlush ?? Promise.resolve(undefined)).then(() => {
+			const snapshot = this.getSnapshot(resource);
+			if (snapshot?.model || this._retainedAgentResources.has(resourceKey) || this._localLongTermResources.has(resourceKey)) {
+				return;
+			}
+			this._registry.delete(resource);
+			this._lastResults.delete(resourceKey);
+			this._longTermCheckpoints.delete(resourceKey);
+		}, error => {
+			this._logService.error(`[UnifiedEditSourceTracking] Failed to finish resource cleanup: ${error}`);
+		});
+	}
+
+	private _key(resource: URI): string {
+		return this._uriIdentityService.extUri.getComparisonKey(this._uriIdentityService.asCanonicalUri(resource));
+	}
+}
+
+function createCheckpoint(
+	content: string,
+	transitions: readonly IUnifiedDocumentTransition<TextModelEditSource>[],
+): IUnifiedEditSourceTrackingCheckpoint {
+	let maxTransitionId = 0;
+	for (const transition of transitions) {
+		maxTransitionId = Math.max(maxTransitionId, transition.id);
+	}
+	return { content, maxTransitionId };
+}

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedEditSourceTracking.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/unifiedEditSourceTracking.ts
@@ -177,7 +177,7 @@ export class UnifiedEditSourceTracking extends Disposable {
 		const reconciler = this._registry.get(resource)?.reconciler;
 		const snapshot = reconciler?.getSnapshot();
 		const trackedResource = this._trackedResources.get(resourceKey);
-		if (!reconciler || !snapshot || !trackedResource || snapshot.pendingReload || snapshot.transitions.length === 0) {
+		if (!reconciler || !snapshot || !trackedResource || snapshot.pendingReload || snapshot.pendingAgentTransitions || snapshot.transitions.length === 0) {
 			return undefined;
 		}
 
@@ -212,7 +212,7 @@ export class UnifiedEditSourceTracking extends Disposable {
 
 	private async _synchronizeDisk(resource: URI): Promise<void> {
 		const snapshot = this.getSnapshot(resource);
-		if (snapshot?.model?.dirty || snapshot?.pendingReload || !this._fileService.hasProvider(resource)) {
+		if (snapshot?.model?.dirty || snapshot?.pendingReload || snapshot?.pendingAgentTransitions || !this._fileService.hasProvider(resource)) {
 			return;
 		}
 		try {

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditSourceTracking.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditSourceTracking.test.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
-import { AgentHostTrackedFile, isDirtyOpenTextModel } from '../../browser/telemetry/agentHostEditSourceTracking.js';
+import { AgentHostTrackedFile, isDirtyOpenTextModel, shouldTrackAgentEdit } from '../../browser/telemetry/agentHostEditSourceTracking.js';
 
 suite('Agent Host Edit Source Tracking', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -54,6 +54,35 @@ suite('Agent Host Edit Source Tracking', () => {
 			closedDirty: false,
 			openClean: false,
 			openDirty: true,
+		});
+
+		test('does not mutate lifecycle tracking for rejected transitions or rename transfers', () => {
+			const result = (outcome: 'applied' | 'duplicate' | 'conflict' | 'skippedDirty', transferOutcome?: 'applied' | 'duplicate' | 'conflict') => ({
+				transitionResult: {
+					outcome,
+					resource: URI.file('C:\\repo\\before.ts'),
+				},
+				transferResult: transferOutcome ? {
+					outcome: transferOutcome,
+					resource: URI.file('C:\\repo\\after.ts'),
+				} : undefined,
+			});
+
+			assert.deepStrictEqual({
+				applied: shouldTrackAgentEdit(result('applied')),
+				duplicate: shouldTrackAgentEdit(result('duplicate')),
+				transitionConflict: shouldTrackAgentEdit(result('conflict')),
+				skippedDirty: shouldTrackAgentEdit(result('skippedDirty')),
+				transferConflict: shouldTrackAgentEdit(result('applied', 'conflict')),
+				transferApplied: shouldTrackAgentEdit(result('applied', 'applied')),
+			}, {
+				applied: true,
+				duplicate: true,
+				transitionConflict: false,
+				skippedDirty: false,
+				transferConflict: false,
+				transferApplied: true,
+			});
 		});
 	});
 

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditSourceTracking.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditSourceTracking.test.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { AgentHostTrackedFile, isDirtyOpenTextModel } from '../../browser/telemetry/agentHostEditSourceTracking.js';
+
+suite('Agent Host Edit Source Tracking', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('flushes current content with the latest language', async () => {
+		const disposables = new DisposableStore();
+		const resource = URI.file('C:\\repo\\file.ts');
+		let currentText = 'alpha';
+		const flushes: { resource: URI; content: string; languageId: string; trigger: string }[] = [];
+		const trackedFile = disposables.add(new AgentHostTrackedFile(
+			resource,
+			async () => currentText,
+			() => undefined,
+			new NullLogService(),
+			() => { },
+			(flushResource, content, languageId, trigger) => flushes.push({ resource: flushResource, content, languageId, trigger }),
+		));
+
+		await trackedFile.applyEdit('typescript');
+		await trackedFile.flush('hashChange');
+		currentText = 'beta';
+		await trackedFile.applyEdit('javascript');
+		await trackedFile.flush('branchChange');
+
+		assert.deepStrictEqual(flushes, [
+			{ resource, content: 'alpha', languageId: 'typescript', trigger: 'hashChange' },
+			{ resource, content: 'beta', languageId: 'javascript', trigger: 'branchChange' },
+		]);
+
+		disposables.dispose();
+	});
+
+	test('only skips attribution for open dirty text models', () => {
+		const resource = URI.file('C:\\repo\\file.ts');
+		const model = Object.create(null) as ITextModel;
+
+		assert.deepStrictEqual({
+			closedDirty: isDirtyOpenTextModel(resource, { getModel: () => null }, { isDirty: () => true }),
+			openClean: isDirtyOpenTextModel(resource, { getModel: () => model }, { isDirty: () => false }),
+			openDirty: isDirtyOpenTextModel(resource, { getModel: () => model }, { isDirty: () => true }),
+		}, {
+			closedDirty: false,
+			openClean: false,
+			openDirty: true,
+		});
+	});
+
+	test('uses the transferred resource when flushing a rename', async () => {
+		const disposables = new DisposableStore();
+		const previousResource = URI.file('C:\\repo\\before.ts');
+		const resource = URI.file('C:\\repo\\after.ts');
+		const reads: URI[] = [];
+		const flushes: URI[] = [];
+		const trackedFile = disposables.add(new AgentHostTrackedFile(
+			previousResource,
+			async currentResource => {
+				reads.push(currentResource);
+				return 'content';
+			},
+			() => undefined,
+			new NullLogService(),
+			() => { },
+			currentResource => flushes.push(currentResource),
+		));
+
+		trackedFile.setResource(resource);
+		await trackedFile.flush('hashChange');
+
+		assert.deepStrictEqual({
+			resource: trackedFile.resource,
+			reads,
+			flushes,
+		}, {
+			resource,
+			reads: [resource],
+			flushes: [resource],
+		});
+		disposables.dispose();
+	});
+});

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
@@ -208,7 +208,7 @@ function setup(visible: ISettableObservable<boolean> = observableValue('visible'
 
 	const workspace = new MutableObservableWorkspace();
 	const annotatedDocuments = disposables.add(new AnnotatedDocuments(workspace, instantiationService));
-	const impl = disposables.add(new EditSourceTrackingImpl(constObservable(true), annotatedDocuments, instantiationService));
+	const impl = disposables.add(new EditSourceTrackingImpl(constObservable(true), annotatedDocuments, undefined, instantiationService));
 	const document = disposables.add(workspace.createDocument({
 		uri: URI.file('C:\\repo\\file.ts'),
 		initialValue: 'hello',

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editTelemetry.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editTelemetry.test.ts
@@ -62,7 +62,7 @@ suite('Edit Telemetry', () => {
 
 		const w = new MutableObservableWorkspace();
 		const docs = disposables.add(new AnnotatedDocuments(w, instantiationService));
-		disposables.add(new EditSourceTrackingImpl(constObservable(true), docs, instantiationService));
+		disposables.add(new EditSourceTrackingImpl(constObservable(true), docs, undefined, instantiationService));
 
 		const d1 = disposables.add(w.createDocument({
 			uri: URI.parse('file:///a'), initialValue: `

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editTelemetryContribution.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editTelemetryContribution.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { ConfigurationTarget, IConfigurationChangeEvent } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ITelemetryService, TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID, TelemetryLevel } from '../../../../../platform/telemetry/common/telemetry.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestChatEntitlementService } from '../../../../test/common/workbenchTestServices.js';
+import { EditTelemetryContribution } from '../../browser/editTelemetryContribution.js';
+import { VSCodeWorkspace } from '../../browser/helpers/vscodeObservableWorkspace.js';
+import { AnnotatedDocuments } from '../../browser/helpers/annotatedDocuments.js';
+import { EditTrackingFeature } from '../../browser/telemetry/editSourceTrackingFeature.js';
+import { AiStatsFeature } from '../../browser/editStats/aiStatsFeature.js';
+
+suite('Edit Telemetry Contribution', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('runs edit tracking only while usage telemetry is enabled', async () => {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		const configurationService = new TestConfigurationService();
+		let telemetryLevel = TelemetryLevel.NONE;
+		const telemetryService = instantiationService.stub(ITelemetryService, {
+			get telemetryLevel() {
+				return telemetryLevel;
+			}
+		});
+		const feature = { dispose: sinon.spy() };
+
+		instantiationService.stubInstance(VSCodeWorkspace, { dispose() { } });
+		instantiationService.stubInstance(AnnotatedDocuments, { dispose() { } });
+		instantiationService.stubInstance(EditTrackingFeature, feature);
+		instantiationService.stubInstance(AiStatsFeature, { dispose() { } });
+		const createInstanceSpy = sinon.spy(instantiationService, 'createInstance');
+
+		const contribution = disposables.add(new EditTelemetryContribution(
+			instantiationService,
+			configurationService,
+			telemetryService,
+			new TestChatEntitlementService()
+		));
+
+		const getFeatureCreationCount = () => createInstanceSpy.getCalls().filter(call => call.args[0] === EditTrackingFeature).length;
+		assert.deepStrictEqual({ creations: getFeatureCreationCount(), disposals: feature.dispose.callCount }, { creations: 0, disposals: 0 });
+
+		telemetryLevel = TelemetryLevel.USAGE;
+		fireTelemetryConfigurationChange(configurationService, TELEMETRY_SETTING_ID);
+		assert.deepStrictEqual({ creations: getFeatureCreationCount(), disposals: feature.dispose.callCount }, { creations: 1, disposals: 0 });
+
+		telemetryLevel = TelemetryLevel.NONE;
+		fireTelemetryConfigurationChange(configurationService, TELEMETRY_CRASH_REPORTER_SETTING_ID);
+		assert.deepStrictEqual({ creations: getFeatureCreationCount(), disposals: feature.dispose.callCount }, { creations: 1, disposals: 1 });
+
+		telemetryLevel = TelemetryLevel.USAGE;
+		fireTelemetryConfigurationChange(configurationService, TELEMETRY_OLD_SETTING_ID);
+		assert.deepStrictEqual({ creations: getFeatureCreationCount(), disposals: feature.dispose.callCount }, { creations: 2, disposals: 1 });
+
+		contribution.dispose();
+	});
+});
+
+function fireTelemetryConfigurationChange(configurationService: TestConfigurationService, settingId: string): void {
+	const event: IConfigurationChangeEvent = {
+		source: ConfigurationTarget.USER,
+		affectedKeys: new Set([settingId]),
+		change: { keys: [settingId], overrides: [] },
+		affectsConfiguration: key => key === settingId,
+	};
+	configurationService.onDidChangeConfigurationEmitter.fire(event);
+}

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentAdapters.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentAdapters.test.ts
@@ -1,0 +1,208 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IObservable, IObservableWithChange, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { StringText } from '../../../../../editor/common/core/text/abstractText.js';
+import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
+import { EditSources, TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
+import {
+	applyUnifiedDocumentAgentEdit,
+	IUnifiedDocumentModelAdapterResult,
+	UnifiedDocumentModelAdapter,
+} from '../../browser/helpers/unifiedDocumentAdapters.js';
+import { IObservableDocument, StringEditWithReason } from '../../browser/helpers/observableWorkspace.js';
+import { UnifiedDocumentRegistry } from '../../browser/helpers/unifiedDocumentRegistry.js';
+
+suite('Unified Document Adapters', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('translates model lifecycle and attributed edits', () => {
+		const disposables = new DisposableStore();
+		const registry = createRegistry();
+		const document = disposables.add(new TestObservableDocument('before'));
+		let dirty = false;
+		const results: IUnifiedDocumentModelAdapterResult<TextModelEditSource>[] = [];
+		const adapter = disposables.add(new UnifiedDocumentModelAdapter(
+			registry,
+			document,
+			'before',
+			() => dirty,
+			change => change.reason,
+			result => results.push(result),
+		));
+
+		dirty = true;
+		document.apply(StringEditWithReason.replace(OffsetRange.ofLength(6), 'after', EditSources.cursor({ kind: 'type' })));
+		adapter.dispose();
+
+		assert.deepStrictEqual(
+			{
+				inputs: results.map(result => result.inputKind),
+				outcomes: results.map(result => result.result.outcome),
+				model: registry.get(document.uri)?.reconciler.getSnapshot().model,
+				sources: registry.get(document.uri)?.reconciler.getSnapshot().transitions.map(transition => transition.source.metadata.source),
+			},
+			{
+				inputs: ['connected', 'edit', 'disconnected'],
+				outcomes: ['applied', 'applied', 'applied'],
+				model: undefined,
+				sources: ['cursor'],
+			},
+		);
+		disposables.dispose();
+	});
+
+	test('deduplicates an Agent Host edit followed by model reload', () => {
+		const disposables = new DisposableStore();
+		const registry = createRegistry();
+		const resource = URI.file('C:\\repo\\file.ts');
+		const agentResult = applyUnifiedDocumentAgentEdit(registry, {
+			resource,
+			before: 'before',
+			after: 'after',
+			source: agentSource(),
+			correlation: 'tool-1',
+			kind: 'edit',
+		});
+		const document = disposables.add(new TestObservableDocument('before', resource));
+		const results: IUnifiedDocumentModelAdapterResult<TextModelEditSource>[] = [];
+		disposables.add(new UnifiedDocumentModelAdapter(
+			registry,
+			document,
+			'before',
+			() => false,
+			change => change.reason,
+			result => results.push(result),
+		));
+
+		document.apply(StringEditWithReason.replace(OffsetRange.ofLength(6), 'after', EditSources.reloadFromDisk()));
+
+		assert.deepStrictEqual(
+			{
+				agentOutcome: agentResult.transitionResult.outcome,
+				modelOutcomes: results.map(result => result.result.outcome),
+				transitions: registry.get(resource)?.reconciler.getSnapshot().transitions.map(transition => ({
+					kind: transition.kind,
+					source: transition.source.metadata.source,
+				})),
+			},
+			{
+				agentOutcome: 'applied',
+				modelOutcomes: ['applied', 'duplicate'],
+				transitions: [{ kind: 'agentHost', source: 'Chat.applyEdits' }],
+			},
+		);
+		disposables.dispose();
+	});
+
+	test('transfers registry identity for Agent Host rename', () => {
+		const registry = createRegistry();
+		const previousResource = URI.file('C:\\repo\\before.ts');
+		const resource = URI.file('C:\\repo\\after.ts');
+		registry.diskSnapshot(previousResource, 'content');
+		const reconciler = registry.get(previousResource)?.reconciler;
+
+		const result = applyUnifiedDocumentAgentEdit(registry, {
+			resource,
+			previousResource,
+			before: 'content',
+			after: 'content',
+			source: agentSource(),
+			correlation: 'rename-1',
+			kind: 'rename',
+		});
+
+		assert.deepStrictEqual(
+			{
+				transitionOutcome: result.transitionResult.outcome,
+				transferOutcome: result.transferResult?.outcome,
+				oldEntry: registry.get(previousResource),
+				sameReconciler: registry.get(resource)?.reconciler === reconciler,
+			},
+			{
+				transitionOutcome: 'applied',
+				transferOutcome: 'applied',
+				oldEntry: undefined,
+				sameReconciler: true,
+			},
+		);
+	});
+
+	test('does not transfer a dirty rename conflict', () => {
+		const registry = createRegistry();
+		const previousResource = URI.file('C:\\repo\\before.ts');
+		const resource = URI.file('C:\\repo\\after.ts');
+		registry.modelConnected(previousResource, 'content', { content: 'dirty content', dirty: true });
+
+		const result = applyUnifiedDocumentAgentEdit(registry, {
+			resource,
+			previousResource,
+			before: 'content',
+			after: 'content',
+			source: agentSource(),
+			correlation: 'rename-1',
+			kind: 'rename',
+		});
+
+		assert.deepStrictEqual(
+			{
+				transitionOutcome: result.transitionResult.outcome,
+				transferResult: result.transferResult,
+				oldEntryExists: !!registry.get(previousResource),
+				newEntry: registry.get(resource),
+			},
+			{
+				transitionOutcome: 'skippedDirty',
+				transferResult: undefined,
+				oldEntryExists: true,
+				newEntry: undefined,
+			},
+		);
+	});
+});
+
+class TestObservableDocument extends Disposable implements IObservableDocument {
+	private readonly _value: ISettableObservable<StringText, StringEditWithReason>;
+	readonly value: IObservableWithChange<StringText, StringEditWithReason>;
+	readonly version: IObservable<number>;
+	readonly languageId: IObservable<string>;
+
+	constructor(initialContent: string, readonly uri = URI.file('C:\\repo\\file.ts')) {
+		super();
+		this.value = this._value = observableValue(this, new StringText(initialContent));
+		this.version = observableValue(this, 1);
+		this.languageId = observableValue(this, 'typescript');
+	}
+
+	apply(edit: StringEditWithReason): void {
+		this._value.set(edit.applyOnText(this._value.get()), undefined, edit);
+	}
+}
+
+function createRegistry(): UnifiedDocumentRegistry<TextModelEditSource> {
+	return new UnifiedDocumentRegistry({
+		externalSource: EditSources.reloadFromDisk(),
+		canonicalize: resource => resource.with({ path: resource.path.toLowerCase() }),
+		getComparisonKey: resource => resource.toString().toLowerCase(),
+	});
+}
+
+function agentSource(): TextModelEditSource {
+	return EditSources.chatApplyEdits({
+		modelId: 'model',
+		sessionId: 'session',
+		requestId: 'request',
+		languageId: 'typescript',
+		mode: 'agent',
+		extensionId: undefined,
+		codeBlockSuggestionId: undefined,
+		harness: 'copilotcli',
+		origin: 'agentHost',
+	});
+}

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentAdapters.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentAdapters.test.ts
@@ -16,6 +16,7 @@ import {
 	IUnifiedDocumentModelAdapterResult,
 	UnifiedDocumentModelAdapter,
 } from '../../browser/helpers/unifiedDocumentAdapters.js';
+import { createMinimalEdit } from '../../browser/helpers/unifiedDocumentReconciler.js';
 import { IObservableDocument, StringEditWithReason } from '../../browser/helpers/observableWorkspace.js';
 import { UnifiedDocumentRegistry } from '../../browser/helpers/unifiedDocumentRegistry.js';
 
@@ -66,6 +67,7 @@ suite('Unified Document Adapters', () => {
 			resource,
 			before: 'before',
 			after: 'after',
+			edit: createMinimalEdit('before', 'after'),
 			source: agentSource(),
 			correlation: 'tool-1',
 			kind: 'edit',
@@ -105,7 +107,7 @@ suite('Unified Document Adapters', () => {
 		const registry = createRegistry();
 		const previousResource = URI.file('C:\\repo\\before.ts');
 		const resource = URI.file('C:\\repo\\after.ts');
-		registry.diskSnapshot(previousResource, 'content');
+		registry.diskSnapshot(previousResource, 'content', createMinimalEdit('content', 'content'));
 		const reconciler = registry.get(previousResource)?.reconciler;
 
 		const result = applyUnifiedDocumentAgentEdit(registry, {
@@ -113,6 +115,7 @@ suite('Unified Document Adapters', () => {
 			previousResource,
 			before: 'content',
 			after: 'content',
+			edit: createMinimalEdit('content', 'content'),
 			source: agentSource(),
 			correlation: 'rename-1',
 			kind: 'rename',
@@ -145,6 +148,7 @@ suite('Unified Document Adapters', () => {
 			previousResource,
 			before: 'content',
 			after: 'content',
+			edit: createMinimalEdit('content', 'content'),
 			source: agentSource(),
 			correlation: 'rename-1',
 			kind: 'rename',

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentReconciler.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentReconciler.test.ts
@@ -24,6 +24,49 @@ suite('UnifiedDocumentReconciler', () => {
 		});
 	});
 
+	test('deduplicates an Agent Host transition chain followed by one model reload', () => {
+		const reconciler = createReconciler('a');
+		reconciler.modelConnected({ content: 'a', dirty: false });
+		reconciler.agentTransition(agentEdit('a', 'ab', 'agent-1'));
+		reconciler.agentTransition(agentEdit('ab', 'abc', 'agent-2'));
+
+		const reloadResult = reconciler.modelEdit(reloadEdit('a', 'abc'));
+
+		assert.deepStrictEqual({
+			reloadOutcome: reloadResult.outcome,
+			reloadChanges: reloadResult.changes,
+			snapshot: snapshotSummary(reconciler),
+		}, {
+			reloadOutcome: 'duplicate',
+			reloadChanges: [],
+			snapshot: {
+				content: 'abc',
+				diskContent: 'abc',
+				pendingReload: false,
+				transitionKinds: ['agentHost', 'agentHost'],
+			},
+		});
+	});
+
+	test('deduplicates a recent Agent Host transition subchain', () => {
+		const reconciler = createReconciler('');
+		reconciler.modelConnected({ content: '', dirty: false });
+		reconciler.agentTransition(agentEdit('', 'a', 'agent-0'));
+		reconciler.modelEdit(reloadEdit('', 'a'));
+		reconciler.agentTransition(agentEdit('a', 'ab', 'agent-1'));
+		reconciler.agentTransition(agentEdit('ab', 'abc', 'agent-2'));
+
+		const reloadResult = reconciler.modelEdit(reloadEdit('a', 'abc'));
+
+		assert.deepStrictEqual({
+			reloadOutcome: reloadResult.outcome,
+			transitionKinds: reloadResult.snapshot.transitions.map(transition => transition.kind),
+		}, {
+			reloadOutcome: 'duplicate',
+			transitionKinds: ['agentHost', 'agentHost', 'agentHost'],
+		});
+	});
+
 	test('reattributes model reload followed by Agent Host', () => {
 		const reconciler = createReconciler('before');
 		reconciler.modelConnected({ content: 'before', dirty: false });
@@ -51,6 +94,211 @@ suite('UnifiedDocumentReconciler', () => {
 				pendingReload: false,
 				transitionKinds: ['agentHost'],
 			},
+		});
+	});
+
+	test('reattributes one pending reload from an Agent Host transition chain', () => {
+		const reconciler = createReconciler('a');
+		reconciler.modelConnected({ content: 'a', dirty: false });
+
+		const reloadResult = reconciler.modelEdit(reloadEdit('a', 'abc'));
+		const firstAgentResult = reconciler.agentTransition(agentEdit('a', 'ab', 'agent-1'));
+		const secondAgentResult = reconciler.agentTransition(agentEdit('ab', 'abc', 'agent-2'));
+
+		assert.deepStrictEqual({
+			reload: {
+				outcome: reloadResult.outcome,
+				changes: reloadResult.changes,
+			},
+			firstAgent: {
+				outcome: firstAgentResult.outcome,
+				changes: firstAgentResult.changes,
+			},
+			secondAgent: {
+				outcome: secondAgentResult.outcome,
+				changes: secondAgentResult.changes.map(change => ({
+					kind: change.kind,
+					before: change.before,
+					after: change.after,
+				})),
+			},
+			snapshot: snapshotSummary(reconciler),
+		}, {
+			reload: {
+				outcome: 'applied',
+				changes: [],
+			},
+			firstAgent: {
+				outcome: 'applied',
+				changes: [],
+			},
+			secondAgent: {
+				outcome: 'applied',
+				changes: [
+					{ kind: 'append', before: 'a', after: 'ab' },
+					{ kind: 'append', before: 'ab', after: 'abc' },
+				],
+			},
+			snapshot: {
+				content: 'abc',
+				diskContent: 'abc',
+				pendingReload: false,
+				transitionKinds: ['agentHost', 'agentHost'],
+			},
+		});
+	});
+
+	test('splits an incomplete Agent Host chain from the external reload remainder', () => {
+		const reconciler = createReconciler('a');
+		reconciler.modelConnected({ content: 'a', dirty: false });
+		reconciler.modelEdit(reloadEdit('a', 'abc'));
+		reconciler.agentTransition(agentEdit('a', 'ab', 'agent-1'));
+
+		const diskResult = diskSnapshot(reconciler, 'abc');
+		const lateAgentResult = reconciler.agentTransition(agentEdit('ab', 'abc', 'agent-2'));
+
+		assert.deepStrictEqual({
+			diskChanges: diskResult.changes.map(change => ({
+				kind: change.kind,
+				before: change.before,
+				after: change.after,
+				transitionKind: change.transition.kind,
+			})),
+			lateAgent: {
+				outcome: lateAgentResult.outcome,
+				changes: lateAgentResult.changes.map(change => change.kind),
+			},
+			transitions: reconciler.getSnapshot().transitions.map(transition => ({
+				kind: transition.kind,
+				correlation: transition.correlation,
+			})),
+		}, {
+			diskChanges: [
+				{ kind: 'append', before: 'a', after: 'ab', transitionKind: 'agentHost' },
+				{ kind: 'append', before: 'ab', after: 'abc', transitionKind: 'reloadFromDisk' },
+			],
+			lateAgent: {
+				outcome: 'applied',
+				changes: ['replace'],
+			},
+			transitions: [
+				{ kind: 'agentHost', correlation: 'agent-1' },
+				{ kind: 'agentHost', correlation: 'agent-2' },
+			],
+		});
+	});
+
+	test('replaces one committed external reload with a late Agent Host transition chain', () => {
+		const reconciler = createReconciler('a');
+		reconciler.modelConnected({ content: 'a', dirty: false });
+		reconciler.modelEdit(reloadEdit('a', 'abc'));
+		diskSnapshot(reconciler, 'abc');
+
+		const firstAgentResult = reconciler.agentTransition(agentEdit('a', 'ab', 'agent-1'));
+		const secondAgentResult = reconciler.agentTransition(agentEdit('ab', 'abc', 'agent-2'));
+
+		assert.deepStrictEqual({
+			firstAgent: {
+				outcome: firstAgentResult.outcome,
+				changes: firstAgentResult.changes,
+			},
+			secondAgent: {
+				outcome: secondAgentResult.outcome,
+				changes: secondAgentResult.changes.map(change => change.kind),
+			},
+			transitions: reconciler.getSnapshot().transitions.map(transition => ({
+				kind: transition.kind,
+				correlation: transition.correlation,
+			})),
+		}, {
+			firstAgent: {
+				outcome: 'applied',
+				changes: [],
+			},
+			secondAgent: {
+				outcome: 'applied',
+				changes: ['replace', 'append'],
+			},
+			transitions: [
+				{ kind: 'agentHost', correlation: 'agent-1' },
+				{ kind: 'agentHost', correlation: 'agent-2' },
+			],
+		});
+	});
+
+	test('splits a late incomplete Agent Host chain when a model edit interrupts it', () => {
+		const reconciler = createReconciler('a');
+		reconciler.modelConnected({ content: 'a', dirty: false });
+		reconciler.modelEdit(reloadEdit('a', 'abc'));
+		diskSnapshot(reconciler, 'abc');
+		reconciler.agentTransition(agentEdit('a', 'ab', 'agent-1'));
+
+		const modelResult = reconciler.modelEdit(modelEdit('abc', 'abcd'));
+
+		assert.deepStrictEqual({
+			outcome: modelResult.outcome,
+			changes: modelResult.changes.map(change => ({
+				kind: change.kind,
+				before: change.before,
+				after: change.after,
+				transitionKind: change.transition.kind,
+			})),
+			transitions: reconciler.getSnapshot().transitions.map(transition => ({
+				kind: transition.kind,
+				correlation: transition.correlation,
+			})),
+		}, {
+			outcome: 'applied',
+			changes: [
+				{ kind: 'replace', before: 'a', after: 'ab', transitionKind: 'agentHost' },
+				{ kind: 'append', before: 'ab', after: 'abc', transitionKind: 'reloadFromDisk' },
+				{ kind: 'append', before: 'abc', after: 'abcd', transitionKind: 'model' },
+			],
+			transitions: [
+				{ kind: 'agentHost', correlation: 'agent-1' },
+				{ kind: 'reloadFromDisk', correlation: undefined },
+				{ kind: 'model', correlation: undefined },
+			],
+		});
+	});
+
+	test('preserves the external endpoint when a late Agent Host prefix follows a model edit', () => {
+		const reconciler = createReconciler('a');
+		reconciler.modelConnected({ content: 'a', dirty: false });
+		reconciler.modelEdit(reloadEdit('a', 'abc'));
+		diskSnapshot(reconciler, 'abc');
+		reconciler.modelEdit(modelEdit('abc', 'abcd'));
+
+		const agentResult = reconciler.agentTransition(agentEdit('a', 'ab', 'agent-1'));
+		const diskResult = diskSnapshot(reconciler, 'abcd');
+		const snapshot = reconciler.getSnapshot();
+		let projectedContent = snapshot.initialContent;
+		for (const transition of snapshot.transitions) {
+			projectedContent = transition.edit.apply(projectedContent);
+		}
+
+		assert.deepStrictEqual({
+			agentPending: agentResult.snapshot.pendingAgentTransitions,
+			diskOutcome: diskResult.outcome,
+			diskChanges: diskResult.changes.map(change => ({
+				kind: change.kind,
+				before: change.before,
+				after: change.after,
+				transitionKind: change.transition.kind,
+			})),
+			pendingAgentTransitions: snapshot.pendingAgentTransitions,
+			transitionKinds: snapshot.transitions.map(transition => transition.kind),
+			projectedContent,
+		}, {
+			agentPending: true,
+			diskOutcome: 'duplicate',
+			diskChanges: [
+				{ kind: 'replace', before: 'a', after: 'ab', transitionKind: 'agentHost' },
+				{ kind: 'append', before: 'ab', after: 'abc', transitionKind: 'reloadFromDisk' },
+			],
+			pendingAgentTransitions: false,
+			transitionKinds: ['agentHost', 'reloadFromDisk', 'model'],
+			projectedContent: 'abcd',
 		});
 	});
 

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentReconciler.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentReconciler.test.ts
@@ -1,0 +1,390 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { UnifiedDocumentReconciler } from '../../browser/helpers/unifiedDocumentReconciler.js';
+
+suite('UnifiedDocumentReconciler', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('deduplicates Agent Host followed by model reload', () => {
+		const reconciler = createReconciler('before');
+		reconciler.modelConnected({ content: 'before', dirty: false });
+
+		assert.strictEqual(reconciler.agentTransition(agentEdit('before', 'after')).outcome, 'applied');
+		assert.strictEqual(reconciler.modelEdit(reloadEdit('before', 'after')).outcome, 'duplicate');
+		assert.deepStrictEqual(reconciler.getSnapshot(), expectedAgentSnapshot('before', 'after'));
+	});
+
+	test('reattributes model reload followed by Agent Host', () => {
+		const reconciler = createReconciler('before');
+		reconciler.modelConnected({ content: 'before', dirty: false });
+
+		const reloadResult = reconciler.modelEdit(reloadEdit('before', 'after'));
+		assert.deepStrictEqual(
+			{ outcome: reloadResult.outcome, changes: reloadResult.changes, pending: reloadResult.snapshot.pendingReload?.kind },
+			{ outcome: 'applied', changes: [], pending: 'reloadFromDisk' },
+		);
+		const agentResult = reconciler.agentTransition(agentEdit('before', 'after'));
+		assert.deepStrictEqual(
+			{ outcome: agentResult.outcome, changes: agentResult.changes.map(change => change.kind) },
+			{ outcome: 'applied', changes: ['append'] },
+		);
+		assert.deepStrictEqual(reconciler.getSnapshot(), expectedAgentSnapshot('before', 'after'));
+	});
+
+	test('produces identical final state for either Agent Host and reload order', () => {
+		const agentFirst = createReconciler('before');
+		agentFirst.modelConnected({ content: 'before', dirty: false });
+		agentFirst.agentTransition(agentEdit('before', 'after'));
+		agentFirst.modelEdit(reloadEdit('before', 'after'));
+
+		const reloadFirst = createReconciler('before');
+		reloadFirst.modelConnected({ content: 'before', dirty: false });
+		reloadFirst.modelEdit(reloadEdit('before', 'after'));
+		reloadFirst.agentTransition(agentEdit('before', 'after'));
+
+		assert.deepStrictEqual(reloadFirst.getSnapshot(), agentFirst.getSnapshot());
+	});
+
+	test('commits unmatched reload as external on disk snapshot', () => {
+		const reconciler = createReconciler('before');
+		reconciler.modelConnected({ content: 'before', dirty: false });
+		reconciler.modelEdit(reloadEdit('before', 'after'));
+
+		const result = reconciler.diskSnapshot('after');
+		assert.deepStrictEqual(
+			{ outcome: result.outcome, changes: result.changes },
+			{
+				outcome: 'applied',
+				changes: [{
+					kind: 'append',
+					transition: {
+						id: 1,
+						before: 'before',
+						after: 'after',
+						source: 'reload',
+						kind: 'reloadFromDisk',
+						correlation: undefined,
+						agentKind: undefined,
+					},
+				}],
+			},
+		);
+	});
+
+	test('skips new Agent Host attribution for a dirty model', () => {
+		const reconciler = createReconciler('base');
+		reconciler.modelConnected({ content: 'user edit', dirty: true });
+
+		const result = reconciler.agentTransition(agentEdit('base', 'agent edit'));
+		assert.deepStrictEqual(
+			{ outcome: result.outcome, snapshot: result.snapshot },
+			{
+				outcome: 'skippedDirty',
+				snapshot: {
+					initialContent: 'base',
+					content: 'base',
+					diskContent: 'agent edit',
+					model: { content: 'user edit', dirty: true },
+					pendingReload: undefined,
+					transitions: [],
+				},
+			},
+		);
+		assert.strictEqual(reconciler.agentTransition(agentEdit('base', 'agent edit')).outcome, 'duplicate');
+	});
+
+	test('claims an already observed reload even if the model became dirty later', () => {
+		const reconciler = createReconciler('before');
+		reconciler.modelConnected({ content: 'before', dirty: false });
+		reconciler.modelEdit(reloadEdit('before', 'after'));
+		reconciler.modelEdit({
+			before: 'after',
+			after: 'after user',
+			source: 'user',
+			kind: 'model',
+			dirty: true,
+		});
+
+		assert.strictEqual(reconciler.agentTransition(agentEdit('before', 'after')).outcome, 'applied');
+		assert.deepStrictEqual(reconciler.getSnapshot().transitions.map(transition => transition.kind), ['agentHost', 'model']);
+	});
+
+	test('tracks create and delete Agent Host transitions', () => {
+		const reconciler = createReconciler('');
+
+		assert.strictEqual(reconciler.agentTransition(agentEdit('', 'created', 'create-1', 'create')).outcome, 'applied');
+		assert.strictEqual(reconciler.agentTransition(agentEdit('created', '', 'delete-1', 'delete')).outcome, 'applied');
+		assert.deepStrictEqual(
+			reconciler.getSnapshot().transitions.map(transition => ({
+				before: transition.before,
+				after: transition.after,
+				agentKind: transition.agentKind,
+			})),
+			[
+				{ before: '', after: 'created', agentKind: 'create' },
+				{ before: 'created', after: '', agentKind: 'delete' },
+			],
+		);
+	});
+
+	test('does not deduplicate a later real transition after content cycles', () => {
+		const reconciler = createReconciler('a');
+		reconciler.agentTransition(agentEdit('a', 'b', 'agent-1'));
+		reconciler.agentTransition(agentEdit('b', 'a', 'agent-2'));
+
+		assert.strictEqual(reconciler.agentTransition(agentEdit('a', 'b', 'agent-3')).outcome, 'applied');
+		assert.deepStrictEqual(
+			reconciler.getSnapshot().transitions.map(transition => transition.correlation),
+			['agent-1', 'agent-2', 'agent-3'],
+		);
+	});
+
+	test('does not claim an old external transition after disk content cycles', () => {
+		const reconciler = createReconciler('a');
+		reconciler.diskSnapshot('b');
+		reconciler.diskSnapshot('a');
+
+		assert.strictEqual(reconciler.agentTransition(agentEdit('a', 'b')).outcome, 'applied');
+		assert.deepStrictEqual(
+			reconciler.getSnapshot().transitions.map(transition => ({
+				before: transition.before,
+				after: transition.after,
+				kind: transition.kind,
+			})),
+			[
+				{ before: 'a', after: 'b', kind: 'diskSnapshot' },
+				{ before: 'b', after: 'a', kind: 'diskSnapshot' },
+				{ before: 'a', after: 'b', kind: 'agentHost' },
+			],
+		);
+	});
+
+	test('applies disk snapshots as external edits without a model', () => {
+		const reconciler = createReconciler('before');
+
+		assert.strictEqual(reconciler.diskSnapshot('after').outcome, 'applied');
+		assert.deepStrictEqual(
+			reconciler.getSnapshot().transitions.map(transition => ({
+				before: transition.before,
+				after: transition.after,
+				source: transition.source,
+				kind: transition.kind,
+			})),
+			[{ before: 'before', after: 'after', source: 'external', kind: 'diskSnapshot' }],
+		);
+	});
+
+	test('deduplicates a disk snapshot followed by model reload', () => {
+		const reconciler = createReconciler('before');
+		reconciler.modelConnected({ content: 'before', dirty: false });
+
+		assert.strictEqual(reconciler.diskSnapshot('after').outcome, 'applied');
+		assert.strictEqual(reconciler.modelEdit(reloadEdit('before', 'after')).outcome, 'duplicate');
+		assert.deepStrictEqual(
+			reconciler.getSnapshot().transitions.map(transition => transition.kind),
+			['diskSnapshot'],
+		);
+	});
+
+	test('treats a model save as synchronization rather than another edit', () => {
+		const reconciler = createReconciler('before');
+		reconciler.modelConnected({ content: 'before', dirty: false });
+		reconciler.modelEdit({
+			before: 'before',
+			after: 'user edit',
+			source: 'user',
+			kind: 'model',
+			dirty: true,
+		});
+
+		assert.strictEqual(reconciler.diskSnapshot('user edit').outcome, 'duplicate');
+		assert.deepStrictEqual(
+			{
+				model: reconciler.getSnapshot().model,
+				sources: reconciler.getSnapshot().transitions.map(transition => transition.source),
+			},
+			{ model: { content: 'user edit', dirty: false }, sources: ['user'] },
+		);
+		assert.strictEqual(reconciler.agentTransition(agentEdit('user edit', 'agent edit')).outcome, 'applied');
+	});
+
+	test('reports a disk conflict while the model is dirty', () => {
+		const reconciler = createReconciler('before');
+		reconciler.modelConnected({ content: 'before', dirty: false });
+		reconciler.modelEdit({
+			before: 'before',
+			after: 'user edit',
+			source: 'user',
+			kind: 'model',
+			dirty: true,
+		});
+
+		const result = reconciler.diskSnapshot('external edit');
+		assert.deepStrictEqual(
+			{ outcome: result.outcome, content: result.snapshot.content, diskContent: result.snapshot.diskContent },
+			{ outcome: 'conflict', content: 'user edit', diskContent: 'external edit' },
+		);
+	});
+
+	test('continues observing a skipped dirty model and resynchronizes on save', () => {
+		const reconciler = createReconciler('base');
+		reconciler.modelConnected({ content: 'dirty one', dirty: true });
+
+		const modelEditResult = reconciler.modelEdit({
+			before: 'dirty one',
+			after: 'dirty two',
+			source: 'user',
+			kind: 'model',
+			dirty: true,
+		});
+		assert.deepStrictEqual(
+			{ outcome: modelEditResult.outcome, model: modelEditResult.snapshot.model },
+			{ outcome: 'conflict', model: { content: 'dirty two', dirty: true } },
+		);
+
+		const saveResult = reconciler.diskSnapshot('dirty two');
+		assert.deepStrictEqual(
+			{
+				outcome: saveResult.outcome,
+				model: saveResult.snapshot.model,
+				content: saveResult.snapshot.content,
+				transition: saveResult.snapshot.transitions[0],
+			},
+			{
+				outcome: 'applied',
+				model: { content: 'dirty two', dirty: false },
+				content: 'dirty two',
+				transition: {
+					id: 1,
+					before: 'base',
+					after: 'dirty two',
+					source: 'external',
+					kind: 'diskSnapshot',
+					correlation: undefined,
+					agentKind: undefined,
+				},
+			},
+		);
+	});
+
+	test('resynchronizes when a dirty save overwrites a skipped Agent Host edit', () => {
+		const reconciler = createReconciler('base');
+		reconciler.modelConnected({ content: 'user edit', dirty: true });
+		reconciler.agentTransition(agentEdit('base', 'agent edit'));
+
+		const result = reconciler.diskSnapshot('user edit');
+		assert.deepStrictEqual(
+			{
+				outcome: result.outcome,
+				content: result.snapshot.content,
+				diskContent: result.snapshot.diskContent,
+				model: result.snapshot.model,
+				transition: result.snapshot.transitions[0],
+			},
+			{
+				outcome: 'applied',
+				content: 'user edit',
+				diskContent: 'user edit',
+				model: { content: 'user edit', dirty: false },
+				transition: {
+					id: 1,
+					before: 'base',
+					after: 'user edit',
+					source: 'external',
+					kind: 'diskSnapshot',
+					correlation: undefined,
+					agentKind: undefined,
+				},
+			},
+		);
+	});
+
+	test('accepts rename as a correlated no-content transition', () => {
+		const reconciler = createReconciler('content');
+		const rename = agentEdit('content', 'content', 'rename-1', 'rename');
+
+		assert.strictEqual(reconciler.agentTransition(rename).outcome, 'applied');
+		assert.strictEqual(reconciler.agentTransition(rename).outcome, 'duplicate');
+		assert.deepStrictEqual(reconciler.getSnapshot().transitions, []);
+	});
+
+	test('connects, disconnects, and reconnects without resetting attribution', () => {
+		const reconciler = createReconciler('before');
+		reconciler.agentTransition(agentEdit('before', 'after'));
+
+		assert.strictEqual(reconciler.modelConnected({ content: 'after', dirty: false }).outcome, 'applied');
+		assert.strictEqual(reconciler.modelDisconnected().outcome, 'applied');
+		assert.strictEqual(reconciler.modelConnected({ content: 'after', dirty: false }).outcome, 'applied');
+		assert.deepStrictEqual(reconciler.getSnapshot().transitions, expectedAgentSnapshot('before', 'after').transitions);
+	});
+
+	test('connects a stale clean model after Agent Host and waits for reload', () => {
+		const reconciler = createReconciler('before');
+		reconciler.agentTransition(agentEdit('before', 'after'));
+
+		assert.strictEqual(reconciler.modelConnected({ content: 'before', dirty: false }).outcome, 'applied');
+		assert.strictEqual(reconciler.modelEdit(reloadEdit('before', 'after')).outcome, 'duplicate');
+		assert.deepStrictEqual(reconciler.getSnapshot(), expectedAgentSnapshot('before', 'after'));
+	});
+
+	test('reports conflicting state and correlation reuse', () => {
+		const reconciler = createReconciler('before');
+
+		assert.strictEqual(reconciler.agentTransition(agentEdit('other', 'after')).outcome, 'conflict');
+		assert.strictEqual(reconciler.agentTransition(agentEdit('before', 'after')).outcome, 'applied');
+		assert.strictEqual(reconciler.agentTransition(agentEdit('before', 'different')).outcome, 'conflict');
+	});
+});
+
+function createReconciler(initialContent: string): UnifiedDocumentReconciler<string> {
+	return new UnifiedDocumentReconciler(initialContent, 'external');
+}
+
+function agentEdit(
+	before: string,
+	after: string,
+	correlation = 'agent-1',
+	kind: 'create' | 'edit' | 'delete' | 'rename' = 'edit',
+) {
+	return {
+		before,
+		after,
+		source: 'agent',
+		correlation,
+		kind,
+	} as const;
+}
+
+function reloadEdit(before: string, after: string) {
+	return {
+		before,
+		after,
+		source: 'reload',
+		kind: 'reloadFromDisk',
+		dirty: false,
+	} as const;
+}
+
+function expectedAgentSnapshot(initialContent: string, content: string) {
+	return {
+		initialContent,
+		content,
+		diskContent: content,
+		model: { content, dirty: false },
+		pendingReload: undefined,
+		transitions: [{
+			id: 1,
+			before: initialContent,
+			after: content,
+			source: 'agent',
+			kind: 'agentHost',
+			correlation: 'agent-1',
+			agentKind: 'edit',
+		}],
+	};
+}

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentReconciler.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentReconciler.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { UnifiedDocumentReconciler } from '../../browser/helpers/unifiedDocumentReconciler.js';
+import { createMinimalEdit, UnifiedDocumentReconciler } from '../../browser/helpers/unifiedDocumentReconciler.js';
 
 suite('UnifiedDocumentReconciler', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -16,7 +16,12 @@ suite('UnifiedDocumentReconciler', () => {
 
 		assert.strictEqual(reconciler.agentTransition(agentEdit('before', 'after')).outcome, 'applied');
 		assert.strictEqual(reconciler.modelEdit(reloadEdit('before', 'after')).outcome, 'duplicate');
-		assert.deepStrictEqual(reconciler.getSnapshot(), expectedAgentSnapshot('before', 'after'));
+		assert.deepStrictEqual(snapshotSummary(reconciler), {
+			content: 'after',
+			diskContent: 'after',
+			pendingReload: false,
+			transitionKinds: ['agentHost'],
+		});
 	});
 
 	test('reattributes model reload followed by Agent Host', () => {
@@ -24,30 +29,48 @@ suite('UnifiedDocumentReconciler', () => {
 		reconciler.modelConnected({ content: 'before', dirty: false });
 
 		const reloadResult = reconciler.modelEdit(reloadEdit('before', 'after'));
-		assert.deepStrictEqual(
-			{ outcome: reloadResult.outcome, changes: reloadResult.changes, pending: reloadResult.snapshot.pendingReload?.kind },
-			{ outcome: 'applied', changes: [], pending: 'reloadFromDisk' },
-		);
 		const agentResult = reconciler.agentTransition(agentEdit('before', 'after'));
-		assert.deepStrictEqual(
-			{ outcome: agentResult.outcome, changes: agentResult.changes.map(change => change.kind) },
-			{ outcome: 'applied', changes: ['append'] },
-		);
-		assert.deepStrictEqual(reconciler.getSnapshot(), expectedAgentSnapshot('before', 'after'));
+
+		assert.deepStrictEqual({
+			reload: {
+				outcome: reloadResult.outcome,
+				changes: reloadResult.changes,
+				pending: reloadResult.snapshot.pendingReload?.transition.kind,
+			},
+			agent: {
+				outcome: agentResult.outcome,
+				changes: agentResult.changes.map(change => change.kind),
+			},
+			snapshot: snapshotSummary(reconciler),
+		}, {
+			reload: { outcome: 'applied', changes: [], pending: 'reloadFromDisk' },
+			agent: { outcome: 'applied', changes: ['append'] },
+			snapshot: {
+				content: 'after',
+				diskContent: 'after',
+				pendingReload: false,
+				transitionKinds: ['agentHost'],
+			},
+		});
 	});
 
-	test('produces identical final state for either Agent Host and reload order', () => {
-		const agentFirst = createReconciler('before');
-		agentFirst.modelConnected({ content: 'before', dirty: false });
-		agentFirst.agentTransition(agentEdit('before', 'after'));
-		agentFirst.modelEdit(reloadEdit('before', 'after'));
+	test('replaces a recently committed external reload when Agent Host arrives late', () => {
+		const reconciler = createReconciler('before');
+		reconciler.modelConnected({ content: 'before', dirty: false });
+		reconciler.modelEdit(reloadEdit('before', 'after'));
+		reconciler.modelEdit(modelEdit('after', 'after user'));
 
-		const reloadFirst = createReconciler('before');
-		reloadFirst.modelConnected({ content: 'before', dirty: false });
-		reloadFirst.modelEdit(reloadEdit('before', 'after'));
-		reloadFirst.agentTransition(agentEdit('before', 'after'));
+		const result = reconciler.agentTransition(agentEdit('before', 'after'));
 
-		assert.deepStrictEqual(reloadFirst.getSnapshot(), agentFirst.getSnapshot());
+		assert.deepStrictEqual({
+			outcome: result.outcome,
+			changes: result.changes.map(change => change.kind),
+			transitionKinds: reconciler.getSnapshot().transitions.map(transition => transition.kind),
+		}, {
+			outcome: 'applied',
+			changes: ['replace'],
+			transitionKinds: ['agentHost', 'model'],
+		});
 	});
 
 	test('commits unmatched reload as external on disk snapshot', () => {
@@ -55,25 +78,27 @@ suite('UnifiedDocumentReconciler', () => {
 		reconciler.modelConnected({ content: 'before', dirty: false });
 		reconciler.modelEdit(reloadEdit('before', 'after'));
 
-		const result = reconciler.diskSnapshot('after');
-		assert.deepStrictEqual(
-			{ outcome: result.outcome, changes: result.changes },
-			{
-				outcome: 'applied',
-				changes: [{
-					kind: 'append',
-					transition: {
-						id: 1,
-						before: 'before',
-						after: 'after',
-						source: 'reload',
-						kind: 'reloadFromDisk',
-						correlation: undefined,
-						agentKind: undefined,
-					},
-				}],
-			},
-		);
+		const result = diskSnapshot(reconciler, 'after');
+
+		assert.deepStrictEqual({
+			outcome: result.outcome,
+			changes: result.changes.map(change => ({
+				kind: change.kind,
+				before: change.before,
+				after: change.after,
+				source: change.transition.source,
+				transitionKind: change.transition.kind,
+			})),
+		}, {
+			outcome: 'applied',
+			changes: [{
+				kind: 'append',
+				before: 'before',
+				after: 'after',
+				source: 'reload',
+				transitionKind: 'reloadFromDisk',
+			}],
+		});
 	});
 
 	test('skips new Agent Host attribution for a dirty model', () => {
@@ -81,246 +106,95 @@ suite('UnifiedDocumentReconciler', () => {
 		reconciler.modelConnected({ content: 'user edit', dirty: true });
 
 		const result = reconciler.agentTransition(agentEdit('base', 'agent edit'));
-		assert.deepStrictEqual(
-			{ outcome: result.outcome, snapshot: result.snapshot },
-			{
-				outcome: 'skippedDirty',
-				snapshot: {
-					initialContent: 'base',
-					content: 'base',
-					diskContent: 'agent edit',
-					model: { content: 'user edit', dirty: true },
-					pendingReload: undefined,
-					transitions: [],
-				},
-			},
-		);
-		assert.strictEqual(reconciler.agentTransition(agentEdit('base', 'agent edit')).outcome, 'duplicate');
-	});
 
-	test('claims an already observed reload even if the model became dirty later', () => {
-		const reconciler = createReconciler('before');
-		reconciler.modelConnected({ content: 'before', dirty: false });
-		reconciler.modelEdit(reloadEdit('before', 'after'));
-		reconciler.modelEdit({
-			before: 'after',
-			after: 'after user',
-			source: 'user',
-			kind: 'model',
-			dirty: true,
+		assert.deepStrictEqual({
+			outcome: result.outcome,
+			content: result.snapshot.content,
+			diskContent: result.snapshot.diskContent,
+			model: result.snapshot.model,
+			transitionCount: result.snapshot.transitions.length,
+			repeatedOutcome: reconciler.agentTransition(agentEdit('base', 'agent edit')).outcome,
+		}, {
+			outcome: 'skippedDirty',
+			content: 'base',
+			diskContent: 'agent edit',
+			model: { content: 'user edit', dirty: true },
+			transitionCount: 0,
+			repeatedOutcome: 'duplicate',
 		});
-
-		assert.strictEqual(reconciler.agentTransition(agentEdit('before', 'after')).outcome, 'applied');
-		assert.deepStrictEqual(reconciler.getSnapshot().transitions.map(transition => transition.kind), ['agentHost', 'model']);
 	});
 
-	test('tracks create and delete Agent Host transitions', () => {
+	test('tracks create, delete, and repeated content cycles', () => {
 		const reconciler = createReconciler('');
+		reconciler.agentTransition(agentEdit('', 'created', 'create-1', 'create'));
+		reconciler.agentTransition(agentEdit('created', '', 'delete-1', 'delete'));
+		reconciler.agentTransition(agentEdit('', 'created', 'create-2', 'create'));
 
-		assert.strictEqual(reconciler.agentTransition(agentEdit('', 'created', 'create-1', 'create')).outcome, 'applied');
-		assert.strictEqual(reconciler.agentTransition(agentEdit('created', '', 'delete-1', 'delete')).outcome, 'applied');
 		assert.deepStrictEqual(
 			reconciler.getSnapshot().transitions.map(transition => ({
-				before: transition.before,
-				after: transition.after,
 				agentKind: transition.agentKind,
+				correlation: transition.correlation,
 			})),
 			[
-				{ before: '', after: 'created', agentKind: 'create' },
-				{ before: 'created', after: '', agentKind: 'delete' },
+				{ agentKind: 'create', correlation: 'create-1' },
+				{ agentKind: 'delete', correlation: 'delete-1' },
+				{ agentKind: 'create', correlation: 'create-2' },
 			],
-		);
-	});
-
-	test('does not deduplicate a later real transition after content cycles', () => {
-		const reconciler = createReconciler('a');
-		reconciler.agentTransition(agentEdit('a', 'b', 'agent-1'));
-		reconciler.agentTransition(agentEdit('b', 'a', 'agent-2'));
-
-		assert.strictEqual(reconciler.agentTransition(agentEdit('a', 'b', 'agent-3')).outcome, 'applied');
-		assert.deepStrictEqual(
-			reconciler.getSnapshot().transitions.map(transition => transition.correlation),
-			['agent-1', 'agent-2', 'agent-3'],
 		);
 	});
 
 	test('does not claim an old external transition after disk content cycles', () => {
 		const reconciler = createReconciler('a');
-		reconciler.diskSnapshot('b');
-		reconciler.diskSnapshot('a');
+		diskSnapshot(reconciler, 'b');
+		diskSnapshot(reconciler, 'a');
 
 		assert.strictEqual(reconciler.agentTransition(agentEdit('a', 'b')).outcome, 'applied');
 		assert.deepStrictEqual(
-			reconciler.getSnapshot().transitions.map(transition => ({
-				before: transition.before,
-				after: transition.after,
-				kind: transition.kind,
-			})),
-			[
-				{ before: 'a', after: 'b', kind: 'diskSnapshot' },
-				{ before: 'b', after: 'a', kind: 'diskSnapshot' },
-				{ before: 'a', after: 'b', kind: 'agentHost' },
-			],
-		);
-	});
-
-	test('applies disk snapshots as external edits without a model', () => {
-		const reconciler = createReconciler('before');
-
-		assert.strictEqual(reconciler.diskSnapshot('after').outcome, 'applied');
-		assert.deepStrictEqual(
-			reconciler.getSnapshot().transitions.map(transition => ({
-				before: transition.before,
-				after: transition.after,
-				source: transition.source,
-				kind: transition.kind,
-			})),
-			[{ before: 'before', after: 'after', source: 'external', kind: 'diskSnapshot' }],
-		);
-	});
-
-	test('deduplicates a disk snapshot followed by model reload', () => {
-		const reconciler = createReconciler('before');
-		reconciler.modelConnected({ content: 'before', dirty: false });
-
-		assert.strictEqual(reconciler.diskSnapshot('after').outcome, 'applied');
-		assert.strictEqual(reconciler.modelEdit(reloadEdit('before', 'after')).outcome, 'duplicate');
-		assert.deepStrictEqual(
 			reconciler.getSnapshot().transitions.map(transition => transition.kind),
-			['diskSnapshot'],
+			['diskSnapshot', 'diskSnapshot', 'agentHost'],
 		);
 	});
 
 	test('treats a model save as synchronization rather than another edit', () => {
 		const reconciler = createReconciler('before');
 		reconciler.modelConnected({ content: 'before', dirty: false });
-		reconciler.modelEdit({
-			before: 'before',
-			after: 'user edit',
-			source: 'user',
-			kind: 'model',
-			dirty: true,
+		reconciler.modelEdit(modelEdit('before', 'user edit'));
+
+		assert.strictEqual(diskSnapshot(reconciler, 'user edit').outcome, 'duplicate');
+		assert.deepStrictEqual({
+			model: reconciler.getSnapshot().model,
+			sources: reconciler.getSnapshot().transitions.map(transition => transition.source),
+		}, {
+			model: { content: 'user edit', dirty: false },
+			sources: ['user'],
 		});
-
-		assert.strictEqual(reconciler.diskSnapshot('user edit').outcome, 'duplicate');
-		assert.deepStrictEqual(
-			{
-				model: reconciler.getSnapshot().model,
-				sources: reconciler.getSnapshot().transitions.map(transition => transition.source),
-			},
-			{ model: { content: 'user edit', dirty: false }, sources: ['user'] },
-		);
-		assert.strictEqual(reconciler.agentTransition(agentEdit('user edit', 'agent edit')).outcome, 'applied');
 	});
 
-	test('reports a disk conflict while the model is dirty', () => {
-		const reconciler = createReconciler('before');
-		reconciler.modelConnected({ content: 'before', dirty: false });
-		reconciler.modelEdit({
-			before: 'before',
-			after: 'user edit',
-			source: 'user',
-			kind: 'model',
-			dirty: true,
+	test('resets compact transition history at a window boundary', () => {
+		const reconciler = createReconciler('a'.repeat(10_000));
+		for (let i = 0; i < 100; i++) {
+			const before = reconciler.getSnapshot().content;
+			const after = `${before}x`;
+			reconciler.modelConnected({ content: before, dirty: false });
+			reconciler.modelEdit(modelEdit(before, after));
+			reconciler.modelDisconnected();
+		}
+
+		const beforeReset = reconciler.getSnapshot();
+		reconciler.resetWindow();
+		const afterReset = reconciler.getSnapshot();
+
+		assert.deepStrictEqual({
+			beforeTransitionCount: beforeReset.transitions.length,
+			storesFullContentOnTransition: Object.hasOwn(beforeReset.transitions[0], 'before') || Object.hasOwn(beforeReset.transitions[0], 'after'),
+			afterTransitionCount: afterReset.transitions.length,
+			initialContentLength: afterReset.initialContent.length,
+		}, {
+			beforeTransitionCount: 100,
+			storesFullContentOnTransition: false,
+			afterTransitionCount: 0,
+			initialContentLength: 10_100,
 		});
-
-		const result = reconciler.diskSnapshot('external edit');
-		assert.deepStrictEqual(
-			{ outcome: result.outcome, content: result.snapshot.content, diskContent: result.snapshot.diskContent },
-			{ outcome: 'conflict', content: 'user edit', diskContent: 'external edit' },
-		);
-	});
-
-	test('continues observing a skipped dirty model and resynchronizes on save', () => {
-		const reconciler = createReconciler('base');
-		reconciler.modelConnected({ content: 'dirty one', dirty: true });
-
-		const modelEditResult = reconciler.modelEdit({
-			before: 'dirty one',
-			after: 'dirty two',
-			source: 'user',
-			kind: 'model',
-			dirty: true,
-		});
-		assert.deepStrictEqual(
-			{ outcome: modelEditResult.outcome, model: modelEditResult.snapshot.model },
-			{ outcome: 'conflict', model: { content: 'dirty two', dirty: true } },
-		);
-
-		const saveResult = reconciler.diskSnapshot('dirty two');
-		assert.deepStrictEqual(
-			{
-				outcome: saveResult.outcome,
-				model: saveResult.snapshot.model,
-				content: saveResult.snapshot.content,
-				transition: saveResult.snapshot.transitions[0],
-			},
-			{
-				outcome: 'applied',
-				model: { content: 'dirty two', dirty: false },
-				content: 'dirty two',
-				transition: {
-					id: 1,
-					before: 'base',
-					after: 'dirty two',
-					source: 'external',
-					kind: 'diskSnapshot',
-					correlation: undefined,
-					agentKind: undefined,
-				},
-			},
-		);
-	});
-
-	test('resynchronizes when a dirty save overwrites a skipped Agent Host edit', () => {
-		const reconciler = createReconciler('base');
-		reconciler.modelConnected({ content: 'user edit', dirty: true });
-		reconciler.agentTransition(agentEdit('base', 'agent edit'));
-
-		const result = reconciler.diskSnapshot('user edit');
-		assert.deepStrictEqual(
-			{
-				outcome: result.outcome,
-				content: result.snapshot.content,
-				diskContent: result.snapshot.diskContent,
-				model: result.snapshot.model,
-				transition: result.snapshot.transitions[0],
-			},
-			{
-				outcome: 'applied',
-				content: 'user edit',
-				diskContent: 'user edit',
-				model: { content: 'user edit', dirty: false },
-				transition: {
-					id: 1,
-					before: 'base',
-					after: 'user edit',
-					source: 'external',
-					kind: 'diskSnapshot',
-					correlation: undefined,
-					agentKind: undefined,
-				},
-			},
-		);
-	});
-
-	test('accepts rename as a correlated no-content transition', () => {
-		const reconciler = createReconciler('content');
-		const rename = agentEdit('content', 'content', 'rename-1', 'rename');
-
-		assert.strictEqual(reconciler.agentTransition(rename).outcome, 'applied');
-		assert.strictEqual(reconciler.agentTransition(rename).outcome, 'duplicate');
-		assert.deepStrictEqual(reconciler.getSnapshot().transitions, []);
-	});
-
-	test('connects, disconnects, and reconnects without resetting attribution', () => {
-		const reconciler = createReconciler('before');
-		reconciler.agentTransition(agentEdit('before', 'after'));
-
-		assert.strictEqual(reconciler.modelConnected({ content: 'after', dirty: false }).outcome, 'applied');
-		assert.strictEqual(reconciler.modelDisconnected().outcome, 'applied');
-		assert.strictEqual(reconciler.modelConnected({ content: 'after', dirty: false }).outcome, 'applied');
-		assert.deepStrictEqual(reconciler.getSnapshot().transitions, expectedAgentSnapshot('before', 'after').transitions);
 	});
 
 	test('connects a stale clean model after Agent Host and waits for reload', () => {
@@ -329,15 +203,12 @@ suite('UnifiedDocumentReconciler', () => {
 
 		assert.strictEqual(reconciler.modelConnected({ content: 'before', dirty: false }).outcome, 'applied');
 		assert.strictEqual(reconciler.modelEdit(reloadEdit('before', 'after')).outcome, 'duplicate');
-		assert.deepStrictEqual(reconciler.getSnapshot(), expectedAgentSnapshot('before', 'after'));
-	});
-
-	test('reports conflicting state and correlation reuse', () => {
-		const reconciler = createReconciler('before');
-
-		assert.strictEqual(reconciler.agentTransition(agentEdit('other', 'after')).outcome, 'conflict');
-		assert.strictEqual(reconciler.agentTransition(agentEdit('before', 'after')).outcome, 'applied');
-		assert.strictEqual(reconciler.agentTransition(agentEdit('before', 'different')).outcome, 'conflict');
+		assert.deepStrictEqual(snapshotSummary(reconciler), {
+			content: 'after',
+			diskContent: 'after',
+			pendingReload: false,
+			transitionKinds: ['agentHost'],
+		});
 	});
 });
 
@@ -354,6 +225,7 @@ function agentEdit(
 	return {
 		before,
 		after,
+		edit: createMinimalEdit(before, after),
 		source: 'agent',
 		correlation,
 		kind,
@@ -364,27 +236,34 @@ function reloadEdit(before: string, after: string) {
 	return {
 		before,
 		after,
+		edit: createMinimalEdit(before, after),
 		source: 'reload',
 		kind: 'reloadFromDisk',
 		dirty: false,
 	} as const;
 }
 
-function expectedAgentSnapshot(initialContent: string, content: string) {
+function modelEdit(before: string, after: string) {
 	return {
-		initialContent,
-		content,
-		diskContent: content,
-		model: { content, dirty: false },
-		pendingReload: undefined,
-		transitions: [{
-			id: 1,
-			before: initialContent,
-			after: content,
-			source: 'agent',
-			kind: 'agentHost',
-			correlation: 'agent-1',
-			agentKind: 'edit',
-		}],
+		before,
+		after,
+		edit: createMinimalEdit(before, after),
+		source: 'user',
+		kind: 'model',
+		dirty: true,
+	} as const;
+}
+
+function diskSnapshot(reconciler: UnifiedDocumentReconciler<string>, content: string) {
+	return reconciler.diskSnapshot(content, createMinimalEdit(reconciler.getSnapshot().content, content));
+}
+
+function snapshotSummary(reconciler: UnifiedDocumentReconciler<string>) {
+	const snapshot = reconciler.getSnapshot();
+	return {
+		content: snapshot.content,
+		diskContent: snapshot.diskContent,
+		pendingReload: !!snapshot.pendingReload,
+		transitionKinds: snapshot.transitions.map(transition => transition.kind),
 	};
 }

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentRegistry.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentRegistry.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { createMinimalEdit } from '../../browser/helpers/unifiedDocumentReconciler.js';
 import { UnifiedDocumentRegistry } from '../../browser/helpers/unifiedDocumentRegistry.js';
 
 suite('UnifiedDocumentRegistry', () => {
@@ -27,8 +28,8 @@ suite('UnifiedDocumentRegistry', () => {
 		const first = URI.from({ scheme: 'vscode-agent-host', authority: 'remote-one', path: '/repo/file.ts' });
 		const second = URI.from({ scheme: 'vscode-agent-host', authority: 'remote-two', path: '/repo/file.ts' });
 
-		registry.diskSnapshot(first, 'one');
-		registry.diskSnapshot(second, 'two');
+		registry.diskSnapshot(first, 'one', createMinimalEdit('one', 'one'));
+		registry.diskSnapshot(second, 'two', createMinimalEdit('two', 'two'));
 
 		assert.strictEqual(registry.size, 2);
 		assert.notStrictEqual(registry.get(first), registry.get(second));
@@ -57,8 +58,7 @@ suite('UnifiedDocumentRegistry', () => {
 					pendingReload: undefined,
 					transitions: [{
 						id: 1,
-						before: 'before',
-						after: 'after',
+						edit: createMinimalEdit('before', 'after'),
 						source: 'agent',
 						kind: 'agentHost',
 						correlation: 'agent-1',
@@ -104,8 +104,8 @@ suite('UnifiedDocumentRegistry', () => {
 		const registry = createRegistry();
 		const before = URI.file('C:\\repo\\before.ts');
 		const after = URI.file('C:\\repo\\after.ts');
-		registry.diskSnapshot(before, 'before');
-		registry.diskSnapshot(after, 'after');
+		registry.diskSnapshot(before, 'before', createMinimalEdit('before', 'before'));
+		registry.diskSnapshot(after, 'after', createMinimalEdit('after', 'after'));
 
 		assert.strictEqual(registry.transfer(before, after).outcome, 'conflict');
 		assert.strictEqual(registry.size, 2);
@@ -115,7 +115,7 @@ suite('UnifiedDocumentRegistry', () => {
 		const registry = createRegistry();
 		const before = URI.file('C:\\repo\\File.ts');
 		const after = URI.file('c:\\REPO\\file.ts');
-		registry.diskSnapshot(before, 'content');
+		registry.diskSnapshot(before, 'content', createMinimalEdit('content', 'content'));
 
 		assert.strictEqual(registry.transfer(before, after).outcome, 'duplicate');
 		assert.strictEqual(registry.size, 1);
@@ -130,6 +130,7 @@ suite('UnifiedDocumentRegistry', () => {
 		assert.strictEqual(registry.modelEdit(resource, {
 			before: 'before',
 			after: 'after',
+			edit: createMinimalEdit('before', 'after'),
 			source: 'user',
 			kind: 'model',
 			dirty: true,
@@ -140,8 +141,8 @@ suite('UnifiedDocumentRegistry', () => {
 		const registry = createRegistry();
 		const first = URI.file('C:\\repo\\first.ts');
 		const second = URI.file('C:\\repo\\second.ts');
-		registry.diskSnapshot(first, 'first');
-		registry.diskSnapshot(second, 'second');
+		registry.diskSnapshot(first, 'first', createMinimalEdit('first', 'first'));
+		registry.diskSnapshot(second, 'second', createMinimalEdit('second', 'second'));
 
 		assert.strictEqual(registry.delete(first), true);
 		assert.strictEqual(registry.delete(first), false);
@@ -167,6 +168,7 @@ function agentEdit(
 	return {
 		before,
 		after,
+		edit: createMinimalEdit(before, after),
 		source: 'agent',
 		correlation,
 		kind,

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentRegistry.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentRegistry.test.ts
@@ -56,6 +56,7 @@ suite('UnifiedDocumentRegistry', () => {
 					diskContent: 'after',
 					model: undefined,
 					pendingReload: undefined,
+					pendingAgentTransitions: false,
 					transitions: [{
 						id: 1,
 						edit: createMinimalEdit('before', 'after'),

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentRegistry.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentRegistry.test.ts
@@ -1,0 +1,174 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { UnifiedDocumentRegistry } from '../../browser/helpers/unifiedDocumentRegistry.js';
+
+suite('UnifiedDocumentRegistry', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('uses canonical resource identity', () => {
+		const registry = createRegistry();
+		const first = URI.file('C:\\repo\\File.ts');
+		const alias = URI.file('c:\\REPO\\file.ts');
+
+		registry.agentTransition(first, agentEdit('', 'content'));
+
+		assert.strictEqual(registry.get(alias), registry.get(first));
+		assert.strictEqual(registry.size, 1);
+	});
+
+	test('keeps matching remote paths on different authorities separate', () => {
+		const registry = createRegistry();
+		const first = URI.from({ scheme: 'vscode-agent-host', authority: 'remote-one', path: '/repo/file.ts' });
+		const second = URI.from({ scheme: 'vscode-agent-host', authority: 'remote-two', path: '/repo/file.ts' });
+
+		registry.diskSnapshot(first, 'one');
+		registry.diskSnapshot(second, 'two');
+
+		assert.strictEqual(registry.size, 2);
+		assert.notStrictEqual(registry.get(first), registry.get(second));
+	});
+
+	test('lazily creates a reconciler from an Agent Host transition', () => {
+		const registry = createRegistry();
+		const resource = URI.file('C:\\repo\\file.ts');
+
+		const result = registry.agentTransition(resource, agentEdit('before', 'after'));
+
+		assert.deepStrictEqual(
+			{
+				outcome: result.outcome,
+				resource: result.resource.toString(),
+				snapshot: registry.get(resource)?.reconciler.getSnapshot(),
+			},
+			{
+				outcome: 'applied',
+				resource: URI.file('c:\\repo\\file.ts').toString(),
+				snapshot: {
+					initialContent: 'before',
+					content: 'after',
+					diskContent: 'after',
+					model: undefined,
+					pendingReload: undefined,
+					transitions: [{
+						id: 1,
+						before: 'before',
+						after: 'after',
+						source: 'agent',
+						kind: 'agentHost',
+						correlation: 'agent-1',
+						agentKind: 'edit',
+					}],
+				},
+			},
+		);
+	});
+
+	test('preserves one reconciler across model connect and disconnect', () => {
+		const registry = createRegistry();
+		const resource = URI.file('C:\\repo\\file.ts');
+		registry.agentTransition(resource, agentEdit('before', 'after'));
+		const reconciler = registry.get(resource)?.reconciler;
+
+		assert.strictEqual(registry.modelConnected(resource, 'before', { content: 'after', dirty: false }).outcome, 'applied');
+		assert.strictEqual(registry.modelDisconnected(resource).outcome, 'applied');
+		assert.strictEqual(registry.modelConnected(resource, 'unused', { content: 'after', dirty: false }).outcome, 'applied');
+		assert.strictEqual(registry.get(resource)?.reconciler, reconciler);
+	});
+
+	test('transfers reconciler identity across a rename', () => {
+		const registry = createRegistry();
+		const before = URI.file('C:\\repo\\before.ts');
+		const after = URI.file('C:\\repo\\after.ts');
+		registry.agentTransition(before, agentEdit('content', 'content', 'rename-1', 'rename'));
+		const reconciler = registry.get(before)?.reconciler;
+
+		const result = registry.transfer(before, after);
+
+		assert.deepStrictEqual(
+			{
+				outcome: result.outcome,
+				oldEntry: registry.get(before),
+				sameReconciler: registry.get(after)?.reconciler === reconciler,
+			},
+			{ outcome: 'applied', oldEntry: undefined, sameReconciler: true },
+		);
+	});
+
+	test('rejects a rename onto an existing resource', () => {
+		const registry = createRegistry();
+		const before = URI.file('C:\\repo\\before.ts');
+		const after = URI.file('C:\\repo\\after.ts');
+		registry.diskSnapshot(before, 'before');
+		registry.diskSnapshot(after, 'after');
+
+		assert.strictEqual(registry.transfer(before, after).outcome, 'conflict');
+		assert.strictEqual(registry.size, 2);
+	});
+
+	test('treats a canonical-only rename as a duplicate', () => {
+		const registry = createRegistry();
+		const before = URI.file('C:\\repo\\File.ts');
+		const after = URI.file('c:\\REPO\\file.ts');
+		registry.diskSnapshot(before, 'content');
+
+		assert.strictEqual(registry.transfer(before, after).outcome, 'duplicate');
+		assert.strictEqual(registry.size, 1);
+		assert.strictEqual(registry.get(after)?.resource.toString(), URI.file('c:\\repo\\file.ts').toString());
+	});
+
+	test('reports model inputs for unknown resources explicitly', () => {
+		const registry = createRegistry();
+		const resource = URI.file('C:\\repo\\file.ts');
+
+		assert.strictEqual(registry.modelDisconnected(resource).outcome, 'duplicate');
+		assert.strictEqual(registry.modelEdit(resource, {
+			before: 'before',
+			after: 'after',
+			source: 'user',
+			kind: 'model',
+			dirty: true,
+		}).outcome, 'conflict');
+	});
+
+	test('deletes and clears registry entries', () => {
+		const registry = createRegistry();
+		const first = URI.file('C:\\repo\\first.ts');
+		const second = URI.file('C:\\repo\\second.ts');
+		registry.diskSnapshot(first, 'first');
+		registry.diskSnapshot(second, 'second');
+
+		assert.strictEqual(registry.delete(first), true);
+		assert.strictEqual(registry.delete(first), false);
+		registry.clear();
+		assert.strictEqual(registry.size, 0);
+	});
+});
+
+function createRegistry(): UnifiedDocumentRegistry<string> {
+	return new UnifiedDocumentRegistry({
+		externalSource: 'external',
+		canonicalize: resource => resource.with({ path: resource.path.toLowerCase() }),
+		getComparisonKey: resource => resource.toString().toLowerCase(),
+	});
+}
+
+function agentEdit(
+	before: string,
+	after: string,
+	correlation = 'agent-1',
+	kind: 'create' | 'edit' | 'delete' | 'rename' = 'edit',
+) {
+	return {
+		before,
+		after,
+		source: 'agent',
+		correlation,
+		kind,
+	} as const;
+}

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentTrackerProjection.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentTrackerProjection.test.ts
@@ -1,0 +1,182 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IObservableWithChange, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { AnnotatedStringEdit, StringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
+import { StringText } from '../../../../../editor/common/core/text/abstractText.js';
+import { computeStringDiff } from '../../../../../editor/common/services/editorWebWorker.js';
+import { EditSources, TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
+import { EditKeySourceData, EditSourceData, IDocumentWithAnnotatedEdits } from '../../browser/helpers/documentWithAnnotatedEdits.js';
+import { UnifiedDocumentReconciler } from '../../browser/helpers/unifiedDocumentReconciler.js';
+import { DocumentEditSourceTracker } from '../../browser/telemetry/editTracker.js';
+import {
+	IEditTrackerSnapshot,
+	projectUnifiedDocumentTracker,
+	snapshotDocumentEditSourceTracker,
+} from '../../browser/telemetry/unifiedDocumentTrackerProjection.js';
+
+suite('Unified Document Tracker Projection', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('matches an independently driven existing tracker', async () => {
+		const initialContent = 'a';
+		const agent = agentSource();
+		const user = EditSources.cursor({ kind: 'type' });
+		const reconciler = new UnifiedDocumentReconciler<TextModelEditSource>(initialContent, EditSources.reloadFromDisk());
+		reconciler.modelConnected({ content: initialContent, dirty: false });
+		reconciler.agentTransition({
+			before: 'a',
+			after: 'ab',
+			source: agent,
+			correlation: 'tool-1',
+			kind: 'edit',
+		});
+		reconciler.modelEdit({
+			before: 'a',
+			after: 'ab',
+			source: EditSources.reloadFromDisk(),
+			kind: 'reloadFromDisk',
+			dirty: false,
+		});
+		reconciler.modelEdit({
+			before: 'ab',
+			after: 'abU',
+			source: user,
+			kind: 'model',
+			dirty: true,
+		});
+
+		const candidate = await projectUnifiedDocumentTracker(reconciler.getSnapshot(), computeDiff);
+		const reference = await createReferenceSnapshot(initialContent, [
+			{ before: 'a', after: 'ab', source: agent },
+			{ before: 'ab', after: 'abU', source: user },
+		]);
+
+		assert.deepStrictEqual(candidate, reference);
+	});
+
+	test('projects reload-first attribution only after Agent Host claims it', async () => {
+		const reconciler = new UnifiedDocumentReconciler<TextModelEditSource>('before', EditSources.reloadFromDisk());
+		reconciler.modelConnected({ content: 'before', dirty: false });
+		reconciler.modelEdit({
+			before: 'before',
+			after: 'after',
+			source: EditSources.reloadFromDisk(),
+			kind: 'reloadFromDisk',
+			dirty: false,
+		});
+
+		const pending = await projectUnifiedDocumentTracker(reconciler.getSnapshot(), computeDiff);
+		reconciler.agentTransition({
+			before: 'before',
+			after: 'after',
+			source: agentSource(),
+			correlation: 'tool-1',
+			kind: 'edit',
+		});
+		const attributed = await projectUnifiedDocumentTracker(reconciler.getSnapshot(), computeDiff);
+
+		assert.deepStrictEqual(
+			{
+				pending: {
+					content: pending.content,
+					targetContent: pending.targetContent,
+					hasPendingReload: pending.hasPendingReload,
+					sources: pending.sources,
+				},
+				attributed: {
+					content: attributed.content,
+					targetContent: attributed.targetContent,
+					hasPendingReload: attributed.hasPendingReload,
+					sources: attributed.sources.map(source => ({
+						sourceKey: source.sourceKey,
+						insertedCount: source.insertedCount,
+						retainedCount: source.retainedCount,
+					})),
+				},
+			},
+			{
+				pending: {
+					content: 'before',
+					targetContent: 'after',
+					hasPendingReload: true,
+					sources: [],
+				},
+				attributed: {
+					content: 'after',
+					targetContent: 'after',
+					hasPendingReload: false,
+					sources: [{
+						sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+						insertedCount: 5,
+						retainedCount: 5,
+					}],
+				},
+			},
+		);
+	});
+
+});
+
+async function createReferenceSnapshot(
+	initialContent: string,
+	transitions: readonly { before: string; after: string; source: TextModelEditSource }[],
+): Promise<IEditTrackerSnapshot> {
+	const store = new DisposableStore();
+	try {
+		const document = store.add(new ReferenceDocument(initialContent));
+		const tracker = store.add(new DocumentEditSourceTracker(document, undefined));
+		let content = initialContent;
+		for (const transition of transitions) {
+			assert.strictEqual(transition.before, content);
+			document.apply(await computeDiff(transition.before, transition.after), transition.source);
+			content = transition.after;
+		}
+		await tracker.waitForQueue();
+		return snapshotDocumentEditSourceTracker(tracker, content);
+	} finally {
+		store.dispose();
+	}
+}
+
+function computeDiff(before: string, after: string): Promise<StringEdit> {
+	return computeStringDiff(before, after, { maxComputationTimeMs: 500 }, 'advanced');
+}
+
+function agentSource(): TextModelEditSource {
+	return EditSources.chatApplyEdits({
+		modelId: 'model',
+		sessionId: 'session',
+		requestId: 'request',
+		languageId: 'typescript',
+		mode: 'agent',
+		extensionId: undefined,
+		codeBlockSuggestionId: undefined,
+		harness: 'copilotcli',
+		origin: 'agentHost',
+	});
+}
+
+class ReferenceDocument extends Disposable implements IDocumentWithAnnotatedEdits<EditKeySourceData> {
+	private readonly _value: ISettableObservable<StringText, { edit: AnnotatedStringEdit<EditKeySourceData> }>;
+	readonly value: IObservableWithChange<StringText, { edit: AnnotatedStringEdit<EditKeySourceData> }>;
+
+	constructor(initialContent: string) {
+		super();
+		this.value = this._value = observableValue(this, new StringText(initialContent));
+	}
+
+	apply(edit: StringEdit, source: TextModelEditSource): void {
+		const data = new EditSourceData(source).toEditSourceData();
+		this._value.set(edit.applyOnText(this._value.get()), undefined, { edit: edit.mapData(() => data) });
+	}
+
+	waitForQueue(): Promise<void> {
+		return Promise.resolve();
+	}
+}

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentTrackerProjection.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedDocumentTrackerProjection.test.ts
@@ -4,149 +4,159 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
-import { IObservableWithChange, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { AnnotatedStringEdit, StringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
-import { StringText } from '../../../../../editor/common/core/text/abstractText.js';
-import { computeStringDiff } from '../../../../../editor/common/services/editorWebWorker.js';
+import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
+import { StringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
 import { EditSources, TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
-import { EditKeySourceData, EditSourceData, IDocumentWithAnnotatedEdits } from '../../browser/helpers/documentWithAnnotatedEdits.js';
-import { UnifiedDocumentReconciler } from '../../browser/helpers/unifiedDocumentReconciler.js';
-import { DocumentEditSourceTracker } from '../../browser/telemetry/editTracker.js';
-import {
-	IEditTrackerSnapshot,
-	projectUnifiedDocumentTracker,
-	snapshotDocumentEditSourceTracker,
-} from '../../browser/telemetry/unifiedDocumentTrackerProjection.js';
+import { createMinimalEdit, UnifiedDocumentReconciler } from '../../browser/helpers/unifiedDocumentReconciler.js';
+import { projectUnifiedDocumentTracker } from '../../browser/telemetry/unifiedDocumentTrackerProjection.js';
 
 suite('Unified Document Tracker Projection', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('matches an independently driven existing tracker', async () => {
-		const initialContent = 'a';
-		const agent = agentSource();
-		const user = EditSources.cursor({ kind: 'type' });
-		const reconciler = new UnifiedDocumentReconciler<TextModelEditSource>(initialContent, EditSources.reloadFromDisk());
-		reconciler.modelConnected({ content: initialContent, dirty: false });
+	test('projects exact model deltas and compact Agent Host edits', async () => {
+		const reconciler = new UnifiedDocumentReconciler<TextModelEditSource>('base', EditSources.reloadFromDisk());
+		reconciler.modelConnected({ content: 'base', dirty: false });
 		reconciler.agentTransition({
-			before: 'a',
-			after: 'ab',
-			source: agent,
+			before: 'base',
+			after: 'baseA',
+			edit: StringEdit.insert(4, 'A'),
+			source: agentSource(),
 			correlation: 'tool-1',
 			kind: 'edit',
 		});
 		reconciler.modelEdit({
-			before: 'a',
-			after: 'ab',
+			before: 'base',
+			after: 'baseA',
+			edit: StringEdit.insert(4, 'A'),
 			source: EditSources.reloadFromDisk(),
 			kind: 'reloadFromDisk',
 			dirty: false,
 		});
 		reconciler.modelEdit({
-			before: 'ab',
-			after: 'abU',
-			source: user,
+			before: 'baseA',
+			after: 'baseAU',
+			edit: StringEdit.insert(5, 'U'),
+			source: EditSources.cursor({ kind: 'type' }),
 			kind: 'model',
 			dirty: true,
 		});
 
-		const candidate = await projectUnifiedDocumentTracker(reconciler.getSnapshot(), computeDiff);
-		const reference = await createReferenceSnapshot(initialContent, [
-			{ before: 'a', after: 'ab', source: agent },
-			{ before: 'ab', after: 'abU', source: user },
-		]);
+		const projected = await projectUnifiedDocumentTracker(reconciler.getSnapshot());
 
-		assert.deepStrictEqual(candidate, reference);
+		assert.deepStrictEqual({
+			content: projected.content,
+			totalRetainedCount: projected.totalRetainedCount,
+			sources: projected.sources.map(source => ({
+				sourceKey: source.sourceKey,
+				insertedCount: source.insertedCount,
+				retainedCount: source.retainedCount,
+			})),
+		}, {
+			content: 'baseAU',
+			totalRetainedCount: 2,
+			sources: [
+				{
+					sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+					insertedCount: 1,
+					retainedCount: 1,
+				},
+				{
+					sourceKey: 'source:cursor-kind:type',
+					insertedCount: 1,
+					retainedCount: 1,
+				},
+			],
+		});
 	});
 
-	test('projects reload-first attribution only after Agent Host claims it', async () => {
+	test('projects a reload only after Agent Host claims it', async () => {
 		const reconciler = new UnifiedDocumentReconciler<TextModelEditSource>('before', EditSources.reloadFromDisk());
 		reconciler.modelConnected({ content: 'before', dirty: false });
 		reconciler.modelEdit({
 			before: 'before',
 			after: 'after',
+			edit: createMinimalEdit('before', 'after'),
 			source: EditSources.reloadFromDisk(),
 			kind: 'reloadFromDisk',
 			dirty: false,
 		});
 
-		const pending = await projectUnifiedDocumentTracker(reconciler.getSnapshot(), computeDiff);
+		const pending = await projectUnifiedDocumentTracker(reconciler.getSnapshot());
 		reconciler.agentTransition({
 			before: 'before',
 			after: 'after',
+			edit: createMinimalEdit('before', 'after'),
 			source: agentSource(),
 			correlation: 'tool-1',
 			kind: 'edit',
 		});
-		const attributed = await projectUnifiedDocumentTracker(reconciler.getSnapshot(), computeDiff);
+		const attributed = await projectUnifiedDocumentTracker(reconciler.getSnapshot());
 
-		assert.deepStrictEqual(
-			{
-				pending: {
-					content: pending.content,
-					targetContent: pending.targetContent,
-					hasPendingReload: pending.hasPendingReload,
-					sources: pending.sources,
-				},
-				attributed: {
-					content: attributed.content,
-					targetContent: attributed.targetContent,
-					hasPendingReload: attributed.hasPendingReload,
-					sources: attributed.sources.map(source => ({
-						sourceKey: source.sourceKey,
-						insertedCount: source.insertedCount,
-						retainedCount: source.retainedCount,
-					})),
-				},
+		assert.deepStrictEqual({
+			pending: {
+				content: pending.content,
+				targetContent: pending.targetContent,
+				hasPendingReload: pending.hasPendingReload,
+				sources: pending.sources,
 			},
-			{
-				pending: {
-					content: 'before',
-					targetContent: 'after',
-					hasPendingReload: true,
-					sources: [],
-				},
-				attributed: {
-					content: 'after',
-					targetContent: 'after',
-					hasPendingReload: false,
-					sources: [{
-						sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
-						insertedCount: 5,
-						retainedCount: 5,
-					}],
-				},
+			attributed: {
+				content: attributed.content,
+				hasPendingReload: attributed.hasPendingReload,
+				sources: attributed.sources.map(source => source.sourceKey),
 			},
-		);
+		}, {
+			pending: {
+				content: 'before',
+				targetContent: 'after',
+				hasPendingReload: true,
+				sources: [],
+			},
+			attributed: {
+				content: 'after',
+				hasPendingReload: false,
+				sources: ['source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost'],
+			},
+		});
 	});
 
+	test('applies trailing external edits to retained attribution', async () => {
+		const reconciler = new UnifiedDocumentReconciler<TextModelEditSource>('', EditSources.reloadFromDisk());
+		reconciler.agentTransition({
+			before: '',
+			after: 'ABCDEFGHIJ',
+			edit: StringEdit.insert(0, 'ABCDEFGHIJ'),
+			source: agentSource(),
+			correlation: 'tool-1',
+			kind: 'create',
+		});
+		reconciler.diskSnapshot('ABCD', StringEdit.delete(new OffsetRange(4, 10)));
+
+		const projected = await projectUnifiedDocumentTracker(reconciler.getSnapshot());
+
+		assert.deepStrictEqual({
+			content: projected.content,
+			totalRetainedCount: projected.totalRetainedCount,
+			sources: projected.sources.map(source => ({
+				sourceKey: source.sourceKey,
+				insertedCount: source.insertedCount,
+				retainedCount: source.retainedCount,
+			})),
+		}, {
+			content: 'ABCD',
+			totalRetainedCount: 4,
+			sources: [{
+				sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+				insertedCount: 10,
+				retainedCount: 4,
+			}, {
+				sourceKey: 'source:reloadFromDisk',
+				insertedCount: 0,
+				retainedCount: 0,
+			}],
+		});
+	});
 });
-
-async function createReferenceSnapshot(
-	initialContent: string,
-	transitions: readonly { before: string; after: string; source: TextModelEditSource }[],
-): Promise<IEditTrackerSnapshot> {
-	const store = new DisposableStore();
-	try {
-		const document = store.add(new ReferenceDocument(initialContent));
-		const tracker = store.add(new DocumentEditSourceTracker(document, undefined));
-		let content = initialContent;
-		for (const transition of transitions) {
-			assert.strictEqual(transition.before, content);
-			document.apply(await computeDiff(transition.before, transition.after), transition.source);
-			content = transition.after;
-		}
-		await tracker.waitForQueue();
-		return snapshotDocumentEditSourceTracker(tracker, content);
-	} finally {
-		store.dispose();
-	}
-}
-
-function computeDiff(before: string, after: string): Promise<StringEdit> {
-	return computeStringDiff(before, after, { maxComputationTimeMs: 500 }, 'advanced');
-}
 
 function agentSource(): TextModelEditSource {
 	return EditSources.chatApplyEdits({
@@ -160,23 +170,4 @@ function agentSource(): TextModelEditSource {
 		harness: 'copilotcli',
 		origin: 'agentHost',
 	});
-}
-
-class ReferenceDocument extends Disposable implements IDocumentWithAnnotatedEdits<EditKeySourceData> {
-	private readonly _value: ISettableObservable<StringText, { edit: AnnotatedStringEdit<EditKeySourceData> }>;
-	readonly value: IObservableWithChange<StringText, { edit: AnnotatedStringEdit<EditKeySourceData> }>;
-
-	constructor(initialContent: string) {
-		super();
-		this.value = this._value = observableValue(this, new StringText(initialContent));
-	}
-
-	apply(edit: StringEdit, source: TextModelEditSource): void {
-		const data = new EditSourceData(source).toEditSourceData();
-		this._value.set(edit.applyOnText(this._value.get()), undefined, { edit: edit.mapData(() => data) });
-	}
-
-	waitForQueue(): Promise<void> {
-		return Promise.resolve();
-	}
 }

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedEditSourceTracking.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedEditSourceTracking.test.ts
@@ -33,7 +33,7 @@ suite('Unified Edit Source Tracking', () => {
 	test('emits mixed local and Agent Host details once per long-term window', async () => {
 		const context = createContext('base');
 		const resource = context.document.uri;
-		context.tracking.applyAgentEdit({
+		await context.tracking.applyAgentEdit({
 			resource,
 			before: 'base',
 			after: 'baseA',
@@ -126,7 +126,7 @@ suite('Unified Edit Source Tracking', () => {
 	test('reconciles the current disk snapshot before emitting retained counts', async () => {
 		const context = createContext('base');
 		const resource = context.document.uri;
-		context.tracking.applyAgentEdit({
+		await context.tracking.applyAgentEdit({
 			resource,
 			before: 'base',
 			after: 'baseABCDEFGHIJ',
@@ -147,10 +147,35 @@ suite('Unified Edit Source Tracking', () => {
 			totalModifiedCount: agentEvent.totalModifiedCount,
 		}, {
 			sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
-			modifiedCount: 7,
-			deltaModifiedCount: 14,
-			totalModifiedCount: 7,
+			modifiedCount: 3,
+			deltaModifiedCount: 10,
+			totalModifiedCount: 3,
 		});
+		context.disposables.dispose();
+	});
+
+	test('preserves exact model insertion counts without snapshot diffing', async () => {
+		const context = createContext('base');
+		context.setDirty(true);
+		context.document.apply(StringEditWithReason.replace(
+			OffsetRange.emptyAt(4),
+			'ABCDEFGHIJ',
+			EditSources.cursor({ kind: 'type' }),
+		));
+
+		await context.tracking.flushLongTermDetails(context.document.uri, 'hashChange', 'typescript', 'stats-1');
+
+		assert.deepStrictEqual(context.details.map(event => ({
+			sourceKey: event.sourceKey,
+			modifiedCount: event.modifiedCount,
+			deltaModifiedCount: event.deltaModifiedCount,
+			totalModifiedCount: event.totalModifiedCount,
+		})), [{
+			sourceKey: 'source:cursor-kind:type',
+			modifiedCount: 10,
+			deltaModifiedCount: 10,
+			totalModifiedCount: 10,
+		}]);
 		context.disposables.dispose();
 	});
 
@@ -160,7 +185,7 @@ suite('Unified Edit Source Tracking', () => {
 		context.document.apply(StringEditWithReason.replace(OffsetRange.ofLength(6), 'after', EditSources.reloadFromDisk()));
 
 		const pending = await context.tracking.flushLongTermDetails(resource, 'hashChange', 'typescript');
-		context.tracking.applyAgentEdit({
+		await context.tracking.applyAgentEdit({
 			resource,
 			before: 'before',
 			after: 'after',
@@ -189,6 +214,46 @@ suite('Unified Edit Source Tracking', () => {
 		context.disposables.dispose();
 	});
 
+	test('rebuilds live attribution when Agent Host claims a committed reload late', async () => {
+		const context = createContext('before');
+		const resource = context.document.uri;
+		context.document.apply(StringEditWithReason.replace(OffsetRange.ofLength(6), 'after', EditSources.reloadFromDisk()));
+		context.setDirty(true);
+		context.document.apply(StringEditWithReason.replace(
+			OffsetRange.emptyAt(5),
+			' user',
+			EditSources.cursor({ kind: 'type' }),
+		));
+		await context.tracking.applyAgentEdit({
+			resource,
+			before: 'before',
+			after: 'after',
+			source: agentSource(),
+			correlation: 'tool-1',
+			kind: 'edit',
+		});
+
+		await context.tracking.flushLongTermDetails(resource, 'hashChange', 'typescript', 'stats-1');
+
+		assert.deepStrictEqual(context.details.map(event => ({
+			sourceKey: event.sourceKey,
+			modifiedCount: event.modifiedCount,
+			deltaModifiedCount: event.deltaModifiedCount,
+		})), [
+			{
+				sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+				modifiedCount: 5,
+				deltaModifiedCount: 5,
+			},
+			{
+				sourceKey: 'source:cursor-kind:type',
+				modifiedCount: 5,
+				deltaModifiedCount: 5,
+			},
+		]);
+		context.disposables.dispose();
+	});
+
 	test('emits only the top thirty retained sources in descending order', async () => {
 		const context = createContext('');
 		context.setDirty(true);
@@ -213,6 +278,63 @@ suite('Unified Edit Source Tracking', () => {
 			first: 'source:unknown-name:source-31',
 			last: 'source:unknown-name:source-2',
 			containsSmallest: false,
+		});
+		context.disposables.dispose();
+	});
+
+	test('resets compact edits and the live tracker after every flush', async () => {
+		const context = createContext('base');
+		context.setDirty(true);
+		for (let i = 0; i < 100; i++) {
+			context.document.apply(StringEditWithReason.replace(
+				OffsetRange.emptyAt(context.document.value.get().value.length),
+				'x',
+				EditSources.cursor({ kind: 'type' }),
+			));
+		}
+
+		await context.tracking.flushLongTermDetails(context.document.uri, 'hashChange', 'typescript');
+
+		assert.deepStrictEqual({
+			transitionCount: context.tracking.getSnapshot(context.document.uri)?.transitions.length,
+			trackedSources: context.tracking.project(context.document.uri)?.sources,
+			contentLength: context.tracking.getSnapshot(context.document.uri)?.content.length,
+		}, {
+			transitionCount: 0,
+			trackedSources: [],
+			contentLength: 104,
+		});
+		context.disposables.dispose();
+	});
+
+	test('does not transfer tracker state when a rename destination conflicts', async () => {
+		const context = createContext('content');
+		const previousResource = context.document.uri;
+		const resource = URI.file('C:\\repo\\existing.ts');
+		await context.tracking.applyDiskSnapshot(resource, 'existing');
+
+		const result = await context.tracking.applyAgentEdit({
+			resource,
+			previousResource,
+			before: 'content',
+			after: 'content',
+			source: agentSource(),
+			correlation: 'rename-1',
+			kind: 'rename',
+		});
+
+		assert.deepStrictEqual({
+			transferOutcome: result.transferResult?.outcome,
+			previousContent: context.tracking.getSnapshot(previousResource)?.content,
+			existingContent: context.tracking.getSnapshot(resource)?.content,
+			previousTracked: !!context.tracking.project(previousResource),
+			existingTracked: !!context.tracking.project(resource),
+		}, {
+			transferOutcome: 'conflict',
+			previousContent: 'content',
+			existingContent: 'existing',
+			previousTracked: true,
+			existingTracked: true,
 		});
 		context.disposables.dispose();
 	});

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedEditSourceTracking.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedEditSourceTracking.test.ts
@@ -1,0 +1,345 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IObservable, IObservableWithChange, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { extUri } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
+import { StringText } from '../../../../../editor/common/core/text/abstractText.js';
+import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
+import { computeStringDiff } from '../../../../../editor/common/services/editorWebWorker.js';
+import { EditSources, TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { IObservableDocument, ObservableWorkspace, StringEditWithReason } from '../../browser/helpers/observableWorkspace.js';
+import { IRandomService } from '../../browser/randomService.js';
+import { IEditSourcesDetailsTelemetryData } from '../../browser/telemetry/editSourceTelemetry.js';
+import { UnifiedEditSourceTracking } from '../../browser/telemetry/unifiedEditSourceTracking.js';
+
+suite('Unified Edit Source Tracking', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('emits mixed local and Agent Host details once per long-term window', async () => {
+		const context = createContext('base');
+		const resource = context.document.uri;
+		context.tracking.applyAgentEdit({
+			resource,
+			before: 'base',
+			after: 'baseA',
+			source: agentSource(),
+			correlation: 'tool-1',
+			kind: 'edit',
+		});
+		context.document.apply(StringEditWithReason.replace(new OffsetRange(4, 4), 'A', EditSources.reloadFromDisk()));
+		context.setDirty(true);
+		context.document.apply(StringEditWithReason.replace(new OffsetRange(5, 5), 'U', EditSources.cursor({ kind: 'type' })));
+
+		const first = await context.tracking.flushLongTermDetails(resource, 'hashChange', 'typescript', 'stats-1');
+		const second = await context.tracking.flushLongTermDetails(resource, 'hashChange', 'typescript', 'stats-2');
+
+		assert.deepStrictEqual({
+			first,
+			second,
+			events: context.details.map(event => ({
+				sourceKey: event.sourceKey,
+				trigger: event.trigger,
+				languageId: event.languageId,
+				statsUuid: event.statsUuid,
+				origin: event.origin,
+				harness: event.harness,
+				modifiedCount: event.modifiedCount,
+				deltaModifiedCount: event.deltaModifiedCount,
+				totalModifiedCount: event.totalModifiedCount,
+			})),
+		}, {
+			first: {
+				totalModifiedCount: 2,
+				rows: [
+					{
+						sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+						cleanedSourceKey: 'source:Chat.applyEdits-$harness:copilotcli-$origin:agentHost',
+						extensionId: undefined,
+						extensionVersion: undefined,
+						modelId: 'model',
+						conversationId: 'session',
+						requestId: 'request',
+						origin: 'agentHost',
+						harness: 'copilotcli',
+						modifiedCount: 1,
+						deltaModifiedCount: 1,
+					},
+					{
+						sourceKey: 'source:cursor-kind:type',
+						cleanedSourceKey: 'source:cursor-kind:type',
+						extensionId: undefined,
+						extensionVersion: undefined,
+						modelId: undefined,
+						conversationId: undefined,
+						requestId: undefined,
+						origin: undefined,
+						harness: undefined,
+						modifiedCount: 1,
+						deltaModifiedCount: 1,
+					},
+				],
+			},
+			second: undefined,
+			events: [
+				{
+					sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+					trigger: 'hashChange',
+					languageId: 'typescript',
+					statsUuid: 'stats-1',
+					origin: 'agentHost',
+					harness: 'copilotcli',
+					modifiedCount: 1,
+					deltaModifiedCount: 1,
+					totalModifiedCount: 2,
+				},
+				{
+					sourceKey: 'source:cursor-kind:type',
+					trigger: 'hashChange',
+					languageId: 'typescript',
+					statsUuid: 'stats-1',
+					origin: undefined,
+					harness: undefined,
+					modifiedCount: 1,
+					deltaModifiedCount: 1,
+					totalModifiedCount: 2,
+				},
+			],
+		});
+		context.disposables.dispose();
+	});
+
+	test('reconciles the current disk snapshot before emitting retained counts', async () => {
+		const context = createContext('base');
+		const resource = context.document.uri;
+		context.tracking.applyAgentEdit({
+			resource,
+			before: 'base',
+			after: 'baseABCDEFGHIJ',
+			source: agentSource(),
+			correlation: 'tool-1',
+			kind: 'edit',
+		});
+		context.document.apply(StringEditWithReason.replace(new OffsetRange(4, 4), 'ABCDEFGHIJ', EditSources.reloadFromDisk()));
+		context.setDiskContent('baseABC');
+
+		await context.tracking.flushLongTermDetails(resource, 'hashChange', 'typescript', 'stats-1');
+
+		const agentEvent = context.details.find(event => event.origin === 'agentHost');
+		assert.deepStrictEqual(agentEvent && {
+			sourceKey: agentEvent.sourceKey,
+			modifiedCount: agentEvent.modifiedCount,
+			deltaModifiedCount: agentEvent.deltaModifiedCount,
+			totalModifiedCount: agentEvent.totalModifiedCount,
+		}, {
+			sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+			modifiedCount: 7,
+			deltaModifiedCount: 14,
+			totalModifiedCount: 7,
+		});
+		context.disposables.dispose();
+	});
+
+	test('waits for a pending reload to be attributed before flushing', async () => {
+		const context = createContext('before');
+		const resource = context.document.uri;
+		context.document.apply(StringEditWithReason.replace(OffsetRange.ofLength(6), 'after', EditSources.reloadFromDisk()));
+
+		const pending = await context.tracking.flushLongTermDetails(resource, 'hashChange', 'typescript');
+		context.tracking.applyAgentEdit({
+			resource,
+			before: 'before',
+			after: 'after',
+			source: agentSource(),
+			correlation: 'tool-1',
+			kind: 'edit',
+		});
+		context.setDiskContent('after');
+		const attributed = await context.tracking.flushLongTermDetails(resource, 'hashChange', 'typescript', 'stats-1');
+
+		assert.deepStrictEqual({
+			pending,
+			attributed: attributed?.rows.map(row => ({
+				sourceKey: row.sourceKey,
+				modifiedCount: row.modifiedCount,
+			})),
+			eventCount: context.details.length,
+		}, {
+			pending: undefined,
+			attributed: [{
+				sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+				modifiedCount: 5,
+			}],
+			eventCount: 1,
+		});
+		context.disposables.dispose();
+	});
+
+	test('emits only the top thirty retained sources in descending order', async () => {
+		const context = createContext('');
+		context.setDirty(true);
+		for (let i = 1; i <= 31; i++) {
+			const content = 'x'.repeat(i);
+			context.document.apply(StringEditWithReason.replace(
+				OffsetRange.emptyAt(context.document.value.get().value.length),
+				content,
+				EditSources.unknown({ name: `source-${i}` }),
+			));
+		}
+
+		await context.tracking.flushLongTermDetails(context.document.uri, 'hashChange', 'typescript');
+
+		assert.deepStrictEqual({
+			count: context.details.length,
+			first: context.details[0]?.sourceKey,
+			last: context.details.at(-1)?.sourceKey,
+			containsSmallest: context.details.some(event => event.sourceKey === 'source:unknown-name:source-1'),
+		}, {
+			count: 30,
+			first: 'source:unknown-name:source-31',
+			last: 'source:unknown-name:source-2',
+			containsSmallest: false,
+		});
+		context.disposables.dispose();
+	});
+
+	test('keeps a resource until local and Agent Host ownership end', async () => {
+		const context = createContext('content');
+		const resource = context.document.uri;
+		context.tracking.retainLocalLongTermResource(resource);
+		context.tracking.retainAgentResource(resource);
+		context.workspace.setDocuments([]);
+		await Promise.resolve();
+		const whileRetained = !!context.tracking.getSnapshot(resource);
+
+		context.tracking.releaseLocalLongTermResource(resource);
+		context.tracking.releaseAgentResource(resource);
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			whileRetained,
+			afterRelease: context.tracking.getSnapshot(resource),
+		}, {
+			whileRetained: true,
+			afterRelease: undefined,
+		});
+		context.disposables.dispose();
+	});
+});
+
+function createContext(initialContent: string) {
+	const disposables = new DisposableStore();
+	const workspace = new TestWorkspace();
+	const document = disposables.add(new TestObservableDocument(initialContent));
+	workspace.setDocuments([document]);
+	const details: IEditSourcesDetailsTelemetryData[] = [];
+	let dirty = false;
+	let diskContent = initialContent;
+	let uuid = 0;
+	const instantiationService = disposables.add(new TestInstantiationService(new ServiceCollection(), false, undefined, true));
+	instantiationService.stub(IFileService, {
+		hasProvider: () => true,
+		readFile: async resource => {
+			const value = VSBuffer.fromString(diskContent);
+			return {
+				resource,
+				name: 'file.ts',
+				size: value.byteLength,
+				mtime: 0,
+				ctime: 0,
+				etag: '',
+				readonly: false,
+				locked: false,
+				executable: false,
+				value,
+			};
+		},
+	});
+	instantiationService.stub(ITextFileService, { isDirty: () => dirty });
+	instantiationService.stub(IUriIdentityService, { extUri, asCanonicalUri: resource => resource });
+	instantiationService.stub(IEditorWorkerService, {
+		computeStringEditFromDiff: (original, modified) => computeStringDiff(original, modified, { maxComputationTimeMs: 500 }, 'advanced'),
+	});
+	instantiationService.stub(IRandomService, {
+		_serviceBrand: undefined,
+		generateUuid: () => `stats-${++uuid}`,
+		generatePrefixedUuid: namespace => `${namespace}-${++uuid}`,
+	});
+	instantiationService.stub(ITelemetryService, {
+		publicLog2(eventName, data) {
+			if (eventName === 'editTelemetry.editSources.details') {
+				details.push(data as IEditSourcesDetailsTelemetryData);
+			}
+		},
+	});
+	instantiationService.stub(ILogService, new NullLogService());
+	const tracking = disposables.add(instantiationService.createInstance(UnifiedEditSourceTracking, workspace));
+	return {
+		disposables,
+		workspace,
+		document,
+		tracking,
+		details,
+		setDirty(value: boolean) {
+			dirty = value;
+		},
+		setDiskContent(value: string) {
+			diskContent = value;
+		},
+	};
+}
+
+function agentSource(): TextModelEditSource {
+	return EditSources.chatApplyEdits({
+		modelId: 'model',
+		sessionId: 'session',
+		requestId: 'request',
+		languageId: 'typescript',
+		mode: 'agent',
+		extensionId: undefined,
+		codeBlockSuggestionId: undefined,
+		harness: 'copilotcli',
+		origin: 'agentHost',
+	});
+}
+
+class TestWorkspace extends ObservableWorkspace {
+	private readonly _documents = observableValue<readonly IObservableDocument[]>(this, []);
+	override readonly documents: IObservable<readonly IObservableDocument[]> = this._documents;
+
+	setDocuments(documents: readonly IObservableDocument[]): void {
+		this._documents.set(documents, undefined);
+	}
+}
+
+class TestObservableDocument extends Disposable implements IObservableDocument {
+	private readonly _value: ISettableObservable<StringText, StringEditWithReason>;
+	readonly value: IObservableWithChange<StringText, StringEditWithReason>;
+	readonly version: IObservable<number>;
+	readonly languageId: IObservable<string>;
+
+	constructor(initialContent: string, readonly uri = URI.file('C:\\repo\\file.ts')) {
+		super();
+		this.value = this._value = observableValue(this, new StringText(initialContent));
+		this.version = observableValue(this, 1);
+		this.languageId = observableValue(this, 'typescript');
+	}
+
+	apply(edit: StringEditWithReason): void {
+		this._value.set(edit.applyOnText(this._value.get()), undefined, edit);
+	}
+}

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedEditSourceTracking.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/unifiedEditSourceTracking.test.ts
@@ -214,6 +214,55 @@ suite('Unified Edit Source Tracking', () => {
 		context.disposables.dispose();
 	});
 
+	test('waits for a late Agent Host transition chain before flushing', async () => {
+		const context = createContext('a');
+		const resource = context.document.uri;
+		context.document.apply(StringEditWithReason.replace(OffsetRange.ofLength(1), 'abc', EditSources.reloadFromDisk()));
+		context.setDiskContent('abc');
+		await context.tracking.applyDiskSnapshot(resource, 'abc');
+		await context.tracking.applyAgentEdit({
+			resource,
+			before: 'a',
+			after: 'ab',
+			source: agentSource(),
+			correlation: 'tool-1',
+			kind: 'edit',
+		});
+
+		const pending = await context.tracking.flushLongTermDetails(resource, 'hashChange', 'typescript');
+		const pendingSnapshot = context.tracking.getSnapshot(resource);
+		await context.tracking.applyAgentEdit({
+			resource,
+			before: 'ab',
+			after: 'abc',
+			source: agentSource(),
+			correlation: 'tool-2',
+			kind: 'edit',
+		});
+		const attributed = await context.tracking.flushLongTermDetails(resource, 'hashChange', 'typescript', 'stats-1');
+
+		assert.deepStrictEqual({
+			pending,
+			pendingAgentTransitions: pendingSnapshot?.pendingAgentTransitions,
+			pendingTransitionKinds: pendingSnapshot?.transitions.map(transition => transition.kind),
+			attributed: attributed?.rows.map(row => ({
+				sourceKey: row.sourceKey,
+				modifiedCount: row.modifiedCount,
+			})),
+			eventCount: context.details.length,
+		}, {
+			pending: undefined,
+			pendingAgentTransitions: true,
+			pendingTransitionKinds: ['reloadFromDisk'],
+			attributed: [{
+				sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+				modifiedCount: 2,
+			}],
+			eventCount: 1,
+		});
+		context.disposables.dispose();
+	});
+
 	test('rebuilds live attribution when Agent Host claims a committed reload late', async () => {
 		const context = createContext('before');
 		const resource = context.document.uri;


### PR DESCRIPTION
closes https://github.com/microsoft/vscode-internalbacklog/issues/8467

## Overview

### What

Unifies long-term `editTelemetry.editSources.details` tracking for local text-model edits and Agent Host file edits in one workbench-owned per-resource stream. Agent Host `ChatToolCallComplete` file snapshots are normalized, deduplicated against matching `reloadFromDisk` observations, reconciled with current disk content, and projected through the existing `DocumentEditSourceTracker` mechanics. The event kind and existing local source fields remain unchanged; Agent Host source rows add `origin=agentHost` and the canonical provider in `harness`. Copilot Agent Host rows continue through the existing GitHub edit-telemetry channel.

Follow-up work will evaluate moving `10minFocusWindow` and `20minFocusWindow` details, `editSources.stats`, and ARC to the canonical stream. Those existing local paths are deliberately unchanged in this PR.

### Why

Tracked in https://github.com/microsoft/vscode-internalbacklog/issues/8247. SDK-driven Agent Host edits occur on disk without passing through `ITextModel`, so the existing long-term tracker cannot attribute their inserted and retained characters. This restores commit/branch survival analysis for Agent Host edits while preventing duplicate attribution when an open editor later observes the same disk change.

---

## Property-by-property parity

Legend: ✅ = exact / verbatim match, ≈ = close analogue, ⊗ = omitted.

| Field | Local source | Agent Host source | Parity |
|---|---|---|---|
| `mode` | Existing long-term window | Canonical long-term window | ✅ `longterm` |
| `sourceKey` | Existing `TextModelEditSource.toKey(1)` | `Chat.applyEdits` plus `origin` and `harness` metadata | ≈ same key construction with AH identity added |
| `sourceKeyCleaned` | Existing cleaned source key | Same cleaning rules | ✅ |
| `extensionId` | Source metadata | Not available for AH file tools | ⊗ |
| `extensionVersion` | Source metadata | Not available for AH file tools | ⊗ |
| `modelId` | Source metadata | Not available on the file-edit action | ⊗ |
| `trigger` | Close, hash, branch, ten-hour boundary | Shared resource lifecycle boundary | ✅ |
| `languageId` | Open model language | Filepath/first-line language inference | ≈ inferred when no model exists |
| `statsUuid` | Generated per window | Shared across every source row in the canonical window | ✅ |
| `conversationId` | Chat edit session id | Agent Host session id | ≈ equivalent conversation correlation |
| `requestId` | Chat request id | Agent Host turn id | ≈ equivalent request/turn correlation |
| `origin` | Existing value or absent | `agentHost` | ✅ discriminator |
| `harness` | Existing value or absent | Canonical provider id (`copilotcli`, `claude`, `codex`) | ✅ provider discriminator |

## Measurement-by-measurement parity

| Metric | Local source | Agent Host source | Parity |
|---|---|---|---|
| `modifiedCount` | Retained attributed ranges | Retained attributed ranges after disk reconciliation | ✅ |
| `deltaModifiedCount` | Total inserted characters per source | Total inserted characters per source | ✅ |
| `totalModifiedCount` | Retained characters across the window | Retained characters across all local, AH, and external sources in the canonical window | ✅ |

---

## Row-count and dashboard implications

- **Historical rows:** local long-term and focus-window rows only.
- **New rows:** long-term windows include Agent Host sources in the same `statsUuid` group as local sources for that resource.
- A local and Agent Host observation of the same physical edit produces one attributed transition, not duplicate rows.
- Queries can identify Agent Host rows with `origin == "agentHost"` and split providers with `harness`.
- Source-key groupings will gain Agent Host `Chat.applyEdits` series containing `origin` and `harness`.
- Focus-window details, stats, and ARC row counts do not change in this PR.

## Semantic-shift ledger

| Field | Shift | Impact |
|---|---|---|
| `languageId` | Inferred from path/first line when no model is open | May differ from an extension-assigned model language id. |
| `conversationId` | Agent Host session id replaces workbench chat-edit session id | Same analytical role, different id namespace. |
| `requestId` | Agent Host turn id replaces workbench chat request id | Same analytical role, different id namespace. |
| `sourceKey` | AH rows add origin/provider identity | New AH source series; local series remain unchanged. |