### PR TITLE
refactor(claude): queue owns its done latch + steering Event (C4)

### DIFF
--- a/src/vs/platform/agentHost/node/claude/architecture-analysis/ROADMAP.md
+++ b/src/vs/platform/agentHost/node/claude/architecture-analysis/ROADMAP.md
@@ -56,7 +56,7 @@ The target end-state is **focused, legible, testable modules** where:
 
 ```
   Tier 0 ✅ → C1 ✅ → C9 ✅ → C5 → { C6, C7 }
-                  └→ C3 · C4 · C8   (independent; any time after C1)
+                  └→ C3 · C4 ✅ · C8   (independent; any time after C1)
 
   C2 = one owner for live config (desired-on-session vs applied-on-pipeline)
        — folded into C9 (shipped): the immutable pipeline holds only the
@@ -176,7 +176,7 @@ Legend — **Serves:** `dup` duplication/rematerializer · `cyc` overlap/circula
   once; suite green.
 - **Risk:** low.
 
-### C4 — Queue owns abort/done; delete the two back-reference closures  ·  Serves: cyc, life  ·  ⬜ proposed
+### C4 — Queue owns abort/done; delete the two back-reference closures  ·  Serves: cyc, life  ·  ✅ shipped
 - **Source:** report 01 (closure inventory).
 - **Goal:** remove the two avoidable dotted edges from the coupling map.
 - **Files:** `claudeSdkPipeline.ts` (`_getAbortSignal` L245, `_onSteeringYielded`

--- a/src/vs/platform/agentHost/node/claude/claudePromptQueue.ts
+++ b/src/vs/platform/agentHost/node/claude/claudePromptQueue.ts
@@ -5,6 +5,7 @@
 
 import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 import { DeferredPromise } from '../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { ILogService } from '../../../log/common/log.js';
@@ -31,19 +32,23 @@ export interface IPendingSdkMessage {
 /**
  * Owns the prompt queue + the async iterable handed to
  * `WarmQuery.query()`. Knows nothing about the SDK Query lifecycle,
- * config push, or message dispatch — those live on the pipeline.
+ * config push, or message dispatch — those live on the pipeline. It holds
+ * NO back-reference into the pipeline: the pipeline pushes abortedness in
+ * via {@link notifyAborted} and subscribes to {@link onDidYieldSteering}.
  *
  * Invariants:
  *   • Pushing wakes the iterable's parked `next()`.
- *   • The iterable returns `done` when the supplied `getAbortSignal()`
- *     is aborted; pipeline calls {@link notifyAborted} after flipping
- *     the controller so the parked `next()` returns immediately.
+ *   • The iterable returns `done` once {@link notifyAborted} has been
+ *     called (the pipeline calls it after aborting its controller); the
+ *     queue tracks this itself via an internal `_done` latch rather than
+ *     reading the pipeline's swap-prone signal. The latch is terminal — an
+ *     immutable pipeline never rebinds, so a rebuild mints a fresh queue.
  *   • {@link settleHead} pops the head of the yielded list (called by
  *     the consumer loop on every `result` message).
  *   • {@link failAll} rejects every pending deferred and clears both
  *     lists; used by abort and crash fan-out.
- *   • {@link resetForRebind} re-creates the parked deferred for a fresh
- *     Query binding (the queue itself survives across rebinds).
+ *   • {@link onDidYieldSteering} fires the moment a steering entry is
+ *     handed to the SDK, carrying its `PendingMessage.id`.
  */
 export class ClaudePromptQueue extends Disposable {
 
@@ -59,11 +64,22 @@ export class ClaudePromptQueue extends Disposable {
 	private _popped: IPendingSdkMessage[] = [];
 	private _pendingPromptDeferred = new DeferredPromise<void>();
 
+	/**
+	 * Terminal latch: once set (by {@link notifyAborted}) the iterable yields
+	 * `done` forever. Never cleared — the pipeline is immutable, so a rebuild
+	 * builds a fresh queue rather than reviving this one.
+	 */
+	private _done = false;
+
+	private readonly _onDidYieldSteering = this._register(new Emitter<string>());
+	/** Fires with a steering entry's `PendingMessage.id` the moment it is handed to the SDK. */
+	readonly onDidYieldSteering: Event<string> = this._onDidYieldSteering.event;
+
 	readonly iterable: AsyncIterable<SDKUserMessage> = {
 		[Symbol.asyncIterator]: () => ({
 			next: async () => {
 				while (true) {
-					if (this._getAbortSignal().aborted) {
+					if (this._done) {
 						return { done: true, value: undefined };
 					}
 					if (this._toYield.length > 0) {
@@ -71,7 +87,7 @@ export class ClaudePromptQueue extends Disposable {
 						this._yielded.push(entry);
 						this._logService.info(`[Claude:${this._sessionId}] queue yielded sdkUuid=${entry.sdkUuid} turnId=${entry.turnId}${entry.steeringPendingId ? ` steeringPendingId=${entry.steeringPendingId}` : ''}`);
 						if (entry.steeringPendingId) {
-							this._onSteeringYielded(entry.steeringPendingId);
+							this._onDidYieldSteering.fire(entry.steeringPendingId);
 						}
 						return { done: false, value: entry.sdkMessage };
 					}
@@ -84,8 +100,6 @@ export class ClaudePromptQueue extends Disposable {
 
 	constructor(
 		private readonly _sessionId: string,
-		private readonly _getAbortSignal: () => AbortSignal,
-		private readonly _onSteeringYielded: (pendingId: string) => void,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
@@ -159,13 +173,9 @@ export class ClaudePromptQueue extends Disposable {
 		this._popped = [];
 	}
 
-	/** Wake any parked `next()` — call after the controller is aborted so the iterable returns `done`. */
+	/** Latch the iterable to `done` and wake any parked `next()`. Call after aborting the controller. */
 	notifyAborted(): void {
+		this._done = true;
 		this._pendingPromptDeferred.complete();
-	}
-
-	/** Re-create the parked deferred for a fresh Query binding. */
-	resetForRebind(): void {
-		this._pendingPromptDeferred = new DeferredPromise<void>();
 	}
 }

--- a/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
@@ -188,17 +188,15 @@ export class ClaudeSdkPipeline extends Disposable {
 		this._appliedModel = appliedConfig.model;
 		this._appliedEffort = appliedConfig.effort;
 		this._appliedPermissionMode = appliedConfig.permissionMode;
+		this._queue = this._register(instantiationService.createInstance(ClaudePromptQueue, sessionId));
+		// The queue owns its own terminal `done` latch; the pipeline pushes abortedness in via
+		// `notifyAborted` (below) and subscribes to steering yields — no back-reference either way.
+		this._register(this._queue.onDidYieldSteering(pendingId => this._onDidProduceSignal.fire({
+			kind: 'steering_consumed',
+			chat: this.chatChannelUri,
+			id: pendingId,
+		})));
 		this._wireAbortHandler(abortController);
-		this._queue = this._register(instantiationService.createInstance(
-			ClaudePromptQueue,
-			sessionId,
-			() => this._abortController.signal,
-			(pendingId: string) => this._onDidProduceSignal.fire({
-				kind: 'steering_consumed',
-				chat: this.chatChannelUri,
-				id: pendingId,
-			}),
-		));
 		this._router = this._register(instantiationService.createInstance(
 			ClaudeSdkMessageRouter, sessionUri, chatChannelUri, dbRef, subagents, clientToolOwner,
 		));
@@ -382,6 +380,12 @@ export class ClaudeSdkPipeline extends Disposable {
 	}
 
 	private _wireAbortHandler(controller: AbortController): void {
+		// Push abortedness into the queue's terminal latch. Handle an already-aborted
+		// controller directly — `addEventListener('abort')` does not fire retroactively.
+		if (controller.signal.aborted) {
+			this._queue.notifyAborted();
+			return;
+		}
 		controller.signal.addEventListener('abort', () => {
 			this._queue.notifyAborted();
 		}, { once: true });

--- a/src/vs/platform/agentHost/test/node/claudePromptQueue.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudePromptQueue.test.ts
@@ -17,22 +17,16 @@ import { ClaudePromptQueue, IPendingSdkMessage } from '../../node/claude/claudeP
 
 interface IQueueHarness {
 	readonly queue: ClaudePromptQueue;
-	readonly controller: AbortController;
 	readonly steeringYielded: string[];
 }
 
 function createQueue(disposables: Pick<DisposableStore, 'add'>): IQueueHarness {
-	const controller = new AbortController();
 	const steeringYielded: string[] = [];
 	const services = new ServiceCollection([ILogService, new NullLogService()]);
 	const instantiationService = disposables.add(new InstantiationService(services));
-	const queue = disposables.add(instantiationService.createInstance(
-		ClaudePromptQueue,
-		'sess-1',
-		() => controller.signal,
-		(id: string) => steeringYielded.push(id),
-	));
-	return { queue, controller, steeringYielded };
+	const queue = disposables.add(instantiationService.createInstance(ClaudePromptQueue, 'sess-1'));
+	disposables.add(queue.onDidYieldSteering(id => steeringYielded.push(id)));
+	return { queue, steeringYielded };
 }
 
 function makeEntry(id: string, opts?: { steeringPendingId?: string; turnId?: string }): IPendingSdkMessage {
@@ -132,22 +126,19 @@ suite('ClaudePromptQueue', () => {
 		assert.strictEqual(queue.isEmpty, true);
 	});
 
-	test('aborted signal makes the iterable return done on the next next()', async () => {
-		const { queue, controller } = createQueue(disposables);
+	test('notifyAborted latches the iterable to done on the next next()', async () => {
+		const { queue } = createQueue(disposables);
 		const iter = queue.iterable[Symbol.asyncIterator]();
-		controller.abort();
 		queue.notifyAborted();
 		const r = await iter.next();
 		assert.strictEqual(r.done, true);
 	});
 
-	test('notifyAborted wakes a parked next() so it can re-check the abort signal', async () => {
-		const { queue, controller } = createQueue(disposables);
+	test('notifyAborted wakes a parked next() so it returns done', async () => {
+		const { queue } = createQueue(disposables);
 		const iter = queue.iterable[Symbol.asyncIterator]();
 		// Park next() with no entries queued.
 		const parked = iter.next();
-		// Abort + wake.
-		controller.abort();
 		queue.notifyAborted();
 		const r = await parked;
 		assert.strictEqual(r.done, true);
@@ -176,7 +167,7 @@ suite('ClaudePromptQueue', () => {
 		assert.strictEqual(queue.peekParent(), undefined);
 	});
 
-	test('steering callback fires when an entry with steeringPendingId is YIELDED, not when it is pushed', async () => {
+	test('onDidYieldSteering fires when an entry with steeringPendingId is YIELDED, not when it is pushed', async () => {
 		const { queue, steeringYielded } = createQueue(disposables);
 		const iter = queue.iterable[Symbol.asyncIterator]();
 		const e = makeEntry('s1', { steeringPendingId: 'pending-42' });
@@ -186,7 +177,7 @@ suite('ClaudePromptQueue', () => {
 		assert.deepStrictEqual(steeringYielded, ['pending-42'], 'fires on yield');
 	});
 
-	test('non-steering entries do not fire the steering callback', async () => {
+	test('non-steering entries do not fire onDidYieldSteering', async () => {
 		const { queue, steeringYielded } = createQueue(disposables);
 		const iter = queue.iterable[Symbol.asyncIterator]();
 		void queue.push(makeEntry('plain'));
@@ -198,41 +189,6 @@ suite('ClaudePromptQueue', () => {
 		const { queue } = createQueue(disposables);
 		assert.strictEqual(queue.settleHead(), undefined);
 		assert.strictEqual(queue.isEmpty, true);
-	});
-
-	test('resetForRebind replaces the parked deferred so a subsequent push wakes a new parked next()', async () => {
-		// Use a controller that we keep un-aborted to isolate the wake mechanic from the abort-done branch.
-		const liveController = new AbortController();
-		const services = new ServiceCollection([ILogService, new NullLogService()]);
-		const inst = disposables.add(new InstantiationService(services));
-		const q = disposables.add(inst.createInstance(
-			ClaudePromptQueue, 'sess-reset', () => liveController.signal, () => { /* no steering */ },
-		));
-
-		// Park next() on the original deferred.
-		const iter = q.iterable[Symbol.asyncIterator]();
-		const parkedA = iter.next();
-
-		// Resetting while parked replaces _pendingPromptDeferred with a fresh one.
-		// The original parked promise is still awaiting the OLD deferred — pushing should
-		// complete the OLD one (because push() calls .complete() on the current field,
-		// which after reset is the new one). So the original parked next() never wakes
-		// from a push alone; it requires a push BEFORE reset OR an entry to drain.
-		q.resetForRebind();
-		// Push an entry — the new deferred resolves AND _toYield has the entry, so a fresh next() wakes.
-		void q.push(makeEntry('after-reset'));
-		const iter2 = q.iterable[Symbol.asyncIterator]();
-		const value = await iter2.next();
-		assert.strictEqual(value.done, false);
-		assert.strictEqual(value.value?.uuid, makeUuid('after-reset'));
-
-		// Original parked promise from the first iterator is still pending; abort to release it.
-		liveController.abort();
-		q.notifyAborted();
-		// notifyAborted completes the (now current) deferred. The OLD deferred from before reset
-		// is leaked-but-settled — the parkedA promise will never resolve. To avoid hanging the test
-		// runner, swap to the fresh iter and abandon parkedA (it's a closure-local promise; GC'd).
-		void parkedA;
 	});
 
 	test('isEmpty is true after every pushed entry has been yielded and settled', async () => {


### PR DESCRIPTION
> **Stacked on #326270** (C9). Review that first; this PR's diff is the single commit on top. Base retargets as the stack lands.

## What

**C4 — delete the last two back-reference closures.** `ClaudeSdkPipeline` injected two closures into `ClaudePromptQueue`: `() => this._abortController.signal` (read on every `next()`) and `(pendingId) => this._onDidProduceSignal.fire(...)` (steering). These are the "closures passed down that call instance functions" from the original review. C4 removes both, so the queue holds **no** back-reference into the pipeline.

- **Abort** → the queue owns a terminal `_done` latch, set by `notifyAborted()` (which the pipeline already calls after aborting its controller). `next()` checks the latch instead of reaching back through a `() => signal` closure into the pipeline's swap-prone field.
- **Steering** → `onDidYieldSteering: Event<string>` replaces the injected callback; the pipeline subscribes, matching the existing router→pipeline `Event` pattern.
- **`resetForRebind` deleted** — dead since C9 made the pipeline immutable (a rebuild mints a *fresh* queue rather than reviving one), so the latch never needs clearing. This is why C4 stacks naturally on C9: the immutability removed the only reason the latch would ever reset.
- **`_wireAbortHandler`** now also handles an already-aborted controller directly (`addEventListener('abort')` doesn't fire retroactively); the queue is constructed *before* wiring so the latch is reachable.

The queue ctor drops from **4 args to 2**. Net **−30 lines**.

## Why it's safe

- `_done` faithfully models "controller aborted": every abort path (`session.abort`, `pipeline.abort`, `shutdownAndWait`, dispose) aborts the controller → fires `_wireAbortHandler` → `notifyAborted()` → `_done`. The queue's termination no longer depends on reading an external signal that could go stale.
- Steering behavior is unchanged — `steering_consumed` still fires the moment a steering entry is handed to the SDK, now via the Event.

## Validation

- Suites green: `claudePromptQueue` **12**, `claudeSdkPipeline` **12**, `claudeAgent` **197**.
- `typecheck-client` / `eslint` / `valid-layers-check` clean.
- The abort/steering/parked-`next()` semantics are pinned by `claudePromptQueue.test.ts`; the end-to-end abort + steering paths by `claudeAgent.test.ts` (incl. this stack's C9 abort/rebuild-race edge tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)