### PR TITLE
Fix stale copilot config slash-command test expecting removed bare form

### DIFF
--- a/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
+++ b/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
@@ -52,13 +52,13 @@ suite('copilotConfigSlashCommands', () => {
 		});
 
 		test('autoApprove state hides the no-op bypass/default toggles across aliases', () => {
-			// Already bypassing: hide the bypass forms (bare + `on`), keep `off`.
+			// Already bypassing: hide the bypass `on` form, keep `off`.
 			const bypassing = new Set(getCopilotConfigSlashCommandItems('yolo', { autoApprove: 'autoApprove' }).map(i => i.label));
 			assert.deepStrictEqual([...bypassing].sort(), ['/yolo off']);
 
-			// Not bypassing: hide `off`, keep the bypass forms (bare + `on`).
+			// Not bypassing: hide `off`, keep the bypass `on` form.
 			const notBypassing = new Set(getCopilotConfigSlashCommandItems('allow-all', { autoApprove: 'default' }).map(i => i.label));
-			assert.deepStrictEqual([...notBypassing].sort(), ['/allow-all', '/allow-all on']);
+			assert.deepStrictEqual([...notBypassing].sort(), ['/allow-all on']);
 		});
 	});
 


### PR DESCRIPTION
The unit test `copilotConfigSlashCommands > getCopilotConfigSlashCommandItems > autoApprove state hides the no-op bypass/default toggles across aliases` is currently **failing on `main`** (all 6 Browser/Electron unit-test jobs are red).

### Root cause
- #326837 removed the no-arg (bare) `/yolo` and `/allow-all` config-action slash-command options.
- #326843 (a descendant of #326837) updated this test to expect the bare form (`'/allow-all'`) alongside `'/allow-all on'`, but the bare option no longer exists.
- With the current source, a not-bypassing session offers only `/allow-all on`, so the assertion `['/allow-all', '/allow-all on']` fails with actual `['/allow-all on']`.

### Fix
Update the expectation (and the two comments referencing "bare + \`on\`") to match the intended post-#326837 behavior: the bare form is gone, only the `on` sub-arg form remains. No production code change.

Verified: `npm run typecheck-client` is clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>