### PR TITLE
Stream agent host debug logs into export instead of buffering

### DIFF
--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -193,10 +193,9 @@ export interface IFile {
 	localPath?: string;
 	/**
 	 * When set (and `contents` is not provided), stream at most this many bytes
-	 * from the start of {@link localPath} into the archive instead of adding the
-	 * whole file. The prefix is clamped to the file's current size, so a file
-	 * that was truncated or rotated after this size was captured still produces a
-	 * valid entry rather than failing the whole archive.
+	 * from the start of {@link localPath} instead of adding the whole file. The
+	 * prefix is clamped to the file's current size so a rotated or truncated file
+	 * still produces a valid entry.
 	 */
 	localPathSize?: number;
 }
@@ -207,10 +206,8 @@ export async function zip(zipPath: string, files: IFile[]): Promise<string> {
 	const zip = new ZipFile();
 	const zipStream = createWriteStream(zipPath);
 
-	// Wire up the output pipe and error handling before adding any entries, so a
-	// read stream that errors while a later entry is still awaiting I/O cannot
-	// emit on `outputStream` before a listener is attached (which would surface
-	// as an uncaught exception).
+	// Attach error/finish handling before adding entries so a read stream that
+	// errors while a later entry is still awaiting I/O has a listener.
 	const result = new Promise<string>((c, e) => {
 		zip.outputStream.once('error', e);
 		zipStream.once('error', e);
@@ -225,14 +222,10 @@ export async function zip(zipPath: string, files: IFile[]): Promise<string> {
 			if (f.localPathSize === undefined) {
 				zip.addFile(f.localPath, f.path);
 			} else {
-				// Stream a bounded prefix of the file. yazl requires the number of
-				// streamed bytes to exactly match the declared size, otherwise it
-				// aborts the whole archive. The size was captured earlier (before,
-				// e.g., a save dialog), so open a single handle and derive the size
-				// and the bytes from that same descriptor: the read is unaffected by
-				// any rotation/truncation of the path, so the counts always match. A
-				// file that vanished (ENOENT) is skipped rather than failing the
-				// entire archive; other open errors are surfaced.
+				// yazl aborts the archive unless the streamed byte count matches the
+				// declared size. Derive both from a single handle so the counts match
+				// even if the path is rotated or truncated concurrently; skip a
+				// vanished file rather than failing the whole archive.
 				let handle: FileHandle;
 				try {
 					handle = await promises.open(f.localPath, 'r');
@@ -254,8 +247,7 @@ export async function zip(zipPath: string, files: IFile[]): Promise<string> {
 						streamOwnsHandle = true;
 					}
 				} finally {
-					// The read stream auto-closes the handle when it finishes; only
-					// close it here if no stream took ownership.
+					// The read stream closes the handle when it finishes.
 					if (!streamOwnsHandle) {
 						await handle.close();
 					}

--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createWriteStream, WriteStream, promises } from 'fs';
+import { createReadStream, createWriteStream, WriteStream, promises } from 'fs';
 import { Readable } from 'stream';
 import { createCancelablePromise, Sequencer } from '../common/async.js';
 import { CancellationToken } from '../common/cancellation.js';
@@ -190,22 +190,54 @@ export interface IFile {
 	path: string;
 	contents?: Buffer | string;
 	localPath?: string;
+	/**
+	 * When set (and `contents` is not provided), stream at most this many bytes
+	 * from the start of {@link localPath} into the archive instead of adding the
+	 * whole file. The prefix is clamped to the file's current size, so a file
+	 * that was truncated or rotated after this size was captured still produces a
+	 * valid entry rather than failing the whole archive.
+	 */
+	localPathSize?: number;
 }
 
 export async function zip(zipPath: string, files: IFile[]): Promise<string> {
 	const { ZipFile } = await import('yazl');
 
-	return new Promise<string>((c, e) => {
-		const zip = new ZipFile();
-		files.forEach(f => {
-			if (f.contents) {
-				zip.addBuffer(typeof f.contents === 'string' ? Buffer.from(f.contents, 'utf8') : f.contents, f.path);
-			} else if (f.localPath) {
+	const zip = new ZipFile();
+	for (const f of files) {
+		if (f.contents !== undefined) {
+			zip.addBuffer(typeof f.contents === 'string' ? Buffer.from(f.contents, 'utf8') : f.contents, f.path);
+		} else if (f.localPath) {
+			if (f.localPathSize === undefined) {
 				zip.addFile(f.localPath, f.path);
+			} else {
+				// Stream a bounded prefix of the file. yazl requires the number of
+				// streamed bytes to exactly match the size we declare, otherwise it
+				// aborts the whole archive. Because the size was captured earlier
+				// (before, e.g., a save dialog) the file may have been rotated or
+				// truncated since. Re-stat here and clamp to the current size so the
+				// declared size always matches what we can actually read. If the file
+				// vanished, skip it rather than failing the entire zip.
+				let currentSize: number;
+				try {
+					currentSize = (await promises.stat(f.localPath)).size;
+				} catch (error) {
+					continue;
+				}
+				const size = Math.min(f.localPathSize, currentSize);
+				if (size === 0) {
+					zip.addBuffer(Buffer.alloc(0), f.path);
+				} else {
+					const readStream = createReadStream(f.localPath, { start: 0, end: size - 1 });
+					readStream.once('error', error => zip.outputStream.emit('error', error));
+					zip.addReadStream(readStream, f.path, { size });
+				}
 			}
-		});
-		zip.end();
+		}
+	}
+	zip.end();
 
+	return new Promise<string>((c, e) => {
 		const zipStream = createWriteStream(zipPath);
 		zip.outputStream.pipe(zipStream);
 

--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createReadStream, createWriteStream, WriteStream, promises } from 'fs';
+import { createWriteStream, WriteStream, promises } from 'fs';
+import type { FileHandle } from 'fs/promises';
 import { Readable } from 'stream';
 import { createCancelablePromise, Sequencer } from '../common/async.js';
 import { CancellationToken } from '../common/cancellation.js';
@@ -204,6 +205,19 @@ export async function zip(zipPath: string, files: IFile[]): Promise<string> {
 	const { ZipFile } = await import('yazl');
 
 	const zip = new ZipFile();
+	const zipStream = createWriteStream(zipPath);
+
+	// Wire up the output pipe and error handling before adding any entries, so a
+	// read stream that errors while a later entry is still awaiting I/O cannot
+	// emit on `outputStream` before a listener is attached (which would surface
+	// as an uncaught exception).
+	const result = new Promise<string>((c, e) => {
+		zip.outputStream.once('error', e);
+		zipStream.once('error', e);
+		zipStream.once('finish', () => c(zipPath));
+	});
+	zip.outputStream.pipe(zipStream);
+
 	for (const f of files) {
 		if (f.contents !== undefined) {
 			zip.addBuffer(typeof f.contents === 'string' ? Buffer.from(f.contents, 'utf8') : f.contents, f.path);
@@ -212,39 +226,46 @@ export async function zip(zipPath: string, files: IFile[]): Promise<string> {
 				zip.addFile(f.localPath, f.path);
 			} else {
 				// Stream a bounded prefix of the file. yazl requires the number of
-				// streamed bytes to exactly match the size we declare, otherwise it
-				// aborts the whole archive. Because the size was captured earlier
-				// (before, e.g., a save dialog) the file may have been rotated or
-				// truncated since. Re-stat here and clamp to the current size so the
-				// declared size always matches what we can actually read. If the file
-				// vanished, skip it rather than failing the entire zip.
-				let currentSize: number;
+				// streamed bytes to exactly match the declared size, otherwise it
+				// aborts the whole archive. The size was captured earlier (before,
+				// e.g., a save dialog), so open a single handle and derive the size
+				// and the bytes from that same descriptor: the read is unaffected by
+				// any rotation/truncation of the path, so the counts always match. A
+				// file that vanished (ENOENT) is skipped rather than failing the
+				// entire archive; other open errors are surfaced.
+				let handle: FileHandle;
 				try {
-					currentSize = (await promises.stat(f.localPath)).size;
+					handle = await promises.open(f.localPath, 'r');
 				} catch (error) {
-					continue;
+					if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+						continue;
+					}
+					throw error;
 				}
-				const size = Math.min(f.localPathSize, currentSize);
-				if (size === 0) {
-					zip.addBuffer(Buffer.alloc(0), f.path);
-				} else {
-					const readStream = createReadStream(f.localPath, { start: 0, end: size - 1 });
-					readStream.once('error', error => zip.outputStream.emit('error', error));
-					zip.addReadStream(readStream, f.path, { size });
+				let streamOwnsHandle = false;
+				try {
+					const size = Math.min(f.localPathSize, (await handle.stat()).size);
+					if (size === 0) {
+						zip.addBuffer(Buffer.alloc(0), f.path);
+					} else {
+						const readStream = handle.createReadStream({ start: 0, end: size - 1 });
+						readStream.once('error', error => zip.outputStream.emit('error', error));
+						zip.addReadStream(readStream, f.path, { size });
+						streamOwnsHandle = true;
+					}
+				} finally {
+					// The read stream auto-closes the handle when it finishes; only
+					// close it here if no stream took ownership.
+					if (!streamOwnsHandle) {
+						await handle.close();
+					}
 				}
 			}
 		}
 	}
 	zip.end();
 
-	return new Promise<string>((c, e) => {
-		const zipStream = createWriteStream(zipPath);
-		zip.outputStream.pipe(zipStream);
-
-		zip.outputStream.once('error', e);
-		zipStream.once('error', e);
-		zipStream.once('finish', () => c(zipPath));
-	});
+	return result;
 }
 
 export function extract(zipPath: string, targetPath: string, options: IExtractOptions = {}, token: CancellationToken): Promise<void> {

--- a/src/vs/base/test/node/zip/zip.test.ts
+++ b/src/vs/base/test/node/zip/zip.test.ts
@@ -72,4 +72,22 @@ suite('Zip', () => {
 
 		await Promises.rm(testDir);
 	});
+
+	test('zip should skip a vanished streamed source without failing the archive', async () => {
+		const testDir = getRandomTestPath(tmpdir(), 'vsctests', 'zip');
+		const presentPath = path.join(testDir, 'present.txt');
+		const missingPath = path.join(testDir, 'missing.txt');
+		const zipPath = path.join(testDir, 'logs.zip');
+		await fs.promises.mkdir(testDir, { recursive: true });
+		await fs.promises.writeFile(presentPath, 'present-contents');
+		await zip(zipPath, [
+			{ path: 'missing.txt', localPath: missingPath, localPathSize: 8 },
+			{ path: 'present.txt', localPath: presentPath, localPathSize: 7 },
+		]);
+
+		assert.strictEqual((await buffer(zipPath, 'present.txt')).toString(), 'present');
+		await assert.rejects(buffer(zipPath, 'missing.txt'));
+
+		await Promises.rm(testDir);
+	});
 });

--- a/src/vs/base/test/node/zip/zip.test.ts
+++ b/src/vs/base/test/node/zip/zip.test.ts
@@ -51,8 +51,7 @@ suite('Zip', () => {
 		const zipPath = path.join(testDir, 'logs.zip');
 		await fs.promises.mkdir(testDir, { recursive: true });
 		await fs.promises.writeFile(sourcePath, 'shrunk');
-		// Request more bytes than the file now holds (e.g. it was rotated after its
-		// size was captured): the entry should contain the whole file, not error.
+		// Request more bytes than the file holds: the entry contains the whole file.
 		await zip(zipPath, [{ path: 'source.txt', localPath: sourcePath, localPathSize: 1024 }]);
 
 		assert.strictEqual((await buffer(zipPath, 'source.txt')).toString(), 'shrunk');

--- a/src/vs/base/test/node/zip/zip.test.ts
+++ b/src/vs/base/test/node/zip/zip.test.ts
@@ -10,7 +10,7 @@ import { createCancelablePromise } from '../../../common/async.js';
 import { FileAccess } from '../../../common/network.js';
 import * as path from '../../../common/path.js';
 import { Promises } from '../../../node/pfs.js';
-import { extract } from '../../../node/zip.js';
+import { buffer, extract, zip } from '../../../node/zip.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../common/utils.js';
 import { getRandomTestPath } from '../testUtils.js';
 
@@ -28,6 +28,47 @@ suite('Zip', () => {
 		await createCancelablePromise(token => extract(fixture, testDir, {}, token));
 		const doesExist = await Promises.exists(path.join(testDir, 'extension'));
 		assert(doesExist);
+
+		await Promises.rm(testDir);
+	});
+
+	test('zip should stream a fixed prefix of a local file', async () => {
+		const testDir = getRandomTestPath(tmpdir(), 'vsctests', 'zip');
+		const sourcePath = path.join(testDir, 'source.txt');
+		const zipPath = path.join(testDir, 'logs.zip');
+		await fs.promises.mkdir(testDir, { recursive: true });
+		await fs.promises.writeFile(sourcePath, 'snapshot-appended');
+		await zip(zipPath, [{ path: 'source.txt', localPath: sourcePath, localPathSize: 8 }]);
+
+		assert.strictEqual((await buffer(zipPath, 'source.txt')).toString(), 'snapshot');
+
+		await Promises.rm(testDir);
+	});
+
+	test('zip should clamp a prefix larger than the current file size', async () => {
+		const testDir = getRandomTestPath(tmpdir(), 'vsctests', 'zip');
+		const sourcePath = path.join(testDir, 'source.txt');
+		const zipPath = path.join(testDir, 'logs.zip');
+		await fs.promises.mkdir(testDir, { recursive: true });
+		await fs.promises.writeFile(sourcePath, 'shrunk');
+		// Request more bytes than the file now holds (e.g. it was rotated after its
+		// size was captured): the entry should contain the whole file, not error.
+		await zip(zipPath, [{ path: 'source.txt', localPath: sourcePath, localPathSize: 1024 }]);
+
+		assert.strictEqual((await buffer(zipPath, 'source.txt')).toString(), 'shrunk');
+
+		await Promises.rm(testDir);
+	});
+
+	test('zip should write an empty entry for a zero-length prefix', async () => {
+		const testDir = getRandomTestPath(tmpdir(), 'vsctests', 'zip');
+		const sourcePath = path.join(testDir, 'source.txt');
+		const zipPath = path.join(testDir, 'logs.zip');
+		await fs.promises.mkdir(testDir, { recursive: true });
+		await fs.promises.writeFile(sourcePath, 'ignored');
+		await zip(zipPath, [{ path: 'source.txt', localPath: sourcePath, localPathSize: 0 }]);
+
+		assert.strictEqual((await buffer(zipPath, 'source.txt')).toString(), '');
 
 		await Promises.rm(testDir);
 	});

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -33,6 +33,13 @@ export interface IToastResult {
 	readonly actionIndex?: number;
 }
 
+/**
+ * A ZIP entry whose contents are inline or streamed from a local file.
+ */
+export type INativeZipFile =
+	| { readonly path: string; readonly contents: string }
+	| { readonly path: string; readonly source: URI; readonly size: number };
+
 export interface ICPUProperties {
 	model: string;
 	speed: number;
@@ -370,7 +377,7 @@ export interface ICommonNativeHostService {
 	 * @param zipPath The URI where the zip file should be created.
 	 * @param files An array of file entries to include in the zip, each with a relative path and string contents.
 	 */
-	createZipFile(zipPath: URI, files: { path: string; contents: string }[]): Promise<void>;
+	createZipFile(zipPath: URI, files: INativeZipFile[]): Promise<void>;
 
 	// Power
 	getSystemIdleState(idleThreshold: number): Promise<SystemIdleState>;

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -375,7 +375,10 @@ export interface ICommonNativeHostService {
 	 * Creates a zip file at the specified path containing the provided files.
 	 *
 	 * @param zipPath The URI where the zip file should be created.
-	 * @param files An array of file entries to include in the zip, each with a relative path and string contents.
+	 * @param files An array of file entries to include in the zip. Each entry has
+	 * a relative path and is either given inline string `contents`, or a local
+	 * file `source` URI together with the number of leading bytes (`size`) to
+	 * stream from it.
 	 */
 	createZipFile(zipPath: URI, files: INativeZipFile[]): Promise<void>;
 

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -14,7 +14,7 @@ import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../
 import { matchesSomeScheme, Schemas } from '../../../base/common/network.js';
 import { dirname, join, posix, resolve, win32 } from '../../../base/common/path.js';
 import { isLinux, isMacintosh, isWindows } from '../../../base/common/platform.js';
-import { AddFirstParameterToFunctions } from '../../../base/common/types.js';
+import { AddFirstParameterToFunctions, hasKey } from '../../../base/common/types.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
 import { virtualMachineHint } from '../../../base/node/id.js';
 import { Promises, SymlinkSupport } from '../../../base/node/pfs.js';
@@ -27,7 +27,7 @@ import { IEnvironmentMainService } from '../../environment/electron-main/environ
 import { createDecorator, IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILifecycleMainService, IRelaunchOptions } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
-import { FocusMode, ICommonNativeHostService, INativeHostOptions, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, IOSProperties, IOSProxy, IOSProxyConfig, IOSStatistics, IStartTracingOptions, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../common/native.js';
+import { FocusMode, ICommonNativeHostService, INativeHostOptions, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, INativeZipFile, IOSProperties, IOSProxy, IOSProxyConfig, IOSStatistics, IStartTracingOptions, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../common/native.js';
 import { IGlobalKeybindingsMainService } from '../../globalKeybindings/electron-main/globalKeybindingsMainService.js';
 import { IProductService } from '../../product/common/productService.js';
 import { IPartsSplash } from '../../theme/common/themeService.js';
@@ -1422,8 +1422,17 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 
 	//#region Zip
 
-	async createZipFile(windowId: number | undefined, zipPath: URI, files: { path: string; contents: string }[]): Promise<void> {
-		await zip(zipPath.fsPath, files);
+	async createZipFile(windowId: number | undefined, zipPath: URI, files: INativeZipFile[]): Promise<void> {
+		await zip(zipPath.fsPath, files.map(file => {
+			if (hasKey(file, { contents: true })) {
+				return file;
+			}
+			const source = URI.revive(file.source);
+			if (source.scheme !== Schemas.file) {
+				throw new Error(`Cannot add non-local resource '${source.toString()}' to a zip file`);
+			}
+			return { path: file.path, localPath: source.fsPath, localPathSize: file.size };
+		}));
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { VSBuffer, streamToBuffer } from '../../../../../base/common/buffer.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { joinPath } from '../../../../../base/common/resources.js';
 import { hasKey } from '../../../../../base/common/types.js';
@@ -216,7 +216,11 @@ export async function collectAgentHostDebugLogs(
 		if (copilotLogsDir) {
 			const copilotLogFiles = await findCopilotLogsForSession(copilotLogsDir, rawSessionId, fileService, logService);
 			for (const file of copilotLogFiles) {
-				files.push(await createDebugLogFile(file.path, file.resource, fileService, file.size));
+				try {
+					files.push(await createDebugLogFile(file.path, file.resource, fileService, file.size));
+				} catch (error) {
+					logService.warn(`[ExportAgentHostDebugLogs] Failed to read Copilot log '${file.path}': ${error instanceof Error ? error.message : String(error)}`);
+				}
 			}
 		}
 	}
@@ -358,6 +362,14 @@ async function createDebugLogFile(path: string, resource: URI, fileService: IFil
 	if (resource.scheme === Schemas.file) {
 		const observedSize = size ?? (await fileService.resolve(resource, { resolveMetadata: true })).size;
 		return { path, resource, size: observedSize };
+	}
+	// Non-local resources (e.g. remote agent-host logs) can't be streamed from
+	// disk, so read them inline. When a captured size is known, read only that
+	// prefix so an actively growing log doesn't produce an unbounded allocation.
+	if (size !== undefined) {
+		const stream = await fileService.readFileStream(resource, { length: size });
+		const content = await streamToBuffer(stream.value);
+		return { path, contents: content.toString() };
 	}
 	const content = await fileService.readFile(resource);
 	return { path, contents: content.value.toString() };

--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -6,6 +6,7 @@
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { joinPath } from '../../../../../base/common/resources.js';
+import { hasKey } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
@@ -30,7 +31,7 @@ import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IChatWidgetService } from '../chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { buildLocalCopilotLogsUri, buildRemoteCopilotLogsUri, COPILOT_CLI_LOCAL_AH_SCHEME, getCopilotCliSessionRawId, parseRemoteAuthorityFromScheme, resolveEventsUri } from '../copilotCliEventsUri.js';
-import { getRemoteConnectionForSession, readCopilotLogsForSession, readRemoteAgentHostLog, sanitizeFilePart } from '../chatDebug/agentHostLogSources.js';
+import { findCopilotLogsForSession, getRemoteConnectionForSession, readRemoteAgentHostLog, sanitizeFilePart } from '../chatDebug/agentHostLogSources.js';
 
 /** Output channel ID for the agent host process logger (forwarded via RemoteLoggerChannelClient). */
 const AGENT_HOST_LOGGER_CHANNEL_ID = AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
@@ -53,8 +54,12 @@ export interface IActiveAgentHostSessionForExport {
 	readonly isLocal: boolean;
 }
 
+export type IAgentHostDebugLogFile =
+	| { readonly path: string; readonly contents: string }
+	| { readonly path: string; readonly resource: URI; readonly size: number };
+
 export interface IAgentHostDebugLogsExport {
-	readonly files: { path: string; contents: string }[];
+	readonly files: IAgentHostDebugLogFile[];
 	readonly exportName: string;
 }
 
@@ -62,7 +67,7 @@ export const IAgentHostDebugLogsExportService = createDecorator<IAgentHostDebugL
 
 export interface IAgentHostDebugLogsExportService {
 	readonly _serviceBrand: undefined;
-	save(exportName: string, files: readonly { path: string; contents: string }[]): Promise<boolean>;
+	save(exportName: string, files: readonly IAgentHostDebugLogFile[]): Promise<boolean>;
 }
 
 export class BrowserAgentHostDebugLogsExportService implements IAgentHostDebugLogsExportService {
@@ -73,7 +78,7 @@ export class BrowserAgentHostDebugLogsExportService implements IAgentHostDebugLo
 		@IFileService private readonly fileService: IFileService,
 	) { }
 
-	async save(exportName: string, files: readonly { path: string; contents: string }[]): Promise<boolean> {
+	async save(exportName: string, files: readonly IAgentHostDebugLogFile[]): Promise<boolean> {
 		return exportFilesToLocalFolder(this.fileDialogService, this.fileService, exportName, files);
 	}
 }
@@ -141,13 +146,12 @@ export async function collectAgentHostDebugLogs(
 	channelIds.add(WINDOW_LOG_CHANNEL_ID);
 	channelIds.add(SHARED_PROCESS_LOG_CHANNEL_ID);
 
-	const files: { path: string; contents: string }[] = [];
+	const files: IAgentHostDebugLogFile[] = [];
 
 	// 1. events.jsonl
 	if (eventsResult.kind === 'ok') {
 		try {
-			const content = await fileService.readFile(eventsResult.resource);
-			files.push({ path: 'events.jsonl', contents: content.value.toString() });
+			files.push(await createDebugLogFile('events.jsonl', eventsResult.resource, fileService));
 		} catch {
 			// File may not exist yet if the session never wrote any events
 		}
@@ -179,8 +183,7 @@ export async function collectAgentHostDebugLogs(
 				continue;
 			}
 			try {
-				const content = await fileService.readFile(child.resource);
-				files.push({ path: `ahp/${child.name}`, contents: content.value.toString() });
+				files.push(await createDebugLogFile(`ahp/${child.name}`, child.resource, fileService, child.size));
 			} catch (error) {
 				logService.warn(`[ExportAgentHostDebugLogs] Failed to read AHP log '${child.name}': ${error instanceof Error ? error.message : String(error)}`);
 			}
@@ -211,8 +214,10 @@ export async function collectAgentHostDebugLogs(
 			? buildLocalCopilotLogsUri(userHome)
 			: remoteConnection ? buildRemoteCopilotLogsUri(remoteConnection) : undefined;
 		if (copilotLogsDir) {
-			const copilotLogFiles = await readCopilotLogsForSession(copilotLogsDir, rawSessionId, fileService, logService);
-			files.push(...copilotLogFiles);
+			const copilotLogFiles = await findCopilotLogsForSession(copilotLogsDir, rawSessionId, fileService, logService);
+			for (const file of copilotLogFiles) {
+				files.push(await createDebugLogFile(file.path, file.resource, fileService, file.size));
+			}
 		}
 	}
 
@@ -310,7 +315,7 @@ async function exportFilesToLocalFolder(
 	fileDialogService: IFileDialogService,
 	fileService: IFileService,
 	exportName: string,
-	files: readonly { path: string; contents: string }[],
+	files: readonly IAgentHostDebugLogFile[],
 ): Promise<boolean> {
 	const folders = await fileDialogService.showOpenDialog({
 		title: localize('exportDebugLogs.folderDialogTitle', "Select Folder for Agent Host Debug Logs"),
@@ -338,9 +343,24 @@ async function exportFilesToLocalFolder(
 			folder = joinPath(folder, segment);
 			await fileService.createFolder(folder);
 		}
-		await fileService.writeFile(joinPath(folder, segments[segments.length - 1]), VSBuffer.fromString(file.contents));
+		const target = joinPath(folder, segments[segments.length - 1]);
+		if (hasKey(file, { contents: true })) {
+			await fileService.writeFile(target, VSBuffer.fromString(file.contents));
+		} else {
+			const source = await fileService.readFileStream(file.resource, { length: file.size });
+			await fileService.writeFile(target, source.value);
+		}
 	}
 	return true;
+}
+
+async function createDebugLogFile(path: string, resource: URI, fileService: IFileService, size?: number): Promise<IAgentHostDebugLogFile> {
+	if (resource.scheme === Schemas.file) {
+		const observedSize = size ?? (await fileService.resolve(resource, { resolveMetadata: true })).size;
+		return { path, resource, size: observedSize };
+	}
+	const content = await fileService.readFile(resource);
+	return { path, contents: content.value.toString() };
 }
 
 function toSafeRelativePathSegments(path: string): string[] {

--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -364,8 +364,7 @@ async function createDebugLogFile(path: string, resource: URI, fileService: IFil
 		return { path, resource, size: observedSize };
 	}
 	// Non-local resources (e.g. remote agent-host logs) can't be streamed from
-	// disk, so read them inline. When a captured size is known, read only that
-	// prefix so an actively growing log doesn't produce an unbounded allocation.
+	// disk, so read them inline, bounded to the captured size when known.
 	if (size !== undefined) {
 		const stream = await fileService.readFileStream(resource, { length: size });
 		const content = await streamToBuffer(stream.value);

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
@@ -32,6 +32,15 @@ export const MAX_COPILOT_LOG_FILE_SIZE = 10 * 1024 * 1024;
 export const DEFAULT_RAW_LOG_VIEW_CAP_BYTES = 2 * 1024 * 1024;
 
 /**
+ * A matching Copilot process log that can be read lazily.
+ */
+export interface ICopilotLogFile {
+	readonly path: string;
+	readonly resource: URI;
+	readonly size: number;
+}
+
+/**
  * Discriminates the kind of agent-host log a {@link IAgentHostLogSource}
  * points at, so the viewer can pick the appropriate reader and syntax.
  */
@@ -366,6 +375,28 @@ export async function readCopilotLogsForSession(
 	fileService: IFileService,
 	logService: ILogService,
 ): Promise<{ path: string; contents: string }[]> {
+	const matchingLogs = await findCopilotLogsForSession(logsDir, rawSessionId, fileService, logService);
+	const files: { path: string; contents: string }[] = [];
+	for (const log of matchingLogs) {
+		try {
+			const content = await fileService.readFile(log.resource, { limits: { size: MAX_COPILOT_LOG_FILE_SIZE } });
+			files.push({ path: log.path, contents: content.value.toString() });
+		} catch (error) {
+			logService.warn(`[AgentHostLogSources] Failed to read Copilot log '${log.resource.path}': ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+	return files;
+}
+
+/**
+ * Finds bounded Copilot process logs whose contents mention the session id.
+ */
+export async function findCopilotLogsForSession(
+	logsDir: URI,
+	rawSessionId: string,
+	fileService: IFileService,
+	logService: ILogService,
+): Promise<ICopilotLogFile[]> {
 	let children: IFileStatWithMetadata[] | undefined;
 	try {
 		children = (await fileService.resolve(logsDir, { resolveMetadata: true })).children;
@@ -373,7 +404,7 @@ export async function readCopilotLogsForSession(
 		return [];
 	}
 
-	const files: { path: string; contents: string }[] = [];
+	const files: ICopilotLogFile[] = [];
 	const candidateLogs = (children ?? [])
 		.filter(child => !child.isDirectory && child.name.endsWith('.log') && child.size <= MAX_COPILOT_LOG_FILE_SIZE)
 		.sort((a, b) => b.mtime - a.mtime)
@@ -381,11 +412,10 @@ export async function readCopilotLogsForSession(
 	for (const child of candidateLogs) {
 		try {
 			if (await logStreamContains(child.resource, rawSessionId, fileService)) {
-				const content = await fileService.readFile(child.resource, { limits: { size: MAX_COPILOT_LOG_FILE_SIZE } });
-				files.push({ path: `copilot-logs/${child.name}`, contents: content.value.toString() });
+				files.push({ path: `copilot-logs/${child.name}`, resource: child.resource, size: child.size });
 			}
 		} catch (error) {
-			logService.warn(`[AgentHostLogSources] Failed to read Copilot log '${child.name}': ${error instanceof Error ? error.message : String(error)}`);
+			logService.warn(`[AgentHostLogSources] Failed to scan Copilot log '${child.name}': ${error instanceof Error ? error.message : String(error)}`);
 		}
 	}
 	return files;

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService.ts
@@ -5,11 +5,12 @@
 
 import { Schemas } from '../../../../../base/common/network.js';
 import { joinPath } from '../../../../../base/common/resources.js';
+import { hasKey } from '../../../../../base/common/types.js';
 import { localize } from '../../../../../nls.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
 import { INativeHostService } from '../../../../../platform/native/common/native.js';
-import { IAgentHostDebugLogsExportService } from '../../browser/actions/exportAgentHostDebugLogsAction.js';
+import { IAgentHostDebugLogFile, IAgentHostDebugLogsExportService } from '../../browser/actions/exportAgentHostDebugLogsAction.js';
 
 class NativeAgentHostDebugLogsExportService implements IAgentHostDebugLogsExportService {
 	declare readonly _serviceBrand: undefined;
@@ -19,7 +20,7 @@ class NativeAgentHostDebugLogsExportService implements IAgentHostDebugLogsExport
 		@INativeHostService private readonly nativeHostService: INativeHostService,
 	) { }
 
-	async save(exportName: string, files: readonly { path: string; contents: string }[]): Promise<boolean> {
+	async save(exportName: string, files: readonly IAgentHostDebugLogFile[]): Promise<boolean> {
 		const defaultUri = joinPath(await this.fileDialogService.preferredHome(Schemas.file), `${exportName}.zip`);
 		const saveUri = await this.fileDialogService.showSaveDialog({
 			title: localize('exportDebugLogs.saveDialogTitle', "Export Agent Host Debug Logs"),
@@ -32,7 +33,11 @@ class NativeAgentHostDebugLogsExportService implements IAgentHostDebugLogsExport
 			return false;
 		}
 
-		await this.nativeHostService.createZipFile(saveUri, [...files]);
+		await this.nativeHostService.createZipFile(saveUri, files.map(file => {
+			return hasKey(file, { contents: true })
+				? file
+				: { path: file.path, source: file.resource, size: file.size };
+		}));
 		return true;
 	}
 }

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -25,7 +25,7 @@ import { InMemoryFileSystemProvider } from '../../../platform/files/common/inMem
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { ISharedProcessService } from '../../../platform/ipc/electron-browser/services.js';
 import { NullLogService } from '../../../platform/log/common/log.js';
-import { INativeHostOptions, INativeHostService, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, IOSProperties, IOSStatistics, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../../../platform/native/common/native.js';
+import { INativeHostOptions, INativeHostService, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, INativeZipFile, IOSProperties, IOSStatistics, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../../../platform/native/common/native.js';
 import { IProductService } from '../../../platform/product/common/productService.js';
 import { AuthInfo, Credentials } from '../../../platform/request/common/request.js';
 import { IStorageService } from '../../../platform/storage/common/storage.js';
@@ -195,7 +195,7 @@ export class TestNativeHostService implements INativeHostService {
 	async readClipboardBuffer(format: string): Promise<VSBuffer> { return VSBuffer.wrap(Uint8Array.from([])); }
 	async hasClipboard(format: string, type?: 'selection' | 'clipboard' | undefined): Promise<boolean> { return false; }
 	async windowsGetStringRegKey(hive: 'HKEY_CURRENT_USER' | 'HKEY_LOCAL_MACHINE' | 'HKEY_CLASSES_ROOT' | 'HKEY_USERS' | 'HKEY_CURRENT_CONFIG', path: string, name: string): Promise<string | undefined> { return undefined; }
-	async createZipFile(zipPath: URI, files: { path: string; contents: string }[]): Promise<void> { }
+	async createZipFile(zipPath: URI, files: INativeZipFile[]): Promise<void> { }
 	async profileRenderer(): Promise<any> { throw new Error(); }
 	async startTracing(): Promise<void> { throw new Error(); }
 	async getScreenshot(rect?: IRectangle): Promise<VSBuffer | undefined> { return undefined; }


### PR DESCRIPTION
### What

The **Export Agent Host Debug Logs** action previously read every log file (`events.jsonl`, AHP logs, Copilot process logs) fully into a JS string and shipped those strings across IPC to build the zip. For large logs that's a lot of renderer memory plus a large IPC payload.

This change passes lazy `{ resource, size }` references instead and streams a bounded prefix of each file straight from disk into the archive:

- `IFile` in `zip.ts` gains an optional `localPathSize`; when set, `zip()` streams that many bytes via `addReadStream` instead of `addFile`.
- A new `INativeZipFile` union (inline `contents` **or** `source: URI` + `size`) flows through `createZipFile` / `NativeHostMainService`, which revives the URI and rejects non-`file` schemes.
- The chat export code (`IAgentHostDebugLogFile` union + `createDebugLogFile` helper) produces lazy file references for `file://` resources and only eagerly reads `contents` for non-file resources. Copilot log discovery is split from reading (`findCopilotLogsForSession`).

### Robustness (TOCTOU)

The file size is captured during collection, but the actual read happens *after* an interactive save/folder dialog. yazl asserts the streamed byte count exactly matches the declared size, so a log rotated or truncated in that window would otherwise abort the **entire** archive.

`zip()` now re-stats the local file immediately before streaming and clamps the prefix to `min(capturedSize, currentSize)`, so the declared size always matches what's readable; a file that vanished is skipped rather than failing the whole export.

### Tests

- `zip should stream a fixed prefix of a local file`
- `zip should clamp a prefix larger than the current file size` (rotation/truncation regression)
- `zip should write an empty entry for a zero-length prefix`

### Verification

- `typecheck-client` :white_check_mark:
- `valid-layers-check` :white_check_mark:
- Zip suite: 4 passing :white_check_mark:

### Still to do

- Manual end-to-end run of the export on both desktop (zip) and web (folder) paths against a live session, ideally while the agent host is actively logging.

(Written by Copilot)