### PR TITLE
Improve settings and terminal accessibility

### DIFF
--- a/extensions/copilot/test/prompts/settingsEditorSearchResultsSelector.stest.ts
+++ b/extensions/copilot/test/prompts/settingsEditorSearchResultsSelector.stest.ts
@@ -169,8 +169,14 @@ ssuite({ title: 'settingsEditorSearchResultsSelector', location: 'external' }, (
 			},
 			{
 				'key': 'terminal.integrated.accessibleViewPreserveCursorPosition',
-				'type': 'boolean',
-				'markdownDescription': `Preserve the cursor position on reopen of the terminal's accessible view rather than setting it to the bottom of the buffer.`
+				'type': 'boolean | string',
+				'markdownDescription': `Controls whether the cursor position is preserved in the terminal's accessible view.`,
+				'enum': [false, true, 'always'],
+				'enumDescriptions': [
+					'Always position the cursor at the bottom of the buffer.',
+					'Preserve the cursor position on reopen until new terminal content arrives.',
+					'Always preserve the cursor position, including when new terminal content arrives.'
+				]
 			},
 			{
 				'key': 'notebook.find.filters',

--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -72,9 +72,10 @@ export interface IAccessibleViewOptions {
 	/**
 	 * By default, places the cursor on the top line of the accessible view.
 	 * If set to 'initial-bottom', places the cursor on the bottom line of the accessible view and preserves it henceforth.
+	 * If set to 'initial-bottom-preserve', places the cursor on the bottom line initially and preserves its position when the content changes.
 	 * If set to 'bottom', places the cursor on the bottom line of the accessible view.
 	 */
-	position?: 'bottom' | 'initial-bottom';
+	position?: 'bottom' | 'initial-bottom' | 'initial-bottom-preserve';
 	/**
 	 * @returns a string that will be used as the content of the help dialog
 	 * instead of the one provided by default.

--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -71,7 +71,7 @@ export interface IAccessibleViewOptions {
 	type: AccessibleViewType;
 	/**
 	 * By default, places the cursor on the top line of the accessible view.
-	 * If set to 'initial-bottom', places the cursor on the bottom line of the accessible view and preserves it henceforth.
+	 * If set to 'initial-bottom', places the cursor on the bottom line initially and returns it to the bottom when the content changes.
 	 * If set to 'initial-bottom-preserve', places the cursor on the bottom line initially and preserves its position when the content changes.
 	 * If set to 'bottom', places the cursor on the bottom line of the accessible view.
 	 */

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -641,8 +641,16 @@ export class AccessibleView extends Disposable {
 			if (this._currentProvider?.options.position) {
 				const position = this._editorWidget.getPosition();
 				const isDefaultPosition = position?.lineNumber === 1 && position.column === 1;
-				if (this._currentProvider.options.position === 'bottom' || this._currentProvider.options.position === 'initial-bottom' && isDefaultPosition) {
-					const lastLine = this.editorWidget.getModel()?.getLineCount();
+				const lineCount = this.editorWidget.getModel()?.getLineCount();
+				const savedPosition = this._lastProviderPosition.get(provider.id);
+				const preservedPosition = this._currentProvider.options.position === 'initial-bottom-preserve'
+					? previousPosition ?? savedPosition
+					: this._currentProvider.options.position === 'initial-bottom' && !isSameProvider ? savedPosition : undefined;
+				if (preservedPosition && preservedPosition.lineNumber <= (lineCount ?? 0)) {
+					this._editorWidget.setPosition(preservedPosition);
+					this._editorWidget.revealLine(preservedPosition.lineNumber);
+				} else if (this._currentProvider.options.position === 'bottom' || this._currentProvider.options.position === 'initial-bottom-preserve' || this._currentProvider.options.position === 'initial-bottom' && isDefaultPosition) {
+					const lastLine = lineCount;
 					const position = lastLine !== undefined && lastLine > 0 ? new Position(lastLine, 1) : undefined;
 					if (position) {
 						this._editorWidget.setPosition(position);

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -54,7 +54,6 @@ import { SettingsEditor2, SettingsFocusContext } from './settingsEditor2.js';
 
 const SETTINGS_EDITOR_COMMAND_SEARCH = 'settings.action.search';
 
-const SETTINGS_EDITOR_COMMAND_FOCUS_FILE = 'settings.action.focusSettingsFile';
 const SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH = 'settings.action.focusSettingsFromSearch';
 const SETTINGS_EDITOR_COMMAND_SHOW_PREVIOUS_SEARCH = 'settings.action.showPreviousSearch';
 const SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH_ON_ENTER = 'settings.action.focusSettingsFromSearchOnEnter';
@@ -644,32 +643,12 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 		this._register(registerAction2(class extends Action2 {
 			constructor() {
 				super({
-					id: SETTINGS_EDITOR_COMMAND_FOCUS_FILE,
-					precondition: ContextKeyExpr.and(CONTEXT_SETTINGS_SEARCH_FOCUS, SuggestContext.Visible.toNegated()),
-					keybinding: {
-						primary: KeyCode.DownArrow,
-						weight: KeybindingWeight.EditorContrib,
-						when: null
-					},
-					title: nls.localize('settings.focusFile', "Focus settings file")
-				});
-			}
-
-			run(accessor: ServicesAccessor): void {
-				const preferencesEditor = getPreferencesEditor(accessor);
-				preferencesEditor?.navigateSearchHistoryNextOrFocusSettings();
-			}
-		}));
-
-		this._register(registerAction2(class extends Action2 {
-			constructor() {
-				super({
 					id: SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH,
 					precondition: ContextKeyExpr.and(CONTEXT_SETTINGS_SEARCH_FOCUS, SuggestContext.Visible.toNegated()),
 					keybinding: {
 						primary: KeyCode.DownArrow,
-						weight: KeybindingWeight.WorkbenchContrib,
-						when: null
+						weight: KeybindingWeight.WorkbenchContrib + 1,
+						when: ContextKeyExpr.and(CONTEXT_SETTINGS_SEARCH_FOCUS, SuggestContext.Visible.toNegated())
 					},
 					title: nls.localize('settings.focusFile', "Focus settings file")
 				});
@@ -688,8 +667,8 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					precondition: ContextKeyExpr.and(CONTEXT_SETTINGS_SEARCH_FOCUS, SuggestContext.Visible.toNegated()),
 					keybinding: {
 						primary: KeyCode.UpArrow,
-						weight: KeybindingWeight.WorkbenchContrib,
-						when: null
+						weight: KeybindingWeight.WorkbenchContrib + 1,
+						when: ContextKeyExpr.and(CONTEXT_SETTINGS_SEARCH_FOCUS, SuggestContext.Visible.toNegated())
 					},
 					title: nls.localize('settings.showPreviousSearch', "Show Previous Search in Settings")
 				});
@@ -709,7 +688,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					keybinding: {
 						primary: KeyCode.Enter,
 						weight: KeybindingWeight.WorkbenchContrib,
-						when: null
+						when: ContextKeyExpr.and(CONTEXT_SETTINGS_SEARCH_FOCUS, SuggestContext.Visible.toNegated())
 					},
 					title: nls.localize('settings.focusSettingsFromSearchOnEnter', "Focus First Setting from Search")
 				});

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -54,6 +54,7 @@ import { SettingsEditor2, SettingsFocusContext } from './settingsEditor2.js';
 
 const SETTINGS_EDITOR_COMMAND_SEARCH = 'settings.action.search';
 
+const SETTINGS_EDITOR_COMMAND_FOCUS_FILE = 'settings.action.focusSettingsFile';
 const SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH = 'settings.action.focusSettingsFromSearch';
 const SETTINGS_EDITOR_COMMAND_SHOW_PREVIOUS_SEARCH = 'settings.action.showPreviousSearch';
 const SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH_ON_ENTER = 'settings.action.focusSettingsFromSearchOnEnter';
@@ -637,6 +638,21 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			run(accessor: ServicesAccessor) {
 				const preferencesEditor = getPreferencesEditor(accessor);
 				preferencesEditor?.clearSearchResults();
+			}
+		}));
+
+		this._register(registerAction2(class extends Action2 {
+			constructor() {
+				super({
+					id: SETTINGS_EDITOR_COMMAND_FOCUS_FILE,
+					precondition: ContextKeyExpr.and(CONTEXT_SETTINGS_SEARCH_FOCUS, SuggestContext.Visible.toNegated()),
+					title: nls.localize('settings.focusFile', "Focus settings file")
+				});
+			}
+
+			run(accessor: ServicesAccessor): void {
+				const preferencesEditor = getPreferencesEditor(accessor);
+				preferencesEditor?.navigateSearchHistoryNextOrFocusSettings();
 			}
 		}));
 

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Terminal } from '@xterm/xterm';
+import { status } from '../../../../../base/browser/ui/aria/aria.js';
 import { Event } from '../../../../../base/common/event.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
@@ -33,7 +34,6 @@ import { BufferContentTracker } from './bufferContentTracker.js';
 import { TerminalAccessibilityHelpProvider } from './terminalAccessibilityHelp.js';
 import { ICommandWithEditorLine, TerminalAccessibleBufferProvider } from './terminalAccessibleBufferProvider.js';
 import { TextAreaSyncAddon } from './textAreaSyncAddon.js';
-import { alert } from '../../../../../base/browser/ui/aria/aria.js';
 
 // #region Terminal Contributions
 
@@ -167,8 +167,7 @@ export class TerminalAccessibleViewContribution extends Disposable implements IT
 				return this._register(this._instantiationService.createInstance(TerminalAccessibilityHelpProvider, this._ctx.instance, this._xterm!)).provideContent();
 			}));
 		}
-		const position = this._configurationService.getValue(TerminalAccessibilitySettingId.AccessibleViewPreserveCursorPosition) ? this._accessibleViewService.getPosition(AccessibleViewProviderId.Terminal) : undefined;
-		this._accessibleViewService.show(this._bufferProvider, position);
+		this._accessibleViewService.show(this._bufferProvider);
 	}
 	navigateToCommand(type: NavigationType): void {
 		const currentLine = this._accessibleViewService.getPosition(AccessibleViewProviderId.Terminal)?.lineNumber;
@@ -185,7 +184,7 @@ export class TerminalAccessibleViewContribution extends Disposable implements IT
 		const commandLine = command.command.command;
 		if (!isWindows && commandLine) {
 			this._accessibleViewService.setPosition(new Position(command.lineNumber, 1), true);
-			alert(commandLine);
+			status(commandLine);
 		} else {
 			this._accessibleViewService.setPosition(new Position(command.lineNumber, 1), true, true);
 		}

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
@@ -117,7 +117,7 @@ export class TerminalAccessibleViewContribution extends Disposable implements IT
 				return;
 			}
 			if (this._isTerminalAccessibleViewOpen() && this._xterm!.raw.buffer.active.baseY === 0) {
-				this.show();
+				this._bufferProvider?.refresh();
 			}
 		}));
 
@@ -127,7 +127,7 @@ export class TerminalAccessibleViewContribution extends Disposable implements IT
 				return;
 			}
 			if (this._isTerminalAccessibleViewOpen()) {
-				this.show();
+				this._bufferProvider?.refresh();
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBufferProvider.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBufferProvider.ts
@@ -12,7 +12,7 @@ import { ICurrentPartialCommand, isFullTerminalCommand } from '../../../../../pl
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { ITerminalInstance, ITerminalService } from '../../../terminal/browser/terminal.js';
 import { BufferContentTracker } from './bufferContentTracker.js';
-import { TerminalAccessibilitySettingId } from '../common/terminalAccessibilityConfiguration.js';
+import { TerminalAccessibilitySettingId, TerminalAccessibleViewPreserveCursorPosition } from '../common/terminalAccessibilityConfiguration.js';
 
 export class TerminalAccessibleBufferProvider extends Disposable implements IAccessibleViewContentProvider {
 	readonly id = AccessibleViewProviderId.Terminal;
@@ -33,11 +33,11 @@ export class TerminalAccessibleBufferProvider extends Disposable implements IAcc
 	) {
 		super();
 		this.options.customHelp = customHelp;
-		this.options.position = configurationService.getValue(TerminalAccessibilitySettingId.AccessibleViewPreserveCursorPosition) ? 'initial-bottom' : 'bottom';
+		this._updatePosition(configurationService);
 		this._register(this._instance.onDisposed(() => this._onDidRequestClearProvider.fire(AccessibleViewProviderId.Terminal)));
 		this._register(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(TerminalAccessibilitySettingId.AccessibleViewPreserveCursorPosition)) {
-				this.options.position = configurationService.getValue(TerminalAccessibilitySettingId.AccessibleViewPreserveCursorPosition) ? 'initial-bottom' : 'bottom';
+				this._updatePosition(configurationService);
 			}
 		}));
 		this._focusedInstance = terminalService.activeInstance;
@@ -47,6 +47,11 @@ export class TerminalAccessibleBufferProvider extends Disposable implements IAcc
 				this._focusedInstance = terminalService.activeInstance;
 			}
 		}));
+	}
+
+	private _updatePosition(configurationService: IConfigurationService): void {
+		const preserveCursorPosition = configurationService.getValue<boolean | TerminalAccessibleViewPreserveCursorPosition>(TerminalAccessibilitySettingId.AccessibleViewPreserveCursorPosition);
+		this.options.position = preserveCursorPosition === TerminalAccessibleViewPreserveCursorPosition.Always ? 'initial-bottom-preserve' : preserveCursorPosition ? 'initial-bottom' : 'bottom';
 	}
 
 	onClose() {
@@ -114,4 +119,3 @@ export class TerminalAccessibleBufferProvider extends Disposable implements IAcc
 	}
 }
 export interface ICommandWithEditorLine { command: ITerminalCommand | ICurrentPartialCommand; lineNumber: number; exitCode?: number }
-

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBufferProvider.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBufferProvider.ts
@@ -24,6 +24,9 @@ export class TerminalAccessibleBufferProvider extends Disposable implements IAcc
 	private readonly _onDidRequestClearProvider = this._register(new Emitter<AccessibleViewProviderId>());
 	readonly onDidRequestClearLastProvider = this._onDidRequestClearProvider.event;
 
+	private readonly _onDidChangeContent = this._register(new Emitter<void>());
+	readonly onDidChangeContent = this._onDidChangeContent.event;
+
 	constructor(
 		private readonly _instance: Pick<ITerminalInstance, 'onDidExecuteText' | 'focus' | 'shellType' | 'capabilities' | 'onDidRequestFocus' | 'resource' | 'onDisposed'>,
 		private _bufferTracker: BufferContentTracker,
@@ -52,6 +55,10 @@ export class TerminalAccessibleBufferProvider extends Disposable implements IAcc
 	private _updatePosition(configurationService: IConfigurationService): void {
 		const preserveCursorPosition = configurationService.getValue<boolean | TerminalAccessibleViewPreserveCursorPosition>(TerminalAccessibilitySettingId.AccessibleViewPreserveCursorPosition);
 		this.options.position = preserveCursorPosition === TerminalAccessibleViewPreserveCursorPosition.Always ? 'initial-bottom-preserve' : preserveCursorPosition ? 'initial-bottom' : 'bottom';
+	}
+
+	refresh(): void {
+		this._onDidChangeContent.fire();
 	}
 
 	onClose() {

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/common/terminalAccessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/common/terminalAccessibilityConfiguration.ts
@@ -12,16 +12,26 @@ export const enum TerminalAccessibilitySettingId {
 	AccessibleViewFocusOnCommandExecution = 'terminal.integrated.accessibleViewFocusOnCommandExecution',
 }
 
+export const enum TerminalAccessibleViewPreserveCursorPosition {
+	Always = 'always',
+}
+
 export interface ITerminalAccessibilityConfiguration {
-	accessibleViewPreserveCursorPosition: boolean;
+	accessibleViewPreserveCursorPosition: boolean | TerminalAccessibleViewPreserveCursorPosition;
 	accessibleViewFocusOnCommandExecution: number;
 }
 
 export const terminalAccessibilityConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 	[TerminalAccessibilitySettingId.AccessibleViewPreserveCursorPosition]: {
-		markdownDescription: localize('terminal.integrated.accessibleViewPreserveCursorPosition', "Preserve the cursor position on reopen of the terminal's accessible view rather than setting it to the bottom of the buffer."),
-		type: 'boolean',
-		default: false
+		markdownDescription: localize('terminal.integrated.accessibleViewPreserveCursorPosition', "Controls whether the cursor position is preserved in the terminal's accessible view."),
+		type: ['boolean', 'string'],
+		enum: [false, true, TerminalAccessibleViewPreserveCursorPosition.Always],
+		enumDescriptions: [
+			localize('terminal.integrated.accessibleViewPreserveCursorPosition.false', "Always position the cursor at the bottom of the buffer."),
+			localize('terminal.integrated.accessibleViewPreserveCursorPosition.true', "Preserve the cursor position on reopen until new terminal content arrives."),
+			localize('terminal.integrated.accessibleViewPreserveCursorPosition.always', "Always preserve the cursor position, including when new terminal content arrives.")
+		],
+		default: false,
 	},
 	[TerminalAccessibilitySettingId.AccessibleViewFocusOnCommandExecution]: {
 		markdownDescription: localize('terminal.integrated.accessibleViewFocusOnCommandExecution', "Focus the terminal accessible view when a command is executed."),


### PR DESCRIPTION
Fixes #327358
Fixes #327359
Fixes #327360

This PR:
- fixes Down Arrow navigation from the Settings editor search input on macOS by removing the competing binding and giving the scoped action explicit precedence
- extends `terminal.integrated.accessibleViewPreserveCursorPosition` with an `always` option while preserving existing boolean behavior
- uses an ARIA status announcement instead of an alert when navigating terminal commands

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>