### PR TITLE
refactor(claude): unify subprocess teardown into one idempotent verb (C8)

### DIFF
--- a/src/vs/platform/agentHost/node/claude/architecture-analysis/ROADMAP.md
+++ b/src/vs/platform/agentHost/node/claude/architecture-analysis/ROADMAP.md
@@ -47,7 +47,8 @@ The target end-state is **focused, legible, testable modules** where:
      (`claudeAgentSession.ts:568-569`);
    - every post-materialize `session.abortController` reader is
      `!isPipelineReady`-guarded (the controller forks after the first rebind);
-   - WarmQuery teardown is idempotent only via SDK `close()` memoization;
+   - WarmQuery teardown is idempotent via the pipeline's `_torndown` flag (C8),
+     not by luck of SDK `close()` memoization;
    - `materialize` throws if `_pipeline` is already set (once-per-session).
 4. **Traceability.** Each step cites its source report and the synthesis
    candidate ID.
@@ -56,7 +57,7 @@ The target end-state is **focused, legible, testable modules** where:
 
 ```
   Tier 0 ✅ → C1 ✅ → C9 ✅ → C5 → { C6, C7 }
-                  └→ C3 · C4 ✅ · C8   (independent; any time after C1)
+                  └→ C3 · C4 ✅ · C8 ✅   (independent; any time after C1)
 
   C2 = one owner for live config (desired-on-session vs applied-on-pipeline)
        — folded into C9 (shipped): the immutable pipeline holds only the
@@ -246,7 +247,7 @@ Legend — **Serves:** `dup` duplication/rematerializer · `cyc` overlap/circula
   smaller. Could be scoped down to just hiding the controller behind
   `abortProvisional()` if the full type split is too invasive.
 
-### C8 — Unify subprocess teardown into one awaitable verb  ·  Serves: life  ·  ⬜ proposed
+### C8 — Unify subprocess teardown into one awaitable verb  ·  Serves: life  ·  ✅ shipped
 - **Source:** report 02 (three teardown spellings, H1/H2).
 - **Goal:** one teardown path whose safety doesn't rest on SDK `close()`
   memoization being an implementation detail.

--- a/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
@@ -151,6 +151,13 @@ export class ClaudeSdkPipeline extends Disposable {
 	 */
 	private _dead = false;
 
+	/**
+	 * Guards {@link _teardown} so the WarmQuery is async-disposed exactly once,
+	 * whether {@link shutdownAndWait} or {@link dispose} runs first. Idempotency
+	 * rests on this flag, not on the SDK `close()` cleanup happening to be memoized.
+	 */
+	private _torndown = false;
+
 	/** Tracks whether the (single) consumer loop has been started. */
 	private _consumerLoopRunning = false;
 
@@ -207,12 +214,10 @@ export class ClaudeSdkPipeline extends Disposable {
 		// to an unbound query. The iterable parks until the first prompt is pushed,
 		// so no turn runs until `send`.
 		this._query = this._warm.query(this._queue.iterable);
-		// Dispose chain → abort → SDK cleanup.
-		this._register(toDisposable(() => this._abortController.abort()));
-		this._register(toDisposable(() => {
-			void Promise.resolve(this._warm[Symbol.asyncDispose]()).catch((err: unknown) =>
-				this._logService.warn(`[ClaudeSdkPipeline] WarmQuery dispose failed: ${err}`));
-		}));
+		// Dispose = the same teardown as `shutdownAndWait`, fired and forgotten
+		// (the abort + WarmQuery async-dispose run synchronously before the first
+		// await, so the subprocess is signalled to stop before `dispose()` returns).
+		this._register(toDisposable(() => { void this._teardown(); }));
 	}
 
 	get isResumed(): boolean { return this._isResumed; }
@@ -230,25 +235,40 @@ export class ClaudeSdkPipeline extends Disposable {
 	get hasActiveTurn(): boolean { return !this._queue.isEmpty; }
 
 	/**
-	 * Abort the live SDK subprocess and **await its actual exit**.
-	 *
-	 * `WarmQuery[Symbol.asyncDispose]()` calls the query's `close()`, which
-	 * *fires* the SDK cleanup but does not await it — so it returns while the
-	 * subprocess is still shutting down (and still re-flushing its transcript).
-	 * `Query.return()` awaits the same (memoized) cleanup, which in turn awaits
-	 * `transport.waitForExit()` — the OS process actually exiting after its
-	 * final transcript flush. Awaiting that is what lets a caller safely reuse
-	 * the `--session-id` (the CLI rejects a fresh spawn while `<id>.jsonl`
-	 * still exists, and the dying process would otherwise recreate it).
+	 * Abort the live SDK subprocess and **await its actual exit** — the awaited
+	 * face of the single {@link _teardown} path. Callers use this (rather than
+	 * {@link dispose}) when they must not spawn a fresh subprocess reusing the same
+	 * `--session-id` until the old one has released `<id>.jsonl` (yield-restart /
+	 * rebuild resume).
 	 */
 	async shutdownAndWait(): Promise<void> {
-		this._abortController.abort();
+		await this._teardown();
+	}
+
+	/**
+	 * The one teardown path for the SDK subprocess, idempotent via {@link _torndown}.
+	 *
+	 * Aborts the controller (signalling the subprocess to stop), then
+	 * `WarmQuery[Symbol.asyncDispose]()` — which calls the query's `close()` and
+	 * *fires* the SDK cleanup but returns while the process is still shutting down
+	 * (and re-flushing its transcript) — then awaits `Query.return()`, which awaits
+	 * the same cleanup down to `transport.waitForExit()`, i.e. the OS process
+	 * actually exiting. {@link shutdownAndWait} awaits this (so `--session-id` reuse
+	 * is safe); {@link dispose} fires it and forgets. Runs at most once regardless
+	 * of which caller wins.
+	 */
+	private async _teardown(): Promise<void> {
+		if (this._torndown) {
+			return;
+		}
+		this._torndown = true;
 		this._dead = true;
+		this._abortController.abort();
 		try {
 			await this._warm[Symbol.asyncDispose]();
 			await this._query.return(undefined);
 		} catch (err) {
-			this._logService.warn(`[ClaudeSdkPipeline:${this.sessionId}] shutdownAndWait: teardown failed`, err);
+			this._logService.warn(`[ClaudeSdkPipeline:${this.sessionId}] teardown failed`, err);
 		}
 	}
 

--- a/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
@@ -304,6 +304,19 @@ suite('ClaudeSdkPipeline', () => {
 			assert.strictEqual(warm.asyncDisposeCount, 1);
 			store.dispose();
 		});
+
+		test('shutdownAndWait then dispose tears down exactly once (idempotent, not reliant on SDK close() memoization)', async () => {
+			const store = new DisposableStore();
+			const { pipeline, warm } = createPipeline(store);
+
+			await pipeline.shutdownAndWait();
+			assert.strictEqual(warm.asyncDisposeCount, 1, 'shutdownAndWait async-disposes once');
+
+			pipeline.dispose();
+			await Promise.resolve();
+			assert.strictEqual(warm.asyncDisposeCount, 1, 'dispose after shutdownAndWait is a guarded no-op');
+			store.dispose();
+		});
 	});
 
 	suite('CancellationError plumbing', () => {


### PR DESCRIPTION
> **Stacked on #326552** (C4) → #326270 (C9) → #326256 (C1). Review the stack in order; this PR's diff is one commit.

## What

**C8 — one teardown path, explicitly idempotent.** The pipeline had two teardown spellings that both async-disposed the `WarmQuery`, and their safety-under-double-call rested on the SDK's `close()` cleanup *happening* to be memoized (report 02, H1/H2). C8 collapses them into one private `_teardown()` guarded by a `_torndown` flag:

- **`shutdownAndWait()`** is the *awaited* face — used where we must not spawn a fresh subprocess reusing the same `--session-id` until the old one has released `<id>.jsonl` (yield-restart / rebuild resume).
- **`dispose()`** fires the *same* `_teardown()` and forgets. The abort + `WarmQuery.asyncDispose` run synchronously before `dispose()` returns, so the subprocess is still signalled to stop promptly.
- Both run `abort → WarmQuery.asyncDispose → Query.return` in one place, **at most once**, regardless of which caller wins.
- Replaces the two dispose-chain `toDisposable`s (separate abort + async-dispose) with one.

C9 already deleted the third spelling (`_rebindQuery`'s manual `asyncDispose`), so this closes out the set.

## Why it's safe

- Idempotency is now a property of *our* code (`_torndown`), not an SDK implementation detail. A `shutdownAndWait` followed by `dispose` (the rebuild path) is a guarded no-op instead of a redundant double-dispose.
- No behavior change to the await-vs-fire-and-forget distinction — `shutdownAndWait` still awaits actual process exit; `dispose` still fires-and-forgets.

## Validation

- New pipeline test pins the idempotency: *shutdownAndWait then dispose async-disposes the WarmQuery exactly once*.
- Suites green: `claudeSdkPipeline` **13**, `claudePromptQueue` **12**, `claudeAgent` **197**.
- `typecheck-client` / `eslint` / `valid-layers-check` clean.
- **Live smoke suite 19/19** (`test/agent-host-e2e/`): materialize / warm reuse / recover-rebuild / abort-churn with subprocess reaping — the scenarios that exercise teardown end-to-end against a real subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)