### PR TITLE
Fix test to assert only '/allow-all on' command visibility without 'off'

### DIFF
--- a/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
+++ b/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
@@ -58,7 +58,7 @@ suite('copilotConfigSlashCommands', () => {
 
 			// Not bypassing: hide `off`, keep the bypass forms (bare + `on`).
 			const notBypassing = new Set(getCopilotConfigSlashCommandItems('allow-all', { autoApprove: 'default' }).map(i => i.label));
-			assert.deepStrictEqual([...notBypassing].sort(), ['/allow-all', '/allow-all on']);
+			assert.deepStrictEqual([...notBypassing].sort(), ['/allow-all on']);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
+++ b/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
@@ -56,7 +56,7 @@ suite('copilotConfigSlashCommands', () => {
 			const bypassing = new Set(getCopilotConfigSlashCommandItems('yolo', { autoApprove: 'autoApprove' }).map(i => i.label));
 			assert.deepStrictEqual([...bypassing].sort(), ['/yolo off']);
 
-			// Not bypassing: hide `off`, keep the bypass forms (bare + `on`).
+			// Not bypassing: hide `off`, keep `on`.
 			const notBypassing = new Set(getCopilotConfigSlashCommandItems('allow-all', { autoApprove: 'default' }).map(i => i.label));
 			assert.deepStrictEqual([...notBypassing].sort(), ['/allow-all on']);
 		});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
