### PR TITLE
Fix Agent Host startup race in Remote-SSH windows

### DIFF
--- a/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
+++ b/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
@@ -64,7 +64,7 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 	private _connectStarted = false;
 
 	constructor(
-		@IRemoteAgentService remoteAgentService: IRemoteAgentService,
+		@IRemoteAgentService private readonly _remoteAgentService: IRemoteAgentService,
 		@IAgentHostEnablementService agentHostEnablementService: IAgentHostEnablementService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
@@ -72,7 +72,7 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 		super();
 
 		const enabled = agentHostEnablementService.enabled;
-		const connection = remoteAgentService.getConnection();
+		const connection = this._remoteAgentService.getConnection();
 		this._logService.info(`${LOG_PREFIX} Initializing (enabled=${enabled}, remoteAuthority=${connection?.remoteAuthority ?? 'none'})`);
 
 		if (!enabled) {
@@ -89,10 +89,9 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 		// Create the protocol client eagerly so consumers can subscribe to
 		// rootState etc. before the AHP handshake completes. The transport's
 		// `connect()` will be awaited by `_connect()` below.
-		const channel = connection.getChannel(AgentHostIpcChannels.RemoteProxy);
-		const transport = new AgentHostIpcChannelTransport(channel);
+		const createTransport = () => new AgentHostIpcChannelTransport(connection.getChannel(AgentHostIpcChannels.RemoteProxy));
 		const address = `vscode-remote://${connection.remoteAuthority}`;
-		this._protocolClient = this._register(instantiationService.createInstance(RemoteAgentHostProtocolClient, address, transport, undefined));
+		this._protocolClient = this._register(instantiationService.createInstance(RemoteAgentHostProtocolClient, address, createTransport, undefined));
 		this._register(this._protocolClient.onDidClose(() => {
 			this._logService.info(`${LOG_PREFIX} Protocol client closed`);
 			this._onAgentHostExit.fire(0);
@@ -110,6 +109,7 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 		}
 		this._connectStarted = true;
 		this._logService.info(`${LOG_PREFIX} Connecting to remote agent host...`);
+		await this._remoteAgentService.getRawEnvironment();
 		await this._protocolClient.connect();
 		this._logService.info(`${LOG_PREFIX} Connected; clientId=${this._protocolClient.clientId}`);
 		this._onAgentHostStart.fire();

--- a/src/vs/workbench/services/agentHost/test/browser/editorRemoteAgentHostServiceClient.test.ts
+++ b/src/vs/workbench/services/agentHost/test/browser/editorRemoteAgentHostServiceClient.test.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DeferredPromise } from '../../../../../base/common/async.js';
+import { Event } from '../../../../../base/common/event.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import type { IChannel, IServerChannel } from '../../../../../base/parts/ipc/common/ipc.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { RemoteAgentHostProtocolClient } from '../../../../../platform/agentHost/browser/remoteAgentHostProtocolClient.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { NullLogService, ILogService } from '../../../../../platform/log/common/log.js';
+import type { RemoteAgentConnectionContext, IRemoteAgentEnvironment } from '../../../../../platform/remote/common/remoteAgentEnvironment.js';
+import type { PersistentConnectionEvent } from '../../../../../platform/remote/common/remoteAgentConnection.js';
+import { EditorRemoteAgentHostServiceClient } from '../../browser/editorRemoteAgentHostServiceClient.js';
+import { IRemoteAgentService, type IRemoteAgentConnection } from '../../../remote/common/remoteAgentService.js';
+import { TestRemoteAgentService } from '../../../../test/browser/workbenchTestServices.js';
+
+class TestRemoteAgentConnection extends Disposable implements IRemoteAgentConnection {
+	readonly remoteAuthority = 'ssh-remote+test';
+	readonly onReconnecting = Event.None;
+	readonly onDidStateChange = Event.None as Event<PersistentConnectionEvent>;
+
+	constructor(private readonly channel: IChannel) {
+		super();
+	}
+
+	end(): Promise<void> {
+		return Promise.resolve();
+	}
+
+	getChannel<T extends IChannel>(_channelName: string): T {
+		return this.channel as T;
+	}
+
+	withChannel<T extends IChannel, R>(_channelName: string, callback: (channel: T) => Promise<R>): Promise<R> {
+		return callback(this.channel as T);
+	}
+
+	registerChannel<T extends IServerChannel<RemoteAgentConnectionContext>>(_channelName: string, _channel: T): void { }
+
+	getInitialConnectionTimeMs(): Promise<number> {
+		return Promise.resolve(0);
+	}
+
+	updateGraceTime(_graceTime: number): void { }
+}
+
+class DeferredRemoteAgentService extends TestRemoteAgentService {
+	readonly environmentReady = new DeferredPromise<IRemoteAgentEnvironment | null>();
+
+	constructor(private readonly connection: IRemoteAgentConnection) {
+		super();
+	}
+
+	override getConnection(): IRemoteAgentConnection {
+		return this.connection;
+	}
+
+	override getRawEnvironment(): Promise<IRemoteAgentEnvironment | null> {
+		return this.environmentReady.p;
+	}
+}
+
+suite('EditorRemoteAgentHostServiceClient', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('waits for the remote environment before connecting to Agent Host', async () => {
+		const channel: IChannel = {
+			call: <T>() => Promise.resolve(undefined as T),
+			listen: () => Event.None,
+		};
+		const remoteAgentService = new DeferredRemoteAgentService(disposables.add(new TestRemoteAgentConnection(channel)));
+		let connectCalls = 0;
+		const protocolClient = {
+			clientId: 'test-client',
+			connect: async () => { connectCalls++; },
+			onDidClose: Event.None,
+			dispose: () => { },
+		};
+		const instantiationService = disposables.add(new TestInstantiationService(new ServiceCollection(
+			[IRemoteAgentService, remoteAgentService],
+			[IAgentHostEnablementService, { _serviceBrand: undefined, enabled: true }],
+			[ILogService, new NullLogService()],
+		)));
+		instantiationService.stubInstance(RemoteAgentHostProtocolClient, protocolClient);
+		instantiationService.set(IInstantiationService, instantiationService);
+
+		const service = disposables.add(instantiationService.createInstance(EditorRemoteAgentHostServiceClient));
+		const started = Event.toPromise(service.onAgentHostStart);
+		const beforeReady = connectCalls;
+
+		remoteAgentService.environmentReady.complete(null);
+		await started;
+
+		assert.deepStrictEqual({ beforeReady, afterReady: connectCalls }, { beforeReady: 0, afterReady: 1 });
+	});
+});


### PR DESCRIPTION
## Summary

- wait for the Remote-SSH environment before starting the editor-side Agent Host handshake
- provide a transport factory so later transport loss can use AHP soft reconnect
- add regression coverage for the startup ordering race

## Root cause

The editor-side Agent Host client could begin connecting while Remote-SSH authority resolution was still replacing the management connection. The stale connection then closed the one-shot AHP client before the replacement server exposed `agentHostProxy`, leaving Agent Host agents unavailable until the window was reloaded.

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- `npm run precommit`
- 58 focused Agent Host connection tests

(Written by Copilot)