### PR TITLE
Declare forwarded response.success tool telemetry fields

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
@@ -45,6 +45,7 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 		"gitHubRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "GitHub identifier for the request." },
 		"modelCallId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Identifier for the model call." },
 		"reasoningEffort": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Reasoning effort used for the response." },
+		"toolCounts": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Tool-call counts keyed by telemetry-safe tool name." },
 		"initiatorType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the response was initiated by a user or an agent." },
 		"copilot_pid": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Process identifier for the Copilot CLI runtime." },
 		"interaction_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an interaction." },
@@ -55,6 +56,9 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 		"completionTokens": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of generated completion tokens.", "isMeasurement": true },
 		"reasoningTokens": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of generated reasoning tokens.", "isMeasurement": true },
 		"tokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Total number of tokens used by the response.", "isMeasurement": true },
+		"toolTokenCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of tokens used by tool definitions.", "isMeasurement": true },
+		"availableToolCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of tools available to the model.", "isMeasurement": true },
+		"numToolCalls": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of tool calls returned by the model.", "isMeasurement": true },
 		"turn": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Turn number within the session.", "isMeasurement": true },
 		"timeToFirstToken": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Time until the first response token.", "isMeasurement": true },
 		"timeToComplete": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Time until the response completed.", "isMeasurement": true }


### PR DESCRIPTION
Companion to github/copilot-agent-runtime#13512 (**merged**), which forwards tool-usage metrics on the Copilot CLI runtime's `response.success` event.

This PR declares those new fields so the Agent Host forwarder ([copilotGitHubTelemetryForwarder.ts](https://github.com/microsoft/vscode/blob/main/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts)) re-emits them through the first-party telemetry service.

### Changes

Adds GDPR annotations under `copilotCli/response.success` only (no new event):

| Field | Kind | Comment |
| --- | --- | --- |
| `toolCounts` | property | Tool-call counts keyed by telemetry-safe tool name. Serialized JSON; unsafe/unknown names are hashed runtime-side via the existing `safeForTelemetry` policy. |
| `toolTokenCount` | measurement | Number of tokens used by tool definitions. |
| `availableToolCount` | measurement | Number of tools available to the model. |
| `numToolCalls` | measurement | Number of tool calls returned by the model. |

The forwarder already spreads `event.properties` and `event.metrics` wholesale with no allowlist, so no forwarding-code change is required — these annotations are the compliance declaration for fields the runtime emits.

### Runtime availability

The runtime change shipped in `@github/copilot@1.0.77` (first release after the 13512 merge), which `main` already pins — verified in the shipped `schemas/session-events.schema.json`, where `AssistantUsageData` now carries `availableToolCount`, `toolTokenCount`, `numToolCalls`, and `toolCounts`. This branch has been rebased onto `main` so it builds against that version.

### Validation

- `npx @vscode/telemetry-extractor@1.14.0 -s .` (the `Telemetry / Check metadata` CI job) succeeds, and the extracted `copilotCli/response.success` event includes all four new fields.
- `tsc --noEmit -p src/tsconfig.json` reports no errors for the changed file.
