### PR TITLE
sessions: never select a harness the picker doesn't offer

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -11,6 +11,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { ISessionsManagementService, inheritableSessionTarget } from '../../../services/sessions/common/sessionsManagement.js';
 import { BranchChatSessionAction } from './branchChatSessionAction.js';
 import { RunScriptContribution } from './runScriptAction.js';
 import './nullInlineChatSessionService.js';
@@ -89,15 +90,19 @@ class NewChatInSessionsWindowAction extends Action2 {
 
 	override run(accessor: ServicesAccessor): void {
 		const sessionsService = accessor.get(ISessionsService);
+		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const activeSession = sessionsService.activeSession.get();
 		// A quick chat never contributes its folder — it is workspace-less by
 		// intent (any scratch working directory must not seed the workspace
 		// composer), so it always falls to the New Session composer's folder picker.
 		const isQuickChat = activeSession?.isQuickChat?.get() ?? false;
+		const folderUri = isQuickChat ? undefined : activeSession?.workspace.get()?.uri;
+		// Inherit the active session's harness so the new session defaults to
+		// the kind the user is working in — but only while the folder still
+		// offers it (see `inheritableSessionTarget`).
 		sessionsService.openNewSession({
-			folderUri: isQuickChat ? undefined : activeSession?.workspace.get()?.uri,
-			providerId: activeSession?.providerId,
-			sessionTypeId: activeSession?.sessionType,
+			folderUri,
+			...inheritableSessionTarget(sessionsManagementService, activeSession, folderUri),
 		});
 	}
 }

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -285,9 +285,30 @@ export class NewChatWidget extends Disposable {
 		const folderUri = sessionWorkspace?.folders[0]?.root;
 		if (folderUri) {
 			this._workspacePicker.setSelectedWorkspace(folderUri, { fireEvent: false });
+			this._replaceDraftOnUnservableHarness(folderUri, activeSession);
 		}
 
 		return true;
+	}
+
+	/**
+	 * Replaces a restored draft whose harness the folder can no longer serve.
+	 * A draft outlives navigation, so it can name a session type that has since
+	 * stopped being advertised — e.g. the extension-host Copilot CLI once
+	 * `chat.agents.copilotCli.hideExtensionHost` is on. Keeping it would leave
+	 * the composer showing, and sending to, an agent the harness picker doesn't
+	 * list. An empty type list means the folder's providers haven't reported yet
+	 * (a late-connecting agent host), so the draft is left alone.
+	 */
+	private _replaceDraftOnUnservableHarness(folderUri: URI, draft: IActiveSession): void {
+		if (draft.isCreated.get()) {
+			return;
+		}
+		const pick = { providerId: draft.providerId, sessionTypeId: draft.sessionType };
+		if (this.sessionsManagementService.getSessionTypesForFolder(folderUri).length === 0 || this._isPreferredServable(folderUri, pick)) {
+			return;
+		}
+		void this._createNewSession(folderUri);
 	}
 
 	private _isPreferredServable(folderUri: URI, pick: IPreferredSessionType): boolean {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -15,7 +15,7 @@ import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../
 import { IProviderSessionType, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { autorun, IObservable, observableValue } from '../../../../base/common/observable.js';
-import { ISession } from '../../../services/sessions/common/session.js';
+import { ISession, SessionStatus } from '../../../services/sessions/common/session.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { isEqual } from '../../../../base/common/resources.js';
@@ -222,11 +222,16 @@ export class SessionTypePicker extends Disposable {
 		const session = this._session.get();
 		if (!this._folderSource && session) {
 			// Reflect the session's type without persisting it; storage changes only on an explicit user pick.
-			return { providerId: session.providerId, sessionTypeId: session.sessionType };
+			const pick = { providerId: session.providerId, sessionTypeId: session.sessionType };
+			// A committed session keeps showing the harness it actually runs on,
+			// even if that harness is no longer offered. An uncommitted draft is
+			// a choice about a session that does not exist yet, so it must never
+			// display a harness the picker doesn't list.
+			return session.status.get() === SessionStatus.Untitled ? this._offeredPick(pick) : pick;
 		}
 		if (!this._folderSource) {
 			// No active session: keep the stored pick to seed the next new session.
-			return this._readStoredPick();
+			return this._offeredPick(this._readStoredPick());
 		}
 		if (this._pendingInitialPick) {
 			if (this._pickServedByFolder(this._pendingInitialPick)) {
@@ -252,6 +257,27 @@ export class SessionTypePicker extends Disposable {
 		return !!pick && this._folderSessionTypes.some(t =>
 			t.sessionType.id === pick.sessionTypeId &&
 			(pick.providerId === undefined || t.providerId === pick.providerId));
+	}
+
+	/**
+	 * Constrains a pick to the types the picker actually offers, falling back to
+	 * the preferred (first) type when it doesn't. A remembered pick outlives the
+	 * harness that produced it: a session type can stop being advertised (e.g.
+	 * the extension-host Copilot CLI once `chat.agents.copilotCli.hideExtensionHost`
+	 * is on), and the stored preference still names it. Displaying it as selected
+	 * while the dropdown hides it would let the user start a session on a harness
+	 * they can no longer pick.
+	 *
+	 * An empty offer list means the types aren't known yet (no session or folder
+	 * to source them from, or a provider still connecting), so the pick is left
+	 * alone until something is actually offered.
+	 */
+	private _offeredPick(pick: IPreferredSessionType | undefined): IPreferredSessionType | undefined {
+		if (this._folderSessionTypes.length === 0 || this._pickServedByFolder(pick)) {
+			return pick;
+		}
+		const preferred = this._folderSessionTypes[0];
+		return { providerId: preferred.providerId, sessionTypeId: preferred.sessionType.id };
 	}
 
 	/** Drive the picker from a folder instead of the active session, optionally seeding the initial pick. */

--- a/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
@@ -23,7 +23,7 @@ import { ChatEntitlement, IChatEntitlementService } from '../../../../../workben
 import { TestStorageService } from '../../../../../workbench/test/common/workbenchTestServices.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IProviderSessionType, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
-import { ISession, ISessionWorkspace } from '../../../../services/sessions/common/session.js';
+import { ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { IPickedSessionType, IPreferredSessionType, ISessionTypePickerOptions, SessionTypePicker } from '../../browser/sessionTypePicker.js';
 
 // ---- Mocks ------------------------------------------------------------------
@@ -66,6 +66,7 @@ function createFakeQuickChatSession(providerId: string, sessionTypeId: string): 
 	return {
 		providerId,
 		sessionType: sessionTypeId,
+		status: constObservable(SessionStatus.Untitled),
 		workspace: constObservable(undefined),
 		isQuickChat: constObservable(true),
 	} as unknown as ISession;
@@ -75,7 +76,7 @@ function sessionType(providerId: string, id: string, label: string, chatSessionT
 	return { providerId, sessionType: { id, label, icon: Codicon.terminal, chatSessionType } };
 }
 
-function createFakeSession(providerId: string, sessionTypeId: string, folderUri: URI): ISession {
+function createFakeSession(providerId: string, sessionTypeId: string, folderUri: URI, status = SessionStatus.Untitled): ISession {
 	const workspace: ISessionWorkspace = {
 		uri: folderUri,
 		label: folderUri.path,
@@ -93,6 +94,7 @@ function createFakeSession(providerId: string, sessionTypeId: string, folderUri:
 	return {
 		providerId,
 		sessionType: sessionTypeId,
+		status: constObservable(status),
 		workspace: constObservable(workspace),
 	} as unknown as ISession;
 }
@@ -212,6 +214,53 @@ suite('SessionTypePicker', () => {
 		// user pick is untouched (only an explicit pick changes it).
 		assert.deepStrictEqual(picker.selectedPick, { providerId: 'local-1', sessionTypeId: 'local' });
 		assert.deepStrictEqual(picker.getUserPickedSessionType(), { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+	});
+
+	test('a draft never displays a harness the picker no longer offers', () => {
+		// `chat.agents.copilotCli.hideExtensionHost`: the extension-host Copilot
+		// CLI ('copilot' provider) stops being advertised, leaving only the agent
+		// host's entry — which shares the 'copilotcli' session type id.
+		management.setSessionTypes([sessionType('local-agent-host', 'copilotcli', 'Copilot')]);
+		const picker = createPicker(disposables, session, management, storage);
+
+		// A draft left over from before the harness was hidden.
+		session.set(createFakeSession('copilot', 'copilotcli', folder), undefined);
+
+		assert.deepStrictEqual(picker.selectedPick, { providerId: 'local-agent-host', sessionTypeId: 'copilotcli' });
+	});
+
+	test('a committed session keeps displaying the harness it runs on', () => {
+		management.setSessionTypes([sessionType('local-agent-host', 'copilotcli', 'Copilot')]);
+		const picker = createPicker(disposables, session, management, storage);
+
+		// An already-created extension-host session reports the truth about
+		// itself, even though its harness is no longer offered for new sessions.
+		session.set(createFakeSession('copilot', 'copilotcli', folder, SessionStatus.Completed), undefined);
+
+		assert.deepStrictEqual(picker.selectedPick, { providerId: 'copilot', sessionTypeId: 'copilotcli' });
+	});
+
+	test('a stored pick for a hidden harness does not survive into an offering picker', () => {
+		management.setSessionTypes([
+			sessionType('local-agent-host', 'copilotcli', 'Copilot'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+		picker.pick({ providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+
+		// The extension-host entry disappears; a fresh picker must not restore it
+		// as the selection just because storage still names it.
+		management.setSessionTypes([sessionType('local-agent-host', 'copilotcli', 'Copilot')]);
+		const reloaded = createPicker(disposables, observableValue<ISession | undefined>('session2', undefined), management, storage);
+		reloaded.setFolderSource(observableValue<URI | undefined>('folder', folder));
+
+		assert.deepStrictEqual({
+			stored: reloaded.getUserPickedSessionType(),
+			selected: reloaded.selectedPick,
+		}, {
+			stored: { providerId: 'copilot', sessionTypeId: 'copilot-cli' },
+			selected: { providerId: 'local-agent-host', sessionTypeId: 'copilotcli' },
+		});
 	});
 
 	test('re-selecting the default (first) session type clears the stored pick', () => {

--- a/src/vs/sessions/services/sessions/browser/sessionsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsService.ts
@@ -18,7 +18,7 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { localize } from '../../../../nls.js';
 import { ChatInteractivity, ChatOriginKind, IChat, ISession, SessionStatus } from '../common/session.js';
-import { IActiveSession, ICreateNewChatInSessionOptions, ICreateNewSessionOptions, IRecentlyOpenedSessions, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
+import { IActiveSession, ICreateNewChatInSessionOptions, ICreateNewSessionOptions, inheritableSessionTarget, IRecentlyOpenedSessions, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
 import { ISessionsProvidersService } from './sessionsProvidersService.js';
 import { SessionsNavigation } from './sessionNavigation.js';
 import { SessionsRecencyHistory } from './sessionsRecencyHistory.js';
@@ -450,7 +450,9 @@ export class SessionsService extends Disposable implements ISessionsService {
 					this.openQuickChat();
 				} else {
 					const folderUri = activeSession.workspace.read(undefined)?.folders[0]?.root;
-					this.openNewSession(folderUri ? { folderUri, providerId: activeSession.providerId, sessionTypeId: activeSession.sessionType } : undefined);
+					this.openNewSession(folderUri
+						? { folderUri, ...inheritableSessionTarget(this.sessionsManagementService, activeSession, folderUri) }
+						: undefined);
 				}
 			}
 			wasArchived = isArchived;

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -466,4 +466,30 @@ export interface ISessionsManagementService {
 
 export const ISessionsManagementService = createDecorator<ISessionsManagementService>('sessionsManagementService');
 
+/**
+ * The provider/session-type to seed a new session with when carrying the
+ * harness over from an existing session, or `undefined` when it should not be
+ * carried over.
+ *
+ * "New Session" gestures default to the harness the user is currently working
+ * in, but a harness can stop being advertised while one of its sessions is
+ * still open — e.g. the extension-host Copilot CLI once
+ * `chat.agents.copilotCli.hideExtensionHost` is on. Inheriting it then makes
+ * session creation fail (the provider no longer offers the type), which drops
+ * the folder and leaves the composer on an agent the harness picker doesn't
+ * list. Falling back to `undefined` lets the folder's preferred harness serve
+ * the new session instead.
+ */
+export function inheritableSessionTarget(
+	sessionsManagementService: ISessionsManagementService,
+	session: Pick<ISession, 'providerId' | 'sessionType'> | undefined,
+	folderUri: URI | undefined,
+): ICreateNewSessionOptions | undefined {
+	if (!session || !folderUri) {
+		return undefined;
+	}
+	const target = { providerId: session.providerId, sessionTypeId: session.sessionType };
+	return sessionsManagementService.isNewSessionTargetAvailable(folderUri, target) ? target : undefined;
+}
+
 //#endregion

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -467,9 +467,10 @@ export interface ISessionsManagementService {
 export const ISessionsManagementService = createDecorator<ISessionsManagementService>('sessionsManagementService');
 
 /**
- * The provider/session-type to seed a new session with when carrying the
- * harness over from an existing session, or `undefined` when it should not be
- * carried over.
+ * The `providerId`/`sessionTypeId` to seed a new session with when carrying the
+ * harness over from an existing session, or an empty object when it should not
+ * be carried over. Designed to be spread into a {@link ICreateNewSessionOptions}
+ * literal alongside the caller's own `folderUri`.
  *
  * "New Session" gestures default to the harness the user is currently working
  * in, but a harness can stop being advertised while one of its sessions is
@@ -477,19 +478,19 @@ export const ISessionsManagementService = createDecorator<ISessionsManagementSer
  * `chat.agents.copilotCli.hideExtensionHost` is on. Inheriting it then makes
  * session creation fail (the provider no longer offers the type), which drops
  * the folder and leaves the composer on an agent the harness picker doesn't
- * list. Falling back to `undefined` lets the folder's preferred harness serve
- * the new session instead.
+ * list. Contributing nothing lets the folder's preferred harness serve the new
+ * session instead.
  */
 export function inheritableSessionTarget(
 	sessionsManagementService: ISessionsManagementService,
 	session: Pick<ISession, 'providerId' | 'sessionType'> | undefined,
 	folderUri: URI | undefined,
-): ICreateNewSessionOptions | undefined {
+): Pick<ICreateNewSessionOptions, 'providerId' | 'sessionTypeId'> {
 	if (!session || !folderUri) {
-		return undefined;
+		return {};
 	}
 	const target = { providerId: session.providerId, sessionTypeId: session.sessionType };
-	return sessionsManagementService.isNewSessionTargetAvailable(folderUri, target) ? target : undefined;
+	return sessionsManagementService.isNewSessionTargetAvailable(folderUri, target) ? target : {};
 }
 
 //#endregion

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -20,6 +20,7 @@ import { ILogService, NullLogService } from '../../../../../platform/log/common/
 import { IProgress, IProgressService, IProgressStep } from '../../../../../platform/progress/common/progress.js';
 import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { ChatViewPaneTarget, IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatEditorOptions } from '../../../../../workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.js';
@@ -156,7 +157,7 @@ class TestSessionsProvider extends mock<ISessionsProvider>() {
 
 	override getSessions(): ISession[] { return [this._session]; }
 	override resolveWorkspace(_folderUri: URI): ISessionWorkspace | undefined { return undefined; }
-	override createNewSession(): ISession { return this._session; }
+	override createNewSession(_folderUri?: URI, _sessionTypeId?: string): ISession { return this._session; }
 	override getSessionTypes(_folderUri: URI): ISessionType[] { return [...this.sessionTypes]; }
 	override async renameChat(): Promise<void> { }
 	override getModelsSnapshot(): ISessionModelsSnapshot { return { models: [], desiredModelResolution: { kind: 'notRequested' }, modelTarget: undefined }; }
@@ -991,10 +992,79 @@ suite('SessionsManagementService', () => {
 			noFolder: inheritableSessionTarget(service, stillOfferedSession, undefined),
 			noSession: inheritableSessionTarget(service, undefined, folderUri),
 		}, {
-			hiddenHarness: undefined,
+			hiddenHarness: {},
 			offeredHarness: { providerId: 'test', sessionTypeId: 'test' },
-			noFolder: undefined,
-			noSession: undefined,
+			noFolder: {},
+			noSession: {},
+		});
+	});
+
+	test('a New Session gesture whose harness is hidden still creates on the fallback provider', async () => {
+		// End-to-end shape of the Agents-window bug: an extension-host session is
+		// open, its harness has since been hidden (`hideExtensionHost`), and the
+		// user presses New. The gesture spreads `inheritableSessionTarget` into
+		// the options, so this also covers the empty-target path at a call site.
+		const folderUri = URI.parse('test:///folder');
+		const extHostSession = stubSession({ sessionId: 'exthost-1', providerId: 'copilot', sessionType: 'copilotcli' });
+		const created: { providerId: string; sessionTypeId: string }[] = [];
+
+		// Still resolves the folder (its existing sessions stay usable) but
+		// advertises nothing for it.
+		const copilot = new class extends TestSessionsProvider {
+			override readonly id = 'copilot';
+			override readonly order = 0;
+			override readonly sessionTypes: readonly ISessionType[] = [];
+			override resolveWorkspace(_folderUri: URI): ISessionWorkspace { return { folderUri: _folderUri } as unknown as ISessionWorkspace; }
+			override getSessionTypes(): ISessionType[] { return []; }
+			override getSessions(): ISession[] { return [extHostSession]; }
+		}(extHostSession);
+
+		// The agent host sorts first (`chat.agentHost.defaultSessionsProvider`).
+		const agentHostSession = stubSession({ sessionId: 'ah-draft', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, sessionType: 'copilotcli' });
+		const agentHost = new class extends TestSessionsProvider {
+			override readonly id = LOCAL_AGENT_HOST_PROVIDER_ID;
+			override readonly order = -1;
+			override readonly sessionTypes: readonly ISessionType[] = [{ id: 'copilotcli', label: 'Copilot', icon: Codicon.vm }];
+			override resolveWorkspace(_folderUri: URI): ISessionWorkspace { return { folderUri: _folderUri } as unknown as ISessionWorkspace; }
+			override getSessionTypes(): ISessionType[] { return [{ id: 'copilotcli', label: 'Copilot', icon: Codicon.vm }]; }
+			override getSessions(): ISession[] { return []; }
+			override createNewSession(_folderUri: URI, sessionTypeId: string): ISession {
+				created.push({ providerId: this.id, sessionTypeId });
+				return agentHostSession;
+			}
+		}(agentHostSession);
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IContextKeyService, disposables.add(new MockContextKeyService()));
+		instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService([copilot, agentHost]));
+		instantiationService.stub(IUriIdentityService, { extUri: extUriBiasedIgnorePathCase });
+		instantiationService.stub(IChatWidgetService, new TestChatWidgetService());
+		instantiationService.stub(IProgressService, new TestProgressService());
+		instantiationService.stub(IChatService, new TestChatService());
+		instantiationService.stub(IWorkspaceTrustRequestService, new class extends mock<IWorkspaceTrustRequestService>() {
+			override async requestResourcesTrust(): Promise<boolean> { return true; }
+		});
+
+		const service = disposables.add(instantiationService.createInstance(SessionsManagementService));
+		const view = createView(instantiationService, service, disposables);
+		await view.openSession(extHostSession.resource);
+
+		const active = view.activeSession.get();
+		const result = await view.openNewSession({
+			folderUri,
+			...inheritableSessionTarget(service, active, folderUri),
+		});
+
+		assert.deepStrictEqual({
+			created,
+			resultProviderId: result.session?.providerId,
+			trustDeclined: result.trustDeclined,
+		}, {
+			created: [{ providerId: LOCAL_AGENT_HOST_PROVIDER_ID, sessionTypeId: 'copilotcli' }],
+			resultProviderId: LOCAL_AGENT_HOST_PROVIDER_ID,
+			trustDeclined: false,
 		});
 	});
 

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -30,7 +30,7 @@ import { ChatInteractivity, ChatOriginKind, IChat, ISession, ISessionType, ISess
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { ISessionChangeEvent, ISendRequestOptions, ISessionModelsSnapshot, ISessionModelPickerOptions, ISessionsProvider } from '../../common/sessionsProvider.js';
 import { SessionsManagementService } from '../../browser/sessionsManagementService.js';
-import { ISessionsManagementService, ICreateNewSessionOptions } from '../../common/sessionsManagement.js';
+import { ISessionsManagementService, ICreateNewSessionOptions, inheritableSessionTarget } from '../../common/sessionsManagement.js';
 import { SessionsService } from '../../browser/sessionsService.js';
 import { ISessionsPartService } from '../../browser/sessionsPartService.js';
 import { ISessionsProvidersService } from '../../browser/sessionsProvidersService.js';
@@ -964,6 +964,38 @@ suite('SessionsManagementService', () => {
 			() => service.createNewSession(URI.parse('test:///folder'), { providerId: 'test', sessionTypeId: 'missing' }),
 			/does not advertise session type 'missing'/,
 		);
+	});
+
+	test('inheritableSessionTarget drops a harness the folder no longer offers', () => {
+		const folderUri = URI.parse('test:///folder');
+		// The provider still resolves the folder (its existing sessions stay
+		// usable) but no longer advertises the type they were created with —
+		// e.g. the extension-host Copilot CLI once
+		// `chat.agents.copilotCli.hideExtensionHost` is on.
+		const hiddenHarnessSession = stubSession({ sessionId: 's1', providerId: 'test', sessionType: 'copilotcli' });
+		const provider = new class extends TestSessionsProvider {
+			override resolveWorkspace(_folderUri: URI): ISessionWorkspace {
+				return { folderUri: _folderUri } as unknown as ISessionWorkspace;
+			}
+			override getSessionTypes(): ISessionType[] {
+				return [{ id: 'test', label: 'Test', icon: Codicon.vm }];
+			}
+		}(hiddenHarnessSession);
+		const { service } = createSessionsManagementService(hiddenHarnessSession, disposables, provider);
+
+		const stillOfferedSession = stubSession({ sessionId: 's2', providerId: 'test', sessionType: 'test' });
+
+		assert.deepStrictEqual({
+			hiddenHarness: inheritableSessionTarget(service, hiddenHarnessSession, folderUri),
+			offeredHarness: inheritableSessionTarget(service, stillOfferedSession, folderUri),
+			noFolder: inheritableSessionTarget(service, stillOfferedSession, undefined),
+			noSession: inheritableSessionTarget(service, undefined, folderUri),
+		}, {
+			hiddenHarness: undefined,
+			offeredHarness: { providerId: 'test', sessionTypeId: 'test' },
+			noFolder: undefined,
+			noSession: undefined,
+		});
 	});
 
 	test('createAndSendQuickChatRequest uses the quick-chat contract without navigation or repository configuration', async () => {


### PR DESCRIPTION
## Problem

While running the experiment that replaces the extension-host Copilot CLI with the Agent Host one:

```jsonc
"chat.agents.copilotCli.hideExtensionHost": true,
"chat.agentHost.enabled": true,
"chat.agentHost.defaultSessionsProvider": true,
```

switching to an extension-host session in the Agents window and then going back to the new chat page left the **extension-host agent selected**, even though it is hidden from the harness picker. You should never be able to have an agent selected that isn't actually offered in the picker.

## Root cause

Two "remember the previous agent" mechanisms compounded.

**1. The New Session gestures inherit the previous session's harness unconditionally.**

`NewChatInSessionsWindowAction` (the New button and <kbd>Cmd+N</kbd>) passed the active session's `providerId` + `sessionType` straight to `openNewSession`. With the setting on, `CopilotChatSessionsProvider.getSessionTypes()` returns `[]`, so `_resolveProviderForNewSession` throws `does not advertise session type 'copilotcli'` — and `openNewSession` swallows it with only a trace log.

A throwaway unit test against the real `SessionsManagementService` / `SessionsService` confirmed the outcome — nothing is created on *either* provider, the folder is dropped, and the composer lands session-less:

```
activeProviderBefore: 'copilot',  createdOnCopilot: [],  createdOnAgentHost: [],
draftProviderId: undefined,       activeAfter: undefined,
folderTypes: ['local-agent-host/copilotcli']
```

**2. With no session, the picker falls back to the stored pick without validating it.**

`SessionTypePicker._computeCurrentPick()` returned either the session's `{providerId, sessionTypeId}` verbatim or `_readStoredPick()` (`sessions.userSelectedSessionType`) — never checking either against `_folderSessionTypes`, the list the dropdown actually renders. So the remembered `{providerId: 'copilot', sessionTypeId: 'copilotcli'}` shows as selected while being absent from the picker.

## Changes

- **`sessionsManagement.ts`** — new shared `inheritableSessionTarget()` helper: carry the harness over only while `isNewSessionTargetAvailable()` says the folder still offers it, otherwise fall back to the folder's preferred harness.
- **`chat.contribution.ts` / `sessionsService.ts`** — both "carry the harness over" sites (New Session, and the archived-session fallback) now route through that helper. New Session keeps the folder and lets the Agent Host's Copilot serve it.
- **`sessionTypePicker.ts`** — new `_offeredPick()` constrains the displayed pick to the offered types. Applied to the stored pick and to *uncommitted drafts*.
- **`newChatWidget.ts`** — `_replaceDraftOnUnservableHarness()` recreates a restored draft whose harness the folder can no longer serve, so the composer can't show one agent while sending to another.

## Notes for reviewers

Two deliberate carve-outs, both covered by tests:

- A **committed** session keeps displaying the harness it genuinely runs on, even if that harness is no longer offered for *new* sessions — the picker should tell the truth about an existing session.
- An **empty** type list means the folder's providers haven't reported yet (a late-connecting agent host), so the pick/draft is left alone. This preserves the existing late-discovery behaviour that `_scheduleRecreateOnProviderChange` and the "preserves an unavailable initial pick until its provider appears" tests rely on.

## Validation

- `npm run typecheck-client`, hygiene, and `npm run valid-layers-check` are clean.
- All **1659** `src/vs/sessions` unit tests pass, including 4 new regression tests:
  - `a draft never displays a harness the picker no longer offers`
  - `a committed session keeps displaying the harness it runs on`
  - `a stored pick for a hidden harness does not survive into an offering picker`
  - `inheritableSessionTarget drops a harness the folder no longer offers`

Not verified by running the app: `npm install` fails on `extensions/copilot`'s private registry here (`npm error code E401`), so the extension-host Copilot CLI side isn't buildable in this environment. Everything above is verified at the unit level against the real services. Worth a manual pass with the experiment settings before this leaves draft.

(Written by Copilot)

Fixes #327429
