### PR TITLE
agentHost: keep the host's own MCP bridges out of session customizations

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -15,10 +15,29 @@ import { resolveClaudeEffort } from '../../common/claudeModelConfig.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import type { ModelSelection } from '../../common/state/protocol/state.js';
 import { IClaudeAgentSdkService } from './claudeAgentSdkService.js';
-import { buildClientToolMcpServer } from './clientTools/claudeClientToolMcpServer.js';
+import { CLAUDE_SERVER_TOOL_MCP_SERVER_NAME } from './claudeServerToolMcpServer.js';
+import { buildClientToolMcpServer, CLAUDE_CLIENT_MCP_SERVER_NAME } from './clientTools/claudeClientToolMcpServer.js';
 import { toSdkModelId } from './claudeModelId.js';
 import type { ClaudeTransport } from './claudeProxyService.js';
 import { SessionClientToolsDiff } from './clientTools/claudeSessionClientToolsModel.js';
+
+/**
+ * The in-process MCP servers the agent host injects into
+ * `Options.mcpServers` itself: the client-tool bridge and the server-tool
+ * bridge. They are internal plumbing — the SDK reports them alongside real,
+ * user-configured servers in `mcpServerStatus()`, but they have no on-disk
+ * definition, cannot be toggled through the CLI's MCP control requests, and
+ * must never surface as user-visible MCP customizations.
+ */
+const HOST_INJECTED_MCP_SERVER_NAMES: ReadonlySet<string> = new Set([
+	CLAUDE_CLIENT_MCP_SERVER_NAME,
+	CLAUDE_SERVER_TOOL_MCP_SERVER_NAME,
+]);
+
+/** Whether `name` is one of the {@link HOST_INJECTED_MCP_SERVER_NAMES}. */
+export function isHostInjectedMcpServerName(name: string): boolean {
+	return HOST_INJECTED_MCP_SERVER_NAMES.has(name);
+}
 
 /**
  * Inputs to {@link buildOptions} that vary per startup. Pure-data: no

--- a/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
@@ -130,7 +130,14 @@ export class ClaudeSdkPipeline extends Disposable {
 		const query = await this._ensureQueryBound();
 		const observed = new Map((await query.mcpServerStatus()).map(server => [server.name, server.status !== 'disabled']));
 		for (const [serverName, enabled] of desired) {
-			if (observed.get(serverName) === enabled) {
+			// `desired` is session-scoped state, so it can name servers this
+			// particular chat's query does not have (a peer chat that has not
+			// finished connecting its servers, or a chat created after the
+			// session state was published). Toggling one of those always fails
+			// with `Server not found: <name>` and would take the turn down with
+			// it, so only reconcile servers the live query actually reports.
+			const current = observed.get(serverName);
+			if (current === undefined || current === enabled) {
 				continue;
 			}
 			if (!await this._applyMcpServerEnablement(query, serverName, enabled)) {

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
@@ -355,13 +355,7 @@ export function buildDiscoveredCustomizations(
 
 	const agentNames = new Set(sdk.agents.map(a => a.name));
 	const commandNames = new Set(sdk.commands.map(c => c.name));
-	// The agent host's own in-process MCP servers (client-tool / server-tool
-	// bridges) are reported by the SDK alongside real servers, but they are
-	// internal plumbing: surfacing them would both show phantom entries in the
-	// customization UI and feed their names back into the session's MCP
-	// enablement reconciliation, which then tries to toggle a server the CLI
-	// has no configuration for (`Server not found: <name>`).
-	const mcpByName = new Map(sdk.mcpServers.filter(s => !isHostInjectedMcpServerName(s.name)).map(s => [s.name, s] as const));
+	const mcpByName = new Map(sdk.mcpServers.map(s => [s.name, s] as const));
 
 	// Keep disk entries the live session actually loaded. A loaded skill
 	// surfaces in the SDK's `supportedCommands()` set, so disk skills are
@@ -416,6 +410,19 @@ export function buildDiscoveredCustomizations(
 	}
 	for (const [name, sdkServer] of mcpByName) {
 		if (seenMcp.has(name) || pluginMcpNames.has(name)) {
+			continue;
+		}
+		// The agent host injects its own in-process MCP servers (the client-tool
+		// and server-tool bridges) into `Options.mcpServers`, and the SDK reports
+		// them here alongside real ones. They are internal plumbing with no
+		// definition the user can act on, so an SDK-only entry under one of those
+		// names is ours: surfacing it would show a phantom customization AND feed
+		// its name into the session's MCP enablement reconciliation, which then
+		// tries to toggle a server the CLI has no configuration for
+		// (`Server not found: <name>`). A server the disk scan did define under
+		// the same name is matched above and kept, so a user-configured server is
+		// never hidden by this.
+		if (isHostInjectedMcpServerName(name)) {
 			continue;
 		}
 		servers.push({ ...makeMcpServerCustomization(nonEditableUri('mcp', name), name), state: deriveMcpState(sdkServer.status) });

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
@@ -13,6 +13,7 @@ import { makeMcpServerCustomization, parseAgentFile, toParsedAgent, type IParsed
 import { CustomizationType, type AgentSelection, type McpServerCustomization } from '../../../common/state/protocol/channels-session/state.js';
 import { CustomizationLoadStatus, customizationId, type AgentCustomization, type ChildCustomization, type Customization, type DirectoryCustomization, type HookCustomization, type PluginCustomization, type RuleCustomization, type SkillCustomization } from '../../../common/state/sessionState.js';
 import type { ISdkResolvedCustomizations } from '../claudeSdkPipeline.js';
+import { isHostInjectedMcpServerName } from '../claudeSdkOptions.js';
 import { deriveMcpState } from './scan/claudeMcpScan.js';
 import { claudeMemoryFiles } from './scan/claudeRuleScan.js';
 import type { IResolvedNativePlugin } from './scan/claudeNativePluginScan.js';
@@ -354,7 +355,13 @@ export function buildDiscoveredCustomizations(
 
 	const agentNames = new Set(sdk.agents.map(a => a.name));
 	const commandNames = new Set(sdk.commands.map(c => c.name));
-	const mcpByName = new Map(sdk.mcpServers.map(s => [s.name, s] as const));
+	// The agent host's own in-process MCP servers (client-tool / server-tool
+	// bridges) are reported by the SDK alongside real servers, but they are
+	// internal plumbing: surfacing them would both show phantom entries in the
+	// customization UI and feed their names back into the session's MCP
+	// enablement reconciliation, which then tries to toggle a server the CLI
+	// has no configuration for (`Server not found: <name>`).
+	const mcpByName = new Map(sdk.mcpServers.filter(s => !isHostInjectedMcpServerName(s.name)).map(s => [s.name, s] as const));
 
 	// Keep disk entries the live session actually loaded. A loaded skill
 	// surfaces in the SDK's `supportedCommands()` set, so disk skills are

--- a/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
@@ -209,6 +209,23 @@ suite('claudeSessionCustomizationDiscovery', () => {
 			assert.deepStrictEqual((builtin?.children ?? []).map(c => c.name), ['init', 'loop']);
 		});
 
+		test('the agent host\'s own in-process MCP servers are never surfaced', () => {
+			const diskMcp: McpServerCustomization = { type: CustomizationType.McpServer, id: 'disk-mcp', uri: 'inmemory:/settings.json', name: 'client', enabled: true, state: { kind: McpServerStatus.Starting } };
+			const sdk: ISdkResolvedCustomizations = {
+				agents: [],
+				commands: [],
+				// `client` / `host` are the agent host's in-process client-tool and
+				// server-tool bridges; only `real` is a user-configured server.
+				mcpServers: [{ name: 'client', status: 'connected' }, { name: 'host', status: 'connected' }, { name: 'real', status: 'connected' }],
+				plugins: [],
+			};
+
+			const result = buildDiscoveredCustomizations([], [diskMcp], [], [], workspace, userHome, sdk);
+			const mcps = result.filter(c => c.type === CustomizationType.McpServer) as McpServerCustomization[];
+
+			assert.deepStrictEqual(mcps.map(m => m.name), ['real']);
+		});
+
 		test('rules survive the post-materialize SDK filter (no SDK counterpart)', () => {
 			const ruleUri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/CLAUDE.md' });
 			const discovered: IParsedRule[] = [{

--- a/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
@@ -209,13 +209,14 @@ suite('claudeSessionCustomizationDiscovery', () => {
 			assert.deepStrictEqual((builtin?.children ?? []).map(c => c.name), ['init', 'loop']);
 		});
 
-		test('the agent host\'s own in-process MCP servers are never surfaced', () => {
-			const diskMcp: McpServerCustomization = { type: CustomizationType.McpServer, id: 'disk-mcp', uri: 'inmemory:/settings.json', name: 'client', enabled: true, state: { kind: McpServerStatus.Starting } };
+		test('SDK-reported in-process host bridges are not surfaced as SDK-only entries', () => {
+			const diskMcp: McpServerCustomization = { type: CustomizationType.McpServer, id: 'disk-mcp', uri: 'inmemory:/settings.json', name: 'real', enabled: true, state: { kind: McpServerStatus.Starting } };
 			const sdk: ISdkResolvedCustomizations = {
 				agents: [],
 				commands: [],
 				// `client` / `host` are the agent host's in-process client-tool and
-				// server-tool bridges; only `real` is a user-configured server.
+				// server-tool bridges, injected into `Options.mcpServers`; only
+				// `real` is user-configured.
 				mcpServers: [{ name: 'client', status: 'connected' }, { name: 'host', status: 'connected' }, { name: 'real', status: 'connected' }],
 				plugins: [],
 			};
@@ -224,6 +225,23 @@ suite('claudeSessionCustomizationDiscovery', () => {
 			const mcps = result.filter(c => c.type === CustomizationType.McpServer) as McpServerCustomization[];
 
 			assert.deepStrictEqual(mcps.map(m => m.name), ['real']);
+		});
+
+		test('a disk-defined MCP server is kept even when its name collides with a host bridge', () => {
+			const diskMcp: McpServerCustomization = { type: CustomizationType.McpServer, id: 'disk-mcp', uri: 'inmemory:/settings.json', name: 'host', enabled: true, state: { kind: McpServerStatus.Starting } };
+			const sdk: ISdkResolvedCustomizations = {
+				agents: [],
+				commands: [],
+				mcpServers: [{ name: 'host', status: 'connected' }],
+				plugins: [],
+			};
+
+			const result = buildDiscoveredCustomizations([], [diskMcp], [], [], workspace, userHome, sdk);
+			const mcps = result.filter(c => c.type === CustomizationType.McpServer) as McpServerCustomization[];
+
+			// The user configured this one, so it stays visible (and editable via
+			// its real URI) rather than being hidden by the injected-name check.
+			assert.deepStrictEqual(mcps.map(m => ({ name: m.name, uri: m.uri })), [{ name: 'host', uri: 'inmemory:/settings.json' }]);
 		});
 
 		test('rules survive the post-materialize SDK filter (no SDK counterpart)', () => {

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -57,26 +57,6 @@ that capability.
 
   Temporarily enable `supportsChatForkE2E` to execute the disabled test.
 
-### Claude fresh peer context after a long shared-suite sequence
-
-- Test: `fresh peer chat does not inherit default chat context`.
-- Scope: Claude deterministic replay with the shared provider process.
-- Expected: materializing a fresh peer after using the default chat succeeds,
-  and the peer request does not contain the default chat's history.
-- Observed: after the preceding peer-lifecycle sequence, the peer turn can fail
-  with `sendFailed: Server not found: host`. The same test passes by itself and
-  while recording with a per-test process.
-- Gate: disabled only for Claude.
-- Reproduce:
-
-  ```bash
-  ./scripts/test-integration.sh --run \
-    src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts
-  ```
-
-  Temporarily enable the Claude variant. Run the whole provider file; a focused
-  run does not reproduce the shared-process symptom.
-
 ### Copilot file-operation turns that do not complete reliably
 
 - Scope: Copilot.

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-fresh-peer-chat-does-not-inherit-default-chat-context.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-fresh-peer-chat-does-not-inherit-default-chat-context.yaml
@@ -1,0 +1,24 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember the code word DEFAULTSECRET. Reply exactly "ready".
+    response:
+      content: |-
+        I'll remember the code word DEFAULTSECRET.
+
+        ready
+      stopReason: end_turn
+  - request:
+      model: claude-opus-4.8
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "fresh".
+    response:
+      content: fresh
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
@@ -613,7 +613,6 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		});
 	});
 
-	// Claude's shared SDK process loses its `host` MCP server after the preceding peer-lifecycle sequence.
 	providerTest('fresh peer chat does not inherit default chat context', async function () {
 		const { sessionUri, defaultChatUri } = await createSession('fresh-context');
 		await driveTurn(defaultChatUri, 'default-secret', 'Remember the code word DEFAULTSECRET. Reply exactly "ready".', 1);
@@ -624,7 +623,7 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		const messages = observedModelMessages(context.observedModelRequestBodies.at(-1) ?? '');
 
 		assert.strictEqual(messages.some(message => message.content.includes('DEFAULTSECRET')), false);
-	}, config.supportsMultipleChats && config.provider !== 'claude');
+	}, config.supportsMultipleChats);
 
 	providerTest('side chat receives bounded source context without copied history', async function () {
 		const { sessionUri, defaultChatUri } = await createSession('side-context');

--- a/src/vs/platform/agentHost/test/node/providerIntegration/copilotCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/copilotCustomizations.integrationTest.ts
@@ -57,6 +57,7 @@ const WATCH_ASSERT_POLL_INTERVAL_MS = 100;
 
 async function waitForAssert(
 	assertion: () => Promise<void> | void,
+	beforeRetry?: () => Promise<void>,
 	timeoutMs = WATCH_ASSERT_TIMEOUT_MS,
 	pollIntervalMs = WATCH_ASSERT_POLL_INTERVAL_MS,
 ): Promise<void> {
@@ -70,10 +71,28 @@ async function waitForAssert(
 			lastError = error;
 		}
 		await new Promise<void>(resolve => setTimeout(resolve, pollIntervalMs));
+		await beforeRetry?.();
 	}
 	throw new Error(
 		`Timed out waiting for expected customizations state (${timeoutMs}ms). Last error: ${lastError instanceof Error ? lastError.message : String(lastError)}`
 	);
+}
+
+/**
+ * Apply a filesystem mutation, then wait for the session's customization
+ * state to reflect it — re-applying the mutation before every retry.
+ *
+ * Recursive filesystem watchers are subscribed asynchronously by the OS
+ * watcher process, so a mutation issued right after the initial discovery
+ * settles can land before the subscription is live and is then never
+ * reported: nothing triggers a re-scan and the wait burns its full timeout.
+ * Re-writing the file on each attempt emits a fresh change event, so the
+ * first attempt that lands after the watcher is live drives the re-scan. A
+ * watcher that never comes up still fails the assertion.
+ */
+async function applyAndWaitForAssert(mutate: () => Promise<void>, assertion: () => Promise<void> | void): Promise<void> {
+	await mutate();
+	await waitForAssert(assertion, mutate);
 }
 
 const TEST_WATCH = true;
@@ -828,33 +847,39 @@ suite('Agent Host Provider Integration — Copilot Customizations', function () 
 		await waitForAssert(() => assertAllCustomizations([{ uri: URI.file(instructionFile).toString(), name: 'Initial Policy' }]));
 
 		client.clearReceived();
-		await writeFile(instructionFile, [
-			'---',
-			'name: Updated Policy',
-			'applyTo:',
-			'  - "**/*"',
-			'---',
-			'Updated instruction body.',
-		].join('\n'));
-		await waitForAssert(() => assertAllCustomizations([{ uri: URI.file(instructionFile).toString(), name: 'Updated Policy' }]));
+		await applyAndWaitForAssert(
+			() => writeFile(instructionFile, [
+				'---',
+				'name: Updated Policy',
+				'applyTo:',
+				'  - "**/*"',
+				'---',
+				'Updated instruction body.',
+			].join('\n')),
+			() => assertAllCustomizations([{ uri: URI.file(instructionFile).toString(), name: 'Updated Policy' }]),
+		);
 
 		client.clearReceived();
-		await writeFile(addedInstructionFile, [
-			'---',
-			'name: Added Policy',
-			'applyTo:',
-			'  - "**/*"',
-			'---',
-			'Added instruction body.',
-		].join('\n'));
-		await waitForAssert(() => assertAllCustomizations([
-			{ uri: URI.file(instructionFile).toString(), name: 'Updated Policy' },
-			{ uri: URI.file(addedInstructionFile).toString(), name: 'Added Policy' },
-		]));
+		await applyAndWaitForAssert(
+			() => writeFile(addedInstructionFile, [
+				'---',
+				'name: Added Policy',
+				'applyTo:',
+				'  - "**/*"',
+				'---',
+				'Added instruction body.',
+			].join('\n')),
+			() => assertAllCustomizations([
+				{ uri: URI.file(instructionFile).toString(), name: 'Updated Policy' },
+				{ uri: URI.file(addedInstructionFile).toString(), name: 'Added Policy' },
+			]),
+		);
 
 		client.clearReceived();
-		await rm(instructionFile, { force: true });
-		await waitForAssert(() => assertAllCustomizations([{ uri: URI.file(addedInstructionFile).toString(), name: 'Added Policy' }]));
+		await applyAndWaitForAssert(
+			() => rm(instructionFile, { force: true }),
+			() => assertAllCustomizations([{ uri: URI.file(addedInstructionFile).toString(), name: 'Added Policy' }]),
+		);
 	}
 
 	async function runSimpleAgentInstructionWatchTest(discoveryMode: SessionCustomizationDiscoveryMode): Promise<void> {
@@ -926,42 +951,52 @@ suite('Agent Host Provider Integration — Copilot Customizations', function () 
 		));
 
 		client.clearReceived();
-		await writeFile(workspaceAgentInstructionsFile, 'Use updated workspace AGENTS instructions.');
-		await waitForAssert(() => assertAllCustomizations(
-			[URI.file(workspaceAgentInstructionsFile).toString()],
-			[URI.file(userCopilotInstructionsFile).toString()],
-		));
+		await applyAndWaitForAssert(
+			() => writeFile(workspaceAgentInstructionsFile, 'Use updated workspace AGENTS instructions.'),
+			() => assertAllCustomizations(
+				[URI.file(workspaceAgentInstructionsFile).toString()],
+				[URI.file(userCopilotInstructionsFile).toString()],
+			),
+		);
 
 		client.clearReceived();
-		await writeFile(userCopilotInstructionsFile, 'Use updated user copilot instructions.');
-		await waitForAssert(() => assertAllCustomizations(
-			[URI.file(workspaceAgentInstructionsFile).toString()],
-			[URI.file(userCopilotInstructionsFile).toString()],
-		));
+		await applyAndWaitForAssert(
+			() => writeFile(userCopilotInstructionsFile, 'Use updated user copilot instructions.'),
+			() => assertAllCustomizations(
+				[URI.file(workspaceAgentInstructionsFile).toString()],
+				[URI.file(userCopilotInstructionsFile).toString()],
+			),
+		);
 
 		client.clearReceived();
-		await writeFile(workspaceClaudeInstructionsFile, 'Use workspace CLAUDE instructions.');
-		await waitForAssert(() => assertAllCustomizations(
-			[
-				URI.file(workspaceAgentInstructionsFile).toString(),
-				URI.file(workspaceClaudeInstructionsFile).toString(),
-			],
-			[URI.file(userCopilotInstructionsFile).toString()],
-		));
+		await applyAndWaitForAssert(
+			() => writeFile(workspaceClaudeInstructionsFile, 'Use workspace CLAUDE instructions.'),
+			() => assertAllCustomizations(
+				[
+					URI.file(workspaceAgentInstructionsFile).toString(),
+					URI.file(workspaceClaudeInstructionsFile).toString(),
+				],
+				[URI.file(userCopilotInstructionsFile).toString()],
+			),
+		);
 
 		client.clearReceived();
-		await rm(workspaceAgentInstructionsFile, { force: true });
-		await waitForAssert(() => assertAllCustomizations(
-			[URI.file(workspaceClaudeInstructionsFile).toString()],
-			[URI.file(userCopilotInstructionsFile).toString()],
-		));
+		await applyAndWaitForAssert(
+			() => rm(workspaceAgentInstructionsFile, { force: true }),
+			() => assertAllCustomizations(
+				[URI.file(workspaceClaudeInstructionsFile).toString()],
+				[URI.file(userCopilotInstructionsFile).toString()],
+			),
+		);
 
 		client.clearReceived();
-		await rm(userCopilotInstructionsFile, { force: true });
-		await waitForAssert(() => assertAllCustomizations(
-			[URI.file(workspaceClaudeInstructionsFile).toString()],
-			[],
-		));
+		await applyAndWaitForAssert(
+			() => rm(userCopilotInstructionsFile, { force: true }),
+			() => assertAllCustomizations(
+				[URI.file(workspaceClaudeInstructionsFile).toString()],
+				[],
+			),
+		);
 	}
 
 
@@ -1028,32 +1063,40 @@ suite('Agent Host Provider Integration — Copilot Customizations', function () 
 		await waitForAssert(() => assertAllCustomizations([{ uri: URI.file(skillFile).toString(), name: 'watch-skill' }]));
 
 		client.clearReceived();
-		await writeFile(skillFile, [
-			'---',
-			'name: watch-skill-renamed',
-			'description: Watches skill changes',
-			'---',
-			'Return a renamed greeting.',
-		].join('\n'));
-		await waitForAssert(() => assertAllCustomizations([{ uri: URI.file(skillFile).toString(), name: 'watch-skill-renamed' }]));
+		await applyAndWaitForAssert(
+			() => writeFile(skillFile, [
+				'---',
+				'name: watch-skill-renamed',
+				'description: Watches skill changes',
+				'---',
+				'Return a renamed greeting.',
+			].join('\n')),
+			() => assertAllCustomizations([{ uri: URI.file(skillFile).toString(), name: 'watch-skill-renamed' }]),
+		);
 
 		client.clearReceived();
-		await mkdir(addedSkillDir, { recursive: true });
-		await writeFile(addedSkillFile, [
-			'---',
-			'name: added-skill',
-			'description: Added after startup',
-			'---',
-			'Return another greeting.',
-		].join('\n'));
-		await waitForAssert(() => assertAllCustomizations([
-			{ uri: URI.file(skillFile).toString(), name: 'watch-skill-renamed' },
-			{ uri: URI.file(addedSkillFile).toString(), name: 'added-skill' },
-		]));
+		await applyAndWaitForAssert(
+			async () => {
+				await mkdir(addedSkillDir, { recursive: true });
+				await writeFile(addedSkillFile, [
+					'---',
+					'name: added-skill',
+					'description: Added after startup',
+					'---',
+					'Return another greeting.',
+				].join('\n'));
+			},
+			() => assertAllCustomizations([
+				{ uri: URI.file(skillFile).toString(), name: 'watch-skill-renamed' },
+				{ uri: URI.file(addedSkillFile).toString(), name: 'added-skill' },
+			]),
+		);
 
 		client.clearReceived();
-		await rm(skillFile, { force: true });
-		await waitForAssert(() => assertAllCustomizations([{ uri: URI.file(addedSkillFile).toString(), name: 'added-skill' }]));
+		await applyAndWaitForAssert(
+			() => rm(skillFile, { force: true }),
+			() => assertAllCustomizations([{ uri: URI.file(addedSkillFile).toString(), name: 'added-skill' }]),
+		);
 	}
 
 	async function runSimpleAgentWatchTest(discoveryMode: SessionCustomizationDiscoveryMode): Promise<void> {
@@ -1117,31 +1160,37 @@ suite('Agent Host Provider Integration — Copilot Customizations', function () 
 		await waitForAssert(() => assertAllCustomizations([{ uri: URI.file(agentFile).toString(), name: 'Watch Agent' }]));
 
 		client.clearReceived();
-		await writeFile(agentFile, [
-			'---',
-			'name: Watch Agent Renamed',
-			'description: Watches agent changes',
-			'---',
-			'You are a renamed test agent.',
-		].join('\n'));
-		await waitForAssert(() => assertAllCustomizations([{ uri: URI.file(agentFile).toString(), name: 'Watch Agent Renamed' }]));
+		await applyAndWaitForAssert(
+			() => writeFile(agentFile, [
+				'---',
+				'name: Watch Agent Renamed',
+				'description: Watches agent changes',
+				'---',
+				'You are a renamed test agent.',
+			].join('\n')),
+			() => assertAllCustomizations([{ uri: URI.file(agentFile).toString(), name: 'Watch Agent Renamed' }]),
+		);
 
 		client.clearReceived();
-		await writeFile(addedAgentFile, [
-			'---',
-			'name: Added Agent',
-			'description: Added after startup',
-			'---',
-			'You are an added test agent.',
-		].join('\n'));
-		await waitForAssert(() => assertAllCustomizations([
-			{ uri: URI.file(agentFile).toString(), name: 'Watch Agent Renamed' },
-			{ uri: URI.file(addedAgentFile).toString(), name: 'Added Agent' },
-		]));
+		await applyAndWaitForAssert(
+			() => writeFile(addedAgentFile, [
+				'---',
+				'name: Added Agent',
+				'description: Added after startup',
+				'---',
+				'You are an added test agent.',
+			].join('\n')),
+			() => assertAllCustomizations([
+				{ uri: URI.file(agentFile).toString(), name: 'Watch Agent Renamed' },
+				{ uri: URI.file(addedAgentFile).toString(), name: 'Added Agent' },
+			]),
+		);
 
 		client.clearReceived();
-		await rm(agentFile, { force: true });
-		await waitForAssert(() => assertAllCustomizations([{ uri: URI.file(addedAgentFile).toString(), name: 'Added Agent' }]));
+		await applyAndWaitForAssert(
+			() => rm(agentFile, { force: true }),
+			() => assertAllCustomizations([{ uri: URI.file(addedAgentFile).toString(), name: 'Added Agent' }]),
+		);
 	}
 
 

--- a/src/vs/platform/agentHost/test/node/providerIntegration/copilotCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/copilotCustomizations.integrationTest.ts
@@ -54,10 +54,19 @@ const TEST_TIMEOUT_MS = 90_000;
 const NOTIFICATION_TIMEOUT_MS = 10_000;
 const WATCH_ASSERT_TIMEOUT_MS = 30_000;
 const WATCH_ASSERT_POLL_INTERVAL_MS = 100;
+/**
+ * Cadence at which {@link applyAndWaitForAssert} re-applies its mutation.
+ *
+ * Must stay comfortably above the agent's own refresh debounce
+ * (`REFRESH_DEBOUNCE_MS`). That debounce is a `Delayer`, so each new change
+ * event cancels and restarts its timer: a mutation stream at (or faster than)
+ * the debounce window starves the delayer and the re-scan never runs at all.
+ */
+const WATCH_MUTATION_RETRY_INTERVAL_MS = 2_000;
 
 async function waitForAssert(
 	assertion: () => Promise<void> | void,
-	beforeRetry?: () => Promise<void>,
+	beforeAttempt?: () => Promise<void>,
 	timeoutMs = WATCH_ASSERT_TIMEOUT_MS,
 	pollIntervalMs = WATCH_ASSERT_POLL_INTERVAL_MS,
 ): Promise<void> {
@@ -65,13 +74,13 @@ async function waitForAssert(
 	let lastError: unknown;
 	while (Date.now() < deadline) {
 		try {
+			await beforeAttempt?.();
 			await assertion();
 			return;
 		} catch (error) {
 			lastError = error;
 		}
 		await new Promise<void>(resolve => setTimeout(resolve, pollIntervalMs));
-		await beforeRetry?.();
 	}
 	throw new Error(
 		`Timed out waiting for expected customizations state (${timeoutMs}ms). Last error: ${lastError instanceof Error ? lastError.message : String(lastError)}`
@@ -79,20 +88,31 @@ async function waitForAssert(
 }
 
 /**
- * Apply a filesystem mutation, then wait for the session's customization
- * state to reflect it — re-applying the mutation before every retry.
+ * Apply a filesystem mutation and wait for the session's customization state
+ * to reflect it, periodically re-applying the mutation.
  *
  * Recursive filesystem watchers are subscribed asynchronously by the OS
  * watcher process, so a mutation issued right after the initial discovery
  * settles can land before the subscription is live and is then never
  * reported: nothing triggers a re-scan and the wait burns its full timeout.
- * Re-writing the file on each attempt emits a fresh change event, so the
- * first attempt that lands after the watcher is live drives the re-scan. A
- * watcher that never comes up still fails the assertion.
+ * Re-applying the mutation emits a fresh change event, so the first attempt
+ * that lands after the watcher is live drives the re-scan.
+ *
+ * The mutation is re-applied on {@link WATCH_MUTATION_RETRY_INTERVAL_MS}
+ * rather than on every poll so it can never starve the agent's refresh
+ * debounce. The mutation runs inside the retry loop, so a transient failure
+ * to apply it is retried too. A watcher that never comes up still fails the
+ * assertion.
  */
 async function applyAndWaitForAssert(mutate: () => Promise<void>, assertion: () => Promise<void> | void): Promise<void> {
-	await mutate();
-	await waitForAssert(assertion, mutate);
+	let nextMutationAt = 0;
+	await waitForAssert(assertion, async () => {
+		if (Date.now() < nextMutationAt) {
+			return;
+		}
+		nextMutationAt = Date.now() + WATCH_MUTATION_RETRY_INTERVAL_MS;
+		await mutate();
+	});
 }
 
 const TEST_WATCH = true;


### PR DESCRIPTION
- The Claude session surfaced every server reported by `mcpServerStatus()` as
  a user-visible MCP customization, including the agent host's own in-process
  `host` (server tools) and `client` (client tools) bridges. Those are internal
  plumbing with no on-disk definition, so they showed up as phantom entries in
  the customization UI.
- Worse, publishing them into session-scoped state fed their names back into
  the per-chat MCP enablement reconciliation. A peer or side chat whose query
  had not yet reported `host` would then try to toggle it, the CLI answered
  `Server not found: host`, and the whole turn failed with `sendFailed`. That
  is the intermittent `side chat receives bounded source context` E2E failure;
  it also explains the previously quarantined Claude `fresh peer chat` test,
  which is re-enabled here with a recorded fixture.
- Reconciliation now skips servers the live query does not report at all
  instead of toggling them, so session-wide state can never take down a turn
  on a chat that has not finished connecting its servers.
- The Copilot customization watch tests raced the OS watcher subscription:
  they mutated a file immediately after initial discovery settled, and under
  load the write landed before the subscription was live, so nothing triggered
  a re-scan and the wait burned its full timeout. They now re-apply the
  mutation on each poll, keeping the assertions unchanged.

Fixes microsoft/vscode-engineering#3400

(Commit message generated by Copilot)
