### PR TITLE
Show the Voice Mode setting in the Settings UI (drop the advanced tag)

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -515,7 +515,7 @@ configurationRegistry.registerConfiguration({
 			experiment: {
 				mode: 'auto',
 			},
-			tags: ['experimental', 'advanced'],
+			tags: ['experimental'],
 			scope: ConfigurationScope.APPLICATION,
 			restricted: true,
 		},


### PR DESCRIPTION
Removes the `advanced` tag from the `agents.voice.enabled` setting so Voice Mode surfaces in the standard Settings UI instead of being hidden as an advanced setting. This makes it discoverable for the upcoming experiment.

### Change
`src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts`:
- `tags: ['experimental', 'advanced']` → `tags: ['experimental']`

The `experimental` tag and `experiment: { mode: 'auto' }` are kept, so the setting still participates in the experimentation service and appears under the experimental filter.

### Notes
- Default remains `false`; this only affects discoverability, not behavior.
