### PR TITLE
sessions: align floating panel sashes

### DIFF
--- a/.github/skills/sessions/SKILL.md
+++ b/.github/skills/sessions/SKILL.md
@@ -26,6 +26,7 @@ Then read the relevant spec for the area you are changing (see table below). If 
 
 ## Common Pitfalls
 
+- **A sash element's `left`/`top` is the hit-area edge, not the split boundary**: `SplitView.getSashPosition` returns the exact boundary after the preceding view, then `Sash.layout` subtracts half the sash size so the draggable element is centered on that boundary. Align the Sessions/Editor and bottom-Panel grid sash hit areas to `agents.layout.floatingPanelGap`; do not apply that token to independent geometry such as the Auxiliary Bar's leading padding.
 - **Wrong menu IDs**: Never use `MenuId.*` from `vs/platform/actions` for Agents window UI. Always use `Menus.*` from `browser/menus.ts`.
 - **Sessions menu ids must live in the shared menu registry**: Do not declare sessions-owned `new MenuId(...)` constants ad hoc inside individual parts. Add them to `browser/menus.ts` under `Menus` with discoverable `SessionsEditor...` names so ownership and reuse stay obvious.
 - **Events instead of observables**: Session state must flow through `IObservable`, not `Event`. Use `autorun`/`derived` for reactive UI, not `onDid*` event listeners.

--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1110,6 +1110,7 @@
 		"--vscode-agents-fontSize-label3",
 		"--vscode-agents-fontWeight-regular",
 		"--vscode-agents-fontWeight-semiBold",
+		"--vscode-agents-layout-floatingPanelGap",
 		"--vscode-bodyFontSize",
 		"--vscode-bodyFontSize-small",
 		"--vscode-bodyFontSize-xSmall",

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -60,6 +60,8 @@ The titlebar spans the full window width at the root level. Below it, a content 
 
 The **Sessions Part is the flexible ("remaining width") view** in the top-right row: it has `LayoutPriority.High` so it absorbs auxiliary bar / editor visibility changes and window resizes. The editor and auxiliary bar keep their user-set widths (`LayoutPriority.Normal` / `Low`). Making the editor the high-priority view caused its width to drift to its 300px minimum when the auxiliary bar was toggled across session switches.
 
+The Sessions Part-to-Editor gap and the gap above the bottom Panel share `AGENTS_FLOATING_PANEL_GAP` in TypeScript layout and its registered CSS token, `--vscode-agents-layout-floatingPanelGap`. Their grid sashes keep the split boundaries unchanged, but expand and shift their hit areas to fill those visual gaps exactly. Each shows the standard persistent three-dot gripper at rest and yields to the full sash highlight while hovered or dragged. The Auxiliary Bar's leading padding and part-internal sashes retain their independent geometry.
+
 ### 2.3 Layout Priority Model
 
 The workbench grid is built with `proportionalLayout: false` (see `createWorkbenchLayout()` in [browser/workbench.ts](src/vs/sessions/browser/workbench.ts)). In this mode the split views do **not** distribute resize deltas proportionally — instead each delta (window resize, or a part being shown/hidden) is absorbed by the highest-`LayoutPriority` view, while the others keep their established sizes. Each part therefore declares an explicit `priority`:

--- a/src/vs/sessions/browser/media/workbench.css
+++ b/src/vs/sessions/browser/media/workbench.css
@@ -197,6 +197,12 @@
 	border-radius: var(--vscode-sash-size);
 }
 
+/*
+ * SplitView centers each sash on its logical boundary, but the card margins put
+ * the Sessions/Editor gap before that boundary and the Panel gap after it.
+ * Grow the hit area to at least the visual gap, then shift it toward that gap
+ * without moving the split itself. `max()` preserves larger configured sashes.
+ */
 .agent-sessions-workbench:not(.noeditorpane) .monaco-split-view2.horizontal:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.sessionspart) > .sash-container > .monaco-sash.vertical:first-child {
 	width: max(var(--vscode-sash-size), var(--vscode-agents-layout-floatingPanelGap));
 	transform: translateX(calc((var(--vscode-sash-size) - max(var(--vscode-sash-size), var(--vscode-agents-layout-floatingPanelGap)) - var(--vscode-agents-layout-floatingPanelGap)) / 2));
@@ -207,6 +213,11 @@
 	transform: translateY(calc((var(--vscode-sash-size) - max(var(--vscode-sash-size), var(--vscode-agents-layout-floatingPanelGap)) + var(--vscode-agents-layout-floatingPanelGap)) / 2));
 }
 
+/*
+ * Match the standard workbench's persistent three-dot sash gripper. The center
+ * dot is the pseudo-element and box shadows draw the outer dots; hide all three
+ * while the full hover/drag highlight communicates the active resize target.
+ */
 .agent-sessions-workbench:not(.noeditorpane) .monaco-split-view2.horizontal:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.sessionspart) > .sash-container > .monaco-sash.vertical:first-child:not(.disabled)::after,
 .agent-sessions-workbench:not(.nopanel) .monaco-split-view2.vertical:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.panel) > .sash-container > .monaco-sash.horizontal:not(.disabled)::after {
 	content: '';

--- a/src/vs/sessions/browser/media/workbench.css
+++ b/src/vs/sessions/browser/media/workbench.css
@@ -142,7 +142,7 @@
 }
 
 .agent-sessions-workbench .part.sessionspart {
-	margin: 0 5px 0 0;
+	margin: 0 var(--vscode-agents-layout-floatingPanelGap) 0 0;
 	background: var(--part-background);
 	border: 1px solid var(--part-border-color, transparent);
 	border-radius: var(--vscode-cornerRadius-large);
@@ -176,7 +176,7 @@
 }
 
 .agent-sessions-workbench .part.panel {
-	margin: 5px 0px 0px 0px;
+	margin: var(--vscode-agents-layout-floatingPanelGap) 0 0 0;
 	background: var(--part-background);
 	border: 1px solid var(--part-border-color, transparent);
 	border-radius: var(--vscode-cornerRadius-large);
@@ -195,6 +195,60 @@
 
 .agent-sessions-workbench .monaco-sash:not(.disabled) > .orthogonal-drag-handle {
 	border-radius: var(--vscode-sash-size);
+}
+
+.agent-sessions-workbench:not(.noeditorpane) .monaco-split-view2.horizontal:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.sessionspart) > .sash-container > .monaco-sash.vertical:first-child {
+	width: max(var(--vscode-sash-size), var(--vscode-agents-layout-floatingPanelGap));
+	transform: translateX(calc((var(--vscode-sash-size) - max(var(--vscode-sash-size), var(--vscode-agents-layout-floatingPanelGap)) - var(--vscode-agents-layout-floatingPanelGap)) / 2));
+}
+
+.agent-sessions-workbench:not(.nopanel) .monaco-split-view2.vertical:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.panel) > .sash-container > .monaco-sash.horizontal {
+	height: max(var(--vscode-sash-size), var(--vscode-agents-layout-floatingPanelGap));
+	transform: translateY(calc((var(--vscode-sash-size) - max(var(--vscode-sash-size), var(--vscode-agents-layout-floatingPanelGap)) + var(--vscode-agents-layout-floatingPanelGap)) / 2));
+}
+
+.agent-sessions-workbench:not(.noeditorpane) .monaco-split-view2.horizontal:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.sessionspart) > .sash-container > .monaco-sash.vertical:first-child:not(.disabled)::after,
+.agent-sessions-workbench:not(.nopanel) .monaco-split-view2.vertical:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.panel) > .sash-container > .monaco-sash.horizontal:not(.disabled)::after {
+	content: '';
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: var(--vscode-spacing-size20);
+	height: var(--vscode-spacing-size20);
+	border-radius: var(--vscode-cornerRadius-circle);
+	background: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
+	color: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
+	opacity: 0.5;
+	pointer-events: none;
+	transform: translate(-50%, -50%);
+}
+
+.agent-sessions-workbench:not(.noeditorpane) .monaco-split-view2.horizontal:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.sessionspart) > .sash-container > .monaco-sash.vertical:first-child:not(.disabled)::after {
+	box-shadow: 0 calc(-1 * var(--vscode-agents-layout-floatingPanelGap)) currentColor, 0 var(--vscode-agents-layout-floatingPanelGap) currentColor;
+}
+
+.agent-sessions-workbench:not(.nopanel) .monaco-split-view2.vertical:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.panel) > .sash-container > .monaco-sash.horizontal:not(.disabled)::after {
+	box-shadow: calc(-1 * var(--vscode-agents-layout-floatingPanelGap)) 0 currentColor, var(--vscode-agents-layout-floatingPanelGap) 0 currentColor;
+}
+
+.agent-sessions-workbench:not(.noeditorpane) .monaco-split-view2.horizontal:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.sessionspart) > .sash-container > .monaco-sash.vertical:first-child:is(.hover, .active)::after,
+.agent-sessions-workbench:not(.nopanel) .monaco-split-view2.vertical:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.panel) > .sash-container > .monaco-sash.horizontal:is(.hover, .active)::after {
+	opacity: 0;
+}
+
+.monaco-enable-motion .agent-sessions-workbench:not(.noeditorpane) .monaco-split-view2.horizontal:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.sessionspart) > .sash-container > .monaco-sash.vertical:first-child:not(.disabled)::after,
+.monaco-enable-motion .agent-sessions-workbench:not(.nopanel) .monaco-split-view2.vertical:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.panel) > .sash-container > .monaco-sash.horizontal:not(.disabled)::after {
+	transition: opacity 0.1s ease-out;
+}
+
+@media (forced-colors: active) {
+
+	.agent-sessions-workbench:not(.noeditorpane) .monaco-split-view2.horizontal:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.sessionspart) > .sash-container > .monaco-sash.vertical:first-child:not(.disabled)::after,
+	.agent-sessions-workbench:not(.nopanel) .monaco-split-view2.vertical:has(> .monaco-scrollable-element > .split-view-container > .split-view-view > .part.panel) > .sash-container > .monaco-sash.horizontal:not(.disabled)::after {
+		background: CanvasText;
+		color: CanvasText;
+		opacity: 1;
+	}
 }
 
 /* ---- Docked Detail Panel ---- */

--- a/src/vs/sessions/browser/parts/panelPart.ts
+++ b/src/vs/sessions/browser/parts/panelPart.ts
@@ -16,6 +16,7 @@ import { IInstantiationService } from '../../../platform/instantiation/common/in
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
 import { PANEL_TITLE_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_INACTIVE_TITLE_FOREGROUND, PANEL_ACTIVE_TITLE_BORDER, PANEL_DRAG_AND_DROP_BORDER } from '../../../workbench/common/theme.js';
 import { agentsBadgeBackground, agentsBadgeForeground, agentsPanelBackground, agentsPanelBorder, agentsPanelForeground } from '../../common/theme.js';
+import { AGENTS_FLOATING_PANEL_GAP } from '../../common/sizes.js';
 import { INotificationService } from '../../../platform/notification/common/notification.js';
 import { IContextKeyService } from '../../../platform/contextkey/common/contextkey.js';
 import { assertReturnsDefined } from '../../../base/common/types.js';
@@ -68,7 +69,7 @@ export class PanelPart extends AbstractPaneCompositePart {
 	static readonly activePanelSettingsKey = 'workbench.agentsession.panelpart.activepanelid';
 
 	/** Visual margin values for the card-like appearance */
-	static readonly MARGIN_TOP = 5;
+	static readonly MARGIN_TOP = AGENTS_FLOATING_PANEL_GAP;
 
 	constructor(
 		@INotificationService notificationService: INotificationService,
@@ -175,8 +176,6 @@ export class PanelPart extends AbstractPaneCompositePart {
 		}
 
 		// Layout content with reduced dimensions to account for visual margins and border.
-		// The right and bottom gutters are provided by the workbench grid; the 5px top
-		// margin pairs with the top row's MARGIN_BOTTOM to center the sash.
 		const borderTotal = 2; // 1px border on each side
 		super.layout(
 			width - borderTotal,

--- a/src/vs/sessions/browser/parts/sessionsPart.ts
+++ b/src/vs/sessions/browser/parts/sessionsPart.ts
@@ -9,6 +9,7 @@ import { IInstantiationService } from '../../../platform/instantiation/common/in
 import { IStorageService } from '../../../platform/storage/common/storage.js';
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
 import { agentsPanelBackground, agentsPanelBorder, agentsPanelForeground } from '../../common/theme.js';
+import { AGENTS_FLOATING_PANEL_GAP } from '../../common/sizes.js';
 import { Parts } from '../../../workbench/services/layout/browser/layoutService.js';
 import { assertReturnsDefined } from '../../../base/common/types.js';
 import { LayoutPriority } from '../../../base/browser/ui/splitview/splitview.js';
@@ -58,7 +59,7 @@ export class SessionsPart extends Part {
 	/** Visual margin values for the card-like appearance */
 	static readonly MARGIN_TOP = 0;
 	static readonly MARGIN_LEFT = 0;
-	static readonly MARGIN_RIGHT = 5;
+	static readonly MARGIN_RIGHT = AGENTS_FLOATING_PANEL_GAP;
 	static readonly MARGIN_RIGHT_NO_EDITOR_PANE = 0;
 	static readonly MARGIN_BOTTOM = 0;
 
@@ -422,9 +423,6 @@ export class SessionsPart extends Part {
 		this._lastLayout = { width, height, top, left };
 
 		// Compute content dimensions accounting for visual margins and border.
-		// MARGIN_BOTTOM applies only when the panel is visible (paired with the panel's
-		// 5px top margin to center the sash). When the panel is hidden the card fills its
-		// cell; the workbench grid's 10px bottom gutter provides the visible gap.
 		const borderTotal = SessionsPart.BORDER_WIDTH * 2;
 		const marginLeft = SessionsPart.MARGIN_LEFT;
 		const marginBottom = SessionsPart.MARGIN_BOTTOM;

--- a/src/vs/sessions/common/sizes.ts
+++ b/src/vs/sessions/common/sizes.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// Agent-sessions font-ramp size tokens.
+// Agent-sessions size tokens.
 //
 // Registrations live here in the sessions layer. The workbench entry point
 // (`workbench.common.main.ts`) imports this file as a side-effect so the
@@ -12,6 +12,19 @@
 
 import { localize } from '../../nls.js';
 import { registerSize, sizeForAllThemes } from '../../platform/theme/common/sizeUtils.js';
+
+// ============================================================================
+// Agents window — layout
+// ============================================================================
+
+export const AGENTS_FLOATING_PANEL_GAP = 5;
+
+/** Gap between floating panels in the Agents window. */
+export const agentsLayoutFloatingPanelGap = registerSize(
+	'agents.layout.floatingPanelGap',
+	sizeForAllThemes(AGENTS_FLOATING_PANEL_GAP, 'px'),
+	localize('agents.layout.floatingPanelGap', "Gap between floating panels in the Agents window.")
+);
 
 // ============================================================================
 // Agents window — font ramp


### PR DESCRIPTION
## Summary
- align the Sessions/Editor and bottom Panel sash hit areas with their floating-panel gaps
- add persistent three-dot sash grippers matching the Modern UI workbench treatment
- share one registered floating-panel gap value between CSS and TypeScript layout

## Validation
- `npm run precommit`
- `npm run typecheck-client` *(blocked by existing unrelated `IOSProxyConfig` error in `nativeHostMainService.ts`)*
- `npm run valid-layers-check` *(blocked by the same existing unrelated error)*

No automated tests were run because compilation is currently blocked by that unrelated baseline error.