### PR TITLE
Add low verbosity for GPT-5.6 responses

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4187,6 +4187,15 @@
               "onExp"
             ]
           },
+          "github.copilot.chat.gpt56Verbosity.enabled": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "%github.copilot.config.gpt56Verbosity.enabled%",
+            "tags": [
+              "experimental",
+              "onExp"
+            ]
+          },
           "github.copilot.chat.gemini3GetChangedFilesTool.enabled": {
             "type": "boolean",
             "default": false,

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -354,6 +354,7 @@
 	"github.copilot.config.claude48OpusPrompt.enabled": "Enables the updated system prompt tuned for the Claude Opus 4.8 model.",
 	"github.copilot.config.claudeSonnet5Prompt.enabled": "Enables the updated system prompt tuned for the Claude Sonnet 5 model.",
 	"github.copilot.config.gpt55GetChangedFilesTool.enabled": "Enables the Get Changed Files tool for gpt-5.5 models.",
+	"github.copilot.config.gpt56Verbosity.enabled": "Sets the response verbosity to low for gpt-5.6 models.",
 	"github.copilot.config.gemini3GetChangedFilesTool.enabled": "Enables the Get Changed Files tool for gemini-3 models.",
 	"github.copilot.config.gemini3LowReasoningEffort.enabled": "Sets the reasoning effort to low for gemini-3 models.",
 	"github.copilot.config.gpt55ReadFileTool.enabled": "Enables the Read File tool for gpt-5.5 models.",

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -993,6 +993,8 @@ export namespace ConfigKey {
 	export const ClaudeSonnet5PromptEnabled = defineSetting<boolean>('chat.claudeSonnet5Prompt.enabled', ConfigType.ExperimentBased, false);
 	/** Enable get_changed_files tool for GPT-5.5 models */
 	export const EnableGpt55GetChangedFilesTool = defineSetting<boolean>('chat.gpt55GetChangedFilesTool.enabled', ConfigType.ExperimentBased, true);
+	/** Enable low verbosity for GPT-5.6 models. */
+	export const EnableGpt56Verbosity = defineSetting<boolean>('chat.gpt56Verbosity.enabled', ConfigType.ExperimentBased, true);
 	/** Enable get_changed_files tool for Gemini 3 models */
 	export const EnableGemini3GetChangedFilesTool = defineSetting<boolean>('chat.gemini3GetChangedFilesTool.enabled', ConfigType.ExperimentBased, false);
 	/** When enabled, sends `reasoning_effort: 'low'` to Gemini 3 models. */

--- a/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -437,11 +437,10 @@ export function isGpt51Family(model: LanguageModelChat | IChatEndpoint | string 
 /**
  * This takes a sync shortcut and should only be called when a model hash would have already been computed while rendering the prompt.
  */
-export function getVerbosityForModelSync(model: IChatEndpoint): 'low' | 'medium' | 'high' | undefined {
-	if (model.family === 'gpt-5.1' || model.family === 'gpt-5-mini') {
+export function getVerbosityForModelSync(model: IChatEndpoint, responsesApiVerbosityEnabled?: boolean): 'low' | 'medium' | 'high' | undefined {
+	if (model.family === 'gpt-5.1' || model.family === 'gpt-5-mini' || (isGpt56(model) && responsesApiVerbosityEnabled)) {
 		return 'low';
 	}
-
 	return undefined;
 }
 

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -45,10 +45,14 @@ export function getResponsesApiCompactionThreshold(configService: IConfiguration
 		: 50000;
 }
 
+export function getVerbosityForModelSyncBasedOnExp(configService: IConfigurationService, expService: IExperimentationService, endpoint: IChatEndpoint): 'low' | 'medium' | 'high' | undefined {
+	return getVerbosityForModelSync(endpoint, configService.getExperimentBasedConfig(ConfigKey.EnableGpt56Verbosity, expService));
+}
+
 export function createResponsesRequestBody(accessor: ServicesAccessor, options: ICreateEndpointBodyOptions, model: string, endpoint: IChatEndpoint): IEndpointBody {
 	const configService = accessor.get(IConfigurationService);
 	const expService = accessor.get(IExperimentationService);
-	const verbosity = getVerbosityForModelSync(endpoint);
+	const verbosity = getVerbosityForModelSyncBasedOnExp(configService, expService, endpoint);
 	const compactThreshold = getResponsesApiCompactionThreshold(configService, expService, endpoint);
 	// compaction supported for all the models but works well for codex models and any future models after 5.3
 


### PR DESCRIPTION
## Summary

- add an experiment-based setting for GPT-5.6 response verbosity
- send `verbosity: "low"` for GPT-5.6 Responses API requests when enabled
- keep the existing GPT-5.1 and GPT-5 mini behavior unchanged

## Validation

- `npm run typecheck`
- `npx eslint src/platform/configuration/common/configurationService.ts src/platform/endpoint/common/chatModelCapabilities.ts src/platform/endpoint/node/responsesApi.ts --max-warnings=0`
- `npx vitest --run src/platform/endpoint/node/test/responsesApi.spec.ts --pool=forks` (53 tests passed)
- `git diff --check`