### PR TITLE
Agents: fix worktree isolation regression for late Worktree toggle (#326963)

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -965,7 +965,9 @@ export class AgentService extends Disposable implements IAgentService {
 		// materializing in the picked folder before the host creates the worktree.
 		const initializeSideEffects = this._sideEffects.initialize();
 		const sessionConfig = await this._resolveCreatedSessionConfig(provider, config);
-		const deferWorktreeCreation = sessionConfig?.values?.[SessionConfigKey.Isolation] === 'worktree' && !config?.fork && !config?.importConversation;
+		const deferWorktreeCreation = (sessionConfig?.schema.properties[SessionConfigKey.Isolation]?.enum?.includes('worktree') === true
+			|| sessionConfig?.values?.[SessionConfigKey.Isolation] === 'worktree')
+			&& !config?.fork && !config?.importConversation;
 
 		this._logService.trace(`[AgentService] createSession: initializing auto-approver and creating session...`);
 		const [, created] = await Promise.all([

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -38,7 +38,7 @@ import { createNoopGitService, createSessionDataService, TestSessionDatabase } f
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { buildSessionChangesetUri, buildUncommittedChangesetUri } from '../../common/changesetUri.js';
 import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
-import { WorktreeIsolation } from '../../node/shared/worktreeIsolation.js';
+import { getWorktreesRoot, WorktreeIsolation } from '../../node/shared/worktreeIsolation.js';
 import { AhpErrorCodes, JSON_RPC_INTERNAL_ERROR, ProtocolError } from '../../common/state/sessionProtocol.js';
 import type { INetworkDiagnosticsService } from '../../node/networkDiagnosticsService.js';
 
@@ -365,66 +365,105 @@ suite('AgentService (node dispatcher)', () => {
 		});
 	});
 
-	test('marks worktree isolation pending before a provisional provider can prewarm', async () => {
+	test('uses the final isolation choice when a Git-capable provisional session first sends', async () => {
 		const session = AgentSession.uri('codex', 'pending-before-create');
-		const workingDirectory = URI.file('/workspace/repo');
+		const workingDirectory = URI.file(mkdtempSync(`${tmpdir()}/agent-host-worktree-`));
+		const worktreesRoot = getWorktreesRoot(workingDirectory);
 		const gitService = createNoopGitService();
 		gitService.getRepositoryRoot = async () => workingDirectory;
 		gitService.revParse = async () => 'head';
 		gitService.getCurrentBranch = async () => 'feature';
-		gitService.getDefaultBranch = async () => ({ name: 'main', startPoint: 'main' });
-		const localService = disposables.add(new AgentService(new NullLogService(), fileService, nullSessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
-		const isolation = disposables.add(new WorktreeIsolation(
-			{ generateBranchName: async () => 'agents/test' },
-			gitService,
-			new TestCopilotApiService(),
-			nullSessionDataService,
-			new NullLogService(),
-		));
-		localService.setWorktreeIsolation(isolation);
+		gitService.getDefaultBranch = async () => ({ name: 'main', startPoint: 'origin/main' });
+		const addWorktreeCalls: Array<{ worktree: URI; branch: string; startPoint: string }> = [];
+		gitService.addWorktree = async (_repositoryRoot, worktree, branch, startPoint) => {
+			addWorktreeCalls.push({ worktree, branch, startPoint });
+		};
+		const sessionDataService = createSessionDataService();
+		const localDisposables = new DisposableStore();
 		const pendingDuringCreate: boolean[] = [];
 		const providerCreateConfigs: Array<Record<string, unknown> | undefined> = [];
 		let failCreate = false;
-		class PrewarmingAgent extends MockAgent {
-			override async createSession(config?: import('../../common/agentService.js').IAgentCreateSessionConfig): Promise<import('../../common/agentService.js').IAgentCreateSessionResult> {
-				pendingDuringCreate.push(localService.configurationService.isWorkingDirectoryPending(config!.session!.toString()));
-				providerCreateConfigs.push(config?.config);
-				if (failCreate) {
-					throw new Error('create failed');
+		try {
+			const localService = localDisposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
+			const isolation = localDisposables.add(new WorktreeIsolation(
+				{ generateBranchName: async () => 'agents/test' },
+				gitService,
+				new TestCopilotApiService(),
+				sessionDataService,
+				new NullLogService(),
+			));
+			localService.setWorktreeIsolation(isolation);
+			class PrewarmingAgent extends MockAgent {
+				override async createSession(config?: import('../../common/agentService.js').IAgentCreateSessionConfig): Promise<import('../../common/agentService.js').IAgentCreateSessionResult> {
+					pendingDuringCreate.push(localService.configurationService.isWorkingDirectoryPending(config!.session!.toString()));
+					providerCreateConfigs.push(config?.config);
+					if (failCreate) {
+						throw new Error('create failed');
+					}
+					return { ...await super.createSession(config), provisional: true };
 				}
-				return { ...await super.createSession(config), provisional: true };
 			}
+			const agent = new PrewarmingAgent('codex');
+			localDisposables.add(toDisposable(() => agent.dispose()));
+			localService.registerProvider(agent);
+
+			await localService.createSession({
+				provider: 'codex',
+				session,
+				workingDirectory,
+				config: { [SessionConfigKey.Isolation]: 'folder' },
+			});
+			const pendingAfterCreate = localService.configurationService.isWorkingDirectoryPending(session.toString());
+			localService.dispatchAction(session.toString(), {
+				type: ActionType.SessionConfigChanged,
+				config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+			}, 'test-client', 1);
+			const didSend = Event.toPromise(agent.onDidSendMessage);
+			localService.dispatchAction(buildDefaultChatUri(session.toString()), {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text: 'hello', origin: { kind: MessageKind.User } },
+			}, 'test-client', 2);
+			await didSend;
+
+			const failedSession = AgentSession.uri('codex', 'failed-before-create');
+			failCreate = true;
+			await assert.rejects(localService.createSession({
+				provider: 'codex',
+				session: failedSession,
+				workingDirectory,
+				config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+			}), /create failed/);
+
+			assert.deepStrictEqual({
+				pendingDuringCreate,
+				providerCreateConfigs,
+				pendingAfterCreate,
+				pendingAfterSend: localService.configurationService.isWorkingDirectoryPending(session.toString()),
+				pendingAfterFailure: localService.configurationService.isWorkingDirectoryPending(failedSession.toString()),
+				configAfterSend: localService.configurationService.getSessionConfigValues(session.toString()),
+				addWorktreeCalls: addWorktreeCalls.map(call => ({ ...call, worktree: call.worktree.toString() })),
+				createdWorktreeSessionIds: isolation.createdWorktreeSessionIds,
+			}, {
+				pendingDuringCreate: [true, true],
+				providerCreateConfigs: [{}, {}],
+				pendingAfterCreate: true,
+				pendingAfterSend: false,
+				pendingAfterFailure: false,
+				configAfterSend: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+				addWorktreeCalls: [{
+					worktree: URI.joinPath(worktreesRoot, 'test').toString(),
+					branch: 'agents/test',
+					startPoint: 'origin/main',
+				}],
+				createdWorktreeSessionIds: ['pending-before-create'],
+			});
+		} finally {
+			localDisposables.dispose();
+			rmSync(workingDirectory.fsPath, { recursive: true, force: true });
+			rmSync(worktreesRoot.fsPath, { recursive: true, force: true });
 		}
-		const agent = new PrewarmingAgent('codex');
-		disposables.add(toDisposable(() => agent.dispose()));
-		localService.registerProvider(agent);
-
-		await localService.createSession({
-			provider: 'codex',
-			session,
-			workingDirectory,
-			config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
-		});
-		const failedSession = AgentSession.uri('codex', 'failed-before-create');
-		failCreate = true;
-		await assert.rejects(localService.createSession({
-			provider: 'codex',
-			session: failedSession,
-			workingDirectory,
-			config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
-		}), /create failed/);
-
-		assert.deepStrictEqual({
-			pendingDuringCreate,
-			providerCreateConfigs,
-			pendingAfterCreate: localService.configurationService.isWorkingDirectoryPending(session.toString()),
-			pendingAfterFailure: localService.configurationService.isWorkingDirectoryPending(failedSession.toString()),
-		}, {
-			pendingDuringCreate: [true, true],
-			providerCreateConfigs: [{}, {}],
-			pendingAfterCreate: true,
-			pendingAfterFailure: false,
-		});
 	});
 
 	suite('resourceRead', () => {


### PR DESCRIPTION
Fixes #326963.

## Problem

Repro (Copilot CLI, git-backed folder): create a session, **uncheck** New Worktree, send; quit; create a session in the same folder, **check** New Worktree, send — the session is created **without** a worktree. Works in 1.129.0, broken in 1.130.0.

Root cause is the worktree-isolation unification (#324246). `AgentService.createSession` froze the worktree decision at create time from the draft's *initial* isolation:

```ts
const deferWorktreeCreation = sessionConfig?.values?.[SessionConfigKey.Isolation] === 'worktree' && ...;
```

A new-session draft is seeded with the user's *remembered* isolation (`folder` after step 2), so `deferWorktreeCreation` is `false` and the session's working directory is fixed to the folder. Checking Worktree before the first send updates the live config, but the host never re-derives the pending decision, so first-send resolution returns the folder. (The reverse, `worktree -> folder`, happened to work because such a session *was* marked pending.)

## Fix

Defer working-directory resolution for **every git-capable provisional session**, not only worktree-initial ones, and resolve the final folder/worktree choice from the **live** session config on first send:

```ts
const worktreeCapable =
    sessionConfig?.schema.properties[SessionConfigKey.Isolation]?.enum?.includes('worktree') === true
    || sessionConfig?.values?.[SessionConfigKey.Isolation] === 'worktree';
const deferWorkingDirectoryResolution = worktreeCapable && !config?.fork && !config?.importConversation;
```

The session stays pending until first send, where `resolveWorkingDirectory` reads the live config and creates the worktree (or returns the folder). Because the pending gate also drives `CodexAgent._schedulePrewarm`, this additionally prevents Codex from prewarming a **folder-scoped** thread before the choice is finalized — so the fix covers Copilot, Claude, and Codex uniformly.

Safety: `_pending` is only ever set in `_createProviderSession` (create time), never on restore, so a restored worktree session still resolves its existing worktree with no duplicate. The `worktree -> folder` path is unchanged. Only cost: git *folder* Codex sessions defer their eager prewarm to first send (minor first-turn latency).

## Relationship to #326973

An alternative minimal fix (#326973) reconciles the pending marker reactively on the client `SessionConfigChanged` while the session is `Creating`. That correctly fixes the reported Copilot case, but leaves a Codex eager-prewarm race (the folder thread is already bound, so the created worktree is ignored) — see my comment there. This PR closes that at the create-time gate instead, so no folder thread is ever bound. The two are alternatives; pick whichever the team prefers.

## Test

`agentService.test.ts`: `folder`-at-create -> `SessionConfigChanged(worktree)` -> first send now creates the worktree end-to-end (`addWorktreeCalls` populated, `pendingAfterSend: false`, config reflects `worktree`), plus the failed-create path leaves no stale pending marker.

## Validation

- `valid-layers-check`: no violations from this change.
- The four changed production files are type-clean and change no cross-file signatures. A fully green `typecheck-client` is currently blocked by a stale shared `@github/copilot-sdk` in `node_modules` (unrelated SDK/native-module errors in untouched files); a real `npm ci` is needed for the full suite.

Draft while the team decides between this and #326973.