### PR TITLE
fix: memory leak in terminalProcessManager

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -90,6 +90,7 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 	private _preLaunchInputQueue: string[] = [];
 	private _initialCwd: string | undefined;
 	private _extEnvironmentVariableCollection: IMergedEnvironmentVariableCollection | undefined;
+	private readonly _environmentVariableCollectionListener = this._register(new MutableDisposable<IDisposable>());
 	private _ackDataBufferer: AckDataBufferer;
 	private _hasWrittenData: boolean = false;
 	private _hasChildProcesses: boolean = false;
@@ -186,7 +187,7 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 
 		if (environmentVariableCollections) {
 			this._extEnvironmentVariableCollection = new MergedEnvironmentVariableCollection(environmentVariableCollections);
-			this._register(this._environmentVariableService.onDidChangeCollections(newCollection => this._onEnvironmentVariableCollectionChange(newCollection)));
+			this._environmentVariableCollectionListener.value = this._environmentVariableService.onDidChangeCollections(newCollection => this._onEnvironmentVariableCollectionChange(newCollection));
 			this.environmentVariableInfo = this._instantiationService.createInstance(EnvironmentVariableInfoChangesActive, this._extEnvironmentVariableCollection);
 			this._onEnvironmentVariableInfoChange.fire(this.environmentVariableInfo);
 		}
@@ -469,10 +470,11 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 		}
 		const env = await terminalEnvironment.createTerminalEnvironment(shellLaunchConfig, envFromConfigValue, variableResolver, this._productService.version, this._terminalConfigurationService.config.detectLocale, baseEnv);
 		this._logService.debug(`Terminal environment created with ${Object.keys(env).length} variables: ${Object.keys(env).sort().join(', ')}`);
+		this._environmentVariableCollectionListener.clear();
 		if (!this._isDisposed && shouldUseEnvironmentVariableCollection(shellLaunchConfig)) {
 			this._extEnvironmentVariableCollection = this._environmentVariableService.mergedCollection;
 
-			this._register(this._environmentVariableService.onDidChangeCollections(newCollection => this._onEnvironmentVariableCollectionChange(newCollection)));
+			this._environmentVariableCollectionListener.value = this._environmentVariableService.onDidChangeCollections(newCollection => this._onEnvironmentVariableCollectionChange(newCollection));
 			// For remote terminals, this is a copy of the mergedEnvironmentCollection created on
 			// the remote side. Since the environment collection is synced between the remote and
 			// local sides immediately this is a fairly safe way of enabling the env var diffing and

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalProcessManager.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalProcessManager.test.ts
@@ -14,7 +14,12 @@ import { TestConfigurationService } from '../../../../../platform/configuration/
 import { ITerminalChildProcess, type ITerminalBackend } from '../../../../../platform/terminal/common/terminal.js';
 import { ITerminalInstanceService, ITerminalService } from '../../browser/terminal.js';
 import { TerminalProcessManager } from '../../browser/terminalProcessManager.js';
+import { IEnvironmentVariableService } from '../../common/environmentVariable.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+
+function listenerCount(emitter: Emitter<unknown>): number {
+	return (emitter as unknown as { _size: number })._size ?? 0;
+}
 
 class TestTerminalChildProcess implements ITerminalChildProcess {
 	id: number = 0;
@@ -80,6 +85,7 @@ class TestTerminalInstanceService implements Partial<ITerminalInstanceService> {
 suite('Workbench - TerminalProcessManager', () => {
 	let manager: TerminalProcessManager;
 	let terminalInstanceService: TestTerminalInstanceService;
+	let environmentVariableService: IEnvironmentVariableService;
 
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -103,8 +109,22 @@ suite('Workbench - TerminalProcessManager', () => {
 		store.add(terminalInstanceService.ptyHostRestartEmitter);
 		instantiationService.stub(ITerminalInstanceService, terminalInstanceService);
 		instantiationService.stub(ITerminalService, { setNextCommandId: async () => { } } as Partial<ITerminalService>);
+		environmentVariableService = instantiationService.get(IEnvironmentVariableService);
 
 		manager = store.add(instantiationService.createInstance(TerminalProcessManager, 1, undefined, undefined, undefined));
+	});
+
+	test('does not accumulate environment variable collection listeners when relaunching', async () => {
+		const changeCollectionsEmitter = (environmentVariableService as unknown as { _onDidChangeCollections: Emitter<unknown> })._onDidChangeCollections;
+		const initialListenerCount = listenerCount(changeCollectionsEmitter);
+
+		await manager.createProcess({}, 80, 24, false);
+		strictEqual(listenerCount(changeCollectionsEmitter), initialListenerCount + 1);
+
+		for (let i = 0; i < 3; i++) {
+			await manager.relaunch({}, 80, 24, false);
+			strictEqual(listenerCount(changeCollectionsEmitter), initialListenerCount + 1);
+		}
 	});
 
 	suite('process persistence', () => {


### PR DESCRIPTION
### Details

Uses a `MutableDisposable` so resolving a terminal environment replaces the previous listener.

### Before

When running the same task 37 times, terminal environment listeners grow each time (outlined in red):

<img width="1400" height="220" alt="task-run-fix-terminal-process-manager-memory-leak-before" src="https://github.com/user-attachments/assets/ed2b0515-9622-47c3-b619-131f31e25e44" />

### After

No more leak is detected for this listener.

<img width="1400" height="200" alt="task-run-fix-terminal-process-manager-memory-leak-after" src="https://github.com/user-attachments/assets/61bf2f19-de1d-4a94-9c02-d30a761dc5c6" />
