### PR TITLE
Debug extension host without requiring a restart

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-browser/debugExtensionHostAction.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/debugExtensionHostAction.ts
@@ -37,9 +37,7 @@ async function getExtensionHostPort(
 	dialogService: IDialogService,
 	productService: IProductService,
 ): Promise<number | undefined> {
-	// Try to enable the inspector on the already running extension host (same as profiling and the
-	// dev tools action do). This avoids forcing a restart just to debug extensions; the restart
-	// prompt below is only used as a fallback when the inspector cannot be enabled on the fly.
+	// Try to enable the inspector on the running host (like profiling) to avoid a restart; the prompt below is the fallback.
 	const inspectPorts = await extensionService.getInspectPorts(ExtensionHostKind.LocalProcess, true);
 	if (inspectPorts.length === 0) {
 		const res = await dialogService.confirm({

--- a/src/vs/workbench/contrib/extensions/electron-browser/debugExtensionHostAction.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/debugExtensionHostAction.ts
@@ -37,7 +37,10 @@ async function getExtensionHostPort(
 	dialogService: IDialogService,
 	productService: IProductService,
 ): Promise<number | undefined> {
-	const inspectPorts = await extensionService.getInspectPorts(ExtensionHostKind.LocalProcess, false);
+	// Try to enable the inspector on the already running extension host (same as profiling and the
+	// dev tools action do). This avoids forcing a restart just to debug extensions; the restart
+	// prompt below is only used as a fallback when the inspector cannot be enabled on the fly.
+	const inspectPorts = await extensionService.getInspectPorts(ExtensionHostKind.LocalProcess, true);
 	if (inspectPorts.length === 0) {
 		const res = await dialogService.confirm({
 			message: nls.localize('restart1', "Debug Extensions"),


### PR DESCRIPTION
Fixes #85422

### Problem
Clicking **Debug Extension Host In New Window** (and **Debug Extension Host and Renderer In New Window**) always prompts for a restart, even when the extension host is already running. This defeats the main use case of the feature — attaching a debugger to a running extension host to investigate an issue that is happening *right now*.

### Cause
Both actions go through the shared `getExtensionHostPort` helper, which called:

```ts
extensionService.getInspectPorts(ExtensionHostKind.LocalProcess, /* tryEnableInspector */ false)
```

With `tryEnableInspector = false`, the extension host manager never calls `enableInspectPort()`, so when the host was not started with `--inspect-extensions` there are no inspect ports and the code falls through to the restart prompt.

The profiling path (`ExtensionHostProfileService.startProfiling`) and the dev-tools path (`DebugExtensionHostInDevToolsAction`) already pass `true`, which enables the inspector on the **running** extension host via node's `process._debugProcess(pid)` (`UtilityProcess.enableInspectPort`) — no restart required. This matches the approach suggested by @weinand and @jrieken in the issue, and explains @connor4312's observation that profiling works without a restart while debugging does not.

### Fix
Pass `tryEnableInspector = true` in the shared helper so the debug actions first try to enable the inspector on the running host, exactly like profiling. The restart prompt is kept as a **fallback** for the case where the inspector cannot be enabled on the fly (e.g. `_debugProcess` unavailable or the host is not running).

### Notes
- No behavior change when the host was already started with `--inspect-extensions`: `enableInspectPort()` short-circuits when an inspect listener already exists.
- No new state and no new UI; the change is limited to the shared helper used by the two debug actions.