### PR TITLE
chat: Add Agent Host turn failure diagnostics

### DIFF
--- a/src/vs/base/common/errors.ts
+++ b/src/vs/base/common/errors.ts
@@ -120,6 +120,22 @@ export function onUnexpectedExternalError(e: any): undefined {
 	return undefined;
 }
 
+type ObjectWithCode = {
+	readonly code: unknown;
+};
+
+function hasErrorCode(error: object): error is ObjectWithCode {
+	return Object.hasOwn(error, 'code');
+}
+
+export function getErrorCode(error: unknown): string | undefined {
+	if (!error || typeof error !== 'object' || !hasErrorCode(error)) {
+		return undefined;
+	}
+	const code = error.code;
+	return typeof code === 'string' || typeof code === 'number' ? String(code) : undefined;
+}
+
 export interface SerializedError {
 	readonly $isError: true;
 	readonly name: string;

--- a/src/vs/base/test/common/errors.test.ts
+++ b/src/vs/base/test/common/errors.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { toErrorMessage } from '../../common/errorMessage.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
-import { transformErrorForSerialization, transformErrorFromSerialization } from '../../common/errors.js';
+import { getErrorCode, transformErrorForSerialization, transformErrorFromSerialization } from '../../common/errors.js';
 import { assertType } from '../../common/types.js';
 
 suite('Errors', () => {
@@ -34,6 +34,17 @@ suite('Errors', () => {
 			assert.strictEqual(toErrorMessage(error), 'An unknown error occurred. Please consult the log for more details.');
 			assert.ok(toErrorMessage(error, true).length > 'An unknown error occurred. Please consult the log for more details.'.length);
 		}
+	});
+
+	test('Get Error Code', () => {
+		const inherited = Object.create({ code: 'inherited' });
+		assert.deepStrictEqual([
+			getErrorCode({ code: 'ENOENT' }),
+			getErrorCode({ code: -32603 }),
+			getErrorCode({ code: true }),
+			getErrorCode(inherited),
+			getErrorCode(undefined),
+		], ['ENOENT', '-32603', undefined, undefined, undefined]);
 	});
 
 	test('Transform Error for Serialization', function () {

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -7,7 +7,7 @@ import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEv
 import type { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { hash } from '../../../base/common/hash.js';
 import { AgentSession } from '../common/agentService.js';
-import type { MessageAttachment, SessionInputRequestKind, ToolDefinition } from '../common/state/protocol/state.js';
+import type { ErrorInfo, MessageAttachment, SessionInputRequestKind, ToolDefinition } from '../common/state/protocol/state.js';
 import { isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
 import type { ToolInvokedResult } from './agentHostToolCallTracker.js';
 import { multiplexProperties, type IAgentHostRestrictedTelemetry, type IAgentHostRestrictedTelemetryContext } from './agentHostRestrictedTelemetry.js';
@@ -42,6 +42,7 @@ export type IAgentHostUserMessageSentClassification = {
 
 export type AgentHostTurnResult = 'success' | 'error' | 'cancelled';
 type AgentHostModelSelectionKind = 'default' | 'auto' | 'explicit';
+export type AgentHostTurnFailureStage = 'validation' | 'workingDirectory' | 'modelSelection' | 'agentSelection' | 'sendMessage' | 'provider';
 
 export interface IAgentHostTurnCompletedEvent {
 	provider: string;
@@ -54,6 +55,7 @@ export interface IAgentHostTurnCompletedEvent {
 	modelSelectionKind: AgentHostModelSelectionKind;
 	permissionLevel: string | undefined;
 	errorType: string | undefined;
+	failureStage: AgentHostTurnFailureStage | undefined;
 }
 
 export type IAgentHostTurnCompletedClassification = {
@@ -67,9 +69,44 @@ export type IAgentHostTurnCompletedClassification = {
 	modelSelectionKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the client used the provider default, Auto, or an explicit model.' };
 	permissionLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The tool auto-approval level configured for the session at turn start (e.g. default, autoApprove, autopilot).' };
 	errorType: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The structured agent host or provider error type when the turn fails.' };
+	failureStage: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded stage at which the agent host turn failed.' };
 	owner: 'roblourens';
 	comment: 'Tracks agent host turn performance including time to first visible progress and total turn duration.';
 };
+
+export interface IAgentHostTurnFailedEvent {
+	provider: string;
+	agentSessionId: string;
+	turnId: string;
+	failureStage: AgentHostTurnFailureStage;
+	errorType: string;
+	errorName: string | undefined;
+	errorCode: string | undefined;
+	errorMessage: string;
+	errorStack: string | undefined;
+}
+
+export type IAgentHostTurnFailedClassification = {
+	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the failed agent host turn.' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
+	turnId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the failed turn within the agent host session.' };
+	failureStage: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded stage at which the agent host turn failed.' };
+	errorType: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The structured agent host or provider error type.' };
+	errorName: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The name of the exception, when available.' };
+	errorCode: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The exception or protocol error code, when available.' };
+	errorMessage: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error message. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	errorStack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error stack. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	owner: 'roblourens';
+	comment: 'Captures diagnostic details for failed agent host turns.';
+};
+
+export interface IAgentHostTurnFailure {
+	stage: AgentHostTurnFailureStage;
+	error: ErrorInfo;
+	errorName?: string;
+	errorCode?: string;
+	errorStack?: string;
+}
 
 export interface IAgentHostTurnCompletedReport {
 	provider: string;
@@ -80,7 +117,7 @@ export interface IAgentHostTurnCompletedReport {
 	result: AgentHostTurnResult;
 	model: string | undefined;
 	permissionLevel: string | undefined;
-	errorType: string | undefined;
+	failure: IAgentHostTurnFailure | undefined;
 }
 
 export interface IAgentHostToolInvokedReport {
@@ -445,8 +482,22 @@ export class AgentHostTelemetryReporter {
 			model: report.model,
 			modelSelectionKind: report.model === undefined ? 'default' : report.model === 'auto' ? 'auto' : 'explicit',
 			permissionLevel: report.permissionLevel,
-			errorType: report.errorType,
+			errorType: report.failure?.error.errorType,
+			failureStage: report.failure?.stage,
 		});
+		if (report.failure) {
+			this._telemetryService.publicLogError2<IAgentHostTurnFailedEvent, IAgentHostTurnFailedClassification>('agentHost.turnFailed', {
+				provider: report.provider,
+				agentSessionId: AgentSession.id(session),
+				turnId: report.turnId,
+				failureStage: report.failure.stage,
+				errorType: report.failure.error.errorType,
+				errorName: report.failure.errorName,
+				errorCode: report.failure.errorCode,
+				errorMessage: report.failure.error.message,
+				errorStack: report.failure.errorStack ?? report.failure.error.stack,
+			});
+		}
 	}
 
 	toolInvoked(report: IAgentHostToolInvokedReport): void {

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -42,7 +42,7 @@ export type IAgentHostUserMessageSentClassification = {
 
 export type AgentHostTurnResult = 'success' | 'error' | 'cancelled';
 type AgentHostModelSelectionKind = 'default' | 'auto' | 'explicit';
-export type AgentHostTurnFailureStage = 'validation' | 'workingDirectory' | 'modelSelection' | 'agentSelection' | 'sendMessage' | 'provider';
+export type AgentHostTurnFailureStage = 'validation' | 'workingDirectory' | 'modelSelection' | 'sendMessage' | 'provider';
 
 export interface IAgentHostTurnCompletedEvent {
 	provider: string;
@@ -82,8 +82,8 @@ export interface IAgentHostTurnFailedEvent {
 	errorType: string;
 	errorName: string | undefined;
 	errorCode: string | undefined;
-	errorMessage: string;
-	errorStack: string | undefined;
+	msg: string;
+	callstack: string | undefined;
 }
 
 export type IAgentHostTurnFailedClassification = {
@@ -94,8 +94,8 @@ export type IAgentHostTurnFailedClassification = {
 	errorType: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The structured agent host or provider error type.' };
 	errorName: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The name of the exception, when available.' };
 	errorCode: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The exception or protocol error code, when available.' };
-	errorMessage: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error message. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
-	errorStack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error stack. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	msg: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error message. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	callstack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error stack. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
 	owner: 'roblourens';
 	comment: 'Captures diagnostic details for failed agent host turns.';
 };
@@ -494,8 +494,8 @@ export class AgentHostTelemetryReporter {
 				errorType: report.failure.error.errorType,
 				errorName: report.failure.errorName,
 				errorCode: report.failure.errorCode,
-				errorMessage: report.failure.error.message,
-				errorStack: report.failure.errorStack ?? report.failure.error.stack,
+				msg: report.failure.error.message,
+				callstack: report.failure.errorStack ?? report.failure.error.stack,
 			});
 		}
 	}

--- a/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { StopWatch } from '../../../base/common/stopwatch.js';
-import type { AgentHostTelemetryReporter, AgentHostTurnResult } from './agentHostTelemetryReporter.js';
+import type { AgentHostTelemetryReporter, AgentHostTurnResult, IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
 
 /** Per-turn timing state, keyed by `session:turnId`. */
 interface ITurnTiming {
@@ -51,7 +51,7 @@ export class AgentHostTurnTracker {
 		}
 	}
 
-	turnCompleted(session: string, turnId: string, result: AgentHostTurnResult, errorType?: string): void {
+	turnCompleted(session: string, turnId: string, result: AgentHostTurnResult, failure?: IAgentHostTurnFailure): void {
 		const key = this._key(session, turnId);
 		const timing = this._turnTimings.get(key);
 		if (!timing) {
@@ -68,7 +68,7 @@ export class AgentHostTurnTracker {
 			result,
 			model: timing.model,
 			permissionLevel: timing.permissionLevel,
-			errorType,
+			failure,
 		});
 	}
 

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1559,13 +1559,16 @@ export class AgentSideEffects extends Disposable {
 			// folder for folder sessions; undefined for workspace-less sessions.
 			const resolvedWorkingDirectory = await this._options.resolveWorkingDirectoryBeforeSend?.({ session: options.sessionChannel, chat, turnId, prompt: message.text });
 
+			const selectionUpdates: Promise<void>[] = [];
 			if (message.model) {
 				failureStage = 'modelSelection';
-				await agent.chats.changeModel(chatUri, message.model);
+				selectionUpdates.push(agent.chats.changeModel(chatUri, message.model));
 			}
+			selectionUpdates.push(agent.chats.changeAgent(chatUri, message.agent).catch(err => {
+				this._logService.error('[AgentSideEffects] changeAgent failed', err);
+			}));
 
-			failureStage = 'agentSelection';
-			await agent.chats.changeAgent(chatUri, message.agent);
+			await Promise.all(selectionUpdates);
 
 			failureStage = 'sendMessage';
 			await agent.chats.sendMessage(chatUri, message.text, resolvedWorkingDirectory, message.attachments, turnId, senderClientId);
@@ -1651,9 +1654,7 @@ function buildTurnFailureError(stage: AgentHostTurnFailureStage, err: unknown): 
 	const message = String(err);
 	const forwarded = tryParseForwardedChatError(err instanceof Error ? err.message : message);
 	const errorType = stage === 'modelSelection' ? 'modelSelectionFailed'
-		: stage === 'agentSelection' ? 'agentSelectionFailed'
-			: stage === 'workingDirectory' ? 'workingDirectoryFailed'
-				: 'sendFailed';
+		: stage === 'workingDirectory' ? 'workingDirectoryFailed' : 'sendFailed';
 	if (forwarded) {
 		return { errorType, message: stripProxyErrorMarker(message), _meta: toChatErrorMeta(forwarded) };
 	}

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { getErrorCode } from '../../../base/common/errors.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { NKeyMap } from '../../../base/common/map.js';
 import { equals } from '../../../base/common/objects.js';
@@ -1584,7 +1585,7 @@ export class AgentSideEffects extends Disposable {
 			});
 			this._turnTracker.turnCompleted(turnChannel, turnId, 'error', failure);
 			this._toolCallTracker.clearSession(turnChannel);
-			this._failSessionCreationIfStillCreating(sessionChannel, err);
+			this._failSessionCreationIfStillCreating(sessionChannel, error);
 		}
 	}
 
@@ -1609,14 +1610,14 @@ export class AgentSideEffects extends Disposable {
 	 * waiting on a client-side timeout. The provisional session survives on the
 	 * agent, so resending re-attempts materialization.
 	 */
-	private _failSessionCreationIfStillCreating(sessionChannel: ProtocolURI, err: unknown): void {
+	private _failSessionCreationIfStillCreating(sessionChannel: ProtocolURI, error: ErrorInfo): void {
 		const state = this._stateManager.getSessionState(sessionChannel);
 		if (state?.lifecycle !== SessionLifecycle.Creating) {
 			return;
 		}
 		this._stateManager.dispatchServerAction(sessionChannel, {
 			type: ActionType.SessionCreationFailed,
-			error: buildTurnFailure('sendMessage', err).error,
+			error,
 		});
 		const summary = this._stateManager.getSessionSummary(sessionChannel);
 		if (summary) {
@@ -1659,16 +1660,4 @@ function buildTurnFailureError(stage: AgentHostTurnFailureStage, err: unknown): 
 		return { errorType, message: stripProxyErrorMarker(message), _meta: toChatErrorMeta(forwarded) };
 	}
 	return { errorType, message };
-}
-
-function hasErrorCode(error: object): error is { readonly code: unknown } {
-	return Object.hasOwn(error, 'code');
-}
-
-function getErrorCode(err: unknown): string | undefined {
-	if (!err || typeof err !== 'object' || !hasErrorCode(err)) {
-		return undefined;
-	}
-	const code = err.code;
-	return typeof code === 'string' || typeof code === 'number' ? String(code) : undefined;
 }

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -54,7 +54,7 @@ import {
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentHostSessionTitleController } from './agentHostSessionTitleController.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
-import { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
+import { AgentHostTelemetryReporter, type AgentHostTurnFailureStage, type IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
 import { AgentHostToolCallTracker } from './agentHostToolCallTracker.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
 import { AgentHostTurnTracker } from './agentHostTurnTracker.js';
@@ -728,7 +728,7 @@ export class AgentSideEffects extends Disposable {
 		}
 
 		if (action.type === ActionType.ChatError) {
-			this._turnTracker.turnCompleted(sessionKey, turnId, 'error', action.error.errorType);
+			this._turnTracker.turnCompleted(sessionKey, turnId, 'error', { stage: 'provider', error: action.error });
 			this._toolCallTracker.clearSession(sessionKey);
 			this._markSessionUnread(sessionUri);
 		}
@@ -1543,13 +1543,14 @@ export class AgentSideEffects extends Disposable {
 				duration: this._turnDuration(turnStopWatch),
 				error,
 			});
-			this._turnTracker.turnCompleted(turnChannel, turnId, 'error', error.errorType);
+			this._turnTracker.turnCompleted(turnChannel, turnId, 'error', { stage: 'validation', error });
 			this._toolCallTracker.clearSession(turnChannel);
 			return;
 		}
 
 		const chatUri = URI.parse(chat);
 
+		let failureStage: AgentHostTurnFailureStage = 'workingDirectory';
 		try {
 			// Host-owned working-directory resolution: resolve the session's working
 			// directory before the agent materializes, so the agent runs in it
@@ -1558,29 +1559,27 @@ export class AgentSideEffects extends Disposable {
 			// folder for folder sessions; undefined for workspace-less sessions.
 			const resolvedWorkingDirectory = await this._options.resolveWorkingDirectoryBeforeSend?.({ session: options.sessionChannel, chat, turnId, prompt: message.text });
 
-			const selectionUpdates: Promise<void>[] = [];
 			if (message.model) {
-				selectionUpdates.push(agent.chats.changeModel(chatUri, message.model).catch(err => {
-					this._logService.error('[AgentSideEffects] changeModel failed', err);
-				}));
+				failureStage = 'modelSelection';
+				await agent.chats.changeModel(chatUri, message.model);
 			}
-			selectionUpdates.push(agent.chats.changeAgent(chatUri, message.agent).catch(err => {
-				this._logService.error('[AgentSideEffects] changeAgent failed', err);
-			}));
 
-			await Promise.all(selectionUpdates);
+			failureStage = 'agentSelection';
+			await agent.chats.changeAgent(chatUri, message.agent);
+
+			failureStage = 'sendMessage';
 			await agent.chats.sendMessage(chatUri, message.text, resolvedWorkingDirectory, message.attachments, turnId, senderClientId);
 		} catch (err) {
-			const errCode = (err as { code?: number })?.code;
-			const error = buildSendFailedError(err);
-			this._logService.error(`[AgentSideEffects] sendMessage failed for session=${turnChannel}: code=${errCode}, message=${err instanceof Error ? err.message : String(err)}, type=${err?.constructor?.name}`, err);
+			const failure = buildTurnFailure(failureStage, err);
+			const error = failure.error;
+			this._logService.error(`[AgentSideEffects] ${failureStage} failed for session=${turnChannel}: code=${failure.errorCode}, message=${error.message}, type=${failure.errorName}`, err);
 			this._stateManager.dispatchServerAction(turnChannel, {
 				type: ActionType.ChatError,
 				turnId,
 				duration: this._turnDuration(turnStopWatch),
 				error,
 			});
-			this._turnTracker.turnCompleted(turnChannel, turnId, 'error', error.errorType);
+			this._turnTracker.turnCompleted(turnChannel, turnId, 'error', failure);
 			this._toolCallTracker.clearSession(turnChannel);
 			this._failSessionCreationIfStillCreating(sessionChannel, err);
 		}
@@ -1614,7 +1613,7 @@ export class AgentSideEffects extends Disposable {
 		}
 		this._stateManager.dispatchServerAction(sessionChannel, {
 			type: ActionType.SessionCreationFailed,
-			error: buildSendFailedError(err),
+			error: buildTurnFailure('sendMessage', err).error,
 		});
 		const summary = this._stateManager.getSessionSummary(sessionChannel);
 		if (summary) {
@@ -1637,11 +1636,38 @@ export class AgentSideEffects extends Disposable {
  * error is attached to `_meta.chatError` so core can render a rich, localized
  * message. Otherwise the raw error message is used as-is.
  */
-function buildSendFailedError(err: unknown): ErrorInfo {
+function buildTurnFailure(stage: AgentHostTurnFailureStage, err: unknown): IAgentHostTurnFailure {
+	const error = buildTurnFailureError(stage, err);
+	return {
+		stage,
+		error,
+		errorName: err instanceof Error ? err.name : typeof err,
+		errorCode: getErrorCode(err),
+		errorStack: err instanceof Error ? err.stack : undefined,
+	};
+}
+
+function buildTurnFailureError(stage: AgentHostTurnFailureStage, err: unknown): ErrorInfo {
 	const message = String(err);
 	const forwarded = tryParseForwardedChatError(err instanceof Error ? err.message : message);
+	const errorType = stage === 'modelSelection' ? 'modelSelectionFailed'
+		: stage === 'agentSelection' ? 'agentSelectionFailed'
+			: stage === 'workingDirectory' ? 'workingDirectoryFailed'
+				: 'sendFailed';
 	if (forwarded) {
-		return { errorType: 'sendFailed', message: stripProxyErrorMarker(message), _meta: toChatErrorMeta(forwarded) };
+		return { errorType, message: stripProxyErrorMarker(message), _meta: toChatErrorMeta(forwarded) };
 	}
-	return { errorType: 'sendFailed', message };
+	return { errorType, message };
+}
+
+function hasErrorCode(error: object): error is { readonly code: unknown } {
+	return Object.hasOwn(error, 'code');
+}
+
+function getErrorCode(err: unknown): string | undefined {
+	if (!err || typeof err !== 'object' || !hasErrorCode(err)) {
+		return undefined;
+	}
+	const code = err.code;
+	return typeof code === 'string' || typeof code === 'number' ? String(code) : undefined;
 }

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -320,14 +320,14 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 				failureStage: data.failureStage,
 				errorType: data.errorType,
 				errorName: data.errorName,
-				errorMessage: data.errorMessage,
-				hasStack: typeof data.errorStack === 'string',
+				msg: data.msg,
+				hasStack: typeof data.callstack === 'string',
 			};
 		}), [{
 			failureStage: 'sendMessage',
 			errorType: 'sendFailed',
 			errorName: 'Error',
-			errorMessage: 'Error: boom',
+			msg: 'Error: boom',
 			hasStack: true,
 		}]);
 	});
@@ -343,11 +343,11 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		const failed = failedEvents()[0].data as Record<string, unknown>;
 		assert.deepStrictEqual({
 			completed: { result: completed.result, errorType: completed.errorType, failureStage: completed.failureStage },
-			failed: { errorType: failed.errorType, failureStage: failed.failureStage, errorMessage: failed.errorMessage },
+			failed: { errorType: failed.errorType, failureStage: failed.failureStage, msg: failed.msg },
 			sendMessageCalls: agent.sendMessageCalls.length,
 		}, {
 			completed: { result: 'error', errorType: 'modelSelectionFailed', failureStage: 'modelSelection' },
-			failed: { errorType: 'modelSelectionFailed', failureStage: 'modelSelection', errorMessage: 'Error: unknown model' },
+			failed: { errorType: 'modelSelectionFailed', failureStage: 'modelSelection', msg: 'Error: unknown model' },
 			sendMessageCalls: 0,
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -95,7 +95,7 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 	const sessionKey = sessionUri.toString();
 	const defaultChatUri = buildDefaultChatUri(sessionUri);
 
-	function setupSession(): void {
+	function setupSession(ready = true): void {
 		stateManager.createSession({
 			resource: sessionKey,
 			provider: 'mock',
@@ -104,7 +104,9 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 			createdAt: new Date().toISOString(),
 			modifiedAt: new Date().toISOString(),
 		});
-		stateManager.dispatchServerAction(sessionKey, { type: ActionType.SessionReady });
+		if (ready) {
+			stateManager.dispatchServerAction(sessionKey, { type: ActionType.SessionReady });
+		}
 	}
 
 	function setAutoApprove(level: string): void {
@@ -333,7 +335,7 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 	});
 
 	test('fails the turn when model selection rejects instead of sending with a stale model', async () => {
-		setupSession();
+		setupSession(false);
 		agent.changeModel = async () => { throw new Error('unknown model'); };
 
 		startTurn('turn-1', 'hello', 'missing-model');
@@ -344,10 +346,12 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		assert.deepStrictEqual({
 			completed: { result: completed.result, errorType: completed.errorType, failureStage: completed.failureStage },
 			failed: { errorType: failed.errorType, failureStage: failed.failureStage, msg: failed.msg },
+			creationErrorType: stateManager.getSessionState(sessionKey)?.creationError?.errorType,
 			sendMessageCalls: agent.sendMessageCalls.length,
 		}, {
 			completed: { result: 'error', errorType: 'modelSelectionFailed', failureStage: 'modelSelection' },
 			failed: { errorType: 'modelSelectionFailed', failureStage: 'modelSelection', msg: 'Error: unknown model' },
+			creationErrorType: 'modelSelectionFailed',
 			sendMessageCalls: 0,
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -69,7 +69,9 @@ class CapturingTelemetryService implements ITelemetryService {
 		this.events.push({ eventName, data });
 	}
 	publicLogError(): void { }
-	publicLogError2(): void { }
+	publicLogError2(eventName: string, data?: unknown): void {
+		this.events.push({ eventName, data });
+	}
 	setExperimentProperty(): void { }
 	setCommonProperty(): void { }
 }
@@ -143,6 +145,10 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 
 	function completedEvents(): { eventName: string; data: unknown }[] {
 		return telemetry.events.filter(e => e.eventName === 'agentHost.turnCompleted');
+	}
+
+	function failedEvents(): { eventName: string; data: unknown }[] {
+		return telemetry.events.filter(e => e.eventName === 'agentHost.turnFailed');
 	}
 
 	setup(() => {
@@ -308,6 +314,42 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		assert.strictEqual(events.length, 1);
 		assert.strictEqual((events[0].data as Record<string, unknown>).result, 'error');
 		assert.strictEqual((events[0].data as Record<string, unknown>).errorType, 'sendFailed');
+		assert.deepStrictEqual(failedEvents().map(event => {
+			const data = event.data as Record<string, unknown>;
+			return {
+				failureStage: data.failureStage,
+				errorType: data.errorType,
+				errorName: data.errorName,
+				errorMessage: data.errorMessage,
+				hasStack: typeof data.errorStack === 'string',
+			};
+		}), [{
+			failureStage: 'sendMessage',
+			errorType: 'sendFailed',
+			errorName: 'Error',
+			errorMessage: 'Error: boom',
+			hasStack: true,
+		}]);
+	});
+
+	test('fails the turn when model selection rejects instead of sending with a stale model', async () => {
+		setupSession();
+		agent.changeModel = async () => { throw new Error('unknown model'); };
+
+		startTurn('turn-1', 'hello', 'missing-model');
+		await new Promise(r => setTimeout(r, 10));
+
+		const completed = completedEvents()[0].data as Record<string, unknown>;
+		const failed = failedEvents()[0].data as Record<string, unknown>;
+		assert.deepStrictEqual({
+			completed: { result: completed.result, errorType: completed.errorType, failureStage: completed.failureStage },
+			failed: { errorType: failed.errorType, failureStage: failed.failureStage, errorMessage: failed.errorMessage },
+			sendMessageCalls: agent.sendMessageCalls.length,
+		}, {
+			completed: { result: 'error', errorType: 'modelSelectionFailed', failureStage: 'modelSelection' },
+			failed: { errorType: 'modelSelectionFailed', failureStage: 'modelSelection', errorMessage: 'Error: unknown model' },
+			sendMessageCalls: 0,
+		});
 	});
 
 	test('emits result=error when a queued sendMessage rejects', async () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -112,8 +112,8 @@ type AgentHostInvocationFailedEvent = {
 	hasUserSelectedModel: boolean;
 	errorName: string;
 	errorCode: string | undefined;
-	errorMessage: string;
-	errorStack: string | undefined;
+	msg: string;
+	callstack: string | undefined;
 };
 
 type AgentHostInvocationFailedClassification = {
@@ -124,8 +124,8 @@ type AgentHostInvocationFailedClassification = {
 	hasUserSelectedModel: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the workbench request carried a selected language model identifier.' };
 	errorName: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The name of the exception.' };
 	errorCode: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The exception or protocol error code, when available.' };
-	errorMessage: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error message. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
-	errorStack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error stack. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	msg: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error message. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	callstack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error stack. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
 	owner: 'roblourens';
 	comment: 'Captures errors that prevent an agent host request from reaching a terminal host turn.';
 };
@@ -1416,8 +1416,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			hasUserSelectedModel: request.userSelectedModelId !== undefined,
 			errorName: error instanceof Error ? error.name : typeof error,
 			errorCode: getErrorCode(error),
-			errorMessage: packed.msg,
-			errorStack: packed.callstack,
+			msg: packed.msg,
+			callstack: packed.callstack,
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -6,7 +6,7 @@
 import { Delayer, disposableTimeout, raceCancellation } from '../../../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
-import { isCancellationError } from '../../../../../../base/common/errors.js';
+import { getErrorCode, isCancellationError } from '../../../../../../base/common/errors.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { getChatErrorDetailsFromMeta, getCopilotPlanFromEntitlement, IChatErrorContext } from '../../../common/chatErrorMessages.js';
@@ -129,18 +129,6 @@ type AgentHostInvocationFailedClassification = {
 	owner: 'roblourens';
 	comment: 'Captures errors that prevent an agent host request from reaching a terminal host turn.';
 };
-
-function hasErrorCode(error: object): error is { readonly code: unknown } {
-	return Object.hasOwn(error, 'code');
-}
-
-function getErrorCode(error: unknown): string | undefined {
-	if (!error || typeof error !== 'object' || !hasErrorCode(error)) {
-		return undefined;
-	}
-	const code = error.code;
-	return typeof code === 'string' || typeof code === 'number' ? String(code) : undefined;
-}
 
 
 // =============================================================================

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -47,6 +47,8 @@ import { IInstantiationService } from '../../../../../../platform/instantiation/
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
+import { packErrorForTelemetry } from '../../../../../../platform/telemetry/common/errorTelemetry.js';
+import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IPathService } from '../../../../../services/path/common/pathService.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceTrustRequestService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
@@ -100,6 +102,46 @@ export { toolDataToDefinition };
  * elsewhere (`chatRepoInfo`). Larger buffers are not inlined; a dirty saved file then falls back to its on-disk path.
  */
 const MAX_INLINED_UNSAVED_EDITOR_BYTES = 1024 * 1024;
+type AgentHostInvocationFailureStage = 'resolveSession' | 'provisionalSession' | 'sessionState' | 'authentication' | 'createSession' | 'subscribeSession' | 'prepareTurn' | 'dispatchTurn' | 'observeTurn';
+
+type AgentHostInvocationFailedEvent = {
+	requestId: string;
+	provider: string;
+	failureStage: AgentHostInvocationFailureStage;
+	isFirstRequest: boolean;
+	hasUserSelectedModel: boolean;
+	errorName: string;
+	errorCode: string | undefined;
+	errorMessage: string;
+	errorStack: string | undefined;
+};
+
+type AgentHostInvocationFailedClassification = {
+	requestId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The chat request identifier, used to correlate this failure with provider and host turn telemetry.' };
+	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host provider handling the request.' };
+	failureStage: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded workbench adapter stage at which the request failed.' };
+	isFirstRequest: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether this was the first request in the chat session.' };
+	hasUserSelectedModel: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the workbench request carried a selected language model identifier.' };
+	errorName: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The name of the exception.' };
+	errorCode: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The exception or protocol error code, when available.' };
+	errorMessage: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error message. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	errorStack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error stack. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	owner: 'roblourens';
+	comment: 'Captures errors that prevent an agent host request from reaching a terminal host turn.';
+};
+
+function hasErrorCode(error: object): error is { readonly code: unknown } {
+	return Object.hasOwn(error, 'code');
+}
+
+function getErrorCode(error: unknown): string | undefined {
+	if (!error || typeof error !== 'object' || !hasErrorCode(error)) {
+		return undefined;
+	}
+	const code = error.code;
+	return typeof code === 'string' || typeof code === 'number' ? String(code) : undefined;
+}
+
 
 // =============================================================================
 // AgentHostSessionHandler - renderer-side handler for a single agent host
@@ -719,6 +761,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		@IPathService private readonly _pathService: IPathService,
 		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
 		@IAgentHostCustomizationService private readonly _customizationService: IAgentHostCustomizationService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 		this._config = config;
@@ -1231,11 +1274,13 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// soon as real progress streams. Normal agent-host sessions — whose first
 		// turn is also slow to spawn — never flash it.
 		const preparingStatus = new MutableDisposable();
+		let failureStage: AgentHostInvocationFailureStage = 'resolveSession';
 
 		try {
 			const resolvedSession = this._resolveSessionUri(request.sessionResource);
 			const sessionKey = resolvedSession.toString();
 
+			failureStage = 'provisionalSession';
 			// The chat-input picker may have pre-created a provisional session
 			// against this resource (`IAgentHostUntitledProvisionalSessionService.getOrCreate`).
 			// In that case the agent already has the session + the user's chip
@@ -1250,6 +1295,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				this._ensureSessionSubscription(sessionKey);
 			}
 
+			failureStage = 'sessionState';
 			// The sessions provider may have eagerly created this session at
 			// folder-pick time and is holding the connection-level subscription
 			// open with hydrated state. Use the unmanaged accessor to peek
@@ -1288,10 +1334,13 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					undefined,
 					Object.keys(initialConfig).length > 0 ? initialConfig : undefined,
 					imported ? { turns: imported.turns, model: imported.model } : undefined,
+					stage => failureStage = stage,
 				);
 			} else {
+				failureStage = 'authentication';
 				await this._ensureRequiredAuthentication();
 
+				failureStage = 'subscribeSession';
 				// Eager-created session: take a refcounted subscription so the
 				// handler observes state changes for the duration of the chat
 				// session, then wire up the per-turn machinery that
@@ -1333,7 +1382,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				progress(parts);
 			};
 
-			const completedTurn = await this._handleTurn(resolvedSession, request, measuredProgress, cancellationToken);
+			failureStage = 'prepareTurn';
+			const completedTurn = await this._handleTurn(resolvedSession, request, measuredProgress, cancellationToken, stage => failureStage = stage);
 			const details = this._getTurnResponseDetails(request.sessionResource, resolvedSession, completedTurn);
 			const errorDetails = this._getTurnErrorDetails(completedTurn);
 
@@ -1342,12 +1392,33 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				...(details ? { details } : {}),
 				...(errorDetails ? { errorDetails } : {}),
 			};
+		} catch (error) {
+			if (!isCancellationError(error)) {
+				this._reportInvocationFailure(request, failureStage, error);
+			}
+			throw error;
 		} finally {
 			// Always cancel the pending "preparing" status — including when an
 			// await above (state read, create/subscribe, turn handling) rejects —
 			// so a stale status can never fire after the invocation has ended.
 			preparingStatus.dispose();
 		}
+	}
+
+	private _reportInvocationFailure(request: IChatAgentRequest, failureStage: AgentHostInvocationFailureStage, error: unknown): void {
+		const packed = packErrorForTelemetry(error);
+		const requests = this._chatService.getSession(request.sessionResource)?.getRequests();
+		this._telemetryService.publicLogError2<AgentHostInvocationFailedEvent, AgentHostInvocationFailedClassification>('agentHost.invocationFailed', {
+			requestId: request.requestId,
+			provider: this._config.provider,
+			failureStage,
+			isFirstRequest: requests?.[0]?.id === request.requestId,
+			hasUserSelectedModel: request.userSelectedModelId !== undefined,
+			errorName: error instanceof Error ? error.name : typeof error,
+			errorCode: getErrorCode(error),
+			errorMessage: packed.msg,
+			errorStack: packed.callstack,
+		});
 	}
 
 	/**
@@ -1769,11 +1840,13 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		request: IChatAgentRequest,
 		progress: (parts: IChatProgress[]) => void,
 		cancellationToken: CancellationToken,
+		onFailureStage: (stage: AgentHostInvocationFailureStage) => void,
 	): Promise<Turn | undefined> {
 		if (cancellationToken.isCancellationRequested) {
 			return;
 		}
 
+		onFailureStage('prepareTurn');
 		const turnId = request.requestId;
 		this._clientDispatchedTurnIds.add(turnId);
 		const chatURI = this._getChatURI(request.sessionResource);
@@ -1837,6 +1910,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			},
 		};
 		this._ensureTurnStopWatch(turnChannel, turnId);
+		onFailureStage('dispatchTurn');
 		this._config.connection.dispatch(turnChannel, turnAction);
 
 		// Ensure the snapshot controller records a sentinel checkpoint for this
@@ -1850,6 +1924,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// sink and resolves the promise from `onTurnEnded`. Cancellation is
 		// surfaced through the same path: the observer disposes itself when
 		// `cancellationToken` fires, then calls `onTurnEnded(undefined)`.
+		onFailureStage('observeTurn');
 		return new Promise<Turn | undefined>(resolve => {
 			const store = new DisposableStore();
 			const cancelSub = store.add(cancellationToken.onCancellationRequested(() => {
@@ -3797,12 +3872,13 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	}
 
 	/** Creates a new backend session and subscribes to its state. */
-	private async _createAndSubscribe(sessionResource: URI, model: ModelSelection | undefined, fork?: { session: URI; turnIndex: number; turnId: string }, config?: Record<string, unknown>, importConversation?: { readonly turns: readonly Turn[]; readonly model?: ModelSelection }): Promise<URI> {
+	private async _createAndSubscribe(sessionResource: URI, model: ModelSelection | undefined, fork?: { session: URI; turnIndex: number; turnId: string }, config?: Record<string, unknown>, importConversation?: { readonly turns: readonly Turn[]; readonly model?: ModelSelection }, onFailureStage?: (stage: AgentHostInvocationFailureStage) => void): Promise<URI> {
 		const workingDirectory = this._resolveRequestedWorkingDirectory(sessionResource);
 		const requestedSession = fork ? undefined : this._resolveSessionUri(sessionResource);
 
 		this._logService.trace(`[AgentHost] Creating new session, model=${model?.id ?? '(default)'}, provider=${this._config.provider}${fork ? `, fork from ${fork.session.toString()} at index ${fork.turnIndex}` : ''}`);
 
+		onFailureStage?.('authentication');
 		const protectedResources = await this._ensureRequiredAuthentication();
 
 		const activeClient = this._getCurrentActiveClient();
@@ -3814,6 +3890,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const progressToken = generateUuid();
 
 		let session: URI;
+		onFailureStage?.('createSession');
 		try {
 			session = await this._config.connection.createSession({
 				session: requestedSession,
@@ -3829,9 +3906,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		} catch (err) {
 			// If authentication is required (e.g. token expired), try interactive auth and retry once
 			if (this._isAuthRequiredError(err) && this._config.resolveAuthentication) {
+				onFailureStage?.('authentication');
 				this._logService.info('[AgentHost] Authentication required, prompting user...');
 				const authenticated = await this._config.resolveAuthentication(protectedResources);
 				if (authenticated) {
+					onFailureStage?.('createSession');
 					session = await this._config.connection.createSession({
 						session: requestedSession,
 						model,
@@ -3858,6 +3937,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		this._logService.trace(`[AgentHost] Created session: ${session.toString()}`);
 
 		// Subscribe to the new session's state
+		onFailureStage?.('subscribeSession');
 		const newSub = this._ensureSessionSubscription(session.toString());
 		if (!this._getSessionState(session.toString())) {
 			// Wait for the subscription to hydrate. `_whenSubscriptionHydrated`

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceTelemetry.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceTelemetry.ts
@@ -144,6 +144,7 @@ export type ChatProviderInvokedEvent = {
 	result: 'success' | 'error' | 'errorWithOutput' | 'cancelled' | 'filtered';
 	requestType: 'string' | 'followup' | 'slashCommand';
 	chatSessionId: string;
+	requestId: string;
 	agent: string;
 	agentExtensionId: string | undefined;
 	slashCommand: string | undefined;
@@ -166,6 +167,7 @@ export type ChatProviderInvokedClassification = {
 	result: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether invoking the ChatProvider resulted in an error.' };
 	requestType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The type of request that the user made.' };
 	chatSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'A random ID for the session.' };
+	requestId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the chat request, used to correlate workbench and agent host telemetry.' };
 	agent: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The type of agent used.' };
 	agentExtensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension that contributed the agent.' };
 	slashCommand?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The type of slashCommand used.' };
@@ -307,6 +309,7 @@ export class ChatRequestTelemetry {
 			totalTime,
 			result,
 			requestType,
+			requestId: request.id,
 			agent: detectedAgent?.id ?? this.opts.agent.id,
 			agentExtensionId: detectedAgent?.extensionId.value ?? this.opts.agent.extensionId.value,
 			slashCommand: this.opts.agentSlashCommandPart ? this.opts.agentSlashCommandPart.command.name : this.opts.commandPart?.slashCommand.command,

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -26,7 +26,7 @@ import type { ChatInputRequestWithPlanReview } from '../../../../../../platform/
 import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
 import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
 import { ActionType, isSessionAction, isChatAction, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type ChatAction as AgentHostChatAction, type TerminalAction, type INotification, type IToolCallConfirmedAction, type ITurnStartedAction, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
-import type { IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
+import { ProtocolError, type IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
 import { ChatInteractivity, ConfirmationOptionKind, CustomizationType, McpAuthRequiredReason, McpServerStatus, type ClientPluginCustomization, type ProtectedResourceMetadata, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, createSessionState, createChatState, createDefaultChatSummary, buildChatUri, buildDefaultChatUri, parseDefaultChatUri, isAhpChatChannel, createActiveTurn, isAhpRootChannel, PolicyState, ResponsePartKind, ROOT_STATE_URI, StateComponents, buildSubagentChatUri, ToolResultContentType, MessageAttachmentKind, MessageKind, type SessionState, type SessionSummary, type ChatState, type ISessionWithDefaultChat, RootState, type ToolCallState, type AgentInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { CompletionItemKind as AhpCompletionItemKind, type CompletionsParams, type CompletionsResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
@@ -34,6 +34,8 @@ import { sessionReducer, chatReducer } from '../../../../../../platform/agentHos
 import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IProgress, IProgressNotificationOptions, IProgressService, IProgressStep } from '../../../../../../platform/progress/common/progress.js';
+import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
 import { IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
 import { IAuthenticationMcpAccessService } from '../../../../../services/authentication/browser/authenticationMcpAccessService.js';
 import { IAuthenticationMcpService } from '../../../../../services/authentication/browser/authenticationMcpService.js';
@@ -669,6 +671,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	instantiationService.stub(IAgentHostService, agentHostService);
 	instantiationService.stub(ILogService, new NullLogService());
 	instantiationService.stub(IProductService, { quality: 'insider' });
+	instantiationService.stub(ITelemetryService, NullTelemetryService);
 	instantiationService.stub(IChatEntitlementService, { entitlement: ChatEntitlement.Free, quotas: {} } as Partial<IChatEntitlementService> as IChatEntitlementService);
 	instantiationService.stub(IChatAgentService, chatAgentService);
 	instantiationService.stub(IChatWidgetService, chatWidgetService);
@@ -7085,6 +7088,61 @@ suite('AgentHostChatContribution', () => {
 			assert.ok(registered);
 			assert.strictEqual(registered.data.extensionId.value, 'vscode.agent-host');
 			assert.strictEqual(registered.data.extensionDisplayName, 'Agent Host');
+		});
+
+		test('reports failures before an agent host turn is dispatched', async () => {
+			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
+			const events: { eventName: string; data: Record<string, unknown> | undefined }[] = [];
+			instantiationService.stub(ITelemetryService, {
+				...NullTelemetryService,
+				publicLogError2(eventName: string, data: Record<string, unknown> | undefined): void {
+					events.push({ eventName, data });
+				},
+			});
+			agentHostService.createSession = async () => {
+				const error = new ProtocolError(-32603, 'create failed');
+				error.stack = 'Error: create failed\n    at createSession (agentHostSessionHandler.ts:1:1)';
+				throw error;
+			};
+
+			disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'invocation-failure-test',
+				sessionType: 'invocation-failure-test',
+				fullName: 'Test',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+
+			const registered = chatAgentService.registeredAgents.get('invocation-failure-test');
+			assert.ok(registered);
+			await assert.rejects(registered.impl.invoke(
+				makeRequest({
+					requestId: 'request-correlation-id',
+					agentId: 'invocation-failure-test',
+					sessionResource: URI.from({ scheme: 'invocation-failure-test', path: '/new-error' }),
+					userSelectedModelId: 'selected-model',
+				}),
+				() => { },
+				[],
+				CancellationToken.None,
+			));
+
+			assert.deepStrictEqual(events, [{
+				eventName: 'agentHost.invocationFailed',
+				data: {
+					requestId: 'request-correlation-id',
+					provider: 'copilot',
+					failureStage: 'createSession',
+					isFirstRequest: false,
+					hasUserSelectedModel: true,
+					errorName: 'Error',
+					errorCode: '-32603',
+					errorMessage: 'create failed',
+					errorStack: 'Error: create failed\n    at createSession (agentHostSessionHandler.ts:1:1)',
+				},
+			}]);
 		});
 
 		test('handler uses resolveWorkingDirectory callback', () => runWithFakedTimers({ useFakeTimers: true }, async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -7101,6 +7101,7 @@ suite('AgentHostChatContribution', () => {
 			});
 			agentHostService.createSession = async () => {
 				const error = new ProtocolError(-32603, 'create failed');
+				error.name = 'ProtocolError';
 				error.stack = 'Error: create failed\n    at createSession (agentHostSessionHandler.ts:1:1)';
 				throw error;
 			};
@@ -7137,7 +7138,7 @@ suite('AgentHostChatContribution', () => {
 					failureStage: 'createSession',
 					isFirstRequest: false,
 					hasUserSelectedModel: true,
-					errorName: 'Error',
+					errorName: 'ProtocolError',
 					errorCode: '-32603',
 					msg: 'create failed',
 					callstack: 'Error: create failed\n    at createSession (agentHostSessionHandler.ts:1:1)',

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -7139,8 +7139,8 @@ suite('AgentHostChatContribution', () => {
 					hasUserSelectedModel: true,
 					errorName: 'Error',
 					errorCode: '-32603',
-					errorMessage: 'create failed',
-					errorStack: 'Error: create failed\n    at createSession (agentHostSessionHandler.ts:1:1)',
+					msg: 'create failed',
+					callstack: 'Error: create failed\n    at createSession (agentHostSessionHandler.ts:1:1)',
 				},
 			}]);
 		});

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -1751,7 +1751,10 @@ suite('ChatService', () => {
 		ChatSendResult.assertSent(response);
 		await response.data.responseCompletePromise;
 
-		assert.deepStrictEqual(providerInvokedEvents.map(event => event.sessionType), ['remote-agent-host']);
+		assert.deepStrictEqual(providerInvokedEvents.map(event => ({
+			sessionType: event.sessionType,
+			hasRequestId: typeof event.requestId === 'string',
+		})), [{ sessionType: 'remote-agent-host', hasRequestId: true }]);
 	});
 
 	test('sendRequest with agentIdSilent passes agent host session capabilities to the request parser', async () => {


### PR DESCRIPTION
## Summary

- add staged diagnostics for caught Agent Host turn failures, including model-selection, working-directory, send, validation, and provider failures
- report workbench failures that happen before a host turn exists, with request correlation to `interactiveSessionProviderInvoked`
- route exception messages and callstacks through `publicLogError2`, using the existing telemetry PII/path scrubbing
- fail a turn when its requested model cannot be applied instead of continuing with stale model state

This complements [#327050](https://github.com/microsoft/vscode/pull/327050), which owns Agent Host process start/exit and unhandled process-error telemetry. This PR covers caught per-turn failures and renderer-side invocation failures that process telemetry cannot observe.

## Validation

- `npm run typecheck-client`
- `npm run gulp compile-client`
- targeted Agent Host/chat telemetry unit tests
- `npm run valid-layers-check`
- hygiene checks and pre-commit hook

(Written by Copilot)