### PR TITLE
fix(github): prioritize authenticated user repositories in clone search

### DIFF
--- a/extensions/github/src/remoteSourceProvider.ts
+++ b/extensions/github/src/remoteSourceProvider.ts
@@ -50,15 +50,19 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 		}
 
 		const all = await Promise.all([
-			this.getQueryRemoteSources(octokit, query),
 			this.getUserRemoteSources(octokit, query),
+			this.getQueryRemoteSources(octokit, query),
 		]);
 
 		const map = new Map<string, RemoteSource>();
 
 		for (const group of all) {
 			for (const remoteSource of group) {
-				map.set(remoteSource.name, remoteSource);
+				//Preserve the first occurance so user/org repositories
+				// take precedence over matching public search results.
+				if (!map.has(remoteSource.name)) {
+					map.set(remoteSource.name, remoteSource);
+				}
 			}
 		}
 
@@ -66,14 +70,24 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 	}
 
 	private async getUserRemoteSources(octokit: Octokit, query?: string): Promise<RemoteSource[]> {
-		if (!query) {
-			const user = await octokit.users.getAuthenticated({});
-			const username = user.data.login;
-			const res = await octokit.repos.listForAuthenticatedUser({ username, sort: 'updated', per_page: 100 });
+		const normalizedQuery = query?.trim().toLowerCase();
+
+		if (!normalizedQuery) {
+			const res = await octokit.repos.listForAuthenticatedUser({ sort: 'updated', per_page: 100 });
+			this.userReposCache = res.data.map(asRemoteSource);
+			return this.userReposCache;
+		}
+
+		if (this.userReposCache.length === 0) {
+			const res = await octokit.repos.listForAuthenticatedUser({ sort: 'updated', per_page: 100 });
 			this.userReposCache = res.data.map(asRemoteSource);
 		}
 
-		return this.userReposCache;
+		return this.userReposCache.filter(repo =>
+			repo.name
+				.toLowerCase()
+				.includes(normalizedQuery)
+		);
 	}
 
 	private async getQueryRemoteSources(octokit: Octokit, query?: string): Promise<RemoteSource[]> {


### PR DESCRIPTION
## Summary
Fixes #141754

User's own repos were getting buried under public search results in the GitHub clone picker. This fixes the merge order so authenticated user repos always show up first.

## Root cause
`GithubRemoteSourceProvider.getRemoteSources()` merges results from `getUserRemoteSources()` and `getQueryRemoteSources()`. The merge was overwriting duplicates instead of keeping the first match, and cached user repos weren't being filtered against the current query. End result: your own repos could rank below public repos with a similar name, and stale cached repos showed up even when they didn't match what you typed.

## Changes
- Merge user repos first, then GitHub search results
- Keep first occurrence on merge so user repos win over duplicates from public search
- Filter cached user repos by the current query instead of returning them all
- Lazily populate the user repo cache if it hasn't been initialized yet

## Testing
Couldn't run the full VS Code build locally — missing the Spectre-mitigated VC++ libs on this machine. Change is small and scoped to `extensions/github/src/remoteSourceProvider.ts`, should be fine for CI to validate.