### PR TITLE
Agents: honor a late Worktree toggle for Codex sessions (#326963)

### DIFF
--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -2846,6 +2846,28 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 	}
 
+	private _evictStalePrewarm(session: ICodexSession): void {
+		if (session.prewarmTimer) {
+			clearTimeout(session.prewarmTimer);
+			session.prewarmTimer = undefined;
+		}
+		const threadId = session.threadId;
+		if (threadId === undefined) {
+			return;
+		}
+		session.threadId = undefined;
+		this._sessionIdByThreadId.delete(threadId);
+		// Tear down the prewarmed thread only if a connection already exists;
+		// unlike `_expirePrewarm` we must never spawn codex just to evict a
+		// prewarm that a config change (folder->worktree) has invalidated.
+		const conn = this._connection;
+		if (conn.kind === 'ready') {
+			conn.client.request<'thread/unsubscribe'>('thread/unsubscribe', { threadId }).catch(err => {
+				this._logService.warn(`[Codex] stale prewarm unsubscribe failed session=${session.sessionUri.toString()} threadId=${threadId}: ${err instanceof Error ? err.message : String(err)}`);
+			});
+		}
+	}
+
 	private _startTurnStopWatch(session: ICodexSession): StopWatch {
 		const stopWatch = StopWatch.create(false);
 		session.turnStopWatch = stopWatch;
@@ -3248,6 +3270,16 @@ export class CodexAgent extends Disposable implements IAgent {
 			}
 		} catch (err) {
 			this._logService.warn(`[Codex:${threadId}] thread/${isArchived ? 'archive' : 'unarchive'} failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	onSessionConfigChanged(session: URI, _values: Record<string, unknown>): void {
+		const entry = this._sessions.get(AgentSession.id(session));
+		if (!entry || entry.prewarmClaimed || entry.threadId === undefined) {
+			return;
+		}
+		if (this._configurationService.isWorkingDirectoryPending(entry.sessionUri.toString())) {
+			this._evictStalePrewarm(entry);
 		}
 	}
 

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { AgentSession } from '../../../common/agentService.js';
+import { SessionConfigKey } from '../../../common/sessionConfigKeys.js';
+import { ISessionDataService } from '../../../common/sessionDataService.js';
+import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
+import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
+import { CodexAgent } from '../../../node/codex/codexAgent.js';
+import { ICodexProxyService } from '../../../node/codex/codexProxyService.js';
+import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
+
+suite('CodexAgent worktree-isolation prewarm eviction', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createAgent(pending: { value: boolean }): CodexAgent {
+		const instantiationService = new TestInstantiationService();
+		instantiationService.stub(ISessionDataService, { _serviceBrand: undefined });
+		instantiationService.stub(ICopilotApiService, { _serviceBrand: undefined });
+		instantiationService.stub(ICodexProxyService, { _serviceBrand: undefined });
+		instantiationService.stub(IAgentConfigurationService, { _serviceBrand: undefined, isWorkingDirectoryPending: () => pending.value });
+		// Keep prewarm from touching the connection: the eager background prewarm
+		// bails when the SDK isn't already local.
+		instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined, isSdkResolvableWithoutDownload: async () => false });
+		instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
+		instantiationService.stub(ILogService, new NullLogService());
+		return disposables.add(instantiationService.createInstance(CodexAgent));
+	}
+
+	test('evicts a folder-bound prewarm once the session flips to a pending worktree', async () => {
+		const pending = { value: false };
+		const agent = createAgent(pending);
+		agent['_githubToken'] = 'test-token';
+
+		const { session } = await agent.createSession({ workingDirectory: URI.file('/repo/folder') });
+		const entry = agent['_sessions'].get(AgentSession.id(session))!;
+
+		// Simulate the materialized folder-bound prewarm thread that createSession
+		// would have produced for a non-pending `folder` session.
+		const threadId = 'thread-folder';
+		entry.threadId = threadId;
+		entry.prewarmTimer = setTimeout(() => { }, 60_000);
+		agent['_sessionIdByThreadId'].set(threadId, entry.sessionId);
+
+		const snapshot = () => ({
+			threadId: entry.threadId,
+			routed: agent['_sessionIdByThreadId'].has(threadId),
+			timerCleared: entry.prewarmTimer === undefined,
+		});
+
+		// A config change while the working directory is still `folder` (not
+		// pending) must leave the prewarm intact.
+		agent.onSessionConfigChanged(session, { [SessionConfigKey.Isolation]: 'folder' });
+		const afterFolder = snapshot();
+
+		// Toggling to `worktree` marks the working directory pending; the stale
+		// folder-bound prewarm must be evicted so the next send re-materializes.
+		pending.value = true;
+		agent.onSessionConfigChanged(session, { [SessionConfigKey.Isolation]: 'worktree' });
+		const afterWorktree = snapshot();
+
+		assert.deepStrictEqual({ afterFolder, afterWorktree }, {
+			afterFolder: { threadId, routed: true, timerCleared: false },
+			afterWorktree: { threadId: undefined, routed: false, timerCleared: true },
+		});
+	});
+});


### PR DESCRIPTION
## What & why

Builds on the now-merged #326973, which added the reactive worktree-isolation handler that reconciles the pending working-directory marker (`notePending` / `clearPending`) when a still-Creating session's isolation config changes. That fix covers Claude; this PR closes the remaining **Codex-only** gap.

**The gap:** A Codex session that starts in **Folder** isolation eagerly prewarms a folder-bound thread during `createSession`. If the user then checks **Worktree** before the first send, the host correctly creates the worktree and marks the working directory pending, but the already-materialized prewarm thread is never evicted. Because `_sendMessage` only adopts the host-provided directory when `threadId === undefined` (and `_materializeIfNeeded` no-ops once a thread exists), the first turn silently ran in the **folder**, ignoring the worktree.

**The fix:** Implement `CodexAgent.onSessionConfigChanged`. The host invokes it *after* updating the pending marker, so it consults the same single-source-of-truth predicate the prewarm scheduler uses (`isWorkingDirectoryPending`). When the working directory has flipped to pending and there is an unclaimed, materialized prewarm thread, it evicts that stale thread: clears the prewarm timer, drops the thread mapping, and best-effort unsubscribes **only** if a connection already exists (we must never spawn Codex just to tear down a prewarm). The next send then re-materializes in the worktree.

## Diff shape

Purely additive — `2 files changed, 108 insertions(+)`, 0 deletions:

- `src/vs/platform/agentHost/node/codex/codexAgent.ts` (+32): `onSessionConfigChanged` + private `_evictStalePrewarm` + exactly one new comment explaining the prewarm-eviction guard.
- `src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts` (+76): new regression test.

No renames, no existing-comment/JSDoc edits anywhere.

## Test

The regression test drives a folder-initial Codex session, simulates the materialized folder-bound prewarm, then asserts a non-pending config change leaves it intact while a pending (worktree) flip evicts it. It **passes with the fix and fails without it** — neutralizing the handler leaves the stale `thread-folder` still routed with the prewarm timer uncleared.

## Refs

- Fixes #326963
- Builds on the merged #326973 (handler-based pending reconcile).
- Supersedes the broader create-time-deferral alternative explored in #326980, now moot given the merged handler-based approach.
