### PR TITLE
agentHost: restore fuzzy slash completions

### DIFF
--- a/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
+++ b/src/vs/platform/agentHost/common/copilotConfigSlashCommands.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { matchesFuzzy2 } from '../../../base/common/filters.js';
 import { localize } from '../../../nls.js';
 import { SessionConfigKey } from './sessionConfigKeys.js';
 
@@ -171,7 +172,7 @@ function shouldOfferOption(option: IConfigSlashOption, state: ICopilotConfigSlas
 
 /**
  * Returns the flattened completion items (one per command form) whose command
- * name matches `typed` (the text after the leading `/`, case-insensitive prefix).
+ * name fuzzy matches `typed` (the text after the leading `/`, case-insensitive).
  * When `typed` is empty, all items are returned.
  *
  * When `state` (the session's current config values) is provided, pure toggle
@@ -182,7 +183,10 @@ export function getCopilotConfigSlashCommandItems(typed: string, state?: ICopilo
 	const typedLower = typed.trim().toLowerCase();
 	const items: ICopilotConfigSlashCommandItem[] = [];
 	for (const command of getConfigSlashCommands()) {
-		if (typedLower && !command.command.toLowerCase().startsWith(typedLower)) {
+		if (typedLower
+			&& !command.command.toLowerCase().startsWith(typedLower)
+			&& (typedLower.length === 1 || matchesFuzzy2(typedLower, command.command) === null)
+		) {
 			continue;
 		}
 		for (const option of command.options) {

--- a/src/vs/platform/agentHost/node/agentHostRenameCommand.ts
+++ b/src/vs/platform/agentHost/node/agentHostRenameCommand.ts
@@ -10,7 +10,7 @@ import { CompletionItem, CompletionItemKind, CompletionsParams } from '../common
 import { MessageAttachmentKind } from '../common/state/protocol/state.js';
 import { toCommandCompletionAttachmentMeta } from '../common/meta/agentCompletionAttachmentMeta.js';
 import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from './agentHostCompletions.js';
-import { extractLeadingSlashToken } from './agentHostSlashCompletion.js';
+import { extractLeadingSlashToken, matchesSlashCompletion } from './agentHostSlashCompletion.js';
 
 /** The generic, agent-agnostic `/rename` slash command name. */
 export const RENAME_SLASH_COMMAND = 'rename';
@@ -62,7 +62,7 @@ export class AgentHostRenameCompletionProvider implements IAgentHostCompletionIt
 		}
 		// `/abc` → typed = 'abc'; empty after just '/' → typed = ''.
 		const typed = leading.typed;
-		if (typed.length > 0 && !RENAME_SLASH_COMMAND.startsWith(typed)) {
+		if (!matchesSlashCompletion(typed, RENAME_SLASH_COMMAND)) {
 			return [];
 		}
 		return [{

--- a/src/vs/platform/agentHost/node/agentHostSkillCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/agentHostSkillCompletionProvider.ts
@@ -13,7 +13,7 @@ import { MessageAttachmentKind } from '../common/state/protocol/state.js';
 import { toSkillCompletionAttachmentMeta } from '../common/meta/agentCompletionAttachmentMeta.js';
 import { CustomizationType, DirectoryCustomization, PluginCustomization, SkillCustomization } from '../common/state/sessionState.js';
 import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from './agentHostCompletions.js';
-import { extractWhitespaceDelimitedSlashToken } from './agentHostSlashCompletion.js';
+import { extractWhitespaceDelimitedSlashToken, matchesSlashCompletion } from './agentHostSlashCompletion.js';
 
 
 /**
@@ -53,7 +53,7 @@ export class AgentHostSkillCompletionProvider extends Disposable implements IAge
 		return candidates
 			.filter(skill => {
 				const uri = skill.uri;
-				if ((!typed.length || skill.slashCommandName.startsWith(typed)) && !skillsSeen.has(uri)) {
+				if (matchesSlashCompletion(typed, skill.slashCommandName) && !skillsSeen.has(uri)) {
 					skillsSeen.add(uri);
 					return true;
 				}

--- a/src/vs/platform/agentHost/node/agentHostSlashCompletion.ts
+++ b/src/vs/platform/agentHost/node/agentHostSlashCompletion.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { matchesFuzzy2 } from '../../../base/common/filters.js';
+
 /**
  * A leading slash token in a user-message input.
  */
@@ -67,6 +69,16 @@ export function extractWhitespaceDelimitedSlashToken(text: string, offset: numbe
 
 	const token = text.slice(start, end);
 	return { token, typed: token.slice(1), rangeStart: start, rangeEnd: end };
+}
+
+/**
+ * Tests whether a slash completion name fuzzy matches the typed token text.
+ */
+export function matchesSlashCompletion(typed: string, name: string): boolean {
+	if (typed.length === 0 || name.toLowerCase().startsWith(typed.toLowerCase())) {
+		return true;
+	}
+	return typed.length > 1 && matchesFuzzy2(typed, name) !== null;
 }
 
 function isSlashTokenWhitespace(ch: number): boolean {

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -10,7 +10,7 @@ import { Customization, CustomizationType, DirectoryCustomization, MessageAttach
 import { getCompletionAction, toCommandCompletionAttachmentMeta } from '../../common/meta/agentCompletionAttachmentMeta.js';
 import { getCopilotConfigSlashCommandItems, ICopilotConfigSlashCommandState, isCopilotConfigSlashCommand } from '../../common/copilotConfigSlashCommands.js';
 import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from '../agentHostCompletions.js';
-import { extractLeadingSlashToken, extractWhitespaceDelimitedSlashToken } from '../agentHostSlashCompletion.js';
+import { extractLeadingSlashToken, extractWhitespaceDelimitedSlashToken, matchesSlashCompletion } from '../agentHostSlashCompletion.js';
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../common/agentHostFileSystemService.js';
 import type { CopilotSession } from '@github/copilot-sdk';
 
@@ -142,7 +142,7 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 			if (!rubberDuckEnabled && command.name === 'rubber-duck') {
 				continue;
 			}
-			if (typed.length > 0 && !command.name.toLowerCase().startsWith(typedLower) && !command.aliases?.some(alias => alias.toLowerCase().startsWith(typedLower))) {
+			if (!matchesSlashCompletion(typedLower, command.name) && !command.aliases?.some(alias => matchesSlashCompletion(typedLower, alias))) {
 				continue;
 			}
 			// Use structured input choices as options; if there are none, emit a single item for the command and surface any free-text hint as a prompt.

--- a/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
+++ b/src/vs/platform/agentHost/test/common/copilotConfigSlashCommands.test.ts
@@ -37,6 +37,11 @@ suite('copilotConfigSlashCommands', () => {
 			assert.strictEqual(getCopilotConfigSlashCommandItems('nope').length, 0);
 		});
 
+		test('fuzzy filters by command name', () => {
+			const commands = new Set(getCopilotConfigSlashCommandItems('pt').map(i => i.command));
+			assert.deepStrictEqual([...commands], ['autopilot']);
+		});
+
 		test('autopilot state hides the no-op toggle but keeps the prompt form', () => {
 			const inAutopilot = new Set(getCopilotConfigSlashCommandItems('autopilot', { mode: 'autopilot' }).map(i => i.label));
 			// Already in autopilot: only offer `off` (plus the always-on prompt form).

--- a/src/vs/platform/agentHost/test/node/agentHostRenameCommand.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRenameCommand.test.ts
@@ -62,6 +62,11 @@ suite('agentHostRenameCommand', () => {
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/rename ']);
 		});
 
+		test('offers /rename when fuzzily matched', async () => {
+			const items = await run('/rae');
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/rename ']);
+		});
+
 		test('omits /rename when the session has no history', async () => {
 			const items = await run('/', false);
 			assert.deepStrictEqual(items, []);

--- a/src/vs/platform/agentHost/test/node/agentHostSkillCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSkillCompletionProvider.test.ts
@@ -197,6 +197,16 @@ suite('AgentHostSkillCompletionProvider', () => {
 		]);
 	});
 
+	test('fuzzy matches skills by the typed slash token', async () => {
+		const agent = new MockAgent('mock');
+		agent.getSessionCustomizations = async () => [plugin('skills', [skill('fix-ci'), skill('other')])];
+		const provider = createProvider(agent);
+
+		const result = await run(provider, '/ci');
+
+		assert.deepStrictEqual(result.map(item => item.insertText), ['/skills:fix-ci ']);
+	});
+
 	test('filters skills by an in-message slash prefix and replaces only that token', async () => {
 		const agent = new MockAgent('mock');
 		agent.getSessionCustomizations = async () => [plugin('skills', [skill('alpha'), skill('beta')])];

--- a/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
@@ -161,6 +161,11 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/compact ']);
 		});
 
+		test('fuzzy matches /compact when "/cc" typed', async () => {
+			const items = await run('/cc');
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/compact ']);
+		});
+
 		test('filters to /env when "/e" typed and runtime command exists', async () => {
 			const items = await run('/e');
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/env ']);

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/editor/chatInputCompletions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/editor/chatInputCompletions.test.ts
@@ -16,7 +16,7 @@ import { LanguageFeaturesService } from '../../../../../../../../editor/common/s
 import { createTextModel } from '../../../../../../../../editor/test/common/testTextModel.js';
 import { AgentHostInputCompletionsBase } from '../../../../../browser/widget/input/editor/agentHostInputCompletionsBase.js';
 import { attachedContextCompletionSortText, computeCompletionRanges, escapeForCharClass, getAttachedContextCompletionFilterText, isAtTriggerCharacterToken } from '../../../../../browser/widget/input/editor/chatInputCompletionUtils.js';
-import { IChatInputCompletionItem, IChatInputCompletionsParams, IChatInputCompletionsResult } from '../../../../../common/chatSessionsService.js';
+import { IChatInputCompletionItem, IChatInputCompletionsParams, IChatInputCompletionsResult, IChatSessionsService } from '../../../../../common/chatSessionsService.js';
 import { chatAgentLeader, chatVariableLeader } from '../../../../../common/requestParser/chatParserTypes.js';
 import { MockChatSessionsService } from '../../../../common/mockChatSessionsService.js';
 
@@ -35,6 +35,14 @@ class TestChatSessionsService extends MockChatSessionsService {
 }
 
 class TestAgentHostInputCompletions extends AgentHostInputCompletionsBase<void> {
+	constructor(
+		languageFeaturesService: LanguageFeaturesService,
+		chatSessionsService: IChatSessionsService,
+		private readonly _completionKind = CompletionItemKind.File,
+	) {
+		super(languageFeaturesService, chatSessionsService);
+	}
+
 	register(): IDisposable {
 		return this._registerProvider({ scheme: 'test' }, 'testAgentHostInputCompletions', ['#'], undefined);
 	}
@@ -48,7 +56,7 @@ class TestAgentHostInputCompletions extends AgentHostInputCompletionsBase<void> 
 			label: item.insertText,
 			insertText: item.insertText,
 			range: Range.fromPositions(position),
-			kind: CompletionItemKind.File,
+			kind: this._completionKind,
 		};
 	}
 }
@@ -75,6 +83,26 @@ suite('AgentHostInputCompletionsBase', () => {
 				insertText: '#roadmap.md',
 				range: new Range(1, 2, 1, 2),
 				kind: CompletionItemKind.File,
+			}],
+			incomplete: true,
+		});
+	});
+
+	test('marks non-file results incomplete so the host can fuzzy match them', async () => {
+		const languageFeaturesService = new LanguageFeaturesService();
+		const completions = store.add(new TestAgentHostInputCompletions(languageFeaturesService, new TestChatSessionsService(), CompletionItemKind.Text));
+		store.add(completions.register());
+		const model = store.add(createTextModel('#', null, undefined, URI.parse('test:input')));
+		const provider = languageFeaturesService.completionProvider.ordered(model)[0];
+
+		const result = await provider.provideCompletionItems(model, new Position(1, 2), { triggerKind: CompletionTriggerKind.TriggerCharacter, triggerCharacter: '#' }, CancellationToken.None);
+
+		assert.deepStrictEqual(result, {
+			suggestions: [{
+				label: '#roadmap.md',
+				insertText: '#roadmap.md',
+				range: new Range(1, 2, 1, 2),
+				kind: CompletionItemKind.Text,
 			}],
 			incomplete: true,
 		});


### PR DESCRIPTION
- Keeps agent-host completion lists incomplete so the host refreshes results as the token changes.
- Applies consistent fuzzy matching to skills and slash commands so non-file results such as /fix-ci remain discoverable from /ci.

Fixes #326474

(Commit message generated by Copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>