### PR TITLE
SCM: add setting to show current line length in the input

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -370,6 +370,23 @@
 	display: none;
 }
 
+.scm-view .scm-input .scm-editor .scm-editor-line-length {
+	position: absolute;
+	right: 4px;
+	bottom: 2px;
+	padding: 0 2px;
+	font-size: 10px;
+	line-height: 14px;
+	color: var(--vscode-descriptionForeground);
+	pointer-events: none;
+	user-select: none;
+	z-index: 1;
+}
+
+.scm-view .scm-input .scm-editor .scm-editor-line-length.hidden {
+	display: none;
+}
+
 .scm-view .scm-input .scm-editor .scm-editor-toolbar.scroll-decoration {
 	box-shadow: var(--vscode-scrollbar-shadow) 0 6px 6px -6px inset;
 }

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -315,6 +315,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			maximum: 50,
 			default: 1
 		},
+		'scm.showInputLineLength': {
+			type: 'boolean',
+			markdownDescription: localize('showInputLineLength', "Controls whether the character count of the current line is shown in the Source Control input."),
+			default: false
+		},
 		'scm.alwaysShowRepositories': {
 			type: 'boolean',
 			markdownDescription: localize('alwaysShowRepository', "Controls whether repositories should always be visible in the Source Control view."),

--- a/src/vs/workbench/contrib/scm/browser/scmInput.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmInput.ts
@@ -366,6 +366,7 @@ export class SCMInputWidget {
 	private readonly inputEditor: CodeEditorWidget;
 	private readonly inputEditorOptions: SCMInputWidgetEditorOptions;
 	private toolbarContainer: HTMLElement;
+	private lineLengthContainer: HTMLElement;
 	private toolbar: SCMInputWidgetToolbar;
 	private readonly disposables = new DisposableStore();
 
@@ -533,6 +534,7 @@ export class SCMInputWidget {
 
 		// Save model
 		this.model = { input, textModel };
+		this.renderLineLength();
 	}
 
 	get selections(): Selection[] | null {
@@ -579,6 +581,8 @@ export class SCMInputWidget {
 	) {
 		this.element = append(container, $('.scm-editor'));
 		this.editorContainer = append(this.element, $('.scm-editor-container'));
+		this.lineLengthContainer = append(this.element, $('.scm-editor-line-length'));
+		this.lineLengthContainer.classList.add('hidden');
 		this.toolbarContainer = append(this.element, $('.scm-editor-toolbar'));
 
 		this.contextKeyService = this.disposables.add(contextKeyService.createScoped(this.element));
@@ -652,12 +656,15 @@ export class SCMInputWidget {
 			const viewPosition = viewModel.coordinatesConverter.convertModelPositionToViewPosition(position);
 			firstLineKey.set(viewPosition.lineNumber === 1 && viewPosition.column === 1);
 			lastLineKey.set(viewPosition.lineNumber === lastLineNumber && viewPosition.column === lastLineCol);
+			this.renderLineLength();
 		}));
+		this.disposables.add(this.inputEditor.onDidChangeModelContent(() => this.renderLineLength()));
 		this.disposables.add(this.inputEditor.onDidScrollChange(e => {
 			this.toolbarContainer.classList.toggle('scroll-decoration', e.scrollTop > 0);
 		}));
 
 		Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('scm.showInputActionButton'))(() => this.layout(), this, this.disposables);
+		Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('scm.showInputLineLength'))(() => this.renderLineLength(), this, this.disposables);
 
 		this.onDidChangeContentHeight = Event.signal(Event.filter(this.inputEditor.onDidContentSizeChange, e => e.contentHeightChanged, this.disposables));
 
@@ -692,6 +699,32 @@ export class SCMInputWidget {
 		const editorMaxHeight = inputMaxLines * lineHeight + top + bottom;
 
 		return clamp(this.inputEditor.getContentHeight(), editorMinHeight, editorMaxHeight);
+	}
+
+	private renderLineLength(): void {
+		const enabled = this.configurationService.getValue<boolean>('scm.showInputLineLength') === true;
+
+		if (!enabled || !this.model) {
+			this.lineLengthContainer.classList.add('hidden');
+			this.lineLengthContainer.textContent = '';
+			return;
+		}
+
+		const position = this.inputEditor.getPosition();
+
+		if (!position) {
+			this.lineLengthContainer.classList.add('hidden');
+			this.lineLengthContainer.textContent = '';
+			return;
+		}
+
+		// Report the length of the line the cursor is on, so the counter tracks the
+		// subject line (line 1) and body lines independently. This is what makes the
+		// 50/72 commit convention observable while typing.
+		const length = this.inputEditor.getModel()?.getLineLength(position.lineNumber) ?? 0;
+
+		this.lineLengthContainer.textContent = String(length);
+		this.lineLengthContainer.classList.remove('hidden');
 	}
 
 	layout(): void {


### PR DESCRIPTION
This PR fixes #81029

@joaomoreno — you closed #81855 with "This definitely misses a setting. Also, SCM now uses the monaco editor, so a lot of the implementation would have to be different. Feel free to file a new one and ping me." This is that PR, addressing both points.

### Setting

Adds `scm.showInputLineLength` (boolean, default `false`). Off by default so nothing changes for anyone who does not opt in.

### Implementation

Built against the current Monaco-based input rather than the old widget:

- `scmInput.ts` — a `.scm-editor-line-length` element appended to `.scm-editor`, updated from `onDidChangeCursorPosition` and `onDidChangeModelContent`, plus an `onDidChangeConfiguration` filter so toggling the setting applies immediately without a reload. Also refreshed when a repository is bound to the widget, so the count is correct on first paint rather than only after the first keystroke.
- `scm.contribution.ts` — the setting registration.
- `scm.css` — absolutely positioned bottom-right, `--vscode-descriptionForeground`, `pointer-events: none` and `user-select: none` so it never interferes with editing or selection.

### Behavior note

The counter reports the length of the line the cursor is currently on, not the total character count. That is deliberate: the request in #81029 is about the 50/72 commit convention, where the subject line and each body line are judged separately. A total-characters counter would not answer the question the issue is asking.

### Testing

`npx tsc --noEmit -p src/tsconfig.json` passes clean (0 errors).

I was not able to run the full Electron app locally to attach a screenshot, so the visual placement is worth a look during review. The rendering logic is small and self-contained, and it early-returns to a hidden, emptied element whenever the setting is off, there is no model, or there is no cursor position, so the disabled path leaves no DOM residue.

Happy to adjust the placement, the styling, or the line-vs-total decision if you would rather it worked differently.
