### PR TITLE
Batch action list width measurements

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -1391,16 +1391,7 @@ export class ActionListWidget<T> extends Disposable {
 			}
 			this._list.layout(allItemsHeight);
 
-			const itemWidths: number[] = [];
-			for (let i = 0; i < allItems.length; i++) {
-				const element = this._getRowElement(i);
-				if (element) {
-					element.style.width = 'auto';
-					const width = element.getBoundingClientRect().width;
-					element.style.width = '';
-					itemWidths.push(width + this._computeToolbarWidth(allItems[i]));
-				}
-			}
+			const itemWidths = this._measureItemWidths(allItems);
 
 			maxWidth = clamp(Math.max(...itemWidths));
 
@@ -1410,16 +1401,11 @@ export class ActionListWidget<T> extends Disposable {
 		}
 
 		// All items are visible, measure them directly
-		const itemWidths: number[] = [];
+		const visibleItems: IActionListItem<T>[] = [];
 		for (let i = 0; i < visibleCount; i++) {
-			const element = this._getRowElement(i);
-			if (element) {
-				element.style.width = 'auto';
-				const width = element.getBoundingClientRect().width;
-				element.style.width = '';
-				itemWidths.push(width + this._computeToolbarWidth(this._list.element(i)));
-			}
+			visibleItems.push(this._list.element(i));
 		}
+		const itemWidths = this._measureItemWidths(visibleItems);
 		return clamp(Math.max(...itemWidths));
 	}
 
@@ -1610,6 +1596,25 @@ export class ActionListWidget<T> extends Disposable {
 			if (item.kind === ActionListItemKind.Action && item.group?.title && !seenTitles.has(item.group.title)) {
 				seenTitles.add(item.group.title);
 				this._groupTitleByIndex.set(i, item.group.title);
+			}
+		}
+	}
+
+	private _measureItemWidths(items: readonly IActionListItem<T>[]): number[] {
+		const rows: { element: HTMLElement; item: IActionListItem<T> }[] = [];
+		for (let i = 0; i < items.length; i++) {
+			const element = this._getRowElement(i);
+			if (element) {
+				element.style.width = 'auto';
+				rows.push({ element, item: items[i] });
+			}
+		}
+
+		try {
+			return rows.map(({ element, item }) => element.getBoundingClientRect().width + this._computeToolbarWidth(item));
+		} finally {
+			for (const { element } of rows) {
+				element.style.width = '';
 			}
 		}
 	}

--- a/src/vs/platform/actionWidget/test/browser/actionList.test.ts
+++ b/src/vs/platform/actionWidget/test/browser/actionList.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { mainWindow } from '../../../../base/browser/window.js';
+import { toAction } from '../../../../base/common/actions.js';
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event as CommonEvent } from '../../../../base/common/event.js';
@@ -200,6 +201,37 @@ suite('ActionListWidget', () => {
 		secondResult.complete([action('ma-fresh-result')]);
 		await timeout(0);
 		assert.ok(widget.domNode.textContent?.includes('ma-fresh-result'));
+	});
+
+	test('batches row width writes before reading layout', () => {
+		const widget = createActionListWidget(disposables, {
+			items: [
+				action('first'),
+				{ ...action('second'), toolbarActions: [toAction({ id: 'toolbar', label: 'Toolbar', run: () => { } })] },
+				action('third'),
+			],
+		});
+		const rows = Array.from(widget.domNode.querySelectorAll<HTMLElement>('.monaco-list-row'));
+		const allRowsAutoAtRead: boolean[] = [];
+		const measuredWidths = [120, 240, 180];
+		for (let i = 0; i < rows.length; i++) {
+			rows[i].getBoundingClientRect = () => {
+				allRowsAutoAtRead.push(rows.every(row => row.style.width === 'auto'));
+				return new mainWindow.DOMRect(0, 0, measuredWidths[i], 24);
+			};
+		}
+
+		const width = widget.computeMaxWidth(0);
+
+		assert.deepStrictEqual({
+			width,
+			allRowsAutoAtRead,
+			restoredWidths: rows.map(row => row.style.width),
+		}, {
+			width: 268,
+			allRowsAutoAtRead: [true, true, true],
+			restoredWidths: ['', '', ''],
+		});
 	});
 
 	test('keeps titled separator above first filtered match', () => {


### PR DESCRIPTION
## Summary

- batch action-list row width writes, geometry reads, and restores into three phases
- preserve the row-to-item mapping used for toolbar-width accounting in visible and temporarily expanded hidden-item paths
- add regression coverage for measurement ordering, toolbar accounting, and width restoration

## Performance

Chromium CDP instrumentation over 49 representative rows and 200 measurement passes:

| Implementation | Layouts | Style recalculations | Duration |
| --- | ---: | ---: | ---: |
| Alternating write/read/write | 9,801 | 9,801 | 110.2 ms |
| Batched write/read/write | 2 | 201 | 7.5 ms |

Measured row widths were identical.

## Validation

- `npm run typecheck-client -- --pretty false`
- `./scripts/test.sh --run src/vs/platform/actionWidget/test/browser/actionList.test.ts`
- `npm run valid-layers-check`
- `npm run precommit`

Fixes #326640

cc @sandy081