### PR TITLE
Multi-select folders in trust editor

### DIFF
--- a/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
@@ -179,7 +179,7 @@ class WorkspaceTrustedUrisTable extends Disposable {
 			const uri = await this.fileDialogService.showOpenDialog({
 				canSelectFiles: false,
 				canSelectFolders: true,
-				canSelectMany: false,
+				canSelectMany: true,
 				defaultUri: this.currentWorkspaceUri,
 				openLabel: localize('trustUri', "Trust Folder"),
 				title: localize('selectTrustedUri', "Select Folder To Trust")


### PR DESCRIPTION
Enable users to select multiple folders within the trust editor, enhancing usability and efficiency. Testing involves verifying that multiple folder selections function correctly and that the intended actions apply to all selected folders.

fixes #125098
