### PR TITLE
Fix missing leading whitespace on custom dialogs

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -139,6 +139,7 @@
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message-detail {
 	line-height: 20px;
 	flex: 1; /* let the message always grow */
+	white-space: pre-wrap; /* preserve leading whitespace in detail text */
 }
 
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message a:focus {

--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -139,7 +139,7 @@
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message-detail {
 	line-height: 20px;
 	flex: 1; /* let the message always grow */
-	white-space: pre-wrap; /* preserve leading whitespace in detail text */
+	white-space: pre-wrap;
 }
 
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message a:focus {


### PR DESCRIPTION
Don't remove leading whitespace on custom dialogs. note that macos native dialogs don't preserve the whitespace but I don't see a reason we shouldn't support this in our custom dialogs

fixes https://github.com/microsoft/vscode/issues/128233
