### PR TITLE
Extend built-in on-device dictation to editor and terminal

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -42,6 +42,7 @@ const MODE_SETTING = 'chat.speechToText.mode';
 
 type SpeechToTextSessionEvent = {
 	outcome: 'completed' | 'cancelled' | 'error';
+	surface: string;
 	mode: string;
 	durationMs: number;
 	segments: number;
@@ -50,8 +51,9 @@ type SpeechToTextSessionEvent = {
 };
 type SpeechToTextSessionClassification = {
 	owner: 'meganrogge';
-	comment: 'Tracks usage and reliability of chat-input dictation (speech-to-text).';
+	comment: 'Tracks usage and reliability of built-in on-device dictation (speech-to-text).';
 	outcome: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How the dictation session ended.' };
+	surface: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Which surface dictated: chat, editor, or terminal.' };
 	mode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Configured dictation shortcut mode (auto, toggle, or pushToTalk).' };
 	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Recording duration in milliseconds.' };
 	segments: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of transcript segments returned.' };
@@ -82,6 +84,13 @@ export const enum ChatSpeechToTextState {
 	/** Recording stopped, awaiting the final transcript. */
 	Transcribing = 'transcribing',
 }
+
+/**
+ * The surface a dictation session was started from. Reported in telemetry so
+ * built-in dictation usage can be attributed to the chat input, an editor, or
+ * the terminal.
+ */
+export type ChatDictationSurface = 'chat' | 'editor' | 'terminal';
 
 /** A live dictation transcript update. */
 export interface IChatDictationTranscript {
@@ -141,9 +150,10 @@ export interface IChatSpeechToTextService {
 	/**
 	 * Begin capturing microphone audio in the given window and streaming it to
 	 * the on-device transcription model. Rejects if the microphone cannot be
-	 * accessed.
+	 * accessed. `surface` identifies the dictation surface for telemetry
+	 * (defaults to the chat input).
 	 */
-	start(window: Window & typeof globalThis): Promise<void>;
+	start(window: Window & typeof globalThis, surface?: ChatDictationSurface): Promise<void>;
 
 	/**
 	 * Stop capturing, flush the final utterance, and resolve with the complete
@@ -227,6 +237,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	private _sessionStartMs = 0;
 	private _sessionSegments = 0;
 	private _sessionErrorCode = '';
+	private _sessionSurface: ChatDictationSurface = 'chat';
 
 	// Model-preparation telemetry accumulator. `_prepareStartMs` is non-zero
 	// while a preparation is being tracked, so the terminal Ready/Error status
@@ -289,6 +300,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		const durationMs = Date.now() - this._sessionStartMs;
 		this._telemetryService.publicLog2<SpeechToTextSessionEvent, SpeechToTextSessionClassification>('chatSpeechToText.session', {
 			outcome,
+			surface: this._sessionSurface,
 			mode: this._getDictationMode(),
 			durationMs,
 			segments: this._sessionSegments,
@@ -340,7 +352,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		return [this._finalizedText, this._deltaText].filter(Boolean).join(' ').replace(/\s{2,}/g, ' ').trim();
 	}
 
-	async start(window: Window & typeof globalThis): Promise<void> {
+	async start(window: Window & typeof globalThis, surface: ChatDictationSurface = 'chat'): Promise<void> {
 		if (this._state !== ChatSpeechToTextState.Idle) {
 			return;
 		}
@@ -360,6 +372,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		this._sessionStartMs = Date.now();
 		this._sessionSegments = 0;
 		this._sessionErrorCode = '';
+		this._sessionSurface = surface;
 
 		let stream: MediaStream;
 		try {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadRing.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadRing.ts
@@ -86,3 +86,18 @@ export function getDictationDownloadHoverContent(): IManagedHoverContent {
 	markdown.appendMarkdown(localize('chatStt.hover.preparing', "Preparing the on-device model. This happens only the first time you dictate."));
 	return { markdown, markdownNotSupportedFallback: markdown.value };
 }
+
+/**
+ * A short, live label describing the on-device model's preparation state, for
+ * surfaces without a progress ring (editor placeholder, terminal decoration).
+ * Reads out the download percentage when known, otherwise a generic preparing
+ * message (indeterminate download or loading into memory).
+ */
+export function getDictationPreparingLabel(service: IChatSpeechToTextService): string {
+	const progress = service.modelDownloadProgress;
+	if (typeof progress === 'number') {
+		const percent = Math.max(0, Math.min(100, Math.round(progress * 100)));
+		return localize('chatStt.preparing.downloading', "Downloading speech-to-text model… {0}%", percent);
+	}
+	return localize('chatStt.preparing.preparing', "Preparing speech-to-text model…");
+}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -14,7 +14,7 @@ import { Range } from '../../../../../editor/common/core/range.js';
 import { Selection } from '../../../../../editor/common/core/selection.js';
 import { localize } from '../../../../../nls.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
+import { ChatDictationSurface, ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
 
 /**
  * Inline decoration class for the still-processing tail of not-yet-finalized
@@ -296,7 +296,7 @@ export function activeDictationEditor(): ICodeEditor | undefined {
 }
 
 /** Start dictating into `editor`, rendering the transcript live. */
-export async function startDictation(service: IChatSpeechToTextService, editor: ICodeEditor, window: Window & typeof globalThis, logService: ILogService): Promise<void> {
+export async function startDictation(service: IChatSpeechToTextService, editor: ICodeEditor, window: Window & typeof globalThis, logService: ILogService, surface: ChatDictationSurface = 'chat'): Promise<void> {
 	if (_active || service.state !== ChatSpeechToTextState.Idle) {
 		return;
 	}
@@ -368,7 +368,7 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	disposables.add(editor.onDidDispose(() => cancelDictation()));
 	_active = { service, editor, inserter, disposables, logService };
 	try {
-		await service.start(window);
+		await service.start(window, surface);
 	} catch {
 		// Acquisition/connection failure is surfaced by the service.
 		if (_active?.service === service) {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -15,6 +15,7 @@ import { Selection } from '../../../../../editor/common/core/selection.js';
 import { localize } from '../../../../../nls.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ChatDictationSurface, ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
+import { getDictationPreparingLabel } from './dictationDownloadRing.js';
 
 /**
  * Inline decoration class for the still-processing tail of not-yet-finalized
@@ -309,37 +310,47 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	const HIDE_CURSOR_CLASS = 'dictation-hide-cursor';
 	editor.getDomNode()?.classList.add(HIDE_CURSOR_CLASS);
 	disposables.add(toDisposable(() => editor.getDomNode()?.classList.remove(HIDE_CURSOR_CLASS)));
-	// Show a "Listening…" placeholder only once the session is actually
-	// connected and recording, i.e. the service is in the Recording state and
-	// the on-device model has finished preparing (downloading/loading). It must
-	// not appear during microphone acquisition or while the model is still being
-	// prepared, since transcription cannot happen yet. The placeholder remains
-	// visible until transcript text is inserted, and is restored to its previous
-	// value when the session ends.
+	// Show a "Listening…" placeholder once the session is actually connected
+	// and recording, i.e. the service is in the Recording state and the
+	// on-device model has finished preparing. While the model is still being
+	// prepared on first use (downloading/loading, which can take a while), show
+	// a "Preparing…/Downloading… X%" placeholder instead so the user knows why
+	// dictation has not started yet rather than staring at an idle editor. The
+	// placeholder must not appear during microphone acquisition. It remains
+	// visible until transcript text is inserted, and is restored to its
+	// previous value when the session ends.
 	const previousPlaceholder = editor.getOption(EditorOption.placeholder);
 	const listeningPlaceholder = localize('chatStt.listening', "Listening…");
+	// The placeholder we last applied (listening or a preparing label), so we
+	// only ever restore the previous placeholder when it was ours to restore.
+	let appliedPlaceholder: string | undefined;
 	const applyPlaceholder = () => {
 		if (!editor.getModel()) {
 			return;
 		}
-		const shouldListen = service.state === ChatSpeechToTextState.Recording && !service.isPreparingModel;
-		const current = editor.getOption(EditorOption.placeholder);
-		if (shouldListen) {
-			if (current !== listeningPlaceholder) {
-				editor.updateOptions({ placeholder: listeningPlaceholder });
+		const recording = service.state === ChatSpeechToTextState.Recording;
+		const desired = recording
+			? (service.isPreparingModel ? getDictationPreparingLabel(service) : listeningPlaceholder)
+			: undefined;
+		if (desired !== undefined) {
+			if (appliedPlaceholder !== desired) {
+				editor.updateOptions({ placeholder: desired });
+				appliedPlaceholder = desired;
 			}
-		} else if (current === listeningPlaceholder) {
+		} else if (appliedPlaceholder !== undefined) {
 			editor.updateOptions({ placeholder: previousPlaceholder });
+			appliedPlaceholder = undefined;
 		}
 	};
 	disposables.add(toDisposable(() => {
 		// Ensure the interim shimmer never lingers, regardless of how the session
 		// ends (final transcript, cancel, editor disposal, or a service-side error).
 		inserter.clearShimmer();
-		if (!editor.getModel() || editor.getOption(EditorOption.placeholder) !== listeningPlaceholder) {
+		if (!editor.getModel() || appliedPlaceholder === undefined) {
 			return;
 		}
 		editor.updateOptions({ placeholder: previousPlaceholder });
+		appliedPlaceholder = undefined;
 	}));
 	const idleSettle = disposables.add(new MutableDisposable());
 	disposables.add(service.onDidUpdateTranscript(update => {
@@ -350,6 +361,8 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 		idleSettle.value = disposableTimeout(() => inserter.settleShimmer(), IDLE_SETTLE_MS);
 	}));
 	disposables.add(service.onDidChangePreparingModel(() => applyPlaceholder()));
+	// Refresh the "Downloading… X%" placeholder as the download progresses.
+	disposables.add(service.onDidChangeModelDownloadProgress(() => applyPlaceholder()));
 	disposables.add(service.onDidChangeState(state => {
 		logService.trace(`${LOG_PREFIX} onDidChangeState ${state}`);
 		if (state === ChatSpeechToTextState.Idle && _active?.service === service) {

--- a/src/vs/workbench/contrib/codeEditor/browser/dictation/editorDictation.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/dictation/editorDictation.ts
@@ -258,7 +258,7 @@ export class EditorDictation extends Disposable implements IEditorContribution {
 		}));
 
 		const window = getWindow(this.editor.getDomNode()) ?? getActiveWindow();
-		await startDictation(this.chatSpeechToTextService, this.editor, window, this.logService);
+		await startDictation(this.chatSpeechToTextService, this.editor, window, this.logService, 'editor');
 
 		// If the session did not take (already dictating elsewhere, or start
 		// failed without a state transition), do not leave the widget stranded.

--- a/src/vs/workbench/contrib/codeEditor/browser/dictation/editorDictation.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/dictation/editorDictation.ts
@@ -5,13 +5,17 @@
 
 import './editorDictation.css';
 import { localize, localize2 } from '../../../../../nls.js';
-import { IDimension } from '../../../../../base/browser/dom.js';
+import { getActiveWindow, getWindow, IDimension } from '../../../../../base/browser/dom.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from '../../../../../editor/browser/editorBrowser.js';
 import { IEditorContribution } from '../../../../../editor/common/editorCommon.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 import { HasSpeechProvider, ISpeechService, SpeechToTextInProgress, SpeechToTextStatus } from '../../../speech/common/speechService.js';
+import { ChatContextKeys } from '../../../chat/common/actions/chatContextKeys.js';
+import { ChatSpeechToTextState, IChatSpeechToTextService } from '../../../chat/browser/speechToText/chatSpeechToTextService.js';
+import { activeDictationEditor, isDictating, startDictation, stopDictation } from '../../../chat/browser/speechToText/dictationSession.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { EditorOption } from '../../../../../editor/common/config/editorOptions.js';
 import { EditorAction2, EditorContributionInstantiation, registerEditorContribution } from '../../../../../editor/browser/editorExtensions.js';
@@ -34,6 +38,14 @@ import { isWindows } from '../../../../../base/common/platform.js';
 const EDITOR_DICTATION_IN_PROGRESS = new RawContextKey<boolean>('editorDictation.inProgress', false);
 const VOICE_CATEGORY = localize2('voiceCategory', "Voice");
 
+/**
+ * True when the built-in on-device dictation engine is available (and AI
+ * features are enabled). Mirrors the chat input's `ChatSpeechToTextConfigured`
+ * gate so editor dictation can run through the built-in engine even when the
+ * `ms-vscode.vscode-speech` extension is not installed.
+ */
+const BuiltinDictationConfigured = ContextKeyExpr.and(ChatContextKeys.enabled, ChatContextKeys.speechToTextConfigured);
+
 export class EditorDictationStartAction extends EditorAction2 {
 
 	constructor() {
@@ -42,7 +54,9 @@ export class EditorDictationStartAction extends EditorAction2 {
 			title: localize2('startDictation', "Start Dictation in Editor"),
 			category: VOICE_CATEGORY,
 			precondition: ContextKeyExpr.and(
-				HasSpeechProvider,
+				// Available either through the built-in on-device engine or the
+				// speech extension's provider.
+				ContextKeyExpr.or(HasSpeechProvider, BuiltinDictationConfigured),
 				SpeechToTextInProgress.toNegated(),		// disable when any speech-to-text is in progress
 				EditorContextKeys.readOnly.toNegated()	// disable in read-only editors
 			),
@@ -196,6 +210,8 @@ export class EditorDictation extends Disposable implements IEditorContribution {
 	constructor(
 		private readonly editor: ICodeEditor,
 		@ISpeechService private readonly speechService: ISpeechService,
+		@IChatSpeechToTextService private readonly chatSpeechToTextService: IChatSpeechToTextService,
+		@ILogService private readonly logService: ILogService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IKeybindingService keybindingService: IKeybindingService
 	) {
@@ -206,6 +222,52 @@ export class EditorDictation extends Disposable implements IEditorContribution {
 	}
 
 	async start(): Promise<void> {
+		// Prefer the built-in on-device engine (private, in-box) when it is
+		// configured, falling back to the speech extension's provider otherwise.
+		if (this.chatSpeechToTextService.isConfigured) {
+			return this.startBuiltin();
+		}
+		return this.startWithProvider();
+	}
+
+	/**
+	 * Run editor dictation through the built-in on-device engine, reusing the
+	 * shared chat dictation renderer (live transcript, interim shimmer, and
+	 * "Listening…" placeholder). A floating stop widget is shown so the mic can
+	 * be stopped by mouse as well as by the Escape keybinding.
+	 */
+	private async startBuiltin(): Promise<void> {
+		const disposables = new DisposableStore();
+		this.sessionDisposables.value = disposables;
+
+		this.widget.show();
+		this.widget.active();
+		disposables.add(toDisposable(() => this.widget.hide()));
+
+		this.editorDictationInProgress.set(true);
+		disposables.add(toDisposable(() => this.editorDictationInProgress.reset()));
+
+		disposables.add(this.editor.onDidChangeCursorPosition(() => this.widget.layout()));
+
+		// When the shared session ends on its own (final transcript applied, an
+		// error, or the model failing to load), tear down the editor-side UI.
+		disposables.add(this.chatSpeechToTextService.onDidChangeState(state => {
+			if (state === ChatSpeechToTextState.Idle) {
+				this.sessionDisposables.clear();
+			}
+		}));
+
+		const window = getWindow(this.editor.getDomNode()) ?? getActiveWindow();
+		await startDictation(this.chatSpeechToTextService, this.editor, window, this.logService);
+
+		// If the session did not take (already dictating elsewhere, or start
+		// failed without a state transition), do not leave the widget stranded.
+		if (activeDictationEditor() !== this.editor) {
+			this.sessionDisposables.clear();
+		}
+	}
+
+	private async startWithProvider(): Promise<void> {
 		const disposables = new DisposableStore();
 		this.sessionDisposables.value = disposables;
 
@@ -295,6 +357,12 @@ export class EditorDictation extends Disposable implements IEditorContribution {
 	}
 
 	stop(): void {
+		// Built-in dictation into this editor is owned by the shared chat
+		// dictation session; stop it there so the final transcript is applied.
+		if (isDictating() && activeDictationEditor() === this.editor) {
+			stopDictation();
+			return;
+		}
 		this.sessionDisposables.clear();
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/media/terminalVoice.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminalVoice.css
@@ -39,9 +39,32 @@
 	}
 }
 
+/* Live (in-progress) dictation transcript. Match the chat input and editor
+ * dictation surfaces: render in the input placeholder color with the same
+ * shimmer animation instead of the static italic ghost-text style, so all
+ * three speech surfaces look identical while words stream in. */
+@keyframes terminal-voice-progress-shimmer {
+	0% {
+		background-position: 120% 0;
+	}
+
+	100% {
+		background-position: -120% 0;
+	}
+}
+
 .terminal-voice-progress-text {
-	font-style: italic;
-	color: var(--vscode-editorGhostText-foreground) !important;
-	border: 1px solid var(--vscode-editorGhostText-border);
+	background: linear-gradient(90deg,
+			var(--vscode-input-placeholderForeground) 0%,
+			var(--vscode-input-placeholderForeground) 30%,
+			var(--vscode-foreground) 50%,
+			var(--vscode-input-placeholderForeground) 70%,
+			var(--vscode-input-placeholderForeground) 100%);
+	background-size: 400% 100%;
+	background-clip: text;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	animation: terminal-voice-progress-shimmer 2s linear infinite;
+	will-change: background-position;
 	z-index: 1000;
 }

--- a/src/vs/workbench/contrib/terminal/browser/media/terminalVoice.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminalVoice.css
@@ -68,3 +68,12 @@
 	will-change: background-position;
 	z-index: 1000;
 }
+
+/* First-use "Preparing…/Downloading… X%" hint shown while the on-device model
+ * loads. Static placeholder-colored italic text (no shimmer) so it reads as a
+ * status message rather than dictated speech. */
+.terminal-voice-preparing-text {
+	font-style: italic;
+	color: var(--vscode-input-placeholderForeground);
+	z-index: 1000;
+}

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice.ts
@@ -16,6 +16,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { SpeechTimeoutDefault } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { ISpeechService, AccessibilityVoiceSettingId, ISpeechToTextEvent, SpeechToTextStatus } from '../../../speech/common/speechService.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from '../../../chat/browser/speechToText/chatSpeechToTextService.js';
+import { getDictationPreparingLabel } from '../../../chat/browser/speechToText/dictationDownloadRing.js';
 import type { IMarker, IDecoration } from '@xterm/xterm';
 import { alert } from '../../../../../base/browser/ui/aria/aria.js';
 import { getActiveWindow } from '../../../../../base/browser/dom.js';
@@ -182,6 +183,23 @@ export class TerminalVoiceSession extends Disposable {
 			this._createDecoration();
 		}
 
+		// On first use the model downloads/loads before any transcript arrives.
+		// Unlike the chat input (which has a toolbar download ring), the terminal
+		// has no progress affordance, so surface a "Preparing…/Downloading… X%"
+		// hint in the ghost-text slot until the model is ready and real
+		// transcripts start streaming.
+		const renderPreparing = () => {
+			if (this._cancellationTokenSource?.token.isCancellationRequested || this._builtinFinalizing) {
+				return;
+			}
+			if (service.isPreparingModel) {
+				this._renderPreparingText(getDictationPreparingLabel(service));
+			}
+		};
+		renderPreparing();
+		this._disposables.add(service.onDidChangePreparingModel(() => renderPreparing()));
+		this._disposables.add(service.onDidChangeModelDownloadProgress(() => renderPreparing()));
+
 		this._disposables.add(service.onDidUpdateTranscript(update => {
 			if (this._cancellationTokenSource?.token.isCancellationRequested || this._builtinFinalizing) {
 				return;
@@ -189,7 +207,8 @@ export class TerminalVoiceSession extends Disposable {
 			// Reuse the provider-path rendering by shaping the cumulative
 			// transcript as a recognizing event. The staged text is only sent
 			// once accepted (silence timeout or Stop Dictation), which fetches
-			// the engine's final transcript.
+			// the engine's final transcript. The first real transcript replaces
+			// any lingering "Preparing…" hint.
 			const event: ISpeechToTextEvent = { status: SpeechToTextStatus.Recognizing, text: update.text };
 			this._updateInput(event);
 			this._renderGhostText(event);
@@ -335,8 +354,20 @@ export class TerminalVoiceSession extends Disposable {
 	}
 
 	private _renderGhostText(e: ISpeechToTextEvent): void {
+		this._renderGhostTextContent(e.text, 'terminal-voice-progress-text');
+	}
+
+	/**
+	 * Render a non-transcript hint (e.g. "Preparing…/Downloading… X%") in the
+	 * ghost-text slot while the on-device model is still preparing on first use.
+	 * Styled distinctly from the live transcript so it does not read as speech.
+	 */
+	private _renderPreparingText(label: string): void {
+		this._renderGhostTextContent(label, 'terminal-voice-preparing-text');
+	}
+
+	private _renderGhostTextContent(text: string | undefined, className: string): void {
 		this._ghostText?.dispose();
-		const text = e.text;
 		if (!text) {
 			return;
 		}
@@ -360,7 +391,7 @@ export class TerminalVoiceSession extends Disposable {
 			this._disposables.add(this._ghostText);
 		}
 		this._ghostText?.onRender((e: HTMLElement) => {
-			e.classList.add('terminal-voice-progress-text');
+			e.classList.add(className);
 			e.textContent = text;
 			e.style.width = (xterm.cols - xterm.buffer.active.cursorX) / xterm.cols * 100 + '%';
 		});

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice.ts
@@ -61,6 +61,10 @@ export class TerminalVoiceSession extends Disposable {
 	private static _instance: TerminalVoiceSession | undefined = undefined;
 	private _acceptTranscriptionScheduler: RunOnceScheduler | undefined;
 	private readonly _terminalDictationInProgress: IContextKey<boolean>;
+	/** True while the current session is driven by the built-in on-device engine. */
+	private _usingBuiltin = false;
+	/** True while awaiting the built-in engine's final transcript during accept. */
+	private _builtinFinalizing = false;
 	static getInstance(instantiationService: IInstantiationService): TerminalVoiceSession {
 		if (!TerminalVoiceSession._instance) {
 			TerminalVoiceSession._instance = instantiationService.createInstance(TerminalVoiceSession);
@@ -91,6 +95,13 @@ export class TerminalVoiceSession extends Disposable {
 			voiceTimeout = SpeechTimeoutDefault;
 		}
 		this._acceptTranscriptionScheduler = this._disposables.add(new RunOnceScheduler(() => {
+			// The built-in engine returns its final utterance only from
+			// stopAndTranscribe(), so accept through stop(true) rather than
+			// sending the interim text and discarding the recording.
+			if (this._usingBuiltin) {
+				this.stop(true);
+				return;
+			}
 			this._sendText();
 			this.stop();
 		}, voiceTimeout));
@@ -155,17 +166,30 @@ export class TerminalVoiceSession extends Disposable {
 	private async _startBuiltin(voiceTimeout: number): Promise<void> {
 		const service = this._chatSpeechToTextService;
 
+		// Only one dictation can run at a time (the on-device engine is a shared
+		// singleton). If it is already recording elsewhere (chat input or an
+		// editor), `service.start()` would no-op while these listeners stayed
+		// attached and streamed that other surface's transcript into the
+		// terminal. Reject a non-idle engine before subscribing.
+		if (service.state !== ChatSpeechToTextState.Idle) {
+			this.stop();
+			return;
+		}
+
+		this._usingBuiltin = true;
 		this._terminalDictationInProgress.set(true);
 		if (!this._decoration) {
 			this._createDecoration();
 		}
 
 		this._disposables.add(service.onDidUpdateTranscript(update => {
-			if (this._cancellationTokenSource?.token.isCancellationRequested) {
+			if (this._cancellationTokenSource?.token.isCancellationRequested || this._builtinFinalizing) {
 				return;
 			}
 			// Reuse the provider-path rendering by shaping the cumulative
-			// transcript as a recognizing event.
+			// transcript as a recognizing event. The staged text is only sent
+			// once accepted (silence timeout or Stop Dictation), which fetches
+			// the engine's final transcript.
 			const event: ISpeechToTextEvent = { status: SpeechToTextStatus.Recognizing, text: update.text };
 			this._updateInput(event);
 			this._renderGhostText(event);
@@ -177,20 +201,13 @@ export class TerminalVoiceSession extends Disposable {
 		}));
 
 		// If the engine ends the session on its own (e.g. the model failed to
-		// load), tear down and send whatever was captured. Guarded by the
-		// cancellation token so the teardown-triggered Idle transition (from
-		// `service.cancel()` below) does not re-enter `stop`.
+		// load), abort the terminal-side rendering. Guarded so neither the
+		// accept-triggered nor the abort-triggered Idle transition re-enters.
 		this._disposables.add(service.onDidChangeState(state => {
-			if (this._cancellationTokenSource?.token.isCancellationRequested) {
-				return;
-			}
-			if (state === ChatSpeechToTextState.Idle) {
-				this.stop(true);
+			if (state === ChatSpeechToTextState.Idle && !this._builtinFinalizing && !this._cancellationTokenSource?.token.isCancellationRequested) {
+				this.stop();
 			}
 		}));
-
-		// Abort the on-device session when this dictation is torn down.
-		this._disposables.add(toDisposable(() => service.cancel()));
 
 		try {
 			await service.start(getActiveWindow());
@@ -200,7 +217,39 @@ export class TerminalVoiceSession extends Disposable {
 		}
 	}
 
+	/**
+	 * Accept the built-in dictation: fetch the engine's final transcript (the
+	 * last utterance is only returned by `stopAndTranscribe`, not the interim
+	 * stream), stage it, then tear down and send it. Used by the silence timeout
+	 * and the Stop Dictation action; abort/error teardown uses `cancel()` instead.
+	 */
+	private async _finalizeBuiltinThenStop(): Promise<void> {
+		let finalText: string | undefined;
+		try {
+			finalText = await this._chatSpeechToTextService.stopAndTranscribe();
+		} catch {
+			// Fall back to the last interim text already staged in `_input`.
+		}
+		// A concurrent abort (e.g. the terminal was disposed) already tore down.
+		if (!this._usingBuiltin || this._cancellationTokenSource?.token.isCancellationRequested) {
+			return;
+		}
+		if (finalText !== undefined) {
+			this._updateInput({ status: SpeechToTextStatus.Recognized, text: finalText });
+		}
+		// _builtinFinalizing is set, so this reaches the synchronous teardown and
+		// sends the staged (final) text.
+		this.stop(true);
+	}
+
 	stop(send?: boolean): void {
+		// Built-in accept path: fetch the final transcript before tearing down.
+		if (this._usingBuiltin && send && !this._builtinFinalizing) {
+			this._builtinFinalizing = true;
+			this._acceptTranscriptionScheduler?.cancel();
+			this._finalizeBuiltinThenStop();
+			return;
+		}
 		this._setInactive();
 		if (send) {
 			this._acceptTranscriptionScheduler!.cancel();
@@ -213,9 +262,16 @@ export class TerminalVoiceSession extends Disposable {
 		this._marker = undefined;
 		this._ghostTextMarker = undefined;
 		this._cancellationTokenSource?.cancel();
+		// Abort the on-device engine on teardown. On the accept path the engine
+		// has already finished via stopAndTranscribe(), so this is a no-op there.
+		if (this._usingBuiltin) {
+			this._chatSpeechToTextService.cancel();
+		}
 		this._disposables.clear();
 		this._input = '';
 		this._terminalDictationInProgress.reset();
+		this._usingBuiltin = false;
+		this._builtinFinalizing = false;
 	}
 
 	private _sendText(): void {

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice.ts
@@ -15,8 +15,10 @@ import { IContextKey, IContextKeyService } from '../../../../../platform/context
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { SpeechTimeoutDefault } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { ISpeechService, AccessibilityVoiceSettingId, ISpeechToTextEvent, SpeechToTextStatus } from '../../../speech/common/speechService.js';
+import { ChatSpeechToTextState, IChatSpeechToTextService } from '../../../chat/browser/speechToText/chatSpeechToTextService.js';
 import type { IMarker, IDecoration } from '@xterm/xterm';
 import { alert } from '../../../../../base/browser/ui/aria/aria.js';
+import { getActiveWindow } from '../../../../../base/browser/dom.js';
 import { ITerminalService } from '../../../terminal/browser/terminal.js';
 import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
 
@@ -70,6 +72,7 @@ export class TerminalVoiceSession extends Disposable {
 	private readonly _disposables: DisposableStore;
 	constructor(
 		@ISpeechService private readonly _speechService: ISpeechService,
+		@IChatSpeechToTextService private readonly _chatSpeechToTextService: IChatSpeechToTextService,
 		@ITerminalService private readonly _terminalService: ITerminalService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -93,6 +96,13 @@ export class TerminalVoiceSession extends Disposable {
 		}, voiceTimeout));
 		this._cancellationTokenSource = new CancellationTokenSource();
 		this._register(toDisposable(() => this._cancellationTokenSource?.dispose(true)));
+
+		// Prefer the built-in on-device engine (private, in-box) when configured,
+		// falling back to the speech extension's provider otherwise.
+		if (this._chatSpeechToTextService.isConfigured) {
+			return this._startBuiltin(voiceTimeout);
+		}
+
 		const session = await this._speechService.createSpeechToTextSession(this._cancellationTokenSource?.token, 'terminal');
 
 		this._disposables.add(session.onDidChange((e) => {
@@ -134,6 +144,62 @@ export class TerminalVoiceSession extends Disposable {
 			}
 		}));
 	}
+
+	/**
+	 * Drive terminal dictation from the built-in on-device engine. Unlike the
+	 * extension provider (which emits discrete `Recognizing`/`Recognized` events
+	 * per utterance), the built-in engine streams a single growing cumulative
+	 * transcript. We render it live as ghost text and keep it staged in
+	 * `_input`, then send it once the silence timeout elapses or the user stops.
+	 */
+	private async _startBuiltin(voiceTimeout: number): Promise<void> {
+		const service = this._chatSpeechToTextService;
+
+		this._terminalDictationInProgress.set(true);
+		if (!this._decoration) {
+			this._createDecoration();
+		}
+
+		this._disposables.add(service.onDidUpdateTranscript(update => {
+			if (this._cancellationTokenSource?.token.isCancellationRequested) {
+				return;
+			}
+			// Reuse the provider-path rendering by shaping the cumulative
+			// transcript as a recognizing event.
+			const event: ISpeechToTextEvent = { status: SpeechToTextStatus.Recognizing, text: update.text };
+			this._updateInput(event);
+			this._renderGhostText(event);
+			this._updateDecoration();
+			if (voiceTimeout > 0) {
+				this._acceptTranscriptionScheduler!.cancel();
+				this._acceptTranscriptionScheduler!.schedule();
+			}
+		}));
+
+		// If the engine ends the session on its own (e.g. the model failed to
+		// load), tear down and send whatever was captured. Guarded by the
+		// cancellation token so the teardown-triggered Idle transition (from
+		// `service.cancel()` below) does not re-enter `stop`.
+		this._disposables.add(service.onDidChangeState(state => {
+			if (this._cancellationTokenSource?.token.isCancellationRequested) {
+				return;
+			}
+			if (state === ChatSpeechToTextState.Idle) {
+				this.stop(true);
+			}
+		}));
+
+		// Abort the on-device session when this dictation is torn down.
+		this._disposables.add(toDisposable(() => service.cancel()));
+
+		try {
+			await service.start(getActiveWindow());
+		} catch {
+			// Microphone acquisition/connection failure is surfaced by the service.
+			this.stop();
+		}
+	}
+
 	stop(send?: boolean): void {
 		this._setInactive();
 		if (send) {

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice.ts
@@ -210,7 +210,7 @@ export class TerminalVoiceSession extends Disposable {
 		}));
 
 		try {
-			await service.start(getActiveWindow());
+			await service.start(getActiveWindow(), 'terminal');
 		} catch {
 			// Microphone acquisition/connection failure is surfaced by the service.
 			this.stop();

--- a/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions.ts
@@ -14,6 +14,7 @@ import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { EnablementState, IWorkbenchExtensionEnablementService } from '../../../../services/extensionManagement/common/extensionManagement.js';
 import { HasSpeechProvider, SpeechToTextInProgress } from '../../../speech/common/speechService.js';
+import { IChatSpeechToTextService } from '../../../chat/browser/speechToText/chatSpeechToTextService.js';
 import { registerActiveInstanceAction, sharedWhenClause } from '../../../terminal/browser/terminalActions.js';
 import { TerminalCommandId } from '../../../terminal/common/terminal.js';
 import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
@@ -38,7 +39,10 @@ export function registerTerminalVoiceActions() {
 			const dialogService = accessor.get(IDialogService);
 			const workbenchExtensionEnablementService = accessor.get(IWorkbenchExtensionEnablementService);
 			const extensionManagementService = accessor.get(IExtensionManagementService);
-			if (HasSpeechProvider.getValue(contextKeyService)) {
+			const chatSpeechToTextService = accessor.get(IChatSpeechToTextService);
+			// Start dictation whenever an engine is available: the built-in
+			// on-device engine (preferred), or the speech extension's provider.
+			if (chatSpeechToTextService.isConfigured || HasSpeechProvider.getValue(contextKeyService)) {
 				const instantiationService = accessor.get(IInstantiationService);
 				TerminalVoiceSession.getInstance(instantiationService).start();
 				return;


### PR DESCRIPTION
https://github.com/user-attachments/assets/1d033fb7-fc5d-4565-acf3-4c4539f641f9

Extends VS Code's built-in on-device dictation engine (`ILocalTranscriptionService`, surfaced through `IChatSpeechToTextService`) to two more speech surfaces that previously required the `ms-vscode.vscode-speech` extension: **editor dictation** and **terminal voice dictation**.

Fixes #326969. This PR intentionally **excludes** item 3 (read-aloud / text-to-speech), which will be covered by voice mode.

## What changed

Both surfaces now prefer the built-in on-device engine when it is configured (private, in-box, no audio leaves the machine), and fall back to the extension's `ISpeechService` provider where built-in transcription is unsupported (web/remote or `chat.speechToText.enabled: false`). This mirrors the chat input's existing precedence and gates on the same `chatSpeechToTextConfigured` predicate.

- **Editor dictation** (`editorDictation.ts`): when built-in is configured, editor dictation reuses the shared chat dictation renderer (`dictationSession.ts`) — live transcript, interim shimmer, caret parking, and the "Listening…" placeholder — since the editor surface is itself an `ICodeEditor`. The floating stop widget is still shown for a mouse affordance. The Start action precondition is now `HasSpeechProvider OR built-in configured`, so it works without the extension. The extension path is unchanged.
- **Terminal voice** (`terminalVoice.ts`): the built-in engine streams a single growing cumulative transcript (rather than discrete per-utterance `Recognizing`/`Recognized` events), so it is rendered live into the existing ghost-text/decoration UI and sent to the terminal once the silence timeout elapses or the user stops. The extension path is unchanged.
- **Terminal action** (`terminalVoiceActions.ts`): "Start Dictation in Terminal" now starts immediately when the built-in engine is configured, only prompting to install/enable the speech extension when neither engine is available.

## Single speech stack / icon behavior

These surfaces each expose a single built-in command; the extension only ever contributed the `ISpeechService` provider (not separate editor/terminal icons). Routing the existing commands through the built-in engine means there is no second mic/keybinding, consistent with how the chat input already shows a single mic when built-in dictation wins.

## Telemetry

The `chatSpeechToText.session` event gains a `surface` dimension (`chat` | `editor` | `terminal`) so built-in dictation usage and reliability can be attributed per surface. It is threaded through `IChatSpeechToTextService.start(window, surface)` and `startDictation(..., surface)`, defaulting to `chat`; editor and terminal pass their respective surface. Previously all three surfaces fired the same event with no way to tell them apart.

## Not included

- Read-aloud / text-to-speech (issue item 3).
- Keyword activation ("Hey Code") stays extension-only for now.
