### PR TITLE
Fix codex agent messages gluing together so headings render

### DIFF
--- a/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
@@ -97,6 +97,16 @@ export interface ICodexSessionMapState {
 	 * turn end) so a genuinely output-less command still finalizes.
 	 */
 	pendingPreflight: ICodexPendingPreflight | undefined;
+	/**
+	 * Number of `agentMessage` markdown parts started in the current turn. Codex
+	 * can emit several `agentMessage` items per turn (e.g. an interim
+	 * "commentary" preamble followed by the "final_answer"), each becoming its
+	 * own markdown response part. The chat model coalesces adjacent markdown
+	 * parts without a separator, so the 2nd+ message is seeded with a leading
+	 * block boundary to keep it a distinct block (see {@link mapItemStartedBody}).
+	 * Reset per turn by {@link resetCodexTurnMapState}.
+	 */
+	agentMessagePartCount: number;
 }
 
 /**
@@ -131,6 +141,7 @@ export function createCodexSessionMapState(serverToolNames: ReadonlySet<string> 
 		mcpCustomizationIds: new Map(),
 		declinedToolCalls: new Set(),
 		pendingPreflight: undefined,
+		agentMessagePartCount: 0,
 	};
 }
 
@@ -147,6 +158,7 @@ export function resetCodexTurnMapState(state: ICodexSessionMapState): void {
 	state.itemToReasoningPartId.clear();
 	state.declinedToolCalls.clear();
 	state.pendingPreflight = undefined;
+	state.agentMessagePartCount = 0;
 }
 
 /**
@@ -452,6 +464,19 @@ function mapItemStartedBody(
 	if (params.item.type === 'agentMessage') {
 		const partId = generateUuid();
 		state.itemToPartId.set(params.item.id, partId);
+		// Codex can emit several `agentMessage` items in a single turn (e.g. an
+		// interim "commentary" preamble followed by the "final_answer"), each of
+		// which becomes its own markdown response part. The chat model coalesces
+		// adjacent markdown parts by concatenating their text with no separator,
+		// which would glue the previous message's trailing text to this one
+		// (e.g. `...tradeoffs.` + `## Conclusion` -> `...tradeoffs.## Conclusion`,
+		// so the heading no longer starts a line and renders as inline text).
+		// Seed a leading block boundary on every message after the first so each
+		// renders as its own block. `phase` would in theory distinguish preamble
+		// from final answer, but providers don't emit it reliably, so we separate
+		// on position instead.
+		const separator = state.agentMessagePartCount > 0 ? '\n\n' : '';
+		state.agentMessagePartCount++;
 		return [
 			{
 				type: ActionType.ChatResponsePart,
@@ -459,7 +484,7 @@ function mapItemStartedBody(
 				part: {
 					kind: ResponsePartKind.Markdown,
 					id: partId,
-					content: params.item.text ?? '',
+					content: separator + (params.item.text ?? ''),
 				},
 			},
 		];

--- a/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
@@ -98,13 +98,8 @@ export interface ICodexSessionMapState {
 	 */
 	pendingPreflight: ICodexPendingPreflight | undefined;
 	/**
-	 * Number of `agentMessage` markdown parts started in the current turn. Codex
-	 * can emit several `agentMessage` items per turn (e.g. an interim
-	 * "commentary" preamble followed by the "final_answer"), each becoming its
-	 * own markdown response part. The chat model coalesces adjacent markdown
-	 * parts without a separator, so the 2nd+ message is seeded with a leading
-	 * block boundary to keep it a distinct block (see {@link mapItemStartedBody}).
-	 * Reset per turn by {@link resetCodexTurnMapState}.
+	 * Count of `agentMessage` markdown parts started in the current turn. Reset
+	 * per turn by {@link resetCodexTurnMapState}; see {@link mapItemStartedBody}.
 	 */
 	agentMessagePartCount: number;
 }
@@ -464,17 +459,8 @@ function mapItemStartedBody(
 	if (params.item.type === 'agentMessage') {
 		const partId = generateUuid();
 		state.itemToPartId.set(params.item.id, partId);
-		// Codex can emit several `agentMessage` items in a single turn (e.g. an
-		// interim "commentary" preamble followed by the "final_answer"), each of
-		// which becomes its own markdown response part. The chat model coalesces
-		// adjacent markdown parts by concatenating their text with no separator,
-		// which would glue the previous message's trailing text to this one
-		// (e.g. `...tradeoffs.` + `## Conclusion` -> `...tradeoffs.## Conclusion`,
-		// so the heading no longer starts a line and renders as inline text).
-		// Seed a leading block boundary on every message after the first so each
-		// renders as its own block. `phase` would in theory distinguish preamble
-		// from final answer, but providers don't emit it reliably, so we separate
-		// on position instead.
+		// Separate consecutive agent messages so the chat model's separator-less
+		// markdown coalescing doesn't glue a following heading onto the prior line.
 		const separator = state.agentMessagePartCount > 0 ? '\n\n' : '';
 		state.agentMessagePartCount++;
 		return [

--- a/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
@@ -64,6 +64,9 @@ type CommandExecutionItem = Extract<ThreadItem, { type: 'commandExecution' }>;
 function replayTurnToTurn(codexTurn: CodexTurn): Turn | undefined {
 	let userText = '';
 	const parts: ResponsePart[] = [];
+	// Separate consecutive agent messages so the chat model's separator-less
+	// markdown coalescing keeps a following heading on its own line.
+	let agentMessageCount = 0;
 	// A successful command that produced no output may be a sandbox pre-flight
 	// that codex immediately re-ran under an approval prompt (same command, new
 	// item). Defer emitting it so the re-run can coalesce into a single box —
@@ -114,10 +117,12 @@ function replayTurnToTurn(codexTurn: CodexTurn): Turn | undefined {
 			}
 		} else if (item.type === 'agentMessage') {
 			if (item.text && item.text.length > 0) {
+				const separator = agentMessageCount > 0 ? '\n\n' : '';
+				agentMessageCount++;
 				parts.push({
 					kind: ResponsePartKind.Markdown,
 					id: generateUuid(),
-					content: item.text,
+					content: separator + item.text,
 				});
 			}
 		} else if (item.type === 'webSearch') {

--- a/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
@@ -6,9 +6,17 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { createCodexSessionMapState, extractUserInputText, mapAgentMessageDelta, mapCommandExecutionOutputDelta, mapFileChangePatchUpdated, mapItemCompleted, mapItemStarted, mapMcpToolCallProgress, mapReasoningSummaryPartAdded, mapReasoningSummaryTextDelta, mapReasoningTextDelta, mapTokenUsageUpdated, mapTurnCompleted, mapTurnStarted, resetCodexTurnMapState, turnStateFromStatus } from '../../../node/codex/codexMapAppServerEvents.js';
-import { ActionType } from '../../../common/state/sessionActions.js';
-import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolResultContentType, TurnState } from '../../../common/state/sessionState.js';
+import { ActionType, type ChatAction, type SessionAction } from '../../../common/state/sessionActions.js';
+import { chatReducer } from '../../../common/state/protocol/reducers.js';
+import { ChatOriginKind, MessageKind, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolResultContentType, TurnState, type ChatState } from '../../../common/state/sessionState.js';
 import { ActiveClientToolSet } from '../../../node/activeClientState.js';
+
+/** Extracts the content of a Markdown response part emitted by a mapper action. */
+function markdownPartContent(action: SessionAction | ChatAction | undefined): string | undefined {
+	return action?.type === ActionType.ChatResponsePart && action.part.kind === ResponsePartKind.Markdown
+		? action.part.content
+		: undefined;
+}
 
 suite('codexMapAppServerEvents', () => {
 
@@ -211,6 +219,73 @@ suite('codexMapAppServerEvents', () => {
 			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
 		});
 		assert.strictEqual(state.itemToPartId.size, 0);
+	});
+
+	test('second agentMessage in a turn is seeded with a leading block separator', () => {
+		const state = createCodexSessionMapState();
+		const first = mapItemStarted(state, {
+			item: { type: 'agentMessage', id: 'm1', text: 'Consolidating the recommendation and tradeoffs.', phase: null, memoryCitation: null },
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const second = mapItemStarted(state, {
+			item: { type: 'agentMessage', id: 'm2', text: '## Conclusion', phase: null, memoryCitation: null },
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		assert.deepStrictEqual({
+			first: markdownPartContent(first[0]),
+			second: markdownPartContent(second[0]),
+		}, {
+			first: 'Consolidating the recommendation and tradeoffs.',
+			second: '\n\n## Conclusion',
+		});
+	});
+
+	test('agentMessage block separator counter resets per turn', () => {
+		const state = createCodexSessionMapState();
+		mapItemStarted(state, { item: { type: 'agentMessage', id: 'm1', text: 'a', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0 });
+		mapItemStarted(state, { item: { type: 'agentMessage', id: 'm2', text: 'b', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0 });
+		// A new turn resets the per-turn bookkeeping, so its first agentMessage is
+		// not seeded with a separator.
+		resetCodexTurnMapState(state);
+		const firstOfNextTurn = mapItemStarted(state, { item: { type: 'agentMessage', id: 'm3', text: 'c', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_b', startedAtMs: 0 });
+		assert.strictEqual(markdownPartContent(firstOfNextTurn[0]), 'c');
+	});
+
+	test('adjacent agentMessages keep a Markdown heading on its own line after coalescing', () => {
+		const state = createCodexSessionMapState();
+		let chat: ChatState = {
+			resource: 'ahp-chat://test',
+			title: 'Test',
+			status: SessionStatus.Idle,
+			modifiedAt: new Date(0).toISOString(),
+			origin: { kind: ChatOriginKind.User },
+			turns: [],
+			activeTurn: undefined,
+		};
+		const apply = (actions: readonly (SessionAction | ChatAction)[]) => {
+			for (const action of actions) {
+				chat = chatReducer(chat, action as ChatAction);
+			}
+		};
+		apply(mapTurnStarted(state, {
+			threadId: 'thr_1',
+			turn: { id: 'turn_a', items: [], itemsView: { type: 'full' } as never, status: 'inProgress' as never, error: null, startedAt: null, completedAt: null, durationMs: null },
+		}, 'prompt'));
+		// Preamble (commentary) message, then the final-answer message; both
+		// arrive as distinct codex `agentMessage` items with no separator of
+		// their own.
+		apply(mapItemStarted(state, { item: { type: 'agentMessage', id: 'm1', text: '', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0 }));
+		apply(mapAgentMessageDelta(state, { threadId: 'thr_1', turnId: 'turn_a', itemId: 'm1', delta: 'Consolidating the recommendation and tradeoffs.' }));
+		apply(mapItemStarted(state, { item: { type: 'agentMessage', id: 'm2', text: '', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0 }));
+		apply(mapAgentMessageDelta(state, { threadId: 'thr_1', turnId: 'turn_a', itemId: 'm2', delta: '## Conclusion\n\nDone.' }));
+
+		// The chat model coalesces adjacent markdown parts by plain concatenation
+		// (appendMarkdownString), so the joined text must keep `## Conclusion` at
+		// the start of a line for it to render as a heading rather than inline.
+		const joined = (chat.activeTurn?.responseParts ?? [])
+			.map(part => part.kind === ResponsePartKind.Markdown ? part.content : '')
+			.join('');
+		assert.strictEqual(joined, 'Consolidating the recommendation and tradeoffs.\n\n## Conclusion\n\nDone.');
 	});
 
 	test('item/started for commandExecution emits ChatToolCallStart + Delta + Ready and registers tool-call entry', () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
@@ -244,8 +244,7 @@ suite('codexMapAppServerEvents', () => {
 		const state = createCodexSessionMapState();
 		mapItemStarted(state, { item: { type: 'agentMessage', id: 'm1', text: 'a', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0 });
 		mapItemStarted(state, { item: { type: 'agentMessage', id: 'm2', text: 'b', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0 });
-		// A new turn resets the per-turn bookkeeping, so its first agentMessage is
-		// not seeded with a separator.
+		// A new turn resets the counter, so its first agentMessage is unseeded.
 		resetCodexTurnMapState(state);
 		const firstOfNextTurn = mapItemStarted(state, { item: { type: 'agentMessage', id: 'm3', text: 'c', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_b', startedAtMs: 0 });
 		assert.strictEqual(markdownPartContent(firstOfNextTurn[0]), 'c');
@@ -271,17 +270,14 @@ suite('codexMapAppServerEvents', () => {
 			threadId: 'thr_1',
 			turn: { id: 'turn_a', items: [], itemsView: { type: 'full' } as never, status: 'inProgress' as never, error: null, startedAt: null, completedAt: null, durationMs: null },
 		}, 'prompt'));
-		// Preamble (commentary) message, then the final-answer message; both
-		// arrive as distinct codex `agentMessage` items with no separator of
-		// their own.
+		// Preamble message, then the final-answer message; two distinct items.
 		apply(mapItemStarted(state, { item: { type: 'agentMessage', id: 'm1', text: '', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0 }));
 		apply(mapAgentMessageDelta(state, { threadId: 'thr_1', turnId: 'turn_a', itemId: 'm1', delta: 'Consolidating the recommendation and tradeoffs.' }));
 		apply(mapItemStarted(state, { item: { type: 'agentMessage', id: 'm2', text: '', phase: null, memoryCitation: null }, threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0 }));
 		apply(mapAgentMessageDelta(state, { threadId: 'thr_1', turnId: 'turn_a', itemId: 'm2', delta: '## Conclusion\n\nDone.' }));
 
-		// The chat model coalesces adjacent markdown parts by plain concatenation
-		// (appendMarkdownString), so the joined text must keep `## Conclusion` at
-		// the start of a line for it to render as a heading rather than inline.
+		// Adjacent markdown parts are coalesced by plain concatenation, so the
+		// joined text must keep `## Conclusion` at the start of a line.
 		const joined = (chat.activeTurn?.responseParts ?? [])
 			.map(part => part.kind === ResponsePartKind.Markdown ? part.content : '')
 			.join('');

--- a/src/vs/platform/agentHost/test/node/codex/codexReplayMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexReplayMapper.test.ts
@@ -106,6 +106,30 @@ suite('codexReplayMapper', () => {
 		assert.deepStrictEqual(turns.map(t => t.id), ['t1', 't2']);
 	});
 
+	test('adjacent agentMessages in a turn are separated so a heading keeps its own line', () => {
+		const turns = replayThreadToTurns({
+			id: 'thr',
+			turns: [{
+				id: 'turn_a',
+				items: [
+					{ type: 'userMessage', id: 'u', content: [{ type: 'text', text: 'go on', text_elements: [] }] },
+					{ type: 'agentMessage', id: 'm1', text: 'Consolidating the recommendation and tradeoffs.', phase: null, memoryCitation: null },
+					{ type: 'agentMessage', id: 'm2', text: '## Conclusion\n\nDone.', phase: null, memoryCitation: null },
+				],
+				itemsView: { type: 'full' } as never,
+				status: 'completed' as never,
+				error: null, startedAt: null, completedAt: null, durationMs: null,
+			}],
+		} as never);
+		// History replay emits one markdownContent per Markdown part; the chat
+		// model coalesces adjacent ones by plain concatenation, so the joined
+		// text must keep `## Conclusion` at the start of a line.
+		const joined = turns[0].responseParts
+			.map(part => part.kind === ResponsePartKind.Markdown ? (part as { content: string }).content : '')
+			.join('');
+		assert.strictEqual(joined, 'Consolidating the recommendation and tradeoffs.\n\n## Conclusion\n\nDone.');
+	});
+
 	test('commandExecution renders a completed terminal tool call', () => {
 		const turns = replayThreadToTurns({
 			id: 'thr',


### PR DESCRIPTION
## Problem

In an Agent Host **codex** session, a final-answer heading rendered glued to the previous message text — e.g. `…design recommendation and tradeoffs.## Conclusion`. Because `## Conclusion` was no longer at the start of a line, markdown rendered it as inline text instead of an `<h2>` heading.

## Root cause

Codex emits **multiple `agentMessage` items in a single turn** (an interim "commentary" preamble, then the "final_answer"). Each becomes its own `ResponsePartKind.Markdown` response part in [`codexMapAppServerEvents.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts).

When these parts are streamed to the chat UI, each emits `markdownContent` progress, and the chat model coalesces **adjacent** `markdownContent` parts via `appendMarkdownString` (`chatModel.ts`), which concatenates with **no separator** (`md1.value + md2.value`). So `…tradeoffs.` + `## Conclusion` became `…tradeoffs.## Conclusion`.

This affected every render path (live streaming, reconnect, and history), since they all read `part.content` and rely on the same coalescing.

## Fix

Seed a `\n\n` block boundary into the **2nd+** codex `agentMessage` part of a turn, at the mapper (`mapItemStartedBody`), tracked by a new per-turn `agentMessagePartCount` on the map state (reset in `resetCodexTurnMapState`). Two distinct codex messages are distinct blocks, so a blank-line boundary between them is always correct. Because the separator lives in `part.content`, this single change fixes all three render paths and is unit-testable end-to-end (mapper → reducer → coalescing).

`MessagePhase` (`"commentary"`/`"final_answer"`) would in theory distinguish preamble from final answer, but it's documented as unreliable (may be `null`), so we separate on **position** instead.

## Testing

- New unit tests in `codexMapAppServerEvents.test.ts`: separator on 2nd message, per-turn counter reset, and an end-to-end assertion through the real chat reducer that `## Conclusion` stays on its own line after coalescing.
- `npm run typecheck-client`: clean.
- Pre-commit hygiene: clean.
- **Verified in a running Code OSS build**: rendered the pre-fix (`…tradeoffs.## Conclusion`) and post-fix (`…tradeoffs.\n\n## Conclusion`) strings through VS Code's actual `markdownRenderer` — pre-fix produces no `<h2>` (inline text), post-fix produces a proper `Conclusion` heading.