### PR TITLE
Don't show a row's hover panel when pointing at action list chrome

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -726,6 +726,10 @@ export class ActionListWidget<T> extends Disposable {
 		this._register(dom.addDisposableListener(this._submenuContainer, 'mouseleave', () => {
 			this._scheduleSubmenuHide();
 		}));
+		// A panel scheduled while crossing a row must not pop up after the pointer has left.
+		this._register(dom.addDisposableListener(this.domNode, dom.EventType.MOUSE_LEAVE, () => {
+			this._cancelSubmenuShow();
+		}));
 		this._register(toDisposable(() => {
 			this._cancelSubmenuHide();
 			this._cancelSubmenuShow();
@@ -872,6 +876,9 @@ export class ActionListWidget<T> extends Disposable {
 			}
 			const text = dom.append(this._headerContainer, dom.$('span.action-list-header-text'));
 			text.textContent = this._options.headerText;
+
+			// The banner is chrome, not an item: pointing at it dismisses a row's hover panel.
+			this._register(dom.addDisposableListener(this._headerContainer, dom.EventType.MOUSE_ENTER, () => this._hideSubmenu()));
 
 			if (this._options.headerLink) {
 				const { label, uri } = this._options.headerLink;

--- a/src/vs/platform/actionWidget/test/browser/actionList.test.ts
+++ b/src/vs/platform/actionWidget/test/browser/actionList.test.ts
@@ -316,6 +316,55 @@ suite('ActionListWidget', () => {
 		);
 	});
 
+	test('shows a row hover panel once the hover delay elapses', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const widget = createActionListWidget(disposables, {
+			items: [{ ...action('auto'), hover: { content: 'Auto routes based on your task' } }, action('other')],
+			listOptions: { headerText: 'Cache hint' },
+		});
+		const panel = widget.domNode.querySelector<HTMLElement>('.action-list-submenu-panel')!;
+
+		widget.domNode.querySelector<HTMLElement>('.monaco-list-row')!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+		await timeout(1000);
+
+		assert.deepStrictEqual({ display: panel.style.display, text: panel.textContent }, { display: '', text: 'Auto routes based on your task' });
+	}));
+
+	test('does not open a row hover panel once the pointer has left the list', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const widget = createActionListWidget(disposables, {
+			items: [{ ...action('auto'), hover: { content: 'Auto routes based on your task' } }, action('other')],
+			listOptions: { headerText: 'Cache hint' },
+		});
+		const panel = widget.domNode.querySelector<HTMLElement>('.action-list-submenu-panel')!;
+
+		// The banner is a sibling of the list, so reaching it drags the pointer across a row.
+		widget.domNode.querySelector<HTMLElement>('.monaco-list-row')!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+		widget.domNode.dispatchEvent(new MouseEvent('mouseleave'));
+		await timeout(1000);
+
+		assert.deepStrictEqual({ display: panel.style.display, text: panel.textContent }, { display: 'none', text: '' });
+	}));
+
+	test('dismisses an open row hover panel when the pointer reaches the header banner', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const widget = createActionListWidget(disposables, {
+			items: [{ ...action('auto'), hover: { content: 'Auto routes based on your task' } }, action('other')],
+			listOptions: { headerText: 'Cache hint' },
+		});
+		const panel = widget.domNode.querySelector<HTMLElement>('.action-list-submenu-panel')!;
+
+		// Dwelling on the row long enough for the panel to open, then continuing to the banner.
+		widget.domNode.querySelector<HTMLElement>('.monaco-list-row')!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+		await timeout(600);
+		const openedWhileOnRow = panel.textContent;
+
+		widget.domNode.dispatchEvent(new MouseEvent('mouseleave'));
+		widget.headerContainer!.dispatchEvent(new MouseEvent('mouseenter'));
+
+		assert.deepStrictEqual(
+			{ openedWhileOnRow, display: panel.style.display, text: panel.textContent },
+			{ openedWhileOnRow: 'Auto routes based on your task', display: 'none', text: '' },
+		);
+	}));
+
 	test('header renders a "Learn more" link to the given uri', () => {
 		const widget = createActionListWidget(disposables, {
 			listOptions: { headerText: 'Cache hint', headerLink: { label: 'Learn more', uri: URI.parse('https://aka.ms/test') } },


### PR DESCRIPTION
Fixes #324770

## The bug

Hovering a row schedules its hover panel with a 500ms delay, but nothing cancelled that timer when the pointer left the rows.

The model picker's cache-break tip is a **sibling above the list**, so moving the mouse up to it drags the pointer across the `Auto` row on the way. The timer then fired while the pointer was already parked on the tip, and `Auto`'s hover appeared instead of the tip's own.

The screenshot in the issue confirms the mechanism: `Claude Opus 4.8` has the checkmark, but `Auto` is highlighted — that focus came from `onListHover`, i.e. the mouse passed over it in transit.

## The fix

Two handlers, because the same symptom has two causes:

1. **Leaving the rows cancels a pending panel.** Covers crossing `Auto` quickly — the timer would otherwise fire once the pointer had already arrived at the tip.
2. **Reaching the banner dismisses an open panel.** Covers dwelling on `Auto` past 500ms — the panel is already open, and without this it stays stranded over the tip. Verified this variant reproduces the report verbatim, which is why the first handler alone is not sufficient.

Deliberately **no mouse-vs-keyboard ownership tracking.** An earlier draft hid open panels whenever the pointer left the list, which needed an ownership flag so keyboard navigation wasn't broken — and that flag then produced two bugs of its own. Dismissing on banner entry needs no such state, so none of it is here.

