### PR TITLE
Fix OS_ID parsing in check-requirements-linux.sh for quoted values

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID="$(sed -n 's/^ID=["'"'"']*\([^"'"'"']*\)["'"'"']*$/\1/p' /etc/os-release | head -n1)"
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Fixes #232159

## Problem

`check-requirements-linux.sh` extracts the distribution ID from `/etc/os-release` with:

```sh
OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
```

This fails when the value is quoted (e.g. `ID="rocky"` on Rocky Linux 8.5, which is permitted by the os-release format), leaving `OS_ID` empty and causing the script to exit non-zero during devcontainer setup. It can also accidentally match the `ID=` substring inside other keys such as `VERSION_ID`.

## Fix

Replace the extraction with an anchored `sed` expression that strips optional single or double quotes:

```sh
OS_ID="$(sed -n 's/^ID=["'"'"']*\([^"'"'"']*\)["'"'"']*$/\1/p' /etc/os-release | head -n1)"
```

Verified locally with all three formats — `ID=rocky`, `ID="rocky"`, `ID='rocky'` — each correctly yields `rocky`, while `VERSION_ID` and `ID_LIKE` lines are no longer matched.