### PR TITLE
style override: Add top spacing for progress container in non-merged header panes

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -233,3 +233,7 @@
 .style-override.monaco-workbench .sidebar .has-composite-bar.header-or-footer .monaco-action-bar .actions-container {
 	gap: 2px;
 }
+
+.style-override.monaco-workbench .monaco-pane-view .pane:not(.merged-header) .monaco-progress-container {
+	top: var(--vscode-spacing-size240);
+}


### PR DESCRIPTION
Introduce top spacing for the progress container in non-merged header panes to improve layout consistency. This change enhances the visual separation of elements within the user interface. Testing can be done by reviewing the appearance of the progress container in the specified context.

