### PR TITLE
Fix timeline rail to render next to the native scrollbar

### DIFF
--- a/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
+++ b/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
@@ -6,7 +6,9 @@
 .prompt-timeline-rail {
 	position: absolute;
 	top: 0;
-	right: 0;
+	/* Sit just to the left of the transcript's native vertical scrollbar (which stays visible and
+	 * keeps handling scroll), leaving a gutter the width of that scrollbar so the marks never overlap it. */
+	right: var(--prompt-timeline-scrollbar-gutter, 10px);
 	bottom: var(--prompt-timeline-bottom, 0);
 	width: var(--prompt-timeline-rail-width, 36px);
 	pointer-events: none;
@@ -22,17 +24,21 @@
 	--prompt-timeline-rail-width: 36px;
 	/* Minimum clear space guaranteed between the message content and the rail marks. */
 	--prompt-timeline-content-gap: 24px;
+	/* Width of the transcript's native vertical scrollbar; the rail is offset by this so it renders
+	 * beside the scrollbar rather than on top of it. Matches the list's default scrollbar size. */
+	--prompt-timeline-scrollbar-gutter: 10px;
 }
 
 /* Reserve room on the transcript's right edge so message content clears the rail's marks.
  * The chat "card" rows (sessions style.css) pad only 32px on the right — where the marks sit — so
- * bubbles crowd the pills. We reserve the rail's full width plus the minimum gap, but only while
- * the rail surface is mounted (`.prompt-timeline-with-rail`); header-only keeps the base layout. */
+ * bubbles crowd the pills. We reserve the rail's full width plus the minimum gap and the scrollbar
+ * gutter the rail is offset by, but only while the rail surface is mounted (`.prompt-timeline-with-rail`);
+ * header-only keeps the base layout. */
 .agent-sessions-workbench .part.sessionspart .prompt-timeline-host.prompt-timeline-with-rail.interactive-session .interactive-item-container,
 .agent-sessions-workbench .part.sessionspart .prompt-timeline-host.prompt-timeline-with-rail.interactive-session > .chat-suggest-next-widget,
 .agent-sessions-workbench .chat-editor-relative .prompt-timeline-host.prompt-timeline-with-rail.interactive-session .interactive-item-container,
 .agent-sessions-workbench .chat-editor-relative .prompt-timeline-host.prompt-timeline-with-rail.interactive-session > .chat-suggest-next-widget {
-	padding-right: calc(var(--prompt-timeline-rail-width) + var(--prompt-timeline-content-gap));
+	padding-right: calc(var(--prompt-timeline-rail-width) + var(--prompt-timeline-content-gap) + var(--prompt-timeline-scrollbar-gutter));
 }
 
 .prompt-timeline-rail.hidden {
@@ -122,7 +128,7 @@
 }
 
 .prompt-timeline-host.prompt-timeline-with-rail .prompt-timeline-sticky-content {
-	padding-right: calc(var(--prompt-timeline-rail-width) + var(--prompt-timeline-content-gap));
+	padding-right: calc(var(--prompt-timeline-rail-width) + var(--prompt-timeline-content-gap) + var(--prompt-timeline-scrollbar-gutter));
 }
 
 .prompt-timeline-sticky-label {
@@ -277,32 +283,29 @@
 }
 
 /* Overview-ruler style: the session compressed into the rail height like the editor overview ruler.
- * The marks column IS the scrollbar lane: it sits at the transcript's right edge over the (hidden)
- * native slider, and the rail draws its own thumb below the marks. At rest the lane is a plain
- * scrollbar (just the thumb); on engagement the thumb recedes and the marks fan in over the same
- * column, so the scrollbar visually morphs into the fan. */
+ * The marks column sits in a gutter just left of the transcript's native scrollbar (which stays
+ * visible and keeps handling scroll and position). At rest the marks are invisible; on engagement
+ * the fisheye "fan" blooms in over the column. */
 .prompt-timeline-ruler-marks {
 	position: absolute;
 	inset: 0 0 0 auto;
 	width: 22px;
-	/* The whole column is the hover/scrub surface: hovering blooms the fisheye "fan" and lets it
-	 * follow the cursor; dragging scrubs the transcript (see the rail's pointer handlers). */
+	/* The whole column is the hover surface: hovering blooms the fisheye "fan" and lets it follow
+	 * the cursor (see the rail's pointer handlers). */
 	pointer-events: auto;
 	/* The marks stay quiet (invisible) at rest and during gentle scrolling so the transcript reads
 	 * calm — only a deliberate gesture surfaces them: hovering the lane (`:hover`), the fisheye bloom
-	 * on a hard scroll (`.engaged`), a scrub drag (`.scrubbing`), or keyboard focus inside the rail
-	 * (`:focus-within`). */
+	 * on a hard scroll (`.engaged`), or keyboard focus inside the rail (`:focus-within`). */
 	opacity: 0;
 	transition: opacity 200ms ease;
 	z-index: 2;
 }
 
 /* Reveal the marks whenever the timeline is engaged: while scrolling + its linger (`.engaged`, which
- * also covers reduced-motion where the fan is disabled), while hovering the lane, while scrubbing, or
- * whenever keyboard focus is inside the rail (so tabbing to a mark and "Go to Prompt" always show it). */
+ * also covers reduced-motion where the fan is disabled), while hovering the lane, or whenever keyboard
+ * focus is inside the rail (so tabbing to a mark and "Go to Prompt" always show it). */
 .prompt-timeline-rail.engaged .prompt-timeline-ruler-marks,
 .prompt-timeline-rail:hover .prompt-timeline-ruler-marks,
-.prompt-timeline-rail.scrubbing .prompt-timeline-ruler-marks,
 .prompt-timeline-rail:focus-within .prompt-timeline-ruler-marks {
 	opacity: 1;
 }
@@ -311,46 +314,6 @@
 	.prompt-timeline-ruler-marks {
 		transition: none;
 	}
-}
-
-/* The rail's own scrollbar thumb (the transcript's native slider is hidden while the rail is active).
- * A plain, translucent scrollbar at rest; it fades out as the fan blooms — or stays put while you
- * drag it to scrub — so the lane reads as one surface morphing scrollbar <-> fan. Non-interactive:
- * the marks column above owns hover + scrub. */
-.prompt-timeline-ruler-thumb {
-	position: absolute;
-	right: 4px;
-	width: 9px;
-	border-radius: var(--vscode-cornerRadius-circle);
-	background-color: var(--vscode-scrollbarSlider-background);
-	pointer-events: none;
-	transition: opacity 160ms ease;
-	z-index: 1;
-}
-
-.prompt-timeline-ruler-thumb.hidden {
-	display: none;
-}
-
-/* The thumb recedes whenever the marks are revealed (engaged/hover/keyboard focus), but stays visible
- * while scrubbing so dragging the lane feels like grabbing a scrollbar. */
-.prompt-timeline-rail.engaged:not(.scrubbing) .prompt-timeline-ruler-thumb,
-.prompt-timeline-rail:hover:not(.scrubbing) .prompt-timeline-ruler-thumb,
-.prompt-timeline-rail:focus-within:not(.scrubbing) .prompt-timeline-ruler-thumb {
-	opacity: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.prompt-timeline-ruler-thumb {
-		transition: none;
-	}
-}
-
-/* The rail is the scrollbar while it is active, so hide the transcript's own vertical slider for a
- * single lane. Scoped to the top-level transcript list via a direct-child chain (nested scrollables
- * inside rows keep their sliders) and only while the rail is actually showing (`.prompt-timeline-active`). */
-.prompt-timeline-host.prompt-timeline-active .interactive-list > .monaco-list > .monaco-scrollable-element > .scrollbar.vertical {
-	display: none;
 }
 
 /* Each mark is a >=24px hit target positioned at its proportional scroll offset. */

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRail.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRail.ts
@@ -14,18 +14,17 @@ export interface IPromptReviewFileEvent {
 }
 
 /**
- * A prompt timeline rail: a presentation-only vertical strip pinned to the right
- * edge of the chat transcript that renders one mark per prompt and lets the user
- * preview, jump to, and review each prompt. Rendered as a proportional overview
- * ruler with a viewport thumb, like the editor overview ruler.
+ * A prompt timeline rail: a presentation-only vertical strip pinned beside the
+ * chat transcript's native scrollbar that renders one mark per prompt and lets the
+ * user preview, jump to, and review each prompt. Rendered as a proportional
+ * overview ruler, like the editor overview ruler; scrolling stays with the
+ * transcript's own scrollbar.
  */
 export interface IPromptTimelineRail extends IDisposable {
 	readonly domNode: HTMLElement;
 
 	/** Fired when a mark is chosen (click / keyboard), with its request id. */
 	readonly onDidSelect: Event<string>;
-	/** Fired while dragging the rail lane to scrub, with the requested transcript scroll offset (px). */
-	readonly onDidScrub: Event<number>;
 	/** Fired to review all of a prompt's changes. */
 	readonly onDidReview: Event<PromptTick>;
 	/** Fired to review a single changed file of a prompt. */
@@ -40,6 +39,6 @@ export interface IPromptTimelineRail extends IDisposable {
 	focusTick(requestId: string): void;
 	setHostWidth(width: number): void;
 
-	/** Supplies proportional scroll positions for the marks and viewport thumb. */
+	/** Supplies proportional scroll positions for the marks. */
 	setScrollLayout(layout: IPromptScrollLayout | undefined): void;
 }

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { $, addDisposableGenericMouseDownListener, addDisposableGenericMouseMoveListener, addDisposableGenericMouseUpListener, addDisposableListener, append, clearNode, EventType, getWindow, scheduleAtNextAnimationFrame } from '../../../../base/browser/dom.js';
+import { $, addDisposableListener, append, clearNode, EventType, getWindow, scheduleAtNextAnimationFrame } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { disposableTimeout } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -30,13 +30,11 @@ const FAN_SPREAD = 14;
 const FAN_LINGER = 2000;
 /** A hard wheel flick only reveals the fan if the transcript actually scrolls within this window (ms) — so flicking against the top/bottom limit, which moves nothing, never blooms it. */
 const HARD_WHEEL_REVEAL_WINDOW = 200;
-/** Minimum height (px) of the rail's own scrollbar thumb so it stays grabbable on tall transcripts. */
-const THUMB_MIN_HEIGHT = 24;
 /**
  * Pill placement. `'proportional'` scatters pills at their real scroll position (an overview ruler);
  * `'even'` stacks them as an evenly-spaced dock centred in the lane (stable under virtualization, and
  * tidier when big responses would otherwise cluster the pills). The scrollbar thumb stays proportional
- * either way, and scrubbing hides the pills, so `'even'` does not make dragging feel disconnected.
+ * either way, and the fan is hidden until engaged, so `'even'` still reads calmly at rest.
  */
 const PILL_LAYOUT: 'proportional' | 'even' = 'even';
 /** Even layout: vertical gap (px) between pill centres — also the min so hit targets never overlap. */
@@ -56,15 +54,14 @@ interface IMarkEntry {
  * The overview-ruler rail. The whole session is compressed into the rail height
  * like the editor's overview ruler: each prompt is a mark at its proportional
  * scroll position, coloured only to signal whether it changed code. The rail sits
- * in a gutter beside the transcript's native scrollbar (no second slider); the
- * active mark is the "you-are-here". Detail lives in the hover card.
+ * in a gutter just beside the transcript's native scrollbar (which keeps handling
+ * scroll and position); the active mark is the "you-are-here". Detail lives in the
+ * hover card.
  */
 export class PromptTimelineRulerRail extends Disposable implements IPromptTimelineRail {
 
 	private readonly _domNode: HTMLElement;
 	private readonly _marksContainer: HTMLElement;
-	/** The rail's own scrollbar thumb (the transcript's native slider is hidden while the rail is active). Shown at rest as a plain scrollbar; recedes as the fan blooms. */
-	private readonly _thumb: HTMLElement;
 	private readonly _card: PromptTimelineCard;
 	private readonly _markDisposables = this._register(new DisposableStore());
 	private readonly _marks: IMarkEntry[] = [];
@@ -97,18 +94,11 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 	private _lastFanActivityAt = 0;
 	/** When the user prefers reduced motion the fan is disabled (marks stay their calm rest size). */
 	private _reducedMotion = false;
-	/** True while the user is dragging the lane to scrub the transcript. */
-	private _scrubbing = false;
 	/** True while keyboard focus is inside the rail: the marks stay revealed (`:focus-within`) but the fisheye is suppressed. */
 	private _focused = false;
-	/** Window listeners for the in-progress scrub drag; cleared on mouse-up (and on rail dispose). */
-	private readonly _scrubSession = this._register(new MutableDisposable<DisposableStore>());
 
 	private readonly _onDidSelect = this._register(new Emitter<string>());
 	readonly onDidSelect: Event<string> = this._onDidSelect.event;
-
-	private readonly _onDidScrub = this._register(new Emitter<number>());
-	readonly onDidScrub: Event<number> = this._onDidScrub.event;
 
 	private readonly _onDidReview = this._register(new Emitter<PromptTick>());
 	readonly onDidReview: Event<PromptTick> = this._onDidReview.event;
@@ -125,10 +115,6 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		this._domNode.setAttribute('role', 'toolbar');
 		this._domNode.setAttribute('aria-orientation', 'vertical');
 		this._marksContainer = append(this._domNode, $('.prompt-timeline-ruler-marks'));
-		// The rail's own scrollbar thumb. It sits under the marks and shows the viewport position as
-		// a plain scrollbar at rest; while the fan is bloomed it fades out so the lane reads as one
-		// surface morphing from scrollbar → fan (the transcript's native slider is hidden via CSS).
-		this._thumb = append(this._domNode, $('.prompt-timeline-ruler-thumb'));
 		this._card = this._register(new PromptTimelineCard(this._domNode));
 		this._register(this._card.onDidReview(tick => this._onDidReview.fire(tick)));
 		this._register(this._card.onDidReviewFile(e => this._onDidReviewFile.fire(e)));
@@ -136,34 +122,25 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		// Toolbar keyboard model: one Tab stop, Arrow/Home/End move between marks.
 		this._register(addDisposableListener(this._marksContainer, EventType.KEY_DOWN, e => this._onMarksKeyDown(e)));
 
-		// The marks column IS the scrollbar lane. Hovering anywhere along it blooms the fisheye "fan"
-		// and lets it FOLLOW the cursor (a macOS-dock feel); dragging it scrubs the transcript like a
-		// scrollbar. The lane's top edge is cached (refreshed on resize) so each hover/move converts
-		// the pointer Y to lane-local space without a per-event getBoundingClientRect (a forced reflow
-		// that would stutter while the transcript's styles are dirty during scroll).
+		// Hovering anywhere along the marks column blooms the fisheye "fan" and lets it FOLLOW the
+		// cursor (a macOS-dock feel). The lane's top edge is cached (refreshed on resize) so each
+		// hover/move converts the pointer Y to lane-local space without a per-event
+		// getBoundingClientRect (a forced reflow that would stutter while the transcript's styles are
+		// dirty during scroll).
 		this._register(addDisposableListener(this._marksContainer, EventType.MOUSE_ENTER, e => {
 			this._laneTop = this._laneTopNow();
 			this._hovering = true;
 			this._fanHide.clear(); // hovering keeps the fan open — no linger countdown
-			if (!this._scrubbing) {
-				this._engage(e.clientY - this._laneTop);
-			}
+			this._engage(e.clientY - this._laneTop);
 		}));
 		this._register(addDisposableListener(this._marksContainer, EventType.MOUSE_MOVE, e => {
 			this._hovering = true;
-			if (!this._scrubbing) {
-				this._engage(e.clientY - this._laneTop);
-			}
+			this._engage(e.clientY - this._laneTop);
 		}));
 		this._register(addDisposableListener(this._marksContainer, EventType.MOUSE_LEAVE, () => {
 			this._hovering = false;
-			if (!this._scrubbing) {
-				this._scheduleFanHide();
-			}
+			this._scheduleFanHide();
 		}));
-		// Drag the lane (anywhere that is not a mark) to scrub the transcript, like grabbing a
-		// scrollbar. Generic mouse-down so it also works with touch/pointer on iOS.
-		this._register(addDisposableGenericMouseDownListener(this._marksContainer, e => this._beginScrub(e)));
 
 		// The fan is a pointer-only flourish, so it must respect reduced-motion. Read it now and
 		// track changes; keyboard users always get the calm, static marks + card + navigation.
@@ -224,9 +201,6 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 			this._renderMark(entry, tick);
 			const requestId = tick.requestId;
 			this._markDisposables.add(addDisposableListener(button, EventType.CLICK, () => this._onDidSelect.fire(requestId)));
-			// A press on a mark must not start a lane scrub — let the click jump to the prompt. Generic
-			// so it also intercepts the pointer-down used on iOS.
-			this._markDisposables.add(addDisposableGenericMouseDownListener(button, e => e.stopPropagation()));
 			this._markDisposables.add(addDisposableListener(button, EventType.MOUSE_ENTER, () => this._showCard(entry)));
 			this._markDisposables.add(addDisposableListener(button, EventType.FOCUS, () => { this._showCard(entry); this._updateTabStops(this._marks.indexOf(entry)); }));
 			this._markDisposables.add(addDisposableListener(button, EventType.MOUSE_LEAVE, () => this._card.scheduleHide()));
@@ -398,11 +372,11 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 
 	/**
 	 * Handles a real transcript scroll: blooms the fan if it followed a deliberate hard flick, and
-	 * keeps it alive (re-arms the linger) while you keep scrolling. Pointer hover/scrub own the fan
-	 * on their own, so this defers to them.
+	 * keeps it alive (re-arms the linger) while you keep scrolling. Pointer hover owns the fan on its
+	 * own, so this defers to it.
 	 */
 	private _onScrolled(): void {
-		if (this._hovering || this._scrubbing || this._focused) {
+		if (this._hovering || this._focused) {
 			return;
 		}
 		if (this._domNode.classList.contains('engaged')) {
@@ -438,8 +412,6 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		const layout = this._layout;
 		const overflowing = this._hostWidth < MIN_HOST_WIDTH;
 		this._domNode.classList.toggle('overflowing', overflowing);
-		// Position the rail's own scrollbar thumb (independent of the marks, which may be absent).
-		this._layoutThumb();
 		if (overflowing || height <= 0 || !layout || layout.total <= 0) {
 			return;
 		}
@@ -489,7 +461,7 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		// While the fan is open because of scrolling (not steered by the pointer, and not while keyboard
 		// focus is showing the calm dock), glide its focus with the viewport so the fisheye travels
 		// smoothly through the pills as you scroll.
-		if (this._domNode.classList.contains('engaged') && !this._hovering && !this._scrubbing && !this._focused) {
+		if (this._domNode.classList.contains('engaged') && !this._hovering && !this._focused) {
 			const scrollCenter = this._scrollFanCenter();
 			if (scrollCenter !== undefined) {
 				this._fanCenter = scrollCenter;
@@ -525,85 +497,6 @@ export class PromptTimelineRulerRail extends Disposable implements IPromptTimeli
 		for (let i = 0; i < n; i++) {
 			visible[i].center = start + i * step;
 		}
-	}
-
-	/**
-	 * The rail's scrollbar geometry, mapping the transcript's real scroll space onto the rail track,
-	 * exactly like the editor's {@link ScrollbarState}: the thumb size is the viewport's share of the
-	 * content (floored to a grabbable minimum), and the thumb travels `track - thumbSize` as the scroll
-	 * position travels `scrollHeight - viewportHeight`. Returns `undefined` when there is nothing to
-	 * scroll or the rail is too narrow to act as the scrollbar.
-	 */
-	private _thumbMetrics(): { size: number; ratio: number; maxScroll: number } | undefined {
-		const track = this._railHeight;
-		const layout = this._layout;
-		if (!layout || track <= 0 || this._hostWidth < MIN_HOST_WIDTH) {
-			return undefined;
-		}
-		const viewport = layout.viewportHeight;
-		const scrollSize = layout.scrollHeight;
-		if (viewport <= 0 || scrollSize <= viewport + 1) {
-			return undefined; // content fits — no scrollbar needed
-		}
-		const size = Math.max(THUMB_MIN_HEIGHT, Math.floor(viewport / scrollSize * track));
-		const maxScroll = scrollSize - viewport;
-		const ratio = (track - size) / maxScroll;
-		return { size, ratio, maxScroll };
-	}
-
-	/** Positions the rail's own scrollbar thumb from the transcript's real scroll offset, or hides it when there is nothing to scroll. */
-	private _layoutThumb(): void {
-		const metrics = this._thumbMetrics();
-		if (!metrics) {
-			this._thumb.classList.add('hidden');
-			return;
-		}
-		const top = Math.max(0, Math.min(this._railHeight - metrics.size, this._layout!.scrollTop * metrics.ratio));
-		this._thumb.classList.remove('hidden');
-		this._thumb.style.top = `${top}px`;
-		this._thumb.style.height = `${metrics.size}px`;
-	}
-
-	/** Begins a lane scrub (grab the scrollbar): scrolls to the pressed position and tracks the drag. */
-	private _beginScrub(e: MouseEvent): void {
-		if (!this._thumbMetrics()) {
-			return; // nothing to scroll
-		}
-		e.preventDefault();
-		this._scrubbing = true;
-		this._laneTop = this._laneTopNow();
-		// Collapse the fan while scrubbing so the lane reads as a clean scrollbar being dragged.
-		this._collapseFan();
-		this._domNode.classList.add('scrubbing');
-		this._scrubTo(e.clientY);
-		const session = new DisposableStore();
-		session.add(addDisposableGenericMouseMoveListener(getWindow(this._domNode), (ev: MouseEvent) => this._scrubTo(ev.clientY)));
-		session.add(addDisposableGenericMouseUpListener(getWindow(this._domNode), () => {
-			this._scrubbing = false;
-			this._domNode.classList.remove('scrubbing');
-			this._scrubSession.clear();
-			// Linger briefly after a scrub so the timeline stays up while the user reads where they landed.
-			if (!this._hovering) {
-				const center = this._activeCenter();
-				if (center !== undefined) {
-					this._engage(center);
-				}
-				this._scheduleFanHide();
-			}
-		}));
-		this._scrubSession.value = session;
-	}
-
-	/** Maps a client Y on the lane to a transcript scroll offset and requests it (viewport centred on the cursor). */
-	private _scrubTo(clientY: number): void {
-		const metrics = this._thumbMetrics();
-		if (!metrics) {
-			return;
-		}
-		// Centre the thumb on the cursor, then invert the thumb->scroll ratio, like ScrollbarState.
-		const desiredThumbTop = (clientY - this._laneTop) - metrics.size / 2;
-		const scrollTop = metrics.ratio > 0 ? desiredThumbTop / metrics.ratio : 0;
-		this._onDidScrub.fire(Math.max(0, Math.min(metrics.maxScroll, scrollTop)));
 	}
 
 	/**

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineWidgetContrib.ts
@@ -16,7 +16,7 @@ import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/con
 import { MIN_PROMPTS, PromptTimelineCommandId, PROMPT_TIMELINE_CONTRIB_ID, PROMPT_TIMELINE_RAIL_SETTING, PROMPT_TIMELINE_STICKY_HEADER_SETTING } from '../common/promptTimeline.js';
 import { PromptTimelineModel, PromptEntry } from './promptTimelineModel.js';
 import { IPromptTimelineRail } from './promptTimelineRail.js';
-import { MIN_HOST_WIDTH, PromptTimelineRulerRail } from './promptTimelineRulerRail.js';
+import { PromptTimelineRulerRail } from './promptTimelineRulerRail.js';
 import { PromptTimelineStickyHeader } from './promptTimelineStickyHeader.js';
 
 /** Normalized wheel distance (device-independent units, ~1 per notch) accumulated within {@link WHEEL_WINDOW_MS} to count as a hard/fast scroll. */
@@ -40,8 +40,6 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 
 	/** Holds the model and every surface's wiring while at least one surface is enabled. */
 	private readonly _enablement = this._register(new DisposableStore());
-	/** Latest tick count is at or above {@link MIN_PROMPTS}; combined with the host width to decide whether the rail replaces the native scrollbar. */
-	private _hasEnoughPrompts = false;
 
 	constructor(
 		private readonly widget: IChatWidget,
@@ -70,7 +68,6 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 		this._enablement.clear();
 		this._model = undefined;
 		this._rail = undefined;
-		this._hasEnoughPrompts = false;
 		const railEnabled = this.configurationService.getValue<boolean>(PROMPT_TIMELINE_RAIL_SETTING) === true;
 		const stickyEnabled = this.configurationService.getValue<boolean>(PROMPT_TIMELINE_STICKY_HEADER_SETTING) === true;
 		if (railEnabled || stickyEnabled) {
@@ -91,18 +88,14 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 		// The host class provides the positioning context and layout variables both surfaces anchor to.
 		const host = this.widget.domNode;
 		host.classList.add('prompt-timeline-host');
-		this._enablement.add(toDisposable(() => host.classList.remove('prompt-timeline-host', 'prompt-timeline-active', 'prompt-timeline-with-rail')));
+		this._enablement.add(toDisposable(() => host.classList.remove('prompt-timeline-host', 'prompt-timeline-with-rail')));
 
-		// Track the prompt count and host width so the native-scrollbar gate (rail only) stays current.
-		this._enablement.add(autorun(reader => {
-			this._hasEnoughPrompts = model.ticks.read(reader).length >= MIN_PROMPTS;
-			this._updateNativeScrollbarHidden();
-		}));
+		// Keep the rail informed of the host width so it can hide its marks when the transcript is too
+		// narrow to fit them beside the native scrollbar.
 		const ResizeObserverCtor = getWindow(host).ResizeObserver;
 		if (ResizeObserverCtor) {
 			const observer = new ResizeObserverCtor(() => {
 				this._rail?.setHostWidth(host.clientWidth);
-				this._updateNativeScrollbarHidden();
 			});
 			observer.observe(host);
 			this._enablement.add(toDisposable(() => observer.disconnect()));
@@ -125,8 +118,6 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 
 		rail.setFilesProvider(tick => model.getRequestFiles(tick));
 		this._enablement.add(rail.onDidSelect(requestId => model.reveal(requestId)));
-		// Dragging the rail lane scrubs the transcript (the rail is the scrollbar now, so it drives scroll).
-		this._enablement.add(rail.onDidScrub(scrollTop => { (this.widget as ChatWidget).scrollTop = scrollTop; }));
 		this._enablement.add(rail.onDidReview(tick => { void model.reviewChanges(tick); }));
 		this._enablement.add(rail.onDidReviewFile(e => { void model.reviewChanges(e.tick, e.file); }));
 
@@ -152,14 +143,13 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 			rail.setActive(model.activeRequestId.read(reader));
 		}));
 
-		// Supply proportional scroll positions for the marks and viewport thumb.
+		// Supply proportional scroll positions for the marks.
 		this._enablement.add(autorun(reader => {
 			model.onDidChangeScrollLayout.read(reader);
 			rail.setScrollLayout(model.getScrollLayout());
 		}));
 
 		rail.setHostWidth(host.clientWidth);
-		this._updateNativeScrollbarHidden();
 	}
 
 	/**
@@ -208,12 +198,6 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 				rail.notifyHardWheel();
 			}
 		}, { capture: true, passive: true });
-	}
-
-	/** Hide the transcript's native scrollbar only while the rail is actually acting as it: rail shown, enough prompts AND wide enough (below {@link MIN_HOST_WIDTH} the rail hides, so the native slider must stay). */
-	private _updateNativeScrollbarHidden(): void {
-		const active = !!this._rail && this._hasEnoughPrompts && this.widget.domNode.clientWidth >= MIN_HOST_WIDTH;
-		this.widget.domNode.classList.toggle('prompt-timeline-active', active);
 	}
 
 	// -- Navigation API (used by promptTimelineActions) --


### PR DESCRIPTION
This pull request modifies the timeline rail feature in chat sessions to ensure it renders next to the native scrollbar instead of replacing it. The changes include:

- **CSS Adjustments**:
  - Introduced a new CSS variable to offset the rail next to the scrollbar.
  - Removed styles that hid the native scrollbar and the rail's custom thumb.

- **TypeScript Changes**:
  - Deleted all logic related to the rail's custom thumb and scrubbing functionality in `promptTimelineRulerRail.ts`.
  - Updated the interface in `promptTimelineRail.ts` to remove scrub-related methods.
  - Cleaned up the contribution file to eliminate unnecessary scrollbar hiding logic.

- **Verification**:
  - Conducted a thorough review of the changes, confirming no dangling references to removed symbols or classes.

These modifications align the timeline rail with the user's request to maintain the native scrollbar functionality while displaying the timeline marks alongside it.