### PR TITLE
agentHost: refresh model catalogs periodically

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1627,6 +1627,19 @@ export interface IAgent {
 	/** Available models from this provider. */
 	readonly models: IObservable<readonly IAgentModelInfo[]>;
 
+	/**
+	 * Re-enumerate this provider's model list and publish the result to
+	 * {@link models}. Called both on provider-owned triggers (authentication,
+	 * transport changes) and periodically by the host's model-refresh
+	 * scheduler, so implementations MUST coalesce concurrent calls into a
+	 * single backend request and MUST NOT reject: a failed refresh is logged
+	 * and leaves the last known-good list in place.
+	 *
+	 * Optional so providers without a dynamic model catalog (mocks, test
+	 * agents) need not implement it.
+	 */
+	refreshModels?(): Promise<void>;
+
 	/** List persisted sessions from this provider. */
 	listSessions(): Promise<IAgentSessionMetadata[]>;
 

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -17,6 +17,7 @@ import * as os from 'os';
 import * as inspector from 'inspector';
 import { AgentHostByokModelsEnabledEnvVar, AgentHostClaudeAgentEnabledEnvVar, AgentHostCodexAgentEnabledEnvVar, AgentHostIpcChannels, IAgentHostInspectInfo, IAgentHostSocketInfo, IAgentService, IConnectionTrackerService, isAgentEnabled } from '../common/agentService.js';
 import { AgentHostCodexEnabledConfigKey, platformRootSchema } from '../common/agentHostSchema.js';
+import { AgentModelRefreshScheduler, MODEL_REFRESH_INTERVAL_MS } from './agentModelRefreshScheduler.js';
 import { AgentService } from './agentService.js';
 import { IAgentHostStateManager } from './agentHostStateManager.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
@@ -277,6 +278,15 @@ async function startAgentHost(): Promise<void> {
 		logService.error('Failed to create AgentService', err);
 		throw err;
 	}
+
+	// Keep every provider's model catalog fresh. Provider-owned refresh
+	// triggers (authentication, transport flips, client restarts) are all
+	// edge-based, so this periodic tick is the only thing that notices a model
+	// added service-side while the host stays up. Owned here, at process
+	// lifetime, rather than inside `AgentHostService`: a service that arms a
+	// recurring timer in its constructor is one that no faked-timer unit test
+	// can ever drain.
+	disposables.add(instantiationService.createInstance(AgentModelRefreshScheduler, agentService.agents, MODEL_REFRESH_INTERVAL_MS));
 
 	// Surface agent-SDK download progress to clients as generic `progress`
 	// notifications. The downloader fires process-global frames keyed by package

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -50,6 +50,7 @@ import { CodexProxyService, ICodexProxyService } from './codex/codexProxyService
 import { AgentSdkDownloader, IAgentSdkDownloader, type IAgentSdkDownloadProgress } from './agentSdkDownloader.js';
 import { IAgentHostOTelService } from '../common/otel/agentHostOTelService.js';
 import { AgentHostOTelService } from './otel/agentHostOTelService.js';
+import { AgentModelRefreshScheduler, MODEL_REFRESH_INTERVAL_MS } from './agentModelRefreshScheduler.js';
 import { AgentService } from './agentService.js';
 import { IAgentHostStateManager } from './agentHostStateManager.js';
 import { AgentHostClaudeAgentEnabledEnvVar, AgentHostClaudeSdkRootEnvVar, AgentHostCodexAgentEnabledEnvVar, IAgentService, AgentHostCodexAgentSdkRootEnvVar, isAgentEnabled } from '../common/agentService.js';
@@ -361,6 +362,15 @@ async function main(): Promise<void> {
 			logService.error('[AgentHostServer] Failed to load mock agent', err);
 		});
 	}
+
+	// Keep every provider's model catalog fresh. Provider-owned refresh
+	// triggers (authentication, transport flips, client restarts) are all
+	// edge-based, so this periodic tick is the only thing that notices a model
+	// added service-side while the host stays up. Owned here, at process
+	// lifetime, rather than inside `AgentHostService`: a service that arms a
+	// recurring timer in its constructor is one that no faked-timer unit test
+	// can ever drain.
+	disposables.add(instantiationService.createInstance(AgentModelRefreshScheduler, agentService.agents, MODEL_REFRESH_INTERVAL_MS));
 
 	// WebSocket server
 	const wsServer = disposables.add(await WebSocketProtocolServer.create({

--- a/src/vs/platform/agentHost/node/agentModelRefreshScheduler.ts
+++ b/src/vs/platform/agentHost/node/agentModelRefreshScheduler.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IntervalTimer } from '../../../base/common/async.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { IObservable, autorun } from '../../../base/common/observable.js';
+import { ILogService } from '../../log/common/log.js';
+import { IAgent } from '../common/agentService.js';
+
+/**
+ * How often every provider re-enumerates its model catalog.
+ *
+ * Model refreshes are otherwise edge-triggered — authentication, transport
+ * flips, client restarts — so without a periodic tick a model added on the
+ * service side stays invisible until the GitHub token happens to rotate, which
+ * on a long-lived window can be hours or never.
+ */
+export const MODEL_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+
+/**
+ * Ticks {@link IAgent.refreshModels} across every registered provider on a
+ * fixed interval.
+ *
+ * Lives in the host rather than the client because model freshness is provider
+ * truth: only the provider knows its backend, holds the credential, and owns
+ * the stale-write and backoff policy. Keeping the timer here also means one
+ * tick per provider regardless of how many windows are connected, and requires
+ * no AHP surface — the existing `models` observable already fans a change out
+ * through `RootAgentsChanged` to every client.
+ *
+ * A tick is cheap when nothing changed: providers short-circuit without a
+ * credential, and `AgentSideEffects` compares the published `AgentInfo[]`
+ * before dispatching, so an unchanged catalog produces no protocol traffic.
+ */
+export class AgentModelRefreshScheduler extends Disposable {
+
+	private readonly _timer = this._register(new IntervalTimer());
+	private _agents: readonly IAgent[] = [];
+	private _isTimerRunning = false;
+
+	constructor(
+		agents: IObservable<readonly IAgent[]>,
+		/**
+		 * Tick cadence, normally {@link MODEL_REFRESH_INTERVAL_MS}. Passed in
+		 * rather than read from an overridable field because the timer is armed
+		 * from this constructor, which runs before a subclass could install its
+		 * own value.
+		 */
+		intervalMs: number,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		// Start ticking once there is at least one provider, and stop again if
+		// they all go away. Provider changes update the snapshot read by each
+		// tick without re-arming the timer: dynamically registering Codex must
+		// not postpone the next refresh for providers that were already present.
+		this._register(autorun(reader => {
+			this._agents = agents.read(reader);
+			if (this._agents.length === 0) {
+				this._timer.cancel();
+				this._isTimerRunning = false;
+				return;
+			}
+			if (!this._isTimerRunning) {
+				this._timer.cancelAndSet(() => this._refreshAll(this._agents), intervalMs);
+				this._isTimerRunning = true;
+			}
+		}));
+	}
+
+	private _refreshAll(agents: readonly IAgent[]): void {
+		for (const agent of agents) {
+			if (!agent.refreshModels) {
+				continue;
+			}
+			this._logService.trace(`[AgentHost] Periodic model refresh for ${agent.getDescriptor().provider}`);
+			// `refreshModels` is contractually non-rejecting, but a provider bug
+			// must not take down the tick for the providers after it.
+			agent.refreshModels().catch(err => this._logService.error(err, '[AgentHost] Periodic model refresh failed'));
+		}
+	}
+}

--- a/src/vs/platform/agentHost/node/agentModelRefreshScheduler.ts
+++ b/src/vs/platform/agentHost/node/agentModelRefreshScheduler.ts
@@ -76,10 +76,11 @@ export class AgentModelRefreshScheduler extends Disposable {
 			if (!agent.refreshModels) {
 				continue;
 			}
-			this._logService.trace(`[AgentHost] Periodic model refresh for ${agent.getDescriptor().provider}`);
+			const provider = agent.getDescriptor().provider;
+			this._logService.trace(`[AgentHost] Periodic model refresh for ${provider}`);
 			// `refreshModels` is contractually non-rejecting, but a provider bug
 			// must not take down the tick for the providers after it.
-			agent.refreshModels().catch(err => this._logService.error(err, '[AgentHost] Periodic model refresh failed'));
+			agent.refreshModels().catch(err => this._logService.error(err, `[AgentHost] Periodic model refresh failed for ${provider}`));
 		}
 	}
 }

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -12,7 +12,7 @@ import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IDis
 import { ResourceMap } from '../../../base/common/map.js';
 import { getExtensionForMimeType, getMediaMime } from '../../../base/common/mime.js';
 import { Schemas } from '../../../base/common/network.js';
-import { observableValue } from '../../../base/common/observable.js';
+import { IObservable, observableValue } from '../../../base/common/observable.js';
 import { dirname as resourcesDirname, extname as resourcesExtname, extUriBiasedIgnorePathCase, isEqual, isEqualOrParent, joinPath } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
@@ -508,6 +508,15 @@ export class AgentService extends Disposable implements IAgentService {
 		// truth in `serverToolGroups.ts`; the session-management group's runtime
 		// dependency (this service) is injected via the accessor.
 		this._serverToolHost = new AgentServerToolHost(this._stateManager, buildServerToolGroups(this._createSessionServerToolAccessor()));
+	}
+
+	/**
+	 * The registered providers. Exposed so process-lifetime background jobs
+	 * (notably {@link AgentModelRefreshScheduler}) can observe registrations
+	 * without this service owning an ambient recurring timer of its own.
+	 */
+	get agents(): IObservable<readonly IAgent[]> {
+		return this._agents;
 	}
 
 	// ---- provider registration ----------------------------------------------

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -592,6 +592,12 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		this._githubToken = token;
 		this._logService.info('[Claude] Auth token updated');
 		oldHandle?.dispose();
+		if (tokenChanged) {
+			// A different account can have different model entitlements. Do
+			// not retain the previous token's catalog if enumeration for the
+			// replacement token fails.
+			this._models.set([], undefined);
+		}
 		void this._startModelRefresh();
 		return true;
 	}

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -227,6 +227,13 @@ export class ClaudeAgent extends Disposable implements IAgent {
 
 	private readonly _models = observableValue<readonly IAgentModelInfo[]>(this, []);
 	readonly models: IObservable<readonly IAgentModelInfo[]> = this._models;
+	/**
+	 * In-flight {@link refreshModels} call, so overlapping triggers (an auth
+	 * token change, a transport flip, or a periodic tick from the host's
+	 * model-refresh scheduler) collapse into a single enumeration instead of
+	 * racing each other's writes to {@link _models}.
+	 */
+	private _modelRefreshInFlight: Promise<void> | undefined;
 
 	private _githubToken: string | undefined;
 	private _proxyHandle: IClaudeProxyHandle | undefined;
@@ -466,7 +473,11 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			const next = this._resolveTransportMode();
 			if (next !== this._transportMode) {
 				this._transportMode = next;
-				void this._refreshModels();
+				// Proxy and native enumerate different catalogs. Do not retain
+				// models from the previous transport if the replacement cannot
+				// enumerate its own list.
+				this._models.set([], undefined);
+				void this._startModelRefresh();
 				// Flipping into proxy makes GitHub Copilot auth newly required.
 				// If no proxy handle was ever established, proactively ask the
 				// client to authenticate rather than waiting for the next command
@@ -490,7 +501,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			// kick off the initial enumeration ourselves. (Transport *flips*
 			// after construction are covered by the `onDidRootConfigChange`
 			// subscription above.) `queueMicrotask` runs it off the ctor stack.
-			queueMicrotask(() => { void this._refreshModels(); });
+			queueMicrotask(() => { void this._startModelRefresh(); });
 		}
 	}
 
@@ -581,7 +592,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		this._githubToken = token;
 		this._logService.info('[Claude] Auth token updated');
 		oldHandle?.dispose();
-		void this._refreshModels();
+		void this._startModelRefresh();
 		return true;
 	}
 
@@ -592,6 +603,34 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	 */
 	private _isProxyEnabled(): boolean {
 		return this._transportMode === 'proxy';
+	}
+
+	/**
+	 * {@link IAgent.refreshModels}. Coalesces onto an in-flight refresh and
+	 * never rejects — {@link _refreshModels} already logs and handles failure.
+	 *
+	 * Only safe for callers with no new input to apply (the host's periodic
+	 * scheduler). Triggers that invalidate the in-flight request — a rotated
+	 * token, a transport flip — must call {@link _startModelRefresh} so they
+	 * are not answered by a refresh bound to the superseded input.
+	 */
+	refreshModels(): Promise<void> {
+		return this._modelRefreshInFlight ?? this._startModelRefresh();
+	}
+
+	/**
+	 * Unconditionally begins a refresh, superseding any in-flight one as the
+	 * coalescing target. The superseded request stays harmless: its own
+	 * stale-write guard drops the result if the token or transport moved on.
+	 */
+	private _startModelRefresh(): Promise<void> {
+		const refresh = this._refreshModels().finally(() => {
+			if (this._modelRefreshInFlight === refresh) {
+				this._modelRefreshInFlight = undefined;
+			}
+		});
+		this._modelRefreshInFlight = refresh;
+		return refresh;
 	}
 
 	private async _refreshModels(): Promise<void> {
@@ -615,9 +654,10 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			this._models.set(filtered, undefined);
 		} catch (err) {
 			this._logService.error(err, '[Claude] Failed to refresh models');
-			if (this._isProxyEnabled() === proxyAtStart && (!proxyAtStart || this._githubToken === tokenAtStart)) {
-				this._models.set([], undefined);
-			}
+			// Keep the last known-good catalog. A periodic refresh is advisory;
+			// a transient service failure must not make every model disappear.
+			// Input changes that invalidate the catalog clear it at the point
+			// where that input changes.
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -1021,14 +1021,24 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 	}
 
-	private _queueModelRefresh(): void {
+	/**
+	 * {@link IAgent.refreshModels}. Coalesces onto an in-flight refresh — from
+	 * an account/usage-source change or an earlier tick — rather than issuing a
+	 * second enumeration, and never rejects: {@link _refreshModels} logs and
+	 * applies its own stale-write guards on failure.
+	 */
+	refreshModels(): Promise<void> {
+		return this._modelsRefreshPromise ?? this._queueModelRefresh();
+	}
+
+	private _queueModelRefresh(): Promise<void> {
 		const refreshPromise = this._refreshModels().finally(() => {
 			if (this._modelsRefreshPromise === refreshPromise) {
 				this._modelsRefreshPromise = undefined;
 			}
 		});
 		this._modelsRefreshPromise = refreshPromise;
-		void this._modelsRefreshPromise;
+		return refreshPromise;
 	}
 
 	private _ensureAuthenticated(): string | undefined {
@@ -1234,9 +1244,9 @@ export class CodexAgent extends Disposable implements IAgent {
 			this._models.set(models, undefined);
 		} catch (err) {
 			this._logService.warn(`[Codex] Failed to refresh models: ${err instanceof Error ? err.message : String(err)}`);
-			if (this._usageSource === usageSource && this._githubToken === token) {
-				this._models.set([], undefined);
-			}
+			// Keep the last known-good catalog. Usage-source changes clear the
+			// list in `_applyUsageSourceChange`; a transient periodic failure
+			// must not make every model disappear.
 		}
 	}
 
@@ -1268,9 +1278,9 @@ export class CodexAgent extends Disposable implements IAgent {
 			}
 		} catch (err) {
 			this._logService.warn(`[Codex] Failed to refresh OpenAI models: ${err instanceof Error ? err.message : String(err)}`);
-			if (this._usageSource === 'openai') {
-				this._models.set([], undefined);
-			}
+			// Keep the last known-good catalog. Usage-source changes clear the
+			// list in `_applyUsageSourceChange`; a transient periodic failure
+			// must not make every model disappear.
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -308,15 +308,31 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * Bounded exponential-backoff retry for {@link _refreshModels}. The SDK's
 	 * `models.list` RPC can fail transiently (e.g. a `429 "too many requests"`
 	 * right after startup). Without a retry the model picker would stay empty
-	 * until the GitHub token next changes — the only other trigger for a
-	 * refresh — so we retry a few times before giving up. Overridable in tests
-	 * to avoid real delays.
+	 * until the next external refresh trigger (a GitHub token change, a CLI
+	 * client restart, or the host's periodic scheduler), so we retry a few
+	 * times before giving up. Overridable in tests to avoid real delays.
 	 */
 	protected readonly _modelRefreshMaxAttempts: number = 5;
 	protected readonly _modelRefreshBaseDelayMs: number = 1_000;
 	protected readonly _modelRefreshMaxDelayMs: number = 30_000;
 	/** Pending model-refresh retry timer; cleared on a fresh refresh, shutdown, or dispose. */
 	private readonly _modelRefreshRetry = this._register(new MutableDisposable());
+	/**
+	 * Invalidates model requests bound to a superseded token/client/catalog
+	 * source. Token identity alone is insufficient: restarting the client for
+	 * a `COPILOT_GH_HOST` change keeps the same token while changing the CAPI
+	 * endpoint whose catalog is authoritative.
+	 */
+	private _modelCatalogGeneration = 0;
+	/**
+	 * In-flight {@link refreshModels} call, so overlapping triggers (an auth
+	 * token change landing on top of a periodic tick) collapse into a single
+	 * `models.list` request. Only covers the request itself: {@link _refreshModels}
+	 * returns as soon as it *schedules* a backoff retry, so a pending retry
+	 * never suppresses a later tick — which is what lets the scheduler act as
+	 * the long-term retry path once the bounded attempts are exhausted.
+	 */
+	private _modelRefreshInFlight: Promise<void> | undefined;
 
 	private _client: CopilotClient | undefined;
 	private _clientStarting: Promise<CopilotClient> | undefined;
@@ -547,6 +563,15 @@ export class CopilotAgent extends Disposable implements IAgent {
 			this._sessions.clearAndDisposeAll();
 			this._mcpNotificationSubs.clearAndDisposeAll();
 			await this._stopClient();
+			// The model list came from the subprocess we just tore down, and the
+			// replacement may be pointed at a different CAPI endpoint entirely
+			// (`COPILOT_GH_HOST` routes through this same helper). Re-enumerate
+			// rather than serving the old client's catalog until the next token
+			// change. Not hooked in `_ensureClient`, since `_listModels` calls
+			// it and would recurse.
+			this._capiModels = [];
+			this._publishModels();
+			void this._startModelRefresh();
 		}
 	}
 
@@ -678,7 +703,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._logService.info(`[Copilot] Auth token ${tokenChanged ? 'updated' : 'unchanged'}`);
 		if (tokenChanged) {
 			await this._restartClientIfProxyChanged();
-			void this._refreshModels();
+			void this._startModelRefresh();
 		}
 		return true;
 	}
@@ -774,7 +799,38 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 	}
 
-	private async _refreshModels(attempt = 0): Promise<void> {
+	/**
+	 * {@link IAgent.refreshModels}. Coalesces onto an in-flight refresh and
+	 * never rejects — {@link _refreshModels} already logs and retains the last
+	 * known-good list on failure.
+	 *
+	 * Only safe for callers with no new input to apply (the host's periodic
+	 * scheduler). Triggers that invalidate the in-flight request — a rotated
+	 * token, a restarted client — must call {@link _startModelRefresh} so they
+	 * are not answered by a refresh bound to the superseded input.
+	 */
+	refreshModels(): Promise<void> {
+		return this._modelRefreshInFlight ?? this._startModelRefresh();
+	}
+
+	/**
+	 * Unconditionally begins a refresh, superseding any in-flight one as the
+	 * coalescing target. The superseded request stays harmless: its own
+	 * stale-write guard drops the result if the token or client generation
+	 * moved on.
+	 */
+	private _startModelRefresh(): Promise<void> {
+		const generation = ++this._modelCatalogGeneration;
+		const refresh = this._refreshModels(0, generation).finally(() => {
+			if (this._modelRefreshInFlight === refresh) {
+				this._modelRefreshInFlight = undefined;
+			}
+		});
+		this._modelRefreshInFlight = refresh;
+		return refresh;
+	}
+
+	private async _refreshModels(attempt = 0, generation = this._modelCatalogGeneration): Promise<void> {
 		// A fresh refresh (e.g. a token change) supersedes any scheduled retry.
 		this._modelRefreshRetry.clear();
 
@@ -793,7 +849,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 		try {
 			const models = await this._listModels(tokenAtRefreshStart);
-			if (this._githubToken === tokenAtRefreshStart) {
+			if (this._githubToken === tokenAtRefreshStart && this._modelCatalogGeneration === generation) {
 				this._capiModels = models;
 				this._publishModels();
 			}
@@ -801,14 +857,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 			// Token rotated mid-flight — a newer refresh owns the result — or
 			// teardown began while the request was in flight, in which case a
 			// retry would just resurrect the client we are tearing down.
-			if (this._githubToken !== tokenAtRefreshStart || this._shutdownPromise) {
+			if (this._githubToken !== tokenAtRefreshStart || this._modelCatalogGeneration !== generation || this._shutdownPromise) {
 				return;
 			}
 			if (attempt + 1 < this._modelRefreshMaxAttempts) {
 				const delay = this._modelRefreshBackoff(attempt);
 				this._logService.warn(`[Copilot] Failed to refresh models (attempt ${attempt + 1}), retrying in ${delay}ms`, err);
 				this._modelRefreshRetry.value = disposableTimeout(() => {
-					void this._refreshModels(attempt + 1);
+					void this._refreshModels(attempt + 1, generation);
 				}, delay);
 				return;
 			}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -7,7 +7,7 @@ import { CopilotClient, RuntimeConnection, type CopilotClientOptions, type GitHu
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import { pathToFileURL } from 'url';
-import { CancelablePromise, createCancelablePromise, Delayer, disposableTimeout, Limiter, SequencerByKey } from '../../../../base/common/async.js';
+import { CancelablePromise, createCancelablePromise, DeferredPromise, Delayer, disposableTimeout, Limiter, SequencerByKey } from '../../../../base/common/async.js';
 import { type CancellationToken } from '../../../../base/common/cancellation.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -325,6 +325,13 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 */
 	private _modelCatalogGeneration = 0;
 	/**
+	 * Forced refreshes are deferred to the next task so related lifecycle
+	 * changes (for example an auth update arriving with a startup-config
+	 * change) collapse into one enumeration of the final token/client source.
+	 */
+	private _scheduledModelRefresh: { readonly deferred: DeferredPromise<void>; generation: number } | undefined;
+	private readonly _modelRefreshSchedule = this._register(new MutableDisposable());
+	/**
 	 * In-flight {@link refreshModels} call, so overlapping triggers (an auth
 	 * token change landing on top of a periodic tick) collapse into a single
 	 * `models.list` request. Only covers the request itself: {@link _refreshModels}
@@ -336,6 +343,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	private _client: CopilotClient | undefined;
 	private _clientStarting: Promise<CopilotClient> | undefined;
+	private _clientStopping: Promise<void> | undefined;
 	/**
 	 * Proxy URL injected into the running client's subprocess env (`undefined`
 	 * when none was injected). Used to detect when a token change alters the
@@ -571,7 +579,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			// it and would recurse.
 			this._capiModels = [];
 			this._publishModels();
-			void this._startModelRefresh();
+			void this._scheduleModelRefresh();
 		}
 	}
 
@@ -703,7 +711,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._logService.info(`[Copilot] Auth token ${tokenChanged ? 'updated' : 'unchanged'}`);
 		if (tokenChanged) {
 			await this._restartClientIfProxyChanged();
-			void this._startModelRefresh();
+			void this._scheduleModelRefresh();
 		}
 		return true;
 	}
@@ -806,21 +814,55 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 *
 	 * Only safe for callers with no new input to apply (the host's periodic
 	 * scheduler). Triggers that invalidate the in-flight request — a rotated
-	 * token, a restarted client — must call {@link _startModelRefresh} so they
+	 * token, a restarted client — must call {@link _scheduleModelRefresh} so they
 	 * are not answered by a refresh bound to the superseded input.
 	 */
 	refreshModels(): Promise<void> {
-		return this._modelRefreshInFlight ?? this._startModelRefresh();
+		return this._scheduledModelRefresh?.deferred.p ?? this._modelRefreshInFlight ?? this._startModelRefresh(++this._modelCatalogGeneration);
 	}
 
 	/**
-	 * Unconditionally begins a refresh, superseding any in-flight one as the
-	 * coalescing target. The superseded request stays harmless: its own
-	 * stale-write guard drops the result if the token or client generation
-	 * moved on.
+	 * Invalidates an in-flight refresh immediately, then starts one refresh on
+	 * the next task. Repeated lifecycle triggers before that task
+	 * share the same deferred and enumerate only the final token/client source.
 	 */
-	private _startModelRefresh(): Promise<void> {
+	private _scheduleModelRefresh(): Promise<void> {
 		const generation = ++this._modelCatalogGeneration;
+		if (this._scheduledModelRefresh) {
+			this._scheduledModelRefresh.generation = generation;
+			return this._scheduledModelRefresh.deferred.p;
+		}
+
+		const scheduled = { deferred: new DeferredPromise<void>(), generation };
+		this._scheduledModelRefresh = scheduled;
+		this._modelRefreshSchedule.value = disposableTimeout(() => {
+			void (async () => {
+				try {
+					// A config-triggered restart clears `_client` before its
+					// asynchronous `stop()` completes. Wait for that stop so this
+					// refresh cannot resurrect the client midway through teardown.
+					await this._clientStopping;
+					if (this._scheduledModelRefresh !== scheduled) {
+						return;
+					}
+					this._scheduledModelRefresh = undefined;
+					this._modelRefreshSchedule.clear();
+					await this._startModelRefresh(scheduled.generation);
+				} catch (err) {
+					this._logService.error(err, '[Copilot] Failed to schedule model refresh');
+				} finally {
+					if (this._scheduledModelRefresh === scheduled) {
+						this._scheduledModelRefresh = undefined;
+						this._modelRefreshSchedule.clear();
+					}
+					scheduled.deferred.complete();
+				}
+			})();
+		}, 0);
+		return scheduled.deferred.p;
+	}
+
+	private _startModelRefresh(generation: number): Promise<void> {
 		const refresh = this._refreshModels(0, generation).finally(() => {
 			if (this._modelRefreshInFlight === refresh) {
 				this._modelRefreshInFlight = undefined;
@@ -928,15 +970,35 @@ export class CopilotAgent extends Disposable implements IAgent {
 		return Math.round(exp / 2 + Math.random() * (exp / 2));
 	}
 
-	private async _stopClient(): Promise<void> {
-		const client = this._client;
-		this._client = undefined;
-		this._clientStarting = undefined;
-		await client?.stop();
-		// The runtime subprocess is now dead, so it is safe to release the BYOK
-		// proxy handle: the next session launch mints a fresh nonce. See the
-		// ownership invariant on `CopilotSessionLauncher.disposeByokProxyHandle`.
-		await this._sessionLauncher.disposeByokProxyHandle();
+	private _stopClient(): Promise<void> {
+		if (this._clientStopping) {
+			return this._clientStopping;
+		}
+		const stopping = (async () => {
+			const clientStarting = this._clientStarting;
+			if (clientStarting) {
+				try {
+					await clientStarting;
+				} catch {
+					// A failed/stale start owns its own cleanup. Continue so
+					// any client it managed to publish is still stopped below.
+				}
+			}
+			const client = this._client;
+			this._client = undefined;
+			this._clientStarting = undefined;
+			await client?.stop();
+			// The runtime subprocess is now dead, so it is safe to release the BYOK
+			// proxy handle: the next session launch mints a fresh nonce. See the
+			// ownership invariant on `CopilotSessionLauncher.disposeByokProxyHandle`.
+			await this._sessionLauncher.disposeByokProxyHandle();
+		})().finally(() => {
+			if (this._clientStopping === stopping) {
+				this._clientStopping = undefined;
+			}
+		});
+		this._clientStopping = stopping;
+		return stopping;
 	}
 
 	/**
@@ -980,6 +1042,15 @@ export class CopilotAgent extends Disposable implements IAgent {
 	// ---- client lifecycle ---------------------------------------------------
 
 	private async _ensureClient(): Promise<CopilotClient> {
+		if (this._shutdownPromise) {
+			throw new CancellationError();
+		}
+		while (this._clientStopping) {
+			await this._clientStopping;
+			if (this._shutdownPromise) {
+				throw new CancellationError();
+			}
+		}
 		if (this._client) {
 			return this._client;
 		}
@@ -1105,6 +1176,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 			};
 			const client = this._createCopilotClient(clientOptions);
 			await client.start();
+			if (this._shutdownPromise) {
+				await client.stop();
+				throw new CancellationError();
+			}
 			if (this._isSessionSyncEnabled() !== sessionSyncAtStartup || this._isRubberDuckEnabled() !== rubberDuckAtStartup || this._getCopilotSdkLogLevelSetting() !== copilotSdkLogLevelSettingAtStartup || this._getEnterpriseHost() !== enterpriseHostAtStartup || this._isSystemProxyEnabled() !== systemProxyEnabledAtStartup) {
 				await client.stop();
 				throw new Error('Copilot startup config changed while the client was starting');
@@ -2737,6 +2812,13 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	async shutdown(): Promise<void> {
 		this._shutdownPromise ??= (async () => {
+			// Invalidate any request that started before teardown. Token
+			// identity alone does not change during shutdown, so without this
+			// guard a late success could republish after the host stopped.
+			this._modelCatalogGeneration++;
+			this._modelRefreshSchedule.clear();
+			this._scheduledModelRefresh?.deferred.complete();
+			this._scheduledModelRefresh = undefined;
 			// Cancel any pending model-refresh retry so its timer cannot fire
 			// after teardown and resurrect the client.
 			this._modelRefreshRetry.clear();
@@ -2745,11 +2827,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			for (const sessionId of sessionIds) {
 				await this._sessionSequencer.queue(sessionId, () => this._destroyAndDisposeSession(sessionId));
 			}
-			await this._client?.stop();
-			this._client = undefined;
-			// Release the BYOK proxy handle only after the runtime subprocess is
-			// gone, mirroring `_stopClient` and the proxy ownership invariant.
-			await this._sessionLauncher.disposeByokProxyHandle();
+			await this._stopClient();
 		})();
 		return this._shutdownPromise;
 	}

--- a/src/vs/platform/agentHost/test/node/agentModelRefreshScheduler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentModelRefreshScheduler.test.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../base/common/async.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../base/common/observable.js';
+import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import type { IAgent, IAgentDescriptor } from '../../common/agentService.js';
+import { AgentModelRefreshScheduler } from '../../node/agentModelRefreshScheduler.js';
+
+/**
+ * Minimal stand-in for a provider: the scheduler only ever reads the descriptor
+ * (for logging) and calls `refreshModels`.
+ */
+class TestAgent {
+	refreshCount = 0;
+	/** When set, `refreshModels` rejects with this instead of resolving. */
+	refreshError: Error | undefined;
+
+	constructor(private readonly _provider: string) { }
+
+	getDescriptor(): IAgentDescriptor {
+		return { provider: this._provider, displayName: this._provider, description: this._provider };
+	}
+
+	async refreshModels(): Promise<void> {
+		this.refreshCount++;
+		if (this.refreshError) {
+			throw this.refreshError;
+		}
+	}
+}
+
+/** A provider that predates `refreshModels` and must simply be skipped. */
+class LegacyTestAgent {
+	getDescriptor(): IAgentDescriptor {
+		return { provider: 'legacy', displayName: 'legacy', description: 'legacy' };
+	}
+}
+
+function asAgents(...agents: readonly (TestAgent | LegacyTestAgent)[]): readonly IAgent[] {
+	return agents as unknown as readonly IAgent[];
+}
+
+suite('AgentModelRefreshScheduler', () => {
+
+	const disposables = new DisposableStore();
+	const INTERVAL_MS = 2;
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createScheduler(agents: ReturnType<typeof observableValue<readonly IAgent[]>>): AgentModelRefreshScheduler {
+		return disposables.add(new AgentModelRefreshScheduler(agents, INTERVAL_MS, new NullLogService()));
+	}
+
+	/** Waits for the tick-driven condition, bounded so a failure fails fast. */
+	async function waitFor(condition: () => boolean): Promise<void> {
+		for (let i = 0; i < 500 && !condition(); i++) {
+			await timeout(INTERVAL_MS);
+		}
+	}
+
+	test('ticks every registered agent repeatedly and stops on dispose', async () => {
+		const copilot = new TestAgent('copilotcli');
+		const claude = new TestAgent('claude');
+		const agents = observableValue<readonly IAgent[]>('agents', asAgents(copilot, claude));
+		const scheduler = createScheduler(agents);
+
+		await waitFor(() => copilot.refreshCount >= 2 && claude.refreshCount >= 2);
+		scheduler.dispose();
+		const countsAtDispose = { copilot: copilot.refreshCount, claude: claude.refreshCount };
+		await timeout(INTERVAL_MS * 10);
+
+		assert.deepStrictEqual({
+			tickedRepeatedly: countsAtDispose.copilot >= 2 && countsAtDispose.claude >= 2,
+			copilotAfterDispose: copilot.refreshCount,
+			claudeAfterDispose: claude.refreshCount,
+		}, {
+			tickedRepeatedly: true,
+			copilotAfterDispose: countsAtDispose.copilot,
+			claudeAfterDispose: countsAtDispose.claude,
+		});
+	});
+
+	test('does not tick while no agents are registered, and starts once one appears', async () => {
+		const agents = observableValue<readonly IAgent[]>('agents', []);
+		createScheduler(agents);
+
+		await timeout(INTERVAL_MS * 10);
+		const agent = new TestAgent('copilotcli');
+		agents.set(asAgents(agent), undefined);
+		await waitFor(() => agent.refreshCount >= 1);
+
+		assert.ok(agent.refreshCount >= 1, 'expected the scheduler to tick after an agent was registered');
+	});
+
+	test('registering another agent does not postpone the next tick', () => {
+		return runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const first = new TestAgent('copilotcli');
+			const second = new TestAgent('codex');
+			const agents = observableValue<readonly IAgent[]>('agents', asAgents(first));
+			const scheduler = createScheduler(agents);
+
+			await timeout(INTERVAL_MS - 1);
+			agents.set(asAgents(first, second), undefined);
+			await timeout(1);
+			scheduler.dispose();
+
+			assert.deepStrictEqual({
+				first: first.refreshCount,
+				second: second.refreshCount,
+			}, {
+				first: 1,
+				second: 1,
+			});
+		});
+	});
+
+	test('a failing or unimplemented refresh does not stop the other agents or later ticks', async () => {
+		const failing = new TestAgent('failing');
+		failing.refreshError = new Error('boom');
+		const healthy = new TestAgent('healthy');
+		const agents = observableValue<readonly IAgent[]>('agents', asAgents(failing, new LegacyTestAgent(), healthy));
+		createScheduler(agents);
+
+		await waitFor(() => healthy.refreshCount >= 3);
+
+		assert.ok(healthy.refreshCount >= 3, 'expected ticks to continue past a rejecting agent');
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentModelRefreshScheduler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentModelRefreshScheduler.test.ts
@@ -5,7 +5,6 @@
 
 import assert from 'assert';
 import { timeout } from '../../../../base/common/async.js';
-import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -49,11 +48,8 @@ function asAgents(...agents: readonly (TestAgent | LegacyTestAgent)[]): readonly
 
 suite('AgentModelRefreshScheduler', () => {
 
-	const disposables = new DisposableStore();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 	const INTERVAL_MS = 2;
-
-	teardown(() => disposables.clear());
-	ensureNoDisposablesAreLeakedInTestSuite();
 
 	function createScheduler(agents: ReturnType<typeof observableValue<readonly IAgent[]>>): AgentModelRefreshScheduler {
 		return disposables.add(new AgentModelRefreshScheduler(agents, INTERVAL_MS, new NullLogService()));

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -983,6 +983,44 @@ suite('ClaudeAgent', () => {
 		);
 	});
 
+	test('coalesces concurrent refreshModels calls onto one CAPI models request', async () => {
+		const { agent, api } = createTestContext(disposables);
+		// Block the first request in flight so the second caller has something
+		// to coalesce onto: a periodic scheduler tick landing on top of an
+		// auth-triggered refresh must not double-hit the service.
+		const gate = new DeferredPromise<void>();
+		let modelsCalls = 0;
+		api.models = async () => { modelsCalls++; await gate.p; return [...ALL_MODELS]; };
+		await agent.authenticate('https://api.github.com', 'tok');
+		await tick();
+
+		const first = agent.refreshModels();
+		const second = agent.refreshModels();
+		gate.complete();
+		await Promise.all([first, second]);
+
+		assert.deepStrictEqual({
+			modelsCalls,
+			hasModels: agent.models.get().length > 0,
+		}, {
+			modelsCalls: 1,
+			hasModels: true,
+		});
+	});
+
+	test('keeps the last known-good models when a periodic refresh fails', async () => {
+		const { agent, api } = createTestContext(disposables);
+		api.models = async () => [...ALL_MODELS];
+		await agent.authenticate('https://api.github.com', 'tok');
+		await agent.refreshModels();
+		const modelIds = agent.models.get().map(model => model.id);
+
+		api.models = async () => { throw new Error('transient failure'); };
+		await agent.refreshModels();
+
+		assert.deepStrictEqual(agent.models.get().map(model => model.id), modelIds);
+	});
+
 	test('native transport: models populate from supportedModels() with no proxy start and no CAPI models() call', async () => {
 		const { agent, proxy, api, sdk } = createTestContext(disposables, { rootConfig: { claudeUseCopilotProxy: false } });
 		let capiModelsCalls = 0;

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -1021,6 +1021,23 @@ suite('ClaudeAgent', () => {
 		assert.deepStrictEqual(agent.models.get().map(model => model.id), modelIds);
 	});
 
+	test('clears models when enumeration for a replacement token fails', async () => {
+		const { agent, api } = createTestContext(disposables);
+		api.models = async token => {
+			if (token === 'tokB') {
+				throw new Error('token B failure');
+			}
+			return [...ALL_MODELS];
+		};
+		await agent.authenticate('https://api.github.com', 'tokA');
+		await agent.refreshModels();
+
+		await agent.authenticate('https://api.github.com', 'tokB');
+		await agent.refreshModels();
+
+		assert.deepStrictEqual(agent.models.get(), []);
+	});
+
 	test('native transport: models populate from supportedModels() with no proxy start and no CAPI models() call', async () => {
 		const { agent, proxy, api, sdk } = createTestContext(disposables, { rootConfig: { claudeUseCopilotProxy: false } });
 		let capiModelsCalls = 0;

--- a/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { CCAModel } from '@vscode/copilot-api';
+import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import type { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { INativeEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IAgentHostGitHubEndpointService } from '../../../node/agentHostGitHubEndpointService.js';
+import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
+import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
+import { CodexAgent } from '../../../node/codex/codexAgent.js';
+import { ICodexProxyService } from '../../../node/codex/codexProxyService.js';
+import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
+import { ISessionDataService } from '../../../common/sessionDataService.js';
+import { createTestGitHubEndpointService } from '../testGitHubEndpointService.js';
+
+function createAgent(disposables: Pick<DisposableStore, 'add'>, models: () => Promise<CCAModel[]>): CodexAgent {
+	const instantiationService = new TestInstantiationService();
+	instantiationService.stub(ISessionDataService, { _serviceBrand: undefined });
+	instantiationService.stub(ICopilotApiService, { _serviceBrand: undefined, models });
+	instantiationService.stub(ICodexProxyService, { _serviceBrand: undefined });
+	instantiationService.stub(IAgentConfigurationService, {
+		_serviceBrand: undefined,
+		onDidRootConfigChange: Event.None,
+		getRootValue: () => undefined,
+	});
+	instantiationService.stub(IAgentHostGitHubEndpointService, createTestGitHubEndpointService());
+	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
+	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
+	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
+	instantiationService.stub(ILogService, new NullLogService());
+	return disposables.add(instantiationService.createInstance(CodexAgent));
+}
+
+suite('CodexAgent model refresh', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('keeps the last known-good models when a periodic refresh fails', async () => {
+		let shouldFail = false;
+		const models = [{ id: 'gpt-5.5', name: 'GPT-5.5', supported_endpoints: ['/responses'] }] as CCAModel[];
+		const agent = createAgent(disposables, async () => {
+			if (shouldFail) {
+				throw new Error('transient failure');
+			}
+			return models;
+		});
+
+		const resource = agent.getProtectedResources()[0].resource;
+		await agent.authenticate(resource, 'token');
+		await agent.refreshModels();
+		shouldFail = true;
+		await agent.refreshModels();
+
+		assert.deepStrictEqual(agent.models.get().map(model => model.id), ['gpt-5.5']);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -345,11 +345,14 @@ class TestCopilotClient implements ITestCopilotClient {
 		models: {
 			list: async params => {
 				this.modelListRequests.push(params);
+				const gate = this.modelListGates.shift() ?? this.modelListGate;
+				const models = this.modelListResponses.shift() ?? this._models;
+				await gate;
 				const error = this.modelListErrors.shift();
 				if (error) {
 					throw error;
 				}
-				return { models: this._models.map(toSdkModelInfo) };
+				return { models: models.map(toSdkModelInfo) };
 			}
 		},
 	};
@@ -358,6 +361,11 @@ class TestCopilotClient implements ITestCopilotClient {
 	listSessionCallCount = 0;
 	readonly modelListRequests: Parameters<CopilotModelsList>[0][] = [];
 	readonly modelListErrors: Error[] = [];
+	/** When set, `models.list` records its request then blocks on this until resolved. */
+	modelListGate: Promise<void> | undefined;
+	/** Per-request gates and results, captured when each request starts. */
+	readonly modelListGates: Promise<void>[] = [];
+	readonly modelListResponses: ITestCopilotModelInfo[][] = [];
 	readonly getSessionMetadataCalls: string[] = [];
 	readonly deletedSessionIds: string[] = [];
 
@@ -1285,6 +1293,37 @@ suite('CopilotAgent', () => {
 		}
 	});
 
+	test('coalesces concurrent refreshModels calls onto one models.list request', async () => {
+		const client = new TestCopilotClient([], [{
+			id: 'gpt-4o',
+			name: 'GPT-4o',
+		}]);
+		const agent = createTestAgent(disposables, { copilotClient: client });
+		try {
+			// Block the first request in flight so the second caller has
+			// something to coalesce onto: an auth-triggered refresh landing on
+			// top of a periodic scheduler tick must not double-hit the service.
+			const gate = new DeferredPromise<void>();
+			client.modelListGate = gate.p;
+			await agent.authenticate('https://api.github.com', 'token');
+
+			const first = agent.refreshModels();
+			const second = agent.refreshModels();
+			gate.complete();
+			await Promise.all([first, second]);
+
+			assert.deepStrictEqual({
+				requests: client.modelListRequests,
+				modelNames: agent.models.get().map(m => m.name),
+			}, {
+				requests: [{ gitHubToken: 'token' }],
+				modelNames: ['GPT-4o'],
+			});
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
 	test('does not refresh models or restart the client after shutdown', async () => {
 		const client = new TestCopilotClient([], [{
 			id: 'gpt-4o',
@@ -1491,6 +1530,72 @@ suite('CopilotAgent', () => {
 					stopCount: 1,
 					logLevel: 'all',
 				});
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('re-enumerates models after a startup-config restart', async () => {
+			const client = new StopCountingClient([], [{ id: 'gpt-4o', name: 'GPT-4o' }]);
+			const { agent, configurationService } = createTestAgentContext(disposables, { copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				await agent.listSessions();
+				await waitForState(agent.models, m => m.length > 0);
+				const requestsBefore = client.modelListRequests.length;
+
+				// The catalog belonged to the subprocess being torn down, and the
+				// replacement may point at a different CAPI endpoint entirely.
+				configurationService.updateRootConfig({ [CopilotCliConfigKey.RubberDuck]: true });
+				for (let i = 0; i < 500 && client.modelListRequests.length <= requestsBefore; i++) {
+					await timeout(1);
+				}
+
+				assert.deepStrictEqual({
+					stopCount: client.stopCount,
+					refreshesAfterRestart: client.modelListRequests.length - requestsBefore,
+				}, {
+					stopCount: 1,
+					refreshesAfterRestart: 1,
+				});
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('drops an in-flight catalog from the previous client generation', async () => {
+			const client = new StopCountingClient([], [{ id: 'initial', name: 'Initial' }]);
+			const { agent, configurationService } = createTestAgentContext(disposables, { copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				await waitForState(agent.models, models => models.some(model => model.id === 'initial'));
+				await Promise.resolve();
+
+				const staleGate = new DeferredPromise<void>();
+				const replacementGate = new DeferredPromise<void>();
+				client.modelListGates.push(staleGate.p, replacementGate.p);
+				client.modelListResponses.push(
+					[{ id: 'stale', name: 'Stale' }],
+					[{ id: 'replacement', name: 'Replacement' }],
+				);
+				const requestsBefore = client.modelListRequests.length;
+				const staleRefresh = agent.refreshModels();
+				for (let i = 0; i < 500 && client.modelListRequests.length < requestsBefore + 1; i++) {
+					await timeout(1);
+				}
+
+				configurationService.updateRootConfig({ [CopilotCliConfigKey.RubberDuck]: true });
+				for (let i = 0; i < 500 && client.modelListRequests.length < requestsBefore + 2; i++) {
+					await timeout(1);
+				}
+				assert.deepStrictEqual(agent.models.get(), []);
+
+				replacementGate.complete();
+				await waitForState(agent.models, models => models.some(model => model.id === 'replacement'));
+				staleGate.complete();
+				await staleRefresh;
+
+				assert.deepStrictEqual(agent.models.get().map(model => model.id), ['replacement']);
 			} finally {
 				await disposeAgent(agent);
 			}

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -347,8 +347,8 @@ class TestCopilotClient implements ITestCopilotClient {
 				this.modelListRequests.push(params);
 				const gate = this.modelListGates.shift() ?? this.modelListGate;
 				const models = this.modelListResponses.shift() ?? this._models;
-				await gate;
 				const error = this.modelListErrors.shift();
+				await gate;
 				if (error) {
 					throw error;
 				}

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
-import { isCancellationError } from '../../../../base/common/errors.js';
+import { CancellationError, isCancellationError } from '../../../../base/common/errors.js';
 import { Disposable, type DisposableStore, type IDisposable, type IReference } from '../../../../base/common/lifecycle.js';
 import { Event } from '../../../../base/common/event.js';
 import { Schemas } from '../../../../base/common/network.js';
@@ -358,6 +358,7 @@ class TestCopilotClient implements ITestCopilotClient {
 	};
 	startCallCount = 0;
 	stopCallCount = 0;
+	startGate: Promise<void> | undefined;
 	listSessionCallCount = 0;
 	readonly modelListRequests: Parameters<CopilotModelsList>[0][] = [];
 	readonly modelListErrors: Error[] = [];
@@ -376,6 +377,7 @@ class TestCopilotClient implements ITestCopilotClient {
 
 	async start(): Promise<void> {
 		this.startCallCount++;
+		await this.startGate;
 	}
 	async stop(): ReturnType<ITestCopilotClient['stop']> {
 		this.stopCallCount++;
@@ -1355,6 +1357,63 @@ suite('CopilotAgent', () => {
 		}
 	});
 
+	test('does not publish an in-flight model refresh after shutdown', async () => {
+		const client = new TestCopilotClient([], [{
+			id: 'initial',
+			name: 'Initial',
+		}]);
+		const agent = createTestAgent(disposables, { copilotClient: client });
+		try {
+			await agent.authenticate('https://api.github.com', 'token');
+			await waitForState(agent.models, models => models.some(model => model.id === 'initial'));
+			await Promise.resolve();
+
+			const gate = new DeferredPromise<void>();
+			client.modelListGates.push(gate.p);
+			client.modelListResponses.push([{ id: 'late', name: 'Late' }]);
+			const requestsBefore = client.modelListRequests.length;
+			const refresh = agent.refreshModels();
+			for (let i = 0; i < 500 && client.modelListRequests.length <= requestsBefore; i++) {
+				await timeout(1);
+			}
+			assert.strictEqual(client.modelListRequests.length, requestsBefore + 1, 'expected the gated model request to start');
+
+			await agent.shutdown();
+			gate.complete();
+			await refresh;
+
+			assert.deepStrictEqual(agent.models.get().map(model => model.id), ['initial']);
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('stops a client that finishes starting after shutdown begins', async () => {
+		const client = new TestCopilotClient([]);
+		const startGate = new DeferredPromise<void>();
+		client.startGate = startGate.p;
+		const agent = createTestAgent(disposables, { copilotClient: client });
+		try {
+			const listPromise = agent.listSessions();
+			await Promise.resolve();
+			const shutdownPromise = agent.shutdown();
+			startGate.complete();
+
+			await assert.rejects(listPromise, CancellationError);
+			await shutdownPromise;
+
+			assert.deepStrictEqual({
+				starts: client.startCallCount,
+				stops: client.stopCallCount,
+			}, {
+				starts: 1,
+				stops: 1,
+			});
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
 	test('createSession infers workspace-less from an omitted workingDirectory and uses a stable scratch dir', async () => {
 		const userHome = URI.file(await fs.mkdtemp(`${os.tmpdir()}/qc-home-`));
 		const agent = createTestAgent(disposables, { userHome });
@@ -1429,8 +1488,14 @@ suite('CopilotAgent', () => {
 
 		class StopCountingClient extends TestCopilotClient {
 			stopCount = 0;
+			stopGate: Promise<void> | undefined;
+			stopError: Error | undefined;
 			override async stop(): ReturnType<ITestCopilotClient['stop']> {
 				this.stopCount++;
+				await this.stopGate;
+				if (this.stopError) {
+					throw this.stopError;
+				}
 				return super.stop();
 			}
 		}
@@ -1558,6 +1623,93 @@ suite('CopilotAgent', () => {
 					stopCount: 1,
 					refreshesAfterRestart: 1,
 				});
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('coalesces concurrent token and startup-config refresh triggers', async () => {
+			const client = new StopCountingClient([], [{ id: 'gpt-4o', name: 'GPT-4o' }]);
+			const { agent, configurationService } = createTestAgentContext(disposables, { copilotClient: client });
+			const stopGate = new DeferredPromise<void>();
+			try {
+				await agent.authenticate('https://api.github.com', 'token-a');
+				await agent.listSessions();
+				await waitForState(agent.models, models => models.length > 0);
+				await Promise.resolve();
+				const requestsBefore = client.modelListRequests.length;
+				client.stopGate = stopGate.p;
+
+				configurationService.updateRootConfig({ [CopilotCliConfigKey.RubberDuck]: true });
+				await agent.authenticate('https://api.github.com', 'token-b');
+				await timeout(10);
+				assert.strictEqual(client.modelListRequests.length, requestsBefore, 'model refresh must wait for the old client to stop');
+				stopGate.complete();
+				for (let i = 0; i < 500 && client.modelListRequests.length <= requestsBefore; i++) {
+					await timeout(1);
+				}
+				await Promise.resolve();
+
+				assert.deepStrictEqual({
+					stopCount: client.stopCount,
+					refreshes: client.modelListRequests.length - requestsBefore,
+					lastToken: client.modelListRequests.at(-1)?.gitHubToken,
+				}, {
+					stopCount: 1,
+					refreshes: 1,
+					lastToken: 'token-b',
+				});
+			} finally {
+				stopGate.complete();
+				await disposeAgent(agent);
+			}
+		});
+
+		test('does not start a replacement client while the previous client is stopping', async () => {
+			const client = new StopCountingClient([]);
+			const { agent, configurationService } = createTestAgentContext(disposables, { copilotClient: client });
+			const stopGate = new DeferredPromise<void>();
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				await agent.listSessions();
+				client.stopGate = stopGate.p;
+
+				configurationService.updateRootConfig({ [CopilotCliConfigKey.RubberDuck]: true });
+				const listPromise = agent.listSessions();
+				await timeout(10);
+				assert.strictEqual(client.startCallCount, 1, 'replacement client must wait for the old client to stop');
+
+				stopGate.complete();
+				await listPromise;
+				assert.deepStrictEqual({
+					starts: client.startCallCount,
+					stops: client.stopCount,
+				}, {
+					starts: 2,
+					stops: 1,
+				});
+			} finally {
+				stopGate.complete();
+				await disposeAgent(agent);
+			}
+		});
+
+		test('a failed client stop does not poison later model refreshes', async () => {
+			const client = new StopCountingClient([], [{ id: 'gpt-4o', name: 'GPT-4o' }]);
+			const { agent, configurationService } = createTestAgentContext(disposables, { copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				await waitForState(agent.models, models => models.length > 0);
+				await agent.listSessions();
+				const requestsBefore = client.modelListRequests.length;
+				client.stopError = new Error('stop failed');
+
+				configurationService.updateRootConfig({ [CopilotCliConfigKey.RubberDuck]: true });
+				await timeout(10);
+				client.stopError = undefined;
+				await agent.refreshModels();
+
+				assert.strictEqual(client.modelListRequests.length, requestsBefore + 1);
 			} finally {
 				await disposeAgent(agent);
 			}


### PR DESCRIPTION
## Summary

- refresh Agent Host provider model catalogs every 10 minutes from a single host-owned scheduler
- coalesce periodic refreshes while preserving forced refreshes for token, transport, usage-source, and client-generation changes
- refresh Copilot models after CLI restart and prevent stale same-token responses from the previous client generation from publishing
- preserve last-known-good Claude, Codex, and Copilot catalogs after transient refresh failures

Fixes [#327413](https://github.com/microsoft/vscode/issues/327413).

## Validation

- TypeScript typecheck
- `npm run valid-layers-check`
- staged-file precommit hygiene
- full Agent Host unit suite: 3427 passing, 0 failing

(Written by Copilot)