### PR TITLE
Fix Voice Mode panel dictation misrouting to background chat editor

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -397,7 +397,16 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			// Voice command bridge — lets the VoiceSessionController reach into the chat widget
 			this._voiceBarDisposables.add(CommandsRegistry.registerCommand('_chat.voice.acceptInput', (accessor, text: string) => {
 				const chatWidgetService = accessor.get(IChatWidgetService);
-				const widget = chatWidgetService.lastFocusedWidget ?? this._widget;
+				// `lastFocusedWidget` is only updated when a chat widget gains focus
+				// and is never cleared on blur, so it can stay pinned to a
+				// background chat editor that was focused earlier. Dictating in this
+				// panel's voice input does not DOM-focus its chat input, so relying
+				// on `lastFocusedWidget` would misroute the request to that stale
+				// editor. Only trust it while it still holds input focus (an
+				// intentionally focused chat editor); otherwise fall back to this
+				// panel's own widget, matching `_chat.voice.getCurrentSession`.
+				const focusedWidget = chatWidgetService.lastFocusedWidget;
+				const widget = focusedWidget?.hasInputFocus() ? focusedWidget : this._widget;
 				if (text && widget?.viewModel) {
 					if (widget.viewModel.editing) {
 						// When editing an old message, populate the active input

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -397,14 +397,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			// Voice command bridge — lets the VoiceSessionController reach into the chat widget
 			this._voiceBarDisposables.add(CommandsRegistry.registerCommand('_chat.voice.acceptInput', (accessor, text: string) => {
 				const chatWidgetService = accessor.get(IChatWidgetService);
-				// `lastFocusedWidget` is only updated when a chat widget gains focus
-				// and is never cleared on blur, so it can stay pinned to a
-				// background chat editor that was focused earlier. Dictating in this
-				// panel's voice input does not DOM-focus its chat input, so relying
-				// on `lastFocusedWidget` would misroute the request to that stale
-				// editor. Only trust it while it still holds input focus (an
-				// intentionally focused chat editor); otherwise fall back to this
-				// panel's own widget, matching `_chat.voice.getCurrentSession`.
+				// Ignore lastFocusedWidget when its input no longer has focus because blur does not clear it.
 				const focusedWidget = chatWidgetService.lastFocusedWidget;
 				const widget = focusedWidget?.hasInputFocus() ? focusedWidget : this._widget;
 				if (text && widget?.viewModel) {


### PR DESCRIPTION
Fixes #327024

## Problem

In Voice Mode with the **panel** chat input, running a request could send it to a **background chat editor** that had been focused earlier instead of the panel, with narration/updates following that background session.

## Root cause

`_chat.voice.acceptInput` routed to `IChatWidgetService.lastFocusedWidget`, which is only updated on a chat widget's `onDidFocus` and is never cleared on blur (only on dispose). After a chat editor was opened/focused it stayed the `lastFocusedWidget`, and because dictating in the panel voice input does not DOM-focus the panel's chat input, the request was dispatched to that stale editor — even though `_chat.voice.getCurrentSession` (reading the panel view pane's own widget) reported the panel.

## Fix

Only trust `lastFocusedWidget` while it still holds input focus (an intentionally focused chat editor); otherwise fall back to the panel view pane's own widget (`this._widget`), keeping the send target consistent with `_chat.voice.getCurrentSession`.

## Validation

- `npm run typecheck-client` — clean
- eslint on changed file — clean
