### PR TITLE
Remove no-arg yolo/allow-all options and autoApprove config command

### DIFF
--- a/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
+++ b/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
@@ -90,7 +90,6 @@ function getConfigSlashCommands(): readonly IConfigSlashCommand[] {
 		{
 			command: 'yolo', sortText: 'z1_yolo',
 			options: [
-				{ detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
 				{ arg: 'on', detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
 				{ arg: 'off', detail: setDefaultDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_DEFAULT } }
 			],
@@ -98,15 +97,6 @@ function getConfigSlashCommands(): readonly IConfigSlashCommand[] {
 		{
 			command: 'allow-all', sortText: 'z1_allow-all',
 			options: [
-				{ detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
-				{ arg: 'on', detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
-				{ arg: 'off', detail: setDefaultDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_DEFAULT } }
-			],
-		},
-		{
-			command: 'autoApprove', sortText: 'z1_autoApprove',
-			options: [
-				{ detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
 				{ arg: 'on', detail: setBypassDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_BYPASS } },
 				{ arg: 'off', detail: setDefaultDetail(), config: { [SessionConfigKey.AutoApprove]: AUTO_APPROVE_DEFAULT } }
 			],

--- a/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
+++ b/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
@@ -16,9 +16,8 @@ suite('copilotConfigSlashCommands', () => {
 			const items = getCopilotConfigSlashCommandItems('');
 			const byLabel = new Map(items.map(i => [i.label, i]));
 
-			// Permission command: bare toggle plus on/off sub-args, inserts nothing.
-			assert.strictEqual(byLabel.get('/yolo')?.insertText, '');
-			assert.deepStrictEqual(byLabel.get('/yolo')?.applyConfig, { autoApprove: 'autoApprove' });
+			// Permission command: on/off sub-args insert nothing.
+			assert.strictEqual(byLabel.get('/yolo on')?.insertText, '');
 			assert.deepStrictEqual(byLabel.get('/yolo on')?.applyConfig, { autoApprove: 'autoApprove' });
 			assert.deepStrictEqual(byLabel.get('/yolo off')?.applyConfig, { autoApprove: 'default' });
 

--- a/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
@@ -146,7 +146,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 		test('injects config-action items (permission/mode toggles) for a leading slash', async () => {
 			const items = await run('/');
 			const byLabel = new Map(items.filter(i => i.attachment?._meta?.action !== undefined).map(i => [i.attachment?.label, i]));
-			assert.ok(byLabel.has('/yolo'));
+			assert.ok(byLabel.has('/yolo on'));
 			assert.ok(byLabel.has('/autopilot on'));
 			assert.strictEqual(byLabel.get('/autopilot')?.insertText, '/autopilot ');
 		});


### PR DESCRIPTION
Cleans up the Copilot agent-host config-action slash commands in `copilotConfigSlashCommands.ts`:

- Remove the bare (no-arg) `yolo` option, leaving only the `on`/`off` sub-args.
- Remove the `autoApprove` config command entirely.
- Remove the bare (no-arg) `allow-all` option, leaving only the `on`/`off` sub-args.

Tests in `copilotConfigSlashCommands.test.ts` are updated accordingly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>