### PR TITLE
Make chat.agentHost.byokModels.enabled experiment-controllable

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -120,6 +120,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.byokModels.enabled', "When enabled, the agent host wires up the BYOK ('bring your own key') language-model bridge so extension-provided BYOK models can run in agent-host sessions. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
 			default: true,
 			tags: ['experimental', 'advanced'],
+			experiment: { mode: 'startup' },
 		},
 		[AgentHostCodexAgentEnabledSettingId]: {
 			type: 'boolean',


### PR DESCRIPTION
Opts the `chat.agentHost.byokModels.enabled` setting into ExP via `experiment: { mode: 'startup' }` so its default can be overridden by an experiment.