### PR TITLE
agentHost: use client request id for tools telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -288,23 +288,21 @@ export class AgentHostTelemetryReporter {
 	 * Mirrors the Copilot extension's enhanced GH `request.options.tools` event for the agent-host
 	 * flow. The extension emits it per LLM request from its model fetcher; the agent host observes
 	 * the equivalent boundary when an `assistant.message` arrives (one per model call). The
-	 * extension populates `headerRequestId` with the client-minted `x-request-id`, which the SDK
-	 * does not surface on success; we keep the same field name (so science queries are undisturbed)
-	 * but fill it with the model call's `x-copilot-service-request-id`, the per-call id the SDK does
-	 * expose. `messagesJson` is the raw tool definitions offered for the call, multiplexed across
-	 * ~8192-char chunks like the extension, so it lands identically downstream.
+	 * `headerRequestId` is the client-minted `x-request-id`, matching the extension. `messagesJson`
+	 * is the raw tool definitions offered for the call, multiplexed across ~8192-char chunks like
+	 * the extension, so it lands identically downstream.
 	 *
 	 * @param session Session URI string; its id becomes `conversationId`.
-	 * @param serviceRequestId The model call's `x-copilot-service-request-id`, mapped to the extension's `headerRequestId`. No-ops when absent (e.g. providers that don't surface it).
+	 * @param clientRequestId The model call's client-minted `x-request-id`, mapped to the extension's `headerRequestId`. No-ops when absent (e.g. providers that don't surface it).
 	 * @param tools The tool definitions offered to the model for this call.
 	 */
-	assistantMessageReceived(session: string, clientType: AgentHostClientType, serviceRequestId: string | undefined, tools: readonly ToolDefinition[]): void {
+	assistantMessageReceived(session: string, clientType: AgentHostClientType, clientRequestId: string | undefined, tools: readonly ToolDefinition[]): void {
 		const restricted = this._restricted;
-		if (!restricted || !serviceRequestId || tools.length === 0) {
+		if (!restricted || !clientRequestId || tools.length === 0) {
 			return;
 		}
 		restricted.sendEnhancedGHTelemetryEvent('request.options.tools', multiplexProperties({
-			headerRequestId: serviceRequestId,
+			headerRequestId: clientRequestId,
 			conversationId: AgentSession.id(session),
 			initiatorClientType: clientType,
 			messagesJson: JSON.stringify(tools),

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3254,12 +3254,12 @@ export class CopilotAgentSession extends Disposable {
 			this._resumeSubagentForEvent(e);
 			// Report the enhanced GH `request.options.tools` event for this model call — parity with
 			// the Copilot extension, which emits it per LLM request. `assistant.message` is the
-			// agent-host's per-model-call boundary; we correlate on its `x-copilot-service-request-id`.
+			// agent-host's per-model-call boundary; we correlate on its client-minted `x-request-id`.
 			// Main agent only: `_appliedSnapshot.tools` is the session's tool set, which does not
 			// describe a subagent's model call, so subagent messages (mapped or dropped) are skipped.
 			if (!e.agentId) {
 				const clientType = this._currentTurn?.clientType ?? AgentHostClientType.Unknown;
-				this._telemetryReporter.assistantMessageReceived(this.sessionUri.toString(), clientType, e.data.serviceRequestId, this._appliedSnapshot.tools);
+				this._telemetryReporter.assistantMessageReceived(this.sessionUri.toString(), clientType, e.data.clientRequestId, this._appliedSnapshot.tools);
 				// Restricted `conversation.messageText` (source=model): the model's raw response text.
 				this._telemetryReporter.modelMessageText(this.sessionUri.toString(), clientType, e.data.content, this._turnOrdinal, e.data.serviceRequestId);
 				// Accumulate the per-turn tool-call aggregate for the restricted `toolCallDetails` event.

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -64,18 +64,18 @@ suite('AgentHostTelemetryReporter', () => {
 	const session = 'agent-session://copilot/abc';
 	const tools: ToolDefinition[] = [{ name: 'grep' }, { name: 'edit' }];
 
-	test('assistantMessageReceived emits request.options.tools keyed on the service request id, and no-ops without one or without tools', () => {
+	test('assistantMessageReceived emits request.options.tools keyed on the client request id, and no-ops without one or without tools', () => {
 		const service = new TestRestrictedTelemetryService();
 		const reporter = new AgentHostTelemetryReporter(service);
 
-		reporter.assistantMessageReceived(session, AgentHostClientType.AgentsWindow, undefined, tools); // dropped: no service request id
-		reporter.assistantMessageReceived(session, AgentHostClientType.AgentsWindow, 'svc-1', []); // dropped: no tools
-		reporter.assistantMessageReceived(session, AgentHostClientType.AgentsWindow, 'svc-1', tools); // emitted
+		reporter.assistantMessageReceived(session, AgentHostClientType.AgentsWindow, undefined, tools); // dropped: no client request id
+		reporter.assistantMessageReceived(session, AgentHostClientType.AgentsWindow, 'client-1', []); // dropped: no tools
+		reporter.assistantMessageReceived(session, AgentHostClientType.AgentsWindow, 'client-1', tools); // emitted
 
 		assert.deepStrictEqual(service.enhancedEvents, [{
 			eventName: 'request.options.tools',
 			properties: {
-				headerRequestId: 'svc-1',
+				headerRequestId: 'client-1',
 				conversationId: AgentSession.id(session),
 				initiatorClientType: 'agents_window',
 				messagesJson: JSON.stringify(tools),


### PR DESCRIPTION
The Copilot SDK now exposes the client-minted `x-request-id` as `clientRequestId` on `assistant.message`. Use it for `request.options.tools.headerRequestId` so the agent-host event matches the Copilot extension instead of placing `x-copilot-service-request-id` in that field.

Related to #324092.

## Testing

- `npm run gulp compile`
- `npm run test-node -- --grep 'AgentHostTelemetryReporter'` (12,700 passing, 192 pending)