### PR TITLE
Fix editor association user scopes

### DIFF
--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -345,11 +345,15 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 	private getAllUserAssociationsForSetting(settingId: string): EditorAssociations {
 		const inspectedEditorAssociations = this.configurationService.inspect<{ [fileNamePattern: string]: string }>(settingId) || {};
 		const defaultAssociations = inspectedEditorAssociations.defaultValue ?? {};
+		const applicationAssociations = inspectedEditorAssociations.applicationValue ?? {};
+		const userLocalAssociations = inspectedEditorAssociations.userLocalValue ?? {};
+		const userRemoteAssociations = inspectedEditorAssociations.userRemoteValue ?? {};
 		const workspaceAssociations = inspectedEditorAssociations.workspaceValue ?? {};
+		const workspaceFolderAssociations = inspectedEditorAssociations.workspaceFolderValue ?? {};
 		const userAssociations = inspectedEditorAssociations.userValue ?? {};
-		const rawAssociations: { [fileNamePattern: string]: string } = { ...workspaceAssociations };
-		// We want to apply the default associations and user associations on top of the workspace associations but ignore duplicate keys.
-		for (const [key, value] of Object.entries({ ...defaultAssociations, ...userAssociations })) {
+		const rawAssociations: { [fileNamePattern: string]: string } = { ...workspaceAssociations, ...workspaceFolderAssociations };
+		// We want to apply lower priority associations after higher priority associations but ignore duplicate keys.
+		for (const [key, value] of Object.entries({ ...defaultAssociations, ...applicationAssociations, ...userLocalAssociations, ...userRemoteAssociations, ...userAssociations })) {
 			if (rawAssociations[key] === undefined) {
 				rawAssociations[key] = value;
 			}

--- a/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
@@ -8,6 +8,7 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationOverrides, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
 import { EditorPart } from '../../../../browser/parts/editor/editorPart.js';
 import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
 import { EditorResolverService } from '../../browser/editorResolverService.js';
@@ -19,6 +20,9 @@ import { createEditorPart, ITestInstantiationService, TestFileEditorInput, TestS
 suite('EditorResolverService', () => {
 
 	const TEST_EDITOR_INPUT_ID = 'testEditorInputForEditorResolverService';
+	const TEST_MARKDOWN_EDITOR_INPUT_ID = 'testMarkdownEditorInputForEditorResolverService';
+	const TEST_MARKDOWN_EDITOR_ID = 'testMarkdownEditorForEditorResolverService';
+	const TEST_MARKDOWN_PATTERN = '*.test-md';
 	const disposables = new DisposableStore();
 
 	teardown(() => disposables.clear());
@@ -50,6 +54,81 @@ suite('EditorResolverService', () => {
 			constructDisposableFileEditorInput(original.resource ?? URI.from({ scheme: Schemas.untitled }), typeId, disposables),
 			constructDisposableFileEditorInput(modified.resource ?? URI.from({ scheme: Schemas.untitled }), typeId, disposables),
 			undefined);
+	}
+
+	class ScopedEditorAssociationsConfigurationService extends TestConfigurationService {
+		constructor(private readonly editorAssociations: Partial<IConfigurationValue<Record<string, string>>>) {
+			super();
+		}
+
+		override inspect<T>(key: string, overrides?: IConfigurationOverrides): IConfigurationValue<T> {
+			if (key === editorsAssociationsSettingId) {
+				return {
+					defaultValue: undefined,
+					applicationValue: undefined,
+					userValue: undefined,
+					userLocalValue: undefined,
+					userRemoteValue: undefined,
+					workspaceValue: undefined,
+					workspaceFolderValue: undefined,
+					memoryValue: undefined,
+					policyValue: undefined,
+					value: undefined,
+					overrideIdentifiers: undefined,
+					...this.editorAssociations
+				} as IConfigurationValue<T>;
+			}
+			return super.inspect(key, overrides);
+		}
+	}
+
+	async function assertScopedUserEditorAssociationResolves(editorAssociations: Partial<IConfigurationValue<Record<string, string>>>): Promise<void> {
+		const instantiationService = workbenchInstantiationService({
+			configurationService: () => new ScopedEditorAssociationsConfigurationService(editorAssociations)
+		}, disposables);
+		const [part, service] = await createEditorResolverService(instantiationService);
+
+		const defaultEditor = service.registerEditor('*',
+			{
+				id: 'default',
+				label: 'Default Editor',
+				detail: 'Default',
+				priority: RegisteredEditorPriority.default
+			},
+			{},
+			{
+				createEditorInput: ({ resource }) => ({ editor: constructDisposableFileEditorInput(resource, TEST_EDITOR_INPUT_ID, disposables) })
+			}
+		);
+
+		const markdownEditor = service.registerEditor(TEST_MARKDOWN_PATTERN,
+			{
+				id: TEST_MARKDOWN_EDITOR_ID,
+				label: 'Markdown Editor',
+				detail: 'Markdown Editor Details',
+				priority: RegisteredEditorPriority.option
+			},
+			{},
+			{
+				createEditorInput: ({ resource }) => ({ editor: constructDisposableFileEditorInput(resource, TEST_MARKDOWN_EDITOR_INPUT_ID, disposables) })
+			}
+		);
+
+		const resultingResolution = await service.resolveEditor(
+			{ resource: URI.file(`resource${TEST_MARKDOWN_PATTERN.slice(1)}`) },
+			part.activeGroup
+		);
+		assert.ok(resultingResolution);
+		assert.notStrictEqual(typeof resultingResolution, 'number');
+		if (resultingResolution !== ResolvedStatus.ABORT && resultingResolution !== ResolvedStatus.NONE) {
+			assert.strictEqual(resultingResolution.editor.typeId, TEST_MARKDOWN_EDITOR_INPUT_ID);
+			resultingResolution.editor.dispose();
+		} else {
+			assert.fail('Expected editor to resolve successfully');
+		}
+
+		defaultEditor.dispose();
+		markdownEditor.dispose();
 	}
 
 	test('Simple Resolve', async () => {
@@ -872,6 +951,22 @@ suite('EditorResolverService', () => {
 
 		defaultEditor.dispose();
 		customEditor.dispose();
+	});
+
+	test('User-local editor association resolves #244597', async () => {
+		await assertScopedUserEditorAssociationResolves({
+			userLocalValue: {
+				[TEST_MARKDOWN_PATTERN]: TEST_MARKDOWN_EDITOR_ID
+			}
+		});
+	});
+
+	test('User-remote editor association resolves #244597', async () => {
+		await assertScopedUserEditorAssociationResolves({
+			userRemoteValue: {
+				[TEST_MARKDOWN_PATTERN]: TEST_MARKDOWN_EDITOR_ID
+			}
+		});
 	});
 
 	test('Diff editor Resolve - priority.diff overrides priority.editor for diffs', async () => {


### PR DESCRIPTION
Fixes #244597

This includes user-local and user-remote editor association values when resolving configured editor associations. The first-run path can read scoped user configuration through inspect() before the flattened user value is populated.

Validation:
- RED: reverted the production change and ran `xvfb-run -a ./scripts/test.sh --no-sandbox --grep "User-local editor association resolves #244597"`; the new test failed with the default editor selected instead of the markdown editor.
- GREEN: `npm run typecheck-client`
- GREEN: `npx gulp compile-client`
- GREEN: `xvfb-run -a ./scripts/test.sh --no-sandbox --grep "User-(local|remote) editor association resolves #244597"`