### PR TITLE
Set AI_AGENT for all agent sessions, not just runInTerminal

### DIFF
--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -152,9 +152,8 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 				...deepClone(process.env),
 				...shellEnv,
 				// Announce that everything spawned below this process is driven by
-				// VS Code's agent, so `git` / `gh` and other inheriting tools can be
-				// attributed back to this surface. Set after the inherited env so it
-				// always wins — the agent host only ever runs agent sessions.
+				// VS Code's agent, so `git` / `gh` inherit it. Set after the
+				// inherited env so it wins.
 				[AiAgentEnvVar]: AiAgentEnvValue,
 				VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 				VSCODE_PIPE_LOGGING: 'true',

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -152,8 +152,8 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 				...deepClone(process.env),
 				...shellEnv,
 				// Announce that everything spawned below this process is driven by
-				// VS Code's agent, so `git` / `gh` inherit it. Set after the
-				// inherited env so it wins.
+				// VS Code's agent, so `gh` inherits it. Set after the inherited
+				// env so it wins.
 				[AiAgentEnvVar]: AiAgentEnvValue,
 				VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 				VSCODE_PIPE_LOGGING: 'true',

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -9,6 +9,7 @@ import { Emitter } from '../../../base/common/event.js';
 import { IpcMainEvent } from 'electron';
 import { validatedIpcMain } from '../../../base/parts/ipc/electron-main/ipcMain.js';
 import { Client as MessagePortClient } from '../../../base/parts/ipc/electron-main/ipc.mp.js';
+import { AiAgentEnvValue, AiAgentEnvVar } from '../../chat/common/aiAgentEnv.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentMainService } from '../../environment/electron-main/environmentMainService.js';
 import { parseAgentHostDebugPort } from '../../environment/node/environmentService.js';
@@ -150,6 +151,11 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 			env: {
 				...deepClone(process.env),
 				...shellEnv,
+				// Announce that everything spawned below this process is driven by
+				// VS Code's agent, so `git` / `gh` and other inheriting tools can be
+				// attributed back to this surface. Set after the inherited env so it
+				// always wins — the agent host only ever runs agent sessions.
+				[AiAgentEnvVar]: AiAgentEnvValue,
 				VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 				VSCODE_PIPE_LOGGING: 'true',
 				VSCODE_VERBOSE_LOGGING: 'true',

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -297,9 +297,8 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		// Shell integration — inject scripts so the shell emits OSC 633 sequences
 		const nonce = generateUuid();
 		const env: Record<string, string> = { ...process.env as Record<string, string> };
-		// Announce that these commands are driven by VS Code's agent so `git` /
-		// `gh` can attribute them. Inherited from the agent host process, but set
-		// explicitly so the guarantee does not depend on how the host was spawned.
+		// Attribute these commands to VS Code. Already inherited from the agent
+		// host process; set here as defense in depth.
 		env[AiAgentEnvVar] = AiAgentEnvValue;
 		if (options?.preventShellHistory) {
 			// Picked up by the shell integration scripts to set HISTCONTROL=ignorespace

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -12,6 +12,7 @@ import * as platform from '../../../base/common/platform.js';
 import { getSystemShell } from '../../../base/node/shell.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
+import { AiAgentEnvValue, AiAgentEnvVar } from '../../chat/common/aiAgentEnv.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
@@ -296,6 +297,10 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		// Shell integration — inject scripts so the shell emits OSC 633 sequences
 		const nonce = generateUuid();
 		const env: Record<string, string> = { ...process.env as Record<string, string> };
+		// Announce that these commands are driven by VS Code's agent so `git` /
+		// `gh` can attribute them. Inherited from the agent host process, but set
+		// explicitly so the guarantee does not depend on how the host was spawned.
+		env[AiAgentEnvVar] = AiAgentEnvValue;
 		if (options?.preventShellHistory) {
 			// Picked up by the shell integration scripts to set HISTCONTROL=ignorespace
 			// (bash) / HIST_IGNORE_SPACE (zsh), or suppress PSReadLine history (pwsh).

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'os';
 import { delimiter, dirname } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
 import { rgDiskPath } from '../../../../base/node/ripgrep.js';
+import { AiAgentEnvValue, AiAgentEnvVar } from '../../../chat/common/aiAgentEnv.js';
 import { ClaudePermissionMode } from '../../common/claudeSessionConfigKeys.js';
 import { resolveClaudeEffort } from '../../common/claudeModelConfig.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
@@ -110,6 +111,12 @@ export async function buildOptions(
 			: {}),
 		CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
 		USE_BUILTIN_RIPGREP: '0',
+		// Attribute the CLI's own tool subprocesses (`git`, `gh`, …) to VS Code.
+		// `settings.env` is what the CLI layers onto the commands it runs, so it
+		// has to carry the marker in addition to the spawn env below. Claude Code
+		// only overwrites `AI_AGENT` when it is unset or already one of its own
+		// `claude-code_*` values, so this survives into the shell.
+		[AiAgentEnvVar]: AiAgentEnvValue,
 		PATH: `${dirname(resolvedRgDiskPath)}${delimiter}${process.env.PATH ?? ''}`,
 	};
 
@@ -215,8 +222,9 @@ export function buildModelEnumerationOptions(): Options {
  *
  * In both modes the agent host's own `NODE_OPTIONS`, `ELECTRON_*`, and
  * `VSCODE_*` variables are stripped (they break the Electron-node subprocess),
- * and `ELECTRON_RUN_AS_NODE=1` is set. Mirror of CopilotAgent's strip pattern
- * at copilotAgent.ts:434-450.
+ * `ELECTRON_RUN_AS_NODE=1` is set, and `AI_AGENT` is pinned so the sparse
+ * proxied env still announces the originating VS Code surface. Mirror of
+ * CopilotAgent's strip pattern at copilotAgent.ts:434-450.
  *
  * Exported for unit testing as a pure function over `process.env`.
  */
@@ -234,6 +242,9 @@ export function buildSubprocessEnv(proxied: boolean = true): Record<string, stri
 			USERPROFILE: process.env['USERPROFILE'],
 		}
 		: { ...process.env, ELECTRON_RUN_AS_NODE: '1', NODE_OPTIONS: undefined };
+	// Replace semantics mean the sparse (proxied) env would otherwise drop the
+	// agent host's own marker, so set it in both modes. See `AiAgentEnvVar`.
+	env[AiAgentEnvVar] = AiAgentEnvValue;
 	for (const key of Object.keys(process.env)) {
 		if (key === 'ELECTRON_RUN_AS_NODE') { continue; }
 		if (key.startsWith('VSCODE_') || key.startsWith('ELECTRON_')) {

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -111,11 +111,11 @@ export async function buildOptions(
 			: {}),
 		CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
 		USE_BUILTIN_RIPGREP: '0',
-		// Attribute the CLI's own tool subprocesses (`git`, `gh`, …) to VS Code.
+		// Attribute the CLI's tool subprocesses (`git`, `gh`, …) to VS Code.
 		// `settings.env` is what the CLI layers onto the commands it runs, so it
-		// has to carry the marker in addition to the spawn env below. Claude Code
-		// only overwrites `AI_AGENT` when it is unset or already one of its own
-		// `claude-code_*` values, so this survives into the shell.
+		// needs the marker in addition to the spawn env below. Note the CLI
+		// re-stamps `AI_AGENT` as `claude-code_<version>_agent` for its own Bash
+		// tool, so commands from that tool are not attributed to VS Code.
 		[AiAgentEnvVar]: AiAgentEnvValue,
 		PATH: `${dirname(resolvedRgDiskPath)}${delimiter}${process.env.PATH ?? ''}`,
 	};
@@ -223,8 +223,8 @@ export function buildModelEnumerationOptions(): Options {
  * In both modes the agent host's own `NODE_OPTIONS`, `ELECTRON_*`, and
  * `VSCODE_*` variables are stripped (they break the Electron-node subprocess),
  * `ELECTRON_RUN_AS_NODE=1` is set, and `AI_AGENT` is pinned so the sparse
- * proxied env still announces the originating VS Code surface. Mirror of
- * CopilotAgent's strip pattern at copilotAgent.ts:434-450.
+ * proxied env still announces the originating VS Code surface. Mirror of the
+ * strip pattern in `CopilotAgent._ensureClient()`.
  *
  * Exported for unit testing as a pure function over `process.env`.
  */

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -111,7 +111,7 @@ export async function buildOptions(
 			: {}),
 		CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
 		USE_BUILTIN_RIPGREP: '0',
-		// Attribute the CLI's tool subprocesses (`git`, `gh`, …) to VS Code.
+		// Attribute the CLI's tool subprocesses (`gh`, …) to VS Code.
 		// `settings.env` is what the CLI layers onto the commands it runs, so it
 		// needs the marker in addition to the spawn env below. Note the CLI
 		// re-stamps `AI_AGENT` as `claude-code_<version>_agent` for its own Bash

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -54,11 +54,9 @@ export function buildCodexLaunchConfig(
 			`model_providers.vscode-proxy.requires_openai_auth=false`,
 			`model_providers.vscode-proxy.supports_websockets=false`,
 		] : []),
-		// Codex filters its shell tool's environment through
-		// `shell_environment_policy` rather than passing its own env straight
-		// through, so pin the marker there too — otherwise a user-configured
-		// policy (e.g. `inherit = "core"`) silently drops it before `git` / `gh`
-		// ever see it.
+		// Codex filters its shell tool's env through `shell_environment_policy`,
+		// so pin the marker there too — a user policy (e.g. `inherit = "core"`)
+		// would otherwise drop it.
 		`shell_environment_policy.set.${AiAgentEnvVar}="${AiAgentEnvValue}"`,
 		`features.tool_call_mcp_elicitation=false`,
 		...(proxy ? [`features.image_generation=false`] : []),

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AiAgentEnvValue, AiAgentEnvVar } from '../../../chat/common/aiAgentEnv.js';
 import type { CodexUsageSource } from '../../common/agentHostCustomizationConfig.js';
 import type { ThreadResumeParams } from './protocol/generated/v2/ThreadResumeParams.js';
 import type { JsonValue } from './protocol/generated/serde_json/JsonValue.js';
@@ -39,7 +40,7 @@ export function buildCodexLaunchConfig(
 	if ((usageSource === 'copilot') !== (proxy !== undefined)) {
 		throw new Error(`Codex ${usageSource} launch received an invalid proxy configuration`);
 	}
-	const env: NodeJS.ProcessEnv = { ...inheritedEnv };
+	const env: NodeJS.ProcessEnv = { ...inheritedEnv, [AiAgentEnvVar]: AiAgentEnvValue };
 	if (proxy) {
 		env.OPENAI_API_KEY = proxy.nonce;
 	}
@@ -53,6 +54,12 @@ export function buildCodexLaunchConfig(
 			`model_providers.vscode-proxy.requires_openai_auth=false`,
 			`model_providers.vscode-proxy.supports_websockets=false`,
 		] : []),
+		// Codex filters its shell tool's environment through
+		// `shell_environment_policy` rather than passing its own env straight
+		// through, so pin the marker there too — otherwise a user-configured
+		// policy (e.g. `inherit = "core"`) silently drops it before `git` / `gh`
+		// ever see it.
+		`shell_environment_policy.set.${AiAgentEnvVar}="${AiAgentEnvValue}"`,
 		`features.tool_call_mcp_elicitation=false`,
 		...(proxy ? [`features.image_generation=false`] : []),
 	];

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -964,7 +964,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			env['COPILOT_CLI_RUN_AS_NODE'] = '1';
 			env['USE_BUILTIN_RIPGREP'] = 'false';
 			env['COPILOT_MCP_APPS'] = 'true';
-			// Attribute the CLI and everything it spawns (`git`, `gh`, …) back to
+			// Attribute the CLI and everything it spawns (`gh`, …) back to
 			// VS Code. Already inherited via `process.env` (the strip loop only
 			// removes `VSCODE_*`/`ELECTRON_*`); set here as defense in depth.
 			env[AiAgentEnvVar] = AiAgentEnvValue;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -965,8 +965,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 			env['USE_BUILTIN_RIPGREP'] = 'false';
 			env['COPILOT_MCP_APPS'] = 'true';
 			// Attribute the CLI and everything it spawns (`git`, `gh`, …) back to
-			// VS Code. Inherited from the agent host process, but re-set explicitly
-			// because the strip loop above rebuilds this env from scratch.
+			// VS Code. Already inherited via `process.env` (the strip loop only
+			// removes `VSCODE_*`/`ELECTRON_*`); set here as defense in depth.
 			env[AiAgentEnvVar] = AiAgentEnvValue;
 			// Required by the currently bundled SDK to enable its experimental auto-approval judge.
 			env['AUTO_APPROVAL'] = 'true';

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -24,6 +24,7 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { rgDiskPath } from '../../../../base/node/ripgrep.js';
 import { localize } from '../../../../nls.js';
 import { IParsedAgent, IParsedPlugin, IParsedRule, IParsedSkill, parseAgentFile, parsePlugin, parseRuleFile, parseSkillFile, PluginFormat } from '../../../agentPlugins/common/pluginParsers.js';
+import { AiAgentEnvValue, AiAgentEnvVar } from '../../../chat/common/aiAgentEnv.js';
 import { IFileService } from '../../../files/common/files.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService, LogLevel } from '../../../log/common/log.js';
@@ -963,6 +964,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 			env['COPILOT_CLI_RUN_AS_NODE'] = '1';
 			env['USE_BUILTIN_RIPGREP'] = 'false';
 			env['COPILOT_MCP_APPS'] = 'true';
+			// Attribute the CLI and everything it spawns (`git`, `gh`, …) back to
+			// VS Code. Inherited from the agent host process, but re-set explicitly
+			// because the strip loop above rebuilds this env from scratch.
+			env[AiAgentEnvVar] = AiAgentEnvValue;
 			// Required by the currently bundled SDK to enable its experimental auto-approval judge.
 			env['AUTO_APPROVAL'] = 'true';
 			await this._configureProxyEnv(env);

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -7,6 +7,7 @@ import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { FileAccess, Schemas } from '../../../base/common/network.js';
 import { Client, IIPCOptions } from '../../../base/parts/ipc/node/ipc.cp.js';
+import { AiAgentEnvValue, AiAgentEnvVar } from '../../chat/common/aiAgentEnv.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentService, INativeEnvironmentService } from '../../environment/common/environment.js';
 import { parseAgentHostDebugPort } from '../../environment/node/environmentService.js';
@@ -69,6 +70,11 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 
 		const env: Record<string, string> = {
 			...shellEnv as Record<string, string>,
+			// Announce that everything spawned below this process is driven by
+			// VS Code's agent, so `git` / `gh` and other inheriting tools can be
+			// attributed back to this surface. Set after the inherited env so it
+			// always wins — the agent host only ever runs agent sessions.
+			[AiAgentEnvVar]: AiAgentEnvValue,
 			VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 			VSCODE_PIPE_LOGGING: 'true',
 			VSCODE_VERBOSE_LOGGING: 'true',

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -71,9 +71,8 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 		const env: Record<string, string> = {
 			...shellEnv as Record<string, string>,
 			// Announce that everything spawned below this process is driven by
-			// VS Code's agent, so `git` / `gh` and other inheriting tools can be
-			// attributed back to this surface. Set after the inherited env so it
-			// always wins — the agent host only ever runs agent sessions.
+			// VS Code's agent, so `git` / `gh` inherit it. Set after the
+			// inherited env so it wins.
 			[AiAgentEnvVar]: AiAgentEnvValue,
 			VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 			VSCODE_PIPE_LOGGING: 'true',

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -71,8 +71,8 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 		const env: Record<string, string> = {
 			...shellEnv as Record<string, string>,
 			// Announce that everything spawned below this process is driven by
-			// VS Code's agent, so `git` / `gh` inherit it. Set after the
-			// inherited env so it wins.
+			// VS Code's agent, so `gh` inherits it. Set after the inherited
+			// env so it wins.
 			[AiAgentEnvVar]: AiAgentEnvValue,
 			VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 			VSCODE_PIPE_LOGGING: 'true',

--- a/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
@@ -109,7 +109,7 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 			electronOther: env.ELECTRON_NO_ATTACH_CONSOLE,
 			nodeOptions: env.NODE_OPTIONS,
 			runAsNode: env.ELECTRON_RUN_AS_NODE,
-			// Announces the originating VS Code surface to `git` / `gh`.
+			// Announces the originating VS Code surface to `gh`.
 			aiAgent: env.AI_AGENT,
 		}, {
 			anthropicKey: 'sk-user-key',

--- a/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
@@ -180,8 +180,8 @@ suite('claudeSdkOptions / buildOptions plugins projection', () => {
 			baseUrl: env.ANTHROPIC_BASE_URL,
 			authToken: env.ANTHROPIC_AUTH_TOKEN,
 			nonessential: env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC,
-			// Layered onto the CLI's own tool subprocesses so `git` / `gh` are
-			// attributed to VS Code.
+			// Projected into `settings.env`; the CLI still re-stamps `AI_AGENT`
+			// for its own Bash tool.
 			aiAgent: env.AI_AGENT,
 		}, {
 			baseUrl: 'http://127.0.0.1:0',

--- a/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
@@ -62,6 +62,7 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 			path: env.PATH,
 			home: env.HOME,
 			userProfile: env.USERPROFILE,
+			aiAgent: env.AI_AGENT,
 		}, {
 			runAsNode: '1',
 			nodeOptions: undefined,
@@ -72,6 +73,7 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 			path: undefined, // not explicitly forwarded; PATH is composed in settingsEnv, not subprocessEnv
 			home: '/Users/test',
 			userProfile: 'C:\\Users\\test',
+			aiAgent: 'github_copilot_vscode_agent',
 		});
 	});
 
@@ -107,6 +109,8 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 			electronOther: env.ELECTRON_NO_ATTACH_CONSOLE,
 			nodeOptions: env.NODE_OPTIONS,
 			runAsNode: env.ELECTRON_RUN_AS_NODE,
+			// Announces the originating VS Code surface to `git` / `gh`.
+			aiAgent: env.AI_AGENT,
 		}, {
 			anthropicKey: 'sk-user-key',
 			oauthToken: 'sk-ant-oat-user',
@@ -116,6 +120,7 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 			electronOther: undefined,
 			nodeOptions: undefined,
 			runAsNode: '1',
+			aiAgent: 'github_copilot_vscode_agent',
 		});
 	});
 });
@@ -175,10 +180,14 @@ suite('claudeSdkOptions / buildOptions plugins projection', () => {
 			baseUrl: env.ANTHROPIC_BASE_URL,
 			authToken: env.ANTHROPIC_AUTH_TOKEN,
 			nonessential: env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC,
+			// Layered onto the CLI's own tool subprocesses so `git` / `gh` are
+			// attributed to VS Code.
+			aiAgent: env.AI_AGENT,
 		}, {
 			baseUrl: 'http://127.0.0.1:0',
 			authToken: 'n.s1',
 			nonessential: '1',
+			aiAgent: 'github_copilot_vscode_agent',
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
@@ -11,16 +11,21 @@ suite('CodexLaunchConfig', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 	test('copilot config injects proxy credentials and provider overrides', () => {
 		const config = buildCodexLaunchConfig('copilot', { PATH: '/bin', OPENAI_API_KEY: 'personal' }, { baseUrl: 'http://127.0.0.1:1234', nonce: 'nonce' }, ['--log-level=debug']);
-		assert.deepStrictEqual(config.env, { PATH: '/bin', OPENAI_API_KEY: 'nonce' });
+		assert.deepStrictEqual(config.env, { PATH: '/bin', OPENAI_API_KEY: 'nonce', AI_AGENT: 'github_copilot_vscode_agent' });
 		assert.ok(config.args.includes('model_provider="vscode-proxy"'));
 		assert.ok(config.args.includes('features.image_generation=false'));
+		assert.ok(config.args.includes('shell_environment_policy.set.AI_AGENT="github_copilot_vscode_agent"'));
 		assert.strictEqual(config.args.at(-1), '--log-level=debug');
 	});
 
 	test('openai config preserves user credentials and omits proxy overrides', () => {
 		const config = buildCodexLaunchConfig('openai', { PATH: '/bin', OPENAI_API_KEY: 'personal', CODEX_HOME: '/codex' }, undefined, []);
-		assert.deepStrictEqual(config.env, { PATH: '/bin', OPENAI_API_KEY: 'personal', CODEX_HOME: '/codex' });
-		assert.deepStrictEqual(config.args, ['app-server', '-c', 'features.tool_call_mcp_elicitation=false']);
+		assert.deepStrictEqual(config.env, { PATH: '/bin', OPENAI_API_KEY: 'personal', CODEX_HOME: '/codex', AI_AGENT: 'github_copilot_vscode_agent' });
+		assert.deepStrictEqual(config.args, [
+			'app-server',
+			'-c', 'shell_environment_policy.set.AI_AGENT="github_copilot_vscode_agent"',
+			'-c', 'features.tool_call_mcp_elicitation=false',
+		]);
 	});
 
 	test('identifies provider-compatible threads', () => {

--- a/src/vs/platform/chat/common/aiAgentEnv.ts
+++ b/src/vs/platform/chat/common/aiAgentEnv.ts
@@ -5,17 +5,17 @@
 
 /**
  * Cross-vendor convention env var that announces which AI agent is driving a
- * process. Tools further down the chain (`git`, `gh`, CI systems, …) inherit it,
- * which lets activity be attributed to the originating AI experience without
- * touching the user's global environment.
+ * process. Child processes inherit it; `gh` in particular reads it and reports
+ * the value in its `User-Agent`, which lets downstream activity be attributed to
+ * the originating AI experience without touching the user's global environment.
  */
 export const AiAgentEnvVar = 'AI_AGENT';
 
 /**
  * The value VS Code announces for processes it spawns on behalf of an agent
- * session, following the `github_copilot_<surface>` form used by the other
- * GitHub Copilot surfaces (e.g. the GitHub Copilot app uses
- * `github_copilot_app_agent`).
+ * session, following the `github_copilot_<surface>` form asked of every GitHub
+ * Copilot surface. Must stay stable: it is a wire contract with the reporting
+ * pipeline, and `gh` only accepts values matching `[a-zA-Z0-9_-]+`.
  *
  * This must be set for *every* process an agent session spawns — the local
  * (in-workbench) harness terminal tool, the agent host process and every agent

--- a/src/vs/platform/chat/common/aiAgentEnv.ts
+++ b/src/vs/platform/chat/common/aiAgentEnv.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cross-vendor convention env var that announces which AI agent is driving a
+ * process. Tools further down the chain (`git`, `gh`, CI systems, …) inherit it,
+ * which lets activity be attributed to the originating AI experience without
+ * touching the user's global environment.
+ */
+export const AiAgentEnvVar = 'AI_AGENT';
+
+/**
+ * The value VS Code announces for processes it spawns on behalf of an agent
+ * session, following the `github_copilot_<surface>` form used by the other
+ * GitHub Copilot surfaces (e.g. the GitHub Copilot app uses
+ * `github_copilot_app_agent`).
+ *
+ * This must be set for *every* process an agent session spawns — the local
+ * (in-workbench) harness terminal tool, the agent host process and every agent
+ * SDK subprocess it launches — otherwise the surface is under-counted.
+ */
+export const AiAgentEnvValue = 'github_copilot_vscode_agent';

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
@@ -13,6 +13,7 @@ import { OperatingSystem } from '../../../../../base/common/platform.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { hasKey, isNumber, isObject, isString } from '../../../../../base/common/types.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
+import { AiAgentEnvValue, AiAgentEnvVar } from '../../../../../platform/chat/common/aiAgentEnv.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { PromptInputState } from '../../../../../platform/terminal/common/capabilities/commandDetection/promptInputModel.js';
@@ -154,7 +155,7 @@ export class ToolTerminalCreator {
 			// See https://github.com/microsoft/vscode/issues/311734
 			// `AI_AGENT` is the cross-vendor standard; `COPILOT_AGENT` is kept
 			// for back-compat with CLIs that already adopted it.
-			AI_AGENT: 'github_copilot_vscode_agent',
+			[AiAgentEnvVar]: AiAgentEnvValue,
 			COPILOT_AGENT: '1',
 			// Avoid making `git diff` interactive when called from copilot
 			GIT_PAGER: 'cat',


### PR DESCRIPTION
Fixes #326069

## What

`AI_AGENT` is a cross-vendor environment-variable convention that `git` and `gh` inherit, and which GitHub's data team uses to attribute downstream activity (commits, PRs) back to the AI surface that originated it. jolitz asked that every GitHub Copilot surface set a distinct value of the form `github_copilot_[SURFACE]`, and cwebster-99 clarified that the intent is to track **all** agent usage in VS Code, not just the CLI.

Before this change VS Code set `AI_AGENT` in exactly one place — the Local harness's `runInTerminal` tool — so every agent-host session was invisible to the metric.

This adds a single shared constant and sets the marker at every layer of the spawn chain, so the guarantee doesn't depend on one inheritance path staying intact.

New module `src/vs/platform/chat/common/aiAgentEnv.ts` exports `AiAgentEnvVar` / `AiAgentEnvValue` (`github_copilot_vscode_agent`), consumed by:

| File | Why it's needed here |
|---|---|
| `electronAgentHostStarter.ts` | root of the desktop agent-host spawn chain |
| `nodeAgentHostStarter.ts` | root of the server/remote chain |
| `copilotAgent.ts` | the CLI env is rebuilt from scratch and a strip loop deletes all `VSCODE_*`/`ELECTRON_*` keys, so it must be re-set afterwards |
| `claudeSdkOptions.ts` | the Claude SDK **replaces** the subprocess env rather than merging, and proxied (Copilot-routed) mode deliberately builds a sparse env — inheritance alone would drop it. Also set in `settings.env`, which the CLI layers onto Bash-tool commands |
| `codexLaunchConfig.ts` | Codex filters its shell tool's env through `shell_environment_policy`, so it also needs `-c shell_environment_policy.set.AI_AGENT=...` |
| `agentHostTerminalManager.ts` | AHP terminal pty env |
| `toolTerminalCreator.ts` | pre-existing Local-harness implementation, switched from a string literal to the shared constant (no behavior change) |

Single value for all harnesses (P1). Per-harness granularity (`github_copilot_vscode_agent_claude`, …) is deliberately deferred.

## Scenarios covered

- Agent host process itself (desktop + server/remote)
- Agent-host **Copilot CLI** sessions
- Agent-host **Codex** sessions
- Agent-host **Claude** sessions (partially — see caveat)
- Agent-host terminals (`chat.agentHost.customTerminalTool.enabled`)
- Local harness `runInTerminal` (unchanged behavior, now sharing the constant)

## Validation

Static: `typecheck-client`, `valid-layers-check`, `eslint` and `compile` are clean; 65 targeted unit tests pass.

Runtime, against a Code OSS build from these sources (Agents window). The probe has the agent run a script that writes the marker vars to a file, which is then read directly from disk rather than parsed out of the chat response:

| Surface | `AI_AGENT` observed by the agent's shell tool |
|---|---|
| Agent host utility process (`ps eww`) | `github_copilot_vscode_agent` |
| Copilot CLI subprocess (`ps eww`) | `github_copilot_vscode_agent` |
| **AH Copilot CLI** shell tool | `github_copilot_vscode_agent` |
| **AH Codex** shell tool | `github_copilot_vscode_agent` |
| **AH Claude** bash tool | `claude-code_<version>_agent` (see caveat) |

Additionally:

- Reproduced the full Copilot stdio path standalone (`CopilotClient` + `RuntimeConnection.forStdio`) and confirmed the marker survives **with** MXC sandbox auto-detection (`MXC_BIN_DIR`) and **with** a `sandboxConfig` pushed via `session.rpc.options.update`.
- Verified the new Codex `-c` argument against the real `codex` binary (`codex-cli 0.142.0`) via `codex sandbox`: the key is accepted, is genuinely necessary (an `inherit = "core"` policy strips an inherited `AI_AGENT`), and it **merges into** rather than clobbers a user's existing `shell_environment_policy.set` table.

## Caveats

1. **Claude re-stamps the variable for its own bash tool.** The bundled `claude` binary overwrites `AI_AGENT` with `claude-code_<version>_agent` when it invokes its agent bash tool. Our value is present in the Claude process and in everything else it spawns, but Claude's bash tool asserts its own vendor marker. This is not overridable from VS Code by setting env alone and would need an upstream change.
2. **The extension-host Copilot CLI harness is not covered.** That harness is being deprecated in favor of the agent-host one, so no change was made there.
3. **The metric counts users who make a `git`/`gh` commit.** A session that only edits files still won't register — that's inherent to how the signal is collected, not something this PR changes.

## How to validate manually

1. Enable the agent-host harnesses in Settings:
   ```jsonc
   "chat.agentHost.enabled": true,
   // makes the *agent-host* Copilot session type the one that surfaces,
   // instead of the extension-host one
   "chat.agents.copilotCli.hideExtensionHost": true,
   // only if you also want to check Codex
   "chat.agentHost.codexAgent.enabled": true
   ```
   Restart VS Code (the agent host process must be restarted to pick these up).

2. Create a scratch folder with this script in it:
   ```sh
   # probe.sh
   #!/bin/sh
   echo "AI_AGENT=$AI_AGENT"
   ```

3. Open the Agents window, start a **new** session in that folder, and pick the session type from the `with …` picker (**Copilot**, **Codex**, or **Claude**).

4. Send: `Run this shell command: sh ./probe.sh` and approve the confirmation.

5. Expected output: `AI_AGENT=github_copilot_vscode_agent` for Copilot and Codex. For Claude, expect `claude-code_<version>_agent` (see caveat 1).

Notes for verification:
- Be sure to use a **new** session created after the restart — a resumed session may be served by the older harness.
- If the composer placeholder still says "Run tasks in the background with the Copilot CLI", you're on the extension-host harness; double-check `chat.agents.copilotCli.hideExtensionHost` and restart.
- Cross-check without a chat at all: find the agent host process and its CLI child and dump their environments, e.g. on macOS/Linux `ps eww -p <pid> | tr ' ' '\n' | grep AI_AGENT`.
