### PR TITLE
sessions: Add first-time Agents window open telemetry

### DIFF
--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -13,7 +13,7 @@ import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { IV8Profile } from '../../profiling/common/profiling.js';
 import { AuthInfo, Credentials } from '../../request/common/request.js';
 import { IPartsSplash } from '../../theme/common/themeService.js';
-import { IColorScheme, IOpenedAuxiliaryWindow, IOpenedMainWindow, IOpenEmptyWindowOptions, IOpenWindowOptions, IPoint, IRectangle, IWindowOpenable } from '../../window/common/window.js';
+import { AgentsWindowOpenSource, IColorScheme, IOpenedAuxiliaryWindow, IOpenedMainWindow, IOpenEmptyWindowOptions, IOpenWindowOptions, IPoint, IRectangle, IWindowOpenable } from '../../window/common/window.js';
 
 export interface IToastOptions {
 	readonly id: string;
@@ -39,6 +39,12 @@ export interface IToastResult {
 export type INativeZipFile =
 	| { readonly path: string; readonly contents: string }
 	| { readonly path: string; readonly source: URI; readonly size: number };
+
+export interface IOpenAgentsWindowOptions {
+	readonly folderUri?: UriComponents;
+	readonly sessionResource?: UriComponents;
+	readonly source?: AgentsWindowOpenSource;
+}
 
 export interface ICPUProperties {
 	model: string;
@@ -225,7 +231,7 @@ export interface ICommonNativeHostService {
 	openWindow(options?: IOpenEmptyWindowOptions): Promise<void>;
 	openWindow(toOpen: IWindowOpenable[], options?: IOpenWindowOptions): Promise<void>;
 
-	openAgentsWindow(options?: { folderUri?: UriComponents; sessionResource?: UriComponents }): Promise<void>;
+	openAgentsWindow(options?: IOpenAgentsWindowOptions): Promise<void>;
 
 	/**
 	 * Registers this window's set of system-wide (OS global) keybindings with the main process,

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -15,7 +15,7 @@ import { matchesSomeScheme, Schemas } from '../../../base/common/network.js';
 import { dirname, join, posix, resolve, win32 } from '../../../base/common/path.js';
 import { isLinux, isMacintosh, isWindows } from '../../../base/common/platform.js';
 import { AddFirstParameterToFunctions, hasKey } from '../../../base/common/types.js';
-import { URI, UriComponents } from '../../../base/common/uri.js';
+import { URI } from '../../../base/common/uri.js';
 import { virtualMachineHint } from '../../../base/node/id.js';
 import { Promises, SymlinkSupport } from '../../../base/node/pfs.js';
 import { findFreePort, isPortFree } from '../../../base/node/ports.js';
@@ -27,7 +27,7 @@ import { IEnvironmentMainService } from '../../environment/electron-main/environ
 import { createDecorator, IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILifecycleMainService, IRelaunchOptions } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
-import { FocusMode, ICommonNativeHostService, INativeHostOptions, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, INativeZipFile, IOSProperties, IOSProxy, IOSProxyConfig, IOSStatistics, IStartTracingOptions, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../common/native.js';
+import { FocusMode, ICommonNativeHostService, INativeHostOptions, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, INativeZipFile, IOpenAgentsWindowOptions, IOSProperties, IOSProxy, IOSProxyConfig, IOSStatistics, IStartTracingOptions, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../common/native.js';
 import { IGlobalKeybindingsMainService } from '../../globalKeybindings/electron-main/globalKeybindingsMainService.js';
 import { IProductService } from '../../product/common/productService.js';
 import { IPartsSplash } from '../../theme/common/themeService.js';
@@ -315,12 +315,12 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		}, options);
 	}
 
-	async openAgentsWindow(windowId: number | undefined, options?: { folderUri?: UriComponents; sessionResource?: UriComponents }): Promise<void> {
+	async openAgentsWindow(windowId: number | undefined, options?: IOpenAgentsWindowOptions): Promise<void> {
 		const windows = await this.windowsMainService.openAgentsWindow({
 			context: OpenContext.API,
 			contextWindowId: windowId,
 			cli: this.environmentMainService.args,
-		}, options?.folderUri ? URI.revive(options.folderUri) : undefined, options?.sessionResource ? URI.revive(options.sessionResource) : undefined);
+		}, options?.folderUri ? URI.revive(options.folderUri) : undefined, options?.sessionResource ? URI.revive(options.sessionResource) : undefined, options?.source);
 		if (windows.length > 0) {
 			windows[0].focus();
 		}

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -104,6 +104,33 @@ export function isOpenedAuxiliaryWindow(candidate: IOpenedMainWindow | IOpenedAu
 
 export interface IOpenEmptyWindowOptions extends IBaseOpenWindowsOptions { }
 
+export const enum AgentsWindowOpenSource {
+	CommandPalette = 'commandPalette',
+	KeyboardShortcut = 'keyboardShortcut',
+	TitleBar = 'titleBar',
+	ChatTitleBar = 'chatTitleBar',
+	ChatHandoff = 'chatHandoff',
+	Banner = 'banner',
+	CommandLine = 'commandLine',
+	Unknown = 'unknown',
+}
+
+export function isAgentsWindowOpenSource(value: unknown): value is AgentsWindowOpenSource {
+	switch (value) {
+		case AgentsWindowOpenSource.CommandPalette:
+		case AgentsWindowOpenSource.KeyboardShortcut:
+		case AgentsWindowOpenSource.TitleBar:
+		case AgentsWindowOpenSource.ChatTitleBar:
+		case AgentsWindowOpenSource.ChatHandoff:
+		case AgentsWindowOpenSource.Banner:
+		case AgentsWindowOpenSource.CommandLine:
+		case AgentsWindowOpenSource.Unknown:
+			return true;
+		default:
+			return false;
+	}
+}
+
 export type IWindowOpenable = IWorkspaceToOpen | IFolderToOpen | IFileToOpen;
 
 export interface IBaseWindowOpenable {

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -17,7 +17,7 @@ import { ServicesAccessor, createDecorator } from '../../instantiation/common/in
 import { ILogService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
 import { IThemeMainService } from '../../theme/electron-main/themeMainService.js';
-import { IOpenEmptyWindowOptions, IWindowOpenable, IWindowSettings, TitlebarStyle, WindowMinimumSize, hasNativeTitlebar, useNativeFullScreen, useWindowControlsOverlay, zoomLevelToZoomFactor } from '../../window/common/window.js';
+import { AgentsWindowOpenSource, IOpenEmptyWindowOptions, IWindowOpenable, IWindowSettings, TitlebarStyle, WindowMinimumSize, hasNativeTitlebar, useNativeFullScreen, useWindowControlsOverlay, zoomLevelToZoomFactor } from '../../window/common/window.js';
 import { ICodeWindow, IWindowState, WindowMode, defaultWindowState } from '../../window/electron-main/window.js';
 
 export const IWindowsMainService = createDecorator<IWindowsMainService>('windowsMainService');
@@ -41,7 +41,7 @@ export interface IWindowsMainService {
 	openExtensionDevelopmentHostWindow(extensionDevelopmentPath: string[], openConfig: IOpenConfiguration): Promise<ICodeWindow[]>;
 	openExistingWindow(window: ICodeWindow, openConfig: IOpenConfiguration): void;
 
-	openAgentsWindow(openConfig: IOpenConfiguration, folderUri?: URI, sessionResource?: URI): Promise<ICodeWindow[]>;
+	openAgentsWindow(openConfig: IOpenConfiguration, folderUri?: URI, sessionResource?: URI, source?: AgentsWindowOpenSource): Promise<ICodeWindow[]>;
 
 	sendToFocused(channel: string, ...args: unknown[]): void;
 	sendToOpeningWindow(channel: string, ...args: unknown[]): void;

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -37,7 +37,7 @@ import product from '../../product/common/product.js';
 import { IProtocolMainService } from '../../protocol/electron-main/protocol.js';
 import { getRemoteAuthority } from '../../remote/common/remoteHosts.js';
 import { IStateService } from '../../state/node/state.js';
-import { IAddRemoveFoldersRequest, INativeOpenFileRequest, INativeWindowConfiguration, IOpenEmptyWindowOptions, IPath, IPathsToWaitFor, isFileToOpen, isFolderToOpen, isWorkspaceToOpen, IWindowOpenable, IWindowSettings } from '../../window/common/window.js';
+import { AgentsWindowOpenSource, IAddRemoveFoldersRequest, INativeOpenFileRequest, INativeWindowConfiguration, IOpenEmptyWindowOptions, IPath, IPathsToWaitFor, isFileToOpen, isFolderToOpen, isWorkspaceToOpen, IWindowOpenable, IWindowSettings } from '../../window/common/window.js';
 import { CodeWindow } from './windowImpl.js';
 import { IOpenConfiguration, IOpenEmptyConfiguration, IWindowsCountChangedEvent, IWindowsMainService, OpenContext, getLastFocused } from './windows.js';
 import { findWindowOnExtensionDevelopmentPath, findWindowOnFile, findWindowOnWorkspaceOrFolder } from './windowsFinder.js';
@@ -292,7 +292,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		this.handleChatRequest(openConfig, [window]);
 	}
 
-	async openAgentsWindow(openConfig: IOpenConfiguration, folderUri?: URI, sessionResource?: URI): Promise<ICodeWindow[]> {
+	async openAgentsWindow(openConfig: IOpenConfiguration, folderUri?: URI, sessionResource?: URI, source?: AgentsWindowOpenSource): Promise<ICodeWindow[]> {
 		this.logService.trace('windowsManager#openAgentsWindow');
 
 		// Open in a new browser window with the agent sessions workspace
@@ -302,8 +302,9 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		// session resource to open. The handler in the agents window sequences
 		// them (folder → open session) so the session-open doesn't race the
 		// folder-resolve.
-		if ((folderUri || sessionResource) && windows.length > 0) {
-			windows[0].sendWhenReady('vscode:selectAgentsFolder', CancellationToken.None, folderUri?.toJSON(), sessionResource?.toJSON());
+		if (windows.length > 0) {
+			const openSource = source ?? (openConfig.cli.agents ? AgentsWindowOpenSource.CommandLine : AgentsWindowOpenSource.Unknown);
+			windows[0].sendWhenReady('vscode:selectAgentsFolder', CancellationToken.None, folderUri?.toJSON(), sessionResource?.toJSON(), openSource);
 		}
 
 		return windows;

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -609,6 +609,12 @@ Providers may fire `onDidReplaceSession` when a temporary (untitled) session is 
 
 Provider add notifications are authoritative upserts. A provisional `listSessions()` entry may already be cached when the backend publishes its materialized project and working directory, so providers update the existing session adapter in place and report it as changed rather than replacing its identity.
 
+### First-Time Window-Open Telemetry
+
+Editor entry points pass an `AgentsWindowOpenSource` through `INativeHostService.openAgentsWindow` and the `vscode:selectAgentsFolder` startup handoff. The source distinguishes command-palette, keyboard, title-bar, chat-title, handoff-tip, discovery-banner, and command-line opens without collecting workspace or session identifiers.
+
+On the first handoff in a window, `SelectAgentsFolderContribution` starts `SessionsWindowOpenTelemetry` only when the application-scoped `TOTAL_SESSIONS_KEY` counter is still zero. The collector freezes whether the settled initial view is a workspace-preselected new-session view (or records `undefined` when a created session is visible), reads whether the initial setup flow showed its sign-in dialog, and emits `agents/firstTimeWindowOpen` once. A close within three minutes includes `windowCloseDurationMs`; otherwise the event emits at the three-minute boundary with that field undefined.
+
 ### Automation Run Lifecycle
 
 `AutomationRunner` exposes separate dispatch and lifecycle promises. It resolves

--- a/src/vs/sessions/browser/sessionsSetUpService.ts
+++ b/src/vs/sessions/browser/sessionsSetUpService.ts
@@ -41,6 +41,7 @@ export const ISessionsSetUpService = createDecorator<ISessionsSetUpService>('ses
 
 export interface ISessionsSetUpService {
 	readonly _serviceBrand: undefined;
+	readonly initialSignInDialogShown: boolean;
 	/**
 	 * Resolves when the welcome/setup flow has completed (or immediately
 	 * if it is not currently active). Use this to defer work until after
@@ -69,12 +70,14 @@ class SessionsSetUpWidget extends Disposable {
 
 	private readonly dialogRef = this._register(new MutableDisposable<DisposableStore>());
 	private readonly watcherRef = this._register(new MutableDisposable());
+	private _initialSetupFlow = true;
 
 	// Non-service params must come before @-decorated service params
 	constructor(
 		private readonly onCompleted: () => void,
 		private readonly serviceWhenSetupDone: () => Promise<boolean>,
 		private readonly serviceMarkDone: () => void,
+		private readonly onInitialSignInDialogShown: () => void,
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 		@IProductService private readonly productService: IProductService,
 		@IStorageService private readonly storageService: IStorageService,
@@ -105,7 +108,7 @@ class SessionsSetUpWidget extends Disposable {
 		}
 
 		if (isWeb) {
-			this._checkWebAuth();
+			void this._checkWebAuth().finally(() => this._initialSetupFlow = false);
 			this._watchWebAuth();
 			return;
 		}
@@ -113,9 +116,9 @@ class SessionsSetUpWidget extends Disposable {
 		const isFirstLaunch = !this.storageService.getBoolean(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION, false);
 
 		if (isFirstLaunch) {
-			this._showWelcome(true);
+			void this._showWelcome(true).finally(() => this._initialSetupFlow = false);
 		} else {
-			this._watchSignInState();
+			void this._watchSignInState().finally(() => this._initialSetupFlow = false);
 		}
 	}
 
@@ -300,6 +303,9 @@ class SessionsSetUpWidget extends Disposable {
 	}
 
 	private async _showSignInDialog(): Promise<void> {
+		if (this._initialSetupFlow) {
+			this.onInitialSignInDialogShown();
+		}
 		this.logService.info('[sessions welcome] Showing sign-in dialog');
 
 		const signingInDialogRef = new MutableDisposable<DisposableStore>();
@@ -401,6 +407,11 @@ export class SessionsSetUpService extends Disposable implements ISessionsSetUpSe
 
 	private readonly _initPromise: Promise<void>;
 	private readonly _welcomeDoneDeferred = new DeferredPromise<void>();
+	private _initialSignInDialogShown = false;
+
+	get initialSignInDialogShown(): boolean {
+		return this._initialSignInDialogShown;
+	}
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -417,7 +428,8 @@ export class SessionsSetUpService extends Disposable implements ISessionsSetUpSe
 			SessionsSetUpWidget,
 			() => this._welcomeDoneDeferred.complete(),
 			() => this.whenSetupDone(),
-			() => this.markDone()
+			() => this.markDone(),
+			() => this._initialSignInDialogShown = true
 		));
 	}
 

--- a/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
@@ -5,7 +5,7 @@
 
 import { ipcRenderer } from '../../../../base/parts/sandbox/electron-browser/globals.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IAgentHostByokLmHandler } from '../../../../platform/agentHost/common/agentHostByokLm.js';
 import { AgentHostByokLmHandler } from '../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostByokLmHandler.js';
@@ -21,10 +21,17 @@ import { ISessionsSetUpService } from '../../../browser/sessionsSetUpService.js'
 import { ISessionsPartService } from '../../../services/sessions/browser/sessionsPartService.js';
 import { SessionStatus } from '../../../services/sessions/common/session.js';
 import { SessionsCopilotConfigSlashSubmitHandlerContribution } from '../browser/copilotConfigSlashSubmitHandler.js';
+import { AgentsWindowOpenSource, isAgentsWindowOpenSource } from '../../../../platform/window/common/window.js';
+import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { TOTAL_SESSIONS_KEY } from '../../sessions/browser/sessionsLifecycleTracker.js';
+import { ISessionsWindowOpenViewState, SessionsWindowOpenTelemetry } from '../../sessions/browser/sessionsWindowOpenTelemetry.js';
 
 class SelectAgentsFolderContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'sessions.selectAgentsFolder';
+	private readonly _windowOpenTelemetry = this._register(new MutableDisposable<SessionsWindowOpenTelemetry>());
+	private _didHandleInitialWindowOpen = false;
 
 	constructor(
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
@@ -35,18 +42,62 @@ class SelectAgentsFolderContribution extends Disposable implements IWorkbenchCon
 		@ISessionsSetUpService private readonly sessionsSetUpService: ISessionsSetUpService,
 		@ILogService private readonly logService: ILogService,
 		@ISessionsPartService private readonly sessionsPartService: ISessionsPartService,
+		@IStorageService private readonly storageService: IStorageService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 		const handleSelectAgentsFolder = (_: unknown, ...args: unknown[]) => {
 			const folderUri = args[0] ? URI.revive(args[0] as UriComponents) : undefined;
 			const sessionResource = args[1] ? URI.revive(args[1] as UriComponents) : undefined;
+			const source = isAgentsWindowOpenSource(args[2]) ? args[2] : AgentsWindowOpenSource.Unknown;
 			this.logService.info(`[AgentsHandoff] IPC received: folderUri=${folderUri?.toString() ?? '(none)'} sessionResource=${sessionResource?.toString() ?? '(none)'}`);
+			this._startWindowOpenTelemetry(source);
 
-			this.handleOpenIntent(folderUri, sessionResource)
+			this._handleOpenIntentAndCaptureInitialState(folderUri, sessionResource)
 				.catch(err => this.logService.error('[AgentsHandoff] handleOpenIntent failed', err));
 		};
 		ipcRenderer.on('vscode:selectAgentsFolder', handleSelectAgentsFolder);
 		this._register({ dispose: () => ipcRenderer.removeListener('vscode:selectAgentsFolder', handleSelectAgentsFolder) });
+	}
+
+	private _startWindowOpenTelemetry(source: AgentsWindowOpenSource): void {
+		if (this._didHandleInitialWindowOpen) {
+			return;
+		}
+		this._didHandleInitialWindowOpen = true;
+		if (this.storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0) !== 0) {
+			return;
+		}
+
+		this._windowOpenTelemetry.value = new SessionsWindowOpenTelemetry(
+			source,
+			() => this.sessionsSetUpService.initialSignInDialogShown,
+			() => this._getWindowOpenViewState(),
+			this.telemetryService,
+			this.lifecycleService,
+		);
+	}
+
+	private async _captureInitialWindowViewState(): Promise<void> {
+		await this.lifecycleService.when(LifecyclePhase.Eventually);
+		this._windowOpenTelemetry.value?.captureInitialViewState();
+	}
+
+	private async _handleOpenIntentAndCaptureInitialState(folderUri: URI | undefined, sessionResource: URI | undefined): Promise<void> {
+		try {
+			await this.handleOpenIntent(folderUri, sessionResource);
+		} finally {
+			await this._captureInitialWindowViewState();
+		}
+	}
+
+	private _getWindowOpenViewState(): ISessionsWindowOpenViewState {
+		const activeSession = this.sessionsService.activeSession.get();
+		return {
+			workspacePreselected: !activeSession || !activeSession.isCreated.get()
+				? activeSession?.workspace.get() !== undefined
+				: undefined,
+		};
 	}
 
 	private async handleOpenIntent(folderUri: URI | undefined, sessionResource: URI | undefined): Promise<void> {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsWindowOpenTelemetry.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsWindowOpenTelemetry.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { disposableTimeout } from '../../../../base/common/async.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { AgentsWindowOpenSource } from '../../../../platform/window/common/window.js';
+import { ILifecycleService, ShutdownReason } from '../../../../workbench/services/lifecycle/common/lifecycle.js';
+
+export const FIRST_TIME_WINDOW_OPEN_DURATION_LIMIT_MS = 3 * 60 * 1000;
+
+export interface ISessionsWindowOpenViewState {
+	readonly workspacePreselected: boolean | undefined;
+}
+
+type FirstTimeWindowOpenEvent = {
+	source: string;
+	signInDialogShown: boolean;
+	workspacePreselected: boolean | undefined;
+	windowCloseDurationMs: number | undefined;
+};
+
+type FirstTimeWindowOpenClassification = {
+	source: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The editor entry point used to open the Agents window.' };
+	signInDialogShown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the initial Agents setup flow showed a sign-in dialog.' };
+	workspacePreselected: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the initial new-session view had a workspace selected. Undefined when a created session was visible.' };
+	windowCloseDurationMs: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Milliseconds before the Agents window closed, capped at three minutes.' };
+	owner: 'benibenj';
+	comment: 'Tracks how users who have never started an Agents session enter and initially experience the Agents window.';
+};
+
+export class SessionsWindowOpenTelemetry extends Disposable {
+
+	private _viewState: ISessionsWindowOpenViewState | undefined;
+	private _didSend = false;
+	private readonly _openedAt = Date.now();
+
+	constructor(
+		private readonly _source: AgentsWindowOpenSource,
+		private readonly _getSignInDialogShown: () => boolean,
+		private readonly _getViewState: () => ISessionsWindowOpenViewState,
+		private readonly _telemetryService: ITelemetryService,
+		lifecycleService: ILifecycleService,
+	) {
+		super();
+
+		const remainingDuration = Math.max(0, FIRST_TIME_WINDOW_OPEN_DURATION_LIMIT_MS - this._elapsed());
+		this._register(disposableTimeout(() => this._send(undefined), remainingDuration));
+		this._register(lifecycleService.onWillShutdown(event => {
+			const windowCloseDurationMs = event.reason === ShutdownReason.CLOSE || event.reason === ShutdownReason.QUIT
+				? this._getCloseDuration()
+				: undefined;
+			this._send(windowCloseDurationMs);
+		}));
+	}
+
+	captureInitialViewState(): void {
+		this._viewState ??= this._getViewState();
+	}
+
+	private _elapsed(): number {
+		return Math.max(0, Date.now() - this._openedAt);
+	}
+
+	private _getCloseDuration(): number | undefined {
+		const duration = this._elapsed();
+		return duration <= FIRST_TIME_WINDOW_OPEN_DURATION_LIMIT_MS ? duration : undefined;
+	}
+
+	private _send(windowCloseDurationMs: number | undefined): void {
+		if (this._didSend) {
+			return;
+		}
+		this._didSend = true;
+		this.captureInitialViewState();
+
+		this._telemetryService.publicLog2<FirstTimeWindowOpenEvent, FirstTimeWindowOpenClassification>('agents/firstTimeWindowOpen', {
+			source: this._source,
+			signInDialogShown: this._getSignInDialogShown(),
+			workspacePreselected: this._viewState?.workspacePreselected,
+			windowCloseDurationMs,
+		});
+	}
+}

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsWindowOpenTelemetry.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsWindowOpenTelemetry.test.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../base/common/async.js';
+import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullTelemetryServiceShape } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { AgentsWindowOpenSource } from '../../../../../platform/window/common/window.js';
+import { TestLifecycleService } from '../../../../../workbench/test/common/workbenchTestServices.js';
+import { ShutdownReason } from '../../../../../workbench/services/lifecycle/common/lifecycle.js';
+import { FIRST_TIME_WINDOW_OPEN_DURATION_LIMIT_MS, SessionsWindowOpenTelemetry } from '../../browser/sessionsWindowOpenTelemetry.js';
+
+class TestTelemetryService extends NullTelemetryServiceShape {
+	readonly events: { readonly name: string; readonly data: unknown }[] = [];
+
+	override publicLog2(eventName?: string, data?: unknown): void {
+		if (eventName) {
+			this.events.push({ name: eventName, data });
+		}
+	}
+}
+
+suite('SessionsWindowOpenTelemetry', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('emits captured initial state and close duration for a quick close', async () => {
+		await runWithFakedTimers({ useFakeTimers: true, startTime: 10_000 }, async () => {
+			const lifecycleService = disposables.add(new TestLifecycleService());
+			const telemetryService = new TestTelemetryService();
+			let workspacePreselected = true;
+			const tracker = disposables.add(new SessionsWindowOpenTelemetry(
+				AgentsWindowOpenSource.TitleBar,
+				() => true,
+				() => ({ workspacePreselected }),
+				telemetryService,
+				lifecycleService,
+			));
+
+			tracker.captureInitialViewState();
+			workspacePreselected = false;
+			await timeout(4_000);
+			lifecycleService.fireShutdown(ShutdownReason.CLOSE);
+
+			assert.deepStrictEqual(telemetryService.events, [{
+				name: 'agents/firstTimeWindowOpen',
+				data: {
+					source: 'titleBar',
+					signInDialogShown: true,
+					workspacePreselected: true,
+					windowCloseDurationMs: 4_000,
+				},
+			}]);
+			tracker.dispose();
+			lifecycleService.dispose();
+		});
+	});
+
+	test('emits once after three minutes without a close duration', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const lifecycleService = disposables.add(new TestLifecycleService());
+			const telemetryService = new TestTelemetryService();
+			const tracker = disposables.add(new SessionsWindowOpenTelemetry(
+				AgentsWindowOpenSource.CommandPalette,
+				() => false,
+				() => ({ workspacePreselected: undefined }),
+				telemetryService,
+				lifecycleService,
+			));
+
+			await timeout(FIRST_TIME_WINDOW_OPEN_DURATION_LIMIT_MS);
+			lifecycleService.fireShutdown(ShutdownReason.CLOSE);
+
+			assert.deepStrictEqual(telemetryService.events, [{
+				name: 'agents/firstTimeWindowOpen',
+				data: {
+					source: 'commandPalette',
+					signInDialogShown: false,
+					workspacePreselected: undefined,
+					windowCloseDurationMs: undefined,
+				},
+			}]);
+			tracker.dispose();
+			lifecycleService.dispose();
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
@@ -11,6 +11,7 @@ import { ITelemetryService } from '../../../../../platform/telemetry/common/tele
 import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 
 import { OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID } from '../../common/constants.js';
+import { AgentsWindowOpenSource } from '../../../../../platform/window/common/window.js';
 
 
 type AgentsBannerClickedEvent = {
@@ -76,7 +77,7 @@ export function createAgentsBanner(
 	disposables.add(addDisposableListener(button, 'click', () => {
 		options.onButtonClick?.();
 		telemetryService.publicLog2<AgentsBannerClickedEvent, AgentsBannerClickedClassification>('agentsBanner.clicked', { source: options.source, action: 'openAgentsWindow' });
-		commandService.executeCommand(OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, { forceNewWindow: true });
+		commandService.executeCommand(OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, { source: AgentsWindowOpenSource.Banner });
 	}));
 
 	const element = $(`.${options.cssClass}`, {}, button);

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -38,36 +38,82 @@ import { OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, OPEN_AGENTS_WINDOW_PRECONDI
 import { CommandsRegistry, ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { AgentsWindowOpenSource, isAgentsWindowOpenSource } from '../../../../../platform/window/common/window.js';
+
+const OPEN_WORKSPACE_IN_AGENTS_WINDOW_TITLE = localize2('openWorkspaceInAgentsWindow', "Open in Agents");
+const OPEN_WORKSPACE_IN_AGENTS_WINDOW_CHAT_TITLE_COMMAND_ID = 'workbench.action.chat.openWorkspaceInAgentsWindow.chatTitle';
+const OPEN_WORKSPACE_IN_AGENTS_WINDOW_TITLE_BAR_COMMAND_ID = 'workbench.action.chat.openWorkspaceInAgentsWindow.titleBar';
+
+async function openCurrentWorkspaceInAgentsWindow(accessor: ServicesAccessor, source: AgentsWindowOpenSource): Promise<void> {
+	const nativeHostService = accessor.get(INativeHostService);
+	const workspaceContextService = accessor.get(IWorkspaceContextService);
+	const folderUri = workspaceContextService.getWorkspace().folders[0]?.uri;
+	await nativeHostService.openAgentsWindow({ folderUri: folderUri?.scheme === Schemas.file ? folderUri : undefined, source });
+}
+
+function isOpenChatSessionInAgentsWindowOptions(value: unknown): value is { readonly agentsWindowOpenSource: AgentsWindowOpenSource } {
+	return !!value
+		&& typeof value === 'object'
+		&& isAgentsWindowOpenSource((value as { readonly agentsWindowOpenSource?: unknown }).agentsWindowOpenSource);
+}
 
 export class OpenWorkspaceInAgentsWindowAction extends Action2 {
 	constructor() {
 		super({
 			id: OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID,
-			title: localize2('openWorkspaceInAgentsWindow', "Open in Agents"),
+			title: OPEN_WORKSPACE_IN_AGENTS_WINDOW_TITLE,
 			category: CHAT_CATEGORY,
 			precondition: OPEN_AGENTS_WINDOW_PRECONDITION,
 			f1: true,
-			menu: [{
+		});
+	}
+
+	async run(accessor: ServicesAccessor, options?: { readonly source?: AgentsWindowOpenSource }): Promise<void> {
+		await openCurrentWorkspaceInAgentsWindow(accessor, options?.source ?? AgentsWindowOpenSource.CommandPalette);
+	}
+}
+
+export class OpenWorkspaceInAgentsWindowChatTitleAction extends Action2 {
+	constructor() {
+		super({
+			id: OPEN_WORKSPACE_IN_AGENTS_WINDOW_CHAT_TITLE_COMMAND_ID,
+			title: OPEN_WORKSPACE_IN_AGENTS_WINDOW_TITLE,
+			precondition: OPEN_AGENTS_WINDOW_PRECONDITION,
+			f1: false,
+			menu: {
 				id: MenuId.ChatTitleBarMenu,
 				group: 'c_sessions',
 				order: 1,
 				when: OPEN_AGENTS_WINDOW_PRECONDITION,
-			}, {
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		await openCurrentWorkspaceInAgentsWindow(accessor, AgentsWindowOpenSource.ChatTitleBar);
+	}
+}
+
+export class OpenWorkspaceInAgentsWindowTitleBarAction extends Action2 {
+	constructor() {
+		super({
+			id: OPEN_WORKSPACE_IN_AGENTS_WINDOW_TITLE_BAR_COMMAND_ID,
+			title: OPEN_WORKSPACE_IN_AGENTS_WINDOW_TITLE,
+			precondition: OPEN_AGENTS_WINDOW_PRECONDITION,
+			f1: false,
+			menu: {
 				id: MenuId.TitleBarAdjacentCenter,
 				order: -1000,
 				when: ContextKeyExpr.and(
 					OPEN_AGENTS_WINDOW_PRECONDITION,
 					ContextKeyExpr.notEquals(`config.${ChatConfiguration.TitleBarOpenInAgentsWindowEnabled}`, false),
 				),
-			}]
+			},
 		});
 	}
 
-	async run(accessor: ServicesAccessor) {
-		const nativeHostService = accessor.get(INativeHostService);
-		const workspaceContextService = accessor.get(IWorkspaceContextService);
-		const folderUri = workspaceContextService.getWorkspace().folders[0]?.uri;
-		await nativeHostService.openAgentsWindow({ folderUri: folderUri?.scheme === Schemas.file ? folderUri : undefined });
+	async run(accessor: ServicesAccessor): Promise<void> {
+		await openCurrentWorkspaceInAgentsWindow(accessor, AgentsWindowOpenSource.TitleBar);
 	}
 }
 
@@ -95,19 +141,21 @@ export class OpenAgentsWindowAction extends Action2 {
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: ContextKeyExpr.and(IsSessionsWindowContext.toNegated(), CONTEXT_ACCESSIBILITY_MODE_ENABLED.toNegated()),
+				args: { source: AgentsWindowOpenSource.KeyboardShortcut },
 			}, {
 				// In screen reader mode, Cmd/Ctrl+Shift+A conflicts with many screen reader keybindings,
 				// so require an additional Alt modifier.
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.KeyA,
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: ContextKeyExpr.and(IsSessionsWindowContext.toNegated(), CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+				args: { source: AgentsWindowOpenSource.KeyboardShortcut },
 			}],
 		});
 	}
 
-	async run(accessor: ServicesAccessor, args?: { folderUri?: UriComponents; sessionResource?: UriComponents }) {
+	async run(accessor: ServicesAccessor, args?: { folderUri?: UriComponents; sessionResource?: UriComponents; source?: AgentsWindowOpenSource }) {
 		const nativeHostService = accessor.get(INativeHostService);
-		await nativeHostService.openAgentsWindow(args);
+		await nativeHostService.openAgentsWindow({ ...args, source: args?.source ?? AgentsWindowOpenSource.CommandPalette });
 	}
 }
 
@@ -147,8 +195,11 @@ export class OpenChatSessionInAgentsWindowAction extends Action2 {
 		const nativeHostService = accessor.get(INativeHostService);
 		const workspaceContextService = accessor.get(IWorkspaceContextService);
 
+		const commandOptions = isOpenChatSessionInAgentsWindowOptions(rest[0]) ? rest[0] : undefined;
+		const source = commandOptions?.agentsWindowOpenSource ?? AgentsWindowOpenSource.ChatTitleBar;
+		const args = commandOptions ? rest.slice(1) : rest;
 		let sessionResource: URI | undefined;
-		const arg = rest[0];
+		const arg = args[0];
 		if (URI.isUri(arg)) {
 			sessionResource = arg;
 		} else if (arg && typeof arg === 'object') {
@@ -170,6 +221,7 @@ export class OpenChatSessionInAgentsWindowAction extends Action2 {
 		await nativeHostService.openAgentsWindow({
 			folderUri: !hasRealSession && folderUri?.scheme === Schemas.file ? folderUri.toJSON() : undefined,
 			sessionResource: hasRealSession ? sessionResource?.toJSON() : undefined,
+			source,
 		});
 	}
 }
@@ -219,7 +271,7 @@ export class OpenWorkspaceInAgentsContribution extends Disposable implements IWo
 		@IProductService productService: IProductService,
 	) {
 		super();
-		this._register(actionViewItemService.register(MenuId.TitleBarAdjacentCenter, OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, (action, options) => {
+		this._register(actionViewItemService.register(MenuId.TitleBarAdjacentCenter, OPEN_WORKSPACE_IN_AGENTS_WINDOW_TITLE_BAR_COMMAND_ID, (action, options) => {
 			return instantiationService.createInstance(OpenWorkspaceInAgentsTitleBarWidget, action, options);
 		}, undefined));
 	}
@@ -312,7 +364,7 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 			this._logTipAction('open');
 			// Opening the tip counts as handling it: don't show it again this window.
 			this._dismissForWindow();
-			return accessor.get(ICommandService).executeCommand(OpenChatSessionInAgentsWindowAction.ID, ...args);
+			return accessor.get(ICommandService).executeCommand(OpenChatSessionInAgentsWindowAction.ID, { agentsWindowOpenSource: AgentsWindowOpenSource.ChatHandoff }, ...args);
 		}));
 
 		this._register(CommandsRegistry.registerCommand(AgentsHandoffInputTipContribution.TIP_MUTE_COMMAND_ID, () => {

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -90,7 +90,7 @@ export class OpenWorkspaceInAgentsWindowChatTitleAction extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor): Promise<void> {
-		await openCurrentWorkspaceInAgentsWindow(accessor, AgentsWindowOpenSource.ChatTitleBar);
+		await accessor.get(ICommandService).executeCommand(OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, { source: AgentsWindowOpenSource.ChatTitleBar });
 	}
 }
 
@@ -113,7 +113,7 @@ export class OpenWorkspaceInAgentsWindowTitleBarAction extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor): Promise<void> {
-		await openCurrentWorkspaceInAgentsWindow(accessor, AgentsWindowOpenSource.TitleBar);
+		await accessor.get(ICommandService).executeCommand(OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, { source: AgentsWindowOpenSource.TitleBar });
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -56,7 +56,7 @@ import { registerChatExportZipAction } from './actions/chatExportZip.js';
 import { registerExportAgentTracesDbAction } from './actions/exportAgentTracesDb.js';
 import { shouldWarnForSessionShutdown } from './chatLifecycle.js';
 import { HoldToVoiceChatInChatViewAction, InlineVoiceChatAction, KeywordActivationContribution, QuickVoiceChatAction, ReadChatResponseAloud, StartVoiceChatAction, StopListeningAction, StopListeningAndSubmitAction, StopReadAloud, StopReadChatItemAloud, VoiceChatInChatViewAction } from './actions/voiceChatActions.js';
-import { OpenWorkspaceInAgentsWindowAction, OpenWorkspaceInAgentsContribution, OpenAgentsWindowAction, OpenChatSessionInAgentsWindowAction, AgentsHandoffInputTipContribution, ToggleOpenInAgentsWindowTitleBarAction } from './agentSessions/agentSessionsActions.js';
+import { OpenWorkspaceInAgentsWindowAction, OpenWorkspaceInAgentsContribution, OpenAgentsWindowAction, OpenChatSessionInAgentsWindowAction, AgentsHandoffInputTipContribution, ToggleOpenInAgentsWindowTitleBarAction, OpenWorkspaceInAgentsWindowChatTitleAction, OpenWorkspaceInAgentsWindowTitleBarAction } from './agentSessions/agentSessionsActions.js';
 import { NativeBuiltinToolsContribution } from './builtInTools/tools.js';
 import { NativePluginGitCommandService } from './pluginGitCommandService.js';
 
@@ -241,6 +241,8 @@ class ChatLifecycleHandler extends Disposable {
 }
 
 registerAction2(OpenWorkspaceInAgentsWindowAction);
+registerAction2(OpenWorkspaceInAgentsWindowChatTitleAction);
+registerAction2(OpenWorkspaceInAgentsWindowTitleBarAction);
 registerAction2(ToggleOpenInAgentsWindowTitleBarAction);
 registerAction2(OpenAgentsWindowAction);
 registerAction2(OpenChatSessionInAgentsWindowAction);


### PR DESCRIPTION
## Summary
- propagate the Agents window entry source from editor and CLI entry points
- emit first-time window-open telemetry for users who have never sent an Agents window message
- capture initial sign-in and workspace-preselection state, plus close duration for up to three minutes

## Testing
- not run locally per request; CI will validate the change