### PR TITLE
Fix hydrated image attachment previews

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
+++ b/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
@@ -189,17 +189,31 @@ async function extractImageFromInlineReference(
 }
 
 export function coerceImageBuffer(value: unknown): Uint8Array | undefined {
-	return value instanceof Uint8Array
-		? value
-		: value instanceof ArrayBuffer
-			? new Uint8Array(value)
-			: (value && typeof value === 'object' && !Array.isArray(value))
-				? new Uint8Array(
-					Object.keys(value as Record<string, number>)
-						.sort((a, b) => Number(a) - Number(b))
-						.map(key => (value as Record<string, number>)[key])
-				)
-				: undefined;
+	if (value instanceof Uint8Array) {
+		return value;
+	}
+	if (value instanceof ArrayBuffer) {
+		return new Uint8Array(value);
+	}
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return undefined;
+	}
+
+	const record = value as Record<string, unknown>;
+	const keys = Object.keys(record).sort((a, b) => Number(a) - Number(b));
+	if (keys.length === 0) {
+		return undefined;
+	}
+
+	const result = new Uint8Array(keys.length);
+	for (let index = 0; index < keys.length; index++) {
+		const byte = record[keys[index]];
+		if (keys[index] !== String(index) || typeof byte !== 'number' || !Number.isInteger(byte) || byte < 0 || byte > 255) {
+			return undefined;
+		}
+		result[index] = byte;
+	}
+	return result;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
@@ -492,6 +492,15 @@ suite('extractImagesFromChatRequest', () => {
 		assert.deepStrictEqual([...result[0].data.buffer], [7, 8, 9]);
 	});
 
+	test('does not treat a URI-backed image attachment as inline image bytes', () => {
+		const uri = URI.file('/tmp/cat.png');
+		const request = makeRequest([
+			makeImageVariableEntry({ value: uri, references: [{ kind: 'reference', reference: uri }] }),
+		]);
+
+		assert.deepStrictEqual(extractImagesFromChatRequest(request), []);
+	});
+
 	test('uses attachment resource URI when available', () => {
 		const uri = URI.file('/tmp/cat.png');
 		const request = makeRequest([


### PR DESCRIPTION
Fixes #327299

## Summary

- reject URI-backed image attachments when coercing serialized inline bytes
- let the image carousel load hydrated attachments from their persisted file resource
- preserve support for contiguous numeric byte maps restored from older serialized sessions

## Why this is correct

Before send, pasted images carry inline `Uint8Array` data. Agent Host intentionally snapshots that data to disk, and history hydration restores the attachment as an image entry whose `value` is a `URI` and whose `references` point to the persisted file.

`coerceImageBuffer` is only responsible for recognizing inline bytes. Its previous object fallback accepted every object, so the seven enumerable fields of a `URI` became seven zero bytes. Because that result was truthy, Images Preview preferred the corrupt inline data and skipped its valid file-resource fallback.

The new validation accepts only the exact legacy serialized-`Uint8Array` shape: contiguous numeric keys starting at `0`, each containing an integer byte from `0` through `255`. Existing `Uint8Array` and `ArrayBuffer` paths are unchanged. URI and other structured objects now return `undefined`, which deliberately lets the existing resource path read the persisted image.

The regression test uses the hydrated shape (`value: URI` plus its resource reference), while the existing numeric-map tests ensure backward compatibility, including reordered numeric keys.

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts`
- focused hygiene checks
- reopened a hydrated Agent Host session and confirmed the sent image renders in Images Preview