### PR TITLE
chat: preserve Agent Host sessions across Remote-SSH reloads

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
@@ -9,6 +9,7 @@ import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { AgentSession, type IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
+import { fromAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { ActionType, type INotification, type SessionAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { SessionStatus, type SessionSummary } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
@@ -357,7 +358,7 @@ export class AgentHostSessionListStore extends Disposable {
 		if (!workingDirectory) {
 			return false;
 		}
-		const workingDirectoryUri = typeof workingDirectory === 'string' ? URI.parse(workingDirectory) : workingDirectory;
+		const workingDirectoryUri = fromAgentHostUri(typeof workingDirectory === 'string' ? URI.parse(workingDirectory) : workingDirectory);
 		return folders.some(folder => extUriBiasedIgnorePathCase.isEqualOrParent(workingDirectoryUri, folder.uri));
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
@@ -6,7 +6,8 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
+import { Schemas } from '../../../../../../base/common/network.js';
+import { extUriBiasedIgnorePathCase, toLocalResource } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { AgentSession, type IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
 import { fromAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
@@ -358,8 +359,14 @@ export class AgentHostSessionListStore extends Disposable {
 		if (!workingDirectory) {
 			return false;
 		}
-		const workingDirectoryUri = fromAgentHostUri(typeof workingDirectory === 'string' ? URI.parse(workingDirectory) : workingDirectory);
-		return folders.some(folder => extUriBiasedIgnorePathCase.isEqualOrParent(workingDirectoryUri, folder.uri));
+		const workingDirectoryUri = typeof workingDirectory === 'string' ? URI.parse(workingDirectory) : workingDirectory;
+		const unwrappedWorkingDirectoryUri = fromAgentHostUri(workingDirectoryUri);
+		return folders.some(folder => {
+			const comparableWorkingDirectoryUri = unwrappedWorkingDirectoryUri.scheme === Schemas.file && folder.uri.scheme === Schemas.vscodeRemote
+				? toLocalResource(unwrappedWorkingDirectoryUri, folder.uri.authority, folder.uri.scheme)
+				: unwrappedWorkingDirectoryUri;
+			return extUriBiasedIgnorePathCase.isEqualOrParent(comparableWorkingDirectoryUri, folder.uri);
+		});
 	}
 
 	private _toRemoval(entry: IAgentHostSessionListEntry): IAgentHostSessionListRemoval {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -2554,7 +2554,7 @@ suite('AgentHostChatContribution', () => {
 				onDidChangeWorkspaceFolders: Event.None,
 			});
 
-			const workingDirectory = toAgentHostUri(URI.joinPath(workspaceFolder, 'sub'), 'remote');
+			const workingDirectory = toAgentHostUri(URI.file('/workspace/root/sub'), 'remote');
 			agentHostService.addSession({ session: AgentSession.uri('copilot', 'remote'), startTime: 1000, modifiedTime: 2000, summary: 'Remote workspace', workingDirectory });
 
 			const listController = createSessionListController(disposables, instantiationService, agentHostService);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -23,6 +23,7 @@ import { createTextModel } from '../../../../../../editor/test/common/testTextMo
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IAgentCreateSessionConfig, IAgentHostService, IAgentSessionMetadata, AgentSession } from '../../../../../../platform/agentHost/common/agentService.js';
+import { toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import type { ChatInputRequestWithPlanReview } from '../../../../../../platform/agentHost/common/agentHostPlanReview.js';
 import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
 import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
@@ -2541,6 +2542,25 @@ suite('AgentHostChatContribution', () => {
 			await listController.refresh(CancellationToken.None);
 
 			assert.deepStrictEqual(listController.items.map(item => item.label), ['In workspace']);
+		});
+
+		test('refresh includes remote agent host sessions from the current workspace', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			const workspaceFolder = URI.parse('vscode-remote://ssh-remote+host/workspace/root');
+			instantiationService.stub(IWorkspaceContextService, {
+				getWorkspace: () => ({ id: '', folders: [{ uri: workspaceFolder, name: 'root', index: 0, toResource: () => workspaceFolder }] }),
+				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: Event.None,
+			});
+
+			const workingDirectory = toAgentHostUri(URI.joinPath(workspaceFolder, 'sub'), 'remote');
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'remote'), startTime: 1000, modifiedTime: 2000, summary: 'Remote workspace', workingDirectory });
+
+			const listController = createSessionListController(disposables, instantiationService, agentHostService);
+			await listController.refresh(CancellationToken.None);
+
+			assert.deepStrictEqual(listController.items.map(item => item.label), ['Remote workspace']);
 		});
 
 		test('refresh does not filter when no workspace folders are open', async () => {


### PR DESCRIPTION
Fixes #326630

Agent Host working directories can use wrapped file URIs under Remote SSH. These were erroneously filtered against the `vscode-remote` workspace after a reload. Normalize all of these URIs to the local workspace before filtering and add a simple regression test.