### PR TITLE
ah: fix client tool call confirmations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -277,11 +277,17 @@ function getClientToolPreApproval(toolCall: ToolCallState): ConfirmedReason | un
 		return { type: ToolConfirmKind.Setting, id: SessionConfigKey.AutoApprove };
 	}
 
+	// Only trust `Running` and `AuthRequired` as evidence of a genuine
+	// approval: they can only be entered after the agent host confirmed the
+	// call, so their `confirmed` reason is authoritative. `Completed` and
+	// `PendingResultConfirmation` are excluded because the reducer
+	// synthesizes a `NotNeeded` confirmation when a `ChatToolCallComplete`
+	// arrives while the call is still `PendingConfirmation`, which would
+	// otherwise let us falsely confirm and execute a call that was never
+	// approved.
 	switch (toolCall.status) {
 		case ToolCallStatus.Running:
 		case ToolCallStatus.AuthRequired:
-		case ToolCallStatus.PendingResultConfirmation:
-		case ToolCallStatus.Completed:
 			switch (toolCall.confirmed) {
 				case ToolCallConfirmationReason.NotNeeded:
 					return { type: ToolConfirmKind.ConfirmationNotNeeded };

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -272,8 +272,27 @@ function confirmedReasonToProtocol(reason: ConfirmedReason | undefined): ToolCal
 	}
 }
 
-function shouldAutoApproveClientToolCall(toolCall: ToolCallState): boolean {
-	return readToolCallMeta(toolCall).autoApproveBySetting === true;
+function getClientToolPreApproval(toolCall: ToolCallState): ConfirmedReason | undefined {
+	if (readToolCallMeta(toolCall).autoApproveBySetting === true) {
+		return { type: ToolConfirmKind.Setting, id: SessionConfigKey.AutoApprove };
+	}
+
+	switch (toolCall.status) {
+		case ToolCallStatus.Running:
+		case ToolCallStatus.AuthRequired:
+		case ToolCallStatus.PendingResultConfirmation:
+		case ToolCallStatus.Completed:
+			switch (toolCall.confirmed) {
+				case ToolCallConfirmationReason.NotNeeded:
+					return { type: ToolConfirmKind.ConfirmationNotNeeded };
+				case ToolCallConfirmationReason.Setting:
+					return { type: ToolConfirmKind.Setting, id: SessionConfigKey.AutoApprove };
+				case ToolCallConfirmationReason.UserAction:
+					return { type: ToolConfirmKind.UserAction };
+			}
+	}
+
+	return undefined;
 }
 
 /**
@@ -2757,8 +2776,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		store.add(autorun(reader => {
 			const state = invocation.state.read(reader);
 			const tc = part$.read(reader).toolCall;
-			if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation && shouldAutoApproveClientToolCall(tc)) {
-				state.confirm({ type: ToolConfirmKind.Setting, id: SessionConfigKey.AutoApprove });
+			const preApproval = getClientToolPreApproval(tc);
+			if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation && preApproval) {
+				state.confirm(preApproval);
 				return;
 			}
 			if (confirmationDispatched) {
@@ -2830,8 +2850,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		store.add(autorun(reader => {
 			const tc = part$.read(reader).toolCall;
 			const state = invocation.state.read(reader);
-			if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation && shouldAutoApproveClientToolCall(tc)) {
-				state.confirm({ type: ToolConfirmKind.Setting, id: SessionConfigKey.AutoApprove });
+			const preApproval = getClientToolPreApproval(tc);
+			if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation && preApproval) {
+				state.confirm(preApproval);
 			}
 			if (tc.status === ToolCallStatus.Cancelled || tc.status === ToolCallStatus.Completed) {
 				// The protocol tool call reached a terminal state. If this was
@@ -2902,9 +2923,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				// pass it through so the invocation transitions straight to
 				// executing instead of briefly flashing a confirmation prompt
 				// (which would flicker "needs input" in the sessions list).
-				preApproved: shouldAutoApproveClientToolCall(tc)
-					? { type: ToolConfirmKind.Setting, id: SessionConfigKey.AutoApprove }
-					: undefined,
+				preApproved: getClientToolPreApproval(tc),
 			};
 			const noOpCountTokens = async () => 0;
 			this._logService.info(`[AgentHost] Invoking client tool: ${toolName} (callId=${toolCallId})`);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -260,7 +260,7 @@ suite('AgentHostClientTools', () => {
 				getTools: () => tools,
 				getAllToolsIncludingDisabled: () => tools,
 				getTool: (id: string) => tools.find(t => t.id === id),
-				invokeTool: async (invocation: IToolInvocation) => {
+				invokeTool: async (invocation: IToolInvocation, _countTokens, token?: CancellationToken) => {
 					invokedToolCalls.push(invocation);
 					const toolInvocation = pendingToolCalls.get(invocation.chatStreamToolCallId ?? invocation.callId);
 					pendingToolCalls.delete(invocation.chatStreamToolCallId ?? invocation.callId);
@@ -279,7 +279,18 @@ suite('AgentHostClientTools', () => {
 								message: 'Run the task?',
 							},
 						}, invocation.parameters, invocation.preApproved);
-						await IChatToolInvocation.awaitConfirmation(toolInvocation, CancellationToken.None);
+						const confirmed = await IChatToolInvocation.awaitConfirmation(toolInvocation, token ?? CancellationToken.None);
+						// Mirror the real service: a cancelled/denied confirmation
+						// aborts execution instead of producing a result. A token
+						// cancellation resolves as `Denied`, so move the still-waiting
+						// invocation to a terminal state and reject.
+						if (confirmed.type === ToolConfirmKind.Denied || confirmed.type === ToolConfirmKind.Skipped) {
+							const state = toolInvocation.state.get();
+							if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation) {
+								state.confirm(confirmed);
+							}
+							throw new CancellationError();
+						}
 					} else {
 						toolInvocation?.transitionFromStreaming(undefined, invocation.parameters, { type: ToolConfirmKind.ConfirmationNotNeeded });
 					}
@@ -926,6 +937,130 @@ suite('AgentHostClientTools', () => {
 					sawWaitingForConfirmation: false,
 				},
 			);
+		});
+
+		async function reachLocalWaitingForConfirmation(handler: AgentHostSessionHandler, connection: MockAgentHostConnection): Promise<URI> {
+			const sessionResource = URI.parse('agent-host-copilot:/session-1');
+			const backendSession = AgentSession.uri('copilot', 'session-1').toString();
+			const chatURI = URI.parse(buildDefaultChatUri(backendSession));
+
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text: 'run the task', origin: { kind: MessageKind.User } },
+			} as ChatAction);
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: connection.clientId },
+			} as ChatAction);
+			// No `confirmed` and no auto-approve metadata: the protocol call
+			// stays `PendingConfirmation`, so the local invocation must reach
+			// `WaitingForConfirmation` and block on the confirmation gate.
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				invocationMessage: 'Run Task',
+				toolInput: '{"task":"build"}',
+				confirmationTitle: 'Run Task',
+			} as ChatAction);
+
+			await handler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			await timeout(0);
+			await timeout(0);
+			return chatURI;
+		}
+
+		test('resolves a waiting client tool confirmation when the agent host approves it late, preserving the reason', async () => {
+			const reasons = [
+				ToolCallConfirmationReason.NotNeeded,
+				ToolCallConfirmationReason.Setting,
+				ToolCallConfirmationReason.UserAction,
+			];
+
+			const results: unknown[] = [];
+			for (const reason of reasons) {
+				const local = disposables.add(new DisposableStore());
+				const { handler, connection, toolsService } = createHandlerWithMocks(local, [testRunTaskTool], { requireConfirmation: true });
+				const chatURI = await reachLocalWaitingForConfirmation(handler, connection);
+
+				const sawWaitingForConfirmation = (toolsService.recordedStateKinds.get('tool-call-1') ?? []).includes(IChatToolInvocation.StateKind.WaitingForConfirmation);
+
+				// The agent host approves the call after the fact, transitioning
+				// the protocol tool call to `Running` with the resolved reason.
+				connection.applySessionAction(chatURI, {
+					type: ActionType.ChatToolCallReady,
+					turnId: 'turn-1',
+					toolCallId: 'tool-call-1',
+					invocationMessage: 'Run Task',
+					toolInput: '{"task":"build"}',
+					confirmed: reason,
+				} as ChatAction);
+				await timeout(0);
+				await timeout(0);
+
+				const confirmedAction = connection.dispatchedActions.find(entry => isChatAction(entry.action)
+					&& entry.action.type === ActionType.ChatToolCallConfirmed
+					&& entry.action.toolCallId === 'tool-call-1');
+				results.push({
+					reason,
+					sawWaitingForConfirmation,
+					dispatchedConfirmed: confirmedAction && confirmedAction.action.type === ActionType.ChatToolCallConfirmed && confirmedAction.action.approved
+						? confirmedAction.action.confirmed
+						: undefined,
+					completed: connection.dispatchedActions.some(entry => isChatAction(entry.action)
+						&& entry.action.type === ActionType.ChatToolCallComplete
+						&& entry.action.toolCallId === 'tool-call-1'
+						&& entry.action.result.success === true),
+				});
+
+				disposables.delete(local);
+			}
+
+			assert.deepStrictEqual(results, reasons.map(reason => ({
+				reason,
+				sawWaitingForConfirmation: true,
+				dispatchedConfirmed: reason,
+				completed: true,
+			})));
+		});
+
+		test('does not confirm or execute a waiting client tool when the protocol call completes while still pending', async () => {
+			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool], { requireConfirmation: true });
+			const chatURI = await reachLocalWaitingForConfirmation(handler, connection);
+
+			const sawWaitingForConfirmation = (toolsService.recordedStateKinds.get('tool-call-1') ?? []).includes(IChatToolInvocation.StateKind.WaitingForConfirmation);
+
+			// The reducer synthesizes `confirmed: NotNeeded` when a completion
+			// arrives during `PendingConfirmation`. That is not evidence of a
+			// genuine approval, so the still-waiting local invocation must not
+			// be confirmed or driven through execution.
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatToolCallComplete,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				result: { success: true, pastTenseMessage: 'Ran task' },
+			} as ChatAction);
+			await timeout(0);
+			await timeout(0);
+
+			assert.deepStrictEqual({
+				sawWaitingForConfirmation,
+				sawExecuting: (toolsService.recordedStateKinds.get('tool-call-1') ?? []).includes(IChatToolInvocation.StateKind.Executing),
+				dispatchedApproval: connection.dispatchedActions.some(entry => isChatAction(entry.action)
+					&& entry.action.type === ActionType.ChatToolCallConfirmed
+					&& entry.action.toolCallId === 'tool-call-1'
+					&& entry.action.approved === true),
+			}, {
+				sawWaitingForConfirmation: true,
+				sawExecuting: false,
+				dispatchedApproval: false,
+			});
 		});
 
 		test('reconnecting to an active turn with owned client tool completes the initial snapshot invocation', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -880,7 +880,7 @@ suite('AgentHostClientTools', () => {
 			]);
 		});
 
-		test('auto-approved client tool never enters WaitingForConfirmation (no needs-input flicker)', async () => {
+		test('protocol-confirmed client tool never enters WaitingForConfirmation (no needs-input flicker)', async () => {
 			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool], { requireConfirmation: true });
 			const sessionResource = URI.parse('agent-host-copilot:/session-1');
 			const backendSession = AgentSession.uri('copilot', 'session-1').toString();
@@ -905,8 +905,7 @@ suite('AgentHostClientTools', () => {
 				toolCallId: 'tool-call-1',
 				invocationMessage: 'Run Task',
 				toolInput: '{"task":"build"}',
-				confirmationTitle: 'Run Task',
-				_meta: { autoApproveBySetting: true },
+				confirmed: ToolCallConfirmationReason.NotNeeded,
 			} as ChatAction);
 
 			await handler.provideChatSessionContent(sessionResource, CancellationToken.None);
@@ -923,7 +922,7 @@ suite('AgentHostClientTools', () => {
 					sawWaitingForConfirmation: (toolsService.recordedStateKinds.get('tool-call-1') ?? []).includes(IChatToolInvocation.StateKind.WaitingForConfirmation),
 				},
 				{
-					preApprovedKind: ToolConfirmKind.Setting,
+					preApprovedKind: ToolConfirmKind.ConfirmationNotNeeded,
 					sawWaitingForConfirmation: false,
 				},
 			);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Summary
- Client-provided tools could still show a confirmation prompt in Allow All or Assisted Permissions mode, even though Agent Host had already approved the invocation.

Root Cause
- Agent Host represented the approval using the protocol’s confirmed field, commonly as not-needed. The client tool bridge only recognized the separate autoApproveBySetting metadata flag, so it invoked the local tool without passing through the existing approval.

The local tool service consequently performed its own confirmation flow.

Changes
- Convert resolved protocol confirmation reasons into local pre-approval reasons.
- Continue supporting the existing autoApproveBySetting metadata path.
- Pass the resolved approval into local client-tool invocation.
- Apply late-arriving approval state if an invocation is already waiting for confirmation.
- Preserve whether approval came from: no confirmation being required, a setting, or, explicit user action.
- Client tools now proceed directly to execution when Agent Host has already approved them, avoiding both the prompt and transient “needs input” state.