### PR TITLE
Avoid layout reads while dragging Issue Reporter bar

### DIFF
--- a/src/vs/workbench/contrib/issue/browser/issueReporterOverlay.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterOverlay.ts
@@ -7,7 +7,7 @@ import { KeybindingLabel } from '../../../../base/browser/ui/keybindingLabel/key
 import { ResolvedKeybinding } from '../../../../base/common/keybindings.js';
 import { OS } from '../../../../base/common/platform.js';
 import './media/issueReporterOverlay.css';
-import { $, addDisposableListener, append, disposableWindowInterval, EventType, getWindow } from '../../../../base/browser/dom.js';
+import { $, addDisposableListener, append, DisposableResizeObserver, disposableWindowInterval, EventType, getWindow } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Button } from '../../../../base/browser/ui/button/button.js';
 import { IContextMenuProvider } from '../../../../base/browser/contextmenu.js';
@@ -20,7 +20,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
-import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { IMarkdownRendererService } from '../../../../platform/markdown/browser/markdownRenderer.js';
 import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
@@ -41,6 +41,17 @@ interface ISimilarIssue {
 	readonly html_url: string;
 	readonly title: string;
 	readonly state?: string;
+}
+
+interface IFloatingBarDragState {
+	readonly pointerStartX: number;
+	readonly pointerStartY: number;
+	readonly barStartX: number;
+	readonly barStartY: number;
+	pointerX: number;
+	pointerY: number;
+	barWidth: number;
+	barHeight: number;
 }
 
 const enum WizardStep {
@@ -154,6 +165,7 @@ export class IssueReporterOverlay {
 	private readonly model: IssueReporterModel;
 	private visible = false;
 	private floatingBar: HTMLElement | undefined;
+	private floatingBarDragState: IFloatingBarDragState | undefined;
 	private previewOpened = false;
 	private previewedDraftKey: string | undefined;
 	private closeButton: Button | undefined;
@@ -173,6 +185,7 @@ export class IssueReporterOverlay {
 		private readonly refreshPerformanceInfo?: () => Promise<void>,
 		/** Returns the user's currently-bound keybinding for the given command id, or undefined when unbound. */
 		private readonly resolveKeybinding?: (commandId: string) => ResolvedKeybinding | undefined,
+		private readonly resizeObserverCtor?: typeof ResizeObserver,
 	) {
 		this._hideToolbarInScreenshots = initialHideToolbar;
 		const hasStandaloneExtensionData = !!data.data && !data.extensionId;
@@ -428,42 +441,59 @@ export class IssueReporterOverlay {
 
 		mountTarget.appendChild(this.floatingBar);
 
-		// Dragging (clamped to window bounds)
-		let dragStartX = 0;
-		let dragStartY = 0;
-		let barStartX = 0;
-		let barStartY = 0;
-
 		const onPointerMove = (e: PointerEvent) => {
-			const dx = e.clientX - dragStartX;
-			const dy = e.clientY - dragStartY;
-			const barW = this.floatingBar!.offsetWidth;
-			const barH = this.floatingBar!.offsetHeight;
-			const maxX = targetWindow.innerWidth - barW;
-			const maxY = targetWindow.innerHeight - barH;
-			const newX = Math.max(0, Math.min(barStartX + dx, maxX));
-			const newY = Math.max(0, Math.min(barStartY + dy, maxY));
-			this.floatingBar!.style.left = `${newX}px`;
-			this.floatingBar!.style.top = `${newY}px`;
-			this.floatingBar!.style.right = 'auto';
+			if (!this.floatingBarDragState) {
+				return;
+			}
+			this.floatingBarDragState.pointerX = e.clientX;
+			this.floatingBarDragState.pointerY = e.clientY;
+			this.updateFloatingBarDragPosition();
 		};
 
+		const dragListeners = this.disposables.add(new MutableDisposable<DisposableStore>());
 		const onPointerUp = () => {
 			dragArea.classList.remove('dragged');
-			targetWindow.document.removeEventListener('pointermove', onPointerMove);
-			targetWindow.document.removeEventListener('pointerup', onPointerUp);
+			this.floatingBarDragState = undefined;
+			dragListeners.clear();
 		};
 
 		this.disposables.add(addDisposableListener(dragArea, EventType.POINTER_DOWN, (e: PointerEvent) => {
 			e.preventDefault();
+			onPointerUp();
 			dragArea.classList.add('dragged');
-			dragStartX = e.clientX;
-			dragStartY = e.clientY;
 			const rect = this.floatingBar!.getBoundingClientRect();
-			barStartX = rect.left;
-			barStartY = rect.top;
-			targetWindow.document.addEventListener('pointermove', onPointerMove);
-			targetWindow.document.addEventListener('pointerup', onPointerUp);
+			const dragWindow = getWindow(this.floatingBar!);
+			this.floatingBarDragState = {
+				pointerStartX: e.clientX,
+				pointerStartY: e.clientY,
+				barStartX: rect.left,
+				barStartY: rect.top,
+				pointerX: e.clientX,
+				pointerY: e.clientY,
+				barWidth: rect.width,
+				barHeight: rect.height,
+			};
+			this.floatingBar!.style.right = 'auto';
+			const listeners = new DisposableStore();
+			listeners.add(addDisposableListener(dragWindow.document, EventType.POINTER_MOVE, onPointerMove));
+			listeners.add(addDisposableListener(dragWindow.document, EventType.POINTER_UP, onPointerUp));
+			listeners.add(addDisposableListener(dragWindow.document, 'pointercancel', onPointerUp));
+			const resizeObserver = listeners.add(new DisposableResizeObserver('IssueReporterOverlay.floatingBarDrag', entries => {
+				const entry = entries.find(entry => entry.target === this.floatingBar);
+				if (!entry || !this.floatingBarDragState) {
+					return;
+				}
+				const size = entry.borderBoxSize[0];
+				if (size) {
+					this.floatingBarDragState.barWidth = size.inlineSize;
+					this.floatingBarDragState.barHeight = size.blockSize;
+					this.updateFloatingBarDragPosition();
+				} else {
+					this.refreshFloatingBarDragGeometry();
+				}
+			}, dragWindow, { resizeObserverCtor: this.resizeObserverCtor }));
+			listeners.add(resizeObserver.observe(this.floatingBar!, { box: 'border-box' }));
+			dragListeners.value = listeners;
 		}));
 
 		// Keep the bar fully within the visible viewport when the window is
@@ -476,6 +506,10 @@ export class IssueReporterOverlay {
 				return;
 			}
 			const rect = this.floatingBar.getBoundingClientRect();
+			if (this.floatingBarDragState) {
+				this.floatingBarDragState.barWidth = rect.width;
+				this.floatingBarDragState.barHeight = rect.height;
+			}
 			const winW = targetWindow.innerWidth;
 			const winH = targetWindow.innerHeight;
 			const margin = 8;
@@ -509,6 +543,30 @@ export class IssueReporterOverlay {
 		this.disposables.add(toDisposable(() => {
 			this.floatingBar?.remove();
 		}));
+	}
+
+	private updateFloatingBarDragPosition(): void {
+		if (!this.floatingBar || !this.floatingBarDragState) {
+			return;
+		}
+		const targetWindow = getWindow(this.floatingBar);
+		const state = this.floatingBarDragState;
+		const maxX = targetWindow.innerWidth - state.barWidth;
+		const maxY = targetWindow.innerHeight - state.barHeight;
+		const newX = Math.max(0, Math.min(state.barStartX + state.pointerX - state.pointerStartX, maxX));
+		const newY = Math.max(0, Math.min(state.barStartY + state.pointerY - state.pointerStartY, maxY));
+		this.floatingBar.style.left = `${newX}px`;
+		this.floatingBar.style.top = `${newY}px`;
+	}
+
+	private refreshFloatingBarDragGeometry(): void {
+		if (!this.floatingBar || !this.floatingBarDragState) {
+			return;
+		}
+		const rect = this.floatingBar.getBoundingClientRect();
+		this.floatingBarDragState.barWidth = rect.width;
+		this.floatingBarDragState.barHeight = rect.height;
+		this.updateFloatingBarDragPosition();
 	}
 
 	private updateCaptureStripVisibility(): void {
@@ -2552,6 +2610,7 @@ ${rows.map(row => row.map(value => this.escapeMarkdownTableCell(value ?? '')).jo
 
 		this.updateScreenshotThumbnails();
 		this.updateAttachmentButtons();
+		this.refreshFloatingBarDragGeometry();
 	}
 
 	addRecording(filePath: string, durationMs: number, thumbnailDataUrl?: string): void {

--- a/src/vs/workbench/contrib/issue/test/browser/issueReporterOverlay.test.ts
+++ b/src/vs/workbench/contrib/issue/test/browser/issueReporterOverlay.test.ts
@@ -4,10 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { mainWindow } from '../../../../../base/browser/window.js';
 import { IContextViewDelegate, IContextViewService, IOpenContextView } from '../../../../../platform/contextview/browser/contextView.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { extractIssueData } from '../../browser/issueFormService.js';
 import { IssueReporterOverlay } from '../../browser/issueReporterOverlay.js';
+import { RecordingState } from '../../browser/recordingService.js';
 import { IssueSource, IssueType } from '../../common/issue.js';
 
 const nesContext = `# Inline Edits Debug Info
@@ -31,6 +33,45 @@ stest({ description: 'NES feedback' });
 { "kind": "changed" }
 \`\`\`
 </details>`;
+
+interface IFakeResizeObserver {
+	readonly ctor: typeof ResizeObserver;
+	fire(target: Element, width: number, height: number): void;
+}
+
+function createFakeResizeObserver(): IFakeResizeObserver {
+	let callback: ResizeObserverCallback | undefined;
+	let observer: ResizeObserver | undefined;
+	class FakeResizeObserver implements ResizeObserver {
+		constructor(observerCallback: ResizeObserverCallback) {
+			callback = observerCallback;
+			observer = this;
+		}
+		observe(): void { }
+		unobserve(): void { }
+		disconnect(): void { }
+	}
+	return {
+		ctor: FakeResizeObserver,
+		fire: (target, width, height) => {
+			if (!callback || !observer) {
+				throw new Error('Resize observer not constructed');
+			}
+			const size: ResizeObserverSize = { inlineSize: width, blockSize: height };
+			callback([{
+				target,
+				borderBoxSize: [size],
+				contentBoxSize: [size],
+				devicePixelContentBoxSize: [size],
+				contentRect: target.getBoundingClientRect(),
+			}], observer);
+		},
+	};
+}
+
+function createPointerEvent(type: string, clientX: number, clientY: number): PointerEvent {
+	return new PointerEvent(type, { bubbles: true, clientX, clientY });
+}
 
 class TestContextViewService implements IContextViewService {
 	declare readonly _serviceBrand: undefined;
@@ -58,6 +99,45 @@ class TestContextViewService implements IContextViewService {
 
 suite('IssueReporterOverlay', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createDragOverlay(recordingSupported = false): {
+		overlay: IssueReporterOverlay;
+		resizeObserver: IFakeResizeObserver;
+		floatingBar: HTMLElement;
+		dragArea: HTMLElement;
+	} {
+		const resizeObserver = createFakeResizeObserver();
+		const container = document.createElement('div');
+		const overlay = store.add(new IssueReporterOverlay(
+			{
+				styles: {},
+				zoomLevel: 0,
+				enabledExtensions: [],
+				restrictedMode: false,
+				isInstallationPure: true,
+				isSessionsWindow: false,
+				githubAccessToken: '',
+			},
+			recordingSupported,
+			container,
+			new TestContextViewService(),
+			undefined,
+			undefined,
+			true,
+			undefined,
+			undefined,
+			false,
+			undefined,
+			undefined,
+			resizeObserver.ctor,
+		));
+		const floatingBar = mainWindow.document.querySelector<HTMLElement>('.issue-reporter-floating-bar');
+		const dragArea = floatingBar?.querySelector<HTMLElement>('.wizard-floating-drag');
+		if (!floatingBar || !dragArea) {
+			throw new Error('Floating bar not found');
+		}
+		return { overlay, resizeObserver, floatingBar, dragArea };
+	}
 
 	test('includes standalone extension data in a VS Code issue', () => {
 		const container = document.createElement('div');
@@ -143,6 +223,86 @@ ${extensionDataSection}
 
 ${systemInfoSection}
 `,
+		});
+	});
+
+	test('drags and clamps without measuring geometry on pointer move', () => {
+		const { floatingBar, dragArea } = createDragOverlay();
+		let geometryReads = 0;
+		floatingBar.getBoundingClientRect = () => {
+			geometryReads++;
+			return DOMRect.fromRect({ x: 100, y: 50, width: 200, height: 40 });
+		};
+
+		dragArea.dispatchEvent(createPointerEvent('pointerdown', 110, 60));
+		document.dispatchEvent(createPointerEvent('pointermove', mainWindow.innerWidth + 100, mainWindow.innerHeight + 100));
+		document.dispatchEvent(createPointerEvent('pointermove', mainWindow.innerWidth + 200, mainWindow.innerHeight + 200));
+		document.dispatchEvent(createPointerEvent('pointerup', mainWindow.innerWidth + 200, mainWindow.innerHeight + 200));
+
+		assert.deepStrictEqual({
+			left: floatingBar.style.left,
+			top: floatingBar.style.top,
+			right: floatingBar.style.right,
+			geometryReads,
+		}, {
+			left: `${mainWindow.innerWidth - 200}px`,
+			top: `${mainWindow.innerHeight - 40}px`,
+			right: 'auto',
+			geometryReads: 1,
+		});
+	});
+
+	test('reclamps a drag when observed bar size grows and shrinks', () => {
+		const { resizeObserver, floatingBar, dragArea } = createDragOverlay();
+		floatingBar.getBoundingClientRect = () => DOMRect.fromRect({ x: 100, y: 50, width: 200, height: 40 });
+
+		dragArea.dispatchEvent(createPointerEvent('pointerdown', 110, 60));
+		document.dispatchEvent(createPointerEvent('pointermove', mainWindow.innerWidth + 100, mainWindow.innerHeight + 100));
+		resizeObserver.fire(floatingBar, 300, 60);
+		const grownPosition = { left: floatingBar.style.left, top: floatingBar.style.top };
+		resizeObserver.fire(floatingBar, 120, 30);
+		const shrunkPosition = { left: floatingBar.style.left, top: floatingBar.style.top };
+		document.dispatchEvent(createPointerEvent('pointerup', mainWindow.innerWidth + 100, mainWindow.innerHeight + 100));
+
+		assert.deepStrictEqual({ grownPosition, shrunkPosition }, {
+			grownPosition: {
+				left: `${mainWindow.innerWidth - 300}px`,
+				top: `${mainWindow.innerHeight - 60}px`,
+			},
+			shrunkPosition: {
+				left: `${mainWindow.innerWidth - 120}px`,
+				top: `${mainWindow.innerHeight - 30}px`,
+			},
+		});
+	});
+
+	test('refreshes drag geometry synchronously when recording state changes', () => {
+		const { overlay, floatingBar, dragArea } = createDragOverlay(true);
+		let barWidth = 200;
+		let barHeight = 40;
+		floatingBar.getBoundingClientRect = () => DOMRect.fromRect({ x: 100, y: 50, width: barWidth, height: barHeight });
+
+		dragArea.dispatchEvent(createPointerEvent('pointerdown', 110, 60));
+		document.dispatchEvent(createPointerEvent('pointermove', mainWindow.innerWidth + 100, mainWindow.innerHeight + 100));
+		barWidth = 300;
+		barHeight = 60;
+		overlay.setRecordingState(RecordingState.Recording);
+		const recordingPosition = { left: floatingBar.style.left, top: floatingBar.style.top };
+		barWidth = 120;
+		barHeight = 30;
+		overlay.setRecordingState(RecordingState.Idle);
+		const idlePosition = { left: floatingBar.style.left, top: floatingBar.style.top };
+		document.dispatchEvent(createPointerEvent('pointerup', mainWindow.innerWidth + 100, mainWindow.innerHeight + 100));
+
+		assert.deepStrictEqual({ recordingPosition, idlePosition }, {
+			recordingPosition: {
+				left: `${mainWindow.innerWidth - 300}px`,
+				top: `${mainWindow.innerHeight - 60}px`,
+			},
+			idlePosition: {
+				left: `${mainWindow.innerWidth - 120}px`,
+				top: `${mainWindow.innerHeight - 30}px`,
+			},
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- cache floating capture bar geometry for each pointer gesture
- refresh cached dimensions on recording-state transitions and border-box resize notifications
- clean up drag listeners on pointer up, pointer cancel, repeated pointer down, and disposal
- cover normal clamping and mid-drag growth/shrink

## Validation
- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/issue/test/browser/issueReporterOverlay.test.ts`
- `npm run valid-layers-check`
- `npm run precommit`

Fixes #326658

cc @Giuspepe