### PR TITLE
Fix: Markdown preview switches content when tab is pinned

### DIFF
--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -797,11 +797,19 @@ export class DynamicMarkdownPreview extends Disposable implements IManagedMarkdo
 				return;
 			}
 
+			if (!isMarkdownFile(editor.document)) {
+				return;
+			}
+
+			if (this.#locked) {
+				return;
+			}
+
 			if (this.#isTabPinned()) {
 				return;
 			}
 
-			if (isMarkdownFile(editor.document) && !this.#locked && !this.#preview.isPreviewOf(editor.document.uri)) {
+			if (!this.#preview.isPreviewOf(editor.document.uri)) {
 				const line = getVisibleLine(editor);
 				this.update(editor.document.uri, line ? new StartingScrollLine(line) : undefined);
 			}
@@ -939,8 +947,8 @@ export class DynamicMarkdownPreview extends Disposable implements IManagedMarkdo
 				if (previewTabs.length === 1) {
 					return true;
 				}
-				// Multiple previews: match by locked state via title convention ([...] prefix)
-				if (tab.label.startsWith('[') === this.#locked) {
+				// Multiple previews: match by exact title
+				if (tab.label === this.#webviewPanel.title) {
 					return true;
 				}
 			}

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -797,6 +797,10 @@ export class DynamicMarkdownPreview extends Disposable implements IManagedMarkdo
 				return;
 			}
 
+			if (this.#isTabPinned()) {
+				return;
+			}
+
 			if (isMarkdownFile(editor.document) && !this.#locked && !this.#preview.isPreviewOf(editor.document.uri)) {
 				const line = getVisibleLine(editor);
 				this.update(editor.document.uri, line ? new StartingScrollLine(line) : undefined);
@@ -908,6 +912,40 @@ export class DynamicMarkdownPreview extends Disposable implements IManagedMarkdo
 
 	public matches(otherPreview: DynamicMarkdownPreview): boolean {
 		return this.matchesResource(otherPreview.#preview.resource, otherPreview.position, otherPreview.#locked);
+	}
+
+	#isTabPinned(): boolean {
+		const viewColumn = this.#webviewPanel.viewColumn;
+		if (typeof viewColumn === 'undefined') {
+			return false;
+		}
+
+		const tabGroup = vscode.window.tabGroups.all.find(group => group.viewColumn === viewColumn);
+		if (!tabGroup) {
+			return false;
+		}
+
+		const previewTabs = tabGroup.tabs.filter(tab =>
+			tab.input instanceof vscode.TabInputWebview &&
+			tab.input.viewType === DynamicMarkdownPreview.viewType
+		);
+		if (previewTabs.length === 0) {
+			return false;
+		}
+
+		for (const tab of previewTabs) {
+			if (tab.isPinned) {
+				// If there's a single preview tab in this column, it's us
+				if (previewTabs.length === 1) {
+					return true;
+				}
+				// Multiple previews: match by locked state via title convention ([...] prefix)
+				if (tab.label.startsWith('[') === this.#locked) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	#createPreview(resource: vscode.Uri, startingScroll?: StartingScrollLocation): MarkdownPreview {


### PR DESCRIPTION
**The problem**  
Currently, if a user pins a Markdown preview tab, editing another \.md\ file causes the preview to switch to the new file, ignoring the \pinned\ state. This contradicts user expectations, as pinning should lock the content.

**The solution**  
Added a check in \onDidChangeActiveTextEditor\ within \preview.ts\:

- **New private method** \#isTabPinned()\: Gets the webview's \iewColumn\ and checks if the corresponding tab has \isPinned === true\.
- **Multiple preview handling**: In the rare case of multiple previews in the same column, the code correctly discriminates between pinned and unpinned previews using exact title match (\	ab.label === this.#webviewPanel.title\), ensuring robustness across all localized versions of VS Code.
- **Guard**: If \#isTabPinned()\ returns \	rue\, the handler returns early, preventing the preview content from being replaced.

**Expected behavior after this fix**:
1. Pinned preview + edit another file → **Preview does NOT change**.
2. Unpinned preview + edit another file → **Preview changes** (existing behavior, unaltered).
3. The \Toggle Lock\ command continues to work independently of the pin state.

**Tests performed**:
- [x] Successful compilation (\
pm run compile\).
- [x] Manual verification: Opened \A.md\ (preview), pinned, opened \B.md\ (editor) → \A.md\ remains.
- [x] Manual verification: Without pin, behavior remains legacy.
- [x] Edge case: Multiple previews in the same split - only the pinned one freezes.

Fixes: #322214