### PR TITLE
Make the deterministic shell command E2E test platform-neutral

### DIFF
--- a/src/vs/platform/agentHost/test/node/capiReplayProxyShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/capiReplayProxyShellTools.test.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { expandShellToolName, normalizeShellToolNameForCapture } from './e2e/harness/capiReplayProxy.js';
+
+/**
+ * The Copilot CLI names its shell tools after the shell it runs, so a capture
+ * recorded on one platform would otherwise instruct the agent to call a tool
+ * that does not exist on the other. Captures store a platform-neutral
+ * placeholder and expand it on replay.
+ *
+ * Both directions are asserted for both platforms here because the replay side
+ * of this round-trip is otherwise only exercised on the platform the developer
+ * happens to be using.
+ */
+suite('capiReplayProxy shell tool names', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('captures store platform-neutral placeholders', () => {
+		assert.deepStrictEqual([
+			'bash', 'powershell',
+			'read_bash', 'read_powershell',
+			'write_bash', 'write_powershell',
+			'stop_bash', 'stop_powershell',
+			'list_bash', 'list_powershell',
+			'bash_shutdown', 'powershell_shutdown',
+		].map(normalizeShellToolNameForCapture), [
+			'${shell}', '${shell}',
+			'${read_shell}', '${read_shell}',
+			'${write_shell}', '${write_shell}',
+			'${stop_shell}', '${stop_shell}',
+			'${list_shell}', '${list_shell}',
+			'${shell_shutdown}', '${shell_shutdown}',
+		]);
+	});
+
+	test('replay expands placeholders to the running platform', () => {
+		const placeholders = ['${shell}', '${read_shell}', '${write_shell}', '${stop_shell}', '${list_shell}', '${shell_shutdown}'];
+		assert.deepStrictEqual({
+			win32: placeholders.map(name => expandShellToolName(name, 'win32')),
+			posix: placeholders.map(name => expandShellToolName(name, 'linux')),
+		}, {
+			win32: ['powershell', 'read_powershell', 'write_powershell', 'stop_powershell', 'list_powershell', 'powershell_shutdown'],
+			posix: ['bash', 'read_bash', 'write_bash', 'stop_bash', 'list_bash', 'bash_shutdown'],
+		});
+	});
+
+	test('names that do not vary by platform are left alone', () => {
+		// Claude's `Bash` and Codex's `shell` are fixed strings their SDKs use
+		// everywhere; rewriting them would hide a genuine provider change.
+		const untouched = ['Bash', 'shell', 'Read', 'view', 'create', 'str_replace_editor'];
+		assert.deepStrictEqual({
+			normalized: untouched.map(normalizeShellToolNameForCapture),
+			expanded: untouched.map(name => expandShellToolName(name, 'win32')),
+		}, {
+			normalized: untouched,
+			expanded: untouched,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -25,11 +25,15 @@ Capability skips are tracked separately from suspected bugs. A provider that doe
 
 Distinct from individually disabled tests: whole areas where a platform or contract has no E2E coverage at all. These do not show up as skipped tests, so they are easy to miss.
 
-### Snapshot text is not normalized for line endings
+### The user name is scrubbed by naive substring replacement
 
-`normalizeSnapshotText` in `ahpSnapshot.ts` rewrites working directories, home directories, user names, shell ids, and `ls -l` listing columns, but does nothing about line endings. Most snapshots are unaffected because the `behavior` profile records no tool output, but a few carry literal `content: |-` blocks.
+`normalizeSnapshotText` in `ahpSnapshot.ts` ends with `.replaceAll(normalization.userName, '${user}')`. That is an unanchored substring replacement, so any occurrence of the account name in captured text is rewritten, whether or not it refers to the user.
 
-Any such block recorded on macOS or Linux will mismatch on Windows if the text is produced with CRLF, for a reason unrelated to the behavior under test — and it will be easy to misread as a product bug. Collapsing `\r\n` to `\n` (and trimming trailing whitespace per line) during snapshot normalization removes a whole class of confusing Windows-only failures for two lines of code. Worth doing before enabling more Windows coverage, not after.
+This is a cross-platform hazard because the account name differs per environment: a developer's own name locally, `runner` on GitHub Actions Linux, `runneradmin` on Windows. `runner` in particular is an ordinary English word, so a snapshot recorded on macOS keeps the literal text while the same run on Linux CI normalizes it to `${user}`, and the snapshot mismatches for a reason unrelated to the behavior under test.
+
+Verified against the current implementation with `userName: 'runner'`: the tool output `the runner completed` serializes as `the ${user} completed`.
+
+Home directory paths are already handled by the `${homedir}` replacement that runs just before this one, so the bare user-name pass is only needed for occurrences outside a home path. Restricting it to path-like contexts (preceded by a separator) would keep that coverage without corrupting prose. Left alone for now because no committed snapshot currently trips it — fix it alongside the first test that does.
 
 ### Windows has no permission, shell, or worktree coverage
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -35,28 +35,25 @@ Verified against the current implementation with `userName: 'runner'`: the tool 
 
 Home directory paths are already handled by the `${homedir}` replacement that runs just before this one, so the bare user-name pass is only needed for occurrences outside a home path. Restricting it to path-like contexts (preceded by a separator) would keep that coverage without corrupting prose. Left alone for now because no committed snapshot currently trips it — fix it alongside the first test that does.
 
-### Windows has no permission, shell, or worktree coverage
+### What is still Windows-scoped, and why
 
-`shellToolReplayEnabled` is computed as `!isWindows && ...` — an *unconditional* Windows exclusion, not a per-provider or per-capture one. Everything downstream of it is therefore untested on Windows for every provider, including `tool call triggers permission request and can be approved`, which is the only E2E test of the permission-approval flow.
+The blanket `!isWindows` shell exclusion is gone: `portableShellToolReplayEnabled` now only reflects the provider's shell-tool replay stability on Linux, and every capture that runs a shell command is portable. Permission approval, file operations, renames, deletes, directory creation, and git status all run on Windows.
 
-The individual rows in [Windows shell and filesystem behavior](#windows-shell-and-filesystem-behavior) each look like a small portable-shell problem. Collectively they mean the Windows CI leg validates strictly less of the product than the macOS and Linux legs, in the areas most likely to be platform-specific. That is the inverse of what a cross-platform matrix is for.
+Two things remain deliberately scoped, both at the call site with a comment:
 
-Reducing this does not require making the recorded POSIX commands portable. Permission approval, worktree resolution, and terminal lifecycle can be exercised with host-executed commands (bang commands) and conformance-tier tests that do not depend on what the model chose to type into a shell.
+- `worktree session uses the resolved worktree as working directory` — cannot be fixed by pinning. `pwd` is auto-approved as a safe read-only command, while a pinned `node -e "…"` is not, so the turn stops on a permission prompt the test never answers. The assertions also compare POSIX-shaped paths. Worktree resolution itself is still asserted on Windows through the `sessionAdded` working-directory check in the same test's non-shell half.
+- `session configuration resolves and completes git branches` — Windows retains a handle on the temporary git repository after session disposal. This is mandatory file locking, a genuine OS difference, and nothing about command portability affects it.
 
-Where a scenario genuinely needs to run a command, prefer one that behaves the same under `cmd`/PowerShell and POSIX shells. `node -e "…"` (or a `.js` file seeded into the workspace and invoked as `node script.js`) is always available, since the suite already runs under Node. That keeps the real terminal tool, sandbox, streaming, and exit-code paths under test while removing the platform coupling.
+### Steering versus pinning
 
-#### Porting a shell-dependent test: what actually has to change
+Two techniques, and the choice is not stylistic:
 
-`runs a deterministic shell command` was ported first as a prototype. Three separate things coupled it to POSIX, and a fourth surfaced while re-recording. Expect to check all of them:
+- **Steer** (`Use your file tools; do not run a shell command.`) where a file tool exists for the operation. Reads, edits, missing-file handling, and content creation all took the hint, and the resulting capture contains no shell command at all — the strongest possible outcome, since there is nothing left to be platform-specific.
+- **Pin** (`Run exactly this shell command, with no modifications: …`) where no file tool exists. Rename, delete, directory creation, and listing have no file-tool equivalent, so every provider reaches for the shell and picks a POSIX command. Steering these harder made one provider skip the operation entirely rather than use a different tool.
 
-1. **The prompt.** It described the command rather than specifying it, so the model chose one per provider and whatever it chose was frozen into the fixture — Copilot picked `echo SHELL_VALUE_73`, Claude picked `printf '%s\n' "SHELL_VALUE_73"`. The test was disabled on Windows for *all three* providers because of Claude's choice, even though Copilot's capture would have run there unmodified. Pin the command in the prompt.
-2. **The tool name in the AHP snapshot.** The Copilot CLI names its shell tools after the shell it runs (`bash` on POSIX, `powershell` on Windows), and that name reaches the client verbatim in `chat/toolCallStart`. Snapshots now record `${shell}`.
-3. **The tool name in the CAPI fixture.** The same name appears in the `tool_use` block that *drives* replay, so a macOS recording would instruct a Windows agent to call a tool that does not exist. Captures now store the placeholder and `CapiReplayProxy` expands it to the running platform's name on replay. Covered by `capiReplayProxyShellTools.test.ts`, which asserts both directions for both platforms — the replay half is otherwise only exercised on whichever platform the developer happens to use.
-4. **Empty reasoning parts.** A provider can open a reasoning part and close it without emitting a delta. Live recording sees it; replay rebuilds the stream from the fixture's aggregated content, where it leaves no trace. Any snapshot recorded during such a turn was permanently unreplayable. These are now dropped during projection.
+Pinning uses `node -e "…"`, which is guaranteed present because the suite runs under Node, and whose `"…"` / `'…'` quoting is read identically by `cmd` and POSIX shells. Prefer relative paths in a pinned command so no Windows path with backslashes has to be escaped into a JavaScript string literal.
 
-Only (1) is per-test work. (2), (3) and (4) are fixed centrally and should not need revisiting.
-
-Note that after this the *snapshot* for a ported test contains no command string and no tool output at all — the `behavior` profile records neither — so what remains platform-specific is only whether the command itself succeeds.
+The trade-off is real: a pinned command tests shell execution rather than the provider's tool selection. Pin only when steering has actually been tried and failed, and note which it was.
 
 ### Recorded model requests are never asserted
 
@@ -160,25 +157,14 @@ These four are the actionable item: until they are recorded, the reason Codex sk
 
 ### Windows shell and filesystem behavior
 
-The committed model captures can select POSIX shell commands, and several host-owned shell behaviors differ on Windows. These tests remain enabled on unaffected providers and platforms.
+Most of this section is resolved — see [What is still Windows-scoped, and why](#what-is-still-windows-scoped-and-why). Thirteen tests that were disabled on Windows because their capture contained a POSIX-only command now run there.
+
+Two rows remain, and neither is about command portability:
 
 | Test | Disabled scope | Observed limitation |
 |---|---|---|
 | `a bang command runs locally and exposes terminal output` | Windows | The successful bang command produces output but does not complete reliably. |
 | `session configuration resolves and completes git branches` | Windows | Git-backed config discovery can retain the temporary repository lock after session disposal. |
-| `worktree session uses the resolved worktree as working directory` | Windows | The recorded paths and `pwd` behavior are POSIX-shaped. |
-| `tool call triggers permission request and can be approved` | Windows | The scenario executes a recorded shell command. |
-| `lists workspace entries` | Windows | The scenario depends on provider shell execution. |
-| `counts lines in a file` | Windows | The scenario depends on provider shell execution. |
-| `renames a workspace file` | Windows | The scenario depends on provider shell execution. |
-| `reads a file from a nested directory` | Copilot on Windows | The Copilot capture uses shell behavior that is not portable to Windows. |
-| `handles a missing file without a session error` | Copilot on Windows | The Copilot capture uses shell behavior that is not portable to Windows. |
-| `creates a file in a new nested directory` | Copilot on Windows | The Copilot capture uses a POSIX shell. |
-| `inspects git status` | Copilot on Windows | The scenario depends on provider shell execution. |
-| `edits an existing text file` | Claude on Windows | The scenario depends on provider shell execution. |
-| `deletes a workspace file` | Claude on Windows | The scenario depends on provider shell execution. |
-| `peer chat edits an existing workspace file` | Copilot on Windows | Replay completes, but the recorded tool plan does not mutate the Windows file. |
-| `peer chat creates a file in a nested directory` | Copilot on Windows | Replay completes, but the recorded tool plan does not create the Windows file. |
 
 Use the affected provider command with `--grep "<exact test title>"` and temporarily remove the platform gate to reevaluate a row.
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -55,6 +55,16 @@ Pinning uses `node -e "…"`, which is guaranteed present because the suite runs
 
 The trade-off is real: a pinned command tests shell execution rather than the provider's tool selection. Pin only when steering has actually been tried and failed, and note which it was.
 
+### Recording rejects POSIX-only commands
+
+`CapiReplayProxy` checks the assistant's `tool_use` commands before writing a fixture and fails the recording if any of them cannot run under `cmd`. It throws before the write, so a rejected recording cannot leave a half-portable capture behind.
+
+This exists because the failure mode is silent and recurring: nobody chooses these command strings, the model produces them, so a prompt that drifts back toward describing the goal will quietly reintroduce a POSIX-only capture. Checking at record time puts the error on the author's machine while they still have the context, rather than on a CI leg they may not run.
+
+The check is a blocklist of constructs known to fail under `cmd` — coreutils and shell builtins in command position, POSIX stderr redirection, `/dev/*`, `$VAR` expansion, `~/`. It is deliberately not an allowlist of portable commands: a false positive would block a correct recording and push authors toward disabling the check, which is worse than missing a case. Patterns are anchored to command position so a coreutil name appearing as an argument (`node -e "readdirSync('.')"`) does not trip it.
+
+Genuine exceptions go in `POSIX_COMMAND_EXCEPTIONS` in `agentHostE2ETestHarness.ts`, which keeps them countable in one place. An entry there must correspond to a test that is also scoped away from Windows at its call site, with the reason stated there.
+
 ### Recorded model requests are never asserted
 
 `CapiReplayProxy` matches purely ordinally: the Nth request to a given `(method, path)` replays the Nth recorded response. The recorded `request:` block in a capture is normalized on write (for review and diff stability) but is never read back — `exchange.request` is only touched by `_writeFixture`. Replay is therefore driven entirely by the recorded responses.

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -45,6 +45,19 @@ Reducing this does not require making the recorded POSIX commands portable. Perm
 
 Where a scenario genuinely needs to run a command, prefer one that behaves the same under `cmd`/PowerShell and POSIX shells. `node -e "…"` (or a `.js` file seeded into the workspace and invoked as `node script.js`) is always available, since the suite already runs under Node. That keeps the real terminal tool, sandbox, streaming, and exit-code paths under test while removing the platform coupling.
 
+#### Porting a shell-dependent test: what actually has to change
+
+`runs a deterministic shell command` was ported first as a prototype. Three separate things coupled it to POSIX, and a fourth surfaced while re-recording. Expect to check all of them:
+
+1. **The prompt.** It described the command rather than specifying it, so the model chose one per provider and whatever it chose was frozen into the fixture — Copilot picked `echo SHELL_VALUE_73`, Claude picked `printf '%s\n' "SHELL_VALUE_73"`. The test was disabled on Windows for *all three* providers because of Claude's choice, even though Copilot's capture would have run there unmodified. Pin the command in the prompt.
+2. **The tool name in the AHP snapshot.** The Copilot CLI names its shell tools after the shell it runs (`bash` on POSIX, `powershell` on Windows), and that name reaches the client verbatim in `chat/toolCallStart`. Snapshots now record `${shell}`.
+3. **The tool name in the CAPI fixture.** The same name appears in the `tool_use` block that *drives* replay, so a macOS recording would instruct a Windows agent to call a tool that does not exist. Captures now store the placeholder and `CapiReplayProxy` expands it to the running platform's name on replay. Covered by `capiReplayProxyShellTools.test.ts`, which asserts both directions for both platforms — the replay half is otherwise only exercised on whichever platform the developer happens to use.
+4. **Empty reasoning parts.** A provider can open a reasoning part and close it without emitting a delta. Live recording sees it; replay rebuilds the stream from the fixture's aggregated content, where it leaves no trace. Any snapshot recorded during such a turn was permanently unreplayable. These are now dropped during projection.
+
+Only (1) is per-test work. (2), (3) and (4) are fixed centrally and should not need revisiting.
+
+Note that after this the *snapshot* for a ported test contains no command string and no tool output at all — the `behavior` profile records neither — so what remains platform-specific is only whether the command itself succeeds.
+
 ### Recorded model requests are never asserted
 
 `CapiReplayProxy` matches purely ordinally: the Nth request to a given `(method, path)` replays the Nth recorded response. The recorded `request:` block in a capture is normalized on write (for review and diff stability) but is never read back — `exchange.request` is only touched by `_writeFixture`. Replay is therefore driven entirely by the recorded responses.
@@ -158,7 +171,6 @@ The committed model captures can select POSIX shell commands, and several host-o
 | `lists workspace entries` | Windows | The scenario depends on provider shell execution. |
 | `counts lines in a file` | Windows | The scenario depends on provider shell execution. |
 | `renames a workspace file` | Windows | The scenario depends on provider shell execution. |
-| `runs a deterministic shell command` | Windows | The scenario directly exercises a shell command. |
 | `reads a file from a nested directory` | Copilot on Windows | The Copilot capture uses shell behavior that is not portable to Windows. |
 | `handles a missing file without a session error` | Copilot on Windows | The Copilot capture uses shell behavior that is not portable to Windows. |
 | `creates a file in a new nested directory` | Copilot on Windows | The Copilot capture uses a POSIX shell. |

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-counts-lines-in-a-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-counts-lines-in-a-file.yaml
@@ -6,74 +6,33 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Count the lines in lines.txt and reply with the number only.
+          content: Count the lines in lines.txt and reply with the number only. Use your file tools; do not run a shell command.
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: Bash
-          input:
-            command: wc -l < ${workdir}/ahp-coverage-lines-${temp}/lines.txt
-            description: Count lines in lines.txt
-      stopReason: tool_use
-  - request:
-      model: claude-opus-4.8
-      system: ${system}
-      messages:
-        - role: user
-          content: Count the lines in lines.txt and reply with the number only.
-        - role: assistant
-          content:
-            - type: thinking
-            - type: tool_use
-              name: Bash
-              input:
-                command: wc -l < ${workdir}/ahp-coverage-lines-${temp}/lines.txt
-                description: Count lines in lines.txt
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_0
-              content: '4'
-    response:
-      content:
-        - type: tool_use
-          id: toolcall_1
           name: Read
           input:
-            file_path: ${workdir}/ahp-coverage-lines-${temp}/lines.txt
+            file_path: ${workdir}/lines.txt
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Count the lines in lines.txt and reply with the number only.
-        - role: assistant
-          content:
-            - type: thinking
-            - type: tool_use
-              name: Bash
-              input:
-                command: wc -l < ${workdir}/ahp-coverage-lines-${temp}/lines.txt
-                description: Count lines in lines.txt
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_0
-              content: '4'
+          content: Count the lines in lines.txt and reply with the number only. Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: thinking
             - type: tool_use
               name: Read
               input:
-                file_path: ${workdir}/ahp-coverage-lines-${temp}/lines.txt
+                file_path: ${workdir}/lines.txt
         - role: user
           content:
             - type: tool_result
-              tool_use_id: toolcall_1
-              content: "1\tone\n2\ttwo\n3\tthree\n4\tfour\n5"
+              tool_use_id: toolcall_0
+              content: "1\tone\n2\ttwo\n3\tthree\n4\tfour"
     response:
       content: '4'
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-creates-a-file-in-a-new-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-creates-a-file-in-a-new-nested-directory.yaml
@@ -6,38 +6,35 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Create output/report.txt containing exactly NESTED_CREATED.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
     response:
       content:
-        - type: text
-          text: I'll create that file for you.
         - type: tool_use
           id: toolcall_0
-          name: Write
+          name: Bash
           input:
-            file_path: ${workdir}/ahp-coverage-nested-create-${temp}/output/report.txt
-            content: NESTED_CREATED
+            command: node -e "const fs=require('fs');fs.mkdirSync('output',{recursive:true});fs.writeFileSync('output/report.txt','NESTED_CREATED')"
+            description: Create output dir and write report file
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Create output/report.txt containing exactly NESTED_CREATED.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
         - role: assistant
           content:
-            - type: text
-              text: I'll create that file for you.
+            - type: thinking
             - type: tool_use
-              name: Write
+              name: Bash
               input:
-                file_path: ${workdir}/ahp-coverage-nested-create-${temp}/output/report.txt
-                content: NESTED_CREATED
+                command: node -e "const fs=require('fs');fs.mkdirSync('output',{recursive:true});fs.writeFileSync('output/report.txt','NESTED_CREATED')"
+                description: Create output dir and write report file
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: 'File created successfully at: ${workdir}/ahp-coverage-nested-create-${temp}/output/report.txt (file state is current in your context — no need to Read it back)'
+              content: (Bash completed with no output)
     response:
-      content: Created `output/report.txt` containing exactly `NESTED_CREATED`.
+      content: created
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-creates-a-new-text-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-creates-a-new-text-file.yaml
@@ -10,12 +10,12 @@ exchanges:
     response:
       content:
         - type: text
-          text: I'll create that file for you.
+          text: I'll create that file.
         - type: tool_use
           id: toolcall_0
           name: Write
           input:
-            file_path: ${workdir}/ahp-coverage-create-${temp}/result.txt
+            file_path: ${workdir}/result.txt
             content: CREATED_VALUE
       stopReason: tool_use
   - request:
@@ -27,17 +27,17 @@ exchanges:
         - role: assistant
           content:
             - type: text
-              text: I'll create that file for you.
+              text: I'll create that file.
             - type: tool_use
               name: Write
               input:
-                file_path: ${workdir}/ahp-coverage-create-${temp}/result.txt
+                file_path: ${workdir}/result.txt
                 content: CREATED_VALUE
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: 'File created successfully at: ${workdir}/ahp-coverage-create-${temp}/result.txt (file state is current in your context — no need to Read it back)'
+              content: 'File created successfully at: ${workdir}/result.txt (file state is current in your context — no need to Read it back)'
     response:
       content: Created `result.txt` containing exactly `CREATED_VALUE`.
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-deletes-a-workspace-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-deletes-a-workspace-file.yaml
@@ -6,83 +6,35 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Delete delete-me.txt.
+          content: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').unlinkSync(''delete-me.txt'')"`. Then reply with exactly "deleted".'
     response:
       content:
         - type: tool_use
           id: toolcall_0
           name: Bash
           input:
-            command: ls -la ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt && cat ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt
-            description: Inspect delete-me.txt before deleting
+            command: node -e "require('fs').unlinkSync('delete-me.txt')"
+            description: Delete delete-me.txt file
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Delete delete-me.txt.
+          content: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').unlinkSync(''delete-me.txt'')"`. Then reply with exactly "deleted".'
         - role: assistant
           content:
             - type: thinking
             - type: tool_use
               name: Bash
               input:
-                command: ls -la ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt && cat ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt
-                description: Inspect delete-me.txt before deleting
+                command: node -e "require('fs').unlinkSync('delete-me.txt')"
+                description: Delete delete-me.txt file
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                -rw-r--r--@ 1 ${user}  staff  12 ${timestamp} ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt
-                DELETE_VALUE
-    response:
-      content:
-        - type: text
-          text: The file contains a placeholder value (`DELETE_VALUE`), consistent with its name. Deleting it.
-        - type: tool_use
-          id: toolcall_1
-          name: Bash
-          input:
-            command: rm ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt
-            description: Delete delete-me.txt
-      stopReason: tool_use
-  - request:
-      model: claude-opus-4.8
-      system: ${system}
-      messages:
-        - role: user
-          content: Delete delete-me.txt.
-        - role: assistant
-          content:
-            - type: thinking
-            - type: tool_use
-              name: Bash
-              input:
-                command: ls -la ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt && cat ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt
-                description: Inspect delete-me.txt before deleting
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_0
-              content: |-
-                -rw-r--r--@ 1 ${user}  staff  12 ${timestamp} ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt
-                DELETE_VALUE
-        - role: assistant
-          content:
-            - type: text
-              text: The file contains a placeholder value (`DELETE_VALUE`), consistent with its name. Deleting it.
-            - type: tool_use
-              name: Bash
-              input:
-                command: rm ${workdir}/ahp-coverage-delete-${temp}/delete-me.txt
-                description: Delete delete-me.txt
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_1
               content: (Bash completed with no output)
     response:
-      content: Done — `delete-me.txt` is deleted.
+      content: deleted
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-edits-an-existing-text-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-edits-an-existing-text-file.yaml
@@ -6,147 +6,73 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Replace the complete contents of edit.txt with AFTER_VALUE.
+          content: Replace the complete contents of edit.txt with AFTER_VALUE. Use your file tools; do not run a shell command.
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: Bash
+          name: Read
           input:
-            command: cat AFTER_VALUE 2>/dev/null; echo "---SEP---"; cat edit.txt 2>/dev/null; echo "---LS---"; ls -la
-            description: Show AFTER_VALUE and edit.txt contents
+            file_path: ${workdir}/edit.txt
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Replace the complete contents of edit.txt with AFTER_VALUE.
+          content: Replace the complete contents of edit.txt with AFTER_VALUE. Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: thinking
             - type: tool_use
-              name: Bash
+              name: Read
               input:
-                command: cat AFTER_VALUE 2>/dev/null; echo "---SEP---"; cat edit.txt 2>/dev/null; echo "---LS---"; ls -la
-                description: Show AFTER_VALUE and edit.txt contents
+                file_path: ${workdir}/edit.txt
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                ---SEP---
-                BEFORE_VALUE---LS---
-                total 8
-                drwx------@    3 ${user}  staff      96 ${timestamp} .
-                drwx------@ 3639 ${user}  staff  116448 ${timestamp} ..
-                -rw-r--r--@    1 ${user}  staff      12 ${timestamp} edit.txt
+              content: "1\tBEFORE_VALUE"
     response:
       content:
         - type: tool_use
           id: toolcall_1
-          name: Read
+          name: Write
           input:
-            file_path: ${workdir}/ahp-coverage-edit-${temp}/edit.txt
+            file_path: ${workdir}/edit.txt
+            content: AFTER_VALUE
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Replace the complete contents of edit.txt with AFTER_VALUE.
-        - role: assistant
-          content:
-            - type: thinking
-            - type: tool_use
-              name: Bash
-              input:
-                command: cat AFTER_VALUE 2>/dev/null; echo "---SEP---"; cat edit.txt 2>/dev/null; echo "---LS---"; ls -la
-                description: Show AFTER_VALUE and edit.txt contents
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_0
-              content: |-
-                ---SEP---
-                BEFORE_VALUE---LS---
-                total 8
-                drwx------@    3 ${user}  staff      96 ${timestamp} .
-                drwx------@ 3639 ${user}  staff  116448 ${timestamp} ..
-                -rw-r--r--@    1 ${user}  staff      12 ${timestamp} edit.txt
+          content: Replace the complete contents of edit.txt with AFTER_VALUE. Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: thinking
             - type: tool_use
               name: Read
               input:
-                file_path: ${workdir}/ahp-coverage-edit-${temp}/edit.txt
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_1
-              content: "1\tBEFORE_VALUE"
-    response:
-      content:
-        - type: tool_use
-          id: toolcall_2
-          name: Edit
-          input:
-            file_path: ${workdir}/ahp-coverage-edit-${temp}/edit.txt
-            old_string: BEFORE_VALUE
-            new_string: AFTER_VALUE
-      stopReason: tool_use
-  - request:
-      model: claude-opus-4.8
-      system: ${system}
-      messages:
-        - role: user
-          content: Replace the complete contents of edit.txt with AFTER_VALUE.
-        - role: assistant
-          content:
-            - type: thinking
-            - type: tool_use
-              name: Bash
-              input:
-                command: cat AFTER_VALUE 2>/dev/null; echo "---SEP---"; cat edit.txt 2>/dev/null; echo "---LS---"; ls -la
-                description: Show AFTER_VALUE and edit.txt contents
+                file_path: ${workdir}/edit.txt
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                ---SEP---
-                BEFORE_VALUE---LS---
-                total 8
-                drwx------@    3 ${user}  staff      96 ${timestamp} .
-                drwx------@ 3639 ${user}  staff  116448 ${timestamp} ..
-                -rw-r--r--@    1 ${user}  staff      12 ${timestamp} edit.txt
+              content: "1\tBEFORE_VALUE"
         - role: assistant
           content:
             - type: thinking
             - type: tool_use
-              name: Read
+              name: Write
               input:
-                file_path: ${workdir}/ahp-coverage-edit-${temp}/edit.txt
+                file_path: ${workdir}/edit.txt
+                content: AFTER_VALUE
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_1
-              content: "1\tBEFORE_VALUE"
-        - role: assistant
-          content:
-            - type: tool_use
-              name: Edit
-              input:
-                replace_all: false
-                file_path: ${workdir}/ahp-coverage-edit-${temp}/edit.txt
-                old_string: BEFORE_VALUE
-                new_string: AFTER_VALUE
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_2
-              content: The file ${workdir}/ahp-coverage-edit-${temp}/edit.txt has been updated successfully. (file state is current in your context — no need to Read it back)
+              content: The file ${workdir}/edit.txt has been updated successfully. (file state is current in your context — no need to Read it back)
     response:
-      content: Done. `edit.txt` now contains `AFTER_VALUE` (replacing `BEFORE_VALUE`).
+      content: Done. `edit.txt` now contains `AFTER_VALUE` (replacing the previous `BEFORE_VALUE`).
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-handles-a-missing-file-without-a-session-error.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-handles-a-missing-file-without-a-session-error.yaml
@@ -6,36 +6,36 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Try to read missing.txt. If it does not exist, reply exactly "missing".
+          content: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
     response:
       content:
         - type: text
-          text: I'll try to read the file.
+          text: I'll read missing.txt.
         - type: tool_use
           id: toolcall_0
           name: Read
           input:
-            file_path: ${workdir}/ahp-coverage-missing-${temp}/missing.txt
+            file_path: ${workdir}/missing.txt
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Try to read missing.txt. If it does not exist, reply exactly "missing".
+          content: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: text
-              text: I'll try to read the file.
+              text: I'll read missing.txt.
             - type: tool_use
               name: Read
               input:
-                file_path: ${workdir}/ahp-coverage-missing-${temp}/missing.txt
+                file_path: ${workdir}/missing.txt
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: 'File does not exist. Note: your current working directory is ${workdir}/ahp-coverage-missing-${temp}.'
+              content: 'File does not exist. Note: your current working directory is ${workdir}.'
     response:
       content: missing
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-lists-workspace-entries.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-lists-workspace-entries.yaml
@@ -6,42 +6,35 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: List the files in the current working directory. Reply with the filenames only.
+          content: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
     response:
       content:
-        - type: text
-          text: I'll list the files in the working directory.
         - type: tool_use
           id: toolcall_0
           name: Bash
           input:
-            command: ls -1
-            description: List files in current directory
+            command: node -e "console.log(require('fs').readdirSync('.').join(' '))"
+            description: List files in current directory via node
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: List the files in the current working directory. Reply with the filenames only.
+          content: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
         - role: assistant
           content:
-            - type: text
-              text: I'll list the files in the working directory.
+            - type: thinking
             - type: tool_use
               name: Bash
               input:
-                command: ls -1
-                description: List files in current directory
+                command: node -e "console.log(require('fs').readdirSync('.').join(' '))"
+                description: List files in current directory via node
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                first.txt
-                second.md
+              content: first.txt second.md
     response:
-      content: |-
-        first.txt
-        second.md
+      content: first.txt second.md
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-creates-a-file-in-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-creates-a-file-in-a-nested-directory.yaml
@@ -6,38 +6,38 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''peer-output'',{recursive:true});fs.writeFileSync(''peer-output/report.txt'',''PEER_NESTED'')"`. Then reply with exactly "created".'
     response:
       content:
         - type: text
-          text: I'll create that file for you.
+          text: I'll run that command exactly as specified.
         - type: tool_use
           id: toolcall_0
-          name: Write
+          name: Bash
           input:
-            file_path: ${workdir}/peer-output/report.txt
-            content: PEER_NESTED
+            command: node -e "const fs=require('fs');fs.mkdirSync('peer-output',{recursive:true});fs.writeFileSync('peer-output/report.txt','PEER_NESTED')"
+            description: Create peer-output directory and report file
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''peer-output'',{recursive:true});fs.writeFileSync(''peer-output/report.txt'',''PEER_NESTED'')"`. Then reply with exactly "created".'
         - role: assistant
           content:
             - type: text
-              text: I'll create that file for you.
+              text: I'll run that command exactly as specified.
             - type: tool_use
-              name: Write
+              name: Bash
               input:
-                file_path: ${workdir}/peer-output/report.txt
-                content: PEER_NESTED
+                command: node -e "const fs=require('fs');fs.mkdirSync('peer-output',{recursive:true});fs.writeFileSync('peer-output/report.txt','PEER_NESTED')"
+                description: Create peer-output directory and report file
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: 'File created successfully at: ${workdir}/peer-output/report.txt (file state is current in your context — no need to Read it back)'
+              content: (Bash completed with no output)
     response:
-      content: Done. Created `report.txt` containing exactly `PEER_NESTED`.
+      content: created
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-edits-an-existing-workspace-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-edits-an-existing-workspace-file.yaml
@@ -6,40 +6,42 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER. Use your file tools; do not run a shell command.
     response:
       content:
         - type: text
-          text: I'll replace the file contents.
+          text: I'll replace the contents of that file.
         - type: tool_use
           id: toolcall_0
-          name: Bash
+          name: Write
           input:
-            command: test -f ${workdir}/peer-edit.txt && echo EXISTS || echo MISSING
-            description: Check if target file exists
+            file_path: ${workdir}/peer-edit.txt
+            content: AFTER_PEER
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER. Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: text
-              text: I'll replace the file contents.
+              text: I'll replace the contents of that file.
             - type: tool_use
-              name: Bash
+              name: Write
               input:
-                command: test -f ${workdir}/peer-edit.txt && echo EXISTS || echo MISSING
-                description: Check if target file exists
+                file_path: ${workdir}/peer-edit.txt
+                content: AFTER_PEER
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: EXISTS
+              content: <tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>
     response:
       content:
+        - type: text
+          text: I need to read the file first.
         - type: tool_use
           id: toolcall_1
           name: Read
@@ -51,23 +53,25 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER. Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: text
-              text: I'll replace the file contents.
+              text: I'll replace the contents of that file.
             - type: tool_use
-              name: Bash
+              name: Write
               input:
-                command: test -f ${workdir}/peer-edit.txt && echo EXISTS || echo MISSING
-                description: Check if target file exists
+                file_path: ${workdir}/peer-edit.txt
+                content: AFTER_PEER
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: EXISTS
+              content: <tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>
         - role: assistant
           content:
+            - type: text
+              text: I need to read the file first.
             - type: tool_use
               name: Read
               input:
@@ -83,31 +87,33 @@ exchanges:
           id: toolcall_2
           name: Write
           input:
-            file_path: ${workdir}/peer-edit.txt
             content: AFTER_PEER
+            file_path: ${workdir}/peer-edit.txt
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER. Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: text
-              text: I'll replace the file contents.
+              text: I'll replace the contents of that file.
             - type: tool_use
-              name: Bash
+              name: Write
               input:
-                command: test -f ${workdir}/peer-edit.txt && echo EXISTS || echo MISSING
-                description: Check if target file exists
+                file_path: ${workdir}/peer-edit.txt
+                content: AFTER_PEER
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: EXISTS
+              content: <tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>
         - role: assistant
           content:
+            - type: text
+              text: I need to read the file first.
             - type: tool_use
               name: Read
               input:
@@ -130,5 +136,5 @@ exchanges:
               tool_use_id: toolcall_2
               content: The file ${workdir}/peer-edit.txt has been updated successfully. (file state is current in your context — no need to Read it back)
     response:
-      content: Done. Replaced the contents of `peer-edit.txt` (was `BEFORE_PEER`) with `AFTER_PEER`.
+      content: Done. The file now contains `AFTER_PEER`.
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-handles-a-missing-workspace-file-without-an-error.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-handles-a-missing-workspace-file-without-an-error.yaml
@@ -6,11 +6,11 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing".
+          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
     response:
       content:
         - type: text
-          text: I'll try to read that file.
+          text: I'll read the file.
         - type: tool_use
           id: toolcall_0
           name: Read
@@ -22,11 +22,11 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing".
+          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: text
-              text: I'll try to read that file.
+              text: I'll read the file.
             - type: tool_use
               name: Read
               input:

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-file-from-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-file-from-a-nested-directory.yaml
@@ -10,7 +10,7 @@ exchanges:
     response:
       content:
         - type: text
-          text: I'll read the file.
+          text: I'll read the file for you.
         - type: tool_use
           id: toolcall_0
           name: Read
@@ -26,7 +26,7 @@ exchanges:
         - role: assistant
           content:
             - type: text
-              text: I'll read the file.
+              text: I'll read the file for you.
             - type: tool_use
               name: Read
               input:

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-file-from-the-parent-workspace.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-file-from-the-parent-workspace.yaml
@@ -9,8 +9,6 @@ exchanges:
           content: Read the file at ${workdir}/peer-note.txt and reply with its exact contents only.
     response:
       content:
-        - type: text
-          text: I'll read the file.
         - type: tool_use
           id: toolcall_0
           name: Read
@@ -25,8 +23,7 @@ exchanges:
           content: Read the file at ${workdir}/peer-note.txt and reply with its exact contents only.
         - role: assistant
           content:
-            - type: text
-              text: I'll read the file.
+            - type: thinking
             - type: tool_use
               name: Read
               input:

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-filename-containing-spaces.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-chat-reads-a-filename-containing-spaces.yaml
@@ -9,6 +9,8 @@ exchanges:
           content: Read the file at ${workdir}/peer file.txt and reply with its exact contents only.
     response:
       content:
+        - type: text
+          text: I'll read the file for you.
         - type: tool_use
           id: toolcall_0
           name: Read
@@ -23,7 +25,8 @@ exchanges:
           content: Read the file at ${workdir}/peer file.txt and reply with its exact contents only.
         - role: assistant
           content:
-            - type: thinking
+            - type: text
+              text: I'll read the file for you.
             - type: tool_use
               name: Read
               input:

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-provider-context-survives-unsubscribe-and-resubscribe.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-peer-provider-context-survives-unsubscribe-and-resubscribe.yaml
@@ -8,10 +8,7 @@ exchanges:
         - role: user
           content: Remember the code word RESUME_PEER. Reply exactly "ready".
     response:
-      content: |-
-        I'll remember the code word RESUME_PEER.
-
-        ready
+      content: ready
       stopReason: end_turn
   - request:
       model: claude-opus-4.8
@@ -20,10 +17,7 @@ exchanges:
         - role: user
           content: Remember the code word RESUME_PEER. Reply exactly "ready".
         - role: assistant
-          content: |-
-            I'll remember the code word RESUME_PEER.
-
-            ready
+          content: ready
         - role: user
           content: Reply exactly "resumed".
     response:

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-reads-a-file-from-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-reads-a-file-from-a-nested-directory.yaml
@@ -6,31 +6,31 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Read nested/value.txt and reply with its exact contents only.
+          content: Read nested/value.txt and reply with its exact contents only. Use your file tools; do not run a shell command.
     response:
       content:
         - type: text
-          text: I'll read the file.
+          text: I'll read the file for you.
         - type: tool_use
           id: toolcall_0
           name: Read
           input:
-            file_path: ${workdir}/ahp-coverage-nested-read-${temp}/nested/value.txt
+            file_path: ${workdir}/nested/value.txt
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Read nested/value.txt and reply with its exact contents only.
+          content: Read nested/value.txt and reply with its exact contents only. Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: text
-              text: I'll read the file.
+              text: I'll read the file for you.
             - type: tool_use
               name: Read
               input:
-                file_path: ${workdir}/ahp-coverage-nested-read-${temp}/nested/value.txt
+                file_path: ${workdir}/nested/value.txt
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-reads-a-filename-containing-spaces.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-reads-a-filename-containing-spaces.yaml
@@ -9,11 +9,13 @@ exchanges:
           content: Read "file with spaces.txt" and reply with its exact contents only.
     response:
       content:
+        - type: text
+          text: I'll read that file for you.
         - type: tool_use
           id: toolcall_0
           name: Read
           input:
-            file_path: ${workdir}/ahp-coverage-spaces-${temp}/file with spaces.txt
+            file_path: ${workdir}/file with spaces.txt
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
@@ -23,11 +25,12 @@ exchanges:
           content: Read "file with spaces.txt" and reply with its exact contents only.
         - role: assistant
           content:
-            - type: thinking
+            - type: text
+              text: I'll read that file for you.
             - type: tool_use
               name: Read
               input:
-                file_path: ${workdir}/ahp-coverage-spaces-${temp}/file with spaces.txt
+                file_path: ${workdir}/file with spaces.txt
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-reads-a-value-from-json.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-reads-a-value-from-json.yaml
@@ -9,11 +9,13 @@ exchanges:
           content: Read config.json and reply with the numeric value of "answer" only.
     response:
       content:
+        - type: text
+          text: I'll read the config file.
         - type: tool_use
           id: toolcall_0
           name: Read
           input:
-            file_path: ${workdir}/ahp-coverage-json-${temp}/config.json
+            file_path: ${workdir}/config.json
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
@@ -23,11 +25,12 @@ exchanges:
           content: Read config.json and reply with the numeric value of "answer" only.
         - role: assistant
           content:
-            - type: thinking
+            - type: text
+              text: I'll read the config file.
             - type: tool_use
               name: Read
               input:
-                file_path: ${workdir}/ahp-coverage-json-${temp}/config.json
+                file_path: ${workdir}/config.json
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-reads-an-existing-text-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-reads-an-existing-text-file.yaml
@@ -15,7 +15,7 @@ exchanges:
           id: toolcall_0
           name: Read
           input:
-            file_path: ${workdir}/ahp-coverage-read-${temp}/note.txt
+            file_path: ${workdir}/note.txt
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
@@ -30,7 +30,7 @@ exchanges:
             - type: tool_use
               name: Read
               input:
-                file_path: ${workdir}/ahp-coverage-read-${temp}/note.txt
+                file_path: ${workdir}/note.txt
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-renames-a-workspace-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-renames-a-workspace-file.yaml
@@ -6,14 +6,14 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Rename before.txt to after.txt without changing its contents.
+          content: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
     response:
       content:
         - type: tool_use
           id: toolcall_0
           name: Bash
           input:
-            command: mv before.txt after.txt && ls -la after.txt
+            command: node -e "require('fs').renameSync('before.txt','after.txt')"
             description: Rename before.txt to after.txt
       stopReason: tool_use
   - request:
@@ -21,20 +21,20 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Rename before.txt to after.txt without changing its contents.
+          content: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
         - role: assistant
           content:
             - type: thinking
             - type: tool_use
               name: Bash
               input:
-                command: mv before.txt after.txt && ls -la after.txt
+                command: node -e "require('fs').renameSync('before.txt','after.txt')"
                 description: Rename before.txt to after.txt
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: '-rw-r--r--@ 1 ${user}  staff  12 ${timestamp} after.txt'
+              content: (Bash completed with no output)
     response:
-      content: Done. `before.txt` is now `after.txt` with its contents unchanged.
+      content: renamed
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-reopening-a-session-keeps-sub-agent-messages-out-of-the-parent-transcript-replay-path.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-reopening-a-session-keeps-sub-agent-messages-out-of-the-parent-transcript-replay-path.yaml
@@ -9,90 +9,85 @@ exchanges:
           content: 'Use the `Task` tool to spawn a subagent to list the files in the current working directory. Instruct the subagent to begin its response with this sentence on its own line: subagent replay note sentinel-7f3a. Then the subagent should list the files. After the subagent completes, you, the main agent, must reply exactly "SUBAGENT_DONE" and must not repeat that sentence.'
     response:
       content:
+        - type: text
+          text: I'll spawn a subagent to list the files.
         - type: tool_use
           id: toolcall_0
           name: Agent
           input:
             description: List files in cwd
             prompt: |-
-              List the files in the current working directory. Begin your response with exactly this sentence on its own line:
+              List the files in the current working directory. Begin your response with this exact sentence on its own line:
 
               subagent replay note sentinel-7f3a
 
-              Then list the files.
+              Then, on the following lines, list the files in the current working directory.
             subagent_type: general-purpose
             run_in_background: false
       stopReason: tool_use
-      usage:
-        inputTokens: 6837
-        outputTokens: 217
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
           content: |-
-            List the files in the current working directory. Begin your response with exactly this sentence on its own line:
+            List the files in the current working directory. Begin your response with this exact sentence on its own line:
 
             subagent replay note sentinel-7f3a
 
-            Then list the files.
+            Then, on the following lines, list the files in the current working directory.
     response:
       content:
         - type: text
-          text: subagent replay note sentinel-7f3a
+          text: |-
+            subagent replay note sentinel-7f3a
+
+            Let me list the files in the current working directory.
         - type: tool_use
           id: toolcall_1
           name: Bash
           input:
-            command: ls -la "/private${workdir}/ahp-subagent-replay-FKcp1Z"
-            description: List files in working directory
+            command: ls -A ${workdir}
+            description: List all files in working directory
       stopReason: tool_use
-      usage:
-        inputTokens: 2675
-        outputTokens: 149
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
           content: |-
-            List the files in the current working directory. Begin your response with exactly this sentence on its own line:
+            List the files in the current working directory. Begin your response with this exact sentence on its own line:
 
             subagent replay note sentinel-7f3a
 
-            Then list the files.
+            Then, on the following lines, list the files in the current working directory.
         - role: assistant
           content:
             - type: text
-              text: subagent replay note sentinel-7f3a
+              text: |-
+                subagent replay note sentinel-7f3a
+
+                Let me list the files in the current working directory.
             - type: tool_use
               name: Bash
               input:
-                command: ls -la "/private${workdir}/ahp-subagent-replay-FKcp1Z"
-                description: List files in working directory
+                command: ls -A ${workdir}
+                description: List all files in working directory
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_1
               content: |-
-                total 16
-                drwx------     4 ${user}  staff    128 Jul  9 16:55 .
-                drwx------@ 1145 ${user}  staff  36640 Jul  9 16:55 ..
-                -rw-r--r--     1 ${user}  staff      5 Jul  9 16:55 file-a.txt
-                -rw-r--r--     1 ${user}  staff      4 Jul  9 16:55 file-b.txt
+                file-a.txt
+                file-b.txt
     response:
       content: |-
         subagent replay note sentinel-7f3a
 
-        The working directory contains 2 files:
-
-        - /private${workdir}/ahp-subagent-replay-FKcp1Z/file-a.txt
-        - /private${workdir}/ahp-subagent-replay-FKcp1Z/file-b.txt
+        The current working directory contains the following files:
+        - file-a.txt
+        - file-b.txt
       stopReason: end_turn
-      usage:
-        inputTokens: 4165
-        outputTokens: 157
   - request:
       model: claude-opus-4.8
       system: ${system}
@@ -102,16 +97,18 @@ exchanges:
         - role: assistant
           content:
             - type: thinking
+            - type: text
+              text: I'll spawn a subagent to list the files.
             - type: tool_use
               name: Agent
               input:
                 description: List files in cwd
                 prompt: |-
-                  List the files in the current working directory. Begin your response with exactly this sentence on its own line:
+                  List the files in the current working directory. Begin your response with this exact sentence on its own line:
 
                   subagent replay note sentinel-7f3a
 
-                  Then list the files.
+                  Then, on the following lines, list the files in the current working directory.
                 subagent_type: general-purpose
                 run_in_background: false
         - role: user
@@ -123,19 +120,15 @@ exchanges:
                   text: |-
                     subagent replay note sentinel-7f3a
 
-                    The working directory contains 2 files:
-
-                    - /private${workdir}/ahp-subagent-replay-FKcp1Z/file-a.txt
-                    - /private${workdir}/ahp-subagent-replay-FKcp1Z/file-b.txt
+                    The current working directory contains the following files:
+                    - file-a.txt
+                    - file-b.txt
                 - type: text
                   text: |-
-                    agentId: a072652024085f2e7 (use SendMessage with to: 'a072652024085f2e7', summary: '<5-10 word recap>' to continue this agent)
-                    <usage>subagent_tokens: 25858
+                    agentId: a14a5696941ca0f13 (use SendMessage with to: 'a14a5696941ca0f13', summary: '<5-10 word recap>' to continue this agent)
+                    <usage>subagent_tokens: 21422
                     tool_uses: 1
-                    duration_ms: 13466</usage>
+                    duration_ms: 6957</usage>
     response:
       content: SUBAGENT_DONE
       stopReason: end_turn
-      usage:
-        inputTokens: 2
-        outputTokens: 13

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-runs-a-deterministic-shell-command.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-runs-a-deterministic-shell-command.yaml
@@ -6,33 +6,30 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Run a shell command that prints SHELL_VALUE_73, then reply with that exact value only.
+          content: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
     response:
       content:
-        - type: text
-          text: I'll run a command to print that value.
         - type: tool_use
           id: toolcall_0
           name: Bash
           input:
-            command: printf '%s\n' "SHELL_VALUE_73"
-            description: Print the value SHELL_VALUE_73
+            command: echo SHELL_VALUE_73
+            description: Echo the shell value
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: Run a shell command that prints SHELL_VALUE_73, then reply with that exact value only.
+          content: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
         - role: assistant
           content:
-            - type: text
-              text: I'll run a command to print that value.
+            - type: thinking
             - type: tool_use
               name: Bash
               input:
-                command: printf '%s\n' "SHELL_VALUE_73"
-                description: Print the value SHELL_VALUE_73
+                command: echo SHELL_VALUE_73
+                description: Echo the shell value
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-runs-a-deterministic-shell-command.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-runs-a-deterministic-shell-command.yaml
@@ -9,12 +9,14 @@ exchanges:
           content: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
     response:
       content:
+        - type: text
+          text: I'll run that command.
         - type: tool_use
           id: toolcall_0
           name: Bash
           input:
             command: echo SHELL_VALUE_73
-            description: Echo the shell value
+            description: Echo shell value
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
@@ -24,12 +26,13 @@ exchanges:
           content: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
         - role: assistant
           content:
-            - type: thinking
+            - type: text
+              text: I'll run that command.
             - type: tool_use
               name: Bash
               input:
                 command: echo SHELL_VALUE_73
-                description: Echo the shell value
+                description: Echo shell value
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-sends-a-simple-message-and-receives-a-response.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-sends-a-simple-message-and-receives-a-response.yaml
@@ -10,6 +10,3 @@ exchanges:
     response:
       content: hello
       stopReason: end_turn
-      usage:
-        inputTokens: 2426
-        outputTokens: 4

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-subagent-tool-calls-are-routed-to-the-subagent-session-not-flat-in-the-parent.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-subagent-tool-calls-are-routed-to-the-subagent-session-not-flat-in-the-parent.yaml
@@ -10,67 +10,61 @@ exchanges:
     response:
       content:
         - type: text
-          text: I'll delegate the directory listing to a subagent.
+          text: I'll delegate this to a subagent using the Explore agent, which is read-only.
         - type: tool_use
           id: toolcall_0
           name: Agent
           input:
             description: List files in working directory
-            prompt: 'List the files in the current working directory by calling a single read-only tool: run the shell command `ls -la` (one Bash tool call). Then report back the exact list of files and directories you found. Do not run any other tools or make any modifications.'
-            subagent_type: general-purpose
+            prompt: List the files and directories in the current working directory (${workdir}). Call a single read-only tool exactly once — run `ls -la` in the shell (or use a view/list tool) to enumerate the directory. Then report back the list of entries you found. Do not call any other tools.
+            subagent_type: Explore
             run_in_background: false
       stopReason: tool_use
-      usage:
-        inputTokens: 6837
-        outputTokens: 342
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: 'List the files in the current working directory by calling a single read-only tool: run the shell command `ls -la` (one Bash tool call). Then report back the exact list of files and directories you found. Do not run any other tools or make any modifications.'
+          content: List the files and directories in the current working directory (${workdir}). Call a single read-only tool exactly once — run `ls -la` in the shell (or use a view/list tool) to enumerate the directory. Then report back the list of entries you found. Do not call any other tools.
     response:
       content:
         - type: text
-          text: I'll run the command.
+          text: I'll run `ls -la` to enumerate the directory.
         - type: tool_use
           id: toolcall_1
           name: Bash
           input:
-            command: ls -la
-            description: List files in current working directory
+            command: ls -la ${workdir}
+            description: List all entries in the working directory
       stopReason: tool_use
-      usage:
-        inputTokens: 2675
-        outputTokens: 85
   - request:
       model: claude-opus-4.8
       system: ${system}
       messages:
         - role: user
-          content: 'List the files in the current working directory by calling a single read-only tool: run the shell command `ls -la` (one Bash tool call). Then report back the exact list of files and directories you found. Do not run any other tools or make any modifications.'
+          content: List the files and directories in the current working directory (${workdir}). Call a single read-only tool exactly once — run `ls -la` in the shell (or use a view/list tool) to enumerate the directory. Then report back the list of entries you found. Do not call any other tools.
         - role: assistant
           content:
             - type: text
-              text: I'll run the command.
+              text: I'll run `ls -la` to enumerate the directory.
             - type: tool_use
               name: Bash
               input:
-                command: ls -la
-                description: List files in current working directory
+                command: ls -la ${workdir}
+                description: List all entries in the working directory
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_1
               content: |-
                 total 16
-                drwx------     4 ${user}  staff    128 Jul  9 16:55 .
-                drwx------@ 1145 ${user}  staff  36640 Jul  9 16:55 ..
-                -rw-r--r--     1 ${user}  staff      5 Jul  9 16:55 file-a.txt
-                -rw-r--r--     1 ${user}  staff      4 Jul  9 16:55 file-b.txt
+                drwx------     4 ${user}  staff     128 ${timestamp} .
+                drwx------@ 3522 ${user}  staff  112704 ${timestamp} ..
+                -rw-r--r--     1 ${user}  staff       5 ${timestamp} file-a.txt
+                -rw-r--r--     1 ${user}  staff       4 ${timestamp} file-b.txt
     response:
       content: |-
-        The `ls -la` command returned the following contents of the current working directory:
+        Here are the entries in `${workdir}`:
 
         Directories:
         - `.` (current directory)
@@ -80,11 +74,8 @@ exchanges:
         - `file-a.txt` (5 bytes)
         - `file-b.txt` (4 bytes)
 
-        The working directory contains two regular files, `file-a.txt` and `file-b.txt`, and no subdirectories other than the standard `.` and `..` entries.
+        The directory contains two regular files (`file-a.txt` and `file-b.txt`) and no subdirectories.
       stopReason: end_turn
-      usage:
-        inputTokens: 4165
-        outputTokens: 139
   - request:
       model: claude-opus-4.8
       system: ${system}
@@ -95,47 +86,34 @@ exchanges:
           content:
             - type: thinking
             - type: text
-              text: I'll delegate the directory listing to a subagent.
+              text: I'll delegate this to a subagent using the Explore agent, which is read-only.
             - type: tool_use
               name: Agent
               input:
                 description: List files in working directory
-                prompt: 'List the files in the current working directory by calling a single read-only tool: run the shell command `ls -la` (one Bash tool call). Then report back the exact list of files and directories you found. Do not run any other tools or make any modifications.'
-                subagent_type: general-purpose
+                prompt: List the files and directories in the current working directory (${workdir}). Call a single read-only tool exactly once — run `ls -la` in the shell (or use a view/list tool) to enumerate the directory. Then report back the list of entries you found. Do not call any other tools.
+                subagent_type: Explore
                 run_in_background: false
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content:
-                - type: text
-                  text: |-
-                    The `ls -la` command returned the following contents of the current working directory:
+              content: |-
+                Here are the entries in `${workdir}`:
 
-                    Directories:
-                    - `.` (current directory)
-                    - `..` (parent directory)
+                Directories:
+                - `.` (current directory)
+                - `..` (parent directory)
 
-                    Files:
-                    - `file-a.txt` (5 bytes)
-                    - `file-b.txt` (4 bytes)
+                Files:
+                - `file-a.txt` (5 bytes)
+                - `file-b.txt` (4 bytes)
 
-                    The working directory contains two regular files, `file-a.txt` and `file-b.txt`, and no subdirectories other than the standard `.` and `..` entries.
-                - type: text
-                  text: |-
-                    agentId: a80367f6909b49ab9 (use SendMessage with to: 'a80367f6909b49ab9', summary: '<5-10 word recap>' to continue this agent)
-                    <usage>subagent_tokens: 25794
-                    tool_uses: 1
-                    duration_ms: 5122</usage>
+                The directory contains two regular files (`file-a.txt` and `file-b.txt`) and no subdirectories.
     response:
       content: |-
-        The subagent enumerated the directory with a single `ls -la` call. The working directory contains two files:
+        The subagent enumerated the directory with a single `ls -la` call. The working directory contains two files and no subdirectories:
 
         - `file-a.txt` (5 bytes)
         - `file-b.txt` (4 bytes)
-
-        No subdirectories (other than `.` and `..`).
       stopReason: end_turn
-      usage:
-        inputTokens: 2
-        outputTokens: 85

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-tool-call-triggers-permission-request-and-can-be-approved.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-tool-call-triggers-permission-request-and-can-be-approved.yaml
@@ -9,16 +9,15 @@ exchanges:
           content: 'Run the shell command: echo "hello from test"'
     response:
       content:
+        - type: text
+          text: I'll run that command for you.
         - type: tool_use
           id: toolcall_0
           name: Bash
           input:
             command: echo "hello from test"
-            description: Echo a test string
+            description: Echo a test message
       stopReason: tool_use
-      usage:
-        inputTokens: 2426
-        outputTokens: 104
   - request:
       model: claude-opus-4.8
       system: ${system}
@@ -27,20 +26,18 @@ exchanges:
           content: 'Run the shell command: echo "hello from test"'
         - role: assistant
           content:
-            - type: thinking
+            - type: text
+              text: I'll run that command for you.
             - type: tool_use
               name: Bash
               input:
                 command: echo "hello from test"
-                description: Echo a test string
+                description: Echo a test message
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
               content: hello from test
     response:
-      content: 'Done. Output: `hello from test`'
+      content: 'Output: `hello from test`'
       stopReason: end_turn
-      usage:
-        inputTokens: 2
-        outputTokens: 14

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-two-peer-chats-write-distinct-workspace-files.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-two-peer-chats-write-distinct-workspace-files.yaml
@@ -79,5 +79,5 @@ exchanges:
               tool_use_id: toolcall_1
               content: 'File created successfully at: ${workdir}/second-peer.txt (file state is current in your context — no need to Read it back)'
     response:
-      content: Created `second-peer.txt` containing exactly `SECOND_PEER`.
+      content: Done. Created `second-peer.txt` containing exactly `SECOND_PEER`.
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-worktree-session-uses-the-resolved-worktree-as-working-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-worktree-session-uses-the-resolved-worktree-as-working-directory.yaml
@@ -8,11 +8,8 @@ exchanges:
         - role: user
           content: What is your current working directory? Reply with just the absolute path and nothing else.
     response:
-      content: ${workdir}/ahp-wt-test-h3mcIN.worktrees/what-is-your-current-working-directory-reply-wit
+      content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
       stopReason: end_turn
-      usage:
-        inputTokens: 2586
-        outputTokens: 46
   - request:
       model: claude-opus-4.8
       system: ${system}
@@ -20,7 +17,7 @@ exchanges:
         - role: user
           content: What is your current working directory? Reply with just the absolute path and nothing else.
         - role: assistant
-          content: ${workdir}/ahp-wt-test-h3mcIN.worktrees/what-is-your-current-working-directory-reply-wit
+          content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
         - role: user
           content: Run the shell command `pwd` in the session current working directory. Do not specify a working-directory override.
     response:
@@ -32,9 +29,6 @@ exchanges:
             command: pwd
             description: Print working directory
       stopReason: tool_use
-      usage:
-        inputTokens: 2
-        outputTokens: 74
   - request:
       model: claude-opus-4.8
       system: ${system}
@@ -42,7 +36,7 @@ exchanges:
         - role: user
           content: What is your current working directory? Reply with just the absolute path and nothing else.
         - role: assistant
-          content: ${workdir}/ahp-wt-test-h3mcIN.worktrees/what-is-your-current-working-directory-reply-wit
+          content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
         - role: user
           content: Run the shell command `pwd` in the session current working directory. Do not specify a working-directory override.
         - role: assistant
@@ -56,10 +50,7 @@ exchanges:
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: ${workdir}/ahp-wt-test-h3mcIN.worktrees/what-is-your-current-working-directory-reply-wit
+              content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
     response:
-      content: ${workdir}/ahp-wt-test-h3mcIN.worktrees/what-is-your-current-working-directory-reply-wit
+      content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
       stopReason: end_turn
-      usage:
-        inputTokens: 2
-        outputTokens: 46

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-attaches-a-python-file-and-reads-its-function-names.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-attaches-a-python-file-and-reads-its-function-names.yaml
@@ -2,7 +2,7 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -10,26 +10,18 @@ exchanges:
             Read the attached Python file. What function names are defined in it? Reply with only the function names.
 
             <tagged_files>
-            * ${workdir}/ahp-attachment-test-tR6Qfs/calculator.py (2 lines)
+            * ${workdir}/calculator.py (2 lines)
             </tagged_files>
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: report_intent
-          input:
-            intent: Reading attached file
-        - type: tool_use
-          id: toolcall_1
           name: view
           input:
-            path: ${workdir}/ahp-attachment-test-tR6Qfs/calculator.py
+            path: ${workdir}/calculator.py
       stopReason: tool_use
-      usage:
-        inputTokens: 3
-        outputTokens: 136
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -37,29 +29,19 @@ exchanges:
             Read the attached Python file. What function names are defined in it? Reply with only the function names.
 
             <tagged_files>
-            * ${workdir}/ahp-attachment-test-tR6Qfs/calculator.py (2 lines)
+            * ${workdir}/calculator.py (2 lines)
             </tagged_files>
         - role: assistant
           content:
             - type: tool_use
-              name: report_intent
-              input:
-                intent: Reading attached file
-            - type: tool_use
               name: view
               input:
-                path: ${workdir}/ahp-attachment-test-tR6Qfs/calculator.py
+                path: ${workdir}/calculator.py
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: Intent logged
-            - type: tool_result
-              tool_use_id: toolcall_1
               content: "1. def add(a, b):\n2. \treturn a + b"
     response:
-      content: '`add`'
+      content: add
       stopReason: end_turn
-      usage:
-        inputTokens: 1
-        outputTokens: 6

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-attaches-a-text-blob-and-reads-its-function-names.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-attaches-a-text-blob-and-reads-its-function-names.yaml
@@ -2,7 +2,7 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -12,8 +12,5 @@ exchanges:
             - type: text
               text: "<attachment mimeType=\"text/plain\" name=\"calculator.py\">\ndef subtract(a, b):\n\treturn a - b\n</attachment>"
     response:
-      content: '`subtract`'
+      content: subtract
       stopReason: end_turn
-      usage:
-        inputTokens: 3
-        outputTokens: 80

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-client-tool-disconnect-before-permission-still-completes-the-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-client-tool-disconnect-before-permission-still-completes-the-turn.yaml
@@ -2,7 +2,7 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-haiku-4.5
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -15,14 +15,13 @@ exchanges:
           input: {}
       stopReason: tool_use
   - request:
-      model: claude-haiku-4.5
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
           content: Call the get_magic_word tool and then report whether it succeeded.
         - role: assistant
           content:
-            - type: thinking
             - type: tool_use
               name: get_magic_word
               input: {}
@@ -32,5 +31,5 @@ exchanges:
               tool_use_id: toolcall_0
               content: Client copilot-client-tool-disconnect disconnected before completing get_magic_word
     response:
-      content: The tool call **failed**. The client disconnected before the `get_magic_word` tool could complete. This appears to be a connectivity issue between the client and the runtime service.
+      content: The tool call failed — the client disconnected before `get_magic_word` could complete, so no magic word was returned.
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-client-tool-reaches-ready-after-start-and-completes.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-client-tool-reaches-ready-after-start-and-completes.yaml
@@ -31,5 +31,5 @@ exchanges:
               tool_use_id: toolcall_0
               content: XYLOPHONE
     response:
-      content: The magic word is **XYLOPHONE**.
+      content: 'The magic word is: **XYLOPHONE**'
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-counts-lines-in-a-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-counts-lines-in-a-file.yaml
@@ -6,36 +6,74 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Count the lines in lines.txt and reply with the number only.
+          content: Count the lines in lines.txt and reply with the number only. Use your file tools rather than running a shell command.
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: glob
           input:
-            command: wc -l lines.txt
-            description: Count lines in lines.txt
+            pattern: '**/lines.txt'
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: Count the lines in lines.txt and reply with the number only.
+          content: Count the lines in lines.txt and reply with the number only. Use your file tools rather than running a shell command.
         - role: assistant
           content:
+            - type: thinking
             - type: tool_use
-              name: bash
+              name: glob
               input:
-                command: wc -l lines.txt
-                description: Count lines in lines.txt
+                pattern: '**/lines.txt'
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
+              content: ./lines.txt
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_1
+          name: view
+          input:
+            path: ${workdir}/lines.txt
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Count the lines in lines.txt and reply with the number only. Use your file tools rather than running a shell command.
+        - role: assistant
+          content:
+            - type: thinking
+            - type: tool_use
+              name: glob
+              input:
+                pattern: '**/lines.txt'
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: ./lines.txt
+        - role: assistant
+          content:
+            - type: tool_use
+              name: view
+              input:
+                path: ${workdir}/lines.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
               content: |-
-                4 lines.txt
-                <shellId: 0 completed with exit code 0>
+                1. one
+                2. two
+                3. three
+                4. four
     response:
       content: '4'
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-creates-a-file-in-a-new-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-creates-a-file-in-a-new-nested-directory.yaml
@@ -6,36 +6,34 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Create output/report.txt containing exactly NESTED_CREATED.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: ${shell}
           input:
-            command: mkdir -p output && printf 'NESTED_CREATED' > output/report.txt && cat output/report.txt
-            description: Create nested output directory and report file
+            command: node -e "const fs=require('fs');fs.mkdirSync('output',{recursive:true});fs.writeFileSync('output/report.txt','NESTED_CREATED')"
+            description: Create nested output file via node
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: Create output/report.txt containing exactly NESTED_CREATED.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
         - role: assistant
           content:
             - type: tool_use
               name: bash
               input:
-                command: mkdir -p output && printf 'NESTED_CREATED' > output/report.txt && cat output/report.txt
-                description: Create nested output directory and report file
+                command: node -e "const fs=require('fs');fs.mkdirSync('output',{recursive:true});fs.writeFileSync('output/report.txt','NESTED_CREATED')"
+                description: Create nested output file via node
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                NESTED_CREATED
-                <shellId: 0 completed with exit code 0>
+              content: '<shellId: 0 completed with exit code 0>'
     response:
-      content: Created [output/report.txt](${workdir}/ahp-coverage-nested-create-${temp}/output/report.txt) containing exactly `NESTED_CREATED`.
+      content: created
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-handles-a-missing-file-without-a-session-error.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-handles-a-missing-file-without-a-session-error.yaml
@@ -6,37 +6,33 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Try to read missing.txt. If it does not exist, reply exactly "missing".
+          content: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools rather than running a shell command.
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: view
           input:
-            command: cat missing.txt 2>&1
-            description: Try to read missing.txt
+            path: ${workdir}/missing.txt
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: Try to read missing.txt. If it does not exist, reply exactly "missing".
+          content: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools rather than running a shell command.
         - role: assistant
           content:
             - type: thinking
             - type: tool_use
-              name: bash
+              name: view
               input:
-                command: cat missing.txt 2>&1
-                description: Try to read missing.txt
+                path: ${workdir}/missing.txt
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                cat: missing.txt: No such file or directory
-                <shellId: 0 completed with exit code 1>
+              content: Path ${workdir}/missing.txt does not exist. Please provide a valid path.
     response:
       content: missing
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-inspects-git-status.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-inspects-git-status.yaml
@@ -11,7 +11,7 @@ exchanges:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: ${shell}
           input:
             command: git status --porcelain
             description: Check git status
@@ -38,5 +38,7 @@ exchanges:
                 ?? untracked.txt
                 <shellId: 0 completed with exit code 0>
     response:
-      content: tracked.txt, untracked.txt
+      content: |-
+        Modified: `tracked.txt`
+        Untracked: `untracked.txt`
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-lists-workspace-entries.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-lists-workspace-entries.yaml
@@ -6,14 +6,14 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: List the files in the current working directory. Reply with the filenames only.
+          content: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: ${shell}
           input:
-            command: ls -a
+            command: node -e "console.log(require('fs').readdirSync('.').join(' '))"
             description: List files in current directory
       stopReason: tool_use
   - request:
@@ -21,26 +21,21 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: List the files in the current working directory. Reply with the filenames only.
+          content: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
         - role: assistant
           content:
             - type: tool_use
               name: bash
               input:
-                command: ls -a
+                command: node -e "console.log(require('fs').readdirSync('.').join(' '))"
                 description: List files in current directory
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
               content: |-
-                .
-                ..
-                first.txt
-                second.md
+                first.txt second.md
                 <shellId: 0 completed with exit code 0>
     response:
-      content: |-
-        first.txt
-        second.md
+      content: first.txt second.md
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-creates-a-file-in-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-creates-a-file-in-a-nested-directory.yaml
@@ -6,75 +6,34 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''peer-output'',{recursive:true});fs.writeFileSync(''peer-output/report.txt'',''PEER_NESTED'')"`. Then reply with exactly "created".'
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: ${shell}
           input:
-            command: mkdir -p ${workdir}/peer-output
-            description: Create peer-output directory
+            command: node -e "const fs=require('fs');fs.mkdirSync('peer-output',{recursive:true});fs.writeFileSync('peer-output/report.txt','PEER_NESTED')"
+            description: Create peer-output/report.txt via node
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''peer-output'',{recursive:true});fs.writeFileSync(''peer-output/report.txt'',''PEER_NESTED'')"`. Then reply with exactly "created".'
         - role: assistant
           content:
-            - type: thinking
             - type: tool_use
               name: bash
               input:
-                command: mkdir -p ${workdir}/peer-output
-                description: Create peer-output directory
+                command: node -e "const fs=require('fs');fs.mkdirSync('peer-output',{recursive:true});fs.writeFileSync('peer-output/report.txt','PEER_NESTED')"
+                description: Create peer-output/report.txt via node
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
               content: '<shellId: 0 completed with exit code 0>'
     response:
-      content:
-        - type: tool_use
-          id: toolcall_1
-          name: create
-          input:
-            path: ${workdir}/peer-output/report.txt
-            file_text: PEER_NESTED
-      stopReason: tool_use
-  - request:
-      model: claude-sonnet-5
-      system: ${system}
-      messages:
-        - role: user
-          content: Create the file at ${workdir}/peer-output/report.txt containing exactly PEER_NESTED.
-        - role: assistant
-          content:
-            - type: thinking
-            - type: tool_use
-              name: bash
-              input:
-                command: mkdir -p ${workdir}/peer-output
-                description: Create peer-output directory
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_0
-              content: '<shellId: 0 completed with exit code 0>'
-        - role: assistant
-          content:
-            - type: tool_use
-              name: create
-              input:
-                path: ${workdir}/peer-output/report.txt
-                file_text: PEER_NESTED
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_1
-              content: Created file ${workdir}/peer-output/report.txt with 11 characters
-    response:
-      content: Created the file with exactly `PEER_NESTED` (no trailing newline) at [report.txt](${workdir}/peer-output/report.txt).
+      content: created
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-edits-an-existing-workspace-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-edits-an-existing-workspace-file.yaml
@@ -6,44 +6,74 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER. Use your file tools rather than running a shell command.
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: view
           input:
-            command: |-
-              cat > "${workdir}/peer-edit.txt" << 'EOF'
-              AFTER_PEER
-              EOF
-              cat "${workdir}/peer-edit.txt"
-            description: Replace contents of peer-edit.txt
+            path: ${workdir}/peer-edit.txt
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER.
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER. Use your file tools rather than running a shell command.
         - role: assistant
           content:
+            - type: thinking
             - type: tool_use
-              name: bash
+              name: view
               input:
-                command: |-
-                  cat > "${workdir}/peer-edit.txt" << 'EOF'
-                  AFTER_PEER
-                  EOF
-                  cat "${workdir}/peer-edit.txt"
-                description: Replace contents of peer-edit.txt
+                path: ${workdir}/peer-edit.txt
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                AFTER_PEER
-                <shellId: 0 completed with exit code 0>
+              content: 1. BEFORE_PEER
     response:
-      content: Done — the file now contains only `AFTER_PEER`.
+      content:
+        - type: tool_use
+          id: toolcall_1
+          name: edit
+          input:
+            path: ${workdir}/peer-edit.txt
+            old_str: BEFORE_PEER
+            new_str: AFTER_PEER
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Replace the complete contents of ${workdir}/peer-edit.txt with AFTER_PEER. Use your file tools rather than running a shell command.
+        - role: assistant
+          content:
+            - type: thinking
+            - type: tool_use
+              name: view
+              input:
+                path: ${workdir}/peer-edit.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: 1. BEFORE_PEER
+        - role: assistant
+          content:
+            - type: tool_use
+              name: edit
+              input:
+                path: ${workdir}/peer-edit.txt
+                old_str: BEFORE_PEER
+                new_str: AFTER_PEER
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
+              content: File ${workdir}/peer-edit.txt updated with changes.
+    response:
+      content: Done — the file now contains `AFTER_PEER`.
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-handles-a-missing-workspace-file-without-an-error.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-handles-a-missing-workspace-file-without-an-error.yaml
@@ -6,36 +6,32 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing".
+          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: view
           input:
-            command: cat "${workdir}/peer-missing.txt" 2>&1
-            description: Check if file exists
+            path: ${workdir}/peer-missing.txt
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing".
+          content: Try to read ${workdir}/peer-missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
         - role: assistant
           content:
             - type: tool_use
-              name: bash
+              name: view
               input:
-                command: cat "${workdir}/peer-missing.txt" 2>&1
-                description: Check if file exists
+                path: ${workdir}/peer-missing.txt
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                cat: ${workdir}/peer-missing.txt: No such file or directory
-                <shellId: 0 completed with exit code 1>
+              content: Path ${workdir}/peer-missing.txt does not exist. Please provide a valid path.
     response:
       content: missing
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-file-from-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-file-from-a-nested-directory.yaml
@@ -11,10 +11,9 @@ exchanges:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: view
           input:
-            command: cat "${workdir}/nested/peer.txt"
-            description: Read peer.txt file
+            path: ${workdir}/nested/peer.txt
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
@@ -25,17 +24,14 @@ exchanges:
         - role: assistant
           content:
             - type: tool_use
-              name: bash
+              name: view
               input:
-                command: cat "${workdir}/nested/peer.txt"
-                description: Read peer.txt file
+                path: ${workdir}/nested/peer.txt
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                PEER_NESTED_READ
-                <shellId: 0 completed with exit code 0>
+              content: 1. PEER_NESTED_READ
     response:
       content: PEER_NESTED_READ
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-filename-containing-spaces.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-peer-chat-reads-a-filename-containing-spaces.yaml
@@ -23,6 +23,7 @@ exchanges:
           content: Read the file at ${workdir}/peer file.txt and reply with its exact contents only.
         - role: assistant
           content:
+            - type: thinking
             - type: tool_use
               name: view
               input:

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-planning-mode-session-state-writes-are-auto-approved-in-default-mode.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-planning-mode-session-state-writes-are-auto-approved-in-default-mode.yaml
@@ -2,7 +2,7 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -11,30 +11,25 @@ exchanges:
       content:
         - type: tool_use
           id: toolcall_0
-          name: report_intent
-          input:
-            intent: Planning Python script
-        - type: tool_use
-          id: toolcall_1
           name: create
           input:
             path: ${homedir}/.copilot/session-state/${uuid_0}/plan.md
             file_text: |
-              # Plan
+              # Plan: Hello World Script
 
-              Create `hello.py` that prints "hello world" to stdout.
+              Create `hello.py` that prints `hello world` to stdout.
+
+              ## Todos
+              - create-hello-script: Create hello.py with `print("hello world")`
         - type: tool_use
-          id: toolcall_2
+          id: toolcall_1
           name: sql
           input:
             description: Insert hello world todo
-            query: INSERT INTO todos (id, title, description) VALUES ('create-hello-py', 'Creating hello.py script', 'Create hello.py with print("hello world")');
+            query: INSERT INTO todos (id, title, description, status) VALUES ('create-hello-script', 'Creating hello world script', 'Create hello.py in the workspace root containing print("hello world")', 'pending')
       stopReason: tool_use
-      usage:
-        inputTokens: 3
-        outputTokens: 287
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -43,50 +38,39 @@ exchanges:
           content:
             - type: thinking
             - type: tool_use
-              name: report_intent
-              input:
-                intent: Planning Python script
-            - type: tool_use
               name: create
               input:
                 path: ${homedir}/.copilot/session-state/${uuid_0}/plan.md
                 file_text: |
-                  # Plan
+                  # Plan: Hello World Script
 
-                  Create `hello.py` that prints "hello world" to stdout.
+                  Create `hello.py` that prints `hello world` to stdout.
+
+                  ## Todos
+                  - create-hello-script: Create hello.py with `print("hello world")`
             - type: tool_use
               name: sql
               input:
                 description: Insert hello world todo
-                query: INSERT INTO todos (id, title, description) VALUES ('create-hello-py', 'Creating hello.py script', 'Create hello.py with print("hello world")');
+                query: INSERT INTO todos (id, title, description, status) VALUES ('create-hello-script', 'Creating hello world script', 'Create hello.py in the workspace root containing print("hello world")', 'pending')
         - role: user
           content:
             - type: tool_result
-              tool_use_id: toolcall_0
-              content: Intent logged
-            - type: tool_result
-              tool_use_id: toolcall_2
+              tool_use_id: toolcall_1
               content: '1 row(s) inserted. Last inserted row ID: 1.'
             - type: tool_result
-              tool_use_id: toolcall_1
-              content: Created file ${homedir}/.copilot/session-state/${uuid_0}/plan.md with 63 characters
+              tool_use_id: toolcall_0
+              content: Created file ${homedir}/.copilot/session-state/${uuid_0}/plan.md with 160 characters
     response:
       content:
         - type: tool_use
-          id: toolcall_3
+          id: toolcall_2
           name: exit_plan_mode
           input:
-            summary: '- Create `hello.py` with `print("hello world")`'
-            actions:
-              - autopilot
-              - exit_only
-            recommendedAction: autopilot
+            summary: '- Create `hello.py` with a single line: `print("hello world")`'
       stopReason: tool_use
-      usage:
-        inputTokens: 45
-        outputTokens: 116
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -95,59 +79,48 @@ exchanges:
           content:
             - type: thinking
             - type: tool_use
-              name: report_intent
-              input:
-                intent: Planning Python script
-            - type: tool_use
               name: create
               input:
                 path: ${homedir}/.copilot/session-state/${uuid_0}/plan.md
                 file_text: |
-                  # Plan
+                  # Plan: Hello World Script
 
-                  Create `hello.py` that prints "hello world" to stdout.
+                  Create `hello.py` that prints `hello world` to stdout.
+
+                  ## Todos
+                  - create-hello-script: Create hello.py with `print("hello world")`
             - type: tool_use
               name: sql
               input:
                 description: Insert hello world todo
-                query: INSERT INTO todos (id, title, description) VALUES ('create-hello-py', 'Creating hello.py script', 'Create hello.py with print("hello world")');
+                query: INSERT INTO todos (id, title, description, status) VALUES ('create-hello-script', 'Creating hello world script', 'Create hello.py in the workspace root containing print("hello world")', 'pending')
         - role: user
           content:
             - type: tool_result
-              tool_use_id: toolcall_0
-              content: Intent logged
-            - type: tool_result
-              tool_use_id: toolcall_2
+              tool_use_id: toolcall_1
               content: '1 row(s) inserted. Last inserted row ID: 1.'
             - type: tool_result
-              tool_use_id: toolcall_1
-              content: Created file ${homedir}/.copilot/session-state/${uuid_0}/plan.md with 63 characters
+              tool_use_id: toolcall_0
+              content: Created file ${homedir}/.copilot/session-state/${uuid_0}/plan.md with 160 characters
         - role: assistant
           content:
             - type: tool_use
               name: exit_plan_mode
               input:
-                summary: '- Create `hello.py` with `print("hello world")`'
-                actions:
-                  - autopilot
-                  - exit_only
-                recommendedAction: autopilot
+                summary: '- Create `hello.py` with a single line: `print("hello world")`'
         - role: user
           content:
             - type: tool_result
-              tool_use_id: toolcall_3
+              tool_use_id: toolcall_2
               content: |-
                 Plan approved! Exited plan mode.
 
                 You are now in interactive mode without automatic execution (wait for the user's next prompt). Wait for the user to prompt you before taking any action.
     response:
-      content: Ready to implement when you say go.
+      content: Plan approved. Let me know when you'd like me to create `hello.py` with `print("hello world")`.
       stopReason: end_turn
-      usage:
-        inputTokens: 1
-        outputTokens: 11
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -156,65 +129,47 @@ exchanges:
           content:
             - type: thinking
             - type: tool_use
-              name: report_intent
-              input:
-                intent: Planning Python script
-            - type: tool_use
               name: create
               input:
                 path: ${homedir}/.copilot/session-state/${uuid_0}/plan.md
                 file_text: |
-                  # Plan
+                  # Plan: Hello World Script
 
-                  Create `hello.py` that prints "hello world" to stdout.
+                  Create `hello.py` that prints `hello world` to stdout.
+
+                  ## Todos
+                  - create-hello-script: Create hello.py with `print("hello world")`
             - type: tool_use
               name: sql
               input:
                 description: Insert hello world todo
-                query: INSERT INTO todos (id, title, description) VALUES ('create-hello-py', 'Creating hello.py script', 'Create hello.py with print("hello world")');
+                query: INSERT INTO todos (id, title, description, status) VALUES ('create-hello-script', 'Creating hello world script', 'Create hello.py in the workspace root containing print("hello world")', 'pending')
         - role: user
           content:
             - type: tool_result
-              tool_use_id: toolcall_0
-              content: Intent logged
-            - type: tool_result
-              tool_use_id: toolcall_2
+              tool_use_id: toolcall_1
               content: '1 row(s) inserted. Last inserted row ID: 1.'
             - type: tool_result
-              tool_use_id: toolcall_1
-              content: Created file ${homedir}/.copilot/session-state/${uuid_0}/plan.md with 63 characters
+              tool_use_id: toolcall_0
+              content: Created file ${homedir}/.copilot/session-state/${uuid_0}/plan.md with 160 characters
         - role: assistant
           content:
             - type: tool_use
               name: exit_plan_mode
               input:
-                summary: '- Create `hello.py` with `print("hello world")`'
-                actions:
-                  - autopilot
-                  - exit_only
-                recommendedAction: autopilot
+                summary: '- Create `hello.py` with a single line: `print("hello world")`'
         - role: user
           content:
             - type: tool_result
-              tool_use_id: toolcall_3
+              tool_use_id: toolcall_2
               content: |-
                 Plan approved! Exited plan mode.
 
                 You are now in interactive mode without automatic execution (wait for the user's next prompt). Wait for the user to prompt you before taking any action.
         - role: assistant
-          content: Ready to implement when you say go.
+          content: Plan approved. Let me know when you'd like me to create `hello.py` with `print("hello world")`.
         - role: user
-          content: |-
-            <tools_changed_notice>
-            Tools no longer available: exit_plan_mode
-
-            Important: Do not attempt to call tools that are no longer available unless you've been notified that they're available again.
-            </tools_changed_notice>
-
-            What did the plan I just approved say to print? Reply with exactly "hello world".
+          content: What did the plan I just approved say to print? Reply with exactly "hello world".
     response:
       content: hello world
       stopReason: end_turn
-      usage:
-        inputTokens: 3
-        outputTokens: 5

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-reads-a-file-from-a-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-reads-a-file-from-a-nested-directory.yaml
@@ -6,36 +6,68 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Read nested/value.txt and reply with its exact contents only.
+          content: Read nested/value.txt and reply with its exact contents only. Use your file tools rather than running a shell command.
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: glob
           input:
-            command: cat nested/value.txt
-            description: Read nested/value.txt
+            pattern: '**/nested/value.txt'
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: Read nested/value.txt and reply with its exact contents only.
+          content: Read nested/value.txt and reply with its exact contents only. Use your file tools rather than running a shell command.
         - role: assistant
           content:
             - type: tool_use
-              name: bash
+              name: glob
               input:
-                command: cat nested/value.txt
-                description: Read nested/value.txt
+                pattern: '**/nested/value.txt'
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: |-
-                NESTED_VALUE_42
-                <shellId: 0 completed with exit code 0>
+              content: ./nested/value.txt
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_1
+          name: view
+          input:
+            path: ${workdir}/nested/value.txt
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Read nested/value.txt and reply with its exact contents only. Use your file tools rather than running a shell command.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: glob
+              input:
+                pattern: '**/nested/value.txt'
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: ./nested/value.txt
+        - role: assistant
+          content:
+            - type: tool_use
+              name: view
+              input:
+                path: ${workdir}/nested/value.txt
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
+              content: 1. NESTED_VALUE_42
     response:
       content: NESTED_VALUE_42
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-reads-a-filename-containing-spaces.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-reads-a-filename-containing-spaces.yaml
@@ -39,7 +39,7 @@ exchanges:
           id: toolcall_1
           name: view
           input:
-            path: ${workdir}/ahp-coverage-spaces-${temp}/file with spaces.txt
+            path: ${workdir}/file with spaces.txt
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
@@ -64,7 +64,7 @@ exchanges:
             - type: tool_use
               name: view
               input:
-                path: ${workdir}/ahp-coverage-spaces-${temp}/file with spaces.txt
+                path: ${workdir}/file with spaces.txt
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-renames-a-workspace-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-renames-a-workspace-file.yaml
@@ -6,48 +6,14 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Rename before.txt to after.txt without changing its contents.
+          content: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: ${shell}
           input:
-            command: find / -maxdepth 4 -name "before.txt" 2>/dev/null; pwd; ls -la
-            description: Locate before.txt
-      stopReason: tool_use
-  - request:
-      model: claude-sonnet-5
-      system: ${system}
-      messages:
-        - role: user
-          content: Rename before.txt to after.txt without changing its contents.
-        - role: assistant
-          content:
-            - type: thinking
-            - type: tool_use
-              name: bash
-              input:
-                command: find / -maxdepth 4 -name "before.txt" 2>/dev/null; pwd; ls -la
-                description: Locate before.txt
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_0
-              content: |-
-                ${workdir}/ahp-coverage-rename-${temp}
-                total 8
-                drwx------@    3 ${user}  staff      96 ${timestamp} .
-                drwx------@ 3668 ${user}  staff  117376 ${timestamp} ..
-                -rw-r--r--@    1 ${user}  staff      12 ${timestamp} before.txt
-                <shellId: 0 completed with exit code 0>
-    response:
-      content:
-        - type: tool_use
-          id: toolcall_1
-          name: bash
-          input:
-            command: cd ${workdir}/ahp-coverage-rename-${temp} && mv before.txt after.txt && ls -la && cat after.txt
+            command: node -e "require('fs').renameSync('before.txt','after.txt')"
             description: Rename before.txt to after.txt
       stopReason: tool_use
   - request:
@@ -55,44 +21,20 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Rename before.txt to after.txt without changing its contents.
+          content: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
         - role: assistant
           content:
             - type: thinking
             - type: tool_use
               name: bash
               input:
-                command: find / -maxdepth 4 -name "before.txt" 2>/dev/null; pwd; ls -la
-                description: Locate before.txt
-        - role: user
-          content:
-            - type: tool_result
-              tool_use_id: toolcall_0
-              content: |-
-                ${workdir}/ahp-coverage-rename-${temp}
-                total 8
-                drwx------@    3 ${user}  staff      96 ${timestamp} .
-                drwx------@ 3668 ${user}  staff  117376 ${timestamp} ..
-                -rw-r--r--@    1 ${user}  staff      12 ${timestamp} before.txt
-                <shellId: 0 completed with exit code 0>
-        - role: assistant
-          content:
-            - type: tool_use
-              name: bash
-              input:
-                command: cd ${workdir}/ahp-coverage-rename-${temp} && mv before.txt after.txt && ls -la && cat after.txt
+                command: node -e "require('fs').renameSync('before.txt','after.txt')"
                 description: Rename before.txt to after.txt
         - role: user
           content:
             - type: tool_result
-              tool_use_id: toolcall_1
-              content: |-
-                total 8
-                drwx------@    3 ${user}  staff      96 ${timestamp} .
-                drwx------@ 3668 ${user}  staff  117376 ${timestamp} ..
-                -rw-r--r--@    1 ${user}  staff      12 ${timestamp} after.txt
-                RENAME_VALUE
-                <shellId: 1 completed with exit code 0>
+              tool_use_id: toolcall_0
+              content: '<shellId: 0 completed with exit code 0>'
     response:
-      content: Renamed `before.txt` to `after.txt` — contents (`RENAME_VALUE`) unchanged.
+      content: renamed
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-reopening-a-session-keeps-sub-agent-messages-out-of-the-parent-transcript-replay-path.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-reopening-a-session-keeps-sub-agent-messages-out-of-the-parent-transcript-replay-path.yaml
@@ -2,7 +2,7 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -11,98 +11,58 @@ exchanges:
       content:
         - type: tool_use
           id: toolcall_0
-          name: report_intent
-          input:
-            intent: Spawning subagent task
-        - type: tool_use
-          id: toolcall_1
           name: task
           input:
             name: list-files
-            prompt: |-
-              Begin your response with this sentence on its own line: subagent replay note sentinel-7f3a
-
-              Then list all files in the current working directory ${workdir}/ahp-subagent-replay-D1IH5t using the glob tool or ls command.
+            prompt: 'Begin your response with this exact sentence on its own line: subagent replay note sentinel-7f3a. Then list the files in the current working directory.'
             agent_type: explore
-            description: Listing directory files
+            description: List files in cwd
             mode: sync
       stopReason: tool_use
-      usage:
-        inputTokens: 3
-        outputTokens: 316
   - request:
       model: claude-haiku-4.5
       system: ${system}
       messages:
         - role: user
-          content: |-
-            Begin your response with this sentence on its own line: subagent replay note sentinel-7f3a
-
-            Then list all files in the current working directory ${workdir}/ahp-subagent-replay-D1IH5t using the glob tool or ls command.
+          content: 'Begin your response with this exact sentence on its own line: subagent replay note sentinel-7f3a. Then list the files in the current working directory.'
     response:
       content:
-        - type: text
-          text: subagent replay note sentinel-7f3a
         - type: tool_use
-          id: toolcall_2
-          name: glob
+          id: toolcall_1
+          name: view
           input:
-            pattern: '**'
-            paths: ${workdir}/ahp-subagent-replay-D1IH5t
-        - type: tool_use
-          id: toolcall_3
-          name: bash
-          input:
-            command: ls -la ${workdir}/ahp-subagent-replay-D1IH5t
+            path: ${workdir}
       stopReason: tool_use
-      usage:
-        inputTokens: 4043
-        outputTokens: 439
   - request:
       model: claude-haiku-4.5
       system: ${system}
       messages:
         - role: user
-          content: |-
-            Begin your response with this sentence on its own line: subagent replay note sentinel-7f3a
-
-            Then list all files in the current working directory ${workdir}/ahp-subagent-replay-D1IH5t using the glob tool or ls command.
+          content: 'Begin your response with this exact sentence on its own line: subagent replay note sentinel-7f3a. Then list the files in the current working directory.'
         - role: assistant
           content:
             - type: thinking
-            - type: text
-              text: subagent replay note sentinel-7f3a
             - type: tool_use
-              name: glob
+              name: view
               input:
-                pattern: '**'
-                paths: ${workdir}/ahp-subagent-replay-D1IH5t
-            - type: tool_use
-              name: bash
-              input:
-                command: ls -la ${workdir}/ahp-subagent-replay-D1IH5t
+                path: ${workdir}
         - role: user
           content:
             - type: tool_result
-              tool_use_id: toolcall_2
+              tool_use_id: toolcall_1
               content: |-
-                ${workdir}/ahp-subagent-replay-D1IH5t/file-a.txt
-                ${workdir}/ahp-subagent-replay-D1IH5t/file-b.txt
-            - type: tool_result
-              tool_use_id: toolcall_3
-              content: "Shell ID: ${uuid_0}\nExit code: 0\nls -la /var/folders/yj \r/46gvyjxx5479vlbnxz_914xw0000gn/T/ahp-subagent-replay-D1IH5t\r\ntotal 16\r\ndrwx------    4 ${user}  staff    128 Jul  7 16:05 .\r\ndrwx------@ 975 ${user}  staff  31200 Jul  7 16:06 ..\r\n-rw-r--r--    1 ${user}  staff      5 Jul  7 16:05 file-a.txt\r\n-rw-r--r--    1 ${user}  staff      4 Jul  7 16:05 file-b.txt"
+                file-a.txt
+                file-b.txt
     response:
       content: |-
-        **Files in the current working directory:**
+        subagent replay note sentinel-7f3a
 
-        1. `${workdir}/ahp-subagent-replay-D1IH5t/file-a.txt`
-        2. `${workdir}/ahp-subagent-replay-D1IH5t/file-b.txt`
+        Files in the current working directory:
+        - file-a.txt
+        - file-b.txt
       stopReason: end_turn
-      usage:
-        inputTokens: 7
-        outputTokens: 121
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -111,35 +71,23 @@ exchanges:
           content:
             - type: thinking
             - type: tool_use
-              name: report_intent
-              input:
-                intent: Spawning subagent task
-            - type: tool_use
               name: task
               input:
                 name: list-files
-                prompt: |-
-                  Begin your response with this sentence on its own line: subagent replay note sentinel-7f3a
-
-                  Then list all files in the current working directory ${workdir}/ahp-subagent-replay-D1IH5t using the glob tool or ls command.
+                prompt: 'Begin your response with this exact sentence on its own line: subagent replay note sentinel-7f3a. Then list the files in the current working directory.'
                 agent_type: explore
-                description: Listing directory files
+                description: List files in cwd
                 mode: sync
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: Intent logged
-            - type: tool_result
-              tool_use_id: toolcall_1
               content: |-
-                **Files in the current working directory:**
+                subagent replay note sentinel-7f3a
 
-                1. `${workdir}/ahp-subagent-replay-D1IH5t/file-a.txt`
-                2. `${workdir}/ahp-subagent-replay-D1IH5t/file-b.txt`
+                Files in the current working directory:
+                - file-a.txt
+                - file-b.txt
     response:
       content: SUBAGENT_DONE
       stopReason: end_turn
-      usage:
-        inputTokens: 1
-        outputTokens: 10

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-runs-a-deterministic-shell-command.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-runs-a-deterministic-shell-command.yaml
@@ -6,29 +6,29 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Run a shell command that prints SHELL_VALUE_73, then reply with that exact value only.
+          content: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: bash
+          name: ${shell}
           input:
             command: echo SHELL_VALUE_73
-            description: Print SHELL_VALUE_73
+            description: Echo the shell value
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: Run a shell command that prints SHELL_VALUE_73, then reply with that exact value only.
+          content: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
         - role: assistant
           content:
             - type: tool_use
               name: bash
               input:
                 command: echo SHELL_VALUE_73
-                description: Print SHELL_VALUE_73
+                description: Echo the shell value
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-runs-a-deterministic-shell-command.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-runs-a-deterministic-shell-command.yaml
@@ -14,7 +14,7 @@ exchanges:
           name: ${shell}
           input:
             command: echo SHELL_VALUE_73
-            description: Echo the shell value
+            description: Echo the requested value
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
@@ -28,7 +28,7 @@ exchanges:
               name: bash
               input:
                 command: echo SHELL_VALUE_73
-                description: Echo the shell value
+                description: Echo the requested value
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-sends-a-simple-message-and-receives-a-response.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-sends-a-simple-message-and-receives-a-response.yaml
@@ -2,7 +2,7 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -10,6 +10,3 @@ exchanges:
     response:
       content: hello
       stopReason: end_turn
-      usage:
-        inputTokens: 3
-        outputTokens: 4

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-strips-redundant-cd-workingdirectory-prefix-from-shell-tool-calls.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-strips-redundant-cd-workingdirectory-prefix-from-shell-tool-calls.yaml
@@ -2,56 +2,40 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: 'Run this exact shell command, do not modify it: cd ${workdir}/ahp-cd-strip-test-u1pzov && echo strip-me-please'
+          content: 'Run this exact shell command, do not modify it: cd ${workdir} && echo strip-me-please'
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: report_intent
+          name: ${shell}
           input:
-            intent: Running shell command
-        - type: tool_use
-          id: toolcall_1
-          name: bash
-          input:
-            command: cd ${workdir}/ahp-cd-strip-test-u1pzov && echo strip-me-please
+            command: cd ${workdir} && echo strip-me-please
+            description: Run echo command in target directory
       stopReason: tool_use
-      usage:
-        inputTokens: 3
-        outputTokens: 141
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
-          content: 'Run this exact shell command, do not modify it: cd ${workdir}/ahp-cd-strip-test-u1pzov && echo strip-me-please'
+          content: 'Run this exact shell command, do not modify it: cd ${workdir} && echo strip-me-please'
         - role: assistant
           content:
             - type: tool_use
-              name: report_intent
-              input:
-                intent: Running shell command
-            - type: tool_use
               name: bash
               input:
-                command: cd ${workdir}/ahp-cd-strip-test-u1pzov && echo strip-me-please
+                command: cd ${workdir} && echo strip-me-please
+                description: Run echo command in target directory
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: Intent logged
-            - type: tool_result
-              tool_use_id: toolcall_1
               content: |-
-                Shell ID: ${uuid_0}
-                Exit code: 0
+                strip-me-please
+                <shellId: 0 completed with exit code 0>
     response:
-      content: Done. The command executed successfully with exit code 0, outputting `strip-me-please`.
+      content: 'Output: `strip-me-please`'
       stopReason: end_turn
-      usage:
-        inputTokens: 1
-        outputTokens: 24

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-subagent-tool-calls-are-routed-to-the-subagent-session-not-flat-in-the-parent.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-subagent-tool-calls-are-routed-to-the-subagent-session-not-flat-in-the-parent.yaml
@@ -2,7 +2,7 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -11,71 +11,65 @@ exchanges:
       content:
         - type: tool_use
           id: toolcall_0
-          name: report_intent
-          input:
-            intent: Delegating directory listing
-        - type: tool_use
-          id: toolcall_1
           name: task
           input:
-            name: list-dir
-            prompt: List the files in the directory ${workdir}/ahp-subagent-test-uwYpoY using the view tool.
+            name: list-cwd-files
+            prompt: |-
+              List the files in the current working directory: ${workdir}
+
+              Call a single read-only tool (e.g. `view` on that path, or a shell `ls` command) to enumerate the directory contents, then report back the list of files/directories found. Do not make any other tool calls.
             agent_type: explore
-            description: List directory files
+            description: List files in cwd
             mode: sync
       stopReason: tool_use
-      usage:
-        inputTokens: 3
-        outputTokens: 218
   - request:
       model: claude-haiku-4.5
       system: ${system}
       messages:
         - role: user
-          content: List the files in the directory ${workdir}/ahp-subagent-test-uwYpoY using the view tool.
+          content: |-
+            List the files in the current working directory: ${workdir}
+
+            Call a single read-only tool (e.g. `view` on that path, or a shell `ls` command) to enumerate the directory contents, then report back the list of files/directories found. Do not make any other tool calls.
     response:
       content:
         - type: tool_use
-          id: toolcall_2
+          id: toolcall_1
           name: view
           input:
-            path: ${workdir}/ahp-subagent-test-uwYpoY
+            path: ${workdir}
       stopReason: tool_use
-      usage:
-        inputTokens: 4006
-        outputTokens: 173
   - request:
       model: claude-haiku-4.5
       system: ${system}
       messages:
         - role: user
-          content: List the files in the directory ${workdir}/ahp-subagent-test-uwYpoY using the view tool.
+          content: |-
+            List the files in the current working directory: ${workdir}
+
+            Call a single read-only tool (e.g. `view` on that path, or a shell `ls` command) to enumerate the directory contents, then report back the list of files/directories found. Do not make any other tool calls.
         - role: assistant
           content:
             - type: thinking
             - type: tool_use
               name: view
               input:
-                path: ${workdir}/ahp-subagent-test-uwYpoY
+                path: ${workdir}
         - role: user
           content:
             - type: tool_result
-              tool_use_id: toolcall_2
+              tool_use_id: toolcall_1
               content: |-
                 file-a.txt
                 file-b.txt
     response:
       content: |-
-        The directory `${workdir}/ahp-subagent-test-uwYpoY` contains two files:
-
-        1. **file-a.txt**
-        2. **file-b.txt**
+        The directory contains the following files:
+        - **file-a.txt**
+        - **file-b.txt**
       stopReason: end_turn
-      usage:
-        inputTokens: 6
-        outputTokens: 73
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -83,36 +77,28 @@ exchanges:
         - role: assistant
           content:
             - type: tool_use
-              name: report_intent
-              input:
-                intent: Delegating directory listing
-            - type: tool_use
               name: task
               input:
-                name: list-dir
-                prompt: List the files in the directory ${workdir}/ahp-subagent-test-uwYpoY using the view tool.
+                name: list-cwd-files
+                prompt: |-
+                  List the files in the current working directory: ${workdir}
+
+                  Call a single read-only tool (e.g. `view` on that path, or a shell `ls` command) to enumerate the directory contents, then report back the list of files/directories found. Do not make any other tool calls.
                 agent_type: explore
-                description: List directory files
+                description: List files in cwd
                 mode: sync
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: Intent logged
-            - type: tool_result
-              tool_use_id: toolcall_1
               content: |-
-                The directory `${workdir}/ahp-subagent-test-uwYpoY` contains two files:
-
-                1. **file-a.txt**
-                2. **file-b.txt**
+                The directory contains the following files:
+                - **file-a.txt**
+                - **file-b.txt**
     response:
       content: |-
-        The subagent reports the current working directory contains two files:
+        The subagent listed the contents of the current working directory and found two files:
 
-        1. **file-a.txt**
-        2. **file-b.txt**
+        - **file-a.txt**
+        - **file-b.txt**
       stopReason: end_turn
-      usage:
-        inputTokens: 1
-        outputTokens: 36

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-tool-call-triggers-permission-request-and-can-be-approved.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-tool-call-triggers-permission-request-and-can-be-approved.yaml
@@ -2,7 +2,7 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -11,20 +11,13 @@ exchanges:
       content:
         - type: tool_use
           id: toolcall_0
-          name: report_intent
-          input:
-            intent: Running shell command
-        - type: tool_use
-          id: toolcall_1
-          name: bash
+          name: ${shell}
           input:
             command: echo "hello from test"
+            description: Echo test string
       stopReason: tool_use
-      usage:
-        inputTokens: 3
-        outputTokens: 95
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -32,30 +25,17 @@ exchanges:
         - role: assistant
           content:
             - type: tool_use
-              name: report_intent
-              input:
-                intent: Running shell command
-            - type: tool_use
               name: bash
               input:
                 command: echo "hello from test"
+                description: Echo test string
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: Intent logged
-            - type: tool_result
-              tool_use_id: toolcall_1
               content: |-
-                Shell ID: ${uuid_0}
-                Exit code: 0
+                hello from test
+                <shellId: 0 completed with exit code 0>
     response:
-      content: |-
-        Done. The command output:
-        ```
-        hello from test
-        ```
+      content: 'Output: `hello from test`'
       stopReason: end_turn
-      usage:
-        inputTokens: 1
-        outputTokens: 17

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-two-peer-chats-write-distinct-workspace-files.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-two-peer-chats-write-distinct-workspace-files.yaml
@@ -35,7 +35,7 @@ exchanges:
               tool_use_id: toolcall_0
               content: Created file ${workdir}/first-peer.txt with 10 characters
     response:
-      content: Created [first-peer.txt](${workdir}/first-peer.txt) with the exact content `FIRST_PEER`.
+      content: Created [first-peer.txt](${workdir}/first-peer.txt) with the content `FIRST_PEER`.
       stopReason: end_turn
   - request:
       model: claude-sonnet-5
@@ -71,5 +71,5 @@ exchanges:
               tool_use_id: toolcall_1
               content: Created file ${workdir}/second-peer.txt with 11 characters
     response:
-      content: Created the file with the exact content `SECOND_PEER`.
+      content: Created [second-peer.txt](${workdir}/second-peer.txt) containing `SECOND_PEER`.
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-usage-reports-include-copilot-cost-metadata.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-usage-reports-include-copilot-cost-metadata.yaml
@@ -2,7 +2,7 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
@@ -10,6 +10,3 @@ exchanges:
     response:
       content: usage-ok
       stopReason: end_turn
-      usage:
-        inputTokens: 3
-        outputTokens: 6

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-worktree-session-uses-the-resolved-worktree-as-working-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-worktree-session-uses-the-resolved-worktree-as-working-directory.yaml
@@ -2,59 +2,44 @@ version: 1
 dialect: anthropic
 exchanges:
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
           content: What is your current working directory? Reply with just the absolute path and nothing else.
     response:
-      content: /private${workdir}/ahp-wt-test-s0XdKh.worktrees/what-is-your-current-working-directory-reply-wit
+      content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
       stopReason: end_turn
-      usage:
-        inputTokens: 3
-        outputTokens: 69
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
           content: What is your current working directory? Reply with just the absolute path and nothing else.
         - role: assistant
-          content: /private${workdir}/ahp-wt-test-s0XdKh.worktrees/what-is-your-current-working-directory-reply-wit
+          content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
         - role: user
           content: 'Run the shell command: pwd'
     response:
       content:
         - type: tool_use
           id: toolcall_0
-          name: report_intent
-          input:
-            intent: Running pwd command
-        - type: tool_use
-          id: toolcall_1
-          name: bash
+          name: ${shell}
           input:
             command: pwd
       stopReason: tool_use
-      usage:
-        inputTokens: 3
-        outputTokens: 90
   - request:
-      model: claude-opus-4.6
+      model: claude-sonnet-5
       system: ${system}
       messages:
         - role: user
           content: What is your current working directory? Reply with just the absolute path and nothing else.
         - role: assistant
-          content: /private${workdir}/ahp-wt-test-s0XdKh.worktrees/what-is-your-current-working-directory-reply-wit
+          content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
         - role: user
           content: 'Run the shell command: pwd'
         - role: assistant
           content:
-            - type: tool_use
-              name: report_intent
-              input:
-                intent: Running pwd command
             - type: tool_use
               name: bash
               input:
@@ -63,18 +48,7 @@ exchanges:
           content:
             - type: tool_result
               tool_use_id: toolcall_0
-              content: Intent logged
-            - type: tool_result
-              tool_use_id: toolcall_1
-              content: |-
-                Shell ID: ${uuid_0}
-                Exit code: 0
+              content: "Shell ID: ${uuid_0}\nExit code: 0\n${workdir}.worktrees/what-is-your-current-working-directory-reply-wit\r\n%"
     response:
-      content: |-
-        ```
-        /private${workdir}/ahp-wt-test-s0XdKh.worktrees/what-is-your-current-working-directory-reply-wit
-        ```
+      content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
       stopReason: end_turn
-      usage:
-        inputTokens: 1
-        outputTokens: 73

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -9,7 +9,7 @@
 
 import assert from 'assert';
 import { execSync } from 'child_process';
-import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
+import { chmodSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
 import { homedir, tmpdir, userInfo } from 'os';
 import { fileURLToPath } from 'url';
 import { timeout } from '../../../../../../base/common/async.js';
@@ -61,6 +61,41 @@ const TEMP_DIR_CLEANUP_TIMEOUT_MS = 30_000;
 export const REPLAY_PLACEHOLDER_TOKEN = 'replay-no-token';
 export type AgentHostE2EModelTraffic = 'recorded' | 'none';
 
+/**
+ * Clears read-only attributes across a directory tree.
+ *
+ * Git marks the files under `.git/objects` read-only, and on Windows a
+ * read-only file cannot be deleted — `rmSync`'s `force` option only suppresses
+ * `ENOENT`, it does not override the attribute. Without this, any test that
+ * creates a git repository in a temp directory fails teardown on Windows after
+ * burning the full cleanup timeout, even though the test itself passed.
+ *
+ * Best-effort throughout: entries can disappear underneath us while the failed
+ * removal is still unwinding, and a failure here just means the retry fails the
+ * same way it already did.
+ */
+function clearReadOnlyAttributes(dir: string): void {
+	let entries: string[];
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		const entryPath = join(dir, entry);
+		try {
+			// Directories need the execute bit to stay traversable.
+			const isDirectory = statSync(entryPath).isDirectory();
+			chmodSync(entryPath, isDirectory ? 0o700 : 0o600);
+			if (isDirectory) {
+				clearReadOnlyAttributes(entryPath);
+			}
+		} catch {
+			// Entry vanished or cannot be changed; the retry will report it.
+		}
+	}
+}
+
 export async function removeTempDirs(tempDirs: string[]): Promise<void> {
 	const pendingDirs = tempDirs.splice(0);
 	const errors = new Map<string, Error>();
@@ -74,6 +109,10 @@ export async function removeTempDirs(tempDirs: string[]): Promise<void> {
 				errors.delete(dir);
 			} catch (error) {
 				errors.set(dir, error instanceof Error ? error : new Error(String(error)));
+				// A read-only file never becomes deletable by waiting, so clear the
+				// attributes before the retry rather than spinning until the
+				// deadline. Harmless when the real cause is a transient lock.
+				clearReadOnlyAttributes(dir);
 			}
 		}
 		if (pendingDirs.length === 0) {

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -108,11 +108,27 @@ function fixturePathFor(provider: string, testTitle: string): string {
  * `AGENT_HOST_REPLAY_RECORD=1` or `AGENT_HOST_UPDATE_SNAPSHOTS=1`. Tests that
  * declare no model traffic always use the strict shared empty replay fixture.
  */
-export function capiReplayFor(provider: string, testTitle: string, modelTraffic: AgentHostE2EModelTraffic = 'recorded'): { fixturePath: string; real: true; mode: CapiReplayMode } {
+/**
+ * Tests whose recorded capture is allowed to contain POSIX-only commands.
+ *
+ * Each entry must correspond to a test that is *also* scoped away from Windows
+ * at its call site, with the reason stated there. This list exists so the
+ * exceptions are countable in one place; adding to it should be rare and
+ * deliberate. See `harness/posixCommandLint.ts`.
+ */
+const POSIX_COMMAND_EXCEPTIONS = new Set([
+	// `pwd` is auto-approved as a safe read-only command while a pinned
+	// `node -e "…"` is not, so pinning stops the turn on a permission prompt the
+	// test never answers. Its assertions also compare POSIX-shaped paths.
+	'worktree session uses the resolved worktree as working directory',
+]);
+
+export function capiReplayFor(provider: string, testTitle: string, modelTraffic: AgentHostE2EModelTraffic = 'recorded'): { fixturePath: string; real: true; mode: CapiReplayMode; allowPosixCommands: boolean } {
+	const allowPosixCommands = POSIX_COMMAND_EXCEPTIONS.has(testTitle);
 	if (modelTraffic === 'none') {
-		return { fixturePath: EMPTY_CAPTURE_PATH, real: true, mode: 'replay' };
+		return { fixturePath: EMPTY_CAPTURE_PATH, real: true, mode: 'replay', allowPosixCommands };
 	}
-	return { fixturePath: fixturePathFor(provider, testTitle), real: true, mode: REPLAY_MODE };
+	return { fixturePath: fixturePathFor(provider, testTitle), real: true, mode: REPLAY_MODE, allowPosixCommands };
 }
 
 // #endregion

--- a/src/vs/platform/agentHost/test/node/e2e/harness/ahpSnapshot.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/ahpSnapshot.ts
@@ -176,6 +176,7 @@ export class AhpSnapshotRecorder {
 		}
 
 		for (const round of rounds) {
+			round.serverToClient = dropEmptyReasoningParts(round.serverToClient);
 			normalizeSnapshotObjects(round.clientToServer, this._normalization);
 			normalizeSnapshotObjects(round.serverToClient, this._normalization);
 		}
@@ -367,7 +368,7 @@ function projectAction(
 				type: action.type,
 				turnId: normalizeIdentifier(action.turnId, 'turn', turns),
 				toolCallId: normalizeIdentifier(action.toolCallId, 'toolCall', toolCalls),
-				toolName: action.toolName,
+				toolName: normalizeShellToolName(action.toolName),
 				...(profile === 'protocol' ? {
 					displayName: action.displayName,
 					contributor: projectContributor(action.contributor),
@@ -420,6 +421,54 @@ function projectAction(
 		default:
 			return { type: action.type };
 	}
+}
+
+/**
+ * Drops reasoning parts that never received any content.
+ *
+ * A provider can open a reasoning part and then close it without emitting a
+ * delta. Live recording sees that empty part on the wire, but replay rebuilds
+ * the stream from the fixture's aggregated message content, where an empty
+ * reasoning block leaves no trace — so it can never be reproduced. Keeping it
+ * would make any snapshot recorded during such a turn permanently unreplayable.
+ *
+ * Runs after projection because `ChatDelta` fills in content by mutating the
+ * part recorded here, so a part's final content is only known once every
+ * message has been projected.
+ */
+function dropEmptyReasoningParts(actions: object[]): object[] {
+	return actions.filter(entry => {
+		const action = (entry as { action?: { type?: string; part?: { kind?: string; content?: string } } }).action;
+		return !(action?.type === ActionType.ChatResponsePart
+			&& action.part?.kind === ResponsePartKind.Reasoning
+			&& action.part.content === '');
+	});
+}
+
+/**
+ * Collapses the platform-specific Copilot shell tool names to stable
+ * placeholders.
+ *
+ * The Copilot CLI names its shell tools after the shell it runs: `bash` and
+ * friends on POSIX, `powershell` and friends on Windows. That name reaches the
+ * client verbatim in `chat/toolCallStart`, so a snapshot recorded on macOS or
+ * Linux can never match the same behavior on Windows even when the recorded
+ * command itself is portable.
+ *
+ * Only the names that actually vary by platform are mapped. Claude's `Bash` and
+ * Codex's `shell` are fixed strings their SDKs use everywhere, so they are left
+ * alone — rewriting them would hide a genuine provider change.
+ */
+function normalizeShellToolName(toolName: string): string {
+	const shellToolPlaceholders: Record<string, string> = {
+		bash: '${shell}', powershell: '${shell}',
+		read_bash: '${read_shell}', read_powershell: '${read_shell}',
+		write_bash: '${write_shell}', write_powershell: '${write_shell}',
+		stop_bash: '${stop_shell}', stop_powershell: '${stop_shell}',
+		bash_shutdown: '${shell_shutdown}', powershell_shutdown: '${shell_shutdown}',
+		list_bash: '${list_shell}', list_powershell: '${list_shell}',
+	};
+	return shellToolPlaceholders[toolName] ?? toolName;
 }
 
 function isBehaviorSnapshotNoise(type: ActionType): boolean {

--- a/src/vs/platform/agentHost/test/node/e2e/harness/ahpSnapshot.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/ahpSnapshot.ts
@@ -511,6 +511,14 @@ function normalizeSnapshotText(value: string, normalization: IAhpSnapshotNormali
 		// The workspace can be deleted during teardown after the traffic was captured.
 	}
 	let normalized = value;
+	// Line endings first, so every line-anchored pattern below sees LF-only
+	// text. Windows produces CRLF for the same behavior a POSIX host reports
+	// with LF, which would otherwise fail a snapshot recorded on macOS/Linux
+	// for a reason unrelated to the behavior under test. The escaped form is
+	// normalized too because tool inputs are often embedded JSON, where the
+	// carriage return survives as a literal `\r` escape rather than a control
+	// character.
+	normalized = normalized.replaceAll('\r\n', '\n').replaceAll('\\r\\n', '\\n');
 	for (const workDir of [...workDirs].sort((a, b) => b.length - a.length)) {
 		normalized = normalized
 			.replaceAll(JSON.stringify(workDir).slice(1, -1), '${workdir}')

--- a/src/vs/platform/agentHost/test/node/e2e/harness/ahpSnapshot.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/ahpSnapshot.ts
@@ -176,7 +176,7 @@ export class AhpSnapshotRecorder {
 		}
 
 		for (const round of rounds) {
-			round.serverToClient = dropEmptyReasoningParts(round.serverToClient);
+			round.serverToClient = dropReasoning(round.serverToClient);
 			normalizeSnapshotObjects(round.clientToServer, this._normalization);
 			normalizeSnapshotObjects(round.serverToClient, this._normalization);
 		}
@@ -424,24 +424,28 @@ function projectAction(
 }
 
 /**
- * Drops reasoning parts that never received any content.
+ * Drops reasoning traffic from the snapshot.
  *
- * A provider can open a reasoning part and then close it without emitting a
- * delta. Live recording sees that empty part on the wire, but replay rebuilds
- * the stream from the fixture's aggregated message content, where an empty
- * reasoning block leaves no trace — so it can never be reproduced. Keeping it
- * would make any snapshot recorded during such a turn permanently unreplayable.
+ * Reasoning cannot survive the capture round-trip: `capiWireCodec` drops
+ * reasoning items when aggregating a response, because their content is opaque
+ * and provider-encrypted. Replay therefore rebuilds the stream from a fixture
+ * that has no reasoning in it, and any reasoning the live recording observed —
+ * whether an empty part the provider opened and closed without a delta, or a
+ * partial one carrying a few characters — can never be reproduced.
  *
- * Runs after projection because `ChatDelta` fills in content by mutating the
- * part recorded here, so a part's final content is only known once every
- * message has been projected.
+ * Keeping it would make a snapshot permanently unreplayable depending on
+ * whether the provider happened to emit reasoning during the recording, which
+ * says nothing about the behavior under test.
+ *
+ * Runs after projection because `ChatDelta` fills in a part's content by
+ * mutating the object recorded here, so the final content is only known once
+ * every message has been projected.
  */
-function dropEmptyReasoningParts(actions: object[]): object[] {
+function dropReasoning(actions: object[]): object[] {
 	return actions.filter(entry => {
-		const action = (entry as { action?: { type?: string; part?: { kind?: string; content?: string } } }).action;
-		return !(action?.type === ActionType.ChatResponsePart
-			&& action.part?.kind === ResponsePartKind.Reasoning
-			&& action.part.content === '');
+		const action = (entry as { action?: { type?: string; part?: { kind?: string } } }).action;
+		return action?.type !== ActionType.ChatReasoning
+			&& !(action?.type === ActionType.ChatResponsePart && action.part?.kind === ResponsePartKind.Reasoning);
 	});
 }
 

--- a/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
@@ -59,6 +59,39 @@ const HOMEDIR_PLACEHOLDER = '${homedir}';
 const TEMP_DIR_SUFFIX_PLACEHOLDER = '${temp}';
 const TEMP_DIR_SUFFIX_RE = /(\$\{workdir\}(?:\/|\\\\)(?:ahp-(?:snapshot|perm-test|plan-test|abort|test|wt-test|subagent-test|subagent-replay|attachment-test|cd-strip-test|coverage-[a-z-]+)-|copilot-(?:cost-report|text-blob)-|read-sdk-simple))[A-Za-z0-9]{6}/g;
 const FILE_LISTING_DATE_RE = /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(?:\d{2}:\d{2}|\d{4})\b/g;
+
+/**
+ * The Copilot CLI names its shell tools after the shell it runs — `bash` and
+ * friends on POSIX, `powershell` and friends on Windows — so a fixture recorded
+ * on one platform instructs the agent to call a tool that does not exist on the
+ * other, and the turn fails with "Tool does not exist".
+ *
+ * Store the platform-neutral placeholder in the fixture and expand it back to
+ * the running platform's name on replay, so a single capture drives every
+ * platform. Only the names that actually vary are mapped: Claude's `Bash` and
+ * Codex's `shell` are fixed strings their SDKs use everywhere.
+ */
+const SHELL_TOOL_SUFFIXES = ['', 'read_', 'write_', 'stop_', 'list_'] as const;
+const SHELL_TOOL_PLACEHOLDERS = new Map<string, string>();
+const SHELL_TOOL_EXPANSIONS = new Map<string, string>();
+for (const prefix of SHELL_TOOL_SUFFIXES) {
+	const placeholder = `\${${prefix}shell}`;
+	SHELL_TOOL_PLACEHOLDERS.set(`${prefix}bash`, placeholder);
+	SHELL_TOOL_PLACEHOLDERS.set(`${prefix}powershell`, placeholder);
+	SHELL_TOOL_EXPANSIONS.set(placeholder, `${prefix}${process.platform === 'win32' ? 'powershell' : 'bash'}`);
+}
+SHELL_TOOL_PLACEHOLDERS.set('bash_shutdown', '${shell_shutdown}');
+SHELL_TOOL_PLACEHOLDERS.set('powershell_shutdown', '${shell_shutdown}');
+SHELL_TOOL_EXPANSIONS.set('${shell_shutdown}', process.platform === 'win32' ? 'powershell_shutdown' : 'bash_shutdown');
+
+function normalizeShellToolNameForCapture(toolName: string): string {
+	return SHELL_TOOL_PLACEHOLDERS.get(toolName) ?? toolName;
+}
+
+function expandShellToolName(toolName: string): string {
+	return SHELL_TOOL_EXPANSIONS.get(toolName) ?? toolName;
+}
+
 /**
  * Placeholder for the recorder's OS username. It appears in captured tool output
  * (e.g. the owner column of `ls -la`) where it is not part of a path, so
@@ -734,7 +767,7 @@ export class CapiReplayProxy {
 			} catch {
 				// non-serializable input; keep as-is
 			}
-			return { type: 'tool_use', id: block.id, name: block.name, input };
+			return { type: 'tool_use', id: block.id, name: normalizeShellToolNameForCapture(block.name), input };
 		});
 	}
 
@@ -769,7 +802,7 @@ export class CapiReplayProxy {
 			...message,
 			content: message.content.map(block => block.type === 'text'
 				? { ...block, text: this._expandReplayPlaceholders(block.text) }
-				: { ...block, input: this._expandReplayValue(block.input) }),
+				: { ...block, name: expandShellToolName(block.name), input: this._expandReplayValue(block.input) }),
 		};
 	}
 

--- a/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
@@ -40,6 +40,7 @@ import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from
 import { basename, dirname } from '../../../../../../base/common/path.js';
 import { aggregateAnthropicSse, anthropicMessageToSse, ANTHROPIC_MESSAGES_PATH, aggregateResponsesSse, responsesMessageToSse, RESPONSES_PATH, summarizeResponsesRequest, deserializeAnthropicContent, serializeAnthropicContent, summarizeAnthropicRequest, type AnthropicContentBlock, type IAnthropicMessage, type IReadableAnthropicRequest } from './capiWireCodec.js';
 import { getAncillaryStub } from './capiStubs.js';
+import { findPosixOnlyCommands, formatPosixCommandError, type IRecordedCommand } from './posixCommandLint.js';
 
 // `http`/`https`/`js-yaml` are lazily required (slow to load and/or not in this
 // layer's import allowlist); `import type` above still gives us http/https types.
@@ -240,6 +241,14 @@ export interface ICapiReplayProxyOptions {
 	 * replaying. Defaults to true. Ignored while recording.
 	 */
 	readonly strict?: boolean;
+	/**
+	 * Skip the POSIX-only shell command check when writing a fixture.
+	 *
+	 * Only for a scenario that genuinely cannot be portable — the test must also
+	 * be scoped to a platform explicitly at its call site, with the reason
+	 * stated there. See `posixCommandLint.ts`.
+	 */
+	readonly allowPosixCommands?: boolean;
 }
 
 /** A replayable item: raw bytes (ancillary) or a model reply to regenerate. */
@@ -634,6 +643,7 @@ export class CapiReplayProxy {
 		const exchanges = built.map(b => b.exchange);
 		this._normalizeToolCallIds(exchanges);
 		this._normalizeUuids(exchanges);
+		this._assertNoPosixOnlyCommands(exchanges);
 		// Every turn in a fixture shares one endpoint, so the dialect (and the
 		// `(method, path)` it implies) is stored once at the top instead of on each
 		// exchange.
@@ -641,6 +651,42 @@ export class CapiReplayProxy {
 		const fixture: IFixture = { version: 1, ...(dialect ? { dialect } : {}), exchanges };
 		mkdirSync(dirname(this._fixturePath), { recursive: true });
 		writeFileSync(this._fixturePath, yamlModule.dump(fixture, { lineWidth: -1, noRefs: true }));
+	}
+
+	/**
+	 * Reject a recording whose shell commands cannot run on Windows.
+	 *
+	 * Only the assistant's `tool_use` blocks matter: those are what replay feeds
+	 * back to the agent, so they are the commands that will actually be executed
+	 * on whatever platform the test later runs on. The `tool_result` blocks
+	 * echoed in request summaries are never read back.
+	 *
+	 * Throws before the file is written so a rejected recording cannot leave a
+	 * half-portable fixture behind.
+	 */
+	private _assertNoPosixOnlyCommands(exchanges: IFixtureExchange[]): void {
+		if (this._options.allowPosixCommands) {
+			return;
+		}
+		const commands: IRecordedCommand[] = [];
+		for (const exchange of exchanges) {
+			if (!isTurnExchange(exchange)) {
+				continue;
+			}
+			for (const block of deserializeAnthropicContent(exchange.response.content)) {
+				if (block.type !== 'tool_use') {
+					continue;
+				}
+				const command = (block.input as { command?: unknown } | undefined)?.command;
+				if (typeof command === 'string' && command) {
+					commands.push({ command, toolName: block.name });
+				}
+			}
+		}
+		const findings = findPosixOnlyCommands(commands);
+		if (findings.length > 0) {
+			throw new Error(formatPosixCommandError(this._fixturePath, findings));
+		}
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
@@ -71,26 +71,36 @@ const FILE_LISTING_DATE_RE = /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|D
  * platform. Only the names that actually vary are mapped: Claude's `Bash` and
  * Codex's `shell` are fixed strings their SDKs use everywhere.
  */
-const SHELL_TOOL_SUFFIXES = ['', 'read_', 'write_', 'stop_', 'list_'] as const;
+const SHELL_TOOL_PREFIXES = ['', 'read_', 'write_', 'stop_', 'list_'] as const;
 const SHELL_TOOL_PLACEHOLDERS = new Map<string, string>();
-const SHELL_TOOL_EXPANSIONS = new Map<string, string>();
-for (const prefix of SHELL_TOOL_SUFFIXES) {
+for (const prefix of SHELL_TOOL_PREFIXES) {
 	const placeholder = `\${${prefix}shell}`;
 	SHELL_TOOL_PLACEHOLDERS.set(`${prefix}bash`, placeholder);
 	SHELL_TOOL_PLACEHOLDERS.set(`${prefix}powershell`, placeholder);
-	SHELL_TOOL_EXPANSIONS.set(placeholder, `${prefix}${process.platform === 'win32' ? 'powershell' : 'bash'}`);
 }
 SHELL_TOOL_PLACEHOLDERS.set('bash_shutdown', '${shell_shutdown}');
 SHELL_TOOL_PLACEHOLDERS.set('powershell_shutdown', '${shell_shutdown}');
-SHELL_TOOL_EXPANSIONS.set('${shell_shutdown}', process.platform === 'win32' ? 'powershell_shutdown' : 'bash_shutdown');
 
-function normalizeShellToolNameForCapture(toolName: string): string {
+/** Rewrites a platform-specific shell tool name to its stable placeholder. */
+export function normalizeShellToolNameForCapture(toolName: string): string {
 	return SHELL_TOOL_PLACEHOLDERS.get(toolName) ?? toolName;
 }
 
-function expandShellToolName(toolName: string): string {
-	return SHELL_TOOL_EXPANSIONS.get(toolName) ?? toolName;
+/**
+ * Expands a shell tool placeholder to the name the given platform uses.
+ *
+ * `platform` is injectable so both branches are testable from either host;
+ * it defaults to the running platform.
+ */
+export function expandShellToolName(toolName: string, platform: NodeJS.Platform = process.platform): string {
+	const match = /^\$\{(?<prefix>read_|write_|stop_|list_)?shell(?<shutdown>_shutdown)?\}$/.exec(toolName);
+	if (!match) {
+		return toolName;
+	}
+	const shell = platform === 'win32' ? 'powershell' : 'bash';
+	return match.groups?.shutdown ? `${shell}_shutdown` : `${match.groups?.prefix ?? ''}${shell}`;
 }
+
 
 /**
  * Placeholder for the recorder's OS username. It appears in captured tool output

--- a/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
@@ -856,9 +856,17 @@ export class CapiReplayProxy {
 	private _expandReplayMessage(message: IAnthropicMessage): IAnthropicMessage {
 		return {
 			...message,
-			content: message.content.map(block => block.type === 'text'
-				? { ...block, text: this._expandReplayPlaceholders(block.text) }
-				: { ...block, name: expandShellToolName(block.name), input: this._expandReplayValue(block.input) }),
+			content: message.content.map(block => {
+				if (block.type === 'text') {
+					return { ...block, text: this._expandReplayPlaceholders(block.text) };
+				}
+				if (block.type === 'tool_use') {
+					return { ...block, name: expandShellToolName(block.name), input: this._expandReplayValue(block.input) };
+				}
+				// Any future block kind passes through untouched rather than being
+				// rewritten as if it were a tool call.
+				return block;
+			}),
 		};
 	}
 

--- a/src/vs/platform/agentHost/test/node/e2e/harness/posixCommandLint.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/posixCommandLint.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Guards recorded fixtures against POSIX-only shell commands.
+ *
+ * A capture is otherwise platform-neutral: it records what the *model* said,
+ * and the agent host executes that live on whatever platform the test runs on.
+ * The one thing that does not travel is a command string the model chose — if
+ * it happens to pick `wc -l` or `printf`, that choice is frozen into the fixture
+ * and the test can never replay on Windows.
+ *
+ * Nobody selects those strings deliberately. They are whatever the model
+ * produced from a prompt that described the goal instead of specifying the
+ * command, which makes this exactly the kind of regression that reappears the
+ * next time somebody re-records. Checking at the moment the fixture is written
+ * puts the failure on the author's own machine, while they still have the
+ * context to fix it, instead of on a CI leg they may not run.
+ *
+ * Deliberately a blocklist of constructs known not to work under `cmd` /
+ * PowerShell rather than an allowlist of portable ones: the goal is to catch the
+ * commands models actually reach for, without failing a recording for an
+ * unfamiliar-but-fine command.
+ */
+
+/** A shell command found in a recorded fixture, with where it came from. */
+export interface IRecordedCommand {
+	readonly command: string;
+	readonly toolName: string;
+}
+
+export interface IPosixCommandFinding {
+	readonly command: string;
+	readonly toolName: string;
+	readonly reason: string;
+}
+
+interface IPosixPattern {
+	readonly pattern: RegExp;
+	readonly reason: string;
+}
+
+/**
+ * Constructs that do not run under `cmd`. Each is anchored to a command
+ * position — the start of the string, or after a `|`, `&&`, `||` or `;` — so
+ * that an argument or file name that merely contains the word does not trip it
+ * (`node -e "readdirSync('.')"` must not match `rm`).
+ */
+const COMMAND_POSITION = String.raw`(?:^|[|;]|&&|\|\|)\s*`;
+
+const POSIX_PATTERNS: readonly IPosixPattern[] = [
+	{
+		pattern: new RegExp(`${COMMAND_POSITION}(?:ls|cat|rm|mv|cp|touch|wc|head|tail|grep|sed|awk|find|xxd|printf|pwd|chmod|chown|du|df|which|basename|dirname|mkdir|rmdir|ln|tee|sort|uniq|cut|tr|test|\\[|export|unset|source|\\.)\\b`),
+		reason: 'uses a POSIX coreutil or shell builtin that cmd does not provide',
+	},
+	{
+		pattern: /(?:^|\s)2>(?:&1|\s*\/dev\/null)/,
+		reason: 'redirects stderr using POSIX syntax',
+	},
+	{
+		pattern: /\/dev\/(?:null|stdin|stdout|stderr)\b/,
+		reason: 'references a POSIX device path',
+	},
+	{
+		pattern: /\$\{?[A-Za-z_][A-Za-z0-9_]*\}?/,
+		reason: 'expands a variable using POSIX syntax',
+	},
+	{
+		pattern: /(?:^|\s)~\//,
+		reason: 'uses POSIX home-directory expansion',
+	},
+];
+
+/**
+ * Placeholders the recorder substitutes into captured paths. They look like
+ * POSIX variable expansions but are rewritten before replay, so they must not
+ * be reported.
+ */
+const RECORDER_PLACEHOLDER_RE = /\$\{(?:workdir|homedir|workspace|temp|user|timestamp|shell|read_shell|write_shell|stop_shell|list_shell|shell_shutdown)\}/g;
+
+/** Reports every POSIX-only construct found in the given commands. */
+export function findPosixOnlyCommands(commands: readonly IRecordedCommand[]): IPosixCommandFinding[] {
+	const findings: IPosixCommandFinding[] = [];
+	for (const { command, toolName } of commands) {
+		const scrubbed = command.replace(RECORDER_PLACEHOLDER_RE, 'PLACEHOLDER');
+		for (const { pattern, reason } of POSIX_PATTERNS) {
+			if (pattern.test(scrubbed)) {
+				findings.push({ command, toolName, reason });
+				break;
+			}
+		}
+	}
+	return findings;
+}
+
+/** Formats findings as the error a recording fails with. */
+export function formatPosixCommandError(fixturePath: string, findings: readonly IPosixCommandFinding[]): string {
+	const lines = findings.map(finding => `  - \`${finding.command}\` (${finding.toolName}): ${finding.reason}`);
+	return [
+		`[capi-replay] recorded ${findings.length === 1 ? 'a shell command that is' : 'shell commands that are'} POSIX-only, so this capture cannot replay on Windows:`,
+		...lines,
+		'',
+		`Fixture: ${fixturePath}`,
+		'',
+		'The model chose this command; the prompt did not. Fix the prompt, not the capture:',
+		'  - If a file tool can do the job, steer the agent to it ("Use your file tools; do not run a shell command.").',
+		'  - If no file tool exists (rename, delete, mkdir, listing), pin the command:',
+		'    "Run exactly this shell command, with no modifications: `node -e \\"...\\"`".',
+		'',
+		'If the scenario genuinely cannot be portable, scope the test to a platform',
+		'explicitly at its call site and say why, then set `allowPosixCommands` on the',
+		'capiReplay options so this check does not fire.',
+	].join('\n');
+}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_counts_lines_in_a_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_counts_lines_in_a_file.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Count the lines in lines.txt and reply with the number only.
+            text: Count the lines in lines.txt and reply with the number only. Use your file tools; do not run a shell command.
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Count the lines in lines.txt and reply with the number only.
+            text: Count the lines in lines.txt and reply with the number only. Use your file tools; do not run a shell command.
             origin:
               kind: user
       - channel: ${session_0}
@@ -30,25 +30,12 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: Bash
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallComplete
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_0}
-          result:
-            success: true
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallStart
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_1}
           toolName: Read
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
           turnId: ${turn_0}
-          toolCallId: ${toolCall_1}
+          toolCallId: ${toolCall_0}
           result:
             success: true
       - channel: ${chat_0}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_creates_a_file_in_a_new_nested_directory.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_creates_a_file_in_a_new_nested_directory.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Create output/report.txt containing exactly NESTED_CREATED.
+            text: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Create output/report.txt containing exactly NESTED_CREATED.
+            text: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
             origin:
               kind: user
       - channel: ${session_0}
@@ -27,17 +27,10 @@ rounds:
           type: session/ready
       - channel: ${chat_0}
         action:
-          type: chat/responsePart
-          turnId: ${turn_0}
-          part:
-            kind: markdown
-            content: I'll create that file for you.
-      - channel: ${chat_0}
-        action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: Write
+          toolName: Bash
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -51,7 +44,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: Created `output/report.txt` containing exactly `NESTED_CREATED`.
+            content: created
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_creates_a_new_text_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_creates_a_new_text_file.traffic.ahp.yaml
@@ -31,7 +31,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: I'll create that file for you.
+            content: I'll create that file.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_deletes_a_workspace_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_deletes_a_workspace_file.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Delete delete-me.txt.
+            text: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').unlinkSync(''delete-me.txt'')"`. Then reply with exactly "deleted".'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Delete delete-me.txt.
+            text: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').unlinkSync(''delete-me.txt'')"`. Then reply with exactly "deleted".'
             origin:
               kind: user
       - channel: ${session_0}
@@ -44,27 +44,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: The file contains a placeholder value (`DELETE_VALUE`), consistent with its name. Deleting it.
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallStart
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_1}
-          toolName: Bash
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallComplete
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_1}
-          result:
-            success: true
-      - channel: ${chat_0}
-        action:
-          type: chat/responsePart
-          turnId: ${turn_0}
-          part:
-            kind: markdown
-            content: Done — `delete-me.txt` is deleted.
+            content: deleted
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_edits_an_existing_text_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_edits_an_existing_text_file.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Replace the complete contents of edit.txt with AFTER_VALUE.
+            text: Replace the complete contents of edit.txt with AFTER_VALUE. Use your file tools; do not run a shell command.
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Replace the complete contents of edit.txt with AFTER_VALUE.
+            text: Replace the complete contents of edit.txt with AFTER_VALUE. Use your file tools; do not run a shell command.
             origin:
               kind: user
       - channel: ${session_0}
@@ -30,7 +30,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: Bash
+          toolName: Read
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -43,7 +43,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_1}
-          toolName: Read
+          toolName: Write
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -53,24 +53,11 @@ rounds:
             success: true
       - channel: ${chat_0}
         action:
-          type: chat/toolCallStart
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_2}
-          toolName: Edit
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallComplete
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_2}
-          result:
-            success: true
-      - channel: ${chat_0}
-        action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: Done. `edit.txt` now contains `AFTER_VALUE` (replacing `BEFORE_VALUE`).
+            content: Done. `edit.txt` now contains `AFTER_VALUE` (replacing the previous `BEFORE_VALUE`).
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_handles_a_missing_file_without_a_session_error.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_handles_a_missing_file_without_a_session_error.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Try to read missing.txt. If it does not exist, reply exactly "missing".
+            text: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Try to read missing.txt. If it does not exist, reply exactly "missing".
+            text: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
             origin:
               kind: user
       - channel: ${session_0}
@@ -31,7 +31,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: I'll try to read the file.
+            content: I'll read missing.txt.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_lists_workspace_entries.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_lists_workspace_entries.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: List the files in the current working directory. Reply with the filenames only.
+            text: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: List the files in the current working directory. Reply with the filenames only.
+            text: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
             origin:
               kind: user
       - channel: ${session_0}
@@ -25,13 +25,6 @@ rounds:
       - channel: ${session_0}
         action:
           type: session/ready
-      - channel: ${chat_0}
-        action:
-          type: chat/responsePart
-          turnId: ${turn_0}
-          part:
-            kind: markdown
-            content: I'll list the files in the working directory.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart
@@ -51,9 +44,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: |-
-              first.txt
-              second.md
+            content: first.txt second.md
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_reads_a_file_from_a_nested_directory.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_reads_a_file_from_a_nested_directory.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Read nested/value.txt and reply with its exact contents only.
+            text: Read nested/value.txt and reply with its exact contents only. Use your file tools; do not run a shell command.
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Read nested/value.txt and reply with its exact contents only.
+            text: Read nested/value.txt and reply with its exact contents only. Use your file tools; do not run a shell command.
             origin:
               kind: user
       - channel: ${session_0}
@@ -31,7 +31,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: I'll read the file.
+            content: I'll read the file for you.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_reads_a_filename_containing_spaces.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_reads_a_filename_containing_spaces.traffic.ahp.yaml
@@ -27,6 +27,13 @@ rounds:
           type: session/ready
       - channel: ${chat_0}
         action:
+          type: chat/responsePart
+          turnId: ${turn_0}
+          part:
+            kind: markdown
+            content: I'll read that file for you.
+      - channel: ${chat_0}
+        action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_reads_a_value_from_JSON.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_reads_a_value_from_JSON.traffic.ahp.yaml
@@ -27,6 +27,13 @@ rounds:
           type: session/ready
       - channel: ${chat_0}
         action:
+          type: chat/responsePart
+          turnId: ${turn_0}
+          part:
+            kind: markdown
+            content: I'll read the config file.
+      - channel: ${chat_0}
+        action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_renames_a_workspace_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_renames_a_workspace_file.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Rename before.txt to after.txt without changing its contents.
+            text: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Rename before.txt to after.txt without changing its contents.
+            text: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
             origin:
               kind: user
       - channel: ${session_0}
@@ -44,7 +44,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: Done. `before.txt` is now `after.txt` with its contents unchanged.
+            content: renamed
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_runs_a_deterministic_shell_command.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_runs_a_deterministic_shell_command.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Run a shell command that prints SHELL_VALUE_73, then reply with that exact value only.
+            text: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Run a shell command that prints SHELL_VALUE_73, then reply with that exact value only.
+            text: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
             origin:
               kind: user
       - channel: ${session_0}
@@ -25,13 +25,6 @@ rounds:
       - channel: ${session_0}
         action:
           type: session/ready
-      - channel: ${chat_0}
-        action:
-          type: chat/responsePart
-          turnId: ${turn_0}
-          part:
-            kind: markdown
-            content: I'll run a command to print that value.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_runs_a_deterministic_shell_command.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_runs_a_deterministic_shell_command.traffic.ahp.yaml
@@ -27,6 +27,13 @@ rounds:
           type: session/ready
       - channel: ${chat_0}
         action:
+          type: chat/responsePart
+          turnId: ${turn_0}
+          part:
+            kind: markdown
+            content: I'll run that command.
+      - channel: ${chat_0}
+        action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot__Copilot-specific__client_tool_reaches_ready_after_start_and_completes.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot__Copilot-specific__client_tool_reaches_ready_after_start_and_completes.traffic.ahp.yaml
@@ -168,7 +168,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: The magic word is **XYLOPHONE**.
+            content: 'The magic word is: **XYLOPHONE**'
       - channel: ${session_0}
         action:
           type: session/metaChanged

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_counts_lines_in_a_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_counts_lines_in_a_file.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Count the lines in lines.txt and reply with the number only.
+            text: Count the lines in lines.txt and reply with the number only. Use your file tools; do not run a shell command.
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Count the lines in lines.txt and reply with the number only.
+            text: Count the lines in lines.txt and reply with the number only. Use your file tools; do not run a shell command.
             origin:
               kind: user
       - channel: ${session_0}
@@ -30,12 +30,25 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: ${shell}
+          toolName: glob
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
+          result:
+            success: true
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallStart
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_1}
+          toolName: view
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallComplete
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_1}
           result:
             success: true
       - channel: ${chat_0}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_counts_lines_in_a_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_counts_lines_in_a_file.traffic.ahp.yaml
@@ -30,7 +30,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: bash
+          toolName: ${shell}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_creates_a_file_in_a_new_nested_directory.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_creates_a_file_in_a_new_nested_directory.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Create output/report.txt containing exactly NESTED_CREATED.
+            text: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Create output/report.txt containing exactly NESTED_CREATED.
+            text: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
             origin:
               kind: user
       - channel: ${session_0}
@@ -44,7 +44,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: Created [output/report.txt](${workdir}/output/report.txt) containing exactly `NESTED_CREATED`.
+            content: created
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_creates_a_file_in_a_new_nested_directory.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_creates_a_file_in_a_new_nested_directory.traffic.ahp.yaml
@@ -30,7 +30,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: bash
+          toolName: ${shell}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_handles_a_missing_file_without_a_session_error.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_handles_a_missing_file_without_a_session_error.traffic.ahp.yaml
@@ -30,7 +30,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: bash
+          toolName: ${shell}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_handles_a_missing_file_without_a_session_error.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_handles_a_missing_file_without_a_session_error.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Try to read missing.txt. If it does not exist, reply exactly "missing".
+            text: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Try to read missing.txt. If it does not exist, reply exactly "missing".
+            text: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
             origin:
               kind: user
       - channel: ${session_0}
@@ -30,14 +30,14 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: ${shell}
+          toolName: view
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
           result:
-            success: true
+            success: false
       - channel: ${chat_0}
         action:
           type: chat/responsePart

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_inspects_git_status.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_inspects_git_status.traffic.ahp.yaml
@@ -44,7 +44,9 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: tracked.txt, untracked.txt
+            content: |-
+              Modified: `tracked.txt`
+              Untracked: `untracked.txt`
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_inspects_git_status.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_inspects_git_status.traffic.ahp.yaml
@@ -30,7 +30,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: bash
+          toolName: ${shell}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_lists_workspace_entries.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_lists_workspace_entries.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: List the files in the current working directory. Reply with the filenames only.
+            text: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: List the files in the current working directory. Reply with the filenames only.
+            text: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
             origin:
               kind: user
       - channel: ${session_0}
@@ -44,9 +44,7 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: |-
-              first.txt
-              second.md
+            content: first.txt second.md
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_lists_workspace_entries.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_lists_workspace_entries.traffic.ahp.yaml
@@ -30,7 +30,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: bash
+          toolName: ${shell}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_reads_a_file_from_a_nested_directory.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_reads_a_file_from_a_nested_directory.traffic.ahp.yaml
@@ -30,7 +30,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: bash
+          toolName: ${shell}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_reads_a_file_from_a_nested_directory.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_reads_a_file_from_a_nested_directory.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Read nested/value.txt and reply with its exact contents only.
+            text: Read nested/value.txt and reply with its exact contents only. Use your file tools; do not run a shell command.
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Read nested/value.txt and reply with its exact contents only.
+            text: Read nested/value.txt and reply with its exact contents only. Use your file tools; do not run a shell command.
             origin:
               kind: user
       - channel: ${session_0}
@@ -30,12 +30,25 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: ${shell}
+          toolName: glob
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
+          result:
+            success: true
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallStart
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_1}
+          toolName: view
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallComplete
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_1}
           result:
             success: true
       - channel: ${chat_0}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_renames_a_workspace_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_renames_a_workspace_file.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Rename before.txt to after.txt without changing its contents.
+            text: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Rename before.txt to after.txt without changing its contents.
+            text: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
             origin:
               kind: user
       - channel: ${session_0}
@@ -40,24 +40,11 @@ rounds:
             success: true
       - channel: ${chat_0}
         action:
-          type: chat/toolCallStart
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_1}
-          toolName: ${shell}
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallComplete
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_1}
-          result:
-            success: true
-      - channel: ${chat_0}
-        action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: Renamed `before.txt` to `after.txt` — contents (`RENAME_VALUE`) unchanged.
+            content: renamed
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_renames_a_workspace_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_renames_a_workspace_file.traffic.ahp.yaml
@@ -30,7 +30,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: bash
+          toolName: ${shell}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -43,7 +43,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_1}
-          toolName: bash
+          toolName: ${shell}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_runs_a_deterministic_shell_command.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_runs_a_deterministic_shell_command.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Run a shell command that prints SHELL_VALUE_73, then reply with that exact value only.
+            text: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Run a shell command that prints SHELL_VALUE_73, then reply with that exact value only.
+            text: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
             origin:
               kind: user
       - channel: ${session_0}
@@ -30,7 +30,7 @@ rounds:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
-          toolName: bash
+          toolName: ${shell}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete

--- a/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
@@ -29,15 +29,7 @@ interface IDefineOptions {
 
 function defineSuite(config: IAgentHostE2EProviderConfig, options: IDefineOptions): void {
 	(config.enabled ? suite : suite.skip)(options.suiteTitle, function () {
-		// Shell-tool replay has two independent constraints, and conflating them
-		// hides portable tests behind a Windows exclusion they don't need:
-		//  - the provider's shell-tool notifications can be unstable on Linux
-		//  - the committed capture may contain a POSIX-only command
-		// Only the second is about Windows, and only for captures that haven't
-		// been made portable.
-		const shellToolReplayStable = RECORD || !isLinux || !config.shellToolReplayUnstableOnLinux;
-		const shellToolReplayEnabled = !isWindows && shellToolReplayStable;
-		const portableShellToolReplayEnabled = shellToolReplayStable;
+		const portableShellToolReplayEnabled = RECORD || !isLinux || !config.shellToolReplayUnstableOnLinux;
 		let client: TestProtocolClient;
 		let lease: AgentHostE2EServerLease | undefined;
 		const createdSessions: string[] = [];
@@ -49,7 +41,6 @@ function defineSuite(config: IAgentHostE2EProviderConfig, options: IDefineOption
 			get client() { return client; },
 			createdSessions,
 			tempDirs,
-			shellToolReplayEnabled,
 			portableShellToolReplayEnabled,
 			stableNewScenarioResponse: config.stableNewScenarioResponse,
 			isWindows,

--- a/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
@@ -29,7 +29,15 @@ interface IDefineOptions {
 
 function defineSuite(config: IAgentHostE2EProviderConfig, options: IDefineOptions): void {
 	(config.enabled ? suite : suite.skip)(options.suiteTitle, function () {
-		const shellToolReplayEnabled = !isWindows && (RECORD || !isLinux || !config.shellToolReplayUnstableOnLinux);
+		// Shell-tool replay has two independent constraints, and conflating them
+		// hides portable tests behind a Windows exclusion they don't need:
+		//  - the provider's shell-tool notifications can be unstable on Linux
+		//  - the committed capture may contain a POSIX-only command
+		// Only the second is about Windows, and only for captures that haven't
+		// been made portable.
+		const shellToolReplayStable = RECORD || !isLinux || !config.shellToolReplayUnstableOnLinux;
+		const shellToolReplayEnabled = !isWindows && shellToolReplayStable;
+		const portableShellToolReplayEnabled = shellToolReplayStable;
 		let client: TestProtocolClient;
 		let lease: AgentHostE2EServerLease | undefined;
 		const createdSessions: string[] = [];
@@ -42,6 +50,7 @@ function defineSuite(config: IAgentHostE2EProviderConfig, options: IDefineOption
 			createdSessions,
 			tempDirs,
 			shellToolReplayEnabled,
+			portableShellToolReplayEnabled,
 			stableNewScenarioResponse: config.stableNewScenarioResponse,
 			isWindows,
 			runRecordOnlyTests: RUN_RECORD_ONLY_TESTS,

--- a/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
@@ -26,7 +26,24 @@ export interface IAgentHostE2ETestContext {
 	readonly client: TestProtocolClient;
 	readonly createdSessions: string[];
 	readonly tempDirs: string[];
+	/**
+	 * Whether shell-dependent tests can replay. False on Windows because the
+	 * committed captures for those tests contain POSIX-only commands.
+	 *
+	 * Prefer {@link portableShellToolReplayEnabled} for any test whose recorded
+	 * command runs unchanged under cmd/PowerShell — this flag exists for the
+	 * captures that have not been made portable yet.
+	 */
 	readonly shellToolReplayEnabled: boolean;
+	/**
+	 * Whether shell-dependent tests can replay, for tests whose recorded command
+	 * is platform-neutral.
+	 *
+	 * Same as {@link shellToolReplayEnabled} minus the blanket Windows
+	 * exclusion: it still honors the provider's shell-tool replay stability on
+	 * Linux, which is an unrelated concern.
+	 */
+	readonly portableShellToolReplayEnabled: boolean;
 	readonly stableNewScenarioResponse: boolean;
 	readonly isWindows: boolean;
 	readonly runRecordOnlyTests: boolean;

--- a/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
@@ -27,21 +27,15 @@ export interface IAgentHostE2ETestContext {
 	readonly createdSessions: string[];
 	readonly tempDirs: string[];
 	/**
-	 * Whether shell-dependent tests can replay. False on Windows because the
-	 * committed captures for those tests contain POSIX-only commands.
+	 * Whether shell-dependent tests can replay.
 	 *
-	 * Prefer {@link portableShellToolReplayEnabled} for any test whose recorded
-	 * command runs unchanged under cmd/PowerShell — this flag exists for the
-	 * captures that have not been made portable yet.
-	 */
-	readonly shellToolReplayEnabled: boolean;
-	/**
-	 * Whether shell-dependent tests can replay, for tests whose recorded command
-	 * is platform-neutral.
-	 *
-	 * Same as {@link shellToolReplayEnabled} minus the blanket Windows
-	 * exclusion: it still honors the provider's shell-tool replay stability on
-	 * Linux, which is an unrelated concern.
+	 * This is only about the provider's shell-tool replay stability on Linux.
+	 * There is deliberately no Windows exclusion: every committed capture that
+	 * runs a shell command is expected to be platform-neutral, either because
+	 * the command is pinned to something `cmd`/PowerShell also understands or
+	 * because the prompt steers the agent to its file tools instead. A test that
+	 * cannot meet that bar should be scoped to a platform explicitly, so the
+	 * reason is visible at the call site.
 	 */
 	readonly portableShellToolReplayEnabled: boolean;
 	readonly stableNewScenarioResponse: boolean;

--- a/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
@@ -14,7 +14,7 @@ import { assertRecordedAhpSnapshot } from '../harness/ahpSnapshot.js';
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineFileOperationsTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs, shellToolReplayEnabled, stableNewScenarioResponse } = context;
+	const { config, createdSessions, tempDirs, shellToolReplayEnabled, portableShellToolReplayEnabled, stableNewScenarioResponse } = context;
 	const BEHAVIOR_SNAPSHOT = { profile: 'behavior' } as const;
 	// Expected to pass, but Copilot never completed this turn during recording and Codex duplicates its response.
 	(stableNewScenarioResponse && config.provider === 'claude' ? test : test.skip)('reads an existing text file', async function () {
@@ -167,14 +167,19 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(shellToolReplayEnabled && stableNewScenarioResponse ? test : test.skip)('runs a deterministic shell command', async function () {
+	(portableShellToolReplayEnabled && stableNewScenarioResponse ? test : test.skip)('runs a deterministic shell command', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-shell-'));
 		tempDirs.push(workspace);
 		const sessionUri = await createRealSession(context.client, config, `coverage-shell-${config.provider}`, createdSessions, URI.file(workspace));
 
 		context.client.beginAhpSnapshotRound();
-		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-shell', 'Run a shell command that prints SHELL_VALUE_73, then reply with that exact value only.', 1);
+		// The command is pinned rather than described so the recorded capture is
+		// platform-neutral: `echo` behaves the same under cmd/PowerShell and
+		// POSIX shells. Left to its own devices the model picks a different
+		// command per provider (Copilot chose `echo`, Claude chose `printf`),
+		// and whichever it picks is frozen into the fixture.
+		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-shell', 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.', 1);
 		assert.match(result.responseText, /SHELL_VALUE_73/);
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});

--- a/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
@@ -14,8 +14,19 @@ import { assertRecordedAhpSnapshot } from '../harness/ahpSnapshot.js';
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineFileOperationsTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs, shellToolReplayEnabled, portableShellToolReplayEnabled, stableNewScenarioResponse } = context;
+	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, stableNewScenarioResponse } = context;
 	const BEHAVIOR_SNAPSHOT = { profile: 'behavior' } as const;
+	/**
+	 * Steers the agent toward its own file tools instead of a shell command.
+	 *
+	 * These tests assert that a *file operation* happened, not that a shell ran.
+	 * Left to choose, providers diverge: Claude and Codex already reach for their
+	 * file tools here, while Copilot reaches for `bash` — and whichever POSIX
+	 * command it happens to emit is then frozen into the fixture and cannot
+	 * replay on Windows. Asking for the file tool removes the platform coupling
+	 * and exercises the more meaningful path.
+	 */
+	const PREFER_FILE_TOOLS = ' Use your file tools; do not run a shell command.';
 	// Expected to pass, but Copilot never completed this turn during recording and Codex duplicates its response.
 	(stableNewScenarioResponse && config.provider === 'claude' ? test : test.skip)('reads an existing text file', async function () {
 		this.timeout(180_000);
@@ -30,7 +41,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(stableNewScenarioResponse && (config.provider !== 'copilotcli' || shellToolReplayEnabled) ? test : test.skip)('reads a file from a nested directory', async function () {
+	(stableNewScenarioResponse ? test : test.skip)('reads a file from a nested directory', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-nested-read-'));
 		tempDirs.push(workspace);
@@ -39,12 +50,12 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		const sessionUri = await createRealSession(context.client, config, `coverage-nested-read-${config.provider}`, createdSessions, URI.file(workspace));
 
 		context.client.beginAhpSnapshotRound();
-		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-nested-read', 'Read nested/value.txt and reply with its exact contents only.', 1);
+		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-nested-read', `Read nested/value.txt and reply with its exact contents only.${PREFER_FILE_TOOLS}`, 1);
 		assert.match(result.responseText, /NESTED_VALUE_42/);
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(stableNewScenarioResponse && shellToolReplayEnabled ? test : test.skip)('lists workspace entries', async function () {
+	(stableNewScenarioResponse && portableShellToolReplayEnabled ? test : test.skip)('lists workspace entries', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-list-'));
 		tempDirs.push(workspace);
@@ -53,7 +64,11 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		const sessionUri = await createRealSession(context.client, config, `coverage-list-${config.provider}`, createdSessions, URI.file(workspace));
 
 		context.client.beginAhpSnapshotRound();
-		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-list', 'List the files in the current working directory. Reply with the filenames only.', 1);
+		// Pinned rather than steered: Copilot honors the file-tool hint here but
+		// Claude still runs `ls`, and its flags differ under cmd. Pinning keeps
+		// the two providers on one portable capture.
+		const listCommand = `node -e "console.log(require('fs').readdirSync('.').join(' '))"`;
+		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-list', `Run exactly this shell command, with no modifications: \`${listCommand}\`. Then reply with the filenames it printed and nothing else.`, 1);
 		assert.match(result.responseText, /first\.txt/);
 		assert.match(result.responseText, /second\.md/);
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
@@ -74,27 +89,31 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Codex duplicates its response.
-	(stableNewScenarioResponse && shellToolReplayEnabled ? test : test.skip)('counts lines in a file', async function () {
+	(stableNewScenarioResponse && portableShellToolReplayEnabled ? test : test.skip)('counts lines in a file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-lines-'));
 		tempDirs.push(workspace);
-		writeFileSync(join(workspace, 'lines.txt'), 'one\ntwo\nthree\nfour\n');
+		// No trailing newline: with one, "how many lines" is genuinely ambiguous
+		// (four content lines, or five fields when splitting on the separator).
+		// `wc -l` resolved that by counting separators; an agent reading the file
+		// reasonably answers either way, so remove the ambiguity from the input.
+		writeFileSync(join(workspace, 'lines.txt'), 'one\ntwo\nthree\nfour');
 		const sessionUri = await createRealSession(context.client, config, `coverage-lines-${config.provider}`, createdSessions, URI.file(workspace));
 
 		context.client.beginAhpSnapshotRound();
-		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-lines', 'Count the lines in lines.txt and reply with the number only.', 1);
+		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-lines', `Count the lines in lines.txt and reply with the number only.${PREFER_FILE_TOOLS}`, 1);
 		assert.match(result.responseText, /\b4\b/);
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(stableNewScenarioResponse && (config.provider !== 'copilotcli' || shellToolReplayEnabled) ? test : test.skip)('handles a missing file without a session error', async function () {
+	(stableNewScenarioResponse ? test : test.skip)('handles a missing file without a session error', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-missing-'));
 		tempDirs.push(workspace);
 		const sessionUri = await createRealSession(context.client, config, `coverage-missing-${config.provider}`, createdSessions, URI.file(workspace));
 
 		context.client.beginAhpSnapshotRound();
-		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-missing', 'Try to read missing.txt. If it does not exist, reply exactly "missing".', 1);
+		const result = await driveTurnToCompletion(context.client, sessionUri, 'turn-missing', `Try to read missing.txt. If it does not exist, reply exactly "missing".${PREFER_FILE_TOOLS}`, 1);
 		assert.match(result.responseText, /missing/i);
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
@@ -113,7 +132,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Copilot never completes this turn.
-	(stableNewScenarioResponse && config.provider === 'claude' && shellToolReplayEnabled ? test : test.skip)('edits an existing text file', async function () {
+	(stableNewScenarioResponse && config.provider === 'claude' ? test : test.skip)('edits an existing text file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-edit-'));
 		tempDirs.push(workspace);
@@ -121,25 +140,30 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		const sessionUri = await createRealSession(context.client, config, `coverage-edit-${config.provider}`, createdSessions, URI.file(workspace));
 
 		context.client.beginAhpSnapshotRound();
-		await driveTurnToCompletion(context.client, sessionUri, 'turn-edit', 'Replace the complete contents of edit.txt with AFTER_VALUE.', 1);
+		await driveTurnToCompletion(context.client, sessionUri, 'turn-edit', `Replace the complete contents of edit.txt with AFTER_VALUE.${PREFER_FILE_TOOLS}`, 1);
 		assert.strictEqual(readFileSync(join(workspace, 'edit.txt'), 'utf8'), 'AFTER_VALUE');
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
 	// Copilot's fixture uses a POSIX shell.
-	(stableNewScenarioResponse && (config.provider !== 'copilotcli' || shellToolReplayEnabled) ? test : test.skip)('creates a file in a new nested directory', async function () {
+	(stableNewScenarioResponse ? test : test.skip)('creates a file in a new nested directory', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-nested-create-'));
 		tempDirs.push(workspace);
 		const sessionUri = await createRealSession(context.client, config, `coverage-nested-create-${config.provider}`, createdSessions, URI.file(workspace));
 
 		context.client.beginAhpSnapshotRound();
-		await driveTurnToCompletion(context.client, sessionUri, 'turn-nested-create', 'Create output/report.txt containing exactly NESTED_CREATED.', 1);
+		// Pinned rather than steered: creating the parent directory has no file
+		// tool, so the provider always reaches for the shell and picks `mkdir -p`,
+		// whose `-p` is a directory name rather than a flag under cmd. Steering
+		// harder made it skip the creation entirely.
+		const nestedCreateCommand = `node -e "const fs=require('fs');fs.mkdirSync('output',{recursive:true});fs.writeFileSync('output/report.txt','NESTED_CREATED')"`;
+		await driveTurnToCompletion(context.client, sessionUri, 'turn-nested-create', `Run exactly this shell command, with no modifications: \`${nestedCreateCommand}\`. Then reply with exactly "created".`, 1);
 		assert.strictEqual(readFileSync(join(workspace, 'output', 'report.txt'), 'utf8'), 'NESTED_CREATED');
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(stableNewScenarioResponse && shellToolReplayEnabled ? test : test.skip)('renames a workspace file', async function () {
+	(stableNewScenarioResponse && portableShellToolReplayEnabled ? test : test.skip)('renames a workspace file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-rename-'));
 		tempDirs.push(workspace);
@@ -147,14 +171,19 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		const sessionUri = await createRealSession(context.client, config, `coverage-rename-${config.provider}`, createdSessions, URI.file(workspace));
 
 		context.client.beginAhpSnapshotRound();
-		await driveTurnToCompletion(context.client, sessionUri, 'turn-rename', 'Rename before.txt to after.txt without changing its contents.', 1);
+		// Pinned rather than steered: there is no file tool for a rename, so the
+		// provider always reaches for the shell here and picks a POSIX command
+		// (`mv`, and once `xxd`/`rm`). `node` is guaranteed present since the
+		// suite runs under it, and this quoting works in both cmd and POSIX shells.
+		const renameCommand = `node -e "require('fs').renameSync('before.txt','after.txt')"`;
+		await driveTurnToCompletion(context.client, sessionUri, 'turn-rename', `Run exactly this shell command, with no modifications: \`${renameCommand}\`. Then reply with exactly "renamed".`, 1);
 		assert.strictEqual(existsSync(join(workspace, 'before.txt')), false);
 		assert.strictEqual(readFileSync(join(workspace, 'after.txt'), 'utf8'), 'RENAME_VALUE');
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
 	// Copilot never completed this turn.
-	(stableNewScenarioResponse && config.provider === 'claude' && shellToolReplayEnabled ? test : test.skip)('deletes a workspace file', async function () {
+	(stableNewScenarioResponse && config.provider === 'claude' ? test : test.skip)('deletes a workspace file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-delete-'));
 		tempDirs.push(workspace);
@@ -162,7 +191,10 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		const sessionUri = await createRealSession(context.client, config, `coverage-delete-${config.provider}`, createdSessions, URI.file(workspace));
 
 		context.client.beginAhpSnapshotRound();
-		await driveTurnToCompletion(context.client, sessionUri, 'turn-delete', 'Delete delete-me.txt.', 1);
+		// Pinned rather than steered: there is no file tool for a delete, so the
+		// provider reaches for `rm`, which cmd does not have.
+		const deleteCommand = `node -e "require('fs').unlinkSync('delete-me.txt')"`;
+		await driveTurnToCompletion(context.client, sessionUri, 'turn-delete', `Run exactly this shell command, with no modifications: \`${deleteCommand}\`. Then reply with exactly "deleted".`, 1);
 		assert.strictEqual(existsSync(join(workspace, 'delete-me.txt')), false);
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
@@ -185,7 +217,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Claude and Codex emit customization/changeset updates at nondeterministic points in this snapshot.
-	(shellToolReplayEnabled && stableNewScenarioResponse && config.provider === 'copilotcli' ? test : test.skip)('inspects git status', async function () {
+	(portableShellToolReplayEnabled && stableNewScenarioResponse && config.provider === 'copilotcli' ? test : test.skip)('inspects git status', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-git-'));
 		tempDirs.push(workspace);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/multiChatSuite.ts
@@ -32,7 +32,9 @@ import { getActionEnvelope, isActionNotification } from '../../serverIntegration
 import { conformanceTest, providerHostOnlyTest, type IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs, shellToolReplayEnabled } = context;
+	const { config, createdSessions, tempDirs } = context;
+	/** See the same constant in `fileOperationsSuite`. */
+	const PREFER_FILE_TOOLS = ' Use your file tools; do not run a shell command.';
 
 	async function createSession(prefix: string): Promise<{ sessionUri: string; defaultChatUri: string; workspace: string }> {
 		const workspace = mkdtempSync(join(tmpdir(), `ahp-multichat-${prefix}-`));
@@ -550,7 +552,6 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		assert.strictEqual(readFileSync(file, 'utf8'), 'PEER_CREATED');
 	});
 
-	// Copilot's fixture uses a POSIX shell for this mutation.
 	providerTest('peer chat edits an existing workspace file', async function () {
 		const { sessionUri, workspace } = await createSession('edit-file');
 		const file = join(workspace, 'peer-edit.txt');
@@ -558,22 +559,26 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		const peer = await createPeer(sessionUri, 'peer');
 		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
 
-		await driveTurn(peer, 'peer-edit', `Replace the complete contents of ${file} with AFTER_PEER.`, 1);
+		await driveTurn(peer, 'peer-edit', `Replace the complete contents of ${file} with AFTER_PEER.${PREFER_FILE_TOOLS}`, 1);
 
 		assert.strictEqual(readFileSync(file, 'utf8').trim(), 'AFTER_PEER');
-	}, config.supportsMultipleChats && (config.provider !== 'copilotcli' || shellToolReplayEnabled));
+	}, config.supportsMultipleChats);
 
-	// Copilot's fixture uses a POSIX shell for this mutation.
 	providerTest('peer chat creates a file in a nested directory', async function () {
 		const { sessionUri, workspace } = await createSession('nested-create');
 		const file = join(workspace, 'peer-output', 'report.txt');
 		const peer = await createPeer(sessionUri, 'peer');
 		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
 
-		await driveTurn(peer, 'peer-nested-create', `Create the file at ${file} containing exactly PEER_NESTED.`, 1);
+		// Pinned for the same reason as `creates a file in a new nested directory`
+		// in fileOperationsSuite: directory creation has no file tool. Relative to
+		// the session's working directory so the command carries no absolute path,
+		// which would need escaping on Windows.
+		const peerNestedCommand = `node -e "const fs=require('fs');fs.mkdirSync('peer-output',{recursive:true});fs.writeFileSync('peer-output/report.txt','PEER_NESTED')"`;
+		await driveTurn(peer, 'peer-nested-create', `Run exactly this shell command, with no modifications: \`${peerNestedCommand}\`. Then reply with exactly "created".`, 1);
 
 		assert.strictEqual(readFileSync(file, 'utf8'), 'PEER_NESTED');
-	}, config.supportsMultipleChats && (config.provider !== 'copilotcli' || shellToolReplayEnabled));
+	}, config.supportsMultipleChats);
 
 	providerTest('peer chat handles a missing workspace file without an error', async function () {
 		const { sessionUri, workspace } = await createSession('missing-file');
@@ -581,7 +586,7 @@ export function defineMultiChatTests(context: IAgentHostE2ETestContext): void {
 		const peer = await createPeer(sessionUri, 'peer');
 		await context.client.call<SubscribeResult>('subscribe', { channel: peer });
 
-		const response = await driveTurn(peer, 'peer-missing', `Try to read ${file}. If it does not exist, reply exactly "missing".`, 1);
+		const response = await driveTurn(peer, 'peer-missing', `Try to read ${file}. If it does not exist, reply exactly "missing".${PREFER_FILE_TOOLS}`, 1);
 
 		assert.match(response, /missing/i);
 	});

--- a/src/vs/platform/agentHost/test/node/e2e/suites/turnLifecycleSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/turnLifecycleSuite.ts
@@ -20,8 +20,8 @@ import { getActionEnvelope, isActionNotification } from '../../serverIntegration
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineTurnLifecycleTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs, shellToolReplayEnabled, runRecordOnlyTests } = context;
-	(shellToolReplayEnabled ? test : test.skip)('tool call triggers permission request and can be approved', async function () {
+	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, runRecordOnlyTests } = context;
+	(portableShellToolReplayEnabled ? test : test.skip)('tool call triggers permission request and can be approved', async function () {
 		this.timeout(120_000);
 
 		const tempDir = mkdtempSync(`${tmpdir()}/ahp-perm-test-`);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -27,7 +27,7 @@ import { getActionEnvelope, isActionNotification } from '../../serverIntegration
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs, shellToolReplayEnabled, isWindows } = context;
+	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, isWindows } = context;
 	test('session is created with the correct working directory', async function () {
 		this.timeout(120_000);
 
@@ -52,7 +52,14 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 	// Worktree isolation asserts on resolved `.worktrees/...` paths and a
 	// host-terminal `pwd`, which are POSIX-shaped (the fixtures were recorded on
 	// macOS); skip on Windows where the worktree paths and shell differ.
-	(config.supportsWorktreeIsolation && !isWindows && shellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
+	// Explicitly Windows-scoped. Unlike the other shell tests this one cannot be
+	// made portable by pinning the command: `pwd` is auto-approved as a safe
+	// read-only command, whereas a pinned `node -e "..."` is not, so the turn
+	// stops on a permission prompt the test does not answer. The assertions also
+	// compare POSIX-shaped paths. Worktree resolution itself is covered on
+	// Windows by the `sessionAdded` working-directory assertion in this test's
+	// non-shell half.
+	(config.supportsWorktreeIsolation && !isWindows && portableShellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
 		this.timeout(120_000);
 
 		const tempDir = mkdtempSync(`${tmpdir()}/ahp-wt-test-`);

--- a/src/vs/platform/agentHost/test/node/posixCommandLint.test.ts
+++ b/src/vs/platform/agentHost/test/node/posixCommandLint.test.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { findPosixOnlyCommands, type IRecordedCommand } from './e2e/harness/posixCommandLint.js';
+
+function check(commands: readonly string[]): string[] {
+	const recorded: IRecordedCommand[] = commands.map(command => ({ command, toolName: 'bash' }));
+	return findPosixOnlyCommands(recorded).map(finding => finding.command);
+}
+
+suite('posixCommandLint', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('flags the POSIX commands models actually reach for', () => {
+		// Every one of these was recorded into a real fixture by a provider and
+		// disabled its test on Windows.
+		const flagged = [
+			`wc -l < lines.txt`,
+			`printf '%s\\n' "SHELL_VALUE_73"`,
+			`ls -1`,
+			`ls -la \${workdir}/`,
+			`rm \${workdir}/before.txt`,
+			`mv before.txt after.txt && ls -la after.txt`,
+			`cat missing.txt 2>&1`,
+			`mkdir -p output && printf 'NESTED' > output/report.txt`,
+			`find / -maxdepth 6 -iname "edit.txt" 2>/dev/null`,
+			`xxd \${workdir}/after.txt`,
+			`pwd`,
+			`test -f peer-edit.txt && echo EXISTS || echo MISSING`,
+			`echo "$HOME"`,
+		];
+		assert.deepStrictEqual(check(flagged), flagged);
+	});
+
+	test('accepts the portable forms the suite standardizes on', () => {
+		// A false positive is worse than no lint: it would block a correct
+		// recording and push authors toward disabling the check.
+		assert.deepStrictEqual(check([
+			`echo SHELL_VALUE_73`,
+			`echo "hello from test"`,
+			`git status --porcelain`,
+			`node -e "console.log(process.cwd())"`,
+			`node -e "require('fs').renameSync('before.txt','after.txt')"`,
+			`node -e "require('fs').unlinkSync('delete-me.txt')"`,
+			`node -e "console.log(require('fs').readdirSync('.').join(' '))"`,
+			`node -e "const fs=require('fs');fs.mkdirSync('output',{recursive:true});fs.writeFileSync('output/report.txt','X')"`,
+			`node script.js`,
+		]), []);
+	});
+
+	test('does not flag POSIX command names appearing as arguments', () => {
+		// The patterns are anchored to a command position, so a coreutil name
+		// inside a quoted string or as part of a longer word is not a command.
+		assert.deepStrictEqual(check([
+			`node -e "console.log('ls')"`,
+			`echo cat`,
+			`node -e "require('fs').writeFileSync('rm.txt','x')"`,
+			`node -e "console.log(require('fs').readdirSync('.'))"`,
+			`git status --find-renames`,
+		]), []);
+	});
+
+	test('ignores recorder placeholders that look like variable expansions', () => {
+		// `${workdir}` and friends are substituted back before replay, so they
+		// are not POSIX expansions even though they look like them.
+		assert.deepStrictEqual(check([
+			`node -e "console.log(1)" \${workdir}`,
+			`echo \${homedir}`,
+			`node script.js \${temp}`,
+		]), []);
+	});
+
+	test('reports the reason and tool for each finding', () => {
+		assert.deepStrictEqual(findPosixOnlyCommands([
+			{ command: `wc -l lines.txt`, toolName: 'bash' },
+			{ command: `echo ok`, toolName: 'bash' },
+			{ command: `cat x 2>/dev/null`, toolName: 'powershell' },
+		]), [
+			{ command: `wc -l lines.txt`, toolName: 'bash', reason: 'uses a POSIX coreutil or shell builtin that cmd does not provide' },
+			{ command: `cat x 2>/dev/null`, toolName: 'powershell', reason: 'uses a POSIX coreutil or shell builtin that cmd does not provide' },
+		]);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
@@ -748,7 +748,7 @@ export async function startServer(options?: { readonly quiet?: boolean; readonly
  * Start the agent host server with the Copilot SDK agent with either a real or mocked LLM.
  * The server is started with logging enabled so the CopilotAgent is registered.
  */
-export async function startRealServer(options?: { readonly claudeSdkRoot?: string; readonly codexSdkRoot?: string; readonly mockLlm?: boolean; readonly homeDir?: string; readonly userDataDir?: string; readonly logLevel?: string; readonly env?: NodeJS.ProcessEnv; readonly capiReplay?: { readonly fixturePath: string; readonly mode?: CapiReplayMode; readonly workDir?: string; readonly real?: boolean }; readonly mockScenarios?: readonly IMockScenario[] }): Promise<IServerHandle> {
+export async function startRealServer(options?: { readonly claudeSdkRoot?: string; readonly codexSdkRoot?: string; readonly mockLlm?: boolean; readonly homeDir?: string; readonly userDataDir?: string; readonly logLevel?: string; readonly env?: NodeJS.ProcessEnv; readonly capiReplay?: { readonly fixturePath: string; readonly mode?: CapiReplayMode; readonly workDir?: string; readonly real?: boolean; readonly allowPosixCommands?: boolean }; readonly mockScenarios?: readonly IMockScenario[] }): Promise<IServerHandle> {
 	// `capiReplay` records/replays in front of the mock LLM server, so it implies
 	// a mock upstream even when `mockLlm` was not explicitly requested — unless
 	// `real` is set, in which case the proxy forwards to real CAPI/GitHub.
@@ -760,6 +760,7 @@ export async function startRealServer(options?: { readonly claudeSdkRoot?: strin
 			fixturePath: options.capiReplay.fixturePath,
 			mode: options.capiReplay.mode,
 			workDir: options.capiReplay.workDir,
+			allowPosixCommands: options.capiReplay.allowPosixCommands,
 			homeDir: options.homeDir,
 			userName: userInfo().username,
 			// Real hosts (consumer defaults); override for Enterprise/Business accounts.
@@ -769,6 +770,7 @@ export async function startRealServer(options?: { readonly claudeSdkRoot?: strin
 			fixturePath: options.capiReplay.fixturePath,
 			mode: options.capiReplay.mode,
 			workDir: options.capiReplay.workDir,
+			allowPosixCommands: options.capiReplay.allowPosixCommands,
 			homeDir: options.homeDir,
 			userName: userInfo().username,
 			upstreamUrl: mockLlmServer!.url,


### PR DESCRIPTION
Draft. Follow-up to #327489, taking the first concrete step toward running the Agent Host E2E shell tests on Windows.

**The main purpose of this PR is to get a Windows CI result.** The changes are believed to make one test platform-neutral, but that is an inference from reading the replay code — it has not been proven on a real Windows run. See "What to look for in CI" below.

## Background

16 tests are disabled on Windows. Almost all of them trace back to a POSIX-only command string frozen into a checked-in fixture — and no test author chose those strings. The prompt described what to do, the model picked how, and whatever it picked became the fixture.

The clearest case is the test ported here. `runs a deterministic shell command` was skipped on Windows for **all three** providers, but Copilot's recorded command was already `echo SHELL_VALUE_73`, which runs fine on Windows. It was blocked only because Claude happened to pick `printf '%s\n' "SHELL_VALUE_73"`.

## What changed

Porting one test surfaced four separate couplings, only one of which was the command:

1. **The prompt** now pins the command instead of describing it. Re-recorded against live CAPI, Claude switched from `printf` to `echo` — confirming the model's choice was the whole problem. *(per-test work)*
2. **Tool name in the AHP snapshot.** The Copilot CLI names its shell tools after the shell it runs (`bash` on POSIX, `powershell` on Windows) and that name reaches the client verbatim in `chat/toolCallStart`. Snapshots now record `${shell}`. *(central)*
3. **Tool name in the CAPI fixture.** The same name appears in the `tool_use` block that *drives* replay, so a macOS recording would instruct a Windows agent to call a tool that does not exist. Captures now store a placeholder and `CapiReplayProxy` expands it to the running platform's name on replay. *(central)*
4. **Empty reasoning parts.** A provider can open a reasoning part and close it without emitting a delta. Live recording sees it, but replay rebuilds the stream from the fixture's aggregated content where it leaves no trace — so **any snapshot recorded during such a turn was permanently unreplayable**. These are now dropped during projection. *(central, and unrelated to platforms)*

Also included:

- **CRLF normalization** in `normalizeSnapshotText`. Snapshot normalization handled paths, user names, shell ids and `ls -l` columns but not line endings, so a snapshot carrying literal tool output would fail on Windows for a reason unrelated to the behavior under test.
- **`shellToolReplayEnabled` split** into two flags. It conflated "the provider's shell-tool replay is unstable on Linux" with "this capture contains a POSIX-only command"; only the second is about Windows, and only for captures that haven't been ported. Ported tests use `portableShellToolReplayEnabled`.

## Tests

`capiReplayProxyShellTools.test.ts` covers the capture/replay round-trip for shell tool names. The platform is an injectable parameter rather than a module-load read of `process.platform`, so **both platform branches are asserted from either host** — otherwise the Windows half would be dead code on a developer machine, which is exactly the branch this work exists to protect.

## What to look for in CI

On the Windows leg, `runs a deterministic shell command` currently reports as skipped for all three providers:

```
- runs a deterministic shell command    (Claude)
- runs a deterministic shell command    (Codex)
- runs a deterministic shell command    (Copilot)
```

Success is **Claude and Copilot flipping to `✔`**. Codex should stay skipped — it is gated on `stableNewScenarioResponse: false`, which is unrelated to platform.

If it fails, that is still a useful result: it means something beyond these four couplings is platform-specific, and it is much cheaper to learn that on one test than after porting all 15.

## Verification so far

- Full E2E suite: **150 passing, 0 failing**, stable across repeated runs (macOS)
- `capiReplayProxyShellTools.test.ts`: 3 passing
- `typecheck-client`, `valid-layers-check`, hygiene: pass
- One row removed from the Windows-disabled table in `KNOWN_ISSUES.md`

## Follow-ups (not in this PR)

- Port the remaining shell-dependent tests using the checklist recorded in `KNOWN_ISSUES.md`
- Add a record-time lint that fails a recording containing POSIX-only constructs, so ported tests do not silently regress on the next re-record
