### PR TITLE
Fix apply_patch prompt instructions

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/defaultAgentInstructions.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/defaultAgentInstructions.tsx
@@ -487,7 +487,7 @@ export class ApplyPatchInstructions extends PromptElement<DefaultAgentPromptProp
 			To edit files in the workspace, use the {ToolName.ApplyPatch} tool. If you have issues with it, you should first try to fix your patch and continue using {ToolName.ApplyPatch}. {this.props.tools[ToolName.EditFile] && <>If you are stuck, you can fall back on the {ToolName.EditFile} tool, but {ToolName.ApplyPatch} is much faster and is the preferred tool.</>}<br />
 			{isGpt5 && <>Prefer the smallest set of changes needed to satisfy the task. Avoid reformatting unrelated code; preserve existing style and public APIs unless the task requires changes. When practical, complete all edits for a file within a single message.<br /></>}
 			{!useSimpleInstructions && <>
-				The input for this tool is a string representing the patch to apply, following a special format. For each snippet of code that needs to be changed, repeat the following:<br />
+				The tool call requires both `input`, a string representing the patch to apply, and `explanation`, a short description of what the patch aims to achieve. The input follows a special format. For each snippet of code that needs to be changed, repeat the following:<br />
 				<ApplyPatchFormatInstructions /><br />
 				NEVER print this out to the user, instead call the tool and the edits will be applied and shown to the user.<br />
 			</>}

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-default/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-default/all_tools.spec.snap
@@ -43,7 +43,7 @@ Tools can be disabled by the user. You may see tools used previously in the conv
 </toolUseInstructions>
 <applyPatchInstructions>
 To edit files in the workspace, use the apply_patch tool. If you have issues with it, you should first try to fix your patch and continue using apply_patch. If you are stuck, you can fall back on the insert_edit_into_file tool, but apply_patch is much faster and is the preferred tool.
-The input for this tool is a string representing the patch to apply, following a special format. For each snippet of code that needs to be changed, repeat the following:
+The tool call requires both `input`, a string representing the patch to apply, and `explanation`, a short description of what the patch aims to achieve. The input follows a special format. For each snippet of code that needs to be changed, repeat the following:
 *** Update File: [file_path]
 [context_before] -> See below for further instructions on context.
 -[old_code] -> Precede each line in the old code with a minus sign.

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gemini-2.0-flash/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gemini-2.0-flash/all_tools.spec.snap
@@ -39,7 +39,7 @@ Tools can be disabled by the user. You may see tools used previously in the conv
 </toolUseInstructions>
 <applyPatchInstructions>
 To edit files in the workspace, use the apply_patch tool. If you have issues with it, you should first try to fix your patch and continue using apply_patch. If you are stuck, you can fall back on the insert_edit_into_file tool, but apply_patch is much faster and is the preferred tool.
-The input for this tool is a string representing the patch to apply, following a special format. For each snippet of code that needs to be changed, repeat the following:
+The tool call requires both `input`, a string representing the patch to apply, and `explanation`, a short description of what the patch aims to achieve. The input follows a special format. For each snippet of code that needs to be changed, repeat the following:
 *** Update File: [file_path]
 [context_before] -> See below for further instructions on context.
 -[old_code] -> Precede each line in the old code with a minus sign.

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-4.1/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-4.1/all_tools.spec.snap
@@ -42,7 +42,7 @@ Tools can be disabled by the user. You may see tools used previously in the conv
 </toolUseInstructions>
 <applyPatchInstructions>
 To edit files in the workspace, use the apply_patch tool. If you have issues with it, you should first try to fix your patch and continue using apply_patch. If you are stuck, you can fall back on the insert_edit_into_file tool, but apply_patch is much faster and is the preferred tool.
-The input for this tool is a string representing the patch to apply, following a special format. For each snippet of code that needs to be changed, repeat the following:
+The tool call requires both `input`, a string representing the patch to apply, and `explanation`, a short description of what the patch aims to achieve. The input follows a special format. For each snippet of code that needs to be changed, repeat the following:
 *** Update File: [file_path]
 [context_before] -> See below for further instructions on context.
 -[old_code] -> Precede each line in the old code with a minus sign.

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5-mini/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5-mini/all_tools.spec.snap
@@ -151,7 +151,7 @@ The messages you send before tool calls should describe what is immediately abou
 <applyPatchInstructions>
 To edit files in the workspace, use the apply_patch tool. If you have issues with it, you should first try to fix your patch and continue using apply_patch. If you are stuck, you can fall back on the insert_edit_into_file tool, but apply_patch is much faster and is the preferred tool.
 Prefer the smallest set of changes needed to satisfy the task. Avoid reformatting unrelated code; preserve existing style and public APIs unless the task requires changes. When practical, complete all edits for a file within a single message.
-The input for this tool is a string representing the patch to apply, following a special format. For each snippet of code that needs to be changed, repeat the following:
+The tool call requires both `input`, a string representing the patch to apply, and `explanation`, a short description of what the patch aims to achieve. The input follows a special format. For each snippet of code that needs to be changed, repeat the following:
 *** Update File: [file_path]
 [context_before] -> See below for further instructions on context.
 -[old_code] -> Precede each line in the old code with a minus sign.

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5.1/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5.1/all_tools.spec.snap
@@ -175,7 +175,7 @@ The class `Person` is in `src/models/person.ts`.
 <applyPatchInstructions>
 To edit files in the workspace, use the apply_patch tool. If you have issues with it, you should first try to fix your patch and continue using apply_patch. If you are stuck, you can fall back on the insert_edit_into_file tool, but apply_patch is much faster and is the preferred tool.
 Prefer the smallest set of changes needed to satisfy the task. Avoid reformatting unrelated code; preserve existing style and public APIs unless the task requires changes. When practical, complete all edits for a file within a single message.
-The input for this tool is a string representing the patch to apply, following a special format. For each snippet of code that needs to be changed, repeat the following:
+The tool call requires both `input`, a string representing the patch to apply, and `explanation`, a short description of what the patch aims to achieve. The input follows a special format. For each snippet of code that needs to be changed, repeat the following:
 *** Update File: [file_path]
 [context_before] -> See below for further instructions on context.
 -[old_code] -> Precede each line in the old code with a minus sign.

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5/all_tools.spec.snap
@@ -151,7 +151,7 @@ The messages you send before tool calls should describe what is immediately abou
 <applyPatchInstructions>
 To edit files in the workspace, use the apply_patch tool. If you have issues with it, you should first try to fix your patch and continue using apply_patch. If you are stuck, you can fall back on the insert_edit_into_file tool, but apply_patch is much faster and is the preferred tool.
 Prefer the smallest set of changes needed to satisfy the task. Avoid reformatting unrelated code; preserve existing style and public APIs unless the task requires changes. When practical, complete all edits for a file within a single message.
-The input for this tool is a string representing the patch to apply, following a special format. For each snippet of code that needs to be changed, repeat the following:
+The tool call requires both `input`, a string representing the patch to apply, and `explanation`, a short description of what the patch aims to achieve. The input follows a special format. For each snippet of code that needs to be changed, repeat the following:
 *** Update File: [file_path]
 [context_before] -> See below for further instructions on context.
 -[old_code] -> Precede each line in the old code with a minus sign.


### PR DESCRIPTION
## Summary
- clarify that `apply_patch` calls require both `input` and `explanation`
- correct the multi-region guidance to use multiple `@@` hunks under one `*** Update File` header
- update the example and generated prompt snapshots

## Testing
- `npm run test:unit -- src/extension/prompts/node/agent/test/agentPrompt.spec.tsx -u` (180 tests passed)