### PR TITLE
Prompt to disable redundant VS Code Speech extension when built-in dictation is available

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -103,6 +103,7 @@ import { registerChatDeveloperActions } from './actions/chatDeveloperActions.js'
 import { registerChatExecuteActions } from './actions/chatExecuteActions.js';
 import { registerChatSpeechToTextActions } from './actions/chatSpeechToTextActions.js';
 import { ChatSpeechToTextService, IChatSpeechToTextService } from './speechToText/chatSpeechToTextService.js';
+import { RedundantDictationExtensionNotifier } from './speechToText/redundantDictationExtensionNotifier.js';
 import { registerChatFileTreeActions } from './actions/chatFileTreeActions.js';
 import { ChatGettingStartedContribution } from './actions/chatGettingStarted.js';
 import { registerChatExportActions } from './actions/chatImportExport.js';
@@ -2732,6 +2733,7 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 
 registerWorkbenchContribution2(CopilotTelemetryContribution.ID, CopilotTelemetryContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatSpeechToTextInitContribution.ID, ChatSpeechToTextInitContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(RedundantDictationExtensionNotifier.ID, RedundantDictationExtensionNotifier, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(ChatResolverContribution.ID, ChatResolverContribution, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(ChatDebugResolverContribution.ID, ChatDebugResolverContribution, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(PromptsDebugContribution.ID, PromptsDebugContribution, WorkbenchPhase.BlockRestore);

--- a/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
@@ -89,7 +89,7 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 		const displayName = extension.displayName || extension.identifier.id;
 		this.notificationService.prompt(
 			Severity.Info,
-			localize('redundantDictationExtension', "VS Code now has built-in dictation, so the '{0}' extension is no longer needed. Disable it?", displayName),
+			localize('redundantDictationExtension', "VS Code now has built-in dictation. Disable the '{0}' extension to avoid conflicts?", displayName),
 			[
 				{
 					label: localize('disableExtension', "Disable Extension"),

--- a/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { ILocalTranscriptionService } from '../../../../../platform/localTranscription/common/localTranscription.js';
+import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { EnablementState } from '../../../../services/extensionManagement/common/extensionManagement.js';
+import { IExtension, IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
+
+/**
+ * When on-device chat dictation is supported on the current platform, the
+ * third-party VS Code Speech extension is redundant. This contribution shows a
+ * one-time notification prompting the user to disable it, but only when:
+ *   1. the platform supports built-in dictation (`ILocalTranscriptionService.isSupported`,
+ *      the same predicate that shows/hides the built-in mic button), and
+ *   2. the extension is installed and currently enabled.
+ * The prompt is shown at most once ever (guarded by an application-scoped storage flag).
+ */
+export class RedundantDictationExtensionNotifier implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.redundantDictationExtensionNotifier';
+
+	/** Identifier of the extension made redundant by built-in dictation. */
+	private static readonly EXTENSION_ID = 'ms-vscode.vscode-speech';
+
+	/** Application-scoped flag so the prompt fires at most once per machine. */
+	private static readonly STORAGE_KEY = 'chat.dictation.redundantExtensionPromptShown';
+
+	constructor(
+		@ILocalTranscriptionService private readonly localTranscriptionService: ILocalTranscriptionService,
+		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@IStorageService private readonly storageService: IStorageService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		this.check();
+	}
+
+	private async check(): Promise<void> {
+		// (1) Only on platforms where built-in dictation actually works.
+		if (!this.localTranscriptionService.isSupported) {
+			return;
+		}
+
+		// (1b) Only when built-in dictation is actually enabled, so we never suggest
+		// disabling a working extension before its replacement is turned on.
+		if (this.configurationService.getValue<boolean>('chat.speechToText.enabled') !== true) {
+			return;
+		}
+
+		// (3) Only ever prompt once.
+		if (this.storageService.getBoolean(RedundantDictationExtensionNotifier.STORAGE_KEY, StorageScope.APPLICATION, false)) {
+			return;
+		}
+
+		// (2) Only when the extension is installed and currently enabled.
+		let extension: IExtension | undefined;
+		try {
+			const installed = await this.extensionsWorkbenchService.queryLocal();
+			extension = installed.find(e => ExtensionIdentifier.equals(e.identifier.id, RedundantDictationExtensionNotifier.EXTENSION_ID));
+		} catch (error) {
+			this.logService.error('[dictation] failed to query installed extensions for redundant dictation prompt', error);
+			return;
+		}
+
+		if (!extension) {
+			return;
+		}
+
+		const isEnabled =
+			extension.enablementState === EnablementState.EnabledGlobally ||
+			extension.enablementState === EnablementState.EnabledWorkspace ||
+			extension.enablementState === EnablementState.EnabledByEnvironment;
+		if (!isEnabled) {
+			return;
+		}
+
+		// Guard now so the prompt is shown at most once regardless of the outcome.
+		this.markShown();
+
+		const displayName = extension.displayName || extension.identifier.id;
+		this.notificationService.prompt(
+			Severity.Info,
+			localize('redundantDictationExtension', "VS Code now has built-in dictation, so the '{0}' extension is no longer needed. Disable it?", displayName),
+			[
+				{
+					label: localize('disableExtension', "Disable Extension"),
+					run: async () => {
+						try {
+							await this.extensionsWorkbenchService.setEnablement(extension!, EnablementState.DisabledGlobally);
+						} catch (error) {
+							this.logService.error('[dictation] failed to disable redundant dictation extension', error);
+						}
+					}
+				},
+				{
+					label: localize('keepExtension', "Keep"),
+					run: () => { }
+				}
+			]
+		);
+	}
+
+	private markShown(): void {
+		this.storageService.store(RedundantDictationExtensionNotifier.STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
@@ -10,9 +10,20 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ILocalTranscriptionService } from '../../../../../platform/localTranscription/common/localTranscription.js';
 import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { EnablementState } from '../../../../services/extensionManagement/common/extensionManagement.js';
 import { IExtension, IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
+
+type RedundantDictationExtensionPromptEvent = {
+	action: string;
+};
+
+type RedundantDictationExtensionPromptClassification = {
+	action: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The user response to the prompt: shown, disable, keep, or dismissed.' };
+	owner: 'meganrogge';
+	comment: 'Tracks how users respond to the prompt suggesting they disable the redundant VS Code Speech extension once built-in dictation is available.';
+};
 
 /**
  * When on-device chat dictation is supported on the current platform, the
@@ -40,6 +51,7 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 		@IStorageService private readonly storageService: IStorageService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ILogService private readonly logService: ILogService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		this.check();
 	}
@@ -85,6 +97,7 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 
 		// Guard now so the prompt is shown at most once regardless of the outcome.
 		this.markShown();
+		this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'shown' });
 
 		const displayName = extension.displayName || extension.identifier.id;
 		this.notificationService.prompt(
@@ -94,6 +107,7 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 				{
 					label: localize('disableExtension', "Disable Extension"),
 					run: async () => {
+						this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'disable' });
 						try {
 							await this.extensionsWorkbenchService.setEnablement(extension!, EnablementState.DisabledGlobally);
 						} catch (error) {
@@ -103,9 +117,16 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 				},
 				{
 					label: localize('keepExtension', "Keep"),
-					run: () => { }
+					run: () => {
+						this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'keep' });
+					}
 				}
-			]
+			],
+			{
+				onCancel: () => {
+					this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'dismissed' });
+				}
+			}
 		);
 	}
 


### PR DESCRIPTION
## Summary

Adds a one-time notification suggesting users disable the [`ms-vscode.vscode-speech`](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-speech) extension once VS Code's built-in on-device chat dictation makes it redundant.

New workbench contribution `RedundantDictationExtensionNotifier` (registered at `WorkbenchPhase.Eventually`) shows the prompt **only when all** of the following hold:

1. **Platform supports built-in dictation** — `ILocalTranscriptionService.isSupported`, the same predicate that shows/hides the built-in mic button (false on macOS Intel, unsupported Linux archs, web, remote — no new platform logic).
2. **Built-in dictation is enabled** — `chat.speechToText.enabled === true`, so we never suggest disabling a working extension before its replacement is turned on.
3. **Extension installed & enabled** — via `IExtensionsWorkbenchService.queryLocal()` + positive `enablementState` check.
4. **Never shown before** — application-scoped `IStorageService` flag, set the moment the prompt appears, so it fires at most once ever regardless of the user's choice.

### Prompt

> VS Code now has built-in dictation, so the 'VS Code Speech' extension is no longer needed. Disable it?

- **Disable Extension** → `setEnablement(ext, EnablementState.DisabledGlobally)`
- **Keep** → dismiss

## Testing

- `npm run typecheck-client` — 0 errors.
- Manual: on a supported platform with the extension installed and `chat.speechToText.enabled` on, the prompt appears once; choosing *Disable Extension* disables it; the prompt does not reappear after restart.