### PR TITLE
Fix Match Whole Word skipping overlapping matches

### DIFF
--- a/src/vs/editor/common/model/textModelSearch.ts
+++ b/src/vs/editor/common/model/textModelSearch.ts
@@ -548,6 +548,9 @@ export class Searcher {
 				return m;
 			}
 
+			// Not a whole-word match; advance one code point so overlapping whole-word matches aren't skipped.
+			this._searchRegex.lastIndex = matchStartIndex + (strings.getNextCodePoint(text, textLength, matchStartIndex) > 0xFFFF ? 2 : 1);
+
 		} while (m);
 
 		return null;

--- a/src/vs/editor/common/model/textModelSearch.ts
+++ b/src/vs/editor/common/model/textModelSearch.ts
@@ -259,13 +259,17 @@ export class TextModelSearch {
 			const searchStringLen = searchString.length;
 			const textLength = text.length;
 
-			let lastMatchIndex = -searchStringLen;
-			while ((lastMatchIndex = text.indexOf(searchString, lastMatchIndex + searchStringLen)) !== -1) {
+			let lastMatchIndex = text.indexOf(searchString);
+			while (lastMatchIndex !== -1) {
 				if (!wordSeparators || isValidMatch(wordSeparators, text, textLength, lastMatchIndex, searchStringLen)) {
 					result[resultLen++] = new FindMatch(new Range(lineNumber, lastMatchIndex + 1 + deltaOffset, lineNumber, lastMatchIndex + 1 + searchStringLen + deltaOffset), null);
 					if (resultLen >= limitResultCount) {
 						return resultLen;
 					}
+					lastMatchIndex = text.indexOf(searchString, lastMatchIndex + searchStringLen);
+				} else {
+					// Not a whole-word match; advance by one so overlapping whole-word matches aren't skipped.
+					lastMatchIndex = text.indexOf(searchString, lastMatchIndex + 1);
 				}
 			}
 			return resultLen;
@@ -550,6 +554,8 @@ export class Searcher {
 
 			// Not a whole-word match; advance one code point so overlapping whole-word matches aren't skipped.
 			this._searchRegex.lastIndex = matchStartIndex + (strings.getNextCodePoint(text, textLength, matchStartIndex) > 0xFFFF ? 2 : 1);
+			this._prevMatchStartIndex = -1;
+			this._prevMatchLength = 0;
 
 		} while (m);
 

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -384,19 +384,22 @@ suite('TextModelSearch', () => {
 	});
 
 	test('issue #291591: Match whole word skips overlapping matches', () => {
-		assertFindMatches(
-			[
-				'[1] aa-aa',
-				'[2] xaa-aa-aa',
-				'[3] aax-aa-aa',
-			].join('\n'),
-			'aa-aa', false, false, USUAL_WORD_SEPARATORS,
-			[
-				[1, 5, 1, 10],
-				[2, 9, 2, 14],
-				[3, 9, 3, 14],
-			]
-		);
+		const text = [
+			'[1] aa-aa',
+			'[2] xaa-aa-aa',
+			'[3] aax-aa-aa',
+		].join('\n');
+		const expected: [number, number, number, number][] = [
+			[1, 5, 1, 10],
+			[2, 9, 2, 14],
+			[3, 9, 3, 14],
+		];
+		// case-insensitive (regex path)
+		assertFindMatches(text, 'aa-aa', false, false, USUAL_WORD_SEPARATORS, expected);
+		// case-sensitive (simple indexOf path)
+		assertFindMatches(text, 'aa-aa', false, true, USUAL_WORD_SEPARATORS, expected);
+		// a rejected candidate ending at end-of-line must not stop the search
+		assertFindMatches('xaa-aa', 'aa-aa|aa', true, false, USUAL_WORD_SEPARATORS, [[1, 5, 1, 7]]);
 	});
 
 	test('findNextMatch without regex', () => {

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -383,6 +383,22 @@ suite('TextModelSearch', () => {
 		);
 	});
 
+	test('issue #291591: Match whole word skips overlapping matches', () => {
+		assertFindMatches(
+			[
+				'[1] aa-aa',
+				'[2] xaa-aa-aa',
+				'[3] aax-aa-aa',
+			].join('\n'),
+			'aa-aa', false, false, USUAL_WORD_SEPARATORS,
+			[
+				[1, 5, 1, 10],
+				[2, 9, 2, 14],
+				[3, 9, 3, 14],
+			]
+		);
+	});
+
 	test('findNextMatch without regex', () => {
 		const model = createTextModel('line line one\nline two\nthree');
 


### PR DESCRIPTION
Fixes #291591. Match Whole Word is applied as a post-filter on each regex match; when a candidate fails the boundary check, the search resumed at the end of that candidate, skipping any valid whole-word match that starts inside it (e.g. the trailing `aa-aa` in `xaa-aa-aa`, which `grep -w` finds). Now it advances one code point on a failed check so overlapping matches are considered. Added a regression test.