### PR TITLE
Fix virtual tool grouping dropping tools

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -795,6 +795,13 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 			}
 		}
 
+		// A registry change can trigger regrouping before the previous round's tool
+		// calls are processed. Expand those paths while the new tree is built so the
+		// prompt context does not capture a stale tool list that rejects the calls.
+		for (const call of this.currentToolCallRounds.at(-1)?.toolCalls ?? []) {
+			this.toolGrouping.ensureExpanded(call.name);
+		}
+
 		const computePromise = this.toolGrouping.compute(this.options.request.prompt, token);		// Show progress if this takes a moment...
 		const timeout = setTimeout(() => {
 			outputStream?.progress(l10n.t('Optimizing tool selection'), async () => {

--- a/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
+++ b/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
@@ -6,7 +6,7 @@
 
 import { Raw, RenderPromptResult } from '@vscode/prompt-tsx';
 import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
-import type { ChatLanguageModelToolReference, ChatPromptReference, ChatRequest, ExtendedChatResponsePart, LanguageModelChat } from 'vscode';
+import type { ChatLanguageModelToolReference, ChatPromptReference, ChatRequest, ExtendedChatResponsePart, LanguageModelChat, LanguageModelToolInformation } from 'vscode';
 import { IChatMLFetcher } from '../../../../platform/chat/common/chatMLFetcher';
 import { toTextPart } from '../../../../platform/chat/common/globalStringUtils';
 import { StaticChatMLFetcher } from '../../../../platform/chat/test/common/staticChatMLFetcher';
@@ -29,6 +29,7 @@ import { ChatLocation, ChatResponseConfirmationPart, ChatResponseMarkdownPart, L
 import { ToolCallingLoop } from '../../../intents/node/toolCallingLoop';
 import { ToolResultMetadata } from '../../../prompts/node/panel/toolCalling';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
+import { IToolGroupingService } from '../../../tools/common/virtualTools/virtualToolTypes';
 import { Conversation, Turn } from '../../common/conversation';
 import { IBuildPromptContext } from '../../common/intents';
 import { ToolCallRound } from '../../common/toolCallRound';
@@ -46,6 +47,7 @@ suite('defaultIntentRequestHandler', () => {
 	let endpoint: IChatEndpoint;
 	let turnIdCounter = 0;
 	let builtPrompts: IBuildPromptContext[] = [];
+	let availableTools: LanguageModelToolInformation[] | undefined;
 	const sessionId = 'some-session-id';
 
 	const getTurnId = () => `turn-id-${turnIdCounter}`;
@@ -62,6 +64,7 @@ suite('defaultIntentRequestHandler', () => {
 		accessor = services.createTestingAccessor();
 		endpoint = accessor.get(IInstantiationService).createInstance(MockEndpoint, undefined);
 		builtPrompts = [];
+		availableTools = undefined;
 		response = [];
 		promptResult = nullRenderPromptResult();
 		turnIdCounter = 0;
@@ -117,6 +120,10 @@ suite('defaultIntentRequestHandler', () => {
 			}
 
 			return promptResult;
+		}
+
+		getAvailableTools(): LanguageModelToolInformation[] | undefined {
+			return availableTools;
 		}
 	}
 
@@ -303,6 +310,49 @@ suite('defaultIntentRequestHandler', () => {
 				response: 'response to tool call',
 			},
 		]);
+	});
+
+	test('expands a pending called tool before regrouping captures the next prompt toolset', async () => {
+		const tool = {
+			name: 'pending_tool',
+			description: 'pending tool',
+			inputSchema: undefined,
+			source: undefined,
+			tags: [],
+		} satisfies LanguageModelToolInformation;
+		availableTools = [tool];
+		let computeCount = 0;
+		let pendingToolExpanded = false;
+		const grouping = {
+			tools: availableTools,
+			didCall: () => undefined,
+			didTakeTurn: () => { },
+			didInvalidateCache: () => { },
+			getContainerFor: () => undefined,
+			ensureExpanded: (toolName: string) => pendingToolExpanded ||= toolName === tool.name,
+			compute: async () => ++computeCount <= 2 || pendingToolExpanded ? [tool] : [],
+			computeAll: async () => [tool],
+		};
+		vi.spyOn(accessor.get(IToolGroupingService), 'create').mockReturnValue(grouping);
+
+		chatResponse[0] = [{
+			text: 'calling pending tool',
+			copilotToolCalls: [{ arguments: '{}', name: tool.name, id: 'pending_call' }],
+		}];
+		chatResponse[1] = 'done';
+		const toolResult = new LanguageModelToolResult([new LanguageModelTextPart('tool-result')]);
+		promptResult = {
+			...nullRenderPromptResult(),
+			messages: [{ role: Raw.ChatRole.User, content: [toTextPart('hello world!')] }],
+			metadata: promptResultMetadata([new ToolResultMetadata('pending_call__vscode-0', toolResult)])
+		};
+
+		await makeHandler().getResult();
+
+		expect({
+			pendingToolExpanded,
+			secondPromptTools: builtPrompts[1].tools?.availableTools.map(tool => tool.name),
+		}).toEqual({ pendingToolExpanded: true, secondPromptTools: [tool.name] });
 	});
 
 	function fillWithToolCalls(insertN = 20) {

--- a/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
@@ -222,6 +222,49 @@ class ParallelAwareToolsService implements IToolsService {
 }
 
 describe('ChatToolCalls (toolCalling.tsx)', () => {
+	test('reports a registered tool missing from the request as not in the request toolset', async () => {
+		const toolInfo: vscode.LanguageModelToolInformation = {
+			name: 'grouped_tool',
+			description: 'grouped tool',
+			source: undefined,
+			inputSchema: undefined,
+			tags: [],
+		};
+		const testingServiceCollection = createExtensionUnitTestingServices();
+		const telemetryService = new SpyingTelemetryService();
+		testingServiceCollection.define(IToolsService, new CapturingToolsService(toolInfo));
+		testingServiceCollection.define(ITelemetryService, telemetryService);
+		const accessor = testingServiceCollection.createTestingAccessor();
+		const endpoint = await accessor.get(IEndpointProvider).getChatEndpoint('copilot-utility');
+		const promptContext: IBuildPromptContext = {
+			query: 'test',
+			history: [],
+			chatVariables: new ChatVariablesCollection(),
+			conversation: { sessionId: 'session-123' } as unknown as Conversation,
+			request: {} as vscode.ChatRequest,
+			tools: {
+				toolReferences: [],
+				toolInvocationToken: {} as vscode.ChatParticipantToolToken,
+				availableTools: [],
+			},
+		};
+
+		await renderPromptElement(accessor.get(IInstantiationService), endpoint, ChatToolCalls, {
+			promptContext,
+			toolCallRounds: [{
+				id: 'round-1',
+				response: 'calling grouped tool',
+				toolInputRetry: 0,
+				toolCalls: [{ name: toolInfo.name, arguments: '{}', id: 'call-1' }],
+			}],
+			toolCallResults: undefined,
+		});
+
+		const event = telemetryService.getEvents().telemetryServiceEvents.find(event => event.eventName === 'toolInvoke');
+		expect(event).toMatchObject({ properties: { invokeOutcome: 'notInRequestToolset' } });
+		accessor.dispose();
+	});
+
 	test('starts multiple sub-agent tool calls in parallel', async () => {
 		const toolName = ToolName.CoreRunSubagent;
 		const firstCallId = 'subagent-call-1';

--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -274,8 +274,8 @@ function buildToolResultElement(accessor: ServicesAccessor, props: ToolResultOpt
 			if (toolResult === undefined) {
 				try {
 					if (promptContext.tools && !promptContext.tools.availableTools.find(t => t.name === props.toolCall.name)) {
-						outcome = ToolInvocationOutcome.DisabledByUser;
-						throw new Error(`Tool ${props.toolCall.name} is currently disabled by the user, and cannot be called.`);
+						outcome = ToolInvocationOutcome.NotInRequestToolset;
+						throw new Error(`Tool ${props.toolCall.name} is not part of this request's toolset, so it cannot be called. It is either disabled in Configure Tools, or grouped behind an activate_* tool that has not been called yet.`);
 					}
 
 					if (copilotTool?.resolveInput) {
@@ -344,7 +344,7 @@ function buildToolResultElement(accessor: ServicesAccessor, props: ToolResultOpt
 					if (errResult.isCancelled) {
 						outcome = ToolInvocationOutcome.Cancelled;
 					} else {
-						outcome = outcome === ToolInvocationOutcome.DisabledByUser ? outcome : ToolInvocationOutcome.Error;
+						outcome = outcome === ToolInvocationOutcome.NotInRequestToolset ? outcome : ToolInvocationOutcome.Error;
 						extraMetadata.push(new ToolFailureEncountered(props.toolCall.id));
 						logService.error(`Error from tool ${props.toolCall.name} with args ${props.toolCall.arguments}`, toErrorMessage(err, true));
 					}
@@ -403,7 +403,7 @@ async function sendToolCallTelemetry(props: ToolResultOpts, promptContext: IBuil
 			"owner": "donjayamanne",
 			"comment": "Details about invocation of tools",
 			"validateOutcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The outcome of the tool input validation. valid, invalid and unknown" },
-			"invokeOutcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The outcome of the tool Invokcation. invalidInput, disabledByUser, success, error, cancelled" },
+			"invokeOutcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The outcome of the tool invocation. invalidInput, notInRequestToolset, success, error, cancelled" },
 			"toolName": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The name of the tool being invoked." },
 			"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model that invoked the tool" }
 		}
@@ -547,7 +547,7 @@ enum ToolValidationOutcome {
 
 enum ToolInvocationOutcome {
 	InvalidInput = 'invalidInput',
-	DisabledByUser = 'disabledByUser',
+	NotInRequestToolset = 'notInRequestToolset',
 	Success = 'success',
 	Error = 'error',
 	Cancelled = 'cancelled',
@@ -1087,7 +1087,7 @@ function sendNotebookEditToolValidationTelemetry(invokeOutcome: ToolInvocationOu
 			"owner": "donjayamanne",
 			"comment": "Validation failure for a Edit Notebook tool invocation",
 			"validationResult": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The result of the tool input validation. valid, invalid and unknown" },
-			"invokeOutcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The result of the tool Invocation. invalidInput, disabledByUser, success, error, cancelled" },
+			"invokeOutcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The result of the tool invocation. invalidInput, notInRequestToolset, success, error, cancelled" },
 			"editType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The type of edit that was attempted. insert, delete, edit or unknown" },
 			"unknownProps": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "List of unknown properties in the input" },
 			"missingProps": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "List of missing properties in the input" },

--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -275,7 +275,7 @@ function buildToolResultElement(accessor: ServicesAccessor, props: ToolResultOpt
 				try {
 					if (promptContext.tools && !promptContext.tools.availableTools.find(t => t.name === props.toolCall.name)) {
 						outcome = ToolInvocationOutcome.NotInRequestToolset;
-						throw new Error(`Tool ${props.toolCall.name} is not part of this request's toolset, so it cannot be called. It is either disabled in Configure Tools, or grouped behind an activate_* tool that has not been called yet.`);
+						throw new Error(`Tool ${props.toolCall.name} is not part of this request's toolset, so it cannot be called.`);
 					}
 
 					if (copilotTool?.resolveInput) {

--- a/extensions/copilot/src/extension/tools/common/virtualTools/toolEmbeddingsComputer.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/toolEmbeddingsComputer.ts
@@ -237,8 +237,8 @@ export class ToolEmbeddingsComputer implements IToolEmbeddingsComputer {
 		// Get embeddings for all tools
 		const toolEmbeddings = await this.getAvailableToolEmbeddings(tools, token);
 		if (toolEmbeddings.length === 0) {
-			this._logService.trace('[virtual-tools] No embeddings available for tools, returning empty groups');
-			return [];
+			this._logService.trace('[virtual-tools] No embeddings available for tools, falling back to positional grouping');
+			return chunkIntoGroups(tools, limit);
 		}
 
 		// Create nodes for the EmbeddingsGrouper
@@ -269,9 +269,11 @@ export class ToolEmbeddingsComputer implements IToolEmbeddingsComputer {
 		const targetClusters = Math.min(limit, Math.ceil(nodes.length / 4));
 
 		if (targetClusters >= nodes.length) {
-			// If we need as many clusters as tools, just return individual tools
+			// If we need as many clusters as tools, just return individual tools. `tools`
+			// can still outnumber the nodes when embeddings were unavailable, so this goes
+			// through the chunker rather than emitting one group per tool unbounded.
 			this._logService.trace(`[virtual-tools] Target clusters (${targetClusters}) >= tool count (${nodes.length}), returning individual tools`);
-			return tools.map(tool => [tool]);
+			return chunkIntoGroups(tools, limit);
 		}
 
 		const tuneResult = grouper.tuneThresholdForTargetClusters(targetClusters);
@@ -283,41 +285,95 @@ export class ToolEmbeddingsComputer implements IToolEmbeddingsComputer {
 
 		// Convert clusters to tool arrays, filtering out small groups
 		const groups: LanguageModelToolInformation[][] = [];
-		const singletons: LanguageModelToolInformation[] = [];
+		const leftovers: LanguageModelToolInformation[] = [];
+		const clustered = new Set<string>();
 
 		for (const cluster of clusters) {
 			const toolsInCluster = cluster.nodes.map(node => node.value);
+			for (const tool of toolsInCluster) {
+				clustered.add(tool.name);
+			}
 
 			if (toolsInCluster.length >= MIN_TOOLSET_SIZE_TO_GROUP) {
 				groups.push(toolsInCluster);
 			} else {
-				// Small groups become singletons unless expanding would exceed limit
-				singletons.push(...toolsInCluster);
+				leftovers.push(...toolsInCluster);
 			}
 		}
 
-		// Check if adding singletons as individual groups would exceed limit
-		const totalGroupsAndSingletons = groups.length + singletons.length;
-		if (totalGroupsAndSingletons <= limit) {
-			// We have room, add singletons as individual groups
-			for (const singleton of singletons) {
-				groups.push([singleton]);
-			}
-		} else {
-			// Try to merge singletons into existing groups if possible
-			// If we can't, keep them as individual groups up to the limit
-			const remainingSlots = limit - groups.length;
-			for (let i = 0; i < Math.min(singletons.length, remainingSlots); i++) {
-				groups.push([singletons[i]]);
-			}
+		// Tools whose embedding was unavailable never became nodes, so no cluster holds them.
+		leftovers.push(...tools.filter(tool => !clustered.has(tool.name)));
 
-			// Log if we had to drop some tools
-			if (singletons.length > remainingSlots) {
-				this._logService.warn(`[virtual-tools] Had to drop ${singletons.length - remainingSlots} tools due to limit constraints`);
-			}
-		}
+		placeLeftovers(groups, leftovers, limit);
+		mergeDownToLimit(groups, limit);
 
 		this._logService.trace(`[virtual-tools] Created ${groups.length} groups from ${tools.length} tools`);
 		return groups;
 	}
+}
+
+/** Splits tools into at most `limit` groups, preserving order. */
+function chunkIntoGroups(tools: readonly LanguageModelToolInformation[], limit: number): LanguageModelToolInformation[][] {
+	if (tools.length === 0) {
+		return [];
+	}
+
+	const groupCount = Math.max(1, Math.min(limit, tools.length));
+	const perGroup = Math.ceil(tools.length / groupCount);
+	const groups: LanguageModelToolInformation[][] = [];
+	for (let i = 0; i < tools.length; i += perGroup) {
+		groups.push(tools.slice(i, i + perGroup));
+	}
+
+	return groups;
+}
+
+/** Places every leftover into `groups`, using its own slot when one is free. */
+function placeLeftovers(groups: LanguageModelToolInformation[][], leftovers: readonly LanguageModelToolInformation[], limit: number): void {
+	if (leftovers.length === 0) {
+		return;
+	}
+
+	const remainingSlots = Math.max(0, limit - groups.length);
+	if (leftovers.length <= remainingSlots) {
+		for (const leftover of leftovers) {
+			groups.push([leftover]);
+		}
+		return;
+	}
+
+	if (remainingSlots > 0) {
+		// All but the last free slot go to one leftover each; the last one takes the rest.
+		for (let i = 0; i < remainingSlots - 1; i++) {
+			groups.push([leftovers[i]]);
+		}
+		groups.push(leftovers.slice(remainingSlots - 1));
+		return;
+	}
+
+	if (groups.length === 0) {
+		groups.push(leftovers.slice());
+		return;
+	}
+
+	groups[indexOfSmallest(groups)].push(...leftovers);
+}
+
+/** Clustering only approximates the target count, so it can overshoot `limit`. */
+function mergeDownToLimit(groups: LanguageModelToolInformation[][], limit: number): void {
+	while (groups.length > limit && groups.length > 1) {
+		const [smallest] = groups.splice(indexOfSmallest(groups), 1);
+		groups[indexOfSmallest(groups)].push(...smallest);
+	}
+}
+
+function indexOfSmallest(groups: readonly LanguageModelToolInformation[][]): number {
+	let index = 0;
+	for (let i = 1; i < groups.length; i++) {
+		if (groups[i].length < groups[index].length) {
+			index = i;
+		}
+	}
+
+	return index;
 }

--- a/extensions/copilot/src/extension/tools/common/virtualTools/toolGrouping.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/toolGrouping.ts
@@ -7,7 +7,7 @@ import type { LanguageModelToolInformation } from 'vscode';
 import { ConfigKey, HARD_TOOL_LIMIT, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
 import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
-import { equals as arraysEqual, uniqueFilter } from '../../../../util/vs/base/common/arrays';
+import { uniqueFilter } from '../../../../util/vs/base/common/arrays';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { Iterable } from '../../../../util/vs/base/common/iterator';
 import { IObservable } from '../../../../util/vs/base/common/observableInternal';
@@ -17,6 +17,16 @@ import { EMBEDDINGS_GROUP_NAME, VIRTUAL_TOOL_NAME_PREFIX, VirtualTool } from './
 import { VirtualToolGrouper } from './virtualToolGrouper';
 import * as Constant from './virtualToolsConstants';
 import { IToolCategorization, IToolGrouping } from './virtualToolTypes';
+
+/** Whether both lists contain the same tool names, regardless of order. */
+function sameToolNames(a: readonly LanguageModelToolInformation[], b: readonly LanguageModelToolInformation[]): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+
+	const names = new Set(a.map(t => t.name));
+	return b.every(t => names.has(t.name));
+}
 
 export function computeToolGroupingMinThreshold(experimentationService: IExperimentationService, configurationService: IConfigurationService): IObservable<number> {
 	return configurationService.getExperimentBasedConfigObservable(ConfigKey.VirtualToolThreshold, experimentationService).map(configured => {
@@ -32,13 +42,17 @@ export class ToolGrouping implements IToolGrouping {
 	private _turnNo = 0;
 	private _trimOnNextCompute = false;
 	private _expandOnNext?: Set<string>;
+	/** Real tools called this session, and the turn they were last called on. */
+	private readonly _calledTools = new Map<string, number>();
 
 	public get tools(): readonly LanguageModelToolInformation[] {
 		return this._tools;
 	}
 
 	public set tools(tools: readonly LanguageModelToolInformation[]) {
-		if (!arraysEqual(this._tools, tools, (a, b) => a.name === b.name)) {
+		// Order-insensitive: repacking on a reordering alone would reshuffle the
+		// serialized tool list and invalidate provider-side prompt caches.
+		if (!sameToolNames(this._tools, tools)) {
 			this._tools = tools;
 			// Keep the root so that we can still expand any in-flight requests.
 			this._didToolsChange = true;
@@ -91,6 +105,7 @@ export class ToolGrouping implements IToolGrouping {
 		}
 
 		if (!(tool instanceof VirtualTool)) {
+			this._calledTools.set(tool.name, this._turnNo);
 			return;
 		}
 
@@ -129,18 +144,28 @@ export class ToolGrouping implements IToolGrouping {
 		return this._root.contents;
 	}
 
+	private _expandPathTo(toolName: string, turn: number): void {
+		this._root.find(toolName)?.path.forEach(p => {
+			p.isExpanded = true;
+			p.lastUsedOnTurn = Math.max(p.lastUsedOnTurn, turn);
+		});
+	}
+
 	private async _doCompute(query: string, token: CancellationToken) {
 		if (this._didToolsChange) {
 			await this._grouper.addGroups(query, this._root, this._tools.slice(), token);
 			this._didToolsChange = false;
+
+			// Regrouping builds a fresh tree, so re-pin tools already in use. Restoring
+			// the turn each was last called on keeps the trim order meaningful.
+			for (const [toolName, turn] of this._calledTools) {
+				this._expandPathTo(toolName, turn);
+			}
 		}
 
 		if (this._expandOnNext) {
 			for (const toolName of this._expandOnNext) {
-				this._root.find(toolName)?.path.forEach(p => {
-					p.isExpanded = true;
-					p.lastUsedOnTurn = this._turnNo;
-				});
+				this._expandPathTo(toolName, this._turnNo);
 			}
 			this._expandOnNext = undefined;
 		}

--- a/extensions/copilot/src/extension/tools/common/virtualTools/toolGrouping.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/toolGrouping.ts
@@ -13,7 +13,7 @@ import { Iterable } from '../../../../util/vs/base/common/iterator';
 import { IObservable } from '../../../../util/vs/base/common/observableInternal';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { LanguageModelTextPart, LanguageModelToolResult } from '../../../../vscodeTypes';
-import { EMBEDDINGS_GROUP_NAME, VIRTUAL_TOOL_NAME_PREFIX, VirtualTool } from './virtualTool';
+import { VIRTUAL_TOOL_NAME_PREFIX, VirtualTool } from './virtualTool';
 import { VirtualToolGrouper } from './virtualToolGrouper';
 import * as Constant from './virtualToolsConstants';
 import { IToolCategorization, IToolGrouping } from './virtualToolTypes';
@@ -99,7 +99,7 @@ export class ToolGrouping implements IToolGrouping {
 				isVirtual: tool instanceof VirtualTool ? 1 : 0,
 				depth: path.length - 1,
 				preExpanded: path.every(p => p.metadata.wasExpandedByDefault) ? 1 : 0,
-				wasEmbedding: path.some(p => p.name === EMBEDDINGS_GROUP_NAME) ? 1 : 0,
+				wasEmbedding: path.some(p => p.metadata.wasEmbeddingsMatched) ? 1 : 0,
 				totalTools: this._tools.length,
 			});
 		}

--- a/extensions/copilot/src/extension/tools/common/virtualTools/virtualTool.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/virtualTool.ts
@@ -40,7 +40,6 @@ export class VirtualTool {
 		this.isExpanded = other.isExpanded;
 		this.metadata.wasExpandedByDefault = other.metadata.wasExpandedByDefault;
 		this.metadata.canBeCollapsed = other.metadata.canBeCollapsed;
-		this.metadata.wasEmbeddingsMatched = other.metadata.wasEmbeddingsMatched;
 		this.lastUsedOnTurn = other.lastUsedOnTurn;
 	}
 

--- a/extensions/copilot/src/extension/tools/common/virtualTools/virtualToolGrouper.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/virtualToolGrouper.ts
@@ -164,7 +164,7 @@ export class VirtualToolGrouper implements IToolCategorization {
 		for (const tool of root.all()) {
 			if (tool instanceof VirtualTool) {
 				const prev = previousGroups.get(tool.name);
-				if (prev) {
+				if (prev && !!prev.metadata.wasEmbeddingsMatched === !!tool.metadata.wasEmbeddingsMatched) {
 					tool.copyStateFrom(prev);
 				}
 			}
@@ -186,9 +186,11 @@ export class VirtualToolGrouper implements IToolCategorization {
 	}
 
 	private _addPredictedToolsGroup(root: VirtualTool, predictedTools: LanguageModelToolInformation[]): void {
+		const existingGroupIndex = root.contents.findIndex(item => item instanceof VirtualTool && item.metadata.wasEmbeddingsMatched);
+		const existingGroup = existingGroupIndex >= 0 ? root.contents[existingGroupIndex] as VirtualTool : undefined;
 		const currentlyAvailable = new Set<string>();
 		for (const item of root.contents) {
-			if (item.name === EMBEDDINGS_GROUP_NAME) {
+			if (item === existingGroup) {
 				continue;
 			}
 
@@ -202,7 +204,17 @@ export class VirtualToolGrouper implements IToolCategorization {
 		}
 
 		let remainingSlots = Math.max(0, HARD_TOOL_LIMIT - currentlyAvailable.size);
-		const newGroup = new VirtualTool(EMBEDDINGS_GROUP_NAME, 'Tools with high predicted relevancy for this query', Infinity, {
+		let groupName = existingGroup?.name ?? EMBEDDINGS_GROUP_NAME;
+		if (!existingGroup) {
+			const usedNames = new Set(Array.from(root.all(), item => item.name));
+			let counter = 1;
+			while (usedNames.has(groupName)) {
+				counter++;
+				groupName = `${EMBEDDINGS_GROUP_NAME}_${counter}`;
+			}
+		}
+
+		const newGroup = new VirtualTool(groupName, 'Tools with high predicted relevancy for this query', Infinity, {
 			wasEmbeddingsMatched: true,
 			wasExpandedByDefault: true,
 			canBeCollapsed: false,
@@ -216,9 +228,8 @@ export class VirtualToolGrouper implements IToolCategorization {
 			newGroup.contents.push(tool);
 		}
 
-		const idx = root.contents.findIndex(t => t.name === EMBEDDINGS_GROUP_NAME);
-		if (idx >= 0) {
-			root.contents[idx] = newGroup;
+		if (existingGroupIndex >= 0) {
+			root.contents[existingGroupIndex] = newGroup;
 		} else {
 			root.contents.push(newGroup);
 		}
@@ -261,7 +272,9 @@ export class VirtualToolGrouper implements IToolCategorization {
 		for (const item of grouped) {
 			if (item instanceof VirtualTool) {
 				for (const nested of item.all()) {
-					placed.add(nested.name);
+					if (!(nested instanceof VirtualTool)) {
+						placed.add(nested.name);
+					}
 				}
 			} else {
 				placed.add(item.name);
@@ -286,14 +299,26 @@ export class VirtualToolGrouper implements IToolCategorization {
 
 	public static deduplicateGroups(grouped: readonly (VirtualTool | LanguageModelToolInformation)[]) {
 		const seen = new Set<string>();
+		const realToolNames = new Set<string>();
 		const result: (VirtualTool | LanguageModelToolInformation)[] = [];
+		for (const item of grouped) {
+			if (item instanceof VirtualTool) {
+				for (const nested of item.all()) {
+					if (!(nested instanceof VirtualTool)) {
+						realToolNames.add(nested.name);
+					}
+				}
+			} else {
+				realToolNames.add(item.name);
+			}
+		}
 
 		for (const item of grouped) {
 			let name = item.name;
 			let counter = 1;
 
-			// Find a unique name by adding numeric suffix if needed
-			while (seen.has(name)) {
+			// Synthetic group names must not shadow registered real tools.
+			while (item instanceof VirtualTool && (seen.has(name) || realToolNames.has(name))) {
 				counter++;
 				name = `${item.name}_${counter}`;
 			}

--- a/extensions/copilot/src/extension/tools/common/virtualTools/virtualToolGrouper.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/virtualToolGrouper.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { LanguageModelToolInformation } from 'vscode';
-import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { ConfigKey, HARD_TOOL_LIMIT, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
 import { IEmbeddingsComputer } from '../../../../platform/embeddings/common/embeddingsComputer';
 import { IEndpointProvider } from '../../../../platform/endpoint/common/endpointProvider';
 import { ILogService } from '../../../../platform/log/common/logService';
@@ -22,7 +22,7 @@ import { EMBEDDING_TYPE_FOR_TOOL_GROUPING } from './preComputedToolEmbeddingsCac
 import { IToolEmbeddingsComputer } from './toolEmbeddingsComputer';
 import { EMBEDDINGS_GROUP_NAME, VIRTUAL_TOOL_NAME_PREFIX, VirtualTool } from './virtualTool';
 import * as Constant from './virtualToolsConstants';
-import { TOOLS_AND_GROUPS_LIMIT } from './virtualToolsConstants';
+import { TOOLS_AND_GROUPS_LIMIT, UNCATEGORIZED_TOOLS_GROUP_NAME, UNCATEGORIZED_TOOLS_GROUP_SUMMARY } from './virtualToolsConstants';
 import { describeBulkToolGroups } from './virtualToolSummarizer';
 import { ISummarizedToolCategory, ISummarizedToolCategoryUpdatable, IToolCategorization, IToolGroupingCache } from './virtualToolTypes';
 
@@ -115,19 +115,27 @@ export class VirtualToolGrouper implements IToolCategorization {
 		if (toolsetEntries.length > 0) {
 			// Calculate available slots after accounting for builtin tools/groups
 			const builtinSlotCount = groupedResults.length;
-			const availableSlots = TOOLS_AND_GROUPS_LIMIT - builtinSlotCount;
+			const availableSlots = Math.max(0, TOOLS_AND_GROUPS_LIMIT - builtinSlotCount);
 			const slotAllocation = this._allocateSlots(toolsetEntries, availableSlots);
 
+			const funded = toolsetEntries.filter(([key]) => (slotAllocation.get(key) ?? 0) > 0);
+			const unfunded = toolsetEntries.filter(([key]) => (slotAllocation.get(key) ?? 0) <= 0);
+
 			// Process each toolset individually
-			const toolsetGrouped = await Promise.all([...toolsetEntries].map(async ([toolsetKey, tools]) => {
-				const allocatedSlots = slotAllocation.get(toolsetKey) || 0;
-				return allocatedSlots > 0 ? await this._processToolset(tools, allocatedSlots, token) : [];
-			}));
+			const toolsetGrouped = await Promise.all(funded.map(([toolsetKey, tools]) =>
+				this._processToolset(tools, slotAllocation.get(toolsetKey)!, token)));
 
 			groupedResults.push(...toolsetGrouped.flat());
+
+			// Toolsets too numerous to each get a slot share one group rather than being dropped.
+			if (unfunded.length > 0) {
+				const shared = unfunded.flatMap(([, tools]) => tools);
+				groupedResults.push(...await this._processToolset(shared, 1, token));
+			}
 		}
 
 		this._cache.flush();
+		this._recoverUngroupedTools(groupedResults, tools);
 		root.contents = VirtualToolGrouper.deduplicateGroups(groupedResults);
 
 		// Send telemetry for per-toolset processing
@@ -178,6 +186,22 @@ export class VirtualToolGrouper implements IToolCategorization {
 	}
 
 	private _addPredictedToolsGroup(root: VirtualTool, predictedTools: LanguageModelToolInformation[]): void {
+		const currentlyAvailable = new Set<string>();
+		for (const item of root.contents) {
+			if (item.name === EMBEDDINGS_GROUP_NAME) {
+				continue;
+			}
+
+			if (item instanceof VirtualTool) {
+				for (const tool of item.tools()) {
+					currentlyAvailable.add(tool.name);
+				}
+			} else {
+				currentlyAvailable.add(item.name);
+			}
+		}
+
+		let remainingSlots = Math.max(0, HARD_TOOL_LIMIT - currentlyAvailable.size);
 		const newGroup = new VirtualTool(EMBEDDINGS_GROUP_NAME, 'Tools with high predicted relevancy for this query', Infinity, {
 			wasEmbeddingsMatched: true,
 			wasExpandedByDefault: true,
@@ -186,6 +210,9 @@ export class VirtualToolGrouper implements IToolCategorization {
 
 		newGroup.isExpanded = true;
 		for (const tool of predictedTools) {
+			if (!currentlyAvailable.has(tool.name) && remainingSlots-- <= 0) {
+				continue;
+			}
 			newGroup.contents.push(tool);
 		}
 
@@ -228,6 +255,35 @@ export class VirtualToolGrouper implements IToolCategorization {
 		}
 	}
 
+	/** Collects any tool categorization failed to place, so that grouping stays lossless. */
+	private _recoverUngroupedTools(grouped: (VirtualTool | LanguageModelToolInformation)[], tools: readonly LanguageModelToolInformation[]): void {
+		const placed = new Set<string>();
+		for (const item of grouped) {
+			if (item instanceof VirtualTool) {
+				for (const nested of item.all()) {
+					placed.add(nested.name);
+				}
+			} else {
+				placed.add(item.name);
+			}
+		}
+
+		const missing = tools.filter(tool => !placed.has(tool.name));
+		if (missing.length === 0) {
+			return;
+		}
+
+		this._logService.warn(`[virtual-tools] Categorization dropped ${missing.length} tools (${missing.map(t => t.name).join(', ')}); recovering them into ${UNCATEGORIZED_TOOLS_GROUP_NAME}`);
+
+		grouped.push(new VirtualTool(
+			VIRTUAL_TOOL_NAME_PREFIX + UNCATEGORIZED_TOOLS_GROUP_NAME,
+			SUMMARY_PREFIX + UNCATEGORIZED_TOOLS_GROUP_SUMMARY + SUMMARY_SUFFIX,
+			0,
+			{},
+			missing,
+		));
+	}
+
 	public static deduplicateGroups(grouped: readonly (VirtualTool | LanguageModelToolInformation)[]) {
 		const seen = new Set<string>();
 		const result: (VirtualTool | LanguageModelToolInformation)[] = [];
@@ -262,10 +318,12 @@ export class VirtualToolGrouper implements IToolCategorization {
 	private _allocateSlots(toolsetEntries: Array<[string, LanguageModelToolInformation[]]>, availableSlots: number): Map<string, number> {
 		const allocation = new Map<string, number>();
 
-		// If we have more toolsets than slots, give each one slot
+		// More toolsets than slots: fund what we can, keeping one slot free for the
+		// shared group that the rest are folded into.
 		if (toolsetEntries.length >= availableSlots) {
+			const fundable = Math.max(0, availableSlots - 1);
 			for (let i = 0; i < toolsetEntries.length; i++) {
-				allocation.set(toolsetEntries[i][0], i < availableSlots ? 1 : 0);
+				allocation.set(toolsetEntries[i][0], i < fundable ? 1 : 0);
 			}
 			return allocation;
 		}

--- a/extensions/copilot/src/extension/tools/test/node/virtualTools/toolDropRepro.spec.ts
+++ b/extensions/copilot/src/extension/tools/test/node/virtualTools/toolDropRepro.spec.ts
@@ -1,0 +1,256 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from 'vitest';
+import type { LanguageModelToolInformation } from 'vscode';
+import { ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
+import { ComputeEmbeddingsOptions, Embedding, EmbeddingType, Embeddings, IEmbeddingsComputer } from '../../../../../platform/embeddings/common/embeddingsComputer';
+import { TelemetryCorrelationId } from '../../../../../util/common/telemetryCorrelationId';
+import { CancellationToken } from '../../../../../util/vs/base/common/cancellation';
+import { SyncDescriptor } from '../../../../../util/vs/platform/instantiation/common/descriptors';
+import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
+import { LanguageModelToolExtensionSource, LanguageModelToolMCPSource } from '../../../../../vscodeTypes';
+import { createExtensionUnitTestingServices } from '../../../../test/node/services';
+import { IToolEmbeddingsCache, IToolEmbeddingsComputer, ToolEmbeddingsComputer } from '../../../common/virtualTools/toolEmbeddingsComputer';
+import { VIRTUAL_TOOL_NAME_PREFIX, VirtualTool } from '../../../common/virtualTools/virtualTool';
+import { VirtualToolGrouper } from '../../../common/virtualTools/virtualToolGrouper';
+import { TOOLS_AND_GROUPS_LIMIT, UNCATEGORIZED_TOOLS_GROUP_NAME } from '../../../common/virtualTools/virtualToolsConstants';
+import { ISummarizedToolCategory } from '../../../common/virtualTools/virtualToolTypes';
+
+/**
+ * Regression coverage for https://github.com/microsoft/vscode/issues/324113 — the
+ * virtual tool packer dropped registered tools so that they were neither top-level
+ * nor reachable through any `activate_*` group.
+ */
+describe('Virtual Tools - grouping must not drop tools (#324113)', () => {
+	const EMBEDDING_TYPE = EmbeddingType.text3small_512;
+
+	function makeTool(name: string, source?: LanguageModelToolExtensionSource | LanguageModelToolMCPSource): LanguageModelToolInformation {
+		return {
+			name,
+			description: `Tool for ${name}`,
+			inputSchema: undefined,
+			source,
+			tags: [],
+		};
+	}
+
+	function makeExtensionSource(id: string): LanguageModelToolExtensionSource {
+		// TODO@connor4312
+		return new (LanguageModelToolExtensionSource as any)(id, id);
+	}
+
+	function makeMCPSource(label: string): LanguageModelToolMCPSource {
+		// TODO@connor4312
+		return new (LanguageModelToolMCPSource as any)(label, label);
+	}
+
+	/** Deterministic vector so clustering behaves identically across runs. */
+	function vectorFor(seed: number, dims = 8): number[] {
+		const value: number[] = [];
+		for (let i = 0; i < dims; i++) {
+			value.push(Math.sin((seed + 1) * (i + 1)));
+		}
+		return value;
+	}
+
+	/**
+	 * Emulates the embeddings endpoint. A batch containing any name in `failFor` comes
+	 * back empty, which is how a failed or truncated remote call surfaces.
+	 */
+	class FakeEmbeddingsComputer implements IEmbeddingsComputer {
+		declare _serviceBrand: undefined;
+
+		constructor(private readonly failFor: ReadonlySet<string> = new Set()) { }
+
+		async computeEmbeddings(type: EmbeddingType, inputs: readonly string[], options?: ComputeEmbeddingsOptions, telemetryInfo?: TelemetryCorrelationId, token?: CancellationToken): Promise<Embeddings> {
+			if (inputs.some(input => this.failFor.has(input.split('\n')[0]))) {
+				return { type, values: [] };
+			}
+
+			const values: Embedding[] = inputs.map((_, i) => ({ type, value: vectorFor(i) }));
+			return { type, values };
+		}
+	}
+
+	/** The real computer, with the pre-computed and on-disk caches removed. */
+	class CachelessToolEmbeddingsComputer extends ToolEmbeddingsComputer {
+		protected override getCaches() {
+			return { embeddingType: EMBEDDING_TYPE, caches: [] };
+		}
+	}
+
+	class PartiallyCachedToolEmbeddingsComputer extends ToolEmbeddingsComputer {
+		protected override getCaches() {
+			const cache: IToolEmbeddingsCache = {
+				initialize: async () => { },
+				get: tool => tool.name === 'partial-0' ? { type: EMBEDDING_TYPE, value: vectorFor(0) } : undefined,
+				set: () => { },
+			};
+			return { embeddingType: EMBEDDING_TYPE, caches: [cache] };
+		}
+	}
+
+	/** Grouper that never reaches the categorization endpoint. */
+	class OfflineVirtualToolGrouper extends VirtualToolGrouper {
+		protected override async _generateBulkGroupDescriptions(embeddingGroups: LanguageModelToolInformation[][]): Promise<{ groups: ISummarizedToolCategory[]; missed: number }> {
+			return {
+				groups: embeddingGroups.map((tools, index) => ({
+					name: `group_${index + 1}`,
+					summary: `Group containing ${tools.map(t => t.name).join(', ')}`,
+					tools,
+				})),
+				missed: 0,
+			};
+		}
+	}
+
+	function createAccessor(failFor: ReadonlySet<string> = new Set()) {
+		const collection = createExtensionUnitTestingServices();
+		collection.define(IEmbeddingsComputer, new FakeEmbeddingsComputer(failFor));
+		collection.define(IToolEmbeddingsComputer, new SyncDescriptor(CachelessToolEmbeddingsComputer));
+		const accessor = collection.createTestingAccessor();
+		// Built-in grouping is experiment-gated; pin it so slot pressure stays predictable.
+		accessor.get(IConfigurationService).setConfig(ConfigKey.Advanced.DefaultToolsGrouped, false);
+		return accessor;
+	}
+
+	function newRoot(): VirtualTool {
+		const root = new VirtualTool(VIRTUAL_TOOL_NAME_PREFIX, '', Infinity, { wasExpandedByDefault: true });
+		root.isExpanded = true;
+		return root;
+	}
+
+	it('keeps a toolset whose embeddings could not be computed', async () => {
+		const accessor = createAccessor(new Set(['exo-run']));
+		try {
+			const tools = ['exo-run', 'exo-ping', 'exo-status', 'exo-logs', 'exo-restart']
+				.map(name => makeTool(name, makeMCPSource('exo')));
+
+			const computer = accessor.get(IInstantiationService).createInstance(CachelessToolEmbeddingsComputer);
+			const groups = await computer.computeToolGroupings(tools, 3, CancellationToken.None);
+
+			expect({
+				groupCount: groups.length,
+				survived: groups.flat().map(t => t.name).sort(),
+			}).toEqual({
+				groupCount: 3,
+				survived: ['exo-logs', 'exo-ping', 'exo-restart', 'exo-run', 'exo-status'],
+			});
+		} finally {
+			accessor.dispose();
+		}
+	});
+
+	it('keeps singletons that do not fit in the remaining slots', async () => {
+		const accessor = createAccessor();
+		try {
+			const tools = Array.from({ length: 24 }, (_, i) => makeTool(`browser-tool-${i}`, makeExtensionSource('browser-automation')));
+
+			const computer = accessor.get(IInstantiationService).createInstance(CachelessToolEmbeddingsComputer);
+			const groups = await computer.computeToolGroupings(tools, 3, CancellationToken.None);
+			const survived = new Set(groups.flat().map(t => t.name));
+
+			expect({
+				withinLimit: groups.length <= 3,
+				lost: tools.map(t => t.name).filter(n => !survived.has(n)),
+			}).toEqual({ withinLimit: true, lost: [] });
+		} finally {
+			accessor.dispose();
+		}
+	});
+
+	it('keeps tools without embeddings when the embedded tools would otherwise fill the limit', async () => {
+		const accessor = createAccessor(new Set(['partial-1']));
+		try {
+			const tools = Array.from({ length: 5 }, (_, i) => makeTool(`partial-${i}`, makeExtensionSource('partial.extension')));
+			const computer = accessor.get(IInstantiationService).createInstance(PartiallyCachedToolEmbeddingsComputer);
+
+			const groups = await computer.computeToolGroupings(tools, 3, CancellationToken.None);
+
+			expect({
+				groupCount: groups.length,
+				survived: groups.flat().map(tool => tool.name).sort(),
+			}).toEqual({ groupCount: 3, survived: tools.map(tool => tool.name).sort() });
+		} finally {
+			accessor.dispose();
+		}
+	});
+
+	it('addGroups is lossless: every registered tool stays reachable', async () => {
+		const accessor = createAccessor(new Set(['exo-run']));
+		try {
+			const tools: LanguageModelToolInformation[] = [
+				...Array.from({ length: 60 }, (_, i) => makeTool(`builtin_tool_${i}`)),
+				...['exo-run', 'exo-ping', 'exo-status', 'exo-logs', 'exo-restart'].map(n => makeTool(n, makeMCPSource('exo'))),
+				...Array.from({ length: 24 }, (_, i) => makeTool(`browser_tool_${i}`, makeExtensionSource('browser-automation'))),
+				...Array.from({ length: 9 }, (_, i) => makeTool(`docs_tool_${i}`, makeMCPSource('docs'))),
+				...Array.from({ length: 8 }, (_, i) => makeTool(`db_tool_${i}`, makeMCPSource('database'))),
+			];
+
+			const grouper = accessor.get(IInstantiationService).createInstance(OfflineVirtualToolGrouper);
+			const root = newRoot();
+
+			// An empty query keeps the embedding-prediction path off the network.
+			await grouper.addGroups('', root, tools.slice(), CancellationToken.None);
+
+			const reachable = new Set(Array.from(root.all(), item => item.name));
+
+			expect({
+				registered: tools.length,
+				lost: tools.map(t => t.name).filter(n => !reachable.has(n)),
+			}).toEqual({ registered: 106, lost: [] });
+		} finally {
+			accessor.dispose();
+		}
+	});
+
+	it('keeps toolsets that are too numerous to each get their own slot', async () => {
+		const accessor = createAccessor();
+		try {
+			// One tool each across far more MCP servers than there are slots.
+			const tools = Array.from({ length: 120 }, (_, i) => makeTool(`srv${i}_tool`, makeMCPSource(`server-${i}`)));
+
+			const grouper = accessor.get(IInstantiationService).createInstance(OfflineVirtualToolGrouper);
+			const root = newRoot();
+			await grouper.addGroups('', root, tools.slice(), CancellationToken.None);
+
+			const reachable = new Set(Array.from(root.all(), item => item.name));
+			const recovered = Array.from(root.all()).some(i => i.name === `${VIRTUAL_TOOL_NAME_PREFIX}${UNCATEGORIZED_TOOLS_GROUP_NAME}`);
+
+			expect({
+				collapsedCount: root.contents.filter(item => item.name !== 'activate_embeddings').length,
+				lost: tools.map(t => t.name).filter(n => !reachable.has(n)),
+				neededBackstop: recovered,
+			}).toEqual({ collapsedCount: TOOLS_AND_GROUPS_LIMIT, lost: [], neededBackstop: false });
+		} finally {
+			accessor.dispose();
+		}
+	});
+
+	it('recovers tools omitted by categorization into the uncategorized group', async () => {
+		const accessor = createAccessor();
+		try {
+			const source = makeExtensionSource('lossy.extension');
+			const extensionTools = Array.from({ length: 5 }, (_, i) => makeTool(`lossy-${i}`, source));
+			const tools = [
+				...Array.from({ length: 86 }, (_, i) => makeTool(`builtin-${i}`)),
+				...extensionTools,
+			];
+			vi.spyOn(accessor.get(IToolEmbeddingsComputer), 'computeToolGroupings')
+				.mockResolvedValue([extensionTools.slice(0, 2)]);
+			const grouper = accessor.get(IInstantiationService).createInstance(OfflineVirtualToolGrouper);
+			const root = newRoot();
+
+			await grouper.addGroups('', root, tools, CancellationToken.None);
+
+			const recovered = root.contents.find(item => item.name === `${VIRTUAL_TOOL_NAME_PREFIX}${UNCATEGORIZED_TOOLS_GROUP_NAME}`) as VirtualTool;
+			expect(recovered.contents.map(tool => tool.name)).toEqual(extensionTools.slice(2).map(tool => tool.name));
+		} finally {
+			accessor.dispose();
+		}
+	});
+
+});

--- a/extensions/copilot/src/extension/tools/test/node/virtualTools/toolDropRepro.spec.ts
+++ b/extensions/copilot/src/extension/tools/test/node/virtualTools/toolDropRepro.spec.ts
@@ -14,7 +14,7 @@ import { IInstantiationService } from '../../../../../util/vs/platform/instantia
 import { LanguageModelToolExtensionSource, LanguageModelToolMCPSource } from '../../../../../vscodeTypes';
 import { createExtensionUnitTestingServices } from '../../../../test/node/services';
 import { IToolEmbeddingsCache, IToolEmbeddingsComputer, ToolEmbeddingsComputer } from '../../../common/virtualTools/toolEmbeddingsComputer';
-import { VIRTUAL_TOOL_NAME_PREFIX, VirtualTool } from '../../../common/virtualTools/virtualTool';
+import { EMBEDDINGS_GROUP_NAME, VIRTUAL_TOOL_NAME_PREFIX, VirtualTool } from '../../../common/virtualTools/virtualTool';
 import { VirtualToolGrouper } from '../../../common/virtualTools/virtualToolGrouper';
 import { TOOLS_AND_GROUPS_LIMIT, UNCATEGORIZED_TOOLS_GROUP_NAME } from '../../../common/virtualTools/virtualToolsConstants';
 import { ISummarizedToolCategory } from '../../../common/virtualTools/virtualToolTypes';
@@ -234,7 +234,13 @@ describe('Virtual Tools - grouping must not drop tools (#324113)', () => {
 		const accessor = createAccessor();
 		try {
 			const source = makeExtensionSource('lossy.extension');
-			const extensionTools = Array.from({ length: 5 }, (_, i) => makeTool(`lossy-${i}`, source));
+			const extensionTools = [
+				makeTool('lossy-0', source),
+				makeTool('lossy-1', source),
+				makeTool(`${VIRTUAL_TOOL_NAME_PREFIX}group_1`, source),
+				makeTool(EMBEDDINGS_GROUP_NAME, source),
+				makeTool('lossy-4', source),
+			];
 			const tools = [
 				...Array.from({ length: 86 }, (_, i) => makeTool(`builtin-${i}`)),
 				...extensionTools,
@@ -247,7 +253,13 @@ describe('Virtual Tools - grouping must not drop tools (#324113)', () => {
 			await grouper.addGroups('', root, tools, CancellationToken.None);
 
 			const recovered = root.contents.find(item => item.name === `${VIRTUAL_TOOL_NAME_PREFIX}${UNCATEGORIZED_TOOLS_GROUP_NAME}`) as VirtualTool;
-			expect(recovered.contents.map(tool => tool.name)).toEqual(extensionTools.slice(2).map(tool => tool.name));
+			expect({
+				recovered: recovered.contents.map(tool => tool.name),
+				virtualGroupNames: root.contents.filter(item => item instanceof VirtualTool).map(item => item.name),
+			}).toEqual({
+				recovered: extensionTools.slice(2).map(tool => tool.name),
+				virtualGroupNames: [`${VIRTUAL_TOOL_NAME_PREFIX}group_1_2`, `${VIRTUAL_TOOL_NAME_PREFIX}${UNCATEGORIZED_TOOLS_GROUP_NAME}`, `${EMBEDDINGS_GROUP_NAME}_2`],
+			});
 		} finally {
 			accessor.dispose();
 		}

--- a/extensions/copilot/src/extension/tools/test/node/virtualTools/virtualToolGrouper.spec.ts
+++ b/extensions/copilot/src/extension/tools/test/node/virtualTools/virtualToolGrouper.spec.ts
@@ -23,13 +23,15 @@ describe('Virtual Tools - Grouper', () => {
 	let root: VirtualTool;
 
 	class TestVirtualToolGrouper extends VirtualToolGrouper {
+		public groupNameOverride: string | undefined;
+
 		// Override the bulk description method to avoid hitting the endpoint
 		protected override async _generateBulkGroupDescriptions(embeddingGroups: LanguageModelToolInformation[][], token: CancellationToken): Promise<{ groups: ISummarizedToolCategory[]; missed: number }> {
 			// Simulate describing groups based on their tool names
 			const groups = embeddingGroups.map((group, index) => {
 				const prefix = group[0]?.name.split('_')[0] || 'unknown';
 				return {
-					name: `${prefix}_group_${index + 1}`,
+					name: this.groupNameOverride ?? `${prefix}_group_${index + 1}`,
 					summary: `Group of ${prefix} tools containing ${group.map(t => t.name).join(', ')}`,
 					tools: group
 				};
@@ -60,7 +62,7 @@ describe('Virtual Tools - Grouper', () => {
 
 	/** Root contents excluding the embeddings group, which `addGroups` always appends. */
 	function contentsWithoutEmbeddings(): (VirtualTool | LanguageModelToolInformation)[] {
-		return root.contents.filter(c => c.name !== EMBEDDINGS_GROUP_NAME);
+		return root.contents.filter(c => !(c instanceof VirtualTool && c.metadata.wasEmbeddingsMatched));
 	}
 
 	function groupsIn(): VirtualTool[] {
@@ -118,11 +120,20 @@ describe('Virtual Tools - Grouper', () => {
 			expect(renamed.contents).toEqual([tool]);
 		});
 
-		it('never drops an item', () => {
+		it('renames virtual tools that collide with real tool names', () => {
 			const dupName = `${VIRTUAL_TOOL_NAME_PREFIX}baz`;
-			const items = [vt(dupName), makeTool(dupName), makeTool('unique'), vt(dupName)];
+			const realTool = makeTool(dupName);
+			const result = VirtualToolGrouper.deduplicateGroups([vt(dupName), realTool, makeTool('unique'), vt(dupName)]);
 
-			expect(VirtualToolGrouper.deduplicateGroups(items)).toHaveLength(items.length);
+			expect({
+				names: result.map(item => item.name),
+				uniqueNames: new Set(result.map(item => item.name)).size,
+				realToolPreserved: result.find(item => item.name === dupName) === realTool,
+			}).toEqual({
+				names: [`${dupName}_2`, dupName, 'unique', `${dupName}_3`],
+				uniqueNames: result.length,
+				realToolPreserved: true,
+			});
 		});
 	});
 
@@ -329,7 +340,7 @@ describe('Virtual Tools - Grouper', () => {
 		}
 
 		function embeddingsGroup(): VirtualTool {
-			return root.contents.find(c => c.name === EMBEDDINGS_GROUP_NAME) as VirtualTool;
+			return root.contents.find(c => c instanceof VirtualTool && c.metadata.wasEmbeddingsMatched) as VirtualTool;
 		}
 
 		it('should create embeddings group with predicted tools', async () => {
@@ -373,8 +384,57 @@ describe('Virtual Tools - Grouper', () => {
 			expect({
 				first,
 				second: embeddingsGroup().contents.map(t => t.name),
-				groupCount: root.contents.filter(c => c.name === EMBEDDINGS_GROUP_NAME).length,
+				groupCount: root.contents.filter(c => c instanceof VirtualTool && c.metadata.wasEmbeddingsMatched).length,
 			}).toEqual({ first: ['tool1'], second: ['tool2', 'tool3'], groupCount: 1 });
+		});
+
+		it('does not replace an ordinary group named activate_embeddings', async () => {
+			const nested = makeTool('nested_tool');
+			const ordinaryGroup = new VirtualTool(EMBEDDINGS_GROUP_NAME, 'ordinary group', 0, {}, [nested]);
+			root.contents = [ordinaryGroup];
+			stubQueryEmbedding();
+			stubPredictions();
+
+			await grouper.recomputeEmbeddingRankings('query', root, CancellationToken.None);
+
+			expect(root.contents.map(item => ({
+				name: item.name,
+				isEmbeddingGroup: item instanceof VirtualTool && item.metadata.wasEmbeddingsMatched === true,
+			}))).toEqual([
+				{ name: EMBEDDINGS_GROUP_NAME, isEmbeddingGroup: false },
+				{ name: `${EMBEDDINGS_GROUP_NAME}_2`, isEmbeddingGroup: true },
+			]);
+			expect(Array.from(root.all())).toContain(nested);
+		});
+
+		it('does not transfer embedding identity to an ordinary group during rebuild', async () => {
+			const source = makeExtensionSource('rebuild.extension');
+			const extensionTools = Array.from({ length: 5 }, (_, i) => makeTool(`rebuild_${i}`, source));
+			const tools = [...builtinsFillingSlots(2), ...extensionTools];
+			stubQueryEmbedding();
+			stubPredictions();
+			await grouper.addGroups('first query', root, tools, CancellationToken.None);
+
+			grouper.groupNameOverride = 'embeddings';
+			await grouper.addGroups('second query', root, [...tools, makeTool('new_builtin')], CancellationToken.None);
+
+			const ordinaryGroup = root.contents.find(item => item.name === EMBEDDINGS_GROUP_NAME) as VirtualTool;
+			const embeddingGroup = embeddingsGroup();
+			expect({
+				ordinaryGroupContents: ordinaryGroup.contents.map(tool => tool.name),
+				ordinaryGroupIsEmbedding: ordinaryGroup.metadata.wasEmbeddingsMatched === true,
+				ordinaryGroupIsExpanded: ordinaryGroup.isExpanded,
+				ordinaryGroupCanBeCollapsed: ordinaryGroup.metadata.canBeCollapsed,
+				embeddingGroupName: embeddingGroup.name,
+				lost: extensionTools.filter(tool => !Array.from(root.all()).includes(tool)).map(tool => tool.name),
+			}).toEqual({
+				ordinaryGroupContents: extensionTools.map(tool => tool.name),
+				ordinaryGroupIsEmbedding: false,
+				ordinaryGroupIsExpanded: false,
+				ordinaryGroupCanBeCollapsed: undefined,
+				embeddingGroupName: `${EMBEDDINGS_GROUP_NAME}_2`,
+				lost: [],
+			});
 		});
 
 		it('should create an empty embeddings group when nothing is predicted', async () => {

--- a/extensions/copilot/src/extension/tools/test/node/virtualTools/virtualToolGrouper.spec.ts
+++ b/extensions/copilot/src/extension/tools/test/node/virtualTools/virtualToolGrouper.spec.ts
@@ -5,20 +5,19 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LanguageModelToolInformation } from 'vscode';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
+import { ConfigKey, HARD_TOOL_LIMIT, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
 import { EmbeddingType, IEmbeddingsComputer } from '../../../../../platform/embeddings/common/embeddingsComputer';
-import { IVSCodeExtensionContext } from '../../../../../platform/extContext/common/extensionContext';
 import { ITestingServicesAccessor } from '../../../../../platform/test/node/services';
 import { CancellationToken } from '../../../../../util/vs/base/common/cancellation';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { LanguageModelToolExtensionSource, LanguageModelToolMCPSource } from '../../../../../vscodeTypes';
 import { createExtensionUnitTestingServices } from '../../../../test/node/services';
-import { VIRTUAL_TOOL_NAME_PREFIX, VirtualTool } from '../../../common/virtualTools/virtualTool';
+import { EMBEDDINGS_GROUP_NAME, VIRTUAL_TOOL_NAME_PREFIX, VirtualTool } from '../../../common/virtualTools/virtualTool';
 import { VirtualToolGrouper } from '../../../common/virtualTools/virtualToolGrouper';
-import { GROUP_WITHIN_TOOLSET, MIN_TOOLSET_SIZE_TO_GROUP, START_GROUPING_AFTER_TOOL_COUNT } from '../../../common/virtualTools/virtualToolsConstants';
+import { GROUP_WITHIN_TOOLSET, MIN_TOOLSET_SIZE_TO_GROUP, NUM_EMBED_MATCHED_TOOLS, START_GROUPING_AFTER_TOOL_COUNT, TOOLS_AND_GROUPS_LIMIT } from '../../../common/virtualTools/virtualToolsConstants';
 import { ISummarizedToolCategory } from '../../../common/virtualTools/virtualToolTypes';
 
-describe.skip('Virtual Tools - Grouper', () => {
+describe('Virtual Tools - Grouper', () => {
 	let accessor: ITestingServicesAccessor;
 	let grouper: TestVirtualToolGrouper;
 	let root: VirtualTool;
@@ -59,88 +58,71 @@ describe.skip('Virtual Tools - Grouper', () => {
 		return new (LanguageModelToolMCPSource as any)(label, label);
 	}
 
-	beforeEach(() => {
+	/** Root contents excluding the embeddings group, which `addGroups` always appends. */
+	function contentsWithoutEmbeddings(): (VirtualTool | LanguageModelToolInformation)[] {
+		return root.contents.filter(c => c.name !== EMBEDDINGS_GROUP_NAME);
+	}
+
+	function groupsIn(): VirtualTool[] {
+		return contentsWithoutEmbeddings().filter((c): c is VirtualTool => c instanceof VirtualTool);
+	}
+
+	/**
+	 * Built-in tools consume top-level slots, so enough of them leaves extension and
+	 * MCP toolsets short of slots. Grouping is driven entirely by that pressure.
+	 */
+	function builtinsFillingSlots(free: number): LanguageModelToolInformation[] {
+		return Array.from({ length: TOOLS_AND_GROUPS_LIMIT - free }, (_, i) => makeTool(`builtin_${i}`));
+	}
+
+	/** Names of the tools reachable from the root, top-level or nested in a group. */
+	function reachableToolNames(): Set<string> {
+		const names = new Set<string>();
+		for (const item of root.all()) {
+			if (!(item instanceof VirtualTool)) {
+				names.add(item.name);
+			}
+		}
+		return names;
+	}
+
+	beforeEach(async () => {
 		const testingServiceCollection = createExtensionUnitTestingServices();
 		accessor = testingServiceCollection.createTestingAccessor();
+		// Built-in grouping is experiment-gated. These tests rely on built-in tools each
+		// taking a slot, which is what puts the other toolsets under slot pressure.
+		await accessor.get(IConfigurationService).setConfig(ConfigKey.Advanced.DefaultToolsGrouped, false);
 		grouper = accessor.get(IInstantiationService).createInstance(TestVirtualToolGrouper);
 		root = new VirtualTool(VIRTUAL_TOOL_NAME_PREFIX, '', Infinity, { wasExpandedByDefault: true });
 		root.isExpanded = true;
 	});
 
-	describe('_deduplicateGroups', () => {
-		function vt(name: string, possiblePrefix?: string): VirtualTool {
-			return new VirtualTool(
-				name,
-				`VT ${name}`,
-				0,
-				{},
-				[]
-			);
+	describe('deduplicateGroups', () => {
+		function vt(name: string, contents: LanguageModelToolInformation[] = []): VirtualTool {
+			return new VirtualTool(name, `VT ${name}`, 0, {}, contents);
 		}
 
-		it('deduplicates VirtualTool against LM tool by prefixing existing VT', () => {
+		it('renames colliding groups with a numeric suffix', () => {
 			const dupName = `${VIRTUAL_TOOL_NAME_PREFIX}foo`;
-			const items = [
-				vt(dupName, 'ext_'),
-				makeTool(dupName),
-			];
+			const result = VirtualToolGrouper.deduplicateGroups([vt(dupName), vt(dupName), vt(dupName)]);
 
-			const result = VirtualToolGrouper.deduplicateGroups(items) as Array<VirtualTool | LanguageModelToolInformation>;
-
-			// Expect both the LM tool and the prefixed VT to exist, and no unprefixed VT
-			const names = result.map(i => i.name);
-			expect(names).toContain(dupName);
-			expect(names).toContain(`activate_ext_${dupName.slice(VIRTUAL_TOOL_NAME_PREFIX.length)}`);
-			expect(result.find(i => i instanceof VirtualTool && i.name === dupName)).toBeUndefined();
+			expect(result.map(i => i.name)).toEqual([dupName, `${dupName}_2`, `${dupName}_3`]);
 		});
 
-		it('deduplicates LM tool against VirtualTool by prefixing new VT', () => {
+		it('carries contents over when renaming a group', () => {
 			const dupName = `${VIRTUAL_TOOL_NAME_PREFIX}bar`;
-			const items = [
-				makeTool(dupName),
-				vt(dupName, 'mcp_'),
-			];
+			const tool = makeTool('inner_tool');
+			const result = VirtualToolGrouper.deduplicateGroups([vt(dupName), vt(dupName, [tool])]);
 
-			const result = VirtualToolGrouper.deduplicateGroups(items) as Array<VirtualTool | LanguageModelToolInformation>;
-			const names = result.map(i => i.name);
-			expect(names).toContain(dupName); // LM tool remains under original name
-			expect(names).toContain(`activate_mcp_${dupName.slice(VIRTUAL_TOOL_NAME_PREFIX.length)}`); // VT is cloned with prefix
+			const renamed = result.find(i => i.name === `${dupName}_2`) as VirtualTool;
+			expect(renamed.contents).toEqual([tool]);
 		});
 
-		it('handles VT vs VT duplicate by prefixing the first and keeping the second', () => {
+		it('never drops an item', () => {
 			const dupName = `${VIRTUAL_TOOL_NAME_PREFIX}baz`;
-			const first = vt(dupName, 'ext_');
-			const second = vt(dupName, 'mcp_');
-			const result = VirtualToolGrouper.deduplicateGroups([first, second]) as Array<VirtualTool | LanguageModelToolInformation>;
+			const items = [vt(dupName), makeTool(dupName), makeTool('unique'), vt(dupName)];
 
-			const vtPrefixed = result.find(i => i instanceof VirtualTool && i.name === `activate_ext_${dupName.slice(VIRTUAL_TOOL_NAME_PREFIX.length)}`) as VirtualTool | undefined;
-			const vtUnprefixed = result.find(i => i.name === dupName) as VirtualTool | undefined;
-
-			expect(vtPrefixed).toBeDefined();
-			// Second VT should remain at the original (unprefixed) name
-			expect(vtUnprefixed).toBeInstanceOf(VirtualTool);
-		});
-
-		it('drops duplicate when no possiblePrefix is available on VT', () => {
-			const dupName = `${VIRTUAL_TOOL_NAME_PREFIX}qux`;
-			const items = [
-				vt(dupName), // no possiblePrefix
-				makeTool(dupName),
-			];
-
-			const result = VirtualToolGrouper.deduplicateGroups(items) as Array<VirtualTool | LanguageModelToolInformation>;
-			// Only the first VT remains
-			expect(result).toHaveLength(1);
-			expect(result[0]).toBeInstanceOf(VirtualTool);
-			expect(result[0].name).toBe(dupName);
-		});
-
-		it('keeps only the first LM tool on LM vs LM duplicate', () => {
-			const dupName = `${VIRTUAL_TOOL_NAME_PREFIX}dup`;
-			const items = [makeTool(dupName), makeTool(dupName)];
-			const result = VirtualToolGrouper.deduplicateGroups(items) as Array<VirtualTool | LanguageModelToolInformation>;
-			expect(result).toHaveLength(1);
-			expect(result[0].name).toBe(dupName);
+			expect(VirtualToolGrouper.deduplicateGroups(items)).toHaveLength(items.length);
 		});
 	});
 
@@ -166,8 +148,7 @@ describe.skip('Virtual Tools - Grouper', () => {
 
 			await grouper.addGroups('', root, tools, CancellationToken.None);
 
-			expect(root.contents.length).toBeGreaterThan(0);
-			expect(root.contents.length).toEqual(tools.length);
+			expect(contentsWithoutEmbeddings()).toHaveLength(tools.length);
 		});
 	});
 
@@ -190,18 +171,16 @@ describe.skip('Virtual Tools - Grouper', () => {
 				makeTool(`ext_tool_${i}`, extensionSource)
 			);
 
-			// Need enough tools to trigger grouping
-			const allTools = [
-				...extensionTools,
-				...Array.from({ length: START_GROUPING_AFTER_TOOL_COUNT }, (_, i) => makeTool(`extra_${i}`))
-			];
+			const allTools = [...extensionTools, ...builtinsFillingSlots(4)];
 
 			await grouper.addGroups('', root, allTools, CancellationToken.None);
 
-			// Should have created virtual tools for the extension
-			const vt = root.contents.filter((tool): tool is VirtualTool => tool instanceof VirtualTool);
-			expect(vt).toHaveLength(1);
-			expect(vt[0].name).toBe('activate_ext');
+			// The extension's tools are grouped, and none of them are lost.
+			const grouped = groupsIn().flatMap(g => Array.from(g.all()).map(t => t.name));
+			expect({
+				groupedExtensionTools: extensionTools.every(t => grouped.includes(t.name)),
+				lost: allTools.map(t => t.name).filter(n => !reachableToolNames().has(n)),
+			}).toEqual({ groupedExtensionTools: true, lost: [] });
 		});
 
 		it('should group MCP tools by MCP source label', async () => {
@@ -210,45 +189,63 @@ describe.skip('Virtual Tools - Grouper', () => {
 				makeTool(`mcp_tool_${i}`, mcpSource)
 			);
 
-			// Need enough tools to trigger grouping
-			const allTools = [
-				...mcpTools,
-				...Array.from({ length: START_GROUPING_AFTER_TOOL_COUNT }, (_, i) => makeTool(`extra_${i}`))
-			];
+			const allTools = [...mcpTools, ...builtinsFillingSlots(4)];
 
 			await grouper.addGroups('', root, allTools, CancellationToken.None);
 
-			// Should have created virtual tools for the extension
-			const vt = root.contents.filter((tool): tool is VirtualTool => tool instanceof VirtualTool);
-			expect(vt).toHaveLength(1);
-			expect(vt[0].name).toBe('activate_mcp');
+			// The MCP server's tools are grouped, and none of them are lost.
+			const grouped = groupsIn().flatMap(g => Array.from(g.all()).map(t => t.name));
+			expect({
+				groupedMcpTools: mcpTools.every(t => grouped.includes(t.name)),
+				lost: allTools.map(t => t.name).filter(n => !reachableToolNames().has(n)),
+			}).toEqual({ groupedMcpTools: true, lost: [] });
 		});
 
 		it('should handle mixed toolsets correctly', async () => {
 			const extensionSource = makeExtensionSource('test.extension');
 			const mcpSource = makeMCPSource('test-mcp');
 
-			const tools = [
-				...Array.from({ length: 5 }, (_, i) => makeTool(`builtin_${i}`)),
+			const builtins = builtinsFillingSlots(4);
+			const allTools = [
+				...builtins,
 				...Array.from({ length: GROUP_WITHIN_TOOLSET + 1 }, (_, i) => makeTool(`ext_${i}`, extensionSource)),
 				...Array.from({ length: GROUP_WITHIN_TOOLSET + 1 }, (_, i) => makeTool(`mcp_${i}`, mcpSource)),
 			];
 
-			// Need enough tools to trigger grouping
-			const allTools = [
-				...tools,
-				...Array.from({ length: START_GROUPING_AFTER_TOOL_COUNT }, (_, i) => makeTool(`extra_${i}`))
-			];
-
 			await grouper.addGroups('', root, allTools, CancellationToken.None);
 
-			// Should have built-in tools and virtual tools for extension and MCP
-			const nonExtra = root.contents.filter(tool => !tool.name.includes('extra_'));
-			const builtInCount = nonExtra.filter(tool => !(tool instanceof VirtualTool)).length;
-			const virtualCount = nonExtra.filter(tool => tool instanceof VirtualTool).length;
+			// Built-in tools stay top-level; extension and MCP tools get grouped.
+			const topLevelNames = contentsWithoutEmbeddings().filter(t => !(t instanceof VirtualTool)).map(t => t.name);
+			expect({
+				builtinsTopLevel: builtins.every(t => topLevelNames.includes(t.name)),
+				hasGroups: groupsIn().length > 0,
+				lost: allTools.map(t => t.name).filter(n => !reachableToolNames().has(n)),
+			}).toEqual({ builtinsTopLevel: true, hasGroups: true, lost: [] });
+		});
 
-			expect(builtInCount).toBe(5); // Built-in tools added directly
-			expect(virtualCount).toBeGreaterThan(0); // Virtual tools for extension and MCP
+		it('keeps serialized tools within the hard limit when built-in grouping is disabled', async () => {
+			const extensionSource = makeExtensionSource('test.extension');
+			const extensionTools = Array.from({ length: NUM_EMBED_MATCHED_TOOLS }, (_, i) => makeTool(`extension_${i}`, extensionSource));
+			const allTools = [
+				...Array.from({ length: HARD_TOOL_LIMIT - NUM_EMBED_MATCHED_TOOLS }, (_, i) => makeTool(`builtin_${i}`)),
+				...extensionTools,
+			];
+
+			vi.spyOn(accessor.get(IEmbeddingsComputer), 'computeEmbeddings').mockResolvedValue({
+				type: EmbeddingType.text3small_512,
+				values: [{ type: EmbeddingType.text3small_512, value: [0.1, 0.2, 0.3, 0.4, 0.5] }]
+			});
+			vi.spyOn(grouper['_toolEmbeddingsComputer'], 'retrieveSimilarEmbeddingsForAvailableTools')
+				.mockResolvedValue(extensionTools.map(tool => tool.name));
+
+			await grouper.addGroups('find extension tools', root, allTools, CancellationToken.None);
+
+			const serialized = Array.from(root.tools());
+			expect({
+				serializedCount: serialized.length,
+				withinHardLimit: serialized.length <= HARD_TOOL_LIMIT,
+				lost: allTools.map(tool => tool.name).filter(name => !reachableToolNames().has(name)),
+			}).toEqual({ serializedCount: HARD_TOOL_LIMIT, withinHardLimit: true, lost: [] });
 		});
 	});
 
@@ -280,390 +277,142 @@ describe.skip('Virtual Tools - Grouper', () => {
 				makeTool(`group${i % 3}_tool_${i}`, extensionSource) // Create 3 groups
 			);
 
-			// Need enough tools to trigger grouping
-			const allTools = [
-				...largeToolset,
-				...Array.from({ length: START_GROUPING_AFTER_TOOL_COUNT }, (_, i) => makeTool(`extra_${i}`))
-			];
-
+			const allTools = [...largeToolset, ...builtinsFillingSlots(4)];
 
 			await grouper.addGroups('', root, allTools, CancellationToken.None);
 
-			// Should have created virtual tools for the extension
-			const vt = root.contents.filter((tool): tool is VirtualTool => tool instanceof VirtualTool);
-			expect(vt).toHaveLength(3);
-			expect(vt.map(vt => vt.name)).toMatchInlineSnapshot(`
-				[
-				  "activate_group0",
-				  "activate_group1",
-				  "activate_group2",
-				]
-			`);
+			// A toolset larger than its slot allocation is split across several groups.
+			expect({
+				groupCount: groupsIn().length > 1,
+				lost: allTools.map(t => t.name).filter(n => !reachableToolNames().has(n)),
+			}).toEqual({ groupCount: true, lost: [] });
 		});
 	});
 
 	describe('addGroups - state preservation', () => {
 		it('should preserve expansion state of existing virtual tools', async () => {
-			const tools = Array.from({ length: START_GROUPING_AFTER_TOOL_COUNT + 1 }, (_, i) =>
-				makeTool(`file_tool_${i}`)
-			);
+			const extensionSource = makeExtensionSource('stateful.extension');
+			const tools = [
+				...Array.from({ length: GROUP_WITHIN_TOOLSET + 1 }, (_, i) => makeTool(`file_tool_${i}`, extensionSource)),
+				...builtinsFillingSlots(4),
+			];
 
 			// First grouping
 			await grouper.addGroups('', root, tools, CancellationToken.None);
 
 			// Expand a virtual tool
-			const virtualTool = root.contents.find(tool => tool instanceof VirtualTool) as VirtualTool;
-			if (virtualTool) {
-				virtualTool.isExpanded = true;
-				virtualTool.lastUsedOnTurn = 5;
-			}
+			const virtualTool = groupsIn()[0];
+			expect(virtualTool).toBeDefined();
+			virtualTool.isExpanded = true;
+			virtualTool.lastUsedOnTurn = 5;
 
 			// Second grouping with same tools
 			await grouper.addGroups('', root, tools, CancellationToken.None);
 
-			// State should be preserved
-			const newVirtualTool = root.contents.find(tool =>
-				tool instanceof VirtualTool && tool.name === virtualTool?.name
-			) as VirtualTool;
-
-			if (newVirtualTool) {
-				expect(newVirtualTool.isExpanded).toBe(true);
-				expect(newVirtualTool.lastUsedOnTurn).toBe(5);
-			}
-		});
-	});
-
-	describe('cache integration', () => {
-		it('should use cache for tool group generation', async () => {
-			const tools1 = Array.from({ length: GROUP_WITHIN_TOOLSET + 1 }, (_, i) =>
-				makeTool(`grouped_tool_${i}`, makeExtensionSource('cached.extension1'))
-			);
-			const tools2 = Array.from({ length: MIN_TOOLSET_SIZE_TO_GROUP + 1 }, (_, i) =>
-				makeTool(`summarized_tool_${i}`, makeExtensionSource('cached.extension2'))
-			);
-
-			const allTools = [
-				...tools1,
-				...tools2,
-				...Array.from({ length: START_GROUPING_AFTER_TOOL_COUNT }, (_, i) => makeTool(`extra_${i}`))
-			];
-
-			await grouper.addGroups('', root, allTools, CancellationToken.None);
-
-			const context = accessor.get(IVSCodeExtensionContext);
-			const cached = context.globalState.get('virtToolGroupCache');
-			function sortObj(obj: unknown): any {
-				if (Array.isArray(obj)) {
-					return obj.map(sortObj).sort();
-				}
-				if (obj && typeof obj === 'object') {
-					return Object.fromEntries(Object.entries(obj)
-						.sort(([a], [b]) => a.localeCompare(b))
-						.map(([k, v]) => [k, sortObj(v)]));
-				}
-				return obj;
-			}
-
-			expect(sortObj(cached)).toMatchInlineSnapshot(`
-				{
-				  "lru": [
-				    [
-				      "5sujG9z5TJJRhFVv6jkxLSvKfLlEi6DEUboDpSCLfvQ=",
-				      {
-				        "groups": [
-				          {
-				            "name": "grouped",
-				            "summary": "Tools for grouped operations",
-				            "tools": [
-				              "grouped_tool_0",
-				              "grouped_tool_1",
-				              "grouped_tool_10",
-				              "grouped_tool_11",
-				              "grouped_tool_12",
-				              "grouped_tool_13",
-				              "grouped_tool_14",
-				              "grouped_tool_15",
-				              "grouped_tool_16",
-				              "grouped_tool_2",
-				              "grouped_tool_3",
-				              "grouped_tool_4",
-				              "grouped_tool_5",
-				              "grouped_tool_6",
-				              "grouped_tool_7",
-				              "grouped_tool_8",
-				              "grouped_tool_9",
-				            ],
-				          },
-				        ],
-				      },
-				    ],
-				    [
-				      {
-				        "groups": [
-				          {
-				            "name": "summarized",
-				            "summary": "Summarized tools for summarized",
-				            "tools": [
-				              "summarized_tool_0",
-				              "summarized_tool_1",
-				              "summarized_tool_2",
-				            ],
-				          },
-				        ],
-				      },
-				      "ukyzHGWUUwylzlhwETqBtsi69Xhj9XqiFp45nH8yqYE=",
-				    ],
-				  ],
-				}
-			`);
-
-			const intoGroups = vi.spyOn(grouper, '_divideToolsIntoGroups' as any);
-			const intoSummary = vi.spyOn(grouper, '_summarizeToolGroup' as any);
-
-			await grouper.addGroups('', root, allTools, CancellationToken.None);
-			expect(intoGroups).not.toHaveBeenCalled();
-			expect(intoSummary).not.toHaveBeenCalled();
-
-			const tools3 = Array.from({ length: MIN_TOOLSET_SIZE_TO_GROUP + 2 }, (_, i) =>
-				makeTool(`summarized_tool_${i}`, makeExtensionSource('cached.extension2'))
-			);
-
-			const allTools2 = [
-				...tools1,
-				...tools3,
-				...Array.from({ length: START_GROUPING_AFTER_TOOL_COUNT }, (_, i) => makeTool(`extra_${i}`))
-			];
-			await grouper.addGroups('', root, allTools2, CancellationToken.None);
-
-			expect(intoGroups).not.toHaveBeenCalled();
-			expect(intoSummary).toHaveBeenCalledOnce();
-		});
-	});
-
-	describe('embedding-based expansion', () => {
-		beforeEach(() => {
-			const configurationService = accessor.get(IConfigurationService);
-			vi.spyOn(configurationService, 'getExperimentBasedConfig').mockReturnValue(true);
-		});
-
-		it('should expand virtual tools containing predicted tools when embedding ranking is enabled', async () => {
-			// Create extension tools that will be grouped
-			const extensionSource = makeExtensionSource('test.extension');
-			const extensionTools = [
-				makeTool('predicted_tool1', extensionSource), // Higher priority (index 0)
-				makeTool('predicted_tool2', extensionSource), // Lower priority (index 1)
-				makeTool('other_tool1', extensionSource),
-				makeTool('other_tool2', extensionSource),
-			];
-
-			// Add enough builtin tools to trigger grouping
-			const builtinTools = Array.from({ length: START_GROUPING_AFTER_TOOL_COUNT }, (_, i) =>
-				makeTool(`builtin_${i}`)
-			);
-
-			const allTools = [...extensionTools, ...builtinTools];
-
-			// Mock the embedding computation and tool retrieval
-			const embeddingsComputer = accessor.get(IEmbeddingsComputer);
-			vi.spyOn(embeddingsComputer, 'computeEmbeddings').mockResolvedValue({
-				type: EmbeddingType.text3small_512,
-				values: [{
-					type: EmbeddingType.text3small_512,
-					value: [0.1, 0.2, 0.3, 0.4, 0.5]
-				}]
-			});
-
-			// Mock the tool embeddings computer to return specific predicted tools
-			vi.spyOn(grouper['_toolEmbeddingsComputer'], 'retrieveSimilarEmbeddingsForAvailableTools')
-				.mockResolvedValue(['predicted_tool1', 'predicted_tool2']);
-
-			const query = 'test query for embeddings';
-
-			// Call addGroups which should trigger embedding-based expansion
-			await grouper.addGroups(query, root, allTools, CancellationToken.None);
-
-			// Find the virtual tool that was created for the extension
-			const virtualTools = root.contents.filter((tool): tool is VirtualTool => tool instanceof VirtualTool);
-			expect(virtualTools.length).toBeGreaterThan(0);
-
-			// The virtual tool containing predicted tools should be expanded
-			const extVirtualTool = virtualTools.find(vt =>
-				vt.contents.some(tool => tool.name === 'predicted_tool1' || tool.name === 'predicted_tool2')
-			);
-			expect(extVirtualTool).toBeDefined();
-			if (extVirtualTool) {
-				expect(extVirtualTool.isExpanded).toBe(true);
-				expect(extVirtualTool.metadata.wasExpandedByDefault).toBe(true);
-			}
+			const regrouped = groupsIn().find(t => t.name === virtualTool.name)!;
+			expect({ isExpanded: regrouped.isExpanded, lastUsedOnTurn: regrouped.lastUsedOnTurn })
+				.toEqual({ isExpanded: true, lastUsedOnTurn: 5 });
 		});
 	});
 
 	describe('recomputeEmbeddingRankings', () => {
-		beforeEach(() => {
-			const configurationService = accessor.get(IConfigurationService);
-			vi.spyOn(configurationService, 'getExperimentBasedConfig').mockReturnValue(true);
-		});
+		function stubQueryEmbedding() {
+			vi.spyOn(accessor.get(IEmbeddingsComputer), 'computeEmbeddings').mockResolvedValue({
+				type: EmbeddingType.text3small_512,
+				values: [{ type: EmbeddingType.text3small_512, value: [0.1, 0.2, 0.3, 0.4, 0.5] }]
+			});
+		}
 
-		it('should do nothing when embedding ranking is disabled', async () => {
-			const configurationService = accessor.get(IConfigurationService);
-			vi.spyOn(configurationService, 'getExperimentBasedConfig').mockReturnValue(false);
+		function stubPredictions(...names: string[]) {
+			vi.spyOn(grouper['_toolEmbeddingsComputer'], 'retrieveSimilarEmbeddingsForAvailableTools')
+				.mockResolvedValue(names);
+		}
 
-			const tools = [makeTool('test1'), makeTool('test2')];
-			root.contents = [...tools];
-
-			const originalContents = [...root.contents];
-			await grouper.recomputeEmbeddingRankings('query', root, CancellationToken.None);
-
-			// Should not have changed anything
-			expect(root.contents).toEqual(originalContents);
-		});
+		function embeddingsGroup(): VirtualTool {
+			return root.contents.find(c => c.name === EMBEDDINGS_GROUP_NAME) as VirtualTool;
+		}
 
 		it('should create embeddings group with predicted tools', async () => {
 			const tools = [makeTool('predicted1'), makeTool('regular1'), makeTool('predicted2'), makeTool('regular2')];
 			root.contents = [...tools];
-
-			// Mock the embeddings computer and tool retrieval
-			const embeddingsComputer = accessor.get(IEmbeddingsComputer);
-			vi.spyOn(embeddingsComputer, 'computeEmbeddings').mockResolvedValue({
-				type: EmbeddingType.text3small_512,
-				values: [{
-					type: EmbeddingType.text3small_512,
-					value: [0.1, 0.2, 0.3, 0.4, 0.5]
-				}]
-			});
-
-			vi.spyOn(grouper['_toolEmbeddingsComputer'], 'retrieveSimilarEmbeddingsForAvailableTools')
-				.mockResolvedValue(['predicted1', 'predicted2']);
+			stubQueryEmbedding();
+			stubPredictions('predicted1', 'predicted2');
 
 			await grouper.recomputeEmbeddingRankings('test query', root, CancellationToken.None);
 
-			// Should have added embeddings group at the beginning
-			expect(root.contents[0]).toBeInstanceOf(VirtualTool);
-			const embeddingsGroup = root.contents[0] as VirtualTool;
-			expect(embeddingsGroup.name).toBe('activate_embeddings');
-			expect(embeddingsGroup.description).toBe('Tools with high predicted relevancy for this query');
-			expect(embeddingsGroup.isExpanded).toBe(true);
-			expect(embeddingsGroup.metadata.canBeCollapsed).toBe(false);
-			expect(embeddingsGroup.metadata.wasExpandedByDefault).toBe(true);
-
-			// Should contain the predicted tools
-			expect(embeddingsGroup.contents).toHaveLength(2);
-			expect(embeddingsGroup.contents.map(t => t.name)).toEqual(['predicted1', 'predicted2']);
-
-			// Original tools should still be in root
-			const remainingTools = root.contents.slice(1);
-			expect(remainingTools).toEqual(tools);
+			const group = embeddingsGroup();
+			expect({
+				description: group.description,
+				isExpanded: group.isExpanded,
+				canBeCollapsed: group.metadata.canBeCollapsed,
+				wasExpandedByDefault: group.metadata.wasExpandedByDefault,
+				contents: group.contents.map(t => t.name),
+				originalToolsIntact: contentsWithoutEmbeddings(),
+			}).toEqual({
+				description: 'Tools with high predicted relevancy for this query',
+				isExpanded: true,
+				canBeCollapsed: false,
+				wasExpandedByDefault: true,
+				contents: ['predicted1', 'predicted2'],
+				originalToolsIntact: tools,
+			});
 		});
 
 		it('should replace existing embeddings group when recomputing', async () => {
 			const tools = [makeTool('tool1'), makeTool('tool2'), makeTool('tool3')];
 			root.contents = [...tools];
+			stubQueryEmbedding();
 
-			const embeddingsComputer = accessor.get(IEmbeddingsComputer);
-			vi.spyOn(embeddingsComputer, 'computeEmbeddings').mockResolvedValue({
-				type: EmbeddingType.text3small_512,
-				values: [{
-					type: EmbeddingType.text3small_512,
-					value: [0.1, 0.2, 0.3, 0.4, 0.5]
-				}]
-			});
-
-			// First call - predict tool1
-			vi.spyOn(grouper['_toolEmbeddingsComputer'], 'retrieveSimilarEmbeddingsForAvailableTools')
-				.mockResolvedValueOnce(['tool1']);
-
+			stubPredictions('tool1');
 			await grouper.recomputeEmbeddingRankings('query1', root, CancellationToken.None);
+			const first = embeddingsGroup().contents.map(t => t.name);
 
-			// Should have embeddings group with tool1
-			expect(root.contents[0]).toBeInstanceOf(VirtualTool);
-			let embeddingsGroup = root.contents[0] as VirtualTool;
-			expect(embeddingsGroup.contents).toHaveLength(1);
-			expect(embeddingsGroup.contents[0].name).toBe('tool1');
-
-			// Second call - predict tool2 and tool3
-			vi.spyOn(grouper['_toolEmbeddingsComputer'], 'retrieveSimilarEmbeddingsForAvailableTools')
-				.mockResolvedValueOnce(['tool2', 'tool3']);
-
+			stubPredictions('tool2', 'tool3');
 			await grouper.recomputeEmbeddingRankings('query2', root, CancellationToken.None);
 
-			// Should have replaced the embeddings group
-			expect(root.contents[0]).toBeInstanceOf(VirtualTool);
-			embeddingsGroup = root.contents[0] as VirtualTool;
-			expect(embeddingsGroup.contents).toHaveLength(2);
-			expect(embeddingsGroup.contents.map(t => t.name)).toEqual(['tool2', 'tool3']);
+			expect({
+				first,
+				second: embeddingsGroup().contents.map(t => t.name),
+				groupCount: root.contents.filter(c => c.name === EMBEDDINGS_GROUP_NAME).length,
+			}).toEqual({ first: ['tool1'], second: ['tool2', 'tool3'], groupCount: 1 });
 		});
 
-		it('should create empty embeddings group when no predicted tools found', async () => {
+		it('should create an empty embeddings group when nothing is predicted', async () => {
 			const tools = [makeTool('tool1'), makeTool('tool2')];
 			root.contents = [...tools];
-
-			const embeddingsComputer = accessor.get(IEmbeddingsComputer);
-			vi.spyOn(embeddingsComputer, 'computeEmbeddings').mockResolvedValue({
-				type: EmbeddingType.text3small_512,
-				values: [{
-					type: EmbeddingType.text3small_512,
-					value: [0.1, 0.2, 0.3, 0.4, 0.5]
-				}]
-			});
-
-			// Return no predicted tools
-			vi.spyOn(grouper['_toolEmbeddingsComputer'], 'retrieveSimilarEmbeddingsForAvailableTools')
-				.mockResolvedValue([]);
+			stubQueryEmbedding();
+			stubPredictions();
 
 			await grouper.recomputeEmbeddingRankings('query', root, CancellationToken.None);
 
-			// Should have added empty embeddings group at the beginning
-			expect(root.contents[0]).toBeInstanceOf(VirtualTool);
-			const embeddingsGroup = root.contents[0] as VirtualTool;
-			expect(embeddingsGroup.name).toBe('activate_embeddings');
-			expect(embeddingsGroup.contents).toHaveLength(0);
-
-			// Original tools should still be in root after the embeddings group
-			const remainingTools = root.contents.slice(1);
-			expect(remainingTools).toEqual(tools);
+			expect({
+				contents: embeddingsGroup().contents,
+				originalToolsIntact: contentsWithoutEmbeddings(),
+			}).toEqual({ contents: [], originalToolsIntact: tools });
 		});
 
-		it('should create empty embeddings group when predicted tools are not found in root', async () => {
+		it('should create an empty embeddings group when predicted tools are not in the root', async () => {
 			const tools = [makeTool('tool1'), makeTool('tool2')];
 			root.contents = [...tools];
-
-			const embeddingsComputer = accessor.get(IEmbeddingsComputer);
-			vi.spyOn(embeddingsComputer, 'computeEmbeddings').mockResolvedValue({
-				type: EmbeddingType.text3small_512,
-				values: [{
-					type: EmbeddingType.text3small_512,
-					value: [0.1, 0.2, 0.3, 0.4, 0.5]
-				}]
-			});
-
-			// Return predicted tools that don't exist in root
-			vi.spyOn(grouper['_toolEmbeddingsComputer'], 'retrieveSimilarEmbeddingsForAvailableTools')
-				.mockResolvedValue(['nonexistent1', 'nonexistent2']);
+			stubQueryEmbedding();
+			stubPredictions('nonexistent1', 'nonexistent2');
 
 			await grouper.recomputeEmbeddingRankings('query', root, CancellationToken.None);
 
-			// Should have added empty embeddings group since predicted tools don't exist in root
-			expect(root.contents[0]).toBeInstanceOf(VirtualTool);
-			const embeddingsGroup = root.contents[0] as VirtualTool;
-			expect(embeddingsGroup.name).toBe('activate_embeddings');
-			expect(embeddingsGroup.contents).toHaveLength(0);
-
-			// Original tools should still be in root after the embeddings group
-			const remainingTools = root.contents.slice(1);
-			expect(remainingTools).toEqual(tools);
+			expect({
+				contents: embeddingsGroup().contents,
+				originalToolsIntact: contentsWithoutEmbeddings(),
+			}).toEqual({ contents: [], originalToolsIntact: tools });
 		});
 
 		it('should handle errors in embeddings computation gracefully', async () => {
 			const tools = [makeTool('tool1'), makeTool('tool2')];
 			root.contents = [...tools];
-
-			// Mock embeddings computation to throw an error
-			const embeddingsComputer = accessor.get(IEmbeddingsComputer);
-			vi.spyOn(embeddingsComputer, 'computeEmbeddings').mockRejectedValue(new Error('Embeddings computation failed'));
+			vi.spyOn(accessor.get(IEmbeddingsComputer), 'computeEmbeddings')
+				.mockRejectedValue(new Error('Embeddings computation failed'));
 
 			const originalContents = [...root.contents];
 
-			// Should not throw and should not modify contents
 			await expect(grouper.recomputeEmbeddingRankings('query', root, CancellationToken.None)).resolves.toBeUndefined();
 			expect(root.contents).toEqual(originalContents);
 		});

--- a/extensions/copilot/src/extension/tools/test/node/virtualTools/virtualToolGrouping.spec.ts
+++ b/extensions/copilot/src/extension/tools/test/node/virtualTools/virtualToolGrouping.spec.ts
@@ -150,6 +150,19 @@ describe('Virtual Tools - Grouping', () => {
 			// Should not be marked as outdated since names are the same
 			expect(grouping.tools).toEqual(tools2);
 		});
+
+		it('does not regroup when the same tools are reordered', async () => {
+			const addGroups = vi.spyOn(mockGrouper, 'addGroups');
+			const tools = [makeTool('test1'), makeTool('test2')];
+			grouping.tools = tools;
+			await grouping.compute('', CancellationToken.None);
+
+			grouping.tools = [tools[1], tools[0]];
+			await grouping.compute('', CancellationToken.None);
+
+			expect({ addGroupsCalls: addGroups.mock.calls.length, stableOrder: grouping.tools.map(tool => tool.name) })
+				.toEqual({ addGroupsCalls: 1, stableOrder: ['test1', 'test2'] });
+		});
 	});
 
 	describe('compute()', () => {
@@ -280,6 +293,22 @@ describe('Virtual Tools - Grouping', () => {
 			// Second compute - should now return the expanded tools
 			result = await grouping.compute('', CancellationToken.None);
 			expect(result).toEqual(tools);
+		});
+
+		it('keeps a previously called real tool expanded after regrouping', async () => {
+			mockGrouper = createGroupingGrouper();
+			grouping = accessor.get(IInstantiationService).createInstance(TestToolGrouping, []);
+			const tools = [makeTool('file_read'), makeTool('file_write'), makeTool('file_delete')];
+			grouping.tools = tools;
+			await grouping.compute('', CancellationToken.None);
+			grouping.didCall(0, `${VIRTUAL_TOOL_NAME_PREFIX}file`);
+			await grouping.compute('', CancellationToken.None);
+			grouping.didCall(0, 'file_read');
+
+			grouping.tools = [...tools, makeTool('other_tool')];
+			const result = await grouping.compute('', CancellationToken.None);
+
+			expect(result.map(tool => tool.name)).toContain('file_read');
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fix virtual tool regrouping so registered tools remain reachable throughout long agent sessions.

- preserve tools when embeddings are unavailable, clustering produces excess singletons, or toolsets outnumber grouping slots
- keep grouping stable across tool reordering and re-expand previously used or pending tool calls after registry changes
- cap novel embedding-matched tools at the request hard limit
- report missing request-toolset calls accurately instead of attributing them to user disablement
- add regression coverage for the reported 106-tool scenario and boundary cases

Fixes #324113
