### PR TITLE
fix: memory leak in modalEditorPart

### DIFF
--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -910,8 +910,7 @@ class ModalEditorPartImpl extends EditorPart implements IModalEditorPart {
 		@IHostService hostService: IHostService,
 		@IContextKeyService private readonly modalContextKeyService: IContextKeyService,
 	) {
-		// Only one modal editor part can exist at a time. Keep its component ID stable
-		// so that recreating the modal does not add new entries to the global memento cache.
+		// Keep a stable component ID so recreating the modal does not grow the global memento cache.
 		super(editorPartsView, 'workbench.parts.modalEditor', localize('modalEditorPart', "Modal Editor Area"), windowId, instantiationService, themeService, configurationService, storageService, layoutService, hostService, modalContextKeyService);
 
 		this._maximized = options?.maximized ?? false;

--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -849,8 +849,6 @@ interface IPosition {
 
 class ModalEditorPartImpl extends EditorPart implements IModalEditorPart {
 
-	private static COUNTER = 1;
-
 	private readonly _onWillClose = this._register(new Emitter<void>());
 	readonly onWillClose = this._onWillClose.event;
 
@@ -912,8 +910,9 @@ class ModalEditorPartImpl extends EditorPart implements IModalEditorPart {
 		@IHostService hostService: IHostService,
 		@IContextKeyService private readonly modalContextKeyService: IContextKeyService,
 	) {
-		const id = ModalEditorPartImpl.COUNTER++;
-		super(editorPartsView, `workbench.parts.modalEditor.${id}`, localize('modalEditorPart', "Modal Editor Area"), windowId, instantiationService, themeService, configurationService, storageService, layoutService, hostService, modalContextKeyService);
+		// Only one modal editor part can exist at a time. Keep its component ID stable
+		// so that recreating the modal does not add new entries to the global memento cache.
+		super(editorPartsView, 'workbench.parts.modalEditor', localize('modalEditorPart', "Modal Editor Area"), windowId, instantiationService, themeService, configurationService, storageService, layoutService, hostService, modalContextKeyService);
 
 		this._maximized = options?.maximized ?? false;
 		this._size = options?.size;


### PR DESCRIPTION
### Details

When opening a modal like the new images preview, a memento seems to be created. But when closing the modal, the memento seems to be not removed.

### Change

This changes it so that there is only one global memento for modals, instead of one per modal. This ensures no extra mementos are created when opening and closing a modal.

My understanding is that `modalEditorPart` doesn't need a memento at all, since it doesn't save any state:

```ts
protected override saveState(): void {
	return; // disabled, modal editor part state is not persisted
}
```

### Before

When opening and closing the images modal 37 times, the number of ScopedMemento objects seems to grow by 1 each time:

<img width="1400" height="20" alt="modal" src="https://github.com/user-attachments/assets/8ff08811-6be3-4bad-9688-a5cd81657d4e" />


### After

No more leak is detected.


### Test Video

https://github.com/user-attachments/assets/78c5c2d8-473a-45cf-a402-a99c62c64219

