### PR TITLE
Update CLI agent commands for AHP 0.6

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "ahp"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa7af01c6ff90f8b54fa169a71de21cc26e5a98621249ad882a5b2e137f57c0"
+checksum = "497aa83cf6866043031b0bab72c3d7543d15d830049ec981defe3a6c73e1c371"
 dependencies = [
  "ahp-types",
  "serde",
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "ahp-types"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1632209b0398b17c4a9928d71eaad0ced329d3617ffcbe32be789f59b1d65c70"
+checksum = "fa028aa3114baa14aeb6a204e95c8ce10487cae3bf0efcdddb4ee7f4d12577d0"
 dependencies = [
  "serde",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,8 +56,8 @@ console = "0.15.7"
 bytes = "1.11.1"
 tar = "0.4.46"
 local-ip-address = "0.6"
-ahp = "0.4"
-ahp-types = "0.4"
+ahp = "0.6"
+ahp-types = "0.6"
 
 [build-dependencies]
 serde = { version="1.0.163", features = ["derive"] }

--- a/cli/src/commands/agent.rs
+++ b/cli/src/commands/agent.rs
@@ -252,6 +252,7 @@ async fn authenticate_from_error(
 					channel: ROOT_RESOURCE_URI.to_string(),
 					resource: resource.resource.clone(),
 					token: credential.access_token().to_string(),
+					scopes: None,
 				},
 			)
 			.await

--- a/cli/src/commands/agent_logs.rs
+++ b/cli/src/commands/agent_logs.rs
@@ -28,6 +28,8 @@ pub async fn agent_logs(ctx: CommandContext, args: AgentLogsArgs) -> Result<i32,
 			"subscribe",
 			SubscribeParams {
 				channel: args.session.clone(),
+				delivery: None,
+				view: None,
 			},
 		)
 		.await?;
@@ -90,12 +92,11 @@ fn print_initial_state(uri: &str, result: &SubscribeResult) {
 	};
 
 	if let SnapshotState::Session(ref session) = snapshot.state {
-		let s = &session.summary;
-		if !s.title.is_empty() {
-			println!("  {} {}", label.apply_to("title:"), s.title);
+		if !session.title.is_empty() {
+			println!("  {} {}", label.apply_to("title:"), session.title);
 		}
-		println!("  {} {}", label.apply_to("provider:"), s.provider);
-		if let Some(ref activity) = s.activity {
+		println!("  {} {}", label.apply_to("provider:"), session.provider);
+		if let Some(ref activity) = session.activity {
 			if !activity.is_empty() {
 				println!("  {} {}", label.apply_to("activity:"), activity);
 			}

--- a/cli/src/commands/agent_ps.rs
+++ b/cli/src/commands/agent_ps.rs
@@ -18,31 +18,45 @@ use super::CommandContext;
 pub async fn agent_ps(ctx: CommandContext, args: AgentPsArgs) -> Result<i32, AnyError> {
 	let client = agent::connect(&ctx, args.address.as_deref(), args.tunnel.as_deref()).await?;
 
-	let result: ListSessionsResult = agent::request_with_auth(
-		&ctx,
-		&client,
-		"listSessions",
-		ListSessionsParams {
-			channel: ROOT_RESOURCE_URI.to_string(),
-			filter: None,
-		},
-	)
-	.await?;
+	// Page through `listSessions` responses until the returned `cursor` is absent.
+	// Some servers may cap page size and require follow-up requests.
+	let mut cursor: Option<String> = None;
+	let mut all_sessions: Vec<SessionSummary> = Vec::new();
+	loop {
+		let res: ListSessionsResult = agent::request_with_auth(
+			&ctx,
+			&client,
+			"listSessions",
+			ListSessionsParams {
+				channel: ROOT_RESOURCE_URI.to_string(),
+				limit: None,
+				cursor: cursor.clone(),
+			},
+		)
+		.await?;
+
+		all_sessions.extend(res.items.into_iter());
+
+		if res.next_cursor.is_none() {
+			break;
+		}
+
+		cursor = res.next_cursor;
+	}
 
 	client.shutdown().await;
 
 	let mut items: Vec<&SessionSummary> = if args.all {
-		result.items.iter().collect()
+		all_sessions.iter().collect()
 	} else {
-		result
-			.items
+		all_sessions
 			.iter()
 			.filter(|s| is_active(s.status))
 			.collect()
 	};
 
 	// Most-recently-modified first.
-	items.sort_by_key(|b| std::cmp::Reverse(b.modified_at));
+	items.sort_by_key(|b| std::cmp::Reverse(b.modified_at.parse::<jiff::Timestamp>().ok()));
 
 	if args.json {
 		let json = serde_json::to_string_pretty(&items)

--- a/cli/src/commands/agent_stop.rs
+++ b/cli/src/commands/agent_stop.rs
@@ -26,6 +26,8 @@ pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32,
 		"subscribe",
 		SubscribeParams {
 			channel: args.session.clone(),
+			delivery: None,
+			view: None,
 		},
 	)
 	.await?;
@@ -51,6 +53,8 @@ pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32,
 			"subscribe",
 			SubscribeParams {
 				channel: chat_uri.clone(),
+				delivery: None,
+				view: None,
 			},
 		)
 		.await?;
@@ -71,6 +75,7 @@ pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32,
 				chat_uri.clone(),
 				StateAction::ChatTurnCancelled(ChatTurnCancelledAction {
 					turn_id: turn_id.clone(),
+					duration: 0,
 					meta: None,
 				}),
 			)


### PR DESCRIPTION
## Summary
Upgrade AHP SDK to 0.6 and update CLI for AHP 0.6 compatibility.
- Files changed: Cargo.toml, Cargo.lock, agent.rs, agent_logs.rs, agent_ps.rs, agent_stop.rs.
- Key code changes: updated param shapes (AuthenticateParams, SubscribeParams, ListSessionsParams), added scopes: None, adapted session snapshot fields, fixed formatting issues.
- Dependencies: ahp and ahp-types bumped 0.4 → 0.6.
- Verification: ran cargo check in cli — no compile errors.

Fixes: #326440