### PR TITLE
agentHost: preserve attachment display metadata on restore

### DIFF
--- a/src/vs/platform/agentHost/common/sessionDataService.ts
+++ b/src/vs/platform/agentHost/common/sessionDataService.ts
@@ -98,6 +98,11 @@ export interface ILocalTurnRecord {
 	payload: string;
 }
 
+/** Presentation metadata retained for one provider attachment in a turn. */
+export interface ITurnAttachmentMetadata {
+	readonly index: number;
+	readonly displayKind?: string;
+}
 
 /**
  * A disposable handle to a per-session SQLite database backed by
@@ -130,6 +135,12 @@ export interface ISessionDatabase extends IDisposable {
 	 * Returns `undefined` if no event ID has been set.
 	 */
 	getTurnEventId(turnId: string): Promise<string | undefined>;
+
+	/** Store attachment metadata that the provider transcript does not preserve. */
+	setTurnAttachmentMetadata(turnId: string, attachmentMetadata: readonly ITurnAttachmentMetadata[]): Promise<void>;
+
+	/** Retrieve attachment metadata keyed by provider event ID. */
+	getTurnAttachmentMetadataByEventId(): Promise<ReadonlyMap<string, readonly ITurnAttachmentMetadata[]>>;
 
 	/**
 	 * Returns the SDK event ID of the turn inserted immediately after the

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -17,7 +17,7 @@ import { isAbsolute, join } from '../../../../base/common/path.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { splitLinesIncludeSeparators } from '../../../../base/common/strings.js';
-import { hasKey, isDefined, isObject, isString, type Mutable } from '../../../../base/common/types.js';
+import { hasKey, isObject, isString, type Mutable } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
@@ -36,7 +36,7 @@ import { readToolCallMeta, toToolCallMeta, type IToolCallMeta, type IToolCallUiM
 import { OtelData, type OtelAttributeValue } from '../../common/otlp/otlpLogEmitter.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAttachment } from '../../common/meta/agentFeedbackAttachments.js';
-import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
+import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME, type ITurnAttachmentMetadata } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, ToolCallContributorKind, type FileEdit, type MessageAttachment } from '../../common/state/protocol/state.js';
 import { ActionType, isChatAction, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
 import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ToolCallStatus, ToolResultContentType, buildSubagentSessionUri, getToolSubagentContent, isSubagentSession, type PendingMessage, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest, type ToolCallResult, type ToolResultContent, type Turn, type UsageInfo, type UsageInfoMeta } from '../../common/state/sessionState.js';
@@ -459,6 +459,7 @@ class CopilotTurn {
 	parallelToolCallsTotal = 0;
 	/** Model of the most recent round, reported as the turn's model. */
 	lastModel: string | undefined;
+	attachmentMetadata: readonly ITurnAttachmentMetadata[] = [];
 
 	constructor(readonly id: string, readonly ordinal: number, readonly senderClientId: string | undefined) { }
 
@@ -1412,17 +1413,29 @@ export class CopilotAgentSession extends Disposable {
 			}
 		}
 
-		const sdkAttachments = attachments?.length
-			? (await Promise.all(attachments.map(a => this._toSdkAttachment(a)))).filter(isDefined)
-			: undefined;
-		if (sdkAttachments?.length) {
+		const sdkAttachments: CopilotSdkAttachment[] = [];
+		const attachmentMetadata: ITurnAttachmentMetadata[] = [];
+		for (const attachment of attachments ?? []) {
+			const sdkAttachment = await this._toSdkAttachment(attachment);
+			if (!sdkAttachment) {
+				continue;
+			}
+			if (attachment.displayKind !== undefined) {
+				attachmentMetadata.push({ index: sdkAttachments.length, displayKind: attachment.displayKind });
+			}
+			sdkAttachments.push(sdkAttachment);
+		}
+		if (this._currentTurn) {
+			this._currentTurn.attachmentMetadata = attachmentMetadata;
+		}
+		if (sdkAttachments.length) {
 			this._logService.trace(`[Copilot:${this.sessionId}] Attachments: ${JSON.stringify(sdkAttachments.map(a => ({ type: a.type })))}`);
 		}
 
 		await this.applyMode(mode);
 		await this.syncPermissionMode('turn-start');
 		await this._applyEffectiveSandboxConfig();
-		await this._wrapper.session.send({ prompt, attachments: sdkAttachments?.length ? sdkAttachments : undefined });
+		await this._wrapper.session.send({ prompt, attachments: sdkAttachments.length ? sdkAttachments : undefined });
 		this._logService.info(`[Copilot:${this.sessionId}] session.send() returned`);
 	}
 
@@ -2733,8 +2746,15 @@ export class CopilotAgentSession extends Disposable {
 			if (steering) {
 				this._beginSteeringTurn(steering);
 			}
-			if (this._turnId) {
-				this._databaseRef.object.setTurnEventId(this._turnId, e.id);
+			const turn = this._currentTurn;
+			if (turn) {
+				const writes: Promise<void>[] = [this._databaseRef.object.setTurnEventId(turn.id, e.id)];
+				if (turn.attachmentMetadata.length > 0) {
+					writes.push(this._databaseRef.object.setTurnAttachmentMetadata(turn.id, turn.attachmentMetadata));
+				}
+				Promise.all(writes).catch(err => {
+					this._logService.warn(`[Copilot:${this.sessionId}] Failed to persist SDK event metadata for turn ${turn.id}`, err);
+				});
 			}
 		}));
 

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -12,7 +12,7 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { AgentSession } from '../../common/agentService.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { toToolCallMeta, type IToolCallUiMeta } from '../../common/meta/agentToolCallMeta.js';
-import { IFileEditRecord, ISessionDatabase } from '../../common/sessionDataService.js';
+import { IFileEditRecord, ISessionDatabase, type ITurnAttachmentMetadata } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/protocol/state.js';
 import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type AgentSelection, type Message, type ModelSelection, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolResultContent, type Turn, type UsageInfo } from '../../common/state/sessionState.js';
 import { getInvocationMessage, getPastTenseMessage, getShellIntention, getShellLanguage, getSubagentMetadata, getTaskCompleteMarkdown, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isTaskCompleteTool, synthesizeSkillToolCall } from './copilotToolDisplay.js';
@@ -282,6 +282,14 @@ export async function mapSessionEvents(
 			// Database may not exist yet for new sessions — that's fine.
 		}
 	}
+	let attachmentMetadataByEventId: ReadonlyMap<string, readonly ITurnAttachmentMetadata[]> | undefined;
+	if (db) {
+		try {
+			attachmentMetadataByEventId = await db.getTurnAttachmentMetadataByEventId();
+		} catch {
+			// Database may not exist yet for new sessions — that's fine.
+		}
+	}
 
 	const sessionUriStr = session.toString();
 	const providerId = session.scheme;
@@ -383,7 +391,10 @@ export async function mapSessionEvents(
 				const d = e.data;
 				const messageId = d.interactionId ?? '';
 				const content = d.content ?? '';
-				const attachments = sdkAttachmentsToProtocol(d.attachments);
+				const attachments = sdkAttachmentsToProtocol(
+					d.attachments,
+					e.id ? attachmentMetadataByEventId?.get(e.id) : undefined,
+				);
 				// User messages carry no deprecated `parentToolCallId`; route
 				// sub-agent user messages by the envelope `agentId` only.
 				const parentToolCallId = resolveParentToolCallId(e.agentId, undefined);
@@ -637,15 +648,21 @@ export async function mapSessionEvents(
  */
 function sdkAttachmentsToProtocol(
 	attachments: readonly Attachment[] | undefined,
+	attachmentMetadata: readonly ITurnAttachmentMetadata[] | undefined,
 ): MessageAttachment[] | undefined {
 	if (!attachments?.length) {
 		return undefined;
 	}
 	const out: MessageAttachment[] = [];
-	for (const a of attachments) {
+	const metadataByIndex = attachmentMetadata?.length
+		? new Map(attachmentMetadata.map(metadata => [metadata.index, metadata]))
+		: undefined;
+	for (let index = 0; index < attachments.length; index++) {
+		const a = attachments[index];
 		const converted = sdkAttachmentToProtocol(a);
 		if (converted) {
-			out.push(converted);
+			const metadata = metadataByIndex?.get(index);
+			out.push(metadata?.displayKind !== undefined ? { ...converted, displayKind: metadata.displayKind } : converted);
 		}
 	}
 	return out.length > 0 ? out : undefined;

--- a/src/vs/platform/agentHost/node/sessionDatabase.ts
+++ b/src/vs/platform/agentHost/node/sessionDatabase.ts
@@ -5,8 +5,9 @@
 
 import * as fs from 'fs';
 import { SequencerByKey } from '../../../base/common/async.js';
+import { isObject } from '../../../base/common/types.js';
 import type { Database, RunResult } from '@vscode/sqlite3';
-import type { IFileEditContent, IFileEditRecord, ILocalTurnRecord, IReviewedFileRecord, ISessionDatabase } from '../common/sessionDataService.js';
+import type { IFileEditContent, IFileEditRecord, ILocalTurnRecord, IReviewedFileRecord, ISessionDatabase, ITurnAttachmentMetadata } from '../common/sessionDataService.js';
 import { dirname } from '../../../base/common/path.js';
 import { URI } from '../../../base/common/uri.js';
 import type { Message } from '../common/state/sessionState.js';
@@ -112,6 +113,10 @@ export const sessionDatabaseMigrations: readonly ISessionDatabaseMigration[] = [
 			payload        TEXT NOT NULL
 		)`,
 	},
+	{
+		version: 9,
+		sql: `ALTER TABLE turns ADD COLUMN attachment_metadata TEXT`,
+	},
 ];
 
 // ---- Promise wrappers around callback-based @vscode/sqlite3 API -----------
@@ -172,6 +177,17 @@ function dbOpen(path: string): Promise<Database> {
 			});
 		}, reject);
 	});
+}
+
+function isTurnAttachmentMetadata(value: unknown): value is ITurnAttachmentMetadata {
+	if (!isObject(value) || !('index' in value)) {
+		return false;
+	}
+	const displayKind = 'displayKind' in value ? value.displayKind : undefined;
+	return typeof value.index === 'number'
+		&& Number.isInteger(value.index)
+		&& value.index >= 0
+		&& (displayKind === undefined || typeof displayKind === 'string');
 }
 
 /**
@@ -335,6 +351,42 @@ export class SessionDatabase implements ISessionDatabase {
 		const db = await this._ensureDb();
 		const row = await dbGet(db, 'SELECT event_id FROM turns WHERE id = ?', [turnId]);
 		return row?.event_id as string | undefined ?? undefined;
+	}
+
+	setTurnAttachmentMetadata(turnId: string, attachmentMetadata: readonly ITurnAttachmentMetadata[]): Promise<void> {
+		return this._track(async () => {
+			const db = await this._ensureDb();
+			await dbRun(db, 'INSERT OR IGNORE INTO turns (id) VALUES (?)', [turnId]);
+			await dbRun(
+				db,
+				'UPDATE turns SET attachment_metadata = ? WHERE id = ?',
+				[attachmentMetadata.length > 0 ? JSON.stringify(attachmentMetadata) : null, turnId],
+			);
+		});
+	}
+
+	async getTurnAttachmentMetadataByEventId(): Promise<ReadonlyMap<string, readonly ITurnAttachmentMetadata[]>> {
+		const db = await this._ensureDb();
+		const rows = await dbAll(
+			db,
+			`SELECT event_id, attachment_metadata FROM turns
+				WHERE event_id IS NOT NULL AND attachment_metadata IS NOT NULL`,
+			[],
+		);
+		const result = new Map<string, readonly ITurnAttachmentMetadata[]>();
+		for (const row of rows) {
+			const eventId = row.event_id;
+			const serializedMetadata = row.attachment_metadata;
+			if (typeof eventId !== 'string' || typeof serializedMetadata !== 'string') {
+				continue;
+			}
+			const parsed: unknown = JSON.parse(serializedMetadata);
+			if (!Array.isArray(parsed) || !parsed.every(isTurnAttachmentMetadata)) {
+				continue;
+			}
+			result.set(eventId, parsed);
+		}
+		return result;
 	}
 
 	async getNextTurnEventId(turnId: string): Promise<string | undefined> {

--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -8,7 +8,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Event } from '../../../../base/common/event.js';
 import type { IDiffComputeService, IDiffCountResult } from '../../common/diffComputeService.js';
-import type { IFileEditContent, IFileEditRecord, ILocalTurnRecord, IReviewedFileRecord, ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
+import type { IFileEditContent, IFileEditRecord, ILocalTurnRecord, IReviewedFileRecord, ISessionDatabase, ISessionDataService, ITurnAttachmentMetadata } from '../../common/sessionDataService.js';
 import type { Message } from '../../common/state/sessionState.js';
 
 export class TestSessionDatabase implements ISessionDatabase {
@@ -17,6 +17,8 @@ export class TestSessionDatabase implements ISessionDatabase {
 	private readonly _drafts = new Map<string, Message>();
 	private readonly _reviewedFiles: IReviewedFileRecord[] = [];
 	private readonly _localTurns = new Map<string, ILocalTurnRecord>();
+	private readonly _turnEventIds = new Map<string, string>();
+	private readonly _turnAttachmentMetadata = new Map<string, readonly ITurnAttachmentMetadata[]>();
 
 	getAllFileEditsCalls = 0;
 	getFileEditsByTurnCalls = 0;
@@ -30,6 +32,8 @@ export class TestSessionDatabase implements ISessionDatabase {
 	async createTurn(): Promise<void> { }
 
 	async deleteTurn(turnId: string): Promise<void> {
+		this._turnEventIds.delete(turnId);
+		this._turnAttachmentMetadata.delete(turnId);
 		for (let i = this._edits.length - 1; i >= 0; i--) {
 			if (this._edits[i].turnId === turnId) {
 				this._edits.splice(i, 1);
@@ -96,9 +100,32 @@ export class TestSessionDatabase implements ISessionDatabase {
 
 	dispose(): void { }
 
-	async setTurnEventId(_turnId: string, _eventId: string): Promise<void> { }
+	async setTurnEventId(turnId: string, eventId: string): Promise<void> {
+		if (!this._turnEventIds.has(turnId)) {
+			this._turnEventIds.set(turnId, eventId);
+		}
+	}
 
-	async getTurnEventId(_turnId: string): Promise<string | undefined> { return undefined; }
+	async getTurnEventId(turnId: string): Promise<string | undefined> { return this._turnEventIds.get(turnId); }
+
+	async setTurnAttachmentMetadata(turnId: string, attachmentMetadata: readonly ITurnAttachmentMetadata[]): Promise<void> {
+		if (attachmentMetadata.length > 0) {
+			this._turnAttachmentMetadata.set(turnId, attachmentMetadata.map(metadata => ({ ...metadata })));
+		} else {
+			this._turnAttachmentMetadata.delete(turnId);
+		}
+	}
+
+	async getTurnAttachmentMetadataByEventId(): Promise<ReadonlyMap<string, readonly ITurnAttachmentMetadata[]>> {
+		const result = new Map<string, readonly ITurnAttachmentMetadata[]>();
+		for (const [turnId, attachmentMetadata] of this._turnAttachmentMetadata) {
+			const eventId = this._turnEventIds.get(turnId);
+			if (eventId) {
+				result.set(eventId, attachmentMetadata);
+			}
+		}
+		return result;
+	}
 
 	async getNextTurnEventId(_turnId: string): Promise<string | undefined> { return undefined; }
 
@@ -113,6 +140,8 @@ export class TestSessionDatabase implements ISessionDatabase {
 	async deleteAllTurns(): Promise<void> {
 		this.deleteAllTurnsCalls++;
 		this._edits.length = 0;
+		this._turnEventIds.clear();
+		this._turnAttachmentMetadata.clear();
 	}
 
 	async insertLocalTurn(record: ILocalTurnRecord): Promise<void> {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { CopilotSession, PermissionAllowAllMode, SessionEvent, SessionEventHandler, SessionEventPayload, SessionEventType, Tool, ToolResultObject, TypedSessionEventHandler } from '@github/copilot-sdk';
+import type { CopilotSession, MessageOptions, PermissionAllowAllMode, SessionEvent, SessionEventHandler, SessionEventPayload, SessionEventType, Tool, ToolResultObject, TypedSessionEventHandler } from '@github/copilot-sdk';
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
@@ -39,7 +39,7 @@ import { AgentHostAutoReplyEnabledConfigKey, AgentHostGlobalAutoApproveEnabledCo
 import { CopilotCliConfigKey } from '../../common/copilotCliConfig.js';
 import { AgentHostSandboxConfigKey, AgentHostSandboxKey } from '../../common/sandboxConfigSchema.js';
 import { AgentSandboxEnabledValue } from '../../../sandbox/common/settings.js';
-import { createSessionDataService, createZeroDiffComputeService } from '../common/sessionTestHelpers.js';
+import { createSessionDataService, createZeroDiffComputeService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { IAgentServerToolHost } from '../../common/agentServerTools.js';
 
 // ---- Mock CopilotSession (SDK level) ----------------------------------------
@@ -51,7 +51,7 @@ import { IAgentServerToolHost } from '../../common/agentServerTools.js';
  */
 class MockCopilotSession {
 	readonly sessionId = 'test-session-1';
-	readonly sendRequests: unknown[] = [];
+	readonly sendRequests: MessageOptions[] = [];
 	readonly modeSetCalls: Array<{ mode: 'interactive' | 'plan' | 'autopilot' }> = [];
 	readonly permissionModeSetCalls: PermissionAllowAllMode[] = [];
 	permissionModeSetSuccess = true;
@@ -117,7 +117,7 @@ class MockCopilotSession {
 	}
 
 	// Stubs for methods the wrapper / session class calls
-	async send(request: unknown) {
+	async send(request: MessageOptions) {
 		this.sendRequests.push(request);
 		return `message-${this.sendRequests.length}`;
 	}
@@ -301,6 +301,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	session: CopilotAgentSession;
 	runtime: ICopilotSessionRuntime;
 	mockSession: MockCopilotSession;
+	database: TestSessionDatabase;
 	signals: AgentSignal[];
 	waitForSignal: (predicate: (signal: AgentSignal) => boolean) => Promise<AgentSignal>;
 	sessionConfigUpdates: ReadonlyArray<{ session: string; patch: Record<string, unknown> }>;
@@ -386,7 +387,8 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 			storedFileContents.delete(resource.fsPath);
 		},
 	} as Partial<IFileService> as IFileService);
-	services.set(ISessionDataService, createSessionDataService());
+	const database = new TestSessionDatabase();
+	services.set(ISessionDataService, createSessionDataService(database));
 	services.set(IDiffComputeService, createZeroDiffComputeService());
 	const sessionConfigUpdates: Array<{ session: string; patch: Record<string, unknown> }> = [];
 	const configValues = options?.configValues ?? {};
@@ -449,6 +451,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 		session,
 		runtime: launchedRuntime,
 		mockSession,
+		database,
 		signals,
 		waitForSignal,
 		sessionConfigUpdates,
@@ -813,6 +816,75 @@ suite('CopilotAgentSession', () => {
 			label: 'Previous conversation',
 			modelRepresentation: 'Transcript text',
 		}]);
+	});
+
+	test('persists attachment display kinds after SDK attachment filtering', async () => {
+		const { session, mockSession, database } = await createAgentSession(disposables);
+
+		await session.send('continue', [
+			{
+				type: MessageAttachmentKind.Simple,
+				label: 'Not sent',
+			},
+			{
+				type: MessageAttachmentKind.Simple,
+				label: 'microsoft/vscode',
+				displayKind: 'workspace',
+				modelRepresentation: 'Current branch: main',
+			},
+			{
+				type: MessageAttachmentKind.Simple,
+				label: 'Other context',
+				displayKind: 'paste',
+				modelRepresentation: 'Other text',
+			},
+		], 'turn-1');
+		assert.deepStrictEqual([...await database.getTurnAttachmentMetadataByEventId()], []);
+		mockSession.fire('user.message', {
+			interactionId: 'message-1',
+			content: 'continue',
+			attachments: [
+				{
+					type: 'blob',
+					data: encodeBase64(VSBuffer.fromString('Current branch: main')),
+					mimeType: 'text/plain',
+					displayName: 'microsoft/vscode',
+				},
+				{
+					type: 'blob',
+					data: encodeBase64(VSBuffer.fromString('Other text')),
+					mimeType: 'text/plain',
+					displayName: 'Other context',
+				},
+			],
+		}, { id: 'evt-1' });
+
+		assert.deepStrictEqual({
+			request: mockSession.sendRequests[0],
+			attachmentMetadata: [...await database.getTurnAttachmentMetadataByEventId()],
+		}, {
+			request: {
+				prompt: 'continue',
+				attachments: [
+					{
+						type: 'blob',
+						data: encodeBase64(VSBuffer.fromString('Current branch: main')),
+						mimeType: 'text/plain',
+						displayName: 'microsoft/vscode',
+					},
+					{
+						type: 'blob',
+						data: encodeBase64(VSBuffer.fromString('Other text')),
+						mimeType: 'text/plain',
+						displayName: 'Other context',
+					},
+				],
+			},
+			attachmentMetadata: [['evt-1', [
+				{ index: 0, displayKind: 'workspace' },
+				{ index: 1, displayKind: 'paste' },
+			]]],
+		});
 	});
 
 	test('`/compact` runs the history compact RPC and completes the turn with output', async () => {

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { readToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { AgentSession } from '../../common/agentService.js';
 import { MessageAttachmentKind, MessageKind, ResponsePartKind, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, TurnState, type ResponsePart, type StringOrMarkdown, type ToolCallResponsePart } from '../../common/state/sessionState.js';
 import { mapSessionEvents } from '../../node/copilot/mapSessionEvents.js';
+import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { toSessionEvents, type ISessionEvent } from './copilotTestEvents.js';
 
 suite('mapSessionEvents — history replay', () => {
@@ -308,6 +310,86 @@ suite('mapSessionEvents — history replay', () => {
 				label: 'example.ts',
 			}],
 		});
+	});
+
+	test('restores attachment display kinds from the turn sidecar', async () => {
+		const db = await SessionDatabase.open(':memory:');
+		try {
+			await db.setTurnAttachmentMetadata('request-1', [
+				{ index: 1, displayKind: 'workspace' },
+				{ index: 2, displayKind: 'paste' },
+			]);
+			await db.setTurnEventId('request-1', 'event-1');
+			const events: ISessionEvent[] = [
+				{
+					type: 'user.message',
+					id: 'event-1',
+					data: {
+						interactionId: 'm1',
+						content: 'first',
+						attachments: [
+							{
+								type: 'blob',
+								mimeType: 'text/plain',
+								displayName: 'Unavailable context',
+							},
+							{
+								type: 'blob',
+								data: encodeBase64(VSBuffer.fromString('Current branch: main')),
+								mimeType: 'text/plain',
+								displayName: 'microsoft/vscode',
+							},
+							{
+								type: 'blob',
+								data: encodeBase64(VSBuffer.fromString('Other text')),
+								mimeType: 'text/plain',
+								displayName: 'Other context',
+							},
+						],
+					},
+				},
+				{
+					type: 'user.message',
+					id: 'event-2',
+					data: {
+						interactionId: 'm2',
+						content: 'second',
+						attachments: [{
+							type: 'blob',
+							data: encodeBase64(VSBuffer.fromString('Current branch: main')),
+							mimeType: 'text/plain',
+							displayName: 'microsoft/vscode',
+						}],
+					},
+				},
+			];
+
+			const { turns } = await mapSessionEvents(session, db, toSessionEvents(events));
+
+			assert.deepStrictEqual(turns.map(turn => turn.message.attachments), [
+				[
+					{
+						type: MessageAttachmentKind.Simple,
+						label: 'microsoft/vscode',
+						modelRepresentation: 'Current branch: main',
+						displayKind: 'workspace',
+					},
+					{
+						type: MessageAttachmentKind.Simple,
+						label: 'Other context',
+						modelRepresentation: 'Other text',
+						displayKind: 'paste',
+					},
+				],
+				[{
+					type: MessageAttachmentKind.Simple,
+					label: 'microsoft/vscode',
+					modelRepresentation: 'Current branch: main',
+				}],
+			]);
+		} finally {
+			await db.close();
+		}
 	});
 
 	test('uses top-level user messages as turn boundaries', async () => {

--- a/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
@@ -414,6 +414,36 @@ suite('SessionDatabase', () => {
 
 	suite('turn event ids', () => {
 
+		test('stores attachment metadata by SDK event id and cleans it up with turns', async () => {
+			db = disposables.add(await SessionDatabase.open(':memory:'));
+			await db.setTurnAttachmentMetadata('turn-1', [
+				{ index: 0, displayKind: 'workspace' },
+				{ index: 2, displayKind: 'browser' },
+			]);
+			await db.setTurnEventId('turn-1', 'evt-1');
+			await db.setTurnAttachmentMetadata('turn-2', [{ index: 1, displayKind: 'selection' }]);
+			await db.setTurnEventId('turn-2', 'evt-2');
+
+			assert.deepStrictEqual([...await db.getTurnAttachmentMetadataByEventId()], [
+				['evt-1', [
+					{ index: 0, displayKind: 'workspace' },
+					{ index: 2, displayKind: 'browser' },
+				]],
+				['evt-2', [{ index: 1, displayKind: 'selection' }]],
+			]);
+
+			await db.deleteTurnsAfter('turn-1');
+			assert.deepStrictEqual([...await db.getTurnAttachmentMetadataByEventId()], [
+				['evt-1', [
+					{ index: 0, displayKind: 'workspace' },
+					{ index: 2, displayKind: 'browser' },
+				]],
+			]);
+
+			await db.deleteTurn('turn-1');
+			assert.deepStrictEqual([...await db.getTurnAttachmentMetadataByEventId()], []);
+		});
+
 		test('getNextTurnEventId returns the next turn\'s event id by `turns.id`', async () => {
 			db = disposables.add(await SessionDatabase.open(':memory:'));
 			await db.createTurn('turn-1');


### PR DESCRIPTION
## Summary

Preserves Agent Host attachment presentation metadata when Copilot-backed sessions are reconstructed from SDK history.

Copilot's persisted attachment shape does not retain AHP `displayKind`, which can cause restored attachments to render differently from their live form. In particular, hidden workspace context can reappear as a visible repository badge after the Agent Host restarts.

This change:

- stores sparse `{ index, displayKind }` metadata on the existing per-turn database row
- records metadata only after the corresponding SDK `user.message` event arrives
- correlates restored metadata through the existing turn-to-SDK-event mapping
- reapplies display kinds against the original SDK attachment array before unsupported attachments are filtered
- avoids duplicating attachment content, labels, types, arbitrary `_meta`, or full messages
- does not heuristically backfill older sessions

## Validation

- `npm run typecheck-client`
- targeted Agent Host unit suites: 269 passing
- changed-file hygiene
- `npm run valid-layers-check`
- focused code review

(Written by Copilot)