### PR TITLE
Agent Host missing non-PTY shell output after completion 

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2797,9 +2797,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			this._tryObserveSubagentToolCall(tc, invocation, store, opts, subagentContext);
 
 			if ((status === ToolCallStatus.Completed || status === ToolCallStatus.Cancelled) && !IChatToolInvocation.isComplete(invocation)) {
-				// Revive terminal before finalizing — handles the case where
-				// Running was skipped (e.g. throttling) and terminal content
-				// only appears at Completed time.
+				// Detach live non-PTY output before completion synchronously rebuilds the terminal subpart.
 				this._ensureLeftStreaming(invocation, tc, opts);
 				this._reviveTerminalIfNeeded(invocation, tc, opts.backendSession, outputTerminalAttachment);
 				const fileEdits = finalizeToolInvocation(invocation, tc, opts.backendSession, this._config.connectionAuthority);
@@ -3430,10 +3428,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	}
 
 	/**
-	 * Detects terminal content in a tool call and creates a local terminal
-	 * instance backed by the agent host connection. Updates the invocation's
-	 * `toolSpecificData` to `kind: 'terminal'` and clears
-	 * `HiddenAfterComplete` so the terminal UI stays visible.
+	 * Synchronizes PTY and non-PTY terminal content, including the live-to-retained output handoff, and updates invocation metadata.
 	 */
 	private _reviveTerminalIfNeeded(
 		invocation: ChatToolInvocation,
@@ -3457,11 +3452,14 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const terminalCommandUri = URI.parse(terminalUri);
 		const isPty = terminalContent.isPty !== false;
 		const terminalInstance = isPty ? this._ensureTerminalInstance(terminalUri, sessionId) : undefined;
-		const hasStaticNonPtyResult = tc.status === ToolCallStatus.Completed
+		const hasRetainedNonPtySnapshot = tc.status === ToolCallStatus.Completed
 			&& !isPty
 			&& terminalContent.result?.exitCode !== undefined
 			&& terminalContent.result.preview !== undefined;
-		if (!isPty && !hasStaticNonPtyResult && outputTerminalAttachment.sessionId !== sessionId) {
+		if (hasRetainedNonPtySnapshot) {
+			outputTerminalAttachment.disposable.clear();
+			outputTerminalAttachment.sessionId = undefined;
+		} else if (!isPty && outputTerminalAttachment.sessionId !== sessionId) {
 			outputTerminalAttachment.disposable.value = this._agentHostTerminalService.attachOutputTerminal(this._config.connection, terminalCommandUri, sessionId);
 			outputTerminalAttachment.sessionId = sessionId;
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -1194,11 +1194,12 @@ function getTerminalOutput(tc: ToolCallState) {
 	// Prefer the structured terminal snapshot. Text content is a compatibility
 	// fallback for older/restored results and can include legacy bookkeeping.
 	let text = terminalResult?.preview;
+	const hasRetainedNonPtySnapshot = terminalContent?.isPty === false && text !== undefined;
 	if (text === undefined && terminalContent?.isPty !== false) {
 		const fallbackText = tc.content?.find(isToolResultTextContent)?.text;
 		text = fallbackText === undefined ? undefined : stripLegacyTerminalExitMarkers(fallbackText);
 	}
-	if (text === undefined || (!text && terminalResult?.truncated !== true)) {
+	if (text === undefined || (!text && !hasRetainedNonPtySnapshot && terminalResult?.truncated !== true)) {
 		return undefined;
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -5435,7 +5435,7 @@ suite('AgentHostChatContribution', () => {
 			await turnPromise;
 		});
 
-		test('output-only terminal attaches to chat without reviving a terminal instance', async () => {
+		test('completed output-only terminal retires its live attachment before finalizing its retained snapshot', async () => {
 			let reviveCalls = 0;
 			let attachmentDisposed = false;
 			let attached: { terminalUri: string; terminalToolSessionId: string } | undefined;
@@ -5471,6 +5471,20 @@ suite('AgentHostChatContribution', () => {
 				terminalUri: 'agenthost-terminal://shell/output',
 				terminalToolSessionId: JSON.stringify({ terminal: 'agenthost-terminal://shell/output', session: 'copilot:/new-turntest' }),
 			});
+			let stateNotifications = 0;
+			let firstCompletedObservation: { attachmentDisposed: boolean; output: string | undefined } | undefined;
+			disposables.add(autorun(reader => {
+				const state = invocation.state.read(reader);
+				stateNotifications++;
+				if (state.type === IChatToolInvocation.StateKind.Completed && !firstCompletedObservation) {
+					const completedTerminalData = invocation.toolSpecificData?.kind === 'terminal' ? invocation.toolSpecificData : undefined;
+					firstCompletedObservation = {
+						attachmentDisposed,
+						output: completedTerminalData?.terminalCommandOutput?.text,
+					};
+				}
+			}));
+			const notificationsBeforeCompletion = stateNotifications;
 
 			fire({
 				type: 'chat/toolCallComplete',
@@ -5493,16 +5507,23 @@ suite('AgentHostChatContribution', () => {
 			assert.deepStrictEqual({
 				output: completedTerminalData?.terminalCommandOutput?.text,
 				attachmentDisposed,
+				firstCompletedObservation,
+				stateNotificationDelta: stateNotifications - notificationsBeforeCompletion,
 			}, {
 				output: 'final output\r\n',
-				attachmentDisposed: false,
+				attachmentDisposed: true,
+				firstCompletedObservation: {
+					attachmentDisposed: true,
+					output: 'final output\r\n',
+				},
+				stateNotificationDelta: 1,
 			});
 			fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session, turnId } as ChatAction);
 			await turnPromise;
 			assert.strictEqual(attachmentDisposed, true);
 		});
 
-		test('completed output-only terminal with static output never attaches to the live resource', async () => {
+		test('completed output-only terminal with a retained snapshot never attaches to the live resource', async () => {
 			let attachCalls = 0;
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
 				agentHostTerminalServiceOverride: {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -2068,6 +2068,52 @@ suite('stateToProgressAdapter', () => {
 			assert.ok(!termData.terminalCommandOutput?.text.includes('shellId'));
 		});
 
+		test('preserves an explicitly empty non-PTY retained completion snapshot', () => {
+			const tc = createCompletedToolCall({
+				_meta: { toolKind: 'terminal' },
+				toolInput: 'true',
+				content: [
+					{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal://shell/copilotNonPtyShells/tc-1', title: 'Run Shell Command', isPty: false, result: { exitCode: 0, preview: '' } },
+				],
+				success: true,
+			});
+
+			const turn = createTurn({
+				responseParts: [{ kind: ResponsePartKind.ToolCall, toolCall: tc } as ToolCallResponsePart],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const serialized = response.parts[0] as IChatToolInvocationSerialized;
+			const termData = getSerializedTerminalData(serialized);
+			assert.deepStrictEqual(termData.terminalCommandOutput, { text: '' });
+		});
+
+		test('does not store an explicitly empty PTY completion preview when isPty is omitted', () => {
+			const tc = createCompletedToolCall({
+				_meta: { toolKind: 'terminal' },
+				toolInput: 'true',
+				content: [
+					{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal:///pty-empty', title: 'Run Shell Command', result: { exitCode: 0, preview: '' } },
+				],
+				success: true,
+			});
+
+			const turn = createTurn({
+				responseParts: [{ kind: ResponsePartKind.ToolCall, toolCall: tc } as ToolCallResponsePart],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const serialized = response.parts[0] as IChatToolInvocationSerialized;
+			const termData = getSerializedTerminalData(serialized);
+			assert.strictEqual(termData.terminalCommandOutput, undefined);
+		});
+
 		test('does not use text content when a terminal block owns the output', () => {
 			const tc = createCompletedToolCall({
 				_meta: { toolKind: 'terminal' },


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/327556
(Seems like race condition) - On fast commands like `ls in terminal` - there is issue where output goes missing "only on UI" for completed non-pty shell output. 

This PR does not change runtime preview truncation behavior.

- Detach the live non-PTY output source before completion synchronously rebuilds the terminal subpart.
- Render the retained completion snapshot instead of leaving the completed card attached to a retired live resource.
- Preserve explicitly empty non-PTY snapshots so silent commands show “No output was produced by the command.”
- Keep PTY commands and non-PTY completions without a preview on their existing lifecycle.
- Verify that the live attachment is disposed and the retained snapshot is available at the first observable completed state, without adding another state transition.
- Cover the production PTY shape where `isPty` is omitted.

## Verification

- `npm run typecheck-client -- --pretty false`
- `npm run test-browser-no-install -- --browser chromium --sequential --run src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.js`
- `npm run test-browser-no-install -- --browser chromium --sequential --run src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.js`
- Manually verified fast output, silent output, and streamed output through completion without a blank frame or collapse/re-expansion.

-----------------------------------------
Inspirations from:

- Live non-PTY attachment retirement follows the host’s existing finalized-preview lifetime in [`CopilotNonPtyShellTerminals`](https://github.com/microsoft/vscode/blob/b38a336463cf9aaed6a162d67fcf6fb49e9b21d0/src/vs/platform/agentHost/node/copilot/copilotNonPtyShellTerminals.ts#L145-L175).
- Empty retained-output behavior matches [`getCommandOutputSnapshot`](https://github.com/microsoft/vscode/blob/b38a336463cf9aaed6a162d67fcf6fb49e9b21d0/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts#L165-L174).
- The non-PTY check follows the existing terminal-content shape: PTY blocks omit `isPty`, while non-PTY blocks explicitly set `isPty: false` in [`CopilotAgentSession`](https://github.com/microsoft/vscode/blob/b38a336463cf9aaed6a162d67fcf6fb49e9b21d0/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts#L3467-L3490).
- The handoff ordering accounts for the renderer caching and prioritizing a registered live output source in [`ChatTerminalToolProgressPart`](https://github.com/microsoft/vscode/blob/b38a336463cf9aaed6a162d67fcf6fb49e9b21d0/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts#L1090-L1096) and [`_updateTerminalContent`](https://github.com/microsoft/vscode/blob/b38a336463cf9aaed6a162d67fcf6fb49e9b21d0/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts#L1514-L1528).