### PR TITLE
Forward CAPI assignment context to VS Code core telemetry

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -107,6 +107,7 @@
     "languageModelToolSupportsModel",
     "findFiles2",
     "textSearchProvider",
+    "telemetryExperimentProperty",
     "terminalDataWriteEvent",
     "terminalExecuteCommandEvent",
     "terminalSelection",

--- a/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
@@ -128,6 +128,8 @@ export class TelemetryService extends BaseTelemetryService {
 
 		// Forward CAPI assignment context to VS Code's core telemetry pipeline
 		// so it appears on all VS Code telemetry events, not just the Copilot extension's.
+		// The proposed API is accessed dynamically because the extension's `vscode` module types
+		// come from a shim that does not expose it, and it may be unavailable on older hosts.
 		if (name === 'capi.assignmentcontext') {
 			const setProperty: ((name: string, value: string) => void) | undefined =
 				(vscode.env as Record<string, unknown>)['setTelemetryExperimentProperty'] as ((name: string, value: string) => void) | undefined;

--- a/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
@@ -129,9 +129,9 @@ export class TelemetryService extends BaseTelemetryService {
 		// Forward CAPI assignment context to VS Code's core telemetry pipeline
 		// so it appears on all VS Code telemetry events, not just the Copilot extension's.
 		if (name === 'capi.assignmentcontext') {
-			const setTelemetryExperimentProperty: ((name: string, value: string) => void) | undefined =
-				(vscode.env as any).setTelemetryExperimentProperty;
-			setTelemetryExperimentProperty?.(name, value);
+			const setProperty: ((name: string, value: string) => void) | undefined =
+				(vscode.env as Record<string, unknown>)['setTelemetryExperimentProperty'] as ((name: string, value: string) => void) | undefined;
+			setProperty?.(name, value);
 		}
 	}
 }

--- a/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CustomFetcher } from '@vscode/extension-telemetry';
+import * as vscode from 'vscode';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 import { ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
@@ -118,6 +119,17 @@ export class TelemetryService extends BaseTelemetryService {
 					statusCode: event.statusCode,
 				});
 			});
+		}
+	}
+
+	// __GDPR__COMMON__ "capi.assignmentcontext" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	override setSharedProperty(name: string, value: string): void {
+		super.setSharedProperty(name, value);
+
+		// Forward CAPI assignment context to VS Code's core telemetry pipeline
+		// so it appears on all VS Code telemetry events, not just the Copilot extension's.
+		if (name === 'capi.assignmentcontext') {
+			vscode.env.setTelemetryExperimentProperty(name, value);
 		}
 	}
 }

--- a/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
@@ -129,7 +129,9 @@ export class TelemetryService extends BaseTelemetryService {
 		// Forward CAPI assignment context to VS Code's core telemetry pipeline
 		// so it appears on all VS Code telemetry events, not just the Copilot extension's.
 		if (name === 'capi.assignmentcontext') {
-			vscode.env.setTelemetryExperimentProperty(name, value);
+			const setTelemetryExperimentProperty: ((name: string, value: string) => void) | undefined =
+				(vscode.env as any).setTelemetryExperimentProperty;
+			setTelemetryExperimentProperty?.(name, value);
 		}
 	}
 }

--- a/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
@@ -181,8 +181,8 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 		this._restricted?.setInternalTelemetryContext(context);
 	}
 
-	setExperimentProperty(name: string, value: string): void {
-		this._delegate.setExperimentProperty(name, value);
+	setExperimentProperty(name: string, value: string, triggerBufferFlush?: boolean): void {
+		this._delegate.setExperimentProperty(name, value, triggerBufferFlush);
 	}
 
 	setCommonProperty(name: string, value: string | boolean): void {

--- a/src/vs/platform/dataChannel/browser/forwardingTelemetryService.ts
+++ b/src/vs/platform/dataChannel/browser/forwardingTelemetryService.ts
@@ -67,8 +67,8 @@ export class InterceptingTelemetryService implements ITelemetryService {
 		this._baseService.publicLogError2(eventName, data);
 	}
 
-	setExperimentProperty(name: string, value: string): void {
-		this._baseService.setExperimentProperty(name, value);
+	setExperimentProperty(name: string, value: string, triggerBufferFlush?: boolean): void {
+		this._baseService.setExperimentProperty(name, value, triggerBufferFlush);
 	}
 
 	setCommonProperty(name: string, value: string | boolean): void {

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -453,6 +453,9 @@ const _allApiProposals = {
 	telemetry: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.telemetry.d.ts',
 	},
+	telemetryExperimentProperty: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.telemetryExperimentProperty.d.ts',
+	},
 	terminalCompletionProvider: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts',
 	},

--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -50,7 +50,14 @@ export interface ITelemetryService {
 
 	publicLogError2<E extends ClassifiedEvent<OmitMetadata<T>> = never, T extends IGDPRProperty = never>(eventName: string, data?: StrictPropertyCheck<T, E>): void;
 
-	setExperimentProperty(name: string, value: string): void;
+	/**
+	 * Sets an experiment property that will be attached to all telemetry events.
+	 *
+	 * @param triggerBufferFlush When events are buffered on startup waiting for experiment
+	 * context, the first property with this set to `true` releases the buffer. Pass `false` for
+	 * additive properties (e.g. forwarded from extensions) that must not release the buffer early.
+	 */
+	setExperimentProperty(name: string, value: string, triggerBufferFlush?: boolean): void;
 
 	/**
 	 * Sets a common property that will be attached to all telemetry events.

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -126,11 +126,14 @@ export class TelemetryService implements ITelemetryService {
 		}
 	}
 
-	setExperimentProperty(name: string, value: string): void {
+	setExperimentProperty(name: string, value: string, triggerBufferFlush: boolean = true): void {
 		this._experimentProperties[name] = new TelemetryTrustedValue(value);
 
-		// On first call, flush all pending events that were buffered waiting for experiment properties
-		if (!this._isExperimentPropertySet) {
+		// On first call, flush all pending events that were buffered waiting for experiment properties.
+		// Additive properties (triggerBufferFlush === false, e.g. forwarded from extensions) are still
+		// stored above so they get mixed into buffered events, but they must not release the startup
+		// buffer, which waits for this window's own experiment context.
+		if (triggerBufferFlush && !this._isExperimentPropertySet) {
 			this._flushPendingEvents();
 		}
 	}

--- a/src/vs/workbench/api/browser/mainThreadTelemetry.ts
+++ b/src/vs/workbench/api/browser/mainThreadTelemetry.ts
@@ -57,6 +57,10 @@ export class MainThreadTelemetry extends Disposable implements MainThreadTelemet
 	$publicLog2<E extends ClassifiedEvent<OmitMetadata<T>> = never, T extends IGDPRProperty = never>(eventName: string, data?: StrictPropertyCheck<T, E>): void {
 		this.$publicLog(eventName, data);
 	}
+
+	$setExperimentProperty(name: string, value: string): void {
+		this._telemetryService.setExperimentProperty(name, value);
+	}
 }
 
 

--- a/src/vs/workbench/api/browser/mainThreadTelemetry.ts
+++ b/src/vs/workbench/api/browser/mainThreadTelemetry.ts
@@ -58,8 +58,11 @@ export class MainThreadTelemetry extends Disposable implements MainThreadTelemet
 		this.$publicLog(eventName, data);
 	}
 
+	// __GDPR__COMMON__ "capi.assignmentcontext" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	$setExperimentProperty(name: string, value: string): void {
-		this._telemetryService.setExperimentProperty(name, value);
+		// Properties forwarded from an extension are additive and must not release the startup
+		// event buffer, which waits for this window's own experiment context (TAS assignment context).
+		this._telemetryService.setExperimentProperty(name, value, false);
 	}
 }
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -456,6 +456,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				ExtHostTelemetryLogger.validateSender(sender);
 				return extHostTelemetry.instantiateLogger(extension, sender, options);
 			},
+			setTelemetryExperimentProperty(name: string, value: string): void {
+				checkProposedApiEnabled(extension, 'telemetryExperimentProperty');
+				rpcProtocol.getProxy(MainContext.MainThreadTelemetry).$setExperimentProperty(name, value);
+			},
 			async openExternal(uri: URI, options?: { allowContributedOpeners?: boolean | string }) {
 				return extHostWindow.openUri(uri, {
 					allowTunneling: initData.remote.isRemote ?? (initData.remote.authority ? await extHostTunnelService.hasTunnelProvider() : false),

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -853,6 +853,7 @@ export interface MainThreadStorageShape extends IDisposable {
 export interface MainThreadTelemetryShape extends IDisposable {
 	$publicLog(eventName: string, data?: any): void;
 	$publicLog2<E extends ClassifiedEvent<OmitMetadata<T>> = never, T extends IGDPRProperty = never>(eventName: string, data?: StrictPropertyCheck<T, E>): void;
+	$setExperimentProperty(name: string, value: string): void;
 }
 
 export interface MainThreadEditorInsetsShape extends IDisposable {

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -131,8 +131,8 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 		return this.impl;
 	}
 
-	setExperimentProperty(name: string, value: string): void {
-		return this.impl.setExperimentProperty(name, value);
+	setExperimentProperty(name: string, value: string, triggerBufferFlush?: boolean): void {
+		return this.impl.setExperimentProperty(name, value, triggerBufferFlush);
 	}
 
 	setCommonProperty(name: string, value: string | boolean): void {

--- a/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
@@ -97,8 +97,8 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 		}));
 	}
 
-	setExperimentProperty(name: string, value: string): void {
-		return this.impl.setExperimentProperty(name, value);
+	setExperimentProperty(name: string, value: string, triggerBufferFlush?: boolean): void {
+		return this.impl.setExperimentProperty(name, value, triggerBufferFlush);
 	}
 
 	setCommonProperty(name: string, value: string | boolean): void {

--- a/src/vscode-dts/vscode.proposed.telemetryExperimentProperty.d.ts
+++ b/src/vscode-dts/vscode.proposed.telemetryExperimentProperty.d.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	export namespace env {
+		/**
+		 * Sets an experiment property that will be attached to all telemetry events
+		 * sent by the host application (VS Code). This is intended for trusted built-in
+		 * extensions that need to propagate server-side experiment assignments to the
+		 * host telemetry pipeline.
+		 *
+		 * @param name The property name (e.g., 'capi.assignmentcontext')
+		 * @param value The property value
+		 */
+		export function setTelemetryExperimentProperty(name: string, value: string): void;
+	}
+}

--- a/src/vscode-dts/vscode.proposed.telemetryExperimentProperty.d.ts
+++ b/src/vscode-dts/vscode.proposed.telemetryExperimentProperty.d.ts
@@ -7,10 +7,13 @@ declare module 'vscode' {
 
 	export namespace env {
 		/**
-		 * Sets an experiment property that will be attached to all telemetry events
-		 * sent by the host application. This is intended for trusted built-in
-		 * extensions that need to propagate server-side experiment assignments to the
-		 * host telemetry pipeline.
+		 * Sets an experiment property that will be attached to telemetry events
+		 * sent by the current window's telemetry service. This is intended for
+		 * trusted built-in extensions that need to propagate server-side experiment
+		 * assignments to the host telemetry pipeline.
+		 *
+		 * Note: This follows the same per-window scope as other experiment properties
+		 * (e.g., TAS assignment context).
 		 *
 		 * @param name The property name (e.g., 'capi.assignmentcontext')
 		 * @param value The property value

--- a/src/vscode-dts/vscode.proposed.telemetryExperimentProperty.d.ts
+++ b/src/vscode-dts/vscode.proposed.telemetryExperimentProperty.d.ts
@@ -8,7 +8,7 @@ declare module 'vscode' {
 	export namespace env {
 		/**
 		 * Sets an experiment property that will be attached to all telemetry events
-		 * sent by the host application (VS Code). This is intended for trusted built-in
+		 * sent by the host application. This is intended for trusted built-in
 		 * extensions that need to propagate server-side experiment assignments to the
 		 * host telemetry pipeline.
 		 *


### PR DESCRIPTION
New functionality related to issue reported in issue https://github.com/microsoft/vscode-internalbacklog/issues/5964#issuecomment-4127382406

Add a proposed API scode.env.setTelemetryExperimentProperty that allows trusted built-in extensions to set experiment properties on VS Code's core telemetry pipeline.

The Copilot extension uses this to forward capi.assignmentcontext (received via X-Copilot-Experiment and x-copilot-api-exp-assignment-context response headers from CAPI) so that it appears on all VS Code telemetry events, not just the Copilot extension's own events.

Flow:
1. CAPI responds with experiment headers
2. Copilot extension extracts them into serverExperiments
3. TelemetryService.setSharedProperty('capi.assignmentcontext', value)
4. Override forwards to vscode.env.setTelemetryExperimentProperty()
5. MainThreadTelemetry calls ITelemetryService.setExperimentProperty()
6. Property appears on all subsequent VS Code telemetry events

Validation:
Manual validation done via examining raw telemetry -> confirmed that VS Code Core events include `capi.assignmentcontext` property after chat usage.