### PR TITLE
Disable native dragging from find input

### DIFF
--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -236,6 +236,10 @@ export class FindInput extends Widget {
 		this.onkeyup(this.inputBox.inputElement, (e) => this._onKeyUp.fire(e));
 		this.oninput(this.inputBox.inputElement, (e) => this._onInput.fire());
 		this.onmousedown(this.inputBox.inputElement, (e) => this._onMouseDown.fire(e));
+		this._register(dom.addDisposableListener(this.inputBox.inputElement, dom.EventType.DRAG_START, (e: DragEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+		}));
 	}
 
 	public get isImeSessionInProgress(): boolean {

--- a/src/vs/base/test/browser/ui/findinput/findInput.test.ts
+++ b/src/vs/base/test/browser/ui/findinput/findInput.test.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { FindInput } from '../../../../../base/browser/ui/findinput/findInput.js';
+import { IInputBoxStyles } from '../../../../../base/browser/ui/inputbox/inputBox.js';
+import { unthemedToggleStyles } from '../../../../../base/browser/ui/toggle/toggle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../common/utils.js';
+
+suite('FindInput', () => {
+
+	const TEST_FIND_INPUT_LABEL = 'Test Find Input';
+	const TEST_INPUT_BOX_STYLES: IInputBoxStyles = {
+		inputBackground: undefined,
+		inputForeground: undefined,
+		inputBorder: undefined,
+		inputValidationInfoBorder: undefined,
+		inputValidationInfoBackground: undefined,
+		inputValidationInfoForeground: undefined,
+		inputValidationWarningBorder: undefined,
+		inputValidationWarningBackground: undefined,
+		inputValidationWarningForeground: undefined,
+		inputValidationErrorBorder: undefined,
+		inputValidationErrorBackground: undefined,
+		inputValidationErrorForeground: undefined
+	};
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('issue #176523: disables native drag from the find input', () => {
+		const findInput = new FindInput(null, undefined, {
+			label: TEST_FIND_INPUT_LABEL,
+			inputBoxStyles: TEST_INPUT_BOX_STYLES,
+			toggleStyles: unthemedToggleStyles
+		});
+		const dragStartEvent = new DragEvent('dragstart', { bubbles: true, cancelable: true });
+
+		findInput.inputBox.inputElement.dispatchEvent(dragStartEvent);
+
+		assert.strictEqual(dragStartEvent.defaultPrevented, true);
+
+		findInput.dispose();
+	});
+});


### PR DESCRIPTION
Fixes #176523

## What

Prevents native drag from starting inside `FindInput`. Dragging selected find text could otherwise leave the input and interact with the editor surface; the find input does not support useful drag behavior there, so the drag is cancelled at the source.

## Test verification (RED → GREEN)

RED, with the regression test and without the `dragstart` prevention:

```text
FindInput
  1) issue #176523: disables native drag from the find input

0 passing
1 failing

AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
false !== true
```

GREEN, on the final branch:

```text
npm run typecheck-client
npx gulp compile-client
xvfb-run -a ./scripts/test.sh --no-sandbox --grep "issue #176523"

FindInput
  ✔ issue #176523: disables native drag from the find input

1 passing
```
