### PR TITLE
sessions: render subagent chat input and make it read-only

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -840,28 +840,35 @@ export class AgentSideEffects extends Disposable {
 
 		this._logService.info(`[AgentSideEffects] Starting subagent turn: ${subagentChatUri} (parent=${chatURI}, toolCallId=${toolCallId})`);
 
-		// Start a turn on the subagent session
+		// The spawning tool call lives in the immediate parent chat — the
+		// top-level chat for a first-level subagent or the immediate parent
+		// subagent chat when nested. Resolve it so both the discovery content
+		// block and the parent-tool-input prompt address the right chat.
+		const contentChatUri = spawningToolParentId
+			? this._subagentChats.get(chatURI, spawningToolParentId)?.chatUri ?? chatURI
+			: chatURI;
+
+		// Start a turn on the subagent session, seeding the request with the
+		// task prompt the parent handed the subagent so the peer chat renders
+		// what it was asked to do. The prompt is recovered from the spawning
+		// tool call's recorded input — already in state by the time the subagent
+		// starts, for every provider — so seeding does not depend on any
+		// provider-side capture timing.
 		const turnId = generateUuid();
 		this._stateManager.dispatchServerAction(subagentChatUri, {
 			type: ActionType.ChatTurnStarted,
 			turnId,
 			startedAt: new Date().toISOString(),
-			message: { text: '', origin: { kind: MessageKind.User } },
+			message: { text: this._taskPromptFromToolInput(contentChatUri, toolCallId) ?? '', origin: { kind: MessageKind.User } },
 		});
 
 		this._subagentChats.set({ parentChatUri: chatURI, toolCallId, sessionUri: parentSessionUri, chatUri: subagentChatUri, turnStopWatch: StopWatch.create(false) }, chatURI, toolCallId);
 
 		// Dispatch content on the spawning tool call so clients discover the
-		// subagent. The tool call lives in the immediate parent chat, which is
-		// the top-level chat for a first-level subagent or the immediate
-		// parent subagent chat when nested (at any depth) — resolve it via
-		// `spawningToolParentId` so the block lands where the tool call is
-		// (dispatching on the top-level chat would be a no-op, leaving nested
-		// subagents undiscoverable). Merge with any existing content to avoid
-		// dropping prior content blocks.
-		const contentChatUri = spawningToolParentId
-			? this._subagentChats.get(chatURI, spawningToolParentId)?.chatUri ?? chatURI
-			: chatURI;
+		// subagent. Merge with any existing content to avoid dropping prior
+		// content blocks. (Dispatching on the top-level chat for a nested
+		// subagent would be a no-op, leaving it undiscoverable — hence
+		// `contentChatUri` above.)
 		const parentTurnId = this._stateManager.getActiveTurnId(contentChatUri);
 		if (parentTurnId) {
 			const parentState = this._stateManager.getSessionState(contentChatUri);
@@ -882,6 +889,33 @@ export class AgentSideEffects extends Disposable {
 				],
 			});
 		}
+	}
+
+	/**
+	 * Recovers the spawning Task tool call's `prompt` input from the parent
+	 * chat's running tool call state — the provider-agnostic source for seeding
+	 * the subagent's opening request.
+	 */
+	private _taskPromptFromToolInput(chatURI: ProtocolURI, toolCallId: string): string | undefined {
+		const state = this._stateManager.getSessionState(chatURI);
+		if (!state?.activeTurn) {
+			return undefined;
+		}
+		for (const rp of state.activeTurn.responseParts) {
+			if (rp.kind === ResponsePartKind.ToolCall && rp.toolCall.toolCallId === toolCallId) {
+				const toolInput = (rp.toolCall as { toolInput?: unknown }).toolInput;
+				if (typeof toolInput !== 'string') {
+					return undefined;
+				}
+				try {
+					const parsed = JSON.parse(toolInput) as Record<string, unknown>;
+					return typeof parsed.prompt === 'string' && parsed.prompt.length > 0 ? parsed.prompt : undefined;
+				} catch {
+					return undefined;
+				}
+			}
+		}
+		return undefined;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -840,20 +840,12 @@ export class AgentSideEffects extends Disposable {
 
 		this._logService.info(`[AgentSideEffects] Starting subagent turn: ${subagentChatUri} (parent=${chatURI}, toolCallId=${toolCallId})`);
 
-		// The spawning tool call lives in the immediate parent chat — the
-		// top-level chat for a first-level subagent or the immediate parent
-		// subagent chat when nested. Resolve it so both the discovery content
-		// block and the parent-tool-input prompt address the right chat.
+		// The spawning tool call lives in the immediate parent chat (top-level, or the parent subagent chat when nested).
 		const contentChatUri = spawningToolParentId
 			? this._subagentChats.get(chatURI, spawningToolParentId)?.chatUri ?? chatURI
 			: chatURI;
 
-		// Start a turn on the subagent session, seeding the request with the
-		// task prompt the parent handed the subagent so the peer chat renders
-		// what it was asked to do. The prompt is recovered from the spawning
-		// tool call's recorded input — already in state by the time the subagent
-		// starts, for every provider — so seeding does not depend on any
-		// provider-side capture timing.
+		// Seed the subagent's opening request with the spawning tool call's prompt.
 		const turnId = generateUuid();
 		this._stateManager.dispatchServerAction(subagentChatUri, {
 			type: ActionType.ChatTurnStarted,
@@ -864,11 +856,7 @@ export class AgentSideEffects extends Disposable {
 
 		this._subagentChats.set({ parentChatUri: chatURI, toolCallId, sessionUri: parentSessionUri, chatUri: subagentChatUri, turnStopWatch: StopWatch.create(false) }, chatURI, toolCallId);
 
-		// Dispatch content on the spawning tool call so clients discover the
-		// subagent. Merge with any existing content to avoid dropping prior
-		// content blocks. (Dispatching on the top-level chat for a nested
-		// subagent would be a no-op, leaving it undiscoverable — hence
-		// `contentChatUri` above.)
+		// Dispatch the discovery content on the spawning tool call's own chat; the top-level chat is a no-op when nested.
 		const parentTurnId = this._stateManager.getActiveTurnId(contentChatUri);
 		if (parentTurnId) {
 			const parentState = this._stateManager.getSessionState(contentChatUri);

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -3635,7 +3635,7 @@ suite('AgentSideEffects', () => {
 			assert.strictEqual(stateManager.getSnapshot(expectedUri), undefined);
 		});
 
-		test('nested subagent_started routes its discovery content block to the immediate parent chat (arbitrary depth)', () => {
+		test('nested subagent_started routes discovery block and seeds each request prompt via the immediate parent chat (arbitrary depth)', () => {
 			// Regression: for a subagent spawned by another subagent, the
 			// `subagent_started` signal's `chat` is the top-level chat, but
 			// its spawning tool call lives in the immediate parent's subagent
@@ -3652,14 +3652,14 @@ suite('AgentSideEffects', () => {
 
 			// Level-1 subagent spawned from the default chat.
 			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action: { type: ActionType.ChatToolCallStart, turnId: 'turn-1', toolCallId: 'tc-l1', toolName: 'task', displayName: 'Task', contributor: undefined, _meta: { toolKind: 'subagent', language: undefined } } });
-			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action: { type: ActionType.ChatToolCallReady, turnId: 'turn-1', toolCallId: 'tc-l1', invocationMessage: 'Delegating...', toolInput: undefined, confirmed: ToolCallConfirmationReason.NotNeeded } });
+			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action: { type: ActionType.ChatToolCallReady, turnId: 'turn-1', toolCallId: 'tc-l1', invocationMessage: 'Delegating...', toolInput: JSON.stringify({ prompt: 'l1 prompt' }), confirmed: ToolCallConfirmationReason.NotNeeded } });
 			agent.fireProgress({ kind: 'subagent_started', chat: URI.parse(defaultChatUri), toolCallId: 'tc-l1', agentName: 'l1', agentDisplayName: 'L1', agentDescription: 'first' });
 
 			// Level-2 subagent's spawning tool runs INSIDE the level-1
 			// subagent (parentToolCallId = tc-l1), so it lands on the level-1
 			// subagent chat rather than the default chat.
 			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), parentToolCallId: 'tc-l1', action: { type: ActionType.ChatToolCallStart, turnId: 'turn-1', toolCallId: 'tc-l2', toolName: 'task', displayName: 'Task', contributor: undefined, _meta: { toolKind: 'subagent', language: undefined } } });
-			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), parentToolCallId: 'tc-l1', action: { type: ActionType.ChatToolCallReady, turnId: 'turn-1', toolCallId: 'tc-l2', invocationMessage: 'Delegating...', toolInput: undefined, confirmed: ToolCallConfirmationReason.NotNeeded } });
+			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), parentToolCallId: 'tc-l1', action: { type: ActionType.ChatToolCallReady, turnId: 'turn-1', toolCallId: 'tc-l2', invocationMessage: 'Delegating...', toolInput: JSON.stringify({ prompt: 'l2 prompt' }), confirmed: ToolCallConfirmationReason.NotNeeded } });
 
 			// Level-2 subagent starts. Its spawning tool (tc-l2) lives in the
 			// level-1 subagent chat, so the signal carries parentToolCallId = tc-l1.
@@ -3668,7 +3668,7 @@ suite('AgentSideEffects', () => {
 			// Level-3 subagent's spawning tool runs INSIDE the level-2
 			// subagent (parentToolCallId = tc-l2), landing on the level-2 chat.
 			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), parentToolCallId: 'tc-l2', action: { type: ActionType.ChatToolCallStart, turnId: 'turn-1', toolCallId: 'tc-l3', toolName: 'task', displayName: 'Task', contributor: undefined, _meta: { toolKind: 'subagent', language: undefined } } });
-			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), parentToolCallId: 'tc-l2', action: { type: ActionType.ChatToolCallReady, turnId: 'turn-1', toolCallId: 'tc-l3', invocationMessage: 'Delegating...', toolInput: undefined, confirmed: ToolCallConfirmationReason.NotNeeded } });
+			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), parentToolCallId: 'tc-l2', action: { type: ActionType.ChatToolCallReady, turnId: 'turn-1', toolCallId: 'tc-l3', invocationMessage: 'Delegating...', toolInput: JSON.stringify({ prompt: 'l3 prompt' }), confirmed: ToolCallConfirmationReason.NotNeeded } });
 
 			// Level-3 subagent starts. Its spawning tool (tc-l3) lives in the
 			// level-2 subagent chat, so the signal carries parentToolCallId = tc-l2.
@@ -3702,6 +3702,14 @@ suite('AgentSideEffects', () => {
 			// Each level's discovery block lands on its immediate parent chat.
 			assertDiscoveryBlock(l1ChatUri, 'tc-l2', l2ChatUri, 'the level-1 chat');
 			assertDiscoveryBlock(l2ChatUri, 'tc-l3', l3ChatUri, 'the level-2 chat');
+
+			// Each child chat's opening request is seeded from its spawning tool
+			// call's prompt, resolved via the immediate parent chat — so a
+			// fallback to the top-level chat would surface the wrong prompt.
+			assert.deepStrictEqual(
+				[l1ChatUri, l2ChatUri, l3ChatUri].map(uri => stateManager.getSessionState(uri)?.activeTurn?.message.text),
+				['l1 prompt', 'l2 prompt', 'l3 prompt'],
+			);
 
 			// Nested spawning tools must NOT be misrouted to the top-level
 			// default chat, where they do not exist.

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -3573,7 +3573,8 @@ suite('AgentSideEffects', () => {
 				kind: 'action', resource: URI.parse(defaultChatUri),
 				action: {
 					type: ActionType.ChatToolCallReady, turnId: 'turn-1',
-					toolCallId: 'tc-1', invocationMessage: 'Delegating task...', toolInput: undefined,
+					toolCallId: 'tc-1', invocationMessage: 'Delegating task...',
+					toolInput: JSON.stringify({ prompt: 'Review the auth module for security issues' }),
 					confirmed: ToolCallConfirmationReason.NotNeeded,
 				},
 			});
@@ -3595,6 +3596,7 @@ suite('AgentSideEffects', () => {
 			assert.strictEqual(subagentSummary?.title, 'Code Reviewer');
 			assert.deepStrictEqual(subagentSummary?.origin, { kind: 'tool', chat: defaultChatUri, toolCallId: 'tc-1' });
 			assert.ok(subState!.activeTurn, 'subagent chat should have an active turn');
+			assert.strictEqual(subState!.activeTurn!.message.text, 'Review the auth module for security issues', 'subagent turn should render the spawning tool call prompt as its request');
 
 			// Verify content was dispatched on the parent tool call
 			const parentState = stateManager.getSessionState(sessionUri.toString());

--- a/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/agentHostE2ETestHelpers.ts
@@ -30,7 +30,7 @@ import {
 	MessageKind,
 	ResponsePartKind, ROOT_STATE_URI, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind,
 	ChatInputResponseKind, ToolResultContentType, ToolCallConfirmationReason, ToolCallCancellationReason, buildDefaultChatUri, buildSubagentSessionUri, parseChatUri,
-	type MessageAttachment, type ChatInputAnswer, type ChatInputRequest, type ISessionWithDefaultChat, type SessionState, type TerminalState,
+	type MessageAttachment, type ChatInputAnswer, type ChatInputRequest, type ISessionWithDefaultChat, type SessionState, type ChatState, type TerminalState,
 	type ToolResultContent, type ToolResultSubagentContent,
 } from '../../../common/state/sessionState.js';
 import type { RootState } from '../../../common/state/protocol/state.js';
@@ -1311,7 +1311,13 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 
 			// The subagent's conversation contents (its inner tool calls) are
 			// emitted on the chat channel carried by the tool result.
-			await client.call<SubscribeResult>('subscribe', { channel: subagentChatUri });
+			const subagentSnap = await client.call<SubscribeResult>('subscribe', { channel: subagentChatUri });
+			const subagentState = subagentSnap.snapshot?.state as ChatState | undefined;
+			const subagentFirstTurn = subagentState?.turns?.[0] ?? subagentState?.activeTurn;
+			assert.ok(
+				subagentFirstTurn?.message.text && subagentFirstTurn.message.text.includes('List the files'),
+				`subagent chat's opening request should render the task prompt, got: ${JSON.stringify(subagentFirstTurn?.message.text)}`,
+			);
 
 			await client.waitForNotification(n => {
 				if (!isActionNotification(n, 'chat/turnComplete')) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -300,6 +300,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	get visible() { return this._visible; }
 
 	private _inputVisible = true;
+	private _readOnly = false;
 
 	private _instructionFilesCheckPromise: Promise<boolean> | undefined;
 	private _instructionFilesExist: boolean | undefined;
@@ -1581,8 +1582,25 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	 * actions (e.g. Start Over, Restore Checkpoint) are not offered.
 	 */
 	setReadOnly(readOnly: boolean): void {
+		this._readOnly = readOnly;
 		this._readOnlyContextKey.set(readOnly);
 		this.setInputVisible(!readOnly);
+		// Read-only chats (e.g. subagent transcripts, archived sessions) must not
+		// offer request editing, so disable the renderer's edit affordance. This
+		// is authoritative over the lock/unlock `editable` toggles below.
+		this._applyRendererEditable(!readOnly);
+		if (this.visible) {
+			this.listWidget?.rerender();
+		}
+	}
+
+	/**
+	 * Applies the renderer's `editable` option, forcing it off while the chat is
+	 * read-only so the lock/unlock transitions can never re-enable request
+	 * editing on a read-only chat.
+	 */
+	private _applyRendererEditable(editable: boolean): void {
+		this.listWidget?.updateRendererOptions({ editable: editable && !this._readOnly });
 	}
 
 	/**
@@ -2394,7 +2412,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		const agent = this.chatAgentService.getAgent(agentId);
 		this._updateAgentCapabilitiesContextKeys(agent);
 		const supportsCheckpoints = this._attachmentCapabilities.supportsCheckpoints ?? false;
-		this.listWidget?.updateRendererOptions({ restorable: supportsCheckpoints, editable: supportsCheckpoints, noFooter: false, progressMessageAtBottomOfResponse: true });
+		this.listWidget?.updateRendererOptions({ restorable: supportsCheckpoints, editable: supportsCheckpoints && !this._readOnly, noFooter: false, progressMessageAtBottomOfResponse: true });
 		if (this.visible) {
 			this.listWidget?.rerender();
 		}
@@ -2422,7 +2440,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.viewModel.resetInputPlaceholder();
 		}
 		this.inputEditor?.updateOptions({ placeholder: undefined });
-		this.listWidget?.updateRendererOptions({ restorable: true, editable: true, progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask });
+		this.listWidget?.updateRendererOptions({ restorable: true, editable: !this._readOnly, progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask });
 		if (this.visible) {
 			this.listWidget?.rerender();
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1585,9 +1585,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this._readOnly = readOnly;
 		this._readOnlyContextKey.set(readOnly);
 		this.setInputVisible(!readOnly);
-		// Read-only chats (e.g. subagent transcripts, archived sessions) must not
-		// offer request editing, so disable the renderer's edit affordance. This
-		// is authoritative over the lock/unlock `editable` toggles below.
+		// Authoritative over the lock/unlock `editable` toggles below.
 		this._applyRendererEditable(!readOnly);
 		if (this.visible) {
 			this.listWidget?.rerender();


### PR DESCRIPTION
Fixes #324666

## What
Subagent (tool-origin) peer chats in the Agents window were surfaced with an **empty opening request**, so the read-only transcript never showed what the subagent was actually asked to do.

This PR:
1. **Seeds the subagent chat's opening request** with the spawning `Task`/`task` tool call's `prompt` input, so the read-only transcript starts with a proper request bubble describing the delegated task.
2. **Makes read-only authoritative over request editing** in the chat widget, so a read-only chat (subagent transcript, archived session) never offers a request-edit affordance.

## How
- **`agentSideEffects.ts`** — When a subagent turn is started (`_handleSubagentStarted`), the request text is recovered from the spawning tool call's recorded `toolInput` (`_taskPromptFromToolInput`) in the parent chat's running tool-call state. This lives in the **shared host layer**, so it is provider-agnostic (works for both Copilot and Claude) and does not depend on any provider-side capture timing — the parent Task tool call's input is always in state by the time the subagent starts.
- **`chatWidget.ts`** — `setReadOnly` now records `_readOnly` and routes the renderer's `editable` option through it. The `lockToCodingAgent`/`unlockFromCodingAgent` transitions (which run async after the model loads) can no longer re-enable request editing on a read-only chat. This fixes an intermittent race where the edit affordance appeared depending on ordering.

## Why the fix lives in the shared layer
An earlier iteration attached the prompt to the `subagent_started` signal from each provider. That was fragile: each provider captured the prompt at a different point, and Claude's capture could land *after* the signal fired, causing the request to render only intermittently. Reading the prompt from the tool call already in state removes all provider-specific code and the timing dependency.

## Testing
- **Unit** (`agentSideEffects.test.ts`): asserts the subagent turn renders the spawning tool call's prompt as its request.
- **E2E** (`agentHostE2ETestHelpers.ts`): the shared subagent e2e test (real host + real SDK + real protocol, replay) now asserts the subagent chat's opening request contains the task prompt — passes for both Copilot and Claude.
- `tsc` typecheck and `eslint` clean.

## Reviewer notes
- No provider-specific code — the seeding is entirely in the shared `AgentSideEffects` host layer.
- The `_readOnly` gate is applied at all three `updateRendererOptions` call sites (`setReadOnly`, lock, unlock).
