### PR TITLE
Disable foundry install for smoke test pipeline

### DIFF
--- a/build/azure-pipelines/common/disableFoundryLocalInstall.ts
+++ b/build/azure-pipelines/common/disableFoundryLocalInstall.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const packageJsonPath = path.resolve(import.meta.dirname, '../../..', 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+	dependencies?: Record<string, string>;
+	allowScripts?: Record<string, boolean>;
+};
+const allowScripts = packageJson.allowScripts;
+const foundryLocalVersion = packageJson.dependencies?.['foundry-local-sdk'];
+const foundryLocalKey = foundryLocalVersion ? `foundry-local-sdk@${foundryLocalVersion}` : undefined;
+
+if (!allowScripts || !foundryLocalKey || allowScripts[foundryLocalKey] !== true) {
+	throw new Error('Expected an approved, pinned foundry-local-sdk install script in package.json');
+}
+
+allowScripts[foundryLocalKey] = false;
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, undefined, 2)}\n`);
+console.log(`Disabled ${foundryLocalKey} install scripts for this CI job`);

--- a/build/azure-pipelines/linux/product-smoke-flaky-linux.yml
+++ b/build/azure-pipelines/linux/product-smoke-flaky-linux.yml
@@ -30,6 +30,12 @@ jobs:
           isProduction: false
           condition: succeededOrFailed()
     steps:
+      # Smoke tests do not exercise on-device dictation, and packaged builds
+      # fetch its native runtime from the VS Code CDN on demand. Avoid the SDK's
+      # redundant install-time NuGet download, which is blocked on this pool.
+      - script: node build/azure-pipelines/common/disableFoundryLocalInstall.ts
+        displayName: Disable Foundry Local Native Install
+
       # Build VS Code from source. No VSCODE_RUN_*_TESTS flags are passed, so the
       # compile template builds the client/server but skips compiling the test
       # suites and skips the unit/integration/smoke test template entirely — we

--- a/build/azure-pipelines/win32/product-smoke-flaky-win32.yml
+++ b/build/azure-pipelines/win32/product-smoke-flaky-win32.yml
@@ -28,6 +28,12 @@ jobs:
           isProduction: false
           condition: succeededOrFailed()
     steps:
+      # Smoke tests do not exercise on-device dictation, and packaged builds
+      # fetch its native runtime from the VS Code CDN on demand. Avoid the SDK's
+      # redundant install-time NuGet download, which is blocked on this pool.
+      - powershell: node build/azure-pipelines/common/disableFoundryLocalInstall.ts
+        displayName: Disable Foundry Local Native Install
+
       # Build VS Code from source. No VSCODE_RUN_*_TESTS flags are passed, so the
       # compile template builds the client/server but skips compiling the test
       # suites and skips the unit/integration/smoke test template entirely — we


### PR DESCRIPTION
We can't access npm in the smoke test pipeline to install this