### PR TITLE
Voice Mode: replace settings gear with 'Configure' context-menu action

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -347,28 +347,15 @@ registerAction2(class extends Action2 {
 	}
 });
 
-// --- Open Voice Mode Settings (gear button, shown left of Disconnect when connected) ---
+// --- Open Voice Mode Settings (surfaced via the mic button context menu, no toolbar gear) ---
 
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'agentsVoice.openSettings',
 			title: nls.localize2('agentsVoice.openSettings', "Voice Mode Settings"),
-			icon: Codicon.settingsGear,
 			f1: true,
 			precondition: ContextKeyExpr.equals('config.agents.voice.enabled', true),
-			menu: {
-				id: MenuId.ChatExecute,
-				when: ContextKeyExpr.and(
-					ContextKeyExpr.equals('config.agents.voice.enabled', true),
-					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
-					ChatContextKeys.currentlyEditing.negate(),
-					AGENTS_VOICE_CONNECTED.isEqualTo(true),
-				),
-				group: 'navigation',
-				// Just before the Disconnect button (order -9) and after the mic/stop button (order -10).
-				order: -9.5
-			},
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
@@ -40,6 +40,12 @@ export interface VoiceWidgetCallbacks {
 	getAnalyserNode(): AnalyserNode | null;
 	onResize(): void;
 	openPttKeySettings(): void;
+	/**
+	 * Show the Voice Mode context menu (Configure, Select Microphone, Disable
+	 * Voice Mode) anchored at the triggering event. Wired to a right-click /
+	 * context-menu gesture on the voice mode mic icon.
+	 */
+	showVoiceContextMenu(e: MouseEvent): void;
 	/** Optional — when provided, header renders a "popout" button. */
 	openPopout?(): void;
 	/** Submit user feedback. Returns success/failure. */
@@ -181,7 +187,6 @@ export class AgentsVoiceWidget extends Disposable {
 	private readonly _inputBoxPlaceholder: HTMLElement | undefined;
 	private readonly _inputBoxToolbar: HTMLElement | undefined;
 	private readonly _inputBoxMicBtn: HTMLElement | undefined;
-	private readonly _inputBoxGearBtn: HTMLElement | undefined;
 	private readonly _inputBoxConnIndicator: HTMLElement | undefined;
 	private readonly _inputBoxFeedbackBtn: HTMLElement | undefined;
 	private readonly _inputBoxSessionsBtn: HTMLElement | undefined;
@@ -335,16 +340,15 @@ export class AgentsVoiceWidget extends Disposable {
 			this._inputBoxMicBtn.ariaLabel = localize('agentsVoice.pushToTalkSpace', "Push to talk (Space)");
 			this._inputBoxMicBtn.title = localize('agentsVoice.pushToTalkSpace', "Push to talk (Space)");
 			this._inputBoxMicBtn.style.cssText = `font-size:${FONT_SIZE.iconMd};cursor:pointer;-webkit-app-region:no-drag;border-radius:4px;padding:2px;`;
+			this._register(dom.addDisposableListener(this._inputBoxMicBtn, 'contextmenu', (e: MouseEvent) => {
+				e.preventDefault(); e.stopPropagation();
+				this.callbacks.showVoiceContextMenu(e);
+			}));
 
 			// Connection indicator
 			this._inputBoxConnIndicator = toolbarBtn('codicon-debug-connected',
 				localize('agentsVoice.disconnect', "Disconnect"),
 				localize('agentsVoice.disconnect', "Disconnect"));
-
-			// Gear button
-			this._inputBoxGearBtn = toolbarBtn('codicon-gear',
-				localize('agentsVoice.configureKeybinding', "Configure keybinding"),
-				localize('agentsVoice.configureKeybinding', "Configure keybinding"));
 
 			// Feedback button
 			this._inputBoxFeedbackBtn = toolbarBtn('codicon-feedback',
@@ -371,7 +375,6 @@ export class AgentsVoiceWidget extends Disposable {
 			this._inputBoxToolbar.append(
 				this._inputBoxMicBtn,
 				this._inputBoxConnIndicator,
-				this._inputBoxGearBtn,
 				toolbarSpacer,
 				this._inputBoxFeedbackBtn,
 				this._inputBoxSessionsBtn,
@@ -760,10 +763,6 @@ export class AgentsVoiceWidget extends Disposable {
 		this._inputBoxConnIndicator!.style.display = showConnected ? '' : 'none';
 		this._inputBoxConnIndicator!.onclick = (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this.callbacks.disconnect(); };
 
-		// Gear button — always visible
-		this._inputBoxGearBtn!.style.display = '';
-		this._inputBoxGearBtn!.onclick = (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this.callbacks.openPttKeySettings(); };
-
 		// Feedback button — always visible
 		this._inputBoxFeedbackBtn!.onclick = (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this._toggleFeedbackDialog(); };
 
@@ -841,7 +840,7 @@ export class AgentsVoiceWidget extends Disposable {
 				onDisconnectClick: (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this.callbacks.disconnect(); },
 				onCloseClick: (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this.callbacks.closeWindow(); },
 				onToggleClick: (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this._expanded.set(!this._expanded.get(), undefined); },
-				onPttKeyClick: (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this.callbacks.openPttKeySettings(); },
+				onMicContextMenu: (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this.callbacks.showVoiceContextMenu(e); },
 				onPopoutClick: (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this.callbacks.openPopout?.(); },
 				onFeedbackClick: (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); this._toggleFeedbackDialog(); },
 				pttKeyLabel: this._pttKeyLabel.read(reader),

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
@@ -17,7 +17,7 @@ import { createSessionList, type SessionRowData, type SessionGroupData } from '.
 import { createFeedbackDialog, type FeedbackDialogState } from './components/feedbackDialog.js';
 import { createOnboarding } from './components/onboardingComponent.js';
 import { createVoiceBar } from './components/voiceBarComponent.js';
-import { FONT_SIZE, addKeyboardActivation } from './components/tokens.js';
+import { FONT_SIZE, addKeyboardActivation, isSecondaryPointerGesture } from './components/tokens.js';
 import type { VoiceState, IPendingToolConfirmation, ITranscriptTurn } from '../../chat/browser/voiceClient/voiceSessionController.js';
 import { computeVoiceGlowStyle } from '../../chat/browser/voiceClient/voiceGlow.js';
 
@@ -756,8 +756,8 @@ export class AgentsVoiceWidget extends Disposable {
 		if (!micIsActive) {
 			this._inputBoxMicBtn!.style.boxShadow = 'none';
 		}
-		this._inputBoxMicBtn!.onmousedown = (e: MouseEvent) => { e.preventDefault(); this.callbacks.pttDown(); };
-		this._inputBoxMicBtn!.onmouseup = () => { this.callbacks.pttUp(); };
+		this._inputBoxMicBtn!.onmousedown = (e: MouseEvent) => { if (isSecondaryPointerGesture(e)) { return; } e.preventDefault(); this.callbacks.pttDown(); };
+		this._inputBoxMicBtn!.onmouseup = (e: MouseEvent) => { if (isSecondaryPointerGesture(e)) { return; } this.callbacks.pttUp(); };
 
 		// Connection indicator — visible when connected
 		this._inputBoxConnIndicator!.style.display = showConnected ? '' : 'none';

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
@@ -6,7 +6,7 @@
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { mainWindow } from '../../../../base/browser/window.js';
-import { disposableWindowInterval } from '../../../../base/browser/dom.js';
+import { disposableWindowInterval, getWindow } from '../../../../base/browser/dom.js';
 import { FileAccess } from '../../../../base/common/network.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
@@ -33,6 +33,9 @@ import { AgentsVoiceWidget } from './agentsVoiceWidget.js';
 import { bindWidgetToController } from './agentsVoiceWidgetBinding.js';
 import { AgentsVoiceSessionsPicker } from './agentsVoiceSessionsPicker.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
+import { StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
+import { getVoiceModeContextMenuActions } from '../../chat/browser/speechToText/micButtonMenuActions.js';
 
 export class AgentsVoiceWindowService extends Disposable implements IAgentsVoiceWindowService {
 
@@ -73,6 +76,7 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		@IThemeService private readonly themeService: IThemeService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 	) {
 		super();
 
@@ -206,6 +210,13 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 			},
 			onResize: () => this._resizeWindow(auxiliaryWindow),
 			openPttKeySettings: () => this.commandService.executeCommand('workbench.action.openGlobalKeybindings', 'agentsVoice.pushToTalk'),
+			showVoiceContextMenu: (e: MouseEvent) => {
+				const anchor = new StandardMouseEvent(getWindow(e.target as Node ?? auxiliaryWindow.container), e);
+				this.contextMenuService.showContextMenu({
+					getAnchor: () => anchor,
+					getActions: () => getVoiceModeContextMenuActions(this.commandService, this.configurationService, this.keybindingService, 'agentsVoice.pushToTalk'),
+				});
+			},
 			submitFeedback: (text) => this.voiceSessionController.submitFeedback(text),
 			showSessionsPicker: () => {
 				const picker = this.instantiationService.createInstance(

--- a/src/vs/workbench/contrib/agentsVoice/browser/components/headerComponent.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/components/headerComponent.ts
@@ -6,7 +6,7 @@
 import * as dom from '../../../../../base/browser/dom.js';
 import { localize } from '../../../../../nls.js';
 import type { VoiceState } from '../../../chat/browser/voiceClient/voiceSessionController.js';
-import { FONT_SIZE, addKeyboardActivation } from './tokens.js';
+import { FONT_SIZE, addKeyboardActivation, isSecondaryPointerGesture } from './tokens.js';
 
 export interface HeaderProps {
 	readonly copilotIconSrc: string;
@@ -157,8 +157,8 @@ export function createHeader(): HeaderComponent {
 			}
 			micBtn.onmouseenter = () => { micBtn.style.color = 'var(--vscode-foreground)'; };
 			micBtn.onmouseleave = () => { micBtn.style.color = micColor; };
-			micBtn.onmousedown = props.onMicDown;
-			micBtn.onmouseup = () => props.onMicUp();
+			micBtn.onmousedown = (e: MouseEvent) => { if (isSecondaryPointerGesture(e)) { return; } props.onMicDown(e); };
+			micBtn.onmouseup = (e: MouseEvent) => { if (isSecondaryPointerGesture(e)) { return; } props.onMicUp(); };
 			micBtn.oncontextmenu = (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); props.onMicContextMenu(e); };
 
 			// Placeholder text — shown when not connected, displays PTT keybinding

--- a/src/vs/workbench/contrib/agentsVoice/browser/components/headerComponent.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/components/headerComponent.ts
@@ -27,7 +27,7 @@ export interface HeaderProps {
 	readonly onDisconnectClick: (e: MouseEvent) => void;
 	readonly onCloseClick: (e: MouseEvent) => void;
 	readonly onToggleClick: (e: MouseEvent) => void;
-	readonly onPttKeyClick: (e: MouseEvent) => void;
+	readonly onMicContextMenu: (e: MouseEvent) => void;
 	readonly onPopoutClick: (e: MouseEvent) => void;
 	readonly onFeedbackClick: (e: MouseEvent) => void;
 	readonly expanded: boolean;
@@ -66,11 +66,6 @@ export function createHeader(): HeaderComponent {
 	micBtn.ariaLabel = localize('agentsVoice.pushToTalkSpace', "Push to talk (Space)");
 	micBtn.title = localize('agentsVoice.pushToTalkSpace', "Push to talk (Space)");
 	micBtn.style.cssText = `font-size:${FONT_SIZE.iconMd};cursor:pointer;-webkit-app-region:no-drag;border-radius:4px;padding:2px;`;
-
-	// PTT key / gear button
-	const gearBtn = hoverButton('codicon-gear',
-		localize('agentsVoice.configureKeybinding', "Configure keybinding"),
-		localize('agentsVoice.configureKeybinding', "Configure keybinding"));
 
 	// Connection indicator
 	const connIndicator = dom.$('span.voice-conn-indicator');
@@ -133,7 +128,7 @@ export function createHeader(): HeaderComponent {
 		}
 	`;
 
-	container.append(copilotIcon, micBtn, placeholderText, gearBtn, connIndicator, spacer, popoutBtn, closeBtn, connStyle);
+	container.append(copilotIcon, micBtn, placeholderText, connIndicator, spacer, popoutBtn, closeBtn, connStyle);
 
 	return {
 		element: container,
@@ -164,6 +159,7 @@ export function createHeader(): HeaderComponent {
 			micBtn.onmouseleave = () => { micBtn.style.color = micColor; };
 			micBtn.onmousedown = props.onMicDown;
 			micBtn.onmouseup = () => props.onMicUp();
+			micBtn.oncontextmenu = (e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); props.onMicContextMenu(e); };
 
 			// Placeholder text — shown when not connected, displays PTT keybinding
 			placeholderText.style.display = showConnected ? 'none' : '';
@@ -174,10 +170,6 @@ export function createHeader(): HeaderComponent {
 			placeholderText.textContent = holdText;
 			placeholderText.ariaLabel = holdText;
 			placeholderText.onclick = props.onConnectClick;
-
-			// Gear
-			gearBtn.style.display = props.isConnected ? '' : 'none';
-			gearBtn.onclick = props.onPttKeyClick;
 
 			// Connection indicator
 			connIndicator.style.display = showConnected && !props.hideDisconnect ? 'inline-flex' : 'none';

--- a/src/vs/workbench/contrib/agentsVoice/browser/components/tokens.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/components/tokens.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { isMacintosh } from '../../../../../base/common/platform.js';
+
 /**
  * Visual design tokens for the agentsVoice floating pane.
  * Centralize sizes and colors so every component pulls from the same palette.
@@ -40,4 +42,13 @@ export function addKeyboardActivation(el: HTMLElement): void {
 			el.click();
 		}
 	});
+}
+
+/**
+ * Whether a mouse event is a secondary-click / context-menu gesture (right-click,
+ * or Ctrl-click on macOS) rather than a primary press. Used to keep such gestures
+ * from starting/stopping push-to-talk when the mic also opens a context menu.
+ */
+export function isSecondaryPointerGesture(e: MouseEvent): boolean {
+	return e.button !== 0 || (isMacintosh && e.ctrlKey);
 }

--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
@@ -84,28 +84,16 @@ export function getDictationContextMenuActions(commandService: ICommandService, 
 }
 
 /**
- * "Configure" entry for the Voice Mode mic button context menu. Opens the
- * keybindings editor scoped to the Voice Mode keybinding — the affordance that
- * used to live behind the toolbar gear button. `keybindingCommandId` is the
- * stable command the keybinding entry targets.
- */
-function createConfigureVoiceModeAction(commandService: ICommandService, keybindingService: IKeybindingService, keybindingCommandId: string): IAction {
-	const configureKeybinding = createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId);
-	return toAction({
-		id: configureKeybinding.id,
-		label: localize('voiceMode.configure', "Configure"),
-		run: () => configureKeybinding.run(),
-	});
-}
-
-/**
  * Actions for the Voice Mode mic button context menu, mirroring
- * {@link getDictationContextMenuActions} but with "Configure" (opening the
- * Voice Mode keybinding) and "Disable Voice Mode".
+ * {@link getDictationContextMenuActions} but with "Disable Voice Mode". The
+ * "Configure Keybinding" entry opens the keybindings editor scoped to the Voice
+ * Mode keybinding — the affordance that used to live behind the toolbar gear
+ * button. `keybindingCommandId` is the stable command the keybinding entry
+ * targets.
  */
 export function getVoiceModeContextMenuActions(commandService: ICommandService, configurationService: IConfigurationService, keybindingService: IKeybindingService, keybindingCommandId: string): IAction[] {
 	return [
-		createConfigureVoiceModeAction(commandService, keybindingService, keybindingCommandId),
+		createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId),
 		createSelectMicrophoneAction(commandService),
 		createDisableVoiceModeAction(commandService, configurationService),
 	];

--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
@@ -92,7 +92,7 @@ export function getDictationContextMenuActions(commandService: ICommandService, 
 function createVoiceModeSettingsAction(commandService: ICommandService): IAction {
 	return toAction({
 		id: VOICE_OPEN_SETTINGS_COMMAND,
-		label: localize('voiceMode.settings', "Voice Mode Settings"),
+		label: localize('voiceMode.openSettings', "Open Settings"),
 		run: () => commandService.executeCommand(VOICE_OPEN_SETTINGS_COMMAND),
 	});
 }

--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
@@ -20,6 +20,8 @@ export const SELECT_MICROPHONE_COMMAND = 'workbench.action.chat.selectSpeechToTe
 const CANCEL_DICTATION_COMMAND = 'workbench.action.chat.cancelSpeechToText';
 /** Command that tears down an active Voice Mode session. */
 const VOICE_DISCONNECT_COMMAND = 'agentsVoice.disconnect';
+/** Command that opens the Voice Mode settings; the affordance that used to live behind the toolbar gear. */
+const VOICE_OPEN_SETTINGS_COMMAND = 'agentsVoice.openSettings';
 /** Setting that enables dictation; toggled off by "Disable Dictation". */
 const DICTATION_ENABLED_SETTING = 'chat.speechToText.enabled';
 /** Setting that enables Voice Mode; toggled off by "Disable Voice Mode". */
@@ -84,16 +86,29 @@ export function getDictationContextMenuActions(commandService: ICommandService, 
 }
 
 /**
+ * "Voice Mode Settings" entry. Opens the Voice Mode settings — the affordance
+ * that used to live behind the toolbar gear button.
+ */
+function createVoiceModeSettingsAction(commandService: ICommandService): IAction {
+	return toAction({
+		id: VOICE_OPEN_SETTINGS_COMMAND,
+		label: localize('voiceMode.settings', "Voice Mode Settings"),
+		run: () => commandService.executeCommand(VOICE_OPEN_SETTINGS_COMMAND),
+	});
+}
+
+/**
  * Actions for the Voice Mode mic button context menu, mirroring
  * {@link getDictationContextMenuActions} but with "Disable Voice Mode". The
  * "Configure Keybinding" entry opens the keybindings editor scoped to the Voice
- * Mode keybinding — the affordance that used to live behind the toolbar gear
- * button. `keybindingCommandId` is the stable command the keybinding entry
- * targets.
+ * Mode keybinding and "Voice Mode Settings" opens the Voice Mode settings — the
+ * affordances that used to live behind the toolbar gear button.
+ * `keybindingCommandId` is the stable command the keybinding entry targets.
  */
 export function getVoiceModeContextMenuActions(commandService: ICommandService, configurationService: IConfigurationService, keybindingService: IKeybindingService, keybindingCommandId: string): IAction[] {
 	return [
 		createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId),
+		createVoiceModeSettingsAction(commandService),
 		createSelectMicrophoneAction(commandService),
 		createDisableVoiceModeAction(commandService, configurationService),
 	];

--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
@@ -84,12 +84,28 @@ export function getDictationContextMenuActions(commandService: ICommandService, 
 }
 
 /**
+ * "Configure" entry for the Voice Mode mic button context menu. Opens the
+ * keybindings editor scoped to the Voice Mode keybinding — the affordance that
+ * used to live behind the toolbar gear button. `keybindingCommandId` is the
+ * stable command the keybinding entry targets.
+ */
+function createConfigureVoiceModeAction(commandService: ICommandService, keybindingService: IKeybindingService, keybindingCommandId: string): IAction {
+	const configureKeybinding = createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId);
+	return toAction({
+		id: configureKeybinding.id,
+		label: localize('voiceMode.configure', "Configure"),
+		run: () => configureKeybinding.run(),
+	});
+}
+
+/**
  * Actions for the Voice Mode mic button context menu, mirroring
- * {@link getDictationContextMenuActions} but with "Disable Voice Mode".
+ * {@link getDictationContextMenuActions} but with "Configure" (opening the
+ * Voice Mode keybinding) and "Disable Voice Mode".
  */
 export function getVoiceModeContextMenuActions(commandService: ICommandService, configurationService: IConfigurationService, keybindingService: IKeybindingService, keybindingCommandId: string): IAction[] {
 	return [
-		createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId),
+		createConfigureVoiceModeAction(commandService, keybindingService, keybindingCommandId),
 		createSelectMicrophoneAction(commandService),
 		createDisableVoiceModeAction(commandService, configurationService),
 	];

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceModeActionViewItem.ts
@@ -16,7 +16,7 @@ import { IThemeService } from '../../../../../platform/theme/common/themeService
 import { addMicButtonContextMenuListener, getVoiceModeContextMenuActions } from '../speechToText/micButtonMenuActions.js';
 
 /**
- * Stable command the "Configure Keybinding" entry targets. Voice Mode swaps the
+ * Stable command the "Configure" entry targets. Voice Mode swaps the
  * rendered action between start and push-to-talk-stop while listening, but the
  * keybinding lives on the start command, so target it in both states.
  */
@@ -25,7 +25,7 @@ const VOICE_START_COMMAND = 'agentsVoice.startVoiceInChat';
 /**
  * Action view item for the chat-input Voice Mode button. Behaves like the normal
  * toolbar voice-mode toggle (click to start/stop) but adds a right-click context
- * menu with voice-specific entries — "Configure Keybinding" (mirroring the
+ * menu with voice-specific entries — "Configure" (mirroring the
  * standard toolbar affordance), "Select Microphone" and "Disable Voice Mode" —
  * instead of the generic toolbar context menu. Mirrors {@link DictationActionViewItem}.
  */

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceModeActionViewItem.ts
@@ -16,7 +16,7 @@ import { IThemeService } from '../../../../../platform/theme/common/themeService
 import { addMicButtonContextMenuListener, getVoiceModeContextMenuActions } from '../speechToText/micButtonMenuActions.js';
 
 /**
- * Stable command the "Configure" entry targets. Voice Mode swaps the
+ * Stable command the "Configure Keybinding" entry targets. Voice Mode swaps the
  * rendered action between start and push-to-talk-stop while listening, but the
  * keybinding lives on the start command, so target it in both states.
  */
@@ -25,7 +25,7 @@ const VOICE_START_COMMAND = 'agentsVoice.startVoiceInChat';
 /**
  * Action view item for the chat-input Voice Mode button. Behaves like the normal
  * toolbar voice-mode toggle (click to start/stop) but adds a right-click context
- * menu with voice-specific entries — "Configure" (mirroring the
+ * menu with voice-specific entries — "Configure Keybinding" (mirroring the
  * standard toolbar affordance), "Select Microphone" and "Disable Voice Mode" —
  * instead of the generic toolbar context menu. Mirrors {@link DictationActionViewItem}.
  */


### PR DESCRIPTION
Fixes #327055


<img width="243" height="144" alt="Screenshot 2026-07-22 at 4 24 52 PM" src="https://github.com/user-attachments/assets/79c561e3-ef7b-44d4-9842-3b23be1704f0" />
<img width="396" height="165" alt="Screenshot 2026-07-22 at 4 24 59 PM" src="https://github.com/user-attachments/assets/8b5ba102-6bd9-4897-8843-e3a6fb465c85" />

Removes **both** Voice Mode gear buttons and surfaces their actions directly in the right-click context menu on the voice mode mic icon, in both the normal window and the Agents window.

### What changed
- **Removed the keybinding gear** (`codicon-gear`, "Configure keybinding") from both `AgentsVoiceWidget` layouts — the header layout (`headerComponent.ts`) and the input-box layout (`agentsVoiceWidget.ts`).
- **Removed the settings gear** (`agentsVoice.openSettings`, `Codicon.settingsGear`) from the chat-input toolbar (`agentsVoice.contribution.ts`). The command stays registered (Command Palette), it just no longer renders a toolbar button.
- **Added a right-click context menu** on the voice mode mic icon in the floating widget (shown over both the normal and Agents windows), via a new `showVoiceContextMenu` widget callback wired to `IContextMenuService` in `agentsVoiceWindowService.ts`.
- **Both gear actions now live directly in the voice mode context menus** (`micButtonMenuActions.ts`), on both the chat-input voice icon and the floating widget:
  - **Configure Keybinding** — opens the Voice Mode keybinding editor (what the keybinding gear did).
  - **Open Settings** — opens the Voice Mode settings (what the settings gear did).

The dictation mic button's "Configure Keybinding" entry is unchanged.

### Behavior
- Right-click the voice mode mic icon → **Configure Keybinding**, **Open Settings**, **Select Microphone**, **Disable Voice Mode**.
- No gear button shows in either the normal window or the Agents window while Voice Mode is active.
- "Configure Keybinding" opens `@command:agentsVoice.pushToTalk` in the floating widget (matching the removed gear) and the Voice Mode start command on the chat-input icon.

### Validation
- `npm run typecheck-client` — clean
- Pre-commit hygiene hook — passing