### PR TITLE
sessions: add a Quick Pick entry point for folder selection in new session

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -17,6 +17,7 @@ import './nullInlineChatSessionService.js';
 import './nullChatTipService.js';
 import './modelPicker.js';
 import './agentHostDelegation.js';
+import './newSessionFolderQuickPickAction.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ISessionsTasksService, SessionsTasksService } from './sessionsTasksService.js';

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -12,6 +12,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { localize } from '../../../../nls.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISession } from '../../../services/sessions/common/session.js';
@@ -83,6 +84,7 @@ export class NewChatWidget extends Disposable {
 		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 		@IAquariumService private readonly aquariumService: IAquariumService,
 		@IAgentHostFilterService private readonly agentHostFilterService: IAgentHostFilterService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 	) {
 		super();
 		this._workspacePickerVisibleKey = SessionWorkspacePickerVisibleContext.bindTo(contextKeyService);
@@ -155,6 +157,16 @@ export class NewChatWidget extends Disposable {
 			}
 			await this._onWorkspaceSelected(this._workspacePicker.selectedFolderUri);
 			this._newChatInput.focus();
+		}));
+
+		// Re-sync the picker's displayed selection when the session's workspace
+		// changes externally (e.g. sessionsService.openNewSession({ folderUri })).
+		this._register(autorun(reader => {
+			const session = this._session.read(reader);
+			const folderUri = session?.workspace.read(reader)?.folders[0]?.root;
+			if (folderUri && !this.uriIdentityService.extUri.isEqual(folderUri, this._workspacePicker.selectedFolderUri)) {
+				this._workspacePicker.setSelectedWorkspace(folderUri, { fireEvent: false });
+			}
 		}));
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/newSessionFolderQuickPickAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSessionFolderQuickPickAction.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { URI } from '../../../../base/common/uri.js';
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { ILabelService } from '../../../../platform/label/common/label.js';
+import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
+import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { CHAT_CATEGORY } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
+import { ISessionsRecentWorkspacesService } from '../../../services/sessions/browser/sessionsRecentWorkspacesService.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+
+export interface IFolderQuickPickItem extends IQuickPickItem {
+	readonly folderUri?: URI;
+	readonly browse?: boolean;
+}
+
+/** Builds the flat folder quick pick list: own recents, then VS Code recents (deduplicated), then Browse. */
+export function buildFolderQuickPickItems(
+	recentWorkspacesService: ISessionsRecentWorkspacesService,
+	labelService: ILabelService,
+): (IFolderQuickPickItem | IQuickPickSeparator)[] {
+	const recents = recentWorkspacesService.getRecentWorkspaces();
+
+	const items: (IFolderQuickPickItem | IQuickPickSeparator)[] = [];
+	if (recents.length > 0) {
+		items.push({ type: 'separator', label: localize('sessions.newSession.pickFolderQuickPick.recent', "Recent") });
+		for (const { workspace } of recents) {
+			const folderUri = workspace.folders[0]?.root;
+			if (!folderUri) {
+				continue;
+			}
+			items.push({
+				folderUri,
+				label: `$(${workspace.icon.id}) ${workspace.label}`,
+				description: labelService.getUriLabel(folderUri, { relative: false }),
+			});
+		}
+		items.push({ type: 'separator', label: '' });
+	}
+
+	items.push({
+		label: `$(${Codicon.folderOpened.id}) ${localize('sessions.newSession.pickFolderQuickPick.browse', "Browse...")}`,
+		browse: true,
+	});
+
+	return items;
+}
+
+/** Alternative entry point to the new-session workspace picker via {@link IQuickInputService.pick}. */
+class NewSessionPickFolderQuickPickAction extends Action2 {
+
+	constructor() {
+		super({
+			id: 'workbench.action.sessions.newSession.pickFolderQuickPick',
+			title: localize2('sessions.newSession.pickFolderQuickPick.label', "New Session in Folder..."),
+			category: CHAT_CATEGORY,
+			f1: true,
+			keybinding: {
+				// Wins over the desktop Open File/Folder actions' Cmd+O when both match.
+				weight: KeybindingWeight.SessionsContrib,
+				when: IsSessionsWindowContext,
+				primary: KeyMod.CtrlCmd | KeyCode.KeyO,
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const sessionsService = accessor.get(ISessionsService);
+		const recentWorkspacesService = accessor.get(ISessionsRecentWorkspacesService);
+		const labelService = accessor.get(ILabelService);
+		const fileDialogService = accessor.get(IFileDialogService);
+
+		const items = buildFolderQuickPickItems(recentWorkspacesService, labelService);
+
+		const picked = await quickInputService.pick(items, {
+			placeHolder: localize('sessions.newSession.pickFolderQuickPick.placeholder', "Select a folder to start a new session in"),
+			matchOnDescription: true,
+		});
+		if (!picked) {
+			return;
+		}
+
+		let folderUri = picked.folderUri;
+		if (picked.browse) {
+			const result = await fileDialogService.showOpenDialog({
+				canSelectFolders: true,
+				canSelectFiles: false,
+				canSelectMany: false,
+			});
+			folderUri = result?.[0];
+		}
+		if (!folderUri) {
+			return;
+		}
+
+		sessionsService.openNewSession({ folderUri });
+	}
+}
+
+registerAction2(NewSessionPickFolderQuickPickAction);

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -11,8 +11,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { disposableTimeout } from '../../../../base/common/async.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
-import { URI, UriComponents } from '../../../../base/common/uri.js';
-import { basename } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
@@ -25,27 +24,25 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService, IContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../services/sessions/common/session.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsRecentWorkspacesService } from '../../../services/sessions/browser/sessionsRecentWorkspacesService.js';
 import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 import { SessionWorkspacePickerGroupContext } from '../../../common/contextkeys.js';
 // eslint-disable-next-line local/code-import-patterns -- TODO: move remote host options out of providers
 import { getStatusHover, getStatusLabel, removeRemoteHost, showRemoteHostOptions } from '../../providers/remoteAgentHost/browser/remoteHostOptions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IWorkspacesService, isRecentFolder } from '../../../../platform/workspaces/common/workspaces.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 import { Menus } from '../../../browser/menus.js';
 import { markOnboardingTarget } from '../../../../workbench/contrib/onboarding/browser/spotlight/onboardingTarget.js';
 
-const STORAGE_KEY_RECENT_WORKSPACES = 'sessions.recentlyPickedWorkspaces';
+
 const FILTER_THRESHOLD = 10;
-const MAX_RECENT_WORKSPACES = 10;
 
 /**
  * Fixed picker width when the categorical tab bar is shown. Keeps the tab
@@ -63,35 +60,15 @@ const TABBED_PICKER_WIDTH = 360;
 const RESTORE_CONNECT_GRACE_MS = 5000;
 
 /**
- * A workspace entry as resolved from a folder URI for rendering. The
- * `providerId` is the provider that resolved the URI (first match in
- * iteration order). For local URIs that any local provider can resolve,
- * this is the first registered local provider; for remote URIs it is the
- * remote provider for that authority.
- *
- * Selection now flows out of the picker as a plain folder URI — the
- * provider is rediscovered at session-creation time by
- * {@link ISessionsManagementService.createNewSession}. The `providerId`
- * carried here is only used internally for rendering (connection state,
- * grouping into tabs).
+ * A workspace as resolved from a folder URI for rendering. The `providerId`
+ * is the provider that resolved the URI (first match in iteration order,
+ * or the preferred hint when honored). For local URIs that any local
+ * provider can resolve, this is the first registered local provider; for
+ * remote URIs it is the remote provider for that authority.
  */
 export interface IResolvedFolderWorkspace {
 	readonly providerId: string;
 	readonly workspace: ISessionWorkspace;
-}
-
-/**
- * Stored recent workspace entry. The `checked` flag marks the currently
- * selected workspace so we only need a single storage key.
- *
- * `providerId` is retained for backwards compatibility with previously
- * stored entries; new entries are written without it. When reading,
- * entries are resolved by iterating registered providers.
- */
-interface IStoredRecentWorkspace {
-	readonly uri: UriComponents;
-	readonly providerId?: string;
-	readonly checked: boolean;
 }
 
 /**
@@ -169,9 +146,6 @@ export class WorkspacePicker extends Disposable {
 	 */
 	private _userPickedTab = false;
 
-	/** Cached VS Code recent folder URIs, resolved lazily. */
-	private _vsCodeRecentFolderUris: URI[] = [];
-
 	get selectedFolderUri(): URI | undefined {
 		return this._selectedFolderUri;
 	}
@@ -189,13 +163,12 @@ export class WorkspacePicker extends Disposable {
 
 	constructor(
 		@IActionWidgetService protected readonly actionWidgetService: IActionWidgetService,
-		@IStorageService private readonly storageService: IStorageService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService protected readonly sessionsProvidersService: ISessionsProvidersService,
+		@ISessionsRecentWorkspacesService private readonly recentWorkspacesService: ISessionsRecentWorkspacesService,
 		@IRemoteAgentHostService private readonly remoteAgentHostService: IRemoteAgentHostService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ICommandService private readonly commandService: ICommandService,
-		@IWorkspacesService private readonly workspacesService: IWorkspacesService,
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -253,10 +226,6 @@ export class WorkspacePicker extends Disposable {
 				}
 			}
 		}));
-
-		// Load VS Code recent folders eagerly and refresh on changes
-		this._loadVSCodeRecentFolders();
-		this._register(this.workspacesService.onDidChangeRecentlyOpened(() => this._loadVSCodeRecentFolders()));
 
 		// Re-arm auto-tab whenever the workspace selection changes to a new
 		// value, but only while the picker is closed. This way picking a tab
@@ -608,10 +577,7 @@ export class WorkspacePicker extends Disposable {
 		this._connectionStatusWatch.clear();
 		this._selectedFolderUri = undefined;
 		this._selectedResolved = undefined;
-		// Clear checked state from all recents
-		const recents = this._getStoredRecentWorkspaces();
-		const updated = recents.map(p => ({ ...p, checked: false }));
-		this.storageService.store(STORAGE_KEY_RECENT_WORKSPACES, JSON.stringify(updated), StorageScope.PROFILE, StorageTarget.MACHINE);
+		this.recentWorkspacesService.clearCheckedWorkspace();
 		this._updateTriggerLabel();
 		this._onDidChangeSelection.fire();
 	}
@@ -633,13 +599,13 @@ export class WorkspacePicker extends Disposable {
 		// providerId stored in the recents for this URI, so re-picking a
 		// Local Agent Host folder restores the Local Agent Host association
 		// even when another provider also resolves the URI.
-		const storedProviderId = this._getStoredRecentWorkspaces()
-			.find(r => this.uriIdentityService.extUri.isEqual(URI.revive(r.uri), folderUri))
+		const storedProviderId = this.recentWorkspacesService.getRecentWorkspaces()
+			.find(r => this.uriIdentityService.extUri.isEqual(r.workspace.folders[0]?.root, folderUri))
 			?.providerId;
 		const resolved = this._resolveFolder(folderUri, providerIdHint ?? storedProviderId);
 		this._selectedFolderUri = folderUri;
 		this._selectedResolved = resolved;
-		this._persistSelectedFolder(folderUri, resolved?.providerId);
+		this.recentWorkspacesService.addRecentWorkspace(folderUri, resolved?.providerId, true);
 		this._updateTriggerLabel();
 		this._onDidChangeSelection.fire();
 		if (fireEvent) {
@@ -778,21 +744,13 @@ export class WorkspacePicker extends Disposable {
 		const tabFilter = this._isTabFiltered()
 			? (w: IResolvedFolderWorkspace) => w.workspace.group === this._activeTab
 			: undefined;
-		const ownRecentWorkspaces = this._getRecentWorkspaces()
+		// Own recents first, then VS Code recents (merged and deduplicated by the service)
+		const recentWorkspaces = this._getRecentWorkspaces()
 			.filter(w => providerIds.has(w.providerId))
 			.filter(w => !tabFilter || tabFilter(w));
-
-		// Merge VS Code recent folders (resolved through providers, deduplicated)
-		const vsCodeRecents = this._getVSCodeRecentWorkspaces()
-			.filter(w => providerIds.has(w.providerId))
-			.filter(w => !tabFilter || tabFilter(w));
-		const ownRecentCount = ownRecentWorkspaces.length;
-		const recentWorkspaces = [...ownRecentWorkspaces, ...vsCodeRecents];
 
 		// Build flat list in recency order (no source grouping)
-		for (let i = 0; i < recentWorkspaces.length; i++) {
-			const { workspace, providerId } = recentWorkspaces[i];
-			const isOwnRecent = i < ownRecentCount;
+		for (const { workspace, providerId } of recentWorkspaces) {
 			const folderUri = workspace.folders[0]?.root;
 			if (!folderUri) {
 				continue;
@@ -805,7 +763,7 @@ export class WorkspacePicker extends Disposable {
 				group: { title: '', icon: workspace.icon },
 				disabled: this._isProviderUnavailable(providerId),
 				item: { folderUri, providerId, checked: selected || undefined },
-				onRemove: isOwnRecent ? () => this._removeRecentWorkspace(folderUri) : () => this._removeVSCodeRecentWorkspace(folderUri),
+				onRemove: () => this._removeRecentWorkspace(folderUri),
 			});
 		}
 
@@ -1004,10 +962,6 @@ export class WorkspacePicker extends Disposable {
 		return this.uriIdentityService.extUri.isEqual(this._selectedFolderUri, folderUri);
 	}
 
-	private _persistSelectedFolder(folderUri: URI, providerId: string | undefined): void {
-		this._addRecentFolder(folderUri, providerId, true);
-	}
-
 	private _restoreSelectedWorkspace(): IResolvedFolderWorkspace | undefined {
 		// Try the checked entry first
 		const checked = this._restoreCheckedWorkspace();
@@ -1020,17 +974,11 @@ export class WorkspacePicker extends Disposable {
 		// to be ready: we don't want to silently land on, e.g., a disconnected
 		// remote workspace that the user never picked.
 		try {
-			const storedRecents = this._getStoredRecentWorkspaces();
-			for (const stored of storedRecents) {
-				const uri = URI.revive(stored.uri);
-				const resolved = this._resolveFolder(uri, stored.providerId);
-				if (!resolved) {
+			for (const recent of this.recentWorkspacesService.getRecentWorkspaces()) {
+				if (this._isProviderUnavailable(recent.providerId)) {
 					continue;
 				}
-				if (this._isProviderUnavailable(resolved.providerId)) {
-					continue;
-				}
-				return resolved;
+				return recent;
 			}
 			return undefined;
 		} catch {
@@ -1048,18 +996,7 @@ export class WorkspacePicker extends Disposable {
 	 */
 	private _restoreCheckedWorkspace(): IResolvedFolderWorkspace | undefined {
 		try {
-			const storedRecents = this._getStoredRecentWorkspaces();
-			for (const stored of storedRecents) {
-				if (!stored.checked) {
-					continue;
-				}
-				const uri = URI.revive(stored.uri);
-				const resolved = this._resolveFolder(uri, stored.providerId);
-				if (resolved) {
-					return resolved;
-				}
-			}
-			return undefined;
+			return this.recentWorkspacesService.getRecentWorkspaces().find(recent => recent.checked);
 		} catch {
 			return undefined;
 		}
@@ -1130,42 +1067,14 @@ export class WorkspacePicker extends Disposable {
 		}, RESTORE_CONNECT_GRACE_MS, store);
 	}
 
-	// -- Recent workspaces storage --
-
-	private _addRecentFolder(folderUri: URI, providerId: string | undefined, checked: boolean): void {
-		const recents = this._getStoredRecentWorkspaces();
-		const filtered = recents.map(p => {
-			// Remove the entry being re-added (it will go to the front)
-			if (this.uriIdentityService.extUri.isEqual(URI.revive(p.uri), folderUri)) {
-				return undefined;
-			}
-			// Clear checked from all other entries when marking checked
-			if (checked && p.checked) {
-				return { ...p, checked: false };
-			}
-			return p;
-		}).filter((p): p is IStoredRecentWorkspace => p !== undefined);
-
-		const entry: IStoredRecentWorkspace = { uri: folderUri.toJSON(), providerId, checked };
-		const updated = [entry, ...filtered].slice(0, MAX_RECENT_WORKSPACES);
-		this.storageService.store(STORAGE_KEY_RECENT_WORKSPACES, JSON.stringify(updated), StorageScope.PROFILE, StorageTarget.MACHINE);
-	}
+	// -- Recent workspaces (sessions' own history) --
 
 	protected _getRecentWorkspaces(): IResolvedFolderWorkspace[] {
-		return this._getStoredRecentWorkspaces()
-			.map(stored => {
-				const uri = URI.revive(stored.uri);
-				return this._resolveFolder(uri, stored.providerId);
-			})
-			.filter((w): w is IResolvedFolderWorkspace => w !== undefined);
+		return this.recentWorkspacesService.getRecentWorkspaces();
 	}
 
 	protected _removeRecentWorkspace(folderUri: URI): void {
-		const recents = this._getStoredRecentWorkspaces();
-		const updated = recents.filter(p =>
-			!this.uriIdentityService.extUri.isEqual(URI.revive(p.uri), folderUri)
-		);
-		this.storageService.store(STORAGE_KEY_RECENT_WORKSPACES, JSON.stringify(updated), StorageScope.PROFILE, StorageTarget.MACHINE);
+		this.recentWorkspacesService.removeRecentWorkspace(folderUri);
 
 		// Clear current selection if it was the removed workspace
 		if (this._isSelectedFolder(folderUri)) {
@@ -1175,82 +1084,6 @@ export class WorkspacePicker extends Disposable {
 			this._updateTriggerLabel();
 			this._onDidSelectWorkspace.fire(undefined);
 		}
-	}
-
-	protected _removeVSCodeRecentWorkspace(folderUri: URI): void {
-		this.workspacesService.removeRecentlyOpened([folderUri]);
-
-		// Clear current selection if it was the removed workspace
-		if (this._isSelectedFolder(folderUri)) {
-			this._hidePicker();
-			this._selectedFolderUri = undefined;
-			this._selectedResolved = undefined;
-			this._updateTriggerLabel();
-			this._onDidSelectWorkspace.fire(undefined);
-		}
-	}
-
-	private _getStoredRecentWorkspaces(): IStoredRecentWorkspace[] {
-		const raw = this.storageService.get(STORAGE_KEY_RECENT_WORKSPACES, StorageScope.PROFILE);
-		if (!raw) {
-			return [];
-		}
-		try {
-			return JSON.parse(raw) as IStoredRecentWorkspace[];
-		} catch {
-			return [];
-		}
-	}
-
-	// -- VS Code recent folders -----------------------------------------------
-
-	private async _loadVSCodeRecentFolders(): Promise<void> {
-		const recentlyOpened = await this.workspacesService.getRecentlyOpened();
-		this._vsCodeRecentFolderUris = recentlyOpened.workspaces
-			.filter(isRecentFolder)
-			.map(f => f.folderUri)
-			.filter(uri => !this._isCopilotWorktree(uri))
-			.slice(0, 10);
-	}
-
-	/**
-	 * Returns whether the given URI points to a copilot-managed folder
-	 * (a folder whose name starts with `copilot-`).
-	 */
-	private _isCopilotWorktree(uri: URI): boolean {
-		return basename(uri).startsWith('copilot-');
-	}
-
-	/**
-	 * Returns VS Code recent folders resolved through registered session
-	 * providers, excluding any URIs already present in the sessions' own
-	 * recent workspace history.
-	 */
-	protected _getVSCodeRecentWorkspaces(): IResolvedFolderWorkspace[] {
-		if (this._vsCodeRecentFolderUris.length === 0) {
-			return [];
-		}
-
-		// Collect URIs already in sessions history to avoid duplicates
-		const ownRecents = this._getStoredRecentWorkspaces();
-		const ownUris = new Set(ownRecents.map(r => URI.revive(r.uri).toString()));
-
-		const result: IResolvedFolderWorkspace[] = [];
-
-		for (const folderUri of this._vsCodeRecentFolderUris) {
-			if (ownUris.has(folderUri.toString())) {
-				continue;
-			}
-			const resolved = this._resolveFolder(folderUri);
-			if (resolved && !this._isProviderUnavailable(resolved.providerId)) {
-				result.push(resolved);
-			}
-			if (result.length >= 10) {
-				break;
-			}
-		}
-
-		return result;
 	}
 
 }

--- a/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
@@ -15,12 +15,11 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
-import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
-import { IWorkspacesService } from '../../../../platform/workspaces/common/workspaces.js';
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsRecentWorkspacesService } from '../../../services/sessions/browser/sessionsRecentWorkspacesService.js';
 import { IAgentHostFilterService } from '../../../services/agentHostFilter/common/agentHostFilter.js';
 import { IWorkspacePickerItem, WorkspacePicker } from './sessionWorkspacePicker.js';
 import { showMobileWorkspacePickerSheet, shouldUseMobileWorkspacePickerSheet } from './mobile/mobileWorkspacePickerSheet.js';
@@ -47,13 +46,12 @@ export class WebWorkspacePicker extends WorkspacePicker {
 
 	constructor(
 		@IActionWidgetService actionWidgetService: IActionWidgetService,
-		@IStorageService storageService: IStorageService,
 		@IUriIdentityService uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@ISessionsRecentWorkspacesService recentWorkspacesService: ISessionsRecentWorkspacesService,
 		@IRemoteAgentHostService remoteAgentHostService: IRemoteAgentHostService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@ICommandService commandService: ICommandService,
-		@IWorkspacesService workspacesService: IWorkspacesService,
 		@IMenuService menuService: IMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -65,13 +63,12 @@ export class WebWorkspacePicker extends WorkspacePicker {
 	) {
 		super(
 			actionWidgetService,
-			storageService,
 			uriIdentityService,
 			sessionsProvidersService,
+			recentWorkspacesService,
 			remoteAgentHostService,
 			configurationService,
 			commandService,
-			workspacesService,
 			menuService,
 			contextKeyService,
 			instantiationService,

--- a/src/vs/sessions/contrib/chat/test/browser/newSessionFolderQuickPickAction.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/newSessionFolderQuickPickAction.test.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Event } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { IQuickPickSeparator } from '../../../../../platform/quickinput/common/quickInput.js';
+import { ISessionWorkspace } from '../../../../services/sessions/common/session.js';
+import { IRecentWorkspace, ISessionsRecentWorkspacesService } from '../../../../services/sessions/browser/sessionsRecentWorkspacesService.js';
+import { buildFolderQuickPickItems, IFolderQuickPickItem } from '../../browser/newSessionFolderQuickPickAction.js';
+
+function isSeparator(item: IFolderQuickPickItem | IQuickPickSeparator): item is IQuickPickSeparator {
+	return (item as IQuickPickSeparator).type === 'separator';
+}
+
+function createResolvedRecent(uri: URI, providerId = 'local-1', checked = false): IRecentWorkspace {
+	const name = uri.path.substring(1) || uri.path;
+	const workspace: ISessionWorkspace = {
+		uri,
+		label: name,
+		icon: Codicon.folder,
+		folders: [{ root: uri, workingDirectory: uri, name, description: undefined }],
+		requiresWorkspaceTrust: false,
+		isVirtualWorkspace: false,
+	};
+	return { workspace, providerId, checked };
+}
+
+function createRecentWorkspacesService(recent: IRecentWorkspace[]): ISessionsRecentWorkspacesService {
+	return upcastPartial<ISessionsRecentWorkspacesService>({
+		_serviceBrand: undefined,
+		onDidChangeRecentWorkspaces: Event.None,
+		getRecentWorkspaces: () => recent,
+	});
+}
+
+const labelService = upcastPartial<ILabelService>({ getUriLabel: (uri: URI) => uri.fsPath });
+
+suite('New Session Folder Quick Pick', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('lists the sessions\' own recents followed by VS Code\'s recents, then a Browse entry', () => {
+		const ownRecentUri = URI.file('/repo-a');
+		const vsCodeRecentUri = URI.file('/repo-b');
+
+		const recentWorkspacesService = createRecentWorkspacesService([
+			createResolvedRecent(ownRecentUri),
+			createResolvedRecent(vsCodeRecentUri),
+		]);
+
+		const items = buildFolderQuickPickItems(recentWorkspacesService, labelService);
+
+		const folderItems = items.filter((i): i is IFolderQuickPickItem => !isSeparator(i) && !i.browse);
+		assert.deepStrictEqual(folderItems.map(i => i.folderUri?.toString()), [ownRecentUri.toString(), vsCodeRecentUri.toString()]);
+
+		const separators = items.filter(isSeparator);
+		assert.strictEqual(separators.length, 2);
+
+		const lastItem = items[items.length - 1];
+		assert.ok(!isSeparator(lastItem) && lastItem.browse, 'last item is the Browse action');
+	});
+
+	test('always includes the Browse entry, even with no recents', () => {
+		const recentWorkspacesService = createRecentWorkspacesService([]);
+
+		const items = buildFolderQuickPickItems(recentWorkspacesService, labelService);
+
+		assert.strictEqual(items.length, 1);
+		assert.ok(!isSeparator(items[0]) && items[0].browse, 'the single item is the Browse action');
+	});
+});

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -32,6 +32,7 @@ import { ISendRequestOptions, ISessionsProvider } from '../../../../services/ses
 import { IAgentHostSessionsProvider } from '../../../../common/agentHostSessionsProvider.js';
 import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
 import { IWorkspacePickerItem, WorkspacePicker } from '../../browser/sessionWorkspacePicker.js';
+import { ISessionsRecentWorkspacesService, SessionsRecentWorkspacesService } from '../../../../services/sessions/browser/sessionsRecentWorkspacesService.js';
 import { AutomationsWorkspacePicker } from '../../../automations/browser/automationDialog.js';
 import { AutomationIsolationModel } from '../../../automations/common/isolationGroupModel.js';
 import { buildMobileWorkspacePickerRows, showMobileWorkspacePickerSheet } from '../../browser/mobile/mobileWorkspacePickerSheet.js';
@@ -173,6 +174,23 @@ class MockSessionsProvidersService extends Disposable {
 	getProvider<T extends ISessionsProvider>(providerId: string): T | undefined {
 		return this._providers.find(p => p.id === providerId) as T | undefined;
 	}
+
+	resolveWorkspace(folderUri: URI, preferredProviderId?: string) {
+		if (preferredProviderId) {
+			const preferred = this.getProvider(preferredProviderId);
+			const workspace = preferred?.resolveWorkspace(folderUri);
+			if (workspace) {
+				return { providerId: preferredProviderId, workspace };
+			}
+		}
+		for (const provider of this.getProviders()) {
+			const workspace = provider.resolveWorkspace(folderUri);
+			if (workspace) {
+				return { providerId: provider.id, workspace };
+			}
+		}
+		return undefined;
+	}
 }
 
 class RecordingNotificationHandle extends NoOpNotification {
@@ -278,6 +296,7 @@ function createTestPicker(
 		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 		onDidChangeRecentlyOpened: Event.None,
 	});
+	instantiationService.stub(ISessionsRecentWorkspacesService, disposables.add(instantiationService.createInstance(SessionsRecentWorkspacesService)));
 	instantiationService.stub(ITelemetryService, NullTelemetryService);
 
 	return disposables.add(instantiationService.createInstance(pickerCtor));
@@ -940,6 +959,7 @@ function createTestablePicker(disposables: DisposableStore, providersService: Mo
 		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 		onDidChangeRecentlyOpened: Event.None,
 	});
+	instantiationService.stub(ISessionsRecentWorkspacesService, disposables.add(instantiationService.createInstance(SessionsRecentWorkspacesService)));
 	instantiationService.stub(ITelemetryService, NullTelemetryService);
 	return disposables.add(instantiationService.createInstance(TestablePicker));
 }
@@ -1053,6 +1073,7 @@ suite('WorkspacePicker - Tab discovery', () => {
 			getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 			onDidChangeRecentlyOpened: Event.None,
 		});
+		instantiationService.stub(ISessionsRecentWorkspacesService, disposables.add(instantiationService.createInstance(SessionsRecentWorkspacesService)));
 		instantiationService.stub(ITelemetryService, NullTelemetryService);
 		const picker = disposables.add(instantiationService.createInstance(TestablePicker));
 		// Recent workspace group ('Cloud') is not added as a tab — only

--- a/src/vs/sessions/services/sessions/browser/sessionsRecentWorkspacesService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsRecentWorkspacesService.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { basename } from '../../../../base/common/resources.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI, UriComponents } from '../../../../base/common/uri.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+import { isRecentFolder, IWorkspacesService } from '../../../../platform/workspaces/common/workspaces.js';
+import { ISessionWorkspace } from '../common/session.js';
+import { ISessionsProvidersService } from './sessionsProvidersService.js';
+
+const STORAGE_KEY_RECENT_WORKSPACES = 'sessions.recentlyPickedWorkspaces';
+const MAX_RECENT_WORKSPACES = 10;
+const MAX_VSCODE_RECENT_WORKSPACES = 10;
+
+/** A recently used folder, resolved to its workspace. `checked` marks the currently selected folder in the new-session workspace picker. */
+export interface IRecentWorkspace {
+	readonly workspace: ISessionWorkspace;
+	readonly providerId: string;
+	readonly checked: boolean;
+}
+
+interface IStoredRecentWorkspace {
+	readonly uri: UriComponents;
+	readonly providerId?: string;
+	readonly checked: boolean;
+}
+
+export const ISessionsRecentWorkspacesService = createDecorator<ISessionsRecentWorkspacesService>('sessionsRecentWorkspacesService');
+
+/** Single source of truth for the sessions' own "recently used" workspace folders, shared by every folder-selection surface. */
+export interface ISessionsRecentWorkspacesService {
+	readonly _serviceBrand: undefined;
+
+	readonly onDidChangeRecentWorkspaces: Event<void>;
+
+	/** The recently used folders, resolved and most recent first: own history first, then VS Code's recents (deduplicated). */
+	getRecentWorkspaces(): IRecentWorkspace[];
+
+	/** Records `folderUri` as most-recently used; `checked` un-checks every other entry. */
+	addRecentWorkspace(folderUri: URI, providerId: string | undefined, checked: boolean): void;
+
+	/** Removes `folderUri` from the recent list, wherever it came from (own history or VS Code's recents). */
+	removeRecentWorkspace(folderUri: URI): void;
+
+	/** Clears the `checked` flag on every recent entry. */
+	clearCheckedWorkspace(): void;
+}
+
+/** Exported for direct instantiation in tests; consumers should depend on {@link ISessionsRecentWorkspacesService}. */
+export class SessionsRecentWorkspacesService extends Disposable implements ISessionsRecentWorkspacesService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeRecentWorkspaces = this._register(new Emitter<void>());
+	readonly onDidChangeRecentWorkspaces: Event<void> = this._onDidChangeRecentWorkspaces.event;
+
+	private _vsCodeRecentFolderUris: URI[] = [];
+
+	constructor(
+		@IStorageService private readonly storageService: IStorageService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
+		@IWorkspacesService private readonly workspacesService: IWorkspacesService,
+		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
+	) {
+		super();
+
+		this._refreshVSCodeRecentWorkspaces();
+		this._register(this.workspacesService.onDidChangeRecentlyOpened(() => this._refreshVSCodeRecentWorkspaces()));
+	}
+
+	getRecentWorkspaces(): IRecentWorkspace[] {
+		const own = this._getStoredRecentWorkspaces();
+		const ownUris = new Set(own.map(o => this.uriIdentityService.extUri.getComparisonKey(URI.revive(o.uri))));
+		const vsCode = this._vsCodeRecentFolderUris
+			.filter(uri => !ownUris.has(this.uriIdentityService.extUri.getComparisonKey(uri)))
+			.map(uri => ({ uri: uri.toJSON(), providerId: undefined, checked: false }) satisfies IStoredRecentWorkspace);
+
+		const recents: IRecentWorkspace[] = [];
+		for (const stored of [...own, ...vsCode]) {
+			const resolved = this._resolveWorkspace(URI.revive(stored.uri), stored.providerId);
+			if (resolved) {
+				recents.push({ workspace: resolved.workspace, providerId: resolved.providerId, checked: stored.checked });
+			}
+		}
+		return recents;
+	}
+
+	addRecentWorkspace(folderUri: URI, providerId: string | undefined, checked: boolean): void {
+		const recents = this._getStoredRecentWorkspaces();
+		const filtered = recents.map(p => {
+			// Remove the entry being re-added (it will go to the front)
+			if (this.uriIdentityService.extUri.isEqual(URI.revive(p.uri), folderUri)) {
+				return undefined;
+			}
+			// Clear checked from all other entries when marking checked
+			if (checked && p.checked) {
+				return { ...p, checked: false };
+			}
+			return p;
+		}).filter((p): p is IStoredRecentWorkspace => p !== undefined);
+
+		const entry: IStoredRecentWorkspace = { uri: folderUri.toJSON(), providerId, checked };
+		const updated = [entry, ...filtered].slice(0, MAX_RECENT_WORKSPACES);
+		this._persistRecentWorkspaces(updated);
+	}
+
+	removeRecentWorkspace(folderUri: URI): void {
+		const recents = this._getStoredRecentWorkspaces();
+		const updated = recents.filter(p => !this.uriIdentityService.extUri.isEqual(URI.revive(p.uri), folderUri));
+		if (updated.length !== recents.length) {
+			this._persistRecentWorkspaces(updated);
+		}
+		this.workspacesService.removeRecentlyOpened([folderUri]);
+	}
+
+	clearCheckedWorkspace(): void {
+		const recents = this._getStoredRecentWorkspaces();
+		const updated = recents.map(p => ({ ...p, checked: false }));
+		this._persistRecentWorkspaces(updated);
+	}
+
+	/** Resolves `folderUri` to its workspace, trying `preferredProviderId` first if given. */
+	private _resolveWorkspace(folderUri: URI, preferredProviderId?: string): { providerId: string; workspace: ISessionWorkspace } | undefined {
+		if (preferredProviderId) {
+			const preferred = this.sessionsProvidersService.getProvider(preferredProviderId);
+			const workspace = preferred?.resolveWorkspace(folderUri);
+			if (workspace) {
+				return { providerId: preferredProviderId, workspace };
+			}
+		}
+		for (const provider of this.sessionsProvidersService.getProviders()) {
+			const workspace = provider.resolveWorkspace(folderUri);
+			if (workspace) {
+				return { providerId: provider.id, workspace };
+			}
+		}
+		return undefined;
+	}
+
+	private async _refreshVSCodeRecentWorkspaces(): Promise<void> {
+		const recentlyOpened = await this.workspacesService.getRecentlyOpened();
+		this._vsCodeRecentFolderUris = recentlyOpened.workspaces
+			.filter(isRecentFolder)
+			.map(f => f.folderUri)
+			.filter(uri => !basename(uri).startsWith('copilot-'))
+			.slice(0, MAX_VSCODE_RECENT_WORKSPACES);
+		this._onDidChangeRecentWorkspaces.fire();
+	}
+
+	private _getStoredRecentWorkspaces(): IStoredRecentWorkspace[] {
+		const raw = this.storageService.get(STORAGE_KEY_RECENT_WORKSPACES, StorageScope.PROFILE);
+		if (!raw) {
+			return [];
+		}
+		try {
+			return JSON.parse(raw) as IStoredRecentWorkspace[];
+		} catch {
+			return [];
+		}
+	}
+
+	private _persistRecentWorkspaces(entries: IStoredRecentWorkspace[]): void {
+		this.storageService.store(STORAGE_KEY_RECENT_WORKSPACES, JSON.stringify(entries), StorageScope.PROFILE, StorageTarget.MACHINE);
+		this._onDidChangeRecentWorkspaces.fire();
+	}
+}
+
+registerSingleton(ISessionsRecentWorkspacesService, SessionsRecentWorkspacesService, InstantiationType.Delayed);


### PR DESCRIPTION
## What changed

Adds a native `IQuickInputService` Quick Pick as an additional entry point for picking the target folder when starting a new session in the Agents Window, alongside the existing `WorkspacePicker` dropdown.

- New command `workbench.action.sessions.newSession.pickFolderQuickPick` ("New Session in Folder...") - discoverable via the Command Palette and bound to `Cmd+O` while the Agents Window is focused. The keybinding uses a higher weight than the desktop Open File/Folder actions so it wins on `Cmd+O` conflicts, without disabling those actions anywhere else.
- Lists recently used folders (own history + VS Code's own recents, deduplicated) followed by an always-present "Browse..." entry that opens the native folder dialog.
- Extracted `ISessionsRecentWorkspacesService`, the single source of truth for the sessions' own recently-used workspace folders, shared by the new Quick Pick and the existing `WorkspacePicker` dropdown (and its `WebWorkspacePicker`/`AutomationsWorkspacePicker` variants) so all folder-selection surfaces always agree on the same recent-folder list.
- Fixed `NewChatWidget` to keep the `WorkspacePicker` dropdown's displayed selection in sync when the active session's workspace changes externally (e.g. via the new Quick Pick command while the composer is already showing) - previously it kept showing the stale folder.

## Why

The Agents Window new-session view only had a custom `ActionWidget`-based dropdown for folder selection. This adds a lighter-weight, keyboard-first Quick Pick alternative without touching the existing dropdown's behavior.

## Notes for reviewers

- `sessionsProvidersService.ts` is untouched (no diff) - workspace resolution stays local to the picker and to the recent-workspaces service (which resolves entries internally before returning them), keeping `ISessionsProvidersService`'s surface unchanged.
- No default keybinding conflicts are introduced outside the Agents Window; `Cmd+O` elsewhere in VS Code is unaffected.
