### PR TITLE
Reliably restore the last-used chat model when it loads late

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -117,6 +117,34 @@ export class ChatInputModelSelectionController extends Disposable {
 		const selection = resolveSelection();
 		onInitialSelection(selection);
 		this._reportInitialization(this._runtime.getConfiguredModelValue(), rememberedModelId, selection);
+		this._applyInitialSelection(selection);
+
+		// The remembered model has not been honored yet when we only applied a provisional fallback
+		// (`FirstAvailable`) or are still waiting for the pool to load (`pending`). In both cases,
+		// watch the catalog and swap the remembered model in once it appears; a configured or
+		// otherwise-available model — or an explicit user pick — supersedes it. Routing both cases
+		// through one wait (instead of arming it only for `pending`) means a remembered model that
+		// lands *after* the first, possibly non-empty, catalog batch is no longer lost.
+		if (rememberedModelId && (selection.kind === 'pending' || (selection.kind === 'apply' && selection.reason === ModelSelectionReason.FirstAvailable))) {
+			const desiredIdentifier = rememberedModelId;
+			this._watchModelChanges(this._authoritativeModelWait, () => true, () => {
+				const lateSelection = resolveSelection();
+				if (lateSelection.kind === 'apply' && lateSelection.reason !== ModelSelectionReason.FirstAvailable) {
+					this._provisionalModelId = undefined;
+					this._model.setSelectionReason(lateSelection.reason);
+					this._runtime.applyModel(lateSelection.model);
+					this.ensureCurrentModelSupported();
+					return 'settled';
+				}
+				// Keep waiting only while the remembered model's vendor still reports its absence as
+				// transient (`pending`); once it is conclusively gone (`unavailable`/`notRequested`)
+				// settle on the applied fallback so the wait cannot linger forever.
+				return this._runtime.resolveModelIdentifier(desiredIdentifier).kind === 'pending' ? 'waiting' : 'settled';
+			});
+		}
+	}
+
+	private _applyInitialSelection(selection: InitialModelSelectionResult): void {
 		if (selection.kind === 'apply') {
 			this._model.setSelectionReason(selection.reason);
 			this._provisionalModelId = selection.reason === ModelSelectionReason.FirstAvailable
@@ -134,19 +162,30 @@ export class ChatInputModelSelectionController extends Disposable {
 					: fallbackModel.identifier;
 				this._runtime.applyModel(fallbackModel);
 			}
-			this._authoritativeModelWait.value = this._runtime.subscribeToModelChanges(() => {
-				const lateSelection = resolveSelection();
-				if (lateSelection.kind === 'apply') {
-					this.clearAuthoritativeModelWait();
-					this._provisionalModelId = undefined;
-					this._model.setSelectionReason(lateSelection.reason);
-					this._runtime.applyModel(lateSelection.model);
-					this.ensureCurrentModelSupported();
-				} else if (lateSelection.kind === 'none') {
-					this.clearAuthoritativeModelWait();
-				}
-			});
 		}
+	}
+
+	/**
+	 * Subscribes to catalog changes and re-runs `reevaluate` on each one, tearing the subscription
+	 * down as soon as it reports `'settled'` — or when `isRelevant()` becomes false (the bound/visible
+	 * conversation moved on) or the controller is disposed. Shared by the restore waits so the
+	 * subscription lifecycle and relevance guard live in one place; `reevaluate` is responsible for
+	 * applying any model change and returning whether the wait is done.
+	 */
+	private _watchModelChanges(
+		wait: MutableDisposable<IDisposable>,
+		isRelevant: () => boolean,
+		reevaluate: () => 'settled' | 'waiting',
+	): void {
+		wait.value = this._runtime.subscribeToModelChanges(() => {
+			if (!isRelevant()) {
+				wait.clear();
+				return;
+			}
+			if (reevaluate() === 'settled') {
+				wait.clear();
+			}
+		});
 	}
 
 	ensureCurrentModelSupported(): void {
@@ -271,28 +310,30 @@ export class ChatInputModelSelectionController extends Disposable {
 			this._model.setSelectionReason(ModelSelectionReason.SessionRestore);
 			this._runtime.applyModel(match);
 		} else if (resolution.kind === 'pending' && shouldWaitForSessionModel(desiredModel, sessionType, allModels)) {
-			this._authoritativeModelWait.value = this._runtime.subscribeToModelChanges(() => {
-				if (this._runtime.getBoundConversationKey() !== conversationKey) {
-					this.clearAuthoritativeModelWait();
-					return;
-				}
-				const lateResolution = this._runtime.resolveModelIdentifier(desiredModel.identifier);
-				if (lateResolution.kind === 'available') {
-					this.clearAuthoritativeModelWait();
-					this._model.setSelectionReason(ModelSelectionReason.SessionRestore);
-					this._runtime.restoreModelConfiguration(desiredModel.identifier, modelConfiguration);
-					this._runtime.applyModel(lateResolution.model);
-				} else if (lateResolution.kind === 'unavailable') {
-					this.clearAuthoritativeModelWait();
-					const lateMatch = findBestMatchingModel(desiredModel, this._runtime.getModels(sessionType));
-					if (lateMatch) {
+			this._watchModelChanges(
+				this._authoritativeModelWait,
+				() => this._runtime.getBoundConversationKey() === conversationKey,
+				() => {
+					const lateResolution = this._runtime.resolveModelIdentifier(desiredModel.identifier);
+					if (lateResolution.kind === 'available') {
 						this._model.setSelectionReason(ModelSelectionReason.SessionRestore);
-						this._runtime.applyModel(lateMatch);
-					} else {
-						this.selectDefault(sessionType);
+						this._runtime.restoreModelConfiguration(desiredModel.identifier, modelConfiguration);
+						this._runtime.applyModel(lateResolution.model);
+						return 'settled';
 					}
-				}
-			});
+					if (lateResolution.kind === 'unavailable') {
+						const lateMatch = findBestMatchingModel(desiredModel, this._runtime.getModels(sessionType));
+						if (lateMatch) {
+							this._model.setSelectionReason(ModelSelectionReason.SessionRestore);
+							this._runtime.applyModel(lateMatch);
+						} else {
+							this.selectDefault(sessionType);
+						}
+						return 'settled';
+					}
+					return 'waiting';
+				},
+			);
 		} else {
 			this.clearAuthoritativeModelWait();
 			this.selectDefault(sessionType);
@@ -340,18 +381,19 @@ export class ChatInputModelSelectionController extends Disposable {
 			this._runtime.applyModel(match);
 			return;
 		}
-		this._historyModelWait.value = this._runtime.subscribeToModelChanges(() => {
-			if (this._runtime.getVisibleConversationKey() !== conversationKey) {
-				this.clearHistoryModelWait();
-				return;
-			}
-			const lateMatch = tryMatch();
-			if (lateMatch) {
-				this.clearHistoryModelWait();
-				this._model.setSelectionReason(ModelSelectionReason.SessionRestore);
-				this._runtime.applyModel(lateMatch);
-			}
-		});
+		this._watchModelChanges(
+			this._historyModelWait,
+			() => this._runtime.getVisibleConversationKey() === conversationKey,
+			() => {
+				const lateMatch = tryMatch();
+				if (lateMatch) {
+					this._model.setSelectionReason(ModelSelectionReason.SessionRestore);
+					this._runtime.applyModel(lateMatch);
+					return 'settled';
+				}
+				return 'waiting';
+			},
+		);
 	}
 
 	resolveDraftModel(

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionModel.test.ts
@@ -833,4 +833,201 @@ suite('ChatModelSelectionModel', () => {
 			current: targeted.identifier,
 		});
 	});
+
+	test('initialize waits for a conclusively-absent remembered model and swaps it in when it appears', () => {
+		// Grace-independent restore. With the simple (conclusive) resolver the remembered model is
+		// `unavailable` at cold start, so `initialize` applies a provisional fallback. The refactor
+		// watches the catalog from the provisional-fallback path too (not only the `pending` path),
+		// so when the remembered model shows up on a later change it is swapped in — instead of being
+		// lost. Reverting the `initialize` restructure (arming the wait only for `pending`) leaves no
+		// wait armed here, so `pendingAfterInit` is false and the remembered model is never applied.
+		const selection = new ChatModelSelectionModel();
+		const modelChanges = disposables.add(new Emitter<string>());
+		const fallback = model('test/fallback');
+		const remembered = model('test/remembered');
+		let models = [fallback];
+		const applied: string[] = [];
+		const runtime: IChatInputModelSelectionRuntime = {
+			location: ChatAgentLocation.Chat,
+			getCurrentModeKind: () => ChatModeKind.Ask,
+			getCurrentSessionType: () => undefined,
+			isEmpty: () => true,
+			getModels: () => models,
+			getAllModels: () => models,
+			requiresCustomModels: () => false,
+			getConfiguredModelValue: () => undefined,
+			resolveModelIdentifier: identifier => resolveModelIdentifier(models, identifier, true),
+			subscribeToModelChanges: listener => modelChanges.event(listener),
+			getBoundConversationKey: () => 'chat:one',
+			getVisibleConversationKey: () => 'chat:one',
+			restoreModelConfiguration: () => { },
+			applyModel: selected => {
+				applied.push(selected.identifier);
+				selection.setCurrentModel(selected, false);
+			},
+		};
+		const controller = disposables.add(new ChatInputModelSelectionController(selection, runtime));
+
+		controller.initialize(remembered.identifier, () => { });
+		const pendingAfterInit = controller.hasAuthoritativeModelWait();
+		const provisional = controller.provisionalModelId;
+		models = [fallback, remembered];
+		modelChanges.fire('loaded');
+
+		assert.deepStrictEqual({
+			pendingAfterInit,
+			provisional,
+			pendingAfterLoad: controller.hasAuthoritativeModelWait(),
+			applied,
+			current: selection.currentModel.get()?.identifier,
+		}, {
+			pendingAfterInit: true,
+			provisional: fallback.identifier,
+			pendingAfterLoad: false,
+			applied: [fallback.identifier, remembered.identifier],
+			current: remembered.identifier,
+		});
+	});
+
+	test('initialize stops waiting when the pool loads without the remembered model', () => {
+		// Termination guard: the wait must not linger. Once the remembered model is conclusively
+		// absent (the pool loaded with other models but not it), settle on the already-applied
+		// fallback and tear the subscription down — without re-applying the fallback.
+		const selection = new ChatModelSelectionModel();
+		const modelChanges = disposables.add(new Emitter<string>());
+		const fallback = model('test/fallback');
+		const other = model('test/other');
+		const remembered = model('test/remembered');
+		let models = [fallback];
+		const applied: string[] = [];
+		const runtime: IChatInputModelSelectionRuntime = {
+			location: ChatAgentLocation.Chat,
+			getCurrentModeKind: () => ChatModeKind.Ask,
+			getCurrentSessionType: () => undefined,
+			isEmpty: () => true,
+			getModels: () => models,
+			getAllModels: () => models,
+			requiresCustomModels: () => false,
+			getConfiguredModelValue: () => undefined,
+			resolveModelIdentifier: identifier => resolveModelIdentifier(models, identifier, true),
+			subscribeToModelChanges: listener => modelChanges.event(listener),
+			getBoundConversationKey: () => 'chat:one',
+			getVisibleConversationKey: () => 'chat:one',
+			restoreModelConfiguration: () => { },
+			applyModel: selected => {
+				applied.push(selected.identifier);
+				selection.setCurrentModel(selected, false);
+			},
+		};
+		const controller = disposables.add(new ChatInputModelSelectionController(selection, runtime));
+
+		controller.initialize(remembered.identifier, () => { });
+		const pendingAfterInit = controller.hasAuthoritativeModelWait();
+		models = [fallback, other];
+		modelChanges.fire('loaded-without-remembered');
+
+		assert.deepStrictEqual({
+			pendingAfterInit,
+			pendingAfterLoad: controller.hasAuthoritativeModelWait(),
+			applied,
+			current: selection.currentModel.get()?.identifier,
+		}, {
+			pendingAfterInit: true,
+			pendingAfterLoad: false,
+			applied: [fallback.identifier],
+			current: fallback.identifier,
+		});
+	});
+
+	test('initialize does not arm a restore wait when there is nothing to wait for', () => {
+		// Guard against over-arming: no remembered model, or a remembered model that is already
+		// available, must not leave a catalog subscription armed.
+		const build = (rememberedId: string | undefined, models: ILanguageModelChatMetadataAndIdentifier[]) => {
+			const selection = new ChatModelSelectionModel();
+			const applied: string[] = [];
+			const runtime: IChatInputModelSelectionRuntime = {
+				location: ChatAgentLocation.Chat,
+				getCurrentModeKind: () => ChatModeKind.Ask,
+				getCurrentSessionType: () => undefined,
+				isEmpty: () => true,
+				getModels: () => models,
+				getAllModels: () => models,
+				requiresCustomModels: () => false,
+				getConfiguredModelValue: () => undefined,
+				resolveModelIdentifier: identifier => resolveModelIdentifier(models, identifier, true),
+				subscribeToModelChanges: () => toDisposable(() => { }),
+				getBoundConversationKey: () => 'chat:one',
+				getVisibleConversationKey: () => 'chat:one',
+				restoreModelConfiguration: () => { },
+				applyModel: selected => {
+					applied.push(selected.identifier);
+					selection.setCurrentModel(selected, false);
+				},
+			};
+			const controller = disposables.add(new ChatInputModelSelectionController(selection, runtime));
+			controller.initialize(rememberedId, () => { });
+			return controller.hasAuthoritativeModelWait();
+		};
+		const first = model('test/first');
+		const remembered = model('test/remembered');
+
+		assert.deepStrictEqual({
+			noRememberedModel: build(undefined, [first]),
+			rememberedAlreadyAvailable: build(remembered.identifier, [first, remembered]),
+		}, {
+			noRememberedModel: false,
+			rememberedAlreadyAvailable: false,
+		});
+	});
+
+	test('an explicit selection cancels the initialize restore wait', () => {
+		// While the wait is armed, an explicit user pick must win permanently: the wait is cancelled
+		// and a later appearance of the remembered model does not override the explicit selection.
+		const selection = new ChatModelSelectionModel();
+		const modelChanges = disposables.add(new Emitter<string>());
+		const fallback = model('test/fallback');
+		const explicit = model('test/explicit');
+		const remembered = model('test/remembered');
+		let models = [fallback, explicit];
+		const applied: string[] = [];
+		const runtime: IChatInputModelSelectionRuntime = {
+			location: ChatAgentLocation.Chat,
+			getCurrentModeKind: () => ChatModeKind.Ask,
+			getCurrentSessionType: () => undefined,
+			isEmpty: () => true,
+			getModels: () => models,
+			getAllModels: () => models,
+			requiresCustomModels: () => false,
+			getConfiguredModelValue: () => undefined,
+			resolveModelIdentifier: identifier => resolveModelIdentifier(models, identifier, true),
+			subscribeToModelChanges: listener => modelChanges.event(listener),
+			getBoundConversationKey: () => 'chat:one',
+			getVisibleConversationKey: () => 'chat:one',
+			restoreModelConfiguration: () => { },
+			applyModel: selected => {
+				applied.push(selected.identifier);
+				selection.setCurrentModel(selected, false);
+			},
+		};
+		const controller = disposables.add(new ChatInputModelSelectionController(selection, runtime));
+
+		controller.initialize(remembered.identifier, () => { });
+		const pendingAfterInit = controller.hasAuthoritativeModelWait();
+		controller.applyExplicitSelection(explicit, undefined, 'chat:one', () => applied.push(explicit.identifier), false);
+		const pendingAfterExplicit = controller.hasAuthoritativeModelWait();
+		models = [fallback, explicit, remembered];
+		modelChanges.fire('loaded');
+
+		assert.deepStrictEqual({
+			pendingAfterInit,
+			pendingAfterExplicit,
+			applied,
+			current: selection.currentModel.get()?.identifier,
+		}, {
+			pendingAfterInit: true,
+			pendingAfterExplicit: false,
+			applied: [fallback.identifier, explicit.identifier],
+			current: explicit.identifier,
+		});
+	});
 });


### PR DESCRIPTION
## What this fixes

When you reopen VS Code (or open a new chat editor) for an agent-host session, the model picker should come back to the **last model you used** (e.g. `GPT-5.6`). Sometimes it came back as **`Auto`** instead.

**Why:** agent-host models load *asynchronously* after the agent host connects. The workbench only waited for your remembered model when the pool was still completely **empty** at startup. If the pool was already **partly** loaded (some models present, but not yours yet), your model looked "gone", so the input fell back to `Auto` **and stopped watching** — so when your model showed up a moment later, nothing switched to it.

## The change

`initialize` now arms **one** wait whenever a remembered model hasn't been restored yet — whether the pool is empty *or* partly loaded — and swaps your model in as soon as it appears. The wait ends cleanly (it can't linger) once the model's vendor says it's genuinely gone. The three restore waits are also consolidated behind a single `_watchModelChanges` helper.

This keeps the existing agent-host behavior (the "grace" from #326938) intact; it just removes the fragile assumption that the pool is either fully empty or fully loaded.

## How to test

1. Open a folder and start an agent-host (Copilot CLI) session; pick a model like **GPT-5.6** and send a message.
2. Wait for it to finish, then quit VS Code.
3. Reopen VS Code in the **same folder**.
4. ✅ The chat model picker restores to **GPT-5.6** (not `Auto`), even if the model list loads in stages.

## Tests

Added controller tests that fail if the fix is reverted:
- restores the remembered model when it appears after a partly-loaded pool,
- stops waiting (no lingering subscription) when the model is genuinely gone,
- doesn't arm a wait when there's nothing to restore,
- an explicit user pick cancels the wait.

Validated: `typecheck-client`, `valid-layers-check`, eslint, and the `ChatModelSelectionModel` / `ModelSelection` / `ChatInputModelUtils` suites all pass.

Follow-up (separate): a proper per-vendor "readiness" signal to also cover BYOK / signed-out and let us drop the agent-host special-case — tracked in #326943.
