### PR TITLE
Ensure voice actions pill is visible in all themes

### DIFF
--- a/src/vs/base/browser/ui/segmentedIconToggle/segmentedIconToggle.css
+++ b/src/vs/base/browser/ui/segmentedIconToggle/segmentedIconToggle.css
@@ -27,7 +27,7 @@
 	box-sizing: border-box;
 	width: var(--segmented-icon-toggle-width, 56px);
 	height: var(--segmented-icon-toggle-height, 24px);
-	border: 1px solid var(--vscode-input-border, transparent);
+	border: 1px solid var(--vscode-input-border, var(--vscode-contrastBorder, color-mix(in srgb, var(--vscode-icon-foreground) 50%, transparent)));
 	border-radius: 8px;
 }
 


### PR DESCRIPTION
Fixes #327314

The segmented voice-actions pill currently falls back to a transparent border when a theme does not define input.border, making the pill housing disappear in themes such as Dark+.

This keeps explicit input.border colors as the first choice, uses contrastBorder for high-contrast themes, and otherwise derives a visible border from the theme icon foreground. The pill now retains a clear boundary without requiring every theme to define a dedicated border color.