### PR TITLE
Round-trip display kinds over plaintext SDK attachments

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -63,6 +63,7 @@ import type { IAgentHostRestrictedTelemetryContext } from '../agentHostRestricte
 import { stripProxyErrorMarker, tryBuildChatErrorMeta, tryBuildChatErrorMetaFromFields } from '../shared/forwardedChatError.js';
 import { getEffectiveMcpServerCustomizations, McpCustomizationController, type ISdkMcpServer } from '../shared/mcpCustomizationController.js';
 import { appendSdkToolResultContent, mapSessionEvents } from './mapSessionEvents.js';
+import { addSimpleAttachmentDisplayKindToMimeType } from './copilotAttachmentUtils.js';
 import { buildPendingEditContentUri } from './pendingEditContentStore.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../agentHostStateManager.js';
 import { McpAuthRequiredReason, McpServerStatus, type McpAuthRequirement, type McpServerState } from '../../common/state/protocol/channels-session/state.js';
@@ -1576,7 +1577,7 @@ export class CopilotAgentSession extends Disposable {
 				return {
 					type: 'blob' as const,
 					data: encodeBase64(VSBuffer.fromString(attachment.modelRepresentation)),
-					mimeType: 'text/plain',
+					mimeType: addSimpleAttachmentDisplayKindToMimeType(attachment),
 					displayName: attachment.label,
 				};
 			}

--- a/src/vs/platform/agentHost/node/copilot/copilotAttachmentUtils.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAttachmentUtils.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { SimpleMessageAttachment } from '../../common/state/protocol/state.js';
+
+const attachmentDisplayKindParameter = 'x-vscode-display-kind=';
+
+export function addSimpleAttachmentDisplayKindToMimeType(attachment: SimpleMessageAttachment): string {
+	if (attachment.displayKind === undefined) {
+		return 'text/plain';
+	}
+	return `text/plain; ${attachmentDisplayKindParameter}${encodeURIComponent(attachment.displayKind)}`;
+}
+
+export function readSimpleAttachmentDisplayKindFromMimeType(mimeType: string): string | undefined {
+	const parameter = mimeType.split(';').map(part => part.trim()).find(part => part.startsWith(attachmentDisplayKindParameter));
+	if (!parameter) {
+		return undefined;
+	}
+	try {
+		return decodeURIComponent(parameter.slice(attachmentDisplayKindParameter.length));
+	} catch {
+		return undefined;
+	}
+}

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -20,6 +20,7 @@ import { buildSessionDbUri } from '../shared/fileEditTracker.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
 import { buildMcpChannel, buildMcpTopLevelCustomizationId } from '../shared/mcpCustomizationController.js';
+import { readSimpleAttachmentDisplayKindFromMimeType } from './copilotAttachmentUtils.js';
 
 function tryStringify(value: unknown): string | undefined {
 	try {
@@ -679,10 +680,12 @@ function sdkAttachmentToProtocol(
 				return undefined;
 			}
 			if (attachment.mimeType.startsWith('text/plain')) {
+				const displayKind = readSimpleAttachmentDisplayKindFromMimeType(attachment.mimeType);
 				return {
 					type: MessageAttachmentKind.Simple,
 					label: attachment.displayName ?? 'attachment',
 					modelRepresentation: decodeBase64(attachment.data ?? '').toString(),
+					...(displayKind !== undefined ? { displayKind } : {}),
 				};
 			}
 			const displayKind = attachment.mimeType.startsWith('image/') ? 'image' : undefined;

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -818,6 +818,42 @@ suite('CopilotAgentSession', () => {
 		}]);
 	});
 
+	test('preserves simple attachment display kind through SDK blobs', async () => {
+		const { session, mockSession } = await createAgentSession(disposables);
+		const attachment = {
+			type: MessageAttachmentKind.Simple,
+			label: 'Browser Pages',
+			displayKind: 'workspace',
+			modelRepresentation: 'No browser pages are currently shared with you.',
+		} as const;
+
+		await session.send('hello', [attachment]);
+		const sdkAttachment = {
+			type: 'blob' as const,
+			data: encodeBase64(VSBuffer.fromString(attachment.modelRepresentation)),
+			mimeType: 'text/plain; x-vscode-display-kind=workspace',
+			displayName: attachment.label,
+		};
+		assert.deepStrictEqual(mockSession.sendRequests, [{
+			prompt: 'hello',
+			attachments: [sdkAttachment],
+		}]);
+
+		mockSession.messages = [{
+			type: 'user.message',
+			id: 'event-1',
+			parentId: null,
+			timestamp: new Date().toISOString(),
+			data: {
+				interactionId: 'message-1',
+				content: 'hello',
+				attachments: [sdkAttachment],
+			},
+		}];
+
+		assert.deepStrictEqual((await session.getMessages())[0].message.attachments, [attachment]);
+	});
+
 	test('forwards an embedded resource with a selection as its already-sliced inline blob', async () => {
 		const { session, mockSession } = await createAgentSession(disposables);
 
@@ -879,7 +915,7 @@ suite('CopilotAgentSession', () => {
 			attachments: [{
 				type: 'blob',
 				data: encodeBase64(VSBuffer.fromString('Transcript text')),
-				mimeType: 'text/plain',
+				mimeType: 'text/plain; x-vscode-display-kind=paste',
 				displayName: 'Previous conversation',
 			}],
 		}]);
@@ -895,7 +931,7 @@ suite('CopilotAgentSession', () => {
 				attachments: [{
 					type: 'blob',
 					data: encodeBase64(VSBuffer.fromString('Transcript text')),
-					mimeType: 'text/plain',
+					mimeType: 'text/plain; x-vscode-display-kind=paste',
 					displayName: 'Previous conversation',
 				}],
 			},
@@ -904,6 +940,7 @@ suite('CopilotAgentSession', () => {
 		assert.deepStrictEqual((await session.getMessages())[0].message.attachments, [{
 			type: MessageAttachmentKind.Simple,
 			label: 'Previous conversation',
+			displayKind: 'paste',
 			modelRepresentation: 'Transcript text',
 		}]);
 	});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/327001