### PR TITLE
docs: fix stale relative paths in Claude chat sessions AGENTS.md

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/claude/AGENTS.md
+++ b/extensions/copilot/src/extension/chatSessions/claude/AGENTS.md
@@ -152,7 +152,7 @@ Adapts raw SDK session data into the internal `IClaudeCodeSession` / `ISubagentS
 - Deduplicates results using `ResourceSet`
 - Plugin roots are passed to the SDK as `SdkPluginConfig[]` with `{ type: 'local', path }` in `ClaudeCodeSession._doStartSession()`
 
-**Shared utility:** `../../common/skillConfigLocations.ts` — `resolveSkillConfigLocations()` handles `~/` expansion, absolute paths, and relative paths joined to workspace folders. Used by both `ClaudePluginService` and `CopilotCLISkills`.
+**Shared utility:** `../common/skillConfigLocations.ts` — `resolveSkillConfigLocations()` handles `~/` expansion, absolute paths, and relative paths joined to workspace folders. Used by both `ClaudePluginService` and `CopilotCLISkills`.
 
 ### `common/claudeTools.ts`
 
@@ -383,7 +383,7 @@ The `ClaudeChatSessionItemController` registers four git-related commands that a
 | `github.copilot.claude.sessions.sync` | Has git repo + no uncommitted changes + upstream | Sends `/sync` prompt |
 | `github.copilot.claude.sessions.initializeRepository` | No git repo | Calls `IGitService.initRepository()` on the session's workspace folder |
 
-The commit, commitAndSync, and sync commands use a shared `_registerPromptCommand()` helper that extracts the session resource and dispatches via `workbench.action.chat.openSessionWithPrompt.claude-code`. The slash command strings come from the shared `builtinSlashCommands` module (`../../common/builtinSlashCommands.ts`).
+The commit, commitAndSync, and sync commands use a shared `_registerPromptCommand()` helper that extracts the session resource and dispatches via `workbench.action.chat.openSessionWithPrompt.claude-code`. The slash command strings come from the shared `builtinSlashCommands` module (`../common/builtinSlashCommands.ts`).
 
 ## Testing
 


### PR DESCRIPTION
Two references in `extensions/copilot/src/extension/chatSessions/claude/AGENTS.md` point one directory level too high:

- `../../common/skillConfigLocations.ts` → the file lives at `chatSessions/common/skillConfigLocations.ts`, i.e. `../common/` from this file
- `../../common/builtinSlashCommands.ts` → same, `../common/builtinSlashCommands.ts`

(The `node/hooks/` references elsewhere in the file also appear stale, but I couldn't determine where that code moved, so this PR only fixes the two paths I could verify.)

Found with [unrot](https://github.com/unrot-dev/unrot), a linter for agent config files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)