### PR TITLE
Enable experimentation on chat.defaultModel setting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -588,6 +588,9 @@ configurationRegistry.registerConfiguration({
 			type: 'string',
 			default: '',
 			markdownDescription: nls.localize('chat.defaultModel.description', "The default model for new chat conversations. Use \"auto\" to let Copilot pick a model, a model family name (such as \"opus\" or \"gemini\") to use the latest available model in that family, or a full model id. You can still switch the model within a conversation; each new conversation starts at this model."),
+			experiment: {
+				mode: 'startup'
+			},
 			policy: {
 				name: 'ChatDefaultModel',
 				category: PolicyCategory.InteractiveSession,

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -589,7 +589,7 @@ configurationRegistry.registerConfiguration({
 			default: '',
 			markdownDescription: nls.localize('chat.defaultModel.description', "The default model for new chat conversations. Use \"auto\" to let Copilot pick a model, a model family name (such as \"opus\" or \"gemini\") to use the latest available model in that family, or a full model id. You can still switch the model within a conversation; each new conversation starts at this model."),
 			experiment: {
-				mode: 'startup'
+				mode: 'auto'
 			},
 			policy: {
 				name: 'ChatDefaultModel',


### PR DESCRIPTION
Adds experiment support to the chat.defaultModel setting so its default value can be assigned via exp service for A/B rollouts.