### PR TITLE
Improve managed settings policy diagnostics

### DIFF
--- a/.github/skills/add-policy/github-managed-settings.md
+++ b/.github/skills/add-policy/github-managed-settings.md
@@ -48,7 +48,7 @@ described delivery slots (native MDM, server-managed, and file-based).
 |---------|-----------------|----------------|----------|
 | **Native MDM** (Windows registry / macOS plist) | OS managed preferences | `NativeManagedSettingsService` (`src/vs/platform/policy/node/nativeManagedSettingsService.ts`) via `@vscode/policy-watcher` | `INativeManagedSettingsService.managedSettings` |
 | **Server-managed** (`/copilot_internal/managed_settings`) | GitHub endpoint; per the code comment in `managedSettings.ts`, it returns the enterprise's `.github/copilot/settings.json` content | `adaptManagedSettings` (`src/vs/workbench/services/accounts/browser/managedSettings.ts`) → `DefaultAccountService.policyData` | `accountPolicyData.managedSettings` |
-| **File-based** (`managed-settings.json`) | well-known per-OS disk path (e.g. `/Library/Application Support/GitHubCopilot/` on macOS), read in the main process and exposed to renderer windows over IPC | `FileManagedSettingsService` (`src/vs/platform/policy/common/fileManagedSettingsService.ts`) | `IFileManagedSettingsService.managedSettings` |
+| **File-based** (`managed-settings.json`) | well-known per-OS disk path (e.g. `/Library/Application Support/GitHubCopilot/` on macOS), read in the main process and exposed to renderer windows over IPC | `FileManagedSettingsService` (`src/vs/platform/policy/common/fileManagedSettingsService.ts`) | `IFileManagedSettingsService.rawManagedSettings` + `.managedSettings` |
 
 All three VS Code channels converge in `AccountPolicyService.getPolicyData()`.
 
@@ -268,7 +268,28 @@ The **file-based** channel is wired the same way (`src/vs/code/electron-main/mai
 `NullFileManagedSettingsService` when no path applies. It is exposed to the renderer over IPC
 via `FileManagedSettingsChannel` / `FileManagedSettingsChannelClient`
 (`fileManagedSettingsIpc.ts`), registered as the `fileManagedSettings` channel in `app.ts`,
-and `AccountPolicyService` subscribes to its `onDidChangeManagedSettings` too.
+and `AccountPolicyService` subscribes to its `onDidChangeManagedSettings` too. The service also
+retains the parsed source object as `rawManagedSettings` with a separate change event. That raw
+snapshot is diagnostics-only; policy evaluation continues to consume the normalized
+`managedSettings` bag.
+
+## Diagnostics pipeline
+
+**Developer: Policy Diagnostics** shows each delivery channel as a pipeline:
+
+1. Source input (the server response, parsed file, or definition-scoped native watcher values).
+2. Canonical normalized bag from `normalizeManagedSettings`.
+3. VS Code policy projection from `projectManagedSettings`.
+
+It then shows per-key channel precedence, the merged normalized bag, and the final bag delivered to
+VS Code policy callbacks. Runtime-owned settings can therefore remain visible in a raw source even
+when VS Code has no corresponding policy declaration and the projected bag is empty.
+
+The report separately queries capable Agent Host providers for their own effective managed-settings
+snapshot. Copilot uses the platform runtime package's public `sdk/index.js#getManagedSettings()`
+API, which returns the same payload as `session.managed_settings_resolved` without requiring an
+active session. This runtime snapshot is not treated as another VS Code delivery channel because
+the runtime owns its schema and authority resolution independently.
 
 ## Adding a brand-new managed-settings key (checklist)
 

--- a/build/lib/test/copilot.test.ts
+++ b/build/lib/test/copilot.test.ts
@@ -126,6 +126,7 @@ suite('copilot', () => {
 		assertCopilotPlatformPackageIncludes(files, 'node_modules/@github/copilot-darwin-arm64', [
 			'index.js',
 			'app.js',
+			'sdk/index.js',
 			'sea-loader.js',
 			'prebuilds/darwin-arm64/runtime.node',
 			'prebuilds/darwin-arm64/pty.node',

--- a/src/vs/platform/agentHost/browser/nullAgentHostService.ts
+++ b/src/vs/platform/agentHost/browser/nullAgentHostService.ts
@@ -7,7 +7,7 @@ import { Event } from '../../../base/common/event.js';
 import { IReference } from '../../../base/common/lifecycle.js';
 import { constObservable, IObservable } from '../../../base/common/observable.js';
 import { URI } from '../../../base/common/uri.js';
-import type { IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentHostService, IAgentHostSocketInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult } from '../common/agentService.js';
+import type { IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentHostService, IAgentHostSocketInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult } from '../common/agentService.js';
 import type { IActiveSubscriptionInfo, IAgentSubscription } from '../common/state/agentSubscription.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import type { InitializeResult } from '../common/state/protocol/common/commands.js';
@@ -49,6 +49,7 @@ export class NullAgentHostService implements IAgentHostService {
 	async restartAgentHost(): Promise<void> { notSupported(); }
 	async authenticate(_params: AuthenticateParams): Promise<AuthenticateResult> { return notSupported(); }
 	async getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> { return notSupported(); }
+	async getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> { return []; }
 	async diagnosticsFetch(_url: string): Promise<IAgentHostNetworkFetchResult> { return notSupported(); }
 	async listSessions(): Promise<IAgentSessionMetadata[]> { return []; }
 	async createSession(_config?: IAgentCreateSessionConfig): Promise<URI> { return notSupported(); }

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -18,7 +18,7 @@ import { generateUuid } from '../../../base/common/uuid.js';
 import { ILogService } from '../../log/common/log.js';
 import { FileSystemProviderErrorCode, toFileSystemProviderErrorCode } from '../../files/common/files.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
-import { AgentSession, AgentHostCodexAgentEnabledSettingId, AgentHostSystemProxyEnabledSettingId, IAgentConnection, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
+import { AgentSession, AgentHostCodexAgentEnabledSettingId, AgentHostSystemProxyEnabledSettingId, IAgentConnection, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
 import { createRemoteWatchHandle, type IRemoteWatchHandle } from '../common/agentHostFileSystemProvider.js';
 import { AgentSubscriptionManager, type IActiveSubscriptionInfo, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import { agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../common/agentHostUri.js';
@@ -97,6 +97,7 @@ function transportLostError(address: string): ProtocolError {
 interface IRemoteAgentHostExtensionCommandMap {
 	'shutdown': { params: undefined; result: void };
 	'getNetworkDiagnosticsInfo': { params: undefined; result: IAgentHostNetworkDiagnosticsInfo };
+	'getManagedSettingsDiagnostics': { params: undefined; result: readonly IAgentHostManagedSettingsDiagnostics[] };
 	'diagnosticsFetch': { params: { url: string }; result: IAgentHostNetworkFetchResult };
 }
 
@@ -941,6 +942,10 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 */
 	async getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> {
 		return this._sendExtensionRequest('getNetworkDiagnosticsInfo');
+	}
+
+	async getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> {
+		return this._sendExtensionRequest('getManagedSettingsDiagnostics');
 	}
 
 	/**

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -618,6 +618,24 @@ export interface IAgentHostNetworkDiagnosticsInfo {
 	readonly endpoints: readonly IAgentHostNetworkEndpoint[];
 }
 
+export interface IAgentHostManagedSettingsSnapshot {
+	readonly account?: string;
+	readonly source: 'server' | 'device' | 'none';
+	readonly serverManaged: boolean;
+	readonly deviceManaged: boolean;
+	readonly failClosed: boolean;
+	readonly bypassPermissionsDisabled: boolean;
+	readonly permissionsAllowIntersected?: boolean;
+	readonly managedKeys: readonly string[];
+	readonly settings?: Readonly<Record<string, unknown>>;
+}
+
+export interface IAgentHostManagedSettingsDiagnostics {
+	readonly provider: AgentProvider;
+	readonly snapshot?: IAgentHostManagedSettingsSnapshot;
+	readonly error?: string;
+}
+
 /** Result of a DNS lookup for a single address family, part of {@link IAgentHostNetworkFetchResult}. */
 export interface IAgentHostDnsResult {
 	/** The resolved address, when the lookup succeeded. */
@@ -1596,6 +1614,9 @@ export interface IAgent {
 	/** Authenticated account name to display in network diagnostics, when known. */
 	getNetworkDiagnosticsAccount?(): Promise<string | undefined>;
 
+	/** Resolve the provider's own effective enterprise managed-settings snapshot. */
+	getManagedSettingsDiagnostics?(): Promise<IAgentHostManagedSettingsSnapshot>;
+
 	/**
 	 * Fires when the agent's host-owned customizations change
 	 * (loading state, resolution results, etc.), so infrastructure
@@ -1867,6 +1888,9 @@ export interface IAgentService {
 	 */
 	getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo>;
 
+	/** Resolve managed settings through each provider's native SDK/runtime implementation. */
+	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]>;
+
 	/**
 	 * Probe connectivity from the agent host process to a single `url`,
 	 * resolving the proxy and timing DNS + reachability. Used by the "Network
@@ -2103,6 +2127,9 @@ export interface IAgentConnection {
 	 * runs in.
 	 */
 	getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo>;
+
+	/** Resolve managed settings through each provider's native SDK/runtime implementation. */
+	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]>;
 
 	/**
 	 * Probe connectivity from the agent host to a single `url`. Runs on the

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -711,6 +711,7 @@ export interface IAgentHostManagementService {
 	createChatWithExtensions(session: URI, chat: URI, options: IAgentCreateChatOptions): Promise<void>;
 	shutdown(): Promise<void>;
 	getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo>;
+	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]>;
 	diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult>;
 	startWebSocketServer(): Promise<IAgentHostSocketInfo>;
 	getInspectInfo(tryEnable: boolean): Promise<IAgentHostInspectInfo | undefined>;

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -332,7 +332,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> {
-		return this._requireClient().getManagedSettingsDiagnostics();
+		return this._management.getManagedSettingsDiagnostics();
 	}
 
 	diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> {

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -33,6 +33,7 @@ import {
 	IAgentCreateSessionConfig,
 	IAgentHostInspectInfo,
 	IAgentHostManagementService,
+	IAgentHostManagedSettingsDiagnostics,
 	IAgentHostNetworkDiagnosticsInfo,
 	IAgentHostNetworkFetchResult,
 	IAgentHostService,
@@ -328,6 +329,10 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 
 	getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> {
 		return this._management.getNetworkDiagnosticsInfo();
+	}
+
+	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> {
+		return this._requireClient().getManagedSettingsDiagnostics();
 	}
 
 	diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> {

--- a/src/vs/platform/agentHost/node/agentHostManagementService.ts
+++ b/src/vs/platform/agentHost/node/agentHostManagementService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../base/common/uri.js';
-import { IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostManagementService, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentHostSocketInfo, IAgentService, IConnectionTrackerService } from '../common/agentService.js';
+import { IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostManagedSettingsDiagnostics, IAgentHostManagementService, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentHostSocketInfo, IAgentService, IConnectionTrackerService } from '../common/agentService.js';
 
 export class AgentHostManagementService implements IAgentHostManagementService {
 	declare readonly _serviceBrand: undefined;
@@ -28,6 +28,10 @@ export class AgentHostManagementService implements IAgentHostManagementService {
 
 	getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> {
 		return this._agentService.getNetworkDiagnosticsInfo();
+	}
+
+	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> {
+		return this._agentService.getManagedSettingsDiagnostics();
 	}
 
 	diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> {

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -22,7 +22,7 @@ import { FileChangeType, FileOperationResult, IFileChange, IFileService, toFileO
 import { InstantiationService } from '../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
 import { ILogService } from '../../log/common/log.js';
-import { AgentProvider, AgentSession, AgentSignal, AgentHostSessionReleaseGraceMsEnvVar, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkEndpoint, IAgentHostNetworkFetchResult, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
+import { AgentProvider, AgentSession, AgentSignal, AgentHostSessionReleaseGraceMsEnvVar, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkEndpoint, IAgentHostNetworkFetchResult, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
 import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import type { IAgentCustomizationSettingsRegistration } from '../common/agentCustomizationSettings.js';
@@ -3450,6 +3450,17 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 		}
 		return this._networkDiagnostics.getInfo(endpoints, accounts.find(account => !!account));
+	}
+
+	async getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> {
+		const providers = [...this._providers.values()].filter(provider => provider.getManagedSettingsDiagnostics);
+		return Promise.all(providers.map(async provider => {
+			try {
+				return { provider: provider.id, snapshot: await provider.getManagedSettingsDiagnostics!() };
+			} catch (error) {
+				return { provider: provider.id, error: error instanceof Error ? error.message : String(error) };
+			}
+		}));
 	}
 
 	async diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -6,6 +6,7 @@
 import { CopilotClient, RuntimeConnection, type CopilotClientOptions, type GitHubTelemetryNotification } from '@github/copilot-sdk';
 import * as fs from 'fs/promises';
 import * as os from 'os';
+import { pathToFileURL } from 'url';
 import { CancelablePromise, createCancelablePromise, Delayer, disposableTimeout, Limiter, SequencerByKey } from '../../../../base/common/async.js';
 import { type CancellationToken } from '../../../../base/common/cancellation.js';
 import { CancellationError } from '../../../../base/common/errors.js';
@@ -38,7 +39,7 @@ import { CopilotCliConfigKey, copilotCliConfigSchema, type CopilotSdkLogLevelSet
 import { AgentHostMcpServersConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AutoApproveLevel, SessionMode, migrateLegacyAutopilotConfig, platformRootSchema, platformSessionSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSessionEntry, decodeProviderData, encodeProviderData, type IPersistedChat } from '../agentPeerChats.js';
-import { AgentSession, AgentSignal, AuthenticateParams, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentLegacyChat, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentHostNetworkEndpoint, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../../common/agentService.js';
+import { AgentSession, AgentSignal, AuthenticateParams, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentLegacyChat, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentHostManagedSettingsSnapshot, IAgentHostNetworkEndpoint, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../../common/agentService.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
@@ -58,6 +59,15 @@ import { IAgentHostCompletions } from '../agentHostCompletions.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { applyMcpServerEnablement, findMcpChildId, type IMcpServerRuntimeState } from '../shared/mcpCustomizationController.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../agentHostStateManager.js';
+
+interface ICopilotRuntimeManagedSettingsSdk {
+	getManagedSettings(input?: { token?: string; host?: string }): Promise<{ account?: string; resolved: IAgentHostManagedSettingsSnapshot }>;
+}
+
+function isCopilotRuntimeManagedSettingsSdk(value: unknown): value is ICopilotRuntimeManagedSettingsSdk {
+	return typeof value === 'object' && value !== null && 'getManagedSettings' in value
+		&& typeof (value as { getManagedSettings?: unknown }).getManagedSettings === 'function';
+}
 import { IByokLmBridgeRegistry } from '../byokLmBridgeRegistry.js';
 import { SessionWorkingDirectoryMissingError } from '../shared/worktreeIsolation.js';
 import { buildSessionEventLogFromTurns } from './buildSessionEvents.js';
@@ -581,6 +591,29 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	async getNetworkDiagnosticsAccount(): Promise<string | undefined> {
 		return this._githubToken ? this._copilotApiService.resolveUserLogin?.(this._githubToken) : undefined;
+	}
+
+	async getManagedSettingsDiagnostics(): Promise<IAgentHostManagedSettingsSnapshot> {
+		const nodeModulesUri = FileAccess.asFileUri(getAppNodeModulesPath());
+		const cliPath = await resolveCopilotCliPath(nodeModulesUri);
+		const runtimeSdkPath = join(dirname(cliPath), 'sdk', 'index.js');
+		if (!await fileExists(runtimeSdkPath)) {
+			throw new Error(`Copilot runtime SDK not found at ${runtimeSdkPath}`);
+		}
+		const runtimeSdk: unknown = await import(pathToFileURL(runtimeSdkPath).href);
+		if (!isCopilotRuntimeManagedSettingsSdk(runtimeSdk)) {
+			throw new Error('Copilot runtime SDK does not expose getManagedSettings()');
+		}
+
+		const enterpriseHost = this._getEnterpriseHost();
+		const result = await runtimeSdk.getManagedSettings({
+			...(this._githubToken ? { token: this._githubToken } : {}),
+			...(enterpriseHost ? { host: enterpriseHost } : {}),
+		});
+		return {
+			...result.resolved,
+			...(result.account ? { account: result.account } : {}),
+		};
 	}
 
 	getCustomizations(): readonly Customization[] {

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -1448,6 +1448,8 @@ export class ProtocolServerHandler extends Disposable {
 				return this._agentService.shutdown();
 			case 'getNetworkDiagnosticsInfo':
 				return this._agentService.getNetworkDiagnosticsInfo();
+			case 'getManagedSettingsDiagnostics':
+				return this._agentService.getManagedSettingsDiagnostics();
 			case 'diagnosticsFetch':
 				return this._agentService.diagnosticsFetch((params as { url: string }).url);
 			default:

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -22,7 +22,7 @@ import { hasKey } from '../../../../base/common/types.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { FileService } from '../../../files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
-import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, IRestoredSubagentSession, SubagentChatSignal, type IAgent, type IAgentChatDataChange, type IAgentChats, type IAgentCreateChatForkSource, type IAgentCreateChatOptions, type IAgentCreateChatResult, type IAgentCreateSessionConfig, type IAgentCreateSessionResult, type IAgentLegacyChat, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
+import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, IConnectionTrackerService, IRestoredSubagentSession, SubagentChatSignal, type IAgent, type IAgentChatDataChange, type IAgentChats, type IAgentCreateChatForkSource, type IAgentCreateChatOptions, type IAgentCreateChatResult, type IAgentCreateSessionConfig, type IAgentCreateSessionResult, type IAgentLegacyChat, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
@@ -31,6 +31,7 @@ import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind,
 import { type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
+import { AgentHostManagementService } from '../../node/agentHostManagementService.js';
 import { MockAgent, ScriptedMockAgent } from './mockAgent.js';
 import { mapSessionEventsToHistoryRecords } from './historyRecordFixtures.js';
 import { type ISessionEvent } from './copilotTestEvents.js';
@@ -224,6 +225,32 @@ suite('AgentService (node dispatcher)', () => {
 				},
 				{ provider: 'failing', error: 'unavailable' },
 			]);
+		});
+
+		test('forwards managed-settings diagnostics through the local management service', async () => {
+			const provider: IAgent = copilotAgent;
+			provider.getManagedSettingsDiagnostics = async () => ({
+				source: 'device',
+				serverManaged: false,
+				deviceManaged: true,
+				failClosed: false,
+				bypassPermissionsDisabled: false,
+				managedKeys: ['permissions'],
+			});
+			service.registerProvider(provider);
+			const managementService = new AgentHostManagementService(service, {} as IConnectionTrackerService);
+
+			assert.deepStrictEqual(await managementService.getManagedSettingsDiagnostics(), [{
+				provider: 'copilot',
+				snapshot: {
+					source: 'device',
+					serverManaged: false,
+					deviceManaged: true,
+					failClosed: false,
+					bypassPermissionsDisabled: false,
+					managedKeys: ['permissions'],
+				},
+			}]);
 		});
 
 		test('maps progress events to protocol actions via onDidAction', async () => {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -186,6 +186,46 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('aggregates managed-settings diagnostics from capable providers', async () => {
+			const provider: IAgent = copilotAgent;
+			provider.getManagedSettingsDiagnostics = async () => ({
+				source: 'device',
+				serverManaged: false,
+				deviceManaged: true,
+				failClosed: false,
+				bypassPermissionsDisabled: false,
+				managedKeys: ['permissions'],
+				settings: { permissions: { allow: ['Shell(echo *)'] } },
+			});
+			const unsupportedProvider = new MockAgent('other');
+			disposables.add(toDisposable(() => unsupportedProvider.dispose()));
+			const failingProvider = new MockAgent('failing');
+			disposables.add(toDisposable(() => failingProvider.dispose()));
+			const failingProviderContract: IAgent = failingProvider;
+			failingProviderContract.getManagedSettingsDiagnostics = async () => { throw new Error('unavailable'); };
+			service.registerProvider(provider);
+			service.registerProvider(unsupportedProvider);
+			service.registerProvider(failingProvider);
+
+			const diagnostics = await service.getManagedSettingsDiagnostics();
+
+			assert.deepStrictEqual(diagnostics, [
+				{
+					provider: 'copilot',
+					snapshot: {
+						source: 'device',
+						serverManaged: false,
+						deviceManaged: true,
+						failClosed: false,
+						bypassPermissionsDisabled: false,
+						managedKeys: ['permissions'],
+						settings: { permissions: { allow: ['Shell(echo *)'] } },
+					},
+				},
+				{ provider: 'failing', error: 'unavailable' },
+			]);
+		});
+
 		test('maps progress events to protocol actions via onDidAction', async () => {
 			service.registerProvider(copilotAgent);
 			const session = await service.createSession({ provider: 'copilot' });

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -11,7 +11,7 @@ import { runWithFakedTimers } from '../../../../base/test/common/timeTravelSched
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { FileType } from '../../../files/common/files.js';
-import { type IAgentCreateSessionConfig, type IAgentHostNetworkDiagnosticsInfo, type IAgentHostNetworkFetchResult, type IAgentResolveSessionConfigParams, type IAgentService, type IAgentSessionConfigCompletionsParams, type IAgentSessionMetadata, type AuthenticateParams, type AuthenticateResult } from '../../common/agentService.js';
+import { type IAgentCreateSessionConfig, type IAgentHostManagedSettingsDiagnostics, type IAgentHostNetworkDiagnosticsInfo, type IAgentHostNetworkFetchResult, type IAgentResolveSessionConfigParams, type IAgentService, type IAgentSessionConfigCompletionsParams, type IAgentSessionMetadata, type AuthenticateParams, type AuthenticateResult } from '../../common/agentService.js';
 import { CompletionsParams, CompletionsResult, ContentEncoding, ListSessionsResult, ResourceReadResult, ResolveSessionConfigResult, SessionConfigCompletionsResult, ResourceMkdirParams, ResourceMkdirResult, ResourceResolveParams, ResourceResolveResult, ResourceCopyParams, ResourceCopyResult } from '../../common/state/protocol/commands.js';
 import { ActionType, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type ClientAnnotationsAction, type ProgressParams } from '../../common/state/sessionActions.js';
 import { PROTOCOL_VERSION } from '../../common/state/protocol/version/registry.js';
@@ -88,6 +88,7 @@ class MockAgentService implements IAgentService {
 	readonly readErrors = new Map<string, Error>();
 	readonly listedSessions: IAgentSessionMetadata[] = [];
 	readonly createSessionConfigs: (IAgentCreateSessionConfig | undefined)[] = [];
+	managedSettingsDiagnostics: readonly IAgentHostManagedSettingsDiagnostics[] = [];
 	shutdownCalls = 0;
 
 	private readonly _onDidAction = new Emitter<import('../../common/state/sessionActions.js').ActionEnvelope>();
@@ -152,6 +153,7 @@ class MockAgentService implements IAgentService {
 	unsubscribe(_resource: URI, _clientId: string): void { }
 	async shutdown(): Promise<void> { this.shutdownCalls++; }
 	async getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> { return { version: 'test', os: 'test', arch: 'test', proxySettings: {}, proxyEnv: {}, endpoints: [] }; }
+	async getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> { return this.managedSettingsDiagnostics; }
 	async diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> { return { url }; }
 	async authenticate(_params: AuthenticateParams): Promise<AuthenticateResult> { return { authenticated: true }; }
 	getAuthToken(): string | undefined { return undefined; }
@@ -1858,6 +1860,30 @@ suite('ProtocolServerHandler', () => {
 
 		assert.ok(!resp.error, `unexpected error: ${resp.error?.message}`);
 		assert.deepStrictEqual(resp.result, {});
+	});
+
+	test('getManagedSettingsDiagnostics returns provider SDK snapshots', async () => {
+		agentService.managedSettingsDiagnostics = [{
+			provider: 'copilot',
+			snapshot: {
+				source: 'device',
+				serverManaged: false,
+				deviceManaged: true,
+				failClosed: false,
+				bypassPermissionsDisabled: false,
+				managedKeys: ['permissions'],
+				settings: { permissions: { allow: ['Shell(echo *)'] } },
+			},
+		}];
+		const transport = connectClient('client-managed-settings');
+		transport.sent.length = 0;
+
+		const responsePromise = waitForResponse(transport, 2);
+		transport.simulateMessage(request(2, 'getManagedSettingsDiagnostics'));
+		const response = await responsePromise as { result?: unknown; error?: { message: string } };
+
+		assert.ok(!response.error, `unexpected error: ${response.error?.message}`);
+		assert.deepStrictEqual(response.result, agentService.managedSettingsDiagnostics);
 	});
 
 	test('extension request preserves ProtocolError code and data', async () => {

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -14,6 +14,8 @@ import { PolicyDefinition } from './policy.js';
 
 export type { ManagedSettingsData } from '../../../base/common/policy.js';
 
+export type RawManagedSettingsData = Readonly<Record<string, unknown>>;
+
 /** Windows registry root for GitHub Copilot policies. */
 export const GITHUB_COPILOT_WIN32_REGISTRY_PATH = 'SOFTWARE\\Policies\\GitHubCopilot';
 
@@ -578,12 +580,16 @@ export const IFileManagedSettingsService = createDecorator<IFileManagedSettingsS
 
 export interface IFileManagedSettingsService {
 	readonly _serviceBrand: undefined;
+	readonly rawManagedSettings: RawManagedSettingsData;
 	readonly managedSettings: ManagedSettingsData;
+	readonly onDidChangeRawManagedSettings: Event<RawManagedSettingsData>;
 	readonly onDidChangeManagedSettings: Event<ManagedSettingsData>;
 }
 
 export class NullFileManagedSettingsService implements IFileManagedSettingsService {
 	readonly _serviceBrand: undefined;
+	readonly rawManagedSettings: RawManagedSettingsData = {};
 	readonly managedSettings: ManagedSettingsData = {};
+	readonly onDidChangeRawManagedSettings = Event.None;
 	readonly onDidChangeManagedSettings = Event.None;
 }

--- a/src/vs/platform/policy/common/fileManagedSettingsIpc.ts
+++ b/src/vs/platform/policy/common/fileManagedSettingsIpc.ts
@@ -8,7 +8,7 @@ import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { equals } from '../../../base/common/objects.js';
 import { ManagedSettingsData } from '../../../base/common/policy.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
-import { IFileManagedSettingsService } from './copilotManagedSettings.js';
+import { IFileManagedSettingsService, RawManagedSettingsData } from './copilotManagedSettings.js';
 
 export class FileManagedSettingsChannel implements IServerChannel {
 
@@ -18,6 +18,7 @@ export class FileManagedSettingsChannel implements IServerChannel {
 
 	listen<T>(_: unknown, event: string): Event<T> {
 		switch (event) {
+			case 'onDidChangeRawManagedSettings': return this.service.onDidChangeRawManagedSettings as Event<T>;
 			case 'onDidChangeManagedSettings': return this.service.onDidChangeManagedSettings as Event<T>;
 		}
 
@@ -26,6 +27,7 @@ export class FileManagedSettingsChannel implements IServerChannel {
 
 	call<T>(_: unknown, command: string): Promise<T> {
 		switch (command) {
+			case 'getRawManagedSettings': return Promise.resolve(this.service.rawManagedSettings as T);
 			case 'getManagedSettings': return Promise.resolve(this.service.managedSettings as T);
 		}
 
@@ -41,21 +43,46 @@ export class FileManagedSettingsChannelClient extends Disposable implements IFil
 
 	readonly _serviceBrand: undefined;
 
+	private _rawManagedSettings: RawManagedSettingsData = {};
+	get rawManagedSettings(): RawManagedSettingsData { return this._rawManagedSettings; }
+	private hasReceivedRawManagedSettings = false;
+
 	private _managedSettings: ManagedSettingsData = {};
 	get managedSettings(): ManagedSettingsData { return this._managedSettings; }
 	private hasReceivedManagedSettings = false;
+
+	private readonly _onDidChangeRawManagedSettings = this._register(new Emitter<RawManagedSettingsData>());
+	readonly onDidChangeRawManagedSettings = this._onDidChangeRawManagedSettings.event;
 
 	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
 	readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
 
 	constructor(channel: IChannel) {
 		super();
+		this._register(channel.listen<RawManagedSettingsData>('onDidChangeRawManagedSettings')(managedSettings => this.updateRawManagedSettings(managedSettings, true)));
 		this._register(channel.listen<ManagedSettingsData>('onDidChangeManagedSettings')(managedSettings => this.updateManagedSettings(managedSettings, true)));
+		channel.call<RawManagedSettingsData>('getRawManagedSettings').then(managedSettings => {
+			if (!this.hasReceivedRawManagedSettings) {
+				this.updateRawManagedSettings(managedSettings, true);
+			}
+		});
 		channel.call<ManagedSettingsData>('getManagedSettings').then(managedSettings => {
 			if (!this.hasReceivedManagedSettings) {
 				this.updateManagedSettings(managedSettings, true);
 			}
 		});
+	}
+
+	private updateRawManagedSettings(managedSettings: RawManagedSettingsData, fireEvent: boolean): void {
+		this.hasReceivedRawManagedSettings = true;
+		if (equals(this._rawManagedSettings, managedSettings)) {
+			return;
+		}
+
+		this._rawManagedSettings = managedSettings;
+		if (fireEvent) {
+			this._onDidChangeRawManagedSettings.fire(this._rawManagedSettings);
+		}
 	}
 
 	private updateManagedSettings(managedSettings: ManagedSettingsData, fireEvent: boolean): void {

--- a/src/vs/platform/policy/common/fileManagedSettingsService.ts
+++ b/src/vs/platform/policy/common/fileManagedSettingsService.ts
@@ -12,7 +12,7 @@ import { isObject } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { FileOperationError, FileOperationResult, IFileService } from '../../files/common/files.js';
 import { ILogService } from '../../log/common/log.js';
-import { IFileManagedSettingsService, normalizeManagedSettings } from './copilotManagedSettings.js';
+import { IFileManagedSettingsService, normalizeManagedSettings, RawManagedSettingsData } from './copilotManagedSettings.js';
 
 /**
  * Upper bound on the size of `managed-settings.json` we will read into the main process. A
@@ -26,8 +26,14 @@ export class FileManagedSettingsService extends Disposable implements IFileManag
 
 	readonly _serviceBrand: undefined;
 
+	private _rawManagedSettings: RawManagedSettingsData = {};
+	get rawManagedSettings(): RawManagedSettingsData { return this._rawManagedSettings; }
+
 	private _managedSettings: ManagedSettingsData = {};
 	get managedSettings(): ManagedSettingsData { return this._managedSettings; }
+
+	private readonly _onDidChangeRawManagedSettings = this._register(new Emitter<RawManagedSettingsData>());
+	readonly onDidChangeRawManagedSettings = this._onDidChangeRawManagedSettings.event;
 
 	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
 	readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
@@ -52,6 +58,7 @@ export class FileManagedSettingsService extends Disposable implements IFileManag
 	}
 
 	private async refresh(): Promise<void> {
+		const previousRaw = this._rawManagedSettings;
 		const previous = this._managedSettings;
 
 		try {
@@ -59,19 +66,25 @@ export class FileManagedSettingsService extends Disposable implements IFileManag
 			const parsed = JSON.parse(content.value.toString());
 
 			if (isObject(parsed)) {
+				this._rawManagedSettings = parsed as Record<string, unknown>;
 				this._managedSettings = normalizeManagedSettings(parsed as Record<string, unknown>,
 					msg => this.logService.warn(`[FileManagedSettingsService] ${msg}`));
 			} else {
 				this.logService.warn('[FileManagedSettingsService] managed-settings.json is not a JSON object');
+				this._rawManagedSettings = {};
 				this._managedSettings = {};
 			}
 		} catch (error) {
 			if ((<FileOperationError>error).fileOperationResult !== FileOperationResult.FILE_NOT_FOUND) {
 				this.logService.error('[FileManagedSettingsService] Failed to read managed-settings.json', error);
 			}
+			this._rawManagedSettings = {};
 			this._managedSettings = {};
 		}
 
+		if (!equals(previousRaw, this._rawManagedSettings)) {
+			this._onDidChangeRawManagedSettings.fire(this._rawManagedSettings);
+		}
 		if (!equals(previous, this._managedSettings)) {
 			this._onDidChangeManagedSettings.fire(this._managedSettings);
 		}

--- a/src/vs/platform/policy/test/common/fileManagedSettingsService.test.ts
+++ b/src/vs/platform/policy/test/common/fileManagedSettingsService.test.ts
@@ -15,7 +15,7 @@ import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesy
 import { NullLogService } from '../../../log/common/log.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
-import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, managedModelValue, normalizeManagedSettings } from '../../common/copilotManagedSettings.js';
+import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, managedModelValue, normalizeManagedSettings, RawManagedSettingsData } from '../../common/copilotManagedSettings.js';
 import { FileManagedSettingsService } from '../../common/fileManagedSettingsService.js';
 import { FileManagedSettingsChannelClient } from '../../common/fileManagedSettingsIpc.js';
 
@@ -142,6 +142,30 @@ suite('FileManagedSettingsService', () => {
 		assert.deepStrictEqual(service.managedSettings, {
 			'permissions.disableBypassPermissionsMode': 'disable',
 			'strictKnownMarketplaces': '["github/foo"]'
+		});
+	}));
+
+	test('retains raw settings that are absent from the normalized bag', () => runWithFakedTimers({}, async () => {
+		const logService = new NullLogService();
+		const fileService = disposables.add(new FileService(logService));
+		const inMemoryProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider('vscode-tests', inMemoryProvider));
+
+		const raw = {
+			permissions: {
+				deny: ['Shell(echo denied *)'],
+				ask: ['Shell(echo ask *)'],
+				allow: ['Shell(echo *)'],
+			}
+		};
+		await fileService.writeFile(managedSettingsFile, VSBuffer.fromString(JSON.stringify(raw)));
+
+		const service = disposables.add(new FileManagedSettingsService(managedSettingsFile, fileService, logService));
+		await Event.toPromise(service.onDidChangeRawManagedSettings);
+
+		assert.deepStrictEqual({ raw: service.rawManagedSettings, normalized: service.managedSettings }, {
+			raw,
+			normalized: {},
 		});
 	}));
 
@@ -279,21 +303,30 @@ suite('FileManagedSettingsChannelClient', () => {
 
 		// A change event arrives before the initial getManagedSettings call resolves; the later,
 		// stale snapshot must not clobber the newer event-delivered state.
+		channel.fireRaw({ permissions: { allow: ['Shell(echo *)'] } });
 		channel.fire({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' });
+		channel.resolveInitialRawSnapshot({ permissions: { deny: ['Shell(echo *)'] } });
 		channel.resolveInitialSnapshot({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'enable' });
-		await channel.initialSnapshot;
+		await Promise.all([channel.initialRawSnapshot, channel.initialSnapshot]);
 
-		assert.deepStrictEqual(client.managedSettings, { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' });
+		assert.deepStrictEqual({ raw: client.rawManagedSettings, normalized: client.managedSettings }, {
+			raw: { permissions: { allow: ['Shell(echo *)'] } },
+			normalized: { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' },
+		});
 	});
 });
 
 class DeferredManagedSettingsChannel extends Disposable implements IChannel {
+	private readonly _onDidChangeRawManagedSettings = this._register(new Emitter<RawManagedSettingsData>());
 	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
+	private resolveInitialRawSnapshotPromise!: (managedSettings: RawManagedSettingsData) => void;
+	readonly initialRawSnapshot = new Promise<RawManagedSettingsData>(resolve => this.resolveInitialRawSnapshotPromise = resolve);
 	private resolveInitialSnapshotPromise!: (managedSettings: ManagedSettingsData) => void;
 	readonly initialSnapshot = new Promise<ManagedSettingsData>(resolve => this.resolveInitialSnapshotPromise = resolve);
 
 	call<T>(command: string): Promise<T> {
 		switch (command) {
+			case 'getRawManagedSettings': return this.initialRawSnapshot as Promise<T>;
 			case 'getManagedSettings': return this.initialSnapshot as Promise<T>;
 		}
 
@@ -301,8 +334,16 @@ class DeferredManagedSettingsChannel extends Disposable implements IChannel {
 	}
 
 	listen<T>(event: string): Event<T> {
-		assert.strictEqual(event, 'onDidChangeManagedSettings');
-		return this._onDidChangeManagedSettings.event as Event<T>;
+		switch (event) {
+			case 'onDidChangeRawManagedSettings': return this._onDidChangeRawManagedSettings.event as Event<T>;
+			case 'onDidChangeManagedSettings': return this._onDidChangeManagedSettings.event as Event<T>;
+		}
+
+		throw new Error(`Event not found: ${event}`);
+	}
+
+	fireRaw(managedSettings: RawManagedSettingsData): void {
+		this._onDidChangeRawManagedSettings.fire(managedSettings);
 	}
 
 	fire(managedSettings: ManagedSettingsData): void {
@@ -311,5 +352,9 @@ class DeferredManagedSettingsChannel extends Disposable implements IChannel {
 
 	resolveInitialSnapshot(managedSettings: ManagedSettingsData): void {
 		this.resolveInitialSnapshotPromise(managedSettings);
+	}
+
+	resolveInitialRawSnapshot(managedSettings: RawManagedSettingsData): void {
+		this.resolveInitialRawSnapshotPromise(managedSettings);
 	}
 }

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -46,13 +46,15 @@ import { IDefaultAccountService } from '../../../platform/defaultAccount/common/
 import { IAuthenticationService } from '../../services/authentication/common/authentication.js';
 import { IAuthenticationAccessService } from '../../services/authentication/browser/authenticationAccessService.js';
 import { IPolicyService } from '../../../platform/policy/common/policy.js';
-import { COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY, INativeManagedSettingsService, IFileManagedSettingsService, IManagedSettingResolution, MANAGED_SETTINGS_CHANNELS, ManagedSettingsChannel, ManagedSettingsSource, projectManagedSettings, pickManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY, INativeManagedSettingsService, IFileManagedSettingsService, IManagedSettingResolution, MANAGED_SETTINGS_CHANNELS, ManagedSettingsChannel, ManagedSettingsSource, normalizeManagedSettings, projectManagedSettings, pickManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
 import { IManagedSettingPolicyDefinition, ManagedSettingValue, ManagedSettingsData } from '../../../base/common/policy.js';
 import { APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateService } from '../../services/policies/common/accountPolicyService.js';
 import { adaptManagedSettings, IManagedSettingsResponse } from '../../services/accounts/browser/managedSettings.js';
 import { isObject } from '../../../base/common/types.js';
 import * as json from '../../../base/common/json.js';
 import { getParseErrorMessage } from '../../../base/common/jsonErrorMessages.js';
+import { IAgentHostService } from '../../../platform/agentHost/common/agentService.js';
+import { IAgentHostEnablementService } from '../../../platform/agentHost/common/agentHostEnablementService.js';
 
 class InspectContextKeysAction extends Action2 {
 
@@ -696,6 +698,16 @@ function jsonBlock(value: unknown): string {
 	return '```json\n' + JSON.stringify(value ?? {}, null, 2) + '\n```\n\n';
 }
 
+function managedSettingsPipeline(rawLabel: string, raw: unknown | undefined, normalized: ManagedSettingsData, projected: ManagedSettingsData, rawUnavailableMessage?: string): string {
+	let content = `**${rawLabel}**\n\n`;
+	content += raw === undefined ? `*${rawUnavailableMessage ?? 'Unavailable'}*\n\n` : jsonBlock(raw);
+	content += '**Normalized bag**\n\n';
+	content += jsonBlock(normalized);
+	content += '**VS Code policy projection**\n\n';
+	content += jsonBlock(projected);
+	return content;
+}
+
 /** Render a managed-settings value for a Markdown table cell: compact JSON with pipes escaped, or a dash when absent. */
 function managedValueCell(value: ManagedSettingValue | undefined): string {
 	if (value === undefined) {
@@ -727,6 +739,8 @@ class PolicyDiagnosticsAction extends Action2 {
 		const authenticationAccessService = accessor.get(IAuthenticationAccessService);
 		const policyService = accessor.get(IPolicyService);
 		const accountPolicyGateService = accessor.get(IAccountPolicyGateService);
+		const agentHostService = accessor.get(IAgentHostService);
+		const agentHostEnablementService = accessor.get(IAgentHostEnablementService);
 		// Native MDM is a desktop-only channel, registered in the renderer service collection on
 		// desktop and Agents windows but absent in web. Resolve it now, synchronously, because the
 		// accessor is only valid before the first `await` below.
@@ -844,10 +858,19 @@ class PolicyDiagnosticsAction extends Action2 {
 		const activeManagedSettingSources = new Map<string, ManagedSettingsChannel>();
 		try {
 			const policyData = defaultAccountService.policyData;
-			const serverManagedSettings = policyData?.managedSettings;
+			const serverManagedSettings = policyData?.managedSettings ?? {};
 
-			const nativeManagedSettings: ManagedSettingsData | undefined = nativeManagedSettingsService?.managedSettings;
-			const fileManagedSettings: ManagedSettingsData | undefined = fileManagedSettingsService?.managedSettings;
+			const nativeManagedSettings = nativeManagedSettingsService?.managedSettings ?? {};
+			const fileManagedSettings = fileManagedSettingsService?.managedSettings ?? {};
+			const fileRawManagedSettings = fileManagedSettingsService?.rawManagedSettings;
+
+			const declaredDefinitions: Record<string, IManagedSettingPolicyDefinition> = {};
+			for (const property of [...Object.values(configurationRegistry.getConfigurationProperties()), ...Object.values(configurationRegistry.getExcludedConfigurationProperties())]) {
+				const declared = property.policy?.managedSettings;
+				if (declared) {
+					Object.assign(declaredDefinitions, declared);
+				}
+			}
 
 			// Reuse the exact per-key resolution that policy evaluation applies so this report can
 			// never drift from what AccountPolicyService actually enforces.
@@ -860,9 +883,22 @@ class PolicyDiagnosticsAction extends Action2 {
 			// (adapt, projection, JSON payload) so the report explains *why* a key was dropped.
 			// jsonc-style: accumulate every error instead of failing on the first.
 			const parseErrors: { stage: string; message: string }[] = [];
+			const projectChannel = (channel: ManagedSettingsChannel, values: ManagedSettingsData): ManagedSettingsData => projectManagedSettings(
+				values,
+				declaredDefinitions,
+				message => parseErrors.push({ stage: `${channel}: project`, message })
+			);
 
 			// Whether a channel supplied at least one *winning* key in the per-key resolution.
 			const channelContributes = (channel: ManagedSettingsChannel) => pick.activeSources.includes(channel);
+			const nativeProjected = projectChannel('nativeMdm', nativeManagedSettings);
+			const serverProjected = projectChannel('server', serverManagedSettings);
+			const fileProjected = projectChannel('file', fileManagedSettings);
+			const effective = projectManagedSettings(pick.values, declaredDefinitions, message => parseErrors.push({ stage: 'effective: project', message }));
+
+			content += '### VS Code Managed-Settings Schema\n\n';
+			content += '*Only keys declared here can reach VS Code policy callbacks. Runtime-owned keys may still be enforced by the Copilot runtime even when absent from the projections below.*\n\n';
+			content += jsonBlock(declaredDefinitions);
 
 			// Sections are listed in precedence order (highest first): native MDM wins over the
 			// server endpoint, which in turn wins over the file on disk.
@@ -871,7 +907,8 @@ class PolicyDiagnosticsAction extends Action2 {
 			content += `| Available | ${nativeManagedSettingsService ? 'yes' : 'no'} |\n`;
 			content += `| Contributes winning keys | ${channelContributes('nativeMdm') ? 'yes' : 'no'} |\n\n`;
 			if (nativeManagedSettingsService) {
-				content += jsonBlock(nativeManagedSettings);
+				content += '*The native policy watcher exposes only declared scalar keys, so its source values are already definition-scoped and canonical.*\n\n';
+				content += managedSettingsPipeline('Source values (definition-scoped)', nativeManagedSettings, nativeManagedSettings, nativeProjected);
 			}
 
 			content += '### GitHub Server API\n\n';
@@ -886,24 +923,34 @@ class PolicyDiagnosticsAction extends Action2 {
 			const rawResponse = defaultAccountService.managedSettingsRawResponse;
 			if (isObject(rawResponse)) {
 				adaptManagedSettings(rawResponse as IManagedSettingsResponse, message => parseErrors.push({ stage: 'adapt', message }));
-				content += '**Raw response** (last successful fetch)\n\n';
-				content += jsonBlock(rawResponse);
 			}
-
-			content += '**Normalized bag**\n\n';
-			content += jsonBlock(serverManagedSettings);
+			content += managedSettingsPipeline(
+				'Raw response (last successful fetch)',
+				isObject(rawResponse) ? rawResponse : undefined,
+				serverManagedSettings,
+				serverProjected,
+				'No successful managed-settings response has been captured.'
+			);
 
 			content += '### File (managed-settings.json)\n\n';
 			content += PROPERTY_VALUE_TABLE_HEADER;
 			content += `| Available | ${fileManagedSettingsService ? 'yes' : 'no'} |\n`;
 			content += `| Contributes winning keys | ${channelContributes('file') ? 'yes' : 'no'} |\n\n`;
 			if (fileManagedSettingsService) {
-				content += jsonBlock(fileManagedSettings);
+				if (fileRawManagedSettings) {
+					normalizeManagedSettings(fileRawManagedSettings, message => parseErrors.push({ stage: 'file: normalize', message }));
+				}
+				content += managedSettingsPipeline('Raw parsed file', fileRawManagedSettings, fileManagedSettings, fileProjected);
 			}
 
 			// Per-key resolution: what each channel supplied, which won, and (struck through) which
 			// were overridden — the authoritative "what came from where, what's effective, and why".
-			content += '### Resolution (per key)\n\n';
+			content += '### Effective Resolution\n\n';
+			content += '**Merged normalized bag**\n\n';
+			content += jsonBlock(pick.values);
+			content += '**Effective VS Code policy bag**\n\n';
+			content += jsonBlock(effective);
+			content += '**Per-key precedence**\n\n';
 			if (pick.resolutions.size > 0) {
 				content += '| Key | Effective | Winning Source | Native MDM | Server | File |\n';
 				content += '|-----|-----------|----------------|------------|--------|------|\n';
@@ -926,16 +973,28 @@ class PolicyDiagnosticsAction extends Action2 {
 				content += '*No managed-settings keys are supplied by any channel.*\n\n';
 			}
 
-			// Mirror AccountPolicyService: project the merged bag onto the keys declared by policies
-			// so the report shows exactly what reaches `policy.value(...)`.
-			const declaredDefinitions: Record<string, IManagedSettingPolicyDefinition> = {};
-			for (const property of [...Object.values(configurationRegistry.getConfigurationProperties()), ...Object.values(configurationRegistry.getExcludedConfigurationProperties())]) {
-				const declared = property.policy?.managedSettings;
-				if (declared) {
-					Object.assign(declaredDefinitions, declared);
+			content += '### Agent Runtime Resolution\n\n';
+			content += '*Resolved independently by each provider through its own SDK/runtime. This may include runtime-owned keys that VS Code does not declare as configuration policies.*\n\n';
+			if (!agentHostEnablementService.enabled) {
+				content += '*Agent Host is disabled; runtime managed-settings diagnostics were not queried.*\n\n';
+			} else {
+				try {
+					const runtimeDiagnostics = await agentHostService.getManagedSettingsDiagnostics();
+					if (runtimeDiagnostics.length === 0) {
+						content += '*No agent provider exposes managed-settings diagnostics.*\n\n';
+					}
+					for (const diagnostic of runtimeDiagnostics) {
+						content += `#### ${diagnostic.provider}\n\n`;
+						if (diagnostic.error) {
+							content += `*Probe failed: ${diagnostic.error}*\n\n`;
+						} else {
+							content += jsonBlock(diagnostic.snapshot);
+						}
+					}
+				} catch (error) {
+					content += `*Agent runtime diagnostics unavailable: ${error}*\n\n`;
 				}
 			}
-			const effective = projectManagedSettings(pick.values, declaredDefinitions, message => parseErrors.push({ stage: 'project', message }));
 
 			// Remember which managed-settings keys actually reached policy evaluation, and from which
 			// channel won each, so the Policy-Controlled Settings table can attribute them accurately.
@@ -961,10 +1020,7 @@ class PolicyDiagnosticsAction extends Action2 {
 				}
 			}
 
-			content += '### Effective\n\n';
-			content += jsonBlock(effective);
-
-			content += `### Parse Errors (${parseErrors.length})\n\n`;
+			content += `### Normalization and Parse Issues (${parseErrors.length})\n\n`;
 			if (parseErrors.length > 0) {
 				content += '| Stage | Message |\n';
 				content += '|-------|---------|\n';
@@ -972,6 +1028,8 @@ class PolicyDiagnosticsAction extends Action2 {
 					content += `| ${stage} | ${message.replace(/\|/g, '\\|')} |\n`;
 				}
 				content += '\n';
+			} else {
+				content += '*None.*\n\n';
 			}
 		} catch (error) {
 			content += `*Error rendering managed settings diagnostics: ${error}*\n\n`;

--- a/src/vs/workbench/contrib/terminal/test/browser/agentHostPty.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/agentHostPty.test.ts
@@ -9,7 +9,7 @@ import { DisposableStore, IReference } from '../../../../../base/common/lifecycl
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { constObservable, IObservable } from '../../../../../base/common/observable.js';
-import { IAgentConnection, IAgentCreateSessionConfig, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult } from '../../../../../platform/agentHost/common/agentService.js';
+import { IAgentConnection, IAgentCreateSessionConfig, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult } from '../../../../../platform/agentHost/common/agentService.js';
 import { ActionType, StateAction } from '../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { RootState, TerminalClaimKind, type TerminalState } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
@@ -74,6 +74,7 @@ class MockAgentConnection implements IAgentConnection {
 	// ---- Unused IAgentService methods (stubs) -----
 	async authenticate(_params: AuthenticateParams): Promise<AuthenticateResult> { return { authenticated: true }; }
 	async getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> { return { version: 'test', os: 'test', arch: 'test', proxySettings: {}, proxyEnv: {}, endpoints: [] }; }
+	async getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> { return []; }
 	async diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> { return { url }; }
 	async listSessions(): Promise<IAgentSessionMetadata[]> { return []; }
 	async createSession(_config?: IAgentCreateSessionConfig): Promise<URI> { return URI.parse('copilot:///test'); }

--- a/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
+++ b/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
@@ -15,7 +15,7 @@ import { IObservable, ISettableObservable, observableValue, constObservable } fr
 import { URI } from '../../../../base/common/uri.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { AgentHostIpcChannels, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentHostService, IAgentHostSocketInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../../../../platform/agentHost/common/agentService.js';
+import { AgentHostIpcChannels, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentHostService, IAgentHostSocketInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../../../../platform/agentHost/common/agentService.js';
 import { IAgentHostEnablementService } from '../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { AgentHostIpcChannelTransport } from '../../../../platform/agentHost/browser/agentHostIpcChannelTransport.js';
 import { RemoteAgentHostProtocolClient } from '../../../../platform/agentHost/browser/remoteAgentHostProtocolClient.js';
@@ -200,6 +200,10 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 
 	getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> {
 		return this._requireClient().getNetworkDiagnosticsInfo();
+	}
+
+	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> {
+		return this._requireClient().getManagedSettingsDiagnostics();
 	}
 
 	diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> {

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -501,6 +501,8 @@ suite('AccountPolicyService', () => {
 
 	class FakeFileManagedSettingsService implements IFileManagedSettingsService {
 		readonly _serviceBrand: undefined;
+		readonly rawManagedSettings = {};
+		readonly onDidChangeRawManagedSettings = Event.None;
 		private readonly _onDidChangeManagedSettings = new Emitter<ManagedSettingsData>();
 		readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
 


### PR DESCRIPTION
## Summary

- show raw input, normalized values, and VS Code policy projection for each managed-settings channel
- preserve raw file-based managed settings through IPC so runtime-owned keys remain diagnosable
- include the Copilot runtime's independently resolved managed-settings snapshot through Agent Host/AHP
- document the diagnostics pipeline and guard the runtime SDK packaging dependency

## Testing

- `npm run typecheck-client`
- `npm run valid-layers-check`
- `cd build && npm run typecheck`
- focused managed-settings and AHP unit tests (4 passing)
- Copilot packaging tests (10 passing)
- hygiene and `git diff --check`
- live OSS `Developer: Policy Diagnostics` validation with file-based deny/ask/allow rules