### PR TITLE
fix: keep creating a profile when an extension fails to install

### DIFF
--- a/src/vs/workbench/services/userDataProfile/browser/extensionsResource.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/extensionsResource.ts
@@ -5,6 +5,7 @@
 
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { getErrorMessage } from '../../../../base/common/errors.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { GlobalExtensionEnablementService } from '../../../../platform/extensionManagement/common/extensionEnablementService.js';
@@ -178,7 +179,11 @@ export class ExtensionsResource implements IProfileResource {
 								return;
 							}
 							progress?.(localize('installingExtension', "Installing extension {0}...", installExtensionInfo.extension.displayName ?? installExtensionInfo.extension.identifier.id));
-							await this.extensionManagementService.installFromGallery(installExtensionInfo.extension, installExtensionInfo.options);
+							try {
+								await this.extensionManagementService.installFromGallery(installExtensionInfo.extension, installExtensionInfo.options);
+							} catch (error) {
+								this.logService.error(`Importing Profile (${profile.name}): Failed to install extension.`, installExtensionInfo.extension.identifier.id, getErrorMessage(error));
+							}
 						}
 					} else {
 						await this.extensionManagementService.installGalleryExtensions(installExtensionInfos);

--- a/src/vs/workbench/services/userDataProfile/browser/extensionsResource.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/extensionsResource.ts
@@ -15,6 +15,7 @@ import { ExtensionType } from '../../../../platform/extensions/common/extensions
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IUserDataProfile, ProfileResourceType } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { IUserDataProfileStorageService } from '../../../../platform/userDataProfile/common/userDataProfileStorageService.js';
@@ -106,6 +107,7 @@ export class ExtensionsResource implements IProfileResource {
 		@IUserDataProfileStorageService private readonly userDataProfileStorageService: IUserDataProfileStorageService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ILogService private readonly logService: ILogService,
+		@INotificationService private readonly notificationService: INotificationService,
 	) {
 	}
 
@@ -172,6 +174,11 @@ export class ExtensionsResource implements IProfileResource {
 					}
 				}));
 				if (installExtensionInfos.length) {
+					const failedExtensions = new Set<string>();
+					const onDidFailInstallExtension = (extensionId: string, error: unknown): void => {
+						failedExtensions.add(extensionId);
+						this.logService.error(`Importing Profile (${profile.name}): Failed to install extension.`, extensionId, getErrorMessage(error));
+					};
 					if (token) {
 						await this.extensionManagementService.requestPublisherTrust(installExtensionInfos);
 						for (const installExtensionInfo of installExtensionInfos) {
@@ -182,11 +189,19 @@ export class ExtensionsResource implements IProfileResource {
 							try {
 								await this.extensionManagementService.installFromGallery(installExtensionInfo.extension, installExtensionInfo.options);
 							} catch (error) {
-								this.logService.error(`Importing Profile (${profile.name}): Failed to install extension.`, installExtensionInfo.extension.identifier.id, getErrorMessage(error));
+								onDidFailInstallExtension(installExtensionInfo.extension.identifier.id, error);
 							}
 						}
 					} else {
-						await this.extensionManagementService.installGalleryExtensions(installExtensionInfos);
+						const results = await this.extensionManagementService.installGalleryExtensions(installExtensionInfos);
+						for (const result of results) {
+							if (result.error) {
+								onDidFailInstallExtension(result.identifier.id, result.error);
+							}
+						}
+					}
+					if (failedExtensions.size) {
+						this.notificationService.warn(localize('failedInstallingProfileExtensions', "Some profile extensions could not be installed: {0}", [...failedExtensions].join(', ')));
 					}
 				}
 				this.logService.info(`Importing Profile (${profile.name}): Finished installing extensions.`);

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService.ts
@@ -40,6 +40,9 @@ import { asText, IRequestService } from '../../../../platform/request/common/req
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { Mutable, isUndefined } from '../../../../base/common/types.js';
 import { CancelablePromise, createCancelablePromise } from '../../../../base/common/async.js';
+import { getErrorMessage, isCancellationError } from '../../../../base/common/errors.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 
 interface IUserDataProfileTemplate {
 	readonly name: string;
@@ -85,6 +88,8 @@ export class UserDataProfileImportExportService extends Disposable implements IU
 		@IRequestService private readonly requestService: IRequestService,
 		@IProductService private readonly productService: IProductService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
+		@ILogService private readonly logService: ILogService,
+		@INotificationService private readonly notificationService: INotificationService,
 	) {
 		super();
 		this.registerProfileContentHandler(Schemas.file, this.fileUserDataProfileContentHandler = instantiationService.createInstance(FileUserDataProfileContentHandler));
@@ -133,6 +138,7 @@ export class UserDataProfileImportExportService extends Disposable implements IU
 					await this.instantiationService.createInstance(ExtensionsResource).copy(from, profile, false);
 				}
 			} catch (error) {
+				this.reportProfileCreationError(error);
 				if (profile) {
 					await this.userDataProfilesService.removeProfile(profile);
 					profile = undefined;
@@ -168,6 +174,7 @@ export class UserDataProfileImportExportService extends Disposable implements IU
 			try {
 				await creationPromise;
 			} catch (error) {
+				this.reportProfileCreationError(error);
 				if (profile) {
 					await this.userDataProfilesService.removeProfile(profile);
 					profile = undefined;
@@ -175,6 +182,15 @@ export class UserDataProfileImportExportService extends Disposable implements IU
 			}
 			return profile;
 		}, () => creationPromise.cancel()).finally(() => disposables.dispose());
+	}
+
+	private reportProfileCreationError(error: unknown): void {
+		if (isCancellationError(error)) {
+			return;
+		}
+		const message = getErrorMessage(error);
+		this.logService.error('Error while creating profile.', message);
+		this.notificationService.error(localize('errorCreatingProfile', "An error occurred while creating the profile: {0}", message));
 	}
 
 	private async applyProfileTemplate(profileTemplate: IUserDataProfileTemplate, profile: IUserDataProfile, options: IUserDataProfileCreateOptions, reportProgress: (message: string) => void, token: CancellationToken): Promise<void> {

--- a/src/vs/workbench/services/userDataProfile/test/browser/extensionsResource.test.ts
+++ b/src/vs/workbench/services/userDataProfile/test/browser/extensionsResource.test.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IExtensionGalleryService, IExtensionInfo, IGalleryExtension, IGalleryExtensionAssets, ILocalExtension } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
+import { ExtensionType, TargetPlatform } from '../../../../../platform/extensions/common/extensions.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { IUserDataProfile, toUserDataProfile } from '../../../../../platform/userDataProfile/common/userDataProfile.js';
+import { IUserDataProfileStorageService } from '../../../../../platform/userDataProfile/common/userDataProfileStorageService.js';
+import { IWorkbenchExtensionManagementService } from '../../../extensionManagement/common/extensionManagement.js';
+import { ExtensionsResource } from '../../browser/extensionsResource.js';
+
+const noAssets: IGalleryExtensionAssets = {
+	changelog: null,
+	download: null!,
+	icon: null!,
+	license: null,
+	manifest: null,
+	readme: null,
+	repository: null,
+	signature: null,
+	coreTranslations: []
+};
+
+function aGalleryExtension(id: string): IGalleryExtension {
+	const [publisher, name] = id.split('.');
+	const galleryExtension = <IGalleryExtension>Object.create({ name, publisher, version: '1.0.0', allTargetPlatforms: [TargetPlatform.UNDEFINED], assets: noAssets });
+	galleryExtension.identifier = { id, uuid: `uuid-${id}` };
+	galleryExtension.properties = { targetPlatform: TargetPlatform.UNDEFINED, isPreReleaseVersion: false, dependencies: [] };
+	return galleryExtension;
+}
+
+function aLocalExtension(id: string, isBuiltin: boolean = false): ILocalExtension {
+	const [publisher, name] = id.split('.');
+	return <ILocalExtension>Object.create({
+		identifier: { id, uuid: `uuid-${id}` },
+		manifest: { name, publisher, version: '1.0.0' },
+		type: isBuiltin ? ExtensionType.System : ExtensionType.User,
+		isBuiltin,
+		isValid: true,
+		isApplicationScoped: false,
+		preRelease: false,
+		pinned: false,
+		location: URI.file(id),
+		targetPlatform: TargetPlatform.UNDEFINED,
+	});
+}
+
+suite('ExtensionsResource', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+	let extensionManagementService: Partial<IWorkbenchExtensionManagementService>;
+	let profile: IUserDataProfile;
+
+	setup(() => {
+		instantiationService = disposables.add(new TestInstantiationService());
+		const storageService = disposables.add(new InMemoryStorageService());
+
+		extensionManagementService = {
+			onDidInstallExtensions: Event.None,
+			async getInstalled() { return []; },
+			async canInstall(): Promise<true> { return true; },
+			async requestPublisherTrust() { },
+			async installFromGallery(extension: IGalleryExtension) { return aLocalExtension(extension.identifier.id); },
+			async uninstall() { },
+		};
+		instantiationService.stub(IWorkbenchExtensionManagementService, extensionManagementService);
+
+		instantiationService.stub(IExtensionGalleryService, <Partial<IExtensionGalleryService>>{
+			async getExtensions(extensionInfos: ReadonlyArray<IExtensionInfo>) {
+				return extensionInfos.map(({ id }) => aGalleryExtension(id));
+			}
+		});
+
+		instantiationService.stub(IUserDataProfileStorageService, new class extends mock<IUserDataProfileStorageService>() {
+			override withProfileScopedStorageService<T>(profile: IUserDataProfile, fn: (storageService: IStorageService) => Promise<T>): Promise<T> {
+				return fn(storageService);
+			}
+		});
+
+		instantiationService.stub(ILogService, new NullLogService());
+
+		profile = toUserDataProfile('test', 'test', URI.file('/profiles/test'), URI.file('/cache'));
+	});
+
+	test('installs the remaining extensions when one extension fails to install', async () => {
+		const installed: string[] = [];
+		extensionManagementService.installFromGallery = async (extension: IGalleryExtension) => {
+			if (extension.identifier.id === 'pub.b') {
+				throw new Error('Failed to install pub.b');
+			}
+			installed.push(extension.identifier.id);
+			return aLocalExtension(extension.identifier.id);
+		};
+
+		const testObject = instantiationService.createInstance(ExtensionsResource);
+
+		// A cancellation token selects the sequential install path in `apply()`.
+		await testObject.apply(JSON.stringify([
+			{ identifier: { id: 'pub.a' } },
+			{ identifier: { id: 'pub.b' } },
+			{ identifier: { id: 'pub.c' } },
+		]), profile, undefined, CancellationToken.None);
+
+		assert.deepStrictEqual(installed, ['pub.a', 'pub.c']);
+	});
+
+	test('reports progress for every extension when one extension fails to install', async () => {
+		const progressMessages: string[] = [];
+		extensionManagementService.installFromGallery = async (extension: IGalleryExtension) => {
+			if (extension.identifier.id === 'pub.a') {
+				throw new Error('Failed to install pub.a');
+			}
+			return aLocalExtension(extension.identifier.id);
+		};
+
+		const testObject = instantiationService.createInstance(ExtensionsResource);
+
+		await testObject.apply(JSON.stringify([
+			{ identifier: { id: 'pub.a' } },
+			{ identifier: { id: 'pub.b' } },
+		]), profile, message => progressMessages.push(message), CancellationToken.None);
+
+		assert.strictEqual(progressMessages.length, 2);
+	});
+
+	test('does not install an extension that is already installed as a builtin', async () => {
+		extensionManagementService.getInstalled = async () => [aLocalExtension('pub.builtin', true)];
+		const installed: string[] = [];
+		extensionManagementService.installFromGallery = async (extension: IGalleryExtension) => {
+			installed.push(extension.identifier.id);
+			return aLocalExtension(extension.identifier.id);
+		};
+
+		const testObject = instantiationService.createInstance(ExtensionsResource);
+
+		await testObject.apply(JSON.stringify([
+			{ identifier: { id: 'pub.builtin' } },
+			{ identifier: { id: 'pub.a' } },
+		]), profile, undefined, CancellationToken.None);
+
+		assert.deepStrictEqual(installed, ['pub.a']);
+	});
+});

--- a/src/vs/workbench/services/userDataProfile/test/browser/extensionsResource.test.ts
+++ b/src/vs/workbench/services/userDataProfile/test/browser/extensionsResource.test.ts
@@ -9,10 +9,12 @@ import { Event } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { IExtensionGalleryService, IExtensionInfo, IGalleryExtension, IGalleryExtensionAssets, ILocalExtension } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
+import { IExtensionGalleryService, IExtensionInfo, IGalleryExtension, IGalleryExtensionAssets, ILocalExtension, InstallOperation } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
 import { ExtensionType, TargetPlatform } from '../../../../../platform/extensions/common/extensions.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
 import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IUserDataProfile, toUserDataProfile } from '../../../../../platform/userDataProfile/common/userDataProfile.js';
 import { IUserDataProfileStorageService } from '../../../../../platform/userDataProfile/common/userDataProfileStorageService.js';
@@ -55,12 +57,33 @@ function aLocalExtension(id: string, isBuiltin: boolean = false): ILocalExtensio
 	});
 }
 
+class RecordingLogService extends NullLogService {
+
+	readonly errors: { message: string | Error; args: unknown[] }[] = [];
+
+	override error(message: string | Error, ...args: unknown[]): void {
+		this.errors.push({ message, args });
+	}
+}
+
+class RecordingNotificationService extends TestNotificationService {
+
+	readonly warnings: string[] = [];
+
+	override warn(message: string) {
+		this.warnings.push(message);
+		return super.warn(message);
+	}
+}
+
 suite('ExtensionsResource', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let instantiationService: TestInstantiationService;
 	let extensionManagementService: Partial<IWorkbenchExtensionManagementService>;
+	let logService: RecordingLogService;
+	let notificationService: RecordingNotificationService;
 	let profile: IUserDataProfile;
 
 	setup(() => {
@@ -89,7 +112,10 @@ suite('ExtensionsResource', () => {
 			}
 		});
 
-		instantiationService.stub(ILogService, new NullLogService());
+		logService = new RecordingLogService();
+		instantiationService.stub(ILogService, logService);
+		notificationService = new RecordingNotificationService();
+		instantiationService.stub(INotificationService, notificationService);
 
 		profile = toUserDataProfile('test', 'test', URI.file('/profiles/test'), URI.file('/cache'));
 	});
@@ -113,7 +139,18 @@ suite('ExtensionsResource', () => {
 			{ identifier: { id: 'pub.c' } },
 		]), profile, undefined, CancellationToken.None);
 
-		assert.deepStrictEqual(installed, ['pub.a', 'pub.c']);
+		assert.deepStrictEqual({
+			installed,
+			errors: logService.errors,
+			warnings: notificationService.warnings,
+		}, {
+			installed: ['pub.a', 'pub.c'],
+			errors: [{
+				message: 'Importing Profile (test): Failed to install extension.',
+				args: ['pub.b', 'Failed to install pub.b'],
+			}],
+			warnings: ['Some profile extensions could not be installed: pub.b'],
+		});
 	});
 
 	test('reports progress for every extension when one extension fails to install', async () => {
@@ -133,6 +170,34 @@ suite('ExtensionsResource', () => {
 		]), profile, message => progressMessages.push(message), CancellationToken.None);
 
 		assert.strictEqual(progressMessages.length, 2);
+	});
+
+	test('reports failed extensions from bulk installation', async () => {
+		extensionManagementService.installGalleryExtensions = async installExtensionInfos => installExtensionInfos.map(({ extension, options }) => ({
+			identifier: extension.identifier,
+			operation: InstallOperation.Install,
+			source: extension,
+			error: extension.identifier.id === 'pub.b' ? new Error('Failed to install pub.b') : undefined,
+			profileLocation: options.profileLocation!,
+		}));
+
+		const testObject = instantiationService.createInstance(ExtensionsResource);
+
+		await testObject.apply(JSON.stringify([
+			{ identifier: { id: 'pub.a' } },
+			{ identifier: { id: 'pub.b' } },
+		]), profile);
+
+		assert.deepStrictEqual({
+			errors: logService.errors,
+			warnings: notificationService.warnings,
+		}, {
+			errors: [{
+				message: 'Importing Profile (test): Failed to install extension.',
+				args: ['pub.b', 'Failed to install pub.b'],
+			}],
+			warnings: ['Some profile extensions could not be installed: pub.b'],
+		});
 	});
 
 	test('does not install an extension that is already installed as a builtin', async () => {


### PR DESCRIPTION
Fixes #327484

### Problem

When a profile is created from a template, `ExtensionsResource.apply()` installs the extensions one by one and none of those calls is guarded:

```ts
for (const installExtensionInfo of installExtensionInfos) {
    if (token.isCancellationRequested) {
        return;
    }
    progress?.(localize('installingExtension', "Installing extension {0}...", ...));
    await this.extensionManagementService.installFromGallery(installExtensionInfo.extension, installExtensionInfo.options);
}
```

A single extension that cannot be installed rejects the whole `apply()`, so `Finished installing extensions.` right below the loop is never reached. The rejection reaches `createProfileFromTemplate`, which removes the profile that was already created. Everything applied up to that point — settings, keybindings, tasks, snippets and UI state — is discarded because of one extension, and the `catch` there neither logs nor notifies, so the user sees the profile simply not being created.

This is reproducible today with the built-in **Python** template, whose CDN-hosted definition lists `github.copilot` and `github.copilot-chat`.

### Change

Make individual extension installation best-effort during profile creation:

- continue installing the remaining extensions when one installation fails
- log the failed extension ID and error
- report all failed extension IDs in a single user-facing warning
- handle error results from the non-cancellable bulk-install path consistently
- surface unexpected profile-creation failures while keeping cancellation quiet

Global failures such as gallery lookup and publisher-trust setup still propagate. They are not treated as individual extension failures.

This mirrors what the initialization path in the same feature area already does in `userDataProfileInit.ts`, where a resource that fails to initialize is logged and the remaining ones still run.

### Tests

Adds `extensionsResource.test.ts`, which did not exist before:

- the remaining extensions are still installed when one of them fails
- progress is still reported for every extension when one of them fails
- sequential failures are logged and reported to the user
- bulk-install error results are logged and reported to the user
- an extension already installed as a builtin is not installed again

### Verification

- `npx eslint` on the changed files — clean
- `npm run typecheck-client` — clean
- `npm run compile-client` — 0 errors
- `xvfb-run -a ./scripts/test.sh --grep ExtensionsResource` — 4 passing

The two tests covering continuation and progress were also confirmed to fail without the original resilience change. The builtin test covers the existing builtin check, while the bulk-install test covers the follow-up consistency change.

### Note

The `python.code-profile` template itself still lists `github.copilot` and `github.copilot-chat` while `GitHub.copilot-chat` now ships as a builtin. That file is served from `main.vscode-cdn.net` and is not part of this repository, so it is out of scope for this PR — but updating it would remove the trigger for the most commonly hit case.
