### PR TITLE
Voice: include response errors in narration

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -5434,7 +5434,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return { state: 'thinking' };
 		}
 
-		const responseText = lastRequest?.response?.response.getMarkdown().trim() ?? '';
+		const responseText = [
+			lastRequest?.response?.response.getMarkdown().trim(),
+			lastRequest?.response?.result?.errorDetails?.message.trim(),
+		].filter(value => !!value).join('\n\n');
 		return { state: 'idle', ...(responseText ? { last_response_summary: responseText } : {}) };
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -244,6 +244,21 @@ function pendingConfirmationModel(resource: URI): IChatModel {
 	} as unknown as IChatModel;
 }
 
+function completedResponseModel(markdown: string, errorMessage?: string): IChatModel {
+	const response = {
+		isPendingConfirmation: observableValue('pending', undefined),
+		isIncomplete: observableValue('incomplete', false),
+		response: {
+			value: [],
+			getMarkdown: () => markdown,
+		},
+		result: errorMessage ? { errorDetails: { message: errorMessage } } : undefined,
+	};
+	return {
+		getRequests: () => [{ response }],
+	} as unknown as IChatModel;
+}
+
 class TestChatWidgetService extends mock<IChatWidgetService>() {
 	override readonly onDidChangeFocusedSession = Event.None;
 	override readonly onDidAddWidget = Event.None;
@@ -330,6 +345,21 @@ suite('VoiceSessionController', () => {
 			new class extends mock<INotificationService>() { }(),
 		));
 	}
+
+	test('includes response errors in the summary sent to the voice backend', () => {
+		const controller = createController(new TestVoiceClientService());
+		const getAgentStateInfo = Reflect.get(controller, '_getAgentStateInfo') as (model: IChatModel) => { state: string; last_response_summary?: string };
+
+		assert.deepStrictEqual([
+			getAgentStateInfo.call(controller, completedResponseModel('', 'The branch main was not found.')),
+			getAgentStateInfo.call(controller, completedResponseModel('I could not rebase the branch.', 'The branch main was not found.')),
+			getAgentStateInfo.call(controller, completedResponseModel('The rebase completed.')),
+		], [
+			{ state: 'idle', last_response_summary: 'The branch main was not found.' },
+			{ state: 'idle', last_response_summary: 'I could not rebase the branch.\n\nThe branch main was not found.' },
+			{ state: 'idle', last_response_summary: 'The rebase completed.' },
+		]);
+	});
 
 	test('explicit disconnect clears routing target and pending confirmations and the tracker cannot repopulate them before reconnect', () => {
 		const voiceClientService = new TestVoiceClientService();


### PR DESCRIPTION
## Summary

- include chat response error details in the session summary sent to the Voice Mode backend
- preserve response markdown and append the error when both are present
- add regression coverage for error-only, mixed, and successful responses

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8518

## Validation

- pre-commit hygiene checks passed
- type-check and unit tests not run per request