### PR TITLE
Fix workingDirectories handling in ListSessionsResult

### DIFF
--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -37,6 +37,7 @@ import {
 	type ReconnectParams,
 	type IStateSnapshot,
 	type SubscribeResult,
+	type ListSessionsResult,
 } from '../common/state/sessionProtocol.js';
 import { isAhpResourceWatchChannel, isAhpRootChannel, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, isAhpChatChannel, parseChatUri, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat, type SessionState } from '../common/state/sessionState.js';
 import type { IProtocolServer, IProtocolTransport } from '../common/state/sessionTransport.js';
@@ -1250,9 +1251,9 @@ export class ProtocolServerHandler extends Disposable {
 					createdAt: new Date(s.startTime).toISOString(),
 					modifiedAt: new Date(s.modifiedTime).toISOString(),
 					...(s.project ? { project: { uri: s.project.uri.toString(), displayName: s.project.displayName } } : {}),
-					workingDirectory: s.workingDirectory?.toString(),
+					workingDirectories: s.workingDirectory ? [s.workingDirectory.toString()] : [],
 					changes: s.changes,
-				};
+				} satisfies ListSessionsResult['items'][number];
 			});
 			return { items };
 		},

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -1251,7 +1251,7 @@ export class ProtocolServerHandler extends Disposable {
 					createdAt: new Date(s.startTime).toISOString(),
 					modifiedAt: new Date(s.modifiedTime).toISOString(),
 					...(s.project ? { project: { uri: s.project.uri.toString(), displayName: s.project.displayName } } : {}),
-					workingDirectories: s.workingDirectory ? [s.workingDirectory.toString()] : [],
+					workingDirectories: s.workingDirectory ? [s.workingDirectory.toString()] : undefined,
 					changes: s.changes,
 				} satisfies ListSessionsResult['items'][number];
 			});


### PR DESCRIPTION
Update the handling of workingDirectories in ListSessionsResult to use an undefined value instead of an empty array when no working directory is present. Additionally, rename workingDirectory to workingDirectories to reflect this change.

