### PR TITLE
Style overrides: Update tab label font weight for consistency

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -40,7 +40,7 @@
 }
 
 .style-override .part.editor .tabs-container > .tab > .tab-label > .monaco-icon-label-container {
-	font-weight: var(--vscode-agents-fontWeight-semiBold);
+	font-weight: var(--vscode-fontWeight-semiBold);
 }
 
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -32,12 +32,17 @@
 	border-right: none !important;
 	border-radius: var(--vscode-cornerRadius-small);
 	font-size: var(--vscode-fontSize-body1) !important;
-	font-weight: var(--vscode-agents-fontWeight-semiBold);
+	font-weight: var(--vscode-agents-fontWeight-regular);
 	box-shadow: none !important;
 	margin-right: var(--vscode-spacing-size40) !important;
 	padding: 0 0 0 4px !important;
 	--tab-border-top-color: transparent !important;
 }
+
+.style-override .part.editor .tabs-container > .tab > .tab-label > .monaco-icon-label-container {
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
+}
+
 
 .style-override .part.editor .tabs-container > .tab.sticky-compact {
 	justify-content: center;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -32,7 +32,7 @@
 	border-right: none !important;
 	border-radius: var(--vscode-cornerRadius-small);
 	font-size: var(--vscode-fontSize-body1) !important;
-	font-weight: var(--vscode-agents-fontWeight-regular);
+	font-weight: var(--vscode-fontWeight-regular);
 	box-shadow: none !important;
 	margin-right: var(--vscode-spacing-size40) !important;
 	padding: 0 0 0 4px !important;


### PR DESCRIPTION
This pull request updates the tab styling in `tabs.css` to adjust font weights for better visual consistency and hierarchy. The main change is to make the tab label font weight semibold, but keep the icon regular.

<img width="718" height="138" alt="image" src="https://github.com/user-attachments/assets/1ecb807a-3762-4f14-a338-af93f608f510" />

