### PR TITLE
agentHost: grant access to local attachments

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -25,7 +25,7 @@ import { agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../common/
 import { AgentHostResourcePermissionError, IAgentHostResourceService } from '../common/agentHostResourceService.js';
 import type { ClientNotificationMap, CommandMap, JsonRpcErrorResponse, JsonRpcRequest } from '../common/state/protocol/messages.js';
 import { ActionType, type ActionEnvelope, type INotification, type IRootConfigChangedAction, type SessionAction, type ChatAction, type TerminalAction, type ClientAnnotationsAction } from '../common/state/sessionActions.js';
-import { SessionSummary, SessionStatus, ROOT_STATE_URI, StateComponents, isAhpRootChannel, type ClientPluginCustomization, type RootState } from '../common/state/sessionState.js';
+import { MessageAttachmentKind, SessionSummary, SessionStatus, ROOT_STATE_URI, StateComponents, isAhpRootChannel, type ClientPluginCustomization, type Message, type RootState } from '../common/state/sessionState.js';
 import { PROTOCOL_VERSION } from '../common/state/protocol/version/registry.js';
 import { isJsonRpcNotification, isJsonRpcRequest, isJsonRpcResponse, ProtocolError, ReconnectResultType, type ProtocolMessage, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { type IVscodeUpgradeResult } from '../common/state/protocolUpgrade.js';
@@ -44,6 +44,7 @@ import type { InitializeResult } from '../common/state/protocol/common/commands.
 import { dirname } from '../../../base/common/resources.js';
 import { observableValue, type IObservable } from '../../../base/common/observable.js';
 import { isFileResourceRead } from '../common/resourceReadLogging.js';
+import { ResourceSet } from '../../../base/common/map.js';
 
 const AHP_CLIENT_CONNECTION_CLOSED = -32000;
 
@@ -261,11 +262,11 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	private readonly _loadEstimator: ILoadEstimator;
 
 	/**
-	 * Comparison keys of customization URIs we have already granted implicit
+	 * Comparison keys of URIs we have already granted implicit
 	 * read access for on this connection. Dedupes repeat sends so we don't
 	 * pile up grants per dispatch. Cleared with the connection.
 	 */
-	private readonly _grantedCustomizationUris = new Set<string>();
+	private readonly _grantedImplicitReadUris = new ResourceSet();
 
 	get clientId(): string {
 		return this._clientId;
@@ -974,14 +975,28 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	}
 
 	/**
-	 * Inspect an outgoing client-dispatched action and grant implicit reads
-	 * for any customization URIs it carries. Today this covers
-	 * `SessionActiveClientSet`, which is the only client-dispatched
-	 * action that ships customization URIs to the host.
+	 * Inspect an outgoing client-dispatched action and grant implicit reads for
+	 * resources that the host will need to read after receiving the action.
 	 */
 	private _grantImplicitReadsForOutgoingAction(action: SessionAction | ChatAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction): void {
-		if (action.type === ActionType.SessionActiveClientSet && action.activeClient.customizations) {
-			this._grantImplicitReadsForCustomizations(action.activeClient.customizations);
+		switch (action.type) {
+			case ActionType.SessionActiveClientSet:
+				if (action.activeClient.customizations) {
+					this._grantImplicitReadsForCustomizations(action.activeClient.customizations);
+				}
+				break;
+			case ActionType.ChatTurnStarted:
+			case ActionType.ChatPendingMessageSet:
+				this._grantImplicitReadsForMessage(action.message);
+				break;
+		}
+	}
+
+	private _grantImplicitReadsForMessage(message: Message): void {
+		for (const attachment of message.attachments ?? []) {
+			if (attachment.type === MessageAttachmentKind.Resource) {
+				this._grantImplicitRead(URI.parse(attachment.uri));
+			}
 		}
 	}
 
@@ -999,16 +1014,17 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			} catch {
 				continue;
 			}
-			const grantUri = dirname(uri);
-			const key = grantUri.toString();
-			if (this._grantedCustomizationUris.has(key)) {
-				continue;
-			}
-			this._grantedCustomizationUris.add(key);
-			// Disposable is owned by the resource service; cleared on
-			// connectionClosed.
-			this._resourceService.grantImplicitRead(this._address, grantUri);
+			this._grantImplicitRead(dirname(uri));
 		}
+	}
+
+	private _grantImplicitRead(uri: URI): void {
+		if (this._grantedImplicitReadUris.has(uri)) {
+			return;
+		}
+		this._grantedImplicitReadUris.add(uri);
+		// The resource service also revokes these grants in connectionClosed.
+		this._resourceService.grantImplicitRead(this._address, uri);
 	}
 
 	/**
@@ -1185,7 +1201,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		}
 		this._rejectPendingRequests(error);
 		this._resourceService.connectionClosed(this._address);
-		this._grantedCustomizationUris.clear();
+		this._grantedImplicitReadUris.clear();
 		this._transitionTo({ kind: AgentHostClientState.Closed, error });
 		this._onDidClose.fire();
 	}

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -262,9 +262,8 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	private readonly _loadEstimator: ILoadEstimator;
 
 	/**
-	 * Comparison keys of URIs we have already granted implicit
-	 * read access for on this connection. Dedupes repeat sends so we don't
-	 * pile up grants per dispatch. Cleared with the connection.
+	 * URIs we have already granted implicit read access for on this connection.
+	 * Uses URI-aware comparison to dedupe repeat sends and is cleared with the connection.
 	 */
 	private readonly _grantedImplicitReadUris = new ResourceSet();
 
@@ -994,8 +993,13 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 	private _grantImplicitReadsForMessage(message: Message): void {
 		for (const attachment of message.attachments ?? []) {
-			if (attachment.type === MessageAttachmentKind.Resource) {
+			if (attachment.type !== MessageAttachmentKind.Resource) {
+				continue;
+			}
+			try {
 				this._grantImplicitRead(URI.parse(attachment.uri));
+			} catch {
+				continue;
 			}
 		}
 	}

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -752,7 +752,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		return this._subscriptionManager.getActiveSubscriptions();
 	}
 
-	dispatch(channel: string, action: SessionAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction): void {
+	dispatch(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction): void {
 		const seq = this._subscriptionManager.dispatchOptimistic(channel, action);
 		this.dispatchAction(channel, action, this._clientId, seq);
 	}
@@ -797,7 +797,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	/**
 	 * Dispatch a client action to the server. Returns the clientSeq used.
 	 */
-	private dispatchAction(channel: string, action: SessionAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction, _clientId: string, clientSeq: number): void {
+	private dispatchAction(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction, _clientId: string, clientSeq: number): void {
 		this._grantImplicitReadsForOutgoingAction(action);
 		this._sendNotification('dispatchAction', { channel, clientSeq, action });
 	}

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
@@ -19,11 +20,11 @@ import { ConfigurationTarget, type IConfigurationValue } from '../../../configur
 import { ContentEncoding, ReconnectResultType } from '../../common/state/protocol/commands.js';
 import { AhpErrorCodes } from '../../common/state/protocol/errors.js';
 import { PROTOCOL_VERSION } from '../../common/state/protocol/version/registry.js';
-import { ActionType, type SessionActiveClientSetAction, type SessionActiveClientRemovedAction, type SessionTitleChangedAction } from '../../common/state/sessionActions.js';
+import { ActionType, type ChatTurnStartedAction, type SessionActiveClientSetAction, type SessionActiveClientRemovedAction, type SessionTitleChangedAction } from '../../common/state/sessionActions.js';
 import { ProtocolError, type AhpServerNotification, type JsonRpcNotification, type JsonRpcRequest, type JsonRpcResponse, type ProtocolMessage } from '../../common/state/sessionProtocol.js';
 import { hasKey } from '../../../../base/common/types.js';
 import { mainWindow } from '../../../../base/browser/window.js';
-import { CustomizationType, ROOT_STATE_URI, StateComponents, customizationId } from '../../common/state/sessionState.js';
+import { CustomizationType, MessageAttachmentKind, MessageKind, PendingMessageKind, ROOT_STATE_URI, StateComponents, customizationId } from '../../common/state/sessionState.js';
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
@@ -145,6 +146,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 		granted?: (address: string, uri: URI, mode: AgentHostPermissionMode) => boolean;
 		onRequest?: (address: string, params: { uri: string; read?: boolean; write?: boolean }) => Promise<void>;
 		onGrantImplicitRead?: (address: string, uri: URI) => void;
+		readBytes?: VSBuffer;
 	}
 
 	/**
@@ -169,7 +171,13 @@ suite('RemoteAgentHostProtocolClient', () => {
 			_serviceBrand: undefined,
 			check: async (addr, uri, mode) => grant(addr, uri, mode),
 			async list(addr, uri) { await gateRead(addr, uri); return { entries: [] }; },
-			async read(addr, uri) { await gateRead(addr, uri); throw new Error('Not implemented in stub'); },
+			async read(addr, uri) {
+				await gateRead(addr, uri);
+				if (opts.readBytes) {
+					return { bytes: opts.readBytes };
+				}
+				throw new Error('Not implemented in stub');
+			},
 			async write(addr, params) { await gateWrite(addr, URI.parse(params.uri)); },
 			async del(addr, params) { await gateWrite(addr, URI.parse(params.uri)); },
 			async move(addr, params) { await gateWrite(addr, URI.parse(params.source)); await gateWrite(addr, URI.parse(params.destination)); },
@@ -943,7 +951,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 		});
 	});
 
-	suite('implicit grants for outgoing customization actions', () => {
+	suite('implicit grants for outgoing actions', () => {
 
 		function createCapturingPermissionService(): { service: IAgentHostResourceService; calls: { address: string; uri: URI }[] } {
 			const calls: { address: string; uri: URI }[] = [];
@@ -977,6 +985,67 @@ suite('RemoteAgentHostProtocolClient', () => {
 					{ address: 'test.example:1234', uri: 'file:///other' },
 				],
 			);
+		});
+
+		test('ChatTurnStarted grants attachment access before reverse resourceRead', async () => {
+			const granted = new Set<string>();
+			const attachmentUri = URI.file('/attachments/example.txt');
+			const service = createResourceServiceStub({
+				granted: (_address, uri, mode) => mode === AgentHostPermissionMode.Read && granted.has(uri.toString()),
+				onGrantImplicitRead: (_address, uri) => granted.add(uri.toString()),
+				readBytes: VSBuffer.fromString('attachment'),
+			});
+			const { client, transport } = createClient(undefined, service);
+			const action: ChatTurnStartedAction = {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2026-07-23T00:00:00.000Z',
+				message: {
+					text: 'Review this file',
+					origin: { kind: MessageKind.User },
+					attachments: [{
+						type: MessageAttachmentKind.Resource,
+						uri: attachmentUri.toString(),
+						label: 'example.txt',
+					}],
+				},
+			};
+
+			client.dispatch('copilot-chat:/test', action);
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: 42,
+				method: 'resourceRead',
+				params: { channel: ROOT_STATE_URI, uri: attachmentUri.toString() },
+			});
+			await timeout(0);
+
+			assert.deepStrictEqual(transport.sentMessages.at(-1), {
+				jsonrpc: '2.0',
+				id: 42,
+				result: { data: 'YXR0YWNobWVudA==', encoding: ContentEncoding.Base64 },
+			});
+		});
+
+		test('ChatPendingMessageSet grants resource attachments only', () => {
+			const { service, calls } = createCapturingPermissionService();
+			const { client } = createClient(undefined, service);
+
+			client.dispatch('copilot-chat:/test', {
+				type: ActionType.ChatPendingMessageSet,
+				kind: PendingMessageKind.Queued,
+				id: 'queued-1',
+				message: {
+					text: 'Review these attachments',
+					origin: { kind: MessageKind.User },
+					attachments: [
+						{ type: MessageAttachmentKind.Resource, uri: 'file:///attachments/queued.txt', label: 'queued.txt' },
+						{ type: MessageAttachmentKind.EmbeddedResource, data: '', contentType: 'text/plain', label: 'inline.txt' },
+					],
+				},
+			});
+
+			assert.deepStrictEqual(calls.map(call => call.uri.toString()), ['file:///attachments/queued.txt']);
 		});
 
 		test('multiple customizations in the same directory dedupe to one grant', () => {
@@ -1129,7 +1198,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 		 * client plus a `transports` array recording each transport handed
 		 * out, so tests can drive handshake/reconnect interactions.
 		 */
-		function createFactoryClient(): { client: RemoteAgentHostProtocolClient; transports: TestClientProtocolTransport[] } {
+		function createFactoryClient(permissionService = createPermissionService()): { client: RemoteAgentHostProtocolClient; transports: TestClientProtocolTransport[] } {
 			const transports: TestClientProtocolTransport[] = [];
 			const factory = () => {
 				const t = disposables.add(new TestClientProtocolTransport());
@@ -1137,7 +1206,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 				return t;
 			};
 			const client = disposables.add(new RemoteAgentHostProtocolClient(
-				'test.example:1234', factory, undefined, new NullLogService(), createPermissionService(), new TestConfigurationService(),
+				'test.example:1234', factory, undefined, new NullLogService(), permissionService, new TestConfigurationService(),
 			));
 			return { client, transports };
 		}
@@ -1228,6 +1297,74 @@ suite('RemoteAgentHostProtocolClient', () => {
 				const replayed = findDispatchAction(reconnectTransport, ActionType.SessionTitleChanged);
 				assert.ok(replayed, 'pending optimistic action should be re-sent after reconnect');
 				assert.strictEqual((replayed.params as { clientSeq: number }).clientSeq, initialSeq, 'replayed dispatch must reuse the original clientSeq');
+
+				subRef.dispose();
+				client.dispose();
+			});
+		});
+
+		test('attachment grant remains available when a pending turn is replayed after reconnect', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const attachmentUri = URI.file('/attachments/replayed.txt');
+				const granted = new Set<string>();
+				const permissionService = createResourceServiceStub({
+					granted: (_address, uri, mode) => mode === AgentHostPermissionMode.Read && granted.has(uri.toString()),
+					onGrantImplicitRead: (_address, uri) => granted.add(uri.toString()),
+					readBytes: VSBuffer.fromString('replayed'),
+				});
+				const { client, transports } = createFactoryClient(permissionService);
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				const chatUri = URI.parse('copilot-chat:/test-chat');
+				const subRef = client.getSubscription(StateComponents.Chat, chatUri, 'test');
+				const subscribeReq = await waitForRequest(transports[0], 'subscribe');
+				transports[0].fireMessage({
+					jsonrpc: '2.0', id: subscribeReq.id,
+					result: { snapshot: { resource: chatUri.toString(), state: { turns: [] }, fromSeq: 5 } },
+				});
+				await Promise.resolve();
+
+				client.dispatch(chatUri.toString(), {
+					type: ActionType.ChatTurnStarted,
+					turnId: 'turn-1',
+					startedAt: '2026-07-23T00:00:00.000Z',
+					message: {
+						text: 'Review this file',
+						origin: { kind: MessageKind.User },
+						attachments: [{
+							type: MessageAttachmentKind.Resource,
+							uri: attachmentUri.toString(),
+							label: 'replayed.txt',
+						}],
+					},
+				});
+
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+				const reconnectTransport = await waitForTransport(transports, 1);
+				reconnectTransport.connectDeferred.complete();
+				const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+				reconnectTransport.fireMessage({
+					jsonrpc: '2.0', id: reconnect.id,
+					result: { type: ReconnectResultType.Replay, actions: [], missing: [] },
+				});
+				await flushMicrotasks();
+
+				assert.ok(findDispatchAction(reconnectTransport, ActionType.ChatTurnStarted));
+				reconnectTransport.fireMessage({
+					jsonrpc: '2.0',
+					id: 42,
+					method: 'resourceRead',
+					params: { channel: ROOT_STATE_URI, uri: attachmentUri.toString() },
+				});
+				await flushMicrotasks();
+				assert.deepStrictEqual(reconnectTransport.sentMessages.at(-1), {
+					jsonrpc: '2.0',
+					id: 42,
+					result: { data: 'cmVwbGF5ZWQ=', encoding: ContentEncoding.Base64 },
+				});
 
 				subRef.dispose();
 				client.dispose();

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -1047,7 +1047,6 @@ suite('RemoteAgentHostProtocolClient', () => {
 					origin: { kind: MessageKind.User },
 					attachments: [
 						{ type: MessageAttachmentKind.Resource, uri: 'file:///attachments/queued.txt', label: 'queued.txt' },
-						{ type: MessageAttachmentKind.Resource, uri: 'file:///attachments/invalid%', label: 'invalid.txt' },
 						{ type: MessageAttachmentKind.EmbeddedResource, data: '', contentType: 'text/plain', label: 'inline.txt' },
 					],
 				},

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -212,6 +212,13 @@ suite('RemoteAgentHostProtocolClient', () => {
 		await connectPromise;
 	}
 
+	async function flushMicrotasks(): Promise<void> {
+		// `await Promise.resolve()` only advances one microtask; loop to drain chained handlers.
+		for (let i = 0; i < 10; i++) {
+			await Promise.resolve();
+		}
+	}
+
 	function fireConfigurationChange(configurationService: TestConfigurationService, settingId: string): void {
 		configurationService.onDidChangeConfigurationEmitter.fire({
 			source: ConfigurationTarget.USER,
@@ -1018,7 +1025,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 				method: 'resourceRead',
 				params: { channel: ROOT_STATE_URI, uri: attachmentUri.toString() },
 			});
-			await timeout(0);
+			await flushMicrotasks();
 
 			assert.deepStrictEqual(transport.sentMessages.at(-1), {
 				jsonrpc: '2.0',
@@ -1040,6 +1047,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 					origin: { kind: MessageKind.User },
 					attachments: [
 						{ type: MessageAttachmentKind.Resource, uri: 'file:///attachments/queued.txt', label: 'queued.txt' },
+						{ type: MessageAttachmentKind.Resource, uri: 'file:///attachments/invalid%', label: 'invalid.txt' },
 						{ type: MessageAttachmentKind.EmbeddedResource, data: '', contentType: 'text/plain', label: 'inline.txt' },
 					],
 				},
@@ -1155,14 +1163,6 @@ suite('RemoteAgentHostProtocolClient', () => {
 					&& !('id' in m)
 					&& ((m as JsonRpcNotification).params as { action?: { type?: unknown } } | undefined)?.action?.type === actionType,
 			);
-		}
-
-		async function flushMicrotasks(): Promise<void> {
-			// `await Promise.resolve()` only advances one microtask; loop a few times to
-			// drain chained .then handlers without resorting to fake timers.
-			for (let i = 0; i < 10; i++) {
-				await Promise.resolve();
-			}
 		}
 
 		/** Wait until the client transitions into the {@link AgentHostClientState.Reconnecting} state. */


### PR DESCRIPTION
Fixes #326523

Remote Agent Host sessions now receive implicit read grants for resource attachments before `ChatTurnStarted` and `ChatPendingMessageSet` actions are sent. The same grant path runs when pending actions are replayed after reconnect, while retaining URI-aware deduplication and per-connection cleanup.

Tests cover immediate reverse `resourceRead`, queued attachments, and reconnect replay.

Validation:
- TypeScript client typecheck
- Changed-file hygiene
- Agent Host protocol client unit tests (59 passing)