### PR TITLE
Await Copilot session teardown before config refresh

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1944,8 +1944,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 			this._logService.info(`[Copilot:${context.sessionId}] sendMessage: cachedEntry=${hadCachedEntry}, hasActiveClient=${!!activeClient}, activeClientId=${activeClient ? '(set)' : '(none)'}`);
 			if (entry && activeClient && await activeClient.requiresRestart(entry.appliedSnapshot)) {
 				this._logService.info(`[Copilot:${context.sessionId}] Session config changed (requiresRestart=true), refreshing session. clients=[${[...activeClient.toolSet.clientIds()].join(', ') || '(none)'}]`);
-				// Dispose only the default chat so it resumes with the updated
-				// config; peer chats on the same entry are left intact.
+				// Finish disconnecting before resuming the same SDK session id.
+				await entry.destroySession();
 				this._sessions.get(context.sessionId)?.clearDefaultChat();
 				entry = undefined;
 			}

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -4091,6 +4091,65 @@ suite('CopilotAgent', () => {
 		});
 	});
 
+	suite('config-driven session refresh', () => {
+		test('waits for the previous SDK session to disconnect before resuming', async () => {
+			const client = new TestCopilotClient([]);
+			const agent = createTestAgent(disposables, { copilotClient: client });
+			const sessionId = 'config-refresh-session';
+			const session = AgentSession.uri('copilotcli', sessionId);
+			const disconnectStarted = new DeferredPromise<void>();
+			const allowDisconnect = new DeferredPromise<void>();
+			const order: string[] = [];
+			const previousSession = {
+				appliedSnapshot: { tools: [], plugins: [], mcpServers: {} },
+				destroySession: async () => {
+					order.push('disconnect-started');
+					disconnectStarted.complete();
+					await allowDisconnect.p;
+					order.push('disconnect-finished');
+				},
+				dispose: () => order.push('previous-disposed'),
+			} as unknown as CopilotAgentSession;
+			const resumedSession = {
+				send: async () => { order.push('send'); },
+				dispose: () => { },
+			} as unknown as CopilotAgentSession;
+			const internals = agent as unknown as {
+				_resumeSession: (id: string) => Promise<CopilotAgentSession>;
+			};
+
+			setDefaultSessionStub(agent, sessionId, previousSession);
+			agent.getOrCreateActiveClient(session, { clientId: 'client' }).tools = [
+				{ name: 'new_tool', description: 'A newly registered tool', inputSchema: { type: 'object', properties: {} } },
+			];
+			internals._resumeSession = async id => {
+				assert.strictEqual(id, sessionId);
+				order.push('resume');
+				setDefaultSessionStub(agent, sessionId, resumedSession);
+				return resumedSession;
+			};
+
+			try {
+				const send = agent.chats.sendMessage(defaultChatUri(session), 'hello', undefined);
+				await disconnectStarted.p;
+				assert.deepStrictEqual(order, ['disconnect-started']);
+
+				allowDisconnect.complete();
+				await send;
+				assert.deepStrictEqual(order, [
+					'disconnect-started',
+					'disconnect-finished',
+					'previous-disposed',
+					'resume',
+					'send',
+				]);
+			} finally {
+				allowDisconnect.complete();
+				await disposeAgent(agent);
+			}
+		});
+	});
+
 	suite('_resumeSession dedup', () => {
 		// Regression: two concurrent paths (e.g. an outdated-config refresh in
 		// `sendMessage` and a `getSessionMessages` subscribe) each calling


### PR DESCRIPTION
Fixes #327125

A structural active-client configuration change refreshes the default Copilot chat by disposing and resuming its SDK session. Disposal previously started `session.disconnect()` without awaiting it, allowing the stale `session.destroy` request to terminate the newly resumed session with the same ID. The next turn then failed with `Holder terminated during creation`.

This change awaits the existing session teardown before clearing and resuming the default chat. Peer chats remain intact. A deterministic regression test holds disconnect open and verifies that dispose, resume, and send occur only after teardown completes.

Testing:
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotAgent.test.ts`
- hygiene checks

cc @connor4312