### PR TITLE
Remove scrollbar from prompt timeline hover card

### DIFF
--- a/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
+++ b/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
@@ -244,8 +244,6 @@
 .prompt-timeline-card-files {
 	border-top: 1px solid var(--vscode-editorHoverWidget-border);
 	margin-top: 8px;
-	max-height: 140px;
-	overflow-y: auto;
 }
 
 .prompt-timeline-card-file {


### PR DESCRIPTION
This pull request removes the scrollbar from the prompt timeline hover card by adjusting the CSS properties that controlled its height and overflow behavior. 

- Removed `max-height: 140px;` and `overflow-y: auto;` from `.prompt-timeline-card-files` in `promptTimeline.css`.
- The hover card now expands to fit the entire file list without introducing a scrollbar, enhancing the user experience by displaying all content at once. 

The card remains positioned correctly and is fully visible within the rail container.