### PR TITLE
agentHost: expand multi-chat end-to-end coverage

### DIFF
--- a/.github/skills/agent-host-e2e-tests/SKILL.md
+++ b/.github/skills/agent-host-e2e-tests/SKILL.md
@@ -19,6 +19,7 @@ It documents the mental model, the fixture format, every config flag, and a symp
 3. **Recording needs a real token** (`GITHUB_TOKEN` or `gh auth token`) and talks to real CAPI. Only run it intentionally, with trivial/read-only prompts in temp dirs.
 4. **Never hand-write or hand-edit fixture contents** (especially not secrets/paths). Fixtures are always produced by recording; normalization/redaction is the proxy's job.
 5. **Gate, don't fight.** If a behavior can't replay deterministically, gate the test (see Workflow C) instead of loosening timeouts or the strict check.
+6. **Track every disabled variant.** Keep `e2e/KNOWN_ISSUES.md` current with the test title, scope, expected and observed behavior, and a focused reproduction command. Record symptoms, not speculative root causes.
 
 ## Workflow A — Add a cross-provider test
 
@@ -54,7 +55,7 @@ Real-time streaming, mid-turn aborts, and POSIX-specific local execution (shell 
 - **POSIX-only** (fails on Windows): gate with `!isWindows`, or a targeted per-provider flag when only one provider diverges. See the worktree and subagent-reopen tests.
 - **Provider/OS-specific replay**: add a targeted config gate that still permits recording and unaffected platforms. See the Codex shell-tool Linux gate.
 
-Always add a comment explaining *why* the gate exists.
+Always add a comment explaining *why* the gate exists. Also add or update the corresponding entry in `e2e/KNOWN_ISSUES.md`. When the variant is enabled again, remove or update the entry in the same change.
 
 ## Verifying & troubleshooting
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -1,0 +1,330 @@
+# Disabled and conditional E2E tests
+
+This document inventories bundled-provider E2E tests that are disabled for at
+least one provider, platform, or execution mode. It exists so a human or agent
+can periodically reevaluate the gaps instead of treating every pending test as
+expected forever.
+
+The test remains the executable specification. This document records the
+observed symptom and scope, not a speculative root cause.
+
+## Process
+
+When a valid E2E scenario exposes behavior that may be a product bug:
+
+1. Minimize the scenario and confirm which provider, platform, and execution
+   mode reproduce it.
+2. Keep the failing test case in the suite, but disable only the affected
+   variant. Do not weaken its assertions to make it pass.
+3. Add a short comment at the gate and an entry here with:
+   - the exact test title
+   - affected provider/platform/mode
+   - expected and observed behavior
+   - a focused reproduction command
+4. Record symptoms only. Root-cause hypotheses belong in an investigation,
+   issue, or fix, where they can be tested.
+5. Keep generated captures for provider variants that are expected to run
+   again. Never hand-edit captures.
+6. When the behavior is fixed or the limitation is removed, enable the test,
+   verify it fails without the fix when practical, and remove or update the
+   entry.
+
+Capability skips are tracked separately from suspected bugs. A provider that
+does not advertise a capability is expected to skip positive-path tests for
+that capability.
+
+## Suspected product bugs
+
+### Claude provider-context fork
+
+- Tests:
+  - `forked peer chat inherits source history through the provider`
+  - `unknown-turn fork does not inherit source provider context`
+- Scope: Claude.
+- Expected: Claude advertises multi-chat fork support, and a provider-backed
+  fork can continue from the requested source history.
+- Observed: exercising a real provider-context fork rejects the AHP turn id as
+  an invalid `upToMessageId`. The unknown-turn context test currently shares
+  the same provider E2E fork gate.
+- Gate: `supportsChatForkE2E: false`.
+- Reproduce:
+
+  ```bash
+  ./scripts/test-integration.sh --run \
+    src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts \
+    --grep "forked peer chat inherits source history through the provider"
+  ```
+
+  Temporarily enable `supportsChatForkE2E` to execute the disabled test.
+
+### Claude fresh peer context after a long shared-suite sequence
+
+- Test: `fresh peer chat does not inherit default chat context`.
+- Scope: Claude deterministic replay with the shared provider process.
+- Expected: materializing a fresh peer after using the default chat succeeds,
+  and the peer request does not contain the default chat's history.
+- Observed: after the preceding peer-lifecycle sequence, the peer turn can fail
+  with `sendFailed: Server not found: host`. The same test passes by itself and
+  while recording with a per-test process.
+- Gate: disabled only for Claude.
+- Reproduce:
+
+  ```bash
+  ./scripts/test-integration.sh --run \
+    src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts
+  ```
+
+  Temporarily enable the Claude variant. Run the whole provider file; a focused
+  run does not reproduce the shared-process symptom.
+
+### Copilot file-operation turns that do not complete reliably
+
+- Scope: Copilot.
+- Tests and observed symptoms:
+  - `reads an existing text file`: the recorded turn did not complete.
+  - `reads a value from JSON`: the replayed turn did not complete.
+  - `creates a new text file`: tool completion is not emitted consistently.
+  - `edits an existing text file`: the replayed turn did not complete.
+  - `deletes a workspace file`: the replayed turn did not complete.
+- Expected: each turn reaches `chat/turnComplete` and the direct filesystem or
+  response assertion succeeds.
+- Gate: provider-specific conditions in `fileOperationsSuite.ts`.
+- Reproduce:
+
+  ```bash
+  ./scripts/test-integration.sh --run \
+    src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts \
+    --grep "<exact test title>"
+  ```
+
+  Temporarily enable the selected Copilot variant. Re-record narrowly if the
+  current capture does not exist.
+
+### Codex duplicated or unstable response behavior
+
+- Scope: Codex deterministic replay.
+- Expected: a model-backed scenario emits one coherent response and honors
+  exact-response prompts.
+- Observed: Codex duplicates response content in these newer behavior
+  scenarios, and some exact-response prompts do not produce the expected
+  response.
+- Gate: `stableNewScenarioResponse` is false for Codex.
+- Tests covered by this broad gate:
+  - `retains context across consecutive turns`
+  - `reads an existing text file`
+  - `reads a file from a nested directory`
+  - `lists workspace entries`
+  - `reads a value from JSON`
+  - `counts lines in a file`
+  - `handles a missing file without a session error`
+  - `creates a new text file`
+  - `edits an existing text file`
+  - `creates a file in a new nested directory`
+  - `renames a workspace file`
+  - `deletes a workspace file`
+  - `runs a deterministic shell command`
+  - `inspects git status`
+  - `reads a filename containing spaces`
+- Reproduce:
+
+  ```bash
+  ./scripts/test-integration.sh --run \
+    src/vs/platform/agentHost/test/node/e2e/providers/codexAgentHostE2E.integrationTest.ts \
+    --grep "<exact test title>"
+  ```
+
+  Temporarily enable only the selected scenario. This broad gate should be
+  narrowed as individual Codex scenarios become stable.
+
+## Platform and deterministic-replay limitations
+
+### Windows shell and filesystem behavior
+
+The committed model captures can select POSIX shell commands, and several
+host-owned shell behaviors differ on Windows. These tests remain enabled on
+unaffected providers and platforms.
+
+| Test | Disabled scope | Observed limitation |
+|---|---|---|
+| `a bang command runs locally and exposes terminal output` | Windows | The successful bang command produces output but does not complete reliably. |
+| `session configuration resolves and completes git branches` | Windows | Git-backed config discovery can retain the temporary repository lock after session disposal. |
+| `worktree session uses the resolved worktree as working directory` | Windows | The recorded paths and `pwd` behavior are POSIX-shaped. |
+| `tool call triggers permission request and can be approved` | Windows | The scenario executes a recorded shell command. |
+| `lists workspace entries` | Windows | The scenario depends on provider shell execution. |
+| `counts lines in a file` | Windows | The scenario depends on provider shell execution. |
+| `renames a workspace file` | Windows | The scenario depends on provider shell execution. |
+| `runs a deterministic shell command` | Windows | The scenario directly exercises a shell command. |
+| `reads a file from a nested directory` | Copilot on Windows | The Copilot capture uses shell behavior that is not portable to Windows. |
+| `handles a missing file without a session error` | Copilot on Windows | The Copilot capture uses shell behavior that is not portable to Windows. |
+| `creates a file in a new nested directory` | Copilot on Windows | The Copilot capture uses a POSIX shell. |
+| `inspects git status` | Copilot on Windows | The scenario depends on provider shell execution. |
+| `edits an existing text file` | Claude on Windows | The scenario depends on provider shell execution. |
+| `deletes a workspace file` | Claude on Windows | The scenario depends on provider shell execution. |
+| `peer chat edits an existing workspace file` | Copilot on Windows | Replay completes, but the recorded tool plan does not mutate the Windows file. |
+| `peer chat creates a file in a nested directory` | Copilot on Windows | Replay completes, but the recorded tool plan does not create the Windows file. |
+
+Use the affected provider command with `--grep "<exact test title>"` and
+temporarily remove the platform gate to reevaluate a row.
+
+### Codex shell-tool replay on Linux
+
+- Scope: Codex on Linux in deterministic replay.
+- Gate: `shellToolReplayUnstableOnLinux: true`.
+- Tests directly affected by this gate:
+  - `tool call triggers permission request and can be approved`
+  - `worktree session uses the resolved worktree as working directory`
+  - `lists workspace entries`
+  - `counts lines in a file`
+  - `renames a workspace file`
+  - `runs a deterministic shell command`
+- Recording mode remains enabled so a future capture or provider update can be
+  evaluated.
+
+### Claude subagent replay on Windows
+
+- Test: `reopening a session keeps sub-agent messages out of the parent transcript (replay path)`.
+- Scope: Claude on Windows.
+- Expected: the reopened parent transcript excludes subagent-only messages.
+- Observed: Claude reconstructs the subagent transcript from
+  `subagents/agent-*.jsonl`, which is not reliably visible on Windows.
+- Gate: `subagentReplayUnstableOnWindows: true`.
+- Related investigation: [#325284](https://github.com/microsoft/vscode/pull/325284).
+
+### Git-status snapshot ordering
+
+- Test: `inspects git status`.
+- Scope: Claude and Codex.
+- Expected: the behavior snapshot contains stable semantic tool traffic.
+- Observed: customization and changeset notifications occur at nondeterministic
+  points in the snapshot.
+- Gate: enabled only for Copilot, subject to shell-platform gates.
+
+### Mid-turn abort is record-only
+
+- Test: `can abort a running turn`.
+- Scope: deterministic replay for every provider.
+- Reason: replay serves the intentionally truncated response immediately, so
+  there is no real streaming window in which to abort.
+- Run:
+
+  ```bash
+  AGENT_HOST_REPLAY_RECORD=1 ./scripts/test-integration.sh --run \
+    src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts \
+    --grep "can abort a running turn"
+  ```
+
+This is an intentional test-mode limitation, not a suspected product bug.
+
+### Live Codex steering suite is opt-in
+
+The tests in `codexAgentHostLive.integrationTest.ts` require
+`AGENT_HOST_REAL_CODEX=1` because they exercise live, timing-sensitive Codex
+behavior that is not represented by deterministic model replay:
+
+- `mid-turn steering surfaces as a new turn and never sticks in pending`
+- `client tool is registered and invoked end-to-end`
+- `client tool registered after the thread prewarms restarts the thread and still works`
+- `server tool (listComments) is registered and executed in-process`
+- `file-change approval is surfaced and can be approved`
+- `truncate rolls back trailing turns and archive/unarchive reach codex`
+- `Plan mode (Agent Mode control) makes request_user_input reachable end-to-end`
+
+These are opt-in live tests, not known failures.
+
+## Test-design limitations
+
+### Claude plan-mode prompt
+
+- Test: `planning-mode session-state writes are auto-approved in default mode`.
+- Scope: Claude.
+- Expected: the shared prompt drives the provider to invoke `ExitPlanMode`.
+- Observed: plan mode is wired, but the Copilot-oriented prompt does not
+  reliably cause Claude to invoke the tool.
+- Gate: `supportsPlanMode: false`.
+- Evaluation goal: make the test prompt provider-neutral or add an equivalent
+  Claude-specific prompt without weakening the plan-mode assertions.
+
+## Expected capability skips
+
+These pending tests do not currently indicate bugs.
+
+### Codex multi-chat
+
+Codex does not advertise `multipleChats`. The negative capability test
+`provider without multiple chat capability rejects peer creation` runs for
+Codex; these positive peer-chat declarations are skipped:
+
+- `creating a peer chat adds it to the session catalog`
+- `peer chat subscription starts empty and idle`
+- `creating the same peer chat twice is idempotent`
+- `creating two peer chats preserves both catalog entries`
+- `disposing a peer chat removes its catalog entry`
+- `disposing one peer chat preserves its sibling`
+- `recreating a disposed peer chat starts empty`
+- `renaming a peer chat updates its catalog title`
+- `renaming a peer chat leaves the session title unchanged`
+- `peer chat survives unsubscribe and resubscribe`
+- `peer creation does not leak a provider backing as a top-level session`
+- `peer file completion uses the parent workspace`
+- `first peer chat snapshots the session title onto the default chat`
+- `session rename after peer creation preserves the default chat title`
+- `forking an unknown turn creates a fresh empty peer chat`
+- `peer chat completes a simple turn`
+- `peer chat retains context across consecutive turns`
+- `forked peer chat inherits source history through the provider`
+- `disposing a peer after a completed turn removes it from the catalog`
+- `peer rename command updates the peer title and records a local turn`
+- `empty peer rename command leaves the peer title unchanged`
+- `failing peer bang command records a failed terminal tool call`
+- `peer chat reads a file from the parent workspace`
+- `peer chat reads a file from a nested directory`
+- `peer chat creates a file in the parent workspace`
+- `peer chat edits an existing workspace file`
+- `peer chat creates a file in a nested directory`
+- `peer chat handles a missing workspace file without an error`
+- `peer chat reads a filename containing spaces`
+- `two peer chats write distinct workspace files`
+- `fresh peer chat does not inherit default chat context`
+- `two peer chats keep independent provider contexts`
+- `peer provider context survives unsubscribe and resubscribe`
+- `recreated peer chat starts with fresh provider context`
+- `unknown-turn fork does not inherit source provider context`
+- `peer simple attachment reaches the provider request`
+- `peer simple attachment without a model representation is omitted from the provider request`
+- `peer multiple simple attachments reach the provider request`
+- `peer resource attachment reaches the provider request`
+- `peer resource selection attachment includes its line reference`
+
+### Codex subagents
+
+Codex does not advertise subagent support, so these tests are skipped:
+
+- `subagent tool calls are routed to the subagent session, not flat in the parent`
+- `reopening a session keeps sub-agent messages out of the parent transcript (replay path)`
+
+### Codex plan mode
+
+Codex does not enable the shared plan-mode contract, so
+`planning-mode session-state writes are auto-approved in default mode` is
+skipped.
+
+### Provider package availability
+
+The complete Claude or Codex deterministic suite is skipped when its bundled
+SDK package is unavailable. This is an environment prerequisite, not a product
+or test failure.
+
+## Review checklist
+
+Periodically:
+
+1. Run the full provider files, not only focused tests, because shared-process
+   failures may depend on suite order.
+2. Reevaluate broad gates such as `stableNewScenarioResponse` one test at a
+   time.
+3. Check whether new provider SDK/CLI versions changed tool selection or
+   completion behavior.
+4. Re-record narrowly when wire behavior changed, then review every generated
+   capture.
+5. Enable fixed variants and remove stale entries, comments, config flags, and
+   orphaned captures together.

--- a/src/vs/platform/agentHost/test/node/e2e/README.md
+++ b/src/vs/platform/agentHost/test/node/e2e/README.md
@@ -173,6 +173,20 @@ Every successful coverage run rewrites the checked-in stats. Test, report, or no
 
 Per-provider reports are deferred until there is a concrete need. Per-test attribution is also intentionally out of scope for native aggregate coverage; it would require inspector-based precise coverage snapshots and deltas.
 
+### Coverage expansion strategy
+
+Coverage is a discovery tool, not the goal by itself. A coverage expansion round should add tests for meaningful full-stack contracts, not manufacture line hits or add equivalent prompt variants.
+
+1. **Measure before selecting work.** Save a fresh baseline from `npm run test-agent-host-e2e-coverage`, rank loaded files by uncovered executable lines/functions, then inspect the exact LCOV ranges and existing lower-layer tests. Compare the final result against that same run, not an older checked-in baseline.
+2. **Choose behavior that belongs at this boundary.** Prefer behavior whose value comes from the real server, provider SDK/CLI, AHP transport, persistence, or local tools working together. Pure reducer rules and provider-independent validation usually belong in protocol or unit tests instead.
+3. **Prioritize useful breadth.** Favor underrepresented host-owned behavior and cross-provider contracts over more variants of an already-covered prompt. Count shared test declarations separately from provider executions (one shared declaration normally executes once per enabled provider).
+4. **Choose the model boundary explicitly.** Use `hostOnlyTest(...)` when crossing the model boundary would be a bug. Use a normal test plus a per-test capture when realistic model behavior drives the scenario.
+5. **Use the narrowest durable oracle.** Follow the snapshot/direct/hybrid guidance below. Assert external effects directly, and snapshot a protocol transcript only when its ordering, routing, or lifecycle is part of the contract.
+6. **Design for every CI platform.** Do not assume POSIX paths, shell syntax, PTY chunk boundaries, shell-integration events, persistent terminal titles, or immediately releasable filesystem locks. Use precise platform/provider gates for genuinely unsupported behavior rather than weakening assertions.
+7. **Keep shared-server isolation.** Drain every model-backed turn, dispose terminals and other owned resources, and keep temporary work inside tracked test directories. A failure that wedges later tests is a lifecycle bug in the test even if its own assertion passed.
+
+A round is complete when TypeScript type-checks, focused replay passes for every enabled provider, model-backed artifacts are reviewed, host-only tests remain strict in recording mode, the full coverage command succeeds, hygiene and layer checks pass, and the measured covered counts/percentages are reported. Native V8 totals have small asynchronous variance; treat broad unrelated failures by rerunning the exact failures in a fresh process before changing code.
+
 ---
 
 ## Updating snapshots and fixtures

--- a/src/vs/platform/agentHost/test/node/e2e/README.md
+++ b/src/vs/platform/agentHost/test/node/e2e/README.md
@@ -68,6 +68,7 @@ Key properties:
 | `harness/` | Record/replay, AHP snapshots, shared turn drivers, and server lifecycle. |
 | `captures/*.yaml` | Committed model fixtures, plus one shared strict empty fixture for tests that declare no model traffic. |
 | `providers/__snapshots__/` | Semantic AHP snapshots for deterministic provider tests. |
+| [`KNOWN_ISSUES.md`](./KNOWN_ISSUES.md) | Inventory and reevaluation process for disabled or conditional tests. |
 
 Use these deterministic E2E tests when the value comes from running the bundled provider process with realistic captured model behavior: SDK event ordering, tool schemas and execution, provider persistence, protocol-to-provider mapping, or cross-provider parity. Use `../providerIntegration/` for a real provider with a synthetic local LLM, `../protocol/` when `ScriptedMockAgent` can express the AHP contract precisely, and an ordinary unit test when no server process is required.
 
@@ -182,7 +183,7 @@ Coverage is a discovery tool, not the goal by itself. A coverage expansion round
 3. **Prioritize useful breadth.** Favor underrepresented host-owned behavior and cross-provider contracts over more variants of an already-covered prompt. Count shared test declarations separately from provider executions (one shared declaration normally executes once per enabled provider).
 4. **Choose the model boundary explicitly.** Use `hostOnlyTest(...)` when crossing the model boundary would be a bug. Use a normal test plus a per-test capture when realistic model behavior drives the scenario.
 5. **Use the narrowest durable oracle.** Follow the snapshot/direct/hybrid guidance below. Assert external effects directly, and snapshot a protocol transcript only when its ordering, routing, or lifecycle is part of the contract.
-6. **Design for every CI platform.** Do not assume POSIX paths, shell syntax, PTY chunk boundaries, shell-integration events, persistent terminal titles, or immediately releasable filesystem locks. Use precise platform/provider gates for genuinely unsupported behavior rather than weakening assertions.
+6. **Design for every CI platform.** Do not assume POSIX paths, shell syntax, PTY chunk boundaries, shell-integration events, persistent terminal titles, or immediately releasable filesystem locks. Use precise platform/provider gates for genuinely unsupported behavior rather than weakening assertions, and keep [`KNOWN_ISSUES.md`](./KNOWN_ISSUES.md) current when a variant is disabled.
 7. **Keep shared-server isolation.** Drain every model-backed turn, dispose terminals and other owned resources, and keep temporary work inside tracked test directories. A failure that wedges later tests is a lifecycle bug in the test even if its own assertion passed.
 
 A round is complete when TypeScript type-checks, focused replay passes for every enabled provider, model-backed artifacts are reviewed, host-only tests remain strict in recording mode, the full coverage command succeeds, hygiene and layer checks pass, and the measured covered counts/percentages are reported. Native V8 totals have small asynchronous variance; treat broad unrelated failures by rerunning the exact failures in a fresh process before changing code.

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-disposing-a-peer-after-a-completed-turn-removes-it-from-the-catalog.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-disposing-a-peer-after-a-completed-turn-removes-it-from-the-catalog.yaml
@@ -1,0 +1,12 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "DONE".
+    response:
+      content: DONE
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-completes-a-simple-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-completes-a-simple-turn.yaml
@@ -1,0 +1,12 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "PEER_OK".
+    response:
+      content: PEER_OK
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-creates-a-file-in-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-creates-a-file-in-a-nested-directory.yaml
@@ -1,0 +1,43 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
+    response:
+      content:
+        - type: text
+          text: I'll create that file for you.
+        - type: tool_use
+          id: toolcall_0
+          name: Write
+          input:
+            file_path: ${workdir}/peer-output/report.txt
+            content: PEER_NESTED
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
+        - role: assistant
+          content:
+            - type: text
+              text: I'll create that file for you.
+            - type: tool_use
+              name: Write
+              input:
+                file_path: ${workdir}/peer-output/report.txt
+                content: PEER_NESTED
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: 'File created successfully at: ${workdir}/peer-output/report.txt (file state is current in your context — no need to Read it back)'
+    response:
+      content: Done. Created `report.txt` containing exactly `PEER_NESTED`.
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-creates-a-file-in-the-parent-workspace.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-creates-a-file-in-the-parent-workspace.yaml
@@ -1,0 +1,43 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/peer-created.txt containing exactly PEER_CREATED.
+    response:
+      content:
+        - type: text
+          text: I'll create that file.
+        - type: tool_use
+          id: toolcall_0
+          name: Write
+          input:
+            file_path: ${workdir}/peer-created.txt
+            content: PEER_CREATED
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/peer-created.txt containing exactly PEER_CREATED.
+        - role: assistant
+          content:
+            - type: text
+              text: I'll create that file.
+            - type: tool_use
+              name: Write
+              input:
+                file_path: ${workdir}/peer-created.txt
+                content: PEER_CREATED
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: 'File created successfully at: ${workdir}/peer-created.txt (file state is current in your context — no need to Read it back)'
+    response:
+      content: Done — created `peer-created.txt` containing exactly `PEER_CREATED`.
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-edits-an-existing-workspace-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-edits-an-existing-workspace-file.yaml
@@ -1,0 +1,134 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+    response:
+      content:
+        - type: text
+          text: I'll replace the file contents.
+        - type: tool_use
+          id: toolcall_0
+          name: Bash
+          input:
+            command: test -f ${workdir}/peer-edit.txt && echo EXISTS || echo MISSING
+            description: Check if target file exists
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+        - role: assistant
+          content:
+            - type: text
+              text: I'll replace the file contents.
+            - type: tool_use
+              name: Bash
+              input:
+                command: test -f ${workdir}/peer-edit.txt && echo EXISTS || echo MISSING
+                description: Check if target file exists
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: EXISTS
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_1
+          name: Read
+          input:
+            file_path: ${workdir}/peer-edit.txt
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+        - role: assistant
+          content:
+            - type: text
+              text: I'll replace the file contents.
+            - type: tool_use
+              name: Bash
+              input:
+                command: test -f ${workdir}/peer-edit.txt && echo EXISTS || echo MISSING
+                description: Check if target file exists
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: EXISTS
+        - role: assistant
+          content:
+            - type: tool_use
+              name: Read
+              input:
+                file_path: ${workdir}/peer-edit.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
+              content: "1\tBEFORE_PEER"
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_2
+          name: Write
+          input:
+            file_path: ${workdir}/peer-edit.txt
+            content: AFTER_PEER
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+        - role: assistant
+          content:
+            - type: text
+              text: I'll replace the file contents.
+            - type: tool_use
+              name: Bash
+              input:
+                command: test -f ${workdir}/peer-edit.txt && echo EXISTS || echo MISSING
+                description: Check if target file exists
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: EXISTS
+        - role: assistant
+          content:
+            - type: tool_use
+              name: Read
+              input:
+                file_path: ${workdir}/peer-edit.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
+              content: "1\tBEFORE_PEER"
+        - role: assistant
+          content:
+            - type: tool_use
+              name: Write
+              input:
+                file_path: ${workdir}/peer-edit.txt
+                content: AFTER_PEER
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_2
+              content: The file ${workdir}/peer-edit.txt has been updated successfully. (file state is current in your context — no need to Read it back)
+    response:
+      content: Done. Replaced the contents of `peer-edit.txt` (was `BEFORE_PEER`) with `AFTER_PEER`.
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-handles-a-missing-workspace-file-without-an-error.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-handles-a-missing-workspace-file-without-an-error.yaml
@@ -1,0 +1,41 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing".
+    response:
+      content:
+        - type: text
+          text: I'll try to read that file.
+        - type: tool_use
+          id: toolcall_0
+          name: Read
+          input:
+            file_path: ${workdir}/peer-missing.txt
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing".
+        - role: assistant
+          content:
+            - type: text
+              text: I'll try to read that file.
+            - type: tool_use
+              name: Read
+              input:
+                file_path: ${workdir}/peer-missing.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: 'File does not exist. Note: your current working directory is ${workdir}.'
+    response:
+      content: missing
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-file-from-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-file-from-a-nested-directory.yaml
@@ -1,0 +1,41 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/nested/peer.txt and reply with its exact contents only.
+    response:
+      content:
+        - type: text
+          text: I'll read the file.
+        - type: tool_use
+          id: toolcall_0
+          name: Read
+          input:
+            file_path: ${workdir}/nested/peer.txt
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/nested/peer.txt and reply with its exact contents only.
+        - role: assistant
+          content:
+            - type: text
+              text: I'll read the file.
+            - type: tool_use
+              name: Read
+              input:
+                file_path: ${workdir}/nested/peer.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: "1\tPEER_NESTED_READ"
+    response:
+      content: PEER_NESTED_READ
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-file-from-the-parent-workspace.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-file-from-the-parent-workspace.yaml
@@ -1,0 +1,41 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/peer-note.txt and reply with its exact contents only.
+    response:
+      content:
+        - type: text
+          text: I'll read the file.
+        - type: tool_use
+          id: toolcall_0
+          name: Read
+          input:
+            file_path: ${workdir}/peer-note.txt
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/peer-note.txt and reply with its exact contents only.
+        - role: assistant
+          content:
+            - type: text
+              text: I'll read the file.
+            - type: tool_use
+              name: Read
+              input:
+                file_path: ${workdir}/peer-note.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: "1\tPEER_FILE_VALUE"
+    response:
+      content: PEER_FILE_VALUE
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-filename-containing-spaces.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-filename-containing-spaces.yaml
@@ -1,0 +1,38 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/peer file.txt and reply with its exact contents only.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: Read
+          input:
+            file_path: ${workdir}/peer file.txt
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/peer file.txt and reply with its exact contents only.
+        - role: assistant
+          content:
+            - type: thinking
+            - type: tool_use
+              name: Read
+              input:
+                file_path: ${workdir}/peer file.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: "1\tPEER_SPACED"
+    response:
+      content: PEER_SPACED
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-retains-context-across-consecutive-turns.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-retains-context-across-consecutive-turns.yaml
@@ -1,0 +1,31 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word PEAR. Reply exactly "ready".
+    response:
+      content: |-
+        I'll remember the code word PEAR.
+
+        ready
+      stopReason: end_turn
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word PEAR. Reply exactly "ready".
+        - role: assistant
+          content: |-
+            I'll remember the code word PEAR.
+
+            ready
+        - role: user
+          content: What code word did I ask you to remember? Reply with only the code word.
+    response:
+      content: PEAR
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-multiple-simple-attachments-reach-the-provider-request.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-multiple-simple-attachments-reach-the-provider-request.yaml
@@ -1,0 +1,19 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content:
+            - type: text
+              text: Reply exactly "attachments".
+            - type: text
+              text: |-
+                PEER_FIRST_ATTACHMENT
+
+                PEER_SECOND_ATTACHMENT
+    response:
+      content: attachments
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-provider-context-survives-unsubscribe-and-resubscribe.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-provider-context-survives-unsubscribe-and-resubscribe.yaml
@@ -1,0 +1,31 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word RESUME_PEER. Reply exactly "ready".
+    response:
+      content: |-
+        I'll remember the code word RESUME_PEER.
+
+        ready
+      stopReason: end_turn
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word RESUME_PEER. Reply exactly "ready".
+        - role: assistant
+          content: |-
+            I'll remember the code word RESUME_PEER.
+
+            ready
+        - role: user
+          content: Reply exactly "resumed".
+    response:
+      content: resumed
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-resource-attachment-reaches-the-provider-request.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-resource-attachment-reaches-the-provider-request.yaml
@@ -1,0 +1,12 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "attachment".
+    response:
+      content: attachment
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-resource-selection-attachment-includes-its-line-reference.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-resource-selection-attachment-includes-its-line-reference.yaml
@@ -1,0 +1,12 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "selection".
+    response:
+      content: selection
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-simple-attachment-reaches-the-provider-request.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-simple-attachment-reaches-the-provider-request.yaml
@@ -1,0 +1,16 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content:
+            - type: text
+              text: Reply exactly "attachment".
+            - type: text
+              text: PEER_SIMPLE_ATTACHMENT
+    response:
+      content: attachment
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-simple-attachment-without-a-model-representation-is-omitted-from-the-provider-request.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-simple-attachment-without-a-model-representation-is-omitted-from-the-provider-request.yaml
@@ -1,0 +1,12 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "attachment".
+    response:
+      content: attachment
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-recreated-peer-chat-starts-with-fresh-provider-context.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-recreated-peer-chat-starts-with-fresh-provider-context.yaml
@@ -1,0 +1,24 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word OLD_PEER. Reply exactly "ready".
+    response:
+      content: |-
+        I'll remember the code word OLD_PEER.
+
+        ready
+      stopReason: end_turn
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "new".
+    response:
+      content: new
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-two-peer-chats-keep-independent-provider-contexts.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-two-peer-chats-keep-independent-provider-contexts.yaml
@@ -1,0 +1,59 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word ALPHA_PEER. Reply exactly "ready".
+    response:
+      content: |-
+        I'll remember the code word ALPHA_PEER.
+
+        ready
+      stopReason: end_turn
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word BETA_PEER. Reply exactly "ready".
+    response:
+      content: |-
+        I'll remember the code word BETA_PEER.
+
+        ready
+      stopReason: end_turn
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word ALPHA_PEER. Reply exactly "ready".
+        - role: assistant
+          content: |-
+            I'll remember the code word ALPHA_PEER.
+
+            ready
+        - role: user
+          content: Reply exactly "first".
+    response:
+      content: first
+      stopReason: end_turn
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word BETA_PEER. Reply exactly "ready".
+        - role: assistant
+          content: |-
+            I'll remember the code word BETA_PEER.
+
+            ready
+        - role: user
+          content: Reply exactly "second".
+    response:
+      content: second
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-two-peer-chats-write-distinct-workspace-files.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-two-peer-chats-write-distinct-workspace-files.yaml
@@ -1,0 +1,83 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/first-peer.txt containing exactly FIRST_PEER.
+    response:
+      content:
+        - type: text
+          text: I'll create that file for you.
+        - type: tool_use
+          id: toolcall_0
+          name: Write
+          input:
+            file_path: ${workdir}/first-peer.txt
+            content: FIRST_PEER
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/first-peer.txt containing exactly FIRST_PEER.
+        - role: assistant
+          content:
+            - type: text
+              text: I'll create that file for you.
+            - type: tool_use
+              name: Write
+              input:
+                file_path: ${workdir}/first-peer.txt
+                content: FIRST_PEER
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: 'File created successfully at: ${workdir}/first-peer.txt (file state is current in your context — no need to Read it back)'
+    response:
+      content: Created `first-peer.txt` containing exactly `FIRST_PEER`.
+      stopReason: end_turn
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/second-peer.txt containing exactly SECOND_PEER.
+    response:
+      content:
+        - type: text
+          text: I'll create that file.
+        - type: tool_use
+          id: toolcall_1
+          name: Write
+          input:
+            file_path: ${workdir}/second-peer.txt
+            content: SECOND_PEER
+      stopReason: tool_use
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/second-peer.txt containing exactly SECOND_PEER.
+        - role: assistant
+          content:
+            - type: text
+              text: I'll create that file.
+            - type: tool_use
+              name: Write
+              input:
+                file_path: ${workdir}/second-peer.txt
+                content: SECOND_PEER
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
+              content: 'File created successfully at: ${workdir}/second-peer.txt (file state is current in your context — no need to Read it back)'
+    response:
+      content: Created `second-peer.txt` containing exactly `SECOND_PEER`.
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-disposing-a-peer-after-a-completed-turn-removes-it-from-the-catalog.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-disposing-a-peer-after-a-completed-turn-removes-it-from-the-catalog.yaml
@@ -1,0 +1,12 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "DONE".
+    response:
+      content: DONE
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-forked-peer-chat-inherits-source-history-through-the-provider.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-forked-peer-chat-inherits-source-history-through-the-provider.yaml
@@ -1,0 +1,25 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word FORKCODE. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word FORKCODE. Reply exactly "ready".
+        - role: assistant
+          content: ready
+        - role: user
+          content: What code word did I ask you to remember? Reply with only the code word.
+    response:
+      content: FORKCODE
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-fresh-peer-chat-does-not-inherit-default-chat-context.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-fresh-peer-chat-does-not-inherit-default-chat-context.yaml
@@ -1,0 +1,21 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word DEFAULTSECRET. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "fresh".
+    response:
+      content: fresh
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-completes-a-simple-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-completes-a-simple-turn.yaml
@@ -1,0 +1,12 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "PEER_OK".
+    response:
+      content: PEER_OK
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-creates-a-file-in-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-creates-a-file-in-a-nested-directory.yaml
@@ -1,0 +1,80 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: bash
+          input:
+            command: mkdir -p ${workdir}/peer-output
+            description: Create peer-output directory
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
+        - role: assistant
+          content:
+            - type: thinking
+            - type: tool_use
+              name: bash
+              input:
+                command: mkdir -p ${workdir}/peer-output
+                description: Create peer-output directory
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '<shellId: 0 completed with exit code 0>'
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_1
+          name: create
+          input:
+            path: ${workdir}/peer-output/report.txt
+            file_text: PEER_NESTED
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
+        - role: assistant
+          content:
+            - type: thinking
+            - type: tool_use
+              name: bash
+              input:
+                command: mkdir -p ${workdir}/peer-output
+                description: Create peer-output directory
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '<shellId: 0 completed with exit code 0>'
+        - role: assistant
+          content:
+            - type: tool_use
+              name: create
+              input:
+                path: ${workdir}/peer-output/report.txt
+                file_text: PEER_NESTED
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
+              content: Created file ${workdir}/peer-output/report.txt with 11 characters
+    response:
+      content: Created the file with exactly `PEER_NESTED` (no trailing newline) at [report.txt](${workdir}/peer-output/report.txt).
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-creates-a-file-in-the-parent-workspace.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-creates-a-file-in-the-parent-workspace.yaml
@@ -1,0 +1,39 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/peer-created.txt containing exactly PEER_CREATED.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: create
+          input:
+            path: ${workdir}/peer-created.txt
+            file_text: PEER_CREATED
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/peer-created.txt containing exactly PEER_CREATED.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: create
+              input:
+                path: ${workdir}/peer-created.txt
+                file_text: PEER_CREATED
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: Created file ${workdir}/peer-created.txt with 12 characters
+    response:
+      content: Created [peer-created.txt](${workdir}/peer-created.txt) with the content `PEER_CREATED`.
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-edits-an-existing-workspace-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-edits-an-existing-workspace-file.yaml
@@ -1,0 +1,49 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: bash
+          input:
+            command: |-
+              cat > "${workdir}/peer-edit.txt" << 'EOF'
+              AFTER_PEER
+              EOF
+              cat "${workdir}/peer-edit.txt"
+            description: Replace contents of peer-edit.txt
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: bash
+              input:
+                command: |-
+                  cat > "${workdir}/peer-edit.txt" << 'EOF'
+                  AFTER_PEER
+                  EOF
+                  cat "${workdir}/peer-edit.txt"
+                description: Replace contents of peer-edit.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: |-
+                AFTER_PEER
+                <shellId: 0 completed with exit code 0>
+    response:
+      content: Done — the file now contains only `AFTER_PEER`.
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-handles-a-missing-workspace-file-without-an-error.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-handles-a-missing-workspace-file-without-an-error.yaml
@@ -1,0 +1,41 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing".
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: bash
+          input:
+            command: cat "${workdir}/peer-missing.txt" 2>&1
+            description: Check if file exists
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing".
+        - role: assistant
+          content:
+            - type: tool_use
+              name: bash
+              input:
+                command: cat "${workdir}/peer-missing.txt" 2>&1
+                description: Check if file exists
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: |-
+                cat: ${workdir}/peer-missing.txt: No such file or directory
+                <shellId: 0 completed with exit code 1>
+    response:
+      content: missing
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-file-from-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-file-from-a-nested-directory.yaml
@@ -1,0 +1,41 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/nested/peer.txt and reply with its exact contents only.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: bash
+          input:
+            command: cat "${workdir}/nested/peer.txt"
+            description: Read peer.txt file
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/nested/peer.txt and reply with its exact contents only.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: bash
+              input:
+                command: cat "${workdir}/nested/peer.txt"
+                description: Read peer.txt file
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: |-
+                PEER_NESTED_READ
+                <shellId: 0 completed with exit code 0>
+    response:
+      content: PEER_NESTED_READ
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-file-from-the-parent-workspace.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-file-from-the-parent-workspace.yaml
@@ -1,0 +1,37 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/peer-note.txt and reply with its exact contents only.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: view
+          input:
+            path: ${workdir}/peer-note.txt
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/peer-note.txt and reply with its exact contents only.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: view
+              input:
+                path: ${workdir}/peer-note.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: 1. PEER_FILE_VALUE
+    response:
+      content: PEER_FILE_VALUE
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-filename-containing-spaces.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-filename-containing-spaces.yaml
@@ -1,0 +1,37 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/peer file.txt and reply with its exact contents only.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: view
+          input:
+            path: ${workdir}/peer file.txt
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Read the file at ${workdir}/peer file.txt and reply with its exact contents only.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: view
+              input:
+                path: ${workdir}/peer file.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: 1. PEER_SPACED
+    response:
+      content: PEER_SPACED
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-retains-context-across-consecutive-turns.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-retains-context-across-consecutive-turns.yaml
@@ -1,0 +1,25 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word PEAR. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word PEAR. Reply exactly "ready".
+        - role: assistant
+          content: ready
+        - role: user
+          content: What code word did I ask you to remember? Reply with only the code word.
+    response:
+      content: PEAR
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-multiple-simple-attachments-reach-the-provider-request.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-multiple-simple-attachments-reach-the-provider-request.yaml
@@ -1,0 +1,24 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content:
+            - type: text
+              text: Reply exactly "attachments".
+            - type: text
+              text: |-
+                <attachment mimeType="text/plain" name="first">
+                PEER_FIRST_ATTACHMENT
+                </attachment>
+            - type: text
+              text: |-
+                <attachment mimeType="text/plain" name="second">
+                PEER_SECOND_ATTACHMENT
+                </attachment>
+    response:
+      content: attachments
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-provider-context-survives-unsubscribe-and-resubscribe.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-provider-context-survives-unsubscribe-and-resubscribe.yaml
@@ -1,0 +1,25 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word RESUME_PEER. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word RESUME_PEER. Reply exactly "ready".
+        - role: assistant
+          content: ready
+        - role: user
+          content: Reply exactly "resumed".
+    response:
+      content: resumed
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-resource-attachment-reaches-the-provider-request.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-resource-attachment-reaches-the-provider-request.yaml
@@ -1,0 +1,17 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: |-
+            Reply exactly "attachment".
+
+            <tagged_files>
+            * ${workdir}/peer-resource.txt (1 lines)
+            </tagged_files>
+    response:
+      content: attachment
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-resource-selection-attachment-includes-its-line-reference.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-resource-selection-attachment-includes-its-line-reference.yaml
@@ -1,0 +1,21 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: |-
+            <ide_selection>
+            The user has the following text selected in their IDE. This may or may not be related to their request.
+            File: peer-selection.txt (line 2)
+            ```
+            second
+            ```
+            </ide_selection>
+
+            Reply exactly "selection".
+    response:
+      content: selection
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-simple-attachment-reaches-the-provider-request.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-simple-attachment-reaches-the-provider-request.yaml
@@ -1,0 +1,19 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content:
+            - type: text
+              text: Reply exactly "attachment".
+            - type: text
+              text: |-
+                <attachment mimeType="text/plain" name="peer-note.txt">
+                PEER_SIMPLE_ATTACHMENT
+                </attachment>
+    response:
+      content: attachment
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-simple-attachment-without-a-model-representation-is-omitted-from-the-provider-request.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-simple-attachment-without-a-model-representation-is-omitted-from-the-provider-request.yaml
@@ -1,0 +1,12 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "attachment".
+    response:
+      content: attachment
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-recreated-peer-chat-starts-with-fresh-provider-context.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-recreated-peer-chat-starts-with-fresh-provider-context.yaml
@@ -1,0 +1,21 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word OLD_PEER. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "new".
+    response:
+      content: new
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-two-peer-chats-keep-independent-provider-contexts.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-two-peer-chats-keep-independent-provider-contexts.yaml
@@ -1,0 +1,47 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word ALPHA_PEER. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word BETA_PEER. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word ALPHA_PEER. Reply exactly "ready".
+        - role: assistant
+          content: ready
+        - role: user
+          content: Reply exactly "first".
+    response:
+      content: first
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word BETA_PEER. Reply exactly "ready".
+        - role: assistant
+          content: ready
+        - role: user
+          content: Reply exactly "second".
+    response:
+      content: second
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-two-peer-chats-write-distinct-workspace-files.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-two-peer-chats-write-distinct-workspace-files.yaml
@@ -1,0 +1,75 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/first-peer.txt containing exactly FIRST_PEER.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: create
+          input:
+            path: ${workdir}/first-peer.txt
+            file_text: FIRST_PEER
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/first-peer.txt containing exactly FIRST_PEER.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: create
+              input:
+                path: ${workdir}/first-peer.txt
+                file_text: FIRST_PEER
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: Created file ${workdir}/first-peer.txt with 10 characters
+    response:
+      content: Created [first-peer.txt](${workdir}/first-peer.txt) with the exact content `FIRST_PEER`.
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/second-peer.txt containing exactly SECOND_PEER.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_1
+          name: create
+          input:
+            path: ${workdir}/second-peer.txt
+            file_text: SECOND_PEER
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Create the file at ${workdir}/second-peer.txt containing exactly SECOND_PEER.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: create
+              input:
+                path: ${workdir}/second-peer.txt
+                file_text: SECOND_PEER
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
+              content: Created file ${workdir}/second-peer.txt with 11 characters
+    response:
+      content: Created the file with the exact content `SECOND_PEER`.
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-unknown-turn-fork-does-not-inherit-source-provider-context.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-unknown-turn-fork-does-not-inherit-source-provider-context.yaml
@@ -1,0 +1,21 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word SOURCE_SECRET. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "fresh".
+    response:
+      content: fresh
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
+++ b/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
@@ -14,24 +14,24 @@
 	},
 	"total": {
 		"statements": {
-			"covered": 60307,
-			"total": 84481,
-			"percentage": 71.38
+			"covered": 60310,
+			"total": 85014,
+			"percentage": 70.94
 		},
 		"branches": {
-			"covered": 5036,
-			"total": 8032,
-			"percentage": 62.69
+			"covered": 4999,
+			"total": 7980,
+			"percentage": 62.64
 		},
 		"functions": {
-			"covered": 1965,
-			"total": 3195,
-			"percentage": 61.5
+			"covered": 1969,
+			"total": 3207,
+			"percentage": 61.39
 		},
 		"lines": {
-			"covered": 60307,
-			"total": 84481,
-			"percentage": 71.38
+			"covered": 60310,
+			"total": 85014,
+			"percentage": 70.94
 		}
 	},
 	"files": {
@@ -191,9 +191,9 @@
 		},
 		"src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts": {
 			"statements": {
-				"covered": 114,
-				"total": 128,
-				"percentage": 89.06
+				"covered": 127,
+				"total": 141,
+				"percentage": 90.07
 			},
 			"branches": {
 				"covered": 1,
@@ -206,9 +206,9 @@
 				"percentage": 0
 			},
 			"lines": {
-				"covered": 114,
-				"total": 128,
-				"percentage": 89.06
+				"covered": 127,
+				"total": 141,
+				"percentage": 90.07
 			}
 		},
 		"src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts": {
@@ -323,14 +323,14 @@
 		},
 		"src/vs/platform/agentHost/common/agentHostSchema.ts": {
 			"statements": {
-				"covered": 624,
+				"covered": 621,
 				"total": 720,
-				"percentage": 86.66
+				"percentage": 86.25
 			},
 			"branches": {
-				"covered": 50,
-				"total": 68,
-				"percentage": 73.52
+				"covered": 46,
+				"total": 65,
+				"percentage": 70.76
 			},
 			"functions": {
 				"covered": 15,
@@ -338,9 +338,9 @@
 				"percentage": 68.18
 			},
 			"lines": {
-				"covered": 624,
+				"covered": 621,
 				"total": 720,
-				"percentage": 86.66
+				"percentage": 86.25
 			}
 		},
 		"src/vs/platform/agentHost/common/agentHostTelemetryEnv.ts": {
@@ -851,24 +851,24 @@
 		},
 		"src/vs/platform/agentHost/common/otlp/otlpLogEmitter.ts": {
 			"statements": {
-				"covered": 335,
+				"covered": 320,
 				"total": 485,
-				"percentage": 69.07
+				"percentage": 65.97
 			},
 			"branches": {
-				"covered": 31,
-				"total": 39,
-				"percentage": 79.48
+				"covered": 22,
+				"total": 31,
+				"percentage": 70.96
 			},
 			"functions": {
-				"covered": 17,
+				"covered": 14,
 				"total": 30,
-				"percentage": 56.66
+				"percentage": 46.66
 			},
 			"lines": {
-				"covered": 335,
+				"covered": 320,
 				"total": 485,
-				"percentage": 69.07
+				"percentage": 65.97
 			}
 		},
 		"src/vs/platform/agentHost/common/pendingRequestRegistry.ts": {
@@ -1093,14 +1093,14 @@
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-changeset/reducer.ts": {
 			"statements": {
-				"covered": 59,
+				"covered": 62,
 				"total": 121,
-				"percentage": 48.76
+				"percentage": 51.23
 			},
 			"branches": {
-				"covered": 4,
-				"total": 14,
-				"percentage": 28.57
+				"covered": 5,
+				"total": 15,
+				"percentage": 33.33
 			},
 			"functions": {
 				"covered": 1,
@@ -1108,9 +1108,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 59,
+				"covered": 62,
 				"total": 121,
-				"percentage": 48.76
+				"percentage": 51.23
 			}
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-chat/reducer.ts": {
@@ -1599,24 +1599,24 @@
 		},
 		"src/vs/platform/agentHost/common/state/sessionState.ts": {
 			"statements": {
-				"covered": 1011,
+				"covered": 1014,
 				"total": 1306,
-				"percentage": 77.41
+				"percentage": 77.64
 			},
 			"branches": {
-				"covered": 83,
-				"total": 119,
-				"percentage": 69.74
+				"covered": 84,
+				"total": 120,
+				"percentage": 70
 			},
 			"functions": {
-				"covered": 33,
+				"covered": 34,
 				"total": 52,
-				"percentage": 63.46
+				"percentage": 65.38
 			},
 			"lines": {
-				"covered": 1011,
+				"covered": 1014,
 				"total": 1306,
-				"percentage": 77.41
+				"percentage": 77.64
 			}
 		},
 		"src/vs/platform/agentHost/node/activeClientState.ts": {
@@ -1648,9 +1648,9 @@
 				"percentage": 90.08
 			},
 			"branches": {
-				"covered": 28,
-				"total": 39,
-				"percentage": 71.79
+				"covered": 27,
+				"total": 38,
+				"percentage": 71.05
 			},
 			"functions": {
 				"covered": 11,
@@ -1819,24 +1819,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetStateCache.ts": {
 			"statements": {
-				"covered": 107,
+				"covered": 112,
 				"total": 126,
-				"percentage": 84.92
+				"percentage": 88.88
 			},
 			"branches": {
-				"covered": 11,
-				"total": 15,
-				"percentage": 73.33
+				"covered": 13,
+				"total": 17,
+				"percentage": 76.47
 			},
 			"functions": {
-				"covered": 8,
+				"covered": 10,
 				"total": 10,
-				"percentage": 80
+				"percentage": 100
 			},
 			"lines": {
-				"covered": 107,
+				"covered": 112,
 				"total": 126,
-				"percentage": 84.92
+				"percentage": 88.88
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetSubscriptionService.ts": {
@@ -1863,14 +1863,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostCheckpointService.ts": {
 			"statements": {
-				"covered": 188,
+				"covered": 200,
 				"total": 272,
-				"percentage": 69.11
+				"percentage": 73.52
 			},
 			"branches": {
-				"covered": 42,
-				"total": 55,
-				"percentage": 76.36
+				"covered": 46,
+				"total": 59,
+				"percentage": 77.96
 			},
 			"functions": {
 				"covered": 11,
@@ -1878,9 +1878,9 @@
 				"percentage": 91.66
 			},
 			"lines": {
-				"covered": 188,
+				"covered": 200,
 				"total": 272,
-				"percentage": 69.11
+				"percentage": 73.52
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostCommitOperationHandler.ts": {
@@ -2457,24 +2457,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostStateManager.ts": {
 			"statements": {
-				"covered": 1238,
+				"covered": 1283,
 				"total": 1437,
-				"percentage": 86.15
+				"percentage": 89.28
 			},
 			"branches": {
-				"covered": 164,
-				"total": 209,
-				"percentage": 78.46
+				"covered": 180,
+				"total": 226,
+				"percentage": 79.64
 			},
 			"functions": {
-				"covered": 46,
+				"covered": 50,
 				"total": 60,
-				"percentage": 76.66
+				"percentage": 83.33
 			},
 			"lines": {
-				"covered": 1238,
+				"covered": 1283,
 				"total": 1437,
-				"percentage": 86.15
+				"percentage": 89.28
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostSyncOperationHandler.ts": {
@@ -2572,9 +2572,9 @@
 				"percentage": 88.78
 			},
 			"branches": {
-				"covered": 98,
-				"total": 126,
-				"percentage": 77.77
+				"covered": 97,
+				"total": 125,
+				"percentage": 77.6
 			},
 			"functions": {
 				"covered": 29,
@@ -2589,14 +2589,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostToolCallTracker.ts": {
 			"statements": {
-				"covered": 158,
+				"covered": 160,
 				"total": 203,
-				"percentage": 77.83
+				"percentage": 78.81
 			},
 			"branches": {
-				"covered": 21,
+				"covered": 22,
 				"total": 30,
-				"percentage": 70
+				"percentage": 73.33
 			},
 			"functions": {
 				"covered": 10,
@@ -2604,9 +2604,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 158,
+				"covered": 160,
 				"total": 203,
-				"percentage": 77.83
+				"percentage": 78.81
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostTurnTracker.ts": {
@@ -2677,46 +2677,46 @@
 		},
 		"src/vs/platform/agentHost/node/agentPeerChats.ts": {
 			"statements": {
-				"covered": 143,
+				"covered": 145,
 				"total": 182,
-				"percentage": 78.57
+				"percentage": 79.67
 			},
 			"branches": {
-				"covered": 21,
-				"total": 22,
-				"percentage": 95.45
+				"covered": 23,
+				"total": 24,
+				"percentage": 95.83
 			},
 			"functions": {
-				"covered": 13,
+				"covered": 14,
 				"total": 17,
-				"percentage": 76.47
+				"percentage": 82.35
 			},
 			"lines": {
-				"covered": 143,
+				"covered": 145,
 				"total": 182,
-				"percentage": 78.57
+				"percentage": 79.67
 			}
 		},
 		"src/vs/platform/agentHost/node/agentPluginManager.ts": {
 			"statements": {
-				"covered": 183,
+				"covered": 152,
 				"total": 292,
-				"percentage": 62.67
+				"percentage": 52.05
 			},
 			"branches": {
-				"covered": 19,
-				"total": 23,
-				"percentage": 82.6
+				"covered": 6,
+				"total": 7,
+				"percentage": 85.71
 			},
 			"functions": {
-				"covered": 6,
+				"covered": 3,
 				"total": 19,
-				"percentage": 31.57
+				"percentage": 15.78
 			},
 			"lines": {
-				"covered": 183,
+				"covered": 152,
 				"total": 292,
-				"percentage": 62.67
+				"percentage": 52.05
 			}
 		},
 		"src/vs/platform/agentHost/node/agentSdkDownloader.ts": {
@@ -2743,36 +2743,36 @@
 		},
 		"src/vs/platform/agentHost/node/agentService.ts": {
 			"statements": {
-				"covered": 2239,
+				"covered": 2298,
 				"total": 3742,
-				"percentage": 59.83
+				"percentage": 61.41
 			},
 			"branches": {
-				"covered": 241,
-				"total": 390,
-				"percentage": 61.79
+				"covered": 252,
+				"total": 410,
+				"percentage": 61.46
 			},
 			"functions": {
-				"covered": 76,
+				"covered": 80,
 				"total": 136,
-				"percentage": 55.88
+				"percentage": 58.82
 			},
 			"lines": {
-				"covered": 2239,
+				"covered": 2298,
 				"total": 3742,
-				"percentage": 59.83
+				"percentage": 61.41
 			}
 		},
 		"src/vs/platform/agentHost/node/agentSideEffects.ts": {
 			"statements": {
-				"covered": 1335,
+				"covered": 1337,
 				"total": 1619,
-				"percentage": 82.45
+				"percentage": 82.58
 			},
 			"branches": {
-				"covered": 208,
-				"total": 282,
-				"percentage": 73.75
+				"covered": 210,
+				"total": 284,
+				"percentage": 73.94
 			},
 			"functions": {
 				"covered": 45,
@@ -2780,9 +2780,9 @@
 				"percentage": 93.75
 			},
 			"lines": {
-				"covered": 1335,
+				"covered": 1337,
 				"total": 1619,
-				"percentage": 82.45
+				"percentage": 82.58
 			}
 		},
 		"src/vs/platform/agentHost/node/appNodeModules.ts": {
@@ -2875,24 +2875,24 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeAgent.ts": {
 			"statements": {
-				"covered": 1569,
+				"covered": 1635,
 				"total": 2241,
-				"percentage": 70.01
+				"percentage": 72.95
 			},
 			"branches": {
-				"covered": 135,
-				"total": 220,
-				"percentage": 61.36
+				"covered": 151,
+				"total": 240,
+				"percentage": 62.91
 			},
 			"functions": {
-				"covered": 62,
+				"covered": 66,
 				"total": 89,
-				"percentage": 69.66
+				"percentage": 74.15
 			},
 			"lines": {
-				"covered": 1569,
+				"covered": 1635,
 				"total": 2241,
-				"percentage": 70.01
+				"percentage": 72.95
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts": {
@@ -2919,24 +2919,24 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeAgentSession.ts": {
 			"statements": {
-				"covered": 911,
+				"covered": 946,
 				"total": 1121,
-				"percentage": 81.26
+				"percentage": 84.38
 			},
 			"branches": {
-				"covered": 50,
-				"total": 78,
-				"percentage": 64.1
+				"covered": 54,
+				"total": 83,
+				"percentage": 65.06
 			},
 			"functions": {
-				"covered": 26,
+				"covered": 27,
 				"total": 51,
-				"percentage": 50.98
+				"percentage": 52.94
 			},
 			"lines": {
-				"covered": 911,
+				"covered": 946,
 				"total": 1121,
-				"percentage": 81.26
+				"percentage": 84.38
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts": {
@@ -3227,14 +3227,14 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts": {
 			"statements": {
-				"covered": 227,
+				"covered": 228,
 				"total": 244,
-				"percentage": 93.03
+				"percentage": 93.44
 			},
 			"branches": {
-				"covered": 10,
-				"total": 19,
-				"percentage": 52.63
+				"covered": 12,
+				"total": 21,
+				"percentage": 57.14
 			},
 			"functions": {
 				"covered": 3,
@@ -3242,31 +3242,31 @@
 				"percentage": 75
 			},
 			"lines": {
-				"covered": 227,
+				"covered": 228,
 				"total": 244,
-				"percentage": 93.03
+				"percentage": 93.44
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts": {
 			"statements": {
-				"covered": 530,
+				"covered": 551,
 				"total": 703,
-				"percentage": 75.39
+				"percentage": 78.37
 			},
 			"branches": {
-				"covered": 36,
-				"total": 60,
-				"percentage": 60
+				"covered": 42,
+				"total": 68,
+				"percentage": 61.76
 			},
 			"functions": {
-				"covered": 18,
+				"covered": 20,
 				"total": 30,
-				"percentage": 60
+				"percentage": 66.66
 			},
 			"lines": {
-				"covered": 530,
+				"covered": 551,
 				"total": 703,
-				"percentage": 75.39
+				"percentage": 78.37
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeServerToolMcpServer.ts": {
@@ -3320,8 +3320,8 @@
 				"percentage": 100
 			},
 			"branches": {
-				"covered": 1,
-				"total": 1,
+				"covered": 2,
+				"total": 2,
 				"percentage": 100
 			},
 			"functions": {
@@ -3738,9 +3738,9 @@
 				"percentage": 60.13
 			},
 			"branches": {
-				"covered": 171,
-				"total": 320,
-				"percentage": 53.43
+				"covered": 166,
+				"total": 317,
+				"percentage": 52.36
 			},
 			"functions": {
 				"covered": 86,
@@ -3887,24 +3887,24 @@
 		},
 		"src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts": {
 			"statements": {
-				"covered": 493,
+				"covered": 471,
 				"total": 1060,
-				"percentage": 46.5
+				"percentage": 44.43
 			},
 			"branches": {
-				"covered": 20,
-				"total": 49,
-				"percentage": 40.81
+				"covered": 18,
+				"total": 44,
+				"percentage": 40.9
 			},
 			"functions": {
-				"covered": 12,
+				"covered": 11,
 				"total": 32,
-				"percentage": 37.5
+				"percentage": 34.37
 			},
 			"lines": {
-				"covered": 493,
+				"covered": 471,
 				"total": 1060,
-				"percentage": 46.5
+				"percentage": 44.43
 			}
 		},
 		"src/vs/platform/agentHost/node/codex/codexMcpServers.ts": {
@@ -4019,14 +4019,14 @@
 		},
 		"src/vs/platform/agentHost/node/codex/codexSessionMetadataStore.ts": {
 			"statements": {
-				"covered": 107,
+				"covered": 97,
 				"total": 112,
-				"percentage": 95.53
+				"percentage": 86.6
 			},
 			"branches": {
-				"covered": 8,
-				"total": 11,
-				"percentage": 72.72
+				"covered": 3,
+				"total": 10,
+				"percentage": 30
 			},
 			"functions": {
 				"covered": 3,
@@ -4034,9 +4034,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 107,
+				"covered": 97,
 				"total": 112,
-				"percentage": 95.53
+				"percentage": 86.6
 			}
 		},
 		"src/vs/platform/agentHost/node/codex/codexShellCommand.ts": {
@@ -4046,9 +4046,9 @@
 				"percentage": 90.47
 			},
 			"branches": {
-				"covered": 6,
-				"total": 9,
-				"percentage": 66.66
+				"covered": 5,
+				"total": 8,
+				"percentage": 62.5
 			},
 			"functions": {
 				"covered": 2,
@@ -4112,9 +4112,9 @@
 				"percentage": 70.21
 			},
 			"branches": {
-				"covered": 5,
+				"covered": 4,
 				"total": 6,
-				"percentage": 83.33
+				"percentage": 66.66
 			},
 			"functions": {
 				"covered": 4,
@@ -4195,46 +4195,46 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgent.ts": {
 			"statements": {
-				"covered": 2910,
-				"total": 4198,
-				"percentage": 69.31
+				"covered": 2931,
+				"total": 4229,
+				"percentage": 69.3
 			},
 			"branches": {
 				"covered": 319,
-				"total": 525,
-				"percentage": 60.76
+				"total": 533,
+				"percentage": 59.84
 			},
 			"functions": {
-				"covered": 137,
-				"total": 186,
-				"percentage": 73.65
+				"covered": 140,
+				"total": 189,
+				"percentage": 74.07
 			},
 			"lines": {
-				"covered": 2910,
-				"total": 4198,
-				"percentage": 69.31
+				"covered": 2931,
+				"total": 4229,
+				"percentage": 69.3
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts": {
 			"statements": {
-				"covered": 2807,
+				"covered": 2728,
 				"total": 4357,
-				"percentage": 64.42
+				"percentage": 62.61
 			},
 			"branches": {
-				"covered": 367,
-				"total": 595,
-				"percentage": 61.68
+				"covered": 344,
+				"total": 555,
+				"percentage": 61.98
 			},
 			"functions": {
-				"covered": 102,
+				"covered": 100,
 				"total": 151,
-				"percentage": 67.54
+				"percentage": 66.22
 			},
 			"lines": {
-				"covered": 2807,
+				"covered": 2728,
 				"total": 4357,
-				"percentage": 64.42
+				"percentage": 62.61
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts": {
@@ -4283,14 +4283,14 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotPluginConverters.ts": {
 			"statements": {
-				"covered": 312,
+				"covered": 266,
 				"total": 516,
-				"percentage": 60.46
+				"percentage": 51.55
 			},
 			"branches": {
-				"covered": 27,
-				"total": 54,
-				"percentage": 50
+				"covered": 13,
+				"total": 31,
+				"percentage": 41.93
 			},
 			"functions": {
 				"covered": 13,
@@ -4298,9 +4298,9 @@
 				"percentage": 54.16
 			},
 			"lines": {
-				"covered": 312,
+				"covered": 266,
 				"total": 516,
-				"percentage": 60.46
+				"percentage": 51.55
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts": {
@@ -4310,9 +4310,9 @@
 				"percentage": 76.37
 			},
 			"branches": {
-				"covered": 44,
-				"total": 66,
-				"percentage": 66.66
+				"covered": 38,
+				"total": 59,
+				"percentage": 64.4
 			},
 			"functions": {
 				"covered": 19,
@@ -4464,9 +4464,9 @@
 				"percentage": 73.68
 			},
 			"branches": {
-				"covered": 83,
-				"total": 209,
-				"percentage": 39.71
+				"covered": 84,
+				"total": 210,
+				"percentage": 40
 			},
 			"functions": {
 				"covered": 21,
@@ -4657,24 +4657,24 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/sessionCustomizationDiscovery.ts": {
 			"statements": {
-				"covered": 456,
-				"total": 627,
-				"percentage": 72.72
+				"covered": 464,
+				"total": 1116,
+				"percentage": 41.57
 			},
 			"branches": {
-				"covered": 70,
-				"total": 88,
-				"percentage": 79.54
+				"covered": 68,
+				"total": 85,
+				"percentage": 80
 			},
 			"functions": {
 				"covered": 16,
-				"total": 23,
-				"percentage": 69.56
+				"total": 32,
+				"percentage": 50
 			},
 			"lines": {
-				"covered": 456,
-				"total": 627,
-				"percentage": 72.72
+				"covered": 464,
+				"total": 1116,
+				"percentage": 41.57
 			}
 		},
 		"src/vs/platform/agentHost/node/diffComputeService.ts": {
@@ -4899,14 +4899,14 @@
 		},
 		"src/vs/platform/agentHost/node/protocolServerHandler.ts": {
 			"statements": {
-				"covered": 1101,
+				"covered": 1104,
 				"total": 1569,
-				"percentage": 70.17
+				"percentage": 70.36
 			},
 			"branches": {
-				"covered": 138,
-				"total": 216,
-				"percentage": 63.88
+				"covered": 143,
+				"total": 220,
+				"percentage": 65
 			},
 			"functions": {
 				"covered": 49,
@@ -4914,9 +4914,9 @@
 				"percentage": 60.49
 			},
 			"lines": {
-				"covered": 1101,
+				"covered": 1104,
 				"total": 1569,
-				"percentage": 70.17
+				"percentage": 70.36
 			}
 		},
 		"src/vs/platform/agentHost/node/serverUrls.ts": {
@@ -4943,14 +4943,14 @@
 		},
 		"src/vs/platform/agentHost/node/sessionDataService.ts": {
 			"statements": {
-				"covered": 153,
+				"covered": 156,
 				"total": 197,
-				"percentage": 77.66
+				"percentage": 79.18
 			},
 			"branches": {
-				"covered": 22,
+				"covered": 23,
 				"total": 26,
-				"percentage": 84.61
+				"percentage": 88.46
 			},
 			"functions": {
 				"covered": 12,
@@ -4958,31 +4958,31 @@
 				"percentage": 85.71
 			},
 			"lines": {
-				"covered": 153,
+				"covered": 156,
 				"total": 197,
-				"percentage": 77.66
+				"percentage": 79.18
 			}
 		},
 		"src/vs/platform/agentHost/node/sessionDatabase.ts": {
 			"statements": {
-				"covered": 592,
+				"covered": 596,
 				"total": 778,
-				"percentage": 76.09
+				"percentage": 76.6
 			},
 			"branches": {
-				"covered": 79,
-				"total": 104,
-				"percentage": 75.96
+				"covered": 80,
+				"total": 105,
+				"percentage": 76.19
 			},
 			"functions": {
-				"covered": 31,
+				"covered": 32,
 				"total": 51,
-				"percentage": 60.78
+				"percentage": 62.74
 			},
 			"lines": {
-				"covered": 592,
+				"covered": 596,
 				"total": 778,
-				"percentage": 76.09
+				"percentage": 76.6
 			}
 		},
 		"src/vs/platform/agentHost/node/sessionDiffAggregator.ts": {
@@ -5273,24 +5273,24 @@
 		},
 		"src/vs/platform/agentHost/node/shared/mcpCustomizationController.ts": {
 			"statements": {
-				"covered": 422,
+				"covered": 334,
 				"total": 555,
-				"percentage": 76.03
+				"percentage": 60.18
 			},
 			"branches": {
-				"covered": 43,
-				"total": 66,
-				"percentage": 65.15
+				"covered": 20,
+				"total": 30,
+				"percentage": 66.66
 			},
 			"functions": {
-				"covered": 17,
+				"covered": 7,
 				"total": 29,
-				"percentage": 58.62
+				"percentage": 24.13
 			},
 			"lines": {
-				"covered": 422,
+				"covered": 334,
 				"total": 555,
-				"percentage": 76.03
+				"percentage": 60.18
 			}
 		},
 		"src/vs/platform/agentHost/node/shared/persistSessionMetadata.ts": {
@@ -5383,14 +5383,14 @@
 		},
 		"src/vs/platform/agentHost/node/shared/worktreeIsolation.ts": {
 			"statements": {
-				"covered": 639,
+				"covered": 628,
 				"total": 822,
-				"percentage": 77.73
+				"percentage": 76.39
 			},
 			"branches": {
-				"covered": 67,
-				"total": 104,
-				"percentage": 64.42
+				"covered": 63,
+				"total": 101,
+				"percentage": 62.37
 			},
 			"functions": {
 				"covered": 30,
@@ -5398,9 +5398,9 @@
 				"percentage": 75
 			},
 			"lines": {
-				"covered": 639,
+				"covered": 628,
 				"total": 822,
-				"percentage": 77.73
+				"percentage": 76.39
 			}
 		},
 		"src/vs/platform/agentHost/node/webSocketTransport.ts": {

--- a/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
+++ b/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
@@ -14,24 +14,24 @@
 	},
 	"total": {
 		"statements": {
-			"covered": 59073,
-			"total": 84486,
-			"percentage": 69.92
+			"covered": 60307,
+			"total": 84481,
+			"percentage": 71.38
 		},
 		"branches": {
-			"covered": 4716,
-			"total": 7563,
-			"percentage": 62.35
+			"covered": 5036,
+			"total": 8032,
+			"percentage": 62.69
 		},
 		"functions": {
-			"covered": 1879,
-			"total": 3193,
-			"percentage": 58.84
+			"covered": 1965,
+			"total": 3195,
+			"percentage": 61.5
 		},
 		"lines": {
-			"covered": 59073,
-			"total": 84486,
-			"percentage": 69.92
+			"covered": 60307,
+			"total": 84481,
+			"percentage": 71.38
 		}
 	},
 	"files": {
@@ -169,24 +169,24 @@
 		},
 		"src/vs/platform/agentHost/common/agentHostConversationContext.ts": {
 			"statements": {
-				"covered": 68,
+				"covered": 82,
 				"total": 98,
-				"percentage": 69.38
+				"percentage": 83.67
 			},
 			"branches": {
-				"covered": 3,
-				"total": 3,
-				"percentage": 100
+				"covered": 4,
+				"total": 10,
+				"percentage": 40
 			},
 			"functions": {
-				"covered": 1,
+				"covered": 2,
 				"total": 3,
-				"percentage": 33.33
+				"percentage": 66.66
 			},
 			"lines": {
-				"covered": 68,
+				"covered": 82,
 				"total": 98,
-				"percentage": 69.38
+				"percentage": 83.67
 			}
 		},
 		"src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts": {
@@ -455,9 +455,9 @@
 		},
 		"src/vs/platform/agentHost/common/agentService.ts": {
 			"statements": {
-				"covered": 1982,
-				"total": 2154,
-				"percentage": 92.01
+				"covered": 1991,
+				"total": 2163,
+				"percentage": 92.04
 			},
 			"branches": {
 				"covered": 24,
@@ -470,9 +470,9 @@
 				"percentage": 42.85
 			},
 			"lines": {
-				"covered": 1982,
-				"total": 2154,
-				"percentage": 92.01
+				"covered": 1991,
+				"total": 2163,
+				"percentage": 92.04
 			}
 		},
 		"src/vs/platform/agentHost/common/ahpJsonlLogger.ts": {
@@ -1181,14 +1181,14 @@
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-session/reducer.ts": {
 			"statements": {
-				"covered": 197,
+				"covered": 206,
 				"total": 365,
-				"percentage": 53.97
+				"percentage": 56.43
 			},
 			"branches": {
-				"covered": 35,
-				"total": 55,
-				"percentage": 63.63
+				"covered": 37,
+				"total": 58,
+				"percentage": 63.79
 			},
 			"functions": {
 				"covered": 3,
@@ -1196,9 +1196,9 @@
 				"percentage": 75
 			},
 			"lines": {
-				"covered": 197,
+				"covered": 206,
 				"total": 365,
-				"percentage": 53.97
+				"percentage": 56.43
 			}
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-terminal/reducer.ts": {
@@ -1599,24 +1599,24 @@
 		},
 		"src/vs/platform/agentHost/common/state/sessionState.ts": {
 			"statements": {
-				"covered": 1004,
+				"covered": 1011,
 				"total": 1306,
-				"percentage": 76.87
+				"percentage": 77.41
 			},
 			"branches": {
-				"covered": 74,
-				"total": 109,
-				"percentage": 67.88
+				"covered": 83,
+				"total": 119,
+				"percentage": 69.74
 			},
 			"functions": {
-				"covered": 32,
+				"covered": 33,
 				"total": 52,
-				"percentage": 61.53
+				"percentage": 63.46
 			},
 			"lines": {
-				"covered": 1004,
+				"covered": 1011,
 				"total": 1306,
-				"percentage": 76.87
+				"percentage": 77.41
 			}
 		},
 		"src/vs/platform/agentHost/node/activeClientState.ts": {
@@ -1731,24 +1731,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts": {
 			"statements": {
-				"covered": 252,
+				"covered": 257,
 				"total": 340,
-				"percentage": 74.11
+				"percentage": 75.58
 			},
 			"branches": {
-				"covered": 19,
-				"total": 39,
-				"percentage": 48.71
+				"covered": 21,
+				"total": 42,
+				"percentage": 50
 			},
 			"functions": {
-				"covered": 11,
+				"covered": 13,
 				"total": 15,
-				"percentage": 73.33
+				"percentage": 86.66
 			},
 			"lines": {
-				"covered": 252,
+				"covered": 257,
 				"total": 340,
-				"percentage": 74.11
+				"percentage": 75.58
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetFileMonitorCoordinator.ts": {
@@ -1797,24 +1797,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetService.ts": {
 			"statements": {
-				"covered": 695,
+				"covered": 713,
 				"total": 1123,
-				"percentage": 61.88
+				"percentage": 63.49
 			},
 			"branches": {
-				"covered": 87,
-				"total": 124,
-				"percentage": 70.16
+				"covered": 89,
+				"total": 130,
+				"percentage": 68.46
 			},
 			"functions": {
-				"covered": 31,
+				"covered": 33,
 				"total": 52,
-				"percentage": 59.61
+				"percentage": 63.46
 			},
 			"lines": {
-				"covered": 695,
+				"covered": 713,
 				"total": 1123,
-				"percentage": 61.88
+				"percentage": 63.49
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetStateCache.ts": {
@@ -2000,9 +2000,9 @@
 				"percentage": 86.85
 			},
 			"branches": {
-				"covered": 25,
-				"total": 37,
-				"percentage": 67.56
+				"covered": 27,
+				"total": 39,
+				"percentage": 69.23
 			},
 			"functions": {
 				"covered": 7,
@@ -2017,14 +2017,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostFileMonitorService.ts": {
 			"statements": {
-				"covered": 141,
+				"covered": 143,
 				"total": 185,
-				"percentage": 76.21
+				"percentage": 77.29
 			},
 			"branches": {
-				"covered": 14,
-				"total": 22,
-				"percentage": 63.63
+				"covered": 16,
+				"total": 23,
+				"percentage": 69.56
 			},
 			"functions": {
 				"covered": 10,
@@ -2032,9 +2032,9 @@
 				"percentage": 71.42
 			},
 			"lines": {
-				"covered": 141,
+				"covered": 143,
 				"total": 185,
-				"percentage": 76.21
+				"percentage": 77.29
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostGitHubEndpointService.ts": {
@@ -2105,14 +2105,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostGitStateService.ts": {
 			"statements": {
-				"covered": 133,
+				"covered": 135,
 				"total": 202,
-				"percentage": 65.84
+				"percentage": 66.83
 			},
 			"branches": {
-				"covered": 18,
-				"total": 34,
-				"percentage": 52.94
+				"covered": 21,
+				"total": 36,
+				"percentage": 58.33
 			},
 			"functions": {
 				"covered": 5,
@@ -2120,9 +2120,9 @@
 				"percentage": 83.33
 			},
 			"lines": {
-				"covered": 133,
+				"covered": 135,
 				"total": 202,
-				"percentage": 65.84
+				"percentage": 66.83
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts": {
@@ -2149,24 +2149,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostLocalTurns.ts": {
 			"statements": {
-				"covered": 126,
+				"covered": 128,
 				"total": 161,
-				"percentage": 78.26
+				"percentage": 79.5
 			},
 			"branches": {
-				"covered": 9,
-				"total": 18,
+				"covered": 10,
+				"total": 20,
 				"percentage": 50
 			},
 			"functions": {
-				"covered": 8,
+				"covered": 9,
 				"total": 11,
-				"percentage": 72.72
+				"percentage": 81.81
 			},
 			"lines": {
-				"covered": 126,
+				"covered": 128,
 				"total": 161,
-				"percentage": 78.26
+				"percentage": 79.5
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostMicrosoftTelemetry.ts": {
@@ -2369,24 +2369,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostSessionTitleController.ts": {
 			"statements": {
-				"covered": 387,
+				"covered": 437,
 				"total": 507,
-				"percentage": 76.33
+				"percentage": 86.19
 			},
 			"branches": {
-				"covered": 49,
-				"total": 75,
-				"percentage": 65.33
+				"covered": 74,
+				"total": 97,
+				"percentage": 76.28
 			},
 			"functions": {
-				"covered": 20,
-				"total": 26,
-				"percentage": 76.92
+				"covered": 22,
+				"total": 28,
+				"percentage": 78.57
 			},
 			"lines": {
-				"covered": 387,
+				"covered": 437,
 				"total": 507,
-				"percentage": 76.33
+				"percentage": 86.19
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostShellUtils.ts": {
@@ -2457,24 +2457,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostStateManager.ts": {
 			"statements": {
-				"covered": 1207,
+				"covered": 1238,
 				"total": 1437,
-				"percentage": 83.99
+				"percentage": 86.15
 			},
 			"branches": {
-				"covered": 148,
-				"total": 193,
-				"percentage": 76.68
+				"covered": 164,
+				"total": 209,
+				"percentage": 78.46
 			},
 			"functions": {
-				"covered": 44,
+				"covered": 46,
 				"total": 60,
-				"percentage": 73.33
+				"percentage": 76.66
 			},
 			"lines": {
-				"covered": 1207,
+				"covered": 1238,
 				"total": 1437,
-				"percentage": 83.99
+				"percentage": 86.15
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostSyncOperationHandler.ts": {
@@ -2660,9 +2660,9 @@
 				"percentage": 73.03
 			},
 			"branches": {
-				"covered": 11,
-				"total": 22,
-				"percentage": 50
+				"covered": 13,
+				"total": 24,
+				"percentage": 54.16
 			},
 			"functions": {
 				"covered": 5,
@@ -2677,24 +2677,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentPeerChats.ts": {
 			"statements": {
-				"covered": 129,
+				"covered": 143,
 				"total": 182,
-				"percentage": 70.87
+				"percentage": 78.57
 			},
 			"branches": {
-				"covered": 9,
-				"total": 11,
-				"percentage": 81.81
+				"covered": 21,
+				"total": 22,
+				"percentage": 95.45
 			},
 			"functions": {
-				"covered": 8,
+				"covered": 13,
 				"total": 17,
-				"percentage": 47.05
+				"percentage": 76.47
 			},
 			"lines": {
-				"covered": 129,
+				"covered": 143,
 				"total": 182,
-				"percentage": 70.87
+				"percentage": 78.57
 			}
 		},
 		"src/vs/platform/agentHost/node/agentPluginManager.ts": {
@@ -2743,46 +2743,46 @@
 		},
 		"src/vs/platform/agentHost/node/agentService.ts": {
 			"statements": {
-				"covered": 1934,
+				"covered": 2239,
 				"total": 3742,
-				"percentage": 51.68
+				"percentage": 59.83
 			},
 			"branches": {
-				"covered": 190,
-				"total": 296,
-				"percentage": 64.18
+				"covered": 241,
+				"total": 390,
+				"percentage": 61.79
 			},
 			"functions": {
-				"covered": 64,
+				"covered": 76,
 				"total": 136,
-				"percentage": 47.05
+				"percentage": 55.88
 			},
 			"lines": {
-				"covered": 1934,
+				"covered": 2239,
 				"total": 3742,
-				"percentage": 51.68
+				"percentage": 59.83
 			}
 		},
 		"src/vs/platform/agentHost/node/agentSideEffects.ts": {
 			"statements": {
-				"covered": 1344,
-				"total": 1644,
-				"percentage": 81.75
+				"covered": 1335,
+				"total": 1619,
+				"percentage": 82.45
 			},
 			"branches": {
-				"covered": 207,
-				"total": 288,
-				"percentage": 71.87
+				"covered": 208,
+				"total": 282,
+				"percentage": 73.75
 			},
 			"functions": {
 				"covered": 45,
-				"total": 49,
-				"percentage": 91.83
+				"total": 48,
+				"percentage": 93.75
 			},
 			"lines": {
-				"covered": 1344,
-				"total": 1644,
-				"percentage": 81.75
+				"covered": 1335,
+				"total": 1619,
+				"percentage": 82.45
 			}
 		},
 		"src/vs/platform/agentHost/node/appNodeModules.ts": {
@@ -2875,68 +2875,68 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeAgent.ts": {
 			"statements": {
-				"covered": 1385,
+				"covered": 1569,
 				"total": 2241,
-				"percentage": 61.8
+				"percentage": 70.01
 			},
 			"branches": {
-				"covered": 92,
-				"total": 151,
-				"percentage": 60.92
+				"covered": 135,
+				"total": 220,
+				"percentage": 61.36
 			},
 			"functions": {
-				"covered": 51,
+				"covered": 62,
 				"total": 89,
-				"percentage": 57.3
+				"percentage": 69.66
 			},
 			"lines": {
-				"covered": 1385,
+				"covered": 1569,
 				"total": 2241,
-				"percentage": 61.8
+				"percentage": 70.01
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts": {
 			"statements": {
-				"covered": 246,
+				"covered": 252,
 				"total": 295,
-				"percentage": 83.38
+				"percentage": 85.42
 			},
 			"branches": {
+				"covered": 13,
+				"total": 17,
+				"percentage": 76.47
+			},
+			"functions": {
 				"covered": 11,
 				"total": 15,
 				"percentage": 73.33
 			},
-			"functions": {
-				"covered": 9,
-				"total": 15,
-				"percentage": 60
-			},
 			"lines": {
-				"covered": 246,
+				"covered": 252,
 				"total": 295,
-				"percentage": 83.38
+				"percentage": 85.42
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeAgentSession.ts": {
 			"statements": {
-				"covered": 905,
+				"covered": 911,
 				"total": 1121,
-				"percentage": 80.73
+				"percentage": 81.26
 			},
 			"branches": {
-				"covered": 43,
-				"total": 72,
-				"percentage": 59.72
+				"covered": 50,
+				"total": 78,
+				"percentage": 64.1
 			},
 			"functions": {
-				"covered": 25,
+				"covered": 26,
 				"total": 51,
-				"percentage": 49.01
+				"percentage": 50.98
 			},
 			"lines": {
-				"covered": 905,
+				"covered": 911,
 				"total": 1121,
-				"percentage": 80.73
+				"percentage": 81.26
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts": {
@@ -3095,24 +3095,24 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudePromptQueue.ts": {
 			"statements": {
-				"covered": 143,
+				"covered": 155,
 				"total": 171,
-				"percentage": 83.62
+				"percentage": 90.64
 			},
 			"branches": {
-				"covered": 12,
-				"total": 19,
-				"percentage": 63.15
+				"covered": 16,
+				"total": 23,
+				"percentage": 69.56
 			},
 			"functions": {
-				"covered": 8,
-				"total": 10,
-				"percentage": 80
+				"covered": 10,
+				"total": 11,
+				"percentage": 90.9
 			},
 			"lines": {
-				"covered": 143,
+				"covered": 155,
 				"total": 171,
-				"percentage": 83.62
+				"percentage": 90.64
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudePromptResolver.ts": {
@@ -3249,24 +3249,24 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts": {
 			"statements": {
-				"covered": 495,
+				"covered": 530,
 				"total": 703,
-				"percentage": 70.41
+				"percentage": 75.39
 			},
 			"branches": {
-				"covered": 29,
-				"total": 46,
-				"percentage": 63.04
+				"covered": 36,
+				"total": 60,
+				"percentage": 60
 			},
 			"functions": {
-				"covered": 16,
+				"covered": 18,
 				"total": 30,
-				"percentage": 53.33
+				"percentage": 60
 			},
 			"lines": {
-				"covered": 495,
+				"covered": 530,
 				"total": 703,
-				"percentage": 70.41
+				"percentage": 75.39
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeServerToolMcpServer.ts": {
@@ -3293,24 +3293,24 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSessionMetadataStore.ts": {
 			"statements": {
-				"covered": 122,
+				"covered": 169,
 				"total": 204,
-				"percentage": 59.8
+				"percentage": 82.84
 			},
 			"branches": {
-				"covered": 2,
-				"total": 4,
-				"percentage": 50
+				"covered": 15,
+				"total": 28,
+				"percentage": 53.57
 			},
 			"functions": {
-				"covered": 2,
+				"covered": 6,
 				"total": 7,
-				"percentage": 28.57
+				"percentage": 85.71
 			},
 			"lines": {
-				"covered": 122,
+				"covered": 169,
 				"total": 204,
-				"percentage": 59.8
+				"percentage": 82.84
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSessionPermissionMode.ts": {
@@ -3337,14 +3337,14 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSubagentRegistry.ts": {
 			"statements": {
-				"covered": 242,
-				"total": 265,
-				"percentage": 91.32
+				"covered": 248,
+				"total": 271,
+				"percentage": 91.51
 			},
 			"branches": {
-				"covered": 33,
-				"total": 42,
-				"percentage": 78.57
+				"covered": 36,
+				"total": 45,
+				"percentage": 80
 			},
 			"functions": {
 				"covered": 15,
@@ -3352,9 +3352,9 @@
 				"percentage": 88.23
 			},
 			"lines": {
-				"covered": 242,
-				"total": 265,
-				"percentage": 91.32
+				"covered": 248,
+				"total": 271,
+				"percentage": 91.51
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSubagentResolver.ts": {
@@ -3381,14 +3381,14 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSubagentSignals.ts": {
 			"statements": {
-				"covered": 276,
-				"total": 305,
-				"percentage": 90.49
+				"covered": 282,
+				"total": 311,
+				"percentage": 90.67
 			},
 			"branches": {
 				"covered": 17,
-				"total": 36,
-				"percentage": 47.22
+				"total": 37,
+				"percentage": 45.94
 			},
 			"functions": {
 				"covered": 5,
@@ -3396,9 +3396,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 276,
-				"total": 305,
-				"percentage": 90.49
+				"covered": 282,
+				"total": 311,
+				"percentage": 90.67
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeToolCallRegistry.ts": {
@@ -3733,24 +3733,24 @@
 		},
 		"src/vs/platform/agentHost/node/codex/codexAgent.ts": {
 			"statements": {
-				"covered": 2460,
-				"total": 4092,
-				"percentage": 60.11
+				"covered": 2462,
+				"total": 4094,
+				"percentage": 60.13
 			},
 			"branches": {
-				"covered": 165,
-				"total": 316,
-				"percentage": 52.21
+				"covered": 171,
+				"total": 320,
+				"percentage": 53.43
 			},
 			"functions": {
-				"covered": 85,
+				"covered": 86,
 				"total": 145,
-				"percentage": 58.62
+				"percentage": 59.31
 			},
 			"lines": {
-				"covered": 2460,
-				"total": 4092,
-				"percentage": 60.11
+				"covered": 2462,
+				"total": 4094,
+				"percentage": 60.13
 			}
 		},
 		"src/vs/platform/agentHost/node/codex/codexAppServerClient.ts": {
@@ -3887,24 +3887,24 @@
 		},
 		"src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts": {
 			"statements": {
-				"covered": 471,
+				"covered": 493,
 				"total": 1060,
-				"percentage": 44.43
+				"percentage": 46.5
 			},
 			"branches": {
-				"covered": 18,
-				"total": 44,
-				"percentage": 40.9
+				"covered": 20,
+				"total": 49,
+				"percentage": 40.81
 			},
 			"functions": {
-				"covered": 11,
+				"covered": 12,
 				"total": 32,
-				"percentage": 34.37
+				"percentage": 37.5
 			},
 			"lines": {
-				"covered": 471,
+				"covered": 493,
 				"total": 1060,
-				"percentage": 44.43
+				"percentage": 46.5
 			}
 		},
 		"src/vs/platform/agentHost/node/codex/codexMcpServers.ts": {
@@ -4019,14 +4019,14 @@
 		},
 		"src/vs/platform/agentHost/node/codex/codexSessionMetadataStore.ts": {
 			"statements": {
-				"covered": 97,
+				"covered": 107,
 				"total": 112,
-				"percentage": 86.6
+				"percentage": 95.53
 			},
 			"branches": {
-				"covered": 3,
-				"total": 10,
-				"percentage": 30
+				"covered": 8,
+				"total": 11,
+				"percentage": 72.72
 			},
 			"functions": {
 				"covered": 3,
@@ -4034,9 +4034,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 97,
+				"covered": 107,
 				"total": 112,
-				"percentage": 86.6
+				"percentage": 95.53
 			}
 		},
 		"src/vs/platform/agentHost/node/codex/codexShellCommand.ts": {
@@ -4046,9 +4046,9 @@
 				"percentage": 90.47
 			},
 			"branches": {
-				"covered": 5,
-				"total": 8,
-				"percentage": 62.5
+				"covered": 6,
+				"total": 9,
+				"percentage": 66.66
 			},
 			"functions": {
 				"covered": 2,
@@ -4195,46 +4195,46 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgent.ts": {
 			"statements": {
-				"covered": 2653,
+				"covered": 2910,
 				"total": 4198,
-				"percentage": 63.19
+				"percentage": 69.31
 			},
 			"branches": {
-				"covered": 276,
-				"total": 444,
-				"percentage": 62.16
+				"covered": 319,
+				"total": 525,
+				"percentage": 60.76
 			},
 			"functions": {
-				"covered": 122,
+				"covered": 137,
 				"total": 186,
-				"percentage": 65.59
+				"percentage": 73.65
 			},
 			"lines": {
-				"covered": 2653,
+				"covered": 2910,
 				"total": 4198,
-				"percentage": 63.19
+				"percentage": 69.31
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts": {
 			"statements": {
-				"covered": 2766,
-				"total": 4354,
-				"percentage": 63.52
+				"covered": 2807,
+				"total": 4357,
+				"percentage": 64.42
 			},
 			"branches": {
-				"covered": 343,
-				"total": 561,
-				"percentage": 61.14
+				"covered": 367,
+				"total": 595,
+				"percentage": 61.68
 			},
 			"functions": {
-				"covered": 92,
+				"covered": 102,
 				"total": 151,
-				"percentage": 60.92
+				"percentage": 67.54
 			},
 			"lines": {
-				"covered": 2766,
-				"total": 4354,
-				"percentage": 63.52
+				"covered": 2807,
+				"total": 4357,
+				"percentage": 64.42
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts": {
@@ -4305,14 +4305,14 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts": {
 			"statements": {
-				"covered": 474,
+				"covered": 485,
 				"total": 635,
-				"percentage": 74.64
+				"percentage": 76.37
 			},
 			"branches": {
-				"covered": 39,
-				"total": 62,
-				"percentage": 62.9
+				"covered": 44,
+				"total": 66,
+				"percentage": 66.66
 			},
 			"functions": {
 				"covered": 19,
@@ -4320,43 +4320,43 @@
 				"percentage": 67.85
 			},
 			"lines": {
-				"covered": 474,
+				"covered": 485,
 				"total": 635,
-				"percentage": 74.64
+				"percentage": 76.37
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts": {
 			"statements": {
-				"covered": 274,
+				"covered": 275,
 				"total": 275,
-				"percentage": 99.63
+				"percentage": 100
 			},
 			"branches": {
-				"covered": 52,
-				"total": 52,
+				"covered": 54,
+				"total": 54,
 				"percentage": 100
 			},
 			"functions": {
-				"covered": 49,
+				"covered": 50,
 				"total": 51,
-				"percentage": 96.07
+				"percentage": 98.03
 			},
 			"lines": {
-				"covered": 274,
+				"covered": 275,
 				"total": 275,
-				"percentage": 99.63
+				"percentage": 100
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotShellTools.ts": {
 			"statements": {
-				"covered": 499,
+				"covered": 505,
 				"total": 811,
-				"percentage": 61.52
+				"percentage": 62.26
 			},
 			"branches": {
-				"covered": 20,
-				"total": 41,
-				"percentage": 48.78
+				"covered": 21,
+				"total": 44,
+				"percentage": 47.72
 			},
 			"functions": {
 				"covered": 16,
@@ -4364,9 +4364,9 @@
 				"percentage": 51.61
 			},
 			"lines": {
-				"covered": 499,
+				"covered": 505,
 				"total": 811,
-				"percentage": 61.52
+				"percentage": 62.26
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts": {
@@ -4481,14 +4481,14 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts": {
 			"statements": {
-				"covered": 531,
-				"total": 802,
-				"percentage": 66.2
+				"covered": 532,
+				"total": 796,
+				"percentage": 66.83
 			},
 			"branches": {
 				"covered": 82,
-				"total": 142,
-				"percentage": 57.74
+				"total": 144,
+				"percentage": 56.94
 			},
 			"functions": {
 				"covered": 17,
@@ -4496,9 +4496,9 @@
 				"percentage": 94.44
 			},
 			"lines": {
-				"covered": 531,
-				"total": 802,
-				"percentage": 66.2
+				"covered": 532,
+				"total": 796,
+				"percentage": 66.83
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/pendingEditContentStore.ts": {
@@ -4899,24 +4899,24 @@
 		},
 		"src/vs/platform/agentHost/node/protocolServerHandler.ts": {
 			"statements": {
-				"covered": 1057,
+				"covered": 1101,
 				"total": 1569,
-				"percentage": 67.36
+				"percentage": 70.17
 			},
 			"branches": {
-				"covered": 129,
-				"total": 197,
-				"percentage": 65.48
+				"covered": 138,
+				"total": 216,
+				"percentage": 63.88
 			},
 			"functions": {
-				"covered": 46,
+				"covered": 49,
 				"total": 81,
-				"percentage": 56.79
+				"percentage": 60.49
 			},
 			"lines": {
-				"covered": 1057,
+				"covered": 1101,
 				"total": 1569,
-				"percentage": 67.36
+				"percentage": 70.17
 			}
 		},
 		"src/vs/platform/agentHost/node/serverUrls.ts": {
@@ -4965,24 +4965,24 @@
 		},
 		"src/vs/platform/agentHost/node/sessionDatabase.ts": {
 			"statements": {
-				"covered": 516,
+				"covered": 592,
 				"total": 778,
-				"percentage": 66.32
+				"percentage": 76.09
 			},
 			"branches": {
-				"covered": 68,
-				"total": 91,
-				"percentage": 74.72
+				"covered": 79,
+				"total": 104,
+				"percentage": 75.96
 			},
 			"functions": {
-				"covered": 27,
+				"covered": 31,
 				"total": 51,
-				"percentage": 52.94
+				"percentage": 60.78
 			},
 			"lines": {
-				"covered": 516,
+				"covered": 592,
 				"total": 778,
-				"percentage": 66.32
+				"percentage": 76.09
 			}
 		},
 		"src/vs/platform/agentHost/node/sessionDiffAggregator.ts": {
@@ -5383,24 +5383,24 @@
 		},
 		"src/vs/platform/agentHost/node/shared/worktreeIsolation.ts": {
 			"statements": {
-				"covered": 637,
+				"covered": 639,
 				"total": 822,
-				"percentage": 77.49
+				"percentage": 77.73
 			},
 			"branches": {
-				"covered": 66,
-				"total": 102,
-				"percentage": 64.7
+				"covered": 67,
+				"total": 104,
+				"percentage": 64.42
 			},
 			"functions": {
-				"covered": 29,
+				"covered": 30,
 				"total": 40,
-				"percentage": 72.5
+				"percentage": 75
 			},
 			"lines": {
-				"covered": 637,
+				"covered": 639,
 				"total": 822,
-				"percentage": 77.49
+				"percentage": 77.73
 			}
 		},
 		"src/vs/platform/agentHost/node/webSocketTransport.ts": {

--- a/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
+++ b/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
@@ -14,24 +14,24 @@
 	},
 	"total": {
 		"statements": {
-			"covered": 60310,
+			"covered": 60426,
 			"total": 85014,
-			"percentage": 70.94
+			"percentage": 71.07
 		},
 		"branches": {
-			"covered": 4999,
-			"total": 7980,
-			"percentage": 62.64
+			"covered": 5099,
+			"total": 8061,
+			"percentage": 63.25
 		},
 		"functions": {
-			"covered": 1969,
+			"covered": 1977,
 			"total": 3207,
-			"percentage": 61.39
+			"percentage": 61.64
 		},
 		"lines": {
-			"covered": 60310,
+			"covered": 60426,
 			"total": 85014,
-			"percentage": 70.94
+			"percentage": 71.07
 		}
 	},
 	"files": {
@@ -1115,14 +1115,14 @@
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-chat/reducer.ts": {
 			"statements": {
-				"covered": 567,
+				"covered": 575,
 				"total": 809,
-				"percentage": 70.08
+				"percentage": 71.07
 			},
 			"branches": {
-				"covered": 103,
-				"total": 171,
-				"percentage": 60.23
+				"covered": 111,
+				"total": 175,
+				"percentage": 63.42
 			},
 			"functions": {
 				"covered": 14,
@@ -1130,9 +1130,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 567,
+				"covered": 575,
 				"total": 809,
-				"percentage": 70.08
+				"percentage": 71.07
 			}
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-resource-watch/reducer.ts": {
@@ -1802,9 +1802,9 @@
 				"percentage": 63.49
 			},
 			"branches": {
-				"covered": 89,
-				"total": 130,
-				"percentage": 68.46
+				"covered": 91,
+				"total": 132,
+				"percentage": 68.93
 			},
 			"functions": {
 				"covered": 33,
@@ -2264,9 +2264,9 @@
 				"percentage": 97.56
 			},
 			"branches": {
-				"covered": 10,
-				"total": 11,
-				"percentage": 90.9
+				"covered": 11,
+				"total": 12,
+				"percentage": 91.66
 			},
 			"functions": {
 				"covered": 3,
@@ -2374,9 +2374,9 @@
 				"percentage": 86.19
 			},
 			"branches": {
-				"covered": 74,
-				"total": 97,
-				"percentage": 76.28
+				"covered": 79,
+				"total": 100,
+				"percentage": 79
 			},
 			"functions": {
 				"covered": 22,
@@ -2589,14 +2589,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostToolCallTracker.ts": {
 			"statements": {
-				"covered": 160,
+				"covered": 164,
 				"total": 203,
-				"percentage": 78.81
+				"percentage": 80.78
 			},
 			"branches": {
-				"covered": 22,
+				"covered": 23,
 				"total": 30,
-				"percentage": 73.33
+				"percentage": 76.66
 			},
 			"functions": {
 				"covered": 10,
@@ -2604,9 +2604,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 160,
+				"covered": 164,
 				"total": 203,
-				"percentage": 78.81
+				"percentage": 80.78
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostTurnTracker.ts": {
@@ -2770,9 +2770,9 @@
 				"percentage": 82.58
 			},
 			"branches": {
-				"covered": 210,
-				"total": 284,
-				"percentage": 73.94
+				"covered": 223,
+				"total": 295,
+				"percentage": 75.59
 			},
 			"functions": {
 				"covered": 45,
@@ -2875,14 +2875,14 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeAgent.ts": {
 			"statements": {
-				"covered": 1635,
+				"covered": 1633,
 				"total": 2241,
-				"percentage": 72.95
+				"percentage": 72.86
 			},
 			"branches": {
 				"covered": 151,
-				"total": 240,
-				"percentage": 62.91
+				"total": 241,
+				"percentage": 62.65
 			},
 			"functions": {
 				"covered": 66,
@@ -2890,9 +2890,9 @@
 				"percentage": 74.15
 			},
 			"lines": {
-				"covered": 1635,
+				"covered": 1633,
 				"total": 2241,
-				"percentage": 72.95
+				"percentage": 72.86
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts": {
@@ -2919,14 +2919,14 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeAgentSession.ts": {
 			"statements": {
-				"covered": 946,
+				"covered": 911,
 				"total": 1121,
-				"percentage": 84.38
+				"percentage": 81.26
 			},
 			"branches": {
-				"covered": 54,
-				"total": 83,
-				"percentage": 65.06
+				"covered": 51,
+				"total": 80,
+				"percentage": 63.75
 			},
 			"functions": {
 				"covered": 27,
@@ -2934,9 +2934,9 @@
 				"percentage": 52.94
 			},
 			"lines": {
-				"covered": 946,
+				"covered": 911,
 				"total": 1121,
-				"percentage": 84.38
+				"percentage": 81.26
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts": {
@@ -3117,24 +3117,24 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudePromptResolver.ts": {
 			"statements": {
-				"covered": 38,
+				"covered": 81,
 				"total": 94,
-				"percentage": 40.42
+				"percentage": 86.17
 			},
 			"branches": {
-				"covered": 1,
-				"total": 3,
-				"percentage": 33.33
+				"covered": 17,
+				"total": 22,
+				"percentage": 77.27
 			},
 			"functions": {
-				"covered": 1,
+				"covered": 2,
 				"total": 2,
-				"percentage": 50
+				"percentage": 100
 			},
 			"lines": {
-				"covered": 38,
+				"covered": 81,
 				"total": 94,
-				"percentage": 40.42
+				"percentage": 86.17
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeProxyAuth.ts": {
@@ -3227,14 +3227,14 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts": {
 			"statements": {
-				"covered": 228,
+				"covered": 227,
 				"total": 244,
-				"percentage": 93.44
+				"percentage": 93.03
 			},
 			"branches": {
-				"covered": 12,
-				"total": 21,
-				"percentage": 57.14
+				"covered": 10,
+				"total": 19,
+				"percentage": 52.63
 			},
 			"functions": {
 				"covered": 3,
@@ -3242,31 +3242,31 @@
 				"percentage": 75
 			},
 			"lines": {
-				"covered": 228,
+				"covered": 227,
 				"total": 244,
-				"percentage": 93.44
+				"percentage": 93.03
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts": {
 			"statements": {
-				"covered": 551,
+				"covered": 530,
 				"total": 703,
-				"percentage": 78.37
+				"percentage": 75.39
 			},
 			"branches": {
-				"covered": 42,
-				"total": 68,
-				"percentage": 61.76
+				"covered": 37,
+				"total": 61,
+				"percentage": 60.65
 			},
 			"functions": {
-				"covered": 20,
+				"covered": 19,
 				"total": 30,
-				"percentage": 66.66
+				"percentage": 63.33
 			},
 			"lines": {
-				"covered": 551,
+				"covered": 530,
 				"total": 703,
-				"percentage": 78.37
+				"percentage": 75.39
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeServerToolMcpServer.ts": {
@@ -3320,8 +3320,8 @@
 				"percentage": 100
 			},
 			"branches": {
-				"covered": 2,
-				"total": 2,
+				"covered": 1,
+				"total": 1,
 				"percentage": 100
 			},
 			"functions": {
@@ -3452,9 +3452,9 @@
 				"percentage": 74.67
 			},
 			"branches": {
-				"covered": 50,
-				"total": 125,
-				"percentage": 40
+				"covered": 51,
+				"total": 126,
+				"percentage": 40.47
 			},
 			"functions": {
 				"covered": 14,
@@ -4019,14 +4019,14 @@
 		},
 		"src/vs/platform/agentHost/node/codex/codexSessionMetadataStore.ts": {
 			"statements": {
-				"covered": 97,
+				"covered": 107,
 				"total": 112,
-				"percentage": 86.6
+				"percentage": 95.53
 			},
 			"branches": {
-				"covered": 3,
-				"total": 10,
-				"percentage": 30
+				"covered": 8,
+				"total": 11,
+				"percentage": 72.72
 			},
 			"functions": {
 				"covered": 3,
@@ -4034,9 +4034,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 97,
+				"covered": 107,
 				"total": 112,
-				"percentage": 86.6
+				"percentage": 95.53
 			}
 		},
 		"src/vs/platform/agentHost/node/codex/codexShellCommand.ts": {
@@ -4085,14 +4085,14 @@
 		},
 		"src/vs/platform/agentHost/node/commandAutoApprover.ts": {
 			"statements": {
-				"covered": 512,
+				"covered": 523,
 				"total": 595,
-				"percentage": 86.05
+				"percentage": 87.89
 			},
 			"branches": {
-				"covered": 53,
-				"total": 88,
-				"percentage": 60.22
+				"covered": 60,
+				"total": 91,
+				"percentage": 65.93
 			},
 			"functions": {
 				"covered": 14,
@@ -4100,9 +4100,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 512,
+				"covered": 523,
 				"total": 595,
-				"percentage": 86.05
+				"percentage": 87.89
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/agentHostSandboxEngine.ts": {
@@ -4195,14 +4195,14 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgent.ts": {
 			"statements": {
-				"covered": 2931,
+				"covered": 2920,
 				"total": 4229,
-				"percentage": 69.3
+				"percentage": 69.04
 			},
 			"branches": {
 				"covered": 319,
-				"total": 533,
-				"percentage": 59.84
+				"total": 531,
+				"percentage": 60.07
 			},
 			"functions": {
 				"covered": 140,
@@ -4210,31 +4210,31 @@
 				"percentage": 74.07
 			},
 			"lines": {
-				"covered": 2931,
+				"covered": 2920,
 				"total": 4229,
-				"percentage": 69.3
+				"percentage": 69.04
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts": {
 			"statements": {
-				"covered": 2728,
+				"covered": 2796,
 				"total": 4357,
-				"percentage": 62.61
+				"percentage": 64.17
 			},
 			"branches": {
-				"covered": 344,
-				"total": 555,
-				"percentage": 61.98
+				"covered": 380,
+				"total": 586,
+				"percentage": 64.84
 			},
 			"functions": {
-				"covered": 100,
+				"covered": 103,
 				"total": 151,
-				"percentage": 66.22
+				"percentage": 68.21
 			},
 			"lines": {
-				"covered": 2728,
+				"covered": 2796,
 				"total": 4357,
-				"percentage": 62.61
+				"percentage": 64.17
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts": {
@@ -4459,14 +4459,14 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts": {
 			"statements": {
-				"covered": 885,
+				"covered": 899,
 				"total": 1201,
-				"percentage": 73.68
+				"percentage": 74.85
 			},
 			"branches": {
-				"covered": 84,
-				"total": 210,
-				"percentage": 40
+				"covered": 86,
+				"total": 216,
+				"percentage": 39.81
 			},
 			"functions": {
 				"covered": 21,
@@ -4474,9 +4474,9 @@
 				"percentage": 67.74
 			},
 			"lines": {
-				"covered": 885,
+				"covered": 899,
 				"total": 1201,
-				"percentage": 73.68
+				"percentage": 74.85
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts": {
@@ -4503,24 +4503,24 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/pendingEditContentStore.ts": {
 			"statements": {
-				"covered": 41,
+				"covered": 47,
 				"total": 47,
-				"percentage": 87.23
+				"percentage": 100
 			},
 			"branches": {
-				"covered": 2,
-				"total": 2,
+				"covered": 3,
+				"total": 3,
 				"percentage": 100
 			},
 			"functions": {
-				"covered": 2,
+				"covered": 3,
 				"total": 3,
-				"percentage": 66.66
+				"percentage": 100
 			},
 			"lines": {
-				"covered": 41,
+				"covered": 47,
 				"total": 47,
-				"percentage": 87.23
+				"percentage": 100
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/prompts/allPrompts.ts": {
@@ -4657,14 +4657,14 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/sessionCustomizationDiscovery.ts": {
 			"statements": {
-				"covered": 464,
+				"covered": 462,
 				"total": 1116,
-				"percentage": 41.57
+				"percentage": 41.39
 			},
 			"branches": {
-				"covered": 68,
-				"total": 85,
-				"percentage": 80
+				"covered": 62,
+				"total": 80,
+				"percentage": 77.5
 			},
 			"functions": {
 				"covered": 16,
@@ -4672,9 +4672,9 @@
 				"percentage": 50
 			},
 			"lines": {
-				"covered": 464,
+				"covered": 462,
 				"total": 1116,
-				"percentage": 41.57
+				"percentage": 41.39
 			}
 		},
 		"src/vs/platform/agentHost/node/diffComputeService.ts": {
@@ -4772,14 +4772,14 @@
 				"percentage": 93.62
 			},
 			"branches": {
-				"covered": 24,
-				"total": 33,
-				"percentage": 72.72
+				"covered": 25,
+				"total": 34,
+				"percentage": 73.52
 			},
 			"functions": {
-				"covered": 11,
+				"covered": 12,
 				"total": 12,
-				"percentage": 91.66
+				"percentage": 100
 			},
 			"lines": {
 				"covered": 235,
@@ -4811,14 +4811,14 @@
 		},
 		"src/vs/platform/agentHost/node/localCommands/renameLocalCommand.ts": {
 			"statements": {
-				"covered": 67,
+				"covered": 70,
 				"total": 70,
-				"percentage": 95.71
+				"percentage": 100
 			},
 			"branches": {
-				"covered": 11,
-				"total": 14,
-				"percentage": 78.57
+				"covered": 15,
+				"total": 16,
+				"percentage": 93.75
 			},
 			"functions": {
 				"covered": 5,
@@ -4826,9 +4826,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 67,
+				"covered": 70,
 				"total": 70,
-				"percentage": 95.71
+				"percentage": 100
 			}
 		},
 		"src/vs/platform/agentHost/node/networkDiagnosticsService.ts": {
@@ -4899,14 +4899,14 @@
 		},
 		"src/vs/platform/agentHost/node/protocolServerHandler.ts": {
 			"statements": {
-				"covered": 1104,
+				"covered": 1103,
 				"total": 1569,
-				"percentage": 70.36
+				"percentage": 70.29
 			},
 			"branches": {
-				"covered": 143,
-				"total": 220,
-				"percentage": 65
+				"covered": 139,
+				"total": 216,
+				"percentage": 64.35
 			},
 			"functions": {
 				"covered": 49,
@@ -4914,9 +4914,9 @@
 				"percentage": 60.49
 			},
 			"lines": {
-				"covered": 1104,
+				"covered": 1103,
 				"total": 1569,
-				"percentage": 70.36
+				"percentage": 70.29
 			}
 		},
 		"src/vs/platform/agentHost/node/serverUrls.ts": {
@@ -4992,9 +4992,9 @@
 				"percentage": 51.08
 			},
 			"branches": {
-				"covered": 13,
-				"total": 28,
-				"percentage": 46.42
+				"covered": 15,
+				"total": 30,
+				"percentage": 50
 			},
 			"functions": {
 				"covered": 3,
@@ -5009,24 +5009,24 @@
 		},
 		"src/vs/platform/agentHost/node/sessionPermissions.ts": {
 			"statements": {
-				"covered": 448,
+				"covered": 458,
 				"total": 583,
-				"percentage": 76.84
+				"percentage": 78.55
 			},
 			"branches": {
-				"covered": 57,
-				"total": 94,
-				"percentage": 60.63
+				"covered": 64,
+				"total": 104,
+				"percentage": 61.53
 			},
 			"functions": {
-				"covered": 20,
+				"covered": 23,
 				"total": 24,
-				"percentage": 83.33
+				"percentage": 95.83
 			},
 			"lines": {
-				"covered": 448,
+				"covered": 458,
 				"total": 583,
-				"percentage": 76.84
+				"percentage": 78.55
 			}
 		},
 		"src/vs/platform/agentHost/node/shared/agentBranchNameGenerator.ts": {
@@ -5141,14 +5141,14 @@
 		},
 		"src/vs/platform/agentHost/node/shared/editChunkExtractor.ts": {
 			"statements": {
-				"covered": 122,
+				"covered": 123,
 				"total": 227,
-				"percentage": 53.74
+				"percentage": 54.18
 			},
 			"branches": {
-				"covered": 4,
+				"covered": 5,
 				"total": 15,
-				"percentage": 26.66
+				"percentage": 33.33
 			},
 			"functions": {
 				"covered": 2,
@@ -5156,9 +5156,9 @@
 				"percentage": 40
 			},
 			"lines": {
-				"covered": 122,
+				"covered": 123,
 				"total": 227,
-				"percentage": 53.74
+				"percentage": 54.18
 			}
 		},
 		"src/vs/platform/agentHost/node/shared/editSurvivalReporter.ts": {
@@ -5168,9 +5168,9 @@
 				"percentage": 88.16
 			},
 			"branches": {
-				"covered": 9,
-				"total": 26,
-				"percentage": 34.61
+				"covered": 11,
+				"total": 27,
+				"percentage": 40.74
 			},
 			"functions": {
 				"covered": 5,
@@ -5190,9 +5190,9 @@
 				"percentage": 86.86
 			},
 			"branches": {
-				"covered": 17,
-				"total": 25,
-				"percentage": 68
+				"covered": 18,
+				"total": 26,
+				"percentage": 69.23
 			},
 			"functions": {
 				"covered": 6,
@@ -5212,9 +5212,9 @@
 				"percentage": 87.44
 			},
 			"branches": {
-				"covered": 20,
-				"total": 26,
-				"percentage": 76.92
+				"covered": 22,
+				"total": 28,
+				"percentage": 78.57
 			},
 			"functions": {
 				"covered": 7,
@@ -5383,14 +5383,14 @@
 		},
 		"src/vs/platform/agentHost/node/shared/worktreeIsolation.ts": {
 			"statements": {
-				"covered": 628,
+				"covered": 639,
 				"total": 822,
-				"percentage": 76.39
+				"percentage": 77.73
 			},
 			"branches": {
-				"covered": 63,
-				"total": 101,
-				"percentage": 62.37
+				"covered": 66,
+				"total": 103,
+				"percentage": 64.07
 			},
 			"functions": {
 				"covered": 30,
@@ -5398,9 +5398,9 @@
 				"percentage": 75
 			},
 			"lines": {
-				"covered": 628,
+				"covered": 639,
 				"total": 822,
-				"percentage": 76.39
+				"percentage": 77.73
 			}
 		},
 		"src/vs/platform/agentHost/node/webSocketTransport.ts": {

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -46,6 +46,13 @@ const UPDATE_SNAPSHOTS = process.env[AgentHostUpdateSnapshotsEnvVar] === '1';
 const RECORD = process.env['AGENT_HOST_REPLAY_RECORD'] === '1' || UPDATE_SNAPSHOTS;
 const REPLAY_MODE: CapiReplayMode = RECORD ? 'record' : 'replay';
 const SERVER_SHUTDOWN_TIMEOUT_MS = 30_000;
+
+/**
+ * Upper bound on tests served by a single shared replay server before it is
+ * proactively recycled. Amortizes startup across many tests while keeping each
+ * cached provider subprocess well within the range where it stays healthy.
+ */
+const MAX_TESTS_PER_SHARED_SERVER = 25;
 const TEMP_DIR_CLEANUP_TIMEOUT_MS = 30_000;
 /** A synthetic token used on replay (no real credential needed). */
 export const REPLAY_PLACEHOLDER_TOKEN = 'replay-no-token';
@@ -610,6 +617,15 @@ export class AgentHostE2EServerLease {
 	private _client: TestProtocolClient | undefined;
 	private readonly _shared: boolean;
 	private _dataDir: string | undefined;
+	/**
+	 * Number of tests served by the current shared server. A single long-lived
+	 * host caches one provider SDK/CLI subprocess and reuses it across every
+	 * test; after enough sessions that subprocess can accumulate state and
+	 * eventually wedge a turn (turn starts, but no model response arrives even
+	 * though replay is instant). Recycling the server well before that keeps each
+	 * host instance within its reliable range while still amortizing startup.
+	 */
+	private _testsOnCurrentServer = 0;
 	private readonly _startOptions: { readonly claudeSdkRoot?: string; readonly codexSdkRoot?: string; readonly homeDir: string; readonly userDataDir: string };
 
 	constructor(
@@ -633,6 +649,11 @@ export class AgentHostE2EServerLease {
 	/** Acquire a server + connected client for a test, returning both. */
 	async acquire(testTitle: string, modelTraffic: AgentHostE2EModelTraffic = 'recorded'): Promise<{ server: IServerHandle; client: TestProtocolClient }> {
 		const capiReplay = capiReplayFor(this._config.provider, testTitle, modelTraffic);
+		// Proactively recycle a shared server that has served enough tests, before
+		// its cached provider subprocess can degrade and wedge a turn.
+		if (this._shared && this._server && this._testsOnCurrentServer >= MAX_TESTS_PER_SHARED_SERVER) {
+			await this._recycleSharedServer();
+		}
 		if (this._shared && this._server) {
 			const proxy = this._server.capiReplay;
 			if (!proxy) {
@@ -641,7 +662,9 @@ export class AgentHostE2EServerLease {
 			proxy.resetForReplay(capiReplay.fixturePath);
 		} else {
 			this._server = await startRealServer({ ...this._startOptions, capiReplay });
+			this._testsOnCurrentServer = 0;
 		}
+		this._testsOnCurrentServer++;
 		this._client = new TestProtocolClient(
 			this._server.port,
 			() => this._server?.capiReplay?.takeCacheMissError(),
@@ -651,16 +674,35 @@ export class AgentHostE2EServerLease {
 		return { server: this._server, client: this._client };
 	}
 
+	/** Stop the current shared server so the next {@link acquire} starts a fresh one. */
+	private async _recycleSharedServer(): Promise<void> {
+		try {
+			await this._server?.capiReplay?.close();
+		} finally {
+			await stopServer(this._server);
+			this._server = undefined;
+			this._testsOnCurrentServer = 0;
+		}
+	}
+
 	get observedModelRequestBodies(): readonly string[] {
 		return this._server?.capiReplay?.observedModelRequestBodies ?? [];
 	}
 
 	/**
 	 * Release a test: dispose its sessions, disconnect the client, and verify the
-	 * replay traffic. A shared server is kept alive (with its cached SDK client)
-	 * for the next test; a per-test server is stopped.
+	 * replay traffic. A shared server is normally kept alive (with its cached SDK
+	 * client) for the next test; a per-test server is stopped.
+	 *
+	 * Pass `forceRestart` when the just-run test failed. A failed test can leave
+	 * a mid-turn session that wedges (or has already killed) the shared host, so
+	 * reusing it would cascade `ECONNREFUSED` / `createSession` timeouts into the
+	 * next, unrelated test. Restarting isolates the failure to the one test that
+	 * caused it. The strict cache-miss assertion is also skipped on restart: the
+	 * test already failed for its own reason, and a secondary cache-miss throw
+	 * would only obscure it.
 	 */
-	async release(createdSessions: string[]): Promise<void> {
+	async release(createdSessions: string[], forceRestart = false): Promise<void> {
 		const client = this._client;
 		if (client) {
 			for (const session of createdSessions) {
@@ -681,15 +723,19 @@ export class AgentHostE2EServerLease {
 		createdSessions.length = 0;
 		this._client = undefined;
 
-		if (this._shared) {
+		if (this._shared && !forceRestart) {
 			// Surface this test's strict cache-misses but keep the server (and its
 			// cached SDK client) alive for the next test.
 			this._server?.capiReplay?.assertNoCacheMisses();
 		} else {
-			// Flush the recording / surface strict replay cache-misses before the
-			// process goes away. Kill even if the strict check throws.
+			// Per-test server, or a shared server being restarted after a failure.
+			// Flush the recording / surface strict replay cache-misses (unless the
+			// test already failed) before the process goes away. Kill even if the
+			// strict check throws.
 			try {
-				await this._server?.capiReplay?.stop();
+				if (!forceRestart) {
+					await this._server?.capiReplay?.stop();
+				}
 			} finally {
 				await stopServer(this._server);
 				this._server = undefined;

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -236,6 +236,11 @@ export interface IAgentHostE2EProviderConfig {
 	 * shared test prompt doesn't reliably drive it to `ExitPlanMode`.
 	 */
 	readonly supportsPlanMode: boolean;
+	/** Whether the provider supports additional peer chats and chat forks. */
+	readonly supportsMultipleChats: boolean;
+	readonly supportsChatFork: boolean;
+	/** Whether provider-backed fork context can be tested end-to-end. */
+	readonly supportsChatForkE2E: boolean;
 
 	/**
 	 * The github token to use. If not provided, the test will attempt to resolve it from the environment or `gh auth token`.
@@ -644,6 +649,10 @@ export class AgentHostE2EServerLease {
 		);
 		await this._client.connect();
 		return { server: this._server, client: this._client };
+	}
+
+	get observedModelRequestBodies(): readonly string[] {
+		return this._server?.capiReplay?.observedModelRequestBodies ?? [];
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
@@ -223,6 +223,7 @@ export class CapiReplayProxy {
 	private readonly _replayBuckets = new Map<string, IReplayBucket>();
 	/** Exchanges captured during recording, in arrival order. */
 	private readonly _recorded: IRecordedExchange[] = [];
+	private readonly _observedModelRequestBodies: string[] = [];
 	private readonly _cacheMisses: string[] = [];
 	private _workingDirectory: string | undefined;
 
@@ -321,12 +322,17 @@ export class CapiReplayProxy {
 		this._fixturePath = fixturePath;
 		this._workingDirectory = undefined;
 		this._replayBuckets.clear();
+		this._observedModelRequestBodies.length = 0;
 		this._cacheMisses.length = 0;
 		this._loadFixture();
 	}
 
 	setWorkingDirectory(workingDirectory: string): void {
 		this._workingDirectory = workingDirectory;
+	}
+
+	get observedModelRequestBodies(): readonly string[] {
+		return this._observedModelRequestBodies;
 	}
 
 	/**
@@ -412,6 +418,9 @@ export class CapiReplayProxy {
 		}
 
 		const key = `${method} ${path}`;
+		if (MODEL_ENDPOINTS.has(path)) {
+			this._observedModelRequestBodies.push(this._normalize(body));
+		}
 		const bucket = this._replayBuckets.get(key);
 
 		let item: IReplayItem | undefined;
@@ -451,6 +460,9 @@ export class CapiReplayProxy {
 	private _record(req: http.IncomingMessage, body: string, res: http.ServerResponse): void {
 		const method = req.method ?? 'GET';
 		const path = new URL(req.url ?? '/', 'http://localhost').pathname;
+		if (MODEL_ENDPOINTS.has(path)) {
+			this._observedModelRequestBodies.push(this._normalize(body));
+		}
 		const upstreamBase = this._upstreamFor(path);
 		const upstream = new URL(req.url ?? '/', upstreamBase);
 		const isHttps = upstream.protocol === 'https:';

--- a/src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts
@@ -78,6 +78,11 @@ const CLAUDE_CONFIG: IAgentHostE2EProviderConfig = {
 	// shared test's Copilot-flavoured prompt doesn't reliably drive Claude
 	// to invoke it. TODO: rework the prompt for Claude conventions.
 	supportsPlanMode: false,
+	supportsMultipleChats: true,
+	supportsChatFork: true,
+	// The Claude SDK currently receives the AHP turn id as upToMessageId and
+	// rejects it as invalid when the fork is exercised against a real transcript.
+	supportsChatForkE2E: false,
 };
 
 defineAgentHostE2ETests(CLAUDE_CONFIG);

--- a/src/vs/platform/agentHost/test/node/e2e/providers/codexTestConfiguration.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/codexTestConfiguration.ts
@@ -27,5 +27,8 @@ export const CODEX_CONFIG: IAgentHostE2EProviderConfig = {
 	supportsHostTerminalTool: false,
 	supportsSubagents: false,
 	supportsPlanMode: false,
+	supportsMultipleChats: false,
+	supportsChatFork: false,
+	supportsChatForkE2E: false,
 	shellToolReplayUnstableOnLinux: true,
 };

--- a/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
@@ -53,6 +53,9 @@ const COPILOT_CONFIG: IAgentHostE2EProviderConfig = {
 	supportsHostTerminalTool: true,
 	supportsSubagents: true,
 	supportsPlanMode: true,
+	supportsMultipleChats: true,
+	supportsChatFork: true,
+	supportsChatForkE2E: true,
 };
 
 defineAgentHostE2ETests(COPILOT_CONFIG);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
@@ -8,6 +8,7 @@ import type { TestProtocolClient } from '../../serverIntegrationTestHelpers.js';
 import { defineCoreTests } from './coreSuite.js';
 import { defineFileOperationsTests } from './fileOperationsSuite.js';
 import { defineHostFeaturesTests } from './hostFeaturesSuite.js';
+import { defineMultiChatTests } from './multiChatSuite.js';
 import { defineStateOperationsTests } from './stateOperationsSuite.js';
 import { defineSubagentTests } from './subagentSuite.js';
 import { defineTurnLifecycleTests } from './turnLifecycleSuite.js';
@@ -38,6 +39,7 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 			isWindows,
 			runRecordOnlyTests: RUN_RECORD_ONLY_TESTS,
 			registerNoModelTrafficTest: title => noModelTrafficTestTitles.add(title),
+			get observedModelRequestBodies() { return lease?.observedModelRequestBodies ?? []; },
 		};
 
 		suiteSetup(async function () {
@@ -76,6 +78,7 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 
 		defineCoreTests(context);
 		defineHostFeaturesTests(context);
+		defineMultiChatTests(context);
 		defineStateOperationsTests(context);
 		defineFileOperationsTests(context);
 		defineTurnLifecycleTests(context);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
@@ -73,7 +73,11 @@ export function defineAgentHostE2ETests(config: IAgentHostE2EProviderConfig): vo
 			if (!lease) {
 				throw new Error('Agent Host E2E server lease was not initialized.');
 			}
-			await lease.release(createdSessions);
+			// A failed test can leave a mid-turn session that wedges (or already
+			// killed) the shared host; restart it so the failure does not cascade
+			// into the next, unrelated test.
+			const failed = this.currentTest?.state === 'failed';
+			await lease.release(createdSessions, failed);
 		});
 
 		defineCoreTests(context);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
@@ -16,6 +16,7 @@ export interface IAgentHostE2ETestContext {
 	readonly isWindows: boolean;
 	readonly runRecordOnlyTests: boolean;
 	readonly registerNoModelTrafficTest: (title: string) => void;
+	readonly observedModelRequestBodies: readonly string[];
 }
 
 /**

--- a/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
@@ -31,7 +31,7 @@ import { getActionEnvelope, isActionNotification } from '../../serverIntegration
 import { hostOnlyTest, type IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs } = context;
+	const { config, createdSessions, tempDirs, shellToolReplayEnabled } = context;
 
 	async function createSession(prefix: string): Promise<{ sessionUri: string; defaultChatUri: string; workspace: string }> {
 		const workspace = mkdtempSync(join(tmpdir(), `ahp-multichat-${prefix}-`));
@@ -535,6 +535,7 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		assert.strictEqual(readFileSync(file, 'utf8'), 'PEER_CREATED');
 	});
 
+	// Copilot's fixture uses a POSIX shell for this mutation.
 	providerTest('peer chat edits an existing workspace file', async function () {
 		const { sessionUri, workspace } = await createSession('edit-file');
 		const file = join(workspace, 'peer-edit.txt');
@@ -545,8 +546,9 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		await driveTurn(peer, 'peer-edit', `Replace the complete contents of ${file} with AFTER_PEER.`, 1);
 
 		assert.strictEqual(readFileSync(file, 'utf8').trim(), 'AFTER_PEER');
-	});
+	}, config.supportsMultipleChats && (config.provider !== 'copilotcli' || shellToolReplayEnabled));
 
+	// Copilot's fixture uses a POSIX shell for this mutation.
 	providerTest('peer chat creates a file in a nested directory', async function () {
 		const { sessionUri, workspace } = await createSession('nested-create');
 		const file = join(workspace, 'peer-output', 'report.txt');
@@ -556,7 +558,7 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		await driveTurn(peer, 'peer-nested-create', `Create the file at ${file} containing exactly PEER_NESTED.`, 1);
 
 		assert.strictEqual(readFileSync(file, 'utf8'), 'PEER_NESTED');
-	});
+	}, config.supportsMultipleChats && (config.provider !== 'copilotcli' || shellToolReplayEnabled));
 
 	providerTest('peer chat handles a missing workspace file without an error', async function () {
 		const { sessionUri, workspace } = await createSession('missing-file');

--- a/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
@@ -410,12 +410,15 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		const firstResponse = await driveTurn(peer, 'peer-context-1', 'Remember the code word PEAR. Reply exactly "ready".', 1);
 		const response = await driveTurn(peer, 'peer-context-2', 'What code word did I ask you to remember? Reply with only the code word.', 2);
 		const messages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+		const priorAssistantResponse = firstResponse.trim();
 
 		assert.deepStrictEqual({
+			priorAssistantResponseIsNonEmpty: priorAssistantResponse.length > 0,
 			responseHasCodeWord: /PEAR/i.test(response),
 			requestHasPriorUserMessage: messages.some(message => message.role === 'user' && message.content.includes('Remember the code word PEAR')),
-			requestHasPriorAssistantMessage: messages.some(message => message.role === 'assistant' && message.content.includes(firstResponse.trim())),
+			requestHasPriorAssistantMessage: messages.some(message => message.role === 'assistant' && message.content.includes(priorAssistantResponse)),
 		}, {
+			priorAssistantResponseIsNonEmpty: true,
 			responseHasCodeWord: true,
 			requestHasPriorUserMessage: true,
 			requestHasPriorAssistantMessage: true,
@@ -430,17 +433,20 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
 		const response = await driveTurn(peer, 'fork-turn', 'What code word did I ask you to remember? Reply with only the code word.', 2);
 		const messages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+		const priorAssistantResponse = sourceResponse.trim();
 
 		assert.deepStrictEqual({
 			seededMessages: (await chatState(peer)).turns.map(turn => turn.message.text),
+			priorAssistantResponseIsNonEmpty: priorAssistantResponse.length > 0,
 			responseHasCodeWord: /FORKCODE/i.test(response),
 			requestHasPriorUserMessage: messages.some(message => message.role === 'user' && message.content.includes('Remember the code word FORKCODE')),
-			requestHasPriorAssistantMessage: messages.some(message => message.role === 'assistant' && message.content.includes(sourceResponse.trim())),
+			requestHasPriorAssistantMessage: messages.some(message => message.role === 'assistant' && message.content.includes(priorAssistantResponse)),
 		}, {
 			seededMessages: [
 				'Remember the code word FORKCODE. Reply exactly "ready".',
 				'What code word did I ask you to remember? Reply with only the code word.',
 			],
+			priorAssistantResponseIsNonEmpty: true,
 			responseHasCodeWord: true,
 			requestHasPriorUserMessage: true,
 			requestHasPriorAssistantMessage: true,

--- a/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
@@ -1,0 +1,421 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from '../../../../../../base/common/path.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ActionType } from '../../../../common/state/sessionActions.js';
+import { CompletionItemKind, type CompletionsResult, type ListSessionsResult, type SubscribeResult } from '../../../../common/state/protocol/commands.js';
+import {
+	buildChatUri,
+	buildDefaultChatUri,
+	isAhpChatChannel,
+	MessageKind,
+	parseRequiredSessionUriFromChatUri,
+	ResponsePartKind,
+	ROOT_STATE_URI,
+	SessionStatus,
+	type ChatState,
+	type RootState,
+	type SessionState,
+} from '../../../../common/state/sessionState.js';
+import { createRealSession } from '../harness/agentHostE2ETestHarness.js';
+import { getActionEnvelope, isActionNotification } from '../../serverIntegrationTestHelpers.js';
+import { hostOnlyTest, type IAgentHostE2ETestContext } from './e2eTestContext.js';
+
+export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
+	const { config, createdSessions, tempDirs } = context;
+
+	async function createSession(prefix: string): Promise<{ sessionUri: string; defaultChatUri: string; workspace: string }> {
+		const workspace = mkdtempSync(join(tmpdir(), `ahp-multichat-${prefix}-`));
+		tempDirs.push(workspace);
+		const sessionUri = await createRealSession(
+			context.client,
+			config,
+			`${prefix}-${config.provider}`,
+			createdSessions,
+			URI.file(workspace),
+		);
+		return { sessionUri, defaultChatUri: buildDefaultChatUri(sessionUri), workspace };
+	}
+
+	async function createPeer(sessionUri: string, id: string, source?: { chat: string; turnId: string }): Promise<string> {
+		const chat = buildChatUri(sessionUri, id);
+		await context.client.call('createChat', {
+			channel: sessionUri,
+			chat,
+			...(source ? { source } : {}),
+		}, 30_000);
+		return chat;
+	}
+
+	async function sessionState(sessionUri: string): Promise<SessionState> {
+		const result = await context.client.call<SubscribeResult>('subscribe', { channel: sessionUri });
+		return result.snapshot!.state as SessionState;
+	}
+
+	async function chatState(chatUri: string): Promise<ChatState> {
+		const result = await context.client.call<SubscribeResult>('subscribe', { channel: chatUri });
+		return result.snapshot!.state as ChatState;
+	}
+
+	async function rename(channel: string, title: string, clientSeq = 1): Promise<void> {
+		context.client.clearReceived();
+		context.client.dispatch({
+			channel,
+			clientSeq,
+			action: { type: ActionType.SessionTitleChanged, title },
+		});
+		if (isAhpChatChannel(channel)) {
+			const session = parseRequiredSessionUriFromChatUri(channel);
+			await context.client.waitForNotification(n => {
+				if (!isActionNotification(n, 'session/chatUpdated') || getActionEnvelope(n).channel !== session) {
+					return false;
+				}
+				const action = getActionEnvelope(n).action as { chat: string; changes: { title?: string } };
+				return action.chat === channel && action.changes.title === title;
+			});
+		} else {
+			await context.client.waitForNotification(n =>
+				isActionNotification(n, 'session/titleChanged')
+				&& getActionEnvelope(n).channel === channel,
+			);
+		}
+	}
+
+	function providerTest(title: string, run: Mocha.AsyncFunc): void {
+		(config.supportsMultipleChats ? test : test.skip)(title, function () {
+			this.timeout(180_000);
+			return run.call(this);
+		});
+	}
+
+	interface IObservedModelMessage {
+		readonly role: string;
+		readonly content: string;
+	}
+
+	function observedModelMessages(body: string): readonly IObservedModelMessage[] {
+		const request: unknown = JSON.parse(body);
+		if (!isRecord(request) || !Array.isArray(request.messages)) {
+			return [];
+		}
+		return request.messages.flatMap(message => {
+			if (!isRecord(message) || typeof message.role !== 'string') {
+				return [];
+			}
+			return [{ role: message.role, content: modelContentText(message.content) }];
+		});
+	}
+
+	function modelContentText(value: unknown): string {
+		if (typeof value === 'string') {
+			return value;
+		}
+		if (Array.isArray(value)) {
+			return value.map(modelContentText).join('');
+		}
+		if (isRecord(value)) {
+			if (typeof value.text === 'string') {
+				return value.text;
+			}
+			return modelContentText(value.content);
+		}
+		return '';
+	}
+
+	function isRecord(value: unknown): value is Record<string, unknown> {
+		return typeof value === 'object' && value !== null;
+	}
+
+	function forkProviderTest(title: string, run: Mocha.AsyncFunc): void {
+		(config.supportsChatForkE2E ? test : test.skip)(title, function () {
+			this.timeout(180_000);
+			return run.call(this);
+		});
+	}
+
+	async function driveTurn(chatUri: string, turnId: string, text: string, clientSeq: number): Promise<string> {
+		context.client.clearReceived();
+		context.client.dispatch({
+			channel: chatUri,
+			clientSeq,
+			action: {
+				type: ActionType.ChatTurnStarted,
+				turnId,
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text, origin: { kind: MessageKind.User } },
+			},
+		});
+		await context.client.waitForNotification(n =>
+			isActionNotification(n, 'chat/turnComplete')
+			&& getActionEnvelope(n).channel === chatUri
+			&& (getActionEnvelope(n).action as { turnId: string }).turnId === turnId,
+			90_000,
+		);
+
+		const markdownPartIds = new Set<string>();
+		const pieces: string[] = [];
+		for (const notification of context.client.receivedNotifications(n =>
+			(isActionNotification(n, 'chat/responsePart') || isActionNotification(n, 'chat/delta'))
+			&& getActionEnvelope(n).channel === chatUri
+		)) {
+			const action = getActionEnvelope(notification).action;
+			if (action.type === ActionType.ChatResponsePart && action.part.kind === ResponsePartKind.Markdown) {
+				markdownPartIds.add(action.part.id);
+				pieces.push(action.part.content);
+			} else if (action.type === ActionType.ChatDelta && markdownPartIds.has(action.partId)) {
+				pieces.push(action.content);
+			}
+		}
+		return pieces.join('');
+	}
+
+	hostOnlyTest(context, 'agent advertises its multiple chat capability', async function () {
+		await createSession('capability');
+		const root = await context.client.call<SubscribeResult>('subscribe', { channel: ROOT_STATE_URI });
+		const agent = (root.snapshot!.state as RootState).agents.find(agent => agent.provider === config.provider);
+
+		assert.deepStrictEqual({
+			multipleChats: !!agent?.capabilities?.multipleChats,
+			fork: agent?.capabilities?.multipleChats?.fork ?? false,
+		}, {
+			multipleChats: config.supportsMultipleChats,
+			fork: config.supportsChatFork,
+		});
+	});
+
+	hostOnlyTest(context, 'provider without multiple chat capability rejects peer creation', async function () {
+		const { sessionUri } = await createSession('unsupported');
+
+		await assert.rejects(
+			() => createPeer(sessionUri, 'unsupported-peer'),
+			/does not support multiple chats/i,
+		);
+	}, !config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'creating a peer chat adds it to the session catalog', async function () {
+		const { sessionUri } = await createSession('catalog-add');
+		const peer = await createPeer(sessionUri, 'peer');
+
+		assert.ok((await sessionState(sessionUri)).chats.some(chat => chat.resource === peer));
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'peer chat subscription starts empty and idle', async function () {
+		const { sessionUri } = await createSession('empty-peer');
+		const peer = await createPeer(sessionUri, 'peer');
+
+		const state = await chatState(peer);
+
+		assert.deepStrictEqual({ turns: state.turns, activeTurn: state.activeTurn, status: state.status }, {
+			turns: [],
+			activeTurn: undefined,
+			status: SessionStatus.Idle,
+		});
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'creating the same peer chat twice is idempotent', async function () {
+		const { sessionUri } = await createSession('idempotent');
+		const peer = await createPeer(sessionUri, 'peer');
+
+		await createPeer(sessionUri, 'peer');
+
+		assert.strictEqual((await sessionState(sessionUri)).chats.filter(chat => chat.resource === peer).length, 1);
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'creating two peer chats preserves both catalog entries', async function () {
+		const { sessionUri } = await createSession('two-peers');
+		const first = await createPeer(sessionUri, 'first');
+		const second = await createPeer(sessionUri, 'second');
+
+		const peers = (await sessionState(sessionUri)).chats.map(chat => chat.resource);
+
+		assert.ok(peers.includes(first) && peers.includes(second));
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'disposing a peer chat removes its catalog entry', async function () {
+		const { sessionUri } = await createSession('dispose');
+		const peer = await createPeer(sessionUri, 'peer');
+
+		await context.client.call('disposeChat', { channel: peer }, 30_000);
+
+		assert.strictEqual((await sessionState(sessionUri)).chats.some(chat => chat.resource === peer), false);
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'disposing one peer chat preserves its sibling', async function () {
+		const { sessionUri } = await createSession('dispose-one');
+		const first = await createPeer(sessionUri, 'first');
+		const second = await createPeer(sessionUri, 'second');
+
+		await context.client.call('disposeChat', { channel: first }, 30_000);
+
+		const peers = (await sessionState(sessionUri)).chats.map(chat => chat.resource);
+		assert.ok(!peers.includes(first) && peers.includes(second));
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'recreating a disposed peer chat starts empty', async function () {
+		const { sessionUri } = await createSession('recreate');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call('disposeChat', { channel: peer }, 30_000);
+
+		await createPeer(sessionUri, 'peer');
+
+		assert.deepStrictEqual((await chatState(peer)).turns, []);
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'renaming a peer chat updates its catalog title', async function () {
+		const { sessionUri } = await createSession('rename-peer');
+		const peer = await createPeer(sessionUri, 'peer');
+
+		await rename(peer, 'Peer Title');
+
+		assert.strictEqual((await sessionState(sessionUri)).chats.find(chat => chat.resource === peer)?.title, 'Peer Title');
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'renaming a peer chat leaves the session title unchanged', async function () {
+		const { sessionUri } = await createSession('rename-isolated');
+		await rename(sessionUri, 'Session Title');
+		const peer = await createPeer(sessionUri, 'peer');
+
+		await rename(peer, 'Peer Title', 2);
+
+		assert.strictEqual((await sessionState(sessionUri)).title, 'Session Title');
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'peer chat survives unsubscribe and resubscribe', async function () {
+		const { sessionUri } = await createSession('resubscribe');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		context.client.notify('unsubscribe', { channel: peer });
+
+		assert.strictEqual((await chatState(peer)).resource, peer);
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'peer creation does not leak a provider backing as a top-level session', async function () {
+		const { sessionUri } = await createSession('session-list');
+		const before = await context.client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+
+		await createPeer(sessionUri, 'peer');
+
+		const after = await context.client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+		const beforeResources = new Set(before.items.map(item => item.resource));
+		const unexpected = after.items
+			.map(item => item.resource)
+			.filter(resource => !beforeResources.has(resource) && resource !== sessionUri);
+
+		assert.deepStrictEqual(unexpected, []);
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'peer file completion uses the parent workspace', async function () {
+		const { sessionUri, workspace } = await createSession('completion');
+		writeFileSync(join(workspace, 'peer-target.txt'), 'target');
+		const peer = await createPeer(sessionUri, 'peer');
+
+		const completions = await context.client.call<CompletionsResult>('completions', {
+			channel: peer,
+			kind: CompletionItemKind.UserMessage,
+			text: '@peer-t',
+			offset: '@peer-t'.length,
+		});
+
+		assert.deepStrictEqual(completions.items.map(item => item.insertText), ['@peer-target.txt']);
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'first peer chat snapshots the session title onto the default chat', async function () {
+		const { sessionUri, defaultChatUri } = await createSession('default-title');
+		await rename(sessionUri, 'Original Session');
+
+		await createPeer(sessionUri, 'peer');
+
+		assert.strictEqual((await sessionState(sessionUri)).chats.find(chat => chat.resource === defaultChatUri)?.title, 'Original Session');
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'session rename after peer creation preserves the default chat title', async function () {
+		const { sessionUri, defaultChatUri } = await createSession('independent-title');
+		await rename(sessionUri, 'Original Session');
+		await createPeer(sessionUri, 'peer');
+
+		await rename(sessionUri, 'Renamed Session', 2);
+
+		assert.strictEqual((await sessionState(sessionUri)).chats.find(chat => chat.resource === defaultChatUri)?.title, 'Original Session');
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'forking an unknown turn creates a fresh empty peer chat', async function () {
+		const { sessionUri, defaultChatUri } = await createSession('unknown-fork');
+
+		const peer = await createPeer(sessionUri, 'fork', { chat: defaultChatUri, turnId: 'missing-turn' });
+
+		assert.deepStrictEqual((await chatState(peer)).turns, []);
+	}, config.supportsMultipleChats);
+
+	providerTest('peer chat completes a simple turn', async function () {
+		const { sessionUri } = await createSession('peer-turn');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		const response = await driveTurn(peer, 'peer-turn', 'Reply exactly "PEER_OK".', 1);
+
+		assert.match(response, /PEER_OK/);
+	});
+
+	providerTest('peer chat retains context across consecutive turns', async function () {
+		const { sessionUri } = await createSession('peer-context');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		const firstResponse = await driveTurn(peer, 'peer-context-1', 'Remember the code word PEAR. Reply exactly "ready".', 1);
+		const response = await driveTurn(peer, 'peer-context-2', 'What code word did I ask you to remember? Reply with only the code word.', 2);
+		const messages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+
+		assert.deepStrictEqual({
+			responseHasCodeWord: /PEAR/i.test(response),
+			requestHasPriorUserMessage: messages.some(message => message.role === 'user' && message.content.includes('Remember the code word PEAR')),
+			requestHasPriorAssistantMessage: messages.some(message => message.role === 'assistant' && message.content.includes(firstResponse.trim())),
+		}, {
+			responseHasCodeWord: true,
+			requestHasPriorUserMessage: true,
+			requestHasPriorAssistantMessage: true,
+		});
+	});
+
+	forkProviderTest('forked peer chat inherits source history through the provider', async function () {
+		const { sessionUri, defaultChatUri } = await createSession('fork-history');
+		const sourceResponse = await driveTurn(defaultChatUri, 'fork-source', 'Remember the code word FORKCODE. Reply exactly "ready".', 1);
+
+		const peer = await createPeer(sessionUri, 'fork', { chat: defaultChatUri, turnId: 'fork-source' });
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+		const response = await driveTurn(peer, 'fork-turn', 'What code word did I ask you to remember? Reply with only the code word.', 2);
+		const messages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+
+		assert.deepStrictEqual({
+			seededMessages: (await chatState(peer)).turns.map(turn => turn.message.text),
+			responseHasCodeWord: /FORKCODE/i.test(response),
+			requestHasPriorUserMessage: messages.some(message => message.role === 'user' && message.content.includes('Remember the code word FORKCODE')),
+			requestHasPriorAssistantMessage: messages.some(message => message.role === 'assistant' && message.content.includes(sourceResponse.trim())),
+		}, {
+			seededMessages: [
+				'Remember the code word FORKCODE. Reply exactly "ready".',
+				'What code word did I ask you to remember? Reply with only the code word.',
+			],
+			responseHasCodeWord: true,
+			requestHasPriorUserMessage: true,
+			requestHasPriorAssistantMessage: true,
+		});
+	});
+
+	providerTest('disposing a peer after a completed turn removes it from the catalog', async function () {
+		const { sessionUri } = await createSession('dispose-after-turn');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+		await driveTurn(peer, 'peer-turn', 'Reply exactly "DONE".', 1);
+
+		await context.client.call('disposeChat', { channel: peer }, 30_000);
+
+		assert.strictEqual((await sessionState(sessionUri)).chats.some(chat => chat.resource === peer), false);
+	});
+}

--- a/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
@@ -4,22 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { mkdtempSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { ActionType } from '../../../../common/state/sessionActions.js';
+import { ActionType, type ChatErrorAction, type ChatToolCallReadyAction } from '../../../../common/state/sessionActions.js';
 import { CompletionItemKind, type CompletionsResult, type ListSessionsResult, type SubscribeResult } from '../../../../common/state/protocol/commands.js';
 import {
 	buildChatUri,
 	buildDefaultChatUri,
 	isAhpChatChannel,
+	MessageAttachmentKind,
 	MessageKind,
 	parseRequiredSessionUriFromChatUri,
 	ResponsePartKind,
 	ROOT_STATE_URI,
 	SessionStatus,
+	ToolCallConfirmationReason,
 	type ChatState,
+	type MessageAttachment,
 	type RootState,
 	type SessionState,
 } from '../../../../common/state/sessionState.js';
@@ -87,8 +90,8 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		}
 	}
 
-	function providerTest(title: string, run: Mocha.AsyncFunc): void {
-		(config.supportsMultipleChats ? test : test.skip)(title, function () {
+	function providerTest(title: string, run: Mocha.AsyncFunc, enabled = config.supportsMultipleChats): void {
+		(enabled ? test : test.skip)(title, function () {
 			this.timeout(180_000);
 			return run.call(this);
 		});
@@ -139,7 +142,13 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		});
 	}
 
-	async function driveTurn(chatUri: string, turnId: string, text: string, clientSeq: number): Promise<string> {
+	async function driveTurn(
+		chatUri: string,
+		turnId: string,
+		text: string,
+		clientSeq: number,
+		attachments?: readonly MessageAttachment[],
+	): Promise<string> {
 		context.client.clearReceived();
 		context.client.dispatch({
 			channel: chatUri,
@@ -148,15 +157,45 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 				type: ActionType.ChatTurnStarted,
 				turnId,
 				startedAt: '2025-01-01T00:00:00.000Z',
-				message: { text, origin: { kind: MessageKind.User } },
+				message: { text, origin: { kind: MessageKind.User }, ...(attachments ? { attachments: [...attachments] } : {}) },
 			},
 		});
-		await context.client.waitForNotification(n =>
-			isActionNotification(n, 'chat/turnComplete')
-			&& getActionEnvelope(n).channel === chatUri
-			&& (getActionEnvelope(n).action as { turnId: string }).turnId === turnId,
-			90_000,
-		);
+		const seen = new Set<object>();
+		let nextClientSeq = clientSeq + 1;
+		while (true) {
+			const notification = await context.client.waitForNotification(n => {
+				if (seen.has(n as object)
+					|| (!isActionNotification(n, 'chat/toolCallReady')
+						&& !isActionNotification(n, 'chat/turnComplete')
+						&& !isActionNotification(n, 'chat/error'))
+				) {
+					return false;
+				}
+				return getActionEnvelope(n).channel === chatUri;
+			}, 90_000);
+			seen.add(notification as object);
+			if (isActionNotification(notification, 'chat/error')) {
+				const action = getActionEnvelope(notification).action as ChatErrorAction;
+				throw new Error(`Peer chat error during ${turnId}: ${JSON.stringify(action.error)}`);
+			}
+			if (isActionNotification(notification, 'chat/turnComplete')) {
+				break;
+			}
+			const action = getActionEnvelope(notification).action as ChatToolCallReadyAction;
+			if (!action.confirmed) {
+				context.client.dispatch({
+					channel: chatUri,
+					clientSeq: nextClientSeq++,
+					action: {
+						type: ActionType.ChatToolCallConfirmed,
+						turnId,
+						toolCallId: action.toolCallId,
+						approved: true,
+						confirmed: ToolCallConfirmationReason.UserAction,
+					},
+				});
+			}
+		}
 
 		const markdownPartIds = new Set<string>();
 		const pieces: string[] = [];
@@ -417,5 +456,326 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		await context.client.call('disposeChat', { channel: peer }, 30_000);
 
 		assert.strictEqual((await sessionState(sessionUri)).chats.some(chat => chat.resource === peer), false);
+	});
+
+	hostOnlyTest(context, 'peer rename command updates the peer title and records a local turn', async function () {
+		const { sessionUri } = await createSession('local-rename');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'peer-rename', '/rename Renamed Peer', 1);
+
+		const state = await chatState(peer);
+		assert.deepStrictEqual({
+			title: state.title,
+			messages: state.turns.map(turn => turn.message.text),
+		}, {
+			title: 'Renamed Peer',
+			messages: ['/rename Renamed Peer'],
+		});
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'empty peer rename command leaves the peer title unchanged', async function () {
+		const { sessionUri } = await createSession('local-empty-rename');
+		const peer = await createPeer(sessionUri, 'peer');
+		await rename(peer, 'Original Peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'peer-empty-rename', '/rename', 2);
+
+		assert.strictEqual((await chatState(peer)).title, 'Original Peer');
+	}, config.supportsMultipleChats);
+
+	hostOnlyTest(context, 'failing peer bang command records a failed terminal tool call', async function () {
+		const { sessionUri } = await createSession('local-bang-failure');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'peer-bang-failure', '!node -e "process.exit(7)"', 1);
+
+		const toolCalls = (await chatState(peer)).turns.flatMap(turn => turn.responseParts)
+			.filter(part => part.kind === ResponsePartKind.ToolCall)
+			.map(part => part.toolCall);
+		assert.ok(toolCalls.some(toolCall => toolCall.status === 'completed' && !toolCall.success));
+	}, config.supportsMultipleChats);
+
+	providerTest('peer chat reads a file from the parent workspace', async function () {
+		const { sessionUri, workspace } = await createSession('read-file');
+		const file = join(workspace, 'peer-note.txt');
+		writeFileSync(file, 'PEER_FILE_VALUE');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		const response = await driveTurn(peer, 'peer-read', `Read the file at ${file} and reply with its exact contents only.`, 1);
+
+		assert.match(response, /PEER_FILE_VALUE/);
+	});
+
+	providerTest('peer chat reads a file from a nested directory', async function () {
+		const { sessionUri, workspace } = await createSession('read-nested-file');
+		mkdirSync(join(workspace, 'nested'));
+		const file = join(workspace, 'nested', 'peer.txt');
+		writeFileSync(file, 'PEER_NESTED_READ');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		const response = await driveTurn(peer, 'peer-read-nested', `Read the file at ${file} and reply with its exact contents only.`, 1);
+
+		assert.match(response, /PEER_NESTED_READ/);
+	});
+
+	providerTest('peer chat creates a file in the parent workspace', async function () {
+		const { sessionUri, workspace } = await createSession('create-file');
+		const file = join(workspace, 'peer-created.txt');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'peer-create', `Create the file at ${file} containing exactly PEER_CREATED.`, 1);
+
+		assert.strictEqual(readFileSync(file, 'utf8'), 'PEER_CREATED');
+	});
+
+	providerTest('peer chat edits an existing workspace file', async function () {
+		const { sessionUri, workspace } = await createSession('edit-file');
+		const file = join(workspace, 'peer-edit.txt');
+		writeFileSync(file, 'BEFORE_PEER');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'peer-edit', `Replace the complete contents of ${file} with AFTER_PEER.`, 1);
+
+		assert.strictEqual(readFileSync(file, 'utf8').trim(), 'AFTER_PEER');
+	});
+
+	providerTest('peer chat creates a file in a nested directory', async function () {
+		const { sessionUri, workspace } = await createSession('nested-create');
+		const file = join(workspace, 'peer-output', 'report.txt');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'peer-nested-create', `Create the file at ${file} containing exactly PEER_NESTED.`, 1);
+
+		assert.strictEqual(readFileSync(file, 'utf8'), 'PEER_NESTED');
+	});
+
+	providerTest('peer chat handles a missing workspace file without an error', async function () {
+		const { sessionUri, workspace } = await createSession('missing-file');
+		const file = join(workspace, 'peer-missing.txt');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		const response = await driveTurn(peer, 'peer-missing', `Try to read ${file}. If it does not exist, reply exactly "missing".`, 1);
+
+		assert.match(response, /missing/i);
+	});
+
+	providerTest('peer chat reads a filename containing spaces', async function () {
+		const { sessionUri, workspace } = await createSession('spaces');
+		const file = join(workspace, 'peer file.txt');
+		writeFileSync(file, 'PEER_SPACED');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		const response = await driveTurn(peer, 'peer-spaces', `Read the file at ${file} and reply with its exact contents only.`, 1);
+
+		assert.match(response, /PEER_SPACED/);
+	});
+
+	providerTest('two peer chats write distinct workspace files', async function () {
+		const { sessionUri, workspace } = await createSession('two-writers');
+		const firstFile = join(workspace, 'first-peer.txt');
+		const secondFile = join(workspace, 'second-peer.txt');
+		const first = await createPeer(sessionUri, 'first');
+		const second = await createPeer(sessionUri, 'second');
+		await context.client.call<SubscribeResult>('subscribe', { channel: first });
+		await context.client.call<SubscribeResult>('subscribe', { channel: second });
+
+		await driveTurn(first, 'first-write', `Create the file at ${firstFile} containing exactly FIRST_PEER.`, 1);
+		await driveTurn(second, 'second-write', `Create the file at ${secondFile} containing exactly SECOND_PEER.`, 10);
+
+		assert.deepStrictEqual({
+			first: readFileSync(firstFile, 'utf8'),
+			second: readFileSync(secondFile, 'utf8'),
+		}, {
+			first: 'FIRST_PEER',
+			second: 'SECOND_PEER',
+		});
+	});
+
+	// Claude's shared SDK process loses its `host` MCP server after the preceding peer-lifecycle sequence.
+	providerTest('fresh peer chat does not inherit default chat context', async function () {
+		const { sessionUri, defaultChatUri } = await createSession('fresh-context');
+		await driveTurn(defaultChatUri, 'default-secret', 'Remember the code word DEFAULTSECRET. Reply exactly "ready".', 1);
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'peer-fresh-context', 'Reply exactly "fresh".', 10);
+		const messages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+
+		assert.strictEqual(messages.some(message => message.content.includes('DEFAULTSECRET')), false);
+	}, config.supportsMultipleChats && config.provider !== 'claude');
+
+	providerTest('two peer chats keep independent provider contexts', async function () {
+		const { sessionUri } = await createSession('two-contexts');
+		const first = await createPeer(sessionUri, 'first');
+		const second = await createPeer(sessionUri, 'second');
+		await context.client.call<SubscribeResult>('subscribe', { channel: first });
+		await context.client.call<SubscribeResult>('subscribe', { channel: second });
+		await driveTurn(first, 'first-context', 'Remember the code word ALPHA_PEER. Reply exactly "ready".', 1);
+		await driveTurn(second, 'second-context', 'Remember the code word BETA_PEER. Reply exactly "ready".', 10);
+
+		await driveTurn(first, 'first-followup', 'Reply exactly "first".', 20);
+		const firstMessages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+		await driveTurn(second, 'second-followup', 'Reply exactly "second".', 30);
+		const secondMessages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+
+		assert.deepStrictEqual({
+			firstHasAlpha: firstMessages.some(message => message.content.includes('ALPHA_PEER')),
+			firstHasBeta: firstMessages.some(message => message.content.includes('BETA_PEER')),
+			secondHasBeta: secondMessages.some(message => message.content.includes('BETA_PEER')),
+			secondHasAlpha: secondMessages.some(message => message.content.includes('ALPHA_PEER')),
+		}, {
+			firstHasAlpha: true,
+			firstHasBeta: false,
+			secondHasBeta: true,
+			secondHasAlpha: false,
+		});
+	});
+
+	providerTest('peer provider context survives unsubscribe and resubscribe', async function () {
+		const { sessionUri } = await createSession('resume-context');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+		await driveTurn(peer, 'peer-resume-1', 'Remember the code word RESUME_PEER. Reply exactly "ready".', 1);
+		context.client.notify('unsubscribe', { channel: peer });
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'peer-resume-2', 'Reply exactly "resumed".', 10);
+		const messages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+
+		assert.ok(messages.some(message => message.content.includes('RESUME_PEER')));
+	});
+
+	providerTest('recreated peer chat starts with fresh provider context', async function () {
+		const { sessionUri } = await createSession('reset-context');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+		await driveTurn(peer, 'peer-old-context', 'Remember the code word OLD_PEER. Reply exactly "ready".', 1);
+		await context.client.call('disposeChat', { channel: peer }, 30_000);
+		await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'peer-new-context', 'Reply exactly "new".', 10);
+		const messages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+
+		assert.strictEqual(messages.some(message => message.content.includes('OLD_PEER')), false);
+	});
+
+	forkProviderTest('unknown-turn fork does not inherit source provider context', async function () {
+		const { sessionUri, defaultChatUri } = await createSession('unknown-fork-context');
+		await driveTurn(defaultChatUri, 'source-secret', 'Remember the code word SOURCE_SECRET. Reply exactly "ready".', 1);
+		const peer = await createPeer(sessionUri, 'fork', { chat: defaultChatUri, turnId: 'missing-turn' });
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+
+		await driveTurn(peer, 'fresh-fork-turn', 'Reply exactly "fresh".', 10);
+		const messages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
+
+		assert.strictEqual(messages.some(message => message.content.includes('SOURCE_SECRET')), false);
+	});
+
+	providerTest('peer simple attachment reaches the provider request', async function () {
+		const { sessionUri } = await createSession('simple-attachment');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+		const attachments: MessageAttachment[] = [{
+			type: MessageAttachmentKind.Simple,
+			label: 'peer-note.txt',
+			displayKind: 'document',
+			modelRepresentation: 'PEER_SIMPLE_ATTACHMENT',
+		}];
+
+		await driveTurn(peer, 'peer-simple-attachment', 'Reply exactly "attachment".', 1, attachments);
+
+		assert.ok((context.observedModelRequestBodies.at(-1) ?? '').includes('PEER_SIMPLE_ATTACHMENT'));
+	});
+
+	providerTest('peer simple attachment without a model representation is omitted from the provider request', async function () {
+		const { sessionUri } = await createSession('simple-attachment-omitted');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+		const attachments: MessageAttachment[] = [{
+			type: MessageAttachmentKind.Simple,
+			label: 'PEER_OMITTED_ATTACHMENT',
+		}];
+
+		await driveTurn(peer, 'peer-simple-attachment-omitted', 'Reply exactly "attachment".', 1, attachments);
+
+		assert.strictEqual((context.observedModelRequestBodies.at(-1) ?? '').includes('PEER_OMITTED_ATTACHMENT'), false);
+	});
+
+	providerTest('peer multiple simple attachments reach the provider request', async function () {
+		const { sessionUri } = await createSession('multiple-attachments');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+		const attachments: MessageAttachment[] = [
+			{
+				type: MessageAttachmentKind.Simple,
+				label: 'first',
+				modelRepresentation: 'PEER_FIRST_ATTACHMENT',
+			},
+			{
+				type: MessageAttachmentKind.Simple,
+				label: 'second',
+				modelRepresentation: 'PEER_SECOND_ATTACHMENT',
+			},
+		];
+
+		await driveTurn(peer, 'peer-multiple-attachments', 'Reply exactly "attachments".', 1, attachments);
+
+		const request = context.observedModelRequestBodies.at(-1) ?? '';
+		assert.ok(request.includes('PEER_FIRST_ATTACHMENT') && request.includes('PEER_SECOND_ATTACHMENT'));
+	});
+
+	providerTest('peer resource attachment reaches the provider request', async function () {
+		const { sessionUri, workspace } = await createSession('resource-attachment');
+		const file = join(workspace, 'peer-resource.txt');
+		writeFileSync(file, 'PEER_RESOURCE_ATTACHMENT');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+		const attachments: MessageAttachment[] = [{
+			type: MessageAttachmentKind.Resource,
+			uri: URI.file(file).toString(),
+			label: 'peer-resource.txt',
+			displayKind: 'document',
+		}];
+
+		await driveTurn(peer, 'peer-resource-attachment', 'Reply exactly "attachment".', 1, attachments);
+
+		assert.ok((context.observedModelRequestBodies.at(-1) ?? '').includes('peer-resource.txt'));
+	});
+
+	providerTest('peer resource selection attachment includes its line reference', async function () {
+		const { sessionUri, workspace } = await createSession('resource-selection');
+		const file = join(workspace, 'peer-selection.txt');
+		writeFileSync(file, 'first\nsecond\nthird');
+		const peer = await createPeer(sessionUri, 'peer');
+		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
+		const attachments: MessageAttachment[] = [{
+			type: MessageAttachmentKind.Resource,
+			uri: URI.file(file).toString(),
+			label: 'peer-selection.txt',
+			displayKind: 'selection',
+			selection: {
+				range: {
+					start: { line: 1, character: 0 },
+					end: { line: 1, character: 6 },
+				},
+			},
+		}];
+
+		await driveTurn(peer, 'peer-resource-selection', 'Reply exactly "selection".', 1, attachments);
+
+		const request = context.observedModelRequestBodies.at(-1) ?? '';
+		assert.ok(request.includes('peer-selection.txt') && (request.includes('peer-selection.txt:2') || request.includes('(line 2)')));
 	});
 }

--- a/src/vs/platform/agentHost/test/node/e2e/suites/turnLifecycleSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/turnLifecycleSuite.ts
@@ -43,13 +43,20 @@ export function defineTurnLifecycleTests(context: IAgentHostE2ETestContext): voi
 		// continuation can outlive any reasonable test timeout for trivial
 		// prompts like this one.
 		let nextSeq = 2;
+		// waitForNotification retains matched notifications, so skip ones already handled.
+		const processedSeqs = new Set<number>();
 		while (true) {
-			const next = await context.client.waitForNotification(n =>
-				(isActionNotification(n, 'chat/toolCallReady')
+			const next = await context.client.waitForNotification(n => {
+				const isRelevant = (isActionNotification(n, 'chat/toolCallReady')
 					&& (getActionEnvelope(n).action as { confirmed?: string }).confirmed === undefined)
-				|| isActionNotification(n, 'chat/toolCallComplete')
-				|| isActionNotification(n, 'chat/error'),
-				90_000);
+					|| isActionNotification(n, 'chat/toolCallComplete')
+					|| isActionNotification(n, 'chat/error');
+				if (!isRelevant) {
+					return false;
+				}
+				return !processedSeqs.has(getActionEnvelope(n).serverSeq);
+			}, 90_000);
+			processedSeqs.add(getActionEnvelope(next).serverSeq);
 			if (isActionNotification(next, 'chat/error')) {
 				throw new Error('Session error during permission test');
 			}


### PR DESCRIPTION
## Summary

- add 42 shared bundled-provider E2E scenarios for multi-chat capability, peer lifecycle, local commands, workspace tools, provider context isolation/resume/reset, attachments, completions, titles, disposal, and fork behavior
- assert actual normalized replay requests carry prior user/assistant context and attachment projections instead of trusting sequence-only replay responses
- add strict generated Claude and Copilot fixtures while keeping host-only scenarios on the shared empty capture
- add a persistent inventory and reevaluation process for all disabled or conditional bundled-provider E2E tests
- document the public strategy for future coverage-guided Agent Host E2E expansion rounds
- refresh loaded-file native V8 coverage metrics

## Coverage

Compared with current `main`:

- lines/statements: 69.92% -> 71.07% (+1.15 pp, +1353 covered)
- functions: 58.84% -> 61.64% (+2.80 pp, +98 covered)
- branches: 62.35% -> 63.25% (+0.90 pp, +383 covered)

The second expansion within this PR contributed +116 covered lines/statements, +8 functions, and +100 branches over the rebased PR baseline.

## Provider notes

- Claude and Copilot cover peer-chat lifecycle, workspace tools, provider context, and attachment projection
- Codex explicitly verifies that multi-chat is not advertised/supported
- Claude still advertises fork support, but provider-context fork tests are skipped because the SDK reproducibly rejects the AHP turn id as `upToMessageId`
- one default-to-fresh-peer context-isolation scenario is Copilot-only because Claude's shared SDK process reproducibly loses its in-process `host` MCP server after the preceding peer-lifecycle sequence; the remaining context-isolation scenarios run on both providers
- Copilot peer edit/nested-create variants are skipped on Windows because their recorded tool plans use POSIX shell behavior and do not produce the expected Windows filesystem effects

## Validation

- `npm run typecheck-client`
- full Claude provider replay: 93 passing, 7 expected pending
- strict host-only recording check: 6 passing, 3 expected pending, no new captures
- `npm run test-agent-host-e2e-coverage`: 231 passing, 73 expected pending
- `npm run valid-layers-check`
- focused replay for the Windows-gated peer mutations: 4 passing, 2 expected pending
- precommit hygiene, fixture redaction checks, mechanical disabled-test inventory audit, and final code review

(Written by Copilot)
