### PR TITLE
chat: show progress while forking conversations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
@@ -21,10 +21,12 @@ import { getChatSessionType } from '../../common/model/chatUri.js';
 import { CHAT_CATEGORY } from './chatActions.js';
 import { ChatTreeItem, ChatViewPaneTarget, IChatWidgetService } from '../chat.js';
 
+export const ForkConversationActionId = 'workbench.action.chat.forkConversation';
+
 export class ForkConversationAction extends Action2 {
 	constructor() {
 		super({
-			id: 'workbench.action.chat.forkConversation',
+			id: ForkConversationActionId,
 			title: localize2('chat.forkConversation.label', "Fork Conversation"),
 			tooltip: localize2('chat.forkConversation.tooltip', "Fork conversation from this point"),
 			f1: false,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatForkActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatForkActionViewItem.ts
@@ -13,6 +13,7 @@ import { CodiconActionViewItem } from '../../../notebook/browser/view/cellParts/
 
 const forkIconClasses = ThemeIcon.asClassNameArray(Codicon.repoForked);
 const spinnerIconClasses = ThemeIcon.asClassNameArray(ThemeIcon.modify(Codicon.loading, 'spin'));
+const labelIconClasses = [...new Set([...forkIconClasses, ...spinnerIconClasses])].filter(className => className !== 'codicon');
 
 export class ChatForkActionViewItem extends CodiconActionViewItem {
 
@@ -46,11 +47,6 @@ export class ChatForkActionViewItem extends CodiconActionViewItem {
 		return this.running
 			? localize('chat.forkConversation.running', "Forking conversation")
 			: super.getTooltip();
-	}
-
-	protected override updateAriaLabel(): void {
-		super.updateAriaLabel();
-		this.label?.setAttribute('aria-label', this.getTooltip());
 	}
 
 	protected override updateClass(): void {
@@ -96,7 +92,7 @@ export class ChatForkActionViewItem extends CodiconActionViewItem {
 			return;
 		}
 
-		this.label.classList.remove(...forkIconClasses, ...spinnerIconClasses);
+		this.label.classList.remove(...labelIconClasses);
 		this.icon.classList.remove(...forkIconClasses, ...spinnerIconClasses);
 		this.icon.classList.add(...(this.running ? spinnerIconClasses : forkIconClasses));
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatForkActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatForkActionViewItem.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { status } from '../../../../../base/browser/ui/aria/aria.js';
+import { IActionRunner } from '../../../../../base/common/actions.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { localize } from '../../../../../nls.js';
+import { CodiconActionViewItem } from '../../../notebook/browser/view/cellParts/cellActionView.js';
+
+const forkIconClasses = ThemeIcon.asClassNameArray(Codicon.repoForked);
+const spinnerIconClasses = ThemeIcon.asClassNameArray(ThemeIcon.modify(Codicon.loading, 'spin'));
+
+export class ChatForkActionViewItem extends CodiconActionViewItem {
+
+	private readonly actionRunnerListener = this._register(new MutableDisposable());
+	private icon: HTMLElement | undefined;
+	private running = false;
+
+	override get actionRunner(): IActionRunner {
+		return super.actionRunner;
+	}
+
+	override set actionRunner(actionRunner: IActionRunner) {
+		super.actionRunner = actionRunner;
+		this.bindActionRunner(actionRunner);
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+		if (this.label) {
+			this.label.textContent = '';
+			this.icon = document.createElement('span');
+			this.icon.classList.add('chat-fork-action-icon');
+			this.icon.setAttribute('aria-hidden', 'true');
+			this.label.appendChild(this.icon);
+		}
+		this.bindActionRunner(super.actionRunner);
+		this.renderRunningState();
+	}
+
+	protected override getTooltip(): string {
+		return this.running
+			? localize('chat.forkConversation.running', "Forking conversation")
+			: super.getTooltip();
+	}
+
+	protected override updateAriaLabel(): void {
+		super.updateAriaLabel();
+		this.label?.setAttribute('aria-label', this.getTooltip());
+	}
+
+	protected override updateClass(): void {
+		super.updateClass();
+		this.updateIcon();
+	}
+
+	private bindActionRunner(actionRunner: IActionRunner): void {
+		const listeners = new DisposableStore();
+		listeners.add(actionRunner.onWillRun(e => {
+			if (e.action === this.action) {
+				this.setRunning(true);
+			}
+		}));
+		listeners.add(actionRunner.onDidRun(e => {
+			if (e.action === this.action) {
+				this.setRunning(false);
+			}
+		}));
+		this.actionRunnerListener.value = listeners;
+	}
+
+	private setRunning(running: boolean): void {
+		if (this.running === running) {
+			return;
+		}
+
+		this.running = running;
+		this.renderRunningState();
+		if (running) {
+			status(localize('chat.forkConversation.runningStatus', "Forking conversation"));
+		}
+	}
+
+	private renderRunningState(): void {
+		this.updateIcon();
+		this.label?.setAttribute('aria-busy', String(this.running));
+		this.updateTooltip();
+	}
+
+	private updateIcon(): void {
+		if (!this.label || !this.icon) {
+			return;
+		}
+
+		this.label.classList.remove(...forkIconClasses, ...spinnerIconClasses);
+		this.icon.classList.remove(...forkIconClasses, ...spinnerIconClasses);
+		this.icon.classList.add(...(this.running ? spinnerIconClasses : forkIconClasses));
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -64,10 +64,12 @@ import { getNWords } from '../../common/model/chatWordCounter.js';
 import { CHAT_OPEN_AGENT_HOST_CHAT_COMMAND_ID, ChatAgentLocation, ChatConfiguration, ChatModeKind, CollapsedToolsDisplayMode, ThinkingDisplayMode } from '../../common/constants.js';
 import { formatChatRequestTimestamp, formatChatResponseDetails, formatElapsedTime } from '../../common/chatProgressFormatting.js';
 import { ClickAnimation } from '../../../../../base/browser/ui/animations/animations.js';
+import { ForkConversationActionId } from '../actions/chatForkActions.js';
 import { MarkHelpfulActionId } from '../actions/chatTitleActions.js';
 import { ChatTreeItem, IChatCodeBlockInfo, IChatFileTreeInfo, IChatListItemRendererOptions, IChatWidgetService } from '../chat.js';
 import { AgentHostSnapshotController } from '../agentSessions/agentHost/agentHostSnapshotController.js';
 import { RestoreCheckpointActionId } from '../chatEditing/chatEditingActions.js';
+import { ChatForkActionViewItem } from './chatForkActionViewItem.js';
 import { ChatRestoreCheckpointActionViewItem } from './chatRestoreCheckpointActionViewItem.js';
 import { ChatAgentHover, getChatAgentHoverOptions } from './chatAgentHover.js';
 import { ChatContentMarkdownRenderer } from './chatContentMarkdownRenderer.js';
@@ -796,6 +798,9 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				if (action instanceof MenuItemAction) {
 					if (action.item.id === RestoreCheckpointActionId) {
 						return this.instantiationService.createInstance(ChatRestoreCheckpointActionViewItem, action, { hoverDelegate: options.hoverDelegate }, (context: unknown) => this.checkpointRestoreNeedsConfirmation(context));
+					}
+					if (action.item.id === ForkConversationActionId) {
+						return this.instantiationService.createInstance(ChatForkActionViewItem, action, { hoverDelegate: options.hoverDelegate });
 					}
 					return this.instantiationService.createInstance(CodiconActionViewItem, action, { hoverDelegate: options.hoverDelegate });
 				}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatForkActionViewItem.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatForkActionViewItem.test.ts
@@ -44,18 +44,22 @@ suite('ChatForkActionViewItem', () => {
 		const runPromise = actionRunner.run(action);
 		const label = container.querySelector<HTMLElement>('.action-label');
 		const icon = label?.querySelector<HTMLElement>('.chat-fork-action-icon');
+		assert.ok(label);
+		assert.ok(icon);
 
 		assert.deepStrictEqual({
 			during: {
-				buttonSpinning: label?.classList.contains('codicon-modifier-spin'),
-				forkIcon: icon?.classList.contains(forkIconClass),
-				loadingIcon: icon?.classList.contains(loadingIconClass),
-				iconSpinning: icon?.classList.contains('codicon-modifier-spin'),
-				busy: label?.getAttribute('aria-busy'),
-				label: label?.getAttribute('aria-label'),
+				buttonCodicon: label.classList.contains('codicon'),
+				buttonSpinning: label.classList.contains('codicon-modifier-spin'),
+				forkIcon: icon.classList.contains(forkIconClass),
+				loadingIcon: icon.classList.contains(loadingIconClass),
+				iconSpinning: icon.classList.contains('codicon-modifier-spin'),
+				busy: label.getAttribute('aria-busy'),
+				label: label.getAttribute('aria-label'),
 			},
 		}, {
 			during: {
+				buttonCodicon: true,
 				buttonSpinning: false,
 				forkIcon: false,
 				loadingIcon: true,
@@ -69,13 +73,15 @@ suite('ChatForkActionViewItem', () => {
 		await runPromise;
 
 		assert.deepStrictEqual({
-			buttonSpinning: label?.classList.contains('codicon-modifier-spin'),
-			forkIcon: icon?.classList.contains(forkIconClass),
-			loadingIcon: icon?.classList.contains(loadingIconClass),
-			iconSpinning: icon?.classList.contains('codicon-modifier-spin'),
-			busy: label?.getAttribute('aria-busy'),
-			label: label?.getAttribute('aria-label'),
+			buttonCodicon: label.classList.contains('codicon'),
+			buttonSpinning: label.classList.contains('codicon-modifier-spin'),
+			forkIcon: icon.classList.contains(forkIconClass),
+			loadingIcon: icon.classList.contains(loadingIconClass),
+			iconSpinning: icon.classList.contains('codicon-modifier-spin'),
+			busy: label.getAttribute('aria-busy'),
+			label: label.getAttribute('aria-label'),
 		}, {
+			buttonCodicon: true,
 			buttonSpinning: false,
 			forkIcon: true,
 			loadingIcon: false,

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatForkActionViewItem.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatForkActionViewItem.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ModifierKeyEmitter } from '../../../../../../base/browser/dom.js';
+import { ActionRunner, IAction } from '../../../../../../base/common/actions.js';
+import { DeferredPromise } from '../../../../../../base/common/async.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { MenuItemAction } from '../../../../../../platform/actions/common/actions.js';
+import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
+import { ForkConversationActionId } from '../../../browser/actions/chatForkActions.js';
+import { ChatForkActionViewItem } from '../../../browser/widget/chatForkActionViewItem.js';
+
+suite('ChatForkActionViewItem', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('shows a spinner while the fork action is running', async () => {
+		store.add(toDisposable(() => ModifierKeyEmitter.disposeInstance()));
+		const instantiationService = workbenchInstantiationService(undefined, store);
+		const action = instantiationService.createInstance(MenuItemAction, {
+			id: ForkConversationActionId,
+			title: 'Fork Conversation',
+			tooltip: 'Fork conversation from this point',
+			icon: Codicon.repoForked,
+		}, undefined, undefined, undefined, undefined);
+		const viewItem = store.add(instantiationService.createInstance(ChatForkActionViewItem, action, undefined));
+		const container = document.createElement('div');
+		viewItem.render(container);
+
+		const operation = new DeferredPromise<void>();
+		const actionRunner = store.add(new class extends ActionRunner {
+			protected override async runAction(_action: IAction): Promise<void> {
+				await operation.p;
+			}
+		});
+		viewItem.actionRunner = actionRunner;
+
+		const forkIconClass = `codicon-${Codicon.repoForked.id}`;
+		const loadingIconClass = `codicon-${Codicon.loading.id}`;
+		const runPromise = actionRunner.run(action);
+		const label = container.querySelector<HTMLElement>('.action-label');
+		const icon = label?.querySelector<HTMLElement>('.chat-fork-action-icon');
+
+		assert.deepStrictEqual({
+			during: {
+				buttonSpinning: label?.classList.contains('codicon-modifier-spin'),
+				forkIcon: icon?.classList.contains(forkIconClass),
+				loadingIcon: icon?.classList.contains(loadingIconClass),
+				iconSpinning: icon?.classList.contains('codicon-modifier-spin'),
+				busy: label?.getAttribute('aria-busy'),
+				label: label?.getAttribute('aria-label'),
+			},
+		}, {
+			during: {
+				buttonSpinning: false,
+				forkIcon: false,
+				loadingIcon: true,
+				iconSpinning: true,
+				busy: 'true',
+				label: 'Forking conversation',
+			},
+		});
+
+		operation.complete();
+		await runPromise;
+
+		assert.deepStrictEqual({
+			buttonSpinning: label?.classList.contains('codicon-modifier-spin'),
+			forkIcon: icon?.classList.contains(forkIconClass),
+			loadingIcon: icon?.classList.contains(loadingIconClass),
+			iconSpinning: icon?.classList.contains('codicon-modifier-spin'),
+			busy: label?.getAttribute('aria-busy'),
+			label: label?.getAttribute('aria-label'),
+		}, {
+			buttonSpinning: false,
+			forkIcon: true,
+			loadingIcon: false,
+			iconSpinning: false,
+			busy: 'false',
+			label: 'Fork conversation from this point',
+		});
+	});
+});


### PR DESCRIPTION
- Forking a conversation can take long enough that the existing static action leaves users unsure whether their click was accepted.
- Replaces the fork glyph with an icon-only spinner for the lifetime of the asynchronous action while keeping the control surface stationary.
- Preserves accessible progress feedback and adds regression coverage for the pending and completed states.

(Commit message generated by Copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>