### PR TITLE
sessions: fix Agents window hang with per-group editor limit of 1

### DIFF
--- a/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
+++ b/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
@@ -85,13 +85,8 @@ export class SinglePaneMainEditorPart extends MainEditorPart {
 	) {
 		super(editorPartsView, _instantiationService, themeService, configurationService, storageService, layoutService, hostService, contextKeyService);
 
-		// The docked tab bar always shows multiple tabs and keeps the managed
-		// Changes/Files tabs alongside file tabs, so ignore the user's
-		// `workbench.editor.showTabs` (single/none) and `workbench.editor.limit`.
-		this._register(this.enforcePartOptions({
-			showTabs: 'multiple',
-			limit: { enabled: false }
-		}));
+		// The docked tab bar always shows multiple tabs, ignoring `workbench.editor.showTabs` (single/none).
+		this._register(this.enforcePartOptions({ showTabs: 'multiple' }));
 	}
 
 	/**

--- a/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
+++ b/src/vs/sessions/browser/parts/singlePaneEditorPart.ts
@@ -84,6 +84,14 @@ export class SinglePaneMainEditorPart extends MainEditorPart {
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super(editorPartsView, _instantiationService, themeService, configurationService, storageService, layoutService, hostService, contextKeyService);
+
+		// The docked tab bar always shows multiple tabs and keeps the managed
+		// Changes/Files tabs alongside file tabs, so ignore the user's
+		// `workbench.editor.showTabs` (single/none) and `workbench.editor.limit`.
+		this._register(this.enforcePartOptions({
+			showTabs: 'multiple',
+			limit: { enabled: false }
+		}));
 	}
 
 	/**

--- a/src/vs/sessions/common/dockedEditorInput.ts
+++ b/src/vs/sessions/common/dockedEditorInput.ts
@@ -4,11 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { EditorInput } from '../../workbench/common/editor/editorInput.js';
+import { EditorInputCapabilities } from '../../workbench/common/editor.js';
 
 /**
  * Base class for Agents window editors whose content is surfaced in the docked
  * detail panel (the managed Changes and Files tabs) rather than the main editor
  * area. In the single-pane (docked details) layout, re-activating such an editor
  * must not reveal the hidden editor area — {@link SinglePaneWorkbench} handles that.
+ * These editors are exempt from the opened editors limit so an editor limit of 1
+ * cannot evict the managed tabs.
  */
-export abstract class DockedEditorInput extends EditorInput { }
+export abstract class DockedEditorInput extends EditorInput {
+	override get capabilities(): EditorInputCapabilities {
+		return super.capabilities | EditorInputCapabilities.ExcludeFromEditorLimit;
+	}
+}

--- a/src/vs/sessions/common/dockedEditorInput.ts
+++ b/src/vs/sessions/common/dockedEditorInput.ts
@@ -16,6 +16,6 @@ import { EditorInputCapabilities } from '../../workbench/common/editor.js';
  */
 export abstract class DockedEditorInput extends EditorInput {
 	override get capabilities(): EditorInputCapabilities {
-		return super.capabilities | EditorInputCapabilities.ExcludeFromEditorLimit;
+		return EditorInputCapabilities.ExcludeFromEditorLimit;
 	}
 }

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditorInput.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditorInput.ts
@@ -46,7 +46,7 @@ export class SessionChangesEditorInput extends DockedEditorInput {
 	}
 
 	override get capabilities(): EditorInputCapabilities {
-		return EditorInputCapabilities.Singleton | EditorInputCapabilities.Readonly;
+		return super.capabilities | EditorInputCapabilities.Singleton;
 	}
 
 	override getName(): string {

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditorInput.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditorInput.ts
@@ -46,7 +46,7 @@ export class SessionChangesEditorInput extends DockedEditorInput {
 	}
 
 	override get capabilities(): EditorInputCapabilities {
-		return super.capabilities | EditorInputCapabilities.Singleton;
+		return EditorInputCapabilities.Singleton | EditorInputCapabilities.Readonly | EditorInputCapabilities.ExcludeFromEditorLimit;
 	}
 
 	override getName(): string {

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditorInput.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditorInput.ts
@@ -46,7 +46,7 @@ export class SessionChangesEditorInput extends DockedEditorInput {
 	}
 
 	override get capabilities(): EditorInputCapabilities {
-		return EditorInputCapabilities.Singleton | EditorInputCapabilities.Readonly | EditorInputCapabilities.ExcludeFromEditorLimit;
+		return super.capabilities | EditorInputCapabilities.Singleton | EditorInputCapabilities.Readonly;
 	}
 
 	override getName(): string {

--- a/src/vs/sessions/contrib/editor/browser/emptyFileEditorInput.ts
+++ b/src/vs/sessions/contrib/editor/browser/emptyFileEditorInput.ts
@@ -31,7 +31,7 @@ export class EmptyFileEditorInput extends DockedEditorInput {
 	}
 
 	override get capabilities(): EditorInputCapabilities {
-		return EditorInputCapabilities.Readonly | EditorInputCapabilities.Singleton | EditorInputCapabilities.ForceReveal;
+		return super.capabilities | EditorInputCapabilities.Singleton | EditorInputCapabilities.ForceReveal;
 	}
 
 	override getName(): string {

--- a/src/vs/sessions/contrib/editor/browser/emptyFileEditorInput.ts
+++ b/src/vs/sessions/contrib/editor/browser/emptyFileEditorInput.ts
@@ -31,7 +31,7 @@ export class EmptyFileEditorInput extends DockedEditorInput {
 	}
 
 	override get capabilities(): EditorInputCapabilities {
-		return super.capabilities | EditorInputCapabilities.Singleton | EditorInputCapabilities.ForceReveal;
+		return EditorInputCapabilities.Readonly | EditorInputCapabilities.Singleton | EditorInputCapabilities.ForceReveal | EditorInputCapabilities.ExcludeFromEditorLimit;
 	}
 
 	override getName(): string {

--- a/src/vs/sessions/contrib/editor/browser/emptyFileEditorInput.ts
+++ b/src/vs/sessions/contrib/editor/browser/emptyFileEditorInput.ts
@@ -31,7 +31,7 @@ export class EmptyFileEditorInput extends DockedEditorInput {
 	}
 
 	override get capabilities(): EditorInputCapabilities {
-		return EditorInputCapabilities.Readonly | EditorInputCapabilities.Singleton | EditorInputCapabilities.ForceReveal | EditorInputCapabilities.ExcludeFromEditorLimit;
+		return super.capabilities | EditorInputCapabilities.Readonly | EditorInputCapabilities.Singleton | EditorInputCapabilities.ForceReveal;
 	}
 
 	override getName(): string {

--- a/src/vs/sessions/test/browser/workbench.test.ts
+++ b/src/vs/sessions/test/browser/workbench.test.ts
@@ -13,6 +13,7 @@ import { Workbench } from '../../browser/workbench.js';
 import { DockedEditorSizeMemento, SinglePaneWorkbench } from '../../browser/singlePaneWorkbench.js';
 import { SinglePaneMainEditorPart } from '../../browser/parts/singlePaneEditorPart.js';
 import { DockedEditorInput } from '../../common/dockedEditorInput.js';
+import { EditorInputCapabilities } from '../../../workbench/common/editor.js';
 import { SESSIONS_LIST_MINIMUM_WIDTH } from '../../browser/parts/sidebarPart.js';
 
 interface IViewSize { width: number; height: number }
@@ -779,6 +780,20 @@ suite('Sessions - Workbench', () => {
 		revealEditorOnOpen.call(harness, { groupId: 1, editor: { typeId: 'workbench.editors.files.fileEditorInput' } });
 
 		assert.deepStrictEqual(setEditorHiddenCalls, []);
+	});
+
+	test('docked editors are excluded from the editor limit (prevents managed-tab open/close loop)', () => {
+		// The managed Changes/Files tabs are pinned but not sticky, so a per-group
+		// editor limit of 1 would otherwise evict them and the managed-tab
+		// reconciliation would reopen them, hanging the renderer. Docked inputs opt
+		// out of the limit so they are never auto-closed.
+		const dockedEditor = new TestDockedEditorInput();
+
+		try {
+			assert.strictEqual(dockedEditor.hasCapability(EditorInputCapabilities.ExcludeFromEditorLimit), true);
+		} finally {
+			dockedEditor.dispose();
+		}
 	});
 
 	test('[Scenario 5] single-pane does not reveal a docked editor while the detail panel is open and the editor is closed', () => {

--- a/src/vs/workbench/browser/parts/editor/editorsObserver.ts
+++ b/src/vs/workbench/browser/parts/editor/editorsObserver.ts
@@ -346,20 +346,21 @@ export class EditorsObserver extends Disposable {
 
 	private async doEnsureOpenedEditorsLimit(limit: number, mostRecentEditors: IEditorIdentifier[], exclude?: IEditorIdentifier): Promise<void> {
 
-		// Check for `excludeDirty` setting and apply it by excluding
-		// any recent editor that is dirty from the opened editors limit
-		let mostRecentEditorsCountingForLimit: IEditorIdentifier[];
-		if (this.editorGroupService.partOptions.limit?.excludeDirty) {
-			mostRecentEditorsCountingForLimit = mostRecentEditors.filter(({ editor }) => {
-				if ((editor.isDirty() && !editor.isSaving()) || editor.hasCapability(EditorInputCapabilities.Scratchpad)) {
-					return false; // not dirty editors (unless in the process of saving) or scratchpads
-				}
+		// Editors that opt out of the limit (e.g. the Agents window's managed
+		// docked tabs) never count towards it and are never auto-closed.
+		const mostRecentEditorsCountingForLimit = mostRecentEditors.filter(({ editor }) => {
+			if (editor.hasCapability(EditorInputCapabilities.ExcludeFromEditorLimit)) {
+				return false;
+			}
 
-				return true;
-			});
-		} else {
-			mostRecentEditorsCountingForLimit = mostRecentEditors;
-		}
+			// Check for `excludeDirty` setting and apply it by excluding
+			// any recent editor that is dirty from the opened editors limit
+			if (this.editorGroupService.partOptions.limit?.excludeDirty && ((editor.isDirty() && !editor.isSaving()) || editor.hasCapability(EditorInputCapabilities.Scratchpad))) {
+				return false; // not dirty editors (unless in the process of saving) or scratchpads
+			}
+
+			return true;
+		});
 
 		if (limit >= mostRecentEditorsCountingForLimit.length) {
 			return; // only if opened editors exceed setting and is valid and enabled

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -880,7 +880,14 @@ export const enum EditorInputCapabilities {
 	 * part. This is honored unless the user has explicitly opted
 	 * out of modal editors via `workbench.editor.useModal: 'off'`.
 	 */
-	RequiresModal = 1 << 11
+	RequiresModal = 1 << 11,
+
+	/**
+	 * Signals that the editor is exempt from the opened editors
+	 * limit (`workbench.editor.limit`): it never counts towards the
+	 * limit and is never auto-closed to satisfy it.
+	 */
+	ExcludeFromEditorLimit = 1 << 12
 }
 
 export type IUntypedEditorInput = IResourceEditorInput | ITextResourceEditorInput | IUntitledTextResourceEditorInput | IResourceDiffEditorInput | IResourceMultiDiffEditorInput | IResourceSideBySideEditorInput | IResourceMergeEditorInput;

--- a/src/vs/workbench/services/editor/test/browser/editorsObserver.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorsObserver.test.ts
@@ -669,5 +669,47 @@ suite('EditorsObserver', function () {
 		assert.strictEqual(observer.hasEditor({ resource: input4.resource, typeId: input4.typeId, editorId: input4.editorId }), true);
 	});
 
+	test('observer does not close editors excluded from the limit but still honors the limit for others', async () => {
+		const [part] = await createPart();
+		disposables.add(part.enforcePartOptions({ limit: { enabled: true, value: 1, perEditorGroup: true } }));
+
+		const storage = disposables.add(new TestStorageService());
+		const observer = disposables.add(new EditorsObserver(undefined, part, storage));
+
+		const rootGroup = part.activeGroup;
+
+		const managed1 = disposables.add(new TestFileEditorInput(URI.parse('foo://managed1'), TEST_EDITOR_INPUT_ID));
+		managed1.capabilities = EditorInputCapabilities.ExcludeFromEditorLimit;
+		const managed2 = disposables.add(new TestFileEditorInput(URI.parse('foo://managed2'), TEST_EDITOR_INPUT_ID));
+		managed2.capabilities = EditorInputCapabilities.ExcludeFromEditorLimit;
+		const file1 = disposables.add(new TestFileEditorInput(URI.parse('foo://file1'), TEST_EDITOR_INPUT_ID));
+		const file2 = disposables.add(new TestFileEditorInput(URI.parse('foo://file2'), TEST_EDITOR_INPUT_ID));
+
+		await rootGroup.openEditor(managed1, { pinned: true });
+		await rootGroup.openEditor(managed2, { pinned: true });
+		await rootGroup.openEditor(file1, { pinned: true });
+		await rootGroup.openEditor(file2, { pinned: true });
+
+		// Excluded editors are never evicted (no open/close loop), while a normal
+		// editor still honors the limit of 1 (only the most recent survives).
+		assert.deepStrictEqual({
+			count: rootGroup.count,
+			managed1: rootGroup.contains(managed1),
+			managed2: rootGroup.contains(managed2),
+			file1: rootGroup.contains(file1),
+			file2: rootGroup.contains(file2),
+			file1Observed: observer.hasEditor({ resource: file1.resource, typeId: file1.typeId, editorId: file1.editorId }),
+			file2Observed: observer.hasEditor({ resource: file2.resource, typeId: file2.typeId, editorId: file2.editorId }),
+		}, {
+			count: 3,
+			managed1: true,
+			managed2: true,
+			file1: false,
+			file2: true,
+			file1Observed: false,
+			file2Observed: true,
+		});
+	});
+
 	ensureNoDisposablesAreLeakedInTestSuite();
 });


### PR DESCRIPTION
Fixes #327066

## What

Enforce `showTabs: 'multiple'` and `limit: { enabled: false }` on the single-pane editor part (`SinglePaneMainEditorPart`) via the existing `enforcePartOptions` API.

## Why

The single-pane docked tab bar keeps several managed editors open at once — the pinned Changes multi-diff tab, the Files placeholder, and any real file tabs (`[Changes][Files][file…]`). Two user settings break this layout:

- `workbench.editor.showTabs` set to `single`/`none` collapses the docked tab strip.
- `workbench.editor.limit` (especially `perEditorGroup: true, value: 1`) makes `EditorsObserver` auto-evict the least-recently-used tab. Since the managed tabs are pinned (not sticky), they get evicted, the managed-tab reconciliation reopens them, and the observer evicts again — an infinite open/close loop that hangs the renderer (the reported bug).

## Notes for reviewers

- Scoped to the single-pane editor part only; the user's `workbench.editor.showTabs` / `workbench.editor.limit` settings are untouched everywhere else.
- `limit: { enabled: false }` is sufficient because `EditorsObserver.ensureOpenedEditorsLimit` returns early when the limit is disabled, so the other limit fields are never read.
- The `showTabs` enforcement was already present; this PR adds the `limit` enforcement to close the hang.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>