### PR TITLE
Multi-root working directories: agent host create pipeline (Phase 0+1, #321651)

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -19,6 +19,7 @@ import { ILogService } from '../../log/common/log.js';
 import { FileSystemProviderErrorCode, toFileSystemProviderErrorCode } from '../../files/common/files.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { AgentSession, AgentHostCodexAgentEnabledSettingId, AgentHostSystemProxyEnabledSettingId, IAgentConnection, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
+import { getConfigPrimaryWorkingDirectory, getConfigWorkingDirectories } from '../common/workingDirectories.js';
 import { createRemoteWatchHandle, type IRemoteWatchHandle } from '../common/agentHostFileSystemProvider.js';
 import { AgentSubscriptionManager, type IActiveSubscriptionInfo, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import { agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../common/agentHostUri.js';
@@ -815,10 +816,12 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		}
 		// Use `.then` (not `async`) so the tracked promise and the returned promise are the same object — callers
 		// awaiting via `getInflightSessionCreate` resume on the same microtask queue as direct `createSession()` awaiters.
+		const primaryWorkingDirectory = getConfigPrimaryWorkingDirectory(config);
 		const promise = this._sendRequest('createSession', {
 			channel: session.toString(),
 			provider,
-			workingDirectories: config?.workingDirectory ? [fromAgentHostUri(config.workingDirectory).toString()] : undefined,
+			workingDirectories: getConfigWorkingDirectories(config)?.map(d => fromAgentHostUri(d).toString()),
+			primaryWorkingDirectory: primaryWorkingDirectory ? fromAgentHostUri(primaryWorkingDirectory).toString() : undefined,
 			config: config?.config,
 			activeClient: config?.activeClient,
 		}).then(() => session);

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -723,6 +723,8 @@ export interface IAgentCreateSessionResult {
 	readonly project?: IAgentSessionProjectInfo;
 	/** The resolved working directory, which may differ from the requested one (e.g. worktree). */
 	readonly workingDirectory?: URI;
+	/** The resolved working directories, which may differ from the requested set (e.g. worktree). */
+	readonly workingDirectories?: readonly URI[];
 	/**
 	 * `true` when the agent only allocated an in-memory placeholder for this
 	 * session (no SDK session, no worktree, no on-disk state). Materialization
@@ -743,6 +745,8 @@ export interface IAgentCreateSessionResult {
 export interface IAgentMaterializeSessionEvent {
 	readonly session: URI;
 	readonly workingDirectory: URI | undefined;
+	/** The resolved working directories (superset of {@link workingDirectory}). */
+	readonly workingDirectories?: readonly URI[];
 	readonly project: IAgentSessionProjectInfo | undefined;
 }
 
@@ -859,7 +863,29 @@ export interface IAgentCreateSessionConfig {
 	 */
 	readonly agent?: AgentSelection;
 	readonly session?: URI;
+	/**
+	 * @deprecated TRANSITIONAL — this singular field is scaffolding for the
+	 * multi-root migration and will be removed once all producers/consumers use
+	 * {@link workingDirectories} / {@link primaryWorkingDirectory}. Do NOT use in
+	 * new code. While present it is treated as `workingDirectories: [workingDirectory]`.
+	 * Read it only via the helpers in `workingDirectories.ts`.
+	 */
 	readonly workingDirectory?: URI;
+	/**
+	 * The working directories the session's agent is granted tool access to.
+	 * A session's directories are equal peers — a session has no primary of its
+	 * own. A client MUST NOT supply more than one entry unless the agent
+	 * advertises the `multipleWorkingDirectories` capability.
+	 */
+	readonly workingDirectories?: readonly URI[];
+	/**
+	 * The primary working directory that seeds the session's **default chat** —
+	 * the distinguished root that chat is centered on (the provider launch
+	 * context, the default location for relative paths). When set it MUST be one
+	 * of {@link workingDirectories}. A session has no primary of its own; this
+	 * only seeds the default chat's primary.
+	 */
+	readonly primaryWorkingDirectory?: URI;
 	readonly config?: Record<string, unknown>;
 	/**
 	 * Eagerly claim the active client role for the new session. When provided,

--- a/src/vs/platform/agentHost/common/workingDirectories.ts
+++ b/src/vs/platform/agentHost/common/workingDirectories.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../base/common/uri.js';
+import type { IAgentCreateSessionConfig } from './agentService.js';
+
+/**
+ * Shared helpers for the multi-root working-directory migration.
+ *
+ * A session's working directories are a set of **equal peers** (there is no
+ * session-level primary); a chat may designate one of its directories as its
+ * {@link https://github.com/microsoft/agent-host-protocol | primary}. These
+ * helpers encapsulate the deterministic bridge between the (transitional)
+ * singular `workingDirectory` on {@link IAgentCreateSessionConfig} and the
+ * plural `workingDirectories` / `primaryWorkingDirectory` fields, so call sites
+ * do not have to branch on which is present.
+ */
+
+/**
+ * The requested working-directory set for a create-session config.
+ *
+ * Precedence: the explicit {@link IAgentCreateSessionConfig.workingDirectories}
+ * when present (including an empty array, which means "explicitly no
+ * directories"), otherwise the transitional singular
+ * {@link IAgentCreateSessionConfig.workingDirectory} wrapped in a one-element
+ * array, otherwise `undefined` (meaning "inherit / unspecified").
+ *
+ * The `!== undefined` check (rather than `.length`) is deliberate so the
+ * distinction between `undefined` (inherit) and `[]` (explicitly none) is
+ * preserved.
+ */
+export function getConfigWorkingDirectories(config: IAgentCreateSessionConfig | undefined): readonly URI[] | undefined {
+	if (config?.workingDirectories !== undefined) {
+		return config.workingDirectories;
+	}
+	return config?.workingDirectory ? [config.workingDirectory] : undefined;
+}
+
+/**
+ * The single directory to use where a create-session config genuinely requires
+ * one (e.g. the provider launch context / the default chat's primary root).
+ *
+ * Precedence: an explicit {@link IAgentCreateSessionConfig.primaryWorkingDirectory},
+ * otherwise the first entry of the {@link getConfigWorkingDirectories | requested
+ * set} (which already folds in the transitional singular field). Returns
+ * `undefined` when the config requests no directories.
+ */
+export function getConfigPrimaryWorkingDirectory(config: IAgentCreateSessionConfig | undefined): URI | undefined {
+	return config?.primaryWorkingDirectory ?? getConfigWorkingDirectories(config)?.[0];
+}
+
+/**
+ * Derives the primary working directory from any object carrying the
+ * multi-root fields (e.g. session/chat state or summary). Prefers an explicit
+ * `primaryWorkingDirectory`, otherwise the first of `workingDirectories`.
+ */
+export function getPrimaryWorkingDirectory(state: { readonly primaryWorkingDirectory?: URI; readonly workingDirectories?: readonly URI[] } | undefined): URI | undefined {
+	return state?.primaryWorkingDirectory ?? state?.workingDirectories?.[0];
+}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1477,8 +1477,11 @@ export class AgentService extends Disposable implements IAgentService {
 		this._stateManager.markSessionPersisted(sessionKey, summary);
 		this._stateManager.dispatchServerAction(sessionKey, { type: ActionType.SessionReady });
 
-		// Attach git state for the working directory (if present)
-		void this._gitStateService.refreshSessionGitState(e.session.toString(), e.workingDirectories?.[0] ?? e.workingDirectory);
+		// Attach git state for the working directory (if present). Git state is a
+		// single-repo operation (part of the deferred git track), so prefer the
+		// provider's resolved singular cwd; `workingDirectories` is an unordered set
+		// of equal peers whose `[0]` is not necessarily the primary.
+		void this._gitStateService.refreshSessionGitState(e.session.toString(), e.workingDirectory ?? e.workingDirectories?.[0]);
 
 		// If a client subscribed to this session's uncommitted changeset
 		// before the working directory was known, the coordinator drains

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -24,6 +24,7 @@ import { ServiceCollection } from '../../instantiation/common/serviceCollection.
 import { ILogService } from '../../log/common/log.js';
 import { AgentProvider, AgentSession, AgentSignal, AgentHostSessionReleaseGraceMsEnvVar, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkEndpoint, IAgentHostNetworkFetchResult, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
 import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
+import { getConfigPrimaryWorkingDirectory, getConfigWorkingDirectories } from '../common/workingDirectories.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import { parseChangesetUri } from '../common/changesetUri.js';
 import { ActionType, ActionEnvelope, AuthRequiredReason, INotification, type ChatAction, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type ClientAnnotationsAction, type ClientChangesetAction } from '../common/state/sessionActions.js';
@@ -1129,7 +1130,7 @@ export class AgentService extends Disposable implements IAgentService {
 			this._stateManager.dispatchServerAction(session.toString(), { type: ActionType.SessionReady });
 
 			// Refresh the git state for the session.
-			const workingDirectory = created.workingDirectory ?? config?.workingDirectory;
+			const workingDirectory = created.workingDirectory ?? getConfigPrimaryWorkingDirectory(config);
 			void this._gitStateService.refreshSessionGitState(session.toString(), workingDirectory);
 		}
 
@@ -1400,9 +1401,15 @@ export class AgentService extends Disposable implements IAgentService {
 		return firstText.length > MAX ? `${firstText.slice(0, MAX)}...` : firstText;
 	}
 
-	private _buildInitialSummary(provider: IAgent, session: URI, config: IAgentCreateSessionConfig | undefined, created: { project?: { uri: URI; displayName: string }; workingDirectory?: URI }, title: string): SessionSummary {
+	private _buildInitialSummary(provider: IAgent, session: URI, config: IAgentCreateSessionConfig | undefined, created: { project?: { uri: URI; displayName: string }; workingDirectory?: URI; workingDirectories?: readonly URI[] }, title: string): SessionSummary {
 		const now = new Date().toISOString();
-		const primaryWorkingDir = (created.workingDirectory ?? config?.workingDirectory)?.toString();
+		// Prefer the RESOLVED directories the provider reports (e.g. a worktree /
+		// scratch dir that differs from the request); fall back to the requested
+		// set. Never build purely from the config set, or a resolved worktree dir
+		// would be dropped.
+		const requestedWorkingDirectories = getConfigWorkingDirectories(config);
+		const resolvedWorkingDirectories = created.workingDirectories
+			?? (created.workingDirectory ? [created.workingDirectory] : requestedWorkingDirectories);
 		return {
 			resource: session.toString(),
 			provider: provider.id,
@@ -1411,11 +1418,11 @@ export class AgentService extends Disposable implements IAgentService {
 			createdAt: now,
 			modifiedAt: now,
 			...(created.project ? { project: { uri: created.project.uri.toString(), displayName: created.project.displayName } } : {}),
-			workingDirectories: primaryWorkingDir ? [primaryWorkingDir] : undefined,
-			// Workspace-less is inferred at create from an absent input
-			// `workingDirectory` (the host assigns a scratch cwd, so it can't be
-			// re-inferred later) and tagged on the generic `_meta` bag.
-			...(config && !config.fork && !config.workingDirectory ? { _meta: withSessionWorkspaceless(undefined, true) } : {}),
+			workingDirectories: resolvedWorkingDirectories?.map(d => d.toString()),
+			// Workspace-less is inferred at create from an absent requested working
+			// directory (the host assigns a scratch cwd, so it can't be re-inferred
+			// later) and tagged on the generic `_meta` bag.
+			...(config && !config.fork && !requestedWorkingDirectories?.length ? { _meta: withSessionWorkspaceless(undefined, true) } : {}),
 		};
 	}
 
@@ -1453,7 +1460,8 @@ export class AgentService extends Disposable implements IAgentService {
 		const summary: SessionSummary = {
 			...currentSummary,
 			...(project ? { project: { uri: project.uri.toString(), displayName: project.displayName } } : {}),
-			workingDirectories: e.workingDirectory ? [e.workingDirectory.toString()] : currentSummary.workingDirectories,
+			workingDirectories: e.workingDirectories?.map(d => d.toString())
+				?? (e.workingDirectory ? [e.workingDirectory.toString()] : currentSummary.workingDirectories),
 			modifiedAt: new Date().toISOString(),
 		};
 		const configValues = state.config?.values;
@@ -1470,7 +1478,7 @@ export class AgentService extends Disposable implements IAgentService {
 		this._stateManager.dispatchServerAction(sessionKey, { type: ActionType.SessionReady });
 
 		// Attach git state for the working directory (if present)
-		void this._gitStateService.refreshSessionGitState(e.session.toString(), e.workingDirectory);
+		void this._gitStateService.refreshSessionGitState(e.session.toString(), e.workingDirectories?.[0] ?? e.workingDirectory);
 
 		// If a client subscribed to this session's uncommitted changeset
 		// before the working directory was known, the coordinator drains
@@ -1557,13 +1565,14 @@ export class AgentService extends Disposable implements IAgentService {
 	}
 
 	private async _resolveCreatedSessionConfig(provider: IAgent, config: IAgentCreateSessionConfig | undefined): Promise<SessionConfigState | undefined> {
-		if (!config?.config && !config?.workingDirectory) {
+		const primaryWorkingDirectory = getConfigPrimaryWorkingDirectory(config);
+		if (!config?.config && !primaryWorkingDirectory) {
 			return undefined;
 		}
 		const params: IAgentResolveSessionConfigParams = {
 			provider: provider.id,
-			workingDirectory: config.workingDirectory,
-			config: config.config,
+			workingDirectory: primaryWorkingDirectory,
+			config: config?.config,
 		};
 		try {
 			// Wrap with the host's isolation schema so the created config carries the
@@ -1576,7 +1585,7 @@ export class AgentService extends Disposable implements IAgentService {
 			return { schema: resolved.schema, values: resolved.values };
 		} catch (err) {
 			this._logService.error(`[AgentService] Failed to resolve created session config for provider ${provider.id}`, err);
-			return config.config ? { schema: { type: 'object', properties: {} }, values: config.config } : undefined;
+			return config?.config ? { schema: { type: 'object', properties: {} }, values: config.config } : undefined;
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -28,6 +28,7 @@ import { createClaudeThinkingLevelSchema, isClaudeEffortLevel } from '../../comm
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { AgentProvider, AgentSession, AgentSignal, CLAUDE_AGENT_PROVIDER_ID, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, SubagentChatSignal } from '../../common/agentService.js';
 import { ensureWorkspacelessScratchDir } from '../workspacelessScratchDir.js';
+import { getConfigPrimaryWorkingDirectory } from '../../common/workingDirectories.js';
 import { ActionType, AuthRequiredReason, type AuthRequiredParams } from '../../common/state/sessionActions.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
@@ -674,6 +675,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		}
 		const sessionId = config.session ? AgentSession.id(config.session) : generateUuid();
 		const sessionUri = AgentSession.uri(this.id, sessionId);
+		const primaryWorkingDirectory = getConfigPrimaryWorkingDirectory(config);
 
 		const existing = this._findAnySession(sessionId);
 		if (existing) {
@@ -689,19 +691,19 @@ export class ClaudeAgent extends Disposable implements IAgent {
 					...(existing.project ? { project: existing.project } : {}),
 				};
 			}
-			return { session: sessionUri, workingDirectory: config.workingDirectory };
+			return { session: sessionUri, workingDirectory: primaryWorkingDirectory };
 		}
 
 		// A workspace-less session (no `workingDirectory` supplied, and not a
 		// fork) runs in a stable per-session scratch dir shared with the Copilot
 		// agent; without a cwd Claude throws at materialize. The workspace-less
 		// marker itself is owned/persisted centrally by the AH service.
-		const workingDirectory = config.workingDirectory ?? await ensureWorkspacelessScratchDir(this._environmentService.userHome, sessionId);
+		const workingDirectory = primaryWorkingDirectory ?? await ensureWorkspacelessScratchDir(this._environmentService.userHome, sessionId);
 
 		// Only probe for a project when the caller supplied a real folder; a
 		// scratch dir is never a code project.
-		const project = config.workingDirectory
-			? await projectFromCopilotContext({ cwd: config.workingDirectory.fsPath }, this._gitService)
+		const project = primaryWorkingDirectory
+			? await projectFromCopilotContext({ cwd: primaryWorkingDirectory.fsPath }, this._gitService)
 			: undefined;
 
 		const permissionMode = this._resolvePermissionMode(config.config);
@@ -944,7 +946,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			// fast (rather than at the first `sendMessage` when `_resumeSession`
 			// requires a cwd). The Query itself starts lazily — see the JSDoc.
 			const sdkInfo = await this._sdkService.getSessionInfo(newSessionId);
-			const workingDirectory = sdkInfo?.cwd ? URI.file(sdkInfo.cwd) : config.workingDirectory;
+			const workingDirectory = sdkInfo?.cwd ? URI.file(sdkInfo.cwd) : getConfigPrimaryWorkingDirectory(config);
 			if (!workingDirectory) {
 				throw new Error(`Cannot fork session ${sourceSessionId}: forked session ${newSessionId} has no working directory (SDK cwd missing and none supplied)`);
 			}

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -25,6 +25,7 @@ import { createPricingMetaFromBilling, normalizeCAPIBilling } from '../../common
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
 import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, CODEX_AGENT_PROVIDER_ID, IActiveClient, IAgent, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatResult, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IMcpNotification, type AgentProvider, type AuthenticateParams } from '../../common/agentService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
+import { getConfigPrimaryWorkingDirectory } from '../../common/workingDirectories.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { ActionType, isChatAction, type SessionAction, type ChatAction } from '../../common/state/sessionActions.js';
 import type { ConfigSchema, ModelSelection, ProtectedResourceMetadata, ToolDefinition, AgentSelection } from '../../common/state/protocol/state.js';
@@ -2379,7 +2380,8 @@ export class CodexAgent extends Disposable implements IAgent {
 	};
 
 	async createSession(config: IAgentCreateSessionConfig = {}): Promise<IAgentCreateSessionResult> {
-		this._logService.info(`[Codex DEBUG] createSession session=${config.session?.toString() ?? '(none)'} model=${config.model?.id ?? '(none)'} cwd=${config.workingDirectory?.toString() ?? '(none)'}`);
+		const primaryWorkingDirectory = getConfigPrimaryWorkingDirectory(config);
+		this._logService.info(`[Codex DEBUG] createSession session=${config.session?.toString() ?? '(none)'} model=${config.model?.id ?? '(none)'} cwd=${primaryWorkingDirectory?.toString() ?? '(none)'}`);
 		this._ensureAuthenticated();
 		if (config.fork) {
 			return this._forkSession(config, config.fork);
@@ -2408,7 +2410,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			existing.model = effectiveModel ?? existing.model;
 			return {
 				session: sessionUri,
-				workingDirectory: existing.workingDirectory ?? config.workingDirectory,
+				workingDirectory: existing.workingDirectory ?? primaryWorkingDirectory,
 				provisional: existing.threadId === undefined,
 			};
 		}
@@ -2418,7 +2420,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			sessionId,
 			threadId: undefined,
 			sessionUri,
-			workingDirectory: config.workingDirectory,
+			workingDirectory: primaryWorkingDirectory,
 			managedWorkingDirectory: undefined,
 			mapState: createCodexSessionMapState(new Set(this._serverToolHost?.toolNames ?? []), clientToolSet),
 			pendingCommandApprovals: new PendingRequestRegistry<CommandExecutionApprovalDecision>(),
@@ -2453,7 +2455,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		this._schedulePrewarm(session);
 		return {
 			session: sessionUri,
-			workingDirectory: config.workingDirectory,
+			workingDirectory: primaryWorkingDirectory,
 			provisional: true,
 		};
 	}
@@ -2589,7 +2591,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		const newSessionUri = AgentSession.uri(this.id, newThreadId);
 		const workingDirectory = forkResult.cwd
 			? URI.file(forkResult.cwd)
-			: (sourceRead.thread.cwd ? URI.file(sourceRead.thread.cwd) : config.workingDirectory);
+			: (sourceRead.thread.cwd ? URI.file(sourceRead.thread.cwd) : getConfigPrimaryWorkingDirectory(config));
 
 		const session = this._createResumedSessionEntry(newThreadId, newThreadId, newSessionUri, workingDirectory, model);
 		this._sessions.set(newThreadId, session);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -40,6 +40,7 @@ import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPlu
 import { AgentSessionEntry, decodeProviderData, encodeProviderData, type IPersistedChat } from '../agentPeerChats.js';
 import { AgentSession, AgentSignal, AuthenticateParams, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentLegacyChat, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentHostNetworkEndpoint, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../../common/agentService.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
+import { getConfigPrimaryWorkingDirectory, getConfigWorkingDirectories } from '../../common/workingDirectories.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
@@ -1324,7 +1325,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * (no `workingDirectory` supplied) — a stable per-session scratch directory.
 	 */
 	private async _resolveCreateWorkingDirectory(sessionConfig: IAgentCreateSessionConfig, sessionId: string, isWorkspaceless: boolean): Promise<URI> {
-		const existing = sessionConfig.workingDirectory ?? this._provisionalSessions.get(sessionId)?.workingDirectory;
+		const existing = getConfigPrimaryWorkingDirectory(sessionConfig) ?? this._provisionalSessions.get(sessionId)?.workingDirectory;
 		if (existing) {
 			return existing;
 		}
@@ -1499,7 +1500,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// pick the workspace-less system prompt. Forks always inherit the source
 		// session's context, so they are never inferred workspace-less even when no
 		// `workingDirectory` is passed.
-		const isWorkspaceless = !sessionConfig.fork && !sessionConfig.workingDirectory;
+		const isWorkspaceless = !sessionConfig.fork && !getConfigWorkingDirectories(sessionConfig)?.length;
 		const workingDirectory = await this._resolveCreateWorkingDirectory(sessionConfig, sessionId, isWorkspaceless);
 		const client = await this._ensureClient();
 		// When forking, use the SDK's sessions.fork RPC. Forking from a source

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -37,6 +37,7 @@ import {
 	type ReconnectParams,
 	type IStateSnapshot,
 	type SubscribeResult,
+	type ListSessionsResult,
 } from '../common/state/sessionProtocol.js';
 import { isAhpResourceWatchChannel, isAhpRootChannel, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, isAhpChatChannel, parseChatUri, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat, type SessionState } from '../common/state/sessionState.js';
 import type { IProtocolServer, IProtocolTransport } from '../common/state/sessionTransport.js';
@@ -1168,10 +1169,17 @@ export class ProtocolServerHandler extends Disposable {
 			if (params.activeClient && params.activeClient.clientId !== _client.clientId) {
 				throw new ProtocolError(JsonRpcErrorCodes.InvalidParams, `createSession.activeClient.clientId must match the connection's clientId`);
 			}
+			const workingDirectories = params.workingDirectories?.map(d => URI.parse(d));
+			const primaryWorkingDirectory = params.primaryWorkingDirectory ? URI.parse(params.primaryWorkingDirectory) : undefined;
 			try {
 				createdSession = await this._agentService.createSession({
 					provider: params.provider,
-					workingDirectory: params.workingDirectories?.[0] ? URI.parse(params.workingDirectories[0]) : undefined,
+					workingDirectories,
+					primaryWorkingDirectory,
+					// TRANSITIONAL: keep the singular alias populated (= primary, or the first
+					// requested directory) until all readers migrate to the plural fields, so
+					// provider cwd resolution is unchanged during the migration.
+					workingDirectory: primaryWorkingDirectory ?? workingDirectories?.[0],
 					session: URI.parse(params.channel),
 					fork,
 					config: params.config,
@@ -1250,9 +1258,9 @@ export class ProtocolServerHandler extends Disposable {
 					createdAt: new Date(s.startTime).toISOString(),
 					modifiedAt: new Date(s.modifiedTime).toISOString(),
 					...(s.project ? { project: { uri: s.project.uri.toString(), displayName: s.project.displayName } } : {}),
-					workingDirectory: s.workingDirectory?.toString(),
+					workingDirectories: s.workingDirectory ? [s.workingDirectory.toString()] : undefined,
 					changes: s.changes,
-				};
+				} satisfies ListSessionsResult['items'][number];
 			});
 			return { items };
 		},

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -682,6 +682,31 @@ suite('ProtocolServerHandler', () => {
 		});
 	});
 
+	test('listSessions maps the working directory into the workingDirectories array (regression: remote wire mismatch)', async () => {
+		agentService.listedSessions.push({
+			session: URI.parse(sessionUri),
+			startTime: 1000,
+			modifiedTime: 2000,
+			summary: 'Session Summary',
+			workingDirectory: URI.file('/workspace/project'),
+		});
+
+		const transport = connectClient('client-list-wd');
+		transport.sent.length = 0;
+		const responsePromise = waitForResponse(transport, 2);
+
+		transport.simulateMessage(request(2, 'listSessions'));
+		const resp = await responsePromise;
+
+		const result = (resp as unknown as { result: ListSessionsResult }).result;
+		const item = result.items[0];
+		assert.deepStrictEqual(item.workingDirectories, [URI.file('/workspace/project').toString()]);
+		// The server must NOT emit the off-schema singular `workingDirectory`; the
+		// client and schema read `workingDirectories`, so emitting the singular
+		// dropped the cwd on the remote list path.
+		assert.strictEqual((item as { workingDirectory?: unknown }).workingDirectory, undefined);
+	});
+
 	test('createSession returns null and broadcasts project in sessionAdded summary', async () => {
 		const transport = connectClient('client-create');
 		transport.sent.length = 0;


### PR DESCRIPTION
Part of #321651 — **Phases 0 and 1** of the staged multi-root working-directory adoption (see the phase checklist on that issue).

## What this does

Teaches the agent-host **create-session pipeline** to carry a directory set + an intended per-chat primary, and fixes a pre-existing wire bug. **Behaviour-preserving** — sessions still have 0–1 directory today (no agent advertises the `multipleWorkingDirectories` capability yet), so `workingDirectories` is a one-element array equal to the primary.

- **Phase 0** — fix the `listSessions` wire mismatch: the server emitted an off-schema singular `workingDirectory` while the client + schema expect `workingDirectories`, so the cwd was dropped on the remote path. (+ regression test.)
- **Phase 1** — plural creation plumbing:
  - `IAgentCreateSessionConfig` gains `workingDirectories?` + `primaryWorkingDirectory?` (singular `workingDirectory` kept as a **transitional** alias, removed in a later phase); new `common/workingDirectories.ts` helpers.
  - Client `createSession` sends the set + primary; server handler forwards them (keeps the transitional alias).
  - Node service `_buildInitialSummary` carries the set (preserving resolved-worktree precedence); all providers (Copilot/Claude/Codex) and node readers resolve the cwd via the primary helper.
  - `IAgentCreateSessionResult` / `IAgentMaterializeSessionEvent` carry the resolved set.

## Not in this PR (later phases, see #321651)

Removing the transitional singular field + default-chat `primaryWorkingDirectory` persistence (Phase 2); Editor/Agents multi-root UI (Phase 3); capability advertising + mutation actions (Phases 4–5); git/changeset track (deferred).

## Validation

- `npm run typecheck-client` — clean
- `npm run valid-layers-check` — clean
- Node unit tests (`agentHost`) — **528 passing** (incl. the new `listSessions` regression test)
- Pre-commit hygiene — passed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
