### PR TITLE
sessions: address Copilot code review feedback on folder Quick Pick

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -231,12 +231,24 @@ Review-capable changesets expose `setReviewState(resource, reviewed)`. Agent-hos
 1. User picks a folder in the workspace picker
    → WorkspacePicker fires onDidSelectWorkspace(folderUri)
    → NewChatWidget → ISessionsService.openNewSession({ folderUri, ...options })
+   → view resolves the folder via SessionsManagementService.resolveWorkspace(folderUri,
+     options?.providerId) and, when the resolved workspace requires trust, awaits the
+     workspace-trust prompt **before** creating anything; declining returns
+     `{ session: undefined, trustDeclined: true }` and never calls createNewSession
    → view calls SessionsManagementService.createNewSession(folderUri, options?)
    → Iterates providers, picks the first one whose resolveWorkspace(folderUri)
      succeeds (filtered by options.sessionTypeId when given)
    → Calls provider.createNewSession(folderUri, sessionTypeId)
    → Returns ISession (model draft, `newSession`); the view then activates it so
-     it becomes the activeSession and the draft slot shows reactively
+     it becomes the activeSession and the draft slot shows reactively, and
+     openNewSession resolves `{ session, trustDeclined: false }`
+
+   This trust gate is the **single** checkpoint for creating a session against a
+   folder — every folder-based entry point (composer, quick pick, dropdown) goes
+   through `openNewSession`, so none can bypass it. Callers distinguish "the user
+   declined trust" from other non-creation outcomes (for example the no-provider
+   case) via the returned `trustDeclined` flag rather than treating any falsy
+   `session` the same way.
 
 2. User picks a different session type for the same folder
    → SessionTypePicker queries getSessionTypesForFolder(folderUri),

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -18,7 +18,6 @@ import { IActiveSession, ISessionsManagementService } from '../../../services/se
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IAquariumService, IMountedToggleHandle } from '../../aquarium/browser/aquariumOverlay.js';
-import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { WorkspacePicker } from './sessionWorkspacePicker.js';
 import { WebWorkspacePicker } from './webWorkspacePicker.js';
 import { IPreferredSessionType } from './sessionTypePicker.js';
@@ -81,7 +80,6 @@ export class NewChatWidget extends Disposable {
 		@ILogService private readonly logService: ILogService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
-		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 		@IAquariumService private readonly aquariumService: IAquariumService,
 		@IAgentHostFilterService private readonly agentHostFilterService: IAgentHostFilterService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
@@ -263,7 +261,7 @@ export class NewChatWidget extends Disposable {
 	private _seedWorkspaceDraft(): void {
 		const restoredFolderUri = this._workspacePicker.selectedFolderUri;
 		if (!this._syncWorkspacePickerFromActiveSession() && restoredFolderUri) {
-			this._createNewSession(restoredFolderUri);
+			void this._createNewSession(restoredFolderUri);
 		}
 	}
 
@@ -298,10 +296,10 @@ export class NewChatWidget extends Disposable {
 			&& t.sessionType.id === pick.sessionTypeId);
 	}
 
-	private _createNewSession(folderUri: URI): void {
+	private async _createNewSession(folderUri: URI): Promise<ISession | undefined> {
 		this._pendingPreferredUpgrade.clear();
 		const userPick = this._newChatInput.sessionTypePicker.getUserPickedSessionType();
-		const created = this._createSessionNow(folderUri, userPick);
+		const created = await this._createSessionNow(folderUri, userPick);
 		// Keep the draft in sync with late-registering providers. Agent hosts
 		// connect lazily, so there is no timeout — the listener lives until the
 		// draft is sent or replaced. We watch when:
@@ -314,9 +312,10 @@ export class NewChatWidget extends Disposable {
 		if (!created || !userPick || !this._isPreferredServable(folderUri, userPick)) {
 			this._scheduleRecreateOnProviderChange(folderUri, userPick, created);
 		}
+		return created;
 	}
 
-	private _createSessionNow(folderUri: URI, userPick: IPreferredSessionType | undefined): ISession | undefined {
+	private async _createSessionNow(folderUri: URI, userPick: IPreferredSessionType | undefined): Promise<ISession | undefined> {
 		// Prefer the user's explicit pick when its provider can serve the
 		// folder; otherwise fall back to the preferred (first) session type.
 		const effectivePick = userPick && this._isPreferredServable(folderUri, userPick)
@@ -324,7 +323,7 @@ export class NewChatWidget extends Disposable {
 			: this._newChatInput.sessionTypePicker.getPreferredSessionType(folderUri);
 		const fallbackProviderId = this._workspacePicker.selectedResolved?.providerId;
 		try {
-			return this.sessionsService.openNewSession({
+			return await this.sessionsService.openNewSession({
 				folderUri,
 				...(effectivePick
 					? { providerId: effectivePick.providerId, sessionTypeId: effectivePick.sessionTypeId }
@@ -359,7 +358,7 @@ export class NewChatWidget extends Disposable {
 					}
 				}
 			}
-			this._createNewSession(folderUri);
+			void this._createNewSession(folderUri);
 		}));
 		this._pendingPreferredUpgrade.value = store;
 	}
@@ -519,20 +518,9 @@ export class NewChatWidget extends Disposable {
 			if (wasQuickChat) {
 				this.sessionsService.openQuickChat();
 			} else if (reseedFolderUri) {
-				this._createNewSession(reseedFolderUri);
+				await this._createNewSession(reseedFolderUri);
 			}
 		}
-	}
-
-	private async _requestFolderTrust(folderUri: URI): Promise<boolean> {
-		const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
-			uri: folderUri,
-			message: localize('trustFolderMessage', "An agent session will be able to read files, run commands, and make changes in this folder."),
-		});
-		if (!trusted) {
-			this._workspacePicker.removeFromRecents(folderUri);
-		}
-		return !!trusted;
 	}
 
 	saveState(): void {
@@ -556,8 +544,10 @@ export class NewChatWidget extends Disposable {
 	}
 
 	/**
-	 * Handles a workspace selection from the workspace picker.
-	 * Requests folder trust if needed and creates a new session.
+	 * Handles a workspace selection from the workspace picker and creates a
+	 * new session for it. Workspace trust (when required) is requested by
+	 * {@link ISessionsService.openNewSession} itself — a single gate shared
+	 * by every path that creates a concrete session for a folder.
 	 */
 	private async _onWorkspaceSelected(folderUri: URI | undefined): Promise<void> {
 		// Cancel any in-flight upgrade for a previous selection.
@@ -568,15 +558,15 @@ export class NewChatWidget extends Disposable {
 			return;
 		}
 
-		const resolved = this.sessionsManagementService.resolveWorkspace(folderUri);
-		if (resolved?.workspace.requiresWorkspaceTrust) {
-			if (!await this._requestFolderTrust(folderUri)) {
-				return;
-			}
+		if (this._store.isDisposed) {
+			return;
 		}
 
-		if (!this._store.isDisposed) {
-			this._createNewSession(folderUri);
+		const created = await this._createNewSession(folderUri);
+		if (!created && this.sessionsManagementService.resolveWorkspace(folderUri)?.workspace.requiresWorkspaceTrust) {
+			// Trust was declined (or the folder became untrustable in the
+			// meantime): don't leave the picker showing it as selected.
+			this._workspacePicker.removeFromRecents(folderUri);
 		}
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -16,7 +16,7 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { localize } from '../../../../nls.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISession } from '../../../services/sessions/common/session.js';
-import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { IOpenNewSessionResult, ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IAquariumService, IMountedToggleHandle } from '../../aquarium/browser/aquariumOverlay.js';
 import { WorkspacePicker } from './sessionWorkspacePicker.js';
 import { WebWorkspacePicker } from './webWorkspacePicker.js';
@@ -296,26 +296,32 @@ export class NewChatWidget extends Disposable {
 			&& t.sessionType.id === pick.sessionTypeId);
 	}
 
-	private async _createNewSession(folderUri: URI): Promise<ISession | undefined> {
+	private async _createNewSession(folderUri: URI): Promise<IOpenNewSessionResult> {
 		this._pendingPreferredUpgrade.clear();
 		const userPick = this._newChatInput.sessionTypePicker.getUserPickedSessionType();
-		const created = await this._createSessionNow(folderUri, userPick);
+		const result = await this._createSessionNow(folderUri, userPick);
+		if (result.trustDeclined) {
+			// The user explicitly declined trust: don't schedule a retry, which
+			// would silently recreate (and possibly re-prompt) the draft once a
+			// provider registers/changes without any further user action.
+			return result;
+		}
 		// Keep the draft in sync with late-registering providers. Agent hosts
 		// connect lazily, so there is no timeout — the listener lives until the
 		// draft is sent or replaced. We watch when:
-		//  - no provider can serve the folder yet (!created),
+		//  - no provider can serve the folder yet (!result.session),
 		//  - the user's explicit pick isn't servable yet (created with a
 		//    fallback, upgrade once its provider connects), or
 		//  - there is no explicit pick, so the draft tracks the preferred
 		//    (first) type, which can change as the folder's session-type list
 		//    grows.
-		if (!created || !userPick || !this._isPreferredServable(folderUri, userPick)) {
-			this._scheduleRecreateOnProviderChange(folderUri, userPick, created);
+		if (!result.session || !userPick || !this._isPreferredServable(folderUri, userPick)) {
+			this._scheduleRecreateOnProviderChange(folderUri, userPick, result.session);
 		}
-		return created;
+		return result;
 	}
 
-	private async _createSessionNow(folderUri: URI, userPick: IPreferredSessionType | undefined): Promise<ISession | undefined> {
+	private async _createSessionNow(folderUri: URI, userPick: IPreferredSessionType | undefined): Promise<IOpenNewSessionResult> {
 		// Prefer the user's explicit pick when its provider can serve the
 		// folder; otherwise fall back to the preferred (first) session type.
 		const effectivePick = userPick && this._isPreferredServable(folderUri, userPick)
@@ -333,7 +339,7 @@ export class NewChatWidget extends Disposable {
 			});
 		} catch (e) {
 			this.logService.error('Failed to create new session:', e);
-			return undefined;
+			return { session: undefined, trustDeclined: false };
 		}
 	}
 
@@ -562,10 +568,9 @@ export class NewChatWidget extends Disposable {
 			return;
 		}
 
-		const created = await this._createNewSession(folderUri);
-		if (!created && this.sessionsManagementService.resolveWorkspace(folderUri)?.workspace.requiresWorkspaceTrust) {
-			// Trust was declined (or the folder became untrustable in the
-			// meantime): don't leave the picker showing it as selected.
+		const result = await this._createNewSession(folderUri);
+		if (result.trustDeclined) {
+			// Don't leave the picker showing the declined folder as selected.
 			this._workspacePicker.removeFromRecents(folderUri);
 		}
 	}

--- a/src/vs/sessions/contrib/chat/browser/newSessionFolderQuickPickAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSessionFolderQuickPickAction.ts
@@ -20,6 +20,8 @@ import { ISessionsService } from '../../../services/sessions/browser/sessionsSer
 
 export interface IFolderQuickPickItem extends IQuickPickItem {
 	readonly folderUri?: URI;
+	/** The provider that previously resolved this folder, so re-picking it keeps the same provider association. */
+	readonly providerId?: string;
 	readonly browse?: boolean;
 }
 
@@ -33,13 +35,14 @@ export function buildFolderQuickPickItems(
 	const items: (IFolderQuickPickItem | IQuickPickSeparator)[] = [];
 	if (recents.length > 0) {
 		items.push({ type: 'separator', label: localize('sessions.newSession.pickFolderQuickPick.recent', "Recent") });
-		for (const { workspace } of recents) {
+		for (const { workspace, providerId } of recents) {
 			const folderUri = workspace.folders[0]?.root;
 			if (!folderUri) {
 				continue;
 			}
 			items.push({
 				folderUri,
+				providerId,
 				label: `$(${workspace.icon.id}) ${workspace.label}`,
 				description: labelService.getUriLabel(folderUri, { relative: false }),
 			});
@@ -91,6 +94,7 @@ class NewSessionPickFolderQuickPickAction extends Action2 {
 		}
 
 		let folderUri = picked.folderUri;
+		let providerId = picked.providerId;
 		if (picked.browse) {
 			const result = await fileDialogService.showOpenDialog({
 				canSelectFolders: true,
@@ -98,12 +102,13 @@ class NewSessionPickFolderQuickPickAction extends Action2 {
 				canSelectMany: false,
 			});
 			folderUri = result?.[0];
+			providerId = undefined;
 		}
 		if (!folderUri) {
 			return;
 		}
 
-		sessionsService.openNewSession({ folderUri });
+		await sessionsService.openNewSession({ folderUri, providerId });
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -976,7 +976,7 @@ export class WorkspacePicker extends Disposable {
 		// own recent history (not VS Code's global recents) so restoration never
 		// seeds a new session from a folder merely opened in another window.
 		try {
-			for (const recent of this.recentWorkspacesService.getOwnRecentWorkspaces()) {
+			for (const recent of this.recentWorkspacesService.getRecentWorkspaces(false)) {
 				if (this._isProviderUnavailable(recent.providerId)) {
 					continue;
 				}
@@ -998,7 +998,7 @@ export class WorkspacePicker extends Disposable {
 	 */
 	private _restoreCheckedWorkspace(): IResolvedFolderWorkspace | undefined {
 		try {
-			return this.recentWorkspacesService.getOwnRecentWorkspaces().find(recent => recent.checked);
+			return this.recentWorkspacesService.getRecentWorkspaces(false).find(recent => recent.checked);
 		} catch {
 			return undefined;
 		}

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -972,9 +972,11 @@ export class WorkspacePicker extends Disposable {
 		// Fall back to the first resolvable recent workspace from a connected provider.
 		// Fallbacks (vs. the user's explicit checked pick) require the provider
 		// to be ready: we don't want to silently land on, e.g., a disconnected
-		// remote workspace that the user never picked.
+		// remote workspace that the user never picked. Restrict to the sessions'
+		// own recent history (not VS Code's global recents) so restoration never
+		// seeds a new session from a folder merely opened in another window.
 		try {
-			for (const recent of this.recentWorkspacesService.getRecentWorkspaces()) {
+			for (const recent of this.recentWorkspacesService.getOwnRecentWorkspaces()) {
 				if (this._isProviderUnavailable(recent.providerId)) {
 					continue;
 				}
@@ -996,7 +998,7 @@ export class WorkspacePicker extends Disposable {
 	 */
 	private _restoreCheckedWorkspace(): IResolvedFolderWorkspace | undefined {
 		try {
-			return this.recentWorkspacesService.getRecentWorkspaces().find(recent => recent.checked);
+			return this.recentWorkspacesService.getOwnRecentWorkspaces().find(recent => recent.checked);
 		} catch {
 			return undefined;
 		}

--- a/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
@@ -27,6 +27,7 @@ export class SessionsChatAccessibilityHelp implements IAccessibleViewImplementat
 		content.push(localize('sessionsChat.input', "You are in the chat input. Type a message and press Enter to send it."));
 		content.push(localize('sessionsChat.inputBackground', "Press Alt+Enter to start the session in the background without navigating into it. The started session appears in the Chat Sessions view."));
 		content.push(localize('sessionsChat.workspace', "Shift+Tab to navigate to the workspace picker and choose a workspace for your session."));
+		content.push(localize('sessionsChat.pickFolderQuickPick', "To choose a folder from a searchable list instead, use the New Session in Folder command{0}.", '<keybinding:workbench.action.sessions.newSession.pickFolderQuickPick>'));
 		content.push(localize('sessionsChat.quickChat', "To start a workspace-less quick chat, use the New Quick Chat command{0} or the plus button on the Chats section in the sessions list. A quick chat has no workspace, so the workspace picker does not apply and the Toggle Side Panel command is disabled.", '<keybinding:sessionsView.newQuickChat>'));
 		content.push(localize('sessionsChat.mobileConfig', "On mobile, the mode and model pickers appear as tappable chips below the input. Tap a chip to open a bottom sheet where you can change the selection."));
 		content.push(localize('sessionsChat.history', "Use up and down arrows to navigate your request history in the input box."));

--- a/src/vs/sessions/contrib/chat/test/browser/newSessionFolderQuickPickAction.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/newSessionFolderQuickPickAction.test.ts
@@ -51,14 +51,15 @@ suite('New Session Folder Quick Pick', () => {
 		const vsCodeRecentUri = URI.file('/repo-b');
 
 		const recentWorkspacesService = createRecentWorkspacesService([
-			createResolvedRecent(ownRecentUri),
-			createResolvedRecent(vsCodeRecentUri),
+			createResolvedRecent(ownRecentUri, 'provider-a'),
+			createResolvedRecent(vsCodeRecentUri, 'provider-b'),
 		]);
 
 		const items = buildFolderQuickPickItems(recentWorkspacesService, labelService);
 
 		const folderItems = items.filter((i): i is IFolderQuickPickItem => !isSeparator(i) && !i.browse);
 		assert.deepStrictEqual(folderItems.map(i => i.folderUri?.toString()), [ownRecentUri.toString(), vsCodeRecentUri.toString()]);
+		assert.deepStrictEqual(folderItems.map(i => i.providerId), ['provider-a', 'provider-b'], 'each item carries its recent entry\'s provider ID');
 
 		const separators = items.filter(isSeparator);
 		assert.strictEqual(separators.length, 2);

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -269,6 +269,8 @@ function createTestPicker(
 	notificationService: INotificationService = new TestNotificationService(),
 	pickerCtor: typeof WorkspacePicker = WorkspacePicker,
 	fileDialogService: Partial<IFileDialogService> = {},
+	workspacesService: IWorkspacesService = { getRecentlyOpened: async () => ({ workspaces: [], files: [] }), onDidChangeRecentlyOpened: Event.None } as unknown as IWorkspacesService,
+	recentWorkspacesService?: ISessionsRecentWorkspacesService,
 ): WorkspacePicker {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	const storage = storageService ?? disposables.add(new TestStorageService());
@@ -292,14 +294,39 @@ function createTestPicker(
 		getMenuActions: () => [],
 	});
 	instantiationService.stub(INotificationService, notificationService);
-	instantiationService.stub(IWorkspacesService, {
-		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
-		onDidChangeRecentlyOpened: Event.None,
-	});
-	instantiationService.stub(ISessionsRecentWorkspacesService, disposables.add(instantiationService.createInstance(SessionsRecentWorkspacesService)));
+	instantiationService.stub(IWorkspacesService, workspacesService);
+	instantiationService.stub(ISessionsRecentWorkspacesService, recentWorkspacesService ?? disposables.add(instantiationService.createInstance(SessionsRecentWorkspacesService)));
 	instantiationService.stub(ITelemetryService, NullTelemetryService);
 
 	return disposables.add(instantiationService.createInstance(pickerCtor));
+}
+
+/**
+ * Builds a {@link SessionsRecentWorkspacesService} and waits for its initial
+ * (asynchronous) VS Code recents fetch to complete, so a picker constructed
+ * against it afterwards restores against a fully-populated recents list
+ * instead of racing the fetch (as happens when {@link createTestPicker}
+ * builds its own service inline).
+ */
+async function createResolvedRecentWorkspacesService(
+	disposables: DisposableStore,
+	storageService: IStorageService,
+	providersService: MockSessionsProvidersService,
+	workspacesService: IWorkspacesService,
+): Promise<ISessionsRecentWorkspacesService> {
+	const instantiationService = disposables.add(new TestInstantiationService());
+	instantiationService.stub(IStorageService, storageService);
+	instantiationService.stub(IUriIdentityService, { extUri });
+	instantiationService.stub(IWorkspacesService, workspacesService);
+	instantiationService.stub(ISessionsProvidersService, providersService);
+	const recentWorkspacesService = disposables.add(instantiationService.createInstance(SessionsRecentWorkspacesService));
+	await new Promise<void>(resolve => {
+		const listener = recentWorkspacesService.onDidChangeRecentWorkspaces(() => {
+			listener.dispose();
+			resolve();
+		});
+	});
+	return recentWorkspacesService;
 }
 
 // ---- Assertion helpers ------------------------------------------------------
@@ -344,6 +371,50 @@ suite('WorkspacePicker - Connection Status', () => {
 		const picker = createTestPicker(disposables, providersService, storage);
 
 		assertSelectedProvider(picker, 'agenthost-remote-1');
+	});
+
+	test('restore ignores VS Code\'s global recents, using only the sessions\' own history', async () => {
+		const localProvider = createMockProvider('local-1');
+		providersService.setProviders([localProvider]);
+
+		const ownUri = URI.file('/local/own-project');
+		const globalUri = URI.file('/local/global-only-project');
+
+		const storage = disposables.add(new TestStorageService());
+		seedStorage(storage, [{ uri: ownUri, providerId: 'local-1', checked: false }]);
+
+		const workspacesService = { getRecentlyOpened: async () => ({ workspaces: [{ folderUri: globalUri }], files: [] }), onDidChangeRecentlyOpened: Event.None } as unknown as IWorkspacesService;
+		const recentWorkspacesService = await createResolvedRecentWorkspacesService(disposables, storage, providersService, workspacesService);
+
+		// Sanity: the merged (display) list includes both entries...
+		assert.deepStrictEqual(
+			recentWorkspacesService.getRecentWorkspaces().map(r => r.workspace.uri.toString()),
+			[ownUri.toString(), globalUri.toString()],
+		);
+		// ...but the own-only query used for restoration excludes the global one.
+		assert.deepStrictEqual(
+			recentWorkspacesService.getRecentWorkspaces(false).map(r => r.workspace.uri.toString()),
+			[ownUri.toString()],
+		);
+
+		const picker = createTestPicker(disposables, providersService, storage, undefined, undefined, undefined, workspacesService, recentWorkspacesService);
+
+		assert.strictEqual(picker.selectedFolderUri?.toString(), ownUri.toString(), 'restore selects only the sessions-owned entry, not the VS Code global recent');
+	});
+
+	test('restore selects nothing when own history is empty, even with VS Code global recents present', async () => {
+		const localProvider = createMockProvider('local-1');
+		providersService.setProviders([localProvider]);
+
+		const globalUri = URI.file('/local/global-only-project');
+		const storage = disposables.add(new TestStorageService());
+
+		const workspacesService = { getRecentlyOpened: async () => ({ workspaces: [{ folderUri: globalUri }], files: [] }), onDidChangeRecentlyOpened: Event.None } as unknown as IWorkspacesService;
+		const recentWorkspacesService = await createResolvedRecentWorkspacesService(disposables, storage, providersService, workspacesService);
+
+		const picker = createTestPicker(disposables, providersService, storage, undefined, undefined, undefined, workspacesService, recentWorkspacesService);
+
+		assert.strictEqual(picker.selectedFolderUri, undefined, 'restore selects nothing when there is no owned history to restore from');
 	});
 
 	test('restored remote that never connects falls back after grace period', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -255,7 +255,14 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		);
 	}
 
-	resolveWorkspace(folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined {
+	resolveWorkspace(folderUri: URI, preferredProviderId?: string): { providerId: string; workspace: ISessionWorkspace } | undefined {
+		if (preferredProviderId) {
+			const preferred = this.sessionsProvidersService.getProvider(preferredProviderId);
+			const workspace = preferred?.resolveWorkspace(folderUri);
+			if (workspace) {
+				return { providerId: preferredProviderId, workspace };
+			}
+		}
 		for (const provider of this.sessionsProvidersService.getProviders()) {
 			const workspace = provider.resolveWorkspace(folderUri);
 			if (workspace) {

--- a/src/vs/sessions/services/sessions/browser/sessionsRecentWorkspacesService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsRecentWorkspacesService.ts
@@ -40,17 +40,18 @@ export interface ISessionsRecentWorkspacesService {
 
 	readonly onDidChangeRecentWorkspaces: Event<void>;
 
-	/** The recently used folders, resolved and most recent first: own history first, then VS Code's recents (deduplicated). */
-	getRecentWorkspaces(): IRecentWorkspace[];
-
 	/**
-	 * Only the sessions' own recently-picked workspaces (excludes VS Code's
-	 * global recents). Use this to restore the last explicit selection made
-	 * in an Agents Window folder picker, so an unrelated folder the user
-	 * merely opened in a regular VS Code window never silently becomes a
-	 * new session's default workspace.
+	 * The recently used folders, resolved and most recent first: own history
+	 * first, then (when `includeVSCodeRecents` is `true`, the default) VS
+	 * Code's own recently opened folders (deduplicated against own history).
+	 *
+	 * Pass `false` to restrict to the sessions' own recently-picked history
+	 * only, e.g. to restore the last explicit selection made in an Agents
+	 * Window folder picker, so an unrelated folder the user merely opened in
+	 * a regular VS Code window never silently becomes a new session's
+	 * default workspace.
 	 */
-	getOwnRecentWorkspaces(): IRecentWorkspace[];
+	getRecentWorkspaces(includeVSCodeRecents?: boolean): IRecentWorkspace[];
 
 	/** Records `folderUri` as most-recently used; `checked` un-checks every other entry. */
 	addRecentWorkspace(folderUri: URI, providerId: string | undefined, checked: boolean): void;
@@ -84,18 +85,18 @@ export class SessionsRecentWorkspacesService extends Disposable implements ISess
 		this._register(this.workspacesService.onDidChangeRecentlyOpened(() => this._refreshVSCodeRecentWorkspaces()));
 	}
 
-	getRecentWorkspaces(): IRecentWorkspace[] {
+	getRecentWorkspaces(includeVSCodeRecents = true): IRecentWorkspace[] {
 		const own = this._getStoredRecentWorkspaces();
+		if (!includeVSCodeRecents) {
+			return this._resolveStored(own);
+		}
+
 		const ownUris = new Set(own.map(o => this.uriIdentityService.extUri.getComparisonKey(URI.revive(o.uri))));
 		const vsCode = this._vsCodeRecentFolderUris
 			.filter(uri => !ownUris.has(this.uriIdentityService.extUri.getComparisonKey(uri)))
 			.map(uri => ({ uri: uri.toJSON(), providerId: undefined, checked: false }) satisfies IStoredRecentWorkspace);
 
 		return this._resolveStored([...own, ...vsCode]);
-	}
-
-	getOwnRecentWorkspaces(): IRecentWorkspace[] {
-		return this._resolveStored(this._getStoredRecentWorkspaces());
 	}
 
 	private _resolveStored(stored: readonly IStoredRecentWorkspace[]): IRecentWorkspace[] {

--- a/src/vs/sessions/services/sessions/browser/sessionsRecentWorkspacesService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsRecentWorkspacesService.ts
@@ -43,6 +43,15 @@ export interface ISessionsRecentWorkspacesService {
 	/** The recently used folders, resolved and most recent first: own history first, then VS Code's recents (deduplicated). */
 	getRecentWorkspaces(): IRecentWorkspace[];
 
+	/**
+	 * Only the sessions' own recently-picked workspaces (excludes VS Code's
+	 * global recents). Use this to restore the last explicit selection made
+	 * in an Agents Window folder picker, so an unrelated folder the user
+	 * merely opened in a regular VS Code window never silently becomes a
+	 * new session's default workspace.
+	 */
+	getOwnRecentWorkspaces(): IRecentWorkspace[];
+
 	/** Records `folderUri` as most-recently used; `checked` un-checks every other entry. */
 	addRecentWorkspace(folderUri: URI, providerId: string | undefined, checked: boolean): void;
 
@@ -82,11 +91,19 @@ export class SessionsRecentWorkspacesService extends Disposable implements ISess
 			.filter(uri => !ownUris.has(this.uriIdentityService.extUri.getComparisonKey(uri)))
 			.map(uri => ({ uri: uri.toJSON(), providerId: undefined, checked: false }) satisfies IStoredRecentWorkspace);
 
+		return this._resolveStored([...own, ...vsCode]);
+	}
+
+	getOwnRecentWorkspaces(): IRecentWorkspace[] {
+		return this._resolveStored(this._getStoredRecentWorkspaces());
+	}
+
+	private _resolveStored(stored: readonly IStoredRecentWorkspace[]): IRecentWorkspace[] {
 		const recents: IRecentWorkspace[] = [];
-		for (const stored of [...own, ...vsCode]) {
-			const resolved = this._resolveWorkspace(URI.revive(stored.uri), stored.providerId);
+		for (const entry of stored) {
+			const resolved = this._resolveWorkspace(URI.revive(entry.uri), entry.providerId);
 			if (resolved) {
-				recents.push({ workspace: resolved.workspace, providerId: resolved.providerId, checked: stored.checked });
+				recents.push({ workspace: resolved.workspace, providerId: resolved.providerId, checked: entry.checked });
 			}
 		}
 		return recents;

--- a/src/vs/sessions/services/sessions/browser/sessionsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsService.ts
@@ -15,6 +15,8 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
+import { localize } from '../../../../nls.js';
 import { ChatInteractivity, ChatOriginKind, IChat, ISession, SessionStatus } from '../common/session.js';
 import { IActiveSession, ICreateNewChatInSessionOptions, ICreateNewSessionOptions, IRecentlyOpenedSessions, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
 import { ISessionsProvidersService } from './sessionsProvidersService.js';
@@ -154,11 +156,15 @@ export interface ISessionsService {
 	 *   showing the empty placeholder. No-op when the empty placeholder is
 	 *   already showing (no session active). Returns the restored pending
 	 *   draft, or `undefined` when none.
-	 * - With `options.folderUri`: create a concrete draft session for that
-	 *   folder (via {@link ISessionsManagementService.createNewSession}) and
-	 *   show it as the active session. Returns the created draft.
+	 * - With `options.folderUri`: resolve the workspace and, when it requires
+	 *   workspace trust, prompt for it first (single gate for every path that
+	 *   creates a concrete session for a folder). If trust is declined,
+	 *   resolves to `undefined` without creating a session. Otherwise creates
+	 *   a concrete draft session for that folder (via
+	 *   {@link ISessionsManagementService.createNewSession}) and shows it as
+	 *   the active session. Returns the created draft.
 	 */
-	openNewSession(options?: IOpenNewSessionOptions): ISession | undefined;
+	openNewSession(options?: IOpenNewSessionOptions): Promise<ISession | undefined>;
 
 	/**
 	 * Open a new **quick chat**: create a concrete workspace-less draft session
@@ -286,6 +292,7 @@ export class SessionsService extends Disposable implements ISessionsService {
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@ISessionsPartService private readonly sessionsPartService: ISessionsPartService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 	) {
 		super();
 
@@ -688,9 +695,24 @@ export class SessionsService extends Disposable implements ISessionsService {
 		this._activate(undefined);
 	}
 
-	openNewSession(options?: IOpenNewSessionOptions): ISession | undefined {
+	async openNewSession(options?: IOpenNewSessionOptions): Promise<ISession | undefined> {
 		const folderUri = options?.folderUri;
 		if (folderUri) {
+			// Single trust gate for every path that creates a concrete session for
+			// a folder (the workspace picker dropdown, the folder Quick Pick, etc.):
+			// resolve the workspace and, if it requires trust, prompt before
+			// creating the session. A no-op if the folder is already trusted.
+			const resolved = this.sessionsManagementService.resolveWorkspace(folderUri);
+			if (resolved?.workspace.requiresWorkspaceTrust) {
+				const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
+					uri: folderUri,
+					message: localize('sessionsService.trustFolderMessage', "An agent session will be able to read files, run commands, and make changes in this folder."),
+				});
+				if (!trusted) {
+					return undefined;
+				}
+			}
+
 			this._startOpenSession();
 			try {
 				const session = this.sessionsManagementService.createNewSession(folderUri, options);

--- a/src/vs/sessions/services/sessions/browser/sessionsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsService.ts
@@ -54,6 +54,19 @@ export interface IOpenNewSessionOptions extends ICreateNewSessionOptions {
 }
 
 /**
+ * Result of {@link ISessionsService.openNewSession}. `session` holds the
+ * created/restored draft on success. `trustDeclined` is `true` only when a
+ * `folderUri` was supplied, the folder required workspace trust, and the
+ * user explicitly declined it — distinct from any other resolution/creation
+ * failure (where `session` is also `undefined` but `trustDeclined` is
+ * `false`, since that may still succeed later once a provider registers).
+ */
+export interface IOpenNewSessionResult {
+	readonly session: ISession | undefined;
+	readonly trustDeclined: boolean;
+}
+
+/**
  * Persisted state for a session.
  * Extend this interface to store additional per-session state that should be
  * remembered across restarts.
@@ -155,16 +168,17 @@ export interface ISessionsService {
 	 *   the pending (composed-but-not-sent) draft if one exists, otherwise
 	 *   showing the empty placeholder. No-op when the empty placeholder is
 	 *   already showing (no session active). Returns the restored pending
-	 *   draft, or `undefined` when none.
+	 *   draft as `result.session`, or `undefined` when none; `trustDeclined`
+	 *   is always `false`.
 	 * - With `options.folderUri`: resolve the workspace and, when it requires
 	 *   workspace trust, prompt for it first (single gate for every path that
 	 *   creates a concrete session for a folder). If trust is declined,
-	 *   resolves to `undefined` without creating a session. Otherwise creates
-	 *   a concrete draft session for that folder (via
-	 *   {@link ISessionsManagementService.createNewSession}) and shows it as
-	 *   the active session. Returns the created draft.
+	 *   returns `{ session: undefined, trustDeclined: true }` without
+	 *   creating a session. Otherwise creates a concrete draft session for
+	 *   that folder (via {@link ISessionsManagementService.createNewSession})
+	 *   and shows it as the active session, returning it as `result.session`.
 	 */
-	openNewSession(options?: IOpenNewSessionOptions): Promise<ISession | undefined>;
+	openNewSession(options?: IOpenNewSessionOptions): Promise<IOpenNewSessionResult>;
 
 	/**
 	 * Open a new **quick chat**: create a concrete workspace-less draft session
@@ -695,21 +709,24 @@ export class SessionsService extends Disposable implements ISessionsService {
 		this._activate(undefined);
 	}
 
-	async openNewSession(options?: IOpenNewSessionOptions): Promise<ISession | undefined> {
+	async openNewSession(options?: IOpenNewSessionOptions): Promise<IOpenNewSessionResult> {
 		const folderUri = options?.folderUri;
 		if (folderUri) {
 			// Single trust gate for every path that creates a concrete session for
 			// a folder (the workspace picker dropdown, the folder Quick Pick, etc.):
 			// resolve the workspace and, if it requires trust, prompt before
 			// creating the session. A no-op if the folder is already trusted.
-			const resolved = this.sessionsManagementService.resolveWorkspace(folderUri);
+			// Resolved with the same provider `createNewSession` below will use
+			// (honoring `options.providerId`), so the trust decision always
+			// reflects the workspace that is actually about to be created.
+			const resolved = this.sessionsManagementService.resolveWorkspace(folderUri, options?.providerId);
 			if (resolved?.workspace.requiresWorkspaceTrust) {
 				const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
 					uri: folderUri,
 					message: localize('sessionsService.trustFolderMessage', "An agent session will be able to read files, run commands, and make changes in this folder."),
 				});
 				if (!trusted) {
-					return undefined;
+					return { session: undefined, trustDeclined: true };
 				}
 			}
 
@@ -717,7 +734,7 @@ export class SessionsService extends Disposable implements ISessionsService {
 			try {
 				const session = this.sessionsManagementService.createNewSession(folderUri, options);
 				this._activate(session);
-				return session;
+				return { session, trustDeclined: false };
 			} catch (e) {
 				// When the folder cannot be resolved (e.g. the active session's
 				// workspace uses an unsupported scheme like 'unknown:/'), fall
@@ -730,7 +747,7 @@ export class SessionsService extends Disposable implements ISessionsService {
 		// the new-session composer view.
 		// No-op when no session is active (empty new-session placeholder showing).
 		if (this._visibility.activeSession.get() === undefined) {
-			return undefined;
+			return { session: undefined, trustDeclined: false };
 		}
 		if (!folderUri) {
 			this._startOpenSession();
@@ -747,11 +764,11 @@ export class SessionsService extends Disposable implements ISessionsService {
 		if (newSession?.isQuickChat?.get()) {
 			this.sessionsManagementService.discardNewSession(newSession);
 			this._activate(undefined);
-			return undefined;
+			return { session: undefined, trustDeclined: false };
 		}
 
 		this._activate(newSession ?? undefined);
-		return newSession ?? undefined;
+		return { session: newSession ?? undefined, trustDeclined: false };
 	}
 
 	openQuickChat(options?: ICreateNewSessionOptions): IActiveSession | undefined {

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -232,11 +232,15 @@ export interface ISessionsManagementService {
 	isQuickChatTargetAvailable(options?: ICreateNewSessionOptions): boolean;
 
 	/**
-	 * Resolve a workspace URI to a workspace using the first provider whose
-	 * {@link ISessionsProvider.resolveWorkspace} succeeds. Returns `undefined`
-	 * when no registered provider can resolve the URI.
+	 * Resolve a workspace URI to a workspace. When `preferredProviderId` is
+	 * given, that provider is tried first (matching the provider-selection
+	 * rules {@link createNewSession} applies for the same options) so the
+	 * resolution reflects the provider that would actually be used to create
+	 * a session; otherwise iterates registered providers and returns the
+	 * first whose {@link ISessionsProvider.resolveWorkspace} succeeds.
+	 * Returns `undefined` when no provider can resolve the URI.
 	 */
-	resolveWorkspace(workspaceUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined;
+	resolveWorkspace(workspaceUri: URI, preferredProviderId?: string): { providerId: string; workspace: ISessionWorkspace } | undefined;
 
 	/**
 	 * Fires when available session types change (providers added/removed).


### PR DESCRIPTION
## What changed

Follow-up to #326921 (merged), addressing the 4 comments left by Copilot code review on that PR.

1. **Provider ID dropped for recent entries** (`newSessionFolderQuickPickAction.ts`) - `buildFolderQuickPickItems` now carries each recent entry's `providerId` on the Quick Pick item, and the action passes it through to `openNewSession`. Previously a folder resolvable by multiple providers would always fall back to the first registered provider instead of the one it was actually created/last used with.

2. **Workspace-trust gate bypassed** (`newSessionFolderQuickPickAction.ts` -> `sessionsService.ts`) - rather than duplicating the trust-request logic per caller, the gate is now centralized in `ISessionsService.openNewSession()`: whenever a `folderUri` is supplied, it resolves the workspace and, if `requiresWorkspaceTrust` is set, prompts via `IWorkspaceTrustRequestService` before creating the session (no-op if already trusted). `openNewSession` is now `async`/`Promise`-returning. `NewChatWidget` no longer performs its own separate trust check before calling into the session-creation flow - it relies on this single gate, while still clearing the picker's shown selection if trust is declined.

3. **Restore-on-startup can seed from an unrelated global recent** (`sessionWorkspacePicker.ts` -> `sessionsRecentWorkspacesService.ts`) - `getRecentWorkspaces()` intentionally merges the sessions' own history with VS Code's global recently-opened folders for **display** purposes (the dropdown and Quick Pick should show both). But the picker's restore-on-startup fallback was also using this merged list, meaning a folder the user merely opened in an unrelated, regular VS Code window could silently become a new session's default workspace. Added `getOwnRecentWorkspaces()` (own history only) and switched both restore code paths (`_restoreSelectedWorkspace`'s fallback loop and `_restoreCheckedWorkspace`) to use it.

4. **New command undocumented for accessibility** (`sessionsChatAccessibilityHelp.ts`) - added a content line referencing the new `workbench.action.sessions.newSession.pickFolderQuickPick` command with a dynamic keybinding placeholder, so screen-reader users can discover it via the accessible-help dialog.

## Validation

- `npm run typecheck-client` - 0 errors (unrelated pre-existing `foundry-local-sdk` module-resolution errors in `localTranscriptionService.ts` are an environment issue, not caused by this change)
- ESLint on all touched files - clean
- Layering checker - clean
- Full `gulp compile` - 0 errors
- `sessions/**` unit test suite - all passing, no regressions (including `sessionsManagementService.test.ts` / `sessionNavigation.test.ts`, which exercise related session-creation flows)
