### PR TITLE
agentHost: Preserve trusted model IDs in telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -5,6 +5,7 @@
 
 import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEvent } from '../../telemetry/common/languageModelToolTelemetry.js';
 import type { ITelemetryService } from '../../telemetry/common/telemetry.js';
+import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js';
 import { hash } from '../../../base/common/hash.js';
 import { AgentSession } from '../common/agentService.js';
 import type { ErrorInfo, MessageAttachment, SessionInputRequestKind, ToolDefinition } from '../common/state/protocol/state.js';
@@ -41,6 +42,7 @@ export type IAgentHostUserMessageSentClassification = {
 };
 
 export type AgentHostTurnResult = 'success' | 'error' | 'cancelled';
+export type AgentHostModelTelemetryKind = 'trusted' | 'byok' | 'unknown';
 type AgentHostModelSelectionKind = 'default' | 'auto' | 'explicit';
 export type AgentHostTurnFailureStage = 'validation' | 'workingDirectory' | 'modelSelection' | 'sendMessage' | 'provider';
 
@@ -51,7 +53,7 @@ export interface IAgentHostTurnCompletedEvent {
 	timeToFirstProgress: number | undefined;
 	totalTime: number;
 	result: AgentHostTurnResult;
-	model: string | undefined;
+	model: string | TelemetryTrustedValue<string> | undefined;
 	modelSelectionKind: AgentHostModelSelectionKind;
 	permissionLevel: string | undefined;
 	errorType: string | undefined;
@@ -65,7 +67,7 @@ export type IAgentHostTurnCompletedClassification = {
 	timeToFirstProgress: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds from turn start to the first visible progress (text delta, response part, tool call start, or reasoning).' };
 	totalTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total time in milliseconds from turn start to turn completion.' };
 	result: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the turn completed successfully, with an error, or was cancelled.' };
-	model: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The model identifier selected for the session at turn start (e.g. gemini-3.5-flash).' };
+	model: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The trusted provider model identifier selected at turn start, or a generic value for BYOK and unknown models.' };
 	modelSelectionKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the client used the provider default, Auto, or an explicit model.' };
 	permissionLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The tool auto-approval level configured for the session at turn start (e.g. default, autoApprove, autopilot).' };
 	errorType: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The structured agent host or provider error type when the turn fails.' };
@@ -116,6 +118,7 @@ export interface IAgentHostTurnCompletedReport {
 	totalTime: number;
 	result: AgentHostTurnResult;
 	model: string | undefined;
+	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
 	permissionLevel: string | undefined;
 	failure: IAgentHostTurnFailure | undefined;
 }
@@ -472,6 +475,11 @@ export class AgentHostTelemetryReporter {
 
 	turnCompleted(report: IAgentHostTurnCompletedReport): void {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
+		const model = report.model === undefined
+			? undefined
+			: report.modelTelemetryKind === 'trusted'
+				? new TelemetryTrustedValue(report.model)
+				: report.modelTelemetryKind === 'byok' ? 'byokModel' : 'unknown';
 		this._telemetryService.publicLog2<IAgentHostTurnCompletedEvent, IAgentHostTurnCompletedClassification>('agentHost.turnCompleted', {
 			provider: report.provider,
 			agentSessionId: AgentSession.id(session),
@@ -479,7 +487,7 @@ export class AgentHostTelemetryReporter {
 			timeToFirstProgress: report.timeToFirstProgress,
 			totalTime: report.totalTime,
 			result: report.result,
-			model: report.model,
+			model,
 			modelSelectionKind: report.model === undefined ? 'default' : report.model === 'auto' ? 'auto' : 'explicit',
 			permissionLevel: report.permissionLevel,
 			errorType: report.failure?.error.errorType,

--- a/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { StopWatch } from '../../../base/common/stopwatch.js';
-import type { AgentHostTelemetryReporter, AgentHostTurnResult, IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
+import type { AgentHostModelTelemetryKind, AgentHostTelemetryReporter, AgentHostTurnResult, IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
 
 /** Per-turn timing state, keyed by `session:turnId`. */
 interface ITurnTiming {
@@ -12,6 +12,7 @@ interface ITurnTiming {
 	readonly provider: string;
 	readonly session: string;
 	readonly model: string | undefined;
+	readonly modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
 	readonly permissionLevel: string | undefined;
 	firstProgressMs: number | undefined;
 }
@@ -32,13 +33,14 @@ export class AgentHostTurnTracker {
 
 	constructor(private readonly _reporter: AgentHostTelemetryReporter) { }
 
-	turnStarted(provider: string, session: string, turnId: string, model: string | undefined, permissionLevel: string | undefined): void {
+	turnStarted(provider: string, session: string, turnId: string, model: string | undefined, modelTelemetryKind: AgentHostModelTelemetryKind | undefined, permissionLevel: string | undefined): void {
 		const key = this._key(session, turnId);
 		this._turnTimings.set(key, {
 			stopWatch: StopWatch.create(false),
 			provider,
 			session,
 			model,
+			modelTelemetryKind,
 			permissionLevel,
 			firstProgressMs: undefined,
 		});
@@ -67,6 +69,7 @@ export class AgentHostTurnTracker {
 			totalTime: timing.stopWatch.elapsed(),
 			result,
 			model: timing.model,
+			modelTelemetryKind: timing.modelTelemetryKind,
 			permissionLevel: timing.permissionLevel,
 			failure,
 		});

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -16,6 +16,7 @@ import { IInstantiationService } from '../../instantiation/common/instantiation.
 import { ILogService } from '../../log/common/log.js';
 import { IAgentHostChangesetService } from '../common/agentHostChangesetService.js';
 import { IAgentHostCheckpointService } from '../common/agentHostCheckpointService.js';
+import { readAgentModelByokIdentifier } from '../common/agentModelByokMeta.js';
 import { AgentSession, AgentSignal, IAgent, IAgentToolPendingConfirmationSignal } from '../common/agentService.js';
 import { readToolCallMeta, toToolCallMeta } from '../common/meta/agentToolCallMeta.js';
 
@@ -55,7 +56,7 @@ import {
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentHostSessionTitleController } from './agentHostSessionTitleController.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
-import { AgentHostTelemetryReporter, type AgentHostTurnFailureStage, type IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
+import { AgentHostTelemetryReporter, type AgentHostModelTelemetryKind, type AgentHostTurnFailureStage, type IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
 import { AgentHostToolCallTracker } from './agentHostToolCallTracker.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
 import { AgentHostTurnTracker } from './agentHostTurnTracker.js';
@@ -1126,8 +1127,8 @@ export class AgentSideEffects extends Disposable {
 				}
 				const attachments = action.message.attachments;
 				this._telemetryReporter.userMessageSent(agent.id, channel, state, 'direct', attachments);
-				const { model, permissionLevel } = this._getTurnTelemetryContext(state, action.message.model?.id);
-				this._turnTracker.turnStarted(agent.id, channel, action.turnId, model, permissionLevel);
+				const { model, modelTelemetryKind, permissionLevel } = this._getTurnTelemetryContext(agent, state, action.message.model?.id);
+				this._turnTracker.turnStarted(agent.id, channel, action.turnId, model, modelTelemetryKind, permissionLevel);
 				void this._sendTurnMessage({
 					agent,
 					sessionChannel,
@@ -1479,8 +1480,8 @@ export class AgentSideEffects extends Disposable {
 		const attachments = msg.message.attachments;
 		const queuedState = this._stateManager.getSessionState(session);
 		this._telemetryReporter.userMessageSent(agent.id, session, queuedState, 'queued', attachments);
-		const { model, permissionLevel } = this._getTurnTelemetryContext(queuedState, msg.message.model?.id);
-		this._turnTracker.turnStarted(agent.id, session, turnId, model, permissionLevel);
+		const { model, modelTelemetryKind, permissionLevel } = this._getTurnTelemetryContext(agent, queuedState, msg.message.model?.id);
+		this._turnTracker.turnStarted(agent.id, session, turnId, model, modelTelemetryKind, permissionLevel);
 		// Selection travels on the queued message; it is applied before sending.
 		void this._sendTurnMessage({
 			agent,
@@ -1495,10 +1496,16 @@ export class AgentSideEffects extends Disposable {
 	}
 
 
-	private _getTurnTelemetryContext(state: SessionState | undefined, modelId: string | undefined): { model: string | undefined; permissionLevel: string | undefined } {
+	private _getTurnTelemetryContext(agent: IAgent, state: SessionState | undefined, modelId: string | undefined): { model: string | undefined; modelTelemetryKind: AgentHostModelTelemetryKind | undefined; permissionLevel: string | undefined } {
 		const permissionValue = state?.config?.values[SessionConfigKey.AutoApprove];
 		const permissionLevel = typeof permissionValue === 'string' ? permissionValue : undefined;
-		return { model: modelId, permissionLevel };
+		const model = modelId === undefined ? undefined : agent.models.get().find(model => model.id === modelId);
+		const modelTelemetryKind = modelId === undefined
+			? undefined
+			: model === undefined
+				? 'unknown'
+				: readAgentModelByokIdentifier(model) === undefined ? 'trusted' : 'byok';
+		return { model: modelId, modelTelemetryKind, permissionLevel };
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1500,11 +1500,16 @@ export class AgentSideEffects extends Disposable {
 		const permissionValue = state?.config?.values[SessionConfigKey.AutoApprove];
 		const permissionLevel = typeof permissionValue === 'string' ? permissionValue : undefined;
 		const model = modelId === undefined ? undefined : agent.models.get().find(model => model.id === modelId);
-		const modelTelemetryKind = modelId === undefined
-			? undefined
-			: model === undefined
-				? 'unknown'
-				: readAgentModelByokIdentifier(model) === undefined ? 'trusted' : 'byok';
+		let modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
+		if (modelId === 'auto') {
+			modelTelemetryKind = 'trusted';
+		} else if (modelId === undefined) {
+			modelTelemetryKind = undefined;
+		} else if (model === undefined) {
+			modelTelemetryKind = 'unknown';
+		} else {
+			modelTelemetryKind = readAgentModelByokIdentifier(model) === undefined ? 'trusted' : 'byok';
+		}
 		return { model: modelId, modelTelemetryKind, permissionLevel };
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -12,6 +12,8 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { TelemetryTrustedValue } from '../../../telemetry/common/telemetryUtils.js';
+import { createAgentModelByokMeta } from '../../common/agentModelByokMeta.js';
 import { AgentSession, IAgent } from '../../common/agentService.js';
 import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
 import { buildDefaultChatUri, MessageKind, PendingMessageKind, ResponsePartKind, SessionStatus } from '../../common/state/sessionState.js';
@@ -192,6 +194,7 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 
 	test('emits turnCompleted with timing, model and permissionLevel on success', () => {
 		setupSession();
+		agent.setModels([{ provider: 'mock', id: 'gpt-5.5', name: 'GPT 5.5', supportsVision: false }]);
 		setAutoApprove('autopilot');
 		startTurn('turn-1', 'hello', 'gpt-5.5');
 
@@ -205,11 +208,35 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		assert.strictEqual(data.agentSessionId, 'session-1');
 		assert.strictEqual(data.turnId, 'turn-1');
 		assert.strictEqual(data.result, 'success');
-		assert.strictEqual(data.model, 'gpt-5.5');
+		assert.deepStrictEqual(data.model, new TelemetryTrustedValue('gpt-5.5'));
 		assert.strictEqual(data.modelSelectionKind, 'explicit');
 		assert.strictEqual(data.permissionLevel, 'autopilot');
 		assert.strictEqual(typeof data.totalTime, 'number');
 		assert.strictEqual(typeof data.timeToFirstProgress, 'number');
+	});
+
+	test('uses generic model values for BYOK and unknown selections', () => {
+		setupSession();
+		agent.setModels([{
+			provider: 'mock',
+			id: 'openrouter/private-model',
+			name: 'Private Model',
+			supportsVision: false,
+			_meta: createAgentModelByokMeta('openrouter/private-model'),
+		}]);
+
+		startTurn('turn-byok', 'hello', 'openrouter/private-model');
+		fire({ type: ActionType.ChatTurnComplete, turnId: 'turn-byok', duration: 1000 });
+		startTurn('turn-unknown', 'hello', 'unadvertised/private-model');
+		fire({ type: ActionType.ChatTurnComplete, turnId: 'turn-unknown', duration: 1000 });
+
+		assert.deepStrictEqual(completedEvents().map(event => {
+			const data = event.data as Record<string, unknown>;
+			return { model: data.model, modelSelectionKind: data.modelSelectionKind };
+		}), [
+			{ model: 'byokModel', modelSelectionKind: 'explicit' },
+			{ model: 'unknown', modelSelectionKind: 'explicit' },
+		]);
 	});
 
 	test('timeToFirstProgress is undefined when no visible progress arrives before completion', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -151,6 +151,11 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		return telemetry.events.filter(e => e.eventName === 'agentHost.turnCompleted');
 	}
 
+	function capturedModel(data: Record<string, unknown>): { trusted: boolean; value: unknown } {
+		const model = data.model;
+		return model instanceof TelemetryTrustedValue ? { trusted: true, value: model.value } : { trusted: false, value: model };
+	}
+
 	function failedEvents(): { eventName: string; data: unknown }[] {
 		return telemetry.events.filter(e => e.eventName === 'agentHost.turnFailed');
 	}
@@ -208,7 +213,7 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		assert.strictEqual(data.agentSessionId, 'session-1');
 		assert.strictEqual(data.turnId, 'turn-1');
 		assert.strictEqual(data.result, 'success');
-		assert.deepStrictEqual(data.model, new TelemetryTrustedValue('gpt-5.5'));
+		assert.deepStrictEqual(capturedModel(data), { trusted: true, value: 'gpt-5.5' });
 		assert.strictEqual(data.modelSelectionKind, 'explicit');
 		assert.strictEqual(data.permissionLevel, 'autopilot');
 		assert.strictEqual(typeof data.totalTime, 'number');
@@ -256,10 +261,12 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		startTurn('turn-1', 'hello', 'auto');
 		fire({ type: ActionType.ChatTurnCancelled, turnId: 'turn-1', duration: 1000 });
 
-		const events = completedEvents();
-		assert.strictEqual(events.length, 1);
-		assert.strictEqual((events[0].data as Record<string, unknown>).result, 'cancelled');
-		assert.strictEqual((events[0].data as Record<string, unknown>).modelSelectionKind, 'auto');
+		const data = completedEvents()[0].data as Record<string, unknown>;
+		assert.deepStrictEqual({
+			model: capturedModel(data),
+			result: data.result,
+			modelSelectionKind: data.modelSelectionKind,
+		}, { model: { trusted: true, value: 'auto' }, result: 'cancelled', modelSelectionKind: 'auto' });
 	});
 
 	test('emits result=error on ChatError', () => {


### PR DESCRIPTION
Wrap provider-advertised Agent Host model IDs in `TelemetryTrustedValue` so known model IDs are not path-redacted. BYOK models are reported as `byokModel`, and selections absent from the provider catalog are reported as `unknown`.

Adds turn telemetry coverage for trusted, BYOK, and unknown model selections.

## Validation

- `npm run precommit`
- `npm run typecheck-client` *(blocked by an unrelated existing `ModelBilling.promo` error in `copilotAgent.test.ts`)*

(Written by Copilot)