### PR TITLE
git: remove repo from SCM when workspace folder is removed

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -477,13 +477,28 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 				.filter(repository => !!repository) as Repository[];
 
 			const activeRepositories = new Set<Repository>(activeRepositoriesList);
-			const openRepositoriesToDispose = removed
-				.map(folder => this.getOpenRepository(folder.uri))
-				.filter(r => !!r)
-				.filter(r => !activeRepositories.has(r!.repository))
-				.filter(r => !(workspace.workspaceFolders || []).some(f => isDescendant(f.uri.fsPath, r!.repository.root))) as OpenRepository[];
+
+			// Find all open repositories whose root is at or inside a removed workspace folder.
+			// The original check only used getOpenRepository(folder.uri) which relies on isDescendant
+			// and misses the common case where the repo root IS the workspace folder itself.
+			const openRepositoriesToDispose = this.openRepositories
+				.filter(r => removed.some(folder => isDescendant(folder.uri.fsPath, r.repository.root) || r.repository.root === folder.uri.fsPath))
+				.filter(r => !activeRepositories.has(r.repository))
+				.filter(r => !(workspace.workspaceFolders || []).some(f => isDescendant(f.uri.fsPath, r.repository.root)));
 
 			openRepositoriesToDispose.forEach(r => r.dispose());
+
+			// Prune stale closedRepositories entries for the removed workspace folders so that
+			// manually-closed repos don't ghost back the next time the workspace is opened.
+			for (const folder of removed) {
+				for (const closedRepo of this._closedRepositoriesManager.repositories) {
+					if (isDescendant(folder.uri.fsPath, closedRepo) || closedRepo === folder.uri.fsPath) {
+						this._closedRepositoriesManager.deleteRepository(closedRepo);
+						this.logger.trace(`[Model][onDidChangeWorkspaceFolders] Pruned stale closed repository: ${closedRepo}`);
+					}
+				}
+			}
+
 			this.logger.trace(`[Model][onDidChangeWorkspaceFolders] Workspace folders: [${possibleRepositoryFolders.map(p => p.uri.fsPath).join(', ')}]`);
 			await Promise.all(possibleRepositoryFolders.map(p => this.openRepository(p.uri.fsPath)));
 		}
@@ -491,6 +506,7 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			this.logger.warn(`[Model][onDidChangeWorkspaceFolders] Error: ${err}`);
 		}
 	}
+
 
 	private async onDidChangeWorkspaceTrustedFolders(): Promise<void> {
 		try {


### PR DESCRIPTION
## Summary

Fixes #108757

When a workspace folder is removed from a multi-root workspace, the corresponding git repository was not being removed from the Source Control (SCM) panel.

## Root Cause

The original code in `onDidChangeWorkspaceFolders` used `getOpenRepository(folder.uri)` to find repositories to dispose. `getOpenRepository(uri)` internally checks `isDescendant(repoRoot, resourcePath)` which returns `false` when the repository root **is** the workspace folder itself (the most common case), because a path is not considered a descendant of itself. As a result, no repository was ever found and nothing was disposed.

## Fix

**1. Correct repository lookup on folder removal**

Instead of relying on the indirect URI lookup, the fix iterates `this.openRepositories` directly and checks whether each repository root is equal to or a descendant of any removed workspace folder.

**2. Prune stale `closedRepositories` entries**

When a repo was manually closed by the user (via "Close Repository") before the workspace folder was removed, its root path remained in the `closedRepositories` workspace state. This caused the repo to reappear in the SCM panel the next time the workspace was opened (step 4 of the original bug report). The fix now prunes these stale entries when their associated workspace folder is removed.

## Testing

Steps to reproduce (from issue #108757):
1. Create a multi-root workspace with two folders, each containing a git repo
2. Verify both repos appear in the SCM panel
3. Remove one folder from the workspace (right-click -> Remove Folder from Workspace)
4. The corresponding repo now immediately disappears from the SCM panel
5. Reopen the workspace
6. The removed repo no longer reappears
