### PR TITLE
Adjust commit instructions

### DIFF
--- a/.github/instructions/committing.instructions.md
+++ b/.github/instructions/committing.instructions.md
@@ -5,7 +5,7 @@ applyTo: '**'
 
 # Committing
 
-Follow these rules when creating git commits:
+Follow these rules when creating git commits unless explicitely requested otherwise by the user:
 
 - Always respect the user's commit signing configuration. Do not disable, override, or work around signing (for example, do not pass `--no-gpg-sign` when the user has signing enabled).
 - Never commit with `--no-verify`. Always let the pre-commit and commit-msg hooks run.


### PR DESCRIPTION
```Copilot Generated Description:``` Update the commit instructions to clarify that rules apply unless explicitly requested otherwise by the user.

