### PR TITLE
Fix: apply chat.defaultModel default on every new local chat session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1574,6 +1574,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}
 			this._syncFromModel(state, forSessionResource);
 		}));
+
+		// A configured default model (`chat.defaultModel`) is the default for every
+		// NEW conversation and must win even when the freshly bound input model already
+		// carries a selection spilled over from the previous session. The draft-based
+		// overrides above only fire while seeding from an absent state, so re-apply here
+		// after the model->view autorun is wired (so it is not overwritten by the sync).
+		// The call no-ops unless the session is empty and the user has not picked a model
+		// in this conversation, so a reopened conversation keeps its saved model.
+		this._applyConfiguredDefaultForEmptySession();
 	}
 
 	private _getPersistedEmptyInputState(): IChatModelInputState | undefined {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1574,15 +1574,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}
 			this._syncFromModel(state, forSessionResource);
 		}));
-
-		// A configured default model (`chat.defaultModel`) is the default for every
-		// NEW conversation and must win even when the freshly bound input model already
-		// carries a selection spilled over from the previous session. The draft-based
-		// overrides above only fire while seeding from an absent state, so re-apply here
-		// after the model->view autorun is wired (so it is not overwritten by the sync).
-		// The call no-ops unless the session is empty and the user has not picked a model
-		// in this conversation, so a reopened conversation keeps its saved model.
-		this._applyConfiguredDefaultForEmptySession();
 	}
 
 	private _getPersistedEmptyInputState(): IChatModelInputState | undefined {
@@ -3081,6 +3072,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this._modelSelectionSessionSwitch = undefined;
 			}
 		});
+
+		// Runs after the incoming view model is assigned so model resolution/validation use the incoming session pool, not the outgoing one.
+		this._applyConfiguredDefaultForEmptySession();
 	}
 
 	private resetPendingDelegationForViewModelChange(transaction: ITransaction): void {


### PR DESCRIPTION
Fixes #326877


### Problem
`chat.defaultModel` was inconsistent between the Local chat harness and the Agents (AHP) harness. In Local sessions, after picking a different model and sending a request, creating a new chat would carry over the previous session's model instead of resetting to the configured default — only a window reload restored it. AHP behaved correctly.

### Root cause
Both harnesses share the pure precedence logic in modelSelection.ts, but drive it differently:

**AHP** (sessionModelSelectionModel.ts → transitionModelSelection) re-pushes the configured default on every new chat key, so a new conversation always resets to the default unless the user explicitly picked a model within that same chat.

**Local** (chatInputPart.ts) only applied the configured-default override on the empty-input draft path — i.e. when the freshly bound input model had no state. When a new chat's input model already carried a spilled-over selection, none of the override paths fired, and _applyConfiguredDefaultForEmptySession() wasn't triggered on a plain session switch. Reload worked only because construction re-runs initSelectedModel().

### Fix
Call the existing, already-guarded _applyConfiguredDefaultForEmptySession() from handleViewModelChange, after the incoming view model has been assigned. This is required because the helper resolves and validates the model through getCurrentSessionType(), which only reflects the incoming session once ChatWidget assigns the new view model (setInputModel runs before that). Running it there also lets reconcileSessionTypeForViewModelChange (which re-runs initSelectedModel on a genuine type change) settle first, and placing it after the transaction restores normal persistence. 

New intended behavior (both local and AHP):

- New session → configured default (chat.defaultModel) always wins, even over a spillover selection.
- Reopened conversation (non-empty) → no-op; the saved per-conversation model is restored.
- Setting unset → no-op; existing sticky "last-used model" behavior is preserved.