### PR TITLE
chat: Default virtual workspaces to local harness

### DIFF
--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -286,11 +286,10 @@ export function isSupportedChatFileScheme(accessor: ServicesAccessor, scheme: st
  * Returns the effective default session type for a new chat in the VS Code
  * editor window.
  *
- * When the agent host is enabled and `chat.defaultToCopilotHarness` is opted
- * in, Agent Host Copilot CLI is the default so that first-time users land on
- * Copilot instead of the local harness. Otherwise it falls back to
- * {@link localChatSessionType} when local is enabled, or to the first visible
- * non-local provider.
+ * Virtual workspaces always default to {@link localChatSessionType}. Otherwise,
+ * when the agent host is enabled and `chat.defaultToCopilotHarness` is opted in,
+ * Agent Host Copilot CLI is the default. It falls back to the local harness
+ * when enabled, or to the first visible non-local provider.
  */
 export function getComputedDefaultSessionType(
 	configurationService: IConfigurationService,
@@ -298,6 +297,10 @@ export function getComputedDefaultSessionType(
 	workspace: IWorkspace,
 	agentHostEnabled: boolean
 ): string {
+	if (isVirtualWorkspace(workspace)) {
+		return localChatSessionType;
+	}
+
 	if (agentHostEnabled && configurationService.getValue<boolean>(ChatConfiguration.DefaultToCopilotHarness)) {
 		return SessionType.AgentHostCopilot;
 	}

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -394,18 +394,25 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('agent host default wins over a virtual workspace local override', () => {
+	test('virtual workspace defaults to local when the agent host default is enabled', () => {
 		const configurationService = new TestConfigurationService({
 			[ChatConfiguration.DefaultToCopilotHarness]: true,
 			[ChatConfiguration.EditorLocalAgentEnabled]: false,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
 		const workspace = createWorkspace(URI.parse('vscode-vfs://github/microsoft/vscode'));
 
 		assert.deepStrictEqual({
 			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, workspace, true),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, true),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, workspace),
+			localRememberedUsable: isRememberedSessionTypeUsable(localChatSessionType, configurationService, chatSessionsService, workspace),
 		}, {
-			computed: SessionType.AgentHostCopilot,
+			computed: localChatSessionType,
+			rememberedAware: localChatSessionType,
+			localVisible: true,
+			localRememberedUsable: true,
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Make virtual workspaces choose the Local chat harness before evaluating `chat.defaultToCopilotHarness`
- Preserve the configured Agent Host default for non-virtual editor windows
- Cover Remote Repositories (`vscode-vfs`) with a regression test that also confirms Local remains visible and usable

## Validation

- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/common/constants.test.ts`
- `npm run valid-layers-check`
- changed-file hygiene and pre-commit hook

(Written by Copilot)