### PR TITLE
Retry transient Agent Host database initialization

### DIFF
--- a/src/vs/platform/agentHost/node/sessionDatabase.ts
+++ b/src/vs/platform/agentHost/node/sessionDatabase.ts
@@ -289,7 +289,10 @@ export class SessionDatabase implements ISessionDatabase {
 					throw new Error('SessionDatabase has been disposed');
 				}
 				return db;
-			})();
+			})().catch(err => {
+				this._dbPromise = undefined;
+				throw err;
+			});
 		}
 		return this._dbPromise;
 	}

--- a/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
@@ -28,6 +28,31 @@ suite('SessionDatabase', () => {
 	});
 	ensureNoDisposablesAreLeakedInTestSuite();
 
+	suite('initialization', () => {
+
+		test('retries after a transient open failure', async () => {
+			const tempRoot = await fs.mkdtemp(join(tmpdir(), 'session-db-retry-' + generateUuid()));
+			try {
+				const databaseDir = join(tempRoot, 'blocked');
+				const databasePath = join(databaseDir, 'session.db');
+				await fs.writeFile(databaseDir, '');
+				const database = new SessionDatabase(databasePath);
+				try {
+					await assert.rejects(() => database.setMetadata('key', 'first'));
+					await fs.rm(databaseDir);
+
+					await database.setMetadata('key', 'second');
+
+					assert.strictEqual(await database.getMetadata('key'), 'second');
+				} finally {
+					await database.close();
+				}
+			} finally {
+				await fs.rm(tempRoot, { recursive: true, force: true });
+			}
+		});
+	});
+
 	/**
 	 * Extends SessionDatabase to allow ejecting/injecting the raw sqlite3
 	 * Database instance, enabling reopen tests with :memory: databases.

--- a/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
@@ -30,7 +30,7 @@ suite('SessionDatabase', () => {
 
 	suite('initialization', () => {
 
-		test('retries after a transient open failure', async () => {
+		test('retries after a transient initialization failure', async () => {
 			const tempRoot = await fs.mkdtemp(join(tmpdir(), 'session-db-retry-' + generateUuid()));
 			try {
 				const databaseDir = join(tempRoot, 'blocked');
@@ -38,7 +38,7 @@ suite('SessionDatabase', () => {
 				await fs.writeFile(databaseDir, '');
 				const database = new SessionDatabase(databasePath);
 				try {
-					await assert.rejects(() => database.setMetadata('key', 'first'));
+					await assert.rejects(() => database.setMetadata('key', 'first'), { code: 'EEXIST' });
 					await fs.rm(databaseDir);
 
 					await database.setMetadata('key', 'second');


### PR DESCRIPTION
This fixes a recovery issue exposed when an Agent Host machine temporarily runs out of disk space.

When the initial per-session SQLite open failed, `SessionDatabase` retained the rejected initialization promise. Long-lived session references would then continue returning the original `SQLITE_CANTOPEN` failure even after the filesystem became writable again.

The initialization promise is now cleared on any setup failure, allowing the next database operation to retry. A regression test covers an initially blocked database path becoming writable.

Validation:
- TypeScript client type-check passed
- Staged-file hygiene passed
- Focused unit test could not run locally because dependency installation is currently blocked by a 404 for the pinned `@vscode/codicons@0.0.46-24` package; CI will run the test

(Written by Copilot)