### PR TITLE
workbench: remove obsolete configuration and dead code

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5226,10 +5226,6 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 					default: defaults.showInlineDetails,
 					description: nls.localize('suggest.showInlineDetails', "Controls whether suggest details show inline with the label or only in the details widget.")
 				},
-				'editor.suggest.maxVisibleSuggestions': {
-					type: 'number',
-					deprecationMessage: nls.localize('suggest.maxVisibleSuggestions.dep', "This setting is deprecated. The suggest widget can now be resized."),
-				},
 				'editor.suggest.filteredTypes': {
 					type: 'object',
 					deprecationMessage: nls.localize('deprecated', "This setting is deprecated, please use separate settings like 'editor.suggest.showKeywords' or 'editor.suggest.showSnippets' instead.")

--- a/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
@@ -531,26 +531,6 @@ export class MainThreadEditorTabs implements MainThreadEditorTabsShape {
 		this._proxy.$acceptEditorTabModel(this._tabGroupModel);
 	}
 
-	// TODOD @lramos15 Remove this after done finishing the tab model code
-	// private _eventToString(event: IEditorsChangeEvent | IEditorsMoveEvent): string {
-	// 	let eventString = '';
-	// 	switch (event.kind) {
-	// 		case GroupModelChangeKind.GROUP_INDEX: eventString += 'GROUP_INDEX'; break;
-	// 		case GroupModelChangeKind.EDITOR_ACTIVE: eventString += 'EDITOR_ACTIVE'; break;
-	// 		case GroupModelChangeKind.EDITOR_PIN: eventString += 'EDITOR_PIN'; break;
-	// 		case GroupModelChangeKind.EDITOR_OPEN: eventString += 'EDITOR_OPEN'; break;
-	// 		case GroupModelChangeKind.EDITOR_CLOSE: eventString += 'EDITOR_CLOSE'; break;
-	// 		case GroupModelChangeKind.EDITOR_MOVE: eventString += 'EDITOR_MOVE'; break;
-	// 		case GroupModelChangeKind.EDITOR_LABEL: eventString += 'EDITOR_LABEL'; break;
-	// 		case GroupModelChangeKind.GROUP_ACTIVE: eventString += 'GROUP_ACTIVE'; break;
-	// 		case GroupModelChangeKind.GROUP_LOCKED: eventString += 'GROUP_LOCKED'; break;
-	// 		case GroupModelChangeKind.EDITOR_DIRTY: eventString += 'EDITOR_DIRTY'; break;
-	// 		case GroupModelChangeKind.EDITOR_STICKY: eventString += 'EDITOR_STICKY'; break;
-	// 		default: eventString += `UNKNOWN: ${event.kind}`; break;
-	// 	}
-	// 	return eventString;
-	// }
-
 	/**
 	 * The main handler for the tab events
 	 * @param events The list of events to process

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -145,12 +145,6 @@ configurationRegistry.registerConfiguration({
 			deprecationMessage: nls.localize('useRipgrepDeprecated', "Deprecated. Consider \"search.usePCRE2\" for advanced regex feature support."),
 			default: true
 		},
-		'search.maintainFileSearchCache': {
-			type: 'boolean',
-			deprecationMessage: nls.localize('maintainFileSearchCacheDeprecated', "The search cache is kept in the extension host which never shuts down, so this setting is no longer needed."),
-			description: nls.localize('search.maintainFileSearchCache', "When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory."),
-			default: false
-		},
 		'search.useIgnoreFiles': {
 			type: 'boolean',
 			markdownDescription: nls.localize('useIgnoreFiles', "Controls whether to use `.gitignore` and `.ignore` files when searching for files."),
@@ -210,13 +204,6 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			description: nls.localize('search.globalFindClipboard', "Controls whether the Search view should read or modify the shared find clipboard on macOS."),
 			included: platform.isMacintosh
-		},
-		'search.location': {
-			type: 'string',
-			enum: ['sidebar', 'panel'],
-			default: 'sidebar',
-			description: nls.localize('search.location', "Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space."),
-			deprecationMessage: nls.localize('search.location.deprecationMessage', "This setting is deprecated. You can drag the search icon to a new location instead.")
 		},
 		'search.maxResults': {
 			type: ['number', 'null'],

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -224,11 +224,6 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 		migrateFn: (value: AutoOpenTesting): ConfigurationKeyValuePairs => {
 			return [[TestingConfigKeys.OpenResults, { value }]];
 		}
-	}, {
-		key: 'testing.automaticallyOpenResults', // insiders only during 1.96, remove after 1.97
-		migrateFn: (value: AutoOpenTesting): ConfigurationKeyValuePairs => {
-			return [[TestingConfigKeys.OpenResults, { value }]];
-		}
 	}]);
 
 export interface ITestingCoverageBarThresholds {

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -440,12 +440,10 @@ export interface ISearchConfigurationProperties {
 	followSymlinks: boolean;
 	smartCase: boolean;
 	globalFindClipboard: boolean;
-	location: 'sidebar' | 'panel';
 	useReplacePreview: boolean;
 	showLineNumbers: boolean;
 	usePCRE2: boolean;
 	actionsPosition: 'auto' | 'right';
-	maintainFileSearchCache: boolean;
 	maxResults: number | null;
 	collapseResults: 'auto' | 'alwaysCollapse' | 'alwaysExpand';
 	searchOnType: boolean;


### PR DESCRIPTION
## Summary

- remove the deprecated `search.maintainFileSearchCache`, `search.location`, and `editor.suggest.maxVisibleSuggestions` settings
- remove the expired Insiders-only `testing.automaticallyOpenResults` migration
- remove an old commented-out editor tabs debugging helper

## Validation

- `npm run precommit`
- `npm run typecheck-client` *(blocked by the pre-existing `ProxyConfig`/`IOSProxyConfig` error in `nativeHostMainService.ts`)*

(Written by Copilot)