### PR TITLE
chat: avoid animated working border

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1075,8 +1075,6 @@
 		"--monaco-editor-warning-decoration",
 		"--animation-angle",
 		"--animation-opacity",
-		"--chat-input-anim-angle",
-		"--chat-input-anim-duration",
 		"--chat-input-working-border-color1",
 		"--session-input-banner-anim-angle",
 		"--session-input-banner-anim-duration",

--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1075,6 +1075,8 @@
 		"--monaco-editor-warning-decoration",
 		"--animation-angle",
 		"--animation-opacity",
+		"--chat-input-anim-angle",
+		"--chat-input-anim-duration",
 		"--chat-input-working-border-color1",
 		"--session-input-banner-anim-angle",
 		"--session-input-banner-anim-duration",

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -857,7 +857,7 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.ProgressBorder]: {
 			type: 'boolean',
 			default: true,
-			markdownDescription: nls.localize('chat.progressBorder.enabled', "Show an animated gradient border around the chat input while the agent is working or thinking. Has no effect when reduced motion is enabled."),
+			markdownDescription: nls.localize('chat.progressBorder.enabled', "Show a gradient border around the chat input while the agent is working or thinking."),
 		},
 		[ChatConfiguration.NotifyWindowOnResponseReceived]: {
 			type: 'string',

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -720,7 +720,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 		const enabled = this.configurationService.getValue<boolean>(ChatConfiguration.ProgressBorder) === true
-			&& !this.accessibilityService.isMotionReduced()
 			&& !isInlineChat(this);
 		const inProgress = !!this.viewModel?.model.requestInProgress.get();
 		inputContainer.classList.toggle('working', enabled && inProgress);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -4389,57 +4389,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	layout(width: number) {
 		this.cachedWidth = width;
 		this._stableInputPartWidth.set(width, undefined);
-		this._updateWorkingProgressAnimationDuration(width);
 
 		return this._layout(width);
-	}
-
-	/**
-	 * Scale the working/progress border comet animation duration with
-	 * the input width so the comet's perceived linear travel speed (the
-	 * rate it sweeps along the perimeter in px/sec) stays roughly
-	 * constant. A fixed cycle time made wide inputs feel sluggish, but
-	 * an aggressive inverse curve made narrow inputs feel slow because
-	 * their cycle was clamped while the comet had little distance to
-	 * cover. Sub-linear scaling with width (`sqrt(width)`) plus tight
-	 * clamps keeps both extremes looking lively.
-	 */
-	private _lastAnimDurationS: number | undefined;
-	private _updateWorkingProgressAnimationDuration(width: number): void {
-		if (!this.inputContainer) {
-			return;
-		}
-		// Sub-linear scaling: cycle time grows with width but tapers off
-		// so wide inputs still feel snappy. Tuned so ~400px → ~1.7s and
-		// ~1000px → ~2.3s rather than ~4s.
-		const MIN_DURATION_S = 1.4;
-		const MAX_DURATION_S = 2.5;
-		const safeWidth = Math.max(50, width);
-		const raw = 0.55 + 0.075 * Math.sqrt(safeWidth);
-		const duration = Math.min(MAX_DURATION_S, Math.max(MIN_DURATION_S, raw));
-
-		// Skip no-op updates (e.g. repeated layout calls during steady state).
-		if (this._lastAnimDurationS !== undefined && Math.abs(this._lastAnimDurationS - duration) < 0.05) {
-			return;
-		}
-		this._lastAnimDurationS = duration;
-		this.inputContainer.style.setProperty('--chat-input-anim-duration', `${duration.toFixed(2)}s`);
-
-		// CSS animations capture animation-duration at start time and most
-		// browsers do not re-pick up values that come from a custom
-		// property mid-flight. If the comet is currently spinning, restart
-		// it on the next animation frame so style and layout changes can
-		// batch without forcing a synchronous reflow. Toggling the .working
-		// class would cancel the in-flight indicator state, so instead we
-		// briefly flip a marker class that the CSS uses to swap
-		// animation-name.
-		if (this.inputContainer.classList.contains('working')) {
-			const inputContainer = this.inputContainer;
-			inputContainer.classList.add('chat-input-anim-restart');
-			dom.scheduleAtNextAnimationFrame(dom.getWindow(inputContainer), () => {
-				inputContainer.classList.remove('chat-input-anim-restart');
-			});
-		}
 	}
 
 	private get _effectiveInputEditorMaxHeight(): number {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1105,6 +1105,18 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	opacity: 1;
 }
 
+.monaco-reduce-motion .interactive-session .chat-input-container::before,
+.monaco-reduce-motion .interactive-session .chat-input-container::after {
+	transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.monaco-workbench .interactive-session .chat-input-container::before,
+	.monaco-workbench .interactive-session .chat-input-container::after {
+		transition: none;
+	}
+}
+
 /* Context usage widget container - positioned in the secondary toolbar below input */
 .interactive-session .chat-input-toolbars .chat-context-usage-container,
 .interactive-session .chat-secondary-toolbar .chat-context-usage-container {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -989,12 +989,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	width: 100%;
 	position: relative;
 	transition: box-shadow 350ms ease;
-	/* Duration of the working/progress border comet animation. Set
-		dynamically by `ChatInputPart#layout` to keep the comet's linear
-		travel speed roughly constant regardless of input width — wider
-		inputs would otherwise feel sluggish at a fixed duration. */
-	--chat-input-anim-duration: 4s;
-	/* Allow host surfaces (like inactive sessions) to tone down the animation
+	/* Allow host surfaces (like inactive sessions) to tone down the working
 		accent without overriding the global chat theme token. */
 	--chat-input-working-border-color1: var(--vscode-chat-inputWorkingBorderColor1);
 }
@@ -1007,37 +1002,19 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	overflow: hidden;
 }
 
-/* Animated "border beam" shown around the chat input while the agent is
+/* "Border beam" shown around the chat input while the agent is
 	working or thinking. Toggled by the `chat.progressBorder.enabled`
 	setting and the chat widget's request-in-progress state.
 
 	Inspired by https://github.com/Jakubantalik/border-beam — a small bright
-	comet travels around the perimeter, leaving a short fading trail. The
-	ring is rendered as a `::before` pseudo-element so it can fade in/out
+	accent marks the perimeter. The ring is rendered as a `::before` pseudo-element so it can fade in/out
 	via `opacity` when the `.working` class is toggled, without disturbing
 	the input's own background. The pseudo uses a 1px padding + inverted
 	mask trick so the conic gradient is clipped to a hairline that follows
 	the input's corner radius. */
-@property --chat-input-anim-angle {
-	syntax: '<angle>';
-	inherits: false;
-	initial-value: 135deg;
-}
-
-@keyframes chat-input-working-border-spin {
-	from {
-		--chat-input-anim-angle: 135deg;
-	}
-
-	to {
-		--chat-input-anim-angle: 495deg;
-	}
-}
-
 /* The beam (`::before`) and its glow (`::after`) are two stacked rings
 	occupying the same outer edge: the glow is wider and blurred, the beam is
-	hairline and sharp. Both share `--chat-input-anim-angle` so the glow
-	travels with the comet head with no gap. */
+	hairline and sharp. */
 
 .monaco-workbench .interactive-session .chat-input-container::before {
 	content: '';
@@ -1047,11 +1024,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		currently using (large by default, small in compact mode). */
 	border-radius: inherit;
 	padding: 1px;
-	/* The beam: a tight bright arc (~40deg) with a short fade, on an otherwise
-		transparent ring. As `--chat-input-anim-angle` rotates, the bright spot
-		travels around the perimeter like a comet. Stops are mostly transparent
-		so the rest of the border stays invisible. */
-	background: conic-gradient(from var(--chat-input-anim-angle),
+	/* The beam: a tight bright arc (~40deg) with a short fade on an otherwise
+		transparent ring. */
+	background: conic-gradient(from 135deg,
 			transparent 0deg,
 			color-mix(in srgb, var(--chat-input-working-border-color1) 90%, transparent) 20deg,
 			var(--chat-input-working-border-color1) 30deg,
@@ -1080,7 +1055,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	inset: -1px;
 	border-radius: inherit;
 	padding: 2px;
-	background: conic-gradient(from var(--chat-input-anim-angle),
+	background: conic-gradient(from 135deg,
 			transparent 0deg,
 			color-mix(in srgb, var(--chat-input-working-border-color1) 60%, transparent) 25deg,
 			color-mix(in srgb, var(--chat-input-working-border-color1) 35%, transparent) 50deg,
@@ -1102,10 +1077,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .monaco-workbench .interactive-session .chat-input-container.working {
-	/* Keep a faint, persistent ring around the input while the comet
-		animates around it. This preserves a visible boundary for the
-		input throughout the animation (including the dim portion of the
-		perimeter behind the comet) and improves contrast for users who
+	/* Keep a faint, persistent ring around the input. This preserves a visible
+		boundary and improves contrast for users who
 		rely on a visible focus/container outline for accessibility. */
 	border-color: var(--vscode-input-border, transparent);
 	overflow: visible;
@@ -1126,29 +1099,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .monaco-workbench .interactive-session .chat-input-container.working::before {
 	opacity: 1;
-	animation: chat-input-working-border-spin var(--chat-input-anim-duration) linear infinite;
 }
 
 .monaco-workbench .interactive-session .chat-input-container.working::after {
 	opacity: 1;
-	animation: chat-input-working-border-spin var(--chat-input-anim-duration) linear infinite;
-}
-
-/* Marker class toggled briefly by `ChatInputPart#_updateWorkingProgressAnimationDuration`
-	to force a restart of the comet animations so a new
-	`--chat-input-anim-duration` takes effect mid-flight (browsers cache
-	animation-duration at start time when sourced from a custom property). */
-.monaco-workbench .interactive-session .chat-input-container.working.chat-input-anim-restart::before,
-.monaco-workbench .interactive-session .chat-input-container.working.chat-input-anim-restart::after {
-	animation: none;
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.monaco-workbench .interactive-session .chat-input-container.working,
-	.monaco-workbench .interactive-session .chat-input-container.working::before,
-	.monaco-workbench .interactive-session .chat-input-container.working::after {
-		animation: none;
-	}
 }
 
 /* Context usage widget container - positioned in the secondary toolbar below input */

--- a/src/vs/workbench/contrib/chat/common/widget/chatColors.ts
+++ b/src/vs/workbench/contrib/chat/common/widget/chatColors.ts
@@ -93,7 +93,7 @@ export const chatThinkingShimmer = registerColor(
 export const chatInputWorkingBorderColor1 = registerColor(
 	'chat.inputWorkingBorderColor1',
 	{ dark: buttonBackground, light: buttonBackground, hcDark: '#FFFFFF', hcLight: '#000000' },
-	localize('chat.inputWorkingBorderColor1', 'First color stop of the animated chat input border shown while a request is in flight.'), true);
+	localize('chat.inputWorkingBorderColor1', 'First color stop of the chat input border shown while a request is in flight.'), true);
 
 export const chatInputWorkingBorderColor2 = registerColor(
 	'chat.inputWorkingBorderColor2',


### PR DESCRIPTION
Fixes #315941

The chat input working indicator continuously animated two full-size masked conic gradients, including one blurred layer. This caused sustained renderer, GPU, and WindowServer activity while an agent was working.

This change:

- Replaces the animated border with a static gradient indicator.
- Removes the animation keyframes, custom properties, and restart logic.
- Keeps the indicator visible when reduced motion is enabled.
- Preserves `chat.progressBorder.enabled` as the opt-out setting.

Before the change, tracing recorded approximately 114 lifecycle frames per second. After the change, settled traces recorded no continuous paint, layout, frame, commit, or raster activity.

### Testing

- Enabled `chat.progressBorder.enabled` and started a chat request.
- Verified the static working border remains visible.
- Verified reduced-motion behavior.
- Verified behavior after resizing the chat input.
- Ran the focused style check.
- Ran `npm run typecheck-client`.
- Ran `npm run gulp -- compile-client`.