### PR TITLE
Reuse terminals when replacing new session drafts

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -239,6 +239,10 @@ Review-capable changesets expose `setReviewState(resource, reviewed)`. Agent-hos
    → Iterates providers, picks the first one whose resolveWorkspace(folderUri)
      succeeds (filtered by options.sessionTypeId when given)
    → Calls provider.createNewSession(folderUri, sessionTypeId)
+   → If another workspace draft is pending, deletes that provider draft and
+     fires onDidReplaceNewDraftSession before publishing the replacement
+   → SessionsTerminalContribution transfers terminals when the drafts share a
+     cwd/backend; otherwise it rehomes the old terminals as standalone
    → Returns ISession (model draft, `newSession`); the view then activates it so
      it becomes the activeSession and the draft slot shows reactively, and
      openNewSession resolves `{ session, trustDeclined: false }`
@@ -606,6 +610,15 @@ Backend state change (turn complete, status update, etc.)
 ```
 
 Providers may fire `onDidReplaceSession` when a temporary (untitled) session is atomically replaced by a committed one after the first turn.
+
+Workspace draft replacement is management-owned: `createNewSession` creates the
+replacement, deletes the previous provider draft, fires
+`onDidReplaceNewDraftSession`, and only then publishes the replacement through
+`newSession`. Terminal ownership relies on this ordering so compatible terminals
+can transfer before activation eagerly ensures the replacement terminal.
+Incompatible terminals are detached as standalone terminals and excluded from
+future session matching and visibility management. A terminal that finishes
+creating after its draft was replaced is disposed before activation.
 
 Provider add notifications are authoritative upserts. A provisional `listSessions()` entry may already be cached when the backend publishes its materialized project and working directory, so providers update the existing session adapter in place and report it as changed rather than replacing its identity.
 

--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -89,6 +89,7 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	private _activeKey: string | undefined;
 	private _activeSessionId: string | undefined;
 	private readonly _sessionTerminals = new Map<string, Set<number>>();
+	private readonly _standaloneTerminalIds = new Set<number>();
 	/** In-flight terminal work for drafts, retained only until each operation settles. */
 	private readonly _pendingTerminalOperations = new Map<string, IPendingTerminalOperation>();
 
@@ -199,6 +200,7 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		// (e.g. user closes a terminal tab) so the map doesn't hold stale entries.
 		this._register(this._terminalService.onDidDisposeInstance(instance => {
 			this._removeTerminalFromTrackedSessions(instance.instanceId);
+			this._standaloneTerminalIds.delete(instance.instanceId);
 		}));
 
 		// Hide restored terminals from a previous window session that don't
@@ -421,7 +423,7 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			if (instance.shellLaunchConfig.hideFromUser) {
 				continue;
 			}
-			if (options?.excludeTracked && this._isTerminalTracked(instance.instanceId)) {
+			if (options?.excludeTracked && (this._isTerminalTracked(instance.instanceId) || this._standaloneTerminalIds.has(instance.instanceId))) {
 				continue;
 			}
 			try {
@@ -483,7 +485,20 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		const toAgentHostAddress = this._getSessionAgentHostAddress(to);
 		if (fromCwd === toCwd && fromAgentHostAddress === toAgentHostAddress) {
 			this._transferTerminals(from.sessionId, to.sessionId);
+		} else {
+			this._rehomeTerminals(from.sessionId);
 		}
+	}
+
+	private _rehomeTerminals(sessionId: string): void {
+		const terminals = this._getTrackedTerminalsForSession(sessionId);
+		for (const terminal of terminals) {
+			this._standaloneTerminalIds.add(terminal.instanceId);
+		}
+		if (terminals.length > 0) {
+			this._logService.trace(`[SessionsTerminal] Rehomed ${terminals.length} terminal(s) from session ${sessionId}`);
+		}
+		this._sessionTerminals.delete(sessionId);
 	}
 
 	private _transferTerminals(fromSessionId: string, toSessionId: string): void {
@@ -573,7 +588,7 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 
 		for (const instance of [...this._terminalService.instances]) {
 			// Skip hidden tool terminals — managed by the chat tool lifecycle
-			if (instance.shellLaunchConfig.hideFromUser) {
+			if (instance.shellLaunchConfig.hideFromUser || this._standaloneTerminalIds.has(instance.instanceId)) {
 				continue;
 			}
 			let cwd: string | undefined;
@@ -622,6 +637,9 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		let mostRecent: ITerminalInstance | undefined;
 		let mostRecentTimestamp = -1;
 		for (const instance of foreground) {
+			if (this._standaloneTerminalIds.has(instance.instanceId)) {
+				continue;
+			}
 			const cmdDetection = instance.capabilities.get(TerminalCapability.CommandDetection);
 			const lastCmd = cmdDetection?.commands.at(-1);
 			if (lastCmd && lastCmd.timestamp > mostRecentTimestamp) {
@@ -696,6 +714,7 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	async dumpTracking(): Promise<void> {
 		console.log(`[SessionsTerminal] Active key: ${this._activeKey ?? '<none>'}`);
 		console.log(`[SessionsTerminal] Session terminals: ${JSON.stringify([...this._sessionTerminals.entries()].map(([sessionId, terminalIds]) => [sessionId, [...terminalIds]]))}`);
+		console.log(`[SessionsTerminal] Standalone terminals: ${JSON.stringify([...this._standaloneTerminalIds])}`);
 		console.log('[SessionsTerminal] === All Terminals ===');
 		for (const instance of this._terminalService.instances) {
 			let cwd = '<unknown>';

--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -44,6 +44,11 @@ interface ISessionTerminalInfo {
 	readonly agentHostCwd?: URI;
 }
 
+interface IPendingTerminalOperation {
+	count: number;
+	replaced: boolean;
+}
+
 /**
  * Returns terminal info for the given session: worktree or repository path for
  * workspace-backed agent sessions. Returns `undefined` for sessions without a
@@ -84,6 +89,8 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	private _activeKey: string | undefined;
 	private _activeSessionId: string | undefined;
 	private readonly _sessionTerminals = new Map<string, Set<number>>();
+	/** In-flight terminal work for drafts, retained only until each operation settles. */
+	private readonly _pendingTerminalOperations = new Map<string, IPendingTerminalOperation>();
 
 	/**
 	 * Session ids already processed as archived. The archive cleanup runs only
@@ -175,23 +182,17 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			this._onActiveSessionChanged(session);
 		}));
 
+		// Repeated New Session actions replace one draft with another. Transfer
+		// the old draft's terminals when both drafts use the same cwd and backend.
+		this._register(this._sessionsManagementService.onDidReplaceNewDraftSession(({ from, to }) => {
+			this._onDidReplaceNewDraftSession(from, to);
+		}));
+
 		// When a session is replaced (untitled → committed graduation), transfer
 		// tracked terminals from the old session id to the new one so they are
 		// not orphaned and closed by the removal cleanup.
 		this._register(this._sessionsManagementService.onDidReplaceSession(({ from, to }) => {
-			const terminalIds = this._sessionTerminals.get(from.sessionId);
-			if (terminalIds && terminalIds.size > 0) {
-				let targetIds = this._sessionTerminals.get(to.sessionId);
-				if (!targetIds) {
-					targetIds = new Set<number>();
-					this._sessionTerminals.set(to.sessionId, targetIds);
-				}
-				for (const id of terminalIds) {
-					targetIds.add(id);
-				}
-				this._logService.trace(`[SessionsTerminal] Transferred ${terminalIds.size} terminal(s) from session ${from.sessionId} to ${to.sessionId}`);
-			}
-			this._sessionTerminals.delete(from.sessionId);
+			this._transferTerminals(from.sessionId, to.sessionId);
 		}));
 
 		// Clean up tracked terminal ids when terminals are externally disposed
@@ -293,10 +294,30 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	 * host, the terminal is created on the agent host instead of locally.
 	 */
 	async ensureTerminal(cwd: URI, focus: boolean, session?: ISession): Promise<ITerminalInstance[]> {
+		if (!session) {
+			return this._ensureTerminal(cwd, focus, session);
+		}
+
+		this._beginTerminalOperation(session.sessionId);
+		try {
+			return await this._ensureTerminal(cwd, focus, session);
+		} finally {
+			this._endTerminalOperation(session.sessionId);
+		}
+	}
+
+	private async _ensureTerminal(cwd: URI, focus: boolean, session?: ISession): Promise<ITerminalInstance[]> {
+		if (session && this._pendingTerminalOperations.get(session.sessionId)?.replaced) {
+			return [];
+		}
+
 		const key = cwd.fsPath.toLowerCase();
 		let existing = session ? this._getTrackedTerminalsForSession(session.sessionId) : [];
 		if (existing.length === 0) {
 			existing = await this._findTerminalsForKey(key, { excludeTracked: !!session });
+			if (session && this._pendingTerminalOperations.get(session.sessionId)?.replaced) {
+				return [];
+			}
 		}
 
 		if (existing.length === 0) {
@@ -304,6 +325,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 				const instance = await this._createTerminalForSession(cwd, session);
 				const createdInstance = this._getAvailableTerminal(instance, `activate created terminal for ${cwd.fsPath}`);
 				if (!createdInstance) {
+					return [];
+				}
+				if (session && this._pendingTerminalOperations.get(session.sessionId)?.replaced) {
+					await this._terminalService.safeDisposeTerminal(createdInstance);
 					return [];
 				}
 				existing = [createdInstance];
@@ -361,23 +386,28 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			return;
 		}
 
-		const info = getSessionTerminalInfo(session);
-		const targetPath = info?.cwd ?? await this._pathService.userHome();
-		const targetKey = targetPath.fsPath.toLowerCase();
-		if (this._activeKey === targetKey && this._activeSessionId === session.sessionId) {
-			return;
-		}
-		this._activeKey = targetKey;
-		this._activeSessionId = session.sessionId;
+		this._beginTerminalOperation(session.sessionId);
+		try {
+			const info = getSessionTerminalInfo(session);
+			const targetPath = info?.cwd ?? await this._pathService.userHome();
+			const targetKey = targetPath.fsPath.toLowerCase();
+			if (this._activeKey === targetKey && this._activeSessionId === session.sessionId) {
+				return;
+			}
+			this._activeKey = targetKey;
+			this._activeSessionId = session.sessionId;
 
-		const instances = await this.ensureTerminal(targetPath, false, session);
+			const instances = await this._ensureTerminal(targetPath, false, session);
 
-		// If the active session or key changed while we were awaiting, a newer
-		// call has taken over — skip the visibility update to avoid flicker.
-		if (this._activeKey !== targetKey || this._activeSessionId !== session.sessionId) {
-			return;
+			// If the active session or key changed while we were awaiting, a newer
+			// call has taken over — skip the visibility update to avoid flicker.
+			if (this._activeKey !== targetKey || this._activeSessionId !== session.sessionId) {
+				return;
+			}
+			await this._updateTerminalVisibility(session, targetKey, instances.map(instance => instance.instanceId));
+		} finally {
+			this._endTerminalOperation(session.sessionId);
 		}
-		await this._updateTerminalVisibility(session, targetKey, instances.map(instance => instance.instanceId));
 	}
 
 	/**
@@ -418,6 +448,58 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		for (const instance of instances) {
 			terminalIds.add(instance.instanceId);
 		}
+	}
+
+	private _beginTerminalOperation(sessionId: string): void {
+		const operation = this._pendingTerminalOperations.get(sessionId);
+		if (operation) {
+			operation.count++;
+			return;
+		}
+		this._pendingTerminalOperations.set(sessionId, { count: 1, replaced: false });
+	}
+
+	private _endTerminalOperation(sessionId: string): void {
+		const operation = this._pendingTerminalOperations.get(sessionId);
+		if (!operation) {
+			return;
+		}
+		operation.count--;
+		if (operation.count > 0) {
+			return;
+		}
+		this._pendingTerminalOperations.delete(sessionId);
+	}
+
+	private _onDidReplaceNewDraftSession(from: ISession, to: ISession): void {
+		const pendingOperation = this._pendingTerminalOperations.get(from.sessionId);
+		if (pendingOperation) {
+			pendingOperation.replaced = true;
+		}
+
+		const fromCwd = getSessionTerminalInfo(from)?.cwd.fsPath.toLowerCase();
+		const toCwd = getSessionTerminalInfo(to)?.cwd.fsPath.toLowerCase();
+		const fromAgentHostAddress = this._getSessionAgentHostAddress(from);
+		const toAgentHostAddress = this._getSessionAgentHostAddress(to);
+		if (fromCwd === toCwd && fromAgentHostAddress === toAgentHostAddress) {
+			this._transferTerminals(from.sessionId, to.sessionId);
+		}
+	}
+
+	private _transferTerminals(fromSessionId: string, toSessionId: string): void {
+		const terminalIds = this._sessionTerminals.get(fromSessionId);
+		if (terminalIds && terminalIds.size > 0) {
+			let targetIds = this._sessionTerminals.get(toSessionId);
+			if (!targetIds) {
+				targetIds = new Set<number>();
+				this._sessionTerminals.set(toSessionId, targetIds);
+			}
+			for (const id of terminalIds) {
+				targetIds.add(id);
+			}
+			this._logService.trace(`[SessionsTerminal] Transferred ${terminalIds.size} terminal(s) from session ${fromSessionId} to ${toSessionId}`);
+		}
+		this._sessionTerminals.delete(fromSessionId);
 	}
 
 	private _getTrackedTerminalsForSession(sessionId: string): ITerminalInstance[] {

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DeferredPromise } from '../../../../../base/common/async.js';
 import { DisposableStore, Disposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { constObservable, observableValue } from '../../../../../base/common/observable.js';
-import { IAgentHostTerminalService } from '../../../../../workbench/contrib/terminal/browser/agentHostTerminalService.js';
+import { IAgentHostTerminalCreateOptions, IAgentHostTerminalService } from '../../../../../workbench/contrib/terminal/browser/agentHostTerminalService.js';
 import { ITerminalProfileService } from '../../../../../workbench/contrib/terminal/common/terminal.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -29,6 +30,7 @@ import { MockContextKeyService } from '../../../../../platform/keybinding/test/c
 import { IViewsService } from '../../../../../workbench/services/views/common/viewsService.js';
 import { IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
 
 const HOME_DIR = URI.file('/home/user');
 
@@ -48,6 +50,7 @@ class TestLogService extends NullLogService {
 type TestTerminalInstance = ITerminalInstance & {
 	_testCommandHistory: { timestamp: number }[];
 	_testSetDisposed(disposed: boolean): void;
+	_testSetInitialCwdBarrier(barrier: Promise<void> | undefined): void;
 	_testSetShellLaunchConfig(shellLaunchConfig: ITerminalInstance['shellLaunchConfig']): void;
 };
 
@@ -62,6 +65,7 @@ function makeAgentSession(opts: {
 	isArchived?: boolean;
 	loading?: boolean;
 	sessionId?: string;
+	providerId?: string;
 }): TestActiveSession {
 	const folder = opts.repository || opts.worktree ? {
 		root: opts.repository ?? opts.worktree!,
@@ -89,7 +93,7 @@ function makeAgentSession(opts: {
 	const session = {
 		sessionId: opts.sessionId ?? 'test:session',
 		resource: chat.resource,
-		providerId: 'test',
+		providerId: opts.providerId ?? 'test',
 		sessionType: opts.providerType ?? AgentSessionProviders.Local,
 		icon: Codicon.copilot,
 		createdAt: chat.createdAt,
@@ -191,6 +195,7 @@ function makeNonAgentSession(opts: { repository?: URI; worktree?: URI; providerT
 function makeTerminalInstance(id: number, cwd: string): TestTerminalInstance {
 	const commandHistory: { timestamp: number }[] = [];
 	let isDisposed = false;
+	let initialCwdBarrier: Promise<void> | undefined;
 	let shellLaunchConfig: ITerminalInstance['shellLaunchConfig'] = {} as ITerminalInstance['shellLaunchConfig'];
 	const capabilities = {
 		get(cap: TerminalCapability) {
@@ -205,11 +210,17 @@ function makeTerminalInstance(id: number, cwd: string): TestTerminalInstance {
 		instanceId: id,
 		get isDisposed() { return isDisposed; },
 		get shellLaunchConfig() { return shellLaunchConfig; },
-		getInitialCwd: () => Promise.resolve(cwd),
+		async getInitialCwd() {
+			await initialCwdBarrier;
+			return cwd;
+		},
 		capabilities,
 		_testCommandHistory: commandHistory,
 		_testSetDisposed(disposed: boolean) {
 			isDisposed = disposed;
+		},
+		_testSetInitialCwdBarrier(barrier: Promise<void> | undefined) {
+			initialCwdBarrier = barrier;
 		},
 		_testSetShellLaunchConfig(value: ITerminalInstance['shellLaunchConfig']) {
 			shellLaunchConfig = value;
@@ -227,10 +238,14 @@ suite('SessionsTerminalContribution', () => {
 	let activeSessionObs: ReturnType<typeof observableValue<IActiveSession | undefined>>;
 	let onDidChangeSessions: Emitter<ISessionsChangeEvent>;
 	let onDidReplaceSession: Emitter<{ readonly from: ISession; readonly to: ISession }>;
+	let onDidReplaceNewDraftSession: Emitter<{ readonly from: ISession; readonly to: ISession }>;
 	let onDidCreateInstance: Emitter<ITerminalInstance>;
 	let onDidDisposeInstance: Emitter<ITerminalInstance>;
 
 	let createdTerminals: { cwd: URI }[];
+	let agentHostTerminalAddresses: string[];
+	let terminalCreationBarriers: Map<string, DeferredPromise<void>>;
+	let terminalCreationStarted: string[];
 	let activeInstanceSet: number[];
 	let activeInstanceId: number | undefined;
 	let focusCalls: number;
@@ -244,10 +259,14 @@ suite('SessionsTerminalContribution', () => {
 	let defaultCwdCalls: (URI | undefined)[];
 	let logService: TestLogService;
 	let allSessions: ISession[];
+	let sessionProviders: Map<string, ISessionsProvider>;
 	let instantiationService: TestInstantiationService;
 
 	setup(() => {
 		createdTerminals = [];
+		agentHostTerminalAddresses = [];
+		terminalCreationBarriers = new Map();
+		terminalCreationStarted = [];
 		activeInstanceSet = [];
 		activeInstanceId = undefined;
 		focusCalls = 0;
@@ -261,12 +280,14 @@ suite('SessionsTerminalContribution', () => {
 		defaultCwdCalls = [];
 		logService = new TestLogService();
 		allSessions = [];
+		sessionProviders = new Map();
 
 		instantiationService = store.add(new TestInstantiationService());
 
 		activeSessionObs = observableValue<IActiveSession | undefined>('activeSession', undefined);
 		onDidChangeSessions = store.add(new Emitter<ISessionsChangeEvent>());
 		onDidReplaceSession = store.add(new Emitter<{ readonly from: ISession; readonly to: ISession }>());
+		onDidReplaceNewDraftSession = store.add(new Emitter<{ readonly from: ISession; readonly to: ISession }>());
 		onDidCreateInstance = store.add(new Emitter<ITerminalInstance>());
 		onDidDisposeInstance = store.add(new Emitter<ITerminalInstance>());
 
@@ -275,6 +296,7 @@ suite('SessionsTerminalContribution', () => {
 		instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
 			override readonly onDidChangeSessions = onDidChangeSessions.event;
 			override readonly onDidReplaceSession = onDidReplaceSession.event;
+			override readonly onDidReplaceNewDraftSession = onDidReplaceNewDraftSession.event;
 			override getSessions(): ISession[] { return [...allSessions]; }
 		});
 		instantiationService.stub(ISessionsService, new class extends mock<ISessionsService>() {
@@ -294,9 +316,11 @@ suite('SessionsTerminalContribution', () => {
 				return activeInstanceId !== undefined ? terminalInstances.get(activeInstanceId) : undefined;
 			}
 			override async createTerminal(opts?: any): Promise<ITerminalInstance> {
-				const id = nextInstanceId++;
 				const cwdUri: URI | undefined = opts?.config?.cwd;
 				const cwdStr = cwdUri?.fsPath ?? '';
+				terminalCreationStarted.push(cwdStr);
+				await terminalCreationBarriers.get(cwdStr)?.p;
+				const id = nextInstanceId++;
 				const instance = makeTerminalInstance(id, cwdStr);
 				createdTerminals.push({ cwd: opts?.config?.cwd });
 				terminalInstances.set(id, instance);
@@ -341,7 +365,17 @@ suite('SessionsTerminalContribution', () => {
 			override readonly profiles = constObservable<never[]>([]);
 			override getProfileForConnection() { return undefined; }
 			override setDefaultCwd(cwd: URI | undefined): void { defaultCwdCalls.push(cwd); }
-			override async createTerminalForEntry() { return undefined; }
+			override async createTerminalForEntry(address: string, options?: IAgentHostTerminalCreateOptions): Promise<ITerminalInstance | undefined> {
+				const cwd = typeof options?.cwd === 'string' ? URI.file(options.cwd) : options?.cwd;
+				if (!cwd) {
+					return undefined;
+				}
+				const instance = makeTerminalInstance(nextInstanceId++, cwd.fsPath);
+				agentHostTerminalAddresses.push(address);
+				createdTerminals.push({ cwd });
+				terminalInstances.set(instance.instanceId, instance);
+				return instance;
+			}
 		});
 
 		instantiationService.stub(ITerminalProfileService, new class extends mock<ITerminalProfileService>() {
@@ -349,7 +383,9 @@ suite('SessionsTerminalContribution', () => {
 		});
 
 		instantiationService.stub(ISessionsProvidersService, new class extends mock<ISessionsProvidersService>() {
-			override getProvider() { return undefined; }
+			override getProvider<T extends ISessionsProvider>(providerId: string): T | undefined {
+				return sessionProviders.get(providerId) as T | undefined;
+			}
 		});
 
 		instantiationService.stub(IContextKeyService, store.add(new MockContextKeyService()));
@@ -558,6 +594,197 @@ suite('SessionsTerminalContribution', () => {
 		assert.strictEqual(instances.length, 0);
 		assert.strictEqual(activeInstanceSet.length, 0);
 		assert.ok(logService.traces.some(message => message.includes(`Cannot activate created terminal for ${cwd.fsPath}; terminal 1 is no longer available`)));
+	});
+
+	// --- new-session draft replacement ---
+
+	test('reuses one terminal across repeated same-cwd replacement drafts', async () => {
+		const cwd = URI.file('/worktree');
+		sessionProviders.set('agenthost-one', new class extends mock<ISessionsProvider>() {
+			override readonly id = 'agenthost-one';
+			readonly remoteAddress = 'ssh-remote+one';
+		});
+		let currentSession = makeAgentSession({
+			sessionId: 'test:draft-1',
+			providerId: 'agenthost-one',
+			worktree: cwd,
+			providerType: AgentSessionProviders.Background,
+		});
+		const [firstTerminal] = await contribution.ensureTerminal(cwd, false, currentSession);
+		let latestResult: ITerminalInstance[] = [firstTerminal];
+
+		for (let i = 2; i <= 10; i++) {
+			const nextSession = makeAgentSession({
+				sessionId: `test:draft-${i}`,
+				providerId: 'agenthost-one',
+				worktree: cwd,
+				providerType: AgentSessionProviders.Background,
+			});
+			onDidReplaceNewDraftSession.fire({ from: currentSession, to: nextSession });
+			latestResult = await contribution.ensureTerminal(cwd, false, nextSession);
+			currentSession = nextSession;
+		}
+
+		assert.deepStrictEqual({
+			created: createdTerminals.length,
+			agentHostAddresses: agentHostTerminalAddresses,
+			transferredTerminalId: latestResult[0]?.instanceId,
+			disposed: disposedInstances.map(instance => instance.instanceId),
+		}, {
+			created: 1,
+			agentHostAddresses: ['ssh-remote+one'],
+			transferredTerminalId: firstTerminal.instanceId,
+			disposed: [],
+		});
+	});
+
+	test('transfers all tracked terminals to a same-cwd replacement draft', async () => {
+		const cwd = URI.file('/worktree');
+		const firstSession = makeAgentSession({ sessionId: 'test:first-draft', worktree: cwd, providerType: AgentSessionProviders.Background });
+		const secondSession = makeAgentSession({ sessionId: 'test:second-draft', worktree: cwd, providerType: AgentSessionProviders.Background });
+		const first = makeTerminalInstance(1, cwd.fsPath);
+		const second = makeTerminalInstance(2, cwd.fsPath);
+		terminalInstances.set(first.instanceId, first);
+		terminalInstances.set(second.instanceId, second);
+		nextInstanceId = 3;
+
+		await contribution.ensureTerminal(cwd, false, firstSession);
+		onDidReplaceNewDraftSession.fire({ from: firstSession, to: secondSession });
+		const result = await contribution.ensureTerminal(cwd, false, secondSession);
+
+		assert.deepStrictEqual({
+			result: result.map(instance => instance.instanceId),
+			created: createdTerminals.length,
+			disposed: disposedInstances.map(instance => instance.instanceId),
+		}, {
+			result: [1, 2],
+			created: 0,
+			disposed: [],
+		});
+	});
+
+	test('leaves an existing terminal untouched when the replacement cwd differs', async () => {
+		const firstCwd = URI.file('/worktree-one');
+		const secondCwd = URI.file('/worktree-two');
+		const firstSession = makeAgentSession({ sessionId: 'test:first-draft', worktree: firstCwd, providerType: AgentSessionProviders.Background });
+		const secondSession = makeAgentSession({ sessionId: 'test:second-draft', worktree: secondCwd, providerType: AgentSessionProviders.Background });
+
+		const [firstTerminal] = await contribution.ensureTerminal(firstCwd, false, firstSession);
+		onDidReplaceNewDraftSession.fire({ from: firstSession, to: secondSession });
+		const [secondTerminal] = await contribution.ensureTerminal(secondCwd, false, secondSession);
+
+		assert.deepStrictEqual({
+			createdCwds: createdTerminals.map(terminal => terminal.cwd.fsPath),
+			firstStillAlive: terminalInstances.has(firstTerminal.instanceId),
+			secondTerminalId: secondTerminal.instanceId,
+			activeTerminalId: activeInstanceId,
+			disposed: disposedInstances.map(instance => instance.instanceId),
+		}, {
+			createdCwds: [firstCwd.fsPath, secondCwd.fsPath],
+			firstStillAlive: true,
+			secondTerminalId: 2,
+			activeTerminalId: 2,
+			disposed: [],
+		});
+	});
+
+	test('does not transfer a same-cwd terminal to a different agent host backend', async () => {
+		const cwd = URI.file('/worktree');
+		sessionProviders.set('agenthost-one', new class extends mock<ISessionsProvider>() {
+			override readonly id = 'agenthost-one';
+			readonly remoteAddress = 'ssh-remote+one';
+		});
+		sessionProviders.set('agenthost-two', new class extends mock<ISessionsProvider>() {
+			override readonly id = 'agenthost-two';
+			readonly remoteAddress = 'ssh-remote+two';
+		});
+		const firstSession = makeAgentSession({
+			sessionId: 'test:first-draft',
+			providerId: 'agenthost-one',
+			worktree: cwd,
+			providerType: AgentSessionProviders.Background,
+		});
+		const secondSession = makeAgentSession({
+			sessionId: 'test:second-draft',
+			providerId: 'agenthost-two',
+			worktree: cwd,
+			providerType: AgentSessionProviders.Background,
+		});
+
+		const [firstTerminal] = await contribution.ensureTerminal(cwd, false, firstSession);
+		onDidReplaceNewDraftSession.fire({ from: firstSession, to: secondSession });
+		const [secondTerminal] = await contribution.ensureTerminal(cwd, false, secondSession);
+
+		assert.deepStrictEqual({
+			created: createdTerminals.length,
+			agentHostAddresses: agentHostTerminalAddresses,
+			firstStillAlive: terminalInstances.has(firstTerminal.instanceId),
+			secondTerminalId: secondTerminal.instanceId,
+			disposed: disposedInstances.map(instance => instance.instanceId),
+		}, {
+			created: 2,
+			agentHostAddresses: ['ssh-remote+one', 'ssh-remote+two'],
+			firstStillAlive: true,
+			secondTerminalId: 2,
+			disposed: [],
+		});
+	});
+
+	test('disposes a terminal whose creation finishes after its draft is replaced', async () => {
+		const firstCwd = URI.file('/worktree-one');
+		const secondCwd = URI.file('/worktree-two');
+		const firstSession = makeAgentSession({ sessionId: 'test:first-draft', worktree: firstCwd, providerType: AgentSessionProviders.Background });
+		const secondSession = makeAgentSession({ sessionId: 'test:second-draft', worktree: secondCwd, providerType: AgentSessionProviders.Background });
+		const creationBarrier = new DeferredPromise<void>();
+		terminalCreationBarriers.set(firstCwd.fsPath, creationBarrier);
+
+		const operation = contribution.ensureTerminal(firstCwd, false, firstSession);
+		await tick();
+		assert.deepStrictEqual(terminalCreationStarted, [firstCwd.fsPath]);
+
+		onDidReplaceNewDraftSession.fire({ from: firstSession, to: secondSession });
+		await creationBarrier.complete();
+		const result = await operation;
+
+		assert.deepStrictEqual({
+			result: result.map(instance => instance.instanceId),
+			disposed: disposedInstances.map(instance => instance.instanceId),
+			activated: activeInstanceSet,
+			remaining: [...terminalInstances.keys()],
+		}, {
+			result: [],
+			disposed: [1],
+			activated: [],
+			remaining: [],
+		});
+	});
+
+	test('leaves an existing terminal untouched when lookup finishes after replacement', async () => {
+		const firstCwd = URI.file('/worktree-one');
+		const secondCwd = URI.file('/worktree-two');
+		const firstSession = makeAgentSession({ sessionId: 'test:first-draft', worktree: firstCwd, providerType: AgentSessionProviders.Background });
+		const secondSession = makeAgentSession({ sessionId: 'test:second-draft', worktree: secondCwd, providerType: AgentSessionProviders.Background });
+		const cwdBarrier = new DeferredPromise<void>();
+		const existing = makeTerminalInstance(1, firstCwd.fsPath);
+		existing._testSetInitialCwdBarrier(cwdBarrier.p);
+		terminalInstances.set(existing.instanceId, existing);
+		nextInstanceId = 2;
+
+		const operation = contribution.ensureTerminal(firstCwd, false, firstSession);
+		await tick();
+		onDidReplaceNewDraftSession.fire({ from: firstSession, to: secondSession });
+		await cwdBarrier.complete();
+		const result = await operation;
+
+		assert.deepStrictEqual({
+			result: result.map(instance => instance.instanceId),
+			disposed: disposedInstances.map(instance => instance.instanceId),
+			remaining: [...terminalInstances.keys()],
+		}, {
+			result: [],
+			disposed: [],
+			remaining: [1],
+		});
 	});
 
 	// --- onDidChangeSessions (archived) ---

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -663,32 +663,45 @@ suite('SessionsTerminalContribution', () => {
 		});
 	});
 
-	test('leaves an existing terminal untouched when the replacement cwd differs', async () => {
+	test('rehomes terminals when replacement drafts use different cwd values', async () => {
 		const firstCwd = URI.file('/worktree-one');
 		const secondCwd = URI.file('/worktree-two');
+		const thirdSession = makeAgentSession({ sessionId: 'test:third-draft', worktree: firstCwd, providerType: AgentSessionProviders.Background });
 		const firstSession = makeAgentSession({ sessionId: 'test:first-draft', worktree: firstCwd, providerType: AgentSessionProviders.Background });
 		const secondSession = makeAgentSession({ sessionId: 'test:second-draft', worktree: secondCwd, providerType: AgentSessionProviders.Background });
 
 		const [firstTerminal] = await contribution.ensureTerminal(firstCwd, false, firstSession);
+		addCommandToInstance(firstTerminal, 100);
 		onDidReplaceNewDraftSession.fire({ from: firstSession, to: secondSession });
-		const [secondTerminal] = await contribution.ensureTerminal(secondCwd, false, secondSession);
+		activeSessionObs.set(secondSession, undefined);
+		await tick();
+		const secondTerminal = terminalInstances.get(activeInstanceId!);
+
+		onDidReplaceNewDraftSession.fire({ from: secondSession, to: thirdSession });
+		activeSessionObs.set(thirdSession, undefined);
+		await tick();
+		const thirdTerminal = terminalInstances.get(activeInstanceId!);
 
 		assert.deepStrictEqual({
 			createdCwds: createdTerminals.map(terminal => terminal.cwd.fsPath),
 			firstStillAlive: terminalInstances.has(firstTerminal.instanceId),
-			secondTerminalId: secondTerminal.instanceId,
+			secondStillAlive: secondTerminal ? terminalInstances.has(secondTerminal.instanceId) : false,
+			thirdTerminalId: thirdTerminal?.instanceId,
 			activeTerminalId: activeInstanceId,
+			backgrounded: moveToBackgroundCalls,
 			disposed: disposedInstances.map(instance => instance.instanceId),
 		}, {
-			createdCwds: [firstCwd.fsPath, secondCwd.fsPath],
+			createdCwds: [firstCwd.fsPath, secondCwd.fsPath, firstCwd.fsPath],
 			firstStillAlive: true,
-			secondTerminalId: 2,
-			activeTerminalId: 2,
+			secondStillAlive: true,
+			thirdTerminalId: 3,
+			activeTerminalId: 3,
+			backgrounded: [],
 			disposed: [],
 		});
 	});
 
-	test('does not transfer a same-cwd terminal to a different agent host backend', async () => {
+	test('rehomes a same-cwd terminal when the Agent Host backend changes', async () => {
 		const cwd = URI.file('/worktree');
 		sessionProviders.set('agenthost-one', new class extends mock<ISessionsProvider>() {
 			override readonly id = 'agenthost-one';
@@ -713,20 +726,43 @@ suite('SessionsTerminalContribution', () => {
 
 		const [firstTerminal] = await contribution.ensureTerminal(cwd, false, firstSession);
 		onDidReplaceNewDraftSession.fire({ from: firstSession, to: secondSession });
-		const [secondTerminal] = await contribution.ensureTerminal(cwd, false, secondSession);
+		activeSessionObs.set(secondSession, undefined);
+		await tick();
+		const secondTerminal = terminalInstances.get(activeInstanceId!);
 
 		assert.deepStrictEqual({
 			created: createdTerminals.length,
 			agentHostAddresses: agentHostTerminalAddresses,
 			firstStillAlive: terminalInstances.has(firstTerminal.instanceId),
-			secondTerminalId: secondTerminal.instanceId,
+			secondTerminalId: secondTerminal?.instanceId,
+			backgrounded: moveToBackgroundCalls,
 			disposed: disposedInstances.map(instance => instance.instanceId),
 		}, {
 			created: 2,
 			agentHostAddresses: ['ssh-remote+one', 'ssh-remote+two'],
 			firstStillAlive: true,
 			secondTerminalId: 2,
+			backgrounded: [],
 			disposed: [],
+		});
+	});
+
+	test('allows generic lookup to reuse a standalone terminal', async () => {
+		const firstCwd = URI.file('/worktree-one');
+		const secondCwd = URI.file('/worktree-two');
+		const firstSession = makeAgentSession({ sessionId: 'test:first-draft', worktree: firstCwd, providerType: AgentSessionProviders.Background });
+		const secondSession = makeAgentSession({ sessionId: 'test:second-draft', worktree: secondCwd, providerType: AgentSessionProviders.Background });
+
+		const [firstTerminal] = await contribution.ensureTerminal(firstCwd, false, firstSession);
+		onDidReplaceNewDraftSession.fire({ from: firstSession, to: secondSession });
+		const result = await contribution.ensureTerminal(firstCwd, false);
+
+		assert.deepStrictEqual({
+			result: result.map(instance => instance.instanceId),
+			created: createdTerminals.length,
+		}, {
+			result: [firstTerminal.instanceId],
+			created: 1,
 		});
 	});
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -66,6 +66,8 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private readonly _onDidDiscardNewSession = this._register(new Emitter<ISession>());
 	readonly onDidDiscardNewSession: Event<ISession> = this._onDidDiscardNewSession.event;
+	private readonly _onDidReplaceNewDraftSession = this._register(new Emitter<{ readonly from: ISession; readonly to: ISession }>());
+	readonly onDidReplaceNewDraftSession: Event<{ readonly from: ISession; readonly to: ISession }> = this._onDidReplaceNewDraftSession.event;
 
 	private _sessionTypes: readonly ISessionType[] = [];
 
@@ -365,7 +367,6 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 		const previousNewSession = this._newSession.get();
 		const session = provider.createNewSession(folderUri, sessionTypeId);
-		this._newSession.set(session, undefined);
 
 		// Providers no longer dispose the previous new session implicitly, so
 		// dispose the one this composer just replaced. Use its own provider
@@ -373,7 +374,11 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		// successful create so a throw above leaves the previous one intact.
 		if (previousNewSession && previousNewSession.sessionId !== session.sessionId) {
 			this._getProvider(previousNewSession)?.deleteNewSession(previousNewSession.sessionId);
+			// Terminal ownership must move before the replacement is published:
+			// publishing eagerly ensures a terminal for the new draft.
+			this._onDidReplaceNewDraftSession.fire({ from: previousNewSession, to: session });
 		}
+		this._newSession.set(session, undefined);
 		return session;
 	}
 

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -292,6 +292,12 @@ export interface ISessionsManagementService {
 	 * {@link sendNewChatRequest} clears it without firing this event.
 	 */
 	readonly onDidDiscardNewSession: Event<ISession>;
+	/**
+	 * Fires when {@link createNewSession} replaces the current in-progress
+	 * draft with another new-session draft (New Session → New Session).
+	 * Draft graduation uses {@link onDidReplaceSession} instead.
+	 */
+	readonly onDidReplaceNewDraftSession: Event<{ readonly from: ISession; readonly to: ISession }>;
 
 	// -- New Session --
 

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -102,6 +102,7 @@ class MockSessionStore implements ISessionsManagementService {
 	readonly onDidRenameSession = Event.None;
 	readonly onDidReplaceSession = Event.None;
 	readonly onDidDiscardNewSession = Event.None;
+	readonly onDidReplaceNewDraftSession = Event.None;
 	readonly onDidToggleSessionStickiness = Event.None;
 
 	readonly newSession: IObservable<ISession | undefined> = constObservable(undefined);

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -168,7 +168,7 @@ class TestSessionsProvider extends mock<ISessionsProvider>() {
 	override async deleteSession(): Promise<void> { }
 	override async deleteSessions(_sessionIds: readonly string[]): Promise<void> { }
 	override async deleteChat(): Promise<boolean> { return true; }
-	override deleteNewSession(): void { }
+	override deleteNewSession(_sessionId: string): void { }
 	override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> { return this._session; }
 	override async createNewChat(): Promise<IChat> { return this._session.mainChat.get(); }
 	override async forkChat(_sessionId: string, _sourceChat: URI, _turnId: string): Promise<IChat> { throw new Error('not implemented'); }
@@ -1398,6 +1398,71 @@ suite('SessionsManagementService', () => {
 		service.discardNewSession();
 
 		assert.deepStrictEqual(discarded, ['s1']);
+	});
+
+	test('createNewSession fires replacement before publishing the new draft', () => {
+		const drafts = [
+			stubSession({ sessionId: 's1', providerId: 'test' }),
+			stubSession({ sessionId: 's2', providerId: 'test' }),
+		];
+		const deleted: string[] = [];
+		let createIndex = 0;
+		const provider = new class extends TestSessionsProvider {
+			override resolveWorkspace(): ISessionWorkspace { return { folderUri: URI.parse('test:///folder') } as unknown as ISessionWorkspace; }
+			override createNewSession(): ISession { return drafts[createIndex++]; }
+			override deleteNewSession(sessionId: string): void { deleted.push(sessionId); }
+		}(drafts[0]);
+		const { service } = createSessionsManagementService(drafts[0], disposables, provider);
+
+		const replacements: { from: string; to: string; currentDraft: string | undefined }[] = [];
+		disposables.add(service.onDidReplaceNewDraftSession(({ from, to }) => {
+			replacements.push({ from: from.sessionId, to: to.sessionId, currentDraft: service.newSession.get()?.sessionId });
+		}));
+
+		service.createNewSession(URI.parse('test:///folder'));
+		service.createNewSession(URI.parse('test:///folder'));
+
+		assert.deepStrictEqual({
+			replacements,
+			deleted,
+			currentDraft: service.newSession.get()?.sessionId,
+		}, {
+			replacements: [{ from: 's1', to: 's2', currentDraft: 's1' }],
+			deleted: ['s1'],
+			currentDraft: 's2',
+		});
+	});
+
+	test('createNewSession keeps the previous draft when replacement creation fails', () => {
+		const draft = stubSession({ sessionId: 's1', providerId: 'test' });
+		let createCount = 0;
+		const deleted: string[] = [];
+		const provider = new class extends TestSessionsProvider {
+			override resolveWorkspace(): ISessionWorkspace { return { folderUri: URI.parse('test:///folder') } as unknown as ISessionWorkspace; }
+			override createNewSession(): ISession {
+				if (createCount++ > 0) {
+					throw new Error('create failed');
+				}
+				return draft;
+			}
+			override deleteNewSession(sessionId: string): void { deleted.push(sessionId); }
+		}(draft);
+		const { service } = createSessionsManagementService(draft, disposables, provider);
+		const replacements: string[] = [];
+		disposables.add(service.onDidReplaceNewDraftSession(({ from, to }) => replacements.push(`${from.sessionId}->${to.sessionId}`)));
+
+		service.createNewSession(URI.parse('test:///folder'));
+		assert.throws(() => service.createNewSession(URI.parse('test:///folder')), /create failed/);
+
+		assert.deepStrictEqual({
+			currentDraft: service.newSession.get()?.sessionId,
+			replacements,
+			deleted,
+		}, {
+			currentDraft: 's1',
+			replacements: [],
+			deleted: [],
+		});
 	});
 
 	test('sendNewChatRequest clears the draft without firing onDidDiscardNewSession', async () => {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/327169

- Add `onDidReplaceNewDraftSession` for the workspace New Session → New Session lifecycle, distinct from draft graduation.
- Fire the event before publishing the replacement draft so terminal ownership moves before eager terminal creation.
- Transfer existing terminals when both drafts use the same CWD and Agent Host backend, preserving the process and scrollback.
- Rehome incompatible terminals as standalone terminals, excluding them from later session matching and visibility management.
- Dispose terminals that finish creating after their draft was replaced, before they can be activated or tracked.
- Document draft replacement ordering and terminal ownership in the Sessions specification.
- Cover repeated Agent Host draft replacement, multiple tracked terminals, compatibility boundaries, standalone ownership, and asynchronous creation races.

-----------------------------------------
Inspirations from:

- The replacement event shape and draft-graduation distinction come from [`ISessionsManagementService.onDidReplaceSession`](https://github.com/microsoft/vscode/blob/a71d15db91072496a839f1400321b35d9f301c60/src/vs/sessions/services/sessions/common/sessionsManagement.ts#L285-L294).
- Terminal ownership transfer follows the existing committed-session graduation behavior in [`SessionsTerminalContribution`](https://github.com/microsoft/vscode/blob/a71d15db91072496a839f1400321b35d9f301c60/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts#L178-L195).
- The reuse and race handling extend the existing terminal lookup, creation, and session tracking flow in [`ensureTerminal`](https://github.com/microsoft/vscode/blob/a71d15db91072496a839f1400321b35d9f301c60/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts#L285-L326).