### PR TITLE
Git - resolve the active notebook for Open Changes / Open File

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5,7 +5,7 @@
 
 import * as os from 'os';
 import * as path from 'path';
-import { Command, commands, Disposable, MessageOptions, Position, QuickPickItem, Range, SourceControlResourceState, TextDocumentShowOptions, TextEditor, Uri, ViewColumn, window, workspace, WorkspaceEdit, WorkspaceFolder, TimelineItem, env, Selection, TextDocumentContentProvider, InputBoxValidationSeverity, TabInputText, TabInputTextMerge, QuickPickItemKind, TextDocument, LogOutputChannel, l10n, Memento, UIKind, QuickInputButton, ThemeIcon, SourceControlHistoryItem, SourceControl, InputBoxValidationMessage, Tab, TabInputNotebook, QuickInputButtonLocation, languages, SourceControlArtifact, ProgressLocation } from 'vscode';
+import { Command, commands, Disposable, MessageOptions, Position, QuickPickItem, Range, SourceControlResourceState, TextDocumentShowOptions, TextEditor, Uri, ViewColumn, window, workspace, WorkspaceEdit, WorkspaceFolder, TimelineItem, env, Selection, TextDocumentContentProvider, InputBoxValidationSeverity, TabInputText, TabInputTextMerge, QuickPickItemKind, TextDocument, LogOutputChannel, l10n, Memento, UIKind, QuickInputButton, ThemeIcon, SourceControlHistoryItem, SourceControl, InputBoxValidationMessage, Tab, TabInputNotebook, TabInputNotebookDiff, QuickInputButtonLocation, languages, SourceControlArtifact, ProgressLocation } from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import type { CommitOptions, RemoteSourcePublisher, Remote, Branch, Ref } from './api/git';
 import { ForcePushMode, GitErrorCodes, RefType, Status } from './api/git.constants';
@@ -5700,7 +5700,13 @@ export class CommandCenter {
 	}
 
 	private getSCMResource(uri?: Uri): Resource | undefined {
-		uri = uri ? uri : (window.activeTextEditor && window.activeTextEditor.document.uri);
+		uri = uri ?? window.activeNotebookEditor?.notebook.uri ?? window.activeTextEditor?.document.uri;
+
+		// A notebook diff editor is neither the active text nor notebook editor, so
+		// fall back to its modified resource.
+		if (!uri && window.tabGroups.activeTabGroup.activeTab?.input instanceof TabInputNotebookDiff) {
+			uri = window.tabGroups.activeTabGroup.activeTab.input.modified;
+		}
 
 		this.logger.debug(`[CommandCenter][getSCMResource] git.getSCMResource.uri: ${uri && uri.toString()}`);
 

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -5,7 +5,7 @@
 
 import 'mocha';
 import assert from 'assert';
-import { workspace, commands, window, Uri, WorkspaceEdit, Range, TextDocument, extensions, TabInputTextDiff } from 'vscode';
+import { workspace, commands, window, Uri, WorkspaceEdit, Range, TextDocument, extensions, TabInputTextDiff, TabInputNotebook, TabInputNotebookDiff } from 'vscode';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -145,6 +145,33 @@ suite('git smoke test', function () {
 
 		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
 		assert.strictEqual(repository.state.indexChanges.length, 0);
+	});
+
+	test('opens notebook diff and file from active notebook editor', async function () {
+		const committed = JSON.stringify({ cells: [{ cell_type: 'code', source: ['x = 1'], metadata: {}, outputs: [], execution_count: null }], metadata: {}, nbformat: 4, nbformat_minor: 5 });
+		fs.writeFileSync(file('notebook.ipynb'), committed);
+		await repository.add([file('notebook.ipynb')]);
+		await repository.commit('add notebook');
+
+		fs.writeFileSync(file('notebook.ipynb'), committed.replace('x = 1', 'x = 2'));
+		await repository.status();
+
+		try {
+			const notebook = await workspace.openNotebookDocument(uri('notebook.ipynb'));
+			await window.showNotebookDocument(notebook);
+
+			// git.openChange without an argument resolves the resource from the active notebook editor
+			await commands.executeCommand('git.openChange');
+			assert(window.tabGroups.activeTabGroup.activeTab?.input instanceof TabInputNotebookDiff);
+
+			// git.openFile toggles back to the notebook from the active notebook diff editor
+			await commands.executeCommand('git.openFile');
+			assert(window.tabGroups.activeTabGroup.activeTab?.input instanceof TabInputNotebook);
+		} finally {
+			// Restore the committed content so the following tests start from a clean tree
+			fs.writeFileSync(file('notebook.ipynb'), committed);
+			await repository.status();
+		}
 	});
 
 	test('rename/delete conflict', async function () {


### PR DESCRIPTION
Fixes #176401

### Problem

`Git: Open Changes`, `Git: Open File` and `Git: Open File (HEAD)` do nothing for notebooks when invoked from a keybinding (or the command palette), even though the editor-title buttons and the SCM context menu work. `git.openChange` logs `Invoking command git.openChange` and then silently returns.

### Cause

The keybinding path of these commands resolves the target through `getSCMResource`, whose fallback only looked at `window.activeTextEditor`. That is `undefined` when a notebook editor is active (and a focused cell is a `vscode-notebook-cell` editor, which the `file`-scheme check rejects), so no resource is found and the command returns. The buttons/menu work because they pass the resource explicitly.

### Fix

In `getSCMResource`, resolve `window.activeNotebookEditor?.notebook.uri` before falling back to the active text editor, and — since a notebook diff editor is neither the active text nor notebook editor — fall back to the active `TabInputNotebookDiff`'s `modified` resource so `Open File` can toggle back from an open notebook diff. This gives notebooks the same round-trip behavior text files already have.

### Validation

Verified in a dev build with `alt+d` → `git.openChange`, `alt+f` → `git.openFile`:

| Case | Before | After |
|---|---|---|
| Notebook active → Open Changes | no-op | opens notebook diff |
| Notebook diff active → Open File | no-op | back to the notebook |
| Focused cell → Open Changes | no-op | opens notebook diff |
| Text file (both directions) | works | unchanged |

Added a git smoke test covering both directions (active notebook → Open Changes, then Open File back from the notebook diff). Full git integration suite green.

`getSCMResource` is shared, so `git.stage`/`git.unstage`/`git.clean` invoked via keybinding while a notebook is active now resolve the notebook file too, consistent with how they already work for text files.
