### PR TITLE
sessions: Shorten input banner reveal labels

### DIFF
--- a/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
@@ -85,7 +85,7 @@
 	white-space: nowrap;
 }
 
-/* Outlined ghost style for secondary action buttons (e.g. "Reveal Checks"). */
+/* Outlined ghost style for secondary action buttons (e.g. "Reveal"). */
 .session-input-banner .session-input-banner-action.secondary {
 	border: var(--vscode-strokeThickness) solid var(--vscode-button-secondaryBackground, var(--vscode-button-border, var(--vscode-contrastBorder)));
 	background: transparent;

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
@@ -222,7 +222,7 @@ export class SessionInputBanners extends Disposable {
 					run: () => state.debug ? undefined : this._executeCommand(FIX_CI_CHECKS_COMMAND_ID),
 				},
 				{
-					label: localize('ci.revealChecks', "Reveal Checks"),
+					label: localize('ci.revealChecks', "Reveal"),
 					run: () => { if (!state.debug) { void this._executeCommand(REVEAL_CI_CHECKS_COMMAND_ID); } },
 				},
 			],
@@ -252,7 +252,7 @@ export class SessionInputBanners extends Disposable {
 					run: () => state.debug ? undefined : this._addressComments(state.sessionResource).catch(err => this.logService.error('[SessionInputBanners] Failed to address comments', err)),
 				},
 				{
-					label: localize('comments.reveal', "Reveal Comments"),
+					label: localize('comments.reveal', "Reveal"),
 					run: () => { if (!state.debug) { this._revealComment(state.sessionResource, state.firstCommentId); } },
 				},
 			],

--- a/src/vs/sessions/contrib/sessionInputBanners/test/browser/sessionInputBanners.fixture.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/test/browser/sessionInputBanners.fixture.ts
@@ -55,7 +55,7 @@ function ciBanner(failed: number, completed: number, pending: number): ISessionI
 		dismissTooltip: 'Hide for this session',
 		actions: [
 			{ label: 'Fix Checks', primary: true, run: () => console.log('Fix Checks') },
-			{ label: 'Reveal Checks', run: () => console.log('Reveal Checks') },
+			{ label: 'Reveal', run: () => console.log('Reveal Checks') },
 		],
 		dismiss: () => console.log('Dismiss CI banner'),
 	};
@@ -72,7 +72,7 @@ function commentsBanner(count: number, kind: 'pr' | 'agent' | 'mixed'): ISession
 		dismissTooltip: 'Hide for this session',
 		actions: [
 			{ label: 'Address Comments', primary: true, run: () => console.log('Address Comments') },
-			{ label: 'Reveal Comments', run: () => console.log('Reveal Comments') },
+			{ label: 'Reveal', run: () => console.log('Reveal Comments') },
 		],
 		dismiss: () => console.log('Dismiss comments banner'),
 	};


### PR DESCRIPTION
## Summary
- shorten the CI checks banner secondary action to Reveal
- shorten the comments banner secondary action to Reveal
- update the component fixture and CSS example

## Validation
Not run locally per request; validation will run in CI.