### PR TITLE
agentHost: Dispose implicit read grants

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -271,6 +271,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 * Uses URI-aware comparison to dedupe repeat sends and is cleared with the connection.
 	 */
 	private readonly _grantedImplicitReadUris = new ResourceSet();
+	private readonly _implicitReadGrants = this._register(new DisposableStore());
 
 	get clientId(): string {
 		return this._clientId;
@@ -1093,8 +1094,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			return;
 		}
 		this._grantedImplicitReadUris.add(uri);
-		// The resource service also revokes these grants in connectionClosed.
-		this._resourceService.grantImplicitRead(this._address, uri);
+		this._implicitReadGrants.add(this._resourceService.grantImplicitRead(this._address, uri));
 	}
 
 	/**
@@ -1275,6 +1275,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._rejectPendingRequests(error);
 		this._resourceService.connectionClosed(this._address);
 		this._grantedImplicitReadUris.clear();
+		this._implicitReadGrants.clear();
 		this._transitionTo({ kind: AgentHostClientState.Closed, error });
 		this._onDidClose.fire();
 	}

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -1273,9 +1273,9 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			this._state.outbox.length = 0;
 		}
 		this._rejectPendingRequests(error);
-		this._resourceService.connectionClosed(this._address);
 		this._grantedImplicitReadUris.clear();
 		this._implicitReadGrants.clear();
+		this._resourceService.connectionClosed(this._address);
 		this._transitionTo({ kind: AgentHostClientState.Closed, error });
 		this._onDidClose.fire();
 	}

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -1336,9 +1336,11 @@ suite('RemoteAgentHostProtocolClient', () => {
 			assert.strictEqual(calls.length, 1);
 		});
 
-		test('connection close disposes implicit read grants', () => {
+		test('connection close disposes implicit read grants', async () => {
+			const didGrant = new DeferredPromise<void>();
 			const revoked: string[] = [];
 			const service = createResourceServiceStub({
+				onGrantImplicitRead: () => didGrant.complete(),
 				onRevokeImplicitRead: (_address, uri) => revoked.push(uri.toString()),
 			});
 			const { client, transport } = createClient(undefined, service);
@@ -1355,6 +1357,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 					],
 				},
 			});
+			await didGrant.p;
 			transport.fireClose();
 
 			assert.deepStrictEqual(revoked, ['file:///attachments/queued.txt']);

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -8,7 +8,7 @@ import { DeferredPromise, timeout } from '../../../../base/common/async.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
@@ -147,6 +147,8 @@ suite('RemoteAgentHostProtocolClient', () => {
 		granted?: (address: string, uri: URI, mode: AgentHostPermissionMode) => boolean;
 		onRequest?: (address: string, params: { uri: string; read?: boolean; write?: boolean }) => Promise<void>;
 		onGrantImplicitRead?: (address: string, uri: URI) => void;
+		/** Test hook that observes disposal of the implicit-read grant. */
+		onRevokeImplicitRead?: (address: string, uri: URI) => void;
 		readBytes?: VSBuffer;
 	}
 
@@ -189,7 +191,10 @@ suite('RemoteAgentHostProtocolClient', () => {
 			pendingFor: () => empty,
 			allPending: empty,
 			findPending: () => undefined,
-			grantImplicitRead: (address, uri) => { opts.onGrantImplicitRead?.(address, uri); return Disposable.None; },
+			grantImplicitRead: (address, uri) => {
+				opts.onGrantImplicitRead?.(address, uri);
+				return opts.onRevokeImplicitRead ? toDisposable(() => opts.onRevokeImplicitRead?.(address, uri)) : Disposable.None;
+			},
 			connectionClosed: () => { },
 		};
 	}
@@ -1329,6 +1334,30 @@ suite('RemoteAgentHostProtocolClient', () => {
 			client.dispatch(sessionUri.toString(), action);
 
 			assert.strictEqual(calls.length, 1);
+		});
+
+		test('connection close disposes implicit read grants', () => {
+			const revoked: string[] = [];
+			const service = createResourceServiceStub({
+				onRevokeImplicitRead: (_address, uri) => revoked.push(uri.toString()),
+			});
+			const { client, transport } = createClient(undefined, service);
+
+			client.dispatch('copilot-chat:/test', {
+				type: ActionType.ChatPendingMessageSet,
+				kind: PendingMessageKind.Queued,
+				id: 'queued-1',
+				message: {
+					text: 'Review this attachment',
+					origin: { kind: MessageKind.User },
+					attachments: [
+						{ type: MessageAttachmentKind.Resource, uri: 'file:///attachments/queued.txt', label: 'queued.txt' },
+					],
+				},
+			});
+			transport.fireClose();
+
+			assert.deepStrictEqual(revoked, ['file:///attachments/queued.txt']);
 		});
 
 		test('active client removal does not crash', () => {


### PR DESCRIPTION
## Summary

- retain implicit-read grant disposables for the lifetime of the remote Agent Host protocol connection
- dispose those grants when the connection closes
- add regression coverage for grant revocation

## Validation

- `npm run compile-client`
- focused `RemoteAgentHostProtocolClient` implicit-grant tests (8 passing)
- `npm run precommit`

(Written by Copilot)