### PR TITLE
Use deprecation messages for Copilot settings

### DIFF
--- a/extensions/copilot/src/extension/settingsSchema/common/settingsSchema.ts
+++ b/extensions/copilot/src/extension/settingsSchema/common/settingsSchema.ts
@@ -47,8 +47,7 @@ export function buildSettingsSchema(isInternal: boolean, configs: Iterable<Setti
 		properties,
 		patternProperties: {
 			[unknownAdvancedSettingPattern]: {
-				deprecated: true,
-				description: 'Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.',
+				deprecationMessage: 'Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.',
 			}
 		}
 	};

--- a/extensions/copilot/src/extension/settingsSchema/common/settingsSchema.ts
+++ b/extensions/copilot/src/extension/settingsSchema/common/settingsSchema.ts
@@ -12,10 +12,10 @@ const advancedSettingPrefixRegex = new RegExp(`^${advancedSettingPrefixPattern}`
 
 type SettingsSchemaConfig = Pick<BaseConfig<unknown>, 'fullyQualifiedId' | 'validator'>;
 
-export function buildSettingsSchema(isInternal: false, configs: Iterable<SettingsSchemaConfig>): EmptyJsonSchema;
-export function buildSettingsSchema(isInternal: true, configs: Iterable<SettingsSchemaConfig>): ObjectJsonSchema;
-export function buildSettingsSchema(isInternal: boolean, configs: Iterable<SettingsSchemaConfig>): JsonSchema;
-export function buildSettingsSchema(isInternal: boolean, configs: Iterable<SettingsSchemaConfig>): JsonSchema {
+export function buildSettingsSchema(isInternal: false, configs: Iterable<SettingsSchemaConfig>, unknownAdvancedSettingDeprecationMessage: string): EmptyJsonSchema;
+export function buildSettingsSchema(isInternal: true, configs: Iterable<SettingsSchemaConfig>, unknownAdvancedSettingDeprecationMessage: string): ObjectJsonSchema;
+export function buildSettingsSchema(isInternal: boolean, configs: Iterable<SettingsSchemaConfig>, unknownAdvancedSettingDeprecationMessage: string): JsonSchema;
+export function buildSettingsSchema(isInternal: boolean, configs: Iterable<SettingsSchemaConfig>, unknownAdvancedSettingDeprecationMessage: string): JsonSchema {
 	if (!isInternal) {
 		return {};
 	}
@@ -47,7 +47,7 @@ export function buildSettingsSchema(isInternal: boolean, configs: Iterable<Setti
 		properties,
 		patternProperties: {
 			[unknownAdvancedSettingPattern]: {
-				deprecationMessage: 'Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.',
+				deprecationMessage: unknownAdvancedSettingDeprecationMessage,
 			}
 		}
 	};

--- a/extensions/copilot/src/extension/settingsSchema/test/common/settingsSchema.spec.ts
+++ b/extensions/copilot/src/extension/settingsSchema/test/common/settingsSchema.spec.ts
@@ -38,8 +38,7 @@ describe('SettingsSchema', () => {
 				type: 'boolean',
 			},
 			fallbackSchema: {
-				deprecated: true,
-				description: 'Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.',
+				deprecationMessage: 'Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.',
 			},
 		});
 	});

--- a/extensions/copilot/src/extension/settingsSchema/test/common/settingsSchema.spec.ts
+++ b/extensions/copilot/src/extension/settingsSchema/test/common/settingsSchema.spec.ts
@@ -8,6 +8,8 @@ import { ConfigKey, globalConfigRegistry } from '../../../../platform/configurat
 import type { JsonSchema, ObjectJsonSchema } from '../../../../platform/configuration/common/jsonSchema';
 import { buildSettingsSchema } from '../../common/settingsSchema';
 
+const unknownAdvancedSettingDeprecationMessage = 'Unknown advanced setting deprecation message';
+
 function getUnknownAdvancedSettingSchema(schema: ObjectJsonSchema): [string, JsonSchema] {
 	const entries = Object.entries(schema.patternProperties ?? {});
 	if (entries.length !== 1) {
@@ -18,11 +20,11 @@ function getUnknownAdvancedSettingSchema(schema: ObjectJsonSchema): [string, Jso
 
 describe('SettingsSchema', () => {
 	test('returns an empty schema for external users', () => {
-		expect(buildSettingsSchema(false, globalConfigRegistry.configs.values())).toEqual({});
+		expect(buildSettingsSchema(false, globalConfigRegistry.configs.values(), unknownAdvancedSettingDeprecationMessage)).toEqual({});
 	});
 
 	test('does not deprecate registered advanced settings', () => {
-		const schema: ObjectJsonSchema = JSON.parse(JSON.stringify(buildSettingsSchema(true, globalConfigRegistry.configs.values())));
+		const schema: ObjectJsonSchema = JSON.parse(JSON.stringify(buildSettingsSchema(true, globalConfigRegistry.configs.values(), unknownAdvancedSettingDeprecationMessage)));
 		const [patternSource, fallbackSchema] = getUnknownAdvancedSettingSchema(schema);
 		const unknownAdvancedSettingRegex = new RegExp(patternSource);
 		const issueSettingId = ConfigKey.TeamInternal.InlineEditsXtabSplitPatchOnDiff.fullyQualifiedId;
@@ -38,7 +40,7 @@ describe('SettingsSchema', () => {
 				type: 'boolean',
 			},
 			fallbackSchema: {
-				deprecationMessage: 'Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.',
+				deprecationMessage: unknownAdvancedSettingDeprecationMessage,
 			},
 		});
 	});
@@ -49,12 +51,12 @@ describe('SettingsSchema', () => {
 		const originalSchema = buildSettingsSchema(true, [
 			{ fullyQualifiedId: registeredChatSetting },
 			{ fullyQualifiedId: registeredSharedSetting },
-		]);
+		], unknownAdvancedSettingDeprecationMessage);
 		const [originalPatternSource] = getUnknownAdvancedSettingSchema(originalSchema);
 		const schema: ObjectJsonSchema = JSON.parse(JSON.stringify(originalSchema));
 		const [patternSource] = getUnknownAdvancedSettingSchema(schema);
 		const unknownAdvancedSettingRegex = new RegExp(patternSource);
-		const [emptyRegistryPatternSource] = getUnknownAdvancedSettingSchema(buildSettingsSchema(true, []));
+		const [emptyRegistryPatternSource] = getUnknownAdvancedSettingSchema(buildSettingsSchema(true, [], unknownAdvancedSettingDeprecationMessage));
 
 		expect({
 			serializedPatternPreserved: patternSource === originalPatternSource,

--- a/extensions/copilot/src/extension/settingsSchema/vscode-node/settingsSchemaFeature.ts
+++ b/extensions/copilot/src/extension/settingsSchema/vscode-node/settingsSchemaFeature.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri } from 'vscode';
+import { l10n, Uri } from 'vscode';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { globalConfigRegistry } from '../../../platform/configuration/common/configurationService';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
@@ -23,7 +23,8 @@ export class SettingsSchemaFeature extends Disposable {
 		this._register(autorunWithStore((reader, store) => {
 			const p = store.add(new VirtualTextDocumentProvider('ccsettings'));
 			const doc = p.createDocumentForUri(Uri.parse('ccsettings://root/schema.json'));
-			const schema = buildSettingsSchema(this._isInternal.read(reader), globalConfigRegistry.configs.values());
+			const unknownAdvancedSettingDeprecationMessage = l10n.t('Unknown advanced setting.\nIf you believe this is a supported setting, please file an issue so that it gets registered.');
+			const schema = buildSettingsSchema(this._isInternal.read(reader), globalConfigRegistry.configs.values(), unknownAdvancedSettingDeprecationMessage);
 			doc.setContent(JSON.stringify(schema));
 		}));
 	}

--- a/extensions/copilot/src/platform/configuration/common/jsonSchema.ts
+++ b/extensions/copilot/src/platform/configuration/common/jsonSchema.ts
@@ -22,7 +22,8 @@ export interface BaseJsonSchema {
 	$schema?: string;
 	title?: string;
 	description?: string;
-	deprecated?: boolean;
+	deprecationMessage?: string;
+	markdownDeprecationMessage?: string;
 
 	definitions?: {
 		[name: string]: JsonSchema;


### PR DESCRIPTION
Addresses the follow-up review on #326336.

- Align the Copilot JSON schema type with VS Code's `deprecationMessage` and `markdownDeprecationMessage` extensions.
- Report unknown advanced settings through `deprecationMessage` instead of the generic `deprecated` marker.
- Update the focused settings-schema regression coverage.

## Validation

- `npx tsc --noEmit --project tsconfig.json`
- `npm run test:unit -- src/extension/settingsSchema/test/common/settingsSchema.spec.ts`
- `npm run precommit`