### PR TITLE
[Bad changes] Broken languageMode arg when changed to language id picking

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -1218,7 +1218,7 @@ export class ChangeLanguageAction extends Action2 {
 			picks.unshift(autoDetectLanguage);
 		}
 
-		const pick = typeof languageMode === 'string' ? { label: languageMode } : await quickInputService.pick(picks, { placeHolder: localize('pickLanguage', "Select Language Mode"), matchOnDescription: true });
+		const pick = typeof languageMode === 'string' ? languageService.createById(languageMode) : await quickInputService.pick(picks, { placeHolder: localize('pickLanguage', "Select Language Mode"), matchOnDescription: true });
 		if (!pick) {
 			return;
 		}


### PR DESCRIPTION
EDIT: Bad changes.

------

Fixes [296494](https://github.com/microsoft/vscode/issues/296494)

When added languageMode as an arg in [aaa5cb462e8e365d0c123378fd89284f1f58ba12](https://github.com/microsoft/vscode/commit/aaa5cb462e8e365d0c123378fd89284f1f58ba12) it was treated as the language label. It got broken after [cce0642bfb890ca622a922cdb202bf834a3f71ba](https://github.com/microsoft/vscode/commit/cce0642bfb890ca622a922cdb202bf834a3f71ba) to prevent ambiguity in cases like "Yaml" and "yaml". To fix the command argument and to be consistent with that last mentioned commit, languageMode should be treated as languageId.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
