### PR TITLE
Fix sandbox dependency installation on apt systems

### DIFF
--- a/src/vs/platform/sandbox/node/sandboxHelper.ts
+++ b/src/vs/platform/sandbox/node/sandboxHelper.ts
@@ -16,7 +16,7 @@ type BubblewrapProbe = (command: string) => Promise<{ usable: boolean; error?: s
 type ResolveLinuxInstallEnvironment = () => Promise<{ distributionIds: readonly string[]; isRoot: boolean }>;
 
 const linuxDependencyInstallCommands: readonly { distributionIds: readonly string[]; commands: readonly [executable: string, command: string][] }[] = [
-	{ distributionIds: ['debian', 'ubuntu', 'linuxmint', 'pop', 'elementary', 'kali', 'raspbian'], commands: [['apt-get', 'apt-get install -y'], ['apt', 'apt install -y']] },
+	{ distributionIds: ['debian', 'ubuntu', 'linuxmint', 'pop', 'elementary', 'kali', 'raspbian'], commands: [['apt-get', 'apt-get update && apt-get install -y'], ['apt', 'apt update && apt install -y']] },
 	{ distributionIds: ['fedora', 'rhel', 'centos', 'rocky', 'almalinux'], commands: [['dnf', 'dnf install -y'], ['yum', 'yum install -y']] },
 	{ distributionIds: ['arch', 'manjaro', 'endeavouros'], commands: [['pacman', 'pacman -S --needed --noconfirm']] },
 	{ distributionIds: ['suse', 'opensuse', 'opensuse-leap', 'opensuse-tumbleweed'], commands: [['zypper', 'zypper --non-interactive install']] },
@@ -61,7 +61,7 @@ export class SandboxHelperService implements ISandboxHelperService {
 		}
 		for (const [executable, command] of installer.commands) {
 			if (await findCommand(executable)) {
-				return `${elevation}${command}`;
+				return command.split(' && ').map(command => `${elevation}${command}`).join(' && ');
 			}
 		}
 		return undefined;

--- a/src/vs/platform/sandbox/test/node/sandboxHelper.test.ts
+++ b/src/vs/platform/sandbox/test/node/sandboxHelper.test.ts
@@ -76,8 +76,8 @@ suite('SandboxHelperService', () => {
 	});
 
 	for (const [distributionId, packageManager, expectedCommand] of [
-		['debian', 'apt-get', 'sudo apt-get install -y'],
-		['ubuntu', 'apt', 'sudo apt install -y'],
+		['debian', 'apt-get', 'sudo apt-get update && sudo apt-get install -y'],
+		['ubuntu', 'apt', 'sudo apt update && sudo apt install -y'],
 		['fedora', 'dnf', 'sudo dnf install -y'],
 		['centos', 'yum', 'sudo yum install -y'],
 		['arch', 'pacman', 'sudo pacman -S --needed --noconfirm'],
@@ -127,6 +127,17 @@ suite('SandboxHelperService', () => {
 		);
 
 		strictEqual(result?.dependencyInstallCommand, 'apk add');
+	});
+
+	test('does not use sudo for chained apt-get commands when running as root', async () => {
+		const result = await SandboxHelperService.checkSandboxDependenciesWith(
+			async command => ['socat', 'apt-get'].includes(command) ? `/usr/bin/${command}` : undefined,
+			true,
+			undefined,
+			async () => ({ distributionIds: ['debian'], isRoot: true }),
+		);
+
+		strictEqual(result?.dependencyInstallCommand, 'apt-get update && apt-get install -y');
 	});
 
 	test('does not offer dependency installation to a non-root user without sudo', async () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1848,8 +1848,16 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						}],
 					};
 				}
-				// Installation and verification succeeded — fall through to execute the original command.
-				this._logService.info('RunInTerminalTool: Sandbox dependency installation succeeded, proceeding with command execution');
+				this._logService.info('RunInTerminalTool: Sandbox dependency installation succeeded');
+				return {
+					content: [{
+						kind: 'text',
+						value: localize(
+							'runInTerminal.missingDeps.installed',
+							"Sandbox dependencies were installed successfully. If the issue persists, reload the window and try running the command again."
+						),
+					}],
+				};
 			} else {
 				// User chose to cancel — do not run the command
 				this._logService.info('RunInTerminalTool: User cancelled sandbox dependency installation');
@@ -1886,7 +1894,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			if (refreshedPrereqs.failedCheck !== undefined) {
 				return {
 					content: [{
-						kind: 'text', value: localize('runInTerminal.bubblewrap.stillUnavailable', "Bubblewrap still cannot create the required sandbox namespace after remediation. The command was not executed.")
+						kind: 'text', value: localize('runInTerminal.bubblewrap.stillUnavailable', "Bubblewrap still cannot create the required sandbox namespace after remediation. Reload the window and try running the command again.")
 					}],
 				};
 			}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -339,7 +339,7 @@ suite('TerminalSandboxService - network domains', () => {
 			bubblewrapInstalled: false,
 			bubblewrapUsable: false,
 			socatInstalled: false,
-			dependencyInstallCommand: 'sudo pacman -S --needed --noconfirm',
+			dependencyInstallCommand: 'sudo apt-get update && sudo apt-get install -y',
 		};
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 		let sentCommand: string | undefined;
@@ -364,7 +364,7 @@ suite('TerminalSandboxService - network domains', () => {
 		});
 
 		strictEqual(result.exitCode, 0);
-		strictEqual(sentCommand, `sudo pacman -S --needed --noconfirm 'bubblewrap' 'socat'`);
+		strictEqual(sentCommand, `sudo apt-get update && sudo apt-get install -y 'bubblewrap' 'socat'`);
 	});
 
 	test('should install sandbox dependencies with the remote host package manager', async () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -598,6 +598,44 @@ suite('RunInTerminalTool', () => {
 			ok((result.content[0] as { value?: string }).value?.includes('bubblewrap'), 'Expected result to identify the failed bubblewrap verification');
 		});
 
+		test('should suggest reloading and retrying if the issue persists after sandbox dependency installation', async () => {
+			terminalSandboxService.checkForSandboxingPrereqs = async forceRefresh => forceRefresh
+				? {
+					enabled: true,
+					sandboxConfigPath: '/tmp/sandbox.json',
+					failedCheck: undefined,
+				}
+				: {
+					enabled: true,
+					sandboxConfigPath: '/tmp/sandbox.json',
+					failedCheck: TerminalSandboxPrerequisiteCheck.Dependencies,
+					missingDependencies: ['bubblewrap', 'socat'],
+					canInstallMissingDependencies: true,
+				};
+
+			const result = await invokeToolTest({ command: 'echo hello' }, 'install');
+
+			strictEqual(createTerminalCallCount, 1, 'Expected only the installation terminal, not original command execution');
+			ok((result.content[0] as { value?: string }).value?.includes('If the issue persists, reload the window and try running the command again'), 'Expected conditional reload and retry guidance');
+		});
+
+		test('should suggest reloading and retrying when bubblewrap remains unavailable after repair', async () => {
+			terminalSandboxService.checkForSandboxingPrereqs = async () => ({
+				enabled: true,
+				sandboxConfigPath: '/tmp/sandbox.json',
+				failedCheck: TerminalSandboxPrerequisiteCheck.Bubblewrap,
+				remediations: [TerminalSandboxPreCheckRemediation.DisableUnprivilagedusernamespaceRestriction],
+			});
+
+			const result = await invokeToolTest(
+				{ command: 'echo hello' },
+				TerminalSandboxPreCheckRemediation.DisableUnprivilagedusernamespaceRestriction,
+			);
+
+			strictEqual(createTerminalCallCount, 0, 'Expected the original command not to execute');
+			ok((result.content[0] as { value?: string }).value?.includes('Reload the window and try running the command again'), 'Expected reload and retry guidance after unsuccessful repair');
+		});
+
 		test('should not execute when bubblewrap is unusable and no supported remediation is available', async () => {
 			sandboxPrereqResult = {
 				enabled: true,


### PR DESCRIPTION
## Summary

- refresh apt package metadata before installing `bubblewrap` and `socat` with both `apt-get` and `apt`
- apply `sudo` to each command in the chained update/install sequence while preserving root execution
-Update to add reload window info after successfully installing the package.

fixes #326751