### PR TITLE
markdown: Update editor package to 0.0.2-24

### DIFF
--- a/extensions/markdown-language-features/package-lock.json
+++ b/extensions/markdown-language-features/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",
-        "@vscode/markdown-editor": "^0.0.2-21",
+        "@vscode/markdown-editor": "^0.0.2-24",
         "dompurify": "^3.4.10",
         "highlight.js": "^11.8.0",
         "katex": "^0.16.33",
@@ -632,9 +632,9 @@
       "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
     },
     "node_modules/@vscode/markdown-editor": {
-      "version": "0.0.2-21",
-      "resolved": "https://registry.npmjs.org/@vscode/markdown-editor/-/markdown-editor-0.0.2-21.tgz",
-      "integrity": "sha512-3tBsEFAYiMkdzYHnVgsgsf4tjp6xujdXLu3cf9FxCFGIQ5/hcL3rE7euN1krFuN7bMpeTYNmKyn6XELkxCsGLw==",
+      "version": "0.0.2-24",
+      "resolved": "https://registry.npmjs.org/@vscode/markdown-editor/-/markdown-editor-0.0.2-24.tgz",
+      "integrity": "sha512-EoshSD4brywRcXO43vp3yuwcPrUS6bOukU9kOEqGBFOYRSqCVhQsMMpEM6Eoum63swZCbENv6FWNF2AcNqc52g==",
       "license": "MIT",
       "dependencies": {
         "@vscode/codicons": "^0.0.45",

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -905,11 +905,11 @@
     "typecheck-web": "node ../../node_modules/@typescript/native/lib/tsc.js --project ./tsconfig.browser.json --noEmit",
     "watch-web": "npm-run-all2 -lp watch-bundle-web watch-typecheck-web",
     "watch-bundle-web": "node ./esbuild.browser.mts --watch",
-  "watch-typecheck-web": "node ../../node_modules/@typescript/native/lib/tsc.js --project ./tsconfig.browser.json --noEmit --watch"
+    "watch-typecheck-web": "node ../../node_modules/@typescript/native/lib/tsc.js --project ./tsconfig.browser.json --noEmit --watch"
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.8",
-    "@vscode/markdown-editor": "^0.0.2-21",
+    "@vscode/markdown-editor": "^0.0.2-24",
     "dompurify": "^3.4.10",
     "highlight.js": "^11.8.0",
     "katex": "^0.16.33",


### PR DESCRIPTION
## Summary

Updates `@vscode/markdown-editor` from `0.0.2-21` to the latest `next` release, `0.0.2-24`.

This targets `release/1.131`; the release branch automation can carry the change to `main`.

## Validation

- `npm run compile` in `extensions/markdown-language-features`
- `npm run precommit`