### PR TITLE
Fix preserveInput leaking draft state, reject empty compaction summaries

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -842,6 +842,14 @@ class ConversationHistorySummarizer {
 		// actually stored — the `<analysis>` scratchpad would otherwise push an
 		// acceptable summary over budget and fail compaction.
 		const summaryText = this.unwrapSummary(response.value);
+		// An empty summary is stored but ignored by the truthy `round.summary` checks
+		// on the next render, so compaction would silently reclaim nothing while
+		// reporting success. Fail instead so the Simple-mode fallback runs.
+		if (!summaryText.trim()) {
+			this.sendSummarizationTelemetry('empty', response.requestId, this.props.endpoint.model, mode, elapsedTime, response.usage, 'summary was empty after extraction');
+			this.logInfo('Summarization produced an empty summary', mode);
+			throw new Error('Summarization request failed');
+		}
 		const summarySize = await this.sizing.countTokens(summaryText);
 		const effectiveBudget =
 			!!this.props.maxSummaryTokens

--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -602,7 +602,9 @@ class ConversationHistorySummarizer {
 		this.progress?.report(new ChatResponseProgressPart2(l10n.t('Compacting conversation...'), async () => {
 			try {
 				await summaryPromise;
-			} catch { }
+			} catch {
+				return l10n.t('Could not compact conversation');
+			}
 			return l10n.t('Compacted conversation');
 		}));
 
@@ -838,13 +840,9 @@ class ConversationHistorySummarizer {
 			throw new Error('Summarization request failed');
 		}
 
-		// Unwrap before the budget check so the size counted here is the text that is
-		// actually stored — the `<analysis>` scratchpad would otherwise push an
-		// acceptable summary over budget and fail compaction.
+		// Count what is actually stored: the <analysis> block would otherwise blow the budget.
 		const summaryText = this.unwrapSummary(response.value);
-		// An empty summary is stored but ignored by the truthy `round.summary` checks
-		// on the next render, so compaction would silently reclaim nothing while
-		// reporting success. Fail instead so the Simple-mode fallback runs.
+		// Empty summaries are ignored by the truthy round.summary checks, so fail into the Simple-mode fallback.
 		if (!summaryText.trim()) {
 			this.sendSummarizationTelemetry('empty', response.requestId, this.props.endpoint.model, mode, elapsedTime, response.usage, 'summary was empty after extraction');
 			this.logInfo('Summarization produced an empty summary', mode);

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -580,8 +580,7 @@ suite('Agent Summarization', () => {
 	});
 
 	test('empty <summary> fails rather than silently compacting to nothing', async () => {
-		// An empty summary is ignored by the truthy round.summary checks on the next
-		// render, so it must fail instead of reporting a successful compaction.
+		// Empty summaries are ignored by the truthy round.summary checks on the next render.
 		chatResponse[0] = '<analysis>reasoning</analysis>\n<summary>   </summary>';
 		const { instaService, endpoint, historyProps } = createSummarizationTestContext();
 

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -579,6 +579,16 @@ suite('Agent Summarization', () => {
 		expect(result.metadata.get(SummarizedConversationHistoryMetadata)!.text).toBe('short summary');
 	});
 
+	test('empty <summary> fails rather than silently compacting to nothing', async () => {
+		// An empty summary is ignored by the truthy round.summary checks on the next
+		// render, so it must fail instead of reporting a successful compaction.
+		chatResponse[0] = '<analysis>reasoning</analysis>\n<summary>   </summary>';
+		const { instaService, endpoint, historyProps } = createSummarizationTestContext();
+
+		const renderer = PromptRenderer.create(instaService, endpoint, SummarizedConversationHistory, historyProps);
+		await expect(renderer.render()).rejects.toThrow();
+	});
+
 	test('failed summarization does not set round.summary', async () => {
 		chatResponse[0] = 'summary that is definitely too large for one token';
 		const { instaService, endpoint, toolCallRounds, historyProps } = createSummarizationTestContext();

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -198,8 +198,9 @@ export interface IChatViewOpenOptions {
 	 * commands such as `/compact` that are not user messages.
 	 *
 	 * Mutually exclusive with `attachScreenshot`, `attachFiles`,
-	 * `attachHistoryItemChanges` and `toolIds`: those attach context via the input
-	 * box, which this option deliberately excludes from the request.
+	 * `attachHistoryItemChanges`, `attachHistoryItemChangeRanges` and `toolIds`:
+	 * those attach context via the input box, which this option deliberately
+	 * excludes from the request.
 	 */
 	preserveInput?: boolean;
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -354,7 +354,7 @@ export interface IChatAcceptInputOptions {
 	 */
 	cancelCurrentRequest?: boolean;
 	preserveFocus?: boolean;
-	/** Keeps the input box contents and attachments after submitting a programmatic query, and omits them from it. */
+	/** Keeps the input box contents and attachments after submitting a programmatic query, and omits them from it. The query itself is sent as-is: prompt slash commands in it are not resolved. */
 	preserveInput?: boolean;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2797,8 +2797,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		// process the prompt command
-		// `preserveInput` means the draft is not this request, so its prompt-file
-		// metadata (agent, model, tools) must not be applied to the query.
+		// `preserveInput` means the draft is not this request: `parsedInput` derives
+		// from the draft, so this would apply the draft prompt file's agent, model and
+		// tools to the query — and an agent switch can clear the session.
 		if (!options.preserveInput) {
 			const promptApplied = await this._applyPromptFileIfSet(requestInputs, this.viewModel.sessionResource);
 			if (!promptApplied) {
@@ -2902,7 +2903,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.updateChatViewVisibility();
 		this.input.acceptInput(options?.storeToHistory ?? isUserQuery, options?.preserveFocus, options?.preserveInput);
 
-		this._maybeStartGoalSummary(requestInputs.input);
+		if (!options.preserveInput) {
+			// Not a user goal: this would cancel the current goal banner and spend an
+			// LLM call summarizing the maintenance command.
+			this._maybeStartGoalSummary(requestInputs.input);
+		}
 
 		const sent = ChatSendResult.isQueued(result) ? await result.deferred : result;
 		if (!ChatSendResult.isSent(sent)) {
@@ -2910,10 +2915,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		if (!options.preserveInput) {
-			// The input box did not source this request: firing would repopulate the
-			// draft with the query, record it as a user agent choice, and let
-			// listeners treat the draft's attachments as sent (agent feedback marks
-			// itself submitted) even though they were excluded from it.
+			// Not a user submission: listeners would repopulate the draft, record the
+			// agent as a user choice, and mark the draft's feedback attachments as
+			// sent even though they were excluded from this request. Side effect:
+			// an editor-hosted chat is not pinned by a maintenance command.
 			this._onDidSubmitAgent.fire({ agent: sent.data.agent, slashCommand: sent.data.slashCommand });
 		}
 		this.handleDelegationExitIfNeeded(this._lockedAgent, sent.data.agent);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2797,9 +2797,13 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		// process the prompt command
-		const promptApplied = await this._applyPromptFileIfSet(requestInputs, this.viewModel.sessionResource);
-		if (!promptApplied) {
-			return;
+		// `preserveInput` means the draft is not this request, so its prompt-file
+		// metadata (agent, model, tools) must not be applied to the query.
+		if (!options.preserveInput) {
+			const promptApplied = await this._applyPromptFileIfSet(requestInputs, this.viewModel.sessionResource);
+			if (!promptApplied) {
+				return;
+			}
 		}
 
 		if (this.viewOptions.enableWorkingSet !== undefined && this.input.currentModeKind === ChatModeKind.Edit) {
@@ -2905,7 +2909,13 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
-		this._onDidSubmitAgent.fire({ agent: sent.data.agent, slashCommand: sent.data.slashCommand });
+		if (!options.preserveInput) {
+			// The input box did not source this request: firing would repopulate the
+			// draft with the query, record it as a user agent choice, and let
+			// listeners treat the draft's attachments as sent (agent feedback marks
+			// itself submitted) even though they were excluded from it.
+			this._onDidSubmitAgent.fire({ agent: sent.data.agent, slashCommand: sent.data.slashCommand });
+		}
 		this.handleDelegationExitIfNeeded(this._lockedAgent, sent.data.agent);
 
 		// If the session was replaced (untitled -> real contributed session), swap the widget's model

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2722,7 +2722,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			}
 		}
 
-		this._onDidAcceptInput.fire();
+		if (!options.preserveInput) {
+			// Would stop dictation the preserved draft may still be using.
+			this._onDidAcceptInput.fire();
+		}
 		this.listWidget.setScrollLock(this.isLockedToCodingAgent || !!checkModeOption(this.input.currentModeKind, this.viewOptions.autoScroll));
 
 		const requestInputs: IChatRequestInputOptions = {
@@ -2797,9 +2800,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		// process the prompt command
-		// `preserveInput` means the draft is not this request: `parsedInput` derives
-		// from the draft, so this would apply the draft prompt file's agent, model and
-		// tools to the query — and an agent switch can clear the session.
+		// Skipped for preserveInput: parsedInput is the draft, and an agent switch can clear the session.
 		if (!options.preserveInput) {
 			const promptApplied = await this._applyPromptFileIfSet(requestInputs, this.viewModel.sessionResource);
 			if (!promptApplied) {
@@ -2904,8 +2905,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.input.acceptInput(options?.storeToHistory ?? isUserQuery, options?.preserveFocus, options?.preserveInput);
 
 		if (!options.preserveInput) {
-			// Not a user goal: this would cancel the current goal banner and spend an
-			// LLM call summarizing the maintenance command.
+			// A maintenance command is not the user's goal.
 			this._maybeStartGoalSummary(requestInputs.input);
 		}
 
@@ -2915,10 +2915,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		if (!options.preserveInput) {
-			// Not a user submission: listeners would repopulate the draft, record the
-			// agent as a user choice, and mark the draft's feedback attachments as
-			// sent even though they were excluded from this request. Side effect:
-			// an editor-hosted chat is not pinned by a maintenance command.
+			// Not a user submission; listeners would consume draft state. Also skips editor pinning.
 			this._onDidSubmitAgent.fire({ agent: sent.data.agent, slashCommand: sent.data.slashCommand });
 		}
 		this.handleDelegationExitIfNeeded(this._lockedAgent, sent.data.agent);


### PR DESCRIPTION
Follow-up to #327548. Fixes issues found by a two-model review council, plus a further trace of the `preserveInput` path.

## `preserveInput` leaked draft state into the request

`preserveInput` (added in #327548) means *the input box did not source this request*. Three paths still read draft state anyway:

- **Prompt-file metadata applied from the draft.** `parsedInput` derives from `getInput()` — the draft — not the submitted query. So `_applyPromptFileIfSet` would read a draft like `/review ...`, attach its prompt file, and apply that prompt's agent, model and tool metadata to `/compact`. An agent switch there can reach `handleModeSwitch` then `clear()`, so this could wipe the session mid-compaction.
- **`onDidSubmitAgent` fired for a request the user didn't send.** Listeners treat it as a user submission: agent feedback calls `markFeedbackSubmitted`, discarding unsent feedback whose attachments `preserveInput` had deliberately excluded from the request; the input contribs also repopulate the draft and record the agent as a user choice.
- **Goal summary started for the maintenance command.** In the local harness with autopilot goal mode on — where the non-agent-host `/compact` runs — `_maybeStartGoalSummary` cancelled the user's goal banner and spent an LLM call summarizing `"/compact"`.

All three are now skipped when `preserveInput` is set.

Known side effect: an editor-hosted chat is no longer pinned by a maintenance command, since pinning rides on `onDidSubmitAgent`.

## Empty summaries silently compacted to nothing

A whitespace-only `<summary>` passed validation and was stored, but the next render's truthy `round.summary` checks ignore it. Compaction reported "Compacted conversation", reclaimed nothing, and the Simple-mode fallback never ran. Empty summaries now fail so the fallback engages.

## Docs

`attachHistoryItemChangeRanges` added to the options that don't compose with `preserveInput`. Also documented that a `preserveInput` query is sent as-is — prompt slash commands inside it are not resolved, since `_applyPromptFileIfSet` reads the draft rather than the query. Not reachable today; `/compact` is the only caller.

## Validation

Core + extension typecheck, hygiene, 380 copilot tests, 2430 core chat tests. Added a regression test for the empty-summary case, confirmed failing without the fix.

The `preserveInput` fixes have no test — there is no harness for `ChatWidget._acceptInput`. They are verified by tracing every `onDidSubmitAgent` listener, the `parsedInput` derivation, and each draft-derived call in `_acceptInput`.

**Design note for reviewers:** two review rounds have now surfaced four separate leaks on this flag, each found by a different method. `preserveInput` has to be re-checked at every point that reads input state and nothing enforces that. A sturdier shape would make programmatic submission its own path rather than a flag threaded through the user path. Happy to follow up if you agree.