### PR TITLE
fix: memory leak in abstractTaskService

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2633,8 +2633,9 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		await ProblemMatcherRegistry.onReady();
 		const taskSystemInfo: ITaskSystemInfo | undefined = this._getTaskSystemInfo(workspaceFolder.uri.scheme);
 		const problemReporter = new ProblemReporter(this._outputChannel);
-		this._register(problemReporter.onDidError(error => this._showOutput(runSource, undefined, error)));
+		const problemReporterListener = problemReporter.onDidError(error => this._showOutput(runSource, undefined, error));
 		const parseResult = TaskConfig.parse(workspaceFolder, undefined, taskSystemInfo ? taskSystemInfo.platform : Platform.platform, workspaceFolderConfiguration.config, problemReporter, TaskConfig.TaskConfigSource.TasksJson, this._contextKeyService);
+		problemReporterListener.dispose();
 		let hasErrors = false;
 		if (!parseResult.validationStatus.isOK() && (parseResult.validationStatus.state !== ValidationState.Info)) {
 			hasErrors = true;


### PR DESCRIPTION
### Details

Disposes the `ProblemReporter.onDidError` listener after task configuration parsing.

### Before

When running the same task 37 times, task problem reporter listeners grow each time (outlined in red):

<img width="1400" height="220" alt="task-run-fix-task-problem-reporter-memory-leak-before" src="https://github.com/user-attachments/assets/d1d3d88b-6f21-4c04-83ba-1cb076904de6" />

### After

No more leak is detected for this listener.

<img width="1400" height="200" alt="task-run-fix-task-problem-reporter-memory-leak-after" src="https://github.com/user-attachments/assets/c9a13079-06c8-4119-9272-c59ccb08050d" />
