### PR TITLE
Add web support for Voice Mode

### DIFF
--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -354,6 +354,7 @@ export class WebClientServer {
 
 		const productConfiguration: Partial<Mutable<IProductConfiguration>> = {
 			embedderIdentifier: 'server-distro',
+			voiceWsUrl: this._productService.voiceWsUrl,
 			extensionsGallery: this._webExtensionResourceUrlTemplate && this._productService.extensionsGallery ? {
 				...this._productService.extensionsGallery,
 				resourceUrlTemplate: this._webExtensionResourceUrlTemplate.with({


### PR DESCRIPTION
## Summary

- forward the configured Voice Mode WebSocket endpoint to the web workbench product configuration
- allow Voice Mode to connect from web clients such as vscode.dev

## Validation

- `npm run precommit`
- TypeScript typecheck skipped as requested

Fixes #327310