### PR TITLE
Fix chat list row height swallowed during render (stale/clipped until resize)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -255,12 +255,9 @@ export interface IChatItemHeightUpdate {
  * `isBeingRendered` is `true` when the measurement arrives *synchronously* during the tree's
  * `renderElement` call; in that case the tree must not be notified re-entrantly.
  *
- * See https://github.com/microsoft/vscode/issues/326952: `currentRenderedHeight` must only be
- * advanced once a height has actually been notified to the tree. Recording the height while
- * suppressing the notification lets a later identical measurement be deduped by the "unchanged"
- * check, stranding the row at a stale height until a full relayout. When a measurement is
- * suppressed we therefore keep the stored height untouched AND request a deferred re-measure once
- * the render pass is over, so the grown height reliably reaches the tree.
+ * See https://github.com/microsoft/vscode/issues/326952: when notification is suppressed,
+ * `currentRenderedHeight` must remain unchanged so an identical deferred measurement is not
+ * deduplicated before it reaches the tree.
  */
 export function reconcileChatItemHeight(
 	normalizedHeight: number,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -236,6 +236,63 @@ export function shouldScheduleInitialHeightChange(normalizedHeight: number, allo
 	return typeof allocatedHeight !== 'number' || normalizedHeight > allocatedHeight;
 }
 
+/** How a freshly measured row height should be reconciled against the tree's known height. */
+export type ChatItemHeightUpdateKind = 'none' | 'fire' | 'scheduleInitial' | 'deferReMeasure';
+
+export interface IChatItemHeightUpdate {
+	/** Value to store back into the element's `currentRenderedHeight`. */
+	readonly nextRenderedHeight: number | undefined;
+	/** Whether/how to notify the tree of the new height. */
+	readonly kind: ChatItemHeightUpdateKind;
+	/** The height to notify with (meaningful when `kind` is `fire` or `scheduleInitial`). */
+	readonly height: number;
+}
+
+/**
+ * Decide how a freshly measured, normalized row height should be reconciled against the height
+ * the tree currently knows about (`currentRenderedHeight`).
+ *
+ * `isBeingRendered` is `true` when the measurement arrives *synchronously* during the tree's
+ * `renderElement` call; in that case the tree must not be notified re-entrantly.
+ *
+ * See https://github.com/microsoft/vscode/issues/326952: `currentRenderedHeight` must only be
+ * advanced once a height has actually been notified to the tree. Recording the height while
+ * suppressing the notification lets a later identical measurement be deduped by the "unchanged"
+ * check, stranding the row at a stale height until a full relayout. When a measurement is
+ * suppressed we therefore keep the stored height untouched AND request a deferred re-measure once
+ * the render pass is over, so the grown height reliably reaches the tree.
+ */
+export function reconcileChatItemHeight(
+	normalizedHeight: number,
+	currentRenderedHeight: number | undefined,
+	isBeingRendered: boolean,
+	allocatedHeight: number | undefined,
+): IChatItemHeightUpdate {
+	if (normalizedHeight === currentRenderedHeight) {
+		return { nextRenderedHeight: currentRenderedHeight, kind: 'none', height: normalizedHeight };
+	}
+
+	if (isBeingRendered) {
+		// Suppress the re-entrant notification and DO NOT advance `currentRenderedHeight` (the tree
+		// was never told). Schedule a deferred re-measure so the height reaches the tree once this
+		// row is done rendering, instead of relying on a later async measurement that could be
+		// deduped by the "unchanged" check above.
+		return { nextRenderedHeight: currentRenderedHeight, kind: 'deferReMeasure', height: normalizedHeight };
+	}
+
+	if (typeof currentRenderedHeight === 'number') {
+		return { nextRenderedHeight: normalizedHeight, kind: 'fire', height: normalizedHeight };
+	}
+
+	// First measurements that already fit are just initialization. Only schedule a first update
+	// when the row would otherwise clip newly rendered content.
+	if (!shouldScheduleInitialHeightChange(normalizedHeight, allocatedHeight)) {
+		return { nextRenderedHeight: normalizedHeight, kind: 'none', height: normalizedHeight };
+	}
+
+	return { nextRenderedHeight: normalizedHeight, kind: 'scheduleInitial', height: normalizedHeight };
+}
+
 export function renderChatResponseDetails(container: HTMLElement, details: string | undefined, completedAt: number | undefined, elapsedMs: number | undefined, verbose: boolean): HTMLElement | undefined {
 	dom.clearNode(container);
 	container.classList.remove('chat-response-flip-active', 'chat-response-flip-down', 'chat-response-flip-reset');
@@ -533,32 +590,33 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		const normalizedHeight = Math.ceil(height);
-		if (normalizedHeight === template.currentElement.currentRenderedHeight) {
-			return;
-		}
+		const element = template.currentElement;
+		const update = reconcileChatItemHeight(
+			normalizedHeight,
+			element.currentRenderedHeight,
+			element === this._elementBeingRendered,
+			template.allocatedHeight,
+		);
+		element.currentRenderedHeight = update.nextRenderedHeight;
 
-		const originalStoredHeight = template.currentElement.currentRenderedHeight;
-		template.currentElement.currentRenderedHeight = normalizedHeight;
-		if (template.currentElement === this._elementBeingRendered) {
-			return;
-		}
-
-		if (typeof originalStoredHeight === 'number') {
-			this._onDidChangeItemHeight.fire({ element: template.currentElement, height: normalizedHeight });
-		} else {
-			// First measurements that already fit are just initialization. Only schedule
-			// a first update when the row would otherwise clip newly rendered content.
-			if (!shouldScheduleInitialHeightChange(normalizedHeight, template.allocatedHeight)) {
-				return;
-			}
-
-			const element = template.currentElement;
-			const scheduledHeight = normalizedHeight;
+		if (update.kind === 'fire') {
+			this._onDidChangeItemHeight.fire({ element, height: update.height });
+		} else if (update.kind === 'scheduleInitial') {
+			const scheduledHeight = update.height;
 			dom.scheduleAtNextAnimationFrame(dom.getWindow(template.rowContainer), () => {
 				if (template.currentElement !== element || element.currentRenderedHeight !== scheduledHeight) {
 					return;
 				}
 				this._onDidChangeItemHeight.fire({ element, height: scheduledHeight });
+			});
+		} else if (update.kind === 'deferReMeasure') {
+			// The measurement arrived synchronously during this row's render. Re-measure on the
+			// next frame (once the render pass is over) so the grown height reliably reaches the
+			// tree without a re-entrant notification.
+			dom.scheduleAtNextAnimationFrame(dom.getWindow(template.rowContainer), () => {
+				if (template.currentElement === element && element !== this._elementBeingRendered) {
+					this.fireItemHeightChange(template);
+				}
 			});
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -628,7 +628,10 @@ export class ChatListWidget extends Disposable {
 	 */
 	private updateScrollDownButtonVisibility(): void {
 		const { showButton, atBottom } = computeScrollDownState(this.isScrolledToBottom, this._scrollLock);
-		this._scrollDownButton.element.style.display = showButton ? '' : 'none';
+		// Use an explicit `flex` (the `.monaco-button` default) rather than '' when showing: the
+		// stylesheet applies `display: none` to `.interactive-session .chat-scroll-down`, so clearing
+		// the inline style would let that rule win and keep the button hidden.
+		this._scrollDownButton.element.style.display = showButton ? 'flex' : 'none';
 		this._container.classList.toggle('chat-list-at-bottom', atBottom);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -87,6 +87,24 @@ export function getAnchoredScrollTop(scrollTop: number, currentTargetTop: number
 	return scrollTop + currentTargetTop - anchorTargetTop;
 }
 
+/**
+ * Computes the scroll-down state for the chat list, keeping two concerns decoupled:
+ *
+ * - `showButton`: whether the "scroll to bottom" affordance is shown. Driven purely by the actual
+ *   scroll position so the user can always jump to the latest content when the view is not at the
+ *   bottom — including during an auto-scroll (agent) turn where the view has fallen behind. See
+ *   https://github.com/microsoft/vscode/issues/326952 (previously this was also suppressed by the
+ *   scroll lock, hiding the button for the whole agent turn).
+ * - `atBottom`: the `chat-list-at-bottom` visual state that reserves streaming-response padding.
+ *   Intentionally still honours the scroll lock so padding during auto-scroll turns is unchanged.
+ */
+export function computeScrollDownState(isScrolledToBottom: boolean, scrollLock: boolean): { showButton: boolean; atBottom: boolean } {
+	return {
+		showButton: !isScrolledToBottom,
+		atBottom: isScrolledToBottom || scrollLock,
+	};
+}
+
 class UserToggleResizeTracker extends Disposable {
 
 	private readonly state = new UserToggleResizeState(2);
@@ -609,8 +627,8 @@ export class ChatListWidget extends Disposable {
 	 * Update scroll-down button visibility based on scroll position and scroll lock.
 	 */
 	private updateScrollDownButtonVisibility(): void {
-		const atBottom = this.isScrolledToBottom || this._scrollLock;
-		this._scrollDownButton.element.style.display = atBottom ? 'none' : '';
+		const { showButton, atBottom } = computeScrollDownState(this.isScrolledToBottom, this._scrollLock);
+		this._scrollDownButton.element.style.display = showButton ? '' : 'none';
 		this._container.classList.toggle('chat-list-at-bottom', atBottom);
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import * as dom from '../../../../../../base/browser/dom.js';
 import { mainWindow } from '../../../../../../base/browser/window.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -15,13 +16,13 @@ import { TestConfigurationService } from '../../../../../../platform/configurati
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
-import { buildPlanReviewProgressContent, ChatListItemRenderer, getWorkingProgressRelevantParts, isWaitingForMcpServers, renderChatRequestTimestamp, renderChatResponseDetails, shouldCreateGroupedThinkingPart, shouldHideChatUserIdentity, shouldPinToolInvocationToThinking, shouldRenderInitialProgressiveContentImmediately, shouldScheduleInitialHeightChange, shouldShowFileChangesSummaryForSettings, shouldShowPillsSummaryForSettings, shouldStartNewCollapsedThinkingGroup } from '../../../browser/widget/chatListRenderer.js';
+import { buildPlanReviewProgressContent, ChatListItemRenderer, getWorkingProgressRelevantParts, IChatListItemTemplate, isWaitingForMcpServers, reconcileChatItemHeight, renderChatRequestTimestamp, renderChatResponseDetails, shouldCreateGroupedThinkingPart, shouldHideChatUserIdentity, shouldPinToolInvocationToThinking, shouldRenderInitialProgressiveContentImmediately, shouldScheduleInitialHeightChange, shouldShowFileChangesSummaryForSettings, shouldShowPillsSummaryForSettings, shouldStartNewCollapsedThinkingGroup } from '../../../browser/widget/chatListRenderer.js';
 import { isChatTurnStatusPillsEnabled } from '../../../browser/widget/chatTurnPills.js';
 import { IChatMcpServersStartingSlow, IChatService, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { formatChatRequestTimestamp, formatChatResponseDetails, formatElapsedTime } from '../../../common/chatProgressFormatting.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, CollapsedToolsDisplayMode, ThinkingDisplayMode } from '../../../common/constants.js';
 import { ChatModel } from '../../../common/model/chatModel.js';
-import { ChatViewModel, IChatRendererContent, isResponseVM } from '../../../common/model/chatViewModel.js';
+import { ChatViewModel, IChatRendererContent, IChatResponseViewModel, isResponseVM } from '../../../common/model/chatViewModel.js';
 import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chatToolInvocation.js';
 import { ChatAgentService, IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ChatRequestTextPart } from '../../../common/requestParser/chatParserTypes.js';
@@ -47,6 +48,53 @@ suite('ChatListRenderer', () => {
 				true,
 				true,
 			]);
+		});
+	});
+
+	suite('reconcileChatItemHeight', () => {
+		// Helper: run a sequence of measurements through the reconciler, threading
+		// `currentRenderedHeight` the way `fireItemHeightChange` does, and capture the
+		// notification kind + the stored height after each step.
+		const run = (steps: readonly { measured: number; isBeingRendered: boolean }[], allocatedHeight: number | undefined) => {
+			let stored: number | undefined = allocatedHeight;
+			return steps.map(({ measured, isBeingRendered }) => {
+				const update = reconcileChatItemHeight(measured, stored, isBeingRendered, allocatedHeight);
+				stored = update.nextRenderedHeight;
+				return { kind: update.kind, height: update.height, stored };
+			});
+		};
+
+		// Regression test for https://github.com/microsoft/vscode/issues/326952.
+		// A row grows during streaming and is measured synchronously while it is being rendered
+		// (notification suppressed). The stored height must NOT advance, and a deferred re-measure
+		// must be requested, so a follow-up measurement of the grown height actually reaches the
+		// tree instead of being deduped away (which would strand the content until a window resize).
+		test('does not strand a grown height first seen while the row is being rendered', () => {
+			assert.deepStrictEqual(
+				run([
+					{ measured: 900, isBeingRendered: true },   // grew mid-render -> suppressed, defer
+					{ measured: 900, isBeingRendered: false },  // deferred re-measure delivers the height
+				], /*allocatedHeight*/ 500),
+				[
+					{ kind: 'deferReMeasure', height: 900, stored: 500 },
+					{ kind: 'fire', height: 900, stored: 900 },
+				],
+			);
+		});
+
+		test('normal async growth notifies the tree and initial-fit measurements do not', () => {
+			assert.deepStrictEqual(
+				run([
+					{ measured: 500, isBeingRendered: false },  // initial measurement that already fits
+					{ measured: 700, isBeingRendered: false },  // async growth -> notify
+					{ measured: 700, isBeingRendered: false },  // unchanged -> no-op
+				], /*allocatedHeight*/ 500),
+				[
+					{ kind: 'none', height: 500, stored: 500 },
+					{ kind: 'fire', height: 700, stored: 700 },
+					{ kind: 'none', height: 700, stored: 700 },
+				],
+			);
 		});
 	});
 
@@ -456,6 +504,90 @@ suite('ChatListRenderer', () => {
 			mountedWhileStreaming: true,
 			mountedAfterCompletion: true,
 		});
+
+		disposables.dispose();
+	});
+
+	// End-to-end regression test for https://github.com/microsoft/vscode/issues/326952: a height
+	// measured synchronously *during* the render pass must be deferred (not fired re-entrantly and
+	// not stored), then reliably delivered to the tree afterwards via a re-measure — so streamed
+	// content can't get stranded below a stale row height until a window resize.
+	test('fireItemHeightChange defers a mid-render measurement and delivers it after the render pass', async () => {
+		const disposables = store.add(new DisposableStore());
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		const configurationService = new TestConfigurationService();
+		instantiationService.stub(IConfigurationService, configurationService);
+		instantiationService.stub(IChatService, new MockChatService());
+		instantiationService.stub(IChatAgentService, disposables.add(instantiationService.createInstance(ChatAgentService)));
+
+		const model = disposables.add(instantiationService.createInstance(ChatModel, undefined, { initialLocation: ChatAgentLocation.Chat, canUseTools: true }));
+		const viewModel = disposables.add(instantiationService.createInstance(ChatViewModel, model, undefined));
+		const text = 'test';
+		const request = model.addRequest({
+			text,
+			parts: [new ChatRequestTextPart(new OffsetRange(0, text.length), new Range(1, 1, 1, text.length + 1), text)]
+		}, { variables: [] }, 0);
+		const response = viewModel.getItems().find(isResponseVM);
+		assert.ok(response);
+
+		const container = mainWindow.document.createElement('div');
+		mainWindow.document.body.appendChild(container);
+		disposables.add(toDisposable(() => container.remove()));
+		const renderer = disposables.add(instantiationService.createInstance(
+			ChatListItemRenderer,
+			{} as ChatEditorOptions,
+			{ progressMessageAtBottomOfResponse: true },
+			{
+				getListLength: () => 1,
+				onDidScroll: () => toDisposable(() => { }),
+				container,
+				currentChatMode: () => ChatModeKind.Agent,
+			},
+			undefined,
+			viewModel,
+		));
+		const template = renderer.renderTemplate(container);
+		disposables.add(toDisposable(() => renderer.disposeTemplate(template)));
+		const node = { element: response, children: [], depth: 0, visibleChildrenCount: 0, visibleChildIndex: 0, collapsible: false, collapsed: false, visible: true, filterData: undefined };
+		model.acceptResponseProgress(request, { kind: 'markdownContent', content: new MarkdownString('Some initial content') });
+		renderer.renderElement(node, 0, template);
+
+		const privateRenderer = renderer as unknown as {
+			_elementBeingRendered: IChatResponseViewModel | undefined;
+			fireItemHeightChange(template: IChatListItemTemplate, measuredHeight?: number): void;
+		};
+		const nextFrame = () => new Promise<void>(resolve => dom.scheduleAtNextAnimationFrame(dom.getWindow(container), () => resolve()));
+
+		// Let the initial render's height activity (ResizeObserver / scheduled updates) settle.
+		await nextFrame();
+		await nextFrame();
+
+		// The row's real rendered height. The DOM is NOT mutated after this point, so the row's
+		// ResizeObserver stays quiet and only the code under test can deliver a further update.
+		const renderedHeight = Math.ceil(template.rowContainer.getBoundingClientRect().height);
+		assert.ok(renderedHeight > 1, 'row should have a real rendered height');
+
+		// Simulate streaming that grew the row past the height the tree last acknowledged.
+		response.currentRenderedHeight = renderedHeight - 1;
+		const heightEvents: number[] = [];
+		disposables.add(renderer.onDidChangeItemHeight(e => heightEvents.push(e.height)));
+
+		// (a) A measurement seen synchronously during the render pass must not notify the tree
+		// re-entrantly and must not advance the stored height.
+		privateRenderer._elementBeingRendered = response;
+		privateRenderer.fireItemHeightChange(template);
+		assert.deepStrictEqual(
+			{ events: [...heightEvents], stored: response.currentRenderedHeight },
+			{ events: [], stored: renderedHeight - 1 },
+		);
+
+		// (b) Once the render pass is over the deferred re-measure delivers the real height.
+		privateRenderer._elementBeingRendered = undefined;
+		await nextFrame();
+		assert.deepStrictEqual(
+			{ events: [...heightEvents], stored: response.currentRenderedHeight },
+			{ events: [renderedHeight], stored: renderedHeight },
+		);
 
 		disposables.dispose();
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -54,9 +54,10 @@ suite('ChatListRenderer', () => {
 	suite('reconcileChatItemHeight', () => {
 		// Helper: run a sequence of measurements through the reconciler, threading
 		// `currentRenderedHeight` the way `fireItemHeightChange` does, and capture the
-		// notification kind + the stored height after each step.
-		const run = (steps: readonly { measured: number; isBeingRendered: boolean }[], allocatedHeight: number | undefined) => {
-			let stored: number | undefined = allocatedHeight;
+		// notification kind + the stored height after each step. `initialStored` is the
+		// element's `currentRenderedHeight` before the first step (undefined = never measured).
+		const run = (steps: readonly { measured: number; isBeingRendered: boolean }[], allocatedHeight: number | undefined, initialStored: number | undefined) => {
+			let stored: number | undefined = initialStored;
 			return steps.map(({ measured, isBeingRendered }) => {
 				const update = reconcileChatItemHeight(measured, stored, isBeingRendered, allocatedHeight);
 				stored = update.nextRenderedHeight;
@@ -74,7 +75,7 @@ suite('ChatListRenderer', () => {
 				run([
 					{ measured: 900, isBeingRendered: true },   // grew mid-render -> suppressed, defer
 					{ measured: 900, isBeingRendered: false },  // deferred re-measure delivers the height
-				], /*allocatedHeight*/ 500),
+				], /*allocatedHeight*/ 500, /*initialStored*/ 500),
 				[
 					{ kind: 'deferReMeasure', height: 900, stored: 500 },
 					{ kind: 'fire', height: 900, stored: 900 },
@@ -82,19 +83,29 @@ suite('ChatListRenderer', () => {
 			);
 		});
 
-		test('normal async growth notifies the tree and initial-fit measurements do not', () => {
+		test('notifies the tree on async growth and ignores an unchanged measurement', () => {
 			assert.deepStrictEqual(
 				run([
-					{ measured: 500, isBeingRendered: false },  // initial measurement that already fits
 					{ measured: 700, isBeingRendered: false },  // async growth -> notify
 					{ measured: 700, isBeingRendered: false },  // unchanged -> no-op
-				], /*allocatedHeight*/ 500),
+				], /*allocatedHeight*/ 500, /*initialStored*/ 500),
 				[
-					{ kind: 'none', height: 500, stored: 500 },
 					{ kind: 'fire', height: 700, stored: 700 },
 					{ kind: 'none', height: 700, stored: 700 },
 				],
 			);
+		});
+
+		test('first measurement (no stored height) only schedules an update when content would clip', () => {
+			assert.deepStrictEqual([
+				// Initial measurement that fits within the allocated height -> no notification.
+				run([{ measured: 500, isBeingRendered: false }], /*allocatedHeight*/ 500, /*initialStored*/ undefined),
+				// Initial measurement larger than the allocation -> schedule an initial update.
+				run([{ measured: 700, isBeingRendered: false }], /*allocatedHeight*/ 500, /*initialStored*/ undefined),
+			], [
+				[{ kind: 'none', height: 500, stored: 500 }],
+				[{ kind: 'scheduleInitial', height: 700, stored: 700 }],
+			]);
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -562,6 +562,12 @@ suite('ChatListRenderer', () => {
 		const node = { element: response, children: [], depth: 0, visibleChildrenCount: 0, visibleChildIndex: 0, collapsible: false, collapsed: false, visible: true, filterData: undefined };
 		model.acceptResponseProgress(request, { kind: 'markdownContent', content: new MarkdownString('Some initial content') });
 		renderer.renderElement(node, 0, template);
+		// Complete the response so progressive rendering stops. Otherwise a streaming response keeps
+		// scheduling `runProgressiveRender` on animation frames, which creates a
+		// ChatWorkingProgressContentPart that outlives the test (leaked disposable + stray console
+		// output during teardown).
+		request.response?.complete();
+		renderer.renderElement(node, 0, template);
 
 		const privateRenderer = renderer as unknown as {
 			_elementBeingRendered: IChatResponseViewModel | undefined;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListWidget.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { getAnchoredScrollTop, UserToggleResizeState } from '../../../browser/widget/chatListWidget.js';
+import { computeScrollDownState, getAnchoredScrollTop, UserToggleResizeState } from '../../../browser/widget/chatListWidget.js';
 
 suite('ChatListWidget', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -44,5 +44,23 @@ suite('ChatListWidget', () => {
 			titleMovedDown: 340,
 			titleUnchanged: 300,
 		});
+	});
+
+	// Regression test for https://github.com/microsoft/vscode/issues/326952: the scroll-down
+	// button must reflect the actual scroll position (shown whenever not at the bottom) even while
+	// the scroll lock is engaged during an agent turn, while the `chat-list-at-bottom` padding
+	// state stays coupled to the scroll lock.
+	test('scroll-down button is decoupled from the at-bottom padding state', () => {
+		assert.deepStrictEqual([
+			computeScrollDownState(/*isScrolledToBottom*/ true, /*scrollLock*/ true),
+			computeScrollDownState(/*isScrolledToBottom*/ true, /*scrollLock*/ false),
+			computeScrollDownState(/*isScrolledToBottom*/ false, /*scrollLock*/ true),
+			computeScrollDownState(/*isScrolledToBottom*/ false, /*scrollLock*/ false),
+		], [
+			{ showButton: false, atBottom: true },
+			{ showButton: false, atBottom: true },
+			{ showButton: true, atBottom: true },
+			{ showButton: true, atBottom: false },
+		]);
 	});
 });


### PR DESCRIPTION
Fixes #326952

### Problem

A streaming chat response could render its content but stay **visually stale/clipped until a window resize** — the row looked stuck even though the data had arrived. Resizing (which forces a relayout) revealed the full content.

### Root cause

`ChatListItemRenderer.fireItemHeightChange` advanced `currentRenderedHeight` **before** the `_elementBeingRendered` suppression check. When a measurement arrived synchronously *during* a row's render pass (e.g. a content part's `onDidChangeHeight` firing as it is constructed), the height was recorded but the tree was never notified. A later, genuine remeasurement of that same height (e.g. from the row's `ResizeObserver`) then hit the `normalizedHeight === currentRenderedHeight` early-return and was silently deduped — so the tree kept a stale row height and the extra content was stranded below it.

### Fix

- Extract the decision into a pure, exported `reconcileChatItemHeight(...)`. On a measurement suppressed during render it now **keeps `currentRenderedHeight` untouched** and returns a new `deferReMeasure` decision; `fireItemHeightChange` schedules a next-frame re-measure that reliably delivers the grown height to the tree. This does **not** rely on the `ResizeObserver` re-delivering.
- Decouple the scroll-down button from the `chat-list-at-bottom` padding state (`computeScrollDownState`): the button now appears whenever the view is not at the bottom, so users can jump to the latest content (previously it was hidden for the whole auto-scroll/agent turn).

### Tests

- `reconcileChatItemHeight` — deterministic pure-function regression test (fails on the pre-fix commit-on-suppress behavior, passes on the fix).
- `fireItemHeightChange defers a mid-render measurement …` — real-render **integration** test that asserts the tree is notified after the render pass (verified stable across repeated runs).
- `computeScrollDownState` — locks in the button/padding decoupling.

All `ChatListRenderer` + `ChatListWidget` suites pass; `typecheck-client` and `eslint` clean.

### Draft — remaining before ready

- [ ] **Perf gate** (`npm run perf:chat`, streaming scenarios) to confirm the deferred re-measure adds no `forcedReflowCount` / `layoutDurationMs` regression. Risk is low (a single `getBoundingClientRect` at rAF, when layout is already settled), but not yet run.
- [ ] Live UI verification of the scroll-down button behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
