### PR TITLE
Adopt SDK managed settings notifications

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -4185,6 +4185,14 @@ export class CopilotAgentSession extends Disposable {
 			this._logService.trace(`[Copilot:${sessionId}] Model changed: ${e.data.previousModel ?? '(none)'} -> ${e.data.newModel}`);
 		}));
 
+		this._register(wrapper.onManagedSettingsResolved(e => {
+			this._logService.info(`[Copilot:${sessionId}] Managed settings resolved: source=${e.data.source}, managedKeys=${e.data.managedKeys.join(',') || '(none)'}, bypassPermissionsDisabled=${e.data.bypassPermissionsDisabled}, failClosed=${e.data.failClosed}`);
+		}));
+
+		this._register(wrapper.onManagedSettingsEnforced(e => {
+			this._logService.warn(`[Copilot:${sessionId}] Managed settings enforced: action=${e.data.action}, setting=${e.data.setting}, escalation=${e.data.escalation ?? '(none)'}, failClosed=${e.data.failClosed}, message=${e.data.message}`);
+		}));
+
 		this._register(wrapper.onSessionHandoff(e => {
 			this._logService.trace(`[Copilot:${sessionId}] Session handoff: sourceType=${e.data.sourceType}, remoteSessionId=${e.data.remoteSessionId ?? '(none)'}`);
 		}));

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -67,13 +67,6 @@ type PostToolUseHookInput = Parameters<NonNullable<SessionHooks['onPostToolUse']
 type CopilotSessionLaunchConfig = ResumeSessionConfig & {
 	readonly pluginDirectories?: string[];
 	readonly remoteSession?: 'export';
-	/**
-	 * Opt the runtime into self-fetching enterprise managed settings at session
-	 * bootstrap. Declared locally until the published `@github/copilot-sdk` carries
-	 * it on `SessionConfigBase`; it is forwarded to `createSession` and read by the
-	 * runtime at runtime regardless of the published SDK's static type.
-	 */
-	readonly enableManagedSettings?: boolean;
 };
 
 /**
@@ -624,11 +617,6 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			// session must opt in via `remoteSession` to actually export
 			// events. Without this, sessions default to "off".
 			remoteSession: this._configurationService.getRootValue(platformRootSchema, AgentHostSessionSyncEnabledConfigKey) === true ? 'export' : undefined,
-			// Opt the runtime into self-fetching enterprise managed settings
-			// (bypass-permissions policy) at session bootstrap. The runtime uses
-			// the session's gitHubToken to call /copilot_internal/managed_settings
-			// and enforces the result fail-closed before the first turn.
-			// Typed locally on CopilotSessionLaunchConfig pending the SDK type update.
 			enableManagedSettings: true,
 		};
 	}

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
@@ -98,6 +98,16 @@ export class CopilotSessionWrapper extends Disposable {
 		return this._onAutoModeResolved ??= this._sdkEvent('session.auto_mode_resolved');
 	}
 
+	private _onManagedSettingsResolved: Event<SessionEventPayload<'session.managed_settings_resolved'>> | undefined;
+	get onManagedSettingsResolved(): Event<SessionEventPayload<'session.managed_settings_resolved'>> {
+		return this._onManagedSettingsResolved ??= this._sdkEvent('session.managed_settings_resolved');
+	}
+
+	private _onManagedSettingsEnforced: Event<SessionEventPayload<'session.managed_settings_enforced'>> | undefined;
+	get onManagedSettingsEnforced(): Event<SessionEventPayload<'session.managed_settings_enforced'>> {
+		return this._onManagedSettingsEnforced ??= this._sdkEvent('session.managed_settings_enforced');
+	}
+
 	private _onSessionHandoff: Event<SessionEventPayload<'session.handoff'>> | undefined;
 	get onSessionHandoff(): Event<SessionEventPayload<'session.handoff'>> {
 		return this._onSessionHandoff ??= this._sdkEvent('session.handoff');

--- a/src/vs/platform/agentHost/node/copilot/copilotSystemNotification.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSystemNotification.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { SessionEventPayload, SystemNotification } from '@github/copilot-sdk';
-import { softAssertNever } from '../../../../base/common/assert.js';
 import { localize } from '../../../../nls.js';
 
 export interface ICopilotSystemNotification {
@@ -55,9 +54,6 @@ export function buildCopilotSystemNotification(event: SessionEventPayload<'syste
 				messageText: localize('agentHost.copilot.systemNotification.instructionDiscovered', "Instruction discovered: {0}", kind.description ?? kind.sourcePath),
 				startsTurn: false,
 			};
-		default:
-			softAssertNever(kind);
-			return undefined;
 	}
 }
 

--- a/src/vs/platform/agentHost/node/copilot/copilotSystemNotification.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSystemNotification.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { SessionEventPayload, SystemNotification } from '@github/copilot-sdk';
+import { softAssertNever } from '../../../../base/common/assert.js';
 import { localize } from '../../../../nls.js';
 
 export interface ICopilotSystemNotification {
@@ -54,6 +55,9 @@ export function buildCopilotSystemNotification(event: SessionEventPayload<'syste
 				messageText: localize('agentHost.copilot.systemNotification.instructionDiscovered', "Instruction discovered: {0}", kind.description ?? kind.sourcePath),
 				startsTurn: false,
 			};
+		default:
+			softAssertNever(kind);
+			return undefined;
 	}
 }
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -612,6 +612,35 @@ suite('CopilotAgentSession', () => {
 		);
 	});
 
+	test('logs managed settings resolution and enforcement', async () => {
+		const logService = new CapturingLogService();
+		const { mockSession } = await createAgentSession(disposables, { logService });
+
+		mockSession.fire('session.managed_settings_resolved', {
+			source: 'server',
+			serverManaged: true,
+			deviceManaged: false,
+			managedKeys: ['permissions'],
+			bypassPermissionsDisabled: true,
+			failClosed: false,
+		} as SessionEventPayload<'session.managed_settings_resolved'>['data']);
+		mockSession.fire('session.managed_settings_enforced', {
+			action: 'bypass_permissions_blocked',
+			escalation: 'allow_all',
+			setting: 'permissions.disableBypassPermissionsMode',
+			failClosed: false,
+			message: 'Bypass permissions mode is disabled by enterprise policy.',
+		} as SessionEventPayload<'session.managed_settings_enforced'>['data']);
+
+		assert.deepStrictEqual({
+			infos: logService.infos.map(entry => entry.message).filter(message => message.includes('Managed settings')),
+			warnings: logService.warnings.map(entry => entry.message).filter(message => message.includes('Managed settings')),
+		}, {
+			infos: ['[Copilot:test-session-1] Managed settings resolved: source=server, managedKeys=permissions, bypassPermissionsDisabled=true, failClosed=false'],
+			warnings: ['[Copilot:test-session-1] Managed settings enforced: action=bypass_permissions_blocked, setting=permissions.disableBypassPermissionsMode, escalation=allow_all, failClosed=false, message=Bypass permissions mode is disabled by enterprise policy.'],
+		});
+	});
+
 	test('maps internal attachment URIs to Copilot SDK path fields', async () => {
 		const fileUri = URI.file('/workspace/file.ts');
 		const selectionUri = URI.file('/workspace/selection.ts');


### PR DESCRIPTION
Enterprise managed settings are now enforced by the Copilot runtime, but Agent Host needs to opt in and expose enough diagnostics to verify which policy was resolved and when it governed an action.

This change keeps `enableManagedSettings` enabled using the public SDK type, adopts the SDK's `session.managed_settings_resolved` and `session.managed_settings_enforced` events, and logs their policy source, managed keys, fail-closed state, and enforcement details. The events remain runtime diagnostics rather than new AHP state; they can be inspected in Agent Host logs.

Includes unit coverage for both managed-settings notification paths.