### PR TITLE
git: skip textconv for quick-diff originals (#113609)

### DIFF
--- a/extensions/git/src/fileSystemProvider.ts
+++ b/extensions/git/src/fileSystemProvider.ts
@@ -70,7 +70,7 @@ export class GitFileSystemProvider implements FileSystemProvider {
 		}
 
 		const diffOriginalResourceUri = toGitUri(uri, '~',);
-		const quickDiffOriginalResourceUri = toGitUri(uri, '', { replaceFileExtension: true });
+		const quickDiffOriginalResourceUri = toGitUri(uri, '', { replaceFileExtension: true, textconv: false });
 
 		this.mtime = new Date().getTime();
 		this._onDidChangeFile.fire([
@@ -197,7 +197,7 @@ export class GitFileSystemProvider implements FileSystemProvider {
 	async readFile(uri: Uri): Promise<Uint8Array> {
 		await this.model.isInitialized;
 
-		const { path, ref, submoduleOf } = fromGitUri(uri);
+		const { path, ref, submoduleOf, textconv } = fromGitUri(uri);
 
 		if (submoduleOf) {
 			const repository = await this.getOrOpenRepository(submoduleOf);
@@ -228,7 +228,8 @@ export class GitFileSystemProvider implements FileSystemProvider {
 		this.cache.set(uri.toString(), cacheValue);
 
 		try {
-			return await repository.buffer(sanitizeRef(ref, path, submoduleOf, repository), path);
+			const bufferOptions = textconv === false ? { textconv: false } : undefined;
+			return await repository.buffer(sanitizeRef(ref, path, submoduleOf, repository), path, bufferOptions);
 		} catch {
 			// Empty tree
 			if (ref === await repository.getEmptyTree()) {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1568,9 +1568,14 @@ export class Repository {
 			.filter(entry => !!entry);
 	}
 
-	async buffer(ref: string, filePath: string): Promise<Buffer> {
+	async buffer(ref: string, filePath: string, options: { textconv?: boolean } = {}): Promise<Buffer> {
 		const relativePath = this.sanitizeRelativePath(filePath);
-		const child = this.stream(['show', '--textconv', `${ref}:${relativePath}`]);
+		const args = ['show'];
+		if (options.textconv !== false) {
+			args.push('--textconv');
+		}
+		args.push(`${ref}:${relativePath}`);
+		const child = this.stream(args);
 
 		if (!child.stdout) {
 			return Promise.reject<Buffer>('Can\'t open file from git');

--- a/extensions/git/src/quickDiffProvider.ts
+++ b/extensions/git/src/quickDiffProvider.ts
@@ -71,7 +71,7 @@ export class GitQuickDiffProvider implements QuickDiffProvider {
 			return undefined;
 		}
 
-		const originalResource = toGitUri(uri, '', { replaceFileExtension: true });
+		const originalResource = toGitUri(uri, '', { replaceFileExtension: true, textconv: false });
 		this.logger.trace(`[Repository][provideOriginalResource] Original resource: ${originalResource.toString()}`);
 
 		return originalResource;
@@ -113,7 +113,7 @@ export class StagedResourceQuickDiffProvider implements QuickDiffProvider {
 			return undefined;
 		}
 
-		const originalResource = toGitUri(uri, 'HEAD', { replaceFileExtension: true });
+		const originalResource = toGitUri(uri, 'HEAD', { replaceFileExtension: true, textconv: false });
 		this.logger.trace(`[StagedResourceQuickDiffProvider][provideOriginalResource] Original resource: ${originalResource.toString()}`);
 		return originalResource;
 	}

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2512,8 +2512,8 @@ export class Repository implements Disposable {
 		});
 	}
 
-	async buffer(ref: string, filePath: string): Promise<Buffer> {
-		return this.run(Operation.Show, () => this.repository.buffer(ref, filePath));
+	async buffer(ref: string, filePath: string, options?: { textconv?: boolean }): Promise<Buffer> {
+		return this.run(Operation.Show, () => this.repository.buffer(ref, filePath, options));
 	}
 
 	getObjectFiles(ref: string): Promise<LsTreeElement[]> {

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -6,7 +6,9 @@
 import 'mocha';
 import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
 import * as assert from 'assert';
+import { Uri } from 'vscode';
 import { splitInChunks } from '../util';
+import { fromGitUri, toGitUri } from '../uri';
 
 suite('git', () => {
 	suite('GitStatusParser', () => {
@@ -715,6 +717,24 @@ suite('git', () => {
 				[...splitInChunks(['0', '01', '012', '0', '01', '012', '0', '01', '012'], 9)],
 				[['0', '01', '012', '0', '01'], ['012', '0', '01', '012']]
 			);
+		});
+	});
+
+	suite('toGitUri textconv (#113609)', () => {
+		test('omits textconv by default', () => {
+			const uri = toGitUri(Uri.file('/repo/sample.txt'), '');
+			assert.strictEqual(fromGitUri(uri).textconv, undefined);
+		});
+
+		test('replaceFileExtension alone does not skip textconv', () => {
+			const uri = toGitUri(Uri.file('/repo/sample.txt'), '', { replaceFileExtension: true });
+			assert.strictEqual(fromGitUri(uri).textconv, undefined);
+			assert.ok(uri.path.endsWith('.git'));
+		});
+
+		test('explicit textconv: false is stored for quick-diff originals', () => {
+			const uri = toGitUri(Uri.file('/repo/sample.txt'), '', { replaceFileExtension: true, textconv: false });
+			assert.strictEqual(fromGitUri(uri).textconv, false);
 		});
 	});
 });

--- a/extensions/git/src/uri.ts
+++ b/extensions/git/src/uri.ts
@@ -11,6 +11,8 @@ export interface GitUriParams {
 	path: string;
 	ref: string;
 	submoduleOf?: string;
+	/** When `false`, `git show` omits `--textconv` (microsoft/vscode#113609). */
+	textconv?: boolean;
 }
 
 export function isGitUri(uri: Uri): boolean {
@@ -25,6 +27,8 @@ export interface GitUriOptions {
 	scheme?: string;
 	replaceFileExtension?: boolean;
 	submoduleOf?: string;
+	/** Pass `false` for quick-diff originals so gutter compares raw-vs-raw (#113609). */
+	textconv?: boolean;
 }
 
 // As a mitigation for extensions like ESLint showing warnings and errors
@@ -46,6 +50,10 @@ export function toGitUri(uri: Uri, ref: string, options: GitUriOptions = {}): Ur
 		path = `${path}.git`;
 	} else if (options.submoduleOf) {
 		path = `${path}.diff`;
+	}
+
+	if (options.textconv === false) {
+		params.textconv = false;
 	}
 
 	return uri.with({ scheme: options.scheme ?? 'git', path, query: JSON.stringify(params) });


### PR DESCRIPTION
Fixes #113609

## Summary
- Quick-diff originals are read via the `git:` FS provider → `Repository.buffer()` → `git show --textconv`, so a global `diff.*.textconv` filter can change the "original" while the editor shows the raw working tree.
- That asymmetry falsely marks clean lines as added in the gutter.
- Pass `textconv: false` on quick-diff original URIs so the gutter compares raw-vs-raw. Other `git:` reads keep `--textconv`.

## Test plan
- [x] Reproduce with a global `diff.globaltxt.textconv` + `.gitattributes` `diff=globaltxt` on a clean `sample.txt` (gutter had phantom `dirty-diff-added` before; none after).
- [x] `./scripts/test-integration.sh --suite git` → 61 passing (includes new `toGitUri textconv` tests).
- [x] Sanity-check a normal modified file without textconv still shows correct gutter diffs (`normal.txt` → `dirty-diff-added` on the new line).
- [x] Confirm SCM "Open Changes" still uses default textconv (left/`git:~` side for `sample.txt` shows only the textconv-filtered line; intentional for this scoped fix).

cc @lszomoru