### PR TITLE
Dictation: show download progress ring instead of spinning mic

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -17,7 +17,6 @@ import { KeybindingWeight } from '../../../../../platform/keybinding/common/keyb
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { spinningLoading } from '../../../../../platform/theme/common/iconRegistry.js';
 import { AgentsVoiceStorageKeys } from '../../../agentsVoice/common/agentsVoice.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { CHAT_CATEGORY } from './chatActions.js';
@@ -152,7 +151,7 @@ class ToggleChatSpeechToTextAction extends Action2 {
  * Shown in place of the mic button while the on-device model is downloading/loading.
  * Renders a spinner; clicking it cancels an in-flight dictation (if any).
  */
-class ChatSpeechToTextPreparingAction extends Action2 {
+export class ChatSpeechToTextPreparingAction extends Action2 {
 	static readonly ID = 'workbench.action.chat.speechToTextPreparing';
 
 	constructor() {
@@ -161,7 +160,7 @@ class ChatSpeechToTextPreparingAction extends Action2 {
 			title: localize2('chat.speechToText.preparing', "Preparing Speech to Text Model…"),
 			category: CHAT_CATEGORY,
 			f1: false,
-			icon: spinningLoading,
+			icon: Codicon.cloudDownload,
 			precondition: ChatSpeechToTextPreparing,
 			menu: [{
 				id: MenuId.ChatExecute,

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -20,6 +20,7 @@ import { ITelemetryService } from '../../../../../platform/telemetry/common/tele
 import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
 import { ILocalTranscriptionModelStatus, ILocalTranscriptionService, LocalTranscriptionModelState } from '../../../../../platform/localTranscription/common/localTranscription.js';
 import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { AgentsVoiceStorageKeys } from '../../../agentsVoice/common/agentsVoice.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 
@@ -107,6 +108,20 @@ export interface IChatSpeechToTextService {
 	readonly isPreparingModel: boolean;
 
 	/**
+	 * Fires whenever the on-device model download progress changes while the
+	 * model is being prepared, so callers can update a progress ring.
+	 */
+	readonly onDidChangeModelDownloadProgress: Event<void>;
+
+	/**
+	 * Fractional download progress in `[0, 1]` while the model is downloading,
+	 * or `undefined` when the fraction is not yet known (indeterminate), the
+	 * download has finished and the model is loading into memory, or no
+	 * preparation is in progress.
+	 */
+	readonly modelDownloadProgress: number | undefined;
+
+	/**
 	 * Begin capturing microphone audio in the given window and streaming it to
 	 * the on-device transcription model. Rejects if the microphone cannot be
 	 * accessed.
@@ -139,6 +154,14 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	private _isPreparingModel = false;
 	get isPreparingModel(): boolean {
 		return this._isPreparingModel;
+	}
+
+	private readonly _onDidChangeModelDownloadProgress = this._register(new Emitter<void>());
+	readonly onDidChangeModelDownloadProgress = this._onDidChangeModelDownloadProgress.event;
+
+	private _modelDownloadProgress: number | undefined;
+	get modelDownloadProgress(): number | undefined {
+		return this._modelDownloadProgress;
 	}
 
 	/**
@@ -201,6 +224,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		@IEnvironmentService private readonly _environmentService: IEnvironmentService,
 		@ILocalTranscriptionService private readonly _localTranscription: ILocalTranscriptionService,
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 	) {
 		super();
 		this._recordingContextKey = ChatContextKeys.speechToTextRecording.bindTo(contextKeyService);
@@ -224,7 +248,18 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		}
 		this._isPreparingModel = preparing;
 		this._preparingContextKey.set(preparing);
+		if (!preparing) {
+			this._setModelDownloadProgress(undefined);
+		}
 		this._onDidChangePreparingModel.fire(preparing);
+	}
+
+	private _setModelDownloadProgress(progress: number | undefined): void {
+		if (this._modelDownloadProgress === progress) {
+			return;
+		}
+		this._modelDownloadProgress = progress;
+		this._onDidChangeModelDownloadProgress.fire();
 	}
 
 	private _logSessionTelemetry(outcome: 'completed' | 'cancelled' | 'error'): void {
@@ -412,12 +447,13 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	}
 
 	/**
-	 * Drive the spinner, download notification, and error handling from a model
-	 * status. Safe to call repeatedly and from both the status snapshot and the
-	 * change listener, since the notification and preparing-state updates are
+	 * Drive the progress ring, download notification, and error handling from a
+	 * model status. Safe to call repeatedly and from both the status snapshot and
+	 * the change listener, since the progress and preparing-state updates are
 	 * idempotent.
 	 */
 	private _handleModelStatus(status: ILocalTranscriptionModelStatus): void {
+		this._updateModelDownloadProgress(status);
 		this._updateDownloadNotification(status);
 		if (status.state === LocalTranscriptionModelState.Ready) {
 			this._logModelPrepareTelemetry(status);
@@ -430,9 +466,22 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	}
 
 	/**
-	 * Show a progress notification while the model is being prepared, and keep it
-	 * visible across both preparation phases so dictation never appears to hang
-	 * with no feedback:
+	 * Feed the toolbar progress ring: expose the download fraction while it is
+	 * known, and `undefined` (indeterminate ring) before the first byte total
+	 * arrives or once the download completes and the model is loading.
+	 */
+	private _updateModelDownloadProgress(status: ILocalTranscriptionModelStatus): void {
+		if (status.state === LocalTranscriptionModelState.Downloading && typeof status.progress === 'number') {
+			this._setModelDownloadProgress(Math.max(0, Math.min(1, status.progress)));
+		} else {
+			this._setModelDownloadProgress(undefined);
+		}
+	}
+
+	/**
+	 * Announce model-preparation progress to screen-reader users via a progress
+	 * notification, and keep it visible across both preparation phases so
+	 * dictation never appears to hang with no feedback:
 	 *  - `Downloading`: a determinate bar advances as bytes arrive (or an
 	 *    indeterminate "Downloading…" message before the first byte total is
 	 *    known).
@@ -440,12 +489,19 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	 *    into memory is still running, so the message switches to "Loading model…"
 	 *    instead of leaving the bar stuck at a full download and then vanishing.
 	 * The notification is dismissed only once the model reaches `Ready`/`Error`.
+	 *
+	 * Sighted users get the toolbar download ring and its rich hover instead, so
+	 * the notification is only surfaced when a screen reader is active (a hover
+	 * is not reachable by assistive technologies).
 	 */
 	private _updateDownloadNotification(status: ILocalTranscriptionModelStatus): void {
 		const preparing = status.state === LocalTranscriptionModelState.Downloading
 			|| status.state === LocalTranscriptionModelState.Loading;
 		if (!preparing) {
 			this._completeDownloadNotification();
+			return;
+		}
+		if (!this._downloadNotification && !this._accessibilityService.isScreenReaderOptimized()) {
 			return;
 		}
 		if (!this._downloadNotification) {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadActionViewItem.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IManagedHoverContent } from '../../../../../base/browser/ui/hover/hover.js';
+import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { localize } from '../../../../../nls.js';
+import { MenuItemAction } from '../../../../../platform/actions/common/actions.js';
+import { IMenuEntryActionViewItemOptions, MenuEntryActionViewItem } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { IChatSpeechToTextService } from './chatSpeechToTextService.js';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** Radius of the progress ring in the 16×16 viewBox used for the toolbar icon. */
+const RING_RADIUS = 7;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+/**
+ * Toolbar affordance shown while the on-device dictation model is downloading:
+ * a download icon wrapped by a circular progress ring that fills as bytes
+ * arrive, plus a rich hover reporting the exact percentage. Replaces the plain
+ * spinning mic so the wait reads as a determinate download rather than a hang.
+ * When the download fraction is not yet known (or the model is loading into
+ * memory) the ring falls back to an indeterminate spin.
+ */
+export class DictationDownloadActionViewItem extends MenuEntryActionViewItem {
+
+	private _progressCircle: SVGCircleElement | undefined;
+	private _ringElement: SVGSVGElement | undefined;
+
+	constructor(
+		action: MenuItemAction,
+		options: IMenuEntryActionViewItemOptions | undefined,
+		@IChatSpeechToTextService private readonly _speechToTextService: IChatSpeechToTextService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@INotificationService notificationService: INotificationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IThemeService themeService: IThemeService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IAccessibilityService accessibilityService: IAccessibilityService,
+	) {
+		super(action, options, keybindingService, notificationService, contextKeyService, themeService, contextMenuService, accessibilityService);
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+
+		container.classList.add('dictation-download-item');
+
+		const ownerDocument = container.ownerDocument;
+		const svg = ownerDocument.createElementNS(SVG_NS, 'svg') as SVGSVGElement;
+		svg.classList.add('dictation-download-ring');
+		svg.setAttribute('viewBox', '0 0 16 16');
+		svg.setAttribute('aria-hidden', 'true');
+
+		const track = ownerDocument.createElementNS(SVG_NS, 'circle') as SVGCircleElement;
+		track.classList.add('dictation-download-ring-track');
+		track.setAttribute('cx', '8');
+		track.setAttribute('cy', '8');
+		track.setAttribute('r', String(RING_RADIUS));
+
+		const progress = ownerDocument.createElementNS(SVG_NS, 'circle') as SVGCircleElement;
+		progress.classList.add('dictation-download-ring-progress');
+		progress.setAttribute('cx', '8');
+		progress.setAttribute('cy', '8');
+		progress.setAttribute('r', String(RING_RADIUS));
+		progress.setAttribute('stroke-dasharray', String(RING_CIRCUMFERENCE));
+
+		svg.appendChild(track);
+		svg.appendChild(progress);
+		container.appendChild(svg);
+
+		this._ringElement = svg;
+		this._progressCircle = progress;
+
+		this._register(this._speechToTextService.onDidChangeModelDownloadProgress(() => this._updateProgress()));
+		this._updateProgress();
+	}
+
+	private _updateProgress(): void {
+		if (!this._ringElement || !this._progressCircle) {
+			return;
+		}
+		const progress = this._speechToTextService.modelDownloadProgress;
+		if (progress === undefined) {
+			// Fraction unknown or model loading: spin a fixed arc so the ring
+			// still reads as active rather than stuck empty.
+			this._ringElement.classList.add('indeterminate');
+			this._progressCircle.style.strokeDashoffset = String(RING_CIRCUMFERENCE * 0.75);
+		} else {
+			this._ringElement.classList.remove('indeterminate');
+			this._progressCircle.style.strokeDashoffset = String(RING_CIRCUMFERENCE * (1 - progress));
+		}
+		// Refresh the rich hover so its reported percentage stays in sync.
+		this.updateTooltip();
+	}
+
+	protected override getHoverContents(): IManagedHoverContent {
+		const markdown = new MarkdownString('', { supportThemeIcons: true });
+		markdown.appendMarkdown(localize('chatStt.hover.title', "**Downloading speech-to-text model**"));
+		markdown.appendMarkdown('\n\n');
+		const progress = this._speechToTextService.modelDownloadProgress;
+		if (progress === undefined) {
+			markdown.appendMarkdown(localize('chatStt.hover.preparing', "Preparing the on-device model. This happens only the first time you dictate."));
+		} else {
+			markdown.appendMarkdown(localize('chatStt.hover.percent', "{0}% downloaded. This happens only the first time you dictate.", Math.round(progress * 100)));
+		}
+		return { markdown, markdownNotSupportedFallback: markdown.value };
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -105,6 +105,8 @@ import { IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
 import { ChatHistoryNavigator } from '../../../common/widget/chatWidgetHistoryService.js';
 import { ChatSessionPrimaryPickerAction, ChatSubmitAction, IChatExecuteActionContext, OpenDelegationPickerAction, OpenModelPickerAction, OpenModePickerAction, OpenPermissionPickerAction, OpenSessionTargetPickerAction, OpenWorkspacePickerAction } from '../../actions/chatExecuteActions.js';
+import { ChatSpeechToTextPreparingAction } from '../../actions/chatSpeechToTextActions.js';
+import { DictationDownloadActionViewItem } from '../../speechToText/dictationDownloadActionViewItem.js';
 import { AgentSessionProviders, AgentSessionTarget, getAgentSessionProvider } from '../../agentSessions/agentSessions.js';
 import { IAgentSessionsService } from '../../agentSessions/agentSessionsService.js';
 import { ChatAttachmentModel } from '../../attachments/chatAttachmentModel.js';
@@ -3558,6 +3560,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			},
 			hoverDelegate,
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			actionViewItemProvider: (action, options) => {
+				// While the on-device dictation model downloads, render the
+				// preparing affordance as a download icon wrapped by a progress
+				// ring (with a rich hover) instead of a spinning mic.
+				if (action.id === ChatSpeechToTextPreparingAction.ID && action instanceof MenuItemAction) {
+					return this.instantiationService.createInstance(DictationDownloadActionViewItem, action, options);
+				}
+				return undefined;
+			},
 		}));
 		this.executeToolbar.getElement().classList.add('chat-execute-toolbar');
 		this.executeToolbar.context = { widget } satisfies IChatExecuteActionContext;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -4604,3 +4604,55 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	-webkit-text-fill-color: currentColor;
 	color: var(--vscode-foreground);
 }
+
+/* Dictation model download: while the on-device speech-to-text model downloads
+	on first use, the toolbar shows a download icon wrapped by a circular
+	progress ring (see DictationDownloadActionViewItem) instead of a spinning
+	mic, so the wait reads as a determinate download rather than a hang. */
+.monaco-action-bar .action-item.dictation-download-item {
+	position: relative;
+}
+
+.monaco-action-bar .action-item.dictation-download-item > .dictation-download-ring {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 22px;
+	height: 22px;
+	transform: translate(-50%, -50%) rotate(-90deg);
+	pointer-events: none;
+}
+
+.monaco-action-bar .action-item.dictation-download-item > .dictation-download-ring .dictation-download-ring-track {
+	fill: none;
+	stroke: var(--vscode-progressBar-background);
+	stroke-width: 1.5;
+	opacity: 0.25;
+}
+
+.monaco-action-bar .action-item.dictation-download-item > .dictation-download-ring .dictation-download-ring-progress {
+	fill: none;
+	stroke: var(--vscode-progressBar-background);
+	stroke-width: 1.5;
+	stroke-linecap: round;
+}
+
+.monaco-workbench.monaco-enable-motion .action-item.dictation-download-item > .dictation-download-ring .dictation-download-ring-progress {
+	transition: stroke-dashoffset 120ms ease;
+}
+
+/* Indeterminate: spin a fixed arc while the download fraction is unknown or the
+	model is loading into memory. Gated on enable-motion to respect reduced
+	motion. */
+.monaco-workbench.monaco-enable-motion .action-item.dictation-download-item > .dictation-download-ring.indeterminate {
+	animation: dictation-download-ring-spin 1.2s linear infinite;
+}
+
+.monaco-workbench.monaco-enable-motion .action-item.dictation-download-item > .dictation-download-ring.indeterminate .dictation-download-ring-progress {
+	transition: none;
+}
+
+@keyframes dictation-download-ring-spin {
+	from { transform: translate(-50%, -50%) rotate(-90deg); }
+	to { transform: translate(-50%, -50%) rotate(270deg); }
+}

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -57,7 +57,7 @@ export namespace ChatContextKeys {
 	export const chatModelId = new RawContextKey<string>('chatModelId', '', { type: 'string', description: localize('chatModelId', "The short id of the currently selected chat model (for example 'gpt-4.1').") });
 	export const speechToTextRecording = new RawContextKey<boolean>('chatSpeechToTextRecording', false, { type: 'boolean', description: localize('chatSpeechToTextRecording', "True while the chat input is recording audio for speech-to-text transcription.") });
 	export const speechToTextConfigured = new RawContextKey<boolean>('chatSpeechToTextConfigured', false, { type: 'boolean', description: localize('chatSpeechToTextConfigured', "True when on-device speech-to-text is available for dictating into the chat input.") });
-	export const speechToTextPreparing = new RawContextKey<boolean>('chatSpeechToTextPreparing', false, { type: 'boolean', description: localize('chatSpeechToTextPreparing', "True while the on-device speech-to-text model is downloading or loading (the preparation notification is shown).") });
+	export const speechToTextPreparing = new RawContextKey<boolean>('chatSpeechToTextPreparing', false, { type: 'boolean', description: localize('chatSpeechToTextPreparing', "True while the on-device speech-to-text model is downloading or loading (the download progress ring is shown).") });
 
 	export const supported = ContextKeyExpr.or(IsWebContext.negate(), RemoteNameContext.notEqualsTo(''), ContextKeyExpr.has('config.chat.experimental.serverlessWebEnabled'));
 	export const enabled = new RawContextKey<boolean>('chatIsEnabled', false, { type: 'boolean', description: localize('chatIsEnabled', "True when chat is enabled because a default chat participant is activated with an implementation.") });


### PR DESCRIPTION
## Improve the dictation initial-download UX

While the on-device speech-to-text model downloads on **first** dictation, the toolbar previously showed an ugly **spinning mic** plus a progress **notification**. This replaces that with a clearer, self-explanatory affordance.

### What changed
- 🔽 **Download icon + progress ring.** During download the mic is replaced by a `cloud-download` icon wrapped in a **circular progress ring** that fills as bytes arrive, then returns to the mic once the model is ready.
- ⏳ **Indeterminate fallback.** Before the byte total is known (or while the model loads into memory) the ring shows an indeterminate spin, gated on `monaco-enable-motion` to respect reduced motion.
- 💬 **Rich hover.** Hovering the affordance shows "**Downloading speech-to-text model** — N% downloaded…", updated live.
- 🔕 **Notification removed** for sighted users. The `IProgressService` notification is now surfaced **only when a screen reader is active** (a hover isn't reachable by assistive technologies), so screen-reader users still get progress announcements.

### Implementation
- `speechToText/chatSpeechToTextService.ts` — exposes `modelDownloadProgress` + `onDidChangeModelDownloadProgress`; gates the notification behind `IAccessibilityService.isScreenReaderOptimized()`.
- `speechToText/dictationDownloadActionViewItem.ts` *(new)* — `MenuEntryActionViewItem` subclass rendering the SVG ring and rich markdown hover.
- `actions/chatSpeechToTextActions.ts` — preparing action icon `spinningLoading` → `Codicon.cloudDownload`.
- `widget/input/chatInputPart.ts` — `actionViewItemProvider` on the execute toolbar wiring the ring.
- `widget/media/chat.css` — ring styling + indeterminate spin.
- `common/actions/chatContextKeys.ts` — updated context-key description.

### Validation
- `typecheck-client` clean (only pre-existing unrelated `localTranscription/node` optional-module errors).
- eslint clean on changed files.
