### PR TITLE
fix pet again

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatPetWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatPetWidget.ts
@@ -82,6 +82,10 @@ function getSpriteSources(): Record<ChatPetState, { animated: string; reducedMot
 	return spriteSources;
 }
 
+export function isChatPetImageSource(image: Pick<HTMLImageElement, 'getAttribute'>, source: string): boolean {
+	return image.getAttribute('src') === source;
+}
+
 export function getChatPetBaseState(hasActiveRequest: boolean, needsInput: boolean, idleExpired: boolean): ChatPetState {
 	if (needsInput) {
 		return 'clapping';
@@ -435,7 +439,7 @@ export class ChatPetWidget extends Disposable {
 	private _renderState(state: ChatPetState, restart = false): void {
 		const sources = getSpriteSources()[state];
 		const source = this._motionReduced ? sources.reducedMotion : sources.animated;
-		if (!restart && this._activeImage?.src === source) {
+		if (!restart && this._activeImage && isChatPetImageSource(this._activeImage, source)) {
 			this._button.element.dataset.state = state;
 			this._renderedState = state;
 			return;
@@ -454,7 +458,7 @@ export class ChatPetWidget extends Disposable {
 	}
 
 	private _onImageLoad(image: HTMLImageElement): void {
-		if (image !== this._pendingImage || image.src !== this._pendingSource || this._pendingState === undefined) {
+		if (image !== this._pendingImage || this._pendingSource === undefined || !isChatPetImageSource(image, this._pendingSource) || this._pendingState === undefined) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatPetWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatPetWidget.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { doesChatPetStateTrackCursor, getChatPetBaseState, getChatPetBuddyName, getChatPetClickInteraction, getChatPetGazeDirection, getChatPetHorizontalPosition, getChatPetSpriteName } from '../../../browser/widget/chatPetWidget.js';
+import { doesChatPetStateTrackCursor, getChatPetBaseState, getChatPetBuddyName, getChatPetClickInteraction, getChatPetGazeDirection, getChatPetHorizontalPosition, getChatPetSpriteName, isChatPetImageSource } from '../../../browser/widget/chatPetWidget.js';
 
 suite('ChatPetWidget', () => {
 
@@ -96,6 +96,20 @@ suite('ChatPetWidget', () => {
 		], [
 			'buddy-idle-insiders',
 			'buddy-yapping-insiders',
+		]);
+	});
+
+	test('matches sprite sources without browser URL normalization', () => {
+		const source = 'vscode-file://vscode-app/Applications/Visual Studio Code - Insiders.app/pet.gif';
+		const image = document.createElement('img');
+		image.src = source;
+
+		assert.deepStrictEqual([
+			image.src === source,
+			isChatPetImageSource(image, source),
+		], [
+			false,
+			true,
 		]);
 	});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix https://github.com/microsoft/vscode/issues/327587

The latest animation update introduced double-buffered image switching to avoid flicker between animations:

- Before: there was one visible <img>. Assigning image.src was enough for the browser to display it. The load event only restarted the eye animation, so URL normalization could not prevent the pet from appearing.
- After PR #327412: two images are created hidden. A newly loaded image is revealed only inside _onImageLoad. That handler added a stale-load guard comparing normalized image.src with the original _pendingSource string.
- In packaged builds, spaces in the application path are percent-encoded by Chromium, the comparison fails, _onImageLoad returns early, and both images remain hidden.