### PR TITLE
Batch ListView horizontal width measurement

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -359,9 +359,7 @@ export class ListView<T> implements IListView<T> {
 		this.domNode.classList.toggle('horizontal-scrolling', this._horizontalScrolling);
 
 		if (this._horizontalScrolling) {
-			for (const item of this.items) {
-				this.measureItemWidth(item);
-			}
+			this.measureItemWidths(this.items);
 
 			this.updateScrollWidth();
 			this.scrollableElement.setScrollDimensions({ width: getContentWidth(this.domNode) });
@@ -716,6 +714,7 @@ export class ListView<T> implements IListView<T> {
 		const unrenderedRestRanges = previousUnrenderedRestRanges.map(r => shift(r, delta));
 		const elementsRange = { start, end: start + elements.length };
 		const insertRanges = [elementsRange, ...unrenderedRestRanges].map(r => Range.intersect(renderRange, r)).reverse();
+		const insertedItems: IItem<T>[] = [];
 
 		for (const range of insertRanges) {
 			for (let i = range.end - 1; i >= range.start; i--) {
@@ -723,6 +722,7 @@ export class ListView<T> implements IListView<T> {
 				const rows = rowsToDispose.get(item.templateId);
 				const row = rows?.pop();
 				this.insertItemInDOM(i, row);
+				insertedItems.push(item);
 			}
 		}
 
@@ -730,6 +730,11 @@ export class ListView<T> implements IListView<T> {
 			for (const row of rows) {
 				this.cache.release(row);
 			}
+		}
+
+		if (this.horizontalScrolling && insertedItems.length > 0) {
+			this.measureItemWidths(insertedItems);
+			this.eventuallyUpdateScrollWidth();
 		}
 
 		this.eventuallyUpdateScrollDimensions();
@@ -787,7 +792,7 @@ export class ListView<T> implements IListView<T> {
 		}
 
 		const item = this.items[index];
-		this.measureItemWidth(item);
+		this.measureItemWidths([item]);
 
 		if (typeof item.width !== 'undefined' && item.width > this.scrollWidth) {
 			this.scrollWidth = item.width;
@@ -919,6 +924,8 @@ export class ListView<T> implements IListView<T> {
 			}
 		}
 
+		const insertedItems: IItem<T>[] = [];
+
 		this.cache.transact(() => {
 			for (const range of rangesToRemove) {
 				for (let i = range.start; i < range.end; i++) {
@@ -929,9 +936,15 @@ export class ListView<T> implements IListView<T> {
 			for (const range of rangesToInsert) {
 				for (let i = range.end - 1; i >= range.start; i--) {
 					this.insertItemInDOM(i);
+					insertedItems.push(this.items[i]);
 				}
 			}
 		});
+
+		if (this.horizontalScrolling && insertedItems.length > 0) {
+			this.measureItemWidths(insertedItems);
+			this.eventuallyUpdateScrollWidth();
+		}
 
 		if (renderLeft !== undefined) {
 			this.rowsContainer.style.left = `-${renderLeft}px`;
@@ -1005,30 +1018,37 @@ export class ListView<T> implements IListView<T> {
 			item.dragStartDisposable = addDisposableListener(item.row.domNode, 'dragstart', event => this.onDragStart(item.element, uri, event));
 		}
 
-		if (this.horizontalScrolling) {
-			this.measureItemWidth(item);
-			this.eventuallyUpdateScrollWidth();
-		}
 	}
 
-	private measureItemWidth(item: IItem<T>): void {
-		if (!item.row || !item.row.domNode) {
-			return;
+	private measureItemWidths(items: readonly IItem<T>[]): void {
+		const itemsWithRows: { item: IItem<T>; domNode: HTMLElement }[] = [];
+
+		for (const item of items) {
+			if (item.row) {
+				itemsWithRows.push({ item, domNode: item.row.domNode });
+			}
 		}
 
-		item.row.domNode.style.width = 'fit-content';
-		item.width = getContentWidth(item.row.domNode);
-		const style = getWindow(item.row.domNode).getComputedStyle(item.row.domNode);
-
-		if (style.paddingLeft) {
-			item.width += parseFloat(style.paddingLeft);
+		for (const { domNode } of itemsWithRows) {
+			domNode.style.width = 'fit-content';
 		}
 
-		if (style.paddingRight) {
-			item.width += parseFloat(style.paddingRight);
+		for (const { item, domNode } of itemsWithRows) {
+			item.width = getContentWidth(domNode);
+			const style = getWindow(domNode).getComputedStyle(domNode);
+
+			if (style.paddingLeft) {
+				item.width += parseFloat(style.paddingLeft);
+			}
+
+			if (style.paddingRight) {
+				item.width += parseFloat(style.paddingRight);
+			}
 		}
 
-		item.row.domNode.style.width = '';
+		for (const { domNode } of itemsWithRows) {
+			domNode.style.width = '';
+		}
 	}
 
 	private updateItemInDOM(item: IItem<T>, index: number): void {
@@ -1588,11 +1608,18 @@ export class ListView<T> implements IListView<T> {
 				}
 
 				const renderRanges = Range.relativeComplement(renderRange, previousRenderRange).reverse();
+				const insertedItems: IItem<T>[] = [];
 
 				for (const range of renderRanges) {
 					for (let i = range.end - 1; i >= range.start; i--) {
 						this.insertItemInDOM(i);
+						insertedItems.push(this.items[i]);
 					}
+				}
+
+				if (this.horizontalScrolling && insertedItems.length > 0) {
+					this.measureItemWidths(insertedItems);
+					this.eventuallyUpdateScrollWidth();
 				}
 
 				for (let i = renderRange.start; i < renderRange.end; i++) {

--- a/src/vs/base/test/browser/ui/list/listView.test.ts
+++ b/src/vs/base/test/browser/ui/list/listView.test.ts
@@ -41,6 +41,88 @@ suite('ListView', function () {
 		assert.strictEqual(templatesCount, 0, 'all templates have been disposed');
 	});
 
+	test('batches horizontal width measurements', function () {
+		const element = document.createElement('div');
+		element.style.height = '100px';
+		element.style.width = '200px';
+		document.body.appendChild(element);
+
+		const delegate: IListVirtualDelegate<number> = {
+			getHeight() { return 20; },
+			getTemplateId() { return 'template'; }
+		};
+
+		const rows: HTMLElement[] = [];
+		const widthReads: { renderedRows: number; fitContentRows: number }[] = [];
+		const renderer: IListRenderer<number, void> = {
+			templateId: 'template',
+			renderTemplate(container) {
+				const rowIndex = rows.length;
+				const paddingLeft = rowIndex;
+				const paddingRight = rowIndex * 2;
+				rows.push(container);
+				container.style.paddingLeft = `${paddingLeft}px`;
+				container.style.paddingRight = `${paddingRight}px`;
+				container.style.borderLeft = '1px solid';
+				container.style.borderRight = '2px solid';
+				Object.defineProperty(container, 'offsetWidth', {
+					configurable: true,
+					get: () => {
+						widthReads.push({
+							renderedRows: rows.length,
+							fitContentRows: rows.filter(row => row.style.width === 'fit-content').length
+						});
+						return 100 + rowIndex + paddingLeft + paddingRight + 3;
+					}
+				});
+			},
+			renderElement() { },
+			disposeTemplate() { }
+		};
+
+		const listView = new ListView<number>(element, delegate, [renderer], { horizontalScrolling: true });
+		try {
+			const expectedBatch = range(5).map(() => ({ renderedRows: 5, fitContentRows: 5 }));
+			const results: { phase: string; widthReads: typeof widthReads; contentWidth: number; rowWidths: string[] }[] = [];
+			listView.layout(100, 200);
+			listView.splice(0, 0, range(10));
+			results.push({
+				phase: 'splice',
+				widthReads: widthReads.slice(),
+				contentWidth: listView.contentWidth,
+				rowWidths: rows.map(row => row.style.width)
+			});
+
+			widthReads.length = 0;
+			listView.setScrollTop(100);
+			results.push({
+				phase: 'scroll',
+				widthReads: widthReads.slice(),
+				contentWidth: listView.contentWidth,
+				rowWidths: rows.map(row => row.style.width)
+			});
+
+			widthReads.length = 0;
+			listView.updateOptions({ horizontalScrolling: false });
+			listView.updateOptions({ horizontalScrolling: true });
+			results.push({
+				phase: 'enable',
+				widthReads: widthReads.slice(),
+				contentWidth: listView.contentWidth,
+				rowWidths: rows.map(row => row.style.width)
+			});
+
+			assert.deepStrictEqual(results, [
+				{ phase: 'splice', widthReads: expectedBatch, contentWidth: 0, rowWidths: ['', '', '', '', ''] },
+				{ phase: 'scroll', widthReads: expectedBatch, contentWidth: 0, rowWidths: ['', '', '', '', ''] },
+				{ phase: 'enable', widthReads: expectedBatch, contentWidth: 116, rowWidths: ['', '', '', '', ''] }
+			]);
+		} finally {
+			listView.dispose();
+			element.remove();
+		}
+	});
+
 	test('publishes freshly measured dynamic heights', function () {
 		const element = document.createElement('div');
 		element.style.height = '200px';


### PR DESCRIPTION
## Summary

- batch horizontal row width measurement into write, read, and reset phases
- apply batching to visible-row insertion, range scrolling, and runtime horizontal-scrolling enablement
- preserve per-row padding calculations, width caching, and deferred scroll-width updates

The dynamic-height probe remains separate; `ListView` rejects combining dynamic heights with horizontal scrolling.

## Verification

- added a deterministic `ListView` test proving all five `fit-content` writes precede all five `offsetWidth` reads for splice, scroll/reuse, and enablement paths
- verified per-row padding arithmetic and row-width resets
- `npm run typecheck-client`
- targeted `ListView` unit suite
- `npm run valid-layers-check`
- staged pre-commit hygiene

Fixes #326639

cc @roblourens