### PR TITLE
chat: Don't Reveal Row Chrome on Focus or Selection

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -157,6 +157,7 @@ export interface IChatListItemTemplate {
 	readonly titleToolbar?: MenuWorkbenchToolBar;
 	readonly header?: HTMLElement;
 	readonly footerToolbar: MenuWorkbenchToolBar;
+	readonly footerToolbarContainer: HTMLElement;
 	readonly footerDetailsContainer: HTMLElement;
 	readonly avatarContainer: HTMLElement;
 	readonly username: HTMLElement;
@@ -837,7 +838,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}));
 		const connectionObserver = document.createElement('connection-observer') as dom.ConnectionObserverElement;
 		dom.append(container, connectionObserver);
-		const template: IChatListItemTemplate = { header, avatarContainer, requestHover, username, detail, value, rowContainer, elementDisposables, templateDisposables, contextKeyService, instantiationService: scopedInstantiationService, agentHover, titleToolbar, footerToolbar, footerDetailsContainer, disabledOverlay, checkpointToolbar, checkpointRestoreToolbar, checkpointContainer, checkpointRestoreContainer };
+		const template: IChatListItemTemplate = { header, avatarContainer, requestHover, username, detail, value, rowContainer, elementDisposables, templateDisposables, contextKeyService, instantiationService: scopedInstantiationService, agentHover, titleToolbar, footerToolbar, footerToolbarContainer, footerDetailsContainer, disabledOverlay, checkpointToolbar, checkpointRestoreToolbar, checkpointContainer, checkpointRestoreContainer };
 		this.templateDataByRow.set(rowContainer, template);
 
 		connectionObserver.onDidDisconnect = () => {
@@ -1117,8 +1118,18 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				reqData?.checkpointContainer.classList.toggle('group-hovered', hovered);
 				resData?.rowContainer.classList.toggle('group-hovered', hovered);
 			};
-			templateData.elementDisposables.add(dom.addDisposableListener(templateData.rowContainer, dom.EventType.MOUSE_ENTER, () => setGroupHover(true)));
-			templateData.elementDisposables.add(dom.addDisposableListener(templateData.rowContainer, dom.EventType.MOUSE_LEAVE, () => setGroupHover(false)));
+			const hoverTargets = isResponseVM(element)
+				? [templateData.value, templateData.footerToolbarContainer]
+				: [templateData.rowContainer];
+			const isHoverTarget = (target: EventTarget | null) => dom.isHTMLElement(target) && hoverTargets.some(hoverTarget => hoverTarget.contains(target));
+			for (const hoverTarget of hoverTargets) {
+				templateData.elementDisposables.add(dom.addDisposableListener(hoverTarget, dom.EventType.MOUSE_ENTER, () => setGroupHover(true)));
+				templateData.elementDisposables.add(dom.addDisposableListener(hoverTarget, dom.EventType.MOUSE_LEAVE, e => {
+					if (!isHoverTarget(e.relatedTarget)) {
+						setGroupHover(false);
+					}
+				}));
+			}
 			templateData.elementDisposables.add(toDisposable(() => setGroupHover(false)));
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -175,13 +175,8 @@
 	font-size: 14px;
 }
 
-.monaco-list-row:not(.focused) .interactive-item-container:not(:hover) .header .monaco-toolbar,
-.monaco-list:not(:focus-within) .monaco-list-row .interactive-item-container:not(:hover) .header .monaco-toolbar,
-.monaco-list-row:not(.focused) .interactive-item-container:not(:hover) .header .monaco-toolbar .action-label,
-.monaco-list:not(:focus-within) .monaco-list-row .interactive-item-container:not(:hover) .header .monaco-toolbar .action-label {
-	/* Also apply this rule to the .action-label directly to work around a strange issue- when the
-	toolbar is hidden without that second rule, tabbing from the list container into a list item doesn't work
-	and the tab key doesn't do anything. */
+.interactive-item-container:not(:hover):not(:focus-within) .header .monaco-toolbar,
+.interactive-item-container:not(:hover):not(:focus-within) .header .monaco-toolbar .action-label {
 	display: none;
 }
 
@@ -284,14 +279,10 @@
 	transition: opacity 0.1s ease-in-out, visibility 0s linear 0.1s;
 }
 
-/* Show toolbar on hover and last response. Also show when the item has keyboard focus (focus-within) or when the surrounding list row is marked focused (monaco list keyboard navigation). */
-.interactive-item-container.interactive-response:not(.chat-response-loading):hover .chat-footer-toolbar,
+/* Show toolbar on hover and last response. Keep it visible when keyboard focus moves inside the response. */
 .interactive-item-container.interactive-response.chat-most-recent-response:not(.chat-response-loading) .chat-footer-toolbar,
-.interactive-item-container.interactive-response:not(.chat-response-loading):hover .chat-footer-toolbar .chat-footer-details,
 .interactive-item-container.interactive-response:not(.chat-response-loading):focus-within .chat-footer-toolbar,
 .interactive-item-container.interactive-response:not(.chat-response-loading):focus-within .chat-footer-toolbar .chat-footer-details,
-.monaco-list-row.focused .interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar,
-.monaco-list-row.focused .interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar .chat-footer-details,
 .interactive-item-container.interactive-response:not(.chat-response-loading).group-hovered .chat-footer-toolbar,
 .interactive-item-container.interactive-response:not(.chat-response-loading).group-hovered .chat-footer-toolbar .chat-footer-details {
 	opacity: 1;
@@ -4289,20 +4280,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 		.interactive-item-container .value .rendered-markdown {
 			outline: 1px solid var(--vscode-focusBorder);
-		}
-
-		.request-hover:not(.has-no-actions) {
-			display: block;
-		}
-
-		.checkpoint-container {
-			opacity: 1;
-		}
-
-		.chat-request-timestamp {
-			opacity: 0.7;
-			visibility: visible;
-			transition: opacity 0.1s ease-in-out, visibility 0s linear 0s;
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -273,10 +273,9 @@
 	/* Complete response only */
 	display: block;
 	opacity: 0;
-	visibility: hidden;
 	padding-top: 6px;
 	height: 22px;
-	transition: opacity 0.1s ease-in-out, visibility 0s linear 0.1s;
+	transition: opacity 0.1s ease-in-out;
 }
 
 /* Show toolbar on hover and last response. Keep it visible when keyboard focus moves inside the response. */
@@ -286,8 +285,7 @@
 .interactive-item-container.interactive-response:not(.chat-response-loading).group-hovered .chat-footer-toolbar,
 .interactive-item-container.interactive-response:not(.chat-response-loading).group-hovered .chat-footer-toolbar .chat-footer-details {
 	opacity: 1;
-	visibility: visible;
-	transition: opacity 0.1s ease-in-out, visibility 0s linear 0s;
+	transition: opacity 0.1s ease-in-out;
 }
 
 /* Style the internal toolbar element to use flexbox */
@@ -3801,20 +3799,17 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		font-size: var(--vscode-fontSize-label3);
 		line-height: var(--vscode-fontSize-label3);
 		opacity: 0.7;
-		visibility: visible;
-		transition: opacity 0.1s ease-in-out, visibility 0s linear 0s;
+		transition: opacity 0.1s ease-in-out;
 	}
 
 	.interactive-item-container.interactive-request:not(.group-hovered) .chat-request-timestamp {
 		opacity: 0;
-		visibility: hidden;
-		transition: opacity 0.1s ease-in-out, visibility 0s linear 0.1s;
+		transition: opacity 0.1s ease-in-out;
 	}
 
-	.interactive-item-container.interactive-request:not(.group-hovered) .chat-request-timestamp:focus-visible {
+	.interactive-item-container.interactive-request:not(.group-hovered) .chat-request-timestamp:focus {
 		opacity: 0.7;
-		visibility: visible;
-		transition: opacity 0.1s ease-in-out, visibility 0s linear 0s;
+		transition: opacity 0.1s ease-in-out;
 	}
 
 	.interactive-item-container.interactive-request .chat-attached-context {

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
@@ -55,6 +55,7 @@ export interface IFixtureMessage {
 		| { kind: 'terminalConfirmation'; command: string; title?: string; disclaimer?: string; requestUnsandboxedExecution?: boolean; requestUnsandboxedExecutionReason?: string; riskAssessment?: { risk: ToolRiskLevel; explanation: string }; riskLoading?: boolean; confirmation?: { commandLine: string; cwdLabel?: string; cdPrefix?: string } }
 		| { kind: 'elicitation'; title: string; message: string; confirmation?: { commandLine: string; cwdLabel?: string; cdPrefix?: string }; riskAssessment?: { risk: ToolRiskLevel; explanation: string }; riskLoading?: boolean }
 	>;
+	readonly details?: string;
 	readonly responseComplete?: boolean;
 	/**
 	 * Per-turn file changes surfaced via {@link IChatResponseFileChangesService},
@@ -70,6 +71,10 @@ export interface IChatWidgetFixtureOptions {
 	readonly height?: number;
 	/** Whether to render the main chat input. Defaults to `true`. */
 	readonly inputVisible?: boolean;
+	/** Chat list rendering style. Defaults to compact for existing fixtures. */
+	readonly renderStyle?: 'default' | 'compact' | 'minimal';
+	/** Whether to populate the response footer with an action. */
+	readonly responseFooterAction?: boolean;
 	/**
 	 * When `false`, registers a stub `IChatToolRiskAssessmentService` whose
 	 * `isEnabled()` returns `false`, exercising the "feature off" code path.
@@ -262,6 +267,9 @@ export async function renderChatWidget(context: ComponentFixtureContext, options
 				model.acceptResponseProgress(request, toolInvocation);
 			}
 		}
+		if (message.details) {
+			response.setResult({ details: message.details });
+		}
 		if (message.responseComplete !== false) {
 			response.complete();
 		}
@@ -304,7 +312,11 @@ export async function renderChatWidget(context: ComponentFixtureContext, options
 	menuService.addItem(MenuId.ChatExecute, { command: { id: 'workbench.action.chat.submit', title: 'Send', icon: Codicon.newLine }, group: 'navigation', order: 4 });
 	menuService.addItem(MenuId.ChatInputSecondary, { command: { id: 'workbench.action.chat.openSessionTargetPicker', title: 'Local' }, group: 'navigation', order: 0 });
 	menuService.addItem(MenuId.ChatInputSecondary, { command: { id: 'workbench.action.chat.openPermissionPicker', title: 'Default Approvals' }, group: 'navigation', order: 10 });
+	if (options.responseFooterAction) {
+		menuService.addItem(MenuId.ChatMessageFooter, { command: { id: 'workbench.action.chat.copyResponse', title: 'Copy', icon: Codicon.copy }, group: 'navigation', order: 1 });
+	}
 
+	const renderStyle = options.renderStyle === 'default' ? undefined : options.renderStyle ?? 'compact';
 	const inputOptions: IChatInputPartOptions = {
 		renderFollowups: false,
 		renderInputToolbarBelowInput: false,
@@ -350,7 +362,7 @@ export async function renderChatWidget(context: ComponentFixtureContext, options
 		{
 			currentChatMode: () => ChatModeKind.Agent,
 			defaultElementHeight: 120,
-			renderStyle: 'compact',
+			renderStyle,
 			styles: {
 				listForeground: 'var(--vscode-foreground)',
 				listBackground: 'var(--vscode-editor-background)',
@@ -378,6 +390,30 @@ const SIMPLE_QA: IFixtureMessage[] = [
 		],
 	},
 ];
+
+const LAST_RESPONSE_HOVER: IFixtureMessage[] = [
+	{
+		user: 'Summarize the changes',
+		assistant: [
+			{ kind: 'markdown', text: 'The response content ends here. The remaining row height is reserved space.' },
+		],
+		details: 'Claude Opus 4.8 - 2 credits',
+	},
+];
+
+async function renderLastResponseHover(context: ComponentFixtureContext, target: 'content' | 'reserved-space'): Promise<void> {
+	await renderChatWidget(context, {
+		messages: LAST_RESPONSE_HOVER,
+		height: 600,
+		inputVisible: false,
+		renderStyle: 'default',
+		responseFooterAction: true,
+	});
+
+	const response = context.container.querySelector<HTMLElement>('.interactive-response.chat-most-recent-response');
+	const hoverTarget = target === 'content' ? response?.querySelector<HTMLElement>(':scope > .value') : response;
+	hoverTarget?.dispatchEvent(new MouseEvent('mouseenter'));
+}
 
 const PENDING_TOOL_APPROVAL: IFixtureMessage[] = [
 	{
@@ -487,4 +523,6 @@ export default defineThemedFixtureGroup({ path: 'chat/widget/' }, {
 		'issue-309796-missing-backslash': defineComponentFixture({ render: ctx => renderChatWidget(ctx, { messages: ISSUE_309796_MISSING_BACKSLASH }) }),
 	}),
 	MultiTurn: defineComponentFixture({ render: ctx => renderChatWidget(ctx, { messages: MULTI_TURN }) }),
+	LastResponseContentHover: defineComponentFixture({ render: ctx => renderLastResponseHover(ctx, 'content') }),
+	LastResponseReservedSpaceHover: defineComponentFixture({ render: ctx => renderLastResponseHover(ctx, 'reserved-space') }),
 });

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
@@ -75,6 +75,8 @@ export interface IChatWidgetFixtureOptions {
 	readonly renderStyle?: 'default' | 'compact' | 'minimal';
 	/** Whether to populate the response footer with an action. */
 	readonly responseFooterAction?: boolean;
+	/** Whether to show request and response timing details. */
+	readonly verbose?: boolean;
 	/**
 	 * When `false`, registers a stub `IChatToolRiskAssessmentService` whose
 	 * `isEnabled()` returns `false`, exercising the "feature off" code path.
@@ -197,6 +199,9 @@ export async function renderChatWidget(context: ComponentFixtureContext, options
 	});
 	configService.setUserConfiguration('editor', { fontFamily: 'monospace', fontLigatures: false });
 	configService.setUserConfiguration(ChatConfiguration.ToolConfirmationCarousel, true);
+	if (options.verbose !== undefined) {
+		configService.setUserConfiguration(ChatConfiguration.Verbose, options.verbose);
+	}
 	if (needsTurnPills) {
 		configService.setUserConfiguration(ChatConfiguration.TurnStatusPills, options.turnStatusPills);
 	}
@@ -415,6 +420,46 @@ async function renderLastResponseHover(context: ComponentFixtureContext, target:
 	hoverTarget?.dispatchEvent(new MouseEvent('mouseenter'));
 }
 
+const KEYBOARD_FOCUS: IFixtureMessage[] = [
+	{
+		user: 'Summarize the changes',
+		assistant: [
+			{ kind: 'markdown', text: 'The first response has keyboard-accessible actions.' },
+		],
+		details: 'Claude Opus 4.8 - 2 credits',
+	},
+	{
+		user: 'What should I do next?',
+		assistant: [
+			{ kind: 'markdown', text: 'Run the tests and review the diff.' },
+		],
+		details: 'Claude Opus 4.8 - 1 credit',
+	},
+];
+
+async function renderKeyboardFocus(context: ComponentFixtureContext, target: 'response-action' | 'request-timestamp'): Promise<void> {
+	await renderChatWidget(context, {
+		messages: KEYBOARD_FOCUS,
+		height: 600,
+		inputVisible: false,
+		renderStyle: 'default',
+		responseFooterAction: true,
+		verbose: target === 'request-timestamp',
+	});
+
+	const selector = target === 'response-action'
+		? '.interactive-response:not(.chat-most-recent-response) .chat-footer-toolbar .action-label'
+		: '.interactive-request .chat-request-timestamp';
+	const focusTarget = context.container.querySelector<HTMLElement>(selector);
+	if (!focusTarget) {
+		throw new Error(`Missing keyboard focus target: ${target}`);
+	}
+	focusTarget.focus();
+	if (focusTarget.ownerDocument.activeElement !== focusTarget) {
+		throw new Error(`Could not focus keyboard target: ${target}`);
+	}
+}
+
 const PENDING_TOOL_APPROVAL: IFixtureMessage[] = [
 	{
 		user: 'run git init',
@@ -525,4 +570,6 @@ export default defineThemedFixtureGroup({ path: 'chat/widget/' }, {
 	MultiTurn: defineComponentFixture({ render: ctx => renderChatWidget(ctx, { messages: MULTI_TURN }) }),
 	LastResponseContentHover: defineComponentFixture({ render: ctx => renderLastResponseHover(ctx, 'content') }),
 	LastResponseReservedSpaceHover: defineComponentFixture({ render: ctx => renderLastResponseHover(ctx, 'reserved-space') }),
+	ResponseActionKeyboardFocus: defineComponentFixture({ render: ctx => renderKeyboardFocus(ctx, 'response-action') }),
+	RequestTimestampKeyboardFocus: defineComponentFixture({ render: ctx => renderKeyboardFocus(ctx, 'request-timestamp') }),
 });


### PR DESCRIPTION
Fixes #326459

## Summary

- stop revealing chat request and response toolbars and metadata from list row focus or selection
- preserve the always-visible toolbar for the most recent completed response
- reveal other hidden-at-rest row chrome on relevant content hover or direct keyboard focus
- limit response hover state to the rendered response content and footer, excluding reserved space below the last response
- add component fixtures covering hover, reserved-space, and keyboard-focus states in light and dark themes

## Validation

- `npm run typecheck-client`
- hygiene checks for all changed files
- component explorer render for all eight hover and keyboard-focus fixture variants

(Written by Copilot)