### PR TITLE
Support Go to Symbol (⇧⌘O) for chat sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -145,7 +145,7 @@ import { ChatEditingEditorOverlay } from './chatEditing/chatEditingEditorOverlay
 import { ChatEditingService } from './chatEditing/chatEditingServiceImpl.js';
 import { ChatEditingNotebookFileSystemProviderContrib } from './chatEditing/notebook/chatEditingNotebookFileSystemProvider.js';
 import { ChatEditor, IChatEditorOptions } from './widgetHosts/editor/chatEditor.js';
-import { ChatOutlineCreator } from './chatOutline.js';
+import { ChatOutlineCreator } from './chatOutlineCreator.js';
 import { ChatEditorInput, ChatEditorInputSerializer } from './widgetHosts/editor/chatEditorInput.js';
 import { ChatLayoutService } from './widget/chatLayoutService.js';
 import { ChatLanguageModelsDataContribution, LanguageModelsConfigurationService } from './languageModelsConfigurationService.js';

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -145,6 +145,7 @@ import { ChatEditingEditorOverlay } from './chatEditing/chatEditingEditorOverlay
 import { ChatEditingService } from './chatEditing/chatEditingServiceImpl.js';
 import { ChatEditingNotebookFileSystemProviderContrib } from './chatEditing/notebook/chatEditingNotebookFileSystemProvider.js';
 import { ChatEditor, IChatEditorOptions } from './widgetHosts/editor/chatEditor.js';
+import { ChatOutlineCreator } from './chatOutline.js';
 import { ChatEditorInput, ChatEditorInputSerializer } from './widgetHosts/editor/chatEditorInput.js';
 import { ChatLayoutService } from './widget/chatLayoutService.js';
 import { ChatLanguageModelsDataContribution, LanguageModelsConfigurationService } from './languageModelsConfigurationService.js';
@@ -2737,6 +2738,7 @@ registerWorkbenchContribution2(AgentHostChatDebugContribution.ID, AgentHostChatD
 registerWorkbenchContribution2(ChatLanguageModelsDataContribution.ID, ChatLanguageModelsDataContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatSlashCommandsContribution.ID, ChatSlashCommandsContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(ChatSessionOptionSlashCommandsContribution.ID, ChatSessionOptionSlashCommandsContribution, WorkbenchPhase.Eventually);
+registerWorkbenchContribution2(ChatOutlineCreator.ID, ChatOutlineCreator, WorkbenchPhase.AfterRestored);
 
 registerWorkbenchContribution2(ChatExtensionPointHandler.ID, ChatExtensionPointHandler, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(LanguageModelToolsExtensionPointHandler.ID, LanguageModelToolsExtensionPointHandler, WorkbenchPhase.BlockRestore);

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -30,6 +30,8 @@ import { ChatWidget, IChatWidgetContrib } from './widget/chatWidget.js';
 import { ICodeBlockActionContext, ICodeBlockRenderOptions } from './widget/chatContentParts/codeBlockPart.js';
 import { AgentSessionTarget } from './agentSessions/agentSessions.js';
 
+export { ChatOutline } from './chatOutline.js';
+
 /**
  * A workspace item that can be selected in the workspace picker.
  */

--- a/src/vs/workbench/contrib/chat/browser/chatOutline.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatOutline.ts
@@ -7,7 +7,6 @@ import { IconLabel, IIconLabelValueOptions } from '../../../../base/browser/ui/i
 import { IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
 import { IListAccessibilityProvider } from '../../../../base/browser/ui/list/listWidget.js';
 import { IDataSource, ITreeNode, ITreeRenderer } from '../../../../base/browser/ui/tree/tree.js';
-import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { createMatches, FuzzyScore } from '../../../../base/common/filters.js';
@@ -18,23 +17,23 @@ import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { IEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { IWorkbenchDataTreeOptions } from '../../../../platform/list/browser/listService.js';
-import { IEditorPane } from '../../../common/editor.js';
-import { IBreadcrumbsDataSource, IBreadcrumbsOutlineElement, IOutline, IOutlineComparator, IOutlineCreator, IOutlineListConfig, IOutlineService, IQuickPickDataSource, IQuickPickOutlineElement, OutlineChangeEvent, OutlineTarget } from '../../../services/outline/browser/outline.js';
+import { IBreadcrumbsDataSource, IBreadcrumbsOutlineElement, IOutline, IOutlineComparator, IOutlineListConfig, IQuickPickDataSource, IQuickPickOutlineElement, OutlineChangeEvent, OutlineTarget } from '../../../services/outline/browser/outline.js';
 import { ChatTreeItem, IChatWidget } from './chat.js';
-import { ChatEditor } from './widgetHosts/editor/chatEditor.js';
 import { IChatRequestViewModel, isRequestVM } from '../common/model/chatViewModel.js';
 import { isChatFollowup } from '../common/chatService/chatService.js';
+import { getExplicitFileOrImageAttachmentSummary } from '../common/attachments/chatVariableEntries.js';
 
 /**
  * Derives the display label for a chat request. Reads the prompt text the same
  * way the chat list renders it (followup message, else the parsed request
  * parts) rather than relying on `messageText`, which some providers (e.g.
- * agent-host sessions) leave empty. Collapses whitespace so multi-line prompts
- * render on a single row. Returns raw text; callers that render into an
- * icon-parsing surface (e.g. the quick pick) must escape `$(...)` codicon
- * markup themselves via `escapeIcons`.
+ * agent-host sessions) leave empty. When there is no prompt text, falls back to
+ * an attachment summary (matching the chat list) and finally a numbered label.
+ * Collapses whitespace so multi-line prompts render on a single row. Returns raw
+ * text; callers that render into an icon-parsing surface (e.g. the quick pick)
+ * must escape `$(...)` codicon markup themselves via `escapeIcons`.
  */
-function getChatRequestLabel(request: IChatRequestViewModel, index: number): string {
+export function getChatRequestLabel(request: IChatRequestViewModel, index: number): string {
 	const message = request.message;
 	let raw: string;
 	if (isChatFollowup(message)) {
@@ -43,7 +42,10 @@ function getChatRequestLabel(request: IChatRequestViewModel, index: number): str
 		raw = message.text || (Array.isArray(message.parts) ? message.parts.map(part => part.text).join('') : '');
 	}
 	const text = typeof raw === 'string' ? raw.replace(/\s+/g, ' ').trim() : '';
-	return text.length > 0 ? text : localize('chatOutline.emptyRequest', "Request {0}", index + 1);
+	if (text.length > 0) {
+		return text;
+	}
+	return getExplicitFileOrImageAttachmentSummary(request.variables) ?? localize('chatOutline.emptyRequest', "Request {0}", index + 1);
 }
 
 /**
@@ -51,7 +53,7 @@ function getChatRequestLabel(request: IChatRequestViewModel, index: number): str
  * request (prompt) in the chat, acting as the top-level "symbol" the user can
  * jump to via Go to Symbol, the Outline pane, and Breadcrumbs.
  */
-class ChatOutlineEntry {
+export class ChatOutlineEntry {
 
 	constructor(
 		readonly index: number,
@@ -183,9 +185,11 @@ export class ChatOutline implements IOutline<ChatOutlineEntry> {
 		this._recomputeEntries();
 
 		this._disposables.add(this._widget.onDidChangeViewModel(() => {
-			this._recomputeEntries();
+			const changed = this._recomputeEntries();
 			this._registerViewModelListener();
-			this._onDidChange.fire({});
+			if (changed) {
+				this._onDidChange.fire({});
+			}
 		}));
 		this._registerViewModelListener();
 
@@ -215,13 +219,18 @@ export class ChatOutline implements IOutline<ChatOutlineEntry> {
 		const viewModel = this._widget.viewModel;
 		if (viewModel) {
 			this._viewModelDisposables.add(viewModel.onDidChange(() => {
-				this._recomputeEntries();
-				this._onDidChange.fire({});
+				// The view model fires on every response update (including each
+				// streamed chunk). Request symbols don't change during streaming,
+				// so only refresh the outline when the entries actually change.
+				if (this._recomputeEntries()) {
+					this._onDidChange.fire({});
+				}
 			}));
 		}
 	}
 
-	private _recomputeEntries(): void {
+	private _entriesSignature = '';
+	private _recomputeEntries(): boolean {
 		const items = this._widget.viewModel?.getItems() ?? [];
 		const entries: ChatOutlineEntry[] = [];
 		let index = 0;
@@ -230,7 +239,15 @@ export class ChatOutline implements IOutline<ChatOutlineEntry> {
 				entries.push(new ChatOutlineEntry(index++, item));
 			}
 		}
+
+		const signature = entries.map(entry => `${entry.id}\u0000${entry.label}`).join('\u0001');
+		if (signature === this._entriesSignature) {
+			return false;
+		}
+
 		this._entries = entries;
+		this._entriesSignature = signature;
+		return true;
 	}
 
 	get entries(): ChatOutlineEntry[] {
@@ -273,28 +290,3 @@ export class ChatOutline implements IOutline<ChatOutlineEntry> {
 	}
 }
 
-export class ChatOutlineCreator implements IOutlineCreator<ChatEditor, ChatOutlineEntry> {
-
-	static readonly ID = 'chat.chatOutlineCreator';
-
-	readonly dispose: () => void;
-
-	constructor(
-		@IOutlineService outlineService: IOutlineService,
-	) {
-		const reg = outlineService.registerOutlineCreator(this);
-		this.dispose = () => reg.dispose();
-	}
-
-	matches(candidate: IEditorPane): candidate is ChatEditor {
-		return candidate instanceof ChatEditor;
-	}
-
-	async createOutline(editor: ChatEditor, target: OutlineTarget, _token: CancellationToken): Promise<IOutline<ChatOutlineEntry> | undefined> {
-		const widget = editor.widget;
-		if (!widget) {
-			return undefined;
-		}
-		return new ChatOutline(widget, target);
-	}
-}

--- a/src/vs/workbench/contrib/chat/browser/chatOutline.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatOutline.ts
@@ -1,0 +1,300 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IconLabel, IIconLabelValueOptions } from '../../../../base/browser/ui/iconLabel/iconLabel.js';
+import { IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
+import { IListAccessibilityProvider } from '../../../../base/browser/ui/list/listWidget.js';
+import { IDataSource, ITreeNode, ITreeRenderer } from '../../../../base/browser/ui/tree/tree.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { createMatches, FuzzyScore } from '../../../../base/common/filters.js';
+import { escapeIcons } from '../../../../base/common/iconLabels.js';
+import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
+import { IEditorOptions } from '../../../../platform/editor/common/editor.js';
+import { IWorkbenchDataTreeOptions } from '../../../../platform/list/browser/listService.js';
+import { IEditorPane } from '../../../common/editor.js';
+import { IBreadcrumbsDataSource, IBreadcrumbsOutlineElement, IOutline, IOutlineComparator, IOutlineCreator, IOutlineListConfig, IOutlineService, IQuickPickDataSource, IQuickPickOutlineElement, OutlineChangeEvent, OutlineTarget } from '../../../services/outline/browser/outline.js';
+import { ChatTreeItem, IChatWidget } from './chat.js';
+import { ChatEditor } from './widgetHosts/editor/chatEditor.js';
+import { IChatRequestViewModel, isRequestVM } from '../common/model/chatViewModel.js';
+import { isChatFollowup } from '../common/chatService/chatService.js';
+
+/**
+ * Derives the display label for a chat request. Reads the prompt text the same
+ * way the chat list renders it (followup message, else the parsed request
+ * parts) rather than relying on `messageText`, which some providers (e.g.
+ * agent-host sessions) leave empty. Collapses whitespace so multi-line prompts
+ * render on a single row. Returns raw text; callers that render into an
+ * icon-parsing surface (e.g. the quick pick) must escape `$(...)` codicon
+ * markup themselves via `escapeIcons`.
+ */
+function getChatRequestLabel(request: IChatRequestViewModel, index: number): string {
+	const message = request.message;
+	let raw: string;
+	if (isChatFollowup(message)) {
+		raw = message.message ?? '';
+	} else {
+		raw = message.text || (Array.isArray(message.parts) ? message.parts.map(part => part.text).join('') : '');
+	}
+	const text = typeof raw === 'string' ? raw.replace(/\s+/g, ' ').trim() : '';
+	return text.length > 0 ? text : localize('chatOutline.emptyRequest', "Request {0}", index + 1);
+}
+
+/**
+ * A single navigable element in a chat outline. Each entry maps to a user
+ * request (prompt) in the chat, acting as the top-level "symbol" the user can
+ * jump to via Go to Symbol, the Outline pane, and Breadcrumbs.
+ */
+class ChatOutlineEntry {
+
+	constructor(
+		readonly index: number,
+		readonly element: IChatRequestViewModel,
+	) { }
+
+	get id(): string {
+		return this.element.id;
+	}
+
+	get icon(): ThemeIcon {
+		return Codicon.commentDiscussion;
+	}
+
+	get label(): string {
+		return getChatRequestLabel(this.element, this.index);
+	}
+}
+
+class ChatOutlineVirtualDelegate implements IListVirtualDelegate<ChatOutlineEntry> {
+	getHeight(): number {
+		return 22;
+	}
+	getTemplateId(): string {
+		return ChatOutlineRenderer.templateId;
+	}
+}
+
+interface IChatOutlineTemplate {
+	readonly container: HTMLElement;
+	readonly iconClass: HTMLElement;
+	readonly iconLabel: IconLabel;
+}
+
+class ChatOutlineRenderer implements ITreeRenderer<ChatOutlineEntry, FuzzyScore, IChatOutlineTemplate> {
+
+	static readonly templateId = 'ChatOutlineRenderer';
+	readonly templateId = ChatOutlineRenderer.templateId;
+
+	renderTemplate(container: HTMLElement): IChatOutlineTemplate {
+		container.classList.add('chat-outline-element');
+		const iconClass = document.createElement('div');
+		container.append(iconClass);
+		const iconLabel = new IconLabel(container, { supportHighlights: true });
+		return { container, iconClass, iconLabel };
+	}
+
+	renderElement(node: ITreeNode<ChatOutlineEntry, FuzzyScore>, _index: number, template: IChatOutlineTemplate): void {
+		const options: IIconLabelValueOptions = {
+			matches: createMatches(node.filterData),
+			labelEscapeNewLines: true,
+		};
+		template.iconClass.className = 'element-icon ' + ThemeIcon.asClassNameArray(node.element.icon).join(' ');
+		template.iconLabel.setLabel(node.element.label, undefined, options);
+	}
+
+	disposeTemplate(template: IChatOutlineTemplate): void {
+		template.iconLabel.dispose();
+	}
+}
+
+class ChatOutlineAccessibility implements IListAccessibilityProvider<ChatOutlineEntry> {
+	getAriaLabel(element: ChatOutlineEntry): string {
+		return element.label;
+	}
+	getWidgetAriaLabel(): string {
+		return localize('chatOutline', "Chat Outline");
+	}
+}
+
+class ChatOutlineComparator implements IOutlineComparator<ChatOutlineEntry> {
+	compareByPosition(a: ChatOutlineEntry, b: ChatOutlineEntry): number {
+		return a.index - b.index;
+	}
+	compareByType(a: ChatOutlineEntry, b: ChatOutlineEntry): number {
+		return a.index - b.index;
+	}
+	compareByName(a: ChatOutlineEntry, b: ChatOutlineEntry): number {
+		return a.label.localeCompare(b.label);
+	}
+}
+
+class ChatOutlineTreeDataSource implements IDataSource<ChatOutline, ChatOutlineEntry> {
+	getChildren(element: ChatOutline | ChatOutlineEntry): Iterable<ChatOutlineEntry> {
+		if (element instanceof ChatOutline) {
+			return element.entries;
+		}
+		return [];
+	}
+}
+
+class ChatOutlineQuickPickDataSource implements IQuickPickDataSource<ChatOutlineEntry> {
+	constructor(private readonly _outline: ChatOutline) { }
+	getQuickPickElements(): IQuickPickOutlineElement<ChatOutlineEntry>[] {
+		return this._outline.entries.map(entry => ({
+			element: entry,
+			// Codicons cannot be passed via `iconClasses` in this quick pick (only
+			// file icons can); embed the icon inline in the label instead and
+			// escape only the request text so `$(...)` in it stays literal.
+			label: `$(${entry.icon.id}) ${escapeIcons(entry.label)}`,
+			ariaLabel: entry.label,
+		}));
+	}
+}
+
+class ChatOutlineBreadcrumbsDataSource implements IBreadcrumbsDataSource<ChatOutlineEntry> {
+	constructor(private readonly _outline: ChatOutline) { }
+	getBreadcrumbElements(): readonly IBreadcrumbsOutlineElement<ChatOutlineEntry>[] {
+		const active = this._outline.activeElement;
+		return active ? [{ element: active, label: active.label }] : [];
+	}
+}
+
+export class ChatOutline implements IOutline<ChatOutlineEntry> {
+
+	readonly outlineKind = 'chat';
+
+	private readonly _disposables = new DisposableStore();
+	private readonly _onDidChange = this._disposables.add(new Emitter<OutlineChangeEvent>());
+	readonly onDidChange: Event<OutlineChangeEvent> = this._onDidChange.event;
+
+	private _entries: ChatOutlineEntry[] = [];
+	readonly config: IOutlineListConfig<ChatOutlineEntry>;
+
+	constructor(
+		private readonly _widget: IChatWidget,
+		target: OutlineTarget,
+	) {
+		this._recomputeEntries();
+
+		this._disposables.add(this._widget.onDidChangeViewModel(() => {
+			this._recomputeEntries();
+			this._registerViewModelListener();
+			this._onDidChange.fire({});
+		}));
+		this._registerViewModelListener();
+
+		const options: IWorkbenchDataTreeOptions<ChatOutlineEntry, FuzzyScore> = {
+			collapseByDefault: target === OutlineTarget.Breadcrumbs,
+			expandOnlyOnTwistieClick: true,
+			multipleSelectionSupport: false,
+			accessibilityProvider: new ChatOutlineAccessibility(),
+			identityProvider: { getId: element => element.id },
+			keyboardNavigationLabelProvider: { getKeyboardNavigationLabel: element => element.label },
+		};
+
+		this.config = {
+			treeDataSource: new ChatOutlineTreeDataSource(),
+			quickPickDataSource: new ChatOutlineQuickPickDataSource(this),
+			breadcrumbsDataSource: new ChatOutlineBreadcrumbsDataSource(this),
+			delegate: new ChatOutlineVirtualDelegate(),
+			renderers: [new ChatOutlineRenderer()],
+			comparator: new ChatOutlineComparator(),
+			options,
+		};
+	}
+
+	private readonly _viewModelDisposables = this._disposables.add(new DisposableStore());
+	private _registerViewModelListener(): void {
+		this._viewModelDisposables.clear();
+		const viewModel = this._widget.viewModel;
+		if (viewModel) {
+			this._viewModelDisposables.add(viewModel.onDidChange(() => {
+				this._recomputeEntries();
+				this._onDidChange.fire({});
+			}));
+		}
+	}
+
+	private _recomputeEntries(): void {
+		const items = this._widget.viewModel?.getItems() ?? [];
+		const entries: ChatOutlineEntry[] = [];
+		let index = 0;
+		for (const item of items) {
+			if (isRequestVM(item)) {
+				entries.push(new ChatOutlineEntry(index++, item));
+			}
+		}
+		this._entries = entries;
+	}
+
+	get entries(): ChatOutlineEntry[] {
+		return this._entries;
+	}
+
+	get uri(): URI | undefined {
+		return this._widget.viewModel?.sessionResource;
+	}
+
+	get isEmpty(): boolean {
+		return this._entries.length === 0;
+	}
+
+	get activeElement(): ChatOutlineEntry | undefined {
+		const focus = this._widget.getFocus();
+		if (!focus) {
+			return undefined;
+		}
+		return this._entries.find(entry => entry.element === focus);
+	}
+
+	reveal(entry: ChatOutlineEntry, _options: IEditorOptions, _sideBySide: boolean, _select: boolean): void {
+		const item: ChatTreeItem = entry.element;
+		this._widget.reveal(item);
+		this._widget.focus(item);
+	}
+
+	preview(entry: ChatOutlineEntry): IDisposable {
+		this._widget.reveal(entry.element);
+		return Disposable.None;
+	}
+
+	captureViewState(): IDisposable {
+		return Disposable.None;
+	}
+
+	dispose(): void {
+		this._disposables.dispose();
+	}
+}
+
+export class ChatOutlineCreator implements IOutlineCreator<ChatEditor, ChatOutlineEntry> {
+
+	static readonly ID = 'chat.chatOutlineCreator';
+
+	readonly dispose: () => void;
+
+	constructor(
+		@IOutlineService outlineService: IOutlineService,
+	) {
+		const reg = outlineService.registerOutlineCreator(this);
+		this.dispose = () => reg.dispose();
+	}
+
+	matches(candidate: IEditorPane): candidate is ChatEditor {
+		return candidate instanceof ChatEditor;
+	}
+
+	async createOutline(editor: ChatEditor, target: OutlineTarget, _token: CancellationToken): Promise<IOutline<ChatOutlineEntry> | undefined> {
+		const widget = editor.widget;
+		if (!widget) {
+			return undefined;
+		}
+		return new ChatOutline(widget, target);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatOutlineCreator.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatOutlineCreator.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { IEditorPane } from '../../../common/editor.js';
+import { IOutline, IOutlineCreator, IOutlineService, OutlineTarget } from '../../../services/outline/browser/outline.js';
+import { ChatOutline, ChatOutlineEntry } from './chatOutline.js';
+import { ChatEditor } from './widgetHosts/editor/chatEditor.js';
+
+/**
+ * Registers a {@link ChatOutline} for the chat editor pane so Go to Symbol, the
+ * Outline pane, and Breadcrumbs work for chat sessions opened as an editor.
+ */
+export class ChatOutlineCreator implements IOutlineCreator<ChatEditor, ChatOutlineEntry> {
+
+	static readonly ID = 'chat.chatOutlineCreator';
+
+	readonly dispose: () => void;
+
+	constructor(
+		@IOutlineService outlineService: IOutlineService,
+	) {
+		const reg = outlineService.registerOutlineCreator(this);
+		this.dispose = () => reg.dispose();
+	}
+
+	matches(candidate: IEditorPane): candidate is ChatEditor {
+		return candidate instanceof ChatEditor;
+	}
+
+	async createOutline(editor: ChatEditor, target: OutlineTarget, _token: CancellationToken): Promise<IOutline<ChatOutlineEntry> | undefined> {
+		const widget = editor.widget;
+		if (!widget) {
+			return undefined;
+		}
+		return new ChatOutline(widget, target);
+	}
+}

--- a/src/vs/workbench/contrib/chat/test/browser/chatOutline.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatOutline.test.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { OutlineTarget } from '../../../../services/outline/browser/outline.js';
+import { ChatOutline, getChatRequestLabel } from '../../browser/chatOutline.js';
+import { ChatTreeItem, IChatWidget } from '../../browser/chat.js';
+import { IChatRequestViewModel } from '../../common/model/chatViewModel.js';
+import { IChatRequestVariableEntry } from '../../common/attachments/chatVariableEntries.js';
+
+function req(message: object, variables: IChatRequestVariableEntry[] = []): IChatRequestViewModel {
+	return { id: 'r', message, variables } as unknown as IChatRequestViewModel;
+}
+
+function reqVM(id: string, text: string): IChatRequestViewModel {
+	return { id, message: { text, parts: [{ text }] }, variables: [] } as unknown as IChatRequestViewModel;
+}
+
+class TestViewModel {
+	readonly onChange = new Emitter<null>();
+	readonly onDidChange: Event<null> = this.onChange.event;
+	readonly sessionResource = URI.parse('chat-session:/test');
+	items: IChatRequestViewModel[] = [];
+	getItems(): IChatRequestViewModel[] {
+		return this.items;
+	}
+}
+
+class TestWidget {
+	readonly onChangeVM = new Emitter<void>();
+	readonly onDidChangeViewModel: Event<void> = this.onChangeVM.event;
+	focusItem: ChatTreeItem | undefined;
+	readonly revealed: ChatTreeItem[] = [];
+	readonly focused: ChatTreeItem[] = [];
+	constructor(readonly viewModel: TestViewModel) { }
+	getFocus(): ChatTreeItem | undefined {
+		return this.focusItem;
+	}
+	reveal(item: ChatTreeItem): void {
+		this.revealed.push(item);
+	}
+	focus(item: ChatTreeItem): void {
+		this.focused.push(item);
+	}
+}
+
+function setup(store: Pick<DisposableStore, 'add'>, items: IChatRequestViewModel[]) {
+	const viewModel = new TestViewModel();
+	viewModel.items = items;
+	store.add(viewModel.onChange);
+	const widget = new TestWidget(viewModel);
+	store.add(widget.onChangeVM);
+	const outline = store.add(new ChatOutline(widget as unknown as IChatWidget, OutlineTarget.QuickPick));
+	return { viewModel, widget, outline };
+}
+
+suite('ChatOutline', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('getChatRequestLabel derives text, parts, followup, and attachment fallbacks', () => {
+		const labels = [
+			getChatRequestLabel(req({ text: 'hello world', parts: [{ text: 'hello world' }] }), 0),
+			getChatRequestLabel(req({ text: '', parts: [{ text: 'what ' }, { text: 'is ' }, { text: 'this' }] }), 1),
+			getChatRequestLabel(req({ kind: 'reply', message: 'do the thing', agentId: 'agent' }), 2),
+			getChatRequestLabel(req({ text: '', parts: [] }, [{ kind: 'file' } as unknown as IChatRequestVariableEntry]), 3),
+			getChatRequestLabel(req({ text: '', parts: [] }, [{ kind: 'image' } as unknown as IChatRequestVariableEntry]), 4),
+			getChatRequestLabel(req({ text: '', parts: [] }), 5),
+			getChatRequestLabel(req({ text: 'line1\n\nline2', parts: [{ text: 'line1\n\nline2' }] }), 6),
+		];
+
+		assert.deepStrictEqual(labels, [
+			'hello world',
+			'what is this',
+			'do the thing',
+			'Attached 1 file',
+			'Attached 1 image',
+			'Request 6',
+			'line1 line2',
+		]);
+	});
+
+	test('quick pick escapes codicon markup in request text', () => {
+		const { outline } = setup(store, [reqVM('r1', '$(bug) fix')]);
+
+		const [element] = outline.config.quickPickDataSource.getQuickPickElements();
+
+		assert.ok(element.label.includes('\\$(bug)'), element.label);
+		assert.strictEqual(element.ariaLabel, '$(bug) fix');
+	});
+
+	test('only fires onDidChange when request entries change', () => {
+		const { viewModel, outline } = setup(store, [reqVM('r1', 'first'), reqVM('r2', 'second')]);
+
+		let changes = 0;
+		store.add(outline.onDidChange(() => changes++));
+
+		// A response-only view-model update (same requests) must not refresh the outline.
+		viewModel.onChange.fire(null);
+		assert.strictEqual(changes, 0);
+
+		// A new request must refresh the outline.
+		viewModel.items = [...viewModel.items, reqVM('r3', 'third')];
+		viewModel.onChange.fire(null);
+		assert.strictEqual(changes, 1);
+
+		assert.deepStrictEqual(outline.entries.map(entry => entry.label), ['first', 'second', 'third']);
+	});
+
+	test('reveal and preview navigate the chat widget', () => {
+		const request = reqVM('r1', 'first');
+		const { widget, outline } = setup(store, [request]);
+		const entry = outline.entries[0];
+
+		outline.reveal(entry, {}, false, false);
+		assert.deepStrictEqual(widget.revealed, [request]);
+		assert.deepStrictEqual(widget.focused, [request]);
+
+		store.add(outline.preview(entry));
+		assert.deepStrictEqual(widget.revealed, [request, request]);
+	});
+});

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
@@ -5,11 +5,11 @@
 
 import { Event } from '../../../../../base/common/event.js';
 import { localize, localize2 } from '../../../../../nls.js';
-import { IKeyMods, IQuickPickSeparator, IQuickInputService, IQuickPick, ItemActivation } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IKeyMods, IQuickPickSeparator, IQuickInputService, IQuickPick, IQuickPickItem, ItemActivation } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IEditorService, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
 import { IRange } from '../../../../../editor/common/core/range.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
-import { IQuickAccessRegistry, Extensions as QuickaccessExtensions } from '../../../../../platform/quickinput/common/quickAccess.js';
+import { IQuickAccessRegistry, Extensions as QuickaccessExtensions, IQuickAccessProviderRunOptions } from '../../../../../platform/quickinput/common/quickAccess.js';
 import { AbstractGotoSymbolQuickAccessProvider, IGotoSymbolQuickPickItem } from '../../../../../editor/contrib/quickAccess/browser/gotoSymbolQuickAccess.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IWorkbenchEditorConfiguration } from '../../../../common/editor.js';
@@ -26,7 +26,7 @@ import { onUnexpectedError } from '../../../../../base/common/errors.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IQuickAccessTextEditorContext } from '../../../../../editor/contrib/quickAccess/browser/editorNavigationQuickAccess.js';
-import { IOutlineService, OutlineTarget } from '../../../../services/outline/browser/outline.js';
+import { IOutline, IOutlineService, OutlineTarget } from '../../../../services/outline/browser/outline.js';
 import { isCompositeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
 import { IOutlineModelService } from '../../../../../editor/contrib/documentSymbols/browser/outlineModel.js';
@@ -34,8 +34,25 @@ import { ILanguageFeaturesService } from '../../../../../editor/common/services/
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { accessibilityHelpIsShown, accessibleViewIsShown } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { matchesFuzzyIconAware, parseLabelWithIcons } from '../../../../../base/common/iconLabels.js';
-import { IChatWidgetService } from '../../../chat/browser/chat.js';
+import { isAncestorOfActiveElement } from '../../../../../base/browser/dom.js';
+import { IChatWidget, IChatWidgetService } from '../../../chat/browser/chat.js';
 import { ISymbolVariableEntry } from '../../../chat/common/attachments/chatVariableEntries.js';
+import { isRequestVM } from '../../../chat/common/model/chatViewModel.js';
+import { ChatOutline } from '../../../chat/browser/chatOutline.js';
+
+/**
+ * A single navigable entry backing the "no text editor" symbol picks (chat
+ * outline or editor-pane outline). Provides the label to render and how to
+ * reveal/preview the underlying element.
+ */
+interface INavigablePickEntry {
+	readonly label: string;
+	readonly description?: string;
+	readonly ariaLabel?: string;
+	readonly iconClasses?: string[];
+	reveal(): void;
+	preview(): IDisposable;
+}
 
 export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccessProvider {
 
@@ -151,15 +168,51 @@ export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccess
 
 	//#endregion
 
+	override provide(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
+		// A focused chat is the navigable resource, even when a regular file
+		// editor is also open side by side. The base `provide()` would otherwise
+		// route to the active text editor's symbols whenever one exists, so the
+		// chat case must be handled here before that decision is made.
+		const chatWidget = this.getActiveChatWidget();
+		if (chatWidget) {
+			picker.canAcceptInBackground = !!this.options?.canAcceptInBackground;
+			picker.matchOnLabel = picker.matchOnDescription = picker.matchOnDetail = picker.sortByLabel = false;
+			return this.doGetChatWidgetPicks(picker as IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>, chatWidget);
+		}
+
+		return super.provide(picker, token, runOptions);
+	}
+
 	protected override provideWithoutTextEditor(picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>): IDisposable {
 		if (this.canPickWithOutlineService()) {
 			return this.doGetOutlinePicks(picker);
 		}
+
 		return super.provideWithoutTextEditor(picker);
 	}
 
 	private canPickWithOutlineService(): boolean {
 		return this.editorService.activeEditorPane ? this.outlineService.canCreateOutline(this.editorService.activeEditorPane) : false;
+	}
+
+	private getActiveChatWidget(): IChatWidget | undefined {
+		// Treat the chat as the navigable resource only when it actually has DOM
+		// focus. This is checked before the quick input steals focus (the picker
+		// is shown after `provide()` runs), works across windows via the focused
+		// document, and avoids hijacking Go to Symbol when a non-chat surface is
+		// focused. Only offer the chat when it has requests to navigate to.
+		const widget = this.chatWidgetService.lastFocusedWidget;
+		if (!widget || !isAncestorOfActiveElement(widget.domNode)) {
+			return undefined;
+		}
+		return widget.viewModel?.getItems().some(isRequestVM) ? widget : undefined;
+	}
+
+	private doGetChatWidgetPicks(picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>, widget: IChatWidget): IDisposable {
+		const disposables = new DisposableStore();
+		const outline = disposables.add(new ChatOutline(widget, OutlineTarget.QuickPick));
+		this.installNavigablePicks(picker, disposables, this.outlineToNavigableEntries(outline));
+		return disposables;
 	}
 
 	private doGetOutlinePicks(picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>): IDisposable {
@@ -193,74 +246,7 @@ export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccess
 				}
 			}));
 
-			const entries = outline.config.quickPickDataSource.getQuickPickElements();
-
-			const items: IGotoSymbolQuickPickItem[] = entries.map((entry, idx) => {
-				return {
-					kind: SymbolKind.File,
-					index: idx,
-					score: 0,
-					label: entry.label,
-					description: entry.description,
-					ariaLabel: entry.ariaLabel,
-					iconClasses: entry.iconClasses
-				};
-			});
-
-			disposables.add(picker.onDidAccept(() => {
-				picker.hide();
-				const [entry] = picker.selectedItems;
-				if (entry && entries[entry.index]) {
-					outline.reveal(entries[entry.index].element, {}, false, false);
-				}
-			}));
-
-			const updatePickerItems = () => {
-				const filteredItems = items.filter(item => {
-					if (picker.value === '@') {
-						// default, no filtering, scoring...
-						item.score = 0;
-						item.highlights = undefined;
-						return true;
-					}
-
-					const trimmedQuery = picker.value.substring(AbstractGotoSymbolQuickAccessProvider.PREFIX.length).trim();
-					const parsedLabel = parseLabelWithIcons(item.label);
-					const score = fuzzyScore(trimmedQuery, trimmedQuery.toLowerCase(), 0,
-						parsedLabel.text, parsedLabel.text.toLowerCase(), 0,
-						{ firstMatchCanBeWeak: true, boostFullMatch: true });
-
-					if (!score) {
-						return false;
-					}
-
-					item.score = score[1];
-					item.highlights = { label: matchesFuzzyIconAware(trimmedQuery, parsedLabel) ?? undefined };
-					return true;
-				});
-
-				if (filteredItems.length === 0) {
-					const label = localize('empty', 'No matching entries');
-					picker.items = [{ label, index: -1, kind: SymbolKind.String }];
-					picker.ariaLabel = label;
-				} else {
-					picker.items = filteredItems;
-				}
-			};
-			updatePickerItems();
-			disposables.add(picker.onDidChangeValue(updatePickerItems));
-
-			const previewDisposable = new MutableDisposable();
-			disposables.add(previewDisposable);
-
-			disposables.add(picker.onDidChangeActive(() => {
-				const [entry] = picker.activeItems;
-				if (entry && entries[entry.index]) {
-					previewDisposable.value = outline.preview(entries[entry.index].element);
-				} else {
-					previewDisposable.clear();
-				}
-			}));
+			this.installNavigablePicks(picker, disposables, this.outlineToNavigableEntries(outline));
 
 		}).catch(err => {
 			onUnexpectedError(err);
@@ -270,6 +256,86 @@ export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccess
 		});
 
 		return disposables;
+	}
+
+	private outlineToNavigableEntries<E>(outline: IOutline<E>): INavigablePickEntry[] {
+		return outline.config.quickPickDataSource.getQuickPickElements().map(element => ({
+			label: element.label,
+			description: element.description,
+			ariaLabel: element.ariaLabel,
+			iconClasses: element.iconClasses,
+			reveal: () => outline.reveal(element.element, {}, false, false),
+			preview: () => outline.preview(element.element)
+		}));
+	}
+
+	private installNavigablePicks(picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>, disposables: DisposableStore, entries: readonly INavigablePickEntry[]): void {
+		const items: IGotoSymbolQuickPickItem[] = entries.map((entry, index) => {
+			return {
+				kind: SymbolKind.File,
+				index,
+				score: 0,
+				label: entry.label,
+				description: entry.description,
+				ariaLabel: entry.ariaLabel,
+				iconClasses: entry.iconClasses
+			};
+		});
+
+		disposables.add(picker.onDidAccept(() => {
+			picker.hide();
+			const [item] = picker.selectedItems;
+			if (item) {
+				entries[item.index]?.reveal();
+			}
+		}));
+
+		const updatePickerItems = () => {
+			const filteredItems = items.filter(item => {
+				if (picker.value === '@') {
+					// default, no filtering, scoring...
+					item.score = 0;
+					item.highlights = undefined;
+					return true;
+				}
+
+				const trimmedQuery = picker.value.substring(AbstractGotoSymbolQuickAccessProvider.PREFIX.length).trim();
+				const parsedLabel = parseLabelWithIcons(item.label);
+				const score = fuzzyScore(trimmedQuery, trimmedQuery.toLowerCase(), 0,
+					parsedLabel.text, parsedLabel.text.toLowerCase(), 0,
+					{ firstMatchCanBeWeak: true, boostFullMatch: true });
+
+				if (!score) {
+					return false;
+				}
+
+				item.score = score[1];
+				item.highlights = { label: matchesFuzzyIconAware(trimmedQuery, parsedLabel) ?? undefined };
+				return true;
+			});
+
+			if (filteredItems.length === 0) {
+				const label = localize('empty', 'No matching entries');
+				picker.items = [{ label, index: -1, kind: SymbolKind.String }];
+				picker.ariaLabel = label;
+			} else {
+				picker.items = filteredItems;
+			}
+		};
+		updatePickerItems();
+		disposables.add(picker.onDidChangeValue(updatePickerItems));
+
+		const previewDisposable = new MutableDisposable();
+		disposables.add(previewDisposable);
+
+		disposables.add(picker.onDidChangeActive(() => {
+			const [item] = picker.activeItems;
+			if (item) {
+				previewDisposable.value = entries[item.index]?.preview();
+			} else {
+				previewDisposable.clear();
+			}
+		}));
 	}
 }
 

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
@@ -35,10 +35,9 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { accessibilityHelpIsShown, accessibleViewIsShown } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { matchesFuzzyIconAware, parseLabelWithIcons } from '../../../../../base/common/iconLabels.js';
 import { isAncestorOfActiveElement } from '../../../../../base/browser/dom.js';
-import { IChatWidget, IChatWidgetService } from '../../../chat/browser/chat.js';
+import { ChatOutline, IChatWidget, IChatWidgetService } from '../../../chat/browser/chat.js';
 import { ISymbolVariableEntry } from '../../../chat/common/attachments/chatVariableEntries.js';
 import { isRequestVM } from '../../../chat/common/model/chatViewModel.js';
-import { ChatOutline } from '../../../chat/browser/chatOutline.js';
 
 /**
  * A single navigable entry backing the "no text editor" symbol picks (chat


### PR DESCRIPTION
## Summary

Makes **Go to Symbol in Editor** (`⇧⌘O` / `Ctrl+Shift+O`) work for chat, treating each user request (prompt) as a navigable "symbol" so you can jump between exchanges in a conversation. Previously the palette just showed *"To go to a symbol, first open a text editor with symbol information."* for chats.

This works for both:
- **Chat editors** — via a new `ChatOutline` registered with `IOutlineService`, which also lights up the Outline pane and Breadcrumbs for free.
- **A focused chat widget** (including the **Agents window** and the sidebar chat view) — handled directly in the quick access provider.

## What a "symbol" is

Each **user request** becomes a top-level entry, labeled with the prompt text and a chat icon. Selecting one reveals and focuses that request in the chat.

## Changes

- **`chatOutline.ts` (new)** — `ChatOutline` / `ChatOutlineCreator` implementing `IOutline`/`IOutlineCreator`, matched to the `ChatEditor` pane. Registered in `chat.shared.contribution.ts`. No changes to the Go to Symbol picker were needed for the editor case — it consumes any registered outline.
- **`gotoSymbolQuickAccess.ts`**
  - Overrides `provide()` to prioritize a **focused chat** over an active file editor, so the chat wins when it has focus even with a file open side by side (otherwise the base routes to the file editor's symbols). Focus is detected via `isAncestorOfActiveElement` on the widget DOM node, checked before the quick input steals focus.
  - Unifies the chat and editor-pane outline paths through a shared `installNavigablePicks` helper.

## Notes / gotchas addressed

- **Label derivation:** request text is derived the way the chat list renders it (followup message, else the parsed request `parts`) rather than `messageText`, which agent-host/cloud sessions leave empty.
- **Icons:** codicons cannot be passed via `iconClasses` in this quick-pick path (see the existing `todo@jrieken` note in `notebookOutline.ts`); the icon is embedded inline in the label as `$(icon-id) …` with the request text escaped via `escapeIcons` so a literal `$(...)` in a prompt stays literal.

## Testing

- [ ] `npm run typecheck-client`
- [ ] `npm run valid-layers-check`
- [ ] Manual: `⇧⌘O` in a chat editor and in the Agents window chat lists requests and navigates to them; a file editor focused side by side still shows file symbols.

<sub>🤖 Draft — validation (build/typecheck/manual) still pending.</sub>