### PR TITLE
Chat dictation: always use Nemotron model, remove model setting

### DIFF
--- a/src/vs/platform/localTranscription/common/localTranscription.ts
+++ b/src/vs/platform/localTranscription/common/localTranscription.ts
@@ -66,10 +66,9 @@ export interface ILocalTranscriptionResult {
  * Microsoft's Foundry Local streaming ASR engine (onnxruntime + onnxruntime-genai
  * native runtime), which handles decoding, VAD and endpointing internally; the
  * default model is NVIDIA's `nemotron-speech-streaming-en-0.6b` streaming RNN-T
- * (the model the GitHub Copilot app ships for dictation). The model is chosen by
- * the `chat.speechToText.model` setting. Runs in a utility process. A single
- * transcription session is active at a time (dictation is a singleton in the
- * renderer).
+ * (the model the GitHub Copilot app ships for dictation). Runs in a utility
+ * process. A single transcription session is active at a time (dictation is a
+ * singleton in the renderer).
  *
  * The renderer streams PCM16 mono 16 kHz audio via `pushAudio`; the service
  * emits interim transcripts on `onDidTranscribe` and a final one after `stop`.
@@ -96,9 +95,8 @@ export interface ILocalTranscriptionService {
 
 	/**
 	 * Ensure the model is downloaded/loaded (idempotent) and begin a new
-	 * transcription session. `cacheDir` is where model files are stored. `model`
-	 * selects the on-device Foundry Local model; when omitted the service default
-	 * is used. `language` optionally hints the spoken language.
+	 * transcription session. `cacheDir` is where model files are stored.
+	 * `language` optionally hints the spoken language.
 	 *
 	 * NOTE: Foundry Local performs the first-use model download itself and does
 	 * not currently expose a hook for VS Code's `http.proxy`/`http.proxyStrictSSL`
@@ -106,7 +104,7 @@ export interface ILocalTranscriptionService {
 	 * corporate proxy the first-use download may fail until Foundry Local gains a
 	 * supported proxy mechanism.
 	 */
-	start(options: { readonly cacheDir: string; readonly model?: string; readonly language?: string }): Promise<void>;
+	start(options: { readonly cacheDir: string; readonly language?: string }): Promise<void>;
 
 	/** Append captured audio (raw little-endian PCM16 mono 16 kHz). */
 	pushAudio(chunk: VSBuffer): Promise<void>;

--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -238,7 +238,7 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._onDidChangeModelStatus.fire(status);
 	}
 
-	async start(options: { cacheDir: string; model?: string; language?: string }): Promise<void> {
+	async start(options: { cacheDir: string; language?: string }): Promise<void> {
 		// Reset any prior session before starting a new one.
 		await this._disposeSession();
 		this._generation++;
@@ -249,11 +249,10 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._pendingChunks = [];
 		this._runtimeError = undefined;
 
-		const model = options.model ?? DEFAULT_MODEL;
 		const language = options.language;
 		// Do not block capture on the (possibly first-use) model download/load and
 		// session open; buffer audio until the session is ready, then flush it.
-		this._openPromise = this._openSession(options.cacheDir, model, language, generation);
+		this._openPromise = this._openSession(options.cacheDir, DEFAULT_MODEL, language, generation);
 		this._openPromise.catch(() => { /* status already reported */ });
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -259,19 +259,6 @@ configurationRegistry.registerConfiguration({
 			default: product.quality !== 'stable',
 			tags: ['experimental']
 		},
-		'chat.speechToText.model': {
-			type: 'string',
-			enum: [
-				'nemotron-speech-streaming-en-0.6b',
-			],
-			enumItemLabels: ['Nemotron Streaming (English)'],
-			markdownEnumDescriptions: [
-				nls.localize('chat.speechToText.model.nemotronStreaming', "NVIDIA Nemotron streaming RNN-T (English), run through Microsoft Foundry Local. Low-latency, high accuracy, matches the GitHub Copilot app."),
-			],
-			markdownDescription: nls.localize('chat.speechToText.model', "The on-device model used for chat dictation. The model is downloaded on first use and cached on disk. Transcription runs locally through Microsoft Foundry Local."),
-			default: 'nemotron-speech-streaming-en-0.6b',
-			tags: ['experimental']
-		},
 		'chat.speechToText.mode': {
 			type: 'string',
 			enum: ['auto', 'toggle', 'pushToTalk'],
@@ -2278,23 +2265,12 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration).
 		}
 	},
 	{
-		// The on-device dictation runtime moved to Foundry Local; the old
-		// transformers.js/onnxruntime model IDs no longer resolve and would fail
-		// with an unknown-model error. Map any explicitly-stored legacy value to
-		// the new default so existing users keep working.
+		// The chat dictation model is no longer configurable; the on-device
+		// runtime always uses NVIDIA Nemotron streaming ASR through Foundry Local.
+		// Clear any explicitly-stored value from the removed setting so it does
+		// not linger as an unknown setting in user configuration.
 		key: 'chat.speechToText.model',
-		migrateFn: (value: unknown) => {
-			const legacyModelIds = [
-				'onnx-community/whisper-tiny',
-				'onnx-community/whisper-base',
-				'onnx-community/whisper-small',
-				'onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4',
-			];
-			if (typeof value === 'string' && legacyModelIds.includes(value)) {
-				return { value: 'nemotron-speech-streaming-en-0.6b' };
-			}
-			return [];
-		}
+		migrateFn: () => ({ value: undefined })
 	},
 ]);
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -31,8 +31,6 @@ const SAMPLE_RATE = 16000;
 
 /** Setting that enables the dictation feature; a kill-switch for rollout. */
 const ENABLED_SETTING = 'chat.speechToText.enabled';
-/** On-device model (Whisper or Nemotron) to use for dictation. */
-const MODEL_SETTING = 'chat.speechToText.model';
 /** Setting that controls the tap-vs-hold behavior of the dictation shortcut. */
 const MODE_SETTING = 'chat.speechToText.mode';
 
@@ -423,8 +421,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 			this._onDidUpdateTranscript.fire({ text: this._transcript, finalizedText: result.finalizedText ?? '' });
 		}));
 		const cacheDir = joinPath(this._environmentService.cacheHome, 'chatDictationModels').fsPath;
-		const model = this._getModelId();
-		await local.start({ cacheDir, model });
+		await local.start({ cacheDir });
 
 		// The model loads in the utility process in the background (start()
 		// returns immediately). On first use it may download hundreds of MB, so
@@ -434,11 +431,6 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		if (status.state !== LocalTranscriptionModelState.Ready && status.state !== LocalTranscriptionModelState.Error) {
 			this._trackModelPreparation();
 		}
-	}
-
-	private _getModelId(): string | undefined {
-		const value = this._configurationService.getValue<string>(MODEL_SETTING);
-		return value ? value.trim() || undefined : undefined;
 	}
 
 	/**

--- a/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
+++ b/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
@@ -73,7 +73,7 @@ export class LocalTranscriptionService {
 	get onDidTranscribe() { return this._getProxy().onDidTranscribe; }
 
 	getModelStatus() { return this._getProxy().getModelStatus(); }
-	start(options: { cacheDir: string; model?: string; language?: string }) { return this._getProxy().start({ cacheDir: options.cacheDir, model: options.model, language: options.language }); }
+	start(options: { readonly cacheDir: string; readonly language?: string }) { return this._getProxy().start({ cacheDir: options.cacheDir, language: options.language }); }
 	pushAudio(chunk: Parameters<ILocalTranscriptionService['pushAudio']>[0]) { return this._getProxy().pushAudio(chunk); }
 	stop() { return this._getProxy().stop(); }
 	cancel() { return this._getProxy().cancel(); }


### PR DESCRIPTION
The on-device chat dictation runtime is Microsoft Foundry Local's streaming ASR engine, and the only supported model is NVIDIA Nemotron (`nemotron-speech-streaming-en-0.6b` — the model the GitHub Copilot app ships). The `chat.speechToText.model` setting therefore only ever had a single valid value, and the legacy Whisper model IDs no longer resolve.

This PR removes model selection entirely and hardcodes Nemotron:

- **Remove the `chat.speechToText.model` setting.** Its migration is replaced with one that clears any explicitly-stored value so it doesn't linger as an unknown setting (this also drops the legacy `onnx-community/whisper-*` references).
- **`ChatSpeechToTextService`**: remove `MODEL_SETTING` and `_getModelId()`; start the local session without a model argument.
- **`ILocalTranscriptionService.start()`**: drop the unused optional `model` option from the interface, the electron-browser proxy, and the node implementation. The node service always uses the Nemotron default.

No user-facing behavior change: dictation already defaulted to Nemotron. This just removes the dead selection surface and the last Whisper references.

### Validation
- `npm run typecheck-client` passes.