### PR TITLE
Restore hydrated image attachment previews in the Agents window

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -538,7 +538,19 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		const currentLanguageModelName = this.currentLanguageModel ? this.languageModelsService.lookupLanguageModel(this.currentLanguageModel.identifier)?.name ?? this.currentLanguageModel.identifier : 'Current model';
 
 		const fullName = resource ? this.labelService.getUriLabel(resource) : (attachment.fullName || attachment.name);
-		this._register(createImageElements(resource, attachment.name, fullName, this.element, imageData ?? (attachment.value as Uint8Array), attachment.id, this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, omittedState));
+
+		const imageElements = this._register(new MutableDisposable<IDisposable>());
+		const renderImageElements = (buffer: Uint8Array) => {
+			imageElements.value = createImageElements(resource, attachment.name, fullName, this.element, buffer, attachment.id, this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, omittedState);
+		};
+		renderImageElements(imageData ?? new Uint8Array());
+
+		// Hydrated image attachments (e.g. after a window reload or session resume) arrive as a
+		// resource reference without inline bytes. Load the bytes from disk so the preview renders
+		// the actual image instead of falling back to a generic file icon.
+		if (!imageData && resource && omittedState !== OmittedState.Full && omittedState !== OmittedState.ImageLimitExceeded) {
+			void this.loadImageBytes(resource, renderImageElements);
+		}
 		this.attachSaveButton(resource, imageData, attachment.name, options.supportsDeletion);
 		this.element.ariaLabel = this.appendDeletionHint(ariaLabel);
 
@@ -556,6 +568,20 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 				this._register(hookUpResourceAttachmentDragAndContextMenu(accessor, this.element, resource));
 			});
 		}
+	}
+
+	private async loadImageBytes(resource: URI, render: (buffer: Uint8Array) => void): Promise<void> {
+		let content: VSBuffer;
+		try {
+			content = (await this.fileService.readFile(resource)).value;
+		} catch {
+			// The file may no longer exist; keep the icon fallback that is already rendered.
+			return;
+		}
+		if (this._store.isDisposed) {
+			return;
+		}
+		render(content.buffer);
 	}
 
 	private async openInCarousel(id: string, name: string, data: Uint8Array | undefined, referenceUri: URI | undefined, preferCurrentInput: boolean | undefined): Promise<void> {
@@ -723,6 +749,14 @@ function createImageElements(resource: URI | undefined, name: string, fullName: 
 			hoverElement.appendChild(dom.$('div', undefined, localize('chat.autoImageAttachmentHover', "Image support depends on the model selected by Auto.")));
 		}
 	}
+
+	// Remove the pill and label from the DOM when disposed so the widget can safely re-render
+	// (e.g. after lazily loading the image bytes for a hydrated attachment).
+	disposable.add(toDisposable(() => {
+		currentPill.remove();
+		textLabel.remove();
+	}));
+
 	return disposable;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -542,17 +542,16 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		const imageElements = this._register(new MutableDisposable<IDisposable>());
 		const renderImageElements = (buffer: Uint8Array) => {
 			imageElements.value = createImageElements(resource, attachment.name, fullName, this.element, buffer, attachment.id, this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, omittedState);
+			// createImageElements resets the label; restore the deletion hint after each render.
+			this.element.ariaLabel = this.appendDeletionHint(ariaLabel);
 		};
 		renderImageElements(imageData ?? new Uint8Array());
 
-		// Hydrated image attachments (e.g. after a window reload or session resume) arrive as a
-		// resource reference without inline bytes. Load the bytes from disk so the preview renders
-		// the actual image instead of falling back to a generic file icon.
+		// Hydrated attachments need disk bytes so the preview does not fall back to a generic file icon.
 		if (!imageData && resource && omittedState !== OmittedState.Full && omittedState !== OmittedState.ImageLimitExceeded) {
 			void this.loadImageBytes(resource, renderImageElements);
 		}
 		this.attachSaveButton(resource, imageData, attachment.name, options.supportsDeletion);
-		this.element.ariaLabel = this.appendDeletionHint(ariaLabel);
 
 		// Wire up click + keyboard (Enter/Space) open handlers
 		const canOpenCarousel = !!imageData && configurationService.getValue<boolean>(ChatConfiguration.ImageCarouselEnabled);
@@ -750,8 +749,7 @@ function createImageElements(resource: URI | undefined, name: string, fullName: 
 		}
 	}
 
-	// Remove the pill and label from the DOM when disposed so the widget can safely re-render
-	// (e.g. after lazily loading the image bytes for a hydrated attachment).
+	// Remove old DOM so the widget can safely re-render after hydrated bytes load.
 	disposable.add(toDisposable(() => {
 		currentPill.remove();
 		textLabel.remove();

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
@@ -11,7 +11,8 @@ import { ExtensionIdentifier } from '../../../../../../../platform/extensions/co
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { IFileService } from '../../../../../../../platform/files/common/files.js';
 import { TestFileService, workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
-import { getEffectiveImageOmittedState } from '../../../../browser/attachments/chatAttachmentWidgets.js';
+import { DEFAULT_LABELS_CONTAINER, ResourceLabels } from '../../../../../../browser/labels.js';
+import { getEffectiveImageOmittedState, ImageAttachmentWidget } from '../../../../browser/attachments/chatAttachmentWidgets.js';
 import { ChatAttachmentsContentPart } from '../../../../browser/widget/chatContentParts/chatAttachmentsContentPart.js';
 import { AgentHostCompletionReferenceKind, IChatRequestVariableEntry, OmittedState, toAgentHostCompletionVariableEntry } from '../../../../common/attachments/chatVariableEntries.js';
 import { ILanguageModelChatMetadata, ILanguageModelsService } from '../../../../common/languageModels.js';
@@ -394,6 +395,35 @@ suite('ChatAttachmentsContentPart', () => {
 				});
 
 				assert.deepStrictEqual(reads, []);
+			});
+
+			test('should keep delete hint after loading hydrated image bytes', async () => {
+				const resource = URI.file('/test/pasted-image.png');
+				const container = mainWindow.document.createElement('div');
+				mainWindow.document.body.appendChild(container);
+				disposables.add(toDisposable(() => container.remove()));
+				const contextResourceLabels = disposables.add(instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
+				const widget = disposables.add(instantiationService.createInstance(
+					ImageAttachmentWidget,
+					resource,
+					{
+						kind: 'image',
+						id: 'hydrated-image-with-delete',
+						name: 'pasted-image.png',
+						value: resource,
+						mimeType: 'image/png',
+						isURL: true,
+						references: [{ kind: 'reference', reference: resource }]
+					},
+					undefined,
+					{ shouldFocusClearButton: false, supportsDeletion: true },
+					container,
+					contextResourceLabels
+				));
+
+				await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+				assert.strictEqual(widget.element.ariaLabel, 'Attached image, pasted-image.png (Delete)');
 			});
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
@@ -9,7 +9,8 @@ import { mainWindow } from '../../../../../../../base/browser/window.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 import { ExtensionIdentifier } from '../../../../../../../platform/extensions/common/extensions.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
-import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
+import { IFileService } from '../../../../../../../platform/files/common/files.js';
+import { TestFileService, workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
 import { getEffectiveImageOmittedState } from '../../../../browser/attachments/chatAttachmentWidgets.js';
 import { ChatAttachmentsContentPart } from '../../../../browser/widget/chatContentParts/chatAttachmentsContentPart.js';
 import { AgentHostCompletionReferenceKind, IChatRequestVariableEntry, OmittedState, toAgentHostCompletionVariableEntry } from '../../../../common/attachments/chatVariableEntries.js';
@@ -346,6 +347,54 @@ suite('ChatAttachmentsContentPart', () => {
 			} satisfies { identifier: string; metadata: ILanguageModelChatMetadata };
 
 			assert.strictEqual(getEffectiveImageOmittedState(OmittedState.Full, autoModel, true), OmittedState.NotOmitted);
+		});
+
+		suite('hydrated image attachments', () => {
+			async function renderImageAndCollectReads(image: IChatRequestVariableEntry): Promise<string[]> {
+				const fileService = instantiationService.get(IFileService) as TestFileService;
+				const part = store.add(instantiationService.createInstance(
+					ChatAttachmentsContentPart,
+					{ variables: [image] }
+				));
+
+				mainWindow.document.body.appendChild(part.domNode!);
+				disposables.add(toDisposable(() => part.domNode?.remove()));
+
+				// Let the widget's lazy byte load (a microtask) settle before inspecting reads.
+				await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+				return fileService.readOperations.map(read => read.resource.toString());
+			}
+
+			test('should load bytes from the resource for a hydrated (uri-only) image', async () => {
+				const resource = URI.file('/test/pasted-image.png');
+				const reads = await renderImageAndCollectReads({
+					kind: 'image',
+					id: 'hydrated-image',
+					name: 'pasted-image.png',
+					value: resource,
+					mimeType: 'image/png',
+					isURL: true,
+					references: [{ kind: 'reference', reference: resource }]
+				});
+
+				assert.deepStrictEqual(reads, [resource.toString()]);
+			});
+
+			test('should not read the resource for an image with inline bytes', async () => {
+				const resource = URI.file('/test/inline-image.png');
+				const reads = await renderImageAndCollectReads({
+					kind: 'image',
+					id: 'inline-image',
+					name: 'inline-image.png',
+					value: new Uint8Array([0x89, 0x50, 0x4E, 0x47]),
+					mimeType: 'image/png',
+					isURL: false,
+					references: [{ kind: 'reference', reference: resource }]
+				});
+
+				assert.deepStrictEqual(reads, []);
+			});
 		});
 	});
 });


### PR DESCRIPTION
cc @justschen 

Fixes #327329
Fixes #327057

Builds on #327300.

## Problem
In the Agents window, an image attachment on a user message loses its thumbnail preview after a window reload / session resume, falling back to a generic file-media icon -- even though the file still exists on disk and is readable.

## Background
Hydrated (reload / resume / reconnect) image attachments arrive as **uri-only** variable entries: `value` is a `URI` and the real file reference is in `references[0]`, with no inline bytes.

#327300 fixed the shared `coerceImageBuffer` helper so it returns `undefined` for such values instead of mis-coercing the URI's enumerable keys into a bogus all-zeros `Uint8Array`. That removed the corrupt buffer and unmasked the "no inline bytes" state, but the **visible preview is still not restored**: `ImageAttachmentWidget` receives `undefined` bytes and never loads the real image, so it renders the generic icon.

## Fix
`ImageAttachmentWidget` now lazily reads the bytes via the injected `IFileService` when inline bytes are absent but a `resource` is available (and the image is not fully omitted / over the image limit), then re-renders the preview with the actual image. The icon fallback is kept if the read fails, e.g. the file no longer exists. Works for `file:` and remote `vscode-agent-host:` resources, since a filesystem provider is registered for both.

The final ARIA label is re-applied after each render so the "Delete" hint survives the async re-render (`ChatInputPart` uses this widget with `supportsDeletion: true`).

## Tests
`chatAttachmentsContentPart.test.ts`:
- a hydrated uri-only image triggers a resource read and re-render; an inline-bytes image does not;
- the delete hint is still announced after the hydrated bytes load.

## Validation
- `npm run typecheck-client` PASS
- Widget browser suite PASS (includes the new hydrated-image tests)
- Rebased on latest `main` (which includes #327300); this branch's earlier `coerceImageBuffer` URI guard and its duplicate extraction test were dropped as redundant.

## Scope
This is a **preview / rendering** fix only. It does not change what the model receives: the Agent Host already materializes uri-only `Resource` attachments to bytes server-side before they reach a provider (`AgentService._rewriteUserMessageAttachments`). The separate defect where the model does not receive an attachment at all is tracked in #327607 (Copilot steering path drops attachments) and is not addressed here.
