### PR TITLE
Treat $$ as an escaped $ in workspace search regex replace

### DIFF
--- a/src/vs/workbench/services/search/common/replace.ts
+++ b/src/vs/workbench/services/search/common/replace.ts
@@ -166,6 +166,7 @@ export class ReplacePattern {
 	 * \t => TAB
 	 * \\ => \
 	 * $0 => $& (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter)
+	 * $$ => $
 	 * everything else stays untouched
 	 */
 	private parseReplaceString(replaceString: string): void {
@@ -230,6 +231,8 @@ export class ReplacePattern {
 						replaceWithCharacter = '$&';
 						this._hasParameters = true;
 						break;
+					// $$ => $
+					case CharCode.DollarSign:
 					case CharCode.BackTick:
 					case CharCode.SingleQuote:
 						this._hasParameters = true;

--- a/src/vs/workbench/services/search/test/common/replace.test.ts
+++ b/src/vs/workbench/services/search/test/common/replace.test.ts
@@ -65,10 +65,10 @@ suite('Replace Pattern test', () => {
 		testParse('hello$100a', 'hello$100a', false);
 		// $10a0 => no treatment
 		testParse('hello$10a0', 'hello$10a0', true);
-		// $$ => no treatment
-		testParse('hello$$', 'hello$$', false);
-		// $$0 => no treatment
-		testParse('hello$$0', 'hello$$0', false);
+		// $$ => escaped dollar sign, handled as a parameter
+		testParse('hello$$', 'hello$$', true);
+		// $$0 => escaped dollar sign followed by 0
+		testParse('hello$$0', 'hello$$0', true);
 
 		// $0 => $&
 		testParse('hello$0', 'hello$&', true);
@@ -140,6 +140,14 @@ suite('Replace Pattern test', () => {
 		testObject = new ReplacePattern('cat$1', { pattern: 'for(.*)', isRegExp: true });
 		actual = testObject.getReplaceString('for ()');
 		assert.strictEqual(actual, 'cat ()');
+	});
+
+	test('issue #299365: $$ inserts a literal dollar sign in regex replace', () => {
+		const replaceString = (pattern: string) => new ReplacePattern(pattern, { pattern: '(bla)', isRegExp: true }).getReplaceString('bla');
+		assert.deepStrictEqual(
+			['$$0', '$$1', '$$$1'].map(replaceString),
+			['$0', '$1', '$bla']
+		);
 	});
 
 	test('case operations', () => {


### PR DESCRIPTION
Fixes #299365

Workspace-search regex replace didn't collapse `$$` to a literal `$`: `$$0` was inserted as `$$0` instead of `$0`. `parseReplaceString` in `replace.ts` handled `$0`, `` $` ``, `$'`, and `$1`–`$99`, but had no case for `$$`, so it was never marked as a parameter and fell through to literal insertion. The in-editor find/replace (`replacePattern.ts`) already treats `$$` as an escaped `$`; this brings workspace search in line.

Adding `$$` to the same branch as `` $` `` / `$'` flags it as a parameter, letting the native `String.replace` collapse `$$` → `$`. Added a regression test covering `$$0` → `$0`, `$$1` → `$1`, and `$$$1` → `$` + group 1.
