### PR TITLE
Config-action slash commands for Copilot agent-host chat inputs

### DIFF
--- a/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
+++ b/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
@@ -1,0 +1,220 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../nls.js';
+import { SessionConfigKey } from './sessionConfigKeys.js';
+
+/**
+ * Copilot agent-host "config action" slash commands: workbench-defined slash
+ * commands that toggle a well-known session-config property (the `autoApprove`
+ * permissions axis and/or the `mode` axis) instead of driving a chat turn.
+ *
+ * The Copilot agent owns the `autoApprove`/`mode` schema, so these commands are
+ * produced server-side (see the Copilot slash-command completion provider) and
+ * carry an `action` bag on their completion `_meta`. The workbench interprets
+ * that bag on accept — applying the config via the active session's provider so
+ * the permission/mode pickers update reactively — while the send path
+ * (`CopilotAgentSession.send`) re-applies the change and strips the leading
+ * token so it is not dispatched to the runtime as a runtime command.
+ *
+ * Values below are the well-known enum members of the Copilot platform session
+ * schema (`autoApprove`: `default` | `autoApprove`; `mode`: `interactive` |
+ * `plan` | `autopilot`).
+ */
+
+const AUTO_APPROVE_BYPASS = 'autoApprove';
+const AUTO_APPROVE_DEFAULT = 'default';
+const MODE_INTERACTIVE = 'interactive';
+const MODE_PLAN = 'plan';
+const MODE_AUTOPILOT = 'autopilot';
+
+/**
+ * A single flattened completion form of a config-action slash command (the bare
+ * command or one of its named sub-arguments), ready to be emitted as a
+ * completion item.
+ */
+export interface ICopilotConfigSlashCommandItem {
+	/**
+	 * The text inserted when accepted. Empty for a pure toggle (nothing is left
+	 * in the input); `/command ` (trailing space) for an item that keeps the text
+	 * so an argument can be typed.
+	 */
+	readonly insertText: string;
+	/** The display label shown in the picker (e.g. `/autopilot on`). */
+	readonly label: string;
+	/** The command name (without the leading `/`). */
+	readonly command: string;
+	/** Human-readable description shown in completion detail. */
+	readonly description: string;
+	/** Argument hint (ghost text) shown after acceptance for keep-text items. */
+	readonly argumentHint?: string;
+	/** The session-config change applied when accepted. */
+	readonly applyConfig: Readonly<Record<string, string>>;
+	/** Sort key used to order completions. */
+	readonly sortText: string;
+}
+
+/** Internal catalog descriptor for one form of a config-action command. */
+interface IConfigSlashOption {
+	/** Named sub-argument (e.g. `on`/`off`), or `undefined` for the bare command. */
+	readonly arg?: string;
+	readonly detail: string;
+	readonly config: Readonly<Record<string, string>>;
+	/**
+	 * When set, the option is a keep-text form: it inserts `/command ` and shows
+	 * this hint as ghost text so an argument can be typed. When omitted, the
+	 * option is a pure toggle that inserts nothing.
+	 */
+	readonly argumentHint?: string;
+}
+
+interface IConfigSlashCommand {
+	readonly command: string;
+	readonly sortText: string;
+	readonly options: readonly IConfigSlashOption[];
+}
+
+function setBypassDetail(): string { return localize('copilotConfigSlash.yolo', "Set permissions to bypass approvals"); }
+function setDefaultDetail(): string { return localize('copilotConfigSlash.default', "Set permissions back to default"); }
+function autopilotOnDetail(): string { return localize('copilotConfigSlash.autopilot.on', "Switch to autopilot mode"); }
+function exitAutopilotDetail(): string { return localize('copilotConfigSlash.exitAutopilot', "Switch to interactive mode"); }
+function autopilotPromptDetail(): string { return localize('copilotConfigSlash.autopilot.prompt', "Switch to autopilot mode with an objective"); }
+function planPromptDetail(): string { return localize('copilotConfigSlash.plan.prompt', "Create an implementation plan before coding"); }
+function autopilotArgumentHint(): string { return localize('copilotConfigSlash.autopilotHint', "objective"); }
+function promptArgumentHint(): string { return localize('copilotConfigSlash.promptHint', "Describe what you want to plan or research"); }
+
+function getConfigSlashCommands(): readonly IConfigSlashCommand[] {
+	return [
+		{
+			command: 'yolo', sortText: 'z1_yolo',
+			options: [
+				{ detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
+				{ arg: 'on', detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
+				{ arg: 'off', detail: setDefaultDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_DEFAULT } }
+			],
+		},
+		{
+			command: 'allow-all', sortText: 'z1_allow-all',
+			options: [
+				{ detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
+				{ arg: 'on', detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
+				{ arg: 'off', detail: setDefaultDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_DEFAULT } }
+			],
+		},
+		{
+			command: 'autoApprove', sortText: 'z1_autoApprove',
+			options: [
+				{ detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
+				{ arg: 'on', detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
+				{ arg: 'off', detail: setDefaultDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_DEFAULT } }
+			],
+		},
+		{
+			command: 'autopilot', sortText: 'z1_autopilot',
+			options: [
+				{ arg: 'on', detail: autopilotOnDetail(), config: { [SessionConfigKey.Mode]: MODE_AUTOPILOT } },
+				{ arg: 'off', detail: exitAutopilotDetail(), config: { [SessionConfigKey.Mode]: MODE_INTERACTIVE } },
+				{ detail: autopilotPromptDetail(), config: { [SessionConfigKey.Mode]: MODE_AUTOPILOT }, argumentHint: autopilotArgumentHint() },
+			],
+		},
+		{
+			command: 'plan', sortText: 'z1_plan',
+			options: [
+				{ detail: planPromptDetail(), config: { [SessionConfigKey.Mode]: MODE_PLAN }, argumentHint: promptArgumentHint() },
+			],
+		},
+		{
+			command: 'goal', sortText: 'z1_goal',
+			options: [
+				{ detail: planPromptDetail(), config: { [SessionConfigKey.Mode]: MODE_PLAN }, argumentHint: promptArgumentHint() },
+			],
+		},
+	];
+}
+
+/**
+ * The set of command names that are config-action commands. Used by the send
+ * path to decide whether a leading slash command should be intercepted (applied
+ * + stripped) rather than dispatched to the runtime.
+ */
+export function isCopilotConfigSlashCommand(command: string): boolean {
+	return getConfigSlashCommands().some(c => c.command.toLowerCase() === command.toLowerCase());
+}
+
+/**
+ * Returns the flattened completion items (one per command form) whose command
+ * name matches `typed` (the text after the leading `/`, case-insensitive prefix).
+ * When `typed` is empty, all items are returned.
+ */
+export function getCopilotConfigSlashCommandItems(typed: string): ICopilotConfigSlashCommandItem[] {
+	const typedLower = typed.trim().toLowerCase();
+	const items: ICopilotConfigSlashCommandItem[] = [];
+	for (const command of getConfigSlashCommands()) {
+		if (typedLower && !command.command.toLowerCase().startsWith(typedLower)) {
+			continue;
+		}
+		for (const option of command.options) {
+			// Keep-text items (those expecting a typed argument) insert `/command `
+			// and show the argument hint; pure toggles insert nothing (the display
+			// comes from `label`).
+			const keep = option.argumentHint !== undefined;
+			const insertText = keep ? `/${command.command} ` : '';
+			const label = keep
+				? `/${command.command}`
+				: (option.arg ? `/${command.command} ${option.arg}` : `/${command.command}`);
+			items.push({
+				insertText,
+				label,
+				command: command.command,
+				description: option.detail,
+				...(option.argumentHint !== undefined ? { argumentHint: option.argumentHint } : {}),
+				applyConfig: option.config,
+				sortText: option.arg ? `${command.sortText}_${option.arg}` : command.sortText,
+			});
+		}
+	}
+	return items;
+}
+
+/**
+ * Result of resolving a config-action slash command on send.
+ */
+export interface ICopilotConfigSlashCommandSendResult {
+	/** The session-config change to (re-)apply. */
+	readonly applyConfig: Readonly<Record<string, string>>;
+	/**
+	 * The prompt text that should be forwarded to the runtime after stripping the
+	 * command token (and any recognized sub-argument). Empty when the command is a
+	 * pure toggle with no trailing prompt.
+	 */
+	readonly strippedPrompt: string;
+}
+
+/**
+ * Resolves a leading config-action slash command for the send path: maps the
+ * command (and any recognized `on`/`off` sub-argument) to the session-config
+ * change to apply, and returns the remaining prompt text to forward with the
+ * command token stripped. Returns `undefined` for non-config-action commands so
+ * callers fall through to their normal (runtime) handling.
+ */
+export function resolveCopilotConfigSlashCommandOnSend(command: string, rest: string): ICopilotConfigSlashCommandSendResult | undefined {
+	const descriptor = getConfigSlashCommands().find(c => c.command.toLowerCase() === command.toLowerCase());
+	if (!descriptor) {
+		return undefined;
+	}
+	const trimmedRest = rest.trim();
+	const namedOptions = descriptor.options.filter(o => o.arg !== undefined);
+	if (namedOptions.length > 0 && trimmedRest.length > 0) {
+		const match = /^(\S+)(?:\s+([\s\S]*))?$/.exec(trimmedRest);
+		const firstToken = match?.[1]?.toLowerCase();
+		const matched = namedOptions.find(o => o.arg?.toLowerCase() === firstToken);
+		if (matched) {
+			return { applyConfig: matched.config, strippedPrompt: (match?.[2] ?? '').trim() };
+		}
+	}
+	// Fall back to the bare command form (the base/prompt option or the sole option).
+	const baseOption = descriptor.options.find(o => o.arg === undefined) ?? descriptor.options[0];
+	return { applyConfig: baseOption.config, strippedPrompt: trimmedRest };
+}

--- a/src/vs/platform/agentHost/common/meta/agentCompletionAttachmentMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentCompletionAttachmentMeta.ts
@@ -15,6 +15,27 @@ import type { SimpleMessageAttachment } from '../state/protocol/state.js';
  */
 
 /**
+ * A client-side side effect a command completion carries. When present, the
+ * workbench interprets it on accept (see the shared agent-host completion action
+ * handler) rather than treating the item as a plain text/reference insertion.
+ *
+ * Used by Copilot agent-host permission/mode toggles (e.g. `/yolo`,
+ * `/autopilot on`): the item applies a well-known session-config change. Whether
+ * the item leaves text behind is expressed by its `insertText` (empty for a pure
+ * toggle; `/command ` for an item that keeps the text so an argument can be
+ * typed, with {@link ICommandCompletionAttachmentMeta.argumentHint} as ghost text).
+ */
+export interface IAgentHostCompletionAction {
+	/**
+	 * A partial agent-host session-config change to apply when the completion is
+	 * accepted, keyed by well-known session-config property (e.g. `autoApprove`,
+	 * `mode`) to the string-enum value. Applied via the active session's provider
+	 * so the corresponding picker updates reactively.
+	 */
+	readonly applyConfig?: Readonly<Record<string, string>>;
+}
+
+/**
  * The `_meta` shape attached to a `completions` result that resolves to a slash
  * command.
  */
@@ -28,6 +49,11 @@ export interface ICommandCompletionAttachmentMeta {
 	 * inline placeholder (ghost text) after an accepted command completion.
 	 */
 	readonly argumentHint?: string;
+	/**
+	 * Optional client-side action to run when the completion is accepted (e.g. a
+	 * permission/mode session-config toggle). See {@link IAgentHostCompletionAction}.
+	 */
+	readonly action?: IAgentHostCompletionAction;
 }
 
 /**
@@ -66,11 +92,13 @@ export function readCompletionAttachmentMeta(attachment: SimpleMessageAttachment
 		return undefined;
 	}
 	if (typeof meta['command'] === 'string') {
+		const action = readCompletionActionMeta(meta['action']);
 		return {
 			kind: 'command',
 			command: meta['command'],
 			...(typeof meta['description'] === 'string' ? { description: meta['description'] } : {}),
 			...(typeof meta['argumentHint'] === 'string' ? { argumentHint: meta['argumentHint'] } : {}),
+			...(action ? { action } : {}),
 		};
 	}
 	if (typeof meta['uri'] === 'string') {
@@ -99,7 +127,62 @@ export function toCommandCompletionAttachmentMeta(meta: ICommandCompletionAttach
 	if (meta.argumentHint !== undefined) {
 		result['argumentHint'] = meta.argumentHint;
 	}
+	const action = toCompletionActionMeta(meta.action);
+	if (action !== undefined) {
+		result['action'] = action;
+	}
 	return result;
+}
+
+/**
+ * Reads the optional {@link IAgentHostCompletionAction} carried on a command
+ * completion's raw `_meta` bag (under the `action` key). Kept as the single
+ * seam consumers use to obtain the action, mirroring {@link getCommandArgumentHint}.
+ * Returns `undefined` when absent or malformed; wrong-typed sub-fields are dropped.
+ */
+export function getCompletionAction(meta: Record<string, unknown> | undefined): IAgentHostCompletionAction | undefined {
+	if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+		return undefined;
+	}
+	return readCompletionActionMeta(meta['action']);
+}
+
+/**
+ * Parses an unknown value into an {@link IAgentHostCompletionAction}. Accepts an
+ * object with a string-map `applyConfig`; returns `undefined` when no valid
+ * `applyConfig` is present.
+ */
+function readCompletionActionMeta(value: unknown): IAgentHostCompletionAction | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return undefined;
+	}
+	const raw = value as Record<string, unknown>;
+	let applyConfig: Record<string, string> | undefined;
+	const rawApplyConfig = raw['applyConfig'];
+	if (rawApplyConfig && typeof rawApplyConfig === 'object' && !Array.isArray(rawApplyConfig)) {
+		for (const [key, entry] of Object.entries(rawApplyConfig as Record<string, unknown>)) {
+			if (typeof entry === 'string') {
+				applyConfig ??= {};
+				applyConfig[key] = entry;
+			}
+		}
+	}
+	if (applyConfig === undefined) {
+		return undefined;
+	}
+	return { applyConfig };
+}
+
+/**
+ * Serializes an {@link IAgentHostCompletionAction} into a plain record for the
+ * `_meta` bag, dropping empty entries. Returns `undefined` when the action
+ * carries nothing meaningful.
+ */
+function toCompletionActionMeta(action: IAgentHostCompletionAction | undefined): Record<string, unknown> | undefined {
+	if (!action?.applyConfig || Object.keys(action.applyConfig).length === 0) {
+		return undefined;
+	}
+	return { applyConfig: { ...action.applyConfig } };
 }
 
 /**

--- a/src/vs/platform/agentHost/common/state/protocol/channels-session/commands.ts
+++ b/src/vs/platform/agentHost/common/state/protocol/channels-session/commands.ts
@@ -251,6 +251,15 @@ export interface CompletionItem {
 	insertText: string;
 
 	/**
+	 * Optional display label for the completion item. When omitted, the client
+	 * SHOULD display {@link insertText}. Provide an explicit label when the
+	 * inserted text differs from the label shown in the picker — e.g. a pure
+	 * action item that inserts nothing (`insertText: ''`) but should still be
+	 * shown to the user.
+	 */
+	label?: string;
+
+	/**
 	 * If defined, the start of the range in the input's `text` that is replaced
 	 * by `insertText`. The range is the half-open interval
 	 * `[rangeStart, rangeEnd)` of character offsets, measured in UTF-16 code

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -36,6 +36,7 @@ import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { readToolCallMeta, toToolCallMeta, type IToolCallMeta, type IToolCallUiMeta } from '../../common/meta/agentToolCallMeta.js';
 import { OtelData, type OtelAttributeValue } from '../../common/otlp/otlpLogEmitter.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
+import { resolveCopilotConfigSlashCommandOnSend } from '../../common/copilotConfigSlashCommands.js';
 import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAttachment } from '../../common/meta/agentFeedbackAttachments.js';
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, ToolCallContributorKind, type FileEdit, type MessageAttachment } from '../../common/state/protocol/state.js';
@@ -176,6 +177,7 @@ function getToolCommand(input: ToolUseHookInput): string | undefined {
 }
 
 function toCopilotSdkMode(mode: string | undefined): CopilotSdkMode | undefined {
+	mode = mode?.toLowerCase() === 'goal' ? 'plan' : mode;
 	switch (mode) {
 		case 'interactive':
 		case 'plan':
@@ -1412,9 +1414,20 @@ export class CopilotAgentSession extends Disposable {
 			this._completeActiveTurn();
 			return;
 		}
-		if (slashCommand?.command === 'plan') {
-			mode = 'plan';
-			prompt = slashCommand.rest;
+		const configAction = slashCommand ? resolveCopilotConfigSlashCommandOnSend(slashCommand.command, slashCommand.rawRest) : undefined;
+		if (configAction) {
+			// Workbench config-action command (permission/mode toggle, e.g.
+			// `/autopilot <prompt>`, `/plan`, `/yolo`). The config is applied
+			// client-side on accept via the session provider; here we re-apply the
+			// mode for this turn (belt-and-suspenders) and strip the command token
+			// so it is not dispatched to the runtime as a runtime command.
+			// `autoApprove` changes are already reflected in the session config and
+			// applied by `syncPermissionMode('turn-start')` below.
+			const sdkMode = toCopilotSdkMode(configAction.applyConfig[SessionConfigKey.Mode]);
+			if (sdkMode) {
+				mode = sdkMode;
+			}
+			prompt = configAction.strippedPrompt;
 		} else if (slashCommand?.command === 'rubber-duck') {
 			if (this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.RubberDuck) !== true) {
 				// Feature not enabled — pass the remaining text through as a plain

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -8,6 +8,7 @@ import { AgentSession } from '../../common/agentService.js';
 import { CompletionItem, CompletionItemKind, CompletionsParams } from '../../common/state/protocol/commands.js';
 import { Customization, CustomizationType, DirectoryCustomization, MessageAttachmentKind, PluginCustomization, SkillCustomization } from '../../common/state/protocol/state.js';
 import { toCommandCompletionAttachmentMeta } from '../../common/meta/agentCompletionAttachmentMeta.js';
+import { getCopilotConfigSlashCommandItems, isCopilotConfigSlashCommand } from '../../common/copilotConfigSlashCommands.js';
 import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from '../agentHostCompletions.js';
 import { extractLeadingSlashToken, extractWhitespaceDelimitedSlashToken } from '../agentHostSlashCompletion.js';
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../common/agentHostFileSystemService.js';
@@ -156,6 +157,12 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 			if (HIDDEN_RUNTIME_COMMANDS.has(command.name) || command.aliases?.some(alias => HIDDEN_RUNTIME_COMMANDS.has(alias))) {
 				continue;
 			}
+			// Config-action commands (permission/mode toggles) are surfaced below
+			// as workbench-defined items; skip any runtime command that collides
+			// with them (e.g. a runtime `plan`) to avoid duplicate suggestions.
+			if (isCopilotConfigSlashCommand(command.name) || command.aliases?.some(alias => isCopilotConfigSlashCommand(alias))) {
+				continue;
+			}
 			if (!rubberDuckEnabled && command.name === 'rubber-duck') {
 				continue;
 			}
@@ -207,7 +214,33 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 				});
 		}
 
-		return completionItems.sort((a, b) => a.insertText.localeCompare(b.insertText));
+		// Prepend workbench-defined config-action commands (permission/mode
+		// toggles). These are not runtime SDK commands; they carry an `action`
+		// bag on their `_meta` that the workbench interprets on accept. Only
+		// offered for leading `/command` tokens (not the whitespace-delimited
+		// skill form).
+		if (!returnJustSkills) {
+			for (const item of getCopilotConfigSlashCommandItems(typed)) {
+				completionItems.push({
+					insertText: item.insertText,
+					label: item.label,
+					rangeStart,
+					rangeEnd,
+					attachment: {
+						type: MessageAttachmentKind.Simple,
+						label: item.label,
+						_meta: toCommandCompletionAttachmentMeta({
+							command: item.command,
+							description: item.description,
+							...(item.argumentHint !== undefined ? { argumentHint: item.argumentHint } : {}),
+							action: { applyConfig: item.applyConfig },
+						}),
+					},
+				});
+			}
+		}
+
+		return completionItems.sort((a, b) => (a.label ?? a.insertText).localeCompare(b.label ?? b.insertText));
 	}
 }
 

--- a/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { readToolCallMeta, toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { readAgentCustomizationMeta, toAgentCustomizationMeta } from '../../common/meta/agentCustomizationMeta.js';
-import { getCommandArgumentHint, readCompletionAttachmentMeta, toCommandCompletionAttachmentMeta, toSkillCompletionAttachmentMeta } from '../../common/meta/agentCompletionAttachmentMeta.js';
+import { getCommandArgumentHint, getCompletionAction, readCompletionAttachmentMeta, toCommandCompletionAttachmentMeta, toSkillCompletionAttachmentMeta } from '../../common/meta/agentCompletionAttachmentMeta.js';
 import { CustomizationType, MessageAttachmentKind, ToolCallStatus, type AgentCustomization, type ToolCallState } from '../../common/state/sessionState.js';
 import type { SessionModelInfo, SimpleMessageAttachment } from '../../common/state/protocol/state.js';
 import { createAgentModelByokMeta, readAgentModelByokIdentifier } from '../../common/agentModelByokMeta.js';
@@ -129,6 +129,35 @@ suite('Agent host _meta readers', () => {
 			assert.strictEqual(getCommandArgumentHint({ argumentHint: 5 }), undefined);
 			assert.strictEqual(getCommandArgumentHint({ command: 'rename' }), undefined);
 			assert.strictEqual(getCommandArgumentHint(undefined), undefined);
+		});
+
+		test('classifies a command bag carrying an action and round-trips it', () => {
+			const wire = toCommandCompletionAttachmentMeta({
+				command: 'autopilot',
+				description: 'Run this request in Autopilot mode',
+				argumentHint: 'prompt',
+				action: { applyConfig: { mode: 'autopilot' } },
+			});
+			assert.deepStrictEqual(wire, {
+				command: 'autopilot',
+				description: 'Run this request in Autopilot mode',
+				argumentHint: 'prompt',
+				action: { applyConfig: { mode: 'autopilot' } },
+			});
+			assert.deepStrictEqual(readCompletionAttachmentMeta(attachment(wire)), {
+				kind: 'command',
+				command: 'autopilot',
+				description: 'Run this request in Autopilot mode',
+				argumentHint: 'prompt',
+				action: { applyConfig: { mode: 'autopilot' } },
+			});
+		});
+
+		test('getCompletionAction reads the action, dropping wrong-typed sub-fields and empty bags', () => {
+			assert.deepStrictEqual(getCompletionAction({ action: { applyConfig: { autoApprove: 'autoApprove', bad: 5 } } }), { applyConfig: { autoApprove: 'autoApprove' } });
+			assert.strictEqual(getCompletionAction({ action: { applyConfig: {} } }), undefined);
+			assert.strictEqual(getCompletionAction({ command: 'yolo' }), undefined);
+			assert.strictEqual(getCompletionAction(undefined), undefined);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
+++ b/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { getCopilotConfigSlashCommandItems, isCopilotConfigSlashCommand, resolveCopilotConfigSlashCommandOnSend } from '../../common/copilotConfigSlashCommands.js';
+
+suite('copilotConfigSlashCommands', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('getCopilotConfigSlashCommandItems', () => {
+		test('empty prefix returns permission and mode items with labels and actions', () => {
+			const items = getCopilotConfigSlashCommandItems('');
+			const byLabel = new Map(items.map(i => [i.label, i]));
+
+			// Permission command: bare toggle plus on/off sub-args, inserts nothing.
+			assert.strictEqual(byLabel.get('/yolo')?.insertText, '');
+			assert.deepStrictEqual(byLabel.get('/yolo')?.applyConfig, { autoApprove: 'autoApprove' });
+			assert.deepStrictEqual(byLabel.get('/yolo on')?.applyConfig, { autoApprove: 'autoApprove' });
+			assert.deepStrictEqual(byLabel.get('/yolo off')?.applyConfig, { autoApprove: 'default' });
+
+			// Mode sub-args (toggles insert nothing) and the keep-text prompt variant.
+			assert.strictEqual(byLabel.get('/autopilot on')?.insertText, '');
+			assert.deepStrictEqual(byLabel.get('/autopilot on')?.applyConfig, { mode: 'autopilot' });
+			assert.deepStrictEqual(byLabel.get('/autopilot off')?.applyConfig, { mode: 'interactive' });
+			const prompt = byLabel.get('/autopilot');
+			assert.strictEqual(prompt?.insertText, '/autopilot ');
+			assert.deepStrictEqual(prompt?.applyConfig, { mode: 'autopilot' });
+			assert.strictEqual(prompt?.argumentHint, 'objective');
+		});
+
+		test('prefix filters by command name', () => {
+			const commands = new Set(getCopilotConfigSlashCommandItems('autop').map(i => i.command));
+			assert.deepStrictEqual([...commands], ['autopilot']);
+			assert.strictEqual(getCopilotConfigSlashCommandItems('nope').length, 0);
+		});
+	});
+
+	suite('resolveCopilotConfigSlashCommandOnSend', () => {
+		test('maps commands, sub-args, and strips the token', () => {
+			assert.deepStrictEqual(resolveCopilotConfigSlashCommandOnSend('yolo', ''), { applyConfig: { autoApprove: 'autoApprove' }, strippedPrompt: '' });
+			assert.deepStrictEqual(resolveCopilotConfigSlashCommandOnSend('autopilot', 'off'), { applyConfig: { mode: 'interactive' }, strippedPrompt: '' });
+			assert.deepStrictEqual(resolveCopilotConfigSlashCommandOnSend('autopilot', 'do the thing'), { applyConfig: { mode: 'autopilot' }, strippedPrompt: 'do the thing' });
+			// `plan` has no sub-args, so trailing text is forwarded as the prompt.
+			assert.deepStrictEqual(resolveCopilotConfigSlashCommandOnSend('plan', 'the feature'), { applyConfig: { mode: 'plan' }, strippedPrompt: 'the feature' });
+			assert.strictEqual(resolveCopilotConfigSlashCommandOnSend('notACommand', 'x'), undefined);
+		});
+	});
+
+	test('isCopilotConfigSlashCommand recognizes config commands only', () => {
+		assert.strictEqual(isCopilotConfigSlashCommand('autopilot'), true);
+		assert.strictEqual(isCopilotConfigSlashCommand('YOLO'), true);
+		assert.strictEqual(isCopilotConfigSlashCommand('rubber-duck'), false);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
@@ -7,9 +7,22 @@ import assert from 'assert';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../common/agentHostFileSystemService.js';
-import { CompletionItemKind } from '../../common/state/protocol/commands.js';
+import { CompletionItem, CompletionItemKind } from '../../common/state/protocol/commands.js';
 import { Customization, CustomizationLoadStatus, CustomizationType, McpServerStatus, MessageAttachmentKind, type PluginCustomization, type SkillCustomization } from '../../common/state/protocol/state.js';
 import { CopilotSlashCommandCompletionProvider, ICopilotRuntimeSlashCommandInfo, parseLeadingSlashCommand } from '../../node/copilot/copilotSlashCommandCompletionProvider.js';
+
+/**
+ * The provider now also injects workbench-defined config-action items
+ * (permission/mode toggles like `/yolo`, `/autopilot`) into every leading-slash
+ * completion result; these carry an `action` bag on their attachment `_meta`.
+ * The runtime-focused assertions below filter them out with this helper so they
+ * keep asserting on the runtime SDK command set. Runtime commands whose name
+ * collides with a config-action command (e.g. `plan`) are intentionally dropped
+ * by the provider, so they no longer appear even after filtering.
+ */
+function runtimeOnly(items: readonly CompletionItem[]): CompletionItem[] {
+	return items.filter(i => i.attachment?._meta?.action === undefined);
+}
 
 suite('CopilotSlashCommandCompletionProvider', () => {
 
@@ -124,9 +137,18 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(items, []);
 		});
 
-		test('returns all items for lone "/"', async () => {
+		test('returns all runtime items for lone "/" (config-action items filtered)', async () => {
 			const items = await run('/');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact ', '/research ', '/rubber-duck ', '/env ', '/review ', '/security-review '].sort());
+			// `plan` collides with a config-action command and is dropped from the runtime set.
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), ['/compact ', '/research ', '/rubber-duck ', '/env ', '/review ', '/security-review '].sort());
+		});
+
+		test('injects config-action items (permission/mode toggles) for a leading slash', async () => {
+			const items = await run('/');
+			const byLabel = new Map(items.filter(i => i.attachment?._meta?.action !== undefined).map(i => [i.attachment?.label, i]));
+			assert.ok(byLabel.has('/yolo'));
+			assert.ok(byLabel.has('/autopilot on'));
+			assert.strictEqual(byLabel.get('/autopilot')?.insertText, '/autopilot ');
 		});
 
 		test('filters to /plan when "/p" typed', async () => {
@@ -183,7 +205,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 
 		test('attachment is Simple with command + description meta', async () => {
 			const items = await run('/');
-			assert.deepStrictEqual(items.map(item => ({ insertText: item.insertText, type: item.attachment?.type, meta: item.attachment?._meta })), [
+			assert.deepStrictEqual(runtimeOnly(items).map(item => ({ insertText: item.insertText, type: item.attachment?.type, meta: item.attachment?._meta })), [
 				{
 					insertText: '/compact ',
 					type: MessageAttachmentKind.Simple,
@@ -198,15 +220,6 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 					meta: {
 						command: 'env',
 						description: 'Runtime env',
-					},
-				},
-				{
-					insertText: '/plan ',
-					type: MessageAttachmentKind.Simple,
-					meta: {
-						command: 'plan',
-						description: 'Runtime plan',
-						argumentHint: 'task',
 					},
 				},
 				{
@@ -257,10 +270,9 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			const items = await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
 			}, CancellationToken.None);
-			assert.deepStrictEqual(items.map(i => i.insertText), [
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), [
 				'/compact ',
 				'/env ',
-				'/plan ',
 				'/research ',
 				'/review ',
 				'/security-review '
@@ -276,7 +288,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			const items = await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
 			}, CancellationToken.None);
-			assert.deepStrictEqual(items, []);
+			assert.deepStrictEqual(runtimeOnly(items), []);
 		});
 
 		test('filters out runtime commands omitted from the catalog', async () => {
@@ -288,9 +300,9 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			const items = await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
 			}, CancellationToken.None);
-			assert.deepStrictEqual(items.map(i => i.insertText), [
+			// `plan` collides with a config-action command and is dropped from the runtime set.
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), [
 				'/compact ',
-				'/plan ',
 				'/research ',
 				'/review ',
 				'/rubber-duck ',
@@ -316,7 +328,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/focus ']);
 		});
 
-		test('keeps runtime commands that also have local send-time handling', async () => {
+		test('config-action commands shadow runtime commands of the same name', async () => {
 			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', {
 				isRubberDuckEnabled: () => true,
 				getRuntimeSlashCommands: async () => [
@@ -329,7 +341,12 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			const items = await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
 			}, CancellationToken.None);
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact ', '/runtime-only '].sort());
+			// `plan` collides with a config-action command, so the runtime `plan` is
+			// dropped; non-colliding runtime commands are kept.
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), ['/compact ', '/runtime-only '].sort());
+			// The config-action `/plan ` item is still surfaced (carrying an action bag).
+			const planItem = items.find(i => i.insertText === '/plan ');
+			assert.ok(planItem?.attachment?._meta?.action !== undefined);
 		});
 
 		test('uses runtime input metadata to determine trailing space insertion', async () => {
@@ -464,7 +481,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 				{ name: 'my-skill', description: 'Runtime skill', kind: 'skill', allowDuringAgentExecution: true },
 			]);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/my-skill ']);
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), ['/my-skill ']);
 		});
 
 		test('excludes runtime skills that match a known plugin skill (with plugin prefix)', async () => {
@@ -473,7 +490,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 				[plugin('my-plugin', [skill('my-skill')])],
 			);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items, []);
+			assert.deepStrictEqual(runtimeOnly(items), []);
 		});
 
 		test('excludes runtime skills that match a known plugin skill with the same name (no prefix)', async () => {
@@ -482,7 +499,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 				[plugin('monitor-pr', [skill('monitor-pr')])],
 			);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items, []);
+			assert.deepStrictEqual(runtimeOnly(items), []);
 		});
 
 		test('excludes runtime skills that match a known synced plugin skill (no prefix)', async () => {
@@ -491,7 +508,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 				[syncedPlugin('skills-bundle', [skill('monitor-pr')])],
 			);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items, []);
+			assert.deepStrictEqual(runtimeOnly(items), []);
 		});
 
 		test('includes runtime skills whose name differs from the prefixed known skill candidate', async () => {
@@ -501,7 +518,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 				[plugin('my-plugin', [skill('my-skill')])],
 			);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/my-skill ']);
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), ['/my-skill ']);
 		});
 
 		test('treats skills inside disabled containers as unknown', async () => {
@@ -510,7 +527,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 				[plugin('my-plugin', [skill('my-skill')], false)],
 			);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/my-plugin:my-skill ']);
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), ['/my-plugin:my-skill ']);
 		});
 
 		test('ignores mcp server containers when computing known skills', async () => {
@@ -527,7 +544,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 				[mcpServer],
 			);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/my-skill ']);
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), ['/my-skill ']);
 		});
 
 		test('surfaces the skill prompt hint as an argument hint', async () => {
@@ -535,7 +552,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 				{ name: 'my-skill', description: 'Runtime skill', kind: 'skill', allowDuringAgentExecution: true, input: { hint: 'do stuff' } },
 			]);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items.map(item => ({ insertText: item.insertText, type: item.attachment?.type, meta: item.attachment?._meta })), [
+			assert.deepStrictEqual(runtimeOnly(items).map(item => ({ insertText: item.insertText, type: item.attachment?.type, meta: item.attachment?._meta })), [
 				{
 					insertText: '/my-skill ',
 					type: MessageAttachmentKind.Simple,
@@ -553,16 +570,16 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 				{ name: 'toggle-skill', description: 'Toggle skill', kind: 'skill', allowDuringAgentExecution: true, input: { hint: '[on|off]' } },
 			]);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/toggle-skill ']);
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), ['/toggle-skill ']);
 		});
 
 		test('surfaces runtime skills alongside builtins for a leading slash', async () => {
 			const provider = createProvider([
-				{ name: 'plan', description: 'Runtime plan', kind: 'builtin', allowDuringAgentExecution: true, input: { hint: 'task' } },
+				{ name: 'compact', description: 'Runtime compact', kind: 'builtin', allowDuringAgentExecution: true },
 				{ name: 'alpha-skill', description: 'Alpha skill', kind: 'skill', allowDuringAgentExecution: true },
 			]);
 			const items = await run(provider, '/');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/alpha-skill '].sort());
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), ['/compact ', '/alpha-skill '].sort());
 		});
 
 		test('returns only runtime skills for an in-message slash token', async () => {

--- a/src/vs/sessions/contrib/chat/browser/agentHostInputCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHostInputCompletions.ts
@@ -16,13 +16,20 @@ import { CompletionItem, CompletionItemKind } from '../../../../editor/common/la
 import { IModelDeltaDecoration, ITextModel } from '../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
-import { getCommandArgumentHint } from '../../../../platform/agentHost/common/meta/agentCompletionAttachmentMeta.js';
+import { getCommandArgumentHint, getCompletionAction, type IAgentHostCompletionAction } from '../../../../platform/agentHost/common/meta/agentCompletionAttachmentMeta.js';
 import { AgentHostCompletionReferenceKind, getAgentHostCompletionReferenceKind, IChatRequestVariableEntry, isAgentHostCompletionVariableEntry, toAgentHostCompletionVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { IChatInputCompletionItem, IChatSessionsService, isAgentHostTarget } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { getChatSessionType } from '../../../../workbench/contrib/chat/common/model/chatUri.js';
 import { AgentHostInputCompletionsBase } from '../../../../workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletionsBase.js';
 import { getInputPlaceholderColor, getRangeForPlaceholder } from '../../../../workbench/contrib/chat/browser/widget/input/editor/chatInputPlaceholderDecoration.js';
+import { applyAgentHostCompletionAction, isPolicyBlockedCompletionAction } from '../../../../workbench/contrib/chat/browser/agentHostCompletionAction.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
+import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { NewChatContextAttachments } from './newChatContextAttachments.js';
 
@@ -42,6 +49,26 @@ interface IReferenceArg {
 
 CommandsRegistry.registerCommand(ADD_REFERENCE_COMMAND, (_accessor, arg: IReferenceArg) => {
 	arg.handler.acceptCompletion(arg.entry, arg.insertText, arg.range);
+});
+
+/**
+ * Command ID used by config-action completion items (permission/mode toggles)
+ * to apply the session-config change on accept.
+ */
+const CONFIG_ACTION_COMMAND = 'sessions.chat.applyAgentHostConfigAction';
+
+interface IConfigActionArg {
+	readonly handler: AgentHostInputCompletionHandler;
+	readonly action: IAgentHostCompletionAction;
+	/** Reference to add (for the argument hint) for keep-text items; undefined for toggles. */
+	readonly entry: IChatRequestVariableEntry | undefined;
+	/** Text of the kept command reference (without the trailing space). */
+	readonly referenceText: string;
+	readonly referenceRange: OffsetRange | undefined;
+}
+
+CommandsRegistry.registerCommand(CONFIG_ACTION_COMMAND, async (accessor: ServicesAccessor, arg: IConfigActionArg) => {
+	await arg.handler.applyConfigAction(accessor, arg);
 });
 
 /**
@@ -162,6 +189,7 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 		@IChatSessionsService chatSessionsService: IChatSessionsService,
 		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
 		@IThemeService private readonly _themeService: IThemeService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super(languageFeaturesService, chatSessionsService);
 
@@ -244,11 +272,48 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 		return { sessionResource, context: undefined };
 	}
 
-	protected override _buildItem(position: Position, item: IChatInputCompletionItem): CompletionItem {
+	protected override _buildItem(position: Position, item: IChatInputCompletionItem): CompletionItem | undefined {
 		const replaceRange = AgentHostInputCompletionHandler.computeRange(position, item);
 		const attachment = item.attachment;
 		switch (attachment.kind) {
 			case 'command': {
+				const action = getCompletionAction(attachment._meta);
+				if (action) {
+					// Omit an elevated auto-approve toggle (Allow all / Assisted)
+					// when enterprise policy disables global auto-approval, rather
+					// than offering an item that would warn then clamp to Default.
+					if (isPolicyBlockedCompletionAction(action, this._configurationService)) {
+						return undefined;
+					}
+					// Config-action completion (permission/mode toggle). Keep-text
+					// items (non-empty insertText) retain the `/command ` text and
+					// its argument-hint reference; toggle items insert nothing.
+					const keep = item.insertText !== '';
+					const label = item.label ?? item.insertText;
+					const referenceText = item.insertText.trimEnd();
+					const entry = keep
+						? toAgentHostCompletionVariableEntry(AgentHostCompletionReferenceKind.Command, referenceText, attachment.command, attachment._meta)
+						: undefined;
+					return {
+						label: { label, description: attachment.description },
+						insertText: item.insertText,
+						filterText: label,
+						range: replaceRange,
+						kind: CompletionItemKind.Text,
+						documentation: attachment.description,
+						command: {
+							id: CONFIG_ACTION_COMMAND,
+							title: '',
+							arguments: [{
+								handler: this,
+								action,
+								entry,
+								referenceText,
+								referenceRange: entry ? this._toOffsetRange(replaceRange.replace, referenceText) : undefined,
+							} satisfies IConfigActionArg],
+						},
+					};
+				}
 				const referenceText = item.insertText.trimEnd();
 				const entry = toAgentHostCompletionVariableEntry(AgentHostCompletionReferenceKind.Command, referenceText, attachment.command, attachment._meta);
 				return {
@@ -341,6 +406,34 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 		this._insertedReferences.set(entry.id, { text: insertText, range });
 		this._contextAttachments.setAttachments([...this._contextAttachments.attachments.filter(e => e.id !== entry.id), entry]);
 		this._updateDecorations();
+	}
+
+	/**
+	 * Accept handler for config-action completions (permission/mode toggles).
+	 * Applies the session-config change (gated by the elevated-permission
+	 * confirmation for `autoApprove`) via the active session's agent-host
+	 * provider. Keep-text items (non-empty insertText) then add their argument-
+	 * hint reference; toggle items insert nothing, so there is no text to remove.
+	 */
+	async applyConfigAction(accessor: ServicesAccessor, arg: IConfigActionArg): Promise<void> {
+		const session = this._sessionsService.activeSession.get();
+		if (!session) {
+			return;
+		}
+		const dialogService = accessor.get(IDialogService);
+		const storageService = accessor.get(IStorageService);
+		const sessionsProvidersService = accessor.get(ISessionsProvidersService);
+		const applied = await applyAgentHostCompletionAction(arg.action, dialogService, storageService, async config => {
+			const provider = sessionsProvidersService.getProvider(session.providerId);
+			if (provider && isAgentHostProvider(provider)) {
+				await Promise.all(Object.entries(config).map(([key, value]) => provider.setSessionConfigValue(session.sessionId, key, value).catch(() => { /* best-effort */ })));
+			}
+		});
+		// Keep-text items add their argument-hint reference once applied. Toggle
+		// items insert nothing, so there is no text to remove.
+		if (applied && arg.entry) {
+			this.acceptCompletion(arg.entry, arg.referenceText, arg.referenceRange);
+		}
 	}
 
 	getAttachmentsForSend(messageText?: string, messageOffset = 0): IChatRequestVariableEntry[] {

--- a/src/vs/sessions/contrib/chat/browser/agentHostInputCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHostInputCompletions.ts
@@ -30,7 +30,7 @@ import { applyAgentHostCompletionAction, isPolicyBlockedCompletionAction } from 
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
-import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { ISessionContext } from '../../../services/sessions/browser/sessionContext.js';
 import { NewChatContextAttachments } from './newChatContextAttachments.js';
 
 /**
@@ -185,7 +185,7 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 		private readonly _editor: CodeEditorWidget,
 		private readonly _contextAttachments: NewChatContextAttachments,
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
-		@ISessionsService private readonly _sessionsService: ISessionsService,
+		@ISessionContext private readonly _sessionContext: ISessionContext,
 		@IChatSessionsService chatSessionsService: IChatSessionsService,
 		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
 		@IThemeService private readonly _themeService: IThemeService,
@@ -198,9 +198,13 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 		this._decorations = this._editor.createDecorationsCollection();
 		this._registerDecorations();
 
-		// Watch the active session and (re-)register the Monaco provider
-		// with the trigger characters announced by whichever content
-		// provider handles the active session's resource scheme.
+		// Watch this input's scoped session and (re-)register the Monaco
+		// provider with the trigger characters announced by whichever content
+		// provider handles that session's resource scheme. Using the
+		// input-scoped `ISessionContext` (rather than the window-global active
+		// session) ensures completions — and the config changes they apply on
+		// accept — target the session this input composes for, even when another
+		// same-type session is the window's active one.
 		//
 		// We key off the resource scheme (via `getChatSessionType`) rather
 		// than `ISession.sessionType` because the latter is the *agent
@@ -211,7 +215,7 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 		// looks up.
 		let currentScheme: string | undefined;
 		this._register(autorun(reader => {
-			const session = this._sessionsService.activeSession.read(reader);
+			const session = this._sessionContext.session.read(reader);
 			const scheme = session ? getChatSessionType(session.resource) : undefined;
 			if (scheme === currentScheme) {
 				return;
@@ -230,9 +234,9 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 			return;
 		}
 
-		// The active session may have changed mid-await — bail if its
+		// The scoped session may have changed mid-await — bail if its
 		// resource scheme is no longer the one we registered for.
-		const activeSession = this._sessionsService.activeSession.get();
+		const activeSession = this._sessionContext.session.get();
 		if (!activeSession || getChatSessionType(activeSession.resource) !== scheme) {
 			return;
 		}
@@ -257,14 +261,14 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 		if (/^\s*\/troubleshoot\b/.test(model.getValue())) {
 			return undefined;
 		}
-		const session = this._sessionsService.activeSession.get();
+		const session = this._sessionContext.session.get();
 		if (!session) {
 			return undefined;
 		}
 		const sessionResource = session.resource;
-		// Only respond when the currently-active session matches the
+		// Only respond when this input's scoped session matches the
 		// scheme this registration was made for. Stale registrations
-		// (active session changed during the host RPC, etc.) are
+		// (the scoped session changed during the host RPC, etc.) are
 		// silently ignored.
 		if (getChatSessionType(sessionResource) !== scheme) {
 			return undefined;
@@ -411,12 +415,13 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 	/**
 	 * Accept handler for config-action completions (permission/mode toggles).
 	 * Applies the session-config change (gated by the elevated-permission
-	 * confirmation for `autoApprove`) via the active session's agent-host
-	 * provider. Keep-text items (non-empty insertText) then add their argument-
-	 * hint reference; toggle items insert nothing, so there is no text to remove.
+	 * confirmation for `autoApprove`) via this input's scoped session's
+	 * agent-host provider. Keep-text items (non-empty insertText) then add their
+	 * argument-hint reference; toggle items insert nothing, so there is no text
+	 * to remove.
 	 */
 	async applyConfigAction(accessor: ServicesAccessor, arg: IConfigActionArg): Promise<void> {
-		const session = this._sessionsService.activeSession.get();
+		const session = this._sessionContext.session.get();
 		if (!session) {
 			return;
 		}

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -675,7 +675,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			SessionReferenceCompletionHandler, this._editor, this._contextAttachments,
 		));
 
-		this._agentHostInputCompletionHandler = this._register(this.instantiationService.createInstance(
+		this._agentHostInputCompletionHandler = this._register(this._scopedInstantiationService.createInstance(
 			AgentHostInputCompletionHandler, this._editor, this._contextAttachments,
 		));
 

--- a/src/vs/workbench/contrib/chat/browser/agentHostCompletionAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentHostCompletionAction.ts
@@ -64,7 +64,7 @@ function getElevatedAutoApproveLevel(value: string | undefined): ChatPermissionL
 	if (!isChatPermissionLevel(value)) {
 		return undefined;
 	}
-	return value === ChatPermissionLevel.AutoApprove || value === ChatPermissionLevel.Assisted ? value : undefined;
+	return value === ChatPermissionLevel.AutoApprove || value === ChatPermissionLevel.Assisted || value === ChatPermissionLevel.Autopilot ? value : undefined;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/agentHostCompletionAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentHostCompletionAction.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { SessionConfigKey } from '../../../../platform/agentHost/common/sessionConfigKeys.js';
+import { IAgentHostCompletionAction } from '../../../../platform/agentHost/common/meta/agentCompletionAttachmentMeta.js';
+import { isAutoApprovePolicyRestricted } from '../common/agentHostConfigPolicy.js';
+import { maybeConfirmElevatedPermissionLevel } from '../common/chatPermissionWarnings.js';
+import { ChatConfiguration, ChatPermissionLevel, isChatPermissionLevel } from '../common/constants.js';
+
+/**
+ * Applies a Copilot agent-host completion {@link IAgentHostCompletionAction}
+ * (a permission/mode session-config toggle carried on a `/command` completion's
+ * `_meta`). Shared by both the editor-window and Agents-window completion accept
+ * paths — the per-window difference (how the config change is dispatched to the
+ * active session) is supplied via {@link apply}.
+ *
+ * Before applying, an elevated `autoApprove` change (Allow all / Assisted) is
+ * gated by the same {@link maybeConfirmElevatedPermissionLevel} confirmation the
+ * permission pickers use, so the slash-command path is not a bypass. Mode-axis
+ * changes are applied without confirmation.
+ *
+ * @returns `true` when the change was applied (or there was nothing to apply),
+ * `false` when the user cancelled the elevated-permission confirmation.
+ */
+export async function applyAgentHostCompletionAction(
+	action: IAgentHostCompletionAction,
+	dialogService: IDialogService,
+	storageService: IStorageService,
+	apply: (config: Readonly<Record<string, string>>) => void | Promise<void>,
+): Promise<boolean> {
+	const config = action.applyConfig;
+	if (!config || Object.keys(config).length === 0) {
+		return true;
+	}
+
+	const elevatedLevel = getElevatedAutoApproveLevel(config[SessionConfigKey.AutoApprove]);
+	if (elevatedLevel !== undefined) {
+		const confirmed = await maybeConfirmElevatedPermissionLevel(elevatedLevel, dialogService, storageService, {
+			defaultSettingKey: ChatConfiguration.DefaultConfiguration,
+		});
+		if (!confirmed) {
+			return false;
+		}
+	}
+
+	await apply(config);
+	return true;
+}
+
+/**
+ * Maps an `autoApprove` config value to the {@link ChatPermissionLevel} whose
+ * elevated-permission warning should be shown, or `undefined` when the value is
+ * not elevated (Default) or not a recognized level.
+ */
+function getElevatedAutoApproveLevel(value: string | undefined): ChatPermissionLevel | undefined {
+	if (value === undefined || value === ChatPermissionLevel.Default) {
+		return undefined;
+	}
+	if (!isChatPermissionLevel(value)) {
+		return undefined;
+	}
+	return value === ChatPermissionLevel.AutoApprove || value === ChatPermissionLevel.Assisted ? value : undefined;
+}
+
+/**
+ * Whether a completion {@link IAgentHostCompletionAction} would set an elevated
+ * `autoApprove` level (Allow all / Assisted) that enterprise policy currently
+ * blocks. Completion consumers use this to omit such items entirely when global
+ * auto-approval is policy-disabled — rather than offering an item that would
+ * show an elevated-permission warning and then be silently clamped to Default.
+ * The node producer cannot see the (client-side) policy, so this gating lives on
+ * the client, mirroring how the permission pickers disable elevated levels.
+ */
+export function isPolicyBlockedCompletionAction(action: IAgentHostCompletionAction, configurationService: IConfigurationService): boolean {
+	return getElevatedAutoApproveLevel(action.applyConfig?.[SessionConfigKey.AutoApprove]) !== undefined
+		&& isAutoApprovePolicyRestricted(configurationService);
+}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -799,6 +799,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			insertText: raw.insertText,
 			attachment
 		};
+		if (raw.label !== undefined) {
+			item.label = raw.label;
+		}
 		if (raw.rangeStart !== undefined) {
 			item.start = offsetToPosition(text, raw.rangeStart);
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/applyAgentHostSessionConfig.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/applyAgentHostSessionConfig.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../../base/common/uri.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
+import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
+import { StateComponents } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { ChatConfiguration, ChatPermissionLevel } from '../../../common/constants.js';
+import { isUntitledChatSession } from '../../../common/model/chatUri.js';
+import { toAgentHostBackendSessionUri } from './agentHostSessionUri.js';
+import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
+import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
+
+/**
+ * Services needed to apply a session-config change to an agent-host-backed chat
+ * session from the editor window.
+ */
+export interface IApplyAgentHostSessionConfigServices {
+	readonly agentHostService: IAgentHostService;
+	readonly provisionalService: IAgentHostUntitledProvisionalSessionService;
+	readonly workingDirectoryResolver: IAgentHostSessionWorkingDirectoryResolver;
+	readonly workspaceContextService: IWorkspaceContextService;
+	readonly configurationService: IConfigurationService;
+}
+
+/**
+ * Applies a partial session-config change (e.g. `autoApprove` and/or `mode`) to
+ * the agent-host session backing `sessionResource` in the editor window. This is
+ * the editor-window analogue of the Agents-window provider `setSessionConfigValue`
+ * path — it routes untitled sessions through the provisional service and existing
+ * sessions through an AHP `SessionConfigChanged` dispatch, matching how the
+ * agent-host chat-input pickers apply changes.
+ *
+ * An elevated `autoApprove` value is clamped back to `default` when enterprise
+ * policy disables global auto-approval, mirroring the pickers.
+ *
+ * @returns `true` when `sessionResource` is agent-host-backed and the change was
+ * dispatched, `false` otherwise (so callers can fall back).
+ */
+export async function applyAgentHostSessionConfigChange(
+	sessionResource: URI,
+	config: Readonly<Record<string, string>>,
+	services: IApplyAgentHostSessionConfigServices,
+): Promise<boolean> {
+	const backendSession = toAgentHostBackendSessionUri(sessionResource);
+	if (!backendSession) {
+		return false;
+	}
+
+	const { agentHostService, provisionalService, workingDirectoryResolver, workspaceContextService, configurationService } = services;
+	const policyRestricted = configurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
+	const partial: Record<string, string> = { ...config };
+	const autoApprove = partial[SessionConfigKey.AutoApprove];
+	if (policyRestricted && autoApprove !== undefined && autoApprove !== ChatPermissionLevel.Default) {
+		partial[SessionConfigKey.AutoApprove] = ChatPermissionLevel.Default;
+	}
+
+	const workingDirectory = workingDirectoryResolver.resolve(sessionResource)
+		?? workspaceContextService.getWorkspace().folders[0]?.uri;
+
+	if (isUntitledChatSession(sessionResource)) {
+		await provisionalService.applyConfigChange(sessionResource, backendSession.scheme, workingDirectory, partial);
+		return true;
+	}
+
+	agentHostService.dispatch(backendSession.toString(), {
+		type: ActionType.SessionConfigChanged,
+		config: partial,
+	});
+	const state = agentHostService.getSubscriptionUnmanaged(StateComponents.Session, backendSession)?.value;
+	const currentValues = state && !(state instanceof Error) ? state.config?.values : undefined;
+	const nextConfig = { ...(currentValues ?? {}), ...partial };
+	void provisionalService.refreshResolvedConfig(sessionResource, backendSession.scheme, workingDirectory, nextConfig);
+	return true;
+}

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -264,7 +264,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				sessionTypes: [SessionType.Local, SessionType.CopilotCLI, SessionType.AgentHostCopilot],
+				sessionTypes: [SessionType.Local, SessionType.CopilotCLI],
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				await setPermissionLevelForSession(sessionResource, ChatPermissionLevel.AutoApprove);
 			}));
@@ -275,7 +275,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				sessionTypes: [SessionType.Local, SessionType.CopilotCLI, SessionType.AgentHostCopilot],
+				sessionTypes: [SessionType.Local, SessionType.CopilotCLI],
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				await setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Default);
 			}));
@@ -286,7 +286,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				sessionTypes: [SessionType.Local, SessionType.CopilotCLI, SessionType.AgentHostCopilot],
+				sessionTypes: [SessionType.Local, SessionType.CopilotCLI],
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				await setPermissionLevelForSession(sessionResource, ChatPermissionLevel.AutoApprove);
 			}));
@@ -297,7 +297,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				sessionTypes: [SessionType.Local, SessionType.CopilotCLI, SessionType.AgentHostCopilot],
+				sessionTypes: [SessionType.Local, SessionType.CopilotCLI],
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				await setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Default);
 			}));
@@ -308,7 +308,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				sessionTypes: [SessionType.Local, SessionType.CopilotCLI, SessionType.AgentHostCopilot],
+				sessionTypes: [SessionType.Local, SessionType.CopilotCLI],
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				await setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Autopilot);
 			}));
@@ -319,7 +319,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				sessionTypes: [SessionType.Local, SessionType.CopilotCLI, SessionType.AgentHostCopilot],
+				sessionTypes: [SessionType.Local, SessionType.CopilotCLI],
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				await setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Default);
 			}));

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletions.ts
@@ -14,6 +14,12 @@ import { CompletionItem, CompletionItemKind } from '../../../../../../../editor/
 import { ITextModel } from '../../../../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../../../../editor/common/services/languageFeatures.js';
 import { CommandsRegistry } from '../../../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { IDialogService } from '../../../../../../../platform/dialogs/common/dialogs.js';
+import { IStorageService } from '../../../../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService } from '../../../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostService } from '../../../../../../../platform/agentHost/common/agentService.js';
+import { getCompletionAction, type IAgentHostCompletionAction } from '../../../../../../../platform/agentHost/common/meta/agentCompletionAttachmentMeta.js';
 import { Registry } from '../../../../../../../platform/registry/common/platform.js';
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from '../../../../../../common/contributions.js';
 import { LifecyclePhase } from '../../../../../../services/lifecycle/common/lifecycle.js';
@@ -21,6 +27,10 @@ import { ChatDynamicVariableModel } from '../../../attachments/chatDynamicVariab
 import { IChatInputCompletionItem, IChatSessionsService, isAgentHostTarget } from '../../../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../../../common/model/chatUri.js';
 import { IChatWidget, IChatWidgetService } from '../../../chat.js';
+import { applyAgentHostCompletionAction, isPolicyBlockedCompletionAction } from '../../../agentHostCompletionAction.js';
+import { applyAgentHostSessionConfigChange } from '../../../agentSessions/agentHost/applyAgentHostSessionConfig.js';
+import { IAgentHostSessionWorkingDirectoryResolver } from '../../../agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
+import { IAgentHostUntitledProvisionalSessionService } from '../../../agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
 import { AgentHostInputCompletionsBase } from './agentHostInputCompletionsBase.js';
 /**
  * Completion provider that delegates `@`-mention (and other server-defined)
@@ -41,6 +51,7 @@ import { AgentHostInputCompletionsBase } from './agentHostInputCompletionsBase.j
 export class AgentHostInputCompletions extends AgentHostInputCompletionsBase<IChatWidget, string> {
 
 	private static readonly addReferenceCommand = '_chatAgentHostAddReferenceCmd';
+	private static readonly configActionCommand = '_chatAgentHostConfigActionCmd';
 
 	/** Per-scheme registrations of the Monaco completion provider. */
 	private readonly _registrations = this._register(new DisposableMap<string>());
@@ -49,6 +60,7 @@ export class AgentHostInputCompletions extends AgentHostInputCompletionsBase<ICh
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@IChatSessionsService chatSessionsService: IChatSessionsService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super(languageFeaturesService, chatSessionsService);
 
@@ -63,6 +75,39 @@ export class AgentHostInputCompletions extends AgentHostInputCompletionsBase<ICh
 				data: arg.data,
 				_meta: arg._meta,
 			});
+		}));
+
+		// Accept handler for config-action completions (permission/mode toggles).
+		// Applies the session-config change (with the elevated-permission
+		// confirmation) and, for keep-text items, adds the argument-hint
+		// reference. Toggle items insert nothing, so there is no text to remove.
+		this._register(CommandsRegistry.registerCommand(AgentHostInputCompletions.configActionCommand, async (accessor, arg) => {
+			assertType(arg instanceof AgentHostConfigActionArgument);
+			const sessionResource = arg.widget.viewModel?.model.sessionResource;
+			if (!sessionResource) {
+				return;
+			}
+			const dialogService = accessor.get(IDialogService);
+			const storageService = accessor.get(IStorageService);
+			const services = {
+				agentHostService: accessor.get(IAgentHostService),
+				provisionalService: accessor.get(IAgentHostUntitledProvisionalSessionService),
+				workingDirectoryResolver: accessor.get(IAgentHostSessionWorkingDirectoryResolver),
+				workspaceContextService: accessor.get(IWorkspaceContextService),
+				configurationService: accessor.get(IConfigurationService),
+			};
+			const applied = await applyAgentHostCompletionAction(arg.action, dialogService, storageService, async config => { await applyAgentHostSessionConfigChange(sessionResource, config, services); });
+			if (applied && arg.reference) {
+				arg.widget.getContrib<ChatDynamicVariableModel>(ChatDynamicVariableModel.ID)?.addReference({
+					id: arg.reference.id,
+					range: arg.reference.range,
+					isFile: arg.reference.isFile,
+					isDirectory: arg.reference.isDirectory,
+					fullName: arg.reference.displayName,
+					data: arg.reference.data,
+					_meta: arg.reference._meta,
+				});
+			}
 		}));
 
 		// Sync existing registrations and observe changes.
@@ -119,11 +164,41 @@ export class AgentHostInputCompletions extends AgentHostInputCompletionsBase<ICh
 		return { sessionResource, context: widget };
 	}
 
-	protected override _buildItem(position: Position, item: IChatInputCompletionItem, widget: IChatWidget): CompletionItem {
+	protected override _buildItem(position: Position, item: IChatInputCompletionItem, widget: IChatWidget): CompletionItem | undefined {
 		const replaceRange = AgentHostInputCompletions.computeRange(position, item);
 		const attachment = item.attachment;
 		switch (attachment.kind) {
 			case 'command': {
+				const action = getCompletionAction(attachment._meta);
+				if (action) {
+					// Omit an elevated auto-approve toggle (Allow all / Assisted)
+					// when enterprise policy disables global auto-approval, rather
+					// than offering an item that would warn then clamp to Default.
+					if (isPolicyBlockedCompletionAction(action, this._configurationService)) {
+						return undefined;
+					}
+					// Config-action completion (permission/mode toggle). Keep-text
+					// items (non-empty insertText) retain the `/command ` text and
+					// add the argument-hint reference; toggle items insert nothing.
+					const keep = item.insertText !== '';
+					const label = item.label ?? item.insertText;
+					const reference = keep
+						? AgentHostReferenceArgument.forCommand(widget, attachment.command, attachment.description, AgentHostInputCompletions._insertedTokenRange(replaceRange, item.insertText), attachment._meta)
+						: undefined;
+					return {
+						label: { label, description: attachment.description },
+						insertText: item.insertText,
+						filterText: label,
+						range: replaceRange,
+						kind: CompletionItemKind.Text,
+						detail: attachment.description,
+						command: {
+							id: AgentHostInputCompletions.configActionCommand,
+							title: '',
+							arguments: [new AgentHostConfigActionArgument(widget, action, reference)],
+						},
+					};
+				}
 				return {
 					label: { label: item.insertText, description: attachment.description },
 					insertText: item.insertText,
@@ -207,6 +282,20 @@ class AgentHostReferenceArgument {
 		const entry = toAgentHostCompletionVariableEntry(AgentHostCompletionReferenceKind.Command, description ?? command, command, _meta);
 		return new AgentHostReferenceArgument(widget, entry.id, entry.value, description, false, false, range, _meta);
 	}
+}
+
+/**
+ * Argument passed to the config-action accept command. Carries the target
+ * widget, the {@link IAgentHostCompletionAction} to apply, and — for keep-text
+ * items — the argument-hint reference to add once applied. Toggle items insert
+ * nothing, so no text needs to be removed.
+ */
+class AgentHostConfigActionArgument {
+	constructor(
+		readonly widget: IChatWidget,
+		readonly action: IAgentHostCompletionAction,
+		readonly reference: AgentHostReferenceArgument | undefined,
+	) { }
 }
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(AgentHostInputCompletions, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletionsBase.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletionsBase.ts
@@ -54,9 +54,10 @@ export abstract class AgentHostInputCompletionsBase<TContext, TRegData = void> e
 
 	/**
 	 * Build the Monaco completion item — including the accept command —
-	 * for one item returned by the host.
+	 * for one item returned by the host. Return `undefined` to omit the item
+	 * (e.g. a config-action item the client suppresses under enterprise policy).
 	 */
-	protected abstract _buildItem(position: Position, item: IChatInputCompletionItem, context: TContext): CompletionItem;
+	protected abstract _buildItem(position: Position, item: IChatInputCompletionItem, context: TContext): CompletionItem | undefined;
 
 	/**
 	 * Register a Monaco completion provider that delegates to this
@@ -100,7 +101,10 @@ export abstract class AgentHostInputCompletionsBase<TContext, TRegData = void> e
 
 		const suggestions: CompletionItem[] = [];
 		for (const item of result.items) {
-			suggestions.push(this._buildItem(position, item, ctx.context));
+			const built = this._buildItem(position, item, ctx.context);
+			if (built) {
+				suggestions.push(built);
+			}
 		}
 		return { suggestions };
 	}

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -479,6 +479,13 @@ export interface IChatInputCompletionItem {
 	/** Text inserted into the input when this item is accepted. */
 	readonly insertText: string;
 	/**
+	 * Optional display label shown in the completion picker. When omitted, the
+	 * workbench displays {@link insertText}. Set this when the inserted text
+	 * differs from the label — e.g. an action item that inserts nothing
+	 * (`insertText: ''`) but should still be shown to the user.
+	 */
+	readonly label?: string;
+	/**
 	 * Half-open range `[start, end)` in the *current* input text that
 	 * {@link insertText} replaces. Positions use 1-based `lineNumber` and
 	 * `column` to match Monaco. When omitted, the workbench replaces the

--- a/src/vs/workbench/contrib/chat/test/browser/agentHostCompletionAction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHostCompletionAction.test.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationOverrides, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestDialogService } from '../../../../../platform/dialogs/test/common/testDialogService.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { applyAgentHostCompletionAction, isPolicyBlockedCompletionAction } from '../../browser/agentHostCompletionAction.js';
+import { ChatConfiguration } from '../../common/constants.js';
+import { resetShownWarnings } from '../../common/chatPermissionWarnings.js';
+
+/** Test configuration service whose `inspect` reports a fixed `policyValue` for the global auto-approve setting. */
+class PolicyTestConfigurationService extends TestConfigurationService {
+	constructor(private readonly _globalAutoApprovePolicyValue: boolean | undefined) {
+		super();
+	}
+	override inspect<T>(key: string, overrides?: IConfigurationOverrides): IConfigurationValue<T> {
+		const base = super.inspect<T>(key, overrides);
+		if (key === ChatConfiguration.GlobalAutoApprove) {
+			return { ...base, policyValue: this._globalAutoApprovePolicyValue as T };
+		}
+		return base;
+	}
+}
+
+suite('applyAgentHostCompletionAction', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	setup(() => resetShownWarnings());
+
+	test('applies a non-elevated (mode) change without a dialog', async () => {
+		const dialog = new TestDialogService(); // default confirms if prompted
+		const storage = store.add(new InMemoryStorageService());
+		let applied: Record<string, string> | undefined;
+		const result = await applyAgentHostCompletionAction(
+			{ applyConfig: { mode: 'autopilot' } },
+			dialog,
+			storage,
+			config => { applied = { ...config }; },
+		);
+		assert.strictEqual(result, true);
+		assert.deepStrictEqual(applied, { mode: 'autopilot' });
+	});
+
+	test('applies an elevated autoApprove change when the confirmation is accepted', async () => {
+		const dialog = new TestDialogService(); // first (confirm) button returns true
+		const storage = store.add(new InMemoryStorageService());
+		let applied: Record<string, string> | undefined;
+		const result = await applyAgentHostCompletionAction(
+			{ applyConfig: { autoApprove: 'autoApprove' } },
+			dialog,
+			storage,
+			config => { applied = { ...config }; },
+		);
+		assert.strictEqual(result, true);
+		assert.deepStrictEqual(applied, { autoApprove: 'autoApprove' });
+	});
+
+	test('does not apply an elevated change when the confirmation is cancelled', async () => {
+		const dialog = new TestDialogService(undefined, { result: false });
+		const storage = store.add(new InMemoryStorageService());
+		let applied = false;
+		const result = await applyAgentHostCompletionAction(
+			{ applyConfig: { autoApprove: 'autoApprove' } },
+			dialog,
+			storage,
+			() => { applied = true; },
+		);
+		assert.strictEqual(result, false);
+		assert.strictEqual(applied, false);
+	});
+
+	suite('isPolicyBlockedCompletionAction', () => {
+		test('elevated autoApprove is blocked only when policy restricts auto-approval', () => {
+			const restricted = new PolicyTestConfigurationService(false);
+			const unrestricted = new PolicyTestConfigurationService(undefined);
+			assert.strictEqual(isPolicyBlockedCompletionAction({ applyConfig: { autoApprove: 'autoApprove' } }, restricted), true);
+			assert.strictEqual(isPolicyBlockedCompletionAction({ applyConfig: { autoApprove: 'assisted' } }, restricted), true);
+			assert.strictEqual(isPolicyBlockedCompletionAction({ applyConfig: { autoApprove: 'autoApprove' } }, unrestricted), false);
+		});
+
+		test('non-elevated and mode-axis actions are never policy-blocked', () => {
+			const restricted = new PolicyTestConfigurationService(false);
+			assert.strictEqual(isPolicyBlockedCompletionAction({ applyConfig: { autoApprove: 'default' } }, restricted), false);
+			assert.strictEqual(isPolicyBlockedCompletionAction({ applyConfig: { mode: 'autopilot' } }, restricted), false);
+			assert.strictEqual(isPolicyBlockedCompletionAction({ applyConfig: {} }, restricted), false);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #325890

## What & why

In Copilot agent-host chat sessions, typing a permission/mode slash command (e.g. `/plan`) did **not** update the mode/permission pickers. This PR introduces **config-action slash commands** that toggle a session-config axis instead of sending a chat turn, and wires them into **both** the editor-window chat input and the Agents window.

Typing `/` now offers, for Copilot agent-host sessions only:

- **Permissions axis (`autoApprove`):** `/yolo`, `/yolo on|off`, `/allow-all`, `/autoApprove`
- **Mode axis (`mode`):** `/autopilot on|off`, `/autopilot <objective>`, `/plan <prompt>`, `/goal`

Selecting an item toggles the corresponding session config and the picker updates reactively; it does not send a chat turn.

## How it works

- **Producer (server):** the Copilot completion provider emits these items with an `action` bag (`{ applyConfig }`) on the completion attachment `_meta`. Runtime commands that collide (e.g. `plan`) are shadowed.
- **Consumer (client, shared across both windows):** a shared accept-handler runs the existing elevated-permission confirmation (`maybeConfirmElevatedPermissionLevel`) for elevated `autoApprove` values, then applies the change via a per-window seam — editor uses the AHP dispatch/provisional path; the Agents window uses `provider.setSessionConfigValue`.
- **Insert behavior:** toggle items insert nothing (`insertText: ''` + explicit `label`); `<prompt>` items keep `/cmd ` and show an argument hint.
- **Send path:** `CopilotAgentSession.send` intercepts these commands, re-applies the mode, and strips the leading token so it is not dispatched to the runtime.
- **Policy:** elevated auto-approve items are omitted when enterprise policy disables global auto-approval (client-side, mirroring the pickers), with clamps kept as defense-in-depth.
- **Cleanup:** the old hardcoded permission commands in `chatSlashCommands.ts` are unscoped from agent-host Copilot sessions so the completion pipeline solely owns them.

## Tests

- `agentMetaReaders` — round-trip of the new `action` `_meta`.
- `copilotConfigSlashCommands` — catalog items + send-path resolver.
- `CopilotSlashCommandCompletionProvider` — config items injected, runtime collision shadowing.
- `applyAgentHostCompletionAction` — elevated confirmation gating + policy-block predicate.

Validation: `typecheck-client`, `valid-layers-check`, ESLint, and the affected unit suites all pass.

## Known follow-ups (not in this PR)

A review flagged a few items to address separately: applying `autoApprove` on the manually-typed send path, avoiding empty turns for bare toggles, the `/goal` vs `toCopilotSdkMode('goal')` naming, tightening `_meta.action` trust, and remote-Copilot editor apply.
