### PR TITLE
Git - support for SHA-256 repositories (#227281)

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -4106,7 +4106,7 @@
           "type": "number",
           "default": 7,
           "minimum": 7,
-          "maximum": 40,
+          "maximum": 64,
           "markdownDescription": "%config.commitShortHashLength%",
           "scope": "resource"
         },

--- a/extensions/git/src/blame.ts
+++ b/extensions/git/src/blame.ts
@@ -153,6 +153,8 @@ class GitBlameInformationCache {
 	}
 }
 
+const commitHashRegex = /^([0-9a-f]{40}|[0-9a-f]{64})$/i;
+
 export class GitBlameController {
 	private readonly _subjectMaxLength = 50;
 
@@ -419,7 +421,7 @@ export class GitBlameController {
 			// 1) Commit - Resource in the multi-file diff editor when viewing the details of a commit.
 			// 2) HEAD   - Resource on the left-hand side of the diff editor when viewing a resource from the index.
 			// 3) ~      - Resource on the left-hand side of the diff editor when viewing a resource from the working tree.
-			if (/^[0-9a-f]{40}$/i.test(ref) || ref === 'HEAD' || ref === '~') {
+			if (commitHashRegex.test(ref) || ref === 'HEAD' || ref === '~') {
 				workingTreeChanges = allChanges = [];
 				workingTreeAndIndexChanges = undefined;
 			} else if (ref === '') {
@@ -478,7 +480,7 @@ export class GitBlameController {
 		} else {
 			// Resource with the `git` scheme
 			const { ref } = fromGitUri(textEditor.document.uri);
-			commit = /^[0-9a-f]{40}$/i.test(ref) ? ref : repository.HEAD.commit;
+			commit = commitHashRegex.test(ref) ? ref : repository.HEAD.commit;
 		}
 
 		// Git blame information

--- a/extensions/git/src/blame.ts
+++ b/extensions/git/src/blame.ts
@@ -8,7 +8,7 @@ import { Model } from './model';
 import { dispose, fromNow, getCommitShortHash, IDisposable, truncate } from './util';
 import { Repository } from './repository';
 import { throttle } from './decorators';
-import { BlameInformation, Commit } from './git';
+import { BlameInformation, Commit, objectIdRegex } from './git';
 import { fromGitUri, isGitUri, toGitUri } from './uri';
 import { emojify, ensureEmojis } from './emoji';
 import { getWorkingTreeAndIndexDiffInformation, getWorkingTreeDiffInformation } from './staging';
@@ -152,8 +152,6 @@ class GitBlameInformationCache {
 		return toGitUri(resource, commit).toString();
 	}
 }
-
-const commitHashRegex = /^([0-9a-f]{40}|[0-9a-f]{64})$/i;
 
 export class GitBlameController {
 	private readonly _subjectMaxLength = 50;
@@ -421,7 +419,7 @@ export class GitBlameController {
 			// 1) Commit - Resource in the multi-file diff editor when viewing the details of a commit.
 			// 2) HEAD   - Resource on the left-hand side of the diff editor when viewing a resource from the index.
 			// 3) ~      - Resource on the left-hand side of the diff editor when viewing a resource from the working tree.
-			if (commitHashRegex.test(ref) || ref === 'HEAD' || ref === '~') {
+			if (objectIdRegex.test(ref) || ref === 'HEAD' || ref === '~') {
 				workingTreeChanges = allChanges = [];
 				workingTreeAndIndexChanges = undefined;
 			} else if (ref === '') {
@@ -480,7 +478,7 @@ export class GitBlameController {
 		} else {
 			// Resource with the `git` scheme
 			const { ref } = fromGitUri(textEditor.document.uri);
-			commit = commitHashRegex.test(ref) ? ref : repository.HEAD.commit;
+			commit = objectIdRegex.test(ref) ? ref : repository.HEAD.commit;
 		}
 
 		// Git blame information

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -923,7 +923,7 @@ export function parseGitRemotes(raw: string): MutableRemote[] {
 	return remotes;
 }
 
-const commitRegex = /([0-9a-f]{40})\n(.*)\n(.*)\n(.*)\n(.*)\n(.*)\n(.*)(?:\n([^]*?))?(?:\x00)(?:\n((?:.*)files? changed(?:.*))$)?/gm;
+const commitRegex = /([0-9a-f]{40}|[0-9a-f]{64})\n(.*)\n(.*)\n(.*)\n(.*)\n(.*)\n(.*)(?:\n([^]*?))?(?:\x00)(?:\n((?:.*)files? changed(?:.*))$)?/gm;
 
 export function parseGitCommits(data: string): Commit[] {
 	const commits: Commit[] = [];
@@ -1031,7 +1031,7 @@ export function parseLsFiles(raw: string): LsFilesElement[] {
 		.map(([, mode, object, stage, file]) => ({ mode, object, stage, file }));
 }
 
-const stashRegex = /([0-9a-f]{40})\n(.*)\nstash@{(\d+)}\n(WIP\s)?on\s([^:]+):\s(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;
+const stashRegex = /([0-9a-f]{40}|[0-9a-f]{64})\n(.*)\nstash@{(\d+)}\n(WIP\s)?on\s([^:]+):\s(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;
 
 function parseGitStashes(raw: string): Stash[] {
 	const result: Stash[] = [];
@@ -1218,7 +1218,7 @@ export interface BlameInformation {
 
 function parseGitBlame(data: string): BlameInformation[] {
 	const lineSeparator = /\r?\n/;
-	const commitRegex = /^([0-9a-f]{40})/gm;
+	const commitRegex = /^([0-9a-f]{40}|[0-9a-f]{64})/gm;
 
 	const blameInformation = new Map<string, BlameInformation>();
 
@@ -1278,7 +1278,7 @@ const REFS_FORMAT = '%(refname)%00%(objectname)%00%(*objectname)';
 const REFS_WITH_DETAILS_FORMAT = `${REFS_FORMAT}%00%(parent)%00%(*parent)%00%(authorname)%00%(*authorname)%00%(committerdate:unix)%00%(*committerdate:unix)%00%(subject)%00%(*subject)`;
 
 function parseRefs(data: string): (Ref | Branch)[] {
-	const refRegex = /^(refs\/[^\0]+)\0([0-9a-f]{40})\0([0-9a-f]{40})?(?:\0(.*))?$/gm;
+	const refRegex = /^(refs\/[^\0]+)\0([0-9a-f]{40}|[0-9a-f]{64})\0([0-9a-f]{40}|[0-9a-f]{64})?(?:\0(.*))?$/gm;
 
 	const headRegex = /^refs\/heads\/([^ ]+)$/;
 	const remoteHeadRegex = /^refs\/remotes\/([^/]+)\/([^ ]+)$/;
@@ -2922,7 +2922,7 @@ export class Repository {
 		}
 
 		// Detached
-		const commitMatch = raw.match(/^(?<commit>[0-9a-f]{40})$/m);
+		const commitMatch = raw.match(/^(?<commit>[0-9a-f]{40}|[0-9a-f]{64})$/m);
 		if (commitMatch?.groups?.commit) {
 			return { name: undefined, commit: commitMatch.groups.commit, type: RefType.Head };
 		}
@@ -2999,9 +2999,9 @@ export class Repository {
 		const fn = (line: string): Ref | null => {
 			let match: RegExpExecArray | null;
 
-			if (match = /^([0-9a-f]{40})\trefs\/heads\/([^ ]+)$/.exec(line)) {
+			if (match = /^([0-9a-f]{40}|[0-9a-f]{64})\trefs\/heads\/([^ ]+)$/.exec(line)) {
 				return { name: match[1], commit: match[2], type: RefType.Head };
-			} else if (match = /^([0-9a-f]{40})\trefs\/tags\/([^ ]+)$/.exec(line)) {
+			} else if (match = /^([0-9a-f]{40}|[0-9a-f]{64})\trefs\/tags\/([^ ]+)$/.exec(line)) {
 				return { name: match[2], commit: match[1], type: RefType.Tag };
 			}
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -376,6 +376,32 @@ function sanitizeRelativePath(path: string): string {
 const COMMIT_FORMAT = '%H%n%aN%n%aE%n%at%n%ct%n%P%n%D%n%B';
 const STASH_FORMAT = '%H%n%P%n%gd%n%gs%n%at%n%ct';
 
+/**
+ * A full git object id is exactly 40 hexadecimal characters (SHA-1) or exactly
+ * 64 (SHA-256) - never a length in between - so the two lengths are matched as
+ * alternatives rather than as a `{40,64}` range.
+ *
+ * The 64 character alternative is always listed first. Regular expression
+ * alternation is ordered, so with the shorter alternative first a SHA-256 id
+ * would match only its first 40 characters in any context where no delimiter
+ * follows it to force the engine to backtrack.
+ *
+ * The alternation is wrapped so that interpolating this into a larger pattern
+ * cannot let it escape its intended position - `^${OBJECT_ID}$` would otherwise
+ * split at the top level and defeat both anchors.
+ */
+const OBJECT_ID = '(?:[0-9a-f]{64}|[0-9a-f]{40})';
+
+/**
+ * Matches a string that consists solely of a full git object id.
+ */
+export const objectIdRegex = new RegExp(`^${OBJECT_ID}$`, 'i');
+
+/**
+ * Matches the object id in the `.git/HEAD` file of a detached HEAD.
+ */
+const detachedHeadRegex = new RegExp(`^(?<commit>${OBJECT_ID})$`, 'm');
+
 export interface ICloneOptions {
 	readonly parentPath: string;
 	readonly targetName?: string;
@@ -923,7 +949,7 @@ export function parseGitRemotes(raw: string): MutableRemote[] {
 	return remotes;
 }
 
-const commitRegex = /([0-9a-f]{40}|[0-9a-f]{64})\n(.*)\n(.*)\n(.*)\n(.*)\n(.*)\n(.*)(?:\n([^]*?))?(?:\x00)(?:\n((?:.*)files? changed(?:.*))$)?/gm;
+const commitRegex = new RegExp(`(${OBJECT_ID})\\n(.*)\\n(.*)\\n(.*)\\n(.*)\\n(.*)\\n(.*)(?:\\n([^]*?))?(?:\\x00)(?:\\n((?:.*)files? changed(?:.*))$)?`, 'gm');
 
 export function parseGitCommits(data: string): Commit[] {
 	const commits: Commit[] = [];
@@ -1031,9 +1057,9 @@ export function parseLsFiles(raw: string): LsFilesElement[] {
 		.map(([, mode, object, stage, file]) => ({ mode, object, stage, file }));
 }
 
-const stashRegex = /([0-9a-f]{40}|[0-9a-f]{64})\n(.*)\nstash@{(\d+)}\n(WIP\s)?on\s([^:]+):\s(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;
+const stashRegex = new RegExp(`(${OBJECT_ID})\\n(.*)\\nstash@{(\\d+)}\\n(WIP\\s)?on\\s([^:]+):\\s(.*)\\n(\\d+)\\n(\\d+)(?:\\x00)`, 'gmi');
 
-function parseGitStashes(raw: string): Stash[] {
+export function parseGitStashes(raw: string): Stash[] {
 	const result: Stash[] = [];
 
 	let match, hash, parents, index, wip, branchName, description, authorDate, commitDate;
@@ -1216,9 +1242,12 @@ export interface BlameInformation {
 	}[];
 }
 
-function parseGitBlame(data: string): BlameInformation[] {
+export function parseGitBlame(data: string): BlameInformation[] {
 	const lineSeparator = /\r?\n/;
-	const commitRegex = /^([0-9a-f]{40}|[0-9a-f]{64})/gm;
+	// Nothing follows the object id in this pattern, so the ordering of the
+	// alternatives documented on OBJECT_ID is what keeps a SHA-256 id from
+	// being matched as only its first 40 characters.
+	const objectIdLineRegex = new RegExp(`^${OBJECT_ID}`, 'gm');
 
 	const blameInformation = new Map<string, BlameInformation>();
 
@@ -1232,7 +1261,7 @@ function parseGitBlame(data: string): BlameInformation[] {
 
 	for (const line of data.split(lineSeparator)) {
 		// Commit
-		const commitMatch = line.match(commitRegex);
+		const commitMatch = line.match(objectIdLineRegex);
 		if (!commitHash && commitMatch) {
 			const segments = line.split(' ');
 
@@ -1277,8 +1306,8 @@ function parseGitBlame(data: string): BlameInformation[] {
 const REFS_FORMAT = '%(refname)%00%(objectname)%00%(*objectname)';
 const REFS_WITH_DETAILS_FORMAT = `${REFS_FORMAT}%00%(parent)%00%(*parent)%00%(authorname)%00%(*authorname)%00%(committerdate:unix)%00%(*committerdate:unix)%00%(subject)%00%(*subject)`;
 
-function parseRefs(data: string): (Ref | Branch)[] {
-	const refRegex = /^(refs\/[^\0]+)\0([0-9a-f]{40}|[0-9a-f]{64})\0([0-9a-f]{40}|[0-9a-f]{64})?(?:\0(.*))?$/gm;
+export function parseRefs(data: string): (Ref | Branch)[] {
+	const refRegex = new RegExp(`^(refs/[^\\0]+)\\0(${OBJECT_ID})\\0(${OBJECT_ID})?(?:\\0(.*))?$`, 'gm');
 
 	const headRegex = /^refs\/heads\/([^ ]+)$/;
 	const remoteHeadRegex = /^refs\/remotes\/([^/]+)\/([^ ]+)$/;
@@ -1341,6 +1370,31 @@ function parseRefs(data: string): (Ref | Branch)[] {
 	} while (true);
 
 	return refs;
+}
+
+const lsRemoteHeadRegex = new RegExp(`^(${OBJECT_ID})\\trefs/heads/([^ ]+)$`);
+const lsRemoteTagRegex = new RegExp(`^(${OBJECT_ID})\\trefs/tags/([^ ]+)$`);
+
+/**
+ * Parses the output of `git ls-remote`, whose lines are `<object id>\t<ref>`.
+ */
+export function parseLsRemote(data: string): Ref[] {
+	const fn = (line: string): Ref | null => {
+		let match: RegExpExecArray | null;
+
+		if (match = lsRemoteHeadRegex.exec(line)) {
+			return { name: match[2], commit: match[1], type: RefType.Head };
+		} else if (match = lsRemoteTagRegex.exec(line)) {
+			return { name: match[2], commit: match[1], type: RefType.Tag };
+		}
+
+		return null;
+	};
+
+	return data.split('\n')
+		.filter(line => !!line)
+		.map(fn)
+		.filter(ref => !!ref) as Ref[];
 }
 
 export interface PullOptions {
@@ -2922,7 +2976,7 @@ export class Repository {
 		}
 
 		// Detached
-		const commitMatch = raw.match(/^(?<commit>[0-9a-f]{40}|[0-9a-f]{64})$/m);
+		const commitMatch = raw.match(detachedHeadRegex);
 		if (commitMatch?.groups?.commit) {
 			return { name: undefined, commit: commitMatch.groups.commit, type: RefType.Head };
 		}
@@ -2996,22 +3050,7 @@ export class Repository {
 
 		const result = await this.exec(args, { cancellationToken: opts?.cancellationToken });
 
-		const fn = (line: string): Ref | null => {
-			let match: RegExpExecArray | null;
-
-			if (match = /^([0-9a-f]{40}|[0-9a-f]{64})\trefs\/heads\/([^ ]+)$/.exec(line)) {
-				return { name: match[1], commit: match[2], type: RefType.Head };
-			} else if (match = /^([0-9a-f]{40}|[0-9a-f]{64})\trefs\/tags\/([^ ]+)$/.exec(line)) {
-				return { name: match[2], commit: match[1], type: RefType.Tag };
-			}
-
-			return null;
-		};
-
-		return result.stdout.split('\n')
-			.filter(line => !!line)
-			.map(fn)
-			.filter(ref => !!ref) as Ref[];
+		return parseLsRemote(result.stdout);
 	}
 
 	async getStashes(): Promise<Stash[]> {

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -534,6 +534,31 @@ suite('git', () => {
 				coAuthors: []
 			}]);
 		});
+
+		test('SHA-256 hash commit', function () {
+			const GIT_OUTPUT_SINGLE_PARENT =
+				'9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098\n' +
+				'John Doe\n' +
+				'john.doe@mail.com\n' +
+				'1580811030\n' +
+				'1580811031\n' +
+				'b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22\n' +
+				'main,branch\n' +
+				'This is a commit message.\x00';
+
+			assert.deepStrictEqual(parseGitCommits(GIT_OUTPUT_SINGLE_PARENT), [{
+				hash: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+				message: 'This is a commit message.',
+				parents: ['b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22'],
+				authorDate: new Date(1580811030000),
+				authorName: 'John Doe',
+				authorEmail: 'john.doe@mail.com',
+				commitDate: new Date(1580811031000),
+				refNames: ['main', 'branch'],
+				shortStat: undefined,
+				coAuthors: []
+			}]);
+		});
 	});
 
 	suite('parseLsTree', function () {
@@ -564,6 +589,36 @@ suite('git', () => {
 				{ mode: '100644', type: 'blob', object: '257cc5642cb1a054f08cc83f2d943e56fd3ebe99', size: '4', file: 'what.js' },
 				{ mode: '100644', type: 'blob', object: 'be859e3f412fa86513cd8bebe8189d1ea1a3e46d', size: '24', file: 'what.txt' },
 				{ mode: '100644', type: 'blob', object: '56ec42c9dc6fcf4534788f0fe34b36e09f37d085', size: '261186', file: 'what.txt2' }
+			]);
+		});
+
+		test('SHA-256 hashes', function () {
+			const input = `040000 tree b97f4f0b6769e62fe152d5093cdb6a1026325d2d569e9985f639b4bb69081810       -	.vscode
+100644 blob a9ae1893d6ccafabb2718269c180be0dc3924a7480f5040f6fc28ba7a002f3b7  491570	Screen Shot 2018-06-01 at 14.48.05.png
+100644 blob 0667e7cdcbf2caa1d3a5dd708cd90fe08c778b20d01a10e28c5eb72b0b54026e  764420	Screen Shot 2018-06-07 at 20.04.59.png
+100644 blob 78ba54c83767be0aa91a2dd8cda6c5d92a3830971099967eaf5931a7532534e1       4	boom.txt
+100644 blob c048ab7ba31f244f98500c3bf7feb7305a460b1bdba0c7e26a993807a152f77a      11	boomcaboom.txt
+100644 blob 3559a563123a2bebf459117d2e66aa9c319f8df8bffa548a7ddc5caf1d9896c1      24	file.js
+100644 blob 59e884c6dbd018ea43e694e821f96a5b08226b5ef345e65e81e665cc44c59d95     201	file.md
+100644 blob f868215c351673fcd5d26414b144a100f986c63e3a0f2822eee1566e766f95ba       8	hello.js
+100644 blob 78ba54c83767be0aa91a2dd8cda6c5d92a3830971099967eaf5931a7532534e1       4	what.js
+100644 blob 20bf819186af6d79b888c89fd94a010f532544a7d3cd6797fc4344c062e0a303      24	what.txt
+100644 blob dcc9c94a5810b1ac3f3ae52937f7dab8087e205b23b1cdc745308e1227b6713c  261186	what.txt2`;
+
+			const output = parseLsTree(input);
+
+			assert.deepStrictEqual(output, [
+				{ mode: '040000', type: 'tree', object: 'b97f4f0b6769e62fe152d5093cdb6a1026325d2d569e9985f639b4bb69081810', size: '-', file: '.vscode' },
+				{ mode: '100644', type: 'blob', object: 'a9ae1893d6ccafabb2718269c180be0dc3924a7480f5040f6fc28ba7a002f3b7', size: '491570', file: 'Screen Shot 2018-06-01 at 14.48.05.png' },
+				{ mode: '100644', type: 'blob', object: '0667e7cdcbf2caa1d3a5dd708cd90fe08c778b20d01a10e28c5eb72b0b54026e', size: '764420', file: 'Screen Shot 2018-06-07 at 20.04.59.png' },
+				{ mode: '100644', type: 'blob', object: '78ba54c83767be0aa91a2dd8cda6c5d92a3830971099967eaf5931a7532534e1', size: '4', file: 'boom.txt' },
+				{ mode: '100644', type: 'blob', object: 'c048ab7ba31f244f98500c3bf7feb7305a460b1bdba0c7e26a993807a152f77a', size: '11', file: 'boomcaboom.txt' },
+				{ mode: '100644', type: 'blob', object: '3559a563123a2bebf459117d2e66aa9c319f8df8bffa548a7ddc5caf1d9896c1', size: '24', file: 'file.js' },
+				{ mode: '100644', type: 'blob', object: '59e884c6dbd018ea43e694e821f96a5b08226b5ef345e65e81e665cc44c59d95', size: '201', file: 'file.md' },
+				{ mode: '100644', type: 'blob', object: 'f868215c351673fcd5d26414b144a100f986c63e3a0f2822eee1566e766f95ba', size: '8', file: 'hello.js' },
+				{ mode: '100644', type: 'blob', object: '78ba54c83767be0aa91a2dd8cda6c5d92a3830971099967eaf5931a7532534e1', size: '4', file: 'what.js' },
+				{ mode: '100644', type: 'blob', object: '20bf819186af6d79b888c89fd94a010f532544a7d3cd6797fc4344c062e0a303', size: '24', file: 'what.txt' },
+				{ mode: '100644', type: 'blob', object: 'dcc9c94a5810b1ac3f3ae52937f7dab8087e205b23b1cdc745308e1227b6713c', size: '261186', file: 'what.txt2' }
 			]);
 		});
 	});

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'mocha';
-import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
+import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors, parseGitBlame, parseRefs, parseLsRemote, parseGitStashes, objectIdRegex } from '../git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
+import { RefType } from '../api/git.constants';
 
 suite('git', () => {
 	suite('GitStatusParser', () => {
@@ -652,6 +653,325 @@ suite('git', () => {
 				{ mode: '100644', object: 'be859e3f412fa86513cd8bebe8189d1ea1a3e46d', stage: '0', file: 'what.txt' },
 				{ mode: '100644', object: '56ec42c9dc6fcf4534788f0fe34b36e09f37d085', stage: '0', file: 'what.txt2' },
 			]);
+		});
+	});
+
+	suite('objectIdRegex', () => {
+		test('matches full object ids', function () {
+			assert.ok(objectIdRegex.test('9505cacb7c710ed17125fcc6cb3669e8ddca6c8c'));
+			assert.ok(objectIdRegex.test('9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098'));
+			assert.ok(objectIdRegex.test('9505CACB7C710ED17125FCC6CB3669E8DDCA6C8CD8AF6A31F6B3CD64604C3098'));
+		});
+
+		test('rejects anything that is not a full object id', function () {
+			assert.ok(!objectIdRegex.test(''));
+			assert.ok(!objectIdRegex.test('HEAD'));
+			assert.ok(!objectIdRegex.test('9505cac'));
+			// The alternation must not escape the anchors
+			assert.ok(!objectIdRegex.test('9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098-junk'));
+			assert.ok(!objectIdRegex.test('junk-9505cacb7c710ed17125fcc6cb3669e8ddca6c8c'));
+			// A length between the two valid ones is not a valid object id
+			assert.ok(!objectIdRegex.test('9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c30'));
+			assert.ok(!objectIdRegex.test('9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098a'));
+		});
+	});
+
+	suite('parseGitBlame', () => {
+		const blameOutput = (hash1: string, hash2: string) => [
+			`${hash1} 1 1 2`,
+			'author John Doe',
+			'author-mail <john.doe@mail.com>',
+			'author-time 1580811030',
+			'author-tz +0100',
+			'committer John Doe',
+			'committer-mail <john.doe@mail.com>',
+			'committer-time 1580811031',
+			'committer-tz +0100',
+			'summary This is a commit message.',
+			'boundary',
+			'filename file.txt',
+			`${hash2} 3 3 1`,
+			'author Jane Roe',
+			'author-mail <jane.roe@mail.com>',
+			'author-time 1580811040',
+			'author-tz +0100',
+			'committer Jane Roe',
+			'committer-mail <jane.roe@mail.com>',
+			'committer-time 1580811041',
+			'committer-tz +0100',
+			'summary Another commit message.',
+			`previous ${hash1} file.txt`,
+			'filename file.txt',
+		].join('\n');
+
+		test('SHA-1 hashes', function () {
+			assert.deepStrictEqual(parseGitBlame(blameOutput(
+				'9505cacb7c710ed17125fcc6cb3669e8ddca6c8c',
+				'5b3f2c9de1e1a5f57c1f5b4c7d9c4f9f0a1b2c3d'
+			)), [{
+				hash: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8c',
+				authorName: 'John Doe',
+				authorEmail: 'john.doe@mail.com',
+				authorDate: 1580811030000,
+				subject: 'This is a commit message.',
+				ranges: [{ startLineNumber: 1, endLineNumber: 2 }]
+			}, {
+				hash: '5b3f2c9de1e1a5f57c1f5b4c7d9c4f9f0a1b2c3d',
+				authorName: 'Jane Roe',
+				authorEmail: 'jane.roe@mail.com',
+				authorDate: 1580811040000,
+				subject: 'Another commit message.',
+				ranges: [{ startLineNumber: 3, endLineNumber: 3 }]
+			}]);
+		});
+
+		// The object id is not followed by a delimiter in the pattern that matches
+		// it, so a SHA-256 hash is easily matched as only its first 40 characters.
+		test('SHA-256 hashes are not truncated', function () {
+			assert.deepStrictEqual(parseGitBlame(blameOutput(
+				'9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+				'b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22'
+			)), [{
+				hash: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+				authorName: 'John Doe',
+				authorEmail: 'john.doe@mail.com',
+				authorDate: 1580811030000,
+				subject: 'This is a commit message.',
+				ranges: [{ startLineNumber: 1, endLineNumber: 2 }]
+			}, {
+				hash: 'b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22',
+				authorName: 'Jane Roe',
+				authorEmail: 'jane.roe@mail.com',
+				authorDate: 1580811040000,
+				subject: 'Another commit message.',
+				ranges: [{ startLineNumber: 3, endLineNumber: 3 }]
+			}]);
+		});
+
+		// A commit that covers more than one range is emitted again as a bare
+		// header line followed by `filename`, and the ranges are merged by hash.
+		test('SHA-256 hashes across multiple ranges', function () {
+			const output = [
+				'd483d3fdacc369559e9ae8a04a752590a350f137ada78ad31fb88c14442f1e05 2 2 1',
+				'author Jane Roe',
+				'author-mail <jane.roe@mail.com>',
+				'author-time 1580811040',
+				'author-tz +0100',
+				'summary Middle change',
+				'filename file.txt',
+				'3bb440793cf7b136c503d864a0473d3eb6ace7f2e9a7a5c9de98ca46a8b799f8 1 1 1',
+				'author John Doe',
+				'author-mail <john.doe@mail.com>',
+				'author-time 1580811030',
+				'author-tz +0100',
+				'summary Base commit',
+				'filename file.txt',
+				'3bb440793cf7b136c503d864a0473d3eb6ace7f2e9a7a5c9de98ca46a8b799f8 3 3 3',
+				'filename file.txt',
+			].join('\n');
+
+			assert.deepStrictEqual(parseGitBlame(output), [{
+				hash: 'd483d3fdacc369559e9ae8a04a752590a350f137ada78ad31fb88c14442f1e05',
+				authorName: 'Jane Roe',
+				authorEmail: 'jane.roe@mail.com',
+				authorDate: 1580811040000,
+				subject: 'Middle change',
+				ranges: [{ startLineNumber: 2, endLineNumber: 2 }]
+			}, {
+				hash: '3bb440793cf7b136c503d864a0473d3eb6ace7f2e9a7a5c9de98ca46a8b799f8',
+				authorName: 'John Doe',
+				authorEmail: 'john.doe@mail.com',
+				authorDate: 1580811030000,
+				subject: 'Base commit',
+				ranges: [
+					{ startLineNumber: 1, endLineNumber: 1 },
+					{ startLineNumber: 3, endLineNumber: 5 }
+				]
+			}]);
+		});
+	});
+
+	suite('parseRefs', () => {
+		test('SHA-1 hashes', function () {
+			const input = [
+				'refs/heads/main\x009505cacb7c710ed17125fcc6cb3669e8ddca6c8c\x00',
+				'refs/tags/v1.0\x005b3f2c9de1e1a5f57c1f5b4c7d9c4f9f0a1b2c3d\x001c6b1a1a1e5ab3d05e5ee2e7d1e0b8fd8d8f3a0d',
+			].join('\n');
+
+			assert.deepStrictEqual(parseRefs(input), [{
+				name: 'main',
+				commit: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8c',
+				commitDetails: undefined,
+				ahead: undefined,
+				behind: undefined,
+				type: RefType.Head
+			}, {
+				name: 'v1.0',
+				commit: '1c6b1a1a1e5ab3d05e5ee2e7d1e0b8fd8d8f3a0d',
+				commitDetails: undefined,
+				type: RefType.Tag
+			}]);
+		});
+
+		test('SHA-256 hashes', function () {
+			const input = [
+				'refs/heads/main\x009505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098\x00',
+				'refs/remotes/origin/main\x009505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098\x00',
+				// Annotated tag - the peeled object id is the commit the tag points at
+				'refs/tags/v1.0\x001c6b1a1a1e5ab3d05e5ee2e7d1e0b8fd8d8f3a0d3b1a4c5e6f70819293a4b5c6\x00b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22',
+				// Lightweight tag - no peeled object id
+				'refs/tags/v0.9\x00b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22\x00',
+			].join('\n');
+
+			assert.deepStrictEqual(parseRefs(input), [{
+				name: 'main',
+				commit: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+				commitDetails: undefined,
+				ahead: undefined,
+				behind: undefined,
+				type: RefType.Head
+			}, {
+				name: 'origin/main',
+				remote: 'origin',
+				commit: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+				commitDetails: undefined,
+				type: RefType.RemoteHead
+			}, {
+				name: 'v1.0',
+				commit: 'b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22',
+				commitDetails: undefined,
+				type: RefType.Tag
+			}, {
+				name: 'v0.9',
+				commit: 'b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22',
+				commitDetails: undefined,
+				type: RefType.Tag
+			}]);
+		});
+
+		test('SHA-256 hashes with commit details', function () {
+			const input = 'refs/heads/main\x009505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098\x00\x00' +
+				'b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22\x00\x00' +
+				'John Doe\x00\x001580811030\x00\x00This is a commit message.\x00\x00[ahead 1, behind 2]';
+
+			assert.deepStrictEqual(parseRefs(input), [{
+				name: 'main',
+				commit: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+				commitDetails: {
+					hash: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+					message: 'This is a commit message.',
+					parents: ['b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22'],
+					authorName: 'John Doe',
+					commitDate: new Date(1580811030000)
+				},
+				ahead: 1,
+				behind: 2,
+				type: RefType.Head
+			}]);
+		});
+	});
+
+	suite('parseLsRemote', () => {
+		test('branches and tags', function () {
+			const input = [
+				'9505cacb7c710ed17125fcc6cb3669e8ddca6c8c\trefs/heads/main',
+				'5b3f2c9de1e1a5f57c1f5b4c7d9c4f9f0a1b2c3d\trefs/tags/v1.0',
+				// `ls-remote` also lists the peeled tag; the caller deduplicates these
+				'1c6b1a1a1e5ab3d05e5ee2e7d1e0b8fd8d8f3a0d\trefs/tags/v1.0^{}',
+				'',
+			].join('\n');
+
+			assert.deepStrictEqual(parseLsRemote(input), [{
+				name: 'main',
+				commit: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8c',
+				type: RefType.Head
+			}, {
+				name: 'v1.0',
+				commit: '5b3f2c9de1e1a5f57c1f5b4c7d9c4f9f0a1b2c3d',
+				type: RefType.Tag
+			}, {
+				name: 'v1.0^{}',
+				commit: '1c6b1a1a1e5ab3d05e5ee2e7d1e0b8fd8d8f3a0d',
+				type: RefType.Tag
+			}]);
+		});
+
+		test('SHA-256 hashes', function () {
+			const input = [
+				'9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098\trefs/heads/main',
+				'b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22\trefs/tags/v1.0',
+				'1c6b1a1a1e5ab3d05e5ee2e7d1e0b8fd8d8f3a0d3b1a4c5e6f70819293a4b5c6\trefs/tags/v1.0^{}',
+				'',
+			].join('\n');
+
+			assert.deepStrictEqual(parseLsRemote(input), [{
+				name: 'main',
+				commit: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+				type: RefType.Head
+			}, {
+				name: 'v1.0',
+				commit: 'b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22',
+				type: RefType.Tag
+			}, {
+				name: 'v1.0^{}',
+				commit: '1c6b1a1a1e5ab3d05e5ee2e7d1e0b8fd8d8f3a0d3b1a4c5e6f70819293a4b5c6',
+				type: RefType.Tag
+			}]);
+		});
+
+		test('ignores lines that are not branches or tags', function () {
+			const input = [
+				'9505cacb7c710ed17125fcc6cb3669e8ddca6c8c\tHEAD',
+				'5b3f2c9de1e1a5f57c1f5b4c7d9c4f9f0a1b2c3d\trefs/pull/1/head',
+				'',
+			].join('\n');
+
+			assert.deepStrictEqual(parseLsRemote(input), []);
+		});
+	});
+
+	suite('parseGitStashes', () => {
+		// A stash created with an explicit message has no `WIP ` prefix
+		test('SHA-1 hashes, explicit stash message', function () {
+			const input = [
+				'9505cacb7c710ed17125fcc6cb3669e8ddca6c8c',
+				'5b3f2c9de1e1a5f57c1f5b4c7d9c4f9f0a1b2c3d',
+				'stash@{1}',
+				'On main: my saved work',
+				'1580811030',
+				'1580811031\x00',
+			].join('\n');
+
+			assert.deepStrictEqual(parseGitStashes(input), [{
+				hash: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8c',
+				parents: ['5b3f2c9de1e1a5f57c1f5b4c7d9c4f9f0a1b2c3d'],
+				index: 1,
+				branchName: 'main',
+				description: 'my saved work',
+				authorDate: new Date(1580811030000),
+				commitDate: new Date(1580811031000)
+			}]);
+		});
+
+		test('SHA-256 hashes', function () {
+			const input = [
+				'9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+				'b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22',
+				'stash@{0}',
+				'WIP on main: 9505cac This is a commit message.',
+				'1580811030',
+				'1580811031\0',
+			].join('\n');
+
+			assert.deepStrictEqual(parseGitStashes(input), [{
+				hash: '9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098',
+				parents: ['b9469a95e64ad83017429739bd95b527100cdfec700ac1fb15d3d7d1dfd6aa22'],
+				index: 0,
+				branchName: 'main',
+				description: 'WIP (9505cac This is a commit message.)',
+				authorDate: new Date(1580811030000),
+				commitDate: new Date(1580811031000)
+			}]);
 		});
 	});
 


### PR DESCRIPTION
Fixes #227281

## Credit

This builds directly on the work of @PositroniumJS in #317363. Their two commits are preserved here with authorship intact, and this PR supersedes that one.

Thank you, @PositroniumJS — the original investigation and the sweep of hash patterns across the Git extension are yours; this PR carries them forward and fixes one case that was still incorrect.

## The case that was still broken

While reviewing #317363 I found that one of the patterns it updates does not actually work for SHA-256:

```ts
// parseGitBlame
const commitRegex = /^([0-9a-f]{40}|[0-9a-f]{64})/gm;
```

Nothing follows the object id in this pattern. Regular expression alternation is **ordered**, so against a 64-character id the engine matches the first alternative — 40 characters — and stops. There is no delimiter after the group to force it to backtrack into the 64-character branch:

```
input:  9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098 4 4 1
match:  9505cacb7c710ed17125fcc6cb3669e8ddca6c8c        (40 chars — truncated)
```

The truncated value is stored as `BlameInformation.hash`. The visible consequence is in the blame hover: `getUnpublishedCommits()` returns full object ids, so `unpublishedCommits.has(blameInformation.hash)` never matches, and remote hover commands ("open on remote", etc.) are offered for commits that have not been pushed.

The other patterns updated in #317363 are correct — but only because a `\n`, `\0`, `\t` or `$` happens to follow the group and forces the backtrack. `parseGitBlame` is the one site without such a delimiter.

## What this PR changes

**Fixes the truncation** by introducing a single documented `OBJECT_ID` pattern used at every site:

```ts
const OBJECT_ID = '(?:[0-9a-f]{64}|[0-9a-f]{40})';
```

Three properties, all deliberate:

* A full object id is **exactly** 40 or **exactly** 64 hexadecimal characters, never a length in between — so the lengths are alternatives, not a `{40,64}` range.
* The 64-character alternative comes **first** everywhere, including the sites that were already correct by accident of an adjacent delimiter. Removing a delimiter can no longer silently reintroduce the truncation.
* The alternation is **wrapped**, so interpolating it into a larger pattern cannot let it escape its position (`^${OBJECT_ID}$` would otherwise split at the top level and defeat both anchors).

**Fixes an unrelated pre-existing bug in `getRemoteRefs`.** The `refs/heads/` branch had `name` and `commit` reversed — `git ls-remote` emits `<object id>\t<ref>`, and the `refs/tags/` branch immediately below it was already correct. The line parsing moves into `parseLsRemote` so it can be covered by tests. No caller passes `heads: true` today, so there is no behaviour change; happy to split this out if you would prefer it separately.

**Raises the maximum of `git.commitShortHashLength`** from 40 to 64, the full length of a SHA-256 object id.

**Adds tests** for the parsers these changes touch — blame, refs, ls-remote and stashes — none of which previously had any coverage. Both SHA-1 and SHA-256 cases, so the SHA-1 paths are protected against regression rather than merely assumed to be fine.

## Verification

* `tsc -p extensions/git/tsconfig.json` is clean, and the extension's mocha suite passes (55 tests).
* Verified against **real repositories** created with `git init --object-format=sha1` and `--object-format=sha256` (git 2.55), running the extension's exact git invocations and format strings and feeding the captured output to the real parsers: commits (including a merge), blame, refs with and without details, annotated and lightweight tags, ls-remote, stashes, ls-tree, ls-files and a detached `.git/HEAD`. Every parsed id is the correct full length in both formats.
* Mutation-tested each changed pattern to confirm the new tests actually fail without the fix. Reordering the three delimiter-terminated patterns is provably a no-op, which is the evidence that `parseGitBlame` was the only broken site.

## Out of scope

This covers the Git extension. Other places in the repository still assume SHA-1 and would need separate changes for end-to-end SHA-256 support — notably the hard-coded empty-tree object id used with `git read-tree` in a few services, and `build/lib/git.ts` / `build/lib/getVersion.ts` when building from a SHA-256 checkout. Happy to open follow-ups if that is wanted.

I also noticed a pre-existing, hash-independent issue while testing against real repositories: `commitRegex` does not pick up the shortstat for **merge** commits, because git emits `\0\0 1 file changed` there rather than `\0\n 1 file changed`, so `getCommit()` returns `shortStat: undefined` for merges. It behaves identically under SHA-1 and SHA-256, so I have left it alone here — let me know if you would like a separate issue.
