### PR TITLE
dictation: publish native runtime to CDN instead of npm/NuGet at runtime

### DIFF
--- a/build/azure-pipelines/common/dictation-runtime-produce.yml
+++ b/build/azure-pipelines/common/dictation-runtime-produce.yml
@@ -6,27 +6,26 @@ parameters:
       - linux
       - win32
 
-# Builds the dictation-runtime tarball for ONE VS Code build, and (on real
-# publish runs) uploads it to the CDN, emits
-# `##vso[task.setvariable variable=DICTATION_RUNTIME_RESULTS_FILE]<path>`, and
-# leaves the downstream gulp packaging step to stamp product.dictationRuntime.
+# Produces the dictation-runtime for ONE VS Code build:
+#   - STAMP: writes the (target-agnostic) product.dictationRuntime results file
+#     and emits `##vso[task.setvariable variable=DICTATION_RUNTIME_RESULTS_FILE]`
+#     on EVERY build that can host dictation, so the downstream gulp packaging
+#     step stamps product.json. Packaged builds strip the SDK's native payload,
+#     so they need this CDN pointer regardless of VSCODE_PUBLISH.
+#   - PAYLOAD: builds this target's tarball and uploads it to the CDN only on
+#     real publish runs (VSCODE_PUBLISH=true). darwin-x64 stamps but uploads
+#     nothing (the darwin-arm64 job publishes the shared Apple Silicon payload).
 #
-# Upload is gated on VSCODE_PUBLISH=true (the same pipeline variable used by
-# the agent SDK upload and similar release-only side effects). Non-publish runs
-# (PRs, CI, local pipeline tests) still produce the tarball into
-# `$(Build.SourcesDirectory)/.build/dictation-runtime/tarballs/` so the calling
-# job can publish it as a pipelineArtifact for inspection, but they skip the CDN
-# write and the dictationRuntime stamp.
-#
-# Unlike the agent SDK step this needs no npm registry auth: the prebuilt addon
-# is copied from the already-restored `node_modules/foundry-local-sdk` and the
-# core libraries are fetched from NuGet by the SDK's own installer.
+# The core libraries are fetched from NuGet for the target's explicit RID (see
+# build/dictation-runtime/nuget.ts), so ARM64 targets build fine on x64 pools;
+# the prebuilt addon is copied from the already-restored node_modules. No npm
+# registry auth is needed.
 #
 # Steps:
 #   1. AzureCLI@2 to fetch the SPN credentials for the CDN storage account —
 #      skipped on non-publish runs (no CDN write to auth for).
-#   2. Run `node build/dictation-runtime/produce.ts`. Always builds; uploads
-#      only on publish; emits task.setvariable only on publish.
+#   2. Run `node build/dictation-runtime/produce.ts`. Always stamps; uploads
+#      only on publish.
 steps:
   - task: AzureCLI@2
     displayName: "Dictation runtime: fetch CDN credentials"

--- a/build/azure-pipelines/common/dictation-runtime-produce.yml
+++ b/build/azure-pipelines/common/dictation-runtime-produce.yml
@@ -1,0 +1,67 @@
+parameters:
+  - name: vscodePlatform
+    type: string
+    values:
+      - darwin
+      - linux
+      - win32
+
+# Builds the dictation-runtime tarball for ONE VS Code build, and (on real
+# publish runs) uploads it to the CDN, emits
+# `##vso[task.setvariable variable=DICTATION_RUNTIME_RESULTS_FILE]<path>`, and
+# leaves the downstream gulp packaging step to stamp product.dictationRuntime.
+#
+# Upload is gated on VSCODE_PUBLISH=true (the same pipeline variable used by
+# the agent SDK upload and similar release-only side effects). Non-publish runs
+# (PRs, CI, local pipeline tests) still produce the tarball into
+# `$(Build.SourcesDirectory)/.build/dictation-runtime/tarballs/` so the calling
+# job can publish it as a pipelineArtifact for inspection, but they skip the CDN
+# write and the dictationRuntime stamp.
+#
+# Unlike the agent SDK step this needs no npm registry auth: the prebuilt addon
+# is copied from the already-restored `node_modules/foundry-local-sdk` and the
+# core libraries are fetched from NuGet by the SDK's own installer.
+#
+# Steps:
+#   1. AzureCLI@2 to fetch the SPN credentials for the CDN storage account —
+#      skipped on non-publish runs (no CDN write to auth for).
+#   2. Run `node build/dictation-runtime/produce.ts`. Always builds; uploads
+#      only on publish; emits task.setvariable only on publish.
+steps:
+  - task: AzureCLI@2
+    displayName: "Dictation runtime: fetch CDN credentials"
+    condition: and(succeeded(), eq(lower(variables['VSCODE_PUBLISH']), 'true'))
+    inputs:
+      azureSubscription: vscode
+      scriptType: pscore
+      scriptLocation: inlineScript
+      addSpnToEnvironment: true
+      inlineScript: |
+        Write-Host "##vso[task.setvariable variable=AZURE_TENANT_ID]$env:tenantId"
+        Write-Host "##vso[task.setvariable variable=AZURE_CLIENT_ID]$env:servicePrincipalId"
+        Write-Host "##vso[task.setvariable variable=AZURE_ID_TOKEN;issecret=true]$env:idToken"
+
+  - ${{ if eq(parameters.vscodePlatform, 'win32') }}:
+    - powershell: |
+        . build/azure-pipelines/win32/exec.ps1
+        $ErrorActionPreference = "Stop"
+        exec { node build/dictation-runtime/produce.ts --vscode-platform=${{ parameters.vscodePlatform }} --arch=$(VSCODE_ARCH) }
+      env:
+        DICTATION_RUNTIME_RESULTS_FILE: $(Build.SourcesDirectory)/.build/dictation-runtime/${{ parameters.vscodePlatform }}-$(VSCODE_ARCH).json
+        AZURE_STORAGE_ACCOUNT: vscodeweb
+        AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+        AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+        AZURE_ID_TOKEN: $(AZURE_ID_TOKEN)
+      displayName: "Dictation runtime: build + upload"
+
+  - ${{ if ne(parameters.vscodePlatform, 'win32') }}:
+    - script: |
+        set -e
+        node build/dictation-runtime/produce.ts --vscode-platform=${{ parameters.vscodePlatform }} --arch=$(VSCODE_ARCH)
+      env:
+        DICTATION_RUNTIME_RESULTS_FILE: $(Build.SourcesDirectory)/.build/dictation-runtime/${{ parameters.vscodePlatform }}-$(VSCODE_ARCH).json
+        AZURE_STORAGE_ACCOUNT: vscodeweb
+        AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+        AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+        AZURE_ID_TOKEN: $(AZURE_ID_TOKEN)
+      displayName: "Dictation runtime: build + upload"

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -142,6 +142,10 @@ steps:
     parameters:
       vscodePlatform: darwin
 
+  - template: ../../common/dictation-runtime-produce.yml@self
+    parameters:
+      vscodePlatform: darwin
+
   - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadCopilotVsix.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -190,6 +190,10 @@ steps:
       parameters:
         vscodePlatform: linux
 
+    - template: ../../common/dictation-runtime-produce.yml@self
+      parameters:
+        vscodePlatform: linux
+
   - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadCopilotVsix.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -131,6 +131,10 @@ steps:
     parameters:
       vscodePlatform: win32
 
+  - template: ../../common/dictation-runtime-produce.yml@self
+    parameters:
+      vscodePlatform: win32
+
   - pwsh: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadCopilotVsix.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/build/dictation-runtime/common.ts
+++ b/build/dictation-runtime/common.ts
@@ -114,6 +114,39 @@ export function getRuntimeTargetForBuild(vscodePlatform: string, arch: string): 
 }
 
 /**
+ * Whether a given VS Code build should stamp `product.dictationRuntime`, EVEN IF
+ * this build's own `(platform, arch)` has no CDN payload of its own.
+ *
+ * The stamp — `{version, urlTemplate}` — is target-agnostic (the `{target}`
+ * placeholder is resolved by the runtime per launch), so it must be present on
+ * every product whose app can host on-device dictation, whether or not this
+ * particular job produced/uploaded the payload:
+ *
+ *   - `darwin-x64`: the macOS app is Universal. Its x64 and arm64 slices are
+ *     merged into one bundle whose single `product.json` must carry the runtime
+ *     config so dictation works when the Universal app runs natively on Apple
+ *     Silicon — even though only the `darwin-arm64` job builds/uploads the
+ *     payload. So `darwin-x64` stamps but does not produce.
+ *   - non-publish product builds: packaging always strips the SDK's native
+ *     payload (`getFoundryLocalExcludeFilter` in `gulpfile.vscode.ts`), so a
+ *     packaged build with no stamp would have NEITHER a CDN location NOR a
+ *     `node_modules` fallback. Stamping regardless of `VSCODE_PUBLISH` gives the
+ *     packaged app a usable CDN source; the payload for that version is uploaded
+ *     (idempotently) by publish runs. Only local dev-from-source (which never
+ *     runs `produce.ts`) keeps the `node_modules` payload.
+ *
+ * Returns `false` for platforms/arches that can never host dictation (armhf,
+ * Alpine/musl, web) so their `product.json` stays clean.
+ */
+export function shouldStampRuntime(vscodePlatform: string, arch: string): boolean {
+	if (getRuntimeTargetForBuild(vscodePlatform, arch)) {
+		return true;
+	}
+	// The Universal macOS x64 slice must match its arm64 sibling's stamp.
+	return vscodePlatform === 'darwin' && arch === 'x64';
+}
+
+/**
  * The CDN URL `product.dictationRuntime.urlTemplate` resolves to for a concrete
  * target. Content-addressed under
  * `dictation-runtime/<RUNTIME_ID>/<version>/<target>.tgz`. Matches the upload
@@ -169,9 +202,11 @@ export interface IDictationRuntimeResult {
 /**
  * Reads the per-platform dictation-runtime results file written by `produce.ts`.
  * Returns `undefined` when `DICTATION_RUNTIME_RESULTS_FILE` is unset, the file
- * doesn't exist, or no runtime applied to this build — that's the local-dev /
- * unsupported-target path (ship product.json without `dictationRuntime`; the
- * runtime falls back to the SDK's own `node_modules` payload).
+ * doesn't exist, or the build can't host dictation. In a pipeline build that CAN
+ * host dictation this is always present (publish or not); it is absent for local
+ * dev-from-source (which never runs `produce.ts`) — that path ships product.json
+ * without `dictationRuntime` and the runtime falls back to the SDK's own
+ * `node_modules` payload.
  */
 export function readDictationRuntimeResults(): IDictationRuntimeResult | undefined {
 	const filePath = process.env.DICTATION_RUNTIME_RESULTS_FILE;

--- a/build/dictation-runtime/common.ts
+++ b/build/dictation-runtime/common.ts
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Shared helpers for the per-platform dictation-runtime build pipeline. Called
+ * from `package.ts`, `upload.ts`, and `produce.ts`, plus the gulpfiles'
+ * `packageTask` (via `readDictationRuntimeResults`) so each VS Code build can
+ * stamp its own `product.dictationRuntime` into the per-platform `product.json`
+ * at packaging time.
+ *
+ * This mirrors `build/agent-sdk/` but for the Foundry Local native runtime used
+ * by on-device dictation: a prebuilt N-API addon (`foundry_local_napi.node`)
+ * plus the Foundry Local Core / onnxruntime / onnxruntime-genai shared
+ * libraries. Rather than downloading those from npm + NuGet at runtime, each
+ * platform build job produces its own tarball and uploads it to
+ * `main.vscode-cdn.net`; the runtime downloads the single content-addressed
+ * tarball for its target (see `foundryLocalRuntime.ts`).
+ *
+ * There is exactly ONE runtime (unlike the multi-SDK agent-sdk pipeline), so
+ * `product.dictationRuntime` is a single `{version, urlTemplate}` object rather
+ * than a map keyed by id. The version is the pinned `foundry-local-sdk`
+ * dependency in the repo-root `package.json` — the same package the runtime
+ * loads — so the shipped types and the CDN payload stay in lockstep.
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Repo-root `package.json`, the source of truth for the pinned SDK version. */
+const ROOT_PACKAGE_JSON = path.join(THIS_DIR, '..', '..', 'package.json');
+
+/** The npm package whose native payload we republish to the CDN. */
+export const SDK_PACKAGE_NAME = 'foundry-local-sdk';
+
+/**
+ * Path segment under the CDN URL and the conceptual id of the runtime. Kept as a
+ * named constant (rather than inlined) so the blob layout, the url builders, and
+ * `upload.ts`'s filename parsing agree on one string.
+ */
+export const RUNTIME_ID = 'foundry-local';
+
+interface IRootPackageJson {
+	readonly dependencies?: Readonly<Record<string, string>>;
+}
+
+let _versionCache: string | undefined;
+
+/**
+ * The exact pinned `foundry-local-sdk` version from the repo-root
+ * `package.json`. Rejects `^`/`~` ranges — a range would let the build resolve
+ * a different version than the runtime types were compiled against, and the
+ * content-addressed CDN upload would then diverge across runs.
+ */
+export function getRuntimeVersion(): string {
+	if (_versionCache) {
+		return _versionCache;
+	}
+	const json = JSON.parse(fs.readFileSync(ROOT_PACKAGE_JSON, 'utf8')) as IRootPackageJson;
+	const version = json.dependencies?.[SDK_PACKAGE_NAME];
+	if (!version) {
+		throw new Error(`Expected a '${SDK_PACKAGE_NAME}' entry in ${ROOT_PACKAGE_JSON} dependencies.`);
+	}
+	if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+		throw new Error(`Refusing to use ${SDK_PACKAGE_NAME}@${version} from ${ROOT_PACKAGE_JSON}: must be an exact version (no ^ or ~ ranges).`);
+	}
+	_versionCache = version;
+	return version;
+}
+
+/** Strict subset of VS Code build platforms the dictation runtime can target. */
+export type VscodeBuildPlatform = 'darwin' | 'linux' | 'win32';
+
+/** Runtime whitelist mirroring `VscodeBuildPlatform`, for CLI guards. */
+export const KNOWN_VSCODE_PLATFORMS: ReadonlySet<string> = new Set<VscodeBuildPlatform>([
+	'darwin', 'linux', 'win32',
+]);
+
+/**
+ * The set of `<platform>-<arch>` targets Foundry Local ships a native runtime
+ * for. Mirrors `FOUNDRY_LOCAL_SUPPORTED_PLATFORMS` in
+ * `src/vs/platform/localTranscription/node/foundryLocalRuntime.ts` and the
+ * `SUPPORTED_TARGETS` runtime gate — keep the three in sync.
+ */
+export const SUPPORTED_TARGETS: ReadonlySet<string> = new Set([
+	'darwin-arm64',
+	'linux-x64',
+	'linux-arm64',
+	'win32-x64',
+	'win32-arm64',
+]);
+
+/**
+ * Resolves the runtime target for a particular VS Code build, or `undefined`
+ * when that `(platform, arch)` has no Foundry Local runtime (e.g. `darwin-x64`,
+ * Alpine/musl, armhf, web). The macOS build is Universal but Foundry Local only
+ * ships `darwin-arm64`, so `darwin-x64` returns `undefined` — the runtime gate
+ * reports on-device dictation unsupported there and never downloads.
+ *
+ * The legacy Alpine x64 encoding (`{platform: 'linux', arch: 'alpine'}`) and any
+ * real `alpine` platform return `undefined`: the core libraries are glibc-linked.
+ */
+export function getRuntimeTargetForBuild(vscodePlatform: string, arch: string): string | undefined {
+	if (vscodePlatform === 'alpine' || arch === 'alpine' || arch === 'musl') {
+		return undefined;
+	}
+	const target = `${vscodePlatform}-${arch}`;
+	return SUPPORTED_TARGETS.has(target) ? target : undefined;
+}
+
+/**
+ * The CDN URL `product.dictationRuntime.urlTemplate` resolves to for a concrete
+ * target. Content-addressed under
+ * `dictation-runtime/<RUNTIME_ID>/<version>/<target>.tgz`. Matches the upload
+ * path written by `upload.ts`.
+ */
+export function buildCdnUrl(version: string, target: string): string {
+	return `https://main.vscode-cdn.net/dictation-runtime/${RUNTIME_ID}/${version}/${target}.tgz`;
+}
+
+/**
+ * The `format2`-style URL template stamped into
+ * `product.dictationRuntime.urlTemplate`. The runtime substitutes `{target}`
+ * per launch via `foundryLocalPlatformKey()`; every platform job emits the same
+ * template so a macOS Universal bundle can share one `product.json`.
+ */
+export function buildCdnUrlTemplate(version: string): string {
+	return `https://main.vscode-cdn.net/dictation-runtime/${RUNTIME_ID}/${version}/{target}.tgz`;
+}
+
+/** Streams `filePath` into a sha256 hasher without buffering the whole file. */
+export function sha256OfFile(filePath: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const hash = crypto.createHash('sha256');
+		const stream = fs.createReadStream(filePath);
+		stream.on('error', reject);
+		stream.on('data', chunk => hash.update(chunk));
+		stream.on('end', () => resolve(hash.digest('hex')));
+	});
+}
+
+/** Parses `--key=value` CLI flags into a Map. */
+export function parseFlags(argv: readonly string[]): Map<string, string> {
+	const flags = new Map<string, string>();
+	for (const arg of argv) {
+		const m = /^--([a-zA-Z-]+)=(.+)$/.exec(arg);
+		if (m) {
+			flags.set(m[1], m[2]);
+		}
+	}
+	return flags;
+}
+
+/**
+ * The `product.dictationRuntime` entry, written by `produce.ts` and read by the
+ * gulpfiles' `packageTask`. Shape matches `IDictationRuntimeProductConfig` in
+ * `src/vs/base/common/product.ts`.
+ */
+export interface IDictationRuntimeResult {
+	readonly version: string;
+	readonly urlTemplate: string;
+}
+
+/**
+ * Reads the per-platform dictation-runtime results file written by `produce.ts`.
+ * Returns `undefined` when `DICTATION_RUNTIME_RESULTS_FILE` is unset, the file
+ * doesn't exist, or no runtime applied to this build — that's the local-dev /
+ * unsupported-target path (ship product.json without `dictationRuntime`; the
+ * runtime falls back to the SDK's own `node_modules` payload).
+ */
+export function readDictationRuntimeResults(): IDictationRuntimeResult | undefined {
+	const filePath = process.env.DICTATION_RUNTIME_RESULTS_FILE;
+	if (!filePath || !fs.existsSync(filePath)) {
+		return undefined;
+	}
+	const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+	if (typeof parsed !== 'object' || parsed === null) {
+		throw new Error(`DICTATION_RUNTIME_RESULTS_FILE at ${filePath} is not a JSON object`);
+	}
+	const result = parsed as Partial<IDictationRuntimeResult>;
+	if (typeof result.version !== 'string' || typeof result.urlTemplate !== 'string') {
+		return undefined;
+	}
+	return { version: result.version, urlTemplate: result.urlTemplate };
+}

--- a/build/dictation-runtime/nuget.ts
+++ b/build/dictation-runtime/nuget.ts
@@ -1,0 +1,228 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Fetches the Foundry Local native core libraries (Foundry Local Core +
+ * onnxruntime + onnxruntime-genai) from NuGet for an EXPLICIT RID, so a single
+ * build agent can assemble a tarball for any target regardless of its own
+ * `process.platform`/`process.arch`.
+ *
+ * This is a deliberate re-implementation of the download/extract loop in
+ * `foundry-local-sdk`'s `script/install-utils.cjs`, whose `runInstall` derives
+ * the RID from the RUNNING host (`os.platform()`/`os.arch()`) at module load and
+ * exposes no override. VS Code's ARM64 desktop builds run on x64 pools, so the
+ * host-locked installer can never produce the `linux-arm64`/`win32-arm64`
+ * tarballs; extracting `runtimes/<rid>/native/*` from the same `.nupkg` files
+ * for an explicit RID is host-independent and fixes that.
+ *
+ * Only the "standard" artifact set is supported (the three packages selected by
+ * `package.ts`); the SDK installer's WinML override / `includeFiles` /
+ * `removeFiles` paths are intentionally not ported.
+ */
+
+import { createRequire } from 'module';
+import * as fs from 'fs';
+import * as https from 'https';
+import * as os from 'os';
+import * as path from 'path';
+import { SDK_PACKAGE_NAME } from './common.ts';
+
+const SCRIPT = 'nuget.ts';
+
+/**
+ * `adm-zip`, resolved through `foundry-local-sdk`'s own dependency tree (it is a
+ * dependency of the SDK), so we don't add a new build dependency just to unzip
+ * `.nupkg` archives.
+ */
+function loadAdmZip(): any {
+	const sdkRequire = createRequire(import.meta.url);
+	const fromSdk = createRequire(sdkRequire.resolve(`${SDK_PACKAGE_NAME}/package.json`));
+	return fromSdk('adm-zip');
+}
+
+/**
+ * NuGet feeds tried in order, matching `foundry-local-sdk`'s installer: the
+ * stable nuget.org feed first, then the public ORT-Nightly Azure DevOps feed
+ * (where pre-release Foundry Local Core / ORT / ORT-GenAI builds live before
+ * they reach nuget.org).
+ */
+const FEEDS: readonly string[] = [
+	'https://api.nuget.org/v3/index.json',
+	'https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json',
+];
+
+/** The NuGet Runtime IDentifier for each supported runtime target. */
+const RID_BY_TARGET: Readonly<Record<string, string>> = {
+	'win32-x64': 'win-x64',
+	'win32-arm64': 'win-arm64',
+	'linux-x64': 'linux-x64',
+	'linux-arm64': 'linux-arm64',
+	'darwin-arm64': 'osx-arm64',
+};
+
+/** The shared-library file extension for a target's OS. */
+function libExt(target: string): string {
+	return target.startsWith('win32-') ? '.dll' : target.startsWith('darwin-') ? '.dylib' : '.so';
+}
+
+export interface INugetArtifact {
+	readonly name: string;
+	readonly version: string;
+}
+
+/**
+ * Download each `artifact` `.nupkg` for `target`'s RID and extract its native
+ * shared libraries into `binDir`. Throws if a package can't be fetched from any
+ * feed; callers verify the resulting library set separately.
+ */
+export async function fetchCoreLibraries(target: string, artifacts: readonly INugetArtifact[], binDir: string): Promise<void> {
+	const rid = RID_BY_TARGET[target];
+	if (!rid) {
+		throw new Error(`[${SCRIPT}] No NuGet RID mapping for target '${target}'.`);
+	}
+	const ext = libExt(target);
+	const AdmZip = loadAdmZip();
+
+	fs.mkdirSync(binDir, { recursive: true });
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dictation-nuget-'));
+	const serviceIndexCache = new Map<string, unknown>();
+	try {
+		console.log(`[${SCRIPT}] Fetching native libraries for RID ${rid} (target ${target})...`);
+		for (const artifact of artifacts) {
+			await installPackage(artifact, rid, ext, tempDir, binDir, AdmZip, serviceIndexCache);
+		}
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+async function installPackage(
+	artifact: INugetArtifact,
+	rid: string,
+	ext: string,
+	tempDir: string,
+	binDir: string,
+	AdmZip: any,
+	serviceIndexCache: Map<string, unknown>,
+): Promise<void> {
+	let lastError: unknown;
+	for (let i = 0; i < FEEDS.length; i++) {
+		const feedUrl = FEEDS[i];
+		const feedHost = new URL(feedUrl).host;
+		try {
+			const baseAddress = await getBaseAddress(feedUrl, serviceIndexCache);
+			const nameLower = artifact.name.toLowerCase();
+			const verLower = artifact.version.toLowerCase();
+			const downloadUrl = `${baseAddress}${nameLower}/${verLower}/${nameLower}.${verLower}.nupkg`;
+
+			const nupkgPath = path.join(tempDir, `${artifact.name}.${artifact.version}.nupkg`);
+			console.log(`[${SCRIPT}]   Downloading ${artifact.name} ${artifact.version} from ${feedHost}...`);
+			await downloadToFile(downloadUrl, nupkgPath);
+
+			const zip = new AdmZip(nupkgPath);
+			const entries = nativeEntriesForRid(zip, rid, ext);
+			if (entries.length === 0) {
+				console.warn(`[${SCRIPT}]   No files found for RID ${rid} in ${artifact.name}.`);
+			}
+			for (const entry of entries) {
+				zip.extractEntryTo(entry, binDir, false, true);
+				console.log(`[${SCRIPT}]     Extracted ${entry.name}`);
+			}
+			return;
+		} catch (err) {
+			lastError = err;
+			const reason = err instanceof Error ? err.message : String(err);
+			if (i < FEEDS.length - 1) {
+				console.warn(`[${SCRIPT}]   ${artifact.name} ${artifact.version}: download from ${feedHost} failed (${reason}); trying next feed...`);
+			}
+		}
+	}
+	const feeds = FEEDS.map(f => new URL(f).host).join(', ');
+	throw new Error(`[${SCRIPT}] Failed to download ${artifact.name} ${artifact.version} from any feed (${feeds}): ${lastError instanceof Error ? lastError.message : lastError}`);
+}
+
+/**
+ * The native shared-library entries in `zip` for `rid`: files ending in `ext`
+ * that live under `runtimes/<rid>/native/` or directly under `runtimes/<rid>/`.
+ */
+function nativeEntriesForRid(zip: any, rid: string, ext: string): any[] {
+	const nativePrefix = `runtimes/${rid}/native/`.toLowerCase();
+	const runtimePrefix = `runtimes/${rid}/`.toLowerCase();
+	return zip.getEntries().filter((e: any) => {
+		const p = String(e.entryName).replace(/\\/g, '/').toLowerCase();
+		if (!p.endsWith(ext.toLowerCase())) {
+			return false;
+		}
+		if (p.startsWith(nativePrefix)) {
+			return true;
+		}
+		if (p.startsWith(runtimePrefix)) {
+			const rest = p.slice(runtimePrefix.length);
+			return rest.length > 0 && !rest.includes('/');
+		}
+		return false;
+	});
+}
+
+/** Resolve a NuGet feed's `PackageBaseAddress/3.0.0` service endpoint. */
+async function getBaseAddress(feedUrl: string, cache: Map<string, unknown>): Promise<string> {
+	if (!cache.has(feedUrl)) {
+		cache.set(feedUrl, JSON.parse(await downloadToString(feedUrl)));
+	}
+	const index = cache.get(feedUrl) as { resources?: { '@type'?: string; '@id'?: string }[] };
+	const res = (index.resources ?? []).find(r => typeof r['@type'] === 'string' && r['@type']!.startsWith('PackageBaseAddress/3.0.0'));
+	if (!res?.['@id']) {
+		throw new Error(`[${SCRIPT}] Could not find PackageBaseAddress/3.0.0 in NuGet feed ${feedUrl}.`);
+	}
+	return res['@id']!.endsWith('/') ? res['@id']! : `${res['@id']}/`;
+}
+
+/** GET `url` following redirects, resolving with the response body as a string. */
+function downloadToString(url: string): Promise<string> {
+	return followRedirects(url, res => new Promise<string>((resolve, reject) => {
+		let data = '';
+		res.on('data', chunk => data += chunk);
+		res.on('end', () => resolve(data));
+		res.on('error', reject);
+	}));
+}
+
+/** GET `url` following redirects, streaming the response body into `dest`. */
+function downloadToFile(url: string, dest: string): Promise<void> {
+	return followRedirects(url, res => new Promise<void>((resolve, reject) => {
+		const file = fs.createWriteStream(dest);
+		res.pipe(file);
+		file.on('finish', () => file.close(err => err ? reject(err) : resolve()));
+		file.on('error', err => { fs.rmSync(dest, { force: true }); reject(err); });
+		res.on('error', reject);
+	}));
+}
+
+/** Issue a GET, following up to 5 redirects, then hand the 200 response to `onOk`. */
+function followRedirects<T>(url: string, onOk: (res: import('http').IncomingMessage) => Promise<T>): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const request = (currentUrl: string, redirectsLeft: number): void => {
+			https.get(currentUrl, res => {
+				const status = res.statusCode ?? 0;
+				if (status >= 300 && status < 400 && res.headers.location) {
+					res.resume();
+					if (redirectsLeft <= 0) {
+						reject(new Error(`Too many redirects downloading ${url}.`));
+						return;
+					}
+					request(new URL(res.headers.location, currentUrl).toString(), redirectsLeft - 1);
+					return;
+				}
+				if (status !== 200) {
+					res.resume();
+					reject(new Error(`Download failed with status ${status}: ${currentUrl}`));
+					return;
+				}
+				onOk(res).then(resolve, reject);
+			}).on('error', reject);
+		};
+		request(url, 5);
+	});
+}

--- a/build/dictation-runtime/package.ts
+++ b/build/dictation-runtime/package.ts
@@ -13,14 +13,12 @@
  * "Dictation runtime: build + upload" pipeline step; the CLI form is for local
  * one-off builds.
  *
- * IMPORTANT — the core libraries are host-specific. `foundry-local-sdk`'s NuGet
- * installer (`script/install-utils.cjs`) selects the RID from the RUNNING host's
- * `process.platform`/`process.arch`, so core libraries can only be produced for
- * the host's own target. `buildOne` therefore refuses a `--target` that doesn't
- * match the host. This matches the pipeline model where each platform build job
- * produces only its own target (`getRuntimeTargetForBuild`). The addon, by
- * contrast, is copied from the pinned `foundry-local-sdk` package's `prebuilds/`
- * (which ships every target), so it is host-independent.
+ * The addon is copied from the pinned `foundry-local-sdk` package's `prebuilds/`
+ * (which ships every target), and the core libraries are fetched from NuGet for
+ * the requested target's RID via `fetchCoreLibraries` (NOT the SDK's host-locked
+ * installer), so ANY build host can produce ANY target's tarball. This is what
+ * lets VS Code's ARM64 desktop builds — which run on x64 pools — publish their
+ * `linux-arm64`/`win32-arm64` runtimes.
  *
  * The produced tarball's internal layout mirrors the runtime cache layout so the
  * runtime extraction is a plain untar:
@@ -35,6 +33,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as tar from 'tar';
 import { getRuntimeVersion, parseFlags, SDK_PACKAGE_NAME, sha256OfFile, SUPPORTED_TARGETS } from './common.ts';
+import { fetchCoreLibraries } from './nuget.ts';
 
 const SCRIPT = 'package.ts';
 
@@ -62,10 +61,6 @@ export interface IBuildArgs {
 export async function buildOne(args: IBuildArgs): Promise<IBuildResult> {
 	if (!SUPPORTED_TARGETS.has(args.target)) {
 		throw new Error(`[${SCRIPT}] Unknown target '${args.target}'. Supported: ${[...SUPPORTED_TARGETS].join(', ')}.`);
-	}
-	const hostTarget = `${process.platform}-${process.arch}`;
-	if (args.target !== hostTarget) {
-		throw new Error(`[${SCRIPT}] Cannot build target '${args.target}' on host '${hostTarget}': the Foundry Local core libraries are fetched for the host RID only. Run this on a '${args.target}' agent.`);
 	}
 
 	const version = getRuntimeVersion();
@@ -107,20 +102,16 @@ async function stageAddon(stagingDir: string, target: string): Promise<void> {
 }
 
 /**
- * Fetch the Foundry Local core libraries for `target` into the staging tree by
- * reusing the SDK's own NuGet installer (`runInstall` with a custom `binDir`).
- * Replicates the standard variant's artifact selection, including the linux-x64
- * GPU ONNX Runtime package. The installer keys off the host RID, so `target`
- * must equal the host (asserted by `buildOne`).
+ * Fetch the Foundry Local core libraries for `target` into the staging tree from
+ * NuGet, for that target's explicit RID (see `fetchCoreLibraries`). Replicates
+ * the standard variant's artifact selection, including the linux-x64 GPU ONNX
+ * Runtime package. Host-independent — `target` need not match the build host.
  */
 async function stageCoreLibraries(stagingDir: string, target: string): Promise<void> {
 	const deps = sdkRequire(`${SDK_PACKAGE_NAME}/deps_versions.json`) as {
 		'foundry-local-core': { nuget: string };
 		onnxruntime: { version: string };
 		'onnxruntime-genai': { version: string };
-	};
-	const { runInstall } = sdkRequire(`${SDK_PACKAGE_NAME}/script/install-utils.cjs`) as {
-		runInstall(artifacts: { name: string; version: string }[], options?: { binDir?: string }): Promise<void>;
 	};
 
 	// Microsoft.ML.OnnxRuntime.Gpu.Linux only ships x86_64 native binaries, so
@@ -135,8 +126,7 @@ async function stageCoreLibraries(stagingDir: string, target: string): Promise<v
 	];
 
 	const coreDir = path.join(stagingDir, 'foundry-local-core', target);
-	fs.mkdirSync(coreDir, { recursive: true });
-	await runInstall(artifacts, { binDir: coreDir });
+	await fetchCoreLibraries(target, artifacts, coreDir);
 
 	for (const name of requiredCoreLibraryNames(target)) {
 		if (!fs.existsSync(path.join(coreDir, name))) {

--- a/build/dictation-runtime/package.ts
+++ b/build/dictation-runtime/package.ts
@@ -1,0 +1,202 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Builds one per-target tarball of the Foundry Local native runtime (the
+ * prebuilt N-API addon + the Foundry Local Core / onnxruntime / onnxruntime-genai
+ * shared libraries). Callable as both a Node library (`buildOne(...)`) and a thin
+ * CLI (bottom of this file).
+ *
+ * The library form is what `produce.ts` calls during the per-platform
+ * "Dictation runtime: build + upload" pipeline step; the CLI form is for local
+ * one-off builds.
+ *
+ * IMPORTANT — the core libraries are host-specific. `foundry-local-sdk`'s NuGet
+ * installer (`script/install-utils.cjs`) selects the RID from the RUNNING host's
+ * `process.platform`/`process.arch`, so core libraries can only be produced for
+ * the host's own target. `buildOne` therefore refuses a `--target` that doesn't
+ * match the host. This matches the pipeline model where each platform build job
+ * produces only its own target (`getRuntimeTargetForBuild`). The addon, by
+ * contrast, is copied from the pinned `foundry-local-sdk` package's `prebuilds/`
+ * (which ships every target), so it is host-independent.
+ *
+ * The produced tarball's internal layout mirrors the runtime cache layout so the
+ * runtime extraction is a plain untar:
+ *
+ *   prebuilds/<target>/foundry_local_napi.node
+ *   foundry-local-core/<target>/<core libraries>
+ */
+
+import { createRequire } from 'module';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as tar from 'tar';
+import { getRuntimeVersion, parseFlags, SDK_PACKAGE_NAME, sha256OfFile, SUPPORTED_TARGETS } from './common.ts';
+
+const SCRIPT = 'package.ts';
+
+/** Resolve `foundry-local-sdk` subpaths from the repo-root `node_modules`. */
+const sdkRequire = createRequire(import.meta.url);
+
+export interface IBuildResult {
+	readonly tgzPath: string;
+	readonly sha256: string;
+	readonly version: string;
+	readonly sizeBytes: number;
+}
+
+export interface IBuildArgs {
+	readonly target: string;
+	readonly outDir: string;
+}
+
+/**
+ * Build one runtime tarball for `args.target`. Copies the prebuilt addon from
+ * the installed SDK, fetches the matching core libraries via the SDK's NuGet
+ * installer, and tars both into a single gzipped tarball. Returns the produced
+ * `.tgz` path and its sha256.
+ */
+export async function buildOne(args: IBuildArgs): Promise<IBuildResult> {
+	if (!SUPPORTED_TARGETS.has(args.target)) {
+		throw new Error(`[${SCRIPT}] Unknown target '${args.target}'. Supported: ${[...SUPPORTED_TARGETS].join(', ')}.`);
+	}
+	const hostTarget = `${process.platform}-${process.arch}`;
+	if (args.target !== hostTarget) {
+		throw new Error(`[${SCRIPT}] Cannot build target '${args.target}' on host '${hostTarget}': the Foundry Local core libraries are fetched for the host RID only. Run this on a '${args.target}' agent.`);
+	}
+
+	const version = getRuntimeVersion();
+	const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dictation-runtime-pkg-'));
+	try {
+		console.log(`[${SCRIPT}] Building ${SDK_PACKAGE_NAME}@${version} native runtime for ${args.target} in ${stagingDir}`);
+
+		await stageAddon(stagingDir, args.target);
+		await stageCoreLibraries(stagingDir, args.target);
+
+		fs.mkdirSync(args.outDir, { recursive: true });
+		const tgzPath = path.join(args.outDir, `${args.target}.tgz`);
+		await buildTarball(stagingDir, tgzPath);
+
+		const sha256 = await sha256OfFile(tgzPath);
+		const sizeBytes = fs.statSync(tgzPath).size;
+
+		console.log(`[${SCRIPT}] Wrote ${tgzPath} (${sizeBytes} bytes, sha256=${sha256})`);
+		return { tgzPath, sha256, version, sizeBytes };
+	} finally {
+		fs.rmSync(stagingDir, { recursive: true, force: true });
+	}
+}
+
+/**
+ * Copy the prebuilt N-API addon for `target` out of the installed
+ * `foundry-local-sdk` package (`prebuilds/<target>/foundry_local_napi.node`)
+ * into the staging tree.
+ */
+async function stageAddon(stagingDir: string, target: string): Promise<void> {
+	const sdkRoot = path.dirname(sdkRequire.resolve(`${SDK_PACKAGE_NAME}/package.json`));
+	const addonSrc = path.join(sdkRoot, 'prebuilds', target, 'foundry_local_napi.node');
+	if (!fs.existsSync(addonSrc)) {
+		throw new Error(`[${SCRIPT}] Prebuilt addon not found for ${target} at ${addonSrc}. Is ${SDK_PACKAGE_NAME} installed?`);
+	}
+	const addonDest = path.join(stagingDir, 'prebuilds', target, 'foundry_local_napi.node');
+	fs.mkdirSync(path.dirname(addonDest), { recursive: true });
+	fs.copyFileSync(addonSrc, addonDest);
+}
+
+/**
+ * Fetch the Foundry Local core libraries for `target` into the staging tree by
+ * reusing the SDK's own NuGet installer (`runInstall` with a custom `binDir`).
+ * Replicates the standard variant's artifact selection, including the linux-x64
+ * GPU ONNX Runtime package. The installer keys off the host RID, so `target`
+ * must equal the host (asserted by `buildOne`).
+ */
+async function stageCoreLibraries(stagingDir: string, target: string): Promise<void> {
+	const deps = sdkRequire(`${SDK_PACKAGE_NAME}/deps_versions.json`) as {
+		'foundry-local-core': { nuget: string };
+		onnxruntime: { version: string };
+		'onnxruntime-genai': { version: string };
+	};
+	const { runInstall } = sdkRequire(`${SDK_PACKAGE_NAME}/script/install-utils.cjs`) as {
+		runInstall(artifacts: { name: string; version: string }[], options?: { binDir?: string }): Promise<void>;
+	};
+
+	// Microsoft.ML.OnnxRuntime.Gpu.Linux only ships x86_64 native binaries, so
+	// linux-arm64 (and every non-linux-x64 target) uses the cross-platform
+	// Foundry ORT package. Mirrors `ensureCoreLibraries` in the runtime.
+	const ortPackageName = target === 'linux-x64' ? 'Microsoft.ML.OnnxRuntime.Gpu.Linux' : 'Microsoft.ML.OnnxRuntime.Foundry';
+
+	const artifacts = [
+		{ name: 'Microsoft.AI.Foundry.Local.Core', version: deps['foundry-local-core'].nuget },
+		{ name: ortPackageName, version: deps.onnxruntime.version },
+		{ name: 'Microsoft.ML.OnnxRuntimeGenAI.Foundry', version: deps['onnxruntime-genai'].version },
+	];
+
+	const coreDir = path.join(stagingDir, 'foundry-local-core', target);
+	fs.mkdirSync(coreDir, { recursive: true });
+	await runInstall(artifacts, { binDir: coreDir });
+
+	for (const name of requiredCoreLibraryNames(target)) {
+		if (!fs.existsSync(path.join(coreDir, name))) {
+			throw new Error(`[${SCRIPT}] Core library '${name}' missing after install for ${target} — refusing to build an incomplete tarball.`);
+		}
+	}
+}
+
+/** The core library filenames required for `target`. Mirrors the runtime gate. */
+function requiredCoreLibraryNames(target: string): string[] {
+	const isWin = target.startsWith('win32-');
+	const isMac = target.startsWith('darwin-');
+	const ext = isWin ? '.dll' : isMac ? '.dylib' : '.so';
+	const prefix = isWin ? '' : 'lib';
+	return [
+		`Microsoft.AI.Foundry.Local.Core${ext}`,
+		`${prefix}onnxruntime${ext}`,
+		`${prefix}onnxruntime-genai${ext}`,
+	];
+}
+
+/**
+ * Build the gzipped tar via node-tar so the output is consistent regardless of
+ * which host's system tar would otherwise be used. `portable`/`mtime` strip
+ * host-specific metadata for reproducible bytes across re-runs on the same host.
+ */
+async function buildTarball(stagingDir: string, outTgz: string): Promise<void> {
+	await tar.c(
+		{
+			file: outTgz,
+			cwd: stagingDir,
+			gzip: { level: 9 },
+			portable: true,
+			mtime: new Date(0),
+		},
+		['prebuilds', 'foundry-local-core'],
+	);
+}
+
+// #region CLI entry point
+
+function isCliInvocation(): boolean {
+	return import.meta.filename === process.argv[1];
+}
+
+function parseCliArgs(): IBuildArgs {
+	const flags = parseFlags(process.argv.slice(2));
+	const target = flags.get('target');
+	if (!target) {
+		throw new Error('--target=<platform-arch> is required (e.g. --target=darwin-arm64)');
+	}
+	const outDir = flags.get('out') ?? path.resolve(process.cwd(), 'out');
+	return { target, outDir };
+}
+
+if (isCliInvocation()) {
+	buildOne(parseCliArgs()).catch(err => {
+		console.error(err);
+		process.exit(1);
+	});
+}
+
+// #endregion

--- a/build/dictation-runtime/produce.ts
+++ b/build/dictation-runtime/produce.ts
@@ -4,27 +4,31 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Per-(vscode-platform, arch) dictation-runtime producer. Builds the tarball
- * needed by ONE VS Code build, optionally uploads it to the CDN, and writes a
- * small JSON results file that the gulfile-side `packageTask` reads to stamp
- * `product.json`'s `dictationRuntime` field.
+ * Per-(vscode-platform, arch) dictation-runtime producer. On publish builds it
+ * assembles + uploads this target's tarball to the CDN, and on ANY pipeline
+ * build it writes a small JSON results file that the gulpfile-side `packageTask`
+ * reads to stamp `product.json`'s `dictationRuntime` field.
  *
  * Run as a pipeline step BEFORE the gulp packaging step on the same agent (via
  * `build/azure-pipelines/common/dictation-runtime-produce.yml`).
  *
- * Behavior split by VSCODE_PUBLISH:
- *   - VSCODE_PUBLISH=true (real release builds): build → upload (HEAD-then-
- *     decide idempotent) → write results JSON → emit task.setvariable so the
- *     gulp step stamps product.dictationRuntime.
- *   - VSCODE_PUBLISH unset / not 'true' (PR / CI / test runs): build only.
- *     The tarball stays on disk at `.build/dictation-runtime/tarballs/` so the
- *     pipeline can publish it as an artifact for inspection, but no CDN upload
- *     happens and no results file is written — so product.json ships without
- *     `dictationRuntime` and the runtime falls back to the SDK's own
- *     `node_modules` payload (dev-from-source behavior).
+ * Two independent axes:
  *
- * For VS Code builds where no runtime applies (e.g. darwin-x64, Alpine, armhf),
- * exits with no result — product.json ships without `dictationRuntime`.
+ *   - STAMP (`product.dictationRuntime = {version, urlTemplate}`): written for
+ *     every build that can host dictation (`shouldStampRuntime`), regardless of
+ *     `VSCODE_PUBLISH`. The stamp is target-agnostic (the runtime resolves
+ *     `{target}` per launch), so packaged non-publish builds — whose native
+ *     payload is stripped at packaging time — still get a usable CDN source, and
+ *     the Universal macOS x64 slice carries the same config as its arm64 sibling.
+ *     Only local dev-from-source (which never runs this script) ships without the
+ *     stamp and falls back to the SDK's `node_modules` payload.
+ *
+ *   - PAYLOAD (the `<target>.tgz` on the CDN): built + uploaded only on publish
+ *     runs (`VSCODE_PUBLISH=true`) and only for a build whose `(platform, arch)`
+ *     has a real target (so `darwin-x64` stamps but uploads nothing — the
+ *     `darwin-arm64` job publishes the shared Apple Silicon payload). Upload is
+ *     idempotent (HEAD-then-decide), so re-runs and the once-per-version nature
+ *     of the stamped URL stay consistent.
  */
 
 import * as fs from 'fs';
@@ -36,6 +40,7 @@ import {
 	type IDictationRuntimeResult,
 	KNOWN_VSCODE_PLATFORMS,
 	parseFlags,
+	shouldStampRuntime,
 } from './common.ts';
 import { buildOne } from './package.ts';
 import { uploadOne } from './upload.ts';
@@ -54,23 +59,29 @@ async function main(): Promise<void> {
 	const args = parseArgs();
 	fs.mkdirSync(args.tarballsDir, { recursive: true });
 
-	const result = await produceOne(args);
+	const version = getRuntimeVersion();
+	const target = getRuntimeTargetForBuild(args.vscodePlatform, args.arch);
 
-	const tarballCount = fs.readdirSync(args.tarballsDir).filter(f => f.endsWith('.tgz')).length;
-	if (tarballCount > 0) {
+	// PAYLOAD: build + upload this target's tarball on publish runs only.
+	if (args.upload && target) {
+		console.log(`[${SCRIPT}] producing payload for ${args.vscodePlatform}/${args.arch} → ${target}`);
+		const built = await buildOne({ target, outDir: args.tarballsDir });
+		await uploadOne({ version: built.version, target, tgzPath: built.tgzPath, sha256: built.sha256 });
 		console.log(`##vso[task.setvariable variable=DICTATION_RUNTIME_TARBALLS_PRODUCED]true`);
+	} else if (target) {
+		console.log(`[${SCRIPT}] upload=false — skipping payload build/upload for ${target} (publish-only).`);
+	} else {
+		console.log(`[${SCRIPT}] no CDN payload for ${args.vscodePlatform}/${args.arch} (not a supported target).`);
 	}
 
-	if (!args.upload) {
-		console.log(`[${SCRIPT}] upload=false — ${tarballCount} tarball(s) left in ${args.tarballsDir}; skipping results file and DICTATION_RUNTIME_RESULTS_FILE setvariable.`);
+	// STAMP: written on every pipeline build that can host dictation, publish or
+	// not — the stamp is target-agnostic and packaged builds have no other source.
+	if (!shouldStampRuntime(args.vscodePlatform, args.arch)) {
+		console.log(`[${SCRIPT}] ${args.vscodePlatform}/${args.arch} cannot host dictation; product.json ships without dictationRuntime.`);
 		return;
 	}
 
-	if (!result) {
-		console.log(`[${SCRIPT}] no runtime applies to ${args.vscodePlatform}/${args.arch}; product.json ships without dictationRuntime.`);
-		return;
-	}
-
+	const result: IDictationRuntimeResult = { version, urlTemplate: buildCdnUrlTemplate(version) };
 	fs.mkdirSync(path.dirname(args.resultsFile), { recursive: true });
 	fs.writeFileSync(args.resultsFile, JSON.stringify(result, null, 2) + '\n');
 	console.log(`[${SCRIPT}] Wrote dictationRuntime entry to ${args.resultsFile}`);
@@ -78,25 +89,6 @@ async function main(): Promise<void> {
 	// Tell Azure Pipelines: subsequent steps in this job see
 	// DICTATION_RUNTIME_RESULTS_FILE in their env (auto-injected from the variable).
 	console.log(`##vso[task.setvariable variable=DICTATION_RUNTIME_RESULTS_FILE]${args.resultsFile}`);
-}
-
-async function produceOne(args: IProduceArgs): Promise<IDictationRuntimeResult | undefined> {
-	const target = getRuntimeTargetForBuild(args.vscodePlatform, args.arch);
-	if (!target) {
-		console.log(`[${SCRIPT}] no target for ${args.vscodePlatform}/${args.arch} — skipping`);
-		return undefined;
-	}
-	console.log(`[${SCRIPT}] producing for ${args.vscodePlatform}/${args.arch} → ${target}`);
-	const built = await buildOne({ target, outDir: args.tarballsDir });
-	if (!args.upload) {
-		return undefined;
-	}
-	// Upload returns the per-target URL; we discard it and emit the `{target}`
-	// template instead. Every platform job ends up with the same `urlTemplate` —
-	// only the version differs across SDK bumps. The runtime substitutes
-	// `{target}` per launch.
-	await uploadOne({ version: built.version, target, tgzPath: built.tgzPath, sha256: built.sha256 });
-	return { version: built.version, urlTemplate: buildCdnUrlTemplate(built.version) };
 }
 
 function parseArgs(): IProduceArgs {

--- a/build/dictation-runtime/produce.ts
+++ b/build/dictation-runtime/produce.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Per-(vscode-platform, arch) dictation-runtime producer. Builds the tarball
+ * needed by ONE VS Code build, optionally uploads it to the CDN, and writes a
+ * small JSON results file that the gulfile-side `packageTask` reads to stamp
+ * `product.json`'s `dictationRuntime` field.
+ *
+ * Run as a pipeline step BEFORE the gulp packaging step on the same agent (via
+ * `build/azure-pipelines/common/dictation-runtime-produce.yml`).
+ *
+ * Behavior split by VSCODE_PUBLISH:
+ *   - VSCODE_PUBLISH=true (real release builds): build → upload (HEAD-then-
+ *     decide idempotent) → write results JSON → emit task.setvariable so the
+ *     gulp step stamps product.dictationRuntime.
+ *   - VSCODE_PUBLISH unset / not 'true' (PR / CI / test runs): build only.
+ *     The tarball stays on disk at `.build/dictation-runtime/tarballs/` so the
+ *     pipeline can publish it as an artifact for inspection, but no CDN upload
+ *     happens and no results file is written — so product.json ships without
+ *     `dictationRuntime` and the runtime falls back to the SDK's own
+ *     `node_modules` payload (dev-from-source behavior).
+ *
+ * For VS Code builds where no runtime applies (e.g. darwin-x64, Alpine, armhf),
+ * exits with no result — product.json ships without `dictationRuntime`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+	buildCdnUrlTemplate,
+	getRuntimeTargetForBuild,
+	getRuntimeVersion,
+	type IDictationRuntimeResult,
+	KNOWN_VSCODE_PLATFORMS,
+	parseFlags,
+} from './common.ts';
+import { buildOne } from './package.ts';
+import { uploadOne } from './upload.ts';
+
+const SCRIPT = 'produce.ts';
+
+interface IProduceArgs {
+	readonly vscodePlatform: string;
+	readonly arch: string;
+	readonly tarballsDir: string;
+	readonly resultsFile: string;
+	readonly upload: boolean;
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs();
+	fs.mkdirSync(args.tarballsDir, { recursive: true });
+
+	const result = await produceOne(args);
+
+	const tarballCount = fs.readdirSync(args.tarballsDir).filter(f => f.endsWith('.tgz')).length;
+	if (tarballCount > 0) {
+		console.log(`##vso[task.setvariable variable=DICTATION_RUNTIME_TARBALLS_PRODUCED]true`);
+	}
+
+	if (!args.upload) {
+		console.log(`[${SCRIPT}] upload=false — ${tarballCount} tarball(s) left in ${args.tarballsDir}; skipping results file and DICTATION_RUNTIME_RESULTS_FILE setvariable.`);
+		return;
+	}
+
+	if (!result) {
+		console.log(`[${SCRIPT}] no runtime applies to ${args.vscodePlatform}/${args.arch}; product.json ships without dictationRuntime.`);
+		return;
+	}
+
+	fs.mkdirSync(path.dirname(args.resultsFile), { recursive: true });
+	fs.writeFileSync(args.resultsFile, JSON.stringify(result, null, 2) + '\n');
+	console.log(`[${SCRIPT}] Wrote dictationRuntime entry to ${args.resultsFile}`);
+
+	// Tell Azure Pipelines: subsequent steps in this job see
+	// DICTATION_RUNTIME_RESULTS_FILE in their env (auto-injected from the variable).
+	console.log(`##vso[task.setvariable variable=DICTATION_RUNTIME_RESULTS_FILE]${args.resultsFile}`);
+}
+
+async function produceOne(args: IProduceArgs): Promise<IDictationRuntimeResult | undefined> {
+	const target = getRuntimeTargetForBuild(args.vscodePlatform, args.arch);
+	if (!target) {
+		console.log(`[${SCRIPT}] no target for ${args.vscodePlatform}/${args.arch} — skipping`);
+		return undefined;
+	}
+	console.log(`[${SCRIPT}] producing for ${args.vscodePlatform}/${args.arch} → ${target}`);
+	const built = await buildOne({ target, outDir: args.tarballsDir });
+	if (!args.upload) {
+		return undefined;
+	}
+	// Upload returns the per-target URL; we discard it and emit the `{target}`
+	// template instead. Every platform job ends up with the same `urlTemplate` —
+	// only the version differs across SDK bumps. The runtime substitutes
+	// `{target}` per launch.
+	await uploadOne({ version: built.version, target, tgzPath: built.tgzPath, sha256: built.sha256 });
+	return { version: built.version, urlTemplate: buildCdnUrlTemplate(built.version) };
+}
+
+function parseArgs(): IProduceArgs {
+	const flags = parseFlags(process.argv.slice(2));
+	const vscodePlatform = flags.get('vscode-platform');
+	if (!vscodePlatform || !KNOWN_VSCODE_PLATFORMS.has(vscodePlatform)) {
+		throw new Error(`--vscode-platform must be one of ${[...KNOWN_VSCODE_PLATFORMS].join(', ')}; got '${vscodePlatform}'`);
+	}
+	const arch = flags.get('arch');
+	if (!arch) {
+		throw new Error('--arch=<arch> is required');
+	}
+	// Fail loud on a bad pin before doing any work.
+	getRuntimeVersion();
+
+	const tarballsDir = path.resolve(process.cwd(), '.build', 'dictation-runtime', 'tarballs');
+	const resultsFile = process.env.DICTATION_RUNTIME_RESULTS_FILE
+		?? path.resolve(process.cwd(), '.build', 'dictation-runtime', `${vscodePlatform}-${arch}.json`);
+	const upload = (process.env.VSCODE_PUBLISH ?? '').toLowerCase() === 'true';
+	return { vscodePlatform, arch, tarballsDir, resultsFile, upload };
+}
+
+main().catch(err => {
+	console.error(err);
+	process.exit(1);
+});

--- a/build/dictation-runtime/upload.ts
+++ b/build/dictation-runtime/upload.ts
@@ -1,0 +1,135 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Uploads one dictation-runtime tarball to the `main.vscode-cdn.net` storage
+ * account. Callable as both a library function (`uploadOne(...)`) and a thin CLI.
+ *
+ * Auth: reads `AZURE_STORAGE_ACCOUNT`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
+ * `AZURE_ID_TOKEN` from env — same shape as `build/agent-sdk/upload.ts`.
+ *
+ * Idempotency: HEAD-first on the `.tgz` blob.
+ *   - Absent → upload.
+ *   - Present with matching sha256 (in `metadata.sha256`) → skip.
+ *   - Present with different / no sha256 metadata → fail loud, refusing to
+ *     overwrite content-addressed history. Recovery: delete the blob in the
+ *     Azure Portal and re-run.
+ */
+
+import { ClientAssertionCredential } from '@azure/identity';
+import { BlobServiceClient } from '@azure/storage-blob';
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildCdnUrl, parseFlags, RUNTIME_ID, SDK_PACKAGE_NAME, sha256OfFile, SUPPORTED_TARGETS } from './common.ts';
+
+const SCRIPT = 'upload.ts';
+
+export interface IUploadArgs {
+	readonly version: string;
+	readonly target: string;
+	readonly tgzPath: string;
+	/** Pre-computed sha (e.g. from `buildOne()`); if omitted, computed here. */
+	readonly sha256?: string;
+}
+
+export interface IUploadResult {
+	readonly url: string;
+	readonly sha256: string;
+}
+
+export async function uploadOne(args: IUploadArgs): Promise<IUploadResult> {
+	if (!fs.existsSync(args.tgzPath)) {
+		throw new Error(`[${SCRIPT}] Tarball does not exist: ${args.tgzPath}`);
+	}
+	const sha256 = args.sha256 ?? await sha256OfFile(args.tgzPath);
+
+	const account = requireEnv('AZURE_STORAGE_ACCOUNT');
+	const tenantId = requireEnv('AZURE_TENANT_ID');
+	const clientId = requireEnv('AZURE_CLIENT_ID');
+	const idToken = requireEnv('AZURE_ID_TOKEN');
+
+	const credential = new ClientAssertionCredential(tenantId, clientId, () => Promise.resolve(idToken));
+	const service = new BlobServiceClient(`https://${account}.blob.core.windows.net`, credential);
+	const container = service.getContainerClient('$web');
+	const blobName = `dictation-runtime/${RUNTIME_ID}/${args.version}/${args.target}.tgz`;
+	const blob = container.getBlockBlobClient(blobName);
+
+	console.log(`[${SCRIPT}] target: https://${account}.blob.core.windows.net/$web/${blobName}`);
+	console.log(`[${SCRIPT}] local sha256: ${sha256}`);
+
+	let existing;
+	try {
+		existing = await blob.getProperties();
+	} catch (err) {
+		const status = (err as { statusCode?: number }).statusCode;
+		if (status !== 404) {
+			throw err;
+		}
+		existing = undefined;
+	}
+
+	if (existing) {
+		const remoteSha = existing.metadata?.sha256;
+		if (remoteSha === sha256) {
+			console.log(`[${SCRIPT}] blob already present with matching sha256 — skipping upload (idempotent).`);
+			return { url: buildCdnUrl(args.version, args.target), sha256 };
+		}
+		throw new Error(
+			`[${SCRIPT}] Blob already present with ${remoteSha ? 'DIFFERENT' : 'NO'} sha256 metadata — refusing to overwrite content-addressed history.\n` +
+			`  remote: ${remoteSha ?? '<no metadata.sha256 — was this blob uploaded out-of-band?>'}\n` +
+			`  local:  ${sha256}\n` +
+			`If the local build is what should ship, delete the remote blob in Azure Portal and re-run. ` +
+			`Otherwise: investigate why the same ${SDK_PACKAGE_NAME}@${args.version} produced different bytes for ${args.target}.`,
+		);
+	}
+
+	console.log(`[${SCRIPT}] uploading ${fs.statSync(args.tgzPath).size} bytes…`);
+	await blob.uploadFile(args.tgzPath, {
+		blobHTTPHeaders: {
+			blobContentType: 'application/gzip',
+			blobCacheControl: 'max-age=31536000, immutable',
+		},
+		metadata: { sha256 },
+	});
+	console.log(`[${SCRIPT}] ✓ uploaded.`);
+	return { url: buildCdnUrl(args.version, args.target), sha256 };
+}
+
+function requireEnv(name: string): string {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`[${SCRIPT}] Missing required environment variable: ${name}`);
+	}
+	return value;
+}
+
+// #region CLI entry point
+
+function isCliInvocation(): boolean {
+	return import.meta.filename === process.argv[1];
+}
+
+function parseCliArgs(): IUploadArgs {
+	const flags = parseFlags(process.argv.slice(2));
+	const tgzPath = flags.get('tarball');
+	if (!tgzPath) { throw new Error('--tarball=<path> is required'); }
+	const version = flags.get('version');
+	if (!version) { throw new Error('--version=<version> is required'); }
+	// Filename convention from package.ts: `<target>.tgz`.
+	const target = path.basename(tgzPath).replace(/\.tgz$/, '');
+	if (!SUPPORTED_TARGETS.has(target)) {
+		throw new Error(`Cannot derive a known target from tarball filename '${path.basename(tgzPath)}'`);
+	}
+	return { version, target, tgzPath: path.resolve(tgzPath) };
+}
+
+if (isCliInvocation()) {
+	uploadOne(parseCliArgs()).catch(err => {
+		console.error(err);
+		process.exit(1);
+	});
+}
+
+// #endregion

--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -31,6 +31,7 @@ import { copyCodiconsTask } from './lib/compilation.ts';
 import { ensureCopilotPlatformPackage, getCopilotExcludeFilter, getCopilotRuntimePrebuildFiles, getCopilotTgrepExcludeFilter, getMxcExcludeFilter, getRipgrepExcludeFilter, prepareBuiltInCopilotRipgrepShim } from './lib/copilot.ts';
 import { ensureOSProxyResolverPlatformPackage, getOSProxyResolverExcludeFilter, getOSProxyResolverPlatformFiles } from './lib/osProxyResolver.ts';
 import { readAgentSdkResults } from './agent-sdk/common.ts';
+import { readDictationRuntimeResults } from './dictation-runtime/common.ts';
 import { useEsbuildTranspile } from './buildConfig.ts';
 import { promisify } from 'util';
 import globCallback from 'glob';
@@ -328,6 +329,13 @@ function packageTask(platform: string, arch: string, sourceFolderName: string, d
 				const agentSdks = readAgentSdkResults();
 				if (Object.keys(agentSdks).length > 0) {
 					json.agentSdks = agentSdks;
+				}
+				// Stamp dictationRuntime from the per-platform results file
+				// produced by `build/dictation-runtime/produce.ts`. Local dev /
+				// unsupported target: file absent → undefined → not stamped.
+				const dictationRuntime = readDictationRuntimeResults();
+				if (dictationRuntime) {
+					json.dictationRuntime = dictationRuntime;
 				}
 				return json;
 			}))

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -83,6 +83,19 @@ export interface IAgentSdkProductConfig {
 	readonly urlTemplate: string;
 }
 
+/**
+ * Configuration for downloading the on-device dictation native runtime (the
+ * Foundry Local addon + core libraries) on demand. Produced per platform build
+ * and stamped by `build/dictation-runtime/produce.ts`; consumed by
+ * `foundryLocalRuntime.ts`, which substitutes `{target}` in `urlTemplate`
+ * against the host's `<platform>-<arch>` key. Absent in local dev builds, in
+ * which case the runtime falls back to the SDK's own `node_modules` payload.
+ */
+export interface IDictationRuntimeProductConfig {
+	readonly version: string;
+	readonly urlTemplate: string;
+}
+
 export interface IProductConfiguration {
 	readonly version: string;
 	readonly date?: string;
@@ -138,6 +151,8 @@ export interface IProductConfiguration {
 	};
 
 	readonly agentSdks?: { readonly [packageId: string]: IAgentSdkProductConfig };
+
+	readonly dictationRuntime?: IDictationRuntimeProductConfig;
 
 	readonly mcpGallery?: {
 		readonly serviceUrl: string;

--- a/src/vs/platform/localTranscription/common/localTranscription.ts
+++ b/src/vs/platform/localTranscription/common/localTranscription.ts
@@ -114,8 +114,14 @@ export interface ILocalTranscriptionService {
 	 * authenticate to the proxy. TLS-intercepting proxies otherwise rely on the CA
 	 * being in the OS trust store (matching `@vscode/proxy-agent` and the desktop
 	 * app).
+	 *
+	 * `runtimeUrlTemplate`/`runtimeVersion` come from `product.dictationRuntime`
+	 * (stamped by `build/dictation-runtime/produce.ts`). When set, the native
+	 * runtime (Foundry Local addon + core libraries) is downloaded from VS Code's
+	 * CDN for this host's target. When omitted (local dev builds), the runtime
+	 * falls back to the SDK's own `node_modules` payload and nothing is downloaded.
 	 */
-	start(options: { readonly cacheDir: string; readonly model?: string; readonly language?: string; readonly proxyUrl?: string; readonly noProxy?: string; readonly proxyStrictSSL?: boolean; readonly proxyAuthorization?: string }): Promise<void>;
+	start(options: { readonly cacheDir: string; readonly model?: string; readonly language?: string; readonly proxyUrl?: string; readonly noProxy?: string; readonly proxyStrictSSL?: boolean; readonly proxyAuthorization?: string; readonly runtimeUrlTemplate?: string; readonly runtimeVersion?: string }): Promise<void>;
 
 	/** Append captured audio (raw little-endian PCM16 mono 16 kHz). */
 	pushAudio(chunk: VSBuffer): Promise<void>;

--- a/src/vs/platform/localTranscription/node/foundryLocalRuntime.ts
+++ b/src/vs/platform/localTranscription/node/foundryLocalRuntime.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import { dirname, join } from '../../../base/common/path.js';
+import { format2 } from '../../../base/common/strings.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { CancellationError } from '../../../base/common/errors.js';
 
@@ -14,31 +15,31 @@ import { CancellationError } from '../../../base/common/errors.js';
  * dictation.
  *
  * `foundry-local-sdk` ships a prebuilt N-API addon (`foundry_local_napi.node`)
- * and downloads native core libraries (Foundry Local Core + ONNX Runtime +
- * ONNX Runtime GenAI) next to it. The addon requires a newer glibc than VS
- * Code's minimum supported Linux distros, so we deliberately do NOT bundle any
- * of this native payload with the product (see `build/gulpfile.vscode.ts`).
- * Instead we download it here, at runtime, only on supported platforms, into a
- * per-user writable cache — keeping the shipped package's glibc floor intact.
+ * and native core libraries (Foundry Local Core + ONNX Runtime + ONNX Runtime
+ * GenAI). The addon requires a newer glibc than VS Code's minimum supported
+ * Linux distros, so we deliberately do NOT bundle any of this native payload
+ * with the product (see `build/gulpfile.vscode.ts`). Instead we republish a
+ * per-target tarball of the addon + core libraries to VS Code's CDN at build
+ * time (see `build/dictation-runtime/`) and download it here, at runtime, only
+ * on supported platforms, into a per-user writable cache — keeping the shipped
+ * package's glibc floor intact and avoiding any runtime dependency on the npm
+ * registry or NuGet.
  *
  * The SDK loader (`dist/detail/coreInterop.js`) is patched during
  * `postinstall` to honor `VSCODE_FOUNDRY_LOCAL_NATIVE_DIR`, pointing it at the
- * cache directory this module populates. The cache layout mirrors the SDK's
- * own package layout so the patched resolution is a trivial path join:
+ * cache directory this module populates. The tarball's internal layout mirrors
+ * the SDK's own package layout so the patched resolution is a trivial path join:
  *
- *   <cacheRoot>/<sdkVersion>/prebuilds/<platformKey>/foundry_local_napi.node
- *   <cacheRoot>/<sdkVersion>/foundry-local-core/<platformKey>/<core libraries>
+ *   <cacheRoot>/<version>/prebuilds/<target>/foundry_local_napi.node
+ *   <cacheRoot>/<version>/foundry-local-core/<target>/<core libraries>
  *
- * NOTE: the two JavaScript download legs — the npm-registry addon tarball and
- * the NuGet core-library fetch (via the SDK's own installer) — honor the
- * standard proxy environment variables (`HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`,
- * with `NO_PROXY`), matching how the GitHub desktop app's Rust
- * `foundry-local-sdk` reaches these endpoints. VS Code's `http.proxy`/
- * `http.noProxy` settings are applied as these same environment variables
- * before provisioning (see `LocalTranscriptionService.start`), so a proxy
- * configured only in VS Code is honored here and by the native model download
- * too; `http.proxyAuthorization` (Basic) is folded into the proxy URL and
- * `http.proxyStrictSSL === false` disables TLS verification for these Node legs.
+ * NOTE: the single CDN download leg honors the standard proxy environment
+ * variables (`HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`, with `NO_PROXY`). VS Code's
+ * `http.proxy`/`http.noProxy` settings are applied as these same environment
+ * variables before provisioning (see `LocalTranscriptionService.start`), so a
+ * proxy configured only in VS Code is honored here and by the native model
+ * download too; `http.proxyAuthorization` (Basic) is folded into the proxy URL
+ * and `http.proxyStrictSSL === false` disables TLS verification for this leg.
  * TLS-intercepting proxies otherwise rely on the CA being in the OS trust store.
  */
 
@@ -68,6 +69,14 @@ export function isFoundryLocalRuntimeSupported(): boolean {
 /** Progress callback invoked while the native runtime is being fetched. */
 export type FoundryLocalRuntimeProgress = (message: string) => void;
 
+/** Where the native runtime tarball is published (from `product.dictationRuntime`). */
+export interface IFoundryLocalRuntimeDownload {
+	/** CDN URL template with a `{target}` placeholder for the host platform key. */
+	readonly urlTemplate: string;
+	/** The published runtime version (the pinned `foundry-local-sdk` version). */
+	readonly version: string;
+}
+
 /** De-dupes concurrent provisioning requests targeting the same cache dir. */
 const inFlight = new Map<string, Promise<string>>();
 
@@ -76,35 +85,34 @@ const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 60_000;
 
 /**
  * Ensure the Foundry Local native runtime (addon + core libraries) is present
- * in `<cacheRoot>`, downloading it if necessary. Returns the versioned override
- * directory to set as `VSCODE_FOUNDRY_LOCAL_NATIVE_DIR` before loading the SDK.
+ * in `<cacheRoot>`, downloading the per-target CDN tarball if necessary. Returns
+ * the versioned override directory to set as `VSCODE_FOUNDRY_LOCAL_NATIVE_DIR`
+ * before loading the SDK.
  *
  * Idempotent: once a version is fully provisioned a per-platform `.complete`
  * marker is written and subsequent calls return immediately (after verifying the
  * payload) without touching the network.
  */
-export async function ensureFoundryLocalRuntime(cacheRoot: string, token: CancellationToken, onProgress?: FoundryLocalRuntimeProgress): Promise<string> {
+export async function ensureFoundryLocalRuntime(cacheRoot: string, download: IFoundryLocalRuntimeDownload, token: CancellationToken, onProgress?: FoundryLocalRuntimeProgress): Promise<string> {
 	const platformKey = foundryLocalPlatformKey();
 	if (!platformKey) {
 		throw new Error(`Foundry Local native runtime is not available on ${process.platform}-${process.arch}.`);
 	}
 
-	const nodeRequire = await getNativeRequire();
-	const sdkVersion: string = nodeRequire('foundry-local-sdk/package.json').version;
-	const overrideDir = join(cacheRoot, sdkVersion);
+	const overrideDir = join(cacheRoot, download.version);
 
 	// A single in-flight provisioning per override dir; late joiners share it.
 	const existing = inFlight.get(overrideDir);
 	if (existing) {
 		return existing;
 	}
-	const promise = doEnsure(overrideDir, platformKey, sdkVersion, nodeRequire, token, onProgress)
+	const promise = doEnsure(overrideDir, platformKey, download, token, onProgress)
 		.finally(() => inFlight.delete(overrideDir));
 	inFlight.set(overrideDir, promise);
 	return promise;
 }
 
-async function doEnsure(overrideDir: string, platformKey: string, sdkVersion: string, nodeRequire: NodeJS.Require, token: CancellationToken, onProgress?: FoundryLocalRuntimeProgress): Promise<string> {
+async function doEnsure(overrideDir: string, platformKey: string, download: IFoundryLocalRuntimeDownload, token: CancellationToken, onProgress?: FoundryLocalRuntimeProgress): Promise<string> {
 	const addonPath = foundryAddonPath(overrideDir, platformKey);
 	const coreDir = foundryCoreDir(overrideDir, platformKey);
 	// The completion marker is per-platform: the shared `<cacheRoot>/<version>`
@@ -130,17 +138,16 @@ async function doEnsure(overrideDir: string, platformKey: string, sdkVersion: st
 	// payload directory into place. Two concurrent first-use downloads therefore
 	// never write to the same final path; whichever process wins the rename is
 	// the published copy and the loser accepts it as success.
+	const url = format2(download.urlTemplate, { target: platformKey });
 	const staging = join(overrideDir, `.staging-${process.pid}-${randomSuffix()}`);
 	const stagingAddon = join(staging, 'prebuilds', platformKey, 'foundry_local_napi.node');
 	const stagingCore = join(staging, 'foundry-local-core', platformKey);
 	try {
-		await ensureAddon(stagingAddon, platformKey, sdkVersion, token);
-		throwIfCancelled(token);
-		await ensureCoreLibraries(stagingCore, nodeRequire);
+		await downloadAndExtractTarball(url, staging, token);
 		throwIfCancelled(token);
 
 		if (!fs.existsSync(stagingAddon) || !hasAllCoreLibraries(stagingCore)) {
-			throw new Error('Foundry Local native runtime download completed but expected files are missing.');
+			throw new Error(`Foundry Local native runtime download from ${url} completed but expected files are missing.`);
 		}
 
 		await promoteDir(dirname(stagingAddon), dirname(addonPath));
@@ -154,7 +161,7 @@ async function doEnsure(overrideDir: string, platformKey: string, sdkVersion: st
 		throw new Error('Foundry Local native runtime is incomplete after provisioning.');
 	}
 
-	await fs.promises.writeFile(foundryMarkerPath(overrideDir, platformKey), `${sdkVersion}\n`).catch(() => { /* best effort marker */ });
+	await fs.promises.writeFile(foundryMarkerPath(overrideDir, platformKey), `${download.version}\n`).catch(() => { /* best effort marker */ });
 	return overrideDir;
 }
 
@@ -246,68 +253,25 @@ function detectGlibcVersion(): [number, number] | undefined {
 }
 
 /**
- * Download the prebuilt N-API addon for `platformKey` from the pinned
- * `foundry-local-sdk` npm tarball and place it at `addonPath`.
+ * Download the per-target runtime tarball from `url` and extract it into
+ * `stagingDir`, which then contains `prebuilds/<target>/foundry_local_napi.node`
+ * and `foundry-local-core/<target>/<core libraries>` (the tarball's layout
+ * mirrors the cache layout). The tarball is published to VS Code's CDN by
+ * `build/dictation-runtime/`.
  */
-async function ensureAddon(addonPath: string, platformKey: string, sdkVersion: string, token: CancellationToken): Promise<void> {
-	const tarballUrl = `https://registry.npmjs.org/foundry-local-sdk/-/foundry-local-sdk-${sdkVersion}.tgz`;
-	const entryName = `package/prebuilds/${platformKey}/foundry_local_napi.node`;
-
-	const tmpDir = await fs.promises.mkdtemp(join(os.tmpdir(), 'vscode-foundry-addon-'));
+async function downloadAndExtractTarball(url: string, stagingDir: string, token: CancellationToken): Promise<void> {
+	await fs.promises.mkdir(stagingDir, { recursive: true });
+	const tmpDir = await fs.promises.mkdtemp(join(os.tmpdir(), 'vscode-foundry-runtime-'));
 	try {
-		const tarballPath = join(tmpDir, 'sdk.tgz');
-		await downloadFile(tarballUrl, tarballPath, token);
+		const tarballPath = join(tmpDir, 'runtime.tgz');
+		await downloadFile(url, tarballPath, token);
 		throwIfCancelled(token);
 
-		// npm tarballs are gzip'd tar; extract only the single addon we need.
 		// `tar` is a node_modules package, so it must be imported dynamically.
 		const tar = await import('tar');
-		await tar.x({ file: tarballPath, cwd: tmpDir, filter: p => p.replace(/\\/g, '/') === entryName });
-
-		const extracted = join(tmpDir, entryName);
-		if (!fs.existsSync(extracted)) {
-			throw new Error(`Foundry Local addon for ${platformKey} not found in ${tarballUrl}.`);
-		}
-
-		await fs.promises.mkdir(dirname(addonPath), { recursive: true });
-		// Publish atomically: copy to a sibling temp file, then rename into place.
-		const stagingPath = `${addonPath}.download`;
-		await fs.promises.copyFile(extracted, stagingPath);
-		await fs.promises.rename(stagingPath, addonPath);
+		await tar.x({ file: tarballPath, cwd: stagingDir });
 	} finally {
 		await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => { /* best effort */ });
-	}
-}
-
-/**
- * Download the Foundry Local core libraries into `coreDir` by reusing the SDK's
- * own NuGet installer (`script/install-utils.cjs`), targeted at our cache with
- * its `binDir` option. Replicates the standard variant's artifact selection
- * (`script/install-standard.cjs`), including the linux-x64 GPU ORT package.
- */
-async function ensureCoreLibraries(coreDir: string, nodeRequire: NodeJS.Require): Promise<void> {
-	const deps = nodeRequire('foundry-local-sdk/deps_versions.json');
-	const { runInstall } = nodeRequire('foundry-local-sdk/script/install-utils.cjs') as {
-		runInstall(artifacts: { name: string; version: string }[], options?: { binDir?: string }): Promise<void>;
-	};
-
-	// Microsoft.ML.OnnxRuntime.Gpu.Linux only ships x86_64 native binaries, so
-	// linux-arm64 falls back to the cross-platform Foundry ORT package.
-	const isLinuxX64 = process.platform === 'linux' && process.arch === 'x64';
-	const ortPackageName = isLinuxX64 ? 'Microsoft.ML.OnnxRuntime.Gpu.Linux' : 'Microsoft.ML.OnnxRuntime.Foundry';
-
-	const artifacts = [
-		{ name: 'Microsoft.AI.Foundry.Local.Core', version: deps['foundry-local-core'].nuget },
-		{ name: ortPackageName, version: deps.onnxruntime.version },
-		{ name: 'Microsoft.ML.OnnxRuntimeGenAI.Foundry', version: deps['onnxruntime-genai'].version },
-	];
-
-	await fs.promises.mkdir(coreDir, { recursive: true });
-	const restoreProxy = await applyGlobalProxyForNuget();
-	try {
-		await runInstall(artifacts, { binDir: coreDir });
-	} finally {
-		restoreProxy();
 	}
 }
 
@@ -383,28 +347,6 @@ async function resolveProxyAgent(targetUrl: string): Promise<import('http').Agen
 	}
 	const { HttpsProxyAgent } = await import('https-proxy-agent');
 	return new HttpsProxyAgent(proxyUrl);
-}
-
-/**
- * Temporarily route `https.globalAgent` — used by the SDK installer's bare
- * `https.get(url, cb)` NuGet downloads — through the env-configured proxy so
- * corporate proxies are honored without patching third-party SDK code. Returns
- * a function that restores the previous global agent; no-ops when no proxy
- * applies.
- */
-async function applyGlobalProxyForNuget(): Promise<() => void> {
-	const agent = await resolveProxyAgent('https://api.nuget.org/');
-	if (!agent) {
-		return () => { /* nothing to restore */ };
-	}
-	const https = await import('https');
-	const previous = https.globalAgent;
-	// `HttpsProxyAgent` extends `http.Agent`, not `https.Agent`; the cast only
-	// satisfies the field's declared type.
-	https.globalAgent = agent as unknown as typeof previous;
-	return () => {
-		https.globalAgent = previous;
-	};
 }
 
 /** Download `url` to `dest`, following redirects, honoring cancellation. */
@@ -487,21 +429,4 @@ function throwIfCancelled(token: CancellationToken): void {
 	if (token.isCancellationRequested) {
 		throw new CancellationError();
 	}
-}
-
-let cachedNativeRequire: NodeJS.Require | undefined;
-/**
- * A CommonJS `require` bound to this module for loading `foundry-local-sdk`'s
- * package metadata and its NuGet installer at runtime. `foundry-local-sdk` has
- * no `exports` map, so its subpaths resolve directly; it is kept external from
- * the bundle (loaded from `node_modules`) like the SDK's own dynamic import.
- * Uses a dynamic `import('node:module')` so the `node:` specifier is resolved
- * lazily at runtime rather than at bundle/load time.
- */
-async function getNativeRequire(): Promise<NodeJS.Require> {
-	if (!cachedNativeRequire) {
-		const nodeModule = await import('node:module');
-		cachedNativeRequire = nodeModule.createRequire(import.meta.url);
-	}
-	return cachedNativeRequire;
 }

--- a/src/vs/platform/localTranscription/node/foundryLocalRuntime.ts
+++ b/src/vs/platform/localTranscription/node/foundryLocalRuntime.ts
@@ -113,8 +113,6 @@ export async function ensureFoundryLocalRuntime(cacheRoot: string, download: IFo
 }
 
 async function doEnsure(overrideDir: string, platformKey: string, download: IFoundryLocalRuntimeDownload, token: CancellationToken, onProgress?: FoundryLocalRuntimeProgress): Promise<string> {
-	const addonPath = foundryAddonPath(overrideDir, platformKey);
-	const coreDir = foundryCoreDir(overrideDir, platformKey);
 	// The completion marker is per-platform: the shared `<cacheRoot>/<version>`
 	// dir can hold payloads for multiple architectures (e.g. a win32-arm64
 	// machine running x64 VS Code under emulation, then arm64 VS Code). Verify
@@ -132,13 +130,27 @@ async function doEnsure(overrideDir: string, platformKey: string, download: IFou
 	assertRuntimeLoadable(platformKey);
 
 	onProgress?.('Downloading dictation runtime…');
+	await provisionRuntime(overrideDir, platformKey, download.urlTemplate, download.version, token);
+	return overrideDir;
+}
+
+/**
+ * Download the `{target}`-substituted CDN tarball for `platformKey` into
+ * `overrideDir`, extract + verify + atomically promote its payload, and write the
+ * per-platform completion marker. Host-independent (does NOT run the glibc
+ * loadability gate); exported for tests. Callers that provision for the running
+ * host should use `ensureFoundryLocalRuntime`, which gates and de-dupes.
+ */
+export async function provisionRuntime(overrideDir: string, platformKey: string, urlTemplate: string, version: string, token: CancellationToken): Promise<void> {
+	const addonPath = foundryAddonPath(overrideDir, platformKey);
+	const coreDir = foundryCoreDir(overrideDir, platformKey);
 
 	// The cache is shared by the utility processes of every open VS Code window,
 	// so provision into a process-unique staging dir and atomically promote each
 	// payload directory into place. Two concurrent first-use downloads therefore
 	// never write to the same final path; whichever process wins the rename is
 	// the published copy and the loser accepts it as success.
-	const url = format2(download.urlTemplate, { target: platformKey });
+	const url = format2(urlTemplate, { target: platformKey });
 	const staging = join(overrideDir, `.staging-${process.pid}-${randomSuffix()}`);
 	const stagingAddon = join(staging, 'prebuilds', platformKey, 'foundry_local_napi.node');
 	const stagingCore = join(staging, 'foundry-local-core', platformKey);
@@ -161,8 +173,7 @@ async function doEnsure(overrideDir: string, platformKey: string, download: IFou
 		throw new Error('Foundry Local native runtime is incomplete after provisioning.');
 	}
 
-	await fs.promises.writeFile(foundryMarkerPath(overrideDir, platformKey), `${download.version}\n`).catch(() => { /* best effort marker */ });
-	return overrideDir;
+	await fs.promises.writeFile(foundryMarkerPath(overrideDir, platformKey), `${version}\n`).catch(() => { /* best effort marker */ });
 }
 
 /** Path of the per-platform completion marker inside a versioned override dir. */
@@ -351,8 +362,11 @@ async function resolveProxyAgent(targetUrl: string): Promise<import('http').Agen
 
 /** Download `url` to `dest`, following redirects, honoring cancellation. */
 async function downloadFile(url: string, dest: string, token: CancellationToken): Promise<void> {
-	// `https` is a slow-to-load builtin; import it lazily at runtime.
-	const https = await import('https');
+	// `http`/`https` are slow-to-load builtins; import them lazily at runtime.
+	// The CDN is always `https:`; `http:` support exists only so provisioning can
+	// be exercised against a local test server.
+	const [https, http] = await Promise.all([import('https'), import('http')]);
+	const getFor = (u: string) => (new URL(u).protocol === 'http:' ? http.get : https.get);
 	// A single proxy agent tunnels to whatever host each request (including any
 	// redirect target) addresses, so resolving it once from the initial URL is
 	// sufficient. `undefined` means "go direct".
@@ -396,7 +410,7 @@ async function downloadFile(url: string, dest: string, token: CancellationToken)
 				return;
 			}
 			armTimeout();
-			activeRequest = https.get(currentUrl, { agent }, response => {
+			activeRequest = getFor(currentUrl)(currentUrl, { agent }, response => {
 				armTimeout();
 				const status = response.statusCode ?? 0;
 				if (status >= 300 && status < 400 && response.headers.location) {

--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -202,6 +202,12 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 	/** In-flight (or resolved) model download+load for the selected model. */
 	private _modelPromise: Promise<IModel> | undefined;
 
+	/**
+	 * Where to download the native runtime from (product.dictationRuntime), or
+	 * `undefined` in dev builds where the SDK's own node_modules payload is used.
+	 */
+	private _runtimeDownload: { urlTemplate: string; version: string } | undefined;
+
 	/** The active streaming session, once `start()` has opened it. */
 	private _session: LiveAudioTranscriptionSession | undefined;
 	/** Resolves when the background stream consumer for `_session` has drained. */
@@ -262,12 +268,18 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._onDidChangeModelStatus.fire(status);
 	}
 
-	async start(options: { cacheDir: string; model?: string; language?: string; proxyUrl?: string; noProxy?: string; proxyStrictSSL?: boolean; proxyAuthorization?: string }): Promise<void> {
+	async start(options: { cacheDir: string; model?: string; language?: string; proxyUrl?: string; noProxy?: string; proxyStrictSSL?: boolean; proxyAuthorization?: string; runtimeUrlTemplate?: string; runtimeVersion?: string }): Promise<void> {
 		// Bridge VS Code's proxy settings into this process's environment before any
 		// first-use download, so both our own fetches and the native Foundry Local
 		// model download route through the configured proxy (they read the OS/env
 		// proxy, not VS Code settings directly).
 		this._applyProxyEnv(options.proxyUrl, options.noProxy, options.proxyStrictSSL, options.proxyAuthorization);
+
+		// Record where the native runtime is published (from product.json). When
+		// unset (dev builds), the SDK's own node_modules payload is used instead.
+		this._runtimeDownload = options.runtimeUrlTemplate && options.runtimeVersion
+			? { urlTemplate: options.runtimeUrlTemplate, version: options.runtimeVersion }
+			: undefined;
 
 		// Reset any prior session before starting a new one.
 		await this._disposeSession();
@@ -455,11 +467,16 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 				// Ensure the Foundry Local native runtime (N-API addon + core
 				// libraries) is available before loading the SDK. We do not ship
 				// it — the addon requires a newer glibc than our minimum supported
-				// Linux distros — so it is downloaded on demand into a per-user
-				// cache and the SDK loader is pointed at it via env var. This is a
-				// no-op once cached.
-				const nativeDir = await ensureFoundryLocalRuntime(runtimeCacheDir(cacheDir), CancellationToken.None);
-				process.env.VSCODE_FOUNDRY_LOCAL_NATIVE_DIR = nativeDir;
+				// Linux distros — so in packaged builds it is downloaded on demand
+				// from VS Code's CDN (per `product.dictationRuntime`) into a
+				// per-user cache and the SDK loader is pointed at it via env var.
+				// This is a no-op once cached. In dev builds (no product config)
+				// the SDK resolves its addon + core libs from node_modules, so we
+				// skip provisioning and leave the loader on its default path.
+				if (this._runtimeDownload) {
+					const nativeDir = await ensureFoundryLocalRuntime(runtimeCacheDir(cacheDir), this._runtimeDownload, CancellationToken.None);
+					process.env.VSCODE_FOUNDRY_LOCAL_NATIVE_DIR = nativeDir;
+				}
 
 				if (!this._sdk) {
 					this._sdk = await import('foundry-local-sdk');

--- a/src/vs/platform/localTranscription/test/node/foundryLocalRuntime.test.ts
+++ b/src/vs/platform/localTranscription/test/node/foundryLocalRuntime.test.ts
@@ -5,7 +5,10 @@
 
 import * as assert from 'assert';
 import * as fs from 'fs';
+import type { AddressInfo } from 'net';
 import { tmpdir } from 'os';
+import * as tar from 'tar';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { join } from '../../../../base/common/path.js';
 import { Promises } from '../../../../base/node/pfs.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -16,6 +19,7 @@ import {
 	isFoundryLocalRuntimeSupported,
 	isRuntimeProvisioned,
 	promoteDir,
+	provisionRuntime,
 	requiredCoreLibraryNames,
 	resolveProxyUrl,
 } from '../../node/foundryLocalRuntime.js';
@@ -139,5 +143,104 @@ flakySuite('FoundryLocalRuntime', () => {
 			noProxyMiss: 'http://proxy:8080',
 			invalidUrl: undefined,
 		});
+	});
+
+	// --- provisionRuntime: download + {target} substitution + extract + verify ---
+
+	/**
+	 * Build a runtime tarball fixture (`<target>.tgz`) whose internal layout
+	 * matches what `provisionRuntime` extracts and verifies. Set `omitCoreLib`
+	 * to leave one required core library out (an incomplete/corrupt payload).
+	 */
+	async function makeTarball(key: string, opts?: { omitCoreLib?: boolean }): Promise<string> {
+		const src = join(testDir, `src-${key}`);
+		fs.mkdirSync(join(src, 'prebuilds', key), { recursive: true });
+		fs.writeFileSync(join(src, 'prebuilds', key, 'foundry_local_napi.node'), 'addon');
+		const coreDir = join(src, 'foundry-local-core', key);
+		fs.mkdirSync(coreDir, { recursive: true });
+		const libs = requiredCoreLibraryNames();
+		for (const name of opts?.omitCoreLib ? libs.slice(1) : libs) {
+			fs.writeFileSync(join(coreDir, name), 'lib');
+		}
+		const tgz = join(testDir, `${key}.tgz`);
+		await tar.c({ file: tgz, cwd: src, gzip: true }, ['prebuilds', 'foundry-local-core']);
+		return tgz;
+	}
+
+	/**
+	 * Serve `/<name>` → the file at `files[name]` (200), everything else 404.
+	 * Records requested paths so `{target}` substitution can be asserted.
+	 */
+	async function startServer(files: Record<string, string>): Promise<{ url: string; requested: string[]; dispose: () => Promise<void> }> {
+		const http = await import('http');
+		const requested: string[] = [];
+		const server = http.createServer((req, res) => {
+			const name = (req.url ?? '').replace(/^\//, '');
+			requested.push(name);
+			const file = files[name];
+			if (!file || !fs.existsSync(file)) {
+				res.statusCode = 404;
+				res.end('not found');
+				return;
+			}
+			res.statusCode = 200;
+			fs.createReadStream(file).pipe(res);
+		});
+		await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+		const port = (server.address() as AddressInfo).port;
+		return {
+			url: `http://127.0.0.1:${port}`,
+			requested,
+			dispose: () => new Promise<void>(resolve => server.close(() => resolve())),
+		};
+	}
+
+	test('provisionRuntime: substitutes {target}, extracts the expected layout, writes the marker', async () => {
+		const tgz = await makeTarball(platformKey);
+		const server = await startServer({ [`${platformKey}.tgz`]: tgz });
+		try {
+			const overrideDir = join(testDir, '1.2.3');
+			await provisionRuntime(overrideDir, platformKey, `${server.url}/{target}.tgz`, '1.2.3', CancellationToken.None);
+
+			// {target} was substituted with the platform key in the request URL.
+			assert.deepStrictEqual(server.requested, [`${platformKey}.tgz`]);
+			// Payload extracted into the cache layout + completion marker written.
+			assert.strictEqual(fs.existsSync(join(overrideDir, 'prebuilds', platformKey, 'foundry_local_napi.node')), true);
+			for (const name of requiredCoreLibraryNames()) {
+				assert.strictEqual(fs.existsSync(join(overrideDir, 'foundry-local-core', platformKey, name)), true);
+			}
+			assert.strictEqual(isRuntimeProvisioned(overrideDir, platformKey), true);
+		} finally {
+			await server.dispose();
+		}
+	});
+
+	test('provisionRuntime: rejects and writes no marker when the download 404s', async () => {
+		const server = await startServer({});
+		try {
+			const overrideDir = join(testDir, '1.2.3');
+			await assert.rejects(
+				provisionRuntime(overrideDir, platformKey, `${server.url}/{target}.tgz`, '1.2.3', CancellationToken.None),
+				/status 404/,
+			);
+			assert.strictEqual(isRuntimeProvisioned(overrideDir, platformKey), false);
+		} finally {
+			await server.dispose();
+		}
+	});
+
+	test('provisionRuntime: rejects an incomplete payload (missing core library) and writes no marker', async () => {
+		const tgz = await makeTarball(platformKey, { omitCoreLib: true });
+		const server = await startServer({ [`${platformKey}.tgz`]: tgz });
+		try {
+			const overrideDir = join(testDir, '1.2.3');
+			await assert.rejects(
+				provisionRuntime(overrideDir, platformKey, `${server.url}/{target}.tgz`, '1.2.3', CancellationToken.None),
+				/expected files are missing/,
+			);
+			assert.strictEqual(isRuntimeProvisioned(overrideDir, platformKey), false);
+		} finally {
+			await server.dispose();
+		}
 	});
 });

--- a/src/vs/platform/utilityProcess/common/utilityProcessWorkerService.ts
+++ b/src/vs/platform/utilityProcess/common/utilityProcessWorkerService.ts
@@ -20,6 +20,15 @@ export interface IUtilityProcessWorkerProcess {
 	 * A human-readable name for the utility process.
 	 */
 	readonly name: string;
+
+	/**
+	 * On macOS, allows the utility process to load native libraries that are
+	 * not signed by the same Team ID as the app (or are unsigned) by routing
+	 * it through the plugin helper, which has library validation disabled.
+	 * Required when the process `dlopen`s a runtime-downloaded native addon
+	 * signed by a third party (e.g. the on-device dictation runtime).
+	 */
+	readonly allowLoadingUnsignedLibraries?: boolean;
 }
 
 export interface IOnDidTerminateUtilityrocessWorkerProcess {

--- a/src/vs/platform/utilityProcess/electron-main/utilityProcessWorkerMainService.ts
+++ b/src/vs/platform/utilityProcess/electron-main/utilityProcessWorkerMainService.ts
@@ -130,6 +130,7 @@ class UtilityProcessWorker extends Disposable {
 			type: this.configuration.process.type,
 			name: this.configuration.process.name,
 			entryPoint: this.configuration.process.moduleId,
+			allowLoadingUnsignedLibraries: this.configuration.process.allowLoadingUnsignedLibraries,
 			parentLifecycleBound: windowPid,
 			windowLifecycleBound: true,
 			correlationId: `${this.configuration.reply.windowId}`,

--- a/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
+++ b/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
@@ -58,7 +58,12 @@ export class LocalTranscriptionService {
 				const { client } = await this.utilityProcessWorkerWorkbenchService.createWorker({
 					moduleId: 'vs/platform/localTranscription/node/localTranscriptionMain',
 					type: 'localTranscription',
-					name: 'local-transcription'
+					name: 'local-transcription',
+					// The on-device dictation runtime is downloaded from our CDN and its
+					// native addon (foundry_local_napi.node) is signed by a third party,
+					// so on macOS it must load in the plugin helper (library validation
+					// disabled) to avoid a Team ID mismatch dlopen failure.
+					allowLoadingUnsignedLibraries: true
 				});
 				return client.getChannel(localTranscriptionChannelName);
 			})());

--- a/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
+++ b/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
@@ -7,6 +7,7 @@ import { getDelayedChannel, IChannel, ProxyChannel } from '../../../../base/part
 import { arch, platform } from '../../../../base/common/process.js';
 import { registerSingleton, InstantiationType } from '../../../../platform/instantiation/common/extensions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
 import { ILocalTranscriptionService, localTranscriptionChannelName } from '../../../../platform/localTranscription/common/localTranscription.js';
 import { IUtilityProcessWorkerWorkbenchService } from '../../utilityProcess/electron-browser/utilityProcessWorkerWorkbenchService.js';
 
@@ -48,6 +49,7 @@ export class LocalTranscriptionService {
 	constructor(
 		@IUtilityProcessWorkerWorkbenchService private readonly utilityProcessWorkerWorkbenchService: IUtilityProcessWorkerWorkbenchService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IProductService private readonly productService: IProductService,
 	) { }
 
 	private _getChannel(): IChannel {
@@ -77,7 +79,18 @@ export class LocalTranscriptionService {
 	getModelStatus() { return this._getProxy().getModelStatus(); }
 	start(options: { cacheDir: string; model?: string; language?: string }) {
 		const { proxyUrl, noProxy, proxyStrictSSL, proxyAuthorization } = this._resolveProxyConfig();
-		return this._getProxy().start({ cacheDir: options.cacheDir, model: options.model, language: options.language, proxyUrl, noProxy, proxyStrictSSL, proxyAuthorization });
+		const runtime = this.productService.dictationRuntime;
+		return this._getProxy().start({
+			cacheDir: options.cacheDir,
+			model: options.model,
+			language: options.language,
+			proxyUrl,
+			noProxy,
+			proxyStrictSSL,
+			proxyAuthorization,
+			runtimeUrlTemplate: runtime?.urlTemplate,
+			runtimeVersion: runtime?.version,
+		});
 	}
 	pushAudio(chunk: Parameters<ILocalTranscriptionService['pushAudio']>[0]) { return this._getProxy().pushAudio(chunk); }
 	stop() { return this._getProxy().stop(); }


### PR DESCRIPTION
## Why

Follow-up to #326839. That PR provisions the Foundry Local native dictation runtime by downloading the N-API addon from **npm** and the core libraries from **NuGet** at runtime. Per review feedback, we shouldn't download from npm at runtime — instead we should **publish the deps to VS Code's CDN and consume them like the Claude/Codex agent SDKs** (see [`build/agent-sdk/README.md`](https://github.com/microsoft/vscode/blob/main/build/agent-sdk/README.md)).

## What

Mirror the `build/agent-sdk/` pipeline for a new per-target **dictation runtime** artifact, and rewire the runtime to download a single content-addressed tarball from `main.vscode-cdn.net`.

### Build side — `build/dictation-runtime/`
- **`common.ts`** — reads the `foundry-local-sdk` version pin from the repo-root `package.json`; target map; CDN url + urlTemplate builders (`dictation-runtime/foundry-local/<version>/<target>.tgz`); sha256; results reader.
- **`package.ts`** — assembles `prebuilds/<target>/foundry_local_napi.node` (from the pinned npm prebuild) + `foundry-local-core/<target>/<libs>` (via the SDK's own NuGet installer, host-locked to the build agent's RID) and tars it with node-tar (portable, deterministic).
- **`upload.ts`** — idempotent HEAD-then-decide blob upload to `$web` (same auth as agent-sdk).
- **`produce.ts`** — per (platform, arch): build + upload (upload gated on `VSCODE_PUBLISH=true`), write a results json, emit `DICTATION_RUNTIME_RESULTS_FILE` setvariable.
- **`dictation-runtime-produce.yml`** — wired into the darwin / linux (non-armhf) / win32 compile steps right after the existing `agent-sdk-produce.yml` include.

### Runtime side
- **`product.ts`** — `IDictationRuntimeProductConfig { version, urlTemplate }` + `dictationRuntime?` field.
- **`gulpfile.vscode.ts`** — stamps `product.dictationRuntime` from the results file (desktop only).
- **`foundryLocalRuntime.ts`** — replaces the npm + NuGet legs with a single CDN tarball download + extract keyed on `{ version, urlTemplate }`; deletes the npm/NuGet/native-require helpers. **Dev builds (no product config) fall back to the SDK's own `node_modules` payload** — no download, no env var.
- **node / electron-browser `localTranscriptionService` + common `start()`** — thread the runtime download config from `product.json` through to provisioning.

The runtime cache/tarball layout mirrors the SDK's own package layout, so the patched loader (`VSCODE_FOUNDRY_LOCAL_NATIVE_DIR`) resolution stays a trivial path join:

```
<cacheRoot>/<version>/prebuilds/<target>/foundry_local_napi.node
<cacheRoot>/<version>/foundry-local-core/<target>/<core libraries>
```


