### PR TITLE
Bump Copilot npm to 1.0.74

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
-        "@github/copilot": "^1.0.73",
+        "@github/copilot": "^1.0.74",
         "@github/copilot-sdk": "^1.0.8",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -1113,9 +1113,9 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.73.tgz",
-      "integrity": "sha512-8I2Ejg2CX/PQA3c2H8W1zuqhniCeR1q1/bD8CrV53/ZLw8GF7DAV0xQpwa8ELYvFgjXb6AADojafCKwdbVef+A==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.74.tgz",
+      "integrity": "sha512-lLeZqtgWZ9ljO3i6A5/scsSIEa/5HNHPtrLjz6DdLaVRVdKNGfJPi7oDzlyymA3s6ok4oY1AAj0hxgF2NhybbQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -1124,20 +1124,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.73",
-        "@github/copilot-darwin-x64": "1.0.73",
-        "@github/copilot-linux-arm64": "1.0.73",
-        "@github/copilot-linux-x64": "1.0.73",
-        "@github/copilot-linuxmusl-arm64": "1.0.73",
-        "@github/copilot-linuxmusl-x64": "1.0.73",
-        "@github/copilot-win32-arm64": "1.0.73",
-        "@github/copilot-win32-x64": "1.0.73"
+        "@github/copilot-darwin-arm64": "1.0.74",
+        "@github/copilot-darwin-x64": "1.0.74",
+        "@github/copilot-linux-arm64": "1.0.74",
+        "@github/copilot-linux-x64": "1.0.74",
+        "@github/copilot-linuxmusl-arm64": "1.0.74",
+        "@github/copilot-linuxmusl-x64": "1.0.74",
+        "@github/copilot-win32-arm64": "1.0.74",
+        "@github/copilot-win32-x64": "1.0.74"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.73.tgz",
-      "integrity": "sha512-5jv7t2sw35/zI0cPze38hG6239NT5/q/Emjx6gLibYkolDqMDJjpm17Ps7tc8oafUEOiMQMb+ar7+qi6rSiGJA==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.74.tgz",
+      "integrity": "sha512-yuYzNVQDe32p9podRicB/cMxWck/E9pNTaY/agBURkZJ1IGard/7Sa8ji3j/RrBOS2RtvobEATFc17kuWufpMw==",
       "cpu": [
         "arm64"
       ],
@@ -1151,9 +1151,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.73.tgz",
-      "integrity": "sha512-l794k6Ahb11AG2FQT/P4TEWxWblzM1h8aQQCzG8jBWp8dfwjhyYjJ+d+0CWQzM3Fc1ddNUZRjKXCUsfvFjiZhQ==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.74.tgz",
+      "integrity": "sha512-7LiLrJPx+Jdy+JzMW9ulUgAmijC0EC2pcLztcJNlu1jVCS2YUEaKapX8xNSYj2Gm7LXO0kgvvAx1nzvZb8Jg7g==",
       "cpu": [
         "x64"
       ],
@@ -1167,9 +1167,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.73.tgz",
-      "integrity": "sha512-Zu0W5nupJjNeem0brqU/pG+VY0IWr6EWr/FsC90g5SEDiaM4VhVNVWcz8t0E3DQCSYetV6IBaNMtjs/3uIIiDQ==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.74.tgz",
+      "integrity": "sha512-VCU+Q2heZbDjiPAIm9QJSQgk92ER+PERBov/6dqVcwvTvqcl+6MgyPHbdeNagEWiASiKqXkgpwKuZozEHckV+w==",
       "cpu": [
         "arm64"
       ],
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.73.tgz",
-      "integrity": "sha512-k33XIr6/PVp+K+5F/zv3No4PPaNImvHz73mcbIw63oxh5iiacXjgr0WqbBIS5s/rkhOWjNPIkbof/TTPZ7mQjA==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.74.tgz",
+      "integrity": "sha512-dBuN0+iCLI/paIUM9XgMA47VEsKEd35k/yxQ08u8EpmEbzwk/zfM8tRCufDhuB9wjs9Y8rcMxr8UvNmBp1Ww+g==",
       "cpu": [
         "x64"
       ],
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.73.tgz",
-      "integrity": "sha512-HJWzhfD3oaiIgfRAHkNWzp17fELtshqM9HVN5n+lFEmSO2EETCEh0P1lhJc4m+FYfXSJnL0raAqVuyaNMuPoPw==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.74.tgz",
+      "integrity": "sha512-Uc1quSMuoDj1xhg697jjJEWhv2efRrMsTYktH9lqXxT01KR4BxcrvmTNstgzuNHPu8Jjndy3iIR/Pwf15EcfUQ==",
       "cpu": [
         "arm64"
       ],
@@ -1224,9 +1224,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.73.tgz",
-      "integrity": "sha512-/BpOXSb16wHEu8I1SaKiLszQ4Kvu4+Z4uCn7W0bv4xI4fPZwTEG0u3zgaI2W9Ao3+aBl0XRpPmpWzE9ziYEq+w==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.74.tgz",
+      "integrity": "sha512-O7j3/Jm3h9UmBMh4EJYMHgxSoi18xv+r/AehwC4LSgRpyRZWYjhaoOs4SavsESBDFZCBHv3gO8waMCIgHg4Esg==",
       "cpu": [
         "x64"
       ],
@@ -1267,9 +1267,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.73.tgz",
-      "integrity": "sha512-DbPeXiYzQjpOy9oboaBvuCzjRwfcL987c3bG09cK1crdCDrKfkTJ7NXpcp1KWRPIRFO1FQm1qToNE89J+L3uvg==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.74.tgz",
+      "integrity": "sha512-V2RmvWvW2pdoW9ZsUrD8Bhbp7+SU5Tgl51Ucc7eXATyVwMY8FAm9KEFongbG06sq1IyylyKRB11tIRhFxLIS2Q==",
       "cpu": [
         "arm64"
       ],
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.73.tgz",
-      "integrity": "sha512-8D3E1l5i+N5Eq8HIOQpx+Zbcb3MXdFxszksM2gqq175Z1S7Zna67oY4GoR3psxlbIpSyHKiLEBWYiaps6ayHWw==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.74.tgz",
+      "integrity": "sha512-g5iuDMGU0Gyb9POvMdukud5UctHvhxImyoea5U28NauS3h/UJqQLnu+qtFEtrGcaOCwsQZBlTNw5MDWUdGN4ng==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
-    "@github/copilot": "^1.0.73",
+    "@github/copilot": "^1.0.74",
     "@github/copilot-sdk": "^1.0.8",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vscode-reh",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "^1.0.73",
+        "@github/copilot": "^1.0.74",
         "@github/copilot-sdk": "^1.0.8",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.73.tgz",
-      "integrity": "sha512-8I2Ejg2CX/PQA3c2H8W1zuqhniCeR1q1/bD8CrV53/ZLw8GF7DAV0xQpwa8ELYvFgjXb6AADojafCKwdbVef+A==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.74.tgz",
+      "integrity": "sha512-lLeZqtgWZ9ljO3i6A5/scsSIEa/5HNHPtrLjz6DdLaVRVdKNGfJPi7oDzlyymA3s6ok4oY1AAj0hxgF2NhybbQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -72,20 +72,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.73",
-        "@github/copilot-darwin-x64": "1.0.73",
-        "@github/copilot-linux-arm64": "1.0.73",
-        "@github/copilot-linux-x64": "1.0.73",
-        "@github/copilot-linuxmusl-arm64": "1.0.73",
-        "@github/copilot-linuxmusl-x64": "1.0.73",
-        "@github/copilot-win32-arm64": "1.0.73",
-        "@github/copilot-win32-x64": "1.0.73"
+        "@github/copilot-darwin-arm64": "1.0.74",
+        "@github/copilot-darwin-x64": "1.0.74",
+        "@github/copilot-linux-arm64": "1.0.74",
+        "@github/copilot-linux-x64": "1.0.74",
+        "@github/copilot-linuxmusl-arm64": "1.0.74",
+        "@github/copilot-linuxmusl-x64": "1.0.74",
+        "@github/copilot-win32-arm64": "1.0.74",
+        "@github/copilot-win32-x64": "1.0.74"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.73.tgz",
-      "integrity": "sha512-5jv7t2sw35/zI0cPze38hG6239NT5/q/Emjx6gLibYkolDqMDJjpm17Ps7tc8oafUEOiMQMb+ar7+qi6rSiGJA==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.74.tgz",
+      "integrity": "sha512-yuYzNVQDe32p9podRicB/cMxWck/E9pNTaY/agBURkZJ1IGard/7Sa8ji3j/RrBOS2RtvobEATFc17kuWufpMw==",
       "cpu": [
         "arm64"
       ],
@@ -99,9 +99,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.73.tgz",
-      "integrity": "sha512-l794k6Ahb11AG2FQT/P4TEWxWblzM1h8aQQCzG8jBWp8dfwjhyYjJ+d+0CWQzM3Fc1ddNUZRjKXCUsfvFjiZhQ==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.74.tgz",
+      "integrity": "sha512-7LiLrJPx+Jdy+JzMW9ulUgAmijC0EC2pcLztcJNlu1jVCS2YUEaKapX8xNSYj2Gm7LXO0kgvvAx1nzvZb8Jg7g==",
       "cpu": [
         "x64"
       ],
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.73.tgz",
-      "integrity": "sha512-Zu0W5nupJjNeem0brqU/pG+VY0IWr6EWr/FsC90g5SEDiaM4VhVNVWcz8t0E3DQCSYetV6IBaNMtjs/3uIIiDQ==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.74.tgz",
+      "integrity": "sha512-VCU+Q2heZbDjiPAIm9QJSQgk92ER+PERBov/6dqVcwvTvqcl+6MgyPHbdeNagEWiASiKqXkgpwKuZozEHckV+w==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.73.tgz",
-      "integrity": "sha512-k33XIr6/PVp+K+5F/zv3No4PPaNImvHz73mcbIw63oxh5iiacXjgr0WqbBIS5s/rkhOWjNPIkbof/TTPZ7mQjA==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.74.tgz",
+      "integrity": "sha512-dBuN0+iCLI/paIUM9XgMA47VEsKEd35k/yxQ08u8EpmEbzwk/zfM8tRCufDhuB9wjs9Y8rcMxr8UvNmBp1Ww+g==",
       "cpu": [
         "x64"
       ],
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.73.tgz",
-      "integrity": "sha512-HJWzhfD3oaiIgfRAHkNWzp17fELtshqM9HVN5n+lFEmSO2EETCEh0P1lhJc4m+FYfXSJnL0raAqVuyaNMuPoPw==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.74.tgz",
+      "integrity": "sha512-Uc1quSMuoDj1xhg697jjJEWhv2efRrMsTYktH9lqXxT01KR4BxcrvmTNstgzuNHPu8Jjndy3iIR/Pwf15EcfUQ==",
       "cpu": [
         "arm64"
       ],
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.73.tgz",
-      "integrity": "sha512-/BpOXSb16wHEu8I1SaKiLszQ4Kvu4+Z4uCn7W0bv4xI4fPZwTEG0u3zgaI2W9Ao3+aBl0XRpPmpWzE9ziYEq+w==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.74.tgz",
+      "integrity": "sha512-O7j3/Jm3h9UmBMh4EJYMHgxSoi18xv+r/AehwC4LSgRpyRZWYjhaoOs4SavsESBDFZCBHv3gO8waMCIgHg4Esg==",
       "cpu": [
         "x64"
       ],
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.73.tgz",
-      "integrity": "sha512-DbPeXiYzQjpOy9oboaBvuCzjRwfcL987c3bG09cK1crdCDrKfkTJ7NXpcp1KWRPIRFO1FQm1qToNE89J+L3uvg==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.74.tgz",
+      "integrity": "sha512-V2RmvWvW2pdoW9ZsUrD8Bhbp7+SU5Tgl51Ucc7eXATyVwMY8FAm9KEFongbG06sq1IyylyKRB11tIRhFxLIS2Q==",
       "cpu": [
         "arm64"
       ],
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.73.tgz",
-      "integrity": "sha512-8D3E1l5i+N5Eq8HIOQpx+Zbcb3MXdFxszksM2gqq175Z1S7Zna67oY4GoR3psxlbIpSyHKiLEBWYiaps6ayHWw==",
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.74.tgz",
+      "integrity": "sha512-g5iuDMGU0Gyb9POvMdukud5UctHvhxImyoea5U28NauS3h/UJqQLnu+qtFEtrGcaOCwsQZBlTNw5MDWUdGN4ng==",
       "cpu": [
         "x64"
       ],

--- a/remote/package.json
+++ b/remote/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@github/copilot": "^1.0.73",
+    "@github/copilot": "^1.0.74",
     "@github/copilot-sdk": "^1.0.8",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",


### PR DESCRIPTION
- Update the root and remote `@github/copilot` runtime from `1.0.73` to `1.0.74`.
- Keep `extensions/copilot` on `1.0.73`: stable `1.0.74` removes the `internal` export from the chat extension internal SDK path (`@github/copilot/sdk`).
- Keep the public SDK at `1.0.8`; its `^1.0.73` dependency deduplicates onto the top-level CLI `1.0.74`.

Validation:

- `npm run typecheck-client`
- Agent Host dependency tree resolves one CLI `1.0.74`
- Real SDK native-storage/config-directory import path passes
- Install-script policy and hygiene pass

Known upstream regression:

- The provider-backed `sessionFs` import test passes with CLI `1.0.73` but fails with `1.0.74` when `session.history.truncate` reports the imported event is not found. Production Agent Host uses the native storage path, which passes. This PR is draft while that upstream behavior is assessed.