### PR TITLE
Keep empty session groups visible

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -62,7 +62,7 @@ Two grouping modes (user-switchable):
 - **By Workspace** (default) — user groups and one section per workspace label share a single, freely-reorderable user-managed order below Pinned. By default groups come first and workspaces are alphabetical ("Unknown" workspace last) until the user drags them.
 - **By Date** — user groups form a contiguous, user-ordered block directly below Pinned; the non-grouped sessions follow in the fixed date sections (Recent, Older), where Recent holds up to 10 sessions from the last 7 days and Older holds the rest. Groups never mix into the date sections.
 
-User groups are **fully user-managed**: their order is owned by `ISessionSectionOrderService`, defaults to newest-first, and is shared across both grouping modes (it no longer derives from the recency of a group's member sessions).
+User groups are **fully user-managed**: their order is owned by `ISessionSectionOrderService`, defaults to newest-first, and is shared across both grouping modes (it no longer derives from the recency of a group's member sessions). Groups remain visible and persisted until explicitly deleted. A group with no currently-visible member rows renders a muted **"No session" placeholder row** like the empty Chats section; this includes genuinely empty groups and groups whose members currently render in Pinned/Done or are hidden by a filter.
 
 Archived sessions always go to the "Done" section regardless of grouping mode. Archive wins over pin — an archived session is never shown in Pinned.
 
@@ -118,7 +118,7 @@ Regular sessions can be reordered by dragging them up or down within the list. P
 - **Grouping by Date** — the regular list is one continuous sequence, so dragging can move a session across date buckets (e.g. to the top makes it "Recent").
 - **Grouping by Workspace** — reordering is restricted to within the same workspace group; drops onto another workspace are rejected.
 - **Pinned** — dropping a non-archived session on the Pinned header pins it and lets it sort naturally. Dropping it on a pinned session shows an insertion line, pins it, and stores the sort key needed to place it at that location.
-- **User groups** — dropping a non-archived session on a group header adds or moves it into the group and lets it sort naturally. Dropping it on a session inside the group shows an insertion line for the exact slot and highlights only the group header to indicate the receiving group.
+- **User groups** — dropping a non-archived session on a group header or its "No session" placeholder adds or moves it into the group and lets it sort naturally. Dropping it on a session inside the group shows an insertion line for the exact slot and highlights only the group header to indicate the receiving group.
 - **Scope** — archived (Done) sessions do not reorder or move into groups. Drops onto the Done section, unsupported section headers, and "show more" rows are rejected.
 - **Multi-selection** — dragging multiple selected sessions moves them as a contiguous block, preserving their relative order. The drag label reads `"N sessions"`. Dragging sessions into the sessions grid opens all of them.
 
@@ -135,6 +135,8 @@ Dragging a **group header** or a **workspace section header** over another reord
 The insertion line relies on the base list widget's `drop-target-before`/`drop-target-after` feedback (colored by `list.dropBetweenBackground`). The widget converts an "after" indicator on row *i* into a "before" indicator on row *i+1*, so hovering the bottom half of the upper row and the top half of the lower row render the exact same DOM line with no shift.
 
 Archived sessions do not show the session group context menu actions ("Create Group", "Add to Group", "Move to Group", or "Remove from Group").
+
+The **Create Group** context-menu action is also available from list blank space, section headers, group headers, "show more" rows, and placeholder rows. These non-session entry points create an empty group and immediately start inline renaming; the session-row action creates the group with the selected sessions as before.
 
 ### Read / Unread
 

--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -185,7 +185,7 @@ The sessions list defines menu IDs that contributions can target to add actions.
 
 | Menu | Constant | Where it appears | Use for |
 |------|----------|------------------|---------|
-| `SessionGroupToolbar` | `SessionGroupToolbarMenuId` | Toolbar on user-created group headers | Group-scoped actions: "New Session" (opens the new-session composer and joins the started session to the group), "Rename", and "Delete Group". The "New Session" intent is recorded via `ISessionGroupsService.setPendingNewSessionGroup` and bound to the committed session when it is started; abandoning the new session clears it. |
+| `SessionGroupToolbar` | `SessionGroupToolbarMenuId` | Toolbar on user-created group headers | Group-scoped actions: "Mark All as Done" when the group has visible sessions, "Delete Group" when it has no members, and "New Session" (opens the new-session composer and joins the started session to the group). A group whose members are all pinned, archived, or filtered out shows neither destructive action. The "New Session" intent is recorded via `ISessionGroupsService.setPendingNewSessionGroup` and bound to the committed session when it is started; abandoning the new session clears it. |
 
 ### View Title Menus
 
@@ -240,6 +240,8 @@ Context keys available for `when` clauses when contributing to session list menu
 | Key | Type | Description |
 |-----|------|-------------|
 | `sessionSection.type` | string | `'pinned'`, `'quickchats'`, `'archived'`, `'workspace:<label>'`, `'recent'`, etc. |
+| `sessionGroup.hasVisibleSessions` | boolean | Whether a user-created group has visible session rows |
+| `sessionGroup.isEmpty` | boolean | Whether a user-created group has no members |
 
 ### View-Level
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -99,6 +99,8 @@ export const SessionItemStatusContext = new RawContextKey<SessionStatus>('sessio
 /** Whether the focused session item currently belongs to a user group. */
 export const SessionItemInGroupContext = new RawContextKey<boolean>('sessionItem.inGroup', false);
 export const SessionSectionTypeContext = new RawContextKey<string>('sessionSection.type', '');
+export const SessionGroupHasVisibleSessionsContext = new RawContextKey<boolean>('sessionGroup.hasVisibleSessions', false);
+export const SessionGroupIsEmptyContext = new RawContextKey<boolean>('sessionGroup.isEmpty', false);
 
 //#region Types
 
@@ -133,6 +135,7 @@ export interface ISessionSection {
 export interface ISessionGroupItem {
 	readonly group: ISessionGroup;
 	readonly sessions: ISession[];
+	readonly isEmpty: boolean;
 	readonly editing: boolean;
 }
 
@@ -1055,6 +1058,8 @@ class SessionGroupRenderer implements ITreeRenderer<SessionListItem, FuzzyScore,
 
 		template.label.textContent = element.group.name;
 		this.updateChevron(template, node.collapsible, node.collapsed);
+		SessionGroupHasVisibleSessionsContext.bindTo(template.contextKeyService).set(element.sessions.length > 0);
+		SessionGroupIsEmptyContext.bindTo(template.contextKeyService).set(element.isEmpty);
 		template.toolbar.context = element;
 
 		template.container.classList.toggle('session-group-editing', element.editing);
@@ -2178,7 +2183,12 @@ export class SessionsList extends Disposable implements ISessionsList {
 		for (const group of this._sessionGroupsService.getGroups()) {
 			const members = groupedMembers.get(group.id) ?? [];
 			const sortedMembers = sortSessions(members, sorting, sortKeyForGrouping);
-			groupItemsById.set(group.id, { group, sessions: sortedMembers, editing: group.id === this._editingGroupId });
+			groupItemsById.set(group.id, {
+				group,
+				sessions: sortedMembers,
+				isEmpty: this._sessionGroupsService.getSessionIdsInGroup(group.id).length === 0,
+				editing: group.id === this._editingGroupId,
+			});
 		}
 		const defaultGroupIds = [...groupItemsById.values()]
 			.sort((a, b) => b.group.createdAt - a.group.createdAt)

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -1485,6 +1485,8 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 		let target: ISession | undefined;
 		if (isSessionGroupItem(targetElement)) {
 			groupId = targetElement.group.id;
+		} else if (isSessionPlaceholder(targetElement) && targetElement.sectionId.startsWith('group:')) {
+			groupId = targetElement.sectionId.slice('group:'.length);
 		} else if (isSessionItem(targetElement)) {
 			groupId = this.delegate.getGroupIdOfSession(targetElement);
 			target = groupId === undefined ? undefined : targetElement;
@@ -2041,7 +2043,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 				this.update();
 			}
 			// Garbage-collect manual order / promotion entries when groups are
-			// deleted or evicted. Group changes are user-driven and happen after
+			// deleted. Group changes are user-driven and happen after
 			// sessions have loaded, so pruning here is safe (unlike at render
 			// time during the asynchronous initial load).
 			if (e.groupsChanged) {
@@ -2166,12 +2168,6 @@ export class SessionsList extends Disposable implements ISessionsList {
 				groupedRegularIds.add(s.sessionId);
 			}
 		}
-		// Keep a group being renamed visible even if it currently has no visible
-		// members, so its inline name editor stays on screen.
-		if (this._editingGroupId && this._sessionGroupsService.getGroup(this._editingGroupId) && !groupedMembers.has(this._editingGroupId)) {
-			groupedMembers.set(this._editingGroupId, []);
-		}
-
 		const forSections = groupedRegularIds.size > 0 ? filtered.filter(s => !groupedRegularIds.has(s.sessionId)) : filtered;
 
 		// Build the group blocks with members sorted by the normal sort logic.
@@ -2179,10 +2175,10 @@ export class SessionsList extends Disposable implements ISessionsList {
 		// service (defaulting to newest-first), independent of their members'
 		// recency, and is shared across both grouping modes.
 		const groupItemsById = new Map<string, ISessionGroupItem>();
-		for (const [groupId, members] of groupedMembers) {
-			const group = this._sessionGroupsService.getGroup(groupId)!;
+		for (const group of this._sessionGroupsService.getGroups()) {
+			const members = groupedMembers.get(group.id) ?? [];
 			const sortedMembers = sortSessions(members, sorting, sortKeyForGrouping);
-			groupItemsById.set(groupId, { group, sessions: sortedMembers, editing: group.id === this._editingGroupId });
+			groupItemsById.set(group.id, { group, sessions: sortedMembers, editing: group.id === this._editingGroupId });
 		}
 		const defaultGroupIds = [...groupItemsById.values()]
 			.sort((a, b) => b.group.createdAt - a.group.createdAt)
@@ -2314,11 +2310,15 @@ export class SessionsList extends Disposable implements ISessionsList {
 		};
 
 		const renderGroup = (groupItem: ISessionGroupItem): IObjectTreeElement<SessionListItem> => {
+			const sectionId = `group:${groupItem.group.id}`;
+			const groupChildren = groupItem.sessions.length === 0
+				? [{ element: { placeholder: true as const, sectionId, label: localize('noSessionInGroup', "No session") } }]
+				: renderSessionChildren(groupItem.sessions, sectionId, groupItem.group.name, !this.hasFindPattern && this.workspaceGroupCapped);
 			return {
 				element: groupItem,
 				collapsible: true,
-				collapsed: this.getSavedCollapseState(`group:${groupItem.group.id}`) ?? ObjectTreeElementCollapseState.PreserveOrExpanded,
-				children: renderSessionChildren(groupItem.sessions, `group:${groupItem.group.id}`, groupItem.group.name, !this.hasFindPattern && this.workspaceGroupCapped),
+				collapsed: this.getSavedCollapseState(sectionId) ?? ObjectTreeElementCollapseState.PreserveOrExpanded,
+				children: groupChildren,
 			};
 		};
 
@@ -2600,6 +2600,10 @@ export class SessionsList extends Disposable implements ISessionsList {
 		if (groupSessions.length === 0) {
 			return;
 		}
+		this.createGroup(groupSessions);
+	}
+
+	private createGroup(groupSessions: ISession[]): void {
 		this._sessionsListModelService.unpinSessions(groupSessions);
 		const group = this._sessionGroupsService.createGroup(localize('newGroupName', "New Group"), groupSessions.map(s => s.sessionId));
 		this._editingGroupId = group.id;
@@ -2728,6 +2732,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 	private onContextMenu(e: ITreeContextMenuEvent<SessionListItem | null>): void {
 		const element = e.element;
 		if (!element || isSessionSection(element) || isSessionShowMore(element) || isSessionPlaceholder(element)) {
+			this.showCreateGroupContextMenu(e.anchor);
 			return;
 		}
 
@@ -2794,9 +2799,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			return actions;
 		}
 
-		actions.push(new Action('sessions.createGroup', localize('createGroupAction', "Create Group"), undefined, true, async () => {
-			this.createGroupFromSessions(selected);
-		}));
+		actions.push(this.getCreateGroupAction(selected));
 
 		const currentGroupIds = new Set(selected.map(s => this._sessionGroupsService.getGroupOfSession(s.sessionId)));
 		const currentGroupId = currentGroupIds.size === 1 ? [...currentGroupIds][0] : undefined;
@@ -2821,8 +2824,27 @@ export class SessionsList extends Disposable implements ISessionsList {
 		return actions;
 	}
 
+	private getCreateGroupAction(sessions?: ISession[]): IAction {
+		return new Action('sessions.createGroup', localize('createGroupAction', "Create Group"), undefined, true, async () => {
+			if (sessions) {
+				this.createGroupFromSessions(sessions);
+			} else {
+				this.createGroup([]);
+			}
+		});
+	}
+
+	private showCreateGroupContextMenu(anchor: ITreeContextMenuEvent<SessionListItem | null>['anchor']): void {
+		this.contextMenuService.showContextMenu({
+			getActions: () => [this.getCreateGroupAction()],
+			getAnchor: () => anchor,
+		});
+	}
+
 	private showGroupContextMenu(groupItem: ISessionGroupItem, anchor: ITreeContextMenuEvent<SessionListItem>['anchor']): void {
 		const actions: IAction[] = [
+			this.getCreateGroupAction(),
+			new Separator(),
 			new Action('sessions.renameGroupAction', localize('renameGroupAction', "Rename..."), undefined, true, async () => {
 				this.beginRenameGroup(groupItem.group.id);
 			}),

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -22,7 +22,7 @@ import { EditorsVisibleContext, EditorAreaFocusContext, IsSessionsWindowContext 
 import { SessionsCategories } from '../../../../common/categories.js';
 import { UNARCHIVE_SESSION_COMMAND_ID } from '../../../../common/sessionCommands.js';
 import { SessionSupportsDeleteContext, SessionSupportsRenameContext, IsNewChatSessionContext, SessionIsArchivedContext, SessionIsCreatedContext, SessionIsReadContext } from '../../../../common/contextkeys.js';
-import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionGroupToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, SessionsGrouping, SessionsSorting, ISessionSection, ISessionGroupItem } from './sessionsList.js';
+import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionGroupToolbarMenuId, SessionSectionTypeContext, SessionGroupHasVisibleSessionsContext, SessionGroupIsEmptyContext, IsSessionPinnedContext, SessionsGrouping, SessionsSorting, ISessionSection, ISessionGroupItem } from './sessionsList.js';
 import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { ISessionGroupsService } from '../../../../services/sessions/browser/sessionGroupsService.js';
 import { IsWorkspaceGroupCappedContext, SessionsViewFilterOptionsSubMenu, SessionsViewFilterSubMenu, SessionsViewGroupingContext, SessionsViewId, SessionsView, SessionsViewSortingContext, openSessionToTheSide } from './sessionsView.js';
@@ -615,6 +615,7 @@ registerAction2(class MarkAllSessionsInGroupAsDoneAction extends Action2 {
 				id: SessionGroupToolbarMenuId,
 				group: 'navigation',
 				order: 0,
+				when: SessionGroupHasVisibleSessionsContext,
 			}]
 		});
 	}
@@ -649,6 +650,31 @@ registerAction2(class MarkAllSessionsInGroupAsDoneAction extends Action2 {
 
 		for (const session of context.sessions) {
 			await sessionsManagementService.archiveSession(session);
+		}
+	}
+});
+
+registerAction2(class DeleteEmptySessionGroupAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsView.deleteEmptyGroup',
+			title: localize2('deleteEmptyGroup', "Delete Group"),
+			icon: Codicon.trash,
+			menu: [{
+				id: SessionGroupToolbarMenuId,
+				group: 'navigation',
+				order: 0,
+				when: SessionGroupIsEmptyContext,
+			}]
+		});
+	}
+	run(accessor: ServicesAccessor, context?: ISessionGroupItem): void {
+		if (!context) {
+			return;
+		}
+		const sessionGroupsService = accessor.get(ISessionGroupsService);
+		if (sessionGroupsService.getSessionIdsInGroup(context.group.id).length === 0) {
+			sessionGroupsService.deleteGroup(context.group.id);
 		}
 	}
 });

--- a/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
@@ -23,7 +23,7 @@ export interface ISessionGroup {
 	readonly id: string;
 	/** User-provided display name. */
 	readonly name: string;
-	/** Creation timestamp (ms). Used to evict the oldest empty group and as the default order (newest first). */
+	/** Creation timestamp (ms). Used as the default order (newest first). */
 	readonly createdAt: number;
 }
 
@@ -51,8 +51,7 @@ export interface ISessionGroupsService {
 	readonly onDidChange: Event<ISessionGroupsChangeEvent>;
 
 	/**
-	 * All groups in display order (including currently-empty ones). The list
-	 * view omits groups with no visible members when rendering.
+	 * All groups in display order, including currently-empty ones.
 	 */
 	getGroups(): ISessionGroup[];
 
@@ -112,12 +111,6 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 
 	private static readonly STORAGE_KEY = 'sessionsListControl.groups';
 
-	/**
-	 * Maximum number of empty groups (no members) retained in storage. When a
-	 * new empty group would exceed this, the oldest empty group is evicted.
-	 */
-	private static readonly MAX_EMPTY_GROUPS = 3;
-
 	private readonly _onDidChange = this._register(new Emitter<ISessionGroupsChangeEvent>());
 	readonly onDidChange: Event<ISessionGroupsChangeEvent> = this._onDidChange.event;
 
@@ -162,9 +155,8 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 				}
 			}
 			if (changed.size > 0) {
-				const evicted = this.evictExcessEmptyGroups();
 				this.save();
-				this._onDidChange.fire({ groupsChanged: evicted, membershipChanged: changed });
+				this._onDidChange.fire({ groupsChanged: false, membershipChanged: changed });
 			}
 		}));
 
@@ -230,7 +222,6 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 			}
 		}
 
-		this.evictExcessEmptyGroups();
 		this.save();
 		this._onDidChange.fire({ groupsChanged: true, membershipChanged });
 		return group;
@@ -281,18 +272,16 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 		if (membershipChanged.size === 0) {
 			return;
 		}
-		const evicted = this.evictExcessEmptyGroups();
 		this.save();
-		this._onDidChange.fire({ groupsChanged: evicted, membershipChanged });
+		this._onDidChange.fire({ groupsChanged: false, membershipChanged });
 	}
 
 	removeFromGroup(sessionId: string): void {
 		if (!this._membership.delete(sessionId)) {
 			return;
 		}
-		const evicted = this.evictExcessEmptyGroups();
 		this.save();
-		this._onDidChange.fire({ groupsChanged: evicted, membershipChanged: new Set([sessionId]) });
+		this._onDidChange.fire({ groupsChanged: false, membershipChanged: new Set([sessionId]) });
 	}
 
 	getGroupOfSession(sessionId: string): string | undefined {
@@ -320,32 +309,6 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 			this._membership.set(sessionId, groupId);
 			changed.add(sessionId);
 		}
-	}
-
-	private hasMembers(groupId: string): boolean {
-		for (const gid of this._membership.values()) {
-			if (gid === groupId) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Keep at most {@link MAX_EMPTY_GROUPS} groups with no members, evicting the
-	 * oldest empty groups (by `createdAt`) beyond that cap. Returns whether any
-	 * group was deleted.
-	 */
-	private evictExcessEmptyGroups(): boolean {
-		const empty = [...this._groups.values()]
-			.filter(group => !this.hasMembers(group.id))
-			.sort((a, b) => a.createdAt - b.createdAt);
-		let deleted = false;
-		for (let i = 0; i < empty.length - SessionGroupsService.MAX_EMPTY_GROUPS; i++) {
-			this._groups.delete(empty[i].id);
-			deleted = true;
-		}
-		return deleted;
 	}
 
 	/**

--- a/src/vs/sessions/services/sessions/test/browser/sessionGroupsService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionGroupsService.test.ts
@@ -155,31 +155,24 @@ suite('SessionGroupsService', () => {
 		const session = createSession('s1');
 		sessionsChangedEmitter.fire({ added: [], removed: [session], changed: [] });
 
-		assert.strictEqual(service.getGroupOfSession('s1'), undefined);
-		assert.deepStrictEqual(service.getSessionIdsInGroup(a.id), ['s2']);
+		assert.deepStrictEqual({
+			groupName: service.getGroup(a.id)?.name,
+			removedMembership: service.getGroupOfSession('s1'),
+			remainingMembers: service.getSessionIdsInGroup(a.id),
+		}, {
+			groupName: 'A',
+			removedMembership: undefined,
+			remainingMembers: ['s2'],
+		});
 	});
 
-	test('empty groups are capped at 3, evicting the oldest', () => {
-		// Four empty groups created in order; the oldest (g1) should be evicted.
-		const g1 = service.createGroup('1');
-		const g2 = service.createGroup('2');
-		const g3 = service.createGroup('3');
-		const g4 = service.createGroup('4');
+	test('empty groups persist until explicitly deleted', () => {
+		for (const name of ['1', '2', '3', '4']) {
+			service.createGroup(name);
+		}
 
-		const ids = service.getGroups().map(g => g.id);
-		assert.strictEqual(ids.includes(g1.id), false);
-		assert.deepStrictEqual([g2, g3, g4].map(g => ids.includes(g.id)), [true, true, true]);
-	});
-
-	test('non-empty groups are never evicted by the empty cap', () => {
-		const kept = service.createGroup('kept', ['s1']);
-		service.createGroup('e1');
-		service.createGroup('e2');
-		service.createGroup('e3');
-		service.createGroup('e4');
-
-		assert.strictEqual(service.getGroup(kept.id)?.name, 'kept');
-		assert.strictEqual(service.getGroups().filter(g => service.getSessionIdsInGroup(g.id).length === 0).length, 3);
+		const reloaded = disposables.add(instantiationService.createInstance(SessionGroupsService));
+		assert.deepStrictEqual(reloaded.getGroups().map(group => group.name).sort(), ['1', '2', '3', '4']);
 	});
 
 	test('state persists across reload', () => {


### PR DESCRIPTION
## Summary
- keep custom session groups visible and persisted when they have no visible sessions
- render a localized `No session` placeholder and accept session drops on it
- expose `Create Group` from blank space and non-session list context menus without adding a session
- remove the three-empty-group retention cap

## Validation
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `scripts\test.bat --run src\vs\sessions\services\sessions\test\browser\sessionGroupsService.test.ts --run src\vs\sessions\contrib\sessions\test\browser\sessionsList.test.ts` (45 passing)
- `npm run precommit`

Closes #327153