### PR TITLE
Open Markdown editor in locked mode by default

### DIFF
--- a/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
+++ b/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
@@ -55,7 +55,7 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		const onMessage = webview.onDidReceiveMessage(async (message) => {
 			switch (message.type) {
 				case 'ready': {
-					webview.postMessage({ type: 'init', content: document.getText(), readonly: this.#globalState.get(MarkdownEditorProvider.#readonlyStateKey, false) });
+					webview.postMessage({ type: 'init', content: document.getText(), readonly: this.#globalState.get(MarkdownEditorProvider.#readonlyStateKey, true) });
 					break;
 				}
 				case 'setReadonly': {


### PR DESCRIPTION
## Summary

Backport the Markdown editor's locked-by-default behavior to the 1.130 release branch. A previously remembered user choice is still preserved.

Refs #326249