### PR TITLE
fix: memory leak in abstractRuntimeExtensionsEditor

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
@@ -439,10 +439,11 @@ export abstract class AbstractRuntimeExtensionsEditor extends EditorPane {
 
 			disposeTemplate: (data: IRuntimeExtensionTemplateData): void => {
 				data.disposables = dispose(data.disposables);
+				data.elementDisposables = dispose(data.elementDisposables);
 			}
 		};
 
-		this._list = this._instantiationService.createInstance(WorkbenchList<IRuntimeExtension>,
+		this._list = this._register(this._instantiationService.createInstance(WorkbenchList<IRuntimeExtension>,
 			'RuntimeExtensions',
 			parent, delegate, [renderer], {
 			multipleSelectionSupport: false,
@@ -459,7 +460,7 @@ export abstract class AbstractRuntimeExtensionsEditor extends EditorPane {
 					return element.description.name;
 				}
 			}
-		});
+		}));
 
 		this._list.splice(0, this._list.length, this._elements || undefined);
 


### PR DESCRIPTION
### Details

Registers a disposable in `abstractRuntimeExtensionsEditor` so it is properly disposed.

### Before

When opening two running extensions editors then closing all editors 37 times, the number of various functions seems to grow each time:

<img width="1400" height="4120" alt="extension-running-extensions-show-side-by-side-before" src="https://github.com/user-attachments/assets/0063bd47-0600-44de-bbf9-970e2da663dd" />



### After

No more leak is detected.



### Test Video



https://github.com/user-attachments/assets/ea65072e-f55c-4cb5-9b44-455ff747453d




