### PR TITLE
Show all cloud sessions in the agents window regardless of active repo

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -444,7 +444,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				let intervalMs: number;
 				let hasHistoricalSessions: boolean;
 				try {
-					const sessionList = await this._backend.fetchSessionList(repoIds, false, false);
+					const sessionList = await this._backend.fetchSessionList(repoIds, vscode.workspace.isAgentSessionsWorkspace, false);
 					hasHistoricalSessions = sessionList.length > 0;
 					intervalMs = this.getRefreshIntervalTime(hasHistoricalSessions);
 				} catch (e) {
@@ -457,7 +457,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				telemetryObj.hasHistoricalSessions = hasHistoricalSessions;
 				const schedulerCallback = async () => {
 					try {
-						const sessionList = await this._backend.fetchSessionList(repoIds, false, true);
+						const sessionList = await this._backend.fetchSessionList(repoIds, vscode.workspace.isAgentSessionsWorkspace, true);
 						if (this.cachedSessionsSize !== sessionList.length) {
 							this.refresh();
 						}

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/taskApiBackend.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/taskApiBackend.ts
@@ -279,11 +279,13 @@ export class TaskApiBackend implements TaskCloudAgentBackend {
 		};
 	}
 
-	async fetchSessionList(repoIds: GithubRepoId[] | undefined, _isAgentWorkspace: boolean, _refresh: boolean): Promise<CloudSessionData[]> {
+	async fetchSessionList(repoIds: GithubRepoId[] | undefined, isAgentWorkspace: boolean, _refresh: boolean): Promise<CloudSessionData[]> {
 		const listOpts: ListTasksOptions = { per_page: 100 };
 		const tasksWithRepo: { task: AgentTask; repo: { owner: string; name: string } | undefined }[] = [];
 
-		if (!repoIds || repoIds.length === 0) {
+		// In the agents window we surface all of the user's sessions rather than scoping to the
+		// active workspace's repositories, so always use the global user-scoped list there.
+		if (isAgentWorkspace || !repoIds || repoIds.length === 0) {
 			// The global `agents/tasks` endpoint is already scoped to the authenticated user, so
 			// no creator filter is needed here.
 			const response = await this._taskApiClient.listTasks(listOpts);

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCloudSessionsProvider.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCloudSessionsProvider.spec.ts
@@ -559,6 +559,18 @@ describe('TaskApiBackend', () => {
 		expect(client.listCalls).toEqual([{ options: { per_page: 100 } }]);
 	});
 
+	it('fetchSessionList uses the global user-scoped list in the agents window even when repoIds are present', async () => {
+		// The agents window surfaces all of the user's sessions rather than scoping to the active
+		// workspace's repositories, so it must hit the global list and never the repo-scoped one.
+		const client = new FakeTaskApiClient();
+		const backend = new TaskApiBackend(client, new TestLogService(), new MockOctoKitService(), NullCloudBackendInstrumentation);
+
+		await backend.fetchSessionList([new GithubRepoId('octocat', 'hello-world')], true, false);
+
+		expect(client.listForRepoCalls).toEqual([]);
+		expect(client.listCalls).toEqual([{ options: { per_page: 100 } }]);
+	});
+
 	it('fetchSessionList resolves a global-list task repo by numeric id when it has no html_url', async () => {
 		// Global-list (repoIds undefined) tasks may carry only `repository.id` and no `html_url`.
 		// Without resolving it the session has no repo metadata and groups under "Unknown".


### PR DESCRIPTION
## Problem

In the agents window, the v2 Task backend's `fetchSessionList` scoped the cloud session list to the active workspace's repositories (via `getRepoId`). As a result, the agents window only showed sessions for the currently selected repo instead of all of the user's cloud sessions.

The `isAgentWorkspace` flag was passed to `fetchSessionList` but ignored (`_isAgentWorkspace`), so the agents window fell through to the repo-scoped code path whenever an active GitHub repo was present.

## Fix

Use the global user-scoped `agents/tasks` list when in the agents window, regardless of `repoIds`. This mirrors the existing v1 Jobs backend behavior in [`jobsApiBackend.ts`](https://github.com/microsoft/vscode/blob/main/extensions/copilot/src/extension/chatSessions/vscode-node/jobsApiBackend.ts), which already gates on `isAgentWorkspace || !repoIds || repoIds.length === 0`.

```ts
if (isAgentWorkspace || !repoIds || repoIds.length === 0) {
    // global agents/tasks list — all the user's sessions
```

The global `agents/tasks` endpoint is already scoped to the authenticated user, so no `creator_id` filter is needed.

## Behavior

- **Agents window**: shows all of the user's cloud sessions across every repo, regardless of which folder/repo is active.
- **Outside the agents window**: unchanged — still repo-scoped via `creator_id`.

## Tests

Added a unit test asserting the agents window uses the global list (and never the repo-scoped endpoint) even when `repoIds` are present. All `fetchSessionList` tests pass.