### PR TITLE
Hide 'Disable' dropdown action when extension is enabled only for workspace

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1778,7 +1778,7 @@ export class DisableGloballyAction extends ExtensionAction {
 				return;
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
@@ -877,6 +877,36 @@ suite('ExtensionsActions', () => {
 			});
 	});
 
+	test('Test Disable actions when the extension is disabled globally but enabled for workspace', () => {
+		const local = aLocalExtension('a');
+		instantiationService.stub(IExtensionService, {
+			extensions: [toExtensionDescription(local)],
+			onDidChangeExtensions: Event.None,
+			whenInstalledExtensionsRegistered: () => Promise.resolve(true)
+		});
+
+		return instantiationService.get(IWorkbenchExtensionEnablementService).setEnablement([local], EnablementState.DisabledGlobally)
+			.then(() => instantiationService.get(IWorkbenchExtensionEnablementService).setEnablement([local], EnablementState.EnabledWorkspace))
+			.then(() => {
+				instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [local]);
+
+				return instantiationService.get(IExtensionsWorkbenchService).queryLocal()
+					.then(extensions => {
+						assert.strictEqual(extensions[0].enablementState, EnablementState.EnabledWorkspace);
+
+						// Disabling globally is meaningless when the extension is
+						// already disabled globally, so only the workspace action remains
+						const testObject: ExtensionsActions.DisableGloballyAction = disposables.add(instantiationService.createInstance(ExtensionsActions.DisableGloballyAction));
+						testObject.extension = extensions[0];
+						assert.ok(!testObject.enabled);
+
+						const workspaceTestObject: ExtensionsActions.DisableForWorkspaceAction = disposables.add(instantiationService.createInstance(ExtensionsActions.DisableForWorkspaceAction));
+						workspaceTestObject.extension = extensions[0];
+						assert.ok(workspaceTestObject.enabled);
+					});
+			});
+	});
+
 	test('Test DisableGloballyAction when extension is installed and enabled', () => {
 		const local = aLocalExtension('a');
 		instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [local]);


### PR DESCRIPTION
Fixes #244138

## Problem

When an extension is disabled globally but then enabled for the current workspace (`EnablementState.EnabledWorkspace`), the Disable button's dropdown shows both **"Disable"** and **"Disable (Workspace)"**. Disabling globally is meaningless in this state, because the extension is already disabled globally — the only sensible action is "Disable (Workspace)".

## Fix

`DisableGloballyAction.update()` previously enabled the action for both `EnabledGlobally` and `EnabledWorkspace`. It now only enables the action when the extension is enabled globally:

```ts
this.enabled = this.extension.state === ExtensionState.Installed
	&& this.extension.enablementState === EnablementState.EnabledGlobally
	&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
```

As a result, when the extension is enabled only for the workspace, the dropdown contains just "Disable (Workspace)", matching the expected behavior described in the issue.

Verified with a full client compile (`npm run compile-client`, `compile-src` finished with 0 errors).