### PR TITLE
Dictation: make redundant-extension prompt sticky and mark shown only after response

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
@@ -42,7 +42,7 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 	private static readonly EXTENSION_ID = 'ms-vscode.vscode-speech';
 
 	/** Application-scoped flag so the prompt fires at most once per machine. */
-	private static readonly STORAGE_KEY = 'chat.dictation.redundantExtensionPromptShown';
+	private static readonly STORAGE_KEY = 'chat.dictation.redundantExtensionPromptShown.v2';
 
 	constructor(
 		@ILocalTranscriptionService private readonly localTranscriptionService: ILocalTranscriptionService,
@@ -95,8 +95,6 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 			return;
 		}
 
-		// Guard now so the prompt is shown at most once regardless of the outcome.
-		this.markShown();
 		this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'shown' });
 
 		const displayName = extension.displayName || extension.identifier.id;
@@ -107,6 +105,8 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 				{
 					label: localize('disableExtension', "Disable Extension"),
 					run: async () => {
+						// Guard so the prompt is not shown again once the user has responded.
+						this.markShown();
 						this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'disable' });
 						try {
 							await this.extensionsWorkbenchService.setEnablement(extension!, EnablementState.DisabledGlobally);
@@ -118,12 +118,18 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 				{
 					label: localize('keepExtension', "Keep"),
 					run: () => {
+						// Guard so the prompt is not shown again once the user has responded.
+						this.markShown();
 						this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'keep' });
 					}
 				}
 			],
 			{
+				// Keep the notification visible until the user makes a choice so it is not missed.
+				sticky: true,
 				onCancel: () => {
+					// Guard so the prompt is not shown again once the user has dismissed it.
+					this.markShown();
 					this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'dismissed' });
 				}
 			}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/redundantDictationExtensionNotifier.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../../nls.js';
+import { Event } from '../../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
@@ -34,7 +36,7 @@ type RedundantDictationExtensionPromptClassification = {
  *   2. the extension is installed and currently enabled.
  * The prompt is shown at most once ever (guarded by an application-scoped storage flag).
  */
-export class RedundantDictationExtensionNotifier implements IWorkbenchContribution {
+export class RedundantDictationExtensionNotifier extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.redundantDictationExtensionNotifier';
 
@@ -42,7 +44,7 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 	private static readonly EXTENSION_ID = 'ms-vscode.vscode-speech';
 
 	/** Application-scoped flag so the prompt fires at most once per machine. */
-	private static readonly STORAGE_KEY = 'chat.dictation.redundantExtensionPromptShown.v2';
+	private static readonly STORAGE_KEY = 'chat.dictation.redundantExtensionPromptWasShown';
 
 	constructor(
 		@ILocalTranscriptionService private readonly localTranscriptionService: ILocalTranscriptionService,
@@ -53,6 +55,7 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 		@ILogService private readonly logService: ILogService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
+		super();
 		this.check();
 	}
 
@@ -62,7 +65,7 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 			return;
 		}
 
-		// (1b) Only when built-in dictation is actually enabled, so we never suggest
+		// (2) Only when built-in dictation is actually enabled, so we never suggest
 		// disabling a working extension before its replacement is turned on.
 		if (this.configurationService.getValue<boolean>('chat.speechToText.enabled') !== true) {
 			return;
@@ -73,7 +76,7 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 			return;
 		}
 
-		// (2) Only when the extension is installed and currently enabled.
+		// (4) Only when the extension is installed.
 		let extension: IExtension | undefined;
 		try {
 			const installed = await this.extensionsWorkbenchService.queryLocal();
@@ -87,10 +90,12 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 			return;
 		}
 
+		// (5) Only when the extension is enabled in a state that `setEnablement` can disable.
+		// Environment-enabled extensions are excluded because `setEnablement` cannot disable
+		// them, so the prompt's primary action would be guaranteed to fail.
 		const isEnabled =
 			extension.enablementState === EnablementState.EnabledGlobally ||
-			extension.enablementState === EnablementState.EnabledWorkspace ||
-			extension.enablementState === EnablementState.EnabledByEnvironment;
+			extension.enablementState === EnablementState.EnabledWorkspace;
 		if (!isEnabled) {
 			return;
 		}
@@ -98,14 +103,13 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 		this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'shown' });
 
 		const displayName = extension.displayName || extension.identifier.id;
-		this.notificationService.prompt(
+		const handle = this.notificationService.prompt(
 			Severity.Info,
 			localize('redundantDictationExtension', "VS Code now has built-in dictation. Disable the '{0}' extension to avoid conflicts?", displayName),
 			[
 				{
 					label: localize('disableExtension', "Disable Extension"),
 					run: async () => {
-						// Guard so the prompt is not shown again once the user has responded.
 						this.markShown();
 						this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'disable' });
 						try {
@@ -118,22 +122,30 @@ export class RedundantDictationExtensionNotifier implements IWorkbenchContributi
 				{
 					label: localize('keepExtension', "Keep"),
 					run: () => {
-						// Guard so the prompt is not shown again once the user has responded.
 						this.markShown();
 						this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'keep' });
 					}
 				}
 			],
 			{
-				// Keep the notification visible until the user makes a choice so it is not missed.
 				sticky: true,
 				onCancel: () => {
-					// Guard so the prompt is not shown again once the user has dismissed it.
 					this.markShown();
 					this.telemetryService.publicLog2<RedundantDictationExtensionPromptEvent, RedundantDictationExtensionPromptClassification>('chat.dictation.redundantExtensionPrompt', { action: 'dismissed' });
 				}
 			}
 		);
+
+		// Multi-window coordination: the flag is only recorded once the user responds, so
+		// every already-open window can show its own prompt. When any window records a
+		// response, close the prompts still open in the others so it is answered once.
+		const listeners = this._register(new DisposableStore());
+		listeners.add(this.storageService.onDidChangeValue(StorageScope.APPLICATION, RedundantDictationExtensionNotifier.STORAGE_KEY, listeners)(() => {
+			if (this.storageService.getBoolean(RedundantDictationExtensionNotifier.STORAGE_KEY, StorageScope.APPLICATION, false)) {
+				handle.close();
+			}
+		}));
+		listeners.add(Event.once(handle.onDidClose)(() => listeners.dispose()));
 	}
 
 	private markShown(): void {


### PR DESCRIPTION
https://github.com/user-attachments/assets/5b7f7377-fec2-456e-87a5-fb60e52e09a5

### Problem

The prompt to disable the redundant `ms-vscode.vscode-speech` extension (added in #326665) could silently never appear:

- It uses a **non-sticky** `Severity.Info` notification, which auto-hides after a few seconds (only error-with-action and progress notifications are sticky).
- It calls `markShown()` — burning the once-per-machine `StorageScope.APPLICATION` flag — **before** the prompt is shown, regardless of outcome.

On Insiders, `chat.speechToText.enabled` defaults to `true`, so the notifier fires on the first eligible launch. If the transient toast appeared while the user wasn't looking, it auto-dismissed and the flag was permanently set — so it never showed again.

### Changes

- Add `sticky: true` so the notification stays until the user responds.
- Move `markShown()` into each choice's `run`/`onCancel` so the flag is only burned once the user has actually acted on the prompt.
- Bump the storage key to `.v2` so machines that already burned the old flag get one more chance to see the (now sticky) prompt.
