### PR TITLE
Add Kimi K3 prompt support

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/test/kimiPrompts.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/kimiPrompts.spec.tsx
@@ -54,6 +54,7 @@ suite('KimiPrompts', () => {
 		const renderedPrompts = await Promise.all([
 			renderSystemPrompt('kimi-k2.6'),
 			renderSystemPrompt('kimi-k2.7-code'),
+			renderSystemPrompt('kimi-k3'),
 		]);
 
 		for (const renderedPrompt of renderedPrompts) {

--- a/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -167,7 +167,7 @@ export function isGpt53Codex(model: LanguageModelChat | IChatEndpoint | string) 
 export function isKimiFamily(model: LanguageModelChat | IChatEndpoint | string): boolean {
 	const matches = (value: string): boolean => {
 		const normalized = value.toLowerCase();
-		return normalized.includes('kimi-k2.6') || normalized.includes('kimi-k2.7-code');
+		return normalized.includes('kimi-k2.6') || normalized.includes('kimi-k2.7-code') || normalized.includes('kimi-k3');
 	};
 
 	if (typeof model === 'string') {

--- a/extensions/copilot/src/platform/endpoint/node/test/copilotChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/copilotChatEndpoint.spec.ts
@@ -529,14 +529,14 @@ describe('ChatEndpoint - Kimi CAPI customization', () => {
 		postOptions: { temperature: 0, top_p: 1 }
 	});
 
-	it.each(['kimi-k2.6', 'kimi-k2.7-code'])('should force temperature=1 and top_p=0.95 for %s', (family) => {
+	it.each(['kimi-k2.6', 'kimi-k2.7-code', 'kimi-k3'])('should force temperature=1 and top_p=0.95 for %s', (family) => {
 		const endpoint = createEndpoint(createNonAnthropicModelMetadata(family));
 		const body = endpoint.createRequestBody(createOptionsWithPostOptions());
 		expect(body.temperature).toBe(1);
 		expect(body.top_p).toBe(0.95);
 	});
 
-	it.each(['kimi-k2.6', 'kimi-k2.7-code'])('should normalize tool call IDs for %s', family => {
+	it.each(['kimi-k2.6', 'kimi-k2.7-code', 'kimi-k3'])('should normalize tool call IDs for %s', family => {
 		const history = createToolHistory();
 		const endpoint = createEndpoint(createNonAnthropicModelMetadata(family));
 		const body = endpoint.createRequestBody(createTestOptions(history));

--- a/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
@@ -46,6 +46,7 @@ describe('Kimi edit tool capabilities', () => {
 		const models = {
 			'kimi-k2.6': fakeModel('kimi-k2.6'),
 			'kimi-k2.7-code': fakeModel('kimi-k2.7-code'),
+			'kimi-k3': fakeModel('kimi-k3'),
 			'moonshot/kimi-k2.7-code': fakeModel('moonshot/kimi-k2.7-code'),
 			'moonshot/kimi-k2.6': fakeModel('moonshot/kimi-k2.6'),
 			'unknown-family + kimi model id': fakeModel('unknown-family', 'kimi-k2.7-code-preview'),
@@ -69,6 +70,14 @@ describe('Kimi edit tool capabilities', () => {
 				canUseApplyPatchExclusively: false,
 			},
 			'kimi-k2.7-code': {
+				isKimiFamily: true,
+				supportsReplaceString: true,
+				supportsMultiReplaceString: true,
+				canUseReplaceStringExclusively: true,
+				supportsApplyPatch: false,
+				canUseApplyPatchExclusively: false,
+			},
+			'kimi-k3': {
 				isKimiFamily: true,
 				supportsReplaceString: true,
 				supportsMultiReplaceString: true,


### PR DESCRIPTION
## Summary

- recognize `kimi-k3` as part of the Kimi model family
- route Kimi K3 through the Kimi-specific agent prompt and endpoint behavior
- add coverage for prompt selection, edit capabilities, and CAPI request customization

## Testing

- `cd extensions/copilot && npm run typecheck`
- `cd extensions/copilot && npm run test:unit -- src/platform/endpoint/test/node/chatModelCapabilities.spec.ts src/extension/prompts/node/agent/test/kimiPrompts.spec.tsx src/platform/endpoint/node/test/copilotChatEndpoint.spec.ts`
- `npm run precommit`