### PR TITLE
Use xterm line translation for snapshot row measurement

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -130,7 +130,6 @@ function computeOutputLineCount(startLine: number, endLine: number): number {
 export function computeSnapshotLineCount(buffer: {
 	readonly baseY: number;
 	readonly cursorY: number;
-	readonly cursorX: number;
 	getLine(y: number): { readonly length: number; getCell(x: number): { getChars(): string } | undefined } | undefined;
 }, lineCount?: number): number {
 	if (lineCount !== undefined) {
@@ -139,8 +138,8 @@ export function computeSnapshotLineCount(buffer: {
 
 	const cursorLineIndex = buffer.baseY + buffer.cursorY;
 	const cursorLine = buffer.getLine(cursorLineIndex);
-	let hasCursorLineContent = buffer.cursorX > 0;
-	if (!hasCursorLineContent && cursorLine) {
+	let hasCursorLineContent = false;
+	if (cursorLine) {
 		for (let x = 0; x < cursorLine.length; x++) {
 			if (cursorLine.getCell(x)?.getChars()) {
 				hasCursorLineContent = true;

--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -122,6 +122,37 @@ function computeOutputLineCount(startLine: number, endLine: number): number {
 	return Math.max(endLine - startLine, 0);
 }
 
+/**
+ * Computes the number of rendered rows occupied by a terminal snapshot.
+ * The cursor line is included when it contains content and excluded when it
+ * is the empty line after a trailing newline.
+ */
+export function computeSnapshotLineCount(buffer: {
+	readonly baseY: number;
+	readonly cursorY: number;
+	readonly cursorX: number;
+	getLine(y: number): { readonly length: number; getCell(x: number): { getChars(): string } | undefined } | undefined;
+}, lineCount?: number): number {
+	if (lineCount !== undefined) {
+		return lineCount;
+	}
+
+	const cursorLineIndex = buffer.baseY + buffer.cursorY;
+	const cursorLine = buffer.getLine(cursorLineIndex);
+	let hasCursorLineContent = buffer.cursorX > 0;
+	if (!hasCursorLineContent && cursorLine) {
+		for (let x = 0; x < cursorLine.length; x++) {
+			if (cursorLine.getCell(x)?.getChars()) {
+				hasCursorLineContent = true;
+				break;
+			}
+		}
+	}
+
+	const endLine = cursorLineIndex + (hasCursorLineContent ? 1 : 0);
+	return computeOutputLineCount(0, endLine);
+}
+
 export async function getCommandOutputSnapshot(
 	xtermTerminal: XtermTerminal,
 	command: ITerminalCommand,
@@ -683,16 +714,16 @@ export class DetachedTerminalSnapshotMirror extends Disposable {
 			this._applyTheme(this._container);
 		}
 		const text = output.text ?? '';
-		const lineCount = output.lineCount ?? this._estimateLineCount(text);
 		if (!text) {
 			if (this._lastRenderedText) {
 				await new Promise<void>(resolve => terminal.xterm.write('\x1b[2J\x1b[3J\x1b[H', resolve));
 			}
+			const lineCount = output.lineCount ?? 0;
 			this._renderedVersion = outputVersion;
 			this._lastRenderedText = '';
 			this._lastRenderedLineCount = lineCount;
 			this._lastRenderedMaxColumnWidth = 0;
-			return { lineCount: 0, maxColumnWidth: 0 };
+			return { lineCount, maxColumnWidth: 0 };
 		}
 		const write = text.startsWith(this._lastRenderedText)
 			? text.slice(this._lastRenderedText.length)
@@ -703,6 +734,7 @@ export class DetachedTerminalSnapshotMirror extends Disposable {
 		if (this._store.isDisposed) {
 			return undefined;
 		}
+		const lineCount = computeSnapshotLineCount(terminal.xterm.buffer.active, output.lineCount);
 		this._renderedVersion = outputVersion;
 		this._lastRenderedText = text;
 		this._lastRenderedLineCount = lineCount;
@@ -715,16 +747,6 @@ export class DetachedTerminalSnapshotMirror extends Disposable {
 
 	private _computeMaxColumnWidth(terminal: IDetachedTerminalInstance): number {
 		return computeMaxBufferColumnWidth(terminal.xterm.buffer.active, terminal.xterm.cols);
-	}
-
-	private _estimateLineCount(text: string): number {
-		if (!text) {
-			return 0;
-		}
-		const sanitized = text.replace(/\r/g, '');
-		const segments = sanitized.split('\n');
-		const count = sanitized.endsWith('\n') ? segments.length - 1 : segments.length;
-		return Math.max(count, 1);
 	}
 
 	private _shouldComputeMaxColumnWidth(lineCount: number): boolean {

--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -130,24 +130,14 @@ function computeOutputLineCount(startLine: number, endLine: number): number {
 export function computeSnapshotLineCount(buffer: {
 	readonly baseY: number;
 	readonly cursorY: number;
-	getLine(y: number): { readonly length: number; getCell(x: number): { getChars(): string } | undefined } | undefined;
+	getLine(y: number): { translateToString(trimRight?: boolean): string } | undefined;
 }, lineCount?: number): number {
 	if (lineCount !== undefined) {
 		return lineCount;
 	}
 
 	const cursorLineIndex = buffer.baseY + buffer.cursorY;
-	const cursorLine = buffer.getLine(cursorLineIndex);
-	let hasCursorLineContent = false;
-	if (cursorLine) {
-		for (let x = 0; x < cursorLine.length; x++) {
-			if (cursorLine.getCell(x)?.getChars()) {
-				hasCursorLineContent = true;
-				break;
-			}
-		}
-	}
-
+	const hasCursorLineContent = !!buffer.getLine(cursorLineIndex)?.translateToString(true);
 	const endLine = cursorLineIndex + (hasCursorLineContent ? 1 : 0);
 	return computeOutputLineCount(0, endLine);
 }

--- a/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
@@ -374,7 +374,8 @@ suite('Workbench - ChatTerminalCommandMirror', () => {
 				twoWrappedRows: await measure('a'.repeat(81)),
 				threeWrappedRows: await measure('a'.repeat(200)),
 				multilineWithWrapping: await measure(`${'a'.repeat(81)}\r\nnext`),
-				trailingNewline: await measure('line\r\n'),
+				trailingCarriageReturnLineFeed: await measure('line\r\n'),
+				trailingLineFeed: await measure('line\n'),
 			}, {
 				empty: 0,
 				short: 1,
@@ -382,7 +383,8 @@ suite('Workbench - ChatTerminalCommandMirror', () => {
 				twoWrappedRows: 2,
 				threeWrappedRows: 3,
 				multilineWithWrapping: 3,
-				trailingNewline: 1,
+				trailingCarriageReturnLineFeed: 1,
+				trailingLineFeed: 1,
 			});
 		});
 

--- a/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Terminal } from '@xterm/xterm';
-import { strictEqual } from 'assert';
+import { deepStrictEqual, strictEqual } from 'assert';
 import { importAMDNodeModule } from '../../../../../amdX.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import type { IEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
@@ -14,7 +14,7 @@ import { TerminalCapabilityStore } from '../../../../../platform/terminal/common
 import { XtermTerminal } from '../../browser/xterm/xtermTerminal.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { TestXtermAddonImporter } from './xterm/xtermTestUtils.js';
-import { computeMaxBufferColumnWidth, vtBoundaryMatches } from '../../browser/chatTerminalCommandMirror.js';
+import { computeMaxBufferColumnWidth, computeSnapshotLineCount, vtBoundaryMatches } from '../../browser/chatTerminalCommandMirror.js';
 
 const defaultTerminalConfig = {
 	fontFamily: 'monospace',
@@ -356,6 +356,59 @@ suite('Workbench - ChatTerminalCommandMirror', () => {
 			const fullRewriteWouldBe = vt1.length + vt2.length + vt3.length;
 			strictEqual(totalWritten < fullRewriteWouldBe, true,
 				`Append path should write less (${totalWritten}) than full rewrites would (${fullRewriteWouldBe})`);
+		});
+
+		test('snapshot line count reflects rendered rows', async () => {
+			async function measure(text: string): Promise<number> {
+				const xterm = await createXterm();
+				if (text) {
+					await write(xterm, text);
+				}
+				return computeSnapshotLineCount(xterm.raw.buffer.active);
+			}
+
+			deepStrictEqual({
+				empty: await measure(''),
+				short: await measure('hello'),
+				exactlyOneRow: await measure('a'.repeat(80)),
+				twoWrappedRows: await measure('a'.repeat(81)),
+				threeWrappedRows: await measure('a'.repeat(200)),
+				multilineWithWrapping: await measure(`${'a'.repeat(81)}\r\nnext`),
+				trailingNewline: await measure('line\r\n'),
+			}, {
+				empty: 0,
+				short: 1,
+				exactlyOneRow: 1,
+				twoWrappedRows: 2,
+				threeWrappedRows: 3,
+				multilineWithWrapping: 3,
+				trailingNewline: 1,
+			});
+		});
+
+		test('snapshot line count updates after appends and rewrites', async () => {
+			const xterm = await createXterm();
+			await write(xterm, 'a'.repeat(81));
+			const initial = computeSnapshotLineCount(xterm.raw.buffer.active);
+
+			await write(xterm, 'b'.repeat(120));
+			const appended = computeSnapshotLineCount(xterm.raw.buffer.active);
+
+			await write(xterm, '\x1b[2J\x1b[3J\x1b[Hshort');
+			const rewritten = computeSnapshotLineCount(xterm.raw.buffer.active);
+
+			deepStrictEqual({ initial, appended, rewritten }, {
+				initial: 2,
+				appended: 3,
+				rewritten: 1,
+			});
+		});
+
+		test('snapshot line count preserves an explicit value', async () => {
+			const xterm = await createXterm();
+			await write(xterm, 'a'.repeat(200));
+
+			strictEqual(computeSnapshotLineCount(xterm.raw.buffer.active, 7), 7);
 		});
 	});
 


### PR DESCRIPTION
Follow-up: https://github.com/microsoft/vscode/pull/327441
Related: https://github.com/microsoft/vscode/issues/327440

- Replace the manual cursor-line cell scan with xterm's `IBufferLine.translateToString(true)` API.
- Avoid allocating a `CellData` object for each inspected cell while determining whether the cursor row contains rendered text.
- Preserve the rendered-row count, explicit `lineCount`, trailing-newline, append, and rewrite behavior introduced by the original fix.

Verification:

- Ran the targeted `ChatTerminalCommandMirror` browser unit suite: 42 passing in Chromium, WebKit, and Firefox.

-----------------------------------------
Inspirations from:

- Cursor-line translation follows the existing xterm buffer-line usage in [`XtermTerminal.getContentsAsText`](https://github.com/microsoft/vscode/blob/e3a9554f399e78f465730aaf5bed58ec178bfc60/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts#L384-L399).