### PR TITLE
Add setting to control terminal resize overlay

### DIFF
--- a/src/vs/workbench/contrib/terminal/terminalContribExports.ts
+++ b/src/vs/workbench/contrib/terminal/terminalContribExports.ts
@@ -16,6 +16,7 @@ import { TerminalDeveloperCommandId } from '../terminalContrib/developer/common/
 import { defaultTerminalFindCommandToSkipShell } from '../terminalContrib/find/common/terminal.find.js';
 import { defaultTerminalHistoryCommandsToSkipShell, terminalHistoryConfiguration } from '../terminalContrib/history/common/terminal.history.js';
 import { terminalOscNotificationsConfiguration } from '../terminalContrib/notification/common/terminalNotificationConfiguration.js';
+import { terminalResizeDimensionsOverlayConfiguration } from '../terminalContrib/resizeDimensionsOverlay/common/terminalResizeDimensionsOverlayConfiguration.js';
 import { TerminalStickyScrollSettingId, terminalStickyScrollConfiguration } from '../terminalContrib/stickyScroll/common/terminalStickyScrollConfiguration.js';
 import { defaultTerminalSuggestCommandsToSkipShell } from '../terminalContrib/suggest/common/terminal.suggest.js';
 import { TerminalSuggestSettingId, terminalSuggestConfiguration } from '../terminalContrib/suggest/common/terminalSuggestConfiguration.js';
@@ -80,6 +81,7 @@ export const terminalContribConfiguration: IConfigurationNode['properties'] = {
 	...terminalCommandGuideConfiguration,
 	...terminalHistoryConfiguration,
 	...terminalOscNotificationsConfiguration,
+	...terminalResizeDimensionsOverlayConfiguration,
 	...terminalStickyScrollConfiguration,
 	...terminalSuggestConfiguration,
 	...terminalTypeAheadConfiguration,

--- a/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/browser/terminal.resizeDimensionsOverlay.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/browser/terminal.resizeDimensionsOverlay.contribution.ts
@@ -5,10 +5,12 @@
 
 import type { Terminal as RawXtermTerminal } from '@xterm/xterm';
 import { Disposable, MutableDisposable, type IDisposable } from '../../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import type { ITerminalContribution, IXtermTerminal } from '../../../terminal/browser/terminal.js';
 import { registerTerminalContribution, type ITerminalContributionContext } from '../../../terminal/browser/terminalExtensions.js';
 import { timeout } from '../../../../../base/common/async.js';
 import { TerminalResizeDimensionsOverlay } from './terminalResizeDimensionsOverlay.js';
+import { TerminalResizeDimensionsOverlaySettingId } from '../common/terminalResizeDimensionsOverlayConfiguration.js';
 
 class TerminalResizeDimensionsOverlayContribution extends Disposable implements ITerminalContribution {
 	static readonly ID = 'terminal.resizeDimensionsOverlay';
@@ -17,6 +19,7 @@ class TerminalResizeDimensionsOverlayContribution extends Disposable implements 
 
 	constructor(
 		private readonly _ctx: ITerminalContributionContext,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 	}
@@ -27,11 +30,28 @@ class TerminalResizeDimensionsOverlayContribution extends Disposable implements 
 			// Wait a second to avoid resize events during startup like when opening a terminal or
 			// when a terminal reconnects. Ideally we'd have an actual event to listen to here.
 			timeout(1000).then(() => {
-				if (!this._store.isDisposed) {
-					this._overlay.value = new TerminalResizeDimensionsOverlay(this._ctx.instance.domElement, xterm);
+				if (this._store.isDisposed) {
+					return;
 				}
+				this._updateOverlay(xterm);
+				this._register(this._configurationService.onDidChangeConfiguration(e => {
+					if (e.affectsConfiguration(TerminalResizeDimensionsOverlaySettingId.Enabled)) {
+						this._updateOverlay(xterm);
+					}
+				}));
 			});
 		});
+	}
+
+	private _updateOverlay(xterm: IXtermTerminal & { raw: RawXtermTerminal }): void {
+		const enabled = this._configurationService.getValue<boolean>(TerminalResizeDimensionsOverlaySettingId.Enabled) !== false;
+		if (enabled) {
+			if (!this._overlay.value) {
+				this._overlay.value = new TerminalResizeDimensionsOverlay(this._ctx.instance.domElement, xterm);
+			}
+		} else {
+			this._overlay.clear();
+		}
 	}
 }
 registerTerminalContribution(TerminalResizeDimensionsOverlayContribution.ID, TerminalResizeDimensionsOverlayContribution);

--- a/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/common/terminalResizeDimensionsOverlayConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/common/terminalResizeDimensionsOverlayConfiguration.ts
@@ -11,10 +11,6 @@ export const enum TerminalResizeDimensionsOverlaySettingId {
 	Enabled = 'terminal.integrated.resizeDimensionsOverlay.enabled',
 }
 
-export interface ITerminalResizeDimensionsOverlayConfiguration {
-	enabled: boolean;
-}
-
 export const terminalResizeDimensionsOverlayConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 	[TerminalResizeDimensionsOverlaySettingId.Enabled]: {
 		markdownDescription: localize('resizeDimensionsOverlay.enabled', "Whether to show a visual overlay with the terminal's columns and rows when it is resized."),

--- a/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/common/terminalResizeDimensionsOverlayConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/common/terminalResizeDimensionsOverlayConfiguration.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { IStringDictionary } from '../../../../../base/common/collections.js';
+import { localize } from '../../../../../nls.js';
+import type { IConfigurationPropertySchema } from '../../../../../platform/configuration/common/configurationRegistry.js';
+
+export const enum TerminalResizeDimensionsOverlaySettingId {
+	Enabled = 'terminal.integrated.resizeDimensionsOverlay.enabled',
+}
+
+export interface ITerminalResizeDimensionsOverlayConfiguration {
+	enabled: boolean;
+}
+
+export const terminalResizeDimensionsOverlayConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
+	[TerminalResizeDimensionsOverlaySettingId.Enabled]: {
+		markdownDescription: localize('resizeDimensionsOverlay.enabled', "Whether to show a visual overlay with the terminal's columns and rows when it is resized."),
+		type: 'boolean',
+		default: true
+	},
+};


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/295790

- Add `terminal.integrated.resizeDimensionsOverlay.enabled` to control the terminal resize dimensions overlay.
- Keep the setting enabled by default to preserve existing behavior.
- Create or dispose the overlay when the setting changes.
- Apply setting changes to open terminals without requiring a reload or terminal restart.

Verification:

- Resize a terminal with the setting enabled and confirm the dimensions overlay appears.
- Disable the setting and confirm resizing no longer shows the overlay.
- Re-enable the setting and confirm the overlay returns without restarting the terminal.
- `npm run typecheck-client`
- `npm run valid-layers-check`

-----------------------------------------
Inspirations from:

- The setting schema follows the feature-owned terminal configuration pattern used by [`terminalCommandGuideConfiguration`](https://github.com/microsoft/vscode/blob/693614c9f239b49f6d13d55da7f1a851d5b82c36/src/vs/workbench/contrib/terminalContrib/commandGuide/common/terminalCommandGuideConfiguration.ts#L10-L27).
- Live setting updates and disposable feature activation follow [`TerminalCommandGuideContribution`](https://github.com/microsoft/vscode/blob/693614c9f239b49f6d13d55da7f1a851d5b82c36/src/vs/workbench/contrib/terminalContrib/commandGuide/browser/terminal.commandGuide.contribution.ts#L29-L62).
- The existing PTY-ready initialization delay is preserved from [`TerminalResizeDimensionsOverlayContribution`](https://github.com/microsoft/vscode/blob/693614c9f239b49f6d13d55da7f1a851d5b82c36/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/browser/terminal.resizeDimensionsOverlay.contribution.ts#L13-L37).
- The setting is registered through the existing [`terminalContribConfiguration`](https://github.com/microsoft/vscode/blob/693614c9f239b49f6d13d55da7f1a851d5b82c36/src/vs/workbench/contrib/terminal/terminalContribExports.ts#L73-L87) aggregation point.