### PR TITLE
Fix persisted Agent Host MCP authentication

### DIFF
--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -9,7 +9,7 @@ import { Emitter, Event } from '../../../base/common/event.js';
 import { MainContext, MainThreadAuthenticationShape, ExtHostAuthenticationShape } from './extHost.protocol.js';
 import { Disposable, ProgressLocation } from './extHostTypes.js';
 import { IExtensionDescription, ExtensionIdentifier } from '../../../platform/extensions/common/extensions.js';
-import { INTERNAL_AUTH_PROVIDER_PREFIX, isAuthenticationWwwAuthenticateRequest } from '../../services/authentication/common/authentication.js';
+import { IAuthenticationGetSessionsOptions, IAuthenticationProviderSessionOptions, INTERNAL_AUTH_PROVIDER_PREFIX, isAuthenticationWwwAuthenticateRequest } from '../../services/authentication/common/authentication.js';
 import { createDecorator } from '../../../platform/instantiation/common/instantiation.js';
 import { IExtHostRpcService } from './extHostRpcService.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
@@ -190,7 +190,7 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 		});
 	}
 
-	$getSessions(providerId: string, scopes: ReadonlyArray<string> | undefined, options: vscode.AuthenticationProviderSessionOptions): Promise<ReadonlyArray<vscode.AuthenticationSession>> {
+	$getSessions(providerId: string, scopes: ReadonlyArray<string> | undefined, options: IAuthenticationGetSessionsOptions): Promise<ReadonlyArray<vscode.AuthenticationSession>> {
 		return this._providerOperations.queue(providerId, async () => {
 			const providerData = this._authenticationProviders.get(providerId);
 			if (providerData) {
@@ -466,6 +466,7 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 		protected _clientSecret: string | undefined,
 		onDidDynamicAuthProviderTokensChange: Emitter<{ authProviderId: string; clientId: string; tokens: IAuthorizationToken[] }>,
 		initialTokens: IAuthorizationToken[],
+		private readonly _fetch: typeof fetch = fetch,
 	) {
 		const stringifiedServer = authorizationServer.toString(true);
 		// Auth Provider Id is a combination of the authorization server and the resource, if provided.
@@ -510,7 +511,7 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 		return this._clientSecret;
 	}
 
-	async getSessions(scopes: readonly string[] | undefined, _options: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession[]> {
+	async getSessions(scopes: readonly string[] | undefined, options: IAuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession[]> {
 		this._logger.info(`Getting sessions for scopes: ${scopes?.join(' ') ?? 'all'}`);
 		if (!scopes) {
 			return this._tokenStore.sessions;
@@ -541,7 +542,7 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 							continue;
 						}
 						try {
-							const newToken = await this.exchangeRefreshTokenForToken(token.refresh_token);
+							const newToken = await this.exchangeRefreshTokenForToken(token.refresh_token, options.silent !== true);
 							// TODO@TylerLeonhardt: When the core scope handling doesn't care about order, this check should be
 							// updated to not care about order
 							if (newToken.scope !== scopeStr) {
@@ -773,7 +774,7 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 		this._logger.trace(`Token request body: ${tokenRequest.toString()}`);
 		let response: Response;
 		try {
-			response = await fetch(this._serverMetadata.token_endpoint, {
+			response = await this._fetch(this._serverMetadata.token_endpoint, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',
@@ -803,7 +804,7 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 		throw new Error(`Invalid authorization token response: ${JSON.stringify(result)}`);
 	}
 
-	protected async exchangeRefreshTokenForToken(refreshToken: string): Promise<IAuthorizationToken> {
+	protected async exchangeRefreshTokenForToken(refreshToken: string, allowClientRegistration: boolean): Promise<IAuthorizationToken> {
 		if (!this._serverMetadata.token_endpoint) {
 			throw new Error('Token endpoint not available in server metadata');
 		}
@@ -823,7 +824,7 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 			tokenRequest.append('client_secret', this._clientSecret);
 		}
 
-		const response = await fetch(this._serverMetadata.token_endpoint, {
+		const response = await this._fetch(this._serverMetadata.token_endpoint, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
@@ -839,6 +840,10 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 				created_at: Date.now(),
 			};
 		} else if (isAuthorizationErrorResponse(result) && result.error === AuthorizationErrorType.InvalidClient) {
+			if (!allowClientRegistration) {
+				this._logger.warn(`Client ID (${this._clientId}) was invalid while silently refreshing the token.`);
+				throw new Error(`Client ID was invalid while silently refreshing the token.`);
+			}
 			this._logger.warn(`Client ID (${this._clientId}) was invalid, generated a new one.`);
 			await this._generateNewClientId();
 			throw new Error(`Client ID was invalid, generated a new one. Please try again.`);

--- a/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
@@ -6,19 +6,27 @@
 import assert from 'assert';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
+import { URI } from '../../../../base/common/uri.js';
+import { mock } from '../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { NullLogger } from '../../../../platform/log/common/log.js';
-import { IAuthorizationToken, TokenStore } from '../../common/extHostAuthentication.js';
+import { ILogger, ILoggerService, NullLogger } from '../../../../platform/log/common/log.js';
+import { IAuthenticationProviderSessionOptions } from '../../../services/authentication/common/authentication.js';
+import { DynamicAuthProvider, IAuthorizationToken, TokenStore } from '../../common/extHostAuthentication.js';
+import { MainThreadAuthenticationShape } from '../../common/extHost.protocol.js';
+import { IExtHostInitDataService } from '../../common/extHostInitDataService.js';
+import { IExtHostProgress } from '../../common/extHostProgress.js';
+import { IExtHostUrlsService } from '../../common/extHostUrls.js';
+import { IExtHostWindow } from '../../common/extHostWindow.js';
+
+/** Builds a structurally-valid JWT carrying the given claims. */
+function jwt(claims: object): string {
+	const segment = (value: object) => encodeBase64(VSBuffer.fromString(JSON.stringify(value)));
+	return `${segment({ alg: 'none', typ: 'JWT' })}.${segment(claims)}.signature`;
+}
 
 suite('TokenStore', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
-
-	/** Builds a structurally-valid JWT (header.payload.signature) carrying the given claims. */
-	function jwt(claims: object): string {
-		const segment = (value: object) => encodeBase64(VSBuffer.fromString(JSON.stringify(value)));
-		return `${segment({ alg: 'none', typ: 'JWT' })}.${segment(claims)}.signature`;
-	}
 
 	function createStore(initialTokens: IAuthorizationToken[]): TokenStore {
 		const persistence = {
@@ -43,5 +51,80 @@ suite('TokenStore', () => {
 			store.sessions.map(session => session.scopes),
 			[[], ['menu:read', 'orders:create'], ['read', 'write']]
 		);
+	});
+});
+
+suite('DynamicAuthProvider', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	class TestDynamicAuthProvider extends DynamicAuthProvider {
+		generateNewClientIdCalls = 0;
+
+		protected override async _generateNewClientId(): Promise<void> {
+			this.generateNewClientIdCalls++;
+		}
+	}
+
+	test('does not rotate the client while silently refreshing a token', async () => {
+		let fetchCalls = 0;
+		const fetcher: typeof fetch = async () => {
+			fetchCalls++;
+			return new Response(JSON.stringify({ error: 'invalid_client' }), {
+				status: 400,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		};
+		const loggerService = new class extends mock<ILoggerService>() {
+			override createLogger(): ILogger {
+				return new NullLogger();
+			}
+		}();
+		const proxy = new class extends mock<MainThreadAuthenticationShape>() {
+			override $setSessionsForDynamicAuthProvider(): Promise<void> {
+				return Promise.resolve();
+			}
+		}();
+		const provider = disposables.add(new TestDynamicAuthProvider(
+			new class extends mock<IExtHostWindow>() { }(),
+			new class extends mock<IExtHostUrlsService>() { }(),
+			new class extends mock<IExtHostInitDataService>() { }(),
+			new class extends mock<IExtHostProgress>() { }(),
+			loggerService,
+			proxy,
+			URI.parse('https://mcp.example.com'),
+			{
+				issuer: 'https://mcp.example.com',
+				response_types_supported: ['code'],
+				token_endpoint: 'https://mcp.example.com/token',
+			},
+			{ resource: 'https://mcp.example.com/resource' },
+			'client-id',
+			undefined,
+			disposables.add(new Emitter()),
+			[{
+				access_token: jwt({ sub: 'account' }),
+				token_type: 'Bearer',
+				scope: '',
+				expires_in: 1,
+				refresh_token: 'refresh-token',
+				created_at: 0,
+			}],
+			fetcher,
+		));
+
+		const sessions = await provider.getSessions([], { silent: true } satisfies IAuthenticationProviderSessionOptions);
+
+		assert.deepStrictEqual({
+			sessions,
+			fetchCalls,
+			generateNewClientIdCalls: provider.generateNewClientIdCalls,
+			clientId: provider.clientId,
+		}, {
+			sessions: [],
+			fetchCalls: 1,
+			generateNewClientIdCalls: 0,
+			clientId: 'client-id',
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { fetchAuthorizationServerMetadata } from '../../../../../../base/common/oauth.js';
+import { SequencerByKey } from '../../../../../../base/common/async.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { type McpOAuthClient, type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
@@ -358,10 +359,8 @@ export async function resolveMcpServerAuthentication(
 	const authenticationMcpAccessService = accessor.get(IAuthenticationMcpAccessService);
 	const authenticationMcpService = accessor.get(IAuthenticationMcpService);
 	const authenticationMcpUsageService = accessor.get(IAuthenticationMcpUsageService);
+	const dynamicAuthenticationProviderStorageService = accessor.get(IDynamicAuthenticationProviderStorageService);
 	const logService = accessor.get(ILogService);
-	const dynamicAuthenticationProviderStorageService = options.oauthClient
-		? accessor.get(IDynamicAuthenticationProviderStorageService)
-		: undefined;
 	const agentHostMeta = options.agentHost
 		? { authority: options.agentHost.authority, label: accessor.get(ILabelService).getHostLabel(options.agentHost.scheme, options.agentHost.authority) }
 		: undefined;
@@ -369,56 +368,75 @@ export async function resolveMcpServerAuthentication(
 	const scopes = options.scopes.length > 0 || isGitHubMcpResource(protectedResource)
 		? options.scopes
 		: protectedResource.scopes_supported ?? [];
+	const authenticationOperations = getMcpAuthenticationOperations(authenticationService);
 	for (const authorizationServer of protectedResource.authorization_servers ?? []) {
 		const authorizationServerUri = URI.parse(authorizationServer);
-		const providerId = await getOrCreateProviderForMcpResource(
-			authorizationServerUri,
-			protectedResource,
-			options.oauthClient,
-			authenticationService,
-			dynamicAuthenticationProviderStorageService,
-			logService,
-			options.logPrefix,
-			options.allowInteraction,
-			options.authorizationServerMetadataFetcher ?? fetchAuthorizationServerMetadata,
-		);
-		if (!providerId) {
-			continue;
-		}
+		const providerOperationId = getDynamicAuthenticationProviderId(authorizationServerUri, protectedResource);
+		const authenticated = await authenticationOperations.queue(providerOperationId, async () => {
+			const providerId = await getOrCreateProviderForMcpResource(
+				authorizationServerUri,
+				protectedResource,
+				options.oauthClient,
+				authenticationService,
+				dynamicAuthenticationProviderStorageService,
+				logService,
+				options.logPrefix,
+				options.allowInteraction,
+				options.authorizationServerMetadataFetcher ?? fetchAuthorizationServerMetadata,
+			);
+			if (!providerId) {
+				return false;
+			}
 
-		const oauthClientOptions = options.oauthClient
-			? { clientId: options.oauthClient.clientId, clientSecret: options.oauthClient.clientSecret }
-			: {};
-		const sessions = await authenticationService.getSessions(providerId, [...scopes], {
-			authorizationServer: authorizationServerUri,
-			resource: protectedResource.resource,
-			...oauthClientOptions,
-		}, true);
-		const allowedSession = getAllowedMcpSession(providerId, sessions, authenticationMcpAccessService, authenticationMcpService, options);
-		if (allowedSession) {
-			await authenticateMcpSession(providerId, allowedSession, scopes, authenticationMcpAccessService, authenticationMcpService, authenticationMcpUsageService, logService, options, false, agentHostMeta);
-			return true;
-		}
-
-		if (!options.allowInteraction) {
-			continue;
-		}
-
-		const provider = authenticationService.getProvider(providerId);
-		const session = sessions.length
-			? provider.supportsMultipleAccounts
-				? await authenticationMcpService.selectSession(providerId, options.mcpServerId, options.mcpServerName, [...scopes], sessions)
-				: sessions[0]
-			: await authenticationService.createSession(providerId, [...scopes], {
-				activateImmediate: true,
+			const oauthClientOptions = options.oauthClient
+				? { clientId: options.oauthClient.clientId, clientSecret: options.oauthClient.clientSecret }
+				: {};
+			const sessions = await authenticationService.getSessions(providerId, [...scopes], {
 				authorizationServer: authorizationServerUri,
 				resource: protectedResource.resource,
 				...oauthClientOptions,
-			});
-		await authenticateMcpSession(providerId, session, scopes, authenticationMcpAccessService, authenticationMcpService, authenticationMcpUsageService, logService, options, true, agentHostMeta);
-		return true;
+				silent: !options.allowInteraction,
+			}, true);
+			const allowedSession = getAllowedMcpSession(providerId, sessions, authenticationMcpAccessService, authenticationMcpService, options);
+			if (allowedSession) {
+				await authenticateMcpSession(providerId, allowedSession, scopes, authenticationMcpAccessService, authenticationMcpService, authenticationMcpUsageService, logService, options, false, agentHostMeta);
+				return true;
+			}
+
+			if (!options.allowInteraction) {
+				return false;
+			}
+
+			const provider = authenticationService.getProvider(providerId);
+			const session = sessions.length
+				? provider.supportsMultipleAccounts
+					? await authenticationMcpService.selectSession(providerId, options.mcpServerId, options.mcpServerName, [...scopes], sessions)
+					: sessions[0]
+				: await authenticationService.createSession(providerId, [...scopes], {
+					activateImmediate: true,
+					authorizationServer: authorizationServerUri,
+					resource: protectedResource.resource,
+					...oauthClientOptions,
+				});
+			await authenticateMcpSession(providerId, session, scopes, authenticationMcpAccessService, authenticationMcpService, authenticationMcpUsageService, logService, options, true, agentHostMeta);
+			return true;
+		});
+		if (authenticated) {
+			return true;
+		}
 	}
 	return false;
+}
+
+const mcpAuthenticationOperations = new WeakMap<IAuthenticationService, SequencerByKey<string>>();
+
+function getMcpAuthenticationOperations(authenticationService: IAuthenticationService): SequencerByKey<string> {
+	let operations = mcpAuthenticationOperations.get(authenticationService);
+	if (!operations) {
+		operations = new SequencerByKey();
+		mcpAuthenticationOperations.set(authenticationService, operations);
+	}
+	return operations;
 }
 
 function isGitHubMcpResource(resource: ProtectedResourceMetadata): boolean {
@@ -430,18 +448,17 @@ async function getOrCreateProviderForMcpResource(
 	protectedResource: ProtectedResourceMetadata,
 	oauthClient: McpOAuthClient | undefined,
 	authenticationService: IAuthenticationService,
-	dynamicAuthenticationProviderStorageService: IDynamicAuthenticationProviderStorageService | undefined,
+	dynamicAuthenticationProviderStorageService: IDynamicAuthenticationProviderStorageService,
 	logService: ILogService,
 	logPrefix: string,
 	allowCreation: boolean,
 	authorizationServerMetadataFetcher: typeof fetchAuthorizationServerMetadata,
 ): Promise<string | undefined> {
 	const resourceUri = URI.parse(protectedResource.resource);
+	const dynamicProviderId = getDynamicAuthenticationProviderId(authorizationServer, protectedResource);
+	let clientId = oauthClient?.clientId;
+	let clientSecret = oauthClient?.clientSecret;
 	if (oauthClient) {
-		if (!dynamicAuthenticationProviderStorageService) {
-			throw new Error('Dynamic authentication provider storage is required for a configured OAuth client.');
-		}
-		const dynamicProviderId = getDynamicAuthenticationProviderId(authorizationServer, protectedResource);
 		const isProviderActive = authenticationService.isDynamicAuthenticationProvider(dynamicProviderId);
 		const registeredClient = await dynamicAuthenticationProviderStorageService.getClientRegistration(dynamicProviderId);
 		const clientMatches = registeredClient?.clientId === oauthClient.clientId && registeredClient.clientSecret === oauthClient.clientSecret;
@@ -460,14 +477,20 @@ async function getOrCreateProviderForMcpResource(
 		}
 	} else {
 		const existing = await authenticationService.getOrActivateProviderIdForServer(authorizationServer, resourceUri);
-		if (existing || !allowCreation) {
+		if (existing) {
 			return existing;
 		}
+		const registeredClient = await dynamicAuthenticationProviderStorageService.getClientRegistration(dynamicProviderId);
+		if (!registeredClient?.clientId && !allowCreation) {
+			return undefined;
+		}
+		clientId = registeredClient?.clientId;
+		clientSecret = registeredClient?.clientSecret;
 	}
 
 	try {
 		const { metadata } = await authorizationServerMetadataFetcher(authorizationServer.toString(true));
-		const provider = await authenticationService.createDynamicAuthenticationProvider(authorizationServer, metadata, protectedResource, oauthClient?.clientId, oauthClient?.clientSecret);
+		const provider = await authenticationService.createDynamicAuthenticationProvider(authorizationServer, metadata, protectedResource, clientId, clientSecret);
 		return provider?.id;
 	} catch (err) {
 		logService.warn(`${logPrefix} Failed to create MCP auth provider for ${authorizationServer.toString(true)}`, err);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
@@ -389,6 +389,7 @@ suite('resolveMcpServerAuthentication', () => {
 			getAccountPreference: () => undefined,
 		});
 		instantiationService.stub(IAuthenticationMcpUsageService, {});
+		instantiationService.stub(IDynamicAuthenticationProviderStorageService, {});
 		instantiationService.stub(ILogService, new NullLogService());
 
 		const result = await instantiationService.invokeFunction(resolveMcpServerAuthentication, {
@@ -427,6 +428,7 @@ suite('resolveMcpServerAuthentication', () => {
 			getAccountPreference: () => undefined,
 		});
 		instantiationService.stub(IAuthenticationMcpUsageService, {});
+		instantiationService.stub(IDynamicAuthenticationProviderStorageService, {});
 		instantiationService.stub(ILogService, new NullLogService());
 
 		const result = await instantiationService.invokeFunction(resolveMcpServerAuthentication, {
@@ -466,6 +468,7 @@ suite('resolveMcpServerAuthentication', () => {
 			getAccountPreference: () => undefined,
 		});
 		instantiationService.stub(IAuthenticationMcpUsageService, {});
+		instantiationService.stub(IDynamicAuthenticationProviderStorageService, {});
 		instantiationService.stub(ILogService, new NullLogService());
 
 		const result = await instantiationService.invokeFunction(resolveMcpServerAuthentication, {
@@ -489,25 +492,35 @@ suite('resolveMcpServerAuthentication', () => {
 		});
 	});
 
-	test('does not attempt dynamic provider creation without user interaction', async () => {
+	test('does not create a dynamic provider silently without a persisted registration', async () => {
 		const warnings: string[] = [];
+		const providerCreations: string[] = [];
+		const metadataRequests: string[] = [];
 		const logService = new class extends NullLogService {
 			override warn(message: string): void {
 				warnings.push(message);
 			}
 		}();
 		const instantiationService = disposables.add(new TestInstantiationService());
-		instantiationService.stub(IAuthenticationService, createMockAuthService({}));
+		instantiationService.stub(IAuthenticationService, createMockAuthService({
+			createDynamicAuthenticationProvider: async authorizationServer => {
+				providerCreations.push(authorizationServer.toString(true));
+				return undefined;
+			},
+		}));
 		instantiationService.stub(IAuthenticationMcpAccessService, {});
 		instantiationService.stub(IAuthenticationMcpService, {
 			getAccountPreference: () => undefined,
 		});
 		instantiationService.stub(IAuthenticationMcpUsageService, {});
+		instantiationService.stub(IDynamicAuthenticationProviderStorageService, {
+			getClientRegistration: () => Promise.resolve(undefined),
+		});
 		instantiationService.stub(ILogService, logService);
 
 		const result = await instantiationService.invokeFunction(resolveMcpServerAuthentication, {
 			resource: 'https://mcp.example.com',
-			authorization_servers: ['not-a-valid-authorization-server'],
+			authorization_servers: ['https://auth.example.com'],
 		}, {
 			allowInteraction: false,
 			logPrefix: '[AgentHost]',
@@ -515,12 +528,195 @@ suite('resolveMcpServerAuthentication', () => {
 			mcpServerName: 'Example',
 			mcpServerUrl: 'https://mcp.example.com',
 			scopes: [],
+			authorizationServerMetadataFetcher: async authorizationServer => {
+				metadataRequests.push(authorizationServer);
+				throw new Error('Unexpected metadata request');
+			},
 			authenticate: async () => { },
 		});
 
-		assert.deepStrictEqual({ result, warnings }, {
+		assert.deepStrictEqual({ result, warnings, metadataRequests, providerCreations }, {
 			result: false,
 			warnings: [],
+			metadataRequests: [],
+			providerCreations: [],
+		});
+	});
+
+	test('restores a persisted dynamically registered provider without user interaction', async () => {
+		const dynamicProviderId = 'https://mcp.notion.com/ https://mcp.notion.com/mcp';
+		const providerCreations: { clientId: string | undefined; clientSecret: string | undefined }[] = [];
+		const sessionRequests: { silent: boolean | undefined }[] = [];
+		const authenticateRequests: { resource: string; scopes?: readonly string[]; token: string }[] = [];
+		const authService = createMockAuthService({
+			createDynamicAuthenticationProvider: async (_authorizationServer, _metadata, _resource, clientId, clientSecret) => {
+				providerCreations.push({ clientId, clientSecret });
+				return { id: dynamicProviderId };
+			},
+			getSessions: (_providerId, _scopes, options) => {
+				sessionRequests.push({ silent: options.silent });
+				return Promise.resolve([{
+					id: 'notion-session',
+					scopes: [],
+					accessToken: 'notion-token',
+					account: { id: 'account-id', label: 'Notion Account' },
+				}]);
+			},
+		});
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IAuthenticationService, authService);
+		instantiationService.stub(IAuthenticationMcpAccessService, {
+			isAccessAllowedForUrl: () => true,
+		});
+		instantiationService.stub(IAuthenticationMcpService, {
+			getAccountPreference: () => 'Notion Account',
+		});
+		instantiationService.stub(IAuthenticationMcpUsageService, {
+			addAccountUsage: () => { },
+		});
+		instantiationService.stub(IDynamicAuthenticationProviderStorageService, {
+			getClientRegistration: () => Promise.resolve({ clientId: 'notion-client-id', clientSecret: 'notion-client-secret' }),
+		});
+		instantiationService.stub(ILogService, new NullLogService());
+
+		const result = await instantiationService.invokeFunction(resolveMcpServerAuthentication, {
+			resource: 'https://mcp.notion.com/mcp',
+			authorization_servers: ['https://mcp.notion.com'],
+		}, {
+			allowInteraction: false,
+			logPrefix: '[AgentHost]',
+			mcpServerId: 'notion',
+			mcpServerName: 'notion',
+			mcpServerUrl: 'https://mcp.notion.com/mcp',
+			scopes: [],
+			authorizationServerMetadataFetcher: async authorizationServer => ({
+				metadata: {
+					issuer: authorizationServer,
+					response_types_supported: ['code'],
+				},
+				discoveryUrl: `${authorizationServer}/.well-known/oauth-authorization-server`,
+				errors: [],
+			}),
+			authenticate: async request => {
+				authenticateRequests.push(request);
+			},
+		});
+
+		assert.deepStrictEqual({ result, providerCreations, sessionRequests, authenticateRequests }, {
+			result: true,
+			providerCreations: [{ clientId: 'notion-client-id', clientSecret: 'notion-client-secret' }],
+			sessionRequests: [{ silent: true }],
+			authenticateRequests: [{
+				resource: 'https://mcp.notion.com/mcp',
+				scopes: [],
+				token: 'notion-token',
+			}],
+		});
+	});
+
+	test('serializes authentication transactions for different configured clients', async () => {
+		const dynamicProviderId = 'https://mcp.example.com/ https://mcp.example.com/resource';
+		const firstSessionStarted = new DeferredPromise<void>();
+		const firstSessionGate = new DeferredPromise<void>();
+		const providerCreations: string[] = [];
+		const sessionRequests: string[] = [];
+		const authenticateRequests: string[] = [];
+		let activeClient: string | undefined;
+		let providerActive = false;
+		const authService = createMockAuthService({
+			isDynamicAuthenticationProvider: providerId => providerId === dynamicProviderId && providerActive,
+			createDynamicAuthenticationProvider: async (_authorizationServer, _metadata, _resource, clientId) => {
+				activeClient = clientId;
+				providerActive = true;
+				providerCreations.push(clientId ?? '');
+				return { id: dynamicProviderId };
+			},
+			unregisterAuthenticationProvider: () => {
+				providerActive = false;
+			},
+			getSessions: async () => {
+				const clientId = activeClient ?? '';
+				sessionRequests.push(clientId);
+				if (clientId === 'first-client') {
+					firstSessionStarted.complete();
+					await firstSessionGate.p;
+				}
+				return [{
+					id: `${clientId}-session`,
+					scopes: [],
+					accessToken: `${clientId}-token`,
+					account: { id: 'account-id', label: 'MCP Account' },
+				}];
+			},
+		});
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IAuthenticationService, authService);
+		instantiationService.stub(IAuthenticationMcpAccessService, {
+			isAccessAllowedForUrl: () => true,
+		});
+		instantiationService.stub(IAuthenticationMcpService, {
+			getAccountPreference: () => 'MCP Account',
+		});
+		instantiationService.stub(IAuthenticationMcpUsageService, {
+			addAccountUsage: () => { },
+		});
+		instantiationService.stub(IDynamicAuthenticationProviderStorageService, {
+			getClientRegistration: () => Promise.resolve(activeClient ? { clientId: activeClient } : undefined),
+			removeDynamicProvider: async () => {
+				activeClient = undefined;
+			},
+		});
+		instantiationService.stub(ILogService, new NullLogService());
+		const protectedResource = {
+			resource: 'https://mcp.example.com/resource',
+			authorization_servers: ['https://mcp.example.com'],
+		};
+		const options = (clientId: string) => ({
+			allowInteraction: true,
+			logPrefix: '[AgentHost]',
+			mcpServerId: 'example',
+			mcpServerName: 'Example',
+			mcpServerUrl: 'https://mcp.example.com/resource',
+			oauthClient: { clientId },
+			scopes: [],
+			authorizationServerMetadataFetcher: async (authorizationServer: string) => ({
+				metadata: {
+					issuer: authorizationServer,
+					response_types_supported: ['code'],
+				},
+				discoveryUrl: `${authorizationServer}/.well-known/oauth-authorization-server`,
+				errors: [],
+			}),
+			authenticate: async (request: { token: string }) => {
+				authenticateRequests.push(request.token);
+			},
+		});
+
+		const first = instantiationService.invokeFunction(resolveMcpServerAuthentication, protectedResource, options('first-client'));
+		const second = instantiationService.invokeFunction(resolveMcpServerAuthentication, protectedResource, options('second-client'));
+		await firstSessionStarted.p;
+		const beforeResolution = {
+			providerCreations: [...providerCreations],
+			sessionRequests: [...sessionRequests],
+		};
+		firstSessionGate.complete();
+		const results = await Promise.all([first, second]);
+
+		assert.deepStrictEqual({
+			beforeResolution,
+			results,
+			providerCreations,
+			sessionRequests,
+			authenticateRequests,
+		}, {
+			beforeResolution: {
+				providerCreations: ['first-client'],
+				sessionRequests: ['first-client'],
+			},
+			results: [true, true],
+			providerCreations: ['first-client', 'second-client'],
+			sessionRequests: ['first-client', 'second-client'],
+			authenticateRequests: ['first-client-token', 'second-client-token'],
 		});
 	});
 

--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -119,6 +119,10 @@ export interface IAuthenticationConstraint {
  */
 export interface IAuthenticationGetSessionsOptions {
 	/**
+	 * Whether the provider must avoid user interaction while resolving existing sessions.
+	 */
+	silent?: boolean;
+	/**
 	 * The account that is being asked about. If this is passed in, the provider should
 	 * attempt to return the sessions that are only related to this account.
 	 */
@@ -408,6 +412,10 @@ export interface IAuthenticationExtensionsService {
  * Options passed to the authentication provider when asking for sessions.
  */
 export interface IAuthenticationProviderSessionOptions {
+	/**
+	 * Whether the provider must avoid user interaction while resolving existing sessions.
+	 */
+	silent?: boolean;
 	/**
 	 * The account that is being asked about. If this is passed in, the provider should
 	 * attempt to return the sessions that are only related to this account.


### PR DESCRIPTION
Fixes #327137

cc @connor4312

## Summary

- restore persisted dynamically registered MCP OAuth providers during silent Agent Host authentication after an extension-host restart
- preserve existing account preference and MCP URL access consent before forwarding tokens
- keep silent token refresh non-interactive when the stored OAuth client is invalid
- serialize each Agent Host provider authentication transaction through token forwarding so concurrent client configurations cannot replace a provider mid-request

## Testing

- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts --run src/vs/workbench/api/test/browser/extHostAuthentication.test.ts`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts --grep "mcp auth prompt|silently authenticates|deduplicates concurrent silent authentication"`
- `npm run valid-layers-check`
- `npm run precommit`