### PR TITLE
Style override: Add top margin for compact activity bar in floating panels

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -167,6 +167,10 @@
 	margin-right: var(--vscode-spacing-size40);
 }
 
+.monaco-workbench.floating-panels .activitybar.compact > .content > .composite-bar {
+	margin-top: var(--vscode-spacing-size20);
+}
+
 /* At the default (non-compact) size, separate the activity bar items with a 4px gap
  * so they read as distinct floating targets. Compact keeps the tighter default stack. */
 .monaco-workbench.floating-panels .part.activitybar:not(.compact) > .content .monaco-action-bar .action-item + .action-item {


### PR DESCRIPTION
Introduce a top margin for the compact activity bar within floating panels to improve visual spacing. This change enhances the layout and usability of the interface.

Resolves https://github.com/microsoft/vscode/issues/325606
