### PR TITLE
Open Markdown editor in locked mode by default

### DIFF
--- a/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
+++ b/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
@@ -55,7 +55,7 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		const onMessage = webview.onDidReceiveMessage(async (message) => {
 			switch (message.type) {
 				case 'ready': {
-					webview.postMessage({ type: 'init', content: document.getText(), readonly: this.#globalState.get(MarkdownEditorProvider.#readonlyStateKey, false) });
+					webview.postMessage({ type: 'init', content: document.getText(), readonly: this.#globalState.get(MarkdownEditorProvider.#readonlyStateKey, true) });
 					break;
 				}
 				case 'setReadonly': {


### PR DESCRIPTION
## Summary

Open the experimental Markdown editor in locked mode when the user has not previously selected a mode. Preserve the remembered edit/locked choice for existing users.

Fixes #326249