### PR TITLE
Capture mic via AudioWorkletNode instead of deprecated ScriptProcessorNode (dictation + Voice Mode)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/pcmCaptureWorklet.ts
+++ b/src/vs/workbench/contrib/chat/browser/pcmCaptureWorklet.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Registered name of the PCM capture audio worklet processor. */
+const PCM_CAPTURE_PROCESSOR = 'vscode-pcm-capture';
+
+/**
+ * Builds the source of the PCM capture worklet for a given chunk size. The
+ * processor runs on the dedicated audio rendering thread (unlike the deprecated
+ * `ScriptProcessorNode`, whose `onaudioprocess` callback runs on the main thread
+ * and gets throttled or stops entirely), buffers mono samples into fixed-size
+ * chunks and transfers them to the main thread for encoding/streaming.
+ */
+function pcmCaptureWorkletSource(chunkSize: number): string {
+	return `
+class PcmCaptureProcessor extends AudioWorkletProcessor {
+	constructor() {
+		super();
+		this._chunkSize = ${chunkSize};
+		this._buffer = new Float32Array(this._chunkSize);
+		this._offset = 0;
+	}
+	process(inputs) {
+		const channel = inputs[0] && inputs[0][0];
+		if (channel) {
+			for (let i = 0; i < channel.length; i++) {
+				this._buffer[this._offset++] = channel[i];
+				if (this._offset === this._chunkSize) {
+					const chunk = this._buffer;
+					this.port.postMessage(chunk, [chunk.buffer]);
+					this._buffer = new Float32Array(this._chunkSize);
+					this._offset = 0;
+				}
+			}
+		}
+		return true;
+	}
+}
+registerProcessor('${PCM_CAPTURE_PROCESSOR}', PcmCaptureProcessor);
+`;
+}
+
+/**
+ * Creates an {@link AudioWorkletNode} that captures mono PCM from `context` in
+ * fixed-size chunks, invoking `onChunk` on the main thread for every chunk. The
+ * worklet module is loaded from a blob URL, which the renderer's `script-src`
+ * CSP allows (worklet scripts fall back to `script-src`).
+ *
+ * The returned node is not connected to the audio graph; the caller is
+ * responsible for connecting it (typically source -> node -> destination) and
+ * for disposing it via `node.disconnect()` and clearing `node.port.onmessage`.
+ */
+export async function createPcmCaptureNode(window: Window & typeof globalThis, context: AudioContext, chunkSize: number, onChunk: (samples: Float32Array) => void): Promise<AudioWorkletNode> {
+	const moduleUrl = URL.createObjectURL(new Blob([pcmCaptureWorkletSource(chunkSize)], { type: 'application/javascript' }));
+	try {
+		await context.audioWorklet.addModule(moduleUrl);
+	} finally {
+		URL.revokeObjectURL(moduleUrl);
+	}
+
+	const node = new window.AudioWorkletNode(context, PCM_CAPTURE_PROCESSOR, { numberOfInputs: 1, numberOfOutputs: 1, channelCount: 1 });
+	node.port.onmessage = e => onChunk(e.data as Float32Array);
+	return node;
+}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -23,51 +23,15 @@ import { AccessibilitySignal, IAccessibilitySignalService } from '../../../../..
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { AgentsVoiceStorageKeys } from '../../../agentsVoice/common/agentsVoice.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
+import { createPcmCaptureNode } from '../pcmCaptureWorklet.js';
 
 export const IChatSpeechToTextService = createDecorator<IChatSpeechToTextService>('chatSpeechToTextService');
 
 /** Sample rate (Hz) of the PCM16 audio streamed to the transcription backend. */
 const SAMPLE_RATE = 16000;
 
-/** Registered name of the audio worklet that captures raw PCM from the mic. */
-const PCM_CAPTURE_PROCESSOR = 'vscode-chat-stt-pcm-capture';
-
 /** Number of samples buffered in the worklet before a chunk is posted to the main thread. */
 const PCM_CAPTURE_CHUNK_SIZE = 4096;
-
-/**
- * Source of the audio worklet used to capture microphone PCM. It runs on the
- * dedicated audio rendering thread (unlike the deprecated `ScriptProcessorNode`,
- * whose `onaudioprocess` callback runs on the main thread and gets throttled or
- * stops entirely), buffers samples into fixed-size chunks and transfers them to
- * the main thread for encoding/streaming.
- */
-const PCM_CAPTURE_WORKLET_SOURCE = `
-class PcmCaptureProcessor extends AudioWorkletProcessor {
-	constructor() {
-		super();
-		this._chunkSize = ${PCM_CAPTURE_CHUNK_SIZE};
-		this._buffer = new Float32Array(this._chunkSize);
-		this._offset = 0;
-	}
-	process(inputs) {
-		const channel = inputs[0] && inputs[0][0];
-		if (channel) {
-			for (let i = 0; i < channel.length; i++) {
-				this._buffer[this._offset++] = channel[i];
-				if (this._offset === this._chunkSize) {
-					const chunk = this._buffer;
-					this.port.postMessage(chunk, [chunk.buffer]);
-					this._buffer = new Float32Array(this._chunkSize);
-					this._offset = 0;
-				}
-			}
-		}
-		return true;
-	}
-}
-registerProcessor('${PCM_CAPTURE_PROCESSOR}', PcmCaptureProcessor);
-`;
 
 /** Setting that enables the dictation feature; a kill-switch for rollout. */
 const ENABLED_SETTING = 'chat.speechToText.enabled';
@@ -677,28 +641,20 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		const source = ctx.createMediaStreamSource(stream);
 		this._sourceNode = source;
 
-		// Load the capture worklet from a blob URL. The renderer's `script-src`
-		// CSP allows `blob:`, and worklet modules fall back to `script-src`.
-		const moduleUrl = URL.createObjectURL(new Blob([PCM_CAPTURE_WORKLET_SOURCE], { type: 'application/javascript' }));
-		try {
-			await ctx.audioWorklet.addModule(moduleUrl);
-		} finally {
-			URL.revokeObjectURL(moduleUrl);
-		}
+		// Load the capture worklet (see `createPcmCaptureNode`). ScriptProcessorNode
+		// is deprecated and its `onaudioprocess` callback is throttled/stops on the
+		// main thread; the worklet runs on the audio thread and streams PCM reliably.
+		const node = await createPcmCaptureNode(window, ctx, PCM_CAPTURE_CHUNK_SIZE, samples => {
+			this._localTranscription.pushAudio(encodeRawPcm16Buffer(samples)).catch(err => this._onAudioPushError(err));
+		});
 
 		// The session may have been torn down while the module was loading.
 		if (this._audioContext !== ctx) {
+			try { node.disconnect(); } catch { /* ignore */ }
 			return;
 		}
 
-		const node = new window.AudioWorkletNode(ctx, PCM_CAPTURE_PROCESSOR, { numberOfInputs: 1, numberOfOutputs: 1, channelCount: 1 });
 		this._workletNode = node;
-
-		node.port.onmessage = e => {
-			const samples = e.data as Float32Array;
-			this._localTranscription.pushAudio(encodeRawPcm16Buffer(samples)).catch(err => this._onAudioPushError(err));
-		};
-
 		source.connect(node);
 		node.connect(ctx.destination);
 	}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -29,6 +29,46 @@ export const IChatSpeechToTextService = createDecorator<IChatSpeechToTextService
 /** Sample rate (Hz) of the PCM16 audio streamed to the transcription backend. */
 const SAMPLE_RATE = 16000;
 
+/** Registered name of the audio worklet that captures raw PCM from the mic. */
+const PCM_CAPTURE_PROCESSOR = 'vscode-chat-stt-pcm-capture';
+
+/** Number of samples buffered in the worklet before a chunk is posted to the main thread. */
+const PCM_CAPTURE_CHUNK_SIZE = 4096;
+
+/**
+ * Source of the audio worklet used to capture microphone PCM. It runs on the
+ * dedicated audio rendering thread (unlike the deprecated `ScriptProcessorNode`,
+ * whose `onaudioprocess` callback runs on the main thread and gets throttled or
+ * stops entirely), buffers samples into fixed-size chunks and transfers them to
+ * the main thread for encoding/streaming.
+ */
+const PCM_CAPTURE_WORKLET_SOURCE = `
+class PcmCaptureProcessor extends AudioWorkletProcessor {
+	constructor() {
+		super();
+		this._chunkSize = ${PCM_CAPTURE_CHUNK_SIZE};
+		this._buffer = new Float32Array(this._chunkSize);
+		this._offset = 0;
+	}
+	process(inputs) {
+		const channel = inputs[0] && inputs[0][0];
+		if (channel) {
+			for (let i = 0; i < channel.length; i++) {
+				this._buffer[this._offset++] = channel[i];
+				if (this._offset === this._chunkSize) {
+					const chunk = this._buffer;
+					this.port.postMessage(chunk, [chunk.buffer]);
+					this._buffer = new Float32Array(this._chunkSize);
+					this._offset = 0;
+				}
+			}
+		}
+		return true;
+	}
+}
+registerProcessor('${PCM_CAPTURE_PROCESSOR}', PcmCaptureProcessor);
+`;
+
 /** Setting that enables the dictation feature; a kill-switch for rollout. */
 const ENABLED_SETTING = 'chat.speechToText.enabled';
 /** On-device model (Whisper or Nemotron) to use for dictation. */
@@ -187,7 +227,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	private _mediaStream: MediaStream | undefined;
 	private _audioContext: AudioContext | undefined;
 	private _sourceNode: MediaStreamAudioSourceNode | undefined;
-	private _processorNode: ScriptProcessorNode | undefined;
+	private _workletNode: AudioWorkletNode | undefined;
 
 	private readonly _localSessionDisposables = this._register(new DisposableStore());
 
@@ -369,7 +409,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		}
 
 		try {
-			this._startCapture(window, stream);
+			await this._startCapture(window, stream);
 		} catch (err) {
 			// Capture setup (AudioContext/nodes) can fail after the mic and the
 			// utility-process session are already live; make sure both are torn
@@ -627,33 +667,47 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		}
 	}
 
-	private _startCapture(window: Window & typeof globalThis, stream: MediaStream): void {
+	private async _startCapture(window: Window & typeof globalThis, stream: MediaStream): Promise<void> {
 		const ctx = new window.AudioContext({ sampleRate: SAMPLE_RATE });
 		this._audioContext = ctx;
 		// The context is created several awaits after the user gesture (mic
 		// acquisition + model startup), so it can start suspended; resume it or
-		// `onaudioprocess` never fires and no audio is streamed.
+		// the worklet never runs and no audio is streamed.
 		ctx.resume().catch(() => { /* ignore */ });
 		const source = ctx.createMediaStreamSource(stream);
 		this._sourceNode = source;
 
-		const processor = ctx.createScriptProcessor(4096, 1, 1);
-		this._processorNode = processor;
+		// Load the capture worklet from a blob URL. The renderer's `script-src`
+		// CSP allows `blob:`, and worklet modules fall back to `script-src`.
+		const moduleUrl = URL.createObjectURL(new Blob([PCM_CAPTURE_WORKLET_SOURCE], { type: 'application/javascript' }));
+		try {
+			await ctx.audioWorklet.addModule(moduleUrl);
+		} finally {
+			URL.revokeObjectURL(moduleUrl);
+		}
 
-		processor.onaudioprocess = e => {
-			const samples = e.inputBuffer.getChannelData(0);
+		// The session may have been torn down while the module was loading.
+		if (this._audioContext !== ctx) {
+			return;
+		}
+
+		const node = new window.AudioWorkletNode(ctx, PCM_CAPTURE_PROCESSOR, { numberOfInputs: 1, numberOfOutputs: 1, channelCount: 1 });
+		this._workletNode = node;
+
+		node.port.onmessage = e => {
+			const samples = e.data as Float32Array;
 			this._localTranscription.pushAudio(encodeRawPcm16Buffer(samples)).catch(err => this._onAudioPushError(err));
 		};
 
-		source.connect(processor);
-		processor.connect(ctx.destination);
+		source.connect(node);
+		node.connect(ctx.destination);
 	}
 
 	private _stopCapture(): void {
-		if (this._processorNode) {
-			this._processorNode.onaudioprocess = null;
-			try { this._processorNode.disconnect(); } catch { /* ignore */ }
-			this._processorNode = undefined;
+		if (this._workletNode) {
+			this._workletNode.port.onmessage = null;
+			try { this._workletNode.disconnect(); } catch { /* ignore */ }
+			this._workletNode = undefined;
 		}
 		try { this._sourceNode?.disconnect(); } catch { /* ignore */ }
 		this._sourceNode = undefined;

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -13,8 +13,16 @@ import { INotificationService, Severity } from '../../../../../platform/notifica
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { localize } from '../../../../../nls.js';
 import { AgentsVoiceStorageKeys } from '../../../../contrib/agentsVoice/common/agentsVoice.js';
+import { createPcmCaptureNode } from '../pcmCaptureWorklet.js';
 
 export const IMicCaptureService = createDecorator<IMicCaptureService>('micCaptureService');
+
+/**
+ * Number of samples buffered in the capture worklet before a chunk is posted to
+ * the main thread. Matches the buffer size previously used with
+ * `ScriptProcessorNode` so the per-chunk drain/diagnostic bookkeeping is unchanged.
+ */
+const MIC_CAPTURE_CHUNK_SIZE = 2048;
 
 /**
  * Per-PTT-press diagnostic emitted after `pttUp` once the diagnostic
@@ -159,7 +167,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	private _window: (Window & typeof globalThis) | undefined;
 	private _micStream: MediaStream | null = null;
 	private _micCtx: AudioContext | undefined;
-	private _scriptNode: ScriptProcessorNode | undefined;
+	private _workletNode: AudioWorkletNode | undefined;
 	private _analyserNode: AnalyserNode | undefined;
 	private _isCapturing = false;
 	private _pttHeld = false;
@@ -415,10 +423,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		source.connect(analyser);
 		this._analyserNode = analyser;
 
-		const processor = ctx.createScriptProcessor(2048, 1, 1);
-		this._scriptNode = processor;
-
-		processor.onaudioprocess = (e: AudioProcessingEvent) => {
+		const node = await createPcmCaptureNode(window, ctx, MIC_CAPTURE_CHUNK_SIZE, samples => {
 			const nowTs = Date.now();
 			const ptUpTs = this._diagPttUpTs;
 			// A callback is a "drain" callback while we're still in the
@@ -451,13 +456,11 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 			if (!this._pttStreaming) {
 				if (isPostReleaseCallback) {
 					this._diagPostReleaseCallbacks++;
-					this._diagPostReleaseSamples += e.inputBuffer.length;
+					this._diagPostReleaseSamples += samples.length;
 				}
 				return;
 			}
 
-			const channelData = e.inputBuffer.getChannelData(0);
-			const samples = new Float32Array(channelData);
 			const b64 = encodeRawPcm16Base64(samples, this._window!);
 			this._diagChunksSent++;
 			this._diagSamplesSent += samples.length;
@@ -475,10 +478,17 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 			if (isDrainCallback && this._pttDrainSamplesSent >= this._pttDrainTargetSamples) {
 				this._finishDrain();
 			}
-		};
+		});
 
-		source.connect(processor);
-		processor.connect(ctx.destination);
+		// stopCapture() may have run while the worklet module was loading.
+		if (this._micCtx !== ctx) {
+			try { node.disconnect(); } catch { /* ignore */ }
+			return;
+		}
+
+		this._workletNode = node;
+		source.connect(node);
+		node.connect(ctx.destination);
 		this._isCapturing = true;
 	}
 
@@ -514,9 +524,10 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		}
 		this._pttDrainTargetSamples = 0;
 		this._pttDrainSamplesSent = 0;
-		if (this._scriptNode) {
-			this._scriptNode.disconnect();
-			this._scriptNode = undefined;
+		if (this._workletNode) {
+			this._workletNode.port.onmessage = null;
+			try { this._workletNode.disconnect(); } catch { /* ignore */ }
+			this._workletNode = undefined;
 		}
 		this._analyserNode = undefined;
 		this._micCtx?.close();


### PR DESCRIPTION
### Problem

Audio capture for chat dictation and Voice Mode used `ctx.createScriptProcessor(...)`, which is deprecated:

> [Deprecation] The ScriptProcessorNode is deprecated. Use AudioWorkletNode instead.

Its `onaudioprocess` callback runs on the **main thread**, where it gets throttled or stops firing entirely (the Voice Mode path already kept a fallback drain timer for exactly this reason). When it stops, no PCM is streamed and dictation silently produces nothing.

### Change

Replace `ScriptProcessorNode` with an `AudioWorkletNode`, which runs on the dedicated audio rendering thread:

- New shared helper `chat/browser/pcmCaptureWorklet.ts` (`createPcmCaptureNode`) loads a PCM-capture worklet from a `blob:` URL (allowed by the renderer's `script-src` CSP) and invokes a callback with each fixed-size mono chunk on the main thread.
- **Chat dictation** (`chatSpeechToTextService.ts`): captures 4096-sample chunks, encodes to PCM16 and streams them. `_startCapture` is now async with a `this._audioContext !== ctx` teardown guard.
- **Voice Mode mic capture** (`voiceClient/micCaptureService.ts`): captures 2048-sample chunks to match the previous ScriptProcessorNode buffer size, so the per-chunk drain/diagnostic bookkeeping is unchanged. Includes a `this._micCtx !== ctx` guard if capture is stopped while the module loads.

### Validation

- `npm run typecheck-client` passes cleanly.
- Pre-commit hygiene hooks ran (no `--no-verify`).
