### PR TITLE
Fix Repository retention leaks in the git and github extensions

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -361,16 +361,17 @@ class ProgressManager {
 
 	private enabled = false;
 	private disposable: IDisposable = EmptyDisposable;
+	private readonly disposables: IDisposable[] = [];
 
 	constructor(private repository: Repository) {
 		const onDidChange = filterEvent(workspace.onDidChangeConfiguration, e => e.affectsConfiguration('git', Uri.file(this.repository.root)));
-		onDidChange(_ => this.updateEnablement());
+		onDidChange(_ => this.updateEnablement(), null, this.disposables);
 		this.updateEnablement();
 
 		this.repository.onDidChangeOperations(() => {
 			// Disable input box when the commit operation is running
 			this.repository.sourceControl.inputBox.enabled = !this.repository.operations.isRunning(OperationKind.Commit);
-		});
+		}, null, this.disposables);
 	}
 
 	private updateEnablement(): void {
@@ -414,6 +415,7 @@ class ProgressManager {
 
 	dispose(): void {
 		this.disable();
+		dispose(this.disposables);
 	}
 }
 

--- a/extensions/github/src/branchProtection.ts
+++ b/extensions/github/src/branchProtection.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EventEmitter, LogOutputChannel, Memento, Uri, workspace } from 'vscode';
+import { Disposable, EventEmitter, LogOutputChannel, Memento, Uri, workspace } from 'vscode';
 import { Repository as GitHubRepository, RepositoryRuleset } from '@octokit/graphql-schema';
 import { AuthenticationError, OctokitService } from './auth.js';
 import type { API, BranchProtection, BranchProtectionProvider, BranchProtectionRule, Repository } from './typings/git.d.ts';
@@ -51,7 +51,12 @@ const REPOSITORY_RULESETS_QUERY = `
 export class GitHubBranchProtectionProviderManager {
 
 	private readonly disposables = new DisposableStore();
-	private readonly providerDisposables = new DisposableStore();
+
+	/**
+	 * Branch protection providers, keyed by repository root. Entries are disposed
+	 * when the repository is closed so that closed repositories are not retained.
+	 */
+	private readonly providers = new Map<string, Disposable>();
 
 	private _enabled = false;
 	private set enabled(enabled: boolean) {
@@ -61,10 +66,10 @@ export class GitHubBranchProtectionProviderManager {
 
 		if (enabled) {
 			for (const repository of this.gitAPI.repositories) {
-				this.providerDisposables.add(this.gitAPI.registerBranchProtectionProvider(repository.rootUri, new GitHubBranchProtectionProvider(repository, this.globalState, this.octokitService, this.logger, this.telemetryReporter)));
+				this.registerProvider(repository);
 			}
 		} else {
-			this.providerDisposables.dispose();
+			this.disposeProviders();
 		}
 
 		this._enabled = enabled;
@@ -78,9 +83,12 @@ export class GitHubBranchProtectionProviderManager {
 		private readonly telemetryReporter: TelemetryReporter) {
 		this.disposables.add(this.gitAPI.onDidOpenRepository(repository => {
 			if (this._enabled) {
-				this.providerDisposables.add(gitAPI.registerBranchProtectionProvider(repository.rootUri,
-					new GitHubBranchProtectionProvider(repository, this.globalState, this.octokitService, this.logger, this.telemetryReporter)));
+				this.registerProvider(repository);
 			}
+		}));
+
+		this.disposables.add(this.gitAPI.onDidCloseRepository(repository => {
+			this.disposeProvider(repository.rootUri.toString());
 		}));
 
 		this.disposables.add(workspace.onDidChangeConfiguration(e => {
@@ -90,6 +98,32 @@ export class GitHubBranchProtectionProviderManager {
 		}));
 
 		this.updateEnablement();
+	}
+
+	private registerProvider(repository: Repository): void {
+		const key = repository.rootUri.toString();
+		this.disposeProvider(key);
+
+		const provider = new GitHubBranchProtectionProvider(repository, this.globalState, this.octokitService, this.logger, this.telemetryReporter);
+		const registration = this.gitAPI.registerBranchProtectionProvider(repository.rootUri, provider);
+
+		this.providers.set(key, new Disposable(() => {
+			registration.dispose();
+			provider.dispose();
+		}));
+	}
+
+	private disposeProvider(key: string): void {
+		this.providers.get(key)?.dispose();
+		this.providers.delete(key);
+	}
+
+	private disposeProviders(): void {
+		for (const provider of this.providers.values()) {
+			provider.dispose();
+		}
+
+		this.providers.clear();
 	}
 
 	private updateEnablement(): void {

--- a/extensions/github/src/util.ts
+++ b/extensions/github/src/util.ts
@@ -9,12 +9,21 @@ import type { Repository } from './typings/git.d.ts';
 export class DisposableStore {
 
 	private disposables = new Set<vscode.Disposable>();
+	private isDisposed = false;
 
 	add(disposable: vscode.Disposable): void {
+		if (this.isDisposed) {
+			// The store was already disposed, so nothing would ever dispose this.
+			disposable.dispose();
+			return;
+		}
+
 		this.disposables.add(disposable);
 	}
 
 	dispose(): void {
+		this.isDisposed = true;
+
 		for (const disposable of this.disposables) {
 			disposable.dispose();
 		}


### PR DESCRIPTION
A heap snapshot of the extension host in the Agents window showed **1,239 MB (47% of a 2.6 GB heap)** held by git ref data. `Model.openRepositories` contained only 28 repositories, but 137 `Repository` objects were still reachable: every repository ever opened was being retained along with its full ref array (~25,600 refs each in this workspace).

Three separate undisposed listeners were responsible. All three predate the Agents window; they were previously invisible because a normal window opens a handful of repositories and never closes them. The Agents window churns worktrees constantly, which is what made this visible.

Full analysis in #327438.

## Changes

**`ProgressManager` (git ext, repository.ts)** subscribed to `workspace.onDidChangeConfiguration` and `repository.onDidChangeOperations` in its constructor and discarded both subscriptions. The class did have a `dispose()`, but it only disposed the progress-notification disposable. The global configuration emitter therefore pinned every `Repository` ever created. The class was clean when it was introduced in 2017; the two listeners were added later (2018 and 2022) by people extending the constructor without noticing there was no store to register into. This is likely the single largest contributor.

**`GitHubBranchProtectionProviderManager` (github ext)** registered one provider per opened repository into a single `DisposableStore` that was only disposed when the whole feature was turned off, with no `onDidCloseRepository` handling. Providers are now tracked in a `Map` keyed by repository root and disposed on close. Note that the previous code only stored the *registration* disposable returned by `registerBranchProtectionProvider`, so the `GitHubBranchProtectionProvider` itself was never disposed and its `octokitService.onDidChangeSessions` listener leaked too. Both are now disposed together.

**`DisposableStore` (github ext, util.ts)** now disposes anything added after it has already been disposed. Without this, the async `repository.status().then(() => this.disposables.add(...))` in the provider constructor could re-register a listener after the provider was disposed and reintroduce the exact leak this PR fixes.

## Not included

Deliberately left for @lszomoru, since it needs a judgement call on git extension API compatibility: `api1.ts` allocates a fresh `ApiRepository` wrapper per event (`mapEvent(..., r => new ApiRepository(r))`), so any consumer keying a `Map`/`DisposableMap` by the API repository object inserts on open and then fails to match on close. There were 910 `ApiRepository` objects in the snapshot. A confirmed victim is `GitCommitMessageServiceImpl._repositoryDisposables`, whose `deleteAndDispose` is silently a no-op. This one is worth fixing centrally because it breaks any extension doing the same thing.

Also not addressed here: the sliced-string retention in `parseRefs` and the per-ref `ThemeIcon` allocation (2.9M instances in the snapshot).

## How to test

There is no easy unit test for this. To verify manually: open and close several repositories (or let worktrees come and go), take an extension host heap snapshot, and confirm the `Repository` count matches `Model.openRepositories` rather than the total ever opened. Functionally, branch protection should continue to work when repositories are opened, and should stop being provided once a repository is closed.

(Written by Copilot)