### PR TITLE
Add 4px spacing between send button and adjacent controls

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -249,6 +249,7 @@
 	align-items: center;
 	justify-content: center;
 	flex-shrink: 0;
+	margin-left: var(--vscode-spacing-size40);
 	position: relative;
 	width: 22px;
 	height: 22px;


### PR DESCRIPTION
Fixes [#326932](https://github.com/microsoft/vscode/issues/326932)

Adds 4px spacing between the send button and any buttons to the left of it in the Agents window new chat view.

Changes made:
- Updated `chatInput.css` to add a 4px gap before the send button, improving the layout and usability of the chat input area.
- The adjustment maintains existing keyboard and ARIA behavior for accessibility.

Validation checks have been performed, confirming that the spacing implementation is correct.

<img width="1768" height="692" alt="ui-diff-20260723-115416" src="https://github.com/user-attachments/assets/29f82109-18bd-4d04-812a-165a3ab245c4" />