### PR TITLE
Add assistant.usage transcript event with per-turn token accounting

### DIFF
--- a/extensions/copilot/src/extension/chat/vscode-node/sessionTranscriptService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/sessionTranscriptService.ts
@@ -9,6 +9,7 @@ import {
 	ISessionTranscriptService,
 	ToolRequest,
 	TranscriptEntry,
+	UsageData,
 } from '../../../platform/chat/common/sessionTranscriptService';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
@@ -188,6 +189,13 @@ export class SessionTranscriptService implements ISessionTranscriptService {
 				success,
 				...(resultContent !== undefined ? { result: { content: resultContent } } : {}),
 			},
+		});
+	}
+
+	logAssistantUsage(sessionId: string, usage: UsageData): void {
+		this._bufferEntry(sessionId, {
+			type: 'assistant.usage',
+			data: usage,
 		});
 	}
 

--- a/extensions/copilot/src/extension/chat/vscode-node/test/sessionTranscriptService.spec.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/test/sessionTranscriptService.spec.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { UsageData } from '../../../../platform/chat/common/sessionTranscriptService';
+import { IEnvService } from '../../../../platform/env/common/envService';
+import { IVSCodeExtensionContext } from '../../../../platform/extContext/common/extensionContext';
+import { IFileSystemService } from '../../../../platform/filesystem/common/fileSystemService';
+import { ILogService } from '../../../../platform/log/common/logService';
+import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
+import { URI } from '../../../../util/vs/base/common/uri';
+import { SessionTranscriptService } from '../sessionTranscriptService';
+
+// ── Test doubles ──
+
+class TestExtensionContext {
+	declare readonly _serviceBrand: undefined;
+	readonly storageUri: URI | undefined;
+
+	constructor(storagePath: string | undefined) {
+		this.storageUri = storagePath ? URI.file(storagePath) : undefined;
+	}
+}
+
+class TestFileSystemService {
+	declare readonly _serviceBrand: undefined;
+
+	async stat(uri: URI) {
+		const stats = await fs.promises.stat(uri.fsPath);
+		return { mtime: stats.mtimeMs, ctime: stats.ctimeMs, size: stats.size };
+	}
+
+	async readDirectory(uri: URI) {
+		const entries = await fs.promises.readdir(uri.fsPath, { withFileTypes: true });
+		return entries.map(e => [e.name, e.isFile() ? 1 : 2] as [string, number]);
+	}
+
+	async createDirectory(uri: URI) {
+		await fs.promises.mkdir(uri.fsPath, { recursive: true });
+	}
+
+	async delete(uri: URI, options?: { recursive?: boolean }) {
+		await fs.promises.rm(uri.fsPath, { recursive: options?.recursive, force: true });
+	}
+}
+
+class TestLogService {
+	declare readonly _serviceBrand: undefined;
+	info() { }
+	warn() { }
+	error() { }
+	debug() { }
+	trace() { }
+}
+
+class TestEnvService {
+	declare readonly _serviceBrand: undefined;
+	readonly vscodeVersion = '1.99.0-test';
+	getVersion() { return '0.0.0-test'; }
+}
+
+describe('SessionTranscriptService', () => {
+	let disposables: DisposableStore;
+	let tmpDir: string;
+	let service: SessionTranscriptService;
+
+	beforeEach(async () => {
+		disposables = new DisposableStore();
+		tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'transcript-'));
+		service = new SessionTranscriptService(
+			new TestFileSystemService() as unknown as IFileSystemService,
+			new TestExtensionContext(tmpDir) as unknown as IVSCodeExtensionContext,
+			new TestEnvService() as unknown as IEnvService,
+			new TestLogService() as unknown as ILogService,
+		);
+	});
+
+	afterEach(async () => {
+		disposables.dispose();
+		await fs.promises.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	async function readEntries(sessionId: string): Promise<Record<string, unknown>[]> {
+		const transcriptPath = service.getTranscriptPath(sessionId);
+		if (!transcriptPath) { return []; }
+		const content = await fs.promises.readFile(transcriptPath.fsPath, 'utf-8');
+		return content.trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+	}
+
+	const sampleUsage: UsageData = {
+		model: 'gpt-4o',
+		inputTokens: 1234,
+		outputTokens: 567,
+		totalTokens: 1801,
+		cacheReadTokens: 800,
+		cacheCreationInputTokens: 64,
+		copilotUsageNanoAiu: 42_000_000,
+		parentToolCallId: null,
+	};
+
+	it('logAssistantUsage writes a valid assistant.usage JSONL line', async () => {
+		await service.startSession('session-1');
+		service.logAssistantUsage('session-1', sampleUsage);
+		await service.flush('session-1');
+
+		const entries = await readEntries('session-1');
+		const usageEntry = entries.find(e => e.type === 'assistant.usage');
+
+		expect(usageEntry).toBeDefined();
+		expect(usageEntry!.data).toEqual(sampleUsage);
+		// Valid id and timestamp.
+		expect(typeof usageEntry!.id).toBe('string');
+		expect((usageEntry!.id as string).length).toBeGreaterThan(0);
+		expect(() => new Date(usageEntry!.timestamp as string).toISOString()).not.toThrow();
+		expect(new Date(usageEntry!.timestamp as string).toISOString()).toBe(usageEntry!.timestamp);
+	});
+
+	it('chains parentId from the previous entry', async () => {
+		await service.startSession('session-chain');
+		service.logUserMessage('session-chain', 'hello');
+		service.logAssistantTurnStart('session-chain', 'turn-0');
+		service.logAssistantUsage('session-chain', sampleUsage);
+		await service.flush('session-chain');
+
+		const entries = await readEntries('session-chain');
+		const turnStart = entries.find(e => e.type === 'assistant.turn_start')!;
+		const usageEntry = entries.find(e => e.type === 'assistant.usage')!;
+
+		// The usage entry links back to the immediately preceding entry (turn_start).
+		expect(usageEntry.parentId).toBe(turnStart.id);
+		// The first entry (session.start) has a null parent.
+		expect(entries[0].type).toBe('session.start');
+		expect(entries[0].parentId).toBeNull();
+	});
+
+	it('records a full turn with usage in append-only order', async () => {
+		await service.startSession('session-e2e');
+		service.logUserMessage('session-e2e', 'What is 2 + 2?');
+		service.logAssistantTurnStart('session-e2e', 'turn-0');
+		service.logAssistantMessage('session-e2e', '4', []);
+		service.logAssistantUsage('session-e2e', sampleUsage);
+		service.logAssistantTurnEnd('session-e2e', 'turn-0');
+		await service.flush('session-e2e');
+
+		const entries = await readEntries('session-e2e');
+		const types = entries.map(e => e.type);
+
+		expect(types).toEqual([
+			'session.start',
+			'user.message',
+			'assistant.turn_start',
+			'assistant.message',
+			'assistant.usage',
+			'assistant.turn_end',
+		]);
+
+		const usageEntry = entries[4];
+		expect(usageEntry.data).toEqual(sampleUsage);
+	});
+
+	it('is a no-op when the session was never started', async () => {
+		// No startSession call — buffering has nowhere to go and must not throw.
+		expect(() => service.logAssistantUsage('missing', sampleUsage)).not.toThrow();
+		expect(service.getTranscriptPath('missing')).toBeUndefined();
+	});
+});

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -12,6 +12,7 @@ import type { ChatParticipantToolToken } from 'vscode';
 import { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
 import { IChatQuotaService, QuotaSnapshot, QuotaSnapshots } from '../../../../platform/chat/common/chatQuotaService';
 import { getQuotaMessageForPlan } from '../../../../platform/chat/common/commonTypes';
+import { ISessionTranscriptService } from '../../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
 import { IGitService } from '../../../../platform/git/common/gitService';
 import { PermissiveAuthRequiredError } from '../../../../platform/github/common/githubService';
@@ -926,6 +927,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 		@IChatQuotaService private readonly _chatQuotaService: IChatQuotaService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ISessionTranscriptService private readonly _sessionTranscriptService: ISessionTranscriptService,
 	) {
 		super();
 		this.sessionId = _sdkSession.sessionId;
@@ -1157,6 +1159,13 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		this._lastResponseModelId = undefined;
 		this._chatQuotaService.resetTurnCredits(request.id);
 		this.logService.info(`[CopilotCLISession] Invoking session ${this.sessionId}`);
+
+		// Start (idempotent) the session transcript and record the user prompt so the per-turn
+		// `assistant.usage` entries logged from the SDK event stream below have coherent,
+		// append-only context. Subsequent turns reuse the already-active session and append.
+		await this._sessionTranscriptService.startSession(this.sessionId, { cwd: getWorkingDirectory(this.workspace)?.fsPath });
+		this._sessionTranscriptService.logUserMessage(this.sessionId, prompt);
+
 		const disposables = new DisposableStore();
 		const logStartTime = Date.now();
 		const requestStream = this._stream;
@@ -1253,6 +1262,9 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		};
 
 		const chunkMessageIds = new Set<string>();
+		// Assistant message ids already written to the session transcript, so a message that is both
+		// streamed as deltas and re-emitted as a complete `assistant.message` is only recorded once.
+		const transcriptLoggedMessageIds = new Set<string>();
 		const assistantMessageChunks: string[] = [];
 		// Tracks the `messageId` of the last assistant text we forwarded to
 		// the stream (via `assistant.message_delta` or `assistant.message`).
@@ -1488,6 +1500,15 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 					copilotUsageNanoAiu,
 					parentToolCallId: event.data.parentToolCallId,
 				});
+				// Append the raw usage to the session transcript as an `assistant.usage` entry.
+				this._sessionTranscriptService.logAssistantUsage(this.sessionId, {
+					model: event.data.model,
+					inputTokens: event.data.inputTokens,
+					outputTokens: event.data.outputTokens,
+					cacheReadTokens: event.data.cacheReadTokens,
+					copilotUsageNanoAiu,
+					parentToolCallId: event.data.parentToolCallId,
+				});
 			})));
 			disposables.add(toDisposable(this._sdkSession.on('session.usage_info', (event) => {
 				lastUsageInfo = {
@@ -1516,6 +1537,13 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				}
 			})));
 			disposables.add(toDisposable(this._sdkSession.on('assistant.message', (event) => {
+				// Record top-level assistant text in the session transcript, independent of the stream
+				// dedup below (a streamed message still arrives here as a complete `assistant.message`).
+				// Sub-agent messages are skipped — they are captured in the subagent tool's result.
+				if (typeof event.data.content === 'string' && event.data.content.length && !event.data.parentToolCallId && !transcriptLoggedMessageIds.has(event.data.messageId)) {
+					transcriptLoggedMessageIds.add(event.data.messageId);
+					this._sessionTranscriptService.logAssistantMessage(this.sessionId, event.data.content, []);
+				}
 				if (typeof event.data.content === 'string' && event.data.content.length && !chunkMessageIds.has(event.data.messageId)) {
 					// Skip sub-agent markdown — it will be captured in the subagent tool's result
 					if (event.data.parentToolCallId) {
@@ -1759,6 +1787,13 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			this._logConversation(prompt, assistantMessageChunks.join(''), modelId || '', attachments, logStartTime, 'Failed', errorMessage);
 		} finally {
 			cancelCancellationAbort?.();
+
+			// Flush the buffered session transcript entries (user prompt, assistant messages and the
+			// per-turn `assistant.usage` accounting) to disk. Best-effort: the append-only writer
+			// serializes concurrent flushes, so a later turn's flush cannot interleave writes.
+			this._sessionTranscriptService.flush(this.sessionId).catch(error => {
+				this.logService.error(`[CopilotCLISession] Failed to flush session transcript for ${this.sessionId}`, error);
+			});
 
 			// Synthesize a `chat` span per model turn so the chat debug logs view shows the model
 			// turns, token metrics, and the agent response for the in-process Copilot CLI experience,

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -935,6 +935,15 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		this._stream = this._streamRouter.stream;
 		this._missionControlApiClient = this.instantiationService.createInstance(MissionControlApiClient);
 		this.add(toDisposable(() => this._todoSqlQuery.dispose()));
+		// End the transcript session when this session is disposed (session close, not per-turn — the
+		// session is ref-counted and cached per conversation). This flushes any buffered entries and
+		// removes it from the active set so retention cleanup can eventually reclaim the file. Mirrors
+		// the debug-logger's endSession wiring in CopilotCLISessionService.
+		this.add(toDisposable(() => {
+			this._sessionTranscriptService.endSession(this.sessionId).catch(err => {
+				this.logService.error(`[CopilotCLISession] Failed to end session transcript for ${this.sessionId}`, err);
+			});
+		}));
 	}
 
 	attachStream(stream: vscode.ChatResponseStream): IDisposable {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -1069,6 +1069,11 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		this.attachments.push(...attachments);
 		const prompt = getPromptLabel(input);
 		this._pendingPrompt = prompt;
+		// Record the steering prompt in the transcript. The in-flight request's SDK listeners will
+		// attribute any resulting `assistant.usage`/messages to this session, so without this the
+		// transcript would show usage and responses with no corresponding user message. The transcript
+		// session was already started by the in-flight `_handleRequestImplInner`.
+		this._sessionTranscriptService.logUserMessage(this.sessionId, prompt);
 		const disposables = new DisposableStore();
 		const logStartTime = Date.now();
 		disposables.add(token.onCancellationRequested(() => {
@@ -1096,6 +1101,9 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			this._logConversation(prompt, '', model?.model || '', attachments, logStartTime, 'Failed', error instanceof Error ? error.message : String(error));
 			throw error;
 		} finally {
+			this._sessionTranscriptService.flush(this.sessionId).catch(error => {
+				this.logService.error(`[CopilotCLISession] Failed to flush session transcript for ${this.sessionId}`, error);
+			});
 			disposables.dispose();
 		}
 	}

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
@@ -12,6 +12,7 @@ import type { ChatContext, ChatCustomAgent, ChatParticipantToolToken, Event as V
 import { CancellationToken } from 'vscode-languageserver-protocol';
 import { IAuthenticationService } from '../../../../../platform/authentication/common/authentication';
 import { NullChatDebugFileLoggerService } from '../../../../../platform/chat/common/chatDebugFileLoggerService';
+import { NullSessionTranscriptService } from '../../../../../platform/chat/common/sessionTranscriptService';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
 import { InMemoryConfigurationService } from '../../../../../platform/configuration/test/common/inMemoryConfigurationService';
 import { NullNativeEnvService } from '../../../../../platform/env/common/nullEnvService';
@@ -224,7 +225,7 @@ describe('CopilotCLISessionService', () => {
 						deleteSession: vi.fn(async () => { }),
 					};
 				}
-				return disposables.add(new CopilotCLISession(workspaceInfo, agentName, sdkSession, [], undefined, logService, workspaceService, new MockChatSessionMetadataStore(), instantiationService, new NullRequestLogger(), new NullICopilotCLIImageSupport(), new FakeToolsService(), new FakeUserQuestionHandler(), accessor.get(IConfigurationService), new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '0.0.0', sessionId: 'test' })), new MockGitService(), { _serviceBrand: undefined } as any, { _serviceBrand: undefined, resetTurnCredits() { }, getCreditsForTurn() { return undefined; }, setLastCopilotUsage() { } } as any, new NullTelemetryService()));
+				return disposables.add(new CopilotCLISession(workspaceInfo, agentName, sdkSession, [], undefined, logService, workspaceService, new MockChatSessionMetadataStore(), instantiationService, new NullRequestLogger(), new NullICopilotCLIImageSupport(), new FakeToolsService(), new FakeUserQuestionHandler(), accessor.get(IConfigurationService), new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '0.0.0', sessionId: 'test' })), new MockGitService(), { _serviceBrand: undefined } as any, { _serviceBrand: undefined, resetTurnCredits() { }, getCreditsForTurn() { return undefined; }, setLastCopilotUsage() { } } as any, new NullTelemetryService(), new NullSessionTranscriptService()));
 			}
 		} as unknown as IInstantiationService;
 		configurationService = accessor.get(IConfigurationService);

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatParticipantToolToken, ChatResponseStream } from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
 import { QuotaSnapshots } from '../../../../../platform/chat/common/chatQuotaService';
+import { ISessionTranscriptService, NullSessionTranscriptService, UsageData } from '../../../../../platform/chat/common/sessionTranscriptService';
 import { MockGitService } from '../../../../../platform/ignore/node/test/mockGitService';
 import { ILogService } from '../../../../../platform/log/common/logService';
 import { GenAiAttr, IOTelService, NoopOTelService, resolveOTelConfig, SpanKind } from '../../../../../platform/otel/common/index';
@@ -267,7 +268,7 @@ describe('CopilotCLISession', () => {
 		return createSessionWith(new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '0.0.0', sessionId: 'test' })), opts?.sandboxEnabled ?? false);
 	}
 
-	async function createSessionWith(otelService: IOTelService, sandboxEnabled = false): Promise<CopilotCLISession> {
+	async function createSessionWith(otelService: IOTelService, sandboxEnabled = false, sessionTranscriptService: ISessionTranscriptService = new NullSessionTranscriptService()): Promise<CopilotCLISession> {
 		class FakeUserQuestionHandler implements IUserQuestionHandler {
 			_serviceBrand: undefined;
 			async askUserQuestion(question: IQuestion, toolInvocationToken: ChatParticipantToolToken, token: CancellationToken, toolCallId?: string): Promise<IQuestionAnswer | undefined> {
@@ -296,7 +297,8 @@ describe('CopilotCLISession', () => {
 			new MockGitService(),
 			{ _serviceBrand: undefined } as any,
 			{ _serviceBrand: undefined, resetTurnCredits() { }, getCreditsForTurn() { return undefined; }, setLastCopilotUsage() { }, processQuotaSnapshots(snapshots: QuotaSnapshots) { processedQuotaSnapshots.push(snapshots); } } as any,
-			telemetryService
+			telemetryService,
+			sessionTranscriptService
 		));
 	}
 
@@ -311,6 +313,69 @@ describe('CopilotCLISession', () => {
 		expect(session.status).toBe(ChatSessionStatus.Completed);
 		expect(stream.output.join('\n')).toContain('Echo: Hello');
 		// Listeners are disposed after completion, so we only assert original streamed content.
+	});
+
+	it('writes the user prompt, assistant message and usage into the session transcript', async () => {
+		const events: string[] = [];
+		let flushed = 0;
+		let startedSessionId: string | undefined;
+		const loggedUsage: { sessionId: string; usage: UsageData }[] = [];
+		const recordingTranscriptService = new class extends NullSessionTranscriptService {
+			override async startSession(sessionId: string): Promise<void> {
+				startedSessionId = sessionId;
+				events.push('start');
+			}
+			override logUserMessage(_sessionId: string, content: string): void {
+				events.push(`user:${content}`);
+			}
+			override logAssistantMessage(_sessionId: string, content: string): void {
+				events.push(`assistant:${content}`);
+			}
+			override logAssistantUsage(sessionId: string, usage: UsageData): void {
+				events.push('usage');
+				loggedUsage.push({ sessionId, usage });
+			}
+			override async flush(): Promise<void> {
+				flushed++;
+			}
+		}();
+
+		sdkSession.send = async ({ prompt }) => {
+			sdkSession.emit('user.message', { content: prompt });
+			sdkSession.emit('assistant.turn_start', {});
+			sdkSession.emit('assistant.usage', {
+				model: 'claude-x',
+				inputTokens: 100,
+				outputTokens: 20,
+				cacheReadTokens: 5,
+				parentToolCallId: null,
+				copilotUsage: { totalNanoAiu: 7_000_000 },
+			});
+			sdkSession.emit('assistant.message', { messageId: 'm1', content: 'Done!' });
+			sdkSession.emit('assistant.turn_end', {});
+		};
+
+		const otel = new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '0.0.0', sessionId: 'test' }));
+		const session = await createSessionWith(otel, false, recordingTranscriptService);
+		session.attachStream(new MockChatResponseStream());
+		await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Run ls' }, [], undefined, authInfo, CancellationToken.None);
+
+		// The transcript is started before the prompt is recorded, and the per-turn usage is logged
+		// from the SDK event stream in causal order, then flushed once at request completion.
+		expect(startedSessionId).toBe(session.sessionId);
+		expect(events).toEqual(['start', 'user:Run ls', 'usage', 'assistant:Done!']);
+		expect(flushed).toBe(1);
+
+		expect(loggedUsage).toHaveLength(1);
+		expect(loggedUsage[0].sessionId).toBe(session.sessionId);
+		expect(loggedUsage[0].usage).toEqual({
+			model: 'claude-x',
+			inputTokens: 100,
+			outputTokens: 20,
+			cacheReadTokens: 5,
+			copilotUsageNanoAiu: 7_000_000,
+			parentToolCallId: null,
+		});
 	});
 
 	it('synthesizes chat and execute_tool spans for the in-process CLI turn', async () => {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -2198,6 +2198,55 @@ describe('CopilotCLISession', () => {
 			expect(session.status).toBe(ChatSessionStatus.Completed);
 		});
 
+		it('records the steering prompt as a user message in the transcript', async () => {
+			const userMessages: string[] = [];
+			const recordingTranscriptService = new class extends NullSessionTranscriptService {
+				override logUserMessage(_sessionId: string, content: string): void {
+					userMessages.push(content);
+				}
+			}();
+
+			let resolveFirstSend: () => void = () => { };
+			let sendCallCount = 0;
+			sdkSession.send = async (options: any) => {
+				sendCallCount++;
+				sdkSession.lastSendOptions = options;
+				if (sendCallCount === 1) {
+					await new Promise<void>(r => { resolveFirstSend = r; });
+				}
+				sdkSession.emit('assistant.turn_start', {});
+				sdkSession.emit('assistant.message', { messageId: `m${sendCallCount}`, content: `Echo: ${options.prompt}` });
+				sdkSession.emit('assistant.turn_end', {});
+			};
+
+			const otel = new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '0.0.0', sessionId: 'test' }));
+			const session = await createSessionWith(otel, false, recordingTranscriptService);
+			session.attachStream(new MockChatResponseStream());
+
+			// First request blocks in `send`, keeping the session InProgress.
+			const firstRequest = session.handleRequest(
+				{ id: 'req-1', toolInvocationToken: undefined as never },
+				{ prompt: 'First prompt' }, [], undefined, authInfo, CancellationToken.None
+			);
+			await new Promise(r => setTimeout(r, 10));
+			expect(session.status).toBe(ChatSessionStatus.InProgress);
+
+			// Second request arrives while busy → routed through the steering path.
+			const steeringRequest = session.handleRequest(
+				{ id: 'req-2', toolInvocationToken: undefined as never },
+				{ prompt: 'Steer this' }, [], undefined, authInfo, CancellationToken.None
+			);
+			await new Promise(r => setTimeout(r, 10));
+
+			resolveFirstSend();
+			await Promise.all([firstRequest, steeringRequest]);
+
+			// Both the initial prompt (normal path) and the steering prompt (steering path) are recorded,
+			// so the steering action's usage/messages have a corresponding user message.
+			expect(userMessages).toContain('First prompt');
+			expect(userMessages).toContain('Steer this');
+		});
+
 		it('lets interrupted output finish before running a local /remote command', async () => {
 			let resolveFirstSend: () => void = () => { };
 			sdkSession.send = async (options: any) => {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -378,6 +378,23 @@ describe('CopilotCLISession', () => {
 		});
 	});
 
+	it('ends the transcript session when the CLI session is disposed', async () => {
+		let endedSessionId: string | undefined;
+		const recordingTranscriptService = new class extends NullSessionTranscriptService {
+			override async endSession(sessionId: string): Promise<void> {
+				endedSessionId = sessionId;
+			}
+		}();
+
+		const otel = new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '0.0.0', sessionId: 'test' }));
+		const session = await createSessionWith(otel, false, recordingTranscriptService);
+
+		// Disposal (session close, not per-turn) must end the transcript so it is flushed and
+		// removed from the active set, otherwise retention cleanup can never reclaim the file.
+		session.dispose();
+		expect(endedSessionId).toBe(session.sessionId);
+	});
+
 	it('synthesizes chat and execute_tool spans for the in-process CLI turn', async () => {
 		sdkSession.send = async ({ prompt }) => {
 			sdkSession.emit('user.message', { content: prompt });

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -1724,6 +1724,20 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 				thinkingItem ? (Array.isArray(thinkingItem.text) ? thinkingItem.text.join('') : thinkingItem.text) : undefined,
 			);
 
+			// Log the token / accounting usage for this model turn to the transcript.
+			if (fetchResult.usage) {
+				const usage = fetchResult.usage;
+				this._sessionTranscriptService.logAssistantUsage(this.options.conversation.sessionId, {
+					model: endpoint.model,
+					inputTokens: usage.prompt_tokens,
+					outputTokens: usage.completion_tokens,
+					totalTokens: usage.total_tokens,
+					cacheReadTokens: usage.prompt_tokens_details?.cached_tokens,
+					cacheCreationInputTokens: usage.prompt_tokens_details?.cache_creation_input_tokens,
+					copilotUsageNanoAiu: usage.copilot_usage?.total_nano_aiu,
+				});
+			}
+
 			return {
 				response: fetchResult,
 				round: ToolCallRound.create({

--- a/extensions/copilot/src/platform/chat/common/sessionTranscriptService.ts
+++ b/extensions/copilot/src/platform/chat/common/sessionTranscriptService.ts
@@ -114,6 +114,35 @@ export interface AssistantTurnEndEntry extends TranscriptEntryBase {
 	readonly data: AssistantTurnEndData;
 }
 
+/**
+ * Token / accounting information reported by the model for a single assistant
+ * action or turn. All fields are optional because different runtimes surface
+ * different subsets of this data.
+ */
+export interface UsageData {
+	/** Model that produced this turn (e.g. `gpt-4o`). */
+	readonly model?: string;
+	/** Prompt (input) tokens consumed. */
+	readonly inputTokens?: number;
+	/** Completion (output) tokens produced. */
+	readonly outputTokens?: number;
+	/** Total tokens (input + output) when reported directly. */
+	readonly totalTokens?: number;
+	/** Prompt tokens served from cache. */
+	readonly cacheReadTokens?: number;
+	/** Prompt tokens written to the cache. */
+	readonly cacheCreationInputTokens?: number;
+	/** Raw internal Copilot AI-unit accounting, in nano-AIU, if available. */
+	readonly copilotUsageNanoAiu?: number;
+	/** Set when this turn originates from a subagent nested under a parent tool call. */
+	readonly parentToolCallId?: string | null;
+}
+
+export interface AssistantUsageEntry extends TranscriptEntryBase {
+	readonly type: 'assistant.usage';
+	readonly data: UsageData;
+}
+
 export type TranscriptEntry =
 	| SessionStartEntry
 	| UserMessageEntry
@@ -121,6 +150,7 @@ export type TranscriptEntry =
 	| AssistantMessageEntry
 	| ToolExecutionStartEntry
 	| ToolExecutionCompleteEntry
+	| AssistantUsageEntry
 	| AssistantTurnEndEntry;
 
 // #endregion
@@ -215,6 +245,14 @@ export interface ISessionTranscriptService {
 	logToolExecutionComplete(sessionId: string, toolCallId: string, success: boolean, resultContent?: string): void;
 
 	/**
+	 * Record token / accounting usage reported for an assistant action or turn.
+	 * Buffered as an append-only `assistant.usage` entry at the moment it is
+	 * observed; prior entries are never rewritten to attach usage retrospectively.
+	 * Entries are buffered; call {@link flush} to write to disk.
+	 */
+	logAssistantUsage(sessionId: string, usage: UsageData): void;
+
+	/**
 	 * Record the end of an assistant turn.
 	 * Entries are buffered; call {@link flush} to write to disk.
 	 */
@@ -259,17 +297,20 @@ export interface ISessionTranscriptService {
 export class NullSessionTranscriptService implements ISessionTranscriptService {
 	declare readonly _serviceBrand: undefined;
 
-	async startSession(): Promise<void> { }
-	logUserMessage(): void { }
-	logAssistantTurnStart(): void { }
-	logAssistantMessage(): void { }
-	logToolExecutionStart(): void { }
-	logToolExecutionComplete(): void { }
-	logAssistantTurnEnd(): void { }
-	async flush(): Promise<void> { }
-	async endSession(): Promise<void> { }
-	getTranscriptPath(): URI | undefined { return undefined; }
-	getLineCount(): number | undefined { return undefined; }
-	async cleanupOldTranscripts(): Promise<void> { }
-	isTranscriptUri(): boolean { return false; }
+	// Signatures mirror {@link ISessionTranscriptService} (rather than paramless no-ops) so
+	// recording/spy subclasses in tests can `override` individual methods without an arity mismatch.
+	async startSession(sessionId: string, context?: { cwd?: string }, history?: readonly IHistoricalTurn[]): Promise<void> { }
+	logUserMessage(sessionId: string, content: string, attachments?: readonly unknown[]): void { }
+	logAssistantTurnStart(sessionId: string, turnId: string): void { }
+	logAssistantMessage(sessionId: string, content: string, toolRequests: readonly ToolRequest[], reasoningText?: string): void { }
+	logToolExecutionStart(sessionId: string, toolCallId: string, toolName: string, args: unknown): void { }
+	logToolExecutionComplete(sessionId: string, toolCallId: string, success: boolean, resultContent?: string): void { }
+	logAssistantUsage(sessionId: string, usage: UsageData): void { }
+	logAssistantTurnEnd(sessionId: string, turnId: string): void { }
+	async flush(sessionId: string): Promise<void> { }
+	async endSession(sessionId: string): Promise<void> { }
+	getTranscriptPath(sessionId: string): URI | undefined { return undefined; }
+	getLineCount(sessionId: string): number | undefined { return undefined; }
+	async cleanupOldTranscripts(maxRetained?: number): Promise<void> { }
+	isTranscriptUri(uri: URI): boolean { return false; }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #326981

Transcripts capture the whole conversation but never recorded any usage data, so you couldn't tell from a transcript how many tokens a turn used or what it cost. This adds a new `assistant.usage` event to the transcript stream carrying the per-turn accounting: model, input/output tokens, cache reads, and raw Copilot AIU.