### PR TITLE
Add `list_browser_pages` tool

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/browser.tools.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/browser.tools.test.ts
@@ -90,6 +90,18 @@ function extractTextContent(result: vscode.LanguageModelToolResult): string {
 		assert.match(output, /Page ID:/, `Expected output to contain "Page ID:", got: ${output}`);
 	});
 
+	test('list_browser_pages returns pages opened through the browser tools', async function () {
+		this.timeout(60000);
+
+		const openOutput = await invokeTool('open_browser_page', { url: 'about:blank', forceNew: true });
+		const pageId = openOutput.match(/Page ID:\s*(\S+)/)?.[1];
+		assert.ok(pageId, `Could not extract Page ID from: ${openOutput}`);
+
+		const listOutput = await invokeTool('list_browser_pages', {});
+
+		assert.match(listOutput, new RegExp(`^- \\[${pageId}\\]`, 'm'), `Expected list output to contain page ID "${pageId}", got: ${listOutput}`);
+	});
+
 	test('Open a page from the web', async function () {
 		this.timeout(60000);
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/browserToolHelpers.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/browserToolHelpers.ts
@@ -71,6 +71,42 @@ export function formatBrowserEditorList(editorService: IEditorService, editors: 
 	}).join('\n');
 }
 
+export function getBrowserPagesContext(
+	editorService: IEditorService,
+	browserViewService: IBrowserViewWorkbenchService,
+	agentNetworkFilterService: IAgentNetworkFilterService,
+	options?: {
+		activeSessionId?: string;
+		canPromptUser?: boolean;
+	},
+): string | undefined {
+	const views = [...browserViewService.getContextualBrowserViews({ activeSessionId: options?.activeSessionId }).values()];
+	const sharedViews = views.filter(view => view.model?.sharingState === BrowserViewSharingState.Shared);
+	const unsharedCount = views.length - sharedViews.length;
+
+	if (sharedViews.length === 0 && unsharedCount === 0) {
+		return undefined;
+	}
+
+	let value: string;
+	if (sharedViews.length > 0) {
+		value = 'The following browser pages are currently shared with you and can be interacted with using the browser tools:';
+		value += '\n' + formatBrowserEditorList(editorService, sharedViews, { agentNetworkFilterService });
+	} else {
+		value = 'No browser pages are currently shared with you.';
+	}
+
+	if (unsharedCount > 0) {
+		value += '\n\n';
+		value += `${unsharedCount} ${unsharedCount === 1 ? 'page is' : 'pages are'} open but not shared.`;
+		value += options?.canPromptUser
+			? `\nUse the 'open_browser_page' tool to open a new page or to help the user share an existing page.`
+			: `\nUse the 'open_browser_page' tool to open a new page.`;
+	}
+
+	return value;
+}
+
 /**
  * Creates a markdown link to a browser page.
  */

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/browserTools.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/browserTools.contribution.ts
@@ -14,12 +14,13 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { IChatContextService } from '../../../chat/browser/contextContrib/chatContextService.js';
 import { IChatService } from '../../../chat/common/chatService/chatService.js';
 import { ILanguageModelToolsService, ToolDataSource, ToolSet } from '../../../chat/common/tools/languageModelToolsService.js';
-import { BrowserViewSharingState, IBrowserViewWorkbenchService } from '../../common/browserView.js';
-import { formatBrowserEditorList } from './browserToolHelpers.js';
+import { IBrowserViewWorkbenchService } from '../../common/browserView.js';
+import { getBrowserPagesContext } from './browserToolHelpers.js';
 import { ClickBrowserTool, ClickBrowserToolData } from './clickBrowserTool.js';
 import { DragElementTool, DragElementToolData } from './dragElementTool.js';
 import { HandleDialogBrowserTool, HandleDialogBrowserToolData } from './handleDialogBrowserTool.js';
 import { HoverElementTool, HoverElementToolData } from './hoverElementTool.js';
+import { ListBrowserPagesTool, ListBrowserPagesToolData } from './listBrowserPagesTool.js';
 import { NavigateBrowserTool, NavigateBrowserToolData } from './navigateBrowserTool.js';
 import { OpenBrowserTool, OpenBrowserToolData } from './openBrowserTool.js';
 import { OpenBrowserToolNonAgentic, OpenBrowserToolNonAgenticData } from './openBrowserToolNonAgentic.js';
@@ -99,6 +100,9 @@ class BrowserChatAgentToolsContribution extends Disposable implements IWorkbench
 		this._toolsStore.add(this.toolsService.registerTool(RunPlaywrightCodeToolData, this.instantiationService.createInstance(RunPlaywrightCodeTool)));
 		this._toolsStore.add(this.toolsService.registerTool(HandleDialogBrowserToolData, this.instantiationService.createInstance(HandleDialogBrowserTool)));
 
+		// Note: this is not currently exposed directly to models. It is mostly exposed so extensions can use it to provide model context via the API.
+		this._toolsStore.add(this.toolsService.registerTool(ListBrowserPagesToolData, this.instantiationService.createInstance(ListBrowserPagesTool)));
+
 		this._toolsStore.add(this._browserToolSet.addTool(OpenBrowserToolData));
 		this._toolsStore.add(this._browserToolSet.addTool(ReadBrowserToolData));
 		this._toolsStore.add(this._browserToolSet.addTool(ScreenshotBrowserToolData));
@@ -147,29 +151,10 @@ class BrowserChatAgentToolsContribution extends Disposable implements IWorkbench
 	}
 
 	private _updateBrowserContext(): void {
-		const views = [...this.browserViewService.getContextualBrowserViews().values()];
-		const sharedViews = views.filter(v => v.model?.sharingState === BrowserViewSharingState.Shared);
-		const unsharedCount = views.length - sharedViews.length;
-
-		if (sharedViews.length === 0 && unsharedCount === 0) {
+		const value = getBrowserPagesContext(this.editorService, this.browserViewService, this.agentNetworkFilterService, { canPromptUser: true });
+		if (!value) {
 			this.chatContextService.updateWorkspaceContextItems(BrowserChatAgentToolsContribution.CONTEXT_ID, []);
 			return;
-		}
-
-		let value = '';
-		if (sharedViews.length > 0) {
-			value = 'The following browser pages are currently shared with you and can be interacted with using the browser tools:';
-			value += '\n' + formatBrowserEditorList(this.editorService, sharedViews, { agentNetworkFilterService: this.agentNetworkFilterService });
-		} else {
-			value = 'No browser pages are currently shared with you.';
-		}
-
-		if (unsharedCount > 0) {
-			if (value) {
-				value += '\n\n';
-			}
-			value += `${unsharedCount} ${unsharedCount === 1 ? 'page is' : 'pages are'} open but not shared.`;
-			value += `\nUse the 'open_browser_page' tool to open a new page or to help the user share an existing page.`;
 		}
 
 		this.chatContextService.updateWorkspaceContextItems(BrowserChatAgentToolsContribution.CONTEXT_ID, [{

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/listBrowserPagesTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/listBrowserPagesTool.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { localize } from '../../../../../nls.js';
+import { IAgentNetworkFilterService } from '../../../../../platform/networkFilter/common/networkFilterService.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { CountTokensCallback, IToolData, IToolImpl, IToolInvocation, IToolResult, ToolDataSource, ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
+import { IBrowserViewWorkbenchService } from '../../common/browserView.js';
+import { getBrowserPagesContext } from './browserToolHelpers.js';
+
+export const ListBrowserPagesToolData: IToolData = {
+	id: 'list_browser_pages',
+	displayName: localize('listBrowserPagesTool.displayName', 'List Browser Pages'),
+	userDescription: localize('listBrowserPagesTool.userDescription', 'List browser pages that are shared with the agent'),
+	modelDescription: 'Lists the browser pages that are currently shared with the agent.',
+	source: ToolDataSource.Internal,
+
+	// Note: this tool has no toolReferenceName and cannot be referenced in prompts.
+	// It is not intended to be used by models directly since browser pages are supplied as context.
+	canBeReferencedInPrompt: false,
+
+	inputSchema: {
+		type: 'object',
+		properties: {},
+	},
+};
+
+export class ListBrowserPagesTool implements IToolImpl {
+	constructor(
+		@IEditorService private readonly editorService: IEditorService,
+		@IBrowserViewWorkbenchService private readonly browserViewService: IBrowserViewWorkbenchService,
+		@IAgentNetworkFilterService private readonly agentNetworkFilterService: IAgentNetworkFilterService,
+	) { }
+
+	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, _token: CancellationToken): Promise<IToolResult> {
+		const activeSessionId = invocation.context?.sessionResource.toString();
+		const value = getBrowserPagesContext(
+			this.editorService,
+			this.browserViewService,
+			this.agentNetworkFilterService,
+			{
+				activeSessionId,
+				canPromptUser: activeSessionId !== undefined,
+			},
+		);
+		return {
+			content: [{
+				kind: 'text',
+				value: value ?? 'No browser pages are currently open.',
+			}],
+		};
+	}
+}


### PR DESCRIPTION
Currently not exposed to built-in agents directly, but accessible via `vscode.lm.tools` APIs