### PR TITLE
preferences: call Delayer.isTriggered() so Down focuses settings results

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -92,6 +92,15 @@ export function createGroupIterator(group: SettingsTreeGroupElement): Iterable<I
 	});
 }
 
+/**
+ * Whether Settings search results are safe to focus from the search input.
+ * `searchPending` must be the boolean from {@link Delayer.isTriggered} (call the method —
+ * a bare method reference is always truthy and would incorrectly block focus forever).
+ */
+export function isSettingsSearchUpToDate(searchPending: boolean, renderedSearchQuery: string | undefined, currentSearchValue: string): boolean {
+	return !searchPending && renderedSearchQuery === currentSearchValue.trim();
+}
+
 const $ = DOM.$;
 
 const searchBoxLabel = localize('SearchSettings.AriaLabel', "Search settings");
@@ -705,7 +714,7 @@ export class SettingsEditor2 extends EditorPane {
 	 * focus is not moved into stale results.
 	 */
 	private isSearchUpToDate(): boolean {
-		return !this.searchInputDelayer.isTriggered && this.renderedSearchQuery === this.searchWidget.getValue().trim();
+		return isSettingsSearchUpToDate(this.searchInputDelayer.isTriggered(), this.renderedSearchQuery, this.searchWidget.getValue());
 	}
 
 	/**
@@ -739,7 +748,7 @@ export class SettingsEditor2 extends EditorPane {
 		}
 
 		// Do not select all if the user is already searching.
-		this.searchWidget.focus(selectAll && !this.searchInputDelayer.isTriggered);
+		this.searchWidget.focus(selectAll && !this.searchInputDelayer.isTriggered());
 	}
 
 	clearSearchResults(): void {

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsEditor2.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsEditor2.test.ts
@@ -33,17 +33,18 @@ suite('SettingsEditor2', () => {
 			assert.strictEqual(isSettingsSearchUpToDate(false, undefined, ''), false);
 		});
 
-		test('uses Delayer.isTriggered() return value (regression #327360)', () => {
+		test('uses Delayer.isTriggered() return value (regression #327360)', async () => {
 			const delayer = store.add(new Delayer<void>(1000));
 
 			assert.strictEqual(delayer.isTriggered(), false);
 			assert.strictEqual(isSettingsSearchUpToDate(delayer.isTriggered(), 'font', 'font'), true);
 
-			delayer.trigger(() => { });
+			const pending = assert.rejects(delayer.trigger(() => { }));
 			assert.strictEqual(delayer.isTriggered(), true);
 			assert.strictEqual(isSettingsSearchUpToDate(delayer.isTriggered(), 'font', 'font'), false);
 
 			delayer.cancel();
+			await pending;
 			assert.strictEqual(delayer.isTriggered(), false);
 			assert.strictEqual(isSettingsSearchUpToDate(delayer.isTriggered(), 'font', 'font'), true);
 		});

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsEditor2.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsEditor2.test.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Delayer } from '../../../../../base/common/async.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { isSettingsSearchUpToDate } from '../../browser/settingsEditor2.js';
+
+suite('SettingsEditor2', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('isSettingsSearchUpToDate', () => {
+		test('allows focus when search is idle and query matches rendered results', () => {
+			assert.strictEqual(isSettingsSearchUpToDate(false, 'font', 'font'), true);
+			assert.strictEqual(isSettingsSearchUpToDate(false, '', ''), true);
+		});
+
+		test('trims the current search value before comparing', () => {
+			assert.strictEqual(isSettingsSearchUpToDate(false, 'font', '  font  '), true);
+			assert.strictEqual(isSettingsSearchUpToDate(false, 'font', ' font size '), false);
+		});
+
+		test('blocks focus while a debounced search is pending', () => {
+			assert.strictEqual(isSettingsSearchUpToDate(true, 'font', 'font'), false);
+			assert.strictEqual(isSettingsSearchUpToDate(true, '', ''), false);
+		});
+
+		test('blocks focus when rendered results are stale', () => {
+			assert.strictEqual(isSettingsSearchUpToDate(false, 'font', 'theme'), false);
+			assert.strictEqual(isSettingsSearchUpToDate(false, 'font', ''), false);
+			assert.strictEqual(isSettingsSearchUpToDate(false, undefined, ''), false);
+		});
+
+		test('uses Delayer.isTriggered() return value (regression #327360)', () => {
+			const delayer = store.add(new Delayer<void>(1000));
+
+			assert.strictEqual(delayer.isTriggered(), false);
+			assert.strictEqual(isSettingsSearchUpToDate(delayer.isTriggered(), 'font', 'font'), true);
+
+			delayer.trigger(() => { });
+			assert.strictEqual(delayer.isTriggered(), true);
+			assert.strictEqual(isSettingsSearchUpToDate(delayer.isTriggered(), 'font', 'font'), false);
+
+			delayer.cancel();
+			assert.strictEqual(delayer.isTriggered(), false);
+			assert.strictEqual(isSettingsSearchUpToDate(delayer.isTriggered(), 'font', 'font'), true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes #327360: Down Arrow (and Enter) from Settings search never moved focus into results because `Delayer.isTriggered` was used without calling it. The method reference is always truthy, so `isSearchUpToDate()` always returned false and focus stayed in the search box.
- Call `isTriggered()` in both `isSearchUpToDate` and `focusSearch`, and extract `isSettingsSearchUpToDate(...)` with a `boolean` parameter so omitting `()` is a TypeScript error.
- Bug is cross-platform (reported on macOS). Related one-liner also appears in the larger #326375 F7 navigation PR; this is a minimal dedicated fix.

## Test plan
- [x] Unit: `SettingsEditor2` / `isSettingsSearchUpToDate` → **5 passing**, including Delayer regression for #327360
- [ ] Manual: Open Settings UI, focus search, press **Down** → focus moves into settings tree
- [ ] Manual: Same with **Enter**
- [ ] Manual: Type a query, press Down before debounce settles → focus stays in search; after results update, Down moves focus
- [ ] Manual: Focus search via command / click so `inSettingsSearch` context is set