### PR TITLE
Resolve relative worktree gitdir paths

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -20,6 +20,7 @@ import { StringDecoder } from 'string_decoder';
 
 // https://github.com/microsoft/vscode/issues/65693
 const MAX_CLI_LENGTH = 30000;
+const WORKTREE_DOT_GIT_PATH_REGEX = /[\\/]\.git.*$/;
 
 export interface IGit {
 	path: string;
@@ -1352,6 +1353,14 @@ export interface PullOptions {
 
 export interface Worktree extends ApiWorktree {
 	readonly commitDetails?: ApiCommit;
+}
+
+export function getWorktreePathFromGitDir(gitdirPath: string, gitdirContent: string): string {
+	const worktreeGitDirPath = path.isAbsolute(gitdirContent)
+		? gitdirContent
+		: path.resolve(path.dirname(gitdirPath), gitdirContent);
+
+	return worktreeGitDirPath.replace(WORKTREE_DOT_GIT_PATH_REGEX, '');
 }
 
 export class Repository {
@@ -3062,8 +3071,7 @@ export class Repository {
 
 					result.push({
 						name: dirent.name,
-						// Remove '/.git' suffix
-						path: gitdirContent.replace(/\/.git.*$/, ''),
+						path: getWorktreePathFromGitDir(gitdirPath, gitdirContent),
 						// Remove 'ref: ' prefix
 						ref: headContent.replace(/^ref: /, ''),
 						// Detached if HEAD does not start with 'ref: '

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -20,7 +20,7 @@ import { StringDecoder } from 'string_decoder';
 
 // https://github.com/microsoft/vscode/issues/65693
 const MAX_CLI_LENGTH = 30000;
-const WORKTREE_DOT_GIT_PATH_REGEX = /[\\/]\.git.*$/;
+const WORKTREE_DOT_GIT_PATH_REGEX = /[\\/]\.git$/;
 
 export interface IGit {
 	path: string;

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -4,11 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'mocha';
-import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
+import { GitStatusParser, getWorktreePathFromGitDir, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
+import * as path from 'path';
 
 suite('git', () => {
+	suite('getWorktreePathFromGitDir', () => {
+		const WORKTREE_METADATA_PATH = path.join('/repo.git', 'worktrees', 'story', 'gitdir');
+		const WORKTREE_PATH = path.join('/repo', 'story');
+
+		test('resolves absolute gitdir content', () => {
+			assert.strictEqual(getWorktreePathFromGitDir(WORKTREE_METADATA_PATH, path.join(WORKTREE_PATH, '.git')), WORKTREE_PATH);
+		});
+
+		test('resolves relative gitdir content #257396', () => {
+			assert.strictEqual(getWorktreePathFromGitDir(WORKTREE_METADATA_PATH, path.join('..', '..', '..', 'repo', 'story', '.git')), WORKTREE_PATH);
+		});
+	});
+
 	suite('GitStatusParser', () => {
 		test('empty parser', () => {
 			const parser = new GitStatusParser();

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -21,6 +21,12 @@ suite('git', () => {
 		test('resolves relative gitdir content #257396', () => {
 			assert.strictEqual(getWorktreePathFromGitDir(WORKTREE_METADATA_PATH, path.join('..', '..', '..', 'repo', 'story', '.git')), WORKTREE_PATH);
 		});
+
+		test('keeps path components that start with .git', () => {
+			const nestedWorktreePath = path.join('/repo', '.github');
+
+			assert.strictEqual(getWorktreePathFromGitDir(WORKTREE_METADATA_PATH, path.join(nestedWorktreePath, '.git')), nestedWorktreePath);
+		});
 	});
 
 	suite('GitStatusParser', () => {


### PR DESCRIPTION
Fixes #257396

When Git is configured with `--relative-paths`, linked worktree metadata can store `.git/worktrees/<name>/gitdir` contents as a relative path. Resolve that path from the metadata file before deriving the worktree folder.

Validation:
- RED: temporarily restored the relative-path bug and ran `INTEGRATION_TEST_ELECTRON_PATH=/tmp/vscode-code-nosandbox-257396.sh xvfb-run -a ./scripts/test-integration.sh --suite git --grep "resolves relative gitdir content #257396"`; the test output showed `0 passing`, `1 failing`, with actual `../../../repo/story` instead of expected `/repo/story`.
- GREEN: `npx gulp compile-extension:git`
- GREEN: `INTEGRATION_TEST_ELECTRON_PATH=/tmp/vscode-code-nosandbox-257396.sh xvfb-run -a ./scripts/test-integration.sh --suite git --grep "resolves relative gitdir content #257396"` output showed `1 passing`.

Note: the integration command in this local environment prints missing optional native module noise because dependency install had to use `--ignore-scripts` after kerberos failed to build without system GSSAPI headers; the targeted test still ran and passed.