### PR TITLE
Add experimental setting to disable the semantic_search tool

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -160,6 +160,7 @@
         "icon": "$(folder)",
         "userDescription": "%copilot.codebase.tool.description%",
         "modelDescription": "Run a natural language search for relevant code or documentation comments from the user's current workspace. Returns relevant code snippets from the user's current workspace if it is large, or the full contents of the workspace if it is small.",
+        "when": "!config.github.copilot.chat.semanticSearchTool.disabled",
         "tags": [
           "codesearch",
           "vscode_codesearch"

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4214,6 +4214,15 @@
               "onExp"
             ]
           },
+          "github.copilot.chat.semanticSearchTool.disabled": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "%github.copilot.config.semanticSearchTool.disabled%",
+            "tags": [
+              "experimental",
+              "onExp"
+            ]
+          },
           "github.copilot.chat.anthropic.tools.websearch.enabled": {
             "type": "boolean",
             "default": false,

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -357,7 +357,7 @@
 	"github.copilot.config.gemini3GetChangedFilesTool.enabled": "Enables the Get Changed Files tool for gemini-3 models.",
 	"github.copilot.config.gemini3LowReasoningEffort.enabled": "Sets the reasoning effort to low for gemini-3 models.",
 	"github.copilot.config.gpt55ReadFileTool.enabled": "Enables the Read File tool for gpt-5.5 models.",
-	"github.copilot.config.semanticSearchTool.disabled": "Disables the semantic search (`#codebase`) tool in chat. Enable to experiment with agent behavior without semantic search available.",
+	"github.copilot.config.semanticSearchTool.disabled": "Disables semantic search in chat: removes the `semantic_search` tool from the agent and hides the `#codebase` chat variable. Enable to experiment with agent behavior without semantic search available.",
 	"github.copilot.config.anthropic.tools.websearch.enabled": "Enable Anthropic's native web search tool for BYOK Claude models. When enabled, allows Claude to search the web for current information. \n\n**Note**: This is an experimental feature only available for BYOK Anthropic Claude models.",
 	"github.copilot.config.anthropic.tools.websearch.maxUses": "Maximum number of web searches allowed per request. Valid range is 1 to 20. Prevents excessive API calls within a single interaction. If Claude exceeds this limit, the response returns an error.",
 	"github.copilot.config.anthropic.tools.websearch.allowedDomains": "List of domains to restrict web search results to (e.g., `[\"example.com\", \"docs.example.com\"]`). Domains should not include the HTTP/HTTPS scheme. Subdomains are automatically included. Cannot be used together with `#github.copilot.chat.anthropic.tools.websearch.blockedDomains#`; configuring both will cause web search requests to fail.",

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -357,6 +357,7 @@
 	"github.copilot.config.gemini3GetChangedFilesTool.enabled": "Enables the Get Changed Files tool for gemini-3 models.",
 	"github.copilot.config.gemini3LowReasoningEffort.enabled": "Sets the reasoning effort to low for gemini-3 models.",
 	"github.copilot.config.gpt55ReadFileTool.enabled": "Enables the Read File tool for gpt-5.5 models.",
+	"github.copilot.config.semanticSearchTool.disabled": "Disables the semantic search (`#codebase`) tool in chat. Enable to experiment with agent behavior without semantic search available.",
 	"github.copilot.config.anthropic.tools.websearch.enabled": "Enable Anthropic's native web search tool for BYOK Claude models. When enabled, allows Claude to search the web for current information. \n\n**Note**: This is an experimental feature only available for BYOK Anthropic Claude models.",
 	"github.copilot.config.anthropic.tools.websearch.maxUses": "Maximum number of web searches allowed per request. Valid range is 1 to 20. Prevents excessive API calls within a single interaction. If Claude exceeds this limit, the response returns an error.",
 	"github.copilot.config.anthropic.tools.websearch.allowedDomains": "List of domains to restrict web search results to (e.g., `[\"example.com\", \"docs.example.com\"]`). Domains should not include the HTTP/HTTPS scheme. Subdomains are automatically included. Cannot be used together with `#github.copilot.chat.anthropic.tools.websearch.blockedDomains#`; configuring both will cause web search requests to fail.",

--- a/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
@@ -326,6 +326,14 @@ export class ToolsService extends BaseToolsService {
 					return false;
 				}
 
+				// For semantic_search (codebase) tool, allow experimentally disabling it entirely.
+				if (
+					tool.name === ToolName.Codebase
+					&& this._configurationService.getExperimentBasedConfig(ConfigKey.DisableSemanticSearchTool, this._experimentationService)
+				) {
+					return false;
+				}
+
 				// 0. Check if the tool was disabled via the tool picker. If so, it must be disabled here
 				const toolPickerSelection = requestToolsByName.get(getContributedToolName(tool.name));
 				if (toolPickerSelection === false) {

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -1000,6 +1000,8 @@ export namespace ConfigKey {
 	export const EnableGemini3LowReasoningEffort = defineSetting<boolean>('chat.gemini3LowReasoningEffort.enabled', ConfigType.ExperimentBased, false);
 	/** Enable read_file tool for GPT-5.5 models */
 	export const EnableGpt55ReadFileTool = defineSetting<boolean>('chat.gpt55ReadFileTool.enabled', ConfigType.ExperimentBased, true);
+	/** Disable the semantic_search (codebase) tool. Enable to experiment with removing it. */
+	export const DisableSemanticSearchTool = defineSetting<boolean>('chat.semanticSearchTool.disabled', ConfigType.ExperimentBased, false);
 	export const EnableChatImageUpload = defineSetting<boolean>('chat.imageUpload.enabled', ConfigType.Simple, true);
 	/** Enable Anthropic web search tool for BYOK Claude models */
 	export const AnthropicWebSearchToolEnabled = defineSetting<boolean>('chat.anthropic.tools.websearch.enabled', ConfigType.ExperimentBased, false);


### PR DESCRIPTION
**Setting:** `github.copilot.chat.semanticSearchTool.disabled` (experiment-based, default `false`)
