### PR TITLE
Improved visual clarity in multi-file diffs in Agents window

### DIFF
--- a/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
@@ -27,6 +27,7 @@ export class TemplateData implements IObjectData {
 	constructor(
 		public readonly viewModel: DocumentDiffItemViewModel,
 		public readonly deltaScrollVertical: (delta: number) => void,
+		public readonly isFirst: boolean,
 	) { }
 
 
@@ -47,7 +48,7 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 	private readonly _modifiedWidth;
 	private readonly _originalContentWidth;
 	private readonly _originalWidth;
-
+	private readonly _itemHorizontalInsets: Readonly<{ left: number; right: number }>;
 	public readonly maxScroll;
 
 	private readonly _elements;
@@ -77,9 +78,15 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 		this._viewModel = observableValue<DocumentDiffItemViewModel | undefined>(this, undefined);
 		this._collapsed = derived(this, reader => this._viewModel.read(reader)?.collapsed.read(reader));
 		this._editorContentHeight = observableValue<number>(this, 500);
+		this._itemHorizontalInsets = this._workbenchUIElementFactory.diffEditorItemHorizontalInsets ?? { left: 9, right: 9 };
 		this.contentHeight = derived(this, reader => {
-			const h = this._collapsed.read(reader) ? 0 : this._editorContentHeight.read(reader);
-			return h + this._outerEditorHeight;
+			// When collapsed, only the header is shown so the entry sits flush against the
+			// divider. The content bottom padding (folded into `_outerEditorHeight`) is an
+			// inset for the expanded diff content only, so it must not inflate the collapsed height.
+			if (this._collapsed.read(reader)) {
+				return this._headerHeight;
+			}
+			return this._editorContentHeight.read(reader) + this._outerEditorHeight;
 		});
 		this._modifiedContentWidth = observableValue<number>(this, 0);
 		this._modifiedWidth = observableValue<number>(this, 0);
@@ -127,17 +134,19 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 			? this._register(this._workbenchUIElementFactory.createResourceLabel(this._elements.secondaryPath, MultiDiffEditorItemLabelKind.Secondary))
 			: undefined;
 		this._dataStore = this._register(new DisposableStore());
-		this._headerHeight = 40;
+		this._headerHeight = this._workbenchUIElementFactory.diffEditorItemHeaderHeight ?? 40;
 		this._lastScrollTop = -1;
 		this._isSettingScrollTop = false;
 
 		const btn = this._register(new Button(this._elements.collapseButton, {}));
+		const activateItem = () => this._viewModel.get()?.setActive(undefined);
 
 		this._register(autorun(reader => {
 			btn.element.className = '';
 			btn.icon = this._collapsed.read(reader) ? Codicon.chevronRight : Codicon.chevronDown;
 		}));
 		this._register(btn.onDidClick(() => {
+			activateItem();
 			this._viewModel.get()?.collapsed.set(!this._collapsed.get(), undefined);
 		}));
 
@@ -146,7 +155,9 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 			this._elements.header.tabIndex = 0;
 			this._elements.header.setAttribute('role', 'button');
 
+			this._register(addDisposableListener(this._elements.header, EventType.FOCUS_IN, activateItem));
 			this._register(addDisposableListener(this._elements.header, EventType.CLICK, (e) => {
+				activateItem();
 				// Don't toggle if clicking on actions or the collapse button itself (already handled)
 				const target = e.target;
 				if (!(target instanceof Element)) {
@@ -160,6 +171,7 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 
 			this._register(addDisposableListener(this._elements.header, EventType.KEY_DOWN, (e) => {
 				if (e.key === 'Enter' || e.key === ' ') {
+					activateItem();
 					const target = e.target;
 					if (target instanceof Element && (target.closest('.actions') || target.closest('.collapse-button'))) {
 						return;
@@ -214,7 +226,9 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 		}));
 
 		this._container.appendChild(this._elements.root);
-		this._outerEditorHeight = this._headerHeight;
+		// Reserve the header plus an optional bottom inset so the embedded editor
+		// lays out below the header and stops short of the entry's separator.
+		this._outerEditorHeight = this._headerHeight + (this._workbenchUIElementFactory.diffEditorItemContentBottomPadding ?? 0);
 
 		this._contextKeyService = this._register(_parentContextKeyService.createScoped(this._elements.actions));
 		const ctxAllUnchangedRegionsShown = EditorContextKeys.multiDiffEditorItemAllUnchangedRegionsShown.bindTo(this._contextKeyService);
@@ -247,6 +261,7 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 
 	public setData(data: TemplateData | undefined): void {
 		this._data = data;
+		this._elements.root.classList.toggle('first-diff-entry', data?.isFirst ?? false);
 		const optionsOverride = this._optionsOverride;
 		function updateOptions(options: IDiffEditorOptions): IDiffEditorOptions {
 			return {
@@ -351,7 +366,7 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 
 		globalTransaction(tx => {
 			this.editor.layout({
-				width: width - 2 * 8 - 2 * 1,
+				width: width - this._itemHorizontalInsets.left - this._itemHorizontalInsets.right,
 				height: verticalRange.length - this._outerEditorHeight,
 			});
 		});

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorViewModel.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorViewModel.ts
@@ -35,7 +35,7 @@ export class MultiDiffEditorViewModel extends Disposable {
 
 	public readonly focusedDiffItem = derived(this, reader => this.items.read(reader).find(i => i.isFocused.read(reader)));
 	public readonly activeDiffItem = derivedObservableWithWritableCache<DocumentDiffItemViewModel | undefined>(this,
-		(reader, lastValue) => this.focusedDiffItem.read(reader) ?? (lastValue && this.items.read(reader).indexOf(lastValue) !== -1) ? lastValue : undefined
+		(reader, lastValue) => this.focusedDiffItem.read(reader) ?? (lastValue && this.items.read(reader).indexOf(lastValue) !== -1 ? lastValue : undefined)
 	);
 
 	public async waitForDiffOr1s(): Promise<void> {
@@ -138,6 +138,10 @@ export class DocumentDiffItemViewModel extends Disposable {
 	public get modifiedUri(): URI | undefined { return this.documentDiffItem.modified?.uri; }
 
 	public readonly isActive: IObservable<boolean> = derived(this, reader => this._editorViewModel.activeDiffItem.read(reader) === this);
+
+	public setActive(tx: ITransaction | undefined): void {
+		this._editorViewModel.activeDiffItem.setCache(this, tx);
+	}
 
 	private readonly _isFocusedSource = observableValue<IObservable<boolean>>(this, constObservable(false));
 	public readonly isFocused = derived(this, reader => this._isFocusedSource.read(reader).read(reader));

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidget.ts
@@ -27,6 +27,7 @@ export class MultiDiffEditorWidget extends Disposable {
 	private readonly _dimension = observableValue<Dimension | undefined>(this, undefined);
 	private readonly _viewModel = observableValue<MultiDiffEditorViewModel | undefined>(this, undefined);
 	private readonly _renderSideBySide = observableValue<boolean | undefined>(this, undefined);
+	private readonly _paddingBottomPx = observableValue<number>(this, 0);
 
 	private readonly _widgetImpl = derived(this, (reader) => {
 		readHotReloadableExport(DiffEditorItemTemplate, reader);
@@ -38,6 +39,7 @@ export class MultiDiffEditorWidget extends Disposable {
 			this._workbenchUIElementFactory,
 			this._renderSideBySide,
 			this._diffEditorOptions,
+			this._paddingBottomPx,
 		));
 	});
 
@@ -106,6 +108,11 @@ export class MultiDiffEditorWidget extends Disposable {
 
 	public toggleRenderSideBySide(): void {
 		this._renderSideBySide.set(!(this._renderSideBySide.get() ?? true), undefined);
+	}
+
+	/** Reserves empty space below the last diff entry. */
+	public setPaddingBottom(px: number): void {
+		this._paddingBottomPx.set(px, undefined);
 	}
 
 	private readonly _activeControl = derived(this, (reader) => this._widgetImpl.read(reader).activeControl.read(reader));

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -79,6 +79,7 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		private readonly _workbenchUIElementFactory: IWorkbenchUIElementFactory,
 		private readonly _renderSideBySide: IObservable<boolean | undefined>,
 		private readonly _diffEditorOptions: IDiffEditorOptions | undefined,
+		private readonly _paddingBottomPx: IObservable<number>,
 		@IContextKeyService private readonly _parentContextKeyService: IContextKeyService,
 		@IInstantiationService private readonly _parentInstantiationService: IInstantiationService,
 	) {
@@ -135,8 +136,8 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 				}
 				const viewModels = vm.items.read(reader);
 				const map = new Map<DocumentDiffItemViewModel, VirtualizedViewItem>();
-				const items = viewModels.map(d => {
-					const item = reader.store.add(new VirtualizedViewItem(d, this._objectPool, this.scrollLeft, delta => {
+				const items = viewModels.map((d, index) => {
+					const item = reader.store.add(new VirtualizedViewItem(d, index === 0, this._objectPool, this.scrollLeft, delta => {
 						this._scrollableElement.setScrollPosition({ scrollTop: this._scrollableElement.getScrollPosition().scrollTop + delta });
 					}));
 					const data = this._lastDocStates?.[item.getKey()];
@@ -153,7 +154,7 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		);
 		this._viewItems = this._viewItemsInfo.map(this, items => items.items);
 		this._spaceBetweenPx = 0;
-		this._totalHeight = this._viewItems.map(this, (items, reader) => items.reduce((r, i) => r + i.contentHeight.read(reader) + this._spaceBetweenPx, 0));
+		this._totalHeight = this._viewItems.map(this, (items, reader) => items.reduce((r, i) => r + i.contentHeight.read(reader) + this._spaceBetweenPx, 0) + this._paddingBottomPx.read(reader));
 		this.activeControl = derived(this, reader => {
 			const activeDiffItem = this._viewModel.read(reader)?.activeDiffItem.read(reader);
 			if (!activeDiffItem) { return undefined; }
@@ -646,6 +647,7 @@ class VirtualizedViewItem extends Disposable {
 
 	constructor(
 		public readonly viewModel: DocumentDiffItemViewModel,
+		private readonly _isFirst: boolean,
 		private readonly _objectPool: ObjectPool<TemplateData, DiffEditorItemTemplate>,
 		private readonly _scrollLeft: IObservable<number>,
 		private readonly _deltaScrollVertical: (delta: number) => void,
@@ -741,7 +743,7 @@ class VirtualizedViewItem extends Disposable {
 
 		let ref = this._templateRef.get();
 		if (!ref) {
-			ref = this._objectPool.getUnusedObj(new TemplateData(this.viewModel, this._deltaScrollVertical));
+			ref = this._objectPool.getUnusedObj(new TemplateData(this.viewModel, this._deltaScrollVertical, this._isFirst));
 			this._templateRef.set(ref, undefined);
 
 			const selections = this.viewModel.lastTemplateData.get().selections;

--- a/src/vs/editor/browser/widget/multiDiffEditor/workbenchUIElementFactory.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/workbenchUIElementFactory.ts
@@ -28,6 +28,18 @@ export const enum MultiDiffEditorItemLabelKind {
 export interface IWorkbenchUIElementFactory {
 	createResourceLabel?(element: HTMLElement, kind: MultiDiffEditorItemLabelKind): IResourceLabel;
 
+	/** Horizontal insets reserved around each embedded diff editor. */
+	readonly diffEditorItemHorizontalInsets?: Readonly<{ left: number; right: number }>;
+
+	/** Height of each entry's file header, in px. Defaults to 40. */
+	readonly diffEditorItemHeaderHeight?: number;
+
+	/**
+	 * Padding reserved below each embedded diff editor, in px, so the file's
+	 * contents never touch the entry's bottom separator. Defaults to 0.
+	 */
+	readonly diffEditorItemContentBottomPadding?: number;
+
 	/**
 	 * When true, the entire header area is clickable to toggle collapse/expand
 	 * and receives keyboard activation (Enter/Space) and ARIA button semantics.

--- a/src/vs/sessions/browser/media/workbench.css
+++ b/src/vs/sessions/browser/media/workbench.css
@@ -157,7 +157,7 @@
 
 .agent-sessions-workbench:not(.dock-detail-panel) .part.auxiliarybar {
 	margin: 0 0 0 0;
-	padding-left: 5px;
+	padding-left: var(--vscode-spacing-size60);
 	background: var(--part-background);
 	border: 1px solid var(--part-border-color, transparent);
 	border-top-left-radius: 0;
@@ -294,9 +294,42 @@
 	background: var(--vscode-agentsPanel-border);
 }
 
-.agent-sessions-workbench.dock-detail-panel .part.editor:not(.modal-editor-part) .editor-group-container > .title {
-	border-bottom: var(--vscode-strokeThickness) solid var(--vscode-agentsPanel-border);
-	box-sizing: border-box;
+/* Match the chat header's horizontal wall padding (10px) so the right pane's
+ * header content lines up with the chat window's top header region instead of
+ * sitting at the editor group's default 8px inset. */
+.agent-sessions-workbench.dock-detail-panel .part.editor > .content .editor-group-container > .editor-group-header .editor-group-header-toolbars:has(> .editor-group-header-primary:not(.has-no-actions), > .editor-group-header-secondary:not(.has-no-actions)) {
+	padding: 2px var(--vscode-spacing-size100, 10px);
+}
+
+/* Divider under the editor group header toolbars (e.g. the Changes view's
+ * Branch Changes / Create PR controls). Inset on both sides to line up with the
+ * header content padding above, matching the chat header where the divider sits
+ * flush with the content edges instead of spanning edge to edge. */
+.agent-sessions-workbench.dock-detail-panel .part.editor .editor-group-header-toolbars {
+	position: relative;
+}
+
+.agent-sessions-workbench.dock-detail-panel .part.editor .editor-group-header-toolbars::after,
+.agent-sessions-workbench.dock-detail-panel .part.editor .editor-group-container:not(:has(.editor-group-header-toolbars)) > .title::after {
+	content: '';
+	position: absolute;
+	bottom: 0;
+	left: var(--vscode-spacing-size100);
+	right: var(--vscode-spacing-size100);
+	width: auto;
+	height: var(--vscode-strokeThickness);
+	background: var(--vscode-agentsPanel-border);
+	pointer-events: none;
+}
+
+/* This divider is the separator directly above the first file in the multi-file
+ * diff (Changes view). When that first file is emphasized (hover / press / focus),
+ * extend it to full bleed too, so its top boundary matches the full-bleed
+ * separators shown between files. */
+.agent-sessions-workbench.dock-detail-panel .part.editor .editor-group-container:has(.multiDiffEntry.first-diff-entry > .header:is(:hover, :active, :focus-visible), .multiDiffEditor:focus-within .multiDiffEntry.first-diff-entry.active) .editor-group-header-toolbars::after,
+.agent-sessions-workbench.dock-detail-panel .part.editor .editor-group-container:not(:has(.editor-group-header-toolbars)):has(.multiDiffEntry.first-diff-entry > .header:is(:hover, :active, :focus-visible), .multiDiffEditor:focus-within .multiDiffEntry.first-diff-entry.active) > .title::after {
+	left: 0;
+	right: 0;
 }
 
 .agent-sessions-workbench.dock-detail-panel .part.auxiliarybar > .content .pane-body,

--- a/src/vs/sessions/contrib/changes/browser/changesActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesActions.ts
@@ -10,6 +10,7 @@ import { structuralEquals } from '../../../../base/common/equals.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { autorun, derivedOpts, IObservable, observableValue, transaction } from '../../../../base/common/observable.js';
+import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
@@ -150,6 +151,20 @@ function getChangesDiffEditor(pane: IEditorPane | undefined, resource: URI): Dif
 	return codeEditor?.diffEditor instanceof DiffEditorWidget ? codeEditor.diffEditor : undefined;
 }
 
+function getExpandedChangesDiffEditor(pane: IEditorPane | undefined, resource: URI): DiffEditorWidget | undefined {
+	if (pane instanceof SessionChangesEditor) {
+		pane.expand(resource);
+	} else if (pane instanceof MultiDiffEditor) {
+		const viewModel = pane.viewModel;
+		const item = viewModel?.items.read(undefined)
+			.find(i => isEqual(i.modifiedUri, resource) || isEqual(i.originalUri, resource));
+		if (viewModel && item) {
+			viewModel.expand(item);
+		}
+	}
+	return getChangesDiffEditor(pane, resource);
+}
+
 /**
  * Reveals all hidden unchanged regions for the file shown in a diff row of the
  * Agents window's Changes editor, showing the whole file at once (a per-file
@@ -182,7 +197,8 @@ class ExpandFullFileAction extends Action2 {
 			return;
 		}
 
-		getChangesDiffEditor(accessor.get(IEditorService).activeEditorPane, resource)?.showAllUnchangedRegions();
+		const activePane = accessor.get(IEditorService).activeEditorPane;
+		getExpandedChangesDiffEditor(activePane, resource)?.showAllUnchangedRegions();
 	}
 }
 registerAction2(ExpandFullFileAction);
@@ -223,7 +239,8 @@ class CollapseUnchangedRegionsAction extends Action2 {
 			return;
 		}
 
-		getChangesDiffEditor(accessor.get(IEditorService).activeEditorPane, resource)?.collapseAllUnchangedRegions();
+		const activePane = accessor.get(IEditorService).activeEditorPane;
+		getExpandedChangesDiffEditor(activePane, resource)?.collapseAllUnchangedRegions();
 	}
 }
 registerAction2(CollapseUnchangedRegionsAction);

--- a/src/vs/sessions/contrib/changes/browser/media/multiFileDiffEditor.css
+++ b/src/vs/sessions/contrib/changes/browser/media/multiFileDiffEditor.css
@@ -7,37 +7,107 @@
  * used by the Changes view / editor). Kept out of the shared workbench style so
  * these overrides live next to the Changes contribution that owns them. */
 
-/* The per-file diff rows intentionally render flush with the panel (the old
- * `padding: 0 8px` inset was removed as part of the spacing rework); only
- * `box-sizing` is kept here. */
-.agent-sessions-workbench .part.editor .multiDiffEntry {
-	box-sizing: border-box;
-}
-
-.agent-sessions-workbench .part.editor .multiDiffEntry .header {
-	cursor: pointer;
-	background: transparent;
-	position: relative;
-}
-
-.agent-sessions-workbench .part.editor .multiDiffEntry .header::before {
+/* Files sit flush against each other, so this inset bottom separator marks the
+ * resting boundary between them. The sticky header (shared style) is a flex item with
+ * `z-index: 1000` and an opaque background; when a file is collapsed the header
+ * fills the whole entry and would paint over this 1px separator. So the divider
+ * has to sit above that header (and the embedded editor, which extends to the
+ * entry's bottom edge) to stay visible in every state. */
+.agent-sessions-workbench .part.editor .multiDiffEntry::after {
 	content: '';
 	position: absolute;
-	inset: 0;
-	background: var(--vscode-agentsPanel-background);
-	z-index: -1;
+	right: var(--vscode-spacing-size100);
+	bottom: 0;
+	left: var(--vscode-spacing-size100);
+	height: var(--vscode-strokeThickness);
+	background: var(--vscode-panel-border);
+	z-index: 1001;
 	pointer-events: none;
 }
 
-/* Include the multi-diff owner to outrank the equally specific core
- * `.monaco-component.multiDiffEditor .multiDiffEntry .header .header-content`
- * rule for the Agents header margin, padding, border, and background. */
-.agent-sessions-workbench .part.editor .multiDiffEditor .multiDiffEntry .header-content {
-	border-radius: var(--vscode-cornerRadius-medium);
+/* The sticky header stays opaque while its content is transparent at rest. */
+.agent-sessions-workbench .part.editor .multiDiffEntry .header {
+	cursor: pointer;
+	background: var(--vscode-multiDiffEditor-background);
+	position: relative;
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry .header:is(:hover, :active) {
+	z-index: 1002;
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry:has(> .header:is(:hover, :active)) {
+	z-index: 1002;
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry .header:focus-visible,
+.agent-sessions-workbench .part.editor .multiDiffEditor:focus-within .multiDiffEntry.active .header,
+.agent-sessions-workbench .part.editor .multiDiffEntry:has(> .header:focus-visible),
+.agent-sessions-workbench .part.editor .multiDiffEditor:focus-within .multiDiffEntry.active {
+	z-index: 1003;
+}
+
+/* Hover, press, or focus lifts the entry above its neighbors and extends the inset
+ * resting dividers that border it out to full bleed. The separators alone convey the
+ * emphasis — nothing is drawn on the header face itself.
+ *
+ * `overflow: visible` lets the top separator paint one pixel above this entry, onto
+ * the previous entry's resting-divider row, so the two coincide as one line instead
+ * of a notched double line. The embedded diff keeps its own `overflow: hidden` (on
+ * `.editorParent`), so nothing else spills. */
+.agent-sessions-workbench .part.editor .multiDiffEntry:has(> .header:is(:hover, :active, :focus-visible)),
+.agent-sessions-workbench .part.editor .multiDiffEditor:focus-within .multiDiffEntry.active {
+	overflow: visible;
+}
+
+/* Bottom separator — extend this entry's own resting divider to full bleed. Raise it
+ * above the entry's header so it stays visible even when a collapsed (entry-height)
+ * header is lifted on hover/focus and would otherwise paint over the bottom edge. */
+.agent-sessions-workbench .part.editor .multiDiffEntry:has(> .header:is(:hover, :active, :focus-visible))::after,
+.agent-sessions-workbench .part.editor .multiDiffEditor:focus-within .multiDiffEntry.active::after {
+	right: 0;
+	left: 0;
+	z-index: 1004;
+}
+
+/* Top separator — the boundary above this entry is physically the previous entry's
+ * resting divider, which can't be selected from here (the list virtualizes and
+ * recycles rows, so DOM order isn't visual order). Instead paint a full-bleed divider
+ * on this entry's top edge, lifted one pixel so it lands on and covers that resting
+ * divider. The emphasized entry outranks the un-lifted previous entry, so it wins.
+ * Skipped for the first entry, which has nothing above it. */
+.agent-sessions-workbench .part.editor .multiDiffEntry:not(.first-diff-entry):has(> .header:is(:hover, :active, :focus-visible))::before,
+.agent-sessions-workbench .part.editor .multiDiffEditor:focus-within .multiDiffEntry.active:not(.first-diff-entry)::before {
+	content: '';
+	position: absolute;
+	top: calc(-1 * var(--vscode-strokeThickness));
+	right: 0;
+	left: 0;
+	height: var(--vscode-strokeThickness);
+	background: var(--vscode-panel-border);
+	z-index: 1;
+	pointer-events: none;
+}
+
+/* Keyboard focus recolors both revealed separators to the focus indicator. */
+.agent-sessions-workbench .part.editor .multiDiffEntry:has(> .header:focus-visible)::after,
+.agent-sessions-workbench .part.editor .multiDiffEntry:not(.first-diff-entry):has(> .header:focus-visible)::before {
+	background: var(--vscode-focusBorder);
+}
+
+/* Neutralize the shared header-content chrome. The shared style
+ * (`.monaco-component.multiDiffEditor .multiDiffEntry .header .header-content`)
+ * has the same specificity as a `.multiDiffEntry .header-content` override and would
+ * win on source order, so this selector includes `.header` to outrank it — otherwise
+ * its `margin-top` (a seam above the row) and `border-top` (a stray divider, tinted
+ * to the focus color on the active file) leak through as an unwanted border. */
+.agent-sessions-workbench .part.editor .multiDiffEntry .header .header-content {
+	height: var(--vscode-spacing-size320);
+	box-sizing: border-box;
 	border: none;
-	background: var(--vscode-sideBarSectionHeader-background);
+	background: transparent;
 	margin: 0;
-	padding-left: var(--vscode-spacing-sizeNone);
+	padding: var(--vscode-spacing-sizeNone);
 	align-items: center;
 }
 
@@ -45,9 +115,34 @@
 	border-bottom: none;
 }
 
-/* The same owner keeps the Agents body font size from tying the core
- * `.header-content .file-path .title` 14px rule. */
-.agent-sessions-workbench .part.editor .multiDiffEditor .multiDiffEntry .header-content .file-path .title {
+/* Match the resting active-session treatment in the sessions list. The active
+ * header only reads as focused while focus is actually inside the multi-diff
+ * editor, so clicking empty space or moving focus to another part clears it. */
+.agent-sessions-workbench .part.editor .multiDiffEditor:focus-within .multiDiffEntry.active .header .header-content {
+	background: var(--vscode-list-inactiveSelectionBackground);
+}
+
+/* The whole header row toggles collapse, so rows reveal on hover/press intent.
+ * The focused-active row keeps its selection background instead (below), so it
+ * doesn't flip to the hover treatment while it reads as selected. */
+.agent-sessions-workbench .part.editor .multiDiffEntry .header:hover .header-content {
+	background: var(--vscode-list-hoverBackground);
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry .header:active .header-content {
+	background: var(--vscode-toolbar-activeBackground);
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEditor:focus-within .multiDiffEntry.active .header:hover .header-content,
+.agent-sessions-workbench .part.editor .multiDiffEditor:focus-within .multiDiffEntry.active .header:active .header-content {
+	background: var(--vscode-list-inactiveSelectionBackground);
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry .header[aria-expanded="false"] + .editorParent {
+	border: none;
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry .header-content .file-path .title {
 	font-size: var(--vscode-agents-fontSize-body1);
 	line-height: 22px;
 }
@@ -90,17 +185,61 @@
 	outline: none;
 }
 
-.agent-sessions-workbench .part.editor .multiDiffEntry .header:focus .header-content,
-.agent-sessions-workbench .part.editor .multiDiffEntry .header:focus-visible .header-content {
-	box-shadow: inset 0 0 0 1px var(--vscode-focusBorder);
+/* Keep secondary actions quiet until the file is hovered or focused. */
+.agent-sessions-workbench .part.editor .multiDiffEntry .header-content .actions-container .action-item:not(.changeset-review-action) {
+	visibility: hidden;
 }
 
+.agent-sessions-workbench .part.editor .multiDiffEntry:hover .header-content .actions-container .action-item:not(.changeset-review-action),
+.agent-sessions-workbench .part.editor .multiDiffEntry:focus-within .header-content .actions-container .action-item:not(.changeset-review-action) {
+	visibility: visible;
+}
+
+/* Match the collapse chevron's target and states to the file toolbar actions.
+ * Both the chevron and the secondary file actions sit on the 4px target-size
+ * step so their hit targets stay consistent. */
 .agent-sessions-workbench .part.editor .multiDiffEntry .collapse-button a {
-	border-radius: var(--vscode-cornerRadius-small);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--vscode-spacing-size40);
+	border-radius: var(--vscode-cornerRadius-medium);
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry .header-content .actions-container .action-item:not(.changeset-review-action) .action-label {
+	padding: var(--vscode-spacing-size40);
+}
+
+/* Behave like a regular icon button: fill only while hovered or pressed, and
+ * show a focus ring for keyboard focus. Including `:focus` here would keep the
+ * fill after a mouse click (focus lingers on the anchor once the cursor leaves). */
+.agent-sessions-workbench .part.editor .multiDiffEntry .collapse-button a:hover {
+	background: var(--vscode-toolbar-hoverBackground);
+}
+
+/* Pressed state uses the dedicated toolbar active token so the chevron matches
+ * the workbench toolbar controls one step darker than hover. */
+.agent-sessions-workbench .part.editor .multiDiffEntry .collapse-button a:active {
+	background: var(--vscode-toolbar-activeBackground);
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry .collapse-button a:focus-visible {
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: calc(-1 * var(--vscode-strokeThickness));
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry .collapse-button a:focus:not(:focus-visible) {
+	outline: none;
 }
 
 .agent-sessions-workbench .part.editor .multiDiffEntry .editorParent {
-	border-bottom: none;
+	border: none;
+	overflow: hidden;
+}
+
+.agent-sessions-workbench .part.editor .multiDiffEntry .header:focus-visible .header-content {
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: calc(-1 * var(--vscode-strokeThickness));
 }
 
 .agent-sessions-workbench .part.editor .diff-hidden-lines .center {
@@ -113,7 +252,7 @@
  * line-number gutter width (which pushes it to the right). */
 .agent-sessions-workbench .part.editor .diff-hidden-lines .center > div:first-child {
 	justify-content: flex-start !important;
-	padding-left: 5px;
+	padding-left: var(--vscode-spacing-size60);
 	box-sizing: border-box;
 }
 

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
@@ -64,9 +64,21 @@ const CHANGES_DIFF_EDITOR_OPTIONS: IDiffEditorOptions = {
 	lineNumbersMinChars: 3,
 };
 
+/** Keeps the overlay scrollbar clear of the final diff entry. */
+const CHANGES_LIST_BOTTOM_PADDING_PX = 24;
+
+/** Compact file header height so the list optimizes for vertical space. */
+const CHANGES_ENTRY_HEADER_HEIGHT_PX = 32;
+
+/** Breathing room below each file's diff so its contents never touch the separator. */
+const CHANGES_ENTRY_CONTENT_BOTTOM_PADDING_PX = 8;
+
 class SessionChangesUIElementFactory implements IWorkbenchUIElementFactory {
 
 	readonly headerClickToCollapse = true;
+	readonly diffEditorItemHorizontalInsets = { left: 0, right: 0 };
+	readonly diffEditorItemHeaderHeight = CHANGES_ENTRY_HEADER_HEIGHT_PX;
+	readonly diffEditorItemContentBottomPadding = CHANGES_ENTRY_CONTENT_BOTTOM_PADDING_PX;
 
 	constructor(
 		private readonly changesObs: IObservable<readonly ISessionFileChange[]>,
@@ -237,6 +249,7 @@ export class SessionChangesEditor extends AbstractEditorWithViewState<IMultiDiff
 			paneInstantiationService.createInstance(SessionChangesUIElementFactory, this._scopedChangesObs),
 			CHANGES_DIFF_EDITOR_OPTIONS,
 		));
+		this.widget.setPaddingBottom(CHANGES_LIST_BOTTOM_PADDING_PX);
 		this._applyRenderSideBySide();
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('diffEditor.renderSideBySide')) {

--- a/src/vs/sessions/contrib/changes/test/browser/agentsDiffEditor.fixture.ts
+++ b/src/vs/sessions/contrib/changes/test/browser/agentsDiffEditor.fixture.ts
@@ -101,6 +101,11 @@ class FixtureAgentFeedbackMenuService implements IMenuService {
 
 class AgentsDiffUIElementFactory implements IWorkbenchUIElementFactory {
 
+	readonly headerClickToCollapse = true;
+	readonly diffEditorItemHorizontalInsets = { left: 0, right: 0 };
+	readonly diffEditorItemHeaderHeight = 32;
+	readonly diffEditorItemContentBottomPadding = 8;
+
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) { }


### PR DESCRIPTION
## Summary

Refines the Changes (multi-file diff) editor in the Agents window for cleaner visual clarity and simplicity.

- Files render as a flush list with flat, transparent headers — with on-hover and focus states to help visually differentiate between files.
- Actions show on the file header only on hover / focus.
- The active file (caret or focused header) gets the sessions-list selection tint, only while focus is inside the diff.
- Show secondary file actions on hover or focus and align the collapse control with toolbar actions.
- Highlight only the focused card with subtle, theme-aware active and keyboard-focus states.
- Expand collapsed cards before running full-file expand or collapse actions.
- Add bottom scroll clearance so the final card is not obscured by the horizontal scrollbar.

Note: This PR only focuses on the Agents window. Once successful, the same changes can be applied to other places in Editor window that show multi-file diffs. 

Before:
<img width="1526" height="896" alt="CleanShot 2026-07-24 at 21 19 56@2x" src="https://github.com/user-attachments/assets/fd3d38e9-f719-4762-a635-040fb9570f3e" />

<img width="1526" height="1654" alt="CleanShot 2026-07-24 at 21 20 12@2x" src="https://github.com/user-attachments/assets/8a7c5f7f-bc6a-4a4f-90e5-cfe0e7023530" />

After:
<img width="1436" height="922" alt="CleanShot 2026-08-05 at 21 11 30@2x" src="https://github.com/user-attachments/assets/4325dcaf-19d0-4863-9be0-00fbe3409ede" />

<img width="1408" height="974" alt="CleanShot 2026-08-05 at 21 11 40@2x" src="https://github.com/user-attachments/assets/28eec785-a90c-427f-a162-08bf8212d6d0" />

<img width="1440" height="1402" alt="CleanShot 2026-08-05 at 21 11 57@2x" src="https://github.com/user-attachments/assets/620a0a96-b57d-4179-9320-d70b8e63b560" />


## Validation

- Core transpilation and extension build pass.
- Changes action tests pass (7 tests).
- Precommit hygiene and diff checks pass.
- Full typecheck remains blocked by unrelated existing Copilot SDK and Agent Host errors.
