### PR TITLE
Make find widget focus shortcut keybinding-dispatchable

### DIFF
--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -1150,6 +1150,17 @@ registerEditorCommand(new FindCommand({
 	}
 }));
 
+export const FocusEditorFromFindWidgetCommand = registerEditorCommand(new FindCommand({
+	id: FIND_IDS.FocusEditorFromFindWidgetCommand,
+	precondition: CONTEXT_FIND_WIDGET_VISIBLE,
+	handler: x => x.editor.focus(),
+	kbOpts: {
+		weight: KeybindingWeight.EditorContrib + 5,
+		kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_FIND_INPUT_FOCUSED),
+		primary: KeyMod.CtrlCmd | KeyCode.DownArrow
+	}
+}));
+
 registerEditorCommand(new FindCommand({
 	id: FIND_IDS.ReplaceOneAction,
 	precondition: CONTEXT_FIND_WIDGET_VISIBLE,

--- a/src/vs/editor/contrib/find/browser/findModel.ts
+++ b/src/vs/editor/contrib/find/browser/findModel.ts
@@ -73,6 +73,7 @@ export const FIND_IDS = {
 	ToggleRegexCommand: 'toggleFindRegex',
 	ToggleSearchScopeCommand: 'toggleFindInSelection',
 	TogglePreserveCaseCommand: 'togglePreserveCase',
+	FocusEditorFromFindWidgetCommand: 'focusEditorFromFindWidget',
 	ReplaceOneAction: 'editor.action.replaceOne',
 	ReplaceAllAction: 'editor.action.replaceAll',
 	SelectAllMatchesAction: 'editor.action.selectAllMatches'

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -912,12 +912,6 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			return;
 		}
 
-		if (e.equals(KeyMod.CtrlCmd | KeyCode.DownArrow)) {
-			this._codeEditor.focus();
-			e.preventDefault();
-			return;
-		}
-
 		if (e.equals(KeyCode.UpArrow)) {
 			// eslint-disable-next-line no-restricted-syntax
 			return stopPropagationForMultiLineUpwards(e, this._findInput.getValue(), this._findInput.domNode.querySelector('textarea'));

--- a/src/vs/editor/contrib/find/test/browser/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findController.test.ts
@@ -13,7 +13,7 @@ import { EditOperation } from '../../../../common/core/editOperation.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
 import { Selection } from '../../../../common/core/selection.js';
-import { CommonFindController, FindStartFocusAction, IFindStartOptions, NextMatchFindAction, NextSelectionMatchFindAction, StartFindAction, StartFindReplaceAction, StartFindWithSelectionAction } from '../../browser/findController.js';
+import { CommonFindController, FindStartFocusAction, FocusEditorFromFindWidgetCommand, IFindStartOptions, NextMatchFindAction, NextSelectionMatchFindAction, StartFindAction, StartFindReplaceAction, StartFindWithSelectionAction } from '../../browser/findController.js';
 import { CONTEXT_FIND_INPUT_FOCUSED } from '../../browser/findModel.js';
 import { withAsyncTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
@@ -289,6 +289,38 @@ suite('FindController', () => {
 			assert.strictEqual(findController.getState().searchString, testRegexString);
 
 			findController.dispose();
+		});
+	});
+
+	test('issue #175444: focus editor from find widget is keybinding-dispatchable', async () => {
+		await withAsyncTestCodeEditor([
+			'ABC',
+		], { serviceCollection: serviceCollection, hasTextFocus: false }, async (editor) => {
+			const findController = editor.registerAndInstantiateContribution(TestFindController.ID, TestFindController);
+			let didFocusEditor = false;
+			const originalFocus = editor.focus.bind(editor);
+			editor.focus = () => {
+				didFocusEditor = true;
+				originalFocus();
+			};
+			try {
+				await findController.start({
+					forceRevealReplace: false,
+					seedSearchStringFromSelection: 'none',
+					seedSearchStringFromNonEmptySelection: false,
+					seedSearchStringFromGlobalClipboard: false,
+					shouldFocus: FindStartFocusAction.FocusFindInput,
+					shouldAnimate: false,
+					updateSearchScope: false,
+					loop: true
+				});
+
+				await editor.runCommand(FocusEditorFromFindWidgetCommand);
+				assert.strictEqual(didFocusEditor, true);
+			} finally {
+				editor.focus = originalFocus;
+				findController.dispose();
+			}
 		});
 	});
 

--- a/src/vs/editor/contrib/find/test/browser/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findController.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { Delayer } from '../../../../../base/common/async.js';
-import { KeyCode } from '../../../../../base/common/keyCodes.js';
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { KeyCodeChord } from '../../../../../base/common/keybindings.js';
 import * as platform from '../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -19,15 +19,20 @@ import { CommonFindController, FindStartFocusAction, FocusEditorFromFindWidgetCo
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_FIND_WIDGET_VISIBLE } from '../../browser/findModel.js';
 import { withAsyncTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
-import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyValue, IContext, IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingsRegistry } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { KeybindingResolver, ResultKind } from '../../../../../platform/keybinding/common/keybindingResolver.js';
+import { ResolvedKeybindingItem } from '../../../../../platform/keybinding/common/resolvedKeybindingItem.js';
+import { createUSLayoutResolvedKeybinding } from '../../../../../platform/keybinding/test/common/keybindingsTestUtils.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 
 const FOCUS_EDITOR_FROM_FIND_WIDGET_COMMAND_ID = 'focusEditorFromFindWidget';
+const FOCUS_EDITOR_FROM_FIND_WIDGET_KEYBINDING = KeyMod.CtrlCmd | KeyCode.DownArrow;
+const FOCUS_EDITOR_FROM_FIND_WIDGET_USER_OVERRIDE_COMMAND_ID = 'test.userFocusOverride';
 const FOCUS_EDITOR_FROM_FIND_WIDGET_CONTEXT_KEYS = ['editorTextFocus', CONTEXT_FIND_INPUT_FOCUSED.key, CONTEXT_FIND_WIDGET_VISIBLE.key];
 
 class TestFindController extends CommonFindController {
@@ -301,10 +306,32 @@ suite('FindController', () => {
 	test('issue #175444: focus editor from find widget is keybinding-dispatchable', async () => {
 		const focusEditorKeybinding = KeybindingsRegistry.getDefaultKeybindings().find(keybinding => keybinding.command === FocusEditorFromFindWidgetCommand.id);
 		const expectedKeybinding = new KeyCodeChord(!platform.isMacintosh, false, false, platform.isMacintosh, KeyCode.DownArrow).toKeybinding();
+		const resolvedKeybinding = createUSLayoutResolvedKeybinding(FOCUS_EDITOR_FROM_FIND_WIDGET_KEYBINDING, platform.OS)!;
+		const dispatchChord = resolvedKeybinding.getDispatchChords()[0];
+		const findInputContext: IContext = {
+			getValue: <T extends ContextKeyValue>(key: string) => FOCUS_EDITOR_FROM_FIND_WIDGET_CONTEXT_KEYS.includes(key) as T
+		};
 
 		assert.strictEqual(focusEditorKeybinding?.keybinding?.equals(expectedKeybinding), true);
 		assert.deepStrictEqual(focusEditorKeybinding?.when?.keys().sort(), [...FOCUS_EDITOR_FROM_FIND_WIDGET_CONTEXT_KEYS].sort());
 		assert.strictEqual(FocusEditorFromFindWidgetCommand.id, FOCUS_EDITOR_FROM_FIND_WIDGET_COMMAND_ID);
+		assert.ok(dispatchChord);
+
+		const defaultItem = new ResolvedKeybindingItem(resolvedKeybinding, FocusEditorFromFindWidgetCommand.id, null, focusEditorKeybinding?.when ?? undefined, true, null, false);
+		const defaultResolver = new KeybindingResolver([defaultItem], [], () => { });
+		const defaultResult = defaultResolver.resolve(findInputContext, [], dispatchChord);
+		assert.ok(defaultResult.kind === ResultKind.KbFound);
+		assert.strictEqual(defaultResult.commandId, FocusEditorFromFindWidgetCommand.id);
+
+		const userOverrideItem = new ResolvedKeybindingItem(resolvedKeybinding, FOCUS_EDITOR_FROM_FIND_WIDGET_USER_OVERRIDE_COMMAND_ID, null, focusEditorKeybinding?.when ?? undefined, false, null, false);
+		const userOverrideResolver = new KeybindingResolver([defaultItem], [userOverrideItem], () => { });
+		const userOverrideResult = userOverrideResolver.resolve(findInputContext, [], dispatchChord);
+		assert.ok(userOverrideResult.kind === ResultKind.KbFound);
+		assert.strictEqual(userOverrideResult.commandId, FOCUS_EDITOR_FROM_FIND_WIDGET_USER_OVERRIDE_COMMAND_ID);
+
+		const userRemovalItem = new ResolvedKeybindingItem(resolvedKeybinding, `-${FocusEditorFromFindWidgetCommand.id}`, null, focusEditorKeybinding?.when ?? undefined, false, null, false);
+		const userRemovalResolver = new KeybindingResolver([defaultItem], [userRemovalItem], () => { });
+		assert.strictEqual(userRemovalResolver.resolve(findInputContext, [], dispatchChord).kind, ResultKind.NoMatchingKb);
 
 		await withAsyncTestCodeEditor([
 			'ABC',

--- a/src/vs/editor/contrib/find/test/browser/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findController.test.ts
@@ -5,6 +5,8 @@
 
 import assert from 'assert';
 import { Delayer } from '../../../../../base/common/async.js';
+import { KeyCode } from '../../../../../base/common/keyCodes.js';
+import { KeyCodeChord } from '../../../../../base/common/keybindings.js';
 import * as platform from '../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ICodeEditor } from '../../../../browser/editorBrowser.js';
@@ -14,15 +16,19 @@ import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
 import { Selection } from '../../../../common/core/selection.js';
 import { CommonFindController, FindStartFocusAction, FocusEditorFromFindWidgetCommand, IFindStartOptions, NextMatchFindAction, NextSelectionMatchFindAction, StartFindAction, StartFindReplaceAction, StartFindWithSelectionAction } from '../../browser/findController.js';
-import { CONTEXT_FIND_INPUT_FOCUSED } from '../../browser/findModel.js';
+import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_FIND_WIDGET_VISIBLE } from '../../browser/findModel.js';
 import { withAsyncTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingsRegistry } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+
+const FOCUS_EDITOR_FROM_FIND_WIDGET_COMMAND_ID = 'focusEditorFromFindWidget';
+const FOCUS_EDITOR_FROM_FIND_WIDGET_CONTEXT_KEYS = ['editorTextFocus', CONTEXT_FIND_INPUT_FOCUSED.key, CONTEXT_FIND_WIDGET_VISIBLE.key];
 
 class TestFindController extends CommonFindController {
 
@@ -293,6 +299,13 @@ suite('FindController', () => {
 	});
 
 	test('issue #175444: focus editor from find widget is keybinding-dispatchable', async () => {
+		const focusEditorKeybinding = KeybindingsRegistry.getDefaultKeybindings().find(keybinding => keybinding.command === FocusEditorFromFindWidgetCommand.id);
+		const expectedKeybinding = new KeyCodeChord(!platform.isMacintosh, false, false, platform.isMacintosh, KeyCode.DownArrow).toKeybinding();
+
+		assert.strictEqual(focusEditorKeybinding?.keybinding?.equals(expectedKeybinding), true);
+		assert.deepStrictEqual(focusEditorKeybinding?.when?.keys().sort(), [...FOCUS_EDITOR_FROM_FIND_WIDGET_CONTEXT_KEYS].sort());
+		assert.strictEqual(FocusEditorFromFindWidgetCommand.id, FOCUS_EDITOR_FROM_FIND_WIDGET_COMMAND_ID);
+
 		await withAsyncTestCodeEditor([
 			'ABC',
 		], { serviceCollection: serviceCollection, hasTextFocus: false }, async (editor) => {

--- a/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
@@ -169,6 +169,7 @@ class EditorFindAccessibilityHelpProvider extends Disposable implements IAccessi
 			content.push(localize('replace.keyEnter', "- Enter: Move to the next match while staying in Find."));
 			content.push(localize('replace.keyShiftEnter', "- Shift+Enter: Move to the previous match while staying in Find."));
 			content.push(localize('replace.keyTab', "- Tab: Move between Find and Replace inputs."));
+			content.push(localize('replace.keyFocusEditor', "- {0}: Move focus to the editor without closing Find and Replace.", '<keybinding:focusEditorFromFindWidget>'));
 			content.push('');
 			content.push(localize('replace.keyNavReplaceHeader', "While focused IN the Replace input:"));
 			content.push(localize('replace.keyReplaceEnter', "- Enter: Replace the current match and move to the next."));
@@ -218,7 +219,7 @@ class EditorFindAccessibilityHelpProvider extends Disposable implements IAccessi
 
 			content.push('');
 			content.push(localize('replace.closingHeader', "Closing:"));
-			content.push(localize('replace.closingDesc', "Press Escape to close Find and Replace. Focus returns to the editor at the last replacement location, and your search and replace history is preserved."));
+			content.push(localize('replace.closingDesc', "Press Escape to close Find and Replace. Focus returns to the editor at the last replacement location, and your search and replace history is preserved. To move focus to the editor without closing Find and Replace, press {0}.", '<keybinding:focusEditorFromFindWidget>'));
 		} else {
 			// ========== FIND-ONLY MODE CONTENT ==========
 			content.push(localize('find.header', "Accessibility Help: Editor Find"));
@@ -275,6 +276,7 @@ class EditorFindAccessibilityHelpProvider extends Disposable implements IAccessi
 			content.push(localize('find.keyNavFindHeader', "While focused IN the Find input:"));
 			content.push(localize('find.keyEnter', "- Enter: Move to the next match while staying in the Find dialog."));
 			content.push(localize('find.keyShiftEnter', "- Shift+Enter: Move to the previous match while staying in the Find dialog."));
+			content.push(localize('find.keyFocusEditor', "- {0}: Move focus to the editor without closing Find.", '<keybinding:focusEditorFromFindWidget>'));
 			content.push('');
 			content.push(localize('find.keyNavEditorHeader', "While focused IN the editor (not the Find input):"));
 			content.push(localize('find.keyF3', "- {0}: Move to the next match.", '<keybinding:editor.action.nextMatchFindAction>'));
@@ -318,7 +320,7 @@ class EditorFindAccessibilityHelpProvider extends Disposable implements IAccessi
 
 			content.push('');
 			content.push(localize('find.closingHeader', "Closing:"));
-			content.push(localize('find.closingDesc', "Press Escape to close Find. Focus returns to the editor at the most recent match, and your search history is preserved."));
+			content.push(localize('find.closingDesc', "Press Escape to close Find. Focus returns to the editor at the most recent match, and your search history is preserved. To move focus to the editor without closing Find, press {0}.", '<keybinding:focusEditorFromFindWidget>'));
 		}
 
 		return content.join('\n');


### PR DESCRIPTION
Fixes #175444

## What

Moves the find widget Ctrl/Cmd+Down behavior out of the find input keydown handler and into a normal editor command/keybinding. This keeps the default behavior, while allowing user keybindings and `when` clauses to override or suppress it through the normal keybinding dispatch path.

## Test verification (RED → GREEN)

RED, with only the regression test added before the command existed:

```text
src/vs/editor/contrib/find/test/browser/findController.test.ts(16,54): error TS2305: Module '"../../browser/findController.js"' has no exported member 'FocusEditorFromFindWidgetCommand'.
```

GREEN, on the final branch:

```text
npm run typecheck-client
npx gulp compile-client
xvfb-run -a ./scripts/test.sh --no-sandbox --grep "issue #175444"

FindController
  ✔ issue #175444: focus editor from find widget is keybinding-dispatchable

1 passing
```
