### PR TITLE
Harden ADO code search endpoint override

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4625,6 +4625,8 @@
           "github.copilot.chat.workspace.prototypeAdoCodeSearchEndpointOverride": {
             "type": "string",
             "default": "",
+            "scope": "application",
+            "restricted": true,
             "markdownDescription": "%github.copilot.config.workspace.prototypeAdoCodeSearchEndpointOverride%",
             "tags": [
               "advanced",

--- a/extensions/copilot/src/extension/test/node/configurations.spec.ts
+++ b/extensions/copilot/src/extension/test/node/configurations.spec.ts
@@ -124,6 +124,14 @@ describe('Configurations', () => {
 		expect(Object.keys(advancedSection.properties)).toContain(promptOverrideStringKey.fullyQualifiedId);
 	});
 
+	it('ADO code search endpoint override is application-scoped and restricted', () => {
+		const advancedSection = packageJson.contributes.configuration.find(section => section.id === 'advanced')!;
+		const setting = advancedSection.properties[ConfigKey.Advanced.WorkspacePrototypeAdoCodeSearchEndpointOverride.fullyQualifiedId] as { readonly scope?: string; readonly restricted?: boolean };
+
+		expect(setting.scope).toBe('application');
+		expect(setting.restricted).toBe(true);
+	});
+
 	it('all localization strings in package.json are present in package.nls.json', async () => {
 		// Get all keys from package.nls.json
 		const packageJsonPath = path.join(__dirname, '../../../../package.json');

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -607,7 +607,12 @@ export namespace ConfigKey {
 		*/
 		export const DebugPromptOverrideString = defineSetting<string | null>('chat.debug.promptOverrideString', ConfigType.Simple, null);
 		export const DebugPromptOverrideFile = defineSetting<string | null>('chat.debug.promptOverrideFile', ConfigType.Simple, null);
-		export const WorkspacePrototypeAdoCodeSearchEndpointOverride = defineAndMigrateSetting<string>('chat.advanced.workspace.prototypeAdoCodeSearchEndpointOverride', 'chat.workspace.prototypeAdoCodeSearchEndpointOverride', '');
+		export const WorkspacePrototypeAdoCodeSearchEndpointOverride = defineAndMigrateSetting<string>(
+			'chat.advanced.workspace.prototypeAdoCodeSearchEndpointOverride',
+			'chat.workspace.prototypeAdoCodeSearchEndpointOverride',
+			'',
+			{ userScopeOnly: true }
+		);
 		export const FeedbackOnChange = defineAndMigrateSetting('chat.advanced.feedback.onChange', 'chat.feedback.onChange', false);
 		export const ReviewIntent = defineAndMigrateSetting('chat.advanced.review.intent', 'chat.review.intent', false);
 		/** Enable the new notebook priorities experiment */

--- a/extensions/copilot/src/platform/configuration/vscode/test/configurationServiceImpl.spec.ts
+++ b/extensions/copilot/src/platform/configuration/vscode/test/configurationServiceImpl.spec.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const { mockConfigStore } = vi.hoisted(() => ({
-	mockConfigStore: { user: {} as Record<string, unknown>, defaults: {} as Record<string, unknown> },
+	mockConfigStore: { user: {} as Record<string, unknown>, workspace: {} as Record<string, unknown>, workspaceFolder: {} as Record<string, unknown>, defaults: {} as Record<string, unknown> },
 }));
 
 vi.mock('vscode', () => {
@@ -15,6 +15,12 @@ vi.mock('vscode', () => {
 		return {
 			get<T>(k: string): T | undefined {
 				const fk = fullKey(k);
+				if (fk in mockConfigStore.workspaceFolder) {
+					return mockConfigStore.workspaceFolder[fk] as T;
+				}
+				if (fk in mockConfigStore.workspace) {
+					return mockConfigStore.workspace[fk] as T;
+				}
 				if (fk in mockConfigStore.user) {
 					return mockConfigStore.user[fk] as T;
 				}
@@ -29,6 +35,8 @@ vi.mock('vscode', () => {
 					key: fk,
 					defaultValue: mockConfigStore.defaults[fk] as T | undefined,
 					globalValue: (fk in mockConfigStore.user ? mockConfigStore.user[fk] : undefined) as T | undefined,
+					workspaceValue: (fk in mockConfigStore.workspace ? mockConfigStore.workspace[fk] : undefined) as T | undefined,
+					workspaceFolderValue: (fk in mockConfigStore.workspaceFolder ? mockConfigStore.workspaceFolder[fk] : undefined) as T | undefined,
 				};
 			},
 		};
@@ -49,6 +57,13 @@ const fakeTokenStore: ICopilotTokenStore = {
 	copilotToken: undefined,
 	onDidStoreUpdate: () => ({ dispose() { } }),
 } as any;
+
+beforeEach(() => {
+	mockConfigStore.user = {};
+	mockConfigStore.workspace = {};
+	mockConfigStore.workspaceFolder = {};
+	mockConfigStore.defaults = {};
+});
 
 describe('ConfigurationServiceImpl - migrated chat.advanced setting fallback', () => {
 	test('reads the user-set OLD key when only the OLD key is configured', () => {
@@ -71,5 +86,59 @@ describe('ConfigurationServiceImpl - migrated chat.advanced setting fallback', (
 		const value = svc.getConfig(ConfigKey.Advanced.InlineEditsXtabProviderModelConfiguration);
 
 		expect(value).toEqual(userValue);
+	});
+});
+
+describe('ConfigurationServiceImpl - user-scoped endpoint overrides', () => {
+	test('ignores workspace values for the ADO code search endpoint override', () => {
+		const key = ConfigKey.Advanced.WorkspacePrototypeAdoCodeSearchEndpointOverride;
+		const legacyKey = key.fullyQualifiedOldId!;
+
+		mockConfigStore.defaults = { [key.fullyQualifiedId]: '' };
+		mockConfigStore.workspace = {
+			[key.fullyQualifiedId]: 'https://workspace.example/current',
+			[legacyKey]: 'https://workspace.example/legacy',
+		};
+		mockConfigStore.workspaceFolder = {
+			[key.fullyQualifiedId]: 'https://workspace-folder.example/current',
+			[legacyKey]: 'https://workspace-folder.example/legacy',
+		};
+
+		const service = new ConfigurationServiceImpl(fakeTokenStore);
+
+		expect(service.getConfig(key)).toBe('');
+	});
+
+	test('uses a user-scoped ADO code search endpoint override', () => {
+		const key = ConfigKey.Advanced.WorkspacePrototypeAdoCodeSearchEndpointOverride;
+
+		mockConfigStore.defaults = { [key.fullyQualifiedId]: '' };
+		mockConfigStore.user = { [key.fullyQualifiedId]: 'https://user.example/current' };
+		mockConfigStore.workspace = { [key.fullyQualifiedId]: 'https://workspace.example/current' };
+		mockConfigStore.workspaceFolder = { [key.fullyQualifiedId]: 'https://workspace-folder.example/current' };
+
+		const service = new ConfigurationServiceImpl(fakeTokenStore);
+
+		expect(service.getConfig(key)).toBe('https://user.example/current');
+	});
+
+	test('preserves the user-scoped legacy ADO code search endpoint override', () => {
+		const key = ConfigKey.Advanced.WorkspacePrototypeAdoCodeSearchEndpointOverride;
+		const legacyKey = key.fullyQualifiedOldId!;
+
+		mockConfigStore.defaults = { [key.fullyQualifiedId]: '' };
+		mockConfigStore.user = { [legacyKey]: 'https://user.example/legacy' };
+		mockConfigStore.workspace = {
+			[key.fullyQualifiedId]: 'https://workspace.example/current',
+			[legacyKey]: 'https://workspace.example/legacy',
+		};
+		mockConfigStore.workspaceFolder = {
+			[key.fullyQualifiedId]: 'https://workspace-folder.example/current',
+			[legacyKey]: 'https://workspace-folder.example/legacy',
+		};
+
+		const service = new ConfigurationServiceImpl(fakeTokenStore);
+
+		expect(service.getConfig(key)).toBe('https://user.example/legacy');
 	});
 });


### PR DESCRIPTION
Fixes #327468

## What changed

- Registers `github.copilot.chat.workspace.prototypeAdoCodeSearchEndpointOverride` as application-scoped and restricted.
- Uses the existing `userScopeOnly` configuration mechanism for the current and migrated legacy keys, so raw workspace and multi-root folder values cannot affect the credential-bearing ADO search request path.
- Adds regression coverage for workspace, workspace-folder, current user, and legacy user values, plus manifest metadata.

## Validation

- `npm run precommit`
- `npm run typecheck` (Copilot extension)
- `npm run compile` (Copilot extension)
- `npm run test:unit -- src/platform/configuration/vscode/test/configurationServiceImpl.spec.ts src/extension/test/node/configurations.spec.ts` — 10 passed
- Targeted ESLint for all changed TypeScript files
- Full Copilot unit suite with four workers: 9,551 passed; four unrelated tests timed out at 5 seconds in the constrained local runner, and none involved the changed configuration paths.

The extension-wide `npm run lint` exceeded the local automation's 10-minute command limit without emitting diagnostics; targeted lint completed successfully.