### PR TITLE
git - open nested repository when a file from it is opened later (fixes #327119)

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -552,7 +552,16 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 				const repository = this.getRepository(uri);
 
 				if (repository) {
-					this.logger.trace(`[Model][onDidChangeVisibleTextEditors] Repository for editor resource ${uri.fsPath} already exists: ${repository.root}`);
+					// Handle nested repositories that are shadowed by the already-open repository
+					const nestedRepositoryPath = await this.findNestedRepositoryPath(path.dirname(uri.fsPath), repository.root);
+
+					if (!nestedRepositoryPath) {
+						this.logger.trace(`[Model][onDidChangeVisibleTextEditors] Repository for editor resource ${uri.fsPath} already exists: ${repository.root}`);
+						return;
+					}
+
+					this.logger.trace(`[Model][onDidChangeVisibleTextEditors] Open nested repository for editor resource ${uri.fsPath}`);
+					await this.openRepository(nestedRepositoryPath);
 					return;
 				}
 
@@ -563,6 +572,30 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 		catch (err) {
 			this.logger.warn(`[Model][onDidChangeVisibleTextEditors] Error: ${err}`);
 		}
+	}
+
+	/**
+	 * Walks from `folderPath` up to (excluding) `repositoryRoot` looking for a
+	 * `.git` folder/file of a nested repository that has not been opened yet.
+	 */
+	private async findNestedRepositoryPath(folderPath: string, repositoryRoot: string): Promise<string | undefined> {
+		while (isDescendant(repositoryRoot, folderPath) && !pathEquals(repositoryRoot, folderPath)) {
+			try {
+				await fs.promises.stat(path.join(folderPath, '.git'));
+				return folderPath;
+			} catch {
+				// no `.git` at this level, continue with the parent folder
+			}
+
+			const parentPath = path.dirname(folderPath);
+			if (pathEquals(parentPath, folderPath)) {
+				break;
+			}
+
+			folderPath = parentPath;
+		}
+
+		return undefined;
 	}
 
 	private onDidChangeActiveTextEditor(): void {

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -202,4 +202,29 @@ suite('git smoke test', function () {
 		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
 		assert.strictEqual(repository.state.indexChanges.length, 0);
 	});
+
+	test('detects nested repository when a file from it is opened after startup', async function () {
+		// Only the parent repository is open
+		assert.strictEqual(git.repositories.length, 1);
+		assert.strictEqual(git.repositories[0].rootUri.fsPath, repository.rootUri.fsPath);
+
+		const nestedRoot = file(path.join('sub', 'nested'));
+		fs.mkdirSync(nestedRoot, { recursive: true });
+		fs.writeFileSync(path.join(nestedRoot, 'nested.txt'), 'hello', 'utf8');
+		cp.execSync('git init -b main', { cwd: nestedRoot });
+		cp.execSync('git config user.name testuser', { cwd: nestedRoot });
+		cp.execSync('git config user.email monacotools@example.com', { cwd: nestedRoot });
+		cp.execSync('git config commit.gpgsign false', { cwd: nestedRoot });
+		cp.execSync('git add .', { cwd: nestedRoot });
+		cp.execSync('git commit -m "initial commit"', { cwd: nestedRoot });
+
+		// Opening a file from the nested repository registers the nested
+		// repository even though an ancestor repository is already open
+		const onDidOpenRepository = eventToPromise(git.onDidOpenRepository);
+		await open(path.join('sub', 'nested', 'nested.txt'));
+		const nestedRepository = await onDidOpenRepository;
+
+		assert.strictEqual(nestedRepository.rootUri.fsPath, nestedRoot);
+		assert.strictEqual(git.repositories.length, 2);
+	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #327119

### Problem

Whether a nested git repository (one whose root sits below an already-open workspace/parent repository) gets registered depends on startup timing. If one of its files is visible when the window loads, the repository appears in Source Control; if the same file is opened later, it never does.

The cause is in `Model.onDidChangeVisibleTextEditors()`: it short-circuits when `getRepository()` returns a match for the editor resource. `getRepository()` matches purely by path ancestry over *already-open* repositories, so once an ancestor repository is open it always shadows a nested repository that has not been opened yet. During `doInitialScan()` the handler runs concurrently with the workspace folder scan, so the ancestor is usually not registered yet and the nested repository gets opened via `git rev-parse --show-toplevel`. After startup the ancestor always wins and `openRepository()` is never called.

### Fix

When the editor resource matches an already-open repository, probe for a `.git` folder/file between the resource and the matched repository root (one `fs.stat` per directory level, bounded by the repository root). If one is found, open that path with the existing `openRepository()`, which keeps all current behavior intact (repositories closed by the user, `git.ignoredRepositories`, unsafe repositories, parent repository handling, workspace trust). If nothing is found, the previous short-circuit behavior is unchanged.

### To test

1. Open a folder whose root is a git repository (the "parent").
2. Create a second git repository nested in a subfolder, e.g. `sub/nested` (`git init` plus a commit).
3. Start with no file from the nested repository visible, then open `sub/nested/<file>` from the Explorer.
4. Before this change: the nested repository never appears in Source Control; the git trace log shows `[Model][onDidChangeVisibleTextEditors] Repository for editor resource … already exists: <parent>`. With this change: the nested repository is registered as its own source control provider as soon as the file becomes visible.
5. Unchanged behavior to verify: files of the parent repository with no `.git` in between still short-circuit, repositories closed by the user stay closed, and detection still respects `git.autoRepositoryDetection` (`true`/`"openEditors"`).
