### PR TITLE
chat: make archived agent sessions read-only

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
@@ -30,7 +30,7 @@ export class ForkConversationAction extends Action2 {
 			f1: false,
 			category: CHAT_CATEGORY,
 			icon: Codicon.repoForked,
-			precondition: ChatContextKeys.enabled,
+			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ChatContextKeys.readOnly.negate()),
 			menu: [
 				{
 					id: MenuId.ChatMessageCheckpoint,
@@ -42,7 +42,8 @@ export class ForkConversationAction extends Action2 {
 						ContextKeyExpr.or(
 							ContextKeyExpr.or(ChatContextKeys.lockedToCodingAgent.negate(), ChatContextKeyExprs.isAgentHostSession),
 							ChatContextKeys.chatSessionSupportsFork
-						)
+						),
+						ChatContextKeys.readOnly.negate()
 					)
 				}
 			]

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1235,8 +1235,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				// handler observes state changes for the duration of the chat
 				// session, then wire up the per-turn machinery that
 				// `_createAndSubscribe` would normally set up.
-				this._ensureSessionSubscription(sessionKey);
-				this._setChatURI(request.sessionResource, this._resolveChatUriFromState(request.sessionResource, existingState));
+				const sessionSub = this._ensureSessionSubscription(sessionKey);
+				const chatURI = this._resolveChatUriFromState(request.sessionResource, existingState);
+				this._setChatURI(request.sessionResource, chatURI);
+				const chatSub = this._ensureChatSubscription(sessionKey, chatURI);
+				this._activeSessions.get(request.sessionResource)?.setStateSubscriptions(sessionSub, chatSub);
 				this._ensurePendingMessageSubscription(request.sessionResource, resolvedSession);
 				this._watchForServerInitiatedTurns(resolvedSession, request.sessionResource);
 
@@ -3757,7 +3760,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const chatURI = this._resolveChatUriFromState(sessionResource, rawState);
 		this._setChatURI(sessionResource, chatURI);
 		const chatSub = this._ensureChatSubscription(session.toString(), chatURI);
-		this._activeSessions.get(sessionResource)?.setStateSubscriptions(newSub, chatSub);
+		if (!fork) {
+			this._activeSessions.get(sessionResource)?.setStateSubscriptions(newSub, chatSub);
+		}
 
 		// Start syncing the chat model's pending requests to the protocol
 		this._ensurePendingMessageSubscription(sessionResource, session);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -409,6 +409,8 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 	readonly progressObs = observableValue<IChatProgress[]>('agentHostProgress', []);
 	readonly isCompleteObs = observableValue<boolean>('agentHostComplete', true);
 	readonly isReadOnly: IObservable<boolean>;
+	private readonly _sessionState = observableValue<IObservable<SessionState | undefined>>(this, constObservable(undefined));
+	private readonly _chatState = observableValue<IObservable<ChatState | undefined>>(this, constObservable(undefined));
 
 	private readonly _onWillDispose = this._register(new Emitter<void>());
 	readonly onWillDispose = this._onWillDispose.event;
@@ -437,11 +439,10 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 	) {
 		super();
 
-		const sessionState = sessionSubscription ? observableFromSubscription(this, sessionSubscription) : constObservable<SessionState | undefined>(undefined);
-		const chatState = chatSubscription ? observableFromSubscription(this, chatSubscription) : constObservable<ChatState | undefined>(undefined);
+		this.setStateSubscriptions(sessionSubscription, chatSubscription);
 		this.isReadOnly = derived(this, reader => {
-			const sessionArchived = Boolean((sessionState.read(reader)?.status ?? 0) & SessionStatus.IsArchived);
-			return isChatReadOnly(chatState.read(reader)?.interactivity, sessionArchived);
+			const sessionArchived = Boolean((this._sessionState.read(reader).read(reader)?.status ?? 0) & SessionStatus.IsArchived);
+			return isChatReadOnly(this._chatState.read(reader).read(reader)?.interactivity, sessionArchived);
 		});
 
 		const hasActiveTurn = initialProgress !== undefined;
@@ -460,6 +461,13 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 
 		this.forkSession = this._forkSession;
 		this.renameSession = this._renameSession;
+	}
+
+	setStateSubscriptions(sessionSubscription: IAgentSubscription<SessionState> | undefined, chatSubscription: IAgentSubscription<ChatState> | undefined): void {
+		transaction(tx => {
+			this._sessionState.set(sessionSubscription ? observableFromSubscription(this, sessionSubscription) : constObservable(undefined), tx);
+			this._chatState.set(chatSubscription ? observableFromSubscription(this, chatSubscription) : constObservable(undefined), tx);
+		});
 	}
 
 	override dispose(): void {
@@ -3748,7 +3756,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const rawState = this._requireRawSessionState(session.toString());
 		const chatURI = this._resolveChatUriFromState(sessionResource, rawState);
 		this._setChatURI(sessionResource, chatURI);
-		this._ensureChatSubscription(session.toString(), chatURI);
+		const chatSub = this._ensureChatSubscription(session.toString(), chatURI);
+		this._activeSessions.get(sessionResource)?.setStateSubscriptions(newSub, chatSub);
 
 		// Start syncing the chat model's pending requests to the protocol
 		this._ensurePendingMessageSubscription(sessionResource, session);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -41,7 +41,7 @@ import { CompletionItemKind as AhpCompletionItemKind, type CompletionItem as Ahp
 import { ConfirmationOptionKind, CustomizationType, JsonPrimitive, McpServerAuthRequiredState, McpServerStatus, SessionInputRequestKind, TerminalClaimKind, ToolCallContributorKind, ToolResultContentType, type ConfirmationOption, type ProtectedResourceMetadata, type SessionActiveClient } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, ChatTurnStartedAction, isChatAction, type ClientChatAction, type ClientSessionAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
-import { buildSubagentChatUri, getToolSubagentContent, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, StateComponents, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, TurnState, parseChatUri, mergeSessionWithDefaultChat, readUsageInfoMeta, type ChatState, type ISessionWithDefaultChat, type ClientPluginCustomization, type ICompletedToolCall, type InputRequestResponsePart, type MarkdownResponsePart, type Message, type MessageAttachment, type MessageAnnotationsAttachment, type MessageResourceAttachment, type MessageEmbeddedResourceAttachment, type ModelSelection, type ReasoningResponsePart, type RootState, type ChatInputAnswer, type ChatInputQuestion, type ChatInputRequest, type SessionState, type ToolCallResponsePart, type ToolCallState, type Turn } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { buildSubagentChatUri, getToolSubagentContent, isChatReadOnly, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, SessionStatus, StateComponents, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, TurnState, parseChatUri, mergeSessionWithDefaultChat, readUsageInfoMeta, type ChatState, type ISessionWithDefaultChat, type ClientPluginCustomization, type ICompletedToolCall, type InputRequestResponsePart, type MarkdownResponsePart, type Message, type MessageAttachment, type MessageAnnotationsAttachment, type MessageResourceAttachment, type MessageEmbeddedResourceAttachment, type ModelSelection, type ReasoningResponsePart, type RootState, type ChatInputAnswer, type ChatInputQuestion, type ChatInputRequest, type SessionState, type ToolCallResponsePart, type ToolCallState, type Turn } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ExtensionIdentifier } from '../../../../../../platform/extensions/common/extensions.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -408,6 +408,7 @@ function inputRequestResponsePartKey(part: InputRequestResponsePart): string {
 class AgentHostChatSession extends Disposable implements IChatSession {
 	readonly progressObs = observableValue<IChatProgress[]>('agentHostProgress', []);
 	readonly isCompleteObs = observableValue<boolean>('agentHostComplete', true);
+	readonly isReadOnly: IObservable<boolean>;
 
 	private readonly _onWillDispose = this._register(new Emitter<void>());
 	readonly onWillDispose = this._onWillDispose.event;
@@ -424,6 +425,8 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 		readonly sessionResource: URI,
 		readonly history: readonly IChatSessionHistoryItem[],
 		readonly title: string | undefined,
+		sessionSubscription: IAgentSubscription<SessionState> | undefined,
+		chatSubscription: IAgentSubscription<ChatState> | undefined,
 		private readonly _forkSession: ((request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => Promise<IChatSessionItem>),
 		private readonly _renameSession: ((title: string, token: CancellationToken) => Promise<void>),
 		inputState: ISerializableChatModelInputState | undefined,
@@ -433,6 +436,13 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
+
+		const sessionState = sessionSubscription ? observableFromSubscription(this, sessionSubscription) : constObservable<SessionState | undefined>(undefined);
+		const chatState = chatSubscription ? observableFromSubscription(this, chatSubscription) : constObservable<ChatState | undefined>(undefined);
+		this.isReadOnly = derived(this, reader => {
+			const sessionArchived = Boolean((sessionState.read(reader)?.status ?? 0) & SessionStatus.IsArchived);
+			return isChatReadOnly(chatState.read(reader)?.interactivity, sessionArchived);
+		});
 
 		const hasActiveTurn = initialProgress !== undefined;
 		this.transferredState = inputState ? { editingSession: undefined, inputState } : undefined;
@@ -851,6 +861,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		let activeTurnId: string | undefined;
 		let sessionTitle: string | undefined;
 		let draftInputState: ISerializableChatModelInputState | undefined;
+		let sessionSubscription: IAgentSubscription<SessionState> | undefined;
+		let chatSubscription: IAgentSubscription<ChatState> | undefined;
 		// Mark this session as hydrating so that a sibling chat of the same
 		// session closing while we await our subscriptions does not tear down
 		// the shared session subscription (which would strand us forever).
@@ -860,6 +872,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			if (!isNewSession) {
 				try {
 					const sub = this._ensureSessionSubscription(resolvedSession.toString());
+					sessionSubscription = sub;
 					// Wait for both the session summary and its default-chat
 					// conversation state to hydrate from the server. After the
 					// multi-chat protocol adoption, turns/activeTurn live on the
@@ -879,6 +892,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					chatURI = this._resolveChatUriFromState(sessionResource, rawState);
 					this._setChatURI(sessionResource, chatURI);
 					const chatSub = this._ensureChatSubscription(resolvedSession.toString(), chatURI);
+					chatSubscription = chatSub;
 					await this._whenSubscriptionHydrated(chatSub, token);
 					const sessionState = this._getSessionState(resolvedSession.toString(), chatURI);
 					if (sessionState) {
@@ -1000,6 +1014,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			sessionResource,
 			history,
 			sessionTitle,
+			sessionSubscription,
+			chatSubscription,
 			(request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => {
 				if (!this._getSessionState(resolvedSession.toString())) {
 					throw new Error('Cannot fork session before the initial request');

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListContribution.ts
@@ -4,14 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableMap, DisposableStore } from '../../../../../../base/common/lifecycle.js';
-import { affectsAgentHostProviderPreference, IAgentHostService, shouldSurfaceLocalAgentHostProvider, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
+import { affectsAgentHostProviderPreference, AgentSession, IAgentHostService, shouldSurfaceLocalAgentHostProvider, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
 import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { ActionType } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { type AgentInfo, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
+import { type IAgentSession } from '../agentSessionsModel.js';
+import { IAgentSessionsService } from '../agentSessionsService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
 import { AgentHostSessionListController } from './agentHostSessionListController.js';
 import { AgentHostSessionListStore } from './agentHostSessionListStore.js';
@@ -21,6 +24,7 @@ export class AgentHostSessionListContribution extends Disposable implements IWor
 	static readonly ID = 'workbench.contrib.agentHostSessionListContribution';
 
 	private readonly _agentRegistrations = this._register(new DisposableMap<AgentProvider, DisposableStore>());
+	private readonly _forwardedArchivedStates = new Map<string, boolean>();
 
 	private readonly _isSessionsWindow: boolean;
 
@@ -32,6 +36,7 @@ export class AgentHostSessionListContribution extends Disposable implements IWor
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 		@IAgentHostSessionWorkingDirectoryResolver private readonly _workingDirectoryResolver: IAgentHostSessionWorkingDirectoryResolver,
 		@IAgentHostEnablementService agentHostEnablementService: IAgentHostEnablementService,
+		@IAgentSessionsService private readonly _agentSessionsService: IAgentSessionsService,
 	) {
 		super();
 
@@ -42,6 +47,9 @@ export class AgentHostSessionListContribution extends Disposable implements IWor
 		}
 
 		const sessionListStore = this._register(this._instantiationService.createInstance(AgentHostSessionListStore, this._agentHostService));
+
+		this._register(this._agentSessionsService.onDidChangeSessionArchivedState(session => this._forwardArchivedState(session)));
+		this._register(this._agentSessionsService.model.onDidChangeSessions(() => this._syncArchivedStates()));
 
 		this._register(this._agentHostService.rootState.onDidChange(rootState => {
 			this._handleRootStateChange(rootState, sessionListStore);
@@ -97,5 +105,41 @@ export class AgentHostSessionListContribution extends Disposable implements IWor
 
 		store.add(this._chatSessionsService.registerChatSessionItemController(sessionType, listController));
 		store.add(this._workingDirectoryResolver.registerResolver(sessionType, _sessionResource => undefined, sessionResource => listController.isNewSession(sessionResource)));
+		this._syncArchivedStates();
+	}
+
+	private _syncArchivedStates(): void {
+		const currentResources = new Set<string>();
+		for (const session of this._agentSessionsService.model.sessions) {
+			currentResources.add(session.resource.toString());
+			if (session.isArchived()) {
+				this._forwardArchivedState(session);
+			}
+		}
+		for (const resource of this._forwardedArchivedStates.keys()) {
+			if (!currentResources.has(resource)) {
+				this._forwardedArchivedStates.delete(resource);
+			}
+		}
+	}
+
+	private _forwardArchivedState(session: IAgentSession): void {
+		for (const provider of this._agentRegistrations.keys()) {
+			if (session.providerType !== `agent-host-${provider}`) {
+				continue;
+			}
+
+			const archived = session.isArchived();
+			const key = session.resource.toString();
+			if (this._forwardedArchivedStates.get(key) === archived) {
+				return;
+			}
+			this._agentHostService.dispatch(AgentSession.uri(provider, AgentSession.id(session.resource)).toString(), {
+				type: ActionType.SessionIsArchivedChanged,
+				isArchived: archived,
+			});
+			this._forwardedArchivedStates.set(key, archived);
+			return;
+		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListContribution.ts
@@ -4,17 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableMap, DisposableStore } from '../../../../../../base/common/lifecycle.js';
-import { affectsAgentHostProviderPreference, AgentSession, IAgentHostService, shouldSurfaceLocalAgentHostProvider, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
+import { affectsAgentHostProviderPreference, IAgentHostService, shouldSurfaceLocalAgentHostProvider, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
 import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
-import { ActionType } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { type AgentInfo, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
-import { type IAgentSession } from '../agentSessionsModel.js';
-import { IAgentSessionsService } from '../agentSessionsService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
 import { AgentHostSessionListController } from './agentHostSessionListController.js';
 import { AgentHostSessionListStore } from './agentHostSessionListStore.js';
@@ -24,7 +21,6 @@ export class AgentHostSessionListContribution extends Disposable implements IWor
 	static readonly ID = 'workbench.contrib.agentHostSessionListContribution';
 
 	private readonly _agentRegistrations = this._register(new DisposableMap<AgentProvider, DisposableStore>());
-	private readonly _forwardedArchivedStates = new Map<string, boolean>();
 
 	private readonly _isSessionsWindow: boolean;
 
@@ -36,7 +32,6 @@ export class AgentHostSessionListContribution extends Disposable implements IWor
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 		@IAgentHostSessionWorkingDirectoryResolver private readonly _workingDirectoryResolver: IAgentHostSessionWorkingDirectoryResolver,
 		@IAgentHostEnablementService agentHostEnablementService: IAgentHostEnablementService,
-		@IAgentSessionsService private readonly _agentSessionsService: IAgentSessionsService,
 	) {
 		super();
 
@@ -47,9 +42,6 @@ export class AgentHostSessionListContribution extends Disposable implements IWor
 		}
 
 		const sessionListStore = this._register(this._instantiationService.createInstance(AgentHostSessionListStore, this._agentHostService));
-
-		this._register(this._agentSessionsService.onDidChangeSessionArchivedState(session => this._forwardArchivedState(session)));
-		this._register(this._agentSessionsService.model.onDidChangeSessions(() => this._syncArchivedStates()));
 
 		this._register(this._agentHostService.rootState.onDidChange(rootState => {
 			this._handleRootStateChange(rootState, sessionListStore);
@@ -105,41 +97,5 @@ export class AgentHostSessionListContribution extends Disposable implements IWor
 
 		store.add(this._chatSessionsService.registerChatSessionItemController(sessionType, listController));
 		store.add(this._workingDirectoryResolver.registerResolver(sessionType, _sessionResource => undefined, sessionResource => listController.isNewSession(sessionResource)));
-		this._syncArchivedStates();
-	}
-
-	private _syncArchivedStates(): void {
-		const currentResources = new Set<string>();
-		for (const session of this._agentSessionsService.model.sessions) {
-			currentResources.add(session.resource.toString());
-			if (session.isArchived()) {
-				this._forwardArchivedState(session);
-			}
-		}
-		for (const resource of this._forwardedArchivedStates.keys()) {
-			if (!currentResources.has(resource)) {
-				this._forwardedArchivedStates.delete(resource);
-			}
-		}
-	}
-
-	private _forwardArchivedState(session: IAgentSession): void {
-		for (const provider of this._agentRegistrations.keys()) {
-			if (session.providerType !== `agent-host-${provider}`) {
-				continue;
-			}
-
-			const archived = session.isArchived();
-			const key = session.resource.toString();
-			if (this._forwardedArchivedStates.get(key) === archived) {
-				return;
-			}
-			this._agentHostService.dispatch(AgentSession.uri(provider, AgentSession.id(session.resource)).toString(), {
-				type: ActionType.SessionIsArchivedChanged,
-				isArchived: archived,
-			});
-			this._forwardedArchivedStates.set(key, archived);
-			return;
-		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -641,7 +641,7 @@ registerAction2(class EditAction extends Action2 {
 			icon: Codicon.edit,
 			keybinding: {
 				primary: KeyCode.Enter,
-				when: ContextKeyExpr.and(ChatContextKeys.inChatSession, EditorContextKeys.textInputFocus.negate()),
+				when: ContextKeyExpr.and(ChatContextKeys.inChatSession, EditorContextKeys.textInputFocus.negate(), ChatContextKeys.readOnly.negate()),
 				weight: KeybindingWeight.WorkbenchContrib,
 			},
 			menu: [
@@ -649,7 +649,7 @@ registerAction2(class EditAction extends Action2 {
 					id: MenuId.ChatMessageTitle,
 					group: 'navigation',
 					order: 2,
-					when: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.equals(`config.${ChatConfiguration.EditRequests}`, 'hover'), ContextKeyExpr.equals(`config.${ChatConfiguration.EditRequests}`, 'input')))
+					when: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.equals(`config.${ChatConfiguration.EditRequests}`, 'hover'), ContextKeyExpr.equals(`config.${ChatConfiguration.EditRequests}`, 'input')), ChatContextKeys.readOnly.negate())
 				}
 			]
 		});

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1677,17 +1677,21 @@ export async function openChatSession(accessor: ServicesAccessor, openOptions: N
 				attachedContext = [promptFile, ...(attachedContext ?? [])];
 			}
 			const result = await chatService.sendRequest(sessionResource, chatSendOptions.prompt, { agentIdSilent: openOptions.type, attachedContext });
-			if (result.kind === 'sent' && result.newSessionResource && !resources.isEqual(result.newSessionResource, sessionResource)) {
+			const newSessionResource = result.kind === 'sent' || result.kind === 'rejected' ? result.newSessionResource : undefined;
+			if (newSessionResource && !resources.isEqual(newSessionResource, sessionResource)) {
 				switch (openOptions.position) {
 					case ChatSessionPosition.Sidebar: {
 						const view = await viewsService.openView(ChatViewId) as ChatViewPane;
-						await view.loadSession(result.newSessionResource);
+						await view.loadSession(newSessionResource);
 						break;
 					}
 					case ChatSessionPosition.Editor: {
-						const activeEditor = editorGroupService.activeGroup.activeEditor;
-						if (activeEditor instanceof ChatEditorInput && resources.isEqual(activeEditor.sessionResource, sessionResource)) {
-							await editorService.replaceEditors([{ editor: activeEditor, replacement: { resource: result.newSessionResource, options: { override: ChatEditorInput.EditorID, pinned: true } } }], editorGroupService.activeGroup);
+						for (const group of editorGroupService.groups) {
+							const editor = group.editors.find(e => e instanceof ChatEditorInput && resources.isEqual(e.sessionResource, sessionResource));
+							if (editor) {
+								await editorService.replaceEditors([{ editor, replacement: { resource: newSessionResource, options: { override: ChatEditorInput.EditorID, pinned: true } } }], group);
+								break;
+							}
 						}
 						break;
 					}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatReadOnlyBanner.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatReadOnlyBanner.ts
@@ -33,7 +33,7 @@ export class ChatReadOnlyBanner extends Disposable {
 		icon.appendChild(renderedIcon);
 
 		const text = dom.append(this.domNode, dom.$('span.chat-readonly-banner-text'));
-		const message = localize('chatReadOnlyBanner.message', "This session is read-only.");
+		const message = localize('chatReadOnlyBanner.message', "Archived sessions are read-only.");
 		text.textContent = message;
 		this._register(hoverService.setupDelayedHover(text, { content: message }));
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatReadOnlyBanner.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatReadOnlyBanner.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './media/chatReadOnlyBanner.css';
+import * as dom from '../../../../../base/browser/dom.js';
+import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+
+export const CHAT_READ_ONLY_BANNER_HEIGHT = 26;
+
+export class ChatReadOnlyBanner extends Disposable {
+
+	readonly domNode: HTMLElement;
+
+	private _visible = false;
+
+	constructor(
+		@IHoverService hoverService: IHoverService,
+	) {
+		super();
+
+		this.domNode = dom.$('.chat-readonly-banner');
+		this.domNode.setAttribute('role', 'status');
+
+		const icon = dom.append(this.domNode, dom.$('.chat-readonly-banner-icon'));
+		const renderedIcon = renderIcon(Codicon.lock);
+		renderedIcon.setAttribute('aria-hidden', 'true');
+		icon.appendChild(renderedIcon);
+
+		const text = dom.append(this.domNode, dom.$('span.chat-readonly-banner-text'));
+		const message = localize('chatReadOnlyBanner.message', "This session is read-only.");
+		text.textContent = message;
+		this._register(hoverService.setupDelayedHover(text, { content: message }));
+
+		this.setVisible(false);
+	}
+
+	get visible(): boolean {
+		return this._visible;
+	}
+
+	setVisible(visible: boolean): void {
+		this._visible = visible;
+		this.domNode.classList.toggle('hidden', !visible);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -88,6 +88,7 @@ import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js'
 import { IChatDebugService } from '../../common/chatDebugService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
+import { CHAT_READ_ONLY_BANNER_HEIGHT, ChatReadOnlyBanner } from './chatReadOnlyBanner.js';
 
 const $ = dom.$;
 
@@ -279,6 +280,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private inputContainer!: HTMLElement;
 	private focusedInputDOM!: HTMLElement;
 	private editorOptions!: ChatEditorOptions;
+	private readonly readOnlyBanner: ChatReadOnlyBanner | undefined;
 
 	private recentlyRestoredCheckpoint: boolean = false;
 
@@ -443,6 +445,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	) {
 		super();
 
+		this.readOnlyBanner = viewOptions.isSessionsWindow ? undefined : this._register(instantiationService.createInstance(ChatReadOnlyBanner));
 		this._lockedToCodingAgentContextKey = ChatContextKeys.lockedToCodingAgent.bindTo(this.contextKeyService);
 		this._lockedCodingAgentIdContextKey = ChatContextKeys.lockedCodingAgentId.bindTo(this.contextKeyService);
 		this._readOnlyContextKey = ChatContextKeys.readOnly.bindTo(this.contextKeyService);
@@ -772,11 +775,17 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}));
 
 		if (renderInputOnTop) {
+			if (this.readOnlyBanner) {
+				this.container.appendChild(this.readOnlyBanner.domNode);
+			}
 			this.createInput(this.container, { renderFollowups, renderStyle, renderInputToolbarBelowInput });
 			this.listContainer = dom.append(this.container, $(`.interactive-list`));
 		} else {
 			this.listContainer = dom.append(this.container, $(`.interactive-list`));
 			dom.append(this.container, this.chatSuggestNextWidget.domNode);
+			if (this.readOnlyBanner) {
+				this.container.appendChild(this.readOnlyBanner.domNode);
+			}
 			this.createInput(this.container, { renderFollowups, renderStyle, renderInputToolbarBelowInput });
 		}
 
@@ -1315,6 +1324,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
+		if (this._readOnly) {
+			this.chatSuggestNextWidget.hide();
+			return;
+		}
+
 		// Skip rendering in coding agent sessions unless the agent supports hand-offs
 		if (this.isLockedToCodingAgent && !this._attachmentCapabilities.supportsHandOffs) {
 			this.chatSuggestNextWidget.hide();
@@ -1582,8 +1596,21 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	 * actions (e.g. Start Over, Restore Checkpoint) are not offered.
 	 */
 	setReadOnly(readOnly: boolean): void {
+		const wasReadOnly = this._readOnly;
 		this._readOnly = readOnly;
 		this._readOnlyContextKey.set(readOnly);
+		if (readOnly) {
+			if (this.viewModel?.editing) {
+				this.finishedEditing();
+			}
+			this.chatSuggestNextWidget.hide();
+			if (this.hasInputFocus()) {
+				this.listWidget.focusLastItem(true);
+			}
+		} else if (wasReadOnly) {
+			this.renderChatSuggestNextWidget();
+		}
+		this.readOnlyBanner?.setVisible(readOnly);
 		this.setInputVisible(!readOnly);
 		// Authoritative over the lock/unlock `editable` toggles below.
 		this._applyRendererEditable(!readOnly);
@@ -1720,6 +1747,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	startEditing(requestId: string): void {
+		if (this._readOnly) {
+			return;
+		}
+
 		const editedRequest = this.listWidget.getTemplateDataForRequestId(requestId);
 		if (editedRequest) {
 			this.clickedRequest(editedRequest);
@@ -2195,6 +2226,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.updateWorkingProgressBorder();
 			this.onDidChangeItems();
 			this._hasPendingRequestsContextKey.set(false);
+			if (!this.viewOptions.isSessionsWindow) {
+				this.setReadOnly(false);
+			}
 			return;
 		}
 
@@ -2226,6 +2260,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.inputPart.setInputModel(model.inputModel, model.getRequests().length === 0, model.sessionResource);
 
 		this.viewModel = this.instantiationService.createInstance(ChatViewModel, model, undefined);
+		if (!this.viewOptions.isSessionsWindow) {
+			this.viewModelDisposables.add(autorun(reader => this.setReadOnly(model.isReadOnly.read(reader))));
+		}
 
 		this.listWidget.setViewModel(this.viewModel);
 
@@ -2457,6 +2494,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	async acceptInput(query?: string, options?: IChatAcceptInputOptions): Promise<IChatResponseModel | undefined> {
+		if (this._readOnly) {
+			return undefined;
+		}
+
 		if (this.viewModel) {
 			markChat(this.viewModel.sessionResource, ChatPerfMark.RequestStart);
 		}
@@ -2464,7 +2505,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	async rerunLastRequest(): Promise<void> {
-		if (!this.viewModel) {
+		if (this._readOnly || !this.viewModel) {
 			return;
 		}
 
@@ -3005,10 +3046,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		const chatSuggestNextWidgetHeight = this.chatSuggestNextWidget.height;
 
 		const inputHeight = this._inputVisible ? this.inputPart.height.get() : this.inputPart.element.offsetHeight;
+		const readOnlyBannerHeight = this.readOnlyBanner?.visible ? CHAT_READ_ONLY_BANNER_HEIGHT : 0;
 		const lastElementVisible = this.listWidget.isScrolledToBottom;
 		const lastItem = this.listWidget.lastItem;
 
-		const contentHeight = Math.max(0, height - inputHeight - chatSuggestNextWidgetHeight);
+		const contentHeight = Math.max(0, height - inputHeight - readOnlyBannerHeight - chatSuggestNextWidgetHeight);
 		this.listWidget.layout(contentHeight, width);
 
 		this.welcomeMessageContainer.style.height = `${contentHeight}px`;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -888,7 +888,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	focusInput(): void {
 		// Read-only chats hide the input; focus the message list instead.
 		if (!this._inputVisible) {
-			this.listWidget.focusLastItem(true);
+			if (this.listWidget.focusLastItem(true) < 0) {
+				this.listWidget.focus();
+			}
 			this._onDidFocus.fire();
 			return;
 		}
@@ -1605,7 +1607,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			}
 			this.chatSuggestNextWidget.hide();
 			if (this.hasInputFocus()) {
-				this.listWidget.focusLastItem(true);
+				if (this.listWidget.focusLastItem(true) < 0) {
+					this.listWidget.focus();
+				}
 			}
 		} else if (wasReadOnly) {
 			this.renderChatSuggestNextWidget();
@@ -2836,6 +2840,12 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		});
 
 		if (ChatSendResult.isRejected(result)) {
+			if (result.newSessionResource) {
+				const newModel = this.chatService.getSession(result.newSessionResource);
+				if (newModel) {
+					this.setModel(newModel);
+				}
+			}
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chatReadOnlyBanner.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chatReadOnlyBanner.css
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.chat-readonly-banner {
+	display: flex;
+	flex: 0 0 26px;
+	align-items: center;
+	justify-content: center;
+	gap: var(--vscode-spacing-size40);
+	box-sizing: border-box;
+	height: 26px;
+	padding: 0 var(--vscode-spacing-size100);
+	background-color: color-mix(in srgb, var(--vscode-focusBorder) 4%, var(--vscode-editorWidget-background));
+	color: var(--vscode-descriptionForeground);
+	font-family: var(--vscode-chat-font-family, inherit);
+	font-size: var(--vscode-fontSize-label1);
+}
+
+.chat-readonly-banner.hidden {
+	display: none;
+}
+
+.chat-readonly-banner-icon {
+	display: flex;
+	flex-shrink: 0;
+	align-items: center;
+	color: var(--vscode-icon-foreground);
+}
+
+.chat-readonly-banner-icon .codicon {
+	font-size: var(--vscode-codiconFontSize);
+}
+
+.chat-readonly-banner-text {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.hc-black .chat-readonly-banner,
+.hc-light .chat-readonly-banner {
+	border-top: var(--vscode-strokeThickness) solid var(--vscode-contrastBorder);
+	border-bottom: var(--vscode-strokeThickness) solid var(--vscode-contrastBorder);
+}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1667,6 +1667,8 @@ export type ChatSendResult =
 export interface ChatSendResultRejected {
 	readonly kind: 'rejected';
 	readonly reason: string;
+	/** Set when the session was replaced before the request was rejected (e.g. untitled -> read-only contributed session). */
+	readonly newSessionResource?: URI;
 }
 
 export interface ChatSendResultSent {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1105,7 +1105,11 @@ export class ChatService extends Disposable implements IChatService {
 			throw new Error(`Unknown session: ${sessionResource}`);
 		}
 		if (model.isReadOnly.get()) {
-			return { kind: 'rejected', reason: 'Session is read-only' };
+			return {
+				kind: 'rejected',
+				reason: 'Session is read-only',
+				...(newSessionResource ? { newSessionResource } : {}),
+			};
 		}
 
 		// Internally blank widgets use special sessions with an untitled- path.
@@ -1120,6 +1124,9 @@ export class ChatService extends Disposable implements IChatService {
 				sessionResource = materialized.sessionResource;
 				newSessionResource = materialized.newSessionResource;
 			}
+		}
+		if (model.isReadOnly.get()) {
+			return { kind: 'rejected', reason: 'Session is read-only', newSessionResource };
 		}
 
 		const hasPendingRequest = this._pendingRequests.has(sessionResource);

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -520,8 +520,8 @@ export class ChatService extends Disposable implements IChatService {
 	}
 
 	private _startSession(props: IStartSessionProps): ChatModel {
-		const { initialData, location, sessionResource, canUseTools, transferEditingSession, disableBackgroundKeepAlive, inputState } = props;
-		const model = this.instantiationService.createInstance(ChatModel, initialData, { initialLocation: location, canUseTools, resource: sessionResource, disableBackgroundKeepAlive, inputState });
+		const { initialData, location, sessionResource, canUseTools, transferEditingSession, disableBackgroundKeepAlive, inputState, isReadOnly } = props;
+		const model = this.instantiationService.createInstance(ChatModel, initialData, { initialLocation: location, canUseTools, resource: sessionResource, disableBackgroundKeepAlive, inputState, isReadOnly });
 		if (location === ChatAgentLocation.Chat) {
 			model.startEditingSession(true, transferEditingSession);
 		}
@@ -739,6 +739,7 @@ export class ChatService extends Disposable implements IChatService {
 			canUseTools: false,
 			transferEditingSession: providedSession.transferredState?.editingSession,
 			inputState,
+			isReadOnly: providedSession.isReadOnly,
 		}, debugOwner ?? 'ChatService#loadRemoteSession');
 
 		logChangesToStateModel(modelRef.object.inputModel, `loadRemoteSession inputState source: session=${sessionResource.toString()}, chatSessionType=${chatSessionType}, historyModelId=${modelId}, agentUri=${agentUri?.toString()}, historySelectedModel=${historySelectedModel}, transferredSelectedModel=${providedSession.transferredState?.inputState?.selectedModel?.identifier}, storedSelectedModel=${storedInputState?.selectedModel?.identifier}, finalSelectedModel=${modelRef.object.inputModel.state.get()?.selectedModel?.identifier}, hasTransferredInputState=${!!providedSession.transferredState?.inputState}, hasStoredInputState=${!!storedInputState}, hasInitialData=${!!initialData}`, modelRef.object.inputModel.state.get(), undefined, this.logService);
@@ -1021,6 +1022,9 @@ export class ChatService extends Disposable implements IChatService {
 		if (!model && model !== request.session) {
 			throw new Error(`Unknown session: ${request.session.sessionResource}`);
 		}
+		if (model.isReadOnly.get()) {
+			return;
+		}
 
 		const cts = this._pendingRequests.get(request.session.sessionResource);
 		if (cts) {
@@ -1099,6 +1103,9 @@ export class ChatService extends Disposable implements IChatService {
 		let model = this._sessionModels.get(sessionResource);
 		if (!model) {
 			throw new Error(`Unknown session: ${sessionResource}`);
+		}
+		if (model.isReadOnly.get()) {
+			return { kind: 'rejected', reason: 'Session is read-only' };
 		}
 
 		// Internally blank widgets use special sessions with an untitled- path.

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -386,6 +386,7 @@ export interface IChatSession extends IDisposable {
 
 	readonly progressObs?: IObservable<IChatProgress[]>;
 	readonly isCompleteObs?: IObservable<boolean>;
+	readonly isReadOnly?: IObservable<boolean>;
 	readonly interruptActiveResponseCallback?: () => Promise<boolean>;
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1686,6 +1686,7 @@ export interface IChatModel extends IDisposable {
 	readonly hasActiveRequest: IObservable<boolean>;
 	/** Provides session information when a request needs user interaction to continue */
 	readonly requestNeedsInput: IObservable<IChatRequestNeedsInputInfo | undefined>;
+	readonly isReadOnly: IObservable<boolean>;
 	readonly inputPlaceholder?: string;
 	readonly editingSession?: IChatEditingSession | undefined;
 	readonly checkpoint: IChatRequestModel | undefined;
@@ -2392,6 +2393,7 @@ export class ChatModel extends Disposable implements IChatModel {
 	readonly requestInProgress: IObservable<boolean>;
 	readonly hasActiveRequest: IObservable<boolean>;
 	readonly requestNeedsInput: IObservable<IChatRequestNeedsInputInfo | undefined>;
+	readonly isReadOnly: IObservable<boolean>;
 
 	/** Input model for managing input state */
 	readonly inputModel: InputModel;
@@ -2497,7 +2499,7 @@ export class ChatModel extends Disposable implements IChatModel {
 
 	constructor(
 		dataRef: ISerializedChatDataReference | undefined,
-		initialModelProps: { initialLocation: ChatAgentLocation; canUseTools: boolean; inputState?: ISerializableChatModelInputState; resource?: URI; disableBackgroundKeepAlive?: boolean },
+		initialModelProps: { initialLocation: ChatAgentLocation; canUseTools: boolean; inputState?: ISerializableChatModelInputState; resource?: URI; disableBackgroundKeepAlive?: boolean; isReadOnly?: IObservable<boolean> },
 		@ILogService private readonly logService: ILogService,
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 		@IChatEditingService private readonly chatEditingService: IChatEditingService,
@@ -2567,6 +2569,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		this._initialLocation = initialData?.initialLocation ?? initialModelProps.initialLocation;
 
 		this._canUseTools = initialModelProps.canUseTools;
+		this.isReadOnly = initialModelProps.isReadOnly ?? constObservable(false);
 
 		this.lastRequestObs = observableFromEvent(this, this.onDidChange, () => this._requests.at(-1));
 

--- a/src/vs/workbench/contrib/chat/common/model/chatModelStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModelStore.ts
@@ -5,7 +5,7 @@
 
 import { Emitter } from '../../../../../base/common/event.js';
 import { Disposable, IReference, ReferenceCollection } from '../../../../../base/common/lifecycle.js';
-import { ObservableMap } from '../../../../../base/common/observable.js';
+import { IObservable, ObservableMap } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ChatAgentLocation } from '../constants.js';
@@ -20,6 +20,7 @@ export interface IStartSessionProps {
 	readonly transferEditingSession?: IChatEditingSession;
 	readonly disableBackgroundKeepAlive?: boolean;
 	readonly inputState?: ISerializableChatModelInputState;
+	readonly isReadOnly?: IObservable<boolean>;
 }
 
 export interface ChatModelStoreDelegate {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -4661,6 +4661,41 @@ suite('AgentHostChatContribution', () => {
 			assert.deepStrictEqual(states, [true, false, true]);
 		});
 
+		test('new session read-only state follows status after materialization', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/new-read-only-session' });
+			const { chatSession, turnPromise, fire, session, turnId } = await startTurn(
+				sessionHandler,
+				agentHostService,
+				chatAgentService,
+				disposables,
+				{ sessionResource },
+			);
+			assert.ok(chatSession.isReadOnly);
+
+			const backendSession = AgentSession.uri('copilot', 'new-read-only-session');
+			const states = [chatSession.isReadOnly.get()];
+			agentHostService.fireAction({
+				channel: backendSession.toString(),
+				action: { type: ActionType.SessionIsArchivedChanged, isArchived: true },
+				serverSeq: 100,
+				origin: undefined,
+			});
+			states.push(chatSession.isReadOnly.get());
+			agentHostService.fireAction({
+				channel: backendSession.toString(),
+				action: { type: ActionType.SessionIsArchivedChanged, isArchived: false },
+				serverSeq: 101,
+				origin: undefined,
+			});
+			states.push(chatSession.isReadOnly.get());
+
+			fire({ type: 'chat/turnComplete', endedAt: new Date().toISOString(), session, turnId } as ChatAction);
+			await turnPromise;
+
+			assert.deepStrictEqual(states, [false, true, false]);
+		});
+
 		test('loads user and assistant messages into history', async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -27,7 +27,7 @@ import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey 
 import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
 import { ActionType, isSessionAction, isChatAction, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type ChatAction as AgentHostChatAction, type TerminalAction, type INotification, type IToolCallConfirmedAction, type ITurnStartedAction, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import type { IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
-import { CustomizationType, McpAuthRequiredReason, McpServerStatus, type ClientPluginCustomization, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { ChatInteractivity, CustomizationType, McpAuthRequiredReason, McpServerStatus, type ClientPluginCustomization, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallContributorKind, createSessionState, createChatState, createDefaultChatSummary, buildChatUri, buildDefaultChatUri, parseDefaultChatUri, isAhpChatChannel, createActiveTurn, isAhpRootChannel, PolicyState, ResponsePartKind, ROOT_STATE_URI, StateComponents, buildSubagentChatUri, ToolResultContentType, MessageAttachmentKind, MessageKind, type SessionState, type SessionSummary, type ChatState, type ISessionWithDefaultChat, RootState, type ToolCallState, type AgentInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { CompletionItemKind as AhpCompletionItemKind, type CompletionsParams, type CompletionsResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { sessionReducer, chatReducer } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
@@ -149,6 +149,7 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	// may hold a SessionState (for session channels) or a ChatState (for the
 	// per-session default chat channel).
 	private readonly _liveSubscriptions = new Map<string, { state: SessionState | ChatState; emitter: Emitter<SessionState | ChatState>; onWillApply: Emitter<ActionEnvelope>; onDidApply: Emitter<ActionEnvelope> }>();
+	private readonly _chatInteractivities = new Map<string, ChatInteractivity>();
 
 	private _nextId = 1;
 	private readonly _sessions = new Map<string, IAgentSessionMetadata>();
@@ -471,6 +472,19 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 		}
 	}
 
+	setChatInteractivity(session: URI, interactivity: ChatInteractivity): void {
+		const entry = this._liveSubscriptions.get(buildDefaultChatUri(session.toString()));
+		if (!entry) {
+			throw new Error(`No live chat subscription for ${session.toString()}`);
+		}
+		entry.state = { ...entry.state, interactivity };
+		entry.emitter.fire(entry.state);
+	}
+
+	seedChatInteractivity(session: URI, interactivity: ChatInteractivity): void {
+		this._chatInteractivities.set(buildDefaultChatUri(session.toString()), interactivity);
+	}
+
 	/**
 	 * Builds the default-chat {@link ChatState} for a session, seeded with any
 	 * conversation fields a test attached to the session's {@link SeededSessionState}.
@@ -490,6 +504,7 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 		const chatSummary = createDefaultChatSummary(sessionSummary, chatUriStr);
 		return {
 			...createChatState(chatSummary),
+			interactivity: this._chatInteractivities.get(chatUriStr),
 			turns: seeded?.turns ?? [],
 			activeTurn: seeded?.activeTurn,
 			steeringMessage: seeded?.steeringMessage,
@@ -4647,6 +4662,34 @@ suite('AgentHostChatContribution', () => {
 			states.push(session.isReadOnly.get());
 
 			assert.deepStrictEqual(states, [true, false, true]);
+		});
+
+		test('non-archived session read-only state follows chat interactivity', async () => {
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const sessionUri = AgentSession.uri('copilot', 'read-only-chat');
+			agentHostService.sessionStates.set(sessionUri.toString(), {
+				...createSessionState({
+					resource: sessionUri.toString(),
+					provider: 'copilot',
+					title: 'Read-only chat',
+					status: SessionStatus.Idle,
+					createdAt: new Date().toISOString(),
+					modifiedAt: new Date().toISOString(),
+				}),
+				lifecycle: SessionLifecycle.Ready,
+			});
+			agentHostService.seedChatInteractivity(sessionUri, ChatInteractivity.ReadOnly);
+
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/read-only-chat' });
+			const session = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => session.dispose()));
+			assert.ok(session.isReadOnly);
+
+			const states = [session.isReadOnly.get()];
+			agentHostService.setChatInteractivity(sessionUri, ChatInteractivity.Full);
+			states.push(session.isReadOnly.get());
+
+			assert.deepStrictEqual(states, [true, false]);
 		});
 
 		test('new session read-only state follows status after materialization', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -78,6 +78,8 @@ import { OpenAgentHostFolderPickerAction } from '../../../browser/agentSessions/
 import { MenuId, MenuRegistry, isIMenuItem, type IMenuItem } from '../../../../../../platform/actions/common/actions.js';
 import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
 import { type ContextKeyValue } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { type IAgentSession, type IAgentSessionsModel } from '../../../browser/agentSessions/agentSessionsModel.js';
+import { IAgentSessionsService } from '../../../browser/agentSessions/agentSessionsService.js';
 import { IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { SyncedCustomizationBundler } from '../../../browser/agentSessions/agentHost/syncedCustomizationBundler.js';
 import { IAgentHostCustomizationService, NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
@@ -622,6 +624,9 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	const chatWidgetService = new MockChatWidgetService();
 	const chatSessionContributions: IChatSessionsExtensionPoint[] = [];
 	const chatSessionItemControllers: { type: string; controller: IChatSessionItemController }[] = [];
+	const onDidChangeSessionArchivedState = disposables.add(new Emitter<IAgentSession>());
+	const onDidChangeAgentSessions = disposables.add(new Emitter<void>());
+	const agentSessions: IAgentSession[] = [];
 	const openerService: { openedUrls: (string | URI)[]; openShouldFail: boolean; openResult: boolean } & Partial<IOpenerService> = {
 		openedUrls: [],
 		openShouldFail: false,
@@ -641,6 +646,13 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	instantiationService.stub(IChatEntitlementService, { entitlement: ChatEntitlement.Free, quotas: {} } as Partial<IChatEntitlementService> as IChatEntitlementService);
 	instantiationService.stub(IChatAgentService, chatAgentService);
 	instantiationService.stub(IChatWidgetService, chatWidgetService);
+	instantiationService.stub(IAgentSessionsService, upcastPartial<IAgentSessionsService>({
+		onDidChangeSessionArchivedState: onDidChangeSessionArchivedState.event,
+		model: upcastPartial<IAgentSessionsModel>({
+			sessions: agentSessions,
+			onDidChangeSessions: onDidChangeAgentSessions.event,
+		}),
+	}));
 	instantiationService.stub(IFileService, TestFileService);
 	instantiationService.stub(ILabelService, MockLabelService);
 	instantiationService.stub(IPathService, new class extends mock<IPathService>() {
@@ -852,7 +864,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	instantiationService.stub(IAgentHostActiveClientService, activeClientService);
 	instantiationService.stub(IOpenerService, openerService as IOpenerService);
 
-	return { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, activeClientService, seedActiveClient, chatSessionContributions, chatSessionItemControllers, newSessionFolderService, trustController, modelService, workingCopyService };
+	return { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, activeClientService, seedActiveClient, chatSessionContributions, chatSessionItemControllers, newSessionFolderService, trustController, modelService, workingCopyService, onDidChangeSessionArchivedState, onDidChangeAgentSessions, agentSessions };
 }
 
 function createSessionListStore(disposables: DisposableStore, instantiationService: TestInstantiationService, connection: IAgentHostSessionListConnection): AgentHostSessionListStore {
@@ -4609,6 +4621,46 @@ suite('AgentHostChatContribution', () => {
 
 	suite('history loading', () => {
 
+		test('archived session read-only state follows session status', async () => {
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+
+			const sessionUri = AgentSession.uri('copilot', 'archived-session');
+			agentHostService.sessionStates.set(sessionUri.toString(), {
+				...createSessionState({
+					resource: sessionUri.toString(),
+					provider: 'copilot',
+					title: 'Archived',
+					status: SessionStatus.Idle | SessionStatus.IsArchived,
+					createdAt: new Date().toISOString(),
+					modifiedAt: new Date().toISOString(),
+				}),
+				lifecycle: SessionLifecycle.Ready,
+			});
+
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/archived-session' });
+			const session = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => session.dispose()));
+			assert.ok(session.isReadOnly);
+
+			const states = [session.isReadOnly.get()];
+			agentHostService.fireAction({
+				channel: sessionUri.toString(),
+				action: { type: ActionType.SessionIsArchivedChanged, isArchived: false },
+				serverSeq: 1,
+				origin: undefined,
+			});
+			states.push(session.isReadOnly.get());
+			agentHostService.fireAction({
+				channel: sessionUri.toString(),
+				action: { type: ActionType.SessionIsArchivedChanged, isArchived: true },
+				serverSeq: 2,
+				origin: undefined,
+			});
+			states.push(session.isReadOnly.get());
+
+			assert.deepStrictEqual(states, [true, false, true]);
+		});
+
 		test('loads user and assistant messages into history', async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
@@ -6707,6 +6759,57 @@ suite('AgentHostChatContribution', () => {
 			});
 
 			assert.deepStrictEqual(chatSessionItemControllers.map(c => c.type), ['agent-host-copilot']);
+		});
+
+		test('session list contribution forwards archived state to the agent host', () => {
+			const { instantiationService, agentHostService, onDidChangeSessionArchivedState } = createTestServices(disposables);
+			disposables.add(instantiationService.createInstance(AgentHostSessionListContribution));
+			agentHostService.setRootState({
+				agents: [{ provider: 'copilot' as const, displayName: 'Agent Host - Copilot', description: 'test', models: [] }],
+				activeSessions: 0,
+			});
+
+			let archived = true;
+			const session = upcastPartial<IAgentSession>({
+				providerType: 'agent-host-copilot',
+				resource: URI.from({ scheme: 'agent-host-copilot', path: '/archive-test' }),
+				isArchived: () => archived,
+			});
+			onDidChangeSessionArchivedState.fire(session);
+			archived = false;
+			onDidChangeSessionArchivedState.fire(session);
+
+			assert.deepStrictEqual(agentHostService.dispatchedActions.map(({ channel, action }) => ({ channel, action })), [
+				{
+					channel: AgentSession.uri('copilot', 'archive-test').toString(),
+					action: { type: ActionType.SessionIsArchivedChanged, isArchived: true },
+				},
+				{
+					channel: AgentSession.uri('copilot', 'archive-test').toString(),
+					action: { type: ActionType.SessionIsArchivedChanged, isArchived: false },
+				},
+			]);
+		});
+
+		test('session list contribution syncs archived state when sessions load', () => {
+			const { instantiationService, agentHostService, agentSessions, onDidChangeAgentSessions } = createTestServices(disposables);
+			disposables.add(instantiationService.createInstance(AgentHostSessionListContribution));
+			agentHostService.setRootState({
+				agents: [{ provider: 'copilot' as const, displayName: 'Agent Host - Copilot', description: 'test', models: [] }],
+				activeSessions: 0,
+			});
+
+			agentSessions.push(upcastPartial<IAgentSession>({
+				providerType: 'agent-host-copilot',
+				resource: URI.from({ scheme: 'agent-host-copilot', path: '/archived-at-startup' }),
+				isArchived: () => true,
+			}));
+			onDidChangeAgentSessions.fire();
+
+			assert.deepStrictEqual(agentHostService.dispatchedActions.map(({ channel, action }) => ({ channel, action })), [{
+				channel: AgentSession.uri('copilot', 'archived-at-startup').toString(),
+				action: { type: ActionType.SessionIsArchivedChanged, isArchived: true },
+			}]);
 		});
 
 		test('session list contribution does not register item controller in sessions window', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -78,8 +78,6 @@ import { OpenAgentHostFolderPickerAction } from '../../../browser/agentSessions/
 import { MenuId, MenuRegistry, isIMenuItem, type IMenuItem } from '../../../../../../platform/actions/common/actions.js';
 import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
 import { type ContextKeyValue } from '../../../../../../platform/contextkey/common/contextkey.js';
-import { type IAgentSession, type IAgentSessionsModel } from '../../../browser/agentSessions/agentSessionsModel.js';
-import { IAgentSessionsService } from '../../../browser/agentSessions/agentSessionsService.js';
 import { IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { SyncedCustomizationBundler } from '../../../browser/agentSessions/agentHost/syncedCustomizationBundler.js';
 import { IAgentHostCustomizationService, NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
@@ -624,9 +622,6 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	const chatWidgetService = new MockChatWidgetService();
 	const chatSessionContributions: IChatSessionsExtensionPoint[] = [];
 	const chatSessionItemControllers: { type: string; controller: IChatSessionItemController }[] = [];
-	const onDidChangeSessionArchivedState = disposables.add(new Emitter<IAgentSession>());
-	const onDidChangeAgentSessions = disposables.add(new Emitter<void>());
-	const agentSessions: IAgentSession[] = [];
 	const openerService: { openedUrls: (string | URI)[]; openShouldFail: boolean; openResult: boolean } & Partial<IOpenerService> = {
 		openedUrls: [],
 		openShouldFail: false,
@@ -646,13 +641,6 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	instantiationService.stub(IChatEntitlementService, { entitlement: ChatEntitlement.Free, quotas: {} } as Partial<IChatEntitlementService> as IChatEntitlementService);
 	instantiationService.stub(IChatAgentService, chatAgentService);
 	instantiationService.stub(IChatWidgetService, chatWidgetService);
-	instantiationService.stub(IAgentSessionsService, upcastPartial<IAgentSessionsService>({
-		onDidChangeSessionArchivedState: onDidChangeSessionArchivedState.event,
-		model: upcastPartial<IAgentSessionsModel>({
-			sessions: agentSessions,
-			onDidChangeSessions: onDidChangeAgentSessions.event,
-		}),
-	}));
 	instantiationService.stub(IFileService, TestFileService);
 	instantiationService.stub(ILabelService, MockLabelService);
 	instantiationService.stub(IPathService, new class extends mock<IPathService>() {
@@ -864,7 +852,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	instantiationService.stub(IAgentHostActiveClientService, activeClientService);
 	instantiationService.stub(IOpenerService, openerService as IOpenerService);
 
-	return { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, activeClientService, seedActiveClient, chatSessionContributions, chatSessionItemControllers, newSessionFolderService, trustController, modelService, workingCopyService, onDidChangeSessionArchivedState, onDidChangeAgentSessions, agentSessions };
+	return { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, activeClientService, seedActiveClient, chatSessionContributions, chatSessionItemControllers, newSessionFolderService, trustController, modelService, workingCopyService };
 }
 
 function createSessionListStore(disposables: DisposableStore, instantiationService: TestInstantiationService, connection: IAgentHostSessionListConnection): AgentHostSessionListStore {
@@ -4696,6 +4684,52 @@ suite('AgentHostChatContribution', () => {
 			assert.deepStrictEqual(states, [false, true, false]);
 		});
 
+		test('eager-created session read-only state follows status after materialization', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+			const backendSession = AgentSession.uri('copilot', 'new-eager-read-only-session');
+			agentHostService.sessionStates.set(backendSession.toString(), {
+				...createSessionState({
+					resource: backendSession.toString(),
+					provider: 'copilot',
+					title: 'Eager',
+					status: SessionStatus.Idle,
+					createdAt: new Date().toISOString(),
+					modifiedAt: new Date().toISOString(),
+				}),
+				lifecycle: SessionLifecycle.Ready,
+			});
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/new-eager-read-only-session' });
+			const { chatSession, turnPromise, fire, session, turnId } = await startTurn(
+				sessionHandler,
+				agentHostService,
+				chatAgentService,
+				disposables,
+				{ sessionResource },
+			);
+			assert.ok(chatSession.isReadOnly);
+
+			const states = [chatSession.isReadOnly.get()];
+			agentHostService.fireAction({
+				channel: backendSession.toString(),
+				action: { type: ActionType.SessionIsArchivedChanged, isArchived: true },
+				serverSeq: 100,
+				origin: undefined,
+			});
+			states.push(chatSession.isReadOnly.get());
+			agentHostService.fireAction({
+				channel: backendSession.toString(),
+				action: { type: ActionType.SessionIsArchivedChanged, isArchived: false },
+				serverSeq: 101,
+				origin: undefined,
+			});
+			states.push(chatSession.isReadOnly.get());
+
+			fire({ type: 'chat/turnComplete', endedAt: new Date().toISOString(), session, turnId } as ChatAction);
+			await turnPromise;
+
+			assert.deepStrictEqual(states, [false, true, false]);
+		});
+
 		test('loads user and assistant messages into history', async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
@@ -6794,57 +6828,6 @@ suite('AgentHostChatContribution', () => {
 			});
 
 			assert.deepStrictEqual(chatSessionItemControllers.map(c => c.type), ['agent-host-copilot']);
-		});
-
-		test('session list contribution forwards archived state to the agent host', () => {
-			const { instantiationService, agentHostService, onDidChangeSessionArchivedState } = createTestServices(disposables);
-			disposables.add(instantiationService.createInstance(AgentHostSessionListContribution));
-			agentHostService.setRootState({
-				agents: [{ provider: 'copilot' as const, displayName: 'Agent Host - Copilot', description: 'test', models: [] }],
-				activeSessions: 0,
-			});
-
-			let archived = true;
-			const session = upcastPartial<IAgentSession>({
-				providerType: 'agent-host-copilot',
-				resource: URI.from({ scheme: 'agent-host-copilot', path: '/archive-test' }),
-				isArchived: () => archived,
-			});
-			onDidChangeSessionArchivedState.fire(session);
-			archived = false;
-			onDidChangeSessionArchivedState.fire(session);
-
-			assert.deepStrictEqual(agentHostService.dispatchedActions.map(({ channel, action }) => ({ channel, action })), [
-				{
-					channel: AgentSession.uri('copilot', 'archive-test').toString(),
-					action: { type: ActionType.SessionIsArchivedChanged, isArchived: true },
-				},
-				{
-					channel: AgentSession.uri('copilot', 'archive-test').toString(),
-					action: { type: ActionType.SessionIsArchivedChanged, isArchived: false },
-				},
-			]);
-		});
-
-		test('session list contribution syncs archived state when sessions load', () => {
-			const { instantiationService, agentHostService, agentSessions, onDidChangeAgentSessions } = createTestServices(disposables);
-			disposables.add(instantiationService.createInstance(AgentHostSessionListContribution));
-			agentHostService.setRootState({
-				agents: [{ provider: 'copilot' as const, displayName: 'Agent Host - Copilot', description: 'test', models: [] }],
-				activeSessions: 0,
-			});
-
-			agentSessions.push(upcastPartial<IAgentSession>({
-				providerType: 'agent-host-copilot',
-				resource: URI.from({ scheme: 'agent-host-copilot', path: '/archived-at-startup' }),
-				isArchived: () => true,
-			}));
-			onDidChangeAgentSessions.fire();
-
-			assert.deepStrictEqual(agentHostService.dispatchedActions.map(({ channel, action }) => ({ channel, action })), [{
-				channel: AgentSession.uri('copilot', 'archived-at-startup').toString(),
-				action: { type: ActionType.SessionIsArchivedChanged, isArchived: true },
-			}]);
 		});
 
 		test('session list contribution does not register item controller in sessions window', () => {

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -2075,6 +2075,7 @@ suite('ChatService', () => {
 		interface IProvidedSessionOptions {
 			readonly progressObs?: ISettableObservable<IChatProgress[]>;
 			readonly isCompleteObs?: ISettableObservable<boolean>;
+			readonly isReadOnly?: ISettableObservable<boolean>;
 			readonly interruptActiveResponseCallback?: () => Promise<boolean>;
 			readonly onDidStartServerRequest?: Event<{ prompt: string; variableData?: IChatRequestVariableData; timestamp?: number; isSystemInitiated?: boolean; systemInitiatedLabel?: string }>;
 			readonly history?: readonly IChatSessionHistoryItem[];
@@ -2094,6 +2095,7 @@ suite('ChatService', () => {
 				onWillDispose: Event.None,
 				progressObs: opts.progressObs,
 				isCompleteObs: opts.isCompleteObs,
+				isReadOnly: opts.isReadOnly,
 				interruptActiveResponseCallback: opts.interruptActiveResponseCallback,
 				onDidStartServerRequest: opts.onDidStartServerRequest,
 				dispose: () => { },
@@ -2109,6 +2111,26 @@ suite('ChatService', () => {
 		function generateId(): string {
 			return `${Date.now()}-${idCounter++}`;
 		}
+
+		test('contributed session read-only state is preserved on the chat model', async () => {
+			const isReadOnly = observableValue<boolean>('isReadOnly', true);
+			const { resource } = setupRemoteProvider({ isReadOnly });
+
+			const testService = createChatService();
+			const ref = await testService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
+			assert.ok(ref);
+			testDisposables.add(ref);
+
+			const sendResult = await testService.sendRequest(resource, 'Do not send');
+			const states = [ref.object.isReadOnly.get()];
+			isReadOnly.set(false, undefined);
+			states.push(ref.object.isReadOnly.get());
+
+			assert.deepStrictEqual({ states, sendResult }, {
+				states: [true, false],
+				sendResult: { kind: 'rejected', reason: 'Session is read-only' },
+			});
+		});
 
 		test('restores request timestamps from remote session history', async () => {
 			const timestamp = 1_752_012_321_000;

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -1453,6 +1453,36 @@ suite('ChatService', () => {
 			await sent.data.responseCompletePromise;
 		});
 
+		test('materialization rejects a send when the real session is read-only', async () => {
+			const realResource = URI.from({ scheme: remoteScheme, path: '/real-read-only' });
+			let invokeCount = 0;
+			const { service, untitledResource } = setupUntitledRemote({
+				createItem: async () => realItem(realResource),
+				invoke: async () => { invokeCount++; return {}; },
+				provideContent: resource => Promise.resolve({
+					sessionResource: resource,
+					history: [],
+					onWillDispose: Event.None,
+					isReadOnly: constObservable(resource.toString() === realResource.toString()),
+					dispose: () => { },
+				}),
+			});
+			testDisposables.add((await service.acquireOrLoadSession(untitledResource, ChatAgentLocation.Chat, CancellationToken.None))!);
+
+			const result = await service.sendRequest(untitledResource, 'hello', { agentId: remoteScheme });
+			const realModel = service.getSession(realResource);
+
+			assert.deepStrictEqual({
+				result,
+				invokeCount,
+				requestCount: realModel?.getRequests().length,
+			}, {
+				result: { kind: 'rejected', reason: 'Session is read-only', newSessionResource: realResource },
+				invokeCount: 0,
+				requestCount: 0,
+			});
+		});
+
 		test('a late send still addressed to the untitled resource re-targets the real session', async () => {
 			const realResource = URI.from({ scheme: remoteScheme, path: '/real-late' });
 			let createCount = 0;
@@ -1480,6 +1510,39 @@ suite('ChatService', () => {
 			assert.strictEqual(createCount, 1, 'no second materialization for a stale untitled send');
 			assert.strictEqual(r2.newSessionResource?.toString(), realResource.toString(), 'late re-target reports the real resource as the new session');
 			assert.strictEqual(realModel.getRequests().length, requestsAfterFirst + 1, 'second request is routed to the real session');
+		});
+
+		test('a late send to a read-only materialized session reports the real resource', async () => {
+			const realResource = URI.from({ scheme: remoteScheme, path: '/real-late-read-only' });
+			const isReadOnly = observableValue<boolean>('isReadOnly', false);
+			let invokeCount = 0;
+			const { service, untitledResource } = setupUntitledRemote({
+				createItem: async () => realItem(realResource),
+				invoke: async () => { invokeCount++; return {}; },
+				provideContent: resource => Promise.resolve({
+					sessionResource: resource,
+					history: [],
+					onWillDispose: Event.None,
+					isReadOnly,
+					dispose: () => { },
+				}),
+			});
+			testDisposables.add((await service.acquireOrLoadSession(untitledResource, ChatAgentLocation.Chat, CancellationToken.None))!);
+
+			const first = await service.sendRequest(untitledResource, 'first', { agentId: remoteScheme });
+			ChatSendResult.assertSent(first);
+			await first.data.responseCompletePromise;
+			isReadOnly.set(true, undefined);
+
+			const second = await service.sendRequest(untitledResource, 'second', { agentId: remoteScheme });
+
+			assert.deepStrictEqual({
+				second,
+				invokeCount,
+			}, {
+				second: { kind: 'rejected', reason: 'Session is read-only', newSessionResource: realResource },
+				invokeCount: 1,
+			});
 		});
 
 		test('a failed materialization does not poison the latch (retry re-attempts)', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/model/mockChatModel.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/mockChatModel.ts
@@ -28,6 +28,7 @@ export class MockChatModel extends Disposable implements IChatModel {
 	readonly requestInProgress = observableValue('requestInProgress', false);
 	readonly hasActiveRequest = observableValue('hasActiveRequest', false);
 	readonly requestNeedsInput = observableValue<IChatRequestNeedsInputInfo | undefined>('requestNeedsInput', undefined);
+	readonly isReadOnly = observableValue(this, false);
 	readonly inputPlaceholder = undefined;
 	readonly editingSession = undefined;
 	readonly checkpoint = undefined;

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatReadOnlyBanner.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatReadOnlyBanner.fixture.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ChatReadOnlyBanner } from '../../../../contrib/chat/browser/widget/chatReadOnlyBanner.js';
+import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
+
+export default defineThemedFixtureGroup({ path: 'chat/' }, {
+	ReadOnlyBanner: defineComponentFixture({ render: renderReadOnlyBanner }),
+});
+
+function renderReadOnlyBanner({ container, disposableStore, theme }: ComponentFixtureContext): void {
+	container.style.width = '480px';
+
+	const instantiationService = createEditorServices(disposableStore, { colorTheme: theme });
+	const banner = disposableStore.add(instantiationService.createInstance(ChatReadOnlyBanner));
+	banner.setVisible(true);
+	container.appendChild(banner.domNode);
+}


### PR DESCRIPTION
## Summary

- propagate Agent Host archive and interactivity state into editor chat models
- show a read-only warning banner and hide the composer for archived sessions
- block send, retry, fork, follow-up, checkpoint restore, and other mutating chat operations
- keep read-only state reactive for existing, directly created, and eagerly created sessions

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- focused hygiene checks
- 310 focused Agent Host and chat service tests
- live editor and Agents window verification

(Written by Copilot)
