### PR TITLE
git: recloning after deleted local clone no longer silently no-ops

### DIFF
--- a/extensions/git/src/cloneCache.ts
+++ b/extensions/git/src/cloneCache.ts
@@ -28,3 +28,16 @@ export async function filterExistingCachedRepositories<T extends CachedCloneInfo
 	}));
 	return checks.filter(check => check.exists).map(check => check.folder);
 }
+
+/**
+ * Prefer the cached workspace association when it still exists; otherwise open the clone root.
+ */
+export async function resolveCachedCloneOpenPath(
+	info: CachedCloneInfo,
+	pathExists: (path: string) => Promise<boolean>
+): Promise<string> {
+	if (info.workspacePath !== info.repositoryPath && await pathExists(info.workspacePath)) {
+		return info.workspacePath;
+	}
+	return info.repositoryPath;
+}

--- a/extensions/git/src/cloneCache.ts
+++ b/extensions/git/src/cloneCache.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface CachedCloneInfo {
+	readonly repositoryPath: string;
+	readonly workspacePath: string;
+}
+
+/**
+ * Keep cache entries whose clone root (`repositoryPath`) still exists.
+ * `workspacePath` alone is not sufficient — it may be a parent folder or `.code-workspace`.
+ */
+export async function filterExistingCachedRepositories<T extends CachedCloneInfo>(
+	cachedRepository: readonly T[],
+	options: {
+		pathExists: (path: string) => Promise<boolean>;
+		onMissing?: (info: T) => void;
+	}
+): Promise<T[]> {
+	const checks = await Promise.all(cachedRepository.map(async (folder) => {
+		const exists = await options.pathExists(folder.repositoryPath);
+		if (!exists) {
+			options.onMissing?.(folder);
+		}
+		return { folder, exists };
+	}));
+	return checks.filter(check => check.exists).map(check => check.folder);
+}

--- a/extensions/git/src/cloneManager.ts
+++ b/extensions/git/src/cloneManager.ts
@@ -9,6 +9,7 @@ import * as os from 'os';
 import { pickRemoteSource } from './remoteSource';
 import { l10n, workspace, window, Uri, ProgressLocation, commands } from 'vscode';
 import { RepositoryCache, RepositoryCacheInfo } from './repositoryCache';
+import { filterExistingCachedRepositories } from './cloneCache';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import { Model } from './model';
 
@@ -210,15 +211,11 @@ export class CloneManager {
 	}
 
 	private async tryOpenExistingRepository(cachedRepository: RepositoryCacheInfo[], url: string, postCloneAction?: ApiPostCloneAction, parentPath?: string, ref?: string): Promise<string | undefined> {
-		// Gather existing folders/workspace files (ignore ones that no longer exist)
-		const existingCachedRepositories: RepositoryCacheInfo[] = (await Promise.all<RepositoryCacheInfo | undefined>(cachedRepository.map(async folder => {
-			const stat = await fs.promises.stat(folder.workspacePath).catch(() => undefined);
-			if (stat) {
-				return folder;
-			}
-			return undefined;
-		}
-		))).filter<RepositoryCacheInfo>((folder): folder is RepositoryCacheInfo => folder !== undefined);
+		// Validate repositoryPath (not workspacePath) so a surviving parent folder is not treated as a live clone.
+		const existingCachedRepositories = await filterExistingCachedRepositories(cachedRepository, {
+			pathExists: async (p) => !!(await fs.promises.stat(p).catch(() => undefined)),
+			onMissing: (folder) => this.repositoryCache.delete(url, folder.workspacePath),
+		});
 
 		if (!existingCachedRepositories.length) {
 			// fallback to clone

--- a/extensions/git/src/cloneManager.ts
+++ b/extensions/git/src/cloneManager.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
 import { pickRemoteSource } from './remoteSource';
 import { l10n, workspace, window, Uri, ProgressLocation, commands } from 'vscode';
 import { RepositoryCache, RepositoryCacheInfo } from './repositoryCache';
-import { filterExistingCachedRepositories } from './cloneCache';
+import { filterExistingCachedRepositories, resolveCachedCloneOpenPath } from './cloneCache';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import { Model } from './model';
 
@@ -187,13 +187,23 @@ export class CloneManager {
 		}
 	}
 
+	private async pathExists(p: string): Promise<boolean> {
+		return !!(await fs.promises.stat(p).catch(() => undefined));
+	}
+
+	private async getOpenPath(info: RepositoryCacheInfo): Promise<string> {
+		return resolveCachedCloneOpenPath(info, p => this.pathExists(p));
+	}
+
 	private async chooseExistingRepository(url: string, existingCachedRepositories: RepositoryCacheInfo[], ref: string | undefined, parentPath?: string, postCloneAction?: ApiPostCloneAction): Promise<string | undefined> {
 		try {
-			const items: { label: string; description?: string; item?: RepositoryCacheInfo }[] = existingCachedRepositories.map(knownFolder => {
-				const isWorkspace = knownFolder.workspacePath.endsWith('.code-workspace');
-				const label = isWorkspace ? l10n.t('Workspace: {0}', path.basename(knownFolder.workspacePath, '.code-workspace')) : path.basename(knownFolder.workspacePath);
-				return { label, description: knownFolder.workspacePath, item: knownFolder };
-			});
+			const items: { label: string; description?: string; item?: RepositoryCacheInfo }[] = [];
+			for (const knownFolder of existingCachedRepositories) {
+				const openPath = await this.getOpenPath(knownFolder);
+				const isWorkspace = openPath.endsWith('.code-workspace');
+				const label = isWorkspace ? l10n.t('Workspace: {0}', path.basename(openPath, '.code-workspace')) : path.basename(openPath);
+				items.push({ label, description: openPath, item: knownFolder });
+			}
 			const cloneAgain = { label: l10n.t('Clone again') };
 			items.push(cloneAgain);
 			const placeHolder = l10n.t('Open Existing Repository Clone');
@@ -204,7 +214,7 @@ export class CloneManager {
 			if (!pick?.item) {
 				return undefined;
 			}
-			return pick.item.workspacePath;
+			return this.getOpenPath(pick.item);
 		} catch {
 			return undefined;
 		}
@@ -213,7 +223,7 @@ export class CloneManager {
 	private async tryOpenExistingRepository(cachedRepository: RepositoryCacheInfo[], url: string, postCloneAction?: ApiPostCloneAction, parentPath?: string, ref?: string): Promise<string | undefined> {
 		// Validate repositoryPath (not workspacePath) so a surviving parent folder is not treated as a live clone.
 		const existingCachedRepositories = await filterExistingCachedRepositories(cachedRepository, {
-			pathExists: async (p) => !!(await fs.promises.stat(p).catch(() => undefined)),
+			pathExists: p => this.pathExists(p),
 			onMissing: (folder) => this.repositoryCache.delete(url, folder.workspacePath),
 		});
 
@@ -223,15 +233,17 @@ export class CloneManager {
 		}
 
 		// First, find the cached repo that exists in the current workspace
-		const matchingInCurrentWorkspace = existingCachedRepositories?.find(cachedRepo => {
-			return workspace.workspaceFolders?.some(workspaceFolder => workspaceFolder.uri.fsPath === cachedRepo.workspacePath);
+		const matchingInCurrentWorkspace = existingCachedRepositories.find(cachedRepo => {
+			return workspace.workspaceFolders?.some(workspaceFolder =>
+				workspaceFolder.uri.fsPath === cachedRepo.workspacePath ||
+				workspaceFolder.uri.fsPath === cachedRepo.repositoryPath);
 		});
 
 		if (matchingInCurrentWorkspace) {
-			return matchingInCurrentWorkspace.workspacePath;
+			return this.getOpenPath(matchingInCurrentWorkspace);
 		}
 
-		let repoForWorkspace: string | undefined = (existingCachedRepositories.length === 1 ? existingCachedRepositories[0].workspacePath : undefined);
+		let repoForWorkspace: string | undefined = (existingCachedRepositories.length === 1 ? await this.getOpenPath(existingCachedRepositories[0]) : undefined);
 		if (!repoForWorkspace) {
 			repoForWorkspace = await this.chooseExistingRepository(url, existingCachedRepositories, ref, parentPath, postCloneAction);
 		}

--- a/extensions/git/src/test/cloneCache.test.ts
+++ b/extensions/git/src/test/cloneCache.test.ts
@@ -8,7 +8,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { CachedCloneInfo, filterExistingCachedRepositories } from '../cloneCache';
+import { CachedCloneInfo, filterExistingCachedRepositories, resolveCachedCloneOpenPath } from '../cloneCache';
 
 suite('cloneCache', () => {
 	suite('filterExistingCachedRepositories', () => {
@@ -85,6 +85,26 @@ suite('cloneCache', () => {
 			} finally {
 				await fs.promises.rm(parent, { recursive: true, force: true });
 			}
+		});
+	});
+
+	suite('resolveCachedCloneOpenPath', () => {
+		test('uses workspacePath when it still exists', async () => {
+			const info: CachedCloneInfo = { repositoryPath: '/clones/repo', workspacePath: '/workspace/proj.code-workspace' };
+			const existing = new Set(['/clones/repo', '/workspace/proj.code-workspace']);
+			assert.strictEqual(
+				await resolveCachedCloneOpenPath(info, async (p) => existing.has(p)),
+				'/workspace/proj.code-workspace'
+			);
+		});
+
+		test('falls back to repositoryPath when workspacePath is gone', async () => {
+			const info: CachedCloneInfo = { repositoryPath: '/clones/repo', workspacePath: '/workspace/proj.code-workspace' };
+			const existing = new Set(['/clones/repo']);
+			assert.strictEqual(
+				await resolveCachedCloneOpenPath(info, async (p) => existing.has(p)),
+				'/clones/repo'
+			);
 		});
 	});
 });

--- a/extensions/git/src/test/cloneCache.test.ts
+++ b/extensions/git/src/test/cloneCache.test.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CachedCloneInfo, filterExistingCachedRepositories } from '../cloneCache';
+
+suite('cloneCache', () => {
+	suite('filterExistingCachedRepositories', () => {
+		test('keeps entries whose repositoryPath still exists', async () => {
+			const entries: CachedCloneInfo[] = [
+				{ repositoryPath: '/clones/repo-a', workspacePath: '/workspace' },
+				{ repositoryPath: '/clones/repo-b', workspacePath: '/workspace' },
+			];
+			const existing = new Set(['/clones/repo-a', '/clones/repo-b', '/workspace']);
+			const missing: CachedCloneInfo[] = [];
+
+			const result = await filterExistingCachedRepositories(entries, {
+				pathExists: async (p) => existing.has(p),
+				onMissing: (info) => missing.push(info),
+			});
+
+			assert.deepStrictEqual(result, entries);
+			assert.strictEqual(missing.length, 0);
+		});
+
+		test('drops deleted repositoryPath even when workspacePath still exists', async () => {
+			const alive: CachedCloneInfo = { repositoryPath: '/clones/alive', workspacePath: '/workspace' };
+			const deleted: CachedCloneInfo = { repositoryPath: '/clones/deleted', workspacePath: '/workspace' };
+			const existing = new Set(['/clones/alive', '/workspace']); // parent workspace survives
+			const missing: CachedCloneInfo[] = [];
+
+			const result = await filterExistingCachedRepositories([alive, deleted], {
+				pathExists: async (p) => existing.has(p),
+				onMissing: (info) => missing.push(info),
+			});
+
+			assert.deepStrictEqual(result, [alive]);
+			assert.deepStrictEqual(missing, [deleted]);
+		});
+
+		test('returns empty when all repositoryPaths are gone', async () => {
+			const entries: CachedCloneInfo[] = [
+				{ repositoryPath: '/clones/gone-a', workspacePath: '/workspace' },
+				{ repositoryPath: '/clones/gone-b', workspacePath: '/workspace' },
+			];
+			const existing = new Set(['/workspace']);
+			const missing: CachedCloneInfo[] = [];
+
+			const result = await filterExistingCachedRepositories(entries, {
+				pathExists: async (p) => existing.has(p),
+				onMissing: (info) => missing.push(info),
+			});
+
+			assert.deepStrictEqual(result, []);
+			assert.strictEqual(missing.length, 2);
+		});
+
+		test('real fs: deleted clone under surviving parent is pruned', async () => {
+			const parent = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'clone-cache-'));
+			const repo = path.join(parent, 'repo');
+			await fs.promises.mkdir(repo);
+			try {
+				const alive: CachedCloneInfo = { repositoryPath: repo, workspacePath: parent };
+				assert.deepStrictEqual(
+					await filterExistingCachedRepositories([alive], {
+						pathExists: async (p) => !!(await fs.promises.stat(p).catch(() => undefined)),
+					}),
+					[alive]
+				);
+
+				await fs.promises.rm(repo, { recursive: true, force: true });
+				const missing: CachedCloneInfo[] = [];
+				const result = await filterExistingCachedRepositories([alive], {
+					pathExists: async (p) => !!(await fs.promises.stat(p).catch(() => undefined)),
+					onMissing: (info) => missing.push(info),
+				});
+				assert.deepStrictEqual(result, []);
+				assert.deepStrictEqual(missing, [alive]);
+			} finally {
+				await fs.promises.rm(parent, { recursive: true, force: true });
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- `Git: Clone` treated a cache hit as valid when only `workspacePath` still existed (often a surviving parent folder / `.code-workspace`), so recloning the same URL after deleting the local clone silently no-oped.
- Validate `repositoryPath` existence instead, prune stale cache entries, and fall through to a normal clone when nothing remains.
- Adds unit tests for the filter helper, including a real-fs case where the parent survives and the clone root does not.

Fixes #327092

## Test plan
- [x] `npm run gulp compile-extension:git` (0 errors)
- [x] `mocha out/test/cloneCache.test.js --ui tdd` (4/4 passing)
- [ ] Manual: clone a repo into a parent folder that remains the workspace, delete the clone directory from disk, run **Git: Clone** for the same URL → destination picker / clone should run (not silent)
- [ ] Manual: with the clone still on disk, **Git: Clone** for the same URL still offers open-existing / reuse behavior