### PR TITLE
Add agent host error telemetry

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -725,6 +725,17 @@ export class CodeApplication extends Disposable {
 		// Error telemetry
 		appInstantiationService.invokeFunction(accessor => this._register(new ErrorTelemetry(accessor.get(ILogService), accessor.get(ITelemetryService))));
 
+		// Agent Host
+		// Always instantiate the starter + manager. They are cheap (the
+		// constructors only register an IPC listener and emitters) and the agent
+		// host utility process is spawned lazily on the first window connection
+		// request. The renderer is the gate: it only requests a connection when
+		// `chat.agentHost.enabled` resolves to `true` there (honoring experiment
+		// overrides + policy + web), which the main process cannot observe since
+		// experiment overrides are never persisted to `settings.json`.
+		const agentHostStarter = new ElectronAgentHostStarter({ machineId, sqmId, devDeviceId }, this.configurationService, this.environmentMainService, this.lifecycleMainService, this.logService);
+		this._register(appInstantiationService.createInstance(AgentHostProcessManager, agentHostStarter));
+
 		// Metered connection telemetry
 		appInstantiationService.invokeFunction(accessor => {
 			(accessor.get(IMeteredConnectionService) as MeteredConnectionMainService).setTelemetryService(accessor.get(ITelemetryService));
@@ -1231,17 +1242,6 @@ export class CodeApplication extends Disposable {
 			this.loggerService
 		);
 		services.set(ILocalPtyService, ptyHostService);
-
-		// Agent Host
-		// Always instantiate the starter + manager. They are cheap (the
-		// constructors only register an IPC listener and emitters) and the agent
-		// host utility process is spawned lazily on the first window connection
-		// request. The renderer is the gate: it only requests a connection when
-		// `chat.agentHost.enabled` resolves to `true` there (honoring experiment
-		// overrides + policy + web), which the main process cannot observe since
-		// experiment overrides are never persisted to `settings.json`.
-		const agentHostStarter = new ElectronAgentHostStarter({ machineId, sqmId, devDeviceId }, this.configurationService, this.environmentMainService, this.lifecycleMainService, this.logService);
-		this._register(new AgentHostProcessManager(agentHostStarter, this.logService, this.loggerService));
 
 		// External terminal
 		if (isWindows) {

--- a/src/vs/platform/agentHost/common/agentHostProcessTelemetry.ts
+++ b/src/vs/platform/agentHost/common/agentHostProcessTelemetry.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { packErrorForTelemetry } from '../../telemetry/common/errorTelemetry.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 
 export type AgentHostProcessErrorData = {
@@ -14,6 +15,8 @@ export type AgentHostProcessErrorData = {
 
 type AgentHostProcessErrorEvent = AgentHostProcessErrorData & {
 	isError: true;
+	callstack?: string;
+	msg?: string;
 };
 
 type AgentHostProcessErrorClassification = {
@@ -22,10 +25,17 @@ type AgentHostProcessErrorClassification = {
 	restartCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The number of agent host restart attempts before this failure.' };
 	willRestart: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether VS Code will attempt to restart the agent host after this failure.' };
 	isError: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether this is an error event.' };
+	callstack?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The callstack of an agent host process start failure.' };
+	msg?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The message of an agent host process start failure.' };
 	owner: 'bryanchen-d';
 	comment: 'Tracks agent host process failures that cannot be reported reliably from inside the agent host process.';
 };
 
-export function reportAgentHostProcessError(telemetryService: ITelemetryService, data: AgentHostProcessErrorData): void {
-	telemetryService.publicLogError2<AgentHostProcessErrorEvent, AgentHostProcessErrorClassification>('agentHost.processError', { ...data, isError: true });
+export function reportAgentHostProcessError(telemetryService: ITelemetryService, data: AgentHostProcessErrorData, error?: unknown): void {
+	const errorData = error === undefined ? undefined : packErrorForTelemetry(error);
+	telemetryService.publicLogError2<AgentHostProcessErrorEvent, AgentHostProcessErrorClassification>('agentHost.processError', {
+		...data,
+		isError: true,
+		...(errorData ? { callstack: errorData.callstack, msg: errorData.msg } : {}),
+	});
 }

--- a/src/vs/platform/agentHost/common/agentHostProcessTelemetry.ts
+++ b/src/vs/platform/agentHost/common/agentHostProcessTelemetry.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITelemetryService } from '../../telemetry/common/telemetry.js';
+
+export type AgentHostProcessErrorEvent = {
+	kind: 'unexpectedExit' | 'startFailed';
+	code?: number;
+	restartCount: number;
+	willRestart: boolean;
+};
+
+type AgentHostProcessErrorClassification = {
+	kind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The kind of agent host process failure.' };
+	code?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The agent host process exit code, when available.' };
+	restartCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The number of agent host restart attempts before this failure.' };
+	willRestart: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether VS Code will attempt to restart the agent host after this failure.' };
+	owner: 'bryanchen-d';
+	comment: 'Tracks agent host process failures that cannot be reported reliably from inside the agent host process.';
+};
+
+export function reportAgentHostProcessError(telemetryService: ITelemetryService, data: AgentHostProcessErrorEvent): void {
+	telemetryService.publicLogError2<AgentHostProcessErrorEvent, AgentHostProcessErrorClassification>('agentHost.processError', data);
+}

--- a/src/vs/platform/agentHost/common/agentHostProcessTelemetry.ts
+++ b/src/vs/platform/agentHost/common/agentHostProcessTelemetry.ts
@@ -5,11 +5,15 @@
 
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 
-export type AgentHostProcessErrorEvent = {
+export type AgentHostProcessErrorData = {
 	kind: 'unexpectedExit' | 'startFailed';
 	code?: number;
 	restartCount: number;
 	willRestart: boolean;
+};
+
+type AgentHostProcessErrorEvent = AgentHostProcessErrorData & {
+	isError: true;
 };
 
 type AgentHostProcessErrorClassification = {
@@ -17,10 +21,11 @@ type AgentHostProcessErrorClassification = {
 	code?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The agent host process exit code, when available.' };
 	restartCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The number of agent host restart attempts before this failure.' };
 	willRestart: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether VS Code will attempt to restart the agent host after this failure.' };
+	isError: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether this is an error event.' };
 	owner: 'bryanchen-d';
 	comment: 'Tracks agent host process failures that cannot be reported reliably from inside the agent host process.';
 };
 
-export function reportAgentHostProcessError(telemetryService: ITelemetryService, data: AgentHostProcessErrorEvent): void {
-	telemetryService.publicLogError2<AgentHostProcessErrorEvent, AgentHostProcessErrorClassification>('agentHost.processError', data);
+export function reportAgentHostProcessError(telemetryService: ITelemetryService, data: AgentHostProcessErrorData): void {
+	telemetryService.publicLogError2<AgentHostProcessErrorEvent, AgentHostProcessErrorClassification>('agentHost.processError', { ...data, isError: true });
 }

--- a/src/vs/platform/agentHost/common/agentHostProcessTelemetry.ts
+++ b/src/vs/platform/agentHost/common/agentHostProcessTelemetry.ts
@@ -20,7 +20,7 @@ type AgentHostProcessErrorClassification = {
 	kind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The kind of agent host process failure.' };
 	code?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The agent host process exit code, when available.' };
 	restartCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The number of agent host restart attempts before this failure.' };
-	willRestart: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether VS Code will attempt to restart the agent host after this failure.' };
+	willRestart: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether VS Code will attempt to restart the agent host after this failure.' };
 	isError: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether this is an error event.' };
 	owner: 'bryanchen-d';
 	comment: 'Tracks agent host process failures that cannot be reported reliably from inside the agent host process.';

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -8,7 +8,7 @@ import { Server as ChildProcessServer } from '../../../base/parts/ipc/node/ipc.c
 import { Server as UtilityProcessServer } from '../../../base/parts/ipc/node/ipc.mp.js';
 import { isUtilityProcess } from '../../../base/parts/sandbox/node/electronTypes.js';
 import { Emitter, type Event } from '../../../base/common/event.js';
-import { DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { joinPath } from '../../../base/common/resources.js';
 import { isWindows } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
@@ -107,6 +107,7 @@ async function startAgentHost(): Promise<void> {
 	}
 
 	const disposables = new DisposableStore();
+	const errorTelemetry = disposables.add(new MutableDisposable<ErrorTelemetry>());
 
 	// Services
 	const productService: IProductService = { _serviceBrand: undefined, ...product };
@@ -166,7 +167,7 @@ async function startAgentHost(): Promise<void> {
 		proxyResolver = networkServices.proxyResolver;
 		const fetchFn = proxyResolver.fetch.bind(proxyResolver);
 		const telemetryService = await createAgentHostTelemetryService({ environmentService, productService, fileService, loggerService, logService, disposables, fetchFn, requestService: networkServices.requestService });
-		disposables.add(new ErrorTelemetry(telemetryService));
+		errorTelemetry.value = new ErrorTelemetry(telemetryService);
 		diServices.set(ITelemetryService, telemetryService);
 		instantiationService = new InstantiationService(diServices);
 		const fileMonitorService = disposables.add(instantiationService.createInstance(AgentHostFileMonitorService));

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -85,6 +85,7 @@ import { registerPendingEditContentProvider } from './copilot/pendingEditContent
 import { join } from '../../../base/common/path.js';
 import { createAgentHostTelemetryService } from './agentHostTelemetryService.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
+import ErrorTelemetry from '../../telemetry/node/errorTelemetry.js';
 
 // Entry point for the agent host utility process.
 // Sets up IPC, logging, and registers agent providers (Copilot).
@@ -165,6 +166,7 @@ async function startAgentHost(): Promise<void> {
 		proxyResolver = networkServices.proxyResolver;
 		const fetchFn = proxyResolver.fetch.bind(proxyResolver);
 		const telemetryService = await createAgentHostTelemetryService({ environmentService, productService, fileService, loggerService, logService, disposables, fetchFn, requestService: networkServices.requestService });
+		disposables.add(new ErrorTelemetry(telemetryService));
 		diServices.set(ITelemetryService, telemetryService);
 		instantiationService = new InstantiationService(diServices);
 		const fileMonitorService = disposables.add(instantiationService.createInstance(AgentHostFileMonitorService));

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -16,7 +16,7 @@ globalThis._VSCODE_FILE_ROOT = fileURLToPath(new URL('../../../..', import.meta.
 import * as fs from 'fs';
 import * as os from 'os';
 import type { Event } from '../../../base/common/event.js';
-import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { raceTimeout } from '../../../base/common/async.js';
 import { joinPath } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
@@ -83,6 +83,7 @@ import { IAgentHostCheckpointService } from '../common/agentHostCheckpointServic
 import { AgentHostFileMonitorService, IAgentHostFileMonitorService } from './agentHostFileMonitorService.js';
 import { createAgentHostTelemetryService } from './agentHostTelemetryService.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
+import ErrorTelemetry from '../../telemetry/node/errorTelemetry.js';
 
 /** Log to stderr so messages appear in the terminal alongside the process. */
 function log(msg: string): void {
@@ -183,6 +184,7 @@ function parseServerOptions(): IServerOptions {
 async function main(): Promise<void> {
 	const options = parseServerOptions();
 	const disposables = new DisposableStore();
+	const errorTelemetry = disposables.add(new MutableDisposable<ErrorTelemetry>());
 
 	// Services
 	const productService: IProductService = { _serviceBrand: undefined, ...product };
@@ -238,6 +240,7 @@ async function main(): Promise<void> {
 	const proxyResolver = networkServices.proxyResolver;
 	const fetchFn = proxyResolver.fetch.bind(proxyResolver);
 	const telemetryService = await createAgentHostTelemetryService({ environmentService, productService, fileService, loggerService, logService, disposables, disableTelemetry: options.quiet, fetchFn, requestService: networkServices.requestService });
+	errorTelemetry.value = new ErrorTelemetry(telemetryService);
 	diServices.set(ITelemetryService, telemetryService);
 	const instantiationService = new InstantiationService(diServices);
 	const fileMonitorService = disposables.add(instantiationService.createInstance(AgentHostFileMonitorService));

--- a/src/vs/platform/agentHost/node/agentHostService.ts
+++ b/src/vs/platform/agentHost/node/agentHostService.ts
@@ -7,7 +7,9 @@ import { Event } from '../../../base/common/event.js';
 import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { ILogService, ILoggerService } from '../../log/common/log.js';
 import { RemoteLoggerChannelClient } from '../../log/common/logIpc.js';
+import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { IAgentHostStarter } from '../common/agent.js';
+import { reportAgentHostProcessError } from '../common/agentHostProcessTelemetry.js';
 import { AgentHostIpcChannels } from '../common/agentService.js';
 
 enum Constants {
@@ -30,6 +32,7 @@ export class AgentHostProcessManager extends Disposable {
 		private readonly _starter: IAgentHostStarter,
 		@ILogService private readonly _logService: ILogService,
 		@ILoggerService private readonly _loggerService: ILoggerService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -69,7 +72,14 @@ export class AgentHostProcessManager extends Disposable {
 			// Handle unexpected exit
 			this._register(connection.onDidProcessExit(e => {
 				if (!this._wasQuitRequested && !this._store.isDisposed) {
-					if (this._restartCount <= Constants.MaxRestarts) {
+					const willRestart = this._restartCount <= Constants.MaxRestarts;
+					reportAgentHostProcessError(this._telemetryService, {
+						kind: 'unexpectedExit',
+						code: e.code,
+						restartCount: this._restartCount,
+						willRestart,
+					});
+					if (willRestart) {
 						this._logService.error(`AgentHostProcessManager: agent host terminated unexpectedly with code ${e.code}`);
 						this._restartCount++;
 						this._started = false;
@@ -85,6 +95,11 @@ export class AgentHostProcessManager extends Disposable {
 		} catch (error) {
 			this._started = false;
 			this._logService.error('AgentHostProcessManager: failed to start agent host', error);
+			reportAgentHostProcessError(this._telemetryService, {
+				kind: 'startFailed',
+				restartCount: this._restartCount,
+				willRestart: false,
+			});
 		}
 	}
 }

--- a/src/vs/platform/agentHost/node/agentHostService.ts
+++ b/src/vs/platform/agentHost/node/agentHostService.ts
@@ -99,7 +99,7 @@ export class AgentHostProcessManager extends Disposable {
 				kind: 'startFailed',
 				restartCount: this._restartCount,
 				willRestart: false,
-			});
+			}, error);
 		}
 	}
 }

--- a/src/vs/server/node/serverAgentHostManager.ts
+++ b/src/vs/server/node/serverAgentHostManager.ts
@@ -119,7 +119,7 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 				kind: 'startFailed',
 				restartCount: this._restartCount,
 				willRestart,
-			});
+			}, error);
 			if (willRestart) {
 				this._logService.error('ServerAgentHostManager: agent host failed to start', error);
 				this._restartCount++;

--- a/src/vs/server/node/serverAgentHostManager.ts
+++ b/src/vs/server/node/serverAgentHostManager.ts
@@ -7,10 +7,12 @@ import { Event } from '../../base/common/event.js';
 import { Disposable, MutableDisposable, toDisposable } from '../../base/common/lifecycle.js';
 import { ProxyChannel } from '../../base/parts/ipc/common/ipc.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../../platform/agentHost/common/agent.js';
+import { reportAgentHostProcessError } from '../../platform/agentHost/common/agentHostProcessTelemetry.js';
 import { AgentHostIpcChannels, IAgentService } from '../../platform/agentHost/common/agentService.js';
 import { createDecorator } from '../../platform/instantiation/common/instantiation.js';
 import { ILogService, ILoggerService } from '../../platform/log/common/log.js';
 import { RemoteLoggerChannelClient } from '../../platform/log/common/logIpc.js';
+import { ITelemetryService } from '../../platform/telemetry/common/telemetry.js';
 import { IServerLifetimeService } from './serverLifetimeService.js';
 
 export const IServerAgentHostManager = createDecorator<IServerAgentHostManager>('serverAgentHostManager');
@@ -57,6 +59,7 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 		@ILogService private readonly _logService: ILogService,
 		@ILoggerService private readonly _loggerService: ILoggerService,
 		@IServerLifetimeService private readonly _serverLifetimeService: IServerLifetimeService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 		this._register(this._starter);
@@ -87,7 +90,14 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 					this._connectionCount = 0;
 					this._lifetimeToken.clear();
 
-					if (this._restartCount <= Constants.MaxRestarts) {
+					const willRestart = this._restartCount <= Constants.MaxRestarts;
+					reportAgentHostProcessError(this._telemetryService, {
+						kind: 'unexpectedExit',
+						code: e.code,
+						restartCount: this._restartCount,
+						willRestart,
+					});
+					if (willRestart) {
 						this._logService.error(`ServerAgentHostManager: agent host terminated unexpectedly with code ${e.code}`);
 						this._restartCount++;
 						connection.store.dispose();
@@ -104,7 +114,13 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 				return;
 			}
 
-			if (this._restartCount <= Constants.MaxRestarts) {
+			const willRestart = this._restartCount <= Constants.MaxRestarts;
+			reportAgentHostProcessError(this._telemetryService, {
+				kind: 'startFailed',
+				restartCount: this._restartCount,
+				willRestart,
+			});
+			if (willRestart) {
 				this._logService.error('ServerAgentHostManager: agent host failed to start', error);
 				this._restartCount++;
 				this._start();

--- a/src/vs/server/test/node/serverAgentHostManager.test.ts
+++ b/src/vs/server/test/node/serverAgentHostManager.test.ts
@@ -237,6 +237,7 @@ suite('ServerAgentHostManager', () => {
 				code: 17,
 				restartCount: 0,
 				willRestart: true,
+				isError: true,
 			},
 		}]);
 	});
@@ -253,6 +254,7 @@ suite('ServerAgentHostManager', () => {
 				kind: 'startFailed',
 				restartCount: 0,
 				willRestart: true,
+				isError: true,
 			},
 		}]);
 	});

--- a/src/vs/server/test/node/serverAgentHostManager.test.ts
+++ b/src/vs/server/test/node/serverAgentHostManager.test.ts
@@ -11,6 +11,7 @@ import { IChannel, IChannelClient } from '../../../base/parts/ipc/common/ipc.js'
 import { IAgentHostConnection, IAgentHostStarter } from '../../../platform/agentHost/common/agent.js';
 import { AgentHostIpcChannels } from '../../../platform/agentHost/common/agentService.js';
 import { NullLogService, NullLoggerService } from '../../../platform/log/common/log.js';
+import { NullTelemetryServiceShape } from '../../../platform/telemetry/common/telemetryUtils.js';
 import { ServerAgentHostManager } from '../../node/serverAgentHostManager.js';
 import { IServerLifetimeService } from '../../node/serverLifetimeService.js';
 
@@ -51,6 +52,7 @@ class MockChannel implements IChannel {
 
 class MockAgentHostStarter implements IAgentHostStarter {
 	private readonly _onDidProcessExit = new Emitter<{ code: number; signal: string }>();
+	private _startError: Error | undefined;
 
 	readonly agentHostChannel = new MockChannel();
 	readonly loggerChannel: MockChannel;
@@ -62,6 +64,12 @@ class MockAgentHostStarter implements IAgentHostStarter {
 	}
 
 	async start(): Promise<IAgentHostConnection> {
+		if (this._startError) {
+			const error = this._startError;
+			this._startError = undefined;
+			throw error;
+		}
+
 		const store = new DisposableStore();
 		const client: IChannelClient = {
 			getChannel: <T extends IChannel>(name: string): T => {
@@ -86,6 +94,10 @@ class MockAgentHostStarter implements IAgentHostStarter {
 
 	fireProcessExit(code: number): void {
 		this._onDidProcessExit.fire({ code, signal: '' });
+	}
+
+	failNextStart(error: Error): void {
+		this._startError = error;
 	}
 
 	dispose(): void {
@@ -113,15 +125,27 @@ class MockServerLifetimeService implements IServerLifetimeService {
 	delay(): void { }
 }
 
+class TestTelemetryService extends NullTelemetryServiceShape {
+	readonly errorEvents: { eventName: string; data: unknown }[] = [];
+
+	override publicLogError2(eventName?: string, data?: unknown): void {
+		if (eventName) {
+			this.errorEvents.push({ eventName, data });
+		}
+	}
+}
+
 suite('ServerAgentHostManager', () => {
 	const ds = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let starter: MockAgentHostStarter;
 	let lifetimeService: MockServerLifetimeService;
+	let telemetryService: TestTelemetryService;
 
 	setup(() => {
 		starter = new MockAgentHostStarter();
 		lifetimeService = new MockServerLifetimeService();
+		telemetryService = new TestTelemetryService();
 	});
 
 	function createManager(): ServerAgentHostManager {
@@ -130,6 +154,7 @@ suite('ServerAgentHostManager', () => {
 			new NullLogService(),
 			ds.add(new NullLoggerService()),
 			lifetimeService,
+			telemetryService,
 		));
 	}
 
@@ -197,5 +222,38 @@ suite('ServerAgentHostManager', () => {
 
 		starter.fireProcessExit(1);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, false);
+	});
+
+	test('reports unexpected process exit', async () => {
+		createManager();
+		await waitForStart();
+
+		starter.fireProcessExit(17);
+
+		assert.deepStrictEqual(telemetryService.errorEvents, [{
+			eventName: 'agentHost.processError',
+			data: {
+				kind: 'unexpectedExit',
+				code: 17,
+				restartCount: 0,
+				willRestart: true,
+			},
+		}]);
+	});
+
+	test('reports process start failure', async () => {
+		starter.failNextStart(new Error('test start failure'));
+		createManager();
+		await waitForStart();
+		await waitForStart();
+
+		assert.deepStrictEqual(telemetryService.errorEvents, [{
+			eventName: 'agentHost.processError',
+			data: {
+				kind: 'startFailed',
+				restartCount: 0,
+				willRestart: true,
+			},
+		}]);
 	});
 });

--- a/src/vs/server/test/node/serverAgentHostManager.test.ts
+++ b/src/vs/server/test/node/serverAgentHostManager.test.ts
@@ -243,7 +243,9 @@ suite('ServerAgentHostManager', () => {
 	});
 
 	test('reports process start failure', async () => {
-		starter.failNextStart(new Error('test start failure'));
+		const error = new Error('test start failure');
+		error.stack = 'test start failure stack';
+		starter.failNextStart(error);
 		createManager();
 		await waitForStart();
 		await waitForStart();
@@ -255,6 +257,8 @@ suite('ServerAgentHostManager', () => {
 				restartCount: 0,
 				willRestart: true,
 				isError: true,
+				callstack: 'test start failure stack',
+				msg: 'test start failure',
 			},
 		}]);
 	});


### PR DESCRIPTION
## Summary
- register the standard Node error telemetry collector in the agent host process
- report agent host start failures and unexpected exits from desktop and server process managers
- add server lifecycle telemetry coverage

## Validation
- Core Typecheck watch: 0 errors
- `scripts\test.bat --run src\vs\server\test\node\serverAgentHostManager.test.ts` (8 passing)
- `npm run valid-layers-check`
- `npm run precommit`