### PR TITLE
Fix: Prevent Shift key from intercepting shortcuts in Web Custom Editors

### DIFF
--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -16,7 +16,7 @@ import { UILabelProvider } from '../../../base/common/keybindingLabels.js';
 import { ResolvedKeybinding } from '../../../base/common/keybindings.js';
 import { KeyCode } from '../../../base/common/keyCodes.js';
 import { combinedDisposable, DisposableStore, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
-import { isLinux, isWindows, OS } from '../../../base/common/platform.js';
+import { isLinux, isWindows, OS, isWeb } from '../../../base/common/platform.js';
 import { ThemeIcon } from '../../../base/common/themables.js';
 import { assertType } from '../../../base/common/types.js';
 import { localize } from '../../../nls.js';
@@ -236,7 +236,7 @@ export class MenuEntryActionViewItem<T extends IMenuEntryActionViewItemOptions =
 				const wantsAltCommand = !!this._menuItemAction.alt?.enabled &&
 					(!this._accessibilityService.isMotionReduced() || isMouseOver) && (
 						this._altKey.keyStatus.altKey ||
-						(this._altKey.keyStatus.shiftKey && isMouseOver)
+						(this._altKey.keyStatus.shiftKey && isMouseOver && !isWeb)
 					);
 
 				if (wantsAltCommand !== this._wantsAltCommand) {

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -236,6 +236,8 @@ export class MenuEntryActionViewItem<T extends IMenuEntryActionViewItemOptions =
 				const wantsAltCommand = !!this._menuItemAction.alt?.enabled &&
 					(!this._accessibilityService.isMotionReduced() || isMouseOver) && (
 						this._altKey.keyStatus.altKey ||
+						// Web: Shift key events are intercepted by the browser and can trigger unwanted Alt-like behavior.
+						// Only use Shift as Alt trigger on desktop where the event model handles it correctly.
 						(this._altKey.keyStatus.shiftKey && isMouseOver && !isWeb)
 					);
 


### PR DESCRIPTION
**The problem**

On VS Code for the Web, pressing Shift (as part of keyboard shortcuts like \Shift+Cmd+V\ for 'Markdown: Toggle Preview') was incorrectly treated as Alt/Option. This caused:

1. Toolbar icons to toggle (shift+icon behavior normally reserved for Alt),
2. Keyboard shortcuts containing Shift to not reach custom editors (markdown preview, etc.).

This does not occur on the desktop version where the native event model handles Shift correctly.

**The solution**

In \MenuEntryActionViewItem\, the condition \(this._altKey.keyStatus.shiftKey && isMouseOver)\ allows Shift held while hovering over a toolbar item to trigger the alt command (secondary action). On the web, browser key events propagate Shift key state to this handler, falsely triggering the alt command UI toggling and intercepting Shift-based shortcuts.

The fix adds \&& !isWeb\ to this condition, limiting shift-as-alt behavior to desktop where the browser event model does not interfere.

**File changed**: \src/vs/platform/actions/browser/menuEntryActionViewItem.ts\ (2 insertions, 2 deletions)

- Added \isWeb\ import from \../../../base/common/platform.js\
- Guarded \	his._altKey.keyStatus.shiftKey && isMouseOver\ with \&& !isWeb\

**Verification**:
- [x] Compilation succeeds (\
pm run compile\)
- [x] Only affects web platform (\isWeb\ guard), desktop behavior unchanged
- [x] Alt key behavior on web remains unchanged (actual altKey is still checked)
- [x] Shift key no longer toggles toolbar icons on web

Fixes: #322505