### PR TITLE
Voice: don't auto-send the turn by default when hands-free is disabled

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -579,13 +579,13 @@ configurationRegistry.registerConfiguration({
 		},
 		'agents.voice.handsFree': {
 			type: 'boolean',
-			markdownDescription: nls.localize('agents.voice.handsFree', "When enabled, voice mode automatically re-enters listening after the assistant finishes speaking, so you can hold a hands-free back-and-forth conversation. When disabled, you start each turn manually. This controls only the auto-listen loop; how a turn ends is controlled by {0} and {1}.", '`#agents.voice.turn.silenceMs#`', '`#agents.voice.turn.stopPhrases#`'),
+			markdownDescription: nls.localize('agents.voice.handsFree', "When enabled, voice mode automatically re-enters listening after the assistant finishes speaking, so you can hold a hands-free back-and-forth conversation. When disabled, you start each turn manually, and turns are not sent automatically on trailing silence or a stop phrase unless {0} or {1} is explicitly configured.", '`#agents.voice.turn.silenceMs#`', '`#agents.voice.turn.stopPhrases#`'),
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
 		},
 		'agents.voice.turn.silenceMs': {
 			type: 'number',
-			markdownDescription: nls.localize('agents.voice.turn.silenceMs', "Trailing silence in milliseconds before the backend ends the turn automatically. Set to `-1` to disable ending the turn on silence, in which case the turn ends only via a stop phrase ({0}) or manually. When enabled, the backend clamps this to its supported range (currently 200-5000 ms) and is the source of truth.", '`#agents.voice.turn.stopPhrases#`'),
+			markdownDescription: nls.localize('agents.voice.turn.silenceMs', "Trailing silence in milliseconds before the backend ends the turn automatically. Set to `-1` to disable ending the turn on silence, in which case the turn ends only via a stop phrase ({0}) or manually. When enabled, the backend clamps this to its supported range (currently 200-5000 ms) and is the source of truth. When hands-free mode ({1}) is disabled, the turn is not ended on silence by default unless this setting is explicitly configured, so you keep manual control over when a turn is sent.", '`#agents.voice.turn.stopPhrases#`', '`#agents.voice.handsFree#`'),
 			default: 800,
 			anyOf: [
 				{
@@ -603,7 +603,7 @@ configurationRegistry.registerConfiguration({
 		'agents.voice.turn.stopPhrases': {
 			type: 'array',
 			items: { type: 'string' },
-			markdownDescription: nls.localize('agents.voice.turn.stopPhrases', "Phrases that end the turn when spoken at the end of an utterance. Leave empty to disable ending the turn on a stop phrase, in which case the turn ends only on trailing silence ({0}) or manually. The backend strips the matched phrase from the transcript before it reaches the agent.", '`#agents.voice.turn.silenceMs#`'),
+			markdownDescription: nls.localize('agents.voice.turn.stopPhrases', "Phrases that end the turn when spoken at the end of an utterance. Leave empty to disable ending the turn on a stop phrase, in which case the turn ends only on trailing silence ({0}) or manually. The backend strips the matched phrase from the transcript before it reaches the agent. When hands-free mode ({1}) is disabled, stop phrases do not end the turn by default unless this setting is explicitly configured, so you keep manual control over when a turn is sent.", '`#agents.voice.turn.silenceMs#`', '`#agents.voice.handsFree#`'),
 			default: ['send it'],
 			scope: ConfigurationScope.APPLICATION,
 		},

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -160,7 +160,8 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (
 				e.affectsConfiguration('agents.voice.turn.silenceMs') ||
-				e.affectsConfiguration('agents.voice.turn.stopPhrases')
+				e.affectsConfiguration('agents.voice.turn.stopPhrases') ||
+				e.affectsConfiguration('agents.voice.handsFree')
 			) {
 				this._sendSetTurnConfig();
 			}
@@ -224,24 +225,51 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	}
 
 	/**
+	 * Whether a configuration setting has an explicit user/workspace/application
+	 * value, as opposed to falling back to its registered default.
+	 */
+	private _isExplicitlyConfigured(key: string): boolean {
+		const inspected = this._configurationService.inspect(key);
+		return inspected.userValue !== undefined
+			|| inspected.userLocalValue !== undefined
+			|| inspected.userRemoteValue !== undefined
+			|| inspected.workspaceValue !== undefined
+			|| inspected.workspaceFolderValue !== undefined
+			|| inspected.applicationValue !== undefined;
+	}
+
+	/**
 	 * Assemble the ``turn_config`` wire object from the ``agents.voice.turn.*``
 	 * settings, normalizing each into the shape the backend expects. The
 	 * ``auto_end_mode`` is derived from the other two settings: trailing-silence
 	 * ending is enabled unless ``silenceMs`` is ``-1`` (or otherwise non-positive),
 	 * and stop-phrase ending is enabled when at least one phrase is configured.
+	 *
+	 * When hands-free mode (``agents.voice.handsFree``) is disabled, the turn is
+	 * not sent automatically by default: trailing-silence and stop-phrase ending
+	 * are each suppressed unless the corresponding setting has been explicitly
+	 * configured, so a user who opts out of the hands-free loop keeps manual
+	 * control over when a turn is sent.
 	 */
 	private _getTurnConfig(): IVoiceTurnConfig {
 		const cfg = this._configurationService;
+		const handsFree = cfg.getValue<boolean>('agents.voice.handsFree') === true;
 
 		const silenceRaw = cfg.getValue<number>('agents.voice.turn.silenceMs');
-		const silenceEnabled = typeof silenceRaw === 'number' && silenceRaw > 0;
+		let silenceEnabled = typeof silenceRaw === 'number' && silenceRaw > 0;
+		if (!handsFree && !this._isExplicitlyConfigured('agents.voice.turn.silenceMs')) {
+			silenceEnabled = false;
+		}
 		const silence_ms = silenceEnabled ? Math.round(silenceRaw) : 800;
 
 		const phrasesRaw = cfg.getValue<string[]>('agents.voice.turn.stopPhrases');
 		const stop_phrases = Array.isArray(phrasesRaw)
 			? phrasesRaw.map(p => String(p).trim()).filter(p => p.length > 0)
 			: [];
-		const phrasesEnabled = stop_phrases.length > 0;
+		let phrasesEnabled = stop_phrases.length > 0;
+		if (!handsFree && !this._isExplicitlyConfigured('agents.voice.turn.stopPhrases')) {
+			phrasesEnabled = false;
+		}
 
 		const auto_end_mode: IVoiceTurnConfig['auto_end_mode'] =
 			silenceEnabled && phrasesEnabled ? 'both'
@@ -249,7 +277,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 					: phrasesEnabled ? 'phrase'
 						: 'off';
 
-		return { auto_end_mode, silence_ms, stop_phrases, vad_gate_asr: true };
+		return { auto_end_mode, silence_ms, stop_phrases: phrasesEnabled ? stop_phrases : [], vad_gate_asr: true };
 	}
 
 	private _sendSetTurnConfig(): void {


### PR DESCRIPTION
Fixes #327217

## What

When hands-free mode (`agents.voice.handsFree`) is **disabled**, voice mode no longer auto-sends the turn by default. Previously the turn ended automatically on trailing silence (`agents.voice.turn.silenceMs`, default `800`) and on a stop phrase (`agents.voice.turn.stopPhrases`, default `['send it']`) regardless of the hands-free setting, which is surprising for users who opt out of the automatic back-and-forth loop.

## How

In `voiceClientService._getTurnConfig()`:
- Read `agents.voice.handsFree`.
- When hands-free is disabled, suppress trailing-silence ending unless `agents.voice.turn.silenceMs` is **explicitly** configured, and suppress stop-phrase ending unless `agents.voice.turn.stopPhrases` is explicitly configured (via `IConfigurationService.inspect()`).
- Users who explicitly set either setting keep that behavior; the derived `auto_end_mode` becomes `off` only when nothing opts in.

Also:
- Re-send the turn config to the backend when `agents.voice.handsFree` changes (previously only silence/phrase changes triggered a resend).
- Update the setting descriptions for `agents.voice.turn.silenceMs`, `agents.voice.turn.stopPhrases`, and `agents.voice.handsFree` to document this.

## Notes

- No behavior change when hands-free is enabled (the default), or when the turn settings are explicitly configured.
- Draft.
