### PR TITLE
Fix text clipping in custom dialog style

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -126,7 +126,7 @@
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message {
 	font-size: 14px;
 	font-weight: 600;
-	flex: 1; /* let the message always grow */
+	flex-grow: 1; /* let the message always grow */
 	white-space: normal;
 	word-wrap: break-word; /* never overflow long words, but break to next line */
 	min-height: 22px;


### PR DESCRIPTION
Adjust the CSS for the dialog message container to use `flex-grow` instead of `flex`, allowing the message to expand properly and preventing text clipping in verbose dialogs. This change addresses the issue where the text was being clipped in the custom dialog style.
Fixes #327260

