### PR TITLE
fix: memory leak in commandDetectionCapability

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -239,7 +239,7 @@ export interface ICommandDetectionCapability {
 	 */
 	getCwdForLine(line: number): string | undefined;
 	getCommandForLine(line: number): ITerminalCommand | ICurrentPartialCommand | undefined;
-	clearCommandsInViewport(): void;
+	clearCommands(): void;
 	handlePromptStart(options?: IHandleCommandOptions): void;
 	handleContinuationStart(): void;
 	handleContinuationEnd(): void;
@@ -295,7 +295,7 @@ export interface IPartialCommandDetectionCapability {
 	readonly type: TerminalCapability.PartialCommandDetection;
 	readonly commands: readonly IMarker[];
 	readonly onCommandFinished: Event<IMarker>;
-	clearCommandsInViewport(): void;
+	clearCommands(): void;
 }
 
 interface IBaseTerminalCommand {

--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -295,6 +295,7 @@ export interface IPartialCommandDetectionCapability {
 	readonly type: TerminalCapability.PartialCommandDetection;
 	readonly commands: readonly IMarker[];
 	readonly onCommandFinished: Event<IMarker>;
+	clearCommandsInViewport(): void;
 }
 
 interface IBaseTerminalCommand {

--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -239,6 +239,7 @@ export interface ICommandDetectionCapability {
 	 */
 	getCwdForLine(line: number): string | undefined;
 	getCommandForLine(line: number): ITerminalCommand | ICurrentPartialCommand | undefined;
+	clearCommandsInViewport(): void;
 	handlePromptStart(options?: IHandleCommandOptions): void;
 	handleContinuationStart(): void;
 	handleContinuationEnd(): void;

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -202,8 +202,10 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		}
 	}
 
-	clearCommandsInViewport(): void {
-		this._clearCommandsInViewport();
+	clearCommands(): void {
+		if (this._commands.length > 0) {
+			this._onCommandInvalidated.fire(this._commands.splice(0));
+		}
 	}
 
 	setContinuationPrompt(value: string): void {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -202,6 +202,10 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		}
 	}
 
+	clearCommandsInViewport(): void {
+		this._clearCommandsInViewport();
+	}
+
 	setContinuationPrompt(value: string): void {
 		this._promptInputModel.setContinuationPrompt(value);
 	}

--- a/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
@@ -37,7 +37,7 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 		this.add(this._terminal.onData(e => this._onData(e)));
 		this.add(this._terminal.parser.registerCsiHandler({ final: 'J' }, params => {
 			if (params.length >= 1 && (params[0] === 2 || params[0] === 3)) {
-				this.clearCommandsInViewport();
+				this._clearCommandsInViewport();
 			}
 			// We don't want to override xterm.js' default behavior, just augment it
 			return false;
@@ -66,7 +66,7 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 		}
 	}
 
-	clearCommandsInViewport(): void {
+	private _clearCommandsInViewport(): void {
 		// Find the number of commands on the tail end of the array that are within the viewport
 		let count = 0;
 		for (let i = this._commands.length - 1; i >= 0; i--) {
@@ -77,5 +77,9 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 		}
 		// Remove them
 		this._commands.splice(this._commands.length - count, count);
+	}
+
+	clearCommands(): void {
+		this._commands.length = 0;
 	}
 }

--- a/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
@@ -37,7 +37,7 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 		this.add(this._terminal.onData(e => this._onData(e)));
 		this.add(this._terminal.parser.registerCsiHandler({ final: 'J' }, params => {
 			if (params.length >= 1 && (params[0] === 2 || params[0] === 3)) {
-				this._clearCommandsInViewport();
+				this.clearCommandsInViewport();
 			}
 			// We don't want to override xterm.js' default behavior, just augment it
 			return false;
@@ -66,7 +66,7 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 		}
 	}
 
-	private _clearCommandsInViewport(): void {
+	clearCommandsInViewport(): void {
 		// Find the number of commands on the tail end of the array that are within the viewport
 		let count = 0;
 		for (let i = this._commands.length - 1; i >= 0; i--) {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -774,6 +774,7 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 
 	clearBuffer(): void {
 		this._capabilities.get(TerminalCapability.CommandDetection)?.clearCommandsInViewport();
+		this._capabilities.get(TerminalCapability.PartialCommandDetection)?.clearCommandsInViewport();
 		this.raw.clear();
 		// xterm.js does not clear the first prompt, so trigger these to simulate
 		// the prompt being written

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -773,8 +773,9 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 	}
 
 	clearBuffer(): void {
-		this._capabilities.get(TerminalCapability.CommandDetection)?.clearCommandsInViewport();
-		this._capabilities.get(TerminalCapability.PartialCommandDetection)?.clearCommandsInViewport();
+		this._decorationAddon.clearDecorations();
+		this._capabilities.get(TerminalCapability.CommandDetection)?.clearCommands();
+		this._capabilities.get(TerminalCapability.PartialCommandDetection)?.clearCommands();
 		this.raw.clear();
 		// xterm.js does not clear the first prompt, so trigger these to simulate
 		// the prompt being written

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -773,6 +773,7 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 	}
 
 	clearBuffer(): void {
+		this._capabilities.get(TerminalCapability.CommandDetection)?.clearCommandsInViewport();
 		this.raw.clear();
 		// xterm.js does not clear the first prompt, so trigger these to simulate
 		// the prompt being written

--- a/src/vs/workbench/contrib/terminal/test/browser/capabilities/commandDetectionCapability.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/capabilities/commandDetectionCapability.test.ts
@@ -16,7 +16,7 @@ import { workbenchInstantiationService } from '../../../../../test/browser/workb
 type TestTerminalCommandMatch = Pick<ITerminalCommand, 'command' | 'cwd' | 'exitCode'> & { marker: { line: number } };
 
 class TestCommandDetectionCapability extends CommandDetectionCapability {
-	clearCommands() {
+	clearCommandsForTest() {
 		this._commands.length = 0;
 	}
 }
@@ -41,7 +41,7 @@ suite('CommandDetectionCapability', () => {
 		deepStrictEqual(addEvents, capability.commands);
 		// Clear the commands to avoid re-asserting past commands
 		addEvents.length = 0;
-		capability.clearCommands();
+		capability.clearCommandsForTest();
 	}
 
 	async function printStandardCommand(prompt: string, command: string, output: string, cwd: string | undefined, exitCode: number) {
@@ -91,6 +91,19 @@ suite('CommandDetectionCapability', () => {
 			cwd: undefined,
 			marker: { line: 0 }
 		}]);
+	});
+
+	test('should invalidate all commands when cleared', async () => {
+		await printStandardCommand('$ ', 'echo foo', 'foo', undefined, 0);
+		await printStandardCommand('$ ', 'echo bar', 'bar', undefined, 0);
+		strictEqual(capability.commands.length, 2);
+
+		const invalidatedCommands: ITerminalCommand[] = [];
+		store.add(capability.onCommandInvalidated(commands => invalidatedCommands.push(...commands)));
+		capability.clearCommands();
+
+		deepStrictEqual(capability.commands, []);
+		deepStrictEqual(invalidatedCommands.map(e => e.command), ['echo foo', 'echo bar']);
 	});
 
 	test('should trim the command when command executed appears on the following line', async () => {

--- a/src/vs/workbench/contrib/terminal/test/browser/capabilities/partialCommandDetectionCapability.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/capabilities/partialCommandDetectionCapability.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { IMarker, Terminal } from '@xterm/xterm';
-import { deepEqual, deepStrictEqual } from 'assert';
+import { deepEqual, deepStrictEqual, strictEqual } from 'assert';
 import { importAMDNodeModule } from '../../../../../../amdX.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { PartialCommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/partialCommandDetectionCapability.js';
@@ -66,7 +66,7 @@ suite('PartialCommandDetectionCapability', () => {
 		deepEqual(addEvents.length, 2);
 	});
 
-	test('should clear commands in the viewport', async () => {
+	test('should clear all commands including scrollback', async () => {
 		await writeP(xterm, 'ab');
 		xterm.input('\x0d');
 		await writeP(xterm, '\r\n\r\n');
@@ -74,8 +74,10 @@ suite('PartialCommandDetectionCapability', () => {
 		xterm.input('\x0d');
 		await writeP(xterm, '\r\n');
 		deepStrictEqual(capability.commands.map(e => e.line), [0, 2]);
+		await writeP(xterm, 'line\r\n'.repeat(xterm.rows));
+		strictEqual(xterm.buffer.active.baseY > 0, true);
 
-		capability.clearCommandsInViewport();
+		capability.clearCommands();
 
 		deepStrictEqual(capability.commands, []);
 	});

--- a/src/vs/workbench/contrib/terminal/test/browser/capabilities/partialCommandDetectionCapability.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/capabilities/partialCommandDetectionCapability.test.ts
@@ -65,4 +65,18 @@ suite('PartialCommandDetectionCapability', () => {
 		onDidExecuteTextEmitter.fire();
 		deepEqual(addEvents.length, 2);
 	});
+
+	test('should clear commands in the viewport', async () => {
+		await writeP(xterm, 'ab');
+		xterm.input('\x0d');
+		await writeP(xterm, '\r\n\r\n');
+		await writeP(xterm, 'cd');
+		xterm.input('\x0d');
+		await writeP(xterm, '\r\n');
+		deepStrictEqual(capability.commands.map(e => e.line), [0, 2]);
+
+		capability.clearCommandsInViewport();
+
+		deepStrictEqual(capability.commands, []);
+	});
 });

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Terminal } from '@xterm/xterm';
+import type { IDecoration, IDecorationOptions, Terminal } from '@xterm/xterm';
 import { deepStrictEqual, ok, strictEqual } from 'assert';
 import { importAMDNodeModule } from '../../../../../../amdX.js';
 import { Color, RGBA } from '../../../../../../base/common/color.js';
@@ -12,6 +12,9 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { IEditorOptions } from '../../../../../../editor/common/config/editorOptions.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ITerminalCommand, TerminalCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
+import { CommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/commandDetectionCapability.js';
+import { PartialCommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/partialCommandDetectionCapability.js';
 import { TerminalCapabilityStore } from '../../../../../../platform/terminal/common/capabilities/terminalCapabilityStore.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
 import { TestColorTheme, TestThemeService } from '../../../../../../platform/theme/test/common/testThemeService.js';
@@ -53,7 +56,11 @@ const defaultTerminalConfig: Partial<ITerminalConfiguration> = {
 	scrollback: 10,
 	fastScrollSensitivity: 2,
 	mouseWheelScrollSensitivity: 1,
-	unicodeVersion: '6'
+	unicodeVersion: '6',
+	shellIntegration: {
+		enabled: true,
+		decorationsEnabled: 'both'
+	}
 };
 
 suite('XtermTerminal', () => {
@@ -64,6 +71,7 @@ suite('XtermTerminal', () => {
 	let themeService: TestThemeService;
 	let xterm: XtermTerminal;
 	let XTermBaseCtor: typeof Terminal;
+	let capabilityStore: TerminalCapabilityStore;
 
 	function write(data: string): Promise<void> {
 		return new Promise<void>((resolve) => {
@@ -90,7 +98,7 @@ suite('XtermTerminal', () => {
 
 		XTermBaseCtor = (await importAMDNodeModule<typeof import('@xterm/xterm')>('@xterm/xterm', 'lib/xterm.js')).Terminal;
 
-		const capabilityStore = store.add(new TerminalCapabilityStore());
+		capabilityStore = store.add(new TerminalCapabilityStore());
 		xterm = store.add(instantiationService.createInstance(XtermTerminal, undefined, XTermBaseCtor, {
 			cols: 80,
 			rows: 30,
@@ -107,6 +115,79 @@ suite('XtermTerminal', () => {
 	test('should use fallback dimensions of 80x30', () => {
 		strictEqual(xterm.raw.cols, 80);
 		strictEqual(xterm.raw.rows, 30);
+	});
+
+	test('clearBuffer should clear rich and partial command history including scrollback', async () => {
+		class TestTerminal extends XTermBaseCtor {
+			override registerDecoration(options: IDecorationOptions): IDecoration | undefined {
+				const disposeListeners = new Set<() => unknown>();
+				let isDisposed = false;
+				return {
+					marker: options.marker,
+					options,
+					get isDisposed() { return isDisposed; },
+					dispose: () => {
+						isDisposed = true;
+						for (const listener of disposeListeners) {
+							listener();
+						}
+						disposeListeners.clear();
+					},
+					onDispose: (listener: () => unknown) => {
+						disposeListeners.add(listener);
+						return { dispose: () => disposeListeners.delete(listener) };
+					},
+					onRender: (listener: (element: HTMLElement) => unknown) => {
+						listener(document.createElement('div'));
+						return { dispose() { } };
+					}
+				} as unknown as IDecoration;
+			}
+		}
+		capabilityStore = store.add(new TerminalCapabilityStore());
+		xterm = store.add(instantiationService.createInstance(XtermTerminal, undefined, TestTerminal, {
+			cols: 80,
+			rows: 30,
+			xtermColorProvider: { getBackgroundColor: () => undefined },
+			capabilities: capabilityStore,
+			disableShellIntegrationReporting: true,
+			xtermAddonImporter: new TestXtermAddonImporter(),
+		}, undefined));
+		const commandDetection = store.add(instantiationService.createInstance(CommandDetectionCapability, xterm.raw));
+		const onDidExecuteText = store.add(new Emitter<void>());
+		const partialCommandDetection = store.add(new PartialCommandDetectionCapability(xterm.raw, onDidExecuteText.event));
+		capabilityStore.add(TerminalCapability.CommandDetection, commandDetection);
+		capabilityStore.add(TerminalCapability.PartialCommandDetection, partialCommandDetection);
+
+		xterm.raw.registerMarker(0);
+		commandDetection.handlePromptStart();
+		await write('$ ');
+		commandDetection.handleCommandStart();
+		await write('echo test');
+		commandDetection.handleCommandExecuted();
+		await write('\r\noutput\r\n');
+		commandDetection.handleCommandFinished(0);
+
+		await write('partial');
+		xterm.raw.input('\r');
+		await write('\r\n');
+		await write('line\r\n'.repeat(xterm.raw.rows));
+
+		strictEqual(xterm.raw.buffer.active.baseY > 0, true);
+		strictEqual(commandDetection.commands.length, 1);
+		strictEqual(partialCommandDetection.commands.length, 1);
+		const decorations = (xterm.decorationAddon as unknown as { _decorations: Map<number, unknown> })._decorations;
+		const clearedCommandMarkerId = commandDetection.commands[0].marker!.id;
+		strictEqual(decorations.has(clearedCommandMarkerId), true);
+		const invalidatedCommands: ITerminalCommand[] = [];
+		store.add(commandDetection.onCommandInvalidated(commands => invalidatedCommands.push(...commands)));
+
+		xterm.clearBuffer();
+
+		deepStrictEqual(commandDetection.commands, []);
+		deepStrictEqual(partialCommandDetection.commands, []);
+		deepStrictEqual(invalidatedCommands.map(e => e.command), ['echo test']);
+		strictEqual(decorations.has(clearedCommandMarkerId), false);
 	});
 
 	suite('getContentsAsText', () => {


### PR DESCRIPTION
### Details

Clears rich and partial command detection history when the terminal buffer is cleared.

### Before

When running the same task and clearing the terminal 37 times, retained commands and their decorations grow each time (outlined in red):

<img width="1400" height="220" alt="task-run-fix-clear-terminal-command-history-before" src="https://github.com/user-attachments/assets/40fed90b-ff6c-4b1a-9137-a6ecce51f8e2" />

### After

No more retained command or partial-command marker growth is detected.

<img width="1400" height="80" alt="task-run-fix-clear-terminal-command-history-after" src="https://github.com/user-attachments/assets/697945e5-2816-4d9d-9abd-ac9b7d3a7916" />
