### PR TITLE
Show a plain spinner while dictation is starting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -32,6 +32,8 @@ import { cancelDictation, isDictating, startDictation, stopDictation } from '../
 export const ChatSpeechToTextConfigured = ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.has(ChatContextKeys.speechToTextConfigured.key));
 /** True while the on-device model is downloading/loading (the mic shows a spinner instead). */
 export const ChatSpeechToTextPreparing = ContextKeyExpr.has(ChatContextKeys.speechToTextPreparing.key);
+/** True while dictation is starting up (mic + session open) before listening is ready. */
+export const ChatSpeechToTextStarting = ContextKeyExpr.has(ChatContextKeys.speechToTextStarting.key);
 
 
 /** Releases shorter than this are treated as an accidental tap and discarded. */
@@ -137,7 +139,7 @@ class ToggleChatSpeechToTextAction extends Action2 {
 			menu: [{
 				id: MenuId.ChatExecute,
 				order: -11,
-				when: ContextKeyExpr.and(ChatSpeechToTextConfigured, ChatSpeechToTextPreparing.negate()),
+				when: ContextKeyExpr.and(ChatSpeechToTextConfigured, ChatSpeechToTextPreparing.negate(), ChatSpeechToTextStarting.negate()),
 				group: 'navigation',
 			}],
 			keybinding: {
@@ -193,6 +195,40 @@ export class ChatSpeechToTextPreparingAction extends Action2 {
 				id: MenuId.ChatExecute,
 				order: -11,
 				when: ContextKeyExpr.and(ChatSpeechToTextConfigured, ChatSpeechToTextPreparing),
+				group: 'navigation',
+			}],
+		});
+	}
+
+	async run(): Promise<void> {
+		if (isDictating()) {
+			cancelDictation();
+		}
+	}
+}
+
+/**
+ * Shown in place of the mic button while dictation is starting up (acquiring the
+ * microphone and opening the session) before listening is ready. Renders a plain
+ * spinner — matching Voice Mode's "Connecting…" affordance — so the brief wait
+ * reads as active. Distinct from {@link ChatSpeechToTextPreparingAction}, which
+ * shows a determinate download ring while the on-device model downloads/loads.
+ */
+export class ChatSpeechToTextConnectingAction extends Action2 {
+	static readonly ID = 'workbench.action.chat.speechToTextConnecting';
+
+	constructor() {
+		super({
+			id: ChatSpeechToTextConnectingAction.ID,
+			title: localize2('chat.speechToText.connecting', "Starting Dictation…"),
+			category: CHAT_CATEGORY,
+			f1: false,
+			icon: Codicon.loading,
+			precondition: ChatSpeechToTextStarting,
+			menu: [{
+				id: MenuId.ChatExecute,
+				order: -11,
+				when: ContextKeyExpr.and(ChatSpeechToTextConfigured, ChatSpeechToTextStarting, ChatSpeechToTextPreparing.negate()),
 				group: 'navigation',
 			}],
 		});
@@ -355,6 +391,7 @@ export function registerChatSpeechToTextActions(): DisposableStore {
 	const store = new DisposableStore();
 	store.add(registerAction2(ToggleChatSpeechToTextAction));
 	store.add(registerAction2(ChatSpeechToTextPreparingAction));
+	store.add(registerAction2(ChatSpeechToTextConnectingAction));
 	store.add(registerAction2(HoldToSpeechToTextAction));
 	store.add(registerAction2(CancelChatSpeechToTextAction));
 	store.add(registerAction2(SelectSpeechToTextMicrophoneAction));

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -156,6 +156,8 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		return this._isPreparingModel;
 	}
 
+	private _isStarting = false;
+
 	private readonly _onDidChangeModelDownloadProgress = this._register(new Emitter<void>());
 	readonly onDidChangeModelDownloadProgress = this._onDidChangeModelDownloadProgress.event;
 
@@ -183,6 +185,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	private readonly _recordingContextKey: IContextKey<boolean>;
 	private readonly _configuredContextKey: IContextKey<boolean>;
 	private readonly _preparingContextKey: IContextKey<boolean>;
+	private readonly _startingContextKey: IContextKey<boolean>;
 
 	private _mediaStream: MediaStream | undefined;
 	private _audioContext: AudioContext | undefined;
@@ -233,6 +236,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		this._recordingContextKey = ChatContextKeys.speechToTextRecording.bindTo(contextKeyService);
 		this._configuredContextKey = ChatContextKeys.speechToTextConfigured.bindTo(contextKeyService);
 		this._preparingContextKey = ChatContextKeys.speechToTextPreparing.bindTo(contextKeyService);
+		this._startingContextKey = ChatContextKeys.speechToTextStarting.bindTo(contextKeyService);
 		this._updateConfiguredContextKey();
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(ENABLED_SETTING)) {
@@ -251,10 +255,29 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		}
 		this._isPreparingModel = preparing;
 		this._preparingContextKey.set(preparing);
+		if (preparing) {
+			// The determinate download ring takes over the toolbar slot, so drop
+			// the plain "starting" spinner to avoid showing both affordances.
+			this._setStarting(false);
+		}
 		if (!preparing) {
 			this._setModelDownloadProgress(undefined);
 		}
 		this._onDidChangePreparingModel.fire(preparing);
+	}
+
+	/**
+	 * Toggle the transient "starting" spinner shown from the moment dictation is
+	 * triggered until it is actually listening (or the determinate download ring
+	 * takes over). This covers the microphone-acquisition and session-open gap so
+	 * the toolbar mic does not sit static while nothing appears to happen.
+	 */
+	private _setStarting(starting: boolean): void {
+		if (this._isStarting === starting) {
+			return;
+		}
+		this._isStarting = starting;
+		this._startingContextKey.set(starting);
 	}
 
 	private _setModelDownloadProgress(progress: number | undefined): void {
@@ -344,6 +367,12 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		this._sessionSegments = 0;
 		this._sessionErrorCode = '';
 
+		// Show a plain spinner from the moment dictation is triggered so the
+		// wait until we are actually listening (microphone acquisition + session
+		// open) reads as active. If the model still needs downloading/loading,
+		// the determinate download ring takes over (see _setPreparingModel).
+		this._setStarting(true);
+
 		let stream: MediaStream;
 		try {
 			stream = await this._acquireStream(window);
@@ -383,6 +412,12 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 			throw err;
 		}
 		this._setState(ChatSpeechToTextState.Recording);
+		// If the model is ready we are now listening, so retire the "starting"
+		// spinner. When it is still preparing, the download ring already took
+		// over and clears itself once the model becomes ready.
+		if (!this._isPreparingModel) {
+			this._setStarting(false);
+		}
 		// Only cue "recording started" once we are actually listening. If the
 		// model is still downloading/loading, defer the cue until it becomes
 		// ready (see _handleModelStatus), so it lands with the "Listening…"
@@ -665,6 +700,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 
 	private _teardown(): void {
 		this._stopCapture();
+		this._setStarting(false);
 		this._setPreparingModel(false);
 		this._completeDownloadNotification();
 		// Drop any in-progress preparation timing; a session torn down before the

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -58,6 +58,7 @@ export namespace ChatContextKeys {
 	export const speechToTextRecording = new RawContextKey<boolean>('chatSpeechToTextRecording', false, { type: 'boolean', description: localize('chatSpeechToTextRecording', "True while the chat input is recording audio for speech-to-text transcription.") });
 	export const speechToTextConfigured = new RawContextKey<boolean>('chatSpeechToTextConfigured', false, { type: 'boolean', description: localize('chatSpeechToTextConfigured', "True when on-device speech-to-text is available for dictating into the chat input.") });
 	export const speechToTextPreparing = new RawContextKey<boolean>('chatSpeechToTextPreparing', false, { type: 'boolean', description: localize('chatSpeechToTextPreparing', "True while the on-device speech-to-text model is downloading or loading (the download progress ring is shown).") });
+	export const speechToTextStarting = new RawContextKey<boolean>('chatSpeechToTextStarting', false, { type: 'boolean', description: localize('chatSpeechToTextStarting', "True while dictation is starting up (acquiring the microphone and opening the session) before listening is ready; a plain spinner is shown.") });
 
 	export const supported = ContextKeyExpr.or(IsWebContext.negate(), RemoteNameContext.notEqualsTo(''), ContextKeyExpr.has('config.chat.experimental.serverlessWebEnabled'));
 	export const enabled = new RawContextKey<boolean>('chatIsEnabled', false, { type: 'boolean', description: localize('chatIsEnabled', "True when chat is enabled because a default chat participant is activated with an implementation.") });


### PR DESCRIPTION
### Problem

When the on-device dictation model is already downloaded (the common case), clicking the dictation mic gave **no feedback** during microphone acquisition + session open. `isPreparingModel` stayed `false`, so the toolbar button sat as a static mic until it abruptly jumped to "Listening…". Only the first-time download path showed any affordance (the determinate download ring).

### Fix

Mirror Voice Mode's `agentsVoice.connecting` pattern:

- New context key **`chatSpeechToTextStarting`**, set the moment dictation is triggered and cleared once we are actually listening (or once the determinate download ring takes over).
- New **`ChatSpeechToTextConnectingAction`** renders a plain auto-spinning `Codicon.loading` during that window.
- The toggle mic is hidden while starting/preparing; the download ring still wins when a real download is in progress, so the two spinner affordances never show together.

Wired in `chatSpeechToTextService.ts` (`start()`, `_setPreparingModel`, `_teardown`) so the state is race-free across the mic → session-open → listening transitions and every failure/cancel path.

### Validation

- `npm run typecheck-client` ✅
- eslint ✅ on all changed files

_Note: the pre-commit hygiene hook is broken in my local environment (`gulp-sort` missing from `node_modules`), unrelated to this change._

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
