### PR TITLE
chat: use theme accent for remote session access

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/media/tunnelHost.css
+++ b/src/vs/workbench/contrib/chat/electron-browser/media/tunnelHost.css
@@ -37,7 +37,7 @@
 }
 
 .tunnel-host-toggle.sharing .tunnel-host-icon .codicon {
-	color: var(--vscode-problemsWarningIcon-foreground) !important;
+	color: var(--vscode-focusBorder) !important;
 }
 
 .tunnel-host-toggle.connecting .tunnel-host-icon .codicon {


### PR DESCRIPTION
- Uses the theme's primary accent for the active remote session indicator so the enabled state reads as active rather than as a warning.
- Preserves theme and high-contrast compatibility by relying on the shared focus color token.

Fixes #322982

(Commit message generated by Copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>