### PR TITLE
agentHost: isolate E2E tests from local provider config

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/README.md
+++ b/src/vs/platform/agentHost/test/node/e2e/README.md
@@ -55,7 +55,7 @@ Key properties:
 - **Wire-agnostic**: works for Anthropic Messages (`/v1/messages`) and OpenAI Responses (`/responses`) SSE dialects.
 - **Strict on replay**: a request with no recorded response is a hard cache miss that fails the test — CI can never silently reach real CAPI.
 - **Ancillary bootstrap endpoints are stubbed, not recorded** (see [What's stubbed](#whats-stubbed-vs-recorded)) — keeps identity, tokens, and the model catalog out of fixtures.
-- **Isolated persistent state**: each shared test uses a temporary home and VS Code user-data directory, which teardown removes after the agent host exits.
+- **Isolated persistent state**: each provider suite uses a temporary home and VS Code user-data directory. Provider config roots resolve under that home, with ambient overrides such as `CLAUDE_CONFIG_DIR` and `CODEX_HOME` cleared, so local config, MCP servers, and session state cannot affect the run. Teardown removes the directory after the agent host exits.
 
 ---
 
@@ -132,6 +132,8 @@ Provider availability:
 ## Server lifecycle
 
 Each test needs an agent host server (a forked subprocess) fronted by a `CapiReplayProxy`. `AgentHostE2EServerLease` (in `harness/agentHostE2ETestHarness.ts`) owns that lifecycle and picks one of two strategies:
+
+The lease also owns a fresh suite data directory. Every server it starts uses that directory as its home and VS Code user-data directory and prevents provider-specific config overrides from escaping it, so both shared and provider-specific scenarios are isolated from developer-machine configuration.
 
 - **Per-test** (always while recording) — fork a fresh server + proxy for every test and kill it in teardown. Full isolation: nothing carries over between tests. The cost is that every test re-pays the server fork **and** the provider SDK/CLI cold start (`_ensureClient` spawns and caches the CLI subprocess per server).
 

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -604,11 +604,20 @@ export class AgentHostE2EServerLease {
 	private _server: IServerHandle | undefined;
 	private _client: TestProtocolClient | undefined;
 	private readonly _shared: boolean;
+	private _dataDir: string | undefined;
+	private readonly _startOptions: { readonly claudeSdkRoot?: string; readonly codexSdkRoot?: string; readonly homeDir: string; readonly userDataDir: string };
 
 	constructor(
 		private readonly _config: IAgentHostE2EProviderConfig,
-		private readonly _startOptions: { readonly claudeSdkRoot?: string; readonly codexSdkRoot?: string; readonly homeDir?: string; readonly userDataDir?: string },
+		startOptions: { readonly claudeSdkRoot?: string; readonly codexSdkRoot?: string } = {},
 	) {
+		const dataDir = mkdtempSync(join(tmpdir(), 'vscode-agent-host-e2e-'));
+		this._dataDir = dataDir;
+		this._startOptions = {
+			...startOptions,
+			homeDir: dataDir,
+			userDataDir: join(dataDir, 'user-data'),
+		};
 		// Server reuse is a replay-only optimization: recording writes one fixture
 		// per proxy and so needs a fresh proxy (hence a fresh server) per test.
 		// In replay it is always safe because every test drains its turns, so the
@@ -681,12 +690,20 @@ export class AgentHostE2EServerLease {
 
 	/** Tear down a shared server at the end of the suite (no-op for per-test). */
 	async dispose(): Promise<void> {
-		if (this._server) {
-			try {
-				await this._server.capiReplay?.close();
-			} finally {
-				await stopServer(this._server);
-				this._server = undefined;
+		const dataDir = this._dataDir;
+		this._dataDir = undefined;
+		try {
+			if (this._server) {
+				try {
+					await this._server.capiReplay?.close();
+				} finally {
+					await stopServer(this._server);
+					this._server = undefined;
+				}
+			}
+		} finally {
+			if (dataDir) {
+				await removeTempDirs([dataDir]);
 			}
 		}
 	}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
@@ -160,7 +160,7 @@ suite('Agent Host E2E — Copilot (Copilot-specific)', function () {
 	});
 
 	suiteTeardown(async function () {
-		this.timeout(60_000);
+		this.timeout(90_000);
 		await lease?.dispose();
 	});
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
@@ -26,7 +26,7 @@
 
 import assert from 'assert';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
-import { homedir, tmpdir } from 'os';
+import { tmpdir } from 'os';
 import { join } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { MessageAttachmentKind, ToolCallConfirmationReason, buildDefaultChatUri, type MessageAttachment } from '../../../../common/state/sessionState.js';
@@ -60,22 +60,32 @@ defineAgentHostE2ETests(COPILOT_CONFIG);
 suite('Agent Host E2E — Copilot (Copilot-specific)', function () {
 
 	let client: TestProtocolClient;
+	let lease: AgentHostE2EServerLease | undefined;
 	const createdSessions: string[] = [];
 	const tempDirs: string[] = [];
-	const lease = new AgentHostE2EServerLease(COPILOT_CONFIG, { homeDir: homedir() });
 
 	// The lease fronts the server with the record/replay proxy: these tests
 	// replay committed fixtures by default (tokenless) and record against real
 	// CAPI with `AGENT_HOST_REPLAY_RECORD=1`, mirroring the shared suite. In
 	// replay the lease reuses one server across the suite and swaps the fixture
 	// per test; while recording it starts a fresh server per test.
+	suiteSetup(function () {
+		lease = new AgentHostE2EServerLease(COPILOT_CONFIG);
+	});
+
 	setup(async function () {
 		this.timeout(60_000);
+		if (!lease) {
+			throw new Error('Agent Host E2E server lease was not initialized.');
+		}
 		({ client } = await lease.acquire(this.currentTest?.title ?? 'unknown'));
 	});
 
 	teardown(async function () {
 		this.timeout(60_000);
+		if (!lease) {
+			throw new Error('Agent Host E2E server lease was not initialized.');
+		}
 		await lease.release(createdSessions);
 
 		for (const dir of tempDirs) {
@@ -151,7 +161,7 @@ suite('Agent Host E2E — Copilot (Copilot-specific)', function () {
 
 	suiteTeardown(async function () {
 		this.timeout(60_000);
-		await lease.dispose();
+		await lease?.dispose();
 	});
 
 	test('usage reports include Copilot cost metadata', async function () {

--- a/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
@@ -3,9 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { mkdtempSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from '../../../../../../base/common/path.js';
 import { AgentHostE2EServerLease, type IAgentHostE2EProviderConfig, removeTempDirs } from '../harness/agentHostE2ETestHarness.js';
 import type { TestProtocolClient } from '../../serverIntegrationTestHelpers.js';
 import { defineCoreTests } from './coreSuite.js';
@@ -28,7 +25,6 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 		const stableNewScenarioResponse = config.provider !== 'codex';
 		let client: TestProtocolClient;
 		let lease: AgentHostE2EServerLease | undefined;
-		let suiteDataDir: string | undefined;
 		const createdSessions: string[] = [];
 		const tempDirs: string[] = [];
 		const noModelTrafficTestTitles = new Set<string>();
@@ -46,12 +42,9 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 
 		suiteSetup(async function () {
 			this.timeout(60_000);
-			suiteDataDir = mkdtempSync(join(tmpdir(), 'vscode-agent-host-e2e-'));
 			lease = new AgentHostE2EServerLease(config, {
 				claudeSdkRoot: config.claudeSdkRoot,
 				codexSdkRoot: config.codexSdkRoot,
-				homeDir: suiteDataDir,
-				userDataDir: join(suiteDataDir, 'user-data'),
 			});
 		});
 
@@ -60,10 +53,6 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 			try {
 				await lease?.dispose();
 			} finally {
-				if (suiteDataDir) {
-					tempDirs.push(suiteDataDir);
-					suiteDataDir = undefined;
-				}
 				await removeTempDirs(tempDirs);
 			}
 		});

--- a/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
@@ -10,7 +10,7 @@ import { userInfo } from 'os';
 import { fileURLToPath } from 'url';
 import { WebSocket } from 'ws';
 import { CapiReplayProxy, type CapiReplayMode } from './e2e/harness/capiReplayProxy.js';
-import { resolve as resolvePath } from '../../../../base/common/path.js';
+import { join, resolve as resolvePath } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
 import { SubscribeResult, type DispatchActionParams } from '../../common/state/protocol/commands.js';
 import { ActionType, type ActionEnvelope } from '../../common/state/sessionActions.js';
@@ -425,6 +425,10 @@ export async function startRealServer(options?: { readonly claudeSdkRoot?: strin
 			...(options?.homeDir ? {
 				HOME: options.homeDir,
 				USERPROFILE: options.homeDir,
+				XDG_CONFIG_HOME: join(options.homeDir, '.config'),
+				COPILOT_HOME: join(options.homeDir, '.copilot'),
+				CLAUDE_CONFIG_DIR: undefined,
+				CODEX_HOME: undefined,
 			} : {}),
 			// Codex defaults to disabled; opt it in for the agent host e2e suite when a
 			// codex SDK root is supplied so the provider actually registers.


### PR DESCRIPTION
## Summary

- make each bundled-provider E2E server lease own a fresh temporary home and VS Code user-data directory
- isolate Copilot, Claude, and Codex config roots from ambient local configuration, MCP servers, and session state
- clean up the isolated suite directory after the Agent Host exits
- apply the same isolation to Copilot-specific E2E scenarios

## Validation

- `npm run typecheck-client`
- `npm run transpile-client`
- `npm run valid-layers-check`
- hygiene checks for all changed TypeScript files
- Copilot E2E: 58 passing with poisoned `COPILOT_HOME`, `CLAUDE_CONFIG_DIR`, and `CODEX_HOME`
- Claude E2E: 55 passing with poisoned config roots
- Codex E2E: 39 passing with poisoned config roots

(Written by Copilot)