### PR TITLE
Style override: Enhance tab styling with margin and row gap

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -39,6 +39,14 @@
 	--tab-border-top-color: transparent !important;
 }
 
+.style-override .part.editor .tabs-and-actions-container.wrapping .tabs-container > .tab:last-child {
+	margin-right: calc(var(--last-tab-margin-right) + var(--vscode-spacing-size40)) !important;
+}
+
+.style-override .part.editor .tabs-and-actions-container.wrapping .tabs-container {
+	row-gap: var(--vscode-spacing-size40);
+}
+
 .style-override .part.editor .tabs-container > .tab > .tab-label > .monaco-icon-label-container {
 	font-weight: var(--vscode-fontWeight-semiBold);
 }


### PR DESCRIPTION
This pull request updates the tab styling in the editor to improve layout and spacing when tabs wrap onto multiple lines. The changes focus on adjusting the right margin for the last tab and increasing the gap between tab rows for better visual clarity.

<img width="971" height="187" alt="image" src="https://github.com/user-attachments/assets/95cbdae3-d796-4eaa-91cd-ae6490439a38" />

**Tab layout and spacing improvements:**

* Added a rule to increase the right margin for the last tab in a wrapped row, using `--last-tab-margin-right` and `--vscode-spacing-size40` for consistency with the design system.
* Introduced a `row-gap` between rows of wrapped tabs, using the design token `--vscode-spacing-size40` to standardize spacing.

Resolves https://github.com/microsoft/vscode/issues/327096