### PR TITLE
sessions: rename Conversations menu title to Chats

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -1198,7 +1198,7 @@ export class SessionNewChatActionViewItemContribution extends Disposable impleme
 // committed chat.
 MenuRegistry.appendMenuItem(Menus.SessionBarToolbar, {
 	submenu: Menus.SessionConversations,
-	title: localize2('chatCompositeBar.conversations', "Conversations"),
+	title: localize2('chatCompositeBar.conversations', "Chats"),
 	icon: Codicon.commentDiscussion,
 	group: 'navigation',
 	order: 10,
@@ -1211,7 +1211,7 @@ MenuRegistry.appendMenuItem(Menus.SessionBarToolbar, {
 // the Conversations menu only ever appears in one place at a time.
 MenuRegistry.appendMenuItem(Menus.SessionChatTabBar, {
 	submenu: Menus.SessionConversations,
-	title: localize2('chatCompositeBar.conversations', "Conversations"),
+	title: localize2('chatCompositeBar.conversations', "Chats"),
 	icon: Codicon.commentDiscussion,
 	group: 'navigation',
 	order: 10,


### PR DESCRIPTION
## What

Renames the user-facing chat picker submenu title from **"Conversations"** to **"Chats"** in the Agents window.

## Why

The menu lists the session's chats, so "Chats" is clearer and consistent with the rest of the Agents window terminology.

## Details

The title change is applied in both places the submenu surfaces (they share the same localization key `chatCompositeBar.conversations`):

- Session header toolbar entry (`Menus.SessionBarToolbar`), shown while the chat tab strip is hidden.
- Chat tab bar mirror entry (`Menus.SessionChatTabBar`), shown at the end of the strip once it is visible.

Internal identifiers (`Menus.SessionConversations`, `SessionConversationsMenuContribution`, context keys) and doc comments are intentionally left unchanged since they are not user-facing.

## Notes for reviewers

Purely a label change — no behavior change.
