### PR TITLE
fix: prevent multi-diff phantom headers while scrolling

### DIFF
--- a/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
@@ -305,6 +305,10 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 
 			this._dataStore.clear();
 			this._viewModel.set(data.viewModel, tx);
+			// Recycled templates keep the previous resource's content height until the new
+			// diff model reports size; seed from this view model's last height instead.
+			const lastContentHeight = data.viewModel.lastTemplateData.get().contentHeight;
+			this._editorContentHeight.set(Math.max(0, lastContentHeight - this._outerEditorHeight), tx);
 			this.editor.setDiffModel(data.viewModel.diffEditorViewModelRef, tx);
 			this.editor.updateOptions(updateOptions(value.options ?? {}));
 		});

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -735,10 +735,7 @@ class VirtualizedViewItem extends Disposable {
 	public hide(): void {
 		this._isHidden.set(true, undefined);
 
-		// Hide the template DOM immediately. Returning the template to the object pool is
-		// still deferred (via the autorun below) so a focused editor is not torn down, but
-		// leaving the node visible/positioned until that autorun runs causes ghost rows —
-		// repeated headers at sliver heights — while scrolling large multi-diffs (#326702).
+		// Hide immediately to avoid stale DOM while focused-template recycling remains deferred.
 		const ref = this._templateRef.get();
 		if (ref) {
 			ref.object.hide();

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -734,6 +734,18 @@ class VirtualizedViewItem extends Disposable {
 
 	public hide(): void {
 		this._isHidden.set(true, undefined);
+
+		// Hide the template DOM immediately. Returning the template to the object pool is
+		// still deferred (via the autorun below) so a focused editor is not torn down, but
+		// leaving the node visible/positioned until that autorun runs causes ghost rows —
+		// repeated headers at sliver heights — while scrolling large multi-diffs (#326702).
+		const ref = this._templateRef.get();
+		if (ref) {
+			ref.object.hide();
+			if (!ref.object.isFocused.get()) {
+				this._clear();
+			}
+		}
 	}
 
 	public render(verticalSpace: OffsetRange, offset: number, width: number, viewPort: OffsetRange): void {

--- a/src/vs/editor/browser/widget/multiDiffEditor/objectPool.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/objectPool.ts
@@ -21,7 +21,9 @@ export class ObjectPool<TData extends IObjectData, T extends IPooledObject<TData
 			this._itemData.set(obj, data);
 		} else {
 			const values = [...this._unused.values()];
-			obj = values.find(obj => this._itemData.get(obj)!.getId() === data.getId()) ?? values[0];
+			// Prefer a pooled object that previously rendered this id so setData can no-op
+			// expensive editor rebinds when the same resource scrolls back into view.
+			obj = values.find(candidate => this._itemData.get(candidate)?.getId() === data.getId()) ?? values[0];
 			this._unused.delete(obj);
 			this._itemData.set(obj, data);
 			obj.setData(data);
@@ -32,6 +34,7 @@ export class ObjectPool<TData extends IObjectData, T extends IPooledObject<TData
 			dispose: () => {
 				this._used.delete(obj);
 				if (this._unused.size > 5) {
+					this._itemData.delete(obj);
 					obj.dispose();
 				} else {
 					this._unused.add(obj);
@@ -49,6 +52,7 @@ export class ObjectPool<TData extends IObjectData, T extends IPooledObject<TData
 		}
 		this._used.clear();
 		this._unused.clear();
+		this._itemData.clear();
 	}
 }
 

--- a/src/vs/editor/test/browser/widget/multiDiffEditor/objectPool.test.ts
+++ b/src/vs/editor/test/browser/widget/multiDiffEditor/objectPool.test.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ObjectPool, IObjectData, IPooledObject } from '../../../../browser/widget/multiDiffEditor/objectPool.js';
+
+suite('ObjectPool', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	class Data implements IObjectData {
+		constructor(readonly id: string) { }
+		getId() { return this.id; }
+	}
+
+	class Obj implements IPooledObject<Data> {
+		data: Data | undefined;
+		disposed = false;
+		setData(data: Data): void { this.data = data; }
+		dispose(): void { this.disposed = true; }
+	}
+
+	test('reuses pooled object and updates data', () => {
+		let created = 0;
+		const pool = new ObjectPool<Data, Obj>((data) => {
+			created++;
+			const obj = new Obj();
+			obj.setData(data);
+			return obj;
+		});
+
+		const a = pool.getUnusedObj(new Data('a'));
+		assert.strictEqual(a.object.data?.id, 'a');
+		a.dispose();
+
+		const b = pool.getUnusedObj(new Data('b'));
+		assert.strictEqual(created, 1, 'should reuse pooled instance');
+		assert.strictEqual(b.object.data?.id, 'b');
+		assert.strictEqual(b.object.disposed, false);
+		b.dispose();
+		pool.dispose();
+	});
+
+	test('prefers object that previously had the same id', () => {
+		const pool = new ObjectPool<Data, Obj>((data) => {
+			const obj = new Obj();
+			obj.setData(data);
+			return obj;
+		});
+
+		const a1 = pool.getUnusedObj(new Data('a'));
+		const b1 = pool.getUnusedObj(new Data('b'));
+		a1.dispose();
+		b1.dispose();
+
+		const a2 = pool.getUnusedObj(new Data('a'));
+		assert.strictEqual(a2.object.data?.id, 'a');
+		// Same physical instance that previously served 'a'
+		assert.strictEqual(a2.object, a1.object);
+		a2.dispose();
+		pool.dispose();
+	});
+
+	test('disposes overflow objects and drops item data', () => {
+		const pool = new ObjectPool<Data, Obj>((data) => {
+			const obj = new Obj();
+			obj.setData(data);
+			return obj;
+		});
+
+		const refs = [];
+		for (let i = 0; i < 8; i++) {
+			refs.push(pool.getUnusedObj(new Data(String(i))));
+		}
+		for (const ref of refs) {
+			ref.dispose();
+		}
+
+		// Pool keeps at most 5 unused; the rest are disposed
+		const again = pool.getUnusedObj(new Data('x'));
+		assert.strictEqual(again.object.disposed, false);
+		assert.strictEqual(again.object.data?.id, 'x');
+		again.dispose();
+		pool.dispose();
+	});
+});


### PR DESCRIPTION
## Summary
- Multi-diff virtualization deferred hiding off-screen row templates until an autorun ran, so during fast scroll the old DOM stayed visible and produced repeated/sliver headers (#326702).
- `VirtualizedViewItem.hide()` now immediately hides the template DOM and synchronously returns unfocused templates to the object pool.
- Recycled templates seed content height from the target view model's `lastTemplateData`, and `ObjectPool` drops `_itemData` when disposing overflow objects.
- Adds unit tests for `ObjectPool` reuse / id preference / overflow dispose.

Fixes #326702

## Test plan
- [x] Unit: `ObjectPool` suite (3 tests) via `test/unit/electron/index.js --grep ObjectPool`
- [ ] Manual: open a multi-diff with ~30+ files (`vscode.changes` / SCM Open All Changes), scroll aggressively up/down; headers should stay 1:1 with files (no repeated phantom headers at ~35px)
- [ ] Manual: focused nested diff editor is not torn down while its row is scrolled off (still deferred recycle when focused)