### PR TITLE
fix: memory leak in debugModel

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -1533,7 +1533,7 @@ export class DebugModel extends Disposable implements IDebugModel {
 		while (rootSession.parentSession) {
 			rootSession = rootSession.parentSession;
 		}
-		return rootSession.configuration.name === newSession.configuration.name;
+		return rootSession.state === State.Inactive && rootSession.configuration.name === newSession.configuration.name;
 	}
 
 	addSession(session: IDebugSession): void {

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -1519,13 +1519,30 @@ export class DebugModel extends Disposable implements IDebugModel {
 		return this.sessions.filter(s => includeInactive || s.state !== State.Inactive);
 	}
 
+	private shouldDisposeSession(session: IDebugSession, newSession: IDebugSession): boolean {
+		if (session.state !== State.Inactive) {
+			return false;
+		}
+		if (session.configuration.name === newSession.configuration.name) {
+			return true;
+		}
+		if (newSession.parentSession) {
+			return false;
+		}
+		let rootSession = session;
+		while (rootSession.parentSession) {
+			rootSession = rootSession.parentSession;
+		}
+		return rootSession.configuration.name === newSession.configuration.name;
+	}
+
 	addSession(session: IDebugSession): void {
 		this.sessions = this.sessions.filter(s => {
 			if (s.getId() === session.getId()) {
 				// Make sure to de-dupe if a session is re-initialized. In case of EH debugging we are adding a session again after an attach.
 				return false;
 			}
-			if (s.state === State.Inactive && s.configuration.name === session.configuration.name) {
+			if (this.shouldDisposeSession(s, session)) {
 				// Make sure to remove all inactive sessions that are using the same configuration as the new session
 				s.dispose();
 				return false;

--- a/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
@@ -390,6 +390,19 @@ suite('Debug - CallStack', () => {
 		assert.deepStrictEqual(model.getSessions(true).map(session => session.getId()), [replacement.getId()]);
 	});
 
+	test('adding a concurrent root session preserves inactive children of an active root session', async () => {
+		const activeRoot = disposables.add(createTestSession(model));
+		model.addSession(activeRoot);
+		const inactiveChild = disposables.add(createTestSession(model, 'inactiveChild', { parentSession: activeRoot }));
+		model.addSession(inactiveChild);
+		await inactiveChild.terminate();
+
+		const concurrentRoot = disposables.add(createTestSession(model));
+		model.addSession(concurrentRoot);
+
+		assert.deepStrictEqual(model.getSessions(true).map(session => session.getId()), [activeRoot.getId(), inactiveChild.getId(), concurrentRoot.getId()]);
+	});
+
 	test('decorations', () => {
 		const session = createTestSession(model);
 		disposables.add(session);

--- a/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
@@ -376,6 +376,20 @@ suite('Debug - CallStack', () => {
 		assert.strictEqual(sessions[5].getId(), thirdSession.getId());
 	});
 
+	test('replacing an inactive root session removes its child sessions', async () => {
+		const oldRoot = createTestSession(model);
+		model.addSession(oldRoot);
+		const oldChild = createTestSession(model, 'oldChild', { parentSession: oldRoot });
+		model.addSession(oldChild);
+		await oldChild.terminate();
+		await oldRoot.terminate();
+
+		const replacement = disposables.add(createTestSession(model));
+		model.addSession(replacement);
+
+		assert.deepStrictEqual(model.getSessions(true).map(session => session.getId()), [replacement.getId()]);
+	});
+
 	test('decorations', () => {
 		const session = createTestSession(model);
 		disposables.add(session);


### PR DESCRIPTION
### Details

Disposes inactive child debug sessions when their root session is replaced.

### Before

When debugging the same JavaScript file 37 times, inactive debug sessions, schedulers, cancellation tokens, and REPL models grow each time (outlined in red):

<img width="1400" height="180" alt="debug-javascript-before" src="https://github.com/user-attachments/assets/3539181d-6a81-4a8b-b0b8-f7609725602c" />

### After

No more leak is detected for these objects after debugging the same file 17 times.


Test Video


https://github.com/user-attachments/assets/dbeae99f-1dc3-4f9a-9899-e39106d7c554

