### PR TITLE
docs(extensions): fix GitHub org capitalization in references-view README

### DIFF
--- a/extensions/references-view/README.md
+++ b/extensions/references-view/README.md
@@ -17,7 +17,7 @@ This extension is just an alternative UI for reference search and extensions imp
 
 ## Issues
 
-This extension ships with Visual Studio Code and uses its issue tracker. Please file issue here: https://github.com/Microsoft/vscode/issues
+This extension ships with Visual Studio Code and uses its issue tracker. Please file issue here: https://github.com/microsoft/vscode/issues
 
 # Contributing
 


### PR DESCRIPTION
This PR fixes a documentation URL in the `references-view` extension README where the GitHub organization was still capitalized as `Microsoft` instead of `microsoft`.

## Changes
- Updated the issue tracker URL from `https://github.com/Microsoft/vscode/issues` to `https://github.com/microsoft/vscode/issues` in `extensions/references-view/README.md`.

This is a small docs-only correctness fix with no functional changes.