### PR TITLE
Fix race condition in modal editor part singleton creation

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorParts.ts
+++ b/src/vs/workbench/browser/parts/editor/editorParts.ts
@@ -186,6 +186,10 @@ export class EditorParts extends MultiWindowParts<EditorPart, IEditorPartsMement
 	private modalEditorSidebarWidth: number | undefined;
 	private modalEditorSidebarHidden: boolean | undefined;
 
+	// Tracks an in-flight creation so concurrent callers await and reuse the
+	// same singleton instance instead of each racing to create their own.
+	private modalEditorPartCreatePromise: Promise<IModalEditorPart> | undefined;
+
 	async createModalEditorPart(options?: IModalEditorPartOptions): Promise<IModalEditorPart> {
 
 		// Reuse existing modal editor part if it exists
@@ -195,6 +199,24 @@ export class EditorParts extends MultiWindowParts<EditorPart, IEditorPartsMement
 			return this.modalEditorPart;
 		}
 
+		// Another creation is already in flight: await it instead of starting
+		// a second one, then apply this call's options to the shared instance
+		if (this.modalEditorPartCreatePromise) {
+			const part = await this.modalEditorPartCreatePromise;
+			part.updateOptions(options);
+
+			return part;
+		}
+
+		const createPromise = this.doCreateModalEditorPart(options).finally(() => {
+			this.modalEditorPartCreatePromise = undefined;
+		});
+		this.modalEditorPartCreatePromise = createPromise;
+
+		return createPromise;
+	}
+
+	private async doCreateModalEditorPart(options: IModalEditorPartOptions | undefined): Promise<IModalEditorPart> {
 		const { part, instantiationService, disposables } = await this.instantiationService.createInstance(ModalEditorPart, this).create({
 			...options,
 			maximized: options?.maximized ?? this.modalEditorMaximized,

--- a/src/vs/workbench/services/editor/test/browser/modalEditorGroup.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/modalEditorGroup.test.ts
@@ -188,6 +188,38 @@ suite('Modal Editor Group', () => {
 		await modalPart1.close();
 	});
 
+	test('createModalEditorPart is race-proof: concurrent creation returns same singleton instance', async () => {
+		const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) }, disposables);
+		instantiationService.invokeFunction(accessor => Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).start(accessor));
+		const parts = await createEditorParts(instantiationService, disposables);
+		instantiationService.stub(IEditorGroupsService, parts);
+
+		let addGroupCount = 0;
+		disposables.add(parts.onDidAddGroup(() => {
+			addGroupCount++;
+		}));
+
+		// Fire multiple concurrent creation requests before any of them has a
+		// chance to resolve and assign the singleton instance
+		const [modalPart1, modalPart2, modalPart3] = await Promise.all([
+			parts.createModalEditorPart(),
+			parts.createModalEditorPart(),
+			parts.createModalEditorPart()
+		]);
+
+		// All concurrent calls must resolve to the exact same singleton instance/group
+		assert.strictEqual(modalPart1, modalPart2);
+		assert.strictEqual(modalPart2, modalPart3);
+		assert.strictEqual(modalPart1.activeGroup.id, modalPart2.activeGroup.id);
+		assert.strictEqual(modalPart1.activeGroup.id, modalPart3.activeGroup.id);
+
+		// Only a single group/registration event should have fired for the singleton,
+		// proving only one modal part was ever created despite the concurrent calls
+		assert.strictEqual(addGroupCount, 1);
+
+		await modalPart1.close();
+	});
+
 	test('modal editor part singleton is reset after close', async () => {
 		const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) }, disposables);
 		instantiationService.invokeFunction(accessor => Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).start(accessor));


### PR DESCRIPTION
## Summary

Fixes a race condition in modal editor part singleton creation identified while reviewing #326885.

EditorParts.createModalEditorPart awaited the ModalEditorPart creation (wait this.instantiationService.createInstance(ModalEditorPart, this).create(...)) *before* assigning 	his.modalEditorPart. If createModalEditorPart was called concurrently (e.g. two callers racing to open a modal editor), both calls could pass the "reuse existing instance" check and each create its own ModalEditorPart, resulting in duplicate modal editor parts/groups and duplicate onDidAddGroup events.

## Fix

- Track the in-flight creation as a promise (modalEditorPartCreatePromise).
- If a creation is already in flight when createModalEditorPart is called again, await that promise and apply the caller's options to the resulting singleton instance instead of starting a second creation.
- Preserves existing option-update behavior for both the "already created" and "creation in flight" cases.

This does **not** include the separate stable-ID change from #326885 — that should land separately.

## Testing

- createModalEditorPart is race-proof: concurrent creation returns same singleton instance (new test in modalEditorGroup.test.ts) fires 3 concurrent createModalEditorPart() calls via Promise.all and asserts:
  - all three calls resolve to the exact same instance/group
  - only one onDidAddGroup event fires
- Ran the full Modal Editor Group suite (42 tests) - all passing.
- 
pm run typecheck-client - 0 errors.