### PR TITLE
Make dictation enterprise managed

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -915,6 +915,21 @@
             "type": "boolean",
             "default": true,
             "included": true
+        },
+        {
+            "key": "dictation.enabled",
+            "name": "DictationEnabled",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.131",
+            "localization": {
+                "description": {
+                    "key": "dictation.enabled.policy",
+                    "value": "Controls whether dictation is available across the product (chat input, editor, and terminal)."
+                }
+            },
+            "type": "boolean",
+            "default": true,
+            "included": true
         }
     ]
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -260,8 +260,19 @@ configurationRegistry.registerConfiguration({
 		'dictation.enabled': {
 			type: 'boolean',
 			markdownDescription: nls.localize('dictation.enabled', "Enables dictation across the product (chat input, editor, and terminal). When enabled on a supported platform, a microphone button appears in the chat input and the dictation shortcut becomes available; the on-device transcription model is downloaded on first use and runs locally."),
-			default: product.quality !== 'stable',
-			tags: ['experimental']
+			default: true,
+			tags: ['experimental'],
+			policy: {
+				name: 'DictationEnabled',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.131',
+				localization: {
+					description: {
+						key: 'dictation.enabled.policy',
+						value: nls.localize('dictation.enabled.policy', "Controls whether dictation is available across the product (chat input, editor, and terminal).")
+					}
+				},
+			}
 		},
 		'dictation.model': {
 			type: 'string',


### PR DESCRIPTION
Adds an enterprise policy for `dictation.enabled` so administrators can disable dictation across chat, editors, and terminals.

Keeps dictation enabled by default.