### PR TITLE
Fix plan-review leak on abort in Copilot Agent Session

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1904,6 +1904,7 @@ export class CopilotAgentSession extends Disposable {
 	async abort(): Promise<void> {
 		this._logService.info(`[Copilot:${this.sessionId}] Aborting session...`);
 		this._denyPendingPermissions();
+		this._cancelPendingPlanReviews();
 		this._drainPendingSteeringFlips();
 		await this._wrapper.session.abort();
 	}

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -5941,6 +5941,26 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual(await responsePromise, { approved: false });
 		});
 
+		test('abort rejects and clears a pending plan review', async () => {
+			const { session, runtime, mockSession, waitForSignal } = await createAgentSession(disposables);
+			session.resetTurnState('turn-plan');
+
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams(), { sessionId: 'test-session-1' });
+			const request = getInputRequest(await waitForSignal(s => isAction(s, ActionType.ChatInputRequested)));
+
+			await session.abort();
+
+			assert.deepStrictEqual({
+				response: await responsePromise,
+				abortCalls: mockSession.abortCalls,
+				lateResponseHandled: session.respondToUserInputRequest(request.id, ChatInputResponseKind.Accept),
+			}, {
+				response: { approved: false },
+				abortCalls: 1,
+				lateResponseHandled: false,
+			});
+		});
+
 		test('exit_only resolves as approved + interactive without autoApproveEdits', async () => {
 			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 			session.resetTurnState('turn-plan');

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -5941,7 +5941,7 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual(await responsePromise, { approved: false });
 		});
 
-		test('abort rejects and clears a pending plan review', async () => {
+		test('abort resolves and clears a pending plan review', async () => {
 			const { session, runtime, mockSession, waitForSignal } = await createAgentSession(disposables);
 			session.resetTurnState('turn-plan');
 
@@ -5949,11 +5949,12 @@ suite('CopilotAgentSession', () => {
 			const request = getInputRequest(await waitForSignal(s => isAction(s, ActionType.ChatInputRequested)));
 
 			await session.abort();
+			const lateResponseHandled = session.respondToUserInputRequest(request.id, ChatInputResponseKind.Accept);
 
 			assert.deepStrictEqual({
 				response: await responsePromise,
 				abortCalls: mockSession.abortCalls,
-				lateResponseHandled: session.respondToUserInputRequest(request.id, ChatInputResponseKind.Accept),
+				lateResponseHandled,
 			}, {
 				response: { approved: false },
 				abortCalls: 1,


### PR DESCRIPTION
This pull request addresses a confirmed defect in the Copilot Agent Session where pending plan reviews were not being cleared upon aborting a turn. The changes made include:

- Updated the `abort()` method to resolve and remove pending plan reviews, preventing orphaned callbacks from accumulating across subsequent prompts.
- Added a regression test to ensure that aborting a pending plan review correctly resolves its callback and that late UI responses are ignored.

Validation steps included running type-checks, all Copilot Agent Session tests, hygiene checks, and layer checks.

Related to #326653. A self-hosted reproduction confirmed that repeatedly sending a new prompt during plan review accumulated unresolved plan-review callbacks and redisplayed the existing plan. The permanent unresponsive state was not reproduced, so this PR intentionally does not claim to fully close the issue.

(Written by Copilot)
