### PR TITLE
Filter Copilot config-action slash commands by session state

### DIFF
--- a/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
+++ b/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
@@ -156,17 +156,8 @@ export interface ICopilotConfigSlashCommandState {
 }
 
 /**
- * Decides whether a single config-action option should be offered given the
- * session's current config `state`. Keep-text (prompt/objective) forms are
- * always offered; pure toggles are hidden when applying them would be a no-op
- * on the axis they target:
- *
- *  - `autoApprove` axis: the bypass forms (`/yolo`, `/yolo on`, ...) are hidden
- *    while already bypassing; the `off` form is hidden while not bypassing.
- *  - `mode` axis: `/autopilot on` is hidden while already in autopilot;
- *    `/autopilot off` is only offered while in autopilot.
- *
- * When `state` is undefined (current values unknown) every option is offered.
+ * Returns whether the option should be offered for the current session state.
+ * Unknown state and keep-text options are always offered.
  */
 function shouldOfferOption(option: IConfigSlashOption, state: ICopilotConfigSlashCommandState | undefined): boolean {
 	// Keep-text forms carry a typed prompt/objective and are always relevant.

--- a/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
+++ b/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
@@ -144,11 +144,60 @@ export function isCopilotConfigSlashCommand(command: string): boolean {
 }
 
 /**
+ * The current session-config state used to filter config-action slash command
+ * completions so only the state-changing forms are offered (e.g. `/autopilot on`
+ * is hidden while already in autopilot mode).
+ */
+export interface ICopilotConfigSlashCommandState {
+	/** The session's current `mode` axis value (e.g. `interactive` / `plan` / `autopilot`). */
+	readonly mode?: string;
+	/** The session's current `autoApprove` axis value (e.g. `default` / `autoApprove`). */
+	readonly autoApprove?: string;
+}
+
+/**
+ * Decides whether a single config-action option should be offered given the
+ * session's current config `state`. Keep-text (prompt/objective) forms are
+ * always offered; pure toggles are hidden when applying them would be a no-op
+ * on the axis they target:
+ *
+ *  - `autoApprove` axis: the bypass forms (`/yolo`, `/yolo on`, ...) are hidden
+ *    while already bypassing; the `off` form is hidden while not bypassing.
+ *  - `mode` axis: `/autopilot on` is hidden while already in autopilot;
+ *    `/autopilot off` is only offered while in autopilot.
+ *
+ * When `state` is undefined (current values unknown) every option is offered.
+ */
+function shouldOfferOption(option: IConfigSlashOption, state: ICopilotConfigSlashCommandState | undefined): boolean {
+	// Keep-text forms carry a typed prompt/objective and are always relevant.
+	if (option.argumentHint !== undefined || !state) {
+		return true;
+	}
+	const autoApproveTarget = option.config[SessionConfigKey.AutoApprove];
+	if (autoApproveTarget !== undefined) {
+		const isBypass = state.autoApprove === AUTO_APPROVE_BYPASS;
+		return autoApproveTarget === AUTO_APPROVE_BYPASS ? !isBypass : isBypass;
+	}
+	const modeTarget = option.config[SessionConfigKey.Mode];
+	if (modeTarget === MODE_AUTOPILOT) {
+		return state.mode !== MODE_AUTOPILOT;
+	}
+	if (modeTarget === MODE_INTERACTIVE) {
+		return state.mode === MODE_AUTOPILOT;
+	}
+	return true;
+}
+
+/**
  * Returns the flattened completion items (one per command form) whose command
  * name matches `typed` (the text after the leading `/`, case-insensitive prefix).
  * When `typed` is empty, all items are returned.
+ *
+ * When `state` (the session's current config values) is provided, pure toggle
+ * forms that would be a no-op are filtered out so only the state-changing forms
+ * are offered (see {@link shouldOfferOption}).
  */
-export function getCopilotConfigSlashCommandItems(typed: string): ICopilotConfigSlashCommandItem[] {
+export function getCopilotConfigSlashCommandItems(typed: string, state?: ICopilotConfigSlashCommandState): ICopilotConfigSlashCommandItem[] {
 	const typedLower = typed.trim().toLowerCase();
 	const items: ICopilotConfigSlashCommandItem[] = [];
 	for (const command of getConfigSlashCommands()) {
@@ -156,6 +205,9 @@ export function getCopilotConfigSlashCommandItems(typed: string): ICopilotConfig
 			continue;
 		}
 		for (const option of command.options) {
+			if (!shouldOfferOption(option, state)) {
+				continue;
+			}
 			// Keep-text items (those expecting a typed argument) insert `/command `
 			// and show the argument hint; pure toggles insert nothing (the display
 			// comes from `label`).

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -43,6 +43,7 @@ import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../co
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
+import { ICopilotConfigSlashCommandState } from '../../common/copilotConfigSlashCommands.js';
 import { ISessionDataService, SESSION_DB_FILENAME } from '../../common/sessionDataService.js';
 import { IAgentHostProxyResolver } from '../agentHostProxyResolver.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
@@ -417,6 +418,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				isRubberDuckEnabled: () => this._isRubberDuckEnabled(),
 				getRuntimeSlashCommands: (sessionId, options) => this._getRuntimeSlashCommands(sessionId, options),
 				getSessionCustomizations: (sessionId) => this.getSessionCustomizations(AgentSession.uri(this.id, sessionId)),
+				getSessionConfigState: (sessionId) => this._getSessionConfigState(sessionId),
 			},
 			RUNTIME_SLASH_COMMAND_COMPLETION_WAIT_MS,
 		)));
@@ -2002,6 +2004,19 @@ export class CopilotAgent extends Disposable implements IAgent {
 			default:
 				return undefined;
 		}
+	}
+
+	/**
+	 * Reads the session's current `mode` and `autoApprove` axis values so the
+	 * slash-command completion provider can hide config-action toggles that would
+	 * be a no-op (e.g. `/autopilot on` while already in autopilot).
+	 */
+	private _getSessionConfigState(sessionId: string): ICopilotConfigSlashCommandState {
+		const sessionKey = AgentSession.uri(this.id, sessionId).toString();
+		return {
+			mode: this._configurationService.getEffectiveValue(sessionKey, platformSessionSchema, SessionConfigKey.Mode),
+			autoApprove: this._configurationService.getEffectiveValue(sessionKey, platformSessionSchema, SessionConfigKey.AutoApprove),
+		};
 	}
 
 	setPendingMessages(session: URI, steeringMessage: PendingMessage | undefined, _queuedMessages: readonly PendingMessage[]): void {

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -8,7 +8,7 @@ import { AgentSession } from '../../common/agentService.js';
 import { CompletionItem, CompletionItemKind, CompletionsParams } from '../../common/state/protocol/commands.js';
 import { Customization, CustomizationType, DirectoryCustomization, MessageAttachmentKind, PluginCustomization, SkillCustomization } from '../../common/state/protocol/state.js';
 import { toCommandCompletionAttachmentMeta } from '../../common/meta/agentCompletionAttachmentMeta.js';
-import { getCopilotConfigSlashCommandItems, isCopilotConfigSlashCommand } from '../../common/copilotConfigSlashCommands.js';
+import { getCopilotConfigSlashCommandItems, ICopilotConfigSlashCommandState, isCopilotConfigSlashCommand } from '../../common/copilotConfigSlashCommands.js';
 import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from '../agentHostCompletions.js';
 import { extractLeadingSlashToken, extractWhitespaceDelimitedSlashToken } from '../agentHostSlashCompletion.js';
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../common/agentHostFileSystemService.js';
@@ -31,6 +31,12 @@ export interface ICopilotSlashCommandSessionInfo {
 	/** Runtime slash commands discovered from the SDK session. */
 	getRuntimeSlashCommands?(sessionId: string, options?: ICopilotRuntimeSlashCommandQueryOptions): Promise<readonly ICopilotRuntimeSlashCommandInfo[]>;
 	getSessionCustomizations: (session: string) => Promise<readonly Customization[]>;
+	/**
+	 * The session's current config state (`mode` / `autoApprove` axes), used to
+	 * filter config-action slash command completions so only the state-changing
+	 * forms are offered. When omitted, all forms are offered.
+	 */
+	getSessionConfigState?(sessionId: string): ICopilotConfigSlashCommandState | undefined;
 }
 
 export interface ICopilotRuntimeSlashCommandQueryOptions {
@@ -220,7 +226,8 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 		// offered for leading `/command` tokens (not the whitespace-delimited
 		// skill form).
 		if (!returnJustSkills) {
-			for (const item of getCopilotConfigSlashCommandItems(typed)) {
+			const configState = this._sessionInfo.getSessionConfigState?.(sessionId);
+			for (const item of getCopilotConfigSlashCommandItems(typed, configState)) {
 				completionItems.push({
 					insertText: item.insertText,
 					label: item.label,

--- a/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
+++ b/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
@@ -37,6 +37,30 @@ suite('copilotConfigSlashCommands', () => {
 			assert.deepStrictEqual([...commands], ['autopilot']);
 			assert.strictEqual(getCopilotConfigSlashCommandItems('nope').length, 0);
 		});
+
+		test('autopilot state hides the no-op toggle but keeps the prompt form', () => {
+			const inAutopilot = new Set(getCopilotConfigSlashCommandItems('autopilot', { mode: 'autopilot' }).map(i => i.label));
+			// Already in autopilot: only offer `off` (plus the always-on prompt form).
+			assert.deepStrictEqual([...inAutopilot].sort(), ['/autopilot', '/autopilot off']);
+
+			const notAutopilot = new Set(getCopilotConfigSlashCommandItems('autopilot', { mode: 'interactive' }).map(i => i.label));
+			// Not in autopilot: only offer `on` (plus the always-on prompt form).
+			assert.deepStrictEqual([...notAutopilot].sort(), ['/autopilot', '/autopilot on']);
+
+			// Plan mode is still "not autopilot", so `on` is offered and `off` is hidden.
+			const inPlan = new Set(getCopilotConfigSlashCommandItems('autopilot', { mode: 'plan' }).map(i => i.label));
+			assert.deepStrictEqual([...inPlan].sort(), ['/autopilot', '/autopilot on']);
+		});
+
+		test('autoApprove state hides the no-op bypass/default toggles across aliases', () => {
+			// Already bypassing: hide the bypass forms (bare + `on`), keep `off`.
+			const bypassing = new Set(getCopilotConfigSlashCommandItems('yolo', { autoApprove: 'autoApprove' }).map(i => i.label));
+			assert.deepStrictEqual([...bypassing].sort(), ['/yolo off']);
+
+			// Not bypassing: hide `off`, keep the bypass forms (bare + `on`).
+			const notBypassing = new Set(getCopilotConfigSlashCommandItems('allow-all', { autoApprove: 'default' }).map(i => i.label));
+			assert.deepStrictEqual([...notBypassing].sort(), ['/allow-all', '/allow-all on']);
+		});
 	});
 
 	suite('resolveCopilotConfigSlashCommandOnSend', () => {


### PR DESCRIPTION
## Summary

Filters the Copilot config-action slash command completions so that toggle forms which would be a no-op given the session's current state are hidden.

### Behavior
- **Autopilot** (symmetric toggle):
  - In autopilot → hide \`/autopilot on\`, show \`/autopilot off\`
  - Not in autopilot → show \`/autopilot on\`, hide \`/autopilot off\`
  - The \`/autopilot <objective>\` prompt form is **always** shown
- **Yolo / allow-all / autoApprove** (all aliases on the \`autoApprove\` axis):
  - Already bypassing → hide the bypass forms (\`/yolo\`, \`/yolo on\`, …), show \`/yolo off\`
  - Not bypassing → show the bypass forms, hide \`/yolo off\`
- When the current state is unknown, all forms are offered (safe default).

### Changes
- \`copilotConfigSlashCommands.ts\` — added \`ICopilotConfigSlashCommandState\`, a \`shouldOfferOption\` filter (prompt/keep-text forms always kept; pure toggles hidden when a no-op on their axis), and an optional \`state\` parameter on \`getCopilotConfigSlashCommandItems\`.
- \`copilotSlashCommandCompletionProvider.ts\` — added \`getSessionConfigState?\` to \`ICopilotSlashCommandSessionInfo\` and passes resolved state into the item builder.
- \`copilotAgent.ts\` — implemented \`_getSessionConfigState\`, reading effective \`mode\`/\`autoApprove\` via \`IAgentConfigurationService.getEffectiveValue\`, and wired it into the provider.
- Added tests covering autopilot and autoApprove state filtering.

### Verification
- \`npm run typecheck-client\` — passes
- ESLint on changed files — clean
- Unit tests — 6 passing (including the 2 new state-filtering tests)