### PR TITLE
Fix NES cached suggestion not shown after rebasing over user indentation

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/common/editRebase.ts
+++ b/extensions/copilot/src/extension/inlineEdits/common/editRebase.ts
@@ -42,6 +42,14 @@ export interface NesRebaseConfigs {
 	 * but explicit {@link NesRebaseConfigs} objects must provide this value.
 	 */
 	readonly maxImperfectAgreementLength: number;
+	/**
+	 * When enabled, the cache serving layer salvages a cached suggestion whose
+	 * strict rebase failed *only* because the user re-typed a line's leading
+	 * indentation differently than the model predicted, re-anchoring the model's
+	 * still-valid content as a clean at-cursor insertion. This is consumed by the
+	 * NES cache (see `tryRebaseCacheEntry`), not by {@link tryRebase} itself.
+	 */
+	readonly reanchorContentOnIndentationMismatch?: boolean;
 }
 
 export class EditDataWithIndex implements IEditData<EditDataWithIndex> {

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
@@ -205,6 +205,7 @@ export class NextEditCache extends Disposable {
 			absorbSubsequenceTyping: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAbsorbSubsequenceTyping, this._expService),
 			reverseAgreement: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsReverseAgreement, this._expService),
 			maxImperfectAgreementLength: typeof maxImperfectAgreementLength === 'number' ? Math.max(0, maxImperfectAgreementLength) : maxImperfectAgreementLength,
+			reanchorContentOnIndentationMismatch: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsReanchorContentOnIndentationMismatch, this._expService),
 		};
 	}
 
@@ -392,13 +393,16 @@ class DocumentEditCache {
 					// Tab to insert a tab character or a different number of spaces on an
 					// empty body line) makes the whole suggestion drop. The model's content
 					// intent is still valid, so re-anchor it as a clean at-cursor insertion
-					// that respects the indentation the user actually typed.
-					const reanchored = tryReanchorContentAfterIndentation(originalEdits, cachedEdit.documentBeforeEdit.value, currentDocumentContents.value, currentSelection);
-					if (reanchored) {
-						if (!cachedEdit.rejected && this.isRejectedNextEdit(currentDocumentContents, reanchored)) {
-							cachedEdit.rejected = true;
+					// that respects the indentation the user actually typed. Gated behind a
+					// setting so the behavior can be rolled out / disabled independently.
+					if (nesRebaseConfigs.reanchorContentOnIndentationMismatch) {
+						const reanchored = tryReanchorContentAfterIndentation(originalEdits, cachedEdit.documentBeforeEdit.value, currentDocumentContents.value, currentSelection);
+						if (reanchored) {
+							if (!cachedEdit.rejected && this.isRejectedNextEdit(currentDocumentContents, reanchored)) {
+								cachedEdit.rejected = true;
+							}
+							return { edit: { ...cachedEdit, rebasedEdit: reanchored, rebasedEditIndex: 0, baseCacheEntry: cachedEdit } };
 						}
-						return { edit: { ...cachedEdit, rebasedEdit: reanchored, rebasedEditIndex: 0, baseCacheEntry: cachedEdit } };
 					}
 					cachedEdit.rebaseFailed = true;
 					return {

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
@@ -399,10 +399,17 @@ class DocumentEditCache {
 					// Try the next window (if available)
 					continue;
 				} else if (res.length) {
-					if (!cachedEdit.rejected && this.isRejectedNextEdit(currentDocumentContents, res[0].rebasedEdit)) {
+					// Minimize the served edit against the current document: the user may have
+					// already typed part of the prediction (e.g. the leading indentation after
+					// tabbing on an empty line). Removing the common prefix/suffix yields a clean
+					// at-cursor edit (a pure insertion when the only remaining change is the
+					// inserted text), which is what the display layer can render as ghost text.
+					// This is semantically neutral (same `apply()` result on the current document).
+					const rebasedEdit = res[0].rebasedEdit.removeCommonSuffixAndPrefix(currentDocumentContents.value);
+					if (!cachedEdit.rejected && this.isRejectedNextEdit(currentDocumentContents, rebasedEdit)) {
 						cachedEdit.rejected = true;
 					}
-					return { edit: { ...cachedEdit, ...res[0], baseCacheEntry: cachedEdit } };
+					return { edit: { ...cachedEdit, ...res[0], rebasedEdit, baseCacheEntry: cachedEdit } };
 				} else if (!originalEdits.length) {
 					return { edit: cachedEdit }; // cached 'no edits'
 				}

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
@@ -387,6 +387,19 @@ class DocumentEditCache {
 			for (const window of windowsToTry) {
 				const res = tryRebase(cachedEdit.documentBeforeEdit.value, window, originalEdits, cachedEdit.detailedEdits, cachedEdit.userEditSince, currentDocumentContents.value, currentSelection, 'strict', logger, nesRebaseConfigs);
 				if (res === 'rebaseFailed') {
+					// Strict rebase treats indentation literally, so re-typing a line's
+					// leading whitespace differently than the model predicted (e.g. pressing
+					// Tab to insert a tab character or a different number of spaces on an
+					// empty body line) makes the whole suggestion drop. The model's content
+					// intent is still valid, so re-anchor it as a clean at-cursor insertion
+					// that respects the indentation the user actually typed.
+					const reanchored = tryReanchorContentAfterIndentation(originalEdits, cachedEdit.documentBeforeEdit.value, currentDocumentContents.value, currentSelection);
+					if (reanchored) {
+						if (!cachedEdit.rejected && this.isRejectedNextEdit(currentDocumentContents, reanchored)) {
+							cachedEdit.rejected = true;
+						}
+						return { edit: { ...cachedEdit, rebasedEdit: reanchored, rebasedEditIndex: 0, baseCacheEntry: cachedEdit } };
+					}
 					cachedEdit.rebaseFailed = true;
 					return {
 						edit: undefined,
@@ -399,17 +412,10 @@ class DocumentEditCache {
 					// Try the next window (if available)
 					continue;
 				} else if (res.length) {
-					// Minimize the served edit against the current document: the user may have
-					// already typed part of the prediction (e.g. the leading indentation after
-					// tabbing on an empty line). Removing the common prefix/suffix yields a clean
-					// at-cursor edit (a pure insertion when the only remaining change is the
-					// inserted text), which is what the display layer can render as ghost text.
-					// This is semantically neutral (same `apply()` result on the current document).
-					const rebasedEdit = res[0].rebasedEdit.removeCommonSuffixAndPrefix(currentDocumentContents.value);
-					if (!cachedEdit.rejected && this.isRejectedNextEdit(currentDocumentContents, rebasedEdit)) {
+					if (!cachedEdit.rejected && this.isRejectedNextEdit(currentDocumentContents, res[0].rebasedEdit)) {
 						cachedEdit.rejected = true;
 					}
-					return { edit: { ...cachedEdit, ...res[0], rebasedEdit, baseCacheEntry: cachedEdit } };
+					return { edit: { ...cachedEdit, ...res[0], baseCacheEntry: cachedEdit } };
 				} else if (!originalEdits.length) {
 					return { edit: cachedEdit }; // cached 'no edits'
 				}
@@ -445,4 +451,66 @@ class DocumentEditCache {
 	private _getKey(val: string): string {
 		return JSON.stringify([this.docId.uri, val]);
 	}
+}
+
+/**
+ * Salvage a cached next edit whose strict rebase failed *only* because the user
+ * re-typed the leading indentation of an (otherwise empty) line differently than
+ * the model predicted — for example pressing Tab to insert a tab character, or a
+ * different number of spaces, on an empty body line where the model wanted to add
+ * a statement.
+ *
+ * The rebase engine matches indentation literally, so a tab-vs-spaces (or
+ * different-width) mismatch drops the whole suggestion even though the model's
+ * *content* intent (the non-whitespace text it wanted to add on that line) is
+ * still valid. Re-anchor that content as a clean at-cursor insertion that respects
+ * the indentation the user actually typed. This mirrors the reconciliation the
+ * engine already performs when the user's indentation happens to match, and yields
+ * a pure insertion the display layer can render as ghost text.
+ *
+ * Returns the salvaged insertion, or `undefined` when the narrow pattern doesn't
+ * apply (in which case the caller keeps the original rebase-failed behavior).
+ */
+function tryReanchorContentAfterIndentation(
+	originalEdits: readonly StringReplacement[],
+	documentBeforeEdit: string,
+	currentDocument: string,
+	currentSelection: readonly OffsetRange[],
+): StringReplacement | undefined {
+	// Only handle the single-edit, single-empty-cursor case.
+	if (originalEdits.length !== 1 || currentSelection.length !== 1 || !currentSelection[0].isEmpty) {
+		return undefined;
+	}
+	const cursor = currentSelection[0].start;
+
+	// The model must only have touched indentation: the text it replaced is
+	// whitespace-only (typically empty for an insertion, or the line's existing
+	// indentation for a line-prefix replacement).
+	const modelEdit = originalEdits[0];
+	const replaced = modelEdit.replaceRange.substring(documentBeforeEdit);
+	if (!/^[ \t]*$/.test(replaced)) {
+		return undefined;
+	}
+
+	// The content the model wanted to add on that line, with its predicted
+	// indentation stripped. Must be a non-empty, single-line insertion.
+	const content = modelEdit.newText.replace(/^[ \t]*/, '');
+	if (content.length === 0 || content.includes('\n')) {
+		return undefined;
+	}
+
+	// The cursor must sit at the end of the current line's leading whitespace,
+	// on a line that has no real content yet (the user is indenting an empty line).
+	const lineStart = currentDocument.lastIndexOf('\n', cursor - 1) + 1;
+	let lineEnd = currentDocument.indexOf('\n', cursor);
+	if (lineEnd === -1) {
+		lineEnd = currentDocument.length;
+	}
+	const prefix = currentDocument.substring(lineStart, cursor);
+	const suffix = currentDocument.substring(cursor, lineEnd);
+	if (!/^[ \t]*$/.test(prefix) || !/^[ \t]*$/.test(suffix)) {
+		return undefined;
+	}
+
+	return StringReplacement.insert(cursor, content);
 }

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
@@ -191,9 +191,10 @@ describe('NextEditCache rebase — Fibonacci scenario', () => {
  * The user then presses Tab to indent the line, inserting a tab character.
  *
  * Strict rebase matches indentation literally, so the tab-vs-spaces mismatch makes
- * the whole suggestion drop (`rebaseFailed`) and nothing is shown. The model's
- * content intent is still valid, so the served edit must be re-anchored as a clean
- * pure insertion of `return [` at the cursor, respecting the tab the user typed.
+ * the whole suggestion drop (`rebaseFailed`) and nothing is shown. When the
+ * `reanchorContentOnIndentationMismatch` setting is enabled, the model's still-valid
+ * content is re-anchored as a clean pure insertion of `return [` at the cursor,
+ * respecting the tab the user typed. When disabled, the suggestion is dropped.
  */
 describe('NextEditCache rebase — indented insertion over mismatched user indentation', () => {
 
@@ -216,20 +217,8 @@ describe('NextEditCache rebase — indented insertion over mismatched user inden
 		return new NextEditFetchRequest(generateUuid(), logContext, undefined, false);
 	}
 
-	beforeEach(async () => {
-		configService = new InMemoryConfigurationService(new DefaultsOnlyConfigurationService());
-		await configService.setConfig(ConfigKey.TeamInternal.InlineEditsReverseAgreement, true);
-		obsWorkspace = new MutableObservableWorkspace();
-		logService = new LogServiceImpl([]);
-		expService = new NullExperimentationService();
-
-		docId = DocumentId.create(URI.file('/test/example.ts').toString());
-		obsWorkspace.addDocument({ id: docId, initialValue: currentDoc });
-
-		cache = new NextEditCache(obsWorkspace, logService, configService, expService);
-	});
-
-	it('serves a clean at-cursor insertion (no leading whitespace) after the user tabs', () => {
+	/** Cache the model's indented prediction, then rebase it over the user's typed tab. */
+	function cacheAndRebase() {
 		// Model predicts the indented `return [` on the empty body line.
 		const modelEdit = new StringReplacement(OffsetRange.emptyAt(emptyLineOffset), '    return [');
 		// The user pressed Tab on that same (empty) line, inserting a tab character.
@@ -250,15 +239,43 @@ describe('NextEditCache rebase — indented insertion over mismatched user inden
 		assert(cachedEdit !== undefined, 'setKthNextEdit should return the cached edit');
 		assert(cachedEdit.userEditSince !== undefined, 'userEditSince should be set');
 
-		const rebaseResult = cache.tryRebaseCacheEntry(
+		return cache.tryRebaseCacheEntry(
 			cachedEdit,
 			new StringText(currentDoc),
 			[OffsetRange.emptyAt(cursorOffset)],
 		);
+	}
+
+	beforeEach(async () => {
+		configService = new InMemoryConfigurationService(new DefaultsOnlyConfigurationService());
+		await configService.setConfig(ConfigKey.TeamInternal.InlineEditsReverseAgreement, true);
+		await configService.setConfig(ConfigKey.TeamInternal.InlineEditsReanchorContentOnIndentationMismatch, true);
+		obsWorkspace = new MutableObservableWorkspace();
+		logService = new LogServiceImpl([]);
+		expService = new NullExperimentationService();
+
+		docId = DocumentId.create(URI.file('/test/example.ts').toString());
+		obsWorkspace.addDocument({ id: docId, initialValue: currentDoc });
+
+		cache = new NextEditCache(obsWorkspace, logService, configService, expService);
+	});
+
+	it('serves a clean at-cursor insertion (no leading whitespace) after the user tabs', () => {
+		const rebaseResult = cacheAndRebase();
 
 		assert(rebaseResult.edit !== undefined, 'should serve a (re-anchored) edit instead of dropping it');
 		assert(rebaseResult.edit.rebasedEdit !== undefined, 'should have a rebased edit');
 		// The tab the user typed must not be part of the edit: a pure insertion at the cursor.
 		assert.strictEqual(rebaseResult.edit.rebasedEdit.toString(), `[${cursorOffset}, ${cursorOffset}) -> "return ["`);
+	});
+
+	it('drops the suggestion when the setting is disabled', async () => {
+		await configService.setConfig(ConfigKey.TeamInternal.InlineEditsReanchorContentOnIndentationMismatch, false);
+
+		const rebaseResult = cacheAndRebase();
+
+		// Without the salvage, the tab-vs-spaces mismatch makes the rebase fail and
+		// the suggestion is dropped (nothing served).
+		assert.strictEqual(rebaseResult.edit, undefined, 'should drop the suggestion when re-anchoring is disabled');
 	});
 });

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
@@ -182,3 +182,85 @@ describe('NextEditCache rebase — Fibonacci scenario', () => {
 		assert.strictEqual(rebaseResult.edit.modelTelemetry, testModelTelemetry, 'should preserve model attribution on the rebased edit');
 	});
 });
+
+/**
+ * Regression test from a real scenario (NES cached suggestion not shown):
+ *
+ * The user is inside `function familyJohn() {` on an empty body line. NES cached a
+ * suggestion that predicts the indented `return [` on that line (a line-based edit
+ * that restates the indentation: `"" -> "    return ["`). The user then tabs to
+ * indent the line.
+ *
+ * When the cached edit is rebased over the user's indentation, the served edit must
+ * be a clean pure insertion of `return [` at the cursor — the indentation the user
+ * already typed must NOT be part of the edit. Serving the raw (non-minimized) rebase
+ * result instead leaves the redundant indentation in the edit's range/new-text, which
+ * is fragile to render as ghost text and can result in the suggestion not being shown.
+ */
+describe('NextEditCache rebase — indented insertion over user indentation', () => {
+
+	let configService: InMemoryConfigurationService;
+	let obsWorkspace: MutableObservableWorkspace;
+	let logService: LogServiceImpl;
+	let expService: NullExperimentationService;
+	let cache: NextEditCache;
+	let docId: DocumentId;
+
+	// cache-time doc: empty body line inside the function
+	const docBefore = 'function familyJohn() {\n\n}\n';
+	const emptyLineOffset = 'function familyJohn() {\n'.length; // start of the empty body line
+	// current doc: the user has tabbed 4 spaces on the (empty) body line
+	const currentDoc = 'function familyJohn() {\n    \n}\n';
+	const cursorOffset = emptyLineOffset + '    '.length; // caret sits after the typed indentation
+
+	function makeSource(): NextEditFetchRequest {
+		const logContext = new InlineEditRequestLogContext('test', 0, undefined);
+		return new NextEditFetchRequest(generateUuid(), logContext, undefined, false);
+	}
+
+	beforeEach(async () => {
+		configService = new InMemoryConfigurationService(new DefaultsOnlyConfigurationService());
+		await configService.setConfig(ConfigKey.TeamInternal.InlineEditsReverseAgreement, true);
+		obsWorkspace = new MutableObservableWorkspace();
+		logService = new LogServiceImpl([]);
+		expService = new NullExperimentationService();
+
+		docId = DocumentId.create(URI.file('/test/example.ts').toString());
+		obsWorkspace.addDocument({ id: docId, initialValue: currentDoc });
+
+		cache = new NextEditCache(obsWorkspace, logService, configService, expService);
+	});
+
+	it('serves a clean at-cursor insertion (no leading whitespace) after the user tabs', () => {
+		// Model predicts the indented `return [` on the empty body line.
+		const modelEdit = new StringReplacement(OffsetRange.emptyAt(emptyLineOffset), '    return [');
+		// The user tabbed 4 spaces on that same (empty) line.
+		const userEditSince = StringEdit.single(new StringReplacement(OffsetRange.emptyAt(emptyLineOffset), '    '));
+
+		const cachedEdit = cache.setKthNextEdit(
+			docId,
+			new StringText(docBefore),
+			undefined, // editWindow
+			modelEdit,
+			0,
+			[modelEdit],
+			userEditSince,
+			makeSource(),
+			{ isFromCursorJump: false, modelTelemetry: testModelTelemetry, cursorOffset: emptyLineOffset },
+		);
+
+		assert(cachedEdit !== undefined, 'setKthNextEdit should return the cached edit');
+		assert(cachedEdit.userEditSince !== undefined, 'userEditSince should be set');
+
+		const rebaseResult = cache.tryRebaseCacheEntry(
+			cachedEdit,
+			new StringText(currentDoc),
+			[OffsetRange.emptyAt(cursorOffset)],
+		);
+
+		assert(rebaseResult.edit !== undefined, 'should rebase successfully');
+		assert(rebaseResult.edit.rebasedEdit !== undefined, 'should have a rebased edit');
+		// The indentation the user typed must not be part of the edit: a pure insertion at the cursor.
+		assert.strictEqual(rebaseResult.edit.rebasedEdit.toString(), '[28, 28) -> "return ["');
+	});
+});

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
@@ -187,17 +187,15 @@ describe('NextEditCache rebase — Fibonacci scenario', () => {
  * Regression test from a real scenario (NES cached suggestion not shown):
  *
  * The user is inside `function familyJohn() {` on an empty body line. NES cached a
- * suggestion that predicts the indented `return [` on that line (a line-based edit
- * that restates the indentation: `"" -> "    return ["`). The user then tabs to
- * indent the line.
+ * suggestion that predicts the indented `return [` on that line (`"" -> "    return ["`).
+ * The user then presses Tab to indent the line, inserting a tab character.
  *
- * When the cached edit is rebased over the user's indentation, the served edit must
- * be a clean pure insertion of `return [` at the cursor — the indentation the user
- * already typed must NOT be part of the edit. Serving the raw (non-minimized) rebase
- * result instead leaves the redundant indentation in the edit's range/new-text, which
- * is fragile to render as ghost text and can result in the suggestion not being shown.
+ * Strict rebase matches indentation literally, so the tab-vs-spaces mismatch makes
+ * the whole suggestion drop (`rebaseFailed`) and nothing is shown. The model's
+ * content intent is still valid, so the served edit must be re-anchored as a clean
+ * pure insertion of `return [` at the cursor, respecting the tab the user typed.
  */
-describe('NextEditCache rebase — indented insertion over user indentation', () => {
+describe('NextEditCache rebase — indented insertion over mismatched user indentation', () => {
 
 	let configService: InMemoryConfigurationService;
 	let obsWorkspace: MutableObservableWorkspace;
@@ -209,9 +207,9 @@ describe('NextEditCache rebase — indented insertion over user indentation', ()
 	// cache-time doc: empty body line inside the function
 	const docBefore = 'function familyJohn() {\n\n}\n';
 	const emptyLineOffset = 'function familyJohn() {\n'.length; // start of the empty body line
-	// current doc: the user has tabbed 4 spaces on the (empty) body line
-	const currentDoc = 'function familyJohn() {\n    \n}\n';
-	const cursorOffset = emptyLineOffset + '    '.length; // caret sits after the typed indentation
+	// current doc: the user pressed Tab (a tab character) on the (empty) body line
+	const currentDoc = 'function familyJohn() {\n\t\n}\n';
+	const cursorOffset = emptyLineOffset + '\t'.length; // caret sits after the typed tab
 
 	function makeSource(): NextEditFetchRequest {
 		const logContext = new InlineEditRequestLogContext('test', 0, undefined);
@@ -234,8 +232,8 @@ describe('NextEditCache rebase — indented insertion over user indentation', ()
 	it('serves a clean at-cursor insertion (no leading whitespace) after the user tabs', () => {
 		// Model predicts the indented `return [` on the empty body line.
 		const modelEdit = new StringReplacement(OffsetRange.emptyAt(emptyLineOffset), '    return [');
-		// The user tabbed 4 spaces on that same (empty) line.
-		const userEditSince = StringEdit.single(new StringReplacement(OffsetRange.emptyAt(emptyLineOffset), '    '));
+		// The user pressed Tab on that same (empty) line, inserting a tab character.
+		const userEditSince = StringEdit.single(new StringReplacement(OffsetRange.emptyAt(emptyLineOffset), '\t'));
 
 		const cachedEdit = cache.setKthNextEdit(
 			docId,
@@ -258,9 +256,9 @@ describe('NextEditCache rebase — indented insertion over user indentation', ()
 			[OffsetRange.emptyAt(cursorOffset)],
 		);
 
-		assert(rebaseResult.edit !== undefined, 'should rebase successfully');
+		assert(rebaseResult.edit !== undefined, 'should serve a (re-anchored) edit instead of dropping it');
 		assert(rebaseResult.edit.rebasedEdit !== undefined, 'should have a rebased edit');
-		// The indentation the user typed must not be part of the edit: a pure insertion at the cursor.
-		assert.strictEqual(rebaseResult.edit.rebasedEdit.toString(), '[28, 28) -> "return ["');
+		// The tab the user typed must not be part of the edit: a pure insertion at the cursor.
+		assert.strictEqual(rebaseResult.edit.rebasedEdit.toString(), `[${cursorOffset}, ${cursorOffset}) -> "return ["`);
 	});
 });

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -842,6 +842,15 @@ export namespace ConfigKey {
 		export const InlineEditsAbsorbSubsequenceTyping = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.absorbSubsequenceTyping', ConfigType.ExperimentBased, false);
 		export const InlineEditsReverseAgreement = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.reverseAgreement', ConfigType.ExperimentBased, true);
 		export const InlineEditsMaxImperfectAgreementLength = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.maxImperfectAgreementLength', ConfigType.ExperimentBased, 1, vNumber());
+		/**
+		 * When enabled, a cached NES suggestion whose strict rebase fails *only*
+		 * because the user re-typed a line's leading indentation differently than
+		 * the model predicted (e.g. pressing Tab to insert a tab character, or a
+		 * different number of spaces, on an otherwise-empty body line) is salvaged
+		 * instead of dropped: the model's still-valid content is re-anchored as a
+		 * clean at-cursor insertion that respects the indentation the user typed.
+		 */
+		export const InlineEditsReanchorContentOnIndentationMismatch = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.reanchorContentOnIndentationMismatch', ConfigType.ExperimentBased, false, vBoolean());
 		export const InlineEditsBackoffDebounceEnabled = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.backoffDebounceEnabled', ConfigType.ExperimentBased, true);
 		export const InlineEditsExtraDebounceEndOfLine = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.extraDebounceEndOfLine', ConfigType.ExperimentBased, 2000);
 		export const InlineEditsSpeculativeRequests = defineTeamInternalSetting<SpeculativeRequestsEnablement>('chat.advanced.inlineEdits.speculativeRequests', ConfigType.ExperimentBased, SpeculativeRequestsEnablement.Off, SpeculativeRequestsEnablement.VALIDATOR);


### PR DESCRIPTION
When a Next Edit Suggestion is cached as an indented insertion on an empty line (for example predicting `    return [` on an empty function body line) and the user then presses Tab to indent that line, the cached suggestion was silently not shown.

## Root cause

The suggestion is served through `tryRebaseCacheEntry`, which rebases the cached edit over what the user has typed since. Rebase runs in `'strict'` mode and matches indentation **literally**. When the user re-types the line's leading whitespace in a different representation than the model predicted (pressing Tab to insert a tab character where the model predicted spaces, or a different number of spaces), the rebase can't reconcile the two and returns `rebaseFailed`. The whole suggestion is then dropped and nothing is shown.

The model's *content* intent (the `return [` it wanted to add on that line) is still perfectly valid; only the indentation representation disagrees.

## Fix

Salvage the dropped case at the cache serving layer. On `rebaseFailed`, re-anchor the model's still-valid content as a clean at-cursor **insertion** that respects the indentation the user actually typed, e.g. turning the dropped `    return [` prediction into `[cursor, cursor) "return ["`. This:

- mirrors the reconciliation the rebase engine already performs when the user's indentation happens to match,
- is a faithful representation of the model's intent, so it upholds the display layer's soundness invariant (the served edit reproduces the model's content exactly), and
- only fires when the suggestion would otherwise be dropped, so the blast radius is minimal (worst case: an ignorable ghost).

The salvage is intentionally narrow: single edit, single empty cursor, the model touched only indentation, the content is a single non-empty line, and the cursor sits at the end of an otherwise-empty line's leading whitespace.

### Behind a setting

The behavior is gated behind a new team-internal, experiment-based setting `chat.advanced.inlineEdits.reanchorContentOnIndentationMismatch` (default **off**), threaded through `NesRebaseConfigs`. This lets it be rolled out or disabled independently, matching how sibling NES cache behaviors are shipped.

### Note on the first commit

The initial commit on this branch minimized the served edit in the rebase *success* branch (`removeCommonSuffixAndPrefix`). That path already renders as ghost text, so the change was a semantic no-op and its test modeled an artificial success path rather than the real drop. It has been reverted in favor of the salvage above.

## How to test

- New regression tests in `nextEditCacheRebase.spec.ts`: empty body line, model predicts `    return [`, user presses **Tab** (tab character).
  - With the setting enabled: asserts the served edit is `[25, 25) -> "return ["` (fails before the fix, where the suggestion is dropped).
  - With the setting disabled: asserts the suggestion is dropped, proving the gate.
- Existing `nextEditCacheRebase`, `nextEditProviderCaching`, `nextEditCacheCursorDistance`, `nextEditProviderSpeculative`, `editRebase`, and the display-layer `isInlineSuggestion` suites all pass unchanged (159 tests), confirming no regression and that the display-layer soundness invariant still holds.