### PR TITLE
Git: Avoid copying tracked files into worktrees

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 import picomatch from 'picomatch';
-import { CancellationError, CancellationToken, CancellationTokenSource, Command, commands, CustomExecution, Disposable, Event, EventEmitter, ExcludeSettingOptions, FileDecoration, l10n, LogLevel, LogOutputChannel, Memento, ProcessExecution, ProgressLocation, ProgressOptions, RelativePattern, scm, ShellExecution, SourceControl, SourceControlInputBox, SourceControlInputBoxValidation, SourceControlInputBoxValidationType, SourceControlResourceDecorations, SourceControlResourceGroup, SourceControlResourceState, TabInputNotebookDiff, TabInputTextDiff, TabInputTextMultiDiff, Task, TaskPanelKind, TaskRevealKind, TaskRunOn, tasks, ThemeColor, ThemeIcon, Uri, window, workspace, WorkspaceEdit, WorkspaceFolder } from 'vscode';
+import { CancellationError, CancellationToken, CancellationTokenSource, Command, commands, CustomExecution, Disposable, Event, EventEmitter, FileDecoration, l10n, LogLevel, LogOutputChannel, Memento, ProcessExecution, ProgressLocation, ProgressOptions, RelativePattern, scm, ShellExecution, SourceControl, SourceControlInputBox, SourceControlInputBoxValidation, SourceControlInputBoxValidationType, SourceControlResourceDecorations, SourceControlResourceGroup, SourceControlResourceState, TabInputNotebookDiff, TabInputTextDiff, TabInputTextMultiDiff, Task, TaskPanelKind, TaskRevealKind, TaskRunOn, tasks, ThemeColor, ThemeIcon, Uri, window, workspace, WorkspaceEdit, WorkspaceFolder } from 'vscode';
 import { ActionButton } from './actionButton';
 import { ApiRepository } from './api/api1';
 import type { Branch, BranchQuery, Change, CommitOptions, DiffChange, FetchOptions, LogOptions, Ref, Remote, RepositoryKind } from './api/git';
@@ -32,6 +32,7 @@ import { ISourceControlHistoryItemDetailsProviderRegistry } from './historyItemD
 import { GitArtifactProvider } from './artifactProvider';
 import { RepositoryCache } from './repositoryCache';
 import { GitQuickDiffProvider, StagedResourceQuickDiffProvider } from './quickDiffProvider';
+import { getWorktreeIncludePaths } from './worktree';
 
 const timeout = (millis: number) => new Promise(c => setTimeout(c, millis));
 
@@ -2007,95 +2008,36 @@ export class Repository implements Disposable {
 		}
 	}
 
-	private async _getWorktreeIncludePaths(): Promise<Set<string>> {
+	private async _getWorktreeIncludePaths(worktreePath: string): Promise<string[]> {
 		const config = workspace.getConfiguration('git', Uri.file(this.root));
 		const worktreeIncludeFiles = config.get<string[]>('worktreeIncludeFiles', []);
 
 		if (worktreeIncludeFiles.length === 0) {
-			return new Set<string>();
+			return [];
 		}
 
-		const filePattern = worktreeIncludeFiles
-			.map(pattern => new RelativePattern(this.root, pattern));
+		const args = ['ls-files', '--others', '--ignored', '--exclude-standard', '-z'];
+		const [files, directories, trackedFiles] = await Promise.all([
+			this.repository.exec(args),
+			this.repository.exec([...args, '--directory', '--no-empty-directory']),
+			this.repository.git.exec(worktreePath, ['ls-files', '-z'])
+		]);
 
-		// Get all files matching the globs (no ignore files applied)
-		const allFiles = await workspace.findFiles2(filePattern, {
-			useExcludeSettings: ExcludeSettingOptions.None,
-			useIgnoreFiles: { local: false, parent: false, global: false }
-		});
-
-		// Get files matching the globs with git ignore files applied
-		const nonIgnoredFiles = await workspace.findFiles2(filePattern, {
-			useExcludeSettings: ExcludeSettingOptions.None,
-			useIgnoreFiles: { local: true, parent: true, global: true }
-		});
-
-		// Files that are git ignored = all files - non-ignored files
-		const gitIgnoredFiles = new Set(allFiles.map(uri => uri.fsPath));
-		for (const uri of nonIgnoredFiles) {
-			gitIgnoredFiles.delete(uri.fsPath);
-		}
-
-		// Compute the base directory for each glob pattern (the fixed
-		// prefix before any wildcard characters). This will be used to
-		// optimize the upward traversal when adding parent directories.
-		const filePatternBases = new Set<string>();
-		for (const pattern of worktreeIncludeFiles) {
-			const segments = pattern.split(/[\/\\]/);
-			const fixedSegments: string[] = [];
-			for (const seg of segments) {
-				if (/[*?{}[\]]/.test(seg)) {
-					break;
-				}
-				fixedSegments.push(seg);
-			}
-			filePatternBases.add(path.join(this.root, ...fixedSegments));
-		}
-
-		// Add the folder paths for git ignored files, walking
-		// up only to the nearest file pattern base directory.
-		const gitIgnoredPaths = new Set(gitIgnoredFiles);
-
-		for (const filePath of gitIgnoredFiles) {
-			let dir = path.dirname(filePath);
-			while (dir !== this.root && !gitIgnoredPaths.has(dir)) {
-				gitIgnoredPaths.add(dir);
-				if (filePatternBases.has(dir)) {
-					break;
-				}
-				dir = path.dirname(dir);
-			}
-		}
-
-		// Find minimal set of paths (folders and files) to copy. Keep only topmost
-		// paths — if a directory is already in the set, all its descendants are
-		// implicitly included and don't need separate entries.
-		let lastTopmost: string | undefined;
-		const pathsToCopy = new Set<string>();
-		for (const p of Array.from(gitIgnoredPaths).sort()) {
-			if (lastTopmost && (p === lastTopmost || p.startsWith(lastTopmost + path.sep))) {
-				continue;
-			}
-			pathsToCopy.add(p);
-			lastTopmost = p;
-		}
-
-		return pathsToCopy;
+		return getWorktreeIncludePaths(this.root, worktreeIncludeFiles, files.stdout, directories.stdout, trackedFiles.stdout);
 	}
 
 	private async _copyWorktreeIncludeFiles(worktreePath: string): Promise<void> {
-		const worktreeIncludePaths = await this._getWorktreeIncludePaths();
-		if (worktreeIncludePaths.size === 0) {
+		const worktreeIncludePaths = await this._getWorktreeIncludePaths(worktreePath);
+		if (worktreeIncludePaths.length === 0) {
 			return;
 		}
 
 		try {
 			const startTime = performance.now();
 			const limiter = new Limiter<void>(15);
-			const files = Array.from(worktreeIncludePaths);
 
 			// Copy files
-			const results = await Promise.allSettled(files.map(sourceFile => {
+			const results = await Promise.allSettled(worktreeIncludePaths.map(sourceFile => {
 				return limiter.queue(async () => {
 					const targetFile = path.join(worktreePath, relativePath(this.root, sourceFile));
 					await fsPromises.mkdir(path.dirname(targetFile), { recursive: true });
@@ -2105,7 +2047,7 @@ export class Repository implements Disposable {
 
 			// Log any failed operations
 			const failedOperations = results.filter(r => r.status === 'rejected');
-			this.logger.info(`[Repository][_copyWorktreeIncludeFiles] Copied ${files.length - failedOperations.length}/${files.length} folder(s)/file(s) to worktree. [${(performance.now() - startTime).toFixed(2)}ms]`);
+			this.logger.info(`[Repository][_copyWorktreeIncludeFiles] Copied ${worktreeIncludePaths.length - failedOperations.length}/${worktreeIncludePaths.length} folder(s)/file(s) to worktree. [${(performance.now() - startTime).toFixed(2)}ms]`);
 
 			if (failedOperations.length > 0) {
 				window.showWarningMessage(l10n.t('Failed to copy {0} folder(s)/file(s) to the worktree.', failedOperations.length));

--- a/extensions/git/src/test/worktree.test.ts
+++ b/extensions/git/src/test/worktree.test.ts
@@ -12,7 +12,29 @@ import { tmpdir } from 'os';
 import * as path from 'path';
 import { getWorktreeIncludePaths } from '../worktree';
 
+const isCaseInsensitiveFileSystem = process.platform === 'win32' || process.platform === 'darwin';
+
+function rmDirWithRetry(directory: string): void {
+	try { fs.rmSync(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }); } catch { }
+}
+
 suite('worktree', () => {
+	test('protects target-tracked files that differ only in case on case-insensitive file systems', () => {
+		const root = path.join(path.parse(process.cwd()).root, 'repo');
+		const includePaths = getWorktreeIncludePaths(
+			root,
+			['Cache/**'],
+			'Cache/config.json',
+			'',
+			'cache/config.json'
+		);
+
+		// On case-insensitive file systems (Windows/macOS) the target-tracked
+		// `cache/config.json` must protect the aliased ignored `Cache/config.json`.
+		const expected = isCaseInsensitiveFileSystem ? [] : [path.join(root, 'Cache/config.json')];
+		assert.deepStrictEqual(includePaths, expected);
+	});
+
 	test('collapses only wholly ignored directories', () => {
 		const root = path.join(path.parse(process.cwd()).root, 'repo');
 		const result = getWorktreeIncludePaths(
@@ -107,8 +129,8 @@ suite('worktree', () => {
 			});
 		} finally {
 			try { runGit(repositoryRoot, ['worktree', 'remove', '--force', worktreePath]); } catch { }
-			fs.rmSync(repositoryRoot, { recursive: true, force: true });
-			fs.rmSync(worktreePath, { recursive: true, force: true });
+			rmDirWithRetry(repositoryRoot);
+			rmDirWithRetry(worktreePath);
 		}
 	});
 
@@ -156,8 +178,8 @@ suite('worktree', () => {
 			});
 		} finally {
 			try { runGit(repositoryRoot, ['worktree', 'remove', '--force', worktreePath]); } catch { }
-			fs.rmSync(repositoryRoot, { recursive: true, force: true });
-			fs.rmSync(worktreePath, { recursive: true, force: true });
+			rmDirWithRetry(repositoryRoot);
+			rmDirWithRetry(worktreePath);
 		}
 	});
 });

--- a/extensions/git/src/test/worktree.test.ts
+++ b/extensions/git/src/test/worktree.test.ts
@@ -1,0 +1,163 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import { cp as copyFile } from '@vscode/fs-copyfile';
+import * as assert from 'assert';
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'path';
+import { getWorktreeIncludePaths } from '../worktree';
+
+suite('worktree', () => {
+	test('collapses only wholly ignored directories', () => {
+		const root = path.join(path.parse(process.cwd()).root, 'repo');
+		const result = getWorktreeIncludePaths(
+			root,
+			['.env', '**/node_modules/**', 'partial/*.txt', 'app/**'],
+			[
+				'.env',
+				'app/config.local',
+				'build/node_modules/.bin/tool',
+				'build/node_modules/pkg/index.js',
+				'extensions/copilot/node_modules/pkg/index.js',
+				'node_modules/.bin/tool',
+				'partial/keep.txt',
+				'partial/skip.bin',
+				'unmatched/cache.bin',
+			].join('\0'),
+			[
+				'build/node_modules/',
+				'extensions/copilot/node_modules/',
+				'node_modules/',
+				'partial/',
+				'unmatched/',
+			].join('\0'),
+			''
+		);
+
+		assert.deepStrictEqual(result.sort(), [
+			path.join(root, '.env'),
+			path.join(root, 'app/config.local'),
+			path.join(root, 'build/node_modules/'),
+			path.join(root, 'extensions/copilot/node_modules/'),
+			path.join(root, 'node_modules/'),
+			path.join(root, 'partial/keep.txt'),
+		].sort());
+	});
+
+	test('supports trailing separators in glob patterns', () => {
+		const root = path.join(path.parse(process.cwd()).root, 'repo');
+		assert.deepStrictEqual(
+			getWorktreeIncludePaths(root, ['**/node_modules/**/'], 'node_modules/pkg/index.js\0', 'node_modules/\0', ''),
+			[path.join(root, 'node_modules/')]
+		);
+	});
+
+	test('does not copy tracked siblings into a worktree', async () => {
+		const repositoryRoot = fs.mkdtempSync(path.join(tmpdir(), 'vscode-git-include-'));
+		const worktreePath = `${repositoryRoot}-worktree`;
+		const fixtureRoot = path.join(repositoryRoot, 'worktree-test');
+		const trackedFile = path.join(fixtureRoot, 'tracked.txt');
+		const dependencyFile = path.join(fixtureRoot, 'node_modules', 'dependency', 'index.js');
+		const runGit = (cwd: string, args: string[]) => childProcess.execFileSync('git', args, { cwd, encoding: 'utf8' });
+
+		try {
+			runGit(repositoryRoot, ['init', '-b', 'main']);
+			runGit(repositoryRoot, ['config', 'user.name', 'test']);
+			runGit(repositoryRoot, ['config', 'user.email', 'test@example.com']);
+			runGit(repositoryRoot, ['config', 'commit.gpgsign', 'false']);
+			fs.mkdirSync(path.dirname(dependencyFile), { recursive: true });
+			fs.writeFileSync(path.join(repositoryRoot, '.gitignore'), 'worktree-test/node_modules/\n');
+			fs.writeFileSync(trackedFile, 'committed');
+			fs.writeFileSync(dependencyFile, 'dependency');
+			runGit(repositoryRoot, ['add', '.']);
+			runGit(repositoryRoot, ['commit', '-m', 'initial']);
+			fs.writeFileSync(trackedFile, 'source change');
+			runGit(repositoryRoot, ['worktree', 'add', '-b', 'agents/test', worktreePath, 'main']);
+
+			const args = ['ls-files', '--others', '--ignored', '--exclude-standard', '-z'];
+			const includePaths = getWorktreeIncludePaths(
+				repositoryRoot,
+				['**/node_modules/**'],
+				runGit(repositoryRoot, args),
+				runGit(repositoryRoot, [...args, '--directory', '--no-empty-directory']),
+				runGit(worktreePath, ['ls-files', '-z'])
+			);
+
+			for (const source of includePaths) {
+				const target = path.join(worktreePath, path.relative(repositoryRoot, source));
+				await fs.promises.mkdir(path.dirname(target), { recursive: true });
+				await copyFile(source, target, { force: true, recursive: true, verbatimSymlinks: true });
+			}
+
+			assert.deepStrictEqual({
+				includePaths: includePaths.map(includePath => path.relative(repositoryRoot, includePath)),
+				tracked: fs.readFileSync(path.join(worktreePath, 'worktree-test', 'tracked.txt'), 'utf8'),
+				dependency: fs.readFileSync(path.join(worktreePath, 'worktree-test', 'node_modules', 'dependency', 'index.js'), 'utf8'),
+				status: runGit(worktreePath, ['status', '--porcelain']),
+			}, {
+				includePaths: [path.join('worktree-test', 'node_modules')],
+				tracked: 'committed',
+				dependency: 'dependency',
+				status: '',
+			});
+		} finally {
+			try { runGit(repositoryRoot, ['worktree', 'remove', '--force', worktreePath]); } catch { }
+			fs.rmSync(repositoryRoot, { recursive: true, force: true });
+			fs.rmSync(worktreePath, { recursive: true, force: true });
+		}
+	});
+
+	test('does not overwrite paths tracked by the target ref', async () => {
+		const repositoryRoot = fs.mkdtempSync(path.join(tmpdir(), 'vscode-git-include-'));
+		const worktreePath = `${repositoryRoot}-worktree`;
+		const sourceFile = path.join(repositoryRoot, 'cache', 'config.json');
+		const runGit = (cwd: string, args: string[]) => childProcess.execFileSync('git', args, { cwd, encoding: 'utf8' });
+
+		try {
+			runGit(repositoryRoot, ['init', '-b', 'main']);
+			runGit(repositoryRoot, ['config', 'user.name', 'test']);
+			runGit(repositoryRoot, ['config', 'user.email', 'test@example.com']);
+			runGit(repositoryRoot, ['config', 'commit.gpgsign', 'false']);
+			fs.mkdirSync(path.dirname(sourceFile), { recursive: true });
+			fs.writeFileSync(sourceFile, 'target');
+			runGit(repositoryRoot, ['add', '.']);
+			runGit(repositoryRoot, ['commit', '-m', 'tracked target file']);
+			runGit(repositoryRoot, ['branch', 'target']);
+			runGit(repositoryRoot, ['rm', 'cache/config.json']);
+			fs.writeFileSync(path.join(repositoryRoot, '.gitignore'), 'cache/\n');
+			runGit(repositoryRoot, ['add', '.']);
+			runGit(repositoryRoot, ['commit', '-m', 'ignore cache']);
+			fs.mkdirSync(path.dirname(sourceFile), { recursive: true });
+			fs.writeFileSync(sourceFile, 'source');
+			runGit(repositoryRoot, ['worktree', 'add', '-b', 'agents/test', worktreePath, 'target']);
+
+			const args = ['ls-files', '--others', '--ignored', '--exclude-standard', '-z'];
+			const includePaths = getWorktreeIncludePaths(
+				repositoryRoot,
+				['cache/**'],
+				runGit(repositoryRoot, args),
+				runGit(repositoryRoot, [...args, '--directory', '--no-empty-directory']),
+				runGit(worktreePath, ['ls-files', '-z'])
+			);
+
+			assert.deepStrictEqual({
+				includePaths,
+				target: fs.readFileSync(path.join(worktreePath, 'cache', 'config.json'), 'utf8'),
+				status: runGit(worktreePath, ['status', '--porcelain']),
+			}, {
+				includePaths: [],
+				target: 'target',
+				status: '',
+			});
+		} finally {
+			try { runGit(repositoryRoot, ['worktree', 'remove', '--force', worktreePath]); } catch { }
+			fs.rmSync(repositoryRoot, { recursive: true, force: true });
+			fs.rmSync(worktreePath, { recursive: true, force: true });
+		}
+	});
+});

--- a/extensions/git/src/worktree.ts
+++ b/extensions/git/src/worktree.ts
@@ -6,6 +6,10 @@
 import * as path from 'path';
 import picomatch from 'picomatch';
 
+// Windows and macOS are treated as case-insensitive file systems in VS Code
+// (see `util.ts`). Kept local to avoid importing `vscode` into this module.
+const isCaseInsensitiveFileSystem = process.platform === 'win32' || process.platform === 'darwin';
+
 export function getWorktreeIncludePaths(repositoryRoot: string, globs: readonly string[], filesOutput: string, directoriesOutput: string, trackedFilesOutput: string): string[] {
 	const ignoredFiles = filesOutput.split('\0').filter(Boolean);
 	if (ignoredFiles.length === 0) {
@@ -17,24 +21,27 @@ export function getWorktreeIncludePaths(repositoryRoot: string, globs: readonly 
 		return picomatch(normalized.endsWith('/') ? `${normalized}**` : normalized, { dot: true });
 	});
 	const wholeDirectories = new Set(directoriesOutput.split('\0').filter(entry => entry.endsWith('/')));
-	const trackedFiles = new Set(trackedFilesOutput.split('\0').filter(Boolean));
+	// Normalized lookup sets for case-insensitive file systems (Windows/macOS). Original
+	// spellings are retained in `wholeDirectories`/`matchedFiles` for the returned copy paths.
+	const normalizedWholeDirectories = new Set([...wholeDirectories].map(normalizePathForComparison));
+	const normalizedTrackedFiles = new Set(trackedFilesOutput.split('\0').filter(Boolean).map(normalizePathForComparison));
 	const matchedFiles: string[] = [];
 	const nonCollapsibleDirectories = new Set<string>();
 
-	for (const file of trackedFiles) {
-		const directory = wholeDirectories.has(`${file}/`) ? `${file}/` : findContainingDirectory(file, wholeDirectories);
+	for (const file of normalizedTrackedFiles) {
+		const directory = normalizedWholeDirectories.has(`${file}/`) ? `${file}/` : findContainingDirectory(file, normalizedWholeDirectories);
 		if (directory) {
 			nonCollapsibleDirectories.add(directory);
 		}
 	}
 
 	for (const file of ignoredFiles) {
-		if (matchers.some(matcher => matcher(file)) && !hasTrackedPathOrAncestor(file, trackedFiles)) {
+		if (matchers.some(matcher => matcher(file)) && !hasTrackedPathOrAncestor(file, normalizedTrackedFiles)) {
 			matchedFiles.push(file);
 			continue;
 		}
 
-		const containingDirectory = findContainingDirectory(file, wholeDirectories);
+		const containingDirectory = findContainingDirectory(file, normalizedWholeDirectories);
 		if (containingDirectory) {
 			nonCollapsibleDirectories.add(containingDirectory);
 		}
@@ -42,14 +49,15 @@ export function getWorktreeIncludePaths(repositoryRoot: string, globs: readonly 
 
 	const collapsedDirectories = new Set<string>();
 	for (const directory of wholeDirectories) {
-		if (!nonCollapsibleDirectories.has(directory)) {
+		if (!nonCollapsibleDirectories.has(normalizePathForComparison(directory))) {
 			collapsedDirectories.add(directory);
 		}
 	}
+	const normalizedCollapsedDirectories = new Set([...collapsedDirectories].map(normalizePathForComparison));
 
 	const includePaths = [...collapsedDirectories];
 	for (const file of matchedFiles) {
-		if (!findContainingDirectory(file, collapsedDirectories)) {
+		if (!findContainingDirectory(file, normalizedCollapsedDirectories)) {
 			includePaths.push(file);
 		}
 	}
@@ -57,29 +65,41 @@ export function getWorktreeIncludePaths(repositoryRoot: string, globs: readonly 
 	return includePaths.map(entry => path.join(repositoryRoot, entry));
 }
 
-function findContainingDirectory(file: string, directories: ReadonlySet<string>): string | undefined {
-	let index = file.indexOf('/');
+/**
+ * Normalizes a Git path for comparison. Windows and macOS are treated as
+ * case-insensitive file systems in VS Code, so casing is lowered to avoid
+ * missing path aliases (e.g. `Cache/` vs `cache/`). Git paths always use `/`
+ * separators, so only the casing needs to be normalized.
+ */
+function normalizePathForComparison(filePath: string): string {
+	return isCaseInsensitiveFileSystem ? filePath.toLowerCase() : filePath;
+}
+
+function findContainingDirectory(file: string, normalizedDirectories: ReadonlySet<string>): string | undefined {
+	const normalizedFile = normalizePathForComparison(file);
+	let index = normalizedFile.indexOf('/');
 	while (index !== -1) {
-		const prefix = file.slice(0, index + 1);
-		if (directories.has(prefix)) {
+		const prefix = normalizedFile.slice(0, index + 1);
+		if (normalizedDirectories.has(prefix)) {
 			return prefix;
 		}
-		index = file.indexOf('/', index + 1);
+		index = normalizedFile.indexOf('/', index + 1);
 	}
 	return undefined;
 }
 
-function hasTrackedPathOrAncestor(file: string, trackedFiles: ReadonlySet<string>): boolean {
-	if (trackedFiles.has(file)) {
+function hasTrackedPathOrAncestor(file: string, normalizedTrackedFiles: ReadonlySet<string>): boolean {
+	const normalizedFile = normalizePathForComparison(file);
+	if (normalizedTrackedFiles.has(normalizedFile)) {
 		return true;
 	}
 
-	let index = file.indexOf('/');
+	let index = normalizedFile.indexOf('/');
 	while (index !== -1) {
-		if (trackedFiles.has(file.slice(0, index))) {
+		if (normalizedTrackedFiles.has(normalizedFile.slice(0, index))) {
 			return true;
 		}
-		index = file.indexOf('/', index + 1);
+		index = normalizedFile.indexOf('/', index + 1);
 	}
 	return false;
 }

--- a/extensions/git/src/worktree.ts
+++ b/extensions/git/src/worktree.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import picomatch from 'picomatch';
+
+export function getWorktreeIncludePaths(repositoryRoot: string, globs: readonly string[], filesOutput: string, directoriesOutput: string, trackedFilesOutput: string): string[] {
+	const ignoredFiles = filesOutput.split('\0').filter(Boolean);
+	if (ignoredFiles.length === 0) {
+		return [];
+	}
+
+	const matchers = globs.map(pattern => {
+		const normalized = pattern.replaceAll('\\', '/');
+		return picomatch(normalized.endsWith('/') ? `${normalized}**` : normalized, { dot: true });
+	});
+	const wholeDirectories = new Set(directoriesOutput.split('\0').filter(entry => entry.endsWith('/')));
+	const trackedFiles = new Set(trackedFilesOutput.split('\0').filter(Boolean));
+	const matchedFiles: string[] = [];
+	const nonCollapsibleDirectories = new Set<string>();
+
+	for (const file of trackedFiles) {
+		const directory = wholeDirectories.has(`${file}/`) ? `${file}/` : findContainingDirectory(file, wholeDirectories);
+		if (directory) {
+			nonCollapsibleDirectories.add(directory);
+		}
+	}
+
+	for (const file of ignoredFiles) {
+		if (matchers.some(matcher => matcher(file)) && !hasTrackedPathOrAncestor(file, trackedFiles)) {
+			matchedFiles.push(file);
+			continue;
+		}
+
+		const containingDirectory = findContainingDirectory(file, wholeDirectories);
+		if (containingDirectory) {
+			nonCollapsibleDirectories.add(containingDirectory);
+		}
+	}
+
+	const collapsedDirectories = new Set<string>();
+	for (const directory of wholeDirectories) {
+		if (!nonCollapsibleDirectories.has(directory)) {
+			collapsedDirectories.add(directory);
+		}
+	}
+
+	const includePaths = [...collapsedDirectories];
+	for (const file of matchedFiles) {
+		if (!findContainingDirectory(file, collapsedDirectories)) {
+			includePaths.push(file);
+		}
+	}
+
+	return includePaths.map(entry => path.join(repositoryRoot, entry));
+}
+
+function findContainingDirectory(file: string, directories: ReadonlySet<string>): string | undefined {
+	let index = file.indexOf('/');
+	while (index !== -1) {
+		const prefix = file.slice(0, index + 1);
+		if (directories.has(prefix)) {
+			return prefix;
+		}
+		index = file.indexOf('/', index + 1);
+	}
+	return undefined;
+}
+
+function hasTrackedPathOrAncestor(file: string, trackedFiles: ReadonlySet<string>): boolean {
+	if (trackedFiles.has(file)) {
+		return true;
+	}
+
+	let index = file.indexOf('/');
+	while (index !== -1) {
+		if (trackedFiles.has(file.slice(0, index))) {
+			return true;
+		}
+		index = file.indexOf('/', index + 1);
+	}
+	return false;
+}


### PR DESCRIPTION
Fixes #326935

cc @sandy081

When `git.worktreeIncludeFiles` contains a broad pattern such as `**/node_modules/**`, the Git extension walked matching ignored files up to partially tracked ancestors such as `build/` and `extensions/`. Recursively copying those directories could overwrite the freshly checked-out worktree with tracked files from the source checkout.

This change:

- enumerates ignored files and wholly ignored directories through Git;
- collapses only directories whose ignored contents all match;
- protects files tracked by the selected target ref, including cross-ref worktrees;
- preserves root, dotfile, Windows-separator, and trailing-separator glob behavior.

Regression coverage uses real temporary Git repositories to verify that dirty source files and source-ignored paths tracked by the target ref never modify the new worktree.

Tests:

- `npm run gulp compile-extension:git -- --quiet`
- `node node_modules/mocha/bin/mocha extensions/git/out/test/worktree.test.js --ui tdd --timeout 60000`
- `npm run precommit`
