### PR TITLE
Show focus differentiator for ask-questions checkbox navigation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -328,6 +328,12 @@
 			background-color: var(--vscode-list-inactiveSelectionBackground, var(--vscode-list-hoverBackground));
 		}
 
+		/* Multi-select: show a focus indicator on the keyboard-focused row so the active checkbox is visible while navigating with the up/down arrow keys */
+		.chat-question-list-item.multi-select:focus {
+			outline: 1px solid var(--vscode-focusBorder);
+			outline-offset: -1px;
+		}
+
 		/* Checkbox for multi-select */
 		.chat-question-list-checkbox {
 			flex-shrink: 0;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -328,7 +328,6 @@
 			background-color: var(--vscode-list-inactiveSelectionBackground, var(--vscode-list-hoverBackground));
 		}
 
-		/* Multi-select: show a focus indicator on the keyboard-focused row so the active checkbox is visible while navigating with the up/down arrow keys */
 		.chat-question-list-item.multi-select:focus {
 			outline: 1px solid var(--vscode-focusBorder);
 			outline-offset: -1px;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/321134


https://github.com/user-attachments/assets/4e797014-ea84-45d8-a58f-5358581cfd8d


## Problem

In the ask-questions carousel, multi-select (checkbox) rows are navigated with the up/down arrow keys by moving DOM focus. However the stylesheet applies `.chat-question-list-item:focus { outline: none; }`, and — unlike single-select, which moves its `.selected` background as you navigate — checkbox rows had no visual state tied to focus. As a result, the currently focused checkbox item had no differentiator during keyboard navigation.

## Fix

Added a focus indicator scoped to multi-select rows in `chatQuestionCarousel.css`:

```css
.chat-question-list-item.multi-select:focus {
	outline: 1px solid var(--vscode-focusBorder);
	outline-offset: -1px;
}
```

- Nested inside `.chat-question-list`, so it out-specifies the `outline: none` rule.
- Uses `--vscode-focusBorder` (matching the freeform textarea's focus treatment; works in high-contrast themes).
- Gated on `.multi-select`, so single-select rows are unaffected.
