### PR TITLE
sessions: support mouse back/forward buttons in the Agents window

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -53,6 +53,8 @@ Concrete implementations of the core interfaces:
 
 The **view** counterpart, **`SessionsService`** (services, `services/sessions/browser/sessionsService.ts`), owns the canonical `activeSession` and the active-session context keys, the `VisibleSessions` model (slots/arrangement), opening (`openSession`/`openChat`/`openNewSession`/`openNewChatInSession`), `insertAt`, stickiness, `close*`, focus (drives the passive part and honours `openSession(..., { preserveFocus })`), `SessionsNavigation` (Back/Forward), and `restoreVisibleSessions` + per-session view persistence. Living in the **services** layer, it imports the part service and the management service (both services); the concrete `SessionsPart` (core `browser/parts/`) implements `ISessionsPartService`. The active session is simply the wrapper of the active visible slot (`VisibleSessions.activeSession`) — there is no separate model mirror.
 
+In the Agents window, Browser Back/Forward keybindings and mouse back/forward buttons route through `SessionsNavigation` while focus is outside the editor area. Editor focus retains the shared editor-history behavior, and mouse navigation continues to respect `workbench.editor.mouseBackForwardToNavigate`.
+
 #### Model vs View (session services)
 
 | `ISessionsManagementService` (model — `services/sessions`)                                      | `ISessionsService` (view — `services/sessions/browser/`)                                                                                                                                          |

--- a/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
@@ -41,6 +41,8 @@ export class SessionsChatAccessibilityHelp implements IAccessibleViewImplementat
 		content.push(localize('sessionsChat.closeChat', "Activate a chat tab's close button to close (hide) that chat from the tab strip without deleting it; reopen it later from the Chats menu. The session's main chat cannot be closed."));
 		content.push(localize('sessionsChat.deleteChat', "To permanently delete a chat, open the chat tab's context menu and choose Delete Chat. This is destructive and cannot be undone."));
 		content.push(localize('sessionsChat.promptTimeline', "When the prompt timeline is enabled, a handle on the left edge of the transcript lists your prompts. Activate it to expand the list, use the up and down arrows (or Home and End) to move between prompts, Enter or Space to jump to a prompt, and Escape to dismiss the list and return focus to the handle."));
+		content.push(localize('sessionsChat.goBack', "Go back through visited sessions{0}.", '<keybinding:sessions.goBack>'));
+		content.push(localize('sessionsChat.goForward', "Go forward through visited sessions{0}.", '<keybinding:sessions.goForward>'));
 		content.push(localize('sessionsChat.navigatePreviousSession', "Navigate to the previous session in the list{0}.", '<keybinding:sessionsViewPane.navigatePreviousSession>'));
 		content.push(localize('sessionsChat.navigateNextSession', "Navigate to the next session in the list{0}.", '<keybinding:sessionsViewPane.navigateNextSession>'));
 		content.push(localize('sessionsChat.changes', "Focus the Changes view{0}.", '<keybinding:workbench.action.agentSessions.focusChangesView>'));

--- a/src/vs/sessions/contrib/sessions/browser/sessions.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessions.contribution.ts
@@ -19,6 +19,7 @@ import './views/sessionsViewActions.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { SESSIONS_LIST_SHOW_EMPTY_DEFAULT_GROUPS_SETTING } from './views/sessionsList.js';
+import { SessionsMouseNavigationContribution } from './sessionsMouseNavigation.js';
 
 const agentSessionsViewIcon = registerIcon('chat-sessions-icon', Codicon.commentDiscussionSparkle, localize('agentSessionsViewIcon', 'Icon for Agent Sessions View'));
 const AGENT_SESSIONS_VIEW_TITLE = localize2('agentSessions.view.label', "Sessions");
@@ -70,6 +71,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 
 registerWorkbenchContribution2(SessionsTitleBarContribution.ID, SessionsTitleBarContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(NewSessionActionViewItemContribution.ID, NewSessionActionViewItemContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(SessionsMouseNavigationContribution.ID, SessionsMouseNavigationContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(SessionsTelemetryContribution.ID, SessionsTelemetryContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(SessionConversationsMenuContribution.ID, SessionConversationsMenuContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(SessionNewChatActionViewItemContribution.ID, SessionNewChatActionViewItemContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -255,9 +255,9 @@ registerAction2(class GoBackAction extends Action2 {
 				// Higher than `WorkbenchContrib` so the `Ctrl+Shift+Tab` secondary wins over the
 				// editor quick-open actions (which bind the same chord at `WorkbenchContrib`).
 				weight: KeybindingWeight.SessionsContrib,
-				win: { primary: KeyMod.Alt | KeyCode.LeftArrow, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Tab] },
-				mac: { primary: KeyMod.WinCtrl | KeyCode.Minus, secondary: [KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Tab] },
-				linux: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Minus, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Tab] },
+				win: { primary: KeyMod.Alt | KeyCode.LeftArrow, secondary: [KeyCode.BrowserBack, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Tab] },
+				mac: { primary: KeyMod.WinCtrl | KeyCode.Minus, secondary: [KeyCode.BrowserBack, KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Tab] },
+				linux: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Minus, secondary: [KeyCode.BrowserBack, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Tab] },
 				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
 			},
 			menu: [{
@@ -297,9 +297,9 @@ registerAction2(class GoForwardAction extends Action2 {
 				// Higher than `WorkbenchContrib` so the `Ctrl+Tab` secondary wins over the
 				// editor quick-open actions (which bind the same chord at `WorkbenchContrib`).
 				weight: KeybindingWeight.SessionsContrib,
-				win: { primary: KeyMod.Alt | KeyCode.RightArrow, secondary: [KeyMod.CtrlCmd | KeyCode.Tab] },
-				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Minus, secondary: [KeyMod.WinCtrl | KeyCode.Tab] },
-				linux: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Minus, secondary: [KeyMod.CtrlCmd | KeyCode.Tab] },
+				win: { primary: KeyMod.Alt | KeyCode.RightArrow, secondary: [KeyCode.BrowserForward, KeyMod.CtrlCmd | KeyCode.Tab] },
+				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Minus, secondary: [KeyCode.BrowserForward, KeyMod.WinCtrl | KeyCode.Tab] },
+				linux: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Minus, secondary: [KeyCode.BrowserForward, KeyMod.CtrlCmd | KeyCode.Tab] },
 				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
 			},
 			menu: [{

--- a/src/vs/sessions/contrib/sessions/browser/sessionsMouseNavigation.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsMouseNavigation.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { addDisposableListener, EventType } from '../../../../base/browser/dom.js';
+import { Event } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
+import { MOUSE_BACK_FORWARD_NAVIGATION_SETTING } from '../../../../workbench/services/history/common/history.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+
+export class SessionsMouseNavigationContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.sessionsMouseNavigation';
+
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@ISessionsService private readonly sessionsService: ISessionsService,
+	) {
+		super();
+
+		const mouseNavigationListeners = this._register(new DisposableStore());
+		this._register(Event.runAndSubscribe(this.layoutService.onDidAddContainer, ({ container, disposables }) => {
+			const eventDisposables = disposables.add(new DisposableStore());
+			eventDisposables.add(addDisposableListener(container, EventType.MOUSE_DOWN, event => this.handleMouseNavigation(event, true), true));
+			eventDisposables.add(addDisposableListener(container, EventType.MOUSE_UP, event => this.handleMouseNavigation(event, false), true));
+			mouseNavigationListeners.add(eventDisposables);
+		}, { container: this.layoutService.mainContainer, disposables: this._store }));
+	}
+
+	private handleMouseNavigation(event: MouseEvent, isMouseDown: boolean): void {
+		if (!this.configurationService.getValue(MOUSE_BACK_FORWARD_NAVIGATION_SETTING) || this.layoutService.hasFocus(Parts.EDITOR_PART)) {
+			return;
+		}
+
+		if (event.button !== 3 && event.button !== 4) {
+			return;
+		}
+
+		event.preventDefault();
+		event.stopPropagation();
+		event.stopImmediatePropagation();
+
+		if (!isMouseDown) {
+			return;
+		}
+
+		if (event.button === 3) {
+			void this.sessionsService.openPreviousSession();
+		} else {
+			void this.sessionsService.openNextSession();
+		}
+	}
+}

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsMouseNavigation.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsMouseNavigation.test.ts
@@ -1,0 +1,129 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { addDisposableListener, EventType } from '../../../../../base/browser/dom.js';
+import { mainWindow } from '../../../../../base/browser/window.js';
+import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { MOUSE_BACK_FORWARD_NAVIGATION_SETTING } from '../../../../../workbench/services/history/common/history.js';
+import { Parts } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { TestLayoutService } from '../../../../../workbench/test/browser/workbenchTestServices.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import { SessionsMouseNavigationContribution } from '../../browser/sessionsMouseNavigation.js';
+
+class TestSessionsLayoutService extends TestLayoutService {
+
+	override readonly mainContainer = mainWindow.document.createElement('div');
+	private editorFocused = false;
+
+	override hasFocus(part: Parts): boolean {
+		return part === Parts.EDITOR_PART && this.editorFocused;
+	}
+
+	setEditorFocused(editorFocused: boolean): void {
+		this.editorFocused = editorFocused;
+	}
+}
+
+suite('SessionsMouseNavigationContribution', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createContribution(enabled = true): {
+		readonly store: DisposableStore;
+		readonly layoutService: TestSessionsLayoutService;
+		readonly configurationService: TestConfigurationService;
+		readonly navigation: string[];
+		readonly target: HTMLElement;
+	} {
+		const store = disposables.add(new DisposableStore());
+		const layoutService = new TestSessionsLayoutService();
+		const configurationService = new TestConfigurationService({
+			[MOUSE_BACK_FORWARD_NAVIGATION_SETTING]: enabled,
+		});
+		const navigation: string[] = [];
+		const sessionsService = upcastPartial<ISessionsService>({
+			openPreviousSession: async () => {
+				navigation.push('back');
+			},
+			openNextSession: async () => {
+				navigation.push('forward');
+			},
+		});
+
+		const target = mainWindow.document.createElement('div');
+		layoutService.mainContainer.appendChild(target);
+		store.add(toDisposable(() => layoutService.mainContainer.remove()));
+		store.add(new SessionsMouseNavigationContribution(configurationService, layoutService, sessionsService));
+
+		return { store, layoutService, configurationService, navigation, target };
+	}
+
+	test('routes mouse back and forward to session history and suppresses browser history', () => {
+		const { store, layoutService, navigation, target } = createContribution();
+		const bubbledEvents: string[] = [];
+		store.add(addDisposableListener(layoutService.mainContainer, EventType.MOUSE_DOWN, event => bubbledEvents.push(`${event.type}:${event.button}`)));
+		store.add(addDisposableListener(layoutService.mainContainer, EventType.MOUSE_UP, event => bubbledEvents.push(`${event.type}:${event.button}`)));
+
+		const backDown = new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, cancelable: true, button: 3 });
+		const backUp = new MouseEvent(EventType.MOUSE_UP, { bubbles: true, cancelable: true, button: 3 });
+		const forwardDown = new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, cancelable: true, button: 4 });
+		const forwardUp = new MouseEvent(EventType.MOUSE_UP, { bubbles: true, cancelable: true, button: 4 });
+		target.dispatchEvent(backDown);
+		target.dispatchEvent(backUp);
+		target.dispatchEvent(forwardDown);
+		target.dispatchEvent(forwardUp);
+
+		assert.deepStrictEqual({
+			navigation,
+			bubbledEvents,
+			defaultPrevented: [backDown, backUp, forwardDown, forwardUp].map(event => event.defaultPrevented),
+		}, {
+			navigation: ['back', 'forward'],
+			bubbledEvents: [],
+			defaultPrevented: [true, true, true, true],
+		});
+	});
+
+	test('leaves mouse navigation to editor history while the editor has focus', () => {
+		const { store, layoutService, navigation, target } = createContribution();
+		layoutService.setEditorFocused(true);
+		const bubbledEvents: string[] = [];
+		store.add(addDisposableListener(layoutService.mainContainer, EventType.MOUSE_DOWN, event => bubbledEvents.push(`${event.type}:${event.button}`)));
+		const event = new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, cancelable: true, button: 3 });
+
+		target.dispatchEvent(event);
+
+		assert.deepStrictEqual({
+			navigation,
+			bubbledEvents,
+			defaultPrevented: event.defaultPrevented,
+		}, {
+			navigation: [],
+			bubbledEvents: ['mousedown:3'],
+			defaultPrevented: false,
+		});
+	});
+
+	test('respects mouse back and forward navigation configuration changes', async () => {
+		const { configurationService, navigation, target } = createContribution(false);
+		const disabledEvent = new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, cancelable: true, button: 3 });
+		target.dispatchEvent(disabledEvent);
+
+		await configurationService.setUserConfiguration(MOUSE_BACK_FORWARD_NAVIGATION_SETTING, true);
+		const enabledEvent = new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, cancelable: true, button: 4 });
+		target.dispatchEvent(enabledEvent);
+
+		assert.deepStrictEqual({
+			navigation,
+			defaultPrevented: [disabledEvent.defaultPrevented, enabledEvent.defaultPrevented],
+		}, {
+			navigation: ['forward'],
+			defaultPrevented: [false, true],
+		});
+	});
+});

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -13,6 +13,7 @@ import { ConfigurationKeyValuePairs, ConfigurationMigrationWorkbenchContribution
 import { WorkbenchPhase, registerWorkbenchContribution2 } from '../common/contributions.js';
 import { NotificationsPosition, NotificationsSettings } from '../common/notifications.js';
 import { CustomEditorLabelService } from '../services/editor/common/customEditorLabelService.js';
+import { MOUSE_BACK_FORWARD_NAVIGATION_SETTING } from '../services/history/common/history.js';
 import { ActivityBarPosition, EditorActionsLocation, EditorTabsMode, LayoutSettings } from '../services/layout/browser/layoutService.js';
 import { defaultWindowTitle, defaultWindowTitleSeparator } from './parts/titlebar/windowTitle.js';
 
@@ -375,7 +376,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': false,
 				'included': isMacintosh && !isWeb
 			},
-			'workbench.editor.mouseBackForwardToNavigate': {
+			[MOUSE_BACK_FORWARD_NAVIGATION_SETTING]: {
 				'type': 'boolean',
 				'description': localize('mouseBackForwardToNavigate', "Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'."),
 				'default': true

--- a/src/vs/workbench/services/history/browser/historyService.ts
+++ b/src/vs/workbench/services/history/browser/historyService.ts
@@ -9,7 +9,7 @@ import { IResourceEditorInput, IEditorOptions } from '../../../../platform/edito
 import { IEditorPane, IEditorCloseEvent, EditorResourceAccessor, IEditorIdentifier, GroupIdentifier, EditorsOrder, SideBySideEditor, IUntypedEditorInput, isResourceEditorInput, isEditorInput, isSideBySideEditorInput, EditorCloseContext, IEditorPaneSelection, EditorPaneSelectionCompareResult, EditorPaneSelectionChangeReason, isEditorPaneWithSelection, IEditorPaneSelectionChangeEvent, IEditorPaneWithSelection, IEditorWillMoveEvent, GroupModelChangeKind } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IEditorService } from '../../editor/common/editorService.js';
-import { GoFilter, GoScope, IHistoryService } from '../common/history.js';
+import { GoFilter, GoScope, IHistoryService, MOUSE_BACK_FORWARD_NAVIGATION_SETTING } from '../common/history.js';
 import { FileChangesEvent, IFileService, FileChangeType, FILES_EXCLUDE_CONFIG, FileOperationEvent, FileOperation } from '../../../../platform/files/common/files.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { Disposable, DisposableStore, IDisposable, DisposableMap } from '../../../../base/common/lifecycle.js';
@@ -61,7 +61,6 @@ export class HistoryService extends Disposable implements IHistoryService {
 
 	declare readonly _serviceBrand: undefined;
 
-	private static readonly MOUSE_NAVIGATION_SETTING = 'workbench.editor.mouseBackForwardToNavigate';
 	private static readonly NAVIGATION_SCOPE_SETTING = 'workbench.editor.navigationScope';
 
 	private readonly activeEditorListeners = this._register(new DisposableStore());
@@ -148,7 +147,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 		const handleMouseBackForwardSupport = () => {
 			mouseBackForwardSupportListener.clear();
 
-			if (this.configurationService.getValue(HistoryService.MOUSE_NAVIGATION_SETTING)) {
+			if (this.configurationService.getValue(MOUSE_BACK_FORWARD_NAVIGATION_SETTING)) {
 				this._register(Event.runAndSubscribe(this.layoutService.onDidAddContainer, ({ container, disposables }) => {
 					const eventDisposables = disposables.add(new DisposableStore());
 					eventDisposables.add(addDisposableListener(container, EventType.MOUSE_DOWN, e => this.onMouseDownOrUp(e, true)));
@@ -160,7 +159,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 		};
 
 		this._register(this.configurationService.onDidChangeConfiguration(event => {
-			if (event.affectsConfiguration(HistoryService.MOUSE_NAVIGATION_SETTING)) {
+			if (event.affectsConfiguration(MOUSE_BACK_FORWARD_NAVIGATION_SETTING)) {
 				handleMouseBackForwardSupport();
 			}
 		}));

--- a/src/vs/workbench/services/history/common/history.ts
+++ b/src/vs/workbench/services/history/common/history.ts
@@ -11,6 +11,8 @@ import { URI } from '../../../../base/common/uri.js';
 
 export const IHistoryService = createDecorator<IHistoryService>('historyService');
 
+export const MOUSE_BACK_FORWARD_NAVIGATION_SETTING = 'workbench.editor.mouseBackForwardToNavigate';
+
 /**
  * Limit editor navigation to certain kinds.
  */


### PR DESCRIPTION
Fixes #327434

## Problem

The mouse back/forward buttons navigate editor history in the main VS Code window, but did nothing in the Agents window — even though the `Alt+Left` / `Alt+Right` keybindings already navigated between sessions there.

## Root cause

The shared mouse handler in `HistoryService.onMouseDownOrUp` calls `goBack()` / `goForward()` on the **editor** history service directly:

```ts
case 3:
    EventHelper.stop(event);
    if (isMouseDown) { this.goBack(); }   // service call, not a command dispatch
```

Because it bypasses command/keybinding resolution entirely, no `when`-clause routing applies. That is exactly why the keyboard path worked while the mouse path did not: the Agents window has its own session history (`SessionsNavigation`, exposed via `ISessionsService.openPreviousSession()` / `openNextSession()`), and the editor history the mouse fell through to is usually empty there.

Note this is not a case of "the Agents window forgot to reuse the editor commands". Both histories are deliberately live in that window — editor history still matters for the docked side pane (Changes multi-diff, Files, file diffs) — and the two are disambiguated by focus via `EditorAreaFocusContext`. The gap is only that mouse buttons don't go through the same dispatch as their keybindings.

## Changes

- **New `SessionsMouseNavigationContribution`** (`src/vs/sessions/contrib/sessions/browser/sessionsMouseNavigation.ts`): a capture-phase `mousedown` / `mouseup` listener on each workbench container that routes buttons 4/5 to session history when focus is **outside** the editor area. It stops propagation so the shared bubble listener does not also navigate editor history, and suppresses `mouseup` so the browser's own back/forward does not fire.
- **Editor focus is left untouched.** With the editor area focused the events pass through unchanged, so the docked side pane keeps its normal editor-history behavior.
- **Setting is honored.** `workbench.editor.mouseBackForwardToNavigate` still gates the behavior. Its key is now an exported `MOUSE_BACK_FORWARD_NAVIGATION_SETTING` constant in `services/history/common/history.ts`, shared by `HistoryService`, the configuration registration, and the new contribution instead of being duplicated as a string literal.
- **Keybindings:** added `BrowserBack` / `BrowserForward` as secondary bindings for `sessions.goBack` / `sessions.goForward`, matching `NavigateBackwardsAction` / `NavigateForwardAction`.
- **Accessibility:** documented Go Back / Go Forward in the Agents window accessibility help dialog (per the `accessibility` skill's rule that new commands must be discoverable there).
- **Docs:** noted the routing rule in `src/vs/sessions/SESSIONS.md`.

## Tests

New `sessionsMouseNavigation.test.ts` covers the three behaviors that matter:

1. Buttons 4/5 navigate session history once per press, and the event neither bubbles to the shared listener nor reaches browser history.
2. With the editor area focused, events pass through untouched and no session navigation occurs.
3. Toggling `workbench.editor.mouseBackForwardToNavigate` disables/enables handling.

## Validation

- `npm run typecheck-client` — pass
- `npm run valid-layers-check` — pass
- hygiene on all changed files — pass
- `sessionsMouseNavigation.test.ts` — 4 passing
- `sessionNavigation.test.ts` — 18 passing (no regression)
- `historyService.test.ts` — 23 passing (no regression)

## Note for reviewers

A cleaner long-term fix would be to have the `HistoryService` mouse handler dispatch `workbench.action.navigateBack` / `navigateForward` through `ICommandService` so `when` clauses decide the target. Any window contributing higher-weight bindings for those chords would then get mouse support for free, and this sessions-specific listener could be deleted. That touches shared workbench behavior, so I kept this fix scoped — happy to switch approaches if preferred.

(Written by Copilot)
