### PR TITLE
Fix: apply chat.defaultModel on every new local session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -231,8 +231,17 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	applyConfiguredDefault(): boolean {
+		// A configured default (`chat.defaultModel`) is the default for every NEW conversation, so
+		// any path that (re)binds an empty session must re-apply it. Only a genuine in-conversation
+		// choice keeps it from doing so: an explicit user pick or a mode-forced programmatic
+		// selection. `SessionRestore` is intentionally NOT a blocker here: a reopened conversation
+		// that legitimately restores its own model is always non-empty (handled by `!isEmpty()`
+		// above), so on an EMPTY session a `SessionRestore` reason only reflects a model that spilled
+		// over from the previous session (e.g. via the "+" new-session button or back-to-list
+		// navigation) and must yield to the configured default.
 		if (!this._runtime.isEmpty()
-			|| isAuthoritativeModelSelectionReason(this._selectionReason)
+			|| this._selectionReason === ModelSelectionReason.UserSelection
+			|| this._selectionReason === ModelSelectionReason.ProgrammaticSelection
 			|| (this._intent && this._intent.kind !== 'remembered')) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -231,14 +231,10 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	applyConfiguredDefault(): boolean {
-		// A configured default (`chat.defaultModel`) is the default for every NEW conversation, so
-		// any path that (re)binds an empty session must re-apply it. Only a genuine in-conversation
-		// choice keeps it from doing so: an explicit user pick or a mode-forced programmatic
-		// selection. `SessionRestore` is intentionally NOT a blocker here: a reopened conversation
-		// that legitimately restores its own model is always non-empty (handled by `!isEmpty()`
-		// above), so on an EMPTY session a `SessionRestore` reason only reflects a model that spilled
-		// over from the previous session (e.g. via the "+" new-session button or back-to-list
-		// navigation) and must yield to the configured default.
+		// `chat.defaultModel` is the default for every new (empty) conversation. Only a genuine
+		// in-conversation choice blocks it: an explicit user pick or a mode-forced programmatic
+		// selection. `SessionRestore` on an empty session is just spillover from the previous
+		// session and must yield (a real reopened conversation is non-empty → `!isEmpty()`).
 		if (!this._runtime.isEmpty()
 			|| this._selectionReason === ModelSelectionReason.UserSelection
 			|| this._selectionReason === ModelSelectionReason.ProgrammaticSelection

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionModel.test.ts
@@ -40,6 +40,8 @@ interface IRuntimeState {
 	resolved: boolean;
 	readonly sessionType: string;
 	configuredModel?: string;
+	/** Defaults to `true` (a new/empty session). Set to `false` to model a reopened conversation with history. */
+	isEmpty?: boolean;
 }
 
 function createRuntime(
@@ -51,7 +53,7 @@ function createRuntime(
 		location: ChatAgentLocation.Chat,
 		getCurrentModeKind: () => ChatModeKind.Ask,
 		getCurrentSessionType: () => state.sessionType,
-		isEmpty: () => true,
+		isEmpty: () => state.isEmpty ?? true,
 		getModels: () => state.models,
 		getAllModels: () => state.models,
 		requiresCustomModels: () => false,
@@ -554,6 +556,9 @@ suite('ChatInputModelSelectionController', () => {
 	});
 
 	test('late configured default does not overwrite a restored conversation model', () => {
+		// A genuine reopened conversation is NON-empty, so the configured default must never override
+		// its restored model. The empty/new-session case (where the configured default wins over a
+		// spilled-over restore) is covered by the empty-session tests above.
 		const restored = model('test/restored');
 		const configured = model('copilot/configured');
 		let models = [restored];
@@ -562,7 +567,7 @@ suite('ChatInputModelSelectionController', () => {
 			location: ChatAgentLocation.Chat,
 			getCurrentModeKind: () => ChatModeKind.Ask,
 			getCurrentSessionType: () => undefined,
-			isEmpty: () => true,
+			isEmpty: () => false,
 			getModels: () => models,
 			getAllModels: () => models,
 			requiresCustomModels: () => false,
@@ -701,6 +706,103 @@ suite('ChatInputModelSelectionController', () => {
 		assert.deepStrictEqual({ configuredApplied, applied }, {
 			configuredApplied: true,
 			applied: [first.identifier, second.identifier],
+		});
+	});
+
+	test('re-applies the configured default over a spilled-over session-restore on an empty session', () => {
+		// Regression for the local "+ new session" / back-to-list cases: a new empty session that
+		// inherits the previous session's model as a session-restore must still reset to the
+		// configured `chat.defaultModel`. See the SessionRestore-is-not-a-blocker rule in
+		// `applyConfiguredDefault`.
+		const gpt = model('test/gpt');
+		const opus = model('test/opus');
+		const modelChanges = disposables.add(new Emitter<string>());
+		const applied: string[] = [];
+		const controller = disposables.add(new ChatInputModelSelectionController(
+			createRuntime({ models: [gpt, opus], resolved: true, sessionType: 'test', configuredModel: gpt.metadata.id }, modelChanges, applied)));
+
+		controller.beginSessionSwitch(true, false, false);
+		controller.syncFromConversationState(opus, undefined, 'test', 'chat:one');
+		const afterSpillover = controller.currentModel.get()?.identifier;
+		const configuredApplied = controller.applyConfiguredDefault();
+
+		assert.deepStrictEqual({ afterSpillover, configuredApplied, applied, current: controller.currentModel.get()?.identifier }, {
+			afterSpillover: opus.identifier,
+			configuredApplied: true,
+			applied: [opus.identifier, gpt.identifier],
+			current: gpt.identifier,
+		});
+	});
+
+	test('preserves an explicit user pick on an empty session over the configured default', () => {
+		const gpt = model('test/gpt');
+		const opus = model('test/opus');
+		const modelChanges = disposables.add(new Emitter<string>());
+		const applied: string[] = [];
+		const controller = disposables.add(new ChatInputModelSelectionController(
+			createRuntime({ models: [gpt, opus], resolved: true, sessionType: 'test', configuredModel: gpt.metadata.id }, modelChanges, applied)));
+
+		controller.beginSessionSwitch(true, false, false);
+		controller.applyExplicitSelection(opus, () => applied.push(opus.identifier), false);
+		const configuredApplied = controller.applyConfiguredDefault();
+
+		assert.deepStrictEqual({ configuredApplied, applied, current: controller.currentModel.get()?.identifier, userPicked: controller.userExplicitlySelectedModel }, {
+			configuredApplied: false,
+			applied: [opus.identifier],
+			current: opus.identifier,
+			userPicked: true,
+		});
+	});
+
+	test('keeps the restored model on a reopened non-empty conversation even when a default is configured', () => {
+		const gpt = model('test/gpt');
+		const opus = model('test/opus');
+		const applied: string[] = [];
+		const runtime: IChatInputModelSelectionRuntime = {
+			location: ChatAgentLocation.Chat,
+			getCurrentModeKind: () => ChatModeKind.Ask,
+			getCurrentSessionType: () => undefined,
+			isEmpty: () => false,
+			getModels: () => [gpt, opus],
+			getAllModels: () => [gpt, opus],
+			requiresCustomModels: () => false,
+			getConfiguredModelValue: () => gpt.metadata.id,
+			resolveModelIdentifier: identifier => resolveModelIdentifier([gpt, opus], identifier, true),
+			subscribeToModelChanges: () => toDisposable(() => { }),
+			getBoundConversationKey: () => 'chat:one',
+			getVisibleConversationKey: () => 'chat:one',
+			restoreModelConfiguration: () => { },
+			applyModel: selected => applied.push(selected.identifier),
+		};
+		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
+
+		controller.syncFromConversationState(opus, undefined, undefined, 'chat:one');
+		const configuredApplied = controller.applyConfiguredDefault();
+
+		assert.deepStrictEqual({ configuredApplied, applied, current: controller.currentModel.get()?.identifier }, {
+			configuredApplied: false,
+			applied: [opus.identifier],
+			current: opus.identifier,
+		});
+	});
+
+	test('leaves the spilled-over model sticky when no default model is configured', () => {
+		// The fix must be inert when `chat.defaultModel` is unset: sticky "last-used" behavior wins.
+		const gpt = model('test/gpt');
+		const opus = model('test/opus');
+		const modelChanges = disposables.add(new Emitter<string>());
+		const applied: string[] = [];
+		const controller = disposables.add(new ChatInputModelSelectionController(
+			createRuntime({ models: [gpt, opus], resolved: true, sessionType: 'test' }, modelChanges, applied)));
+
+		controller.beginSessionSwitch(true, false, false);
+		controller.syncFromConversationState(opus, undefined, 'test', 'chat:one');
+		const configuredApplied = controller.applyConfiguredDefault();
+
+		assert.deepStrictEqual({ configuredApplied, applied, current: controller.currentModel.get()?.identifier }, {
+			configuredApplied: false,
+			applied: [opus.identifier],
+			current: opus.identifier,
 		});
 	});
 
@@ -924,7 +1026,9 @@ suite('ChatInputModelSelectionController', () => {
 		const matchBase = targetedModel('test/match', sessionType);
 		const match = { ...matchBase, metadata: { ...matchBase.metadata, id: desired.metadata.id } };
 		const configured = targetedModel('test/configured', sessionType);
-		const state: IRuntimeState = { models: [], resolved: false, sessionType, configuredModel: configured.metadata.id };
+		// A genuine reopened conversation is NON-empty, so its best-match restore stays authoritative and
+		// the configured default must not override it. The empty-session behavior is covered above.
+		const state: IRuntimeState = { models: [], resolved: false, sessionType, configuredModel: configured.metadata.id, isEmpty: false };
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/326877

Follow-up to the chat.defaultModel work. Fixes remaining cases in local agent sessions where a new/empty conversation kept the previous session's model instead of resetting to the configured default. These already worked correctly in Agent Host (AHP) sessions.

### **Repro (local only)**
Case 1: Set chat.defaultModel → new session → change model → run a command → press + (new session) → new session showed the previous model instead of the default.

Case 2: Open an old session (non-default model) → back to list resets to default ✓ → change model → run a command → back to list → did not reset to default.

### **Root cause**
Model selection lives in ChatInputModelSelectionController. When any path (re)binds a new/empty session whose incoming input state carries a model spilled over from the previous session, the sync path applies it as a SessionRestore:

> _syncFromModel → syncFromConversationState → _applySessionRestore → _selectionReason = SessionRestore.

applyConfiguredDefault() (run at the end of handleViewModelChange) then bailed because its guard used isAuthoritativeModelSelectionReason(_selectionReason), which counts SessionRestore as authoritative — so the configured default never re-applied.


### Fix
In chatInputModelSelectionController.ts, applyConfiguredDefault() now blocks only on a genuine in-conversation choice — UserSelection or ProgrammaticSelection — instead of any authoritative reason:

```
if (!this._runtime.isEmpty()
    || this._selectionReason === ModelSelectionReason.UserSelection
    || this._selectionReason === ModelSelectionReason.ProgrammaticSelection
    || (this._intent && this._intent.kind !== 'remembered')) {
    return false;
}

```
### Rationale:

A genuinely reopened conversation is non-empty, so it's already protected by !isEmpty() (its saved model is kept).
On an empty session, SessionRestore can only be spillover, so it must yield to the configured default — covering the + new-session, back-to-list, clear/new-chat, late-policy, and model-list-load paths (all route through applyConfiguredDefault).
Genuine in-empty-session user picks and mode-forced selections still stick.