### PR TITLE
Enforce workspace trust for unattended agent sessions

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -90,6 +90,7 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatQuotaService private readonly _chatQuotaService: IChatQuotaService,
 		@IClaudeAgentSdkLoaderService private readonly _sdkLoader: IClaudeAgentSdkLoaderService,
+		@IWorkspaceService private readonly _workspaceService: IWorkspaceService,
 	) {
 		super();
 		this._controller = this._register(instantiationService.createInstance(ClaudeChatSessionItemController));
@@ -162,6 +163,21 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 			const permissionMode = selectedPermissionId;
 			const selectedFolderUri = getSelectedFolderUri(chatSessionContext.inputState);
 			const folderInfo = await this._controller.getFolderInfoForSession(effectiveSessionId, selectedFolderUri);
+			let untrustedDirectory: URI | undefined;
+			for (const directory of [folderInfo.cwd, ...folderInfo.additionalDirectories]) {
+				const directoryUri = URI.file(directory);
+				if (!await this._workspaceService.isResourceTrusted(directoryUri)) {
+					untrustedDirectory = directoryUri;
+					break;
+				}
+			}
+			if (untrustedDirectory) {
+				return {
+					errorDetails: {
+						message: vscode.l10n.t("Workspace '{0}' is not trusted", untrustedDirectory.fsPath)
+					}
+				};
+			}
 
 			// Commit UI state to session state service before invoking agent manager
 			this.sessionStateService.setModelIdForSession(effectiveSessionId, modelId);

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
@@ -955,7 +955,7 @@ describe('ChatSessionContentProvider', () => {
 		let handlerProvider: ClaudeChatSessionContentProvider;
 		let handlerAccessor: ITestingServicesAccessor;
 
-		function createChatContext(sessionId: string): vscode.ChatContext {
+		function createChatContext(sessionId: string, options?: { folderPath?: string; allFolderPaths?: string[] }): vscode.ChatContext {
 			return {
 				history: [],
 				yieldRequested: false,
@@ -965,7 +965,7 @@ describe('ChatSessionContentProvider', () => {
 						resource: ClaudeSessionUri.forSessionId(sessionId),
 						label: 'Test Session',
 					},
-					inputState: { groups: buildInputStateGroups(), sessionResource: undefined, onDidChange: Event.None, onDidDispose: Event.None },
+					inputState: { groups: buildInputStateGroups(options), sessionResource: undefined, onDidChange: Event.None, onDidDispose: Event.None },
 				},
 			} as vscode.ChatContext;
 		}
@@ -996,6 +996,49 @@ describe('ChatSessionContentProvider', () => {
 			await handler(createTestRequest('hello'), context, stream, CancellationToken.None);
 
 			expect(setModelSpy).toHaveBeenCalledWith('session-1', parseClaudeModelId('claude-3-5-sonnet-20241022'));
+		});
+
+		it('rejects an untrusted folder before invoking the agent manager', async () => {
+			const mocks = createDefaultMocks();
+			const workspaceService = new TestWorkspaceService([workspaceFolderUri]);
+			vi.spyOn(workspaceService, 'isResourceTrusted').mockResolvedValue(false);
+			const untrustedAgentManager = createMockAgentManager();
+			const { provider } = createProviderWithServices(store, [workspaceFolderUri], mocks, untrustedAgentManager, workspaceService);
+			seedSessionItem('session-untrusted');
+
+			const result = await provider.createHandler()(
+				createTestRequest('hello'),
+				createChatContext('session-untrusted'),
+				new MockChatResponseStream(),
+				CancellationToken.None,
+			);
+
+			expect(result).toEqual({ errorDetails: { message: `Workspace '${workspaceFolderUri.fsPath}' is not trusted` } });
+			expect(vi.mocked(untrustedAgentManager.handleRequest)).not.toHaveBeenCalled();
+		});
+
+		it('rejects an untrusted additional directory before invoking the agent manager', async () => {
+			const primaryFolder = URI.file('/primary');
+			const additionalFolder = URI.file('/additional');
+			const mocks = createDefaultMocks();
+			const workspaceService = new TestWorkspaceService([primaryFolder, additionalFolder]);
+			vi.spyOn(workspaceService, 'isResourceTrusted').mockImplementation(async resource => resource.fsPath !== additionalFolder.fsPath);
+			const untrustedAgentManager = createMockAgentManager();
+			const { provider } = createProviderWithServices(store, [primaryFolder, additionalFolder], mocks, untrustedAgentManager, workspaceService);
+			seedSessionItem('session-additional-untrusted');
+
+			const result = await provider.createHandler()(
+				createTestRequest('hello'),
+				createChatContext('session-additional-untrusted', {
+					folderPath: primaryFolder.fsPath,
+					allFolderPaths: [primaryFolder.fsPath, additionalFolder.fsPath],
+				}),
+				new MockChatResponseStream(),
+				CancellationToken.None,
+			);
+
+			expect(result).toEqual({ errorDetails: { message: `Workspace '${additionalFolder.fsPath}' is not trusted` } });
+			expect(vi.mocked(untrustedAgentManager.handleRequest)).not.toHaveBeenCalled();
 		});
 
 		it('short-circuits before session resolution when slash command is handled', async () => {

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -374,7 +374,12 @@ the pending/active session or navigating the current view — the started sessio
 just appears in the sessions list once the provider commits it. It shares the
 underlying commit helper with the composer's background send; if the send fails
 it disposes the stranded draft via `deleteNewSession` and rejects so the caller
-can react.
+can react. After resolving
+the exact provider/session type and workspace once, it checks that workspace's
+`requiresWorkspaceTrust` policy and queries resource trust before
+`provider.createNewSession`. An untrusted required workspace rejects with
+`WorkspaceNotTrustedError`, so headless callers fail closed before provider code
+can load workspace-controlled configuration or run commands.
 
 ### Adding a Chat to an Existing Session (Agent Host Multi-Chat)
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -21,12 +21,13 @@ import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/co
 import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { getSessionReferenceResource } from './sessionReference.js';
-import { ICreateNewChatInSessionOptions, ICreateNewSessionOptions, IProviderSessionType, ISendRequestOptions, ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
+import { ICreateNewChatInSessionOptions, ICreateNewSessionOptions, IProviderSessionType, ISendRequestOptions, ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService, WorkspaceNotTrustedError } from '../common/sessionsManagement.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sessionsProvidersService.js';
 import { IDeleteChatOptions, ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
 import { IChat, ISession, ISessionWorkspace, ISideChatSelection, SessionStatus, ISessionType } from '../common/session.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
 
 /** Storage key for the last session type used to create a quick chat. */
 const LAST_USED_QUICK_CHAT_SESSION_TYPE_STORAGE_KEY = 'sessions.quickChat.lastUsedSessionType';
@@ -96,6 +97,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		@IStorageService private readonly storageService: IStorageService,
 		@IPathService private readonly pathService: IPathService,
 		@IRemoteAgentHostService private readonly remoteAgentHostService: IRemoteAgentHostService,
+		@IWorkspaceTrustManagementService private readonly workspaceTrustManagementService: IWorkspaceTrustManagementService,
 	) {
 		super();
 
@@ -316,19 +318,21 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	/**
 	 * Resolve the provider and session type to use for a new session in the
-	 * given folder, applying the same selection rules as
-	 * {@link createNewSession}. Throws when no provider/type can be resolved.
+	 * given folder. Includes that provider's resolved workspace so headless
+	 * callers can enforce provider-specific trust without resolving it again.
 	 */
-	private _resolveProviderForNewSession(folderUri: URI, options?: ICreateNewSessionOptions): { provider: ISessionsProvider; sessionTypeId: string } {
+	private _resolveProviderForNewSession(folderUri: URI, options?: ICreateNewSessionOptions): { provider: ISessionsProvider; sessionTypeId: string; workspace: ISessionWorkspace } {
 		const providers = this.sessionsProvidersService.getProviders();
 		let provider: ISessionsProvider | undefined;
+		let workspace: ISessionWorkspace | undefined;
 
 		if (options?.providerId) {
 			provider = providers.find(p => p.id === options.providerId);
 			if (!provider) {
 				throw new Error(`Sessions provider '${options.providerId}' not found`);
 			}
-			if (!provider.resolveWorkspace(folderUri)) {
+			workspace = provider.resolveWorkspace(folderUri);
+			if (!workspace) {
 				throw new Error(`Sessions provider '${options.providerId}' cannot resolve folder '${folderUri.toString()}'`);
 			}
 			if (options.sessionTypeId && !provider.getSessionTypes(folderUri).some(type => type.id === options.sessionTypeId)) {
@@ -339,16 +343,18 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			// When a specific session type was requested, also require the provider to
 			// advertise that type for the folder.
 			for (const candidate of providers) {
-				if (!candidate.resolveWorkspace(folderUri)) {
+				const candidateWorkspace = candidate.resolveWorkspace(folderUri);
+				if (!candidateWorkspace) {
 					continue;
 				}
 				if (options?.sessionTypeId && !candidate.getSessionTypes(folderUri).some(t => t.id === options.sessionTypeId)) {
 					continue;
 				}
 				provider = candidate;
+				workspace = candidateWorkspace;
 				break;
 			}
-			if (!provider) {
+			if (!provider || !workspace) {
 				throw new Error(`No sessions provider can resolve folder '${folderUri.toString()}'`);
 			}
 		}
@@ -359,7 +365,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 				throw new Error(`No session types available for provider '${provider.id}'`);
 			}
 		}
-		return { provider, sessionTypeId };
+		return { provider, sessionTypeId, workspace };
 	}
 
 	createNewSession(folderUri: URI, options?: ICreateNewSessionOptions): ISession {
@@ -618,7 +624,13 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	 * disposed through its provider and the error is rethrown.
 	 */
 	async createAndSendNewChatRequest(folderUri: URI, options: ISendRequestOptions, createOptions?: ICreateNewSessionOptions, token: CancellationToken = CancellationToken.None): Promise<ISession | undefined> {
-		const { provider, sessionTypeId } = this._resolveProviderForNewSession(folderUri, createOptions);
+		const { provider, sessionTypeId, workspace } = this._resolveProviderForNewSession(folderUri, createOptions);
+		if (workspace.requiresWorkspaceTrust) {
+			const trustInfo = await this.workspaceTrustManagementService.getUriTrustInfo(folderUri);
+			if (!trustInfo.trusted) {
+				throw new WorkspaceNotTrustedError();
+			}
+		}
 		const session = provider.createNewSession(folderUri, sessionTypeId);
 		const supportsWorktreeConfiguration = provider.getSessionTypes(folderUri)
 			.find(sessionType => sessionType.id === sessionTypeId)?.supportsWorktreeConfiguration === true;

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -11,6 +11,14 @@ import { createDecorator } from '../../../../platform/instantiation/common/insta
 import { IChat, ISession, ISessionType, ISessionWorkspace, ISideChatSelection } from './session.js';
 import { IDeleteChatOptions, ISendRequestOptions as ISessionsProviderSendRequestOptions } from './sessionsProvider.js';
 
+/** Raised when unattended session creation targets a workspace that requires trust. */
+export class WorkspaceNotTrustedError extends Error {
+	constructor() {
+		super('Workspace not trusted');
+		this.name = 'WorkspaceNotTrustedError';
+	}
+}
+
 /**
  * Options for sending a request through the sessions management service.
  *

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -20,7 +20,7 @@ import { ILogService, NullLogService } from '../../../../../platform/log/common/
 import { IProgress, IProgressService, IProgressStep } from '../../../../../platform/progress/common/progress.js';
 import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
-import { IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
+import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { ChatViewPaneTarget, IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatEditorOptions } from '../../../../../workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.js';
@@ -31,7 +31,7 @@ import { ChatInteractivity, ChatOriginKind, IChat, ISession, ISessionType, ISess
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { ISessionChangeEvent, ISendRequestOptions, ISessionModelsSnapshot, ISessionModelPickerOptions, ISessionsProvider } from '../../common/sessionsProvider.js';
 import { SessionsManagementService } from '../../browser/sessionsManagementService.js';
-import { ISessionsManagementService, ICreateNewSessionOptions, inheritableSessionTarget } from '../../common/sessionsManagement.js';
+import { ISessionsManagementService, ICreateNewSessionOptions, inheritableSessionTarget, WorkspaceNotTrustedError } from '../../common/sessionsManagement.js';
 import { SessionsService } from '../../browser/sessionsService.js';
 import { ISessionsPartService } from '../../browser/sessionsPartService.js';
 import { ISessionsProvidersService } from '../../browser/sessionsProvidersService.js';
@@ -121,6 +121,16 @@ class TestProgressService extends mock<IProgressService>() {
 	}
 }
 
+class TestWorkspaceTrustManagementService extends mock<IWorkspaceTrustManagementService>() {
+	trusted = true;
+	readonly requestedUris: URI[] = [];
+
+	override async getUriTrustInfo(uri: URI) {
+		this.requestedUris.push(uri);
+		return { uri, trusted: this.trusted };
+	}
+}
+
 class TestSessionsProvidersService extends mock<ISessionsProvidersService>() {
 	override readonly onDidChangeProviders = Event.None;
 
@@ -176,7 +186,12 @@ class TestSessionsProvider extends mock<ISessionsProvider>() {
 	override async createSideChat(_sessionId: string, _sourceChat: URI, _turnId: string, _selection?: ISideChatSelection): Promise<IChat> { throw new Error('not implemented'); }
 }
 
-function createSessionsManagementService(session: ISession, disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>, provider: ISessionsProvider = new TestSessionsProvider(session)): { service: ISessionsManagementService; view: SessionsService; chatWidgetService: TestChatWidgetService; chatService: TestChatService } {
+function createSessionsManagementService(
+	session: ISession,
+	disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>,
+	provider: ISessionsProvider = new TestSessionsProvider(session),
+	workspaceTrustManagementService = new TestWorkspaceTrustManagementService(),
+): { service: ISessionsManagementService; view: SessionsService; chatWidgetService: TestChatWidgetService; chatService: TestChatService } {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	const chatWidgetService = new TestChatWidgetService();
 	const chatService = new TestChatService();
@@ -192,6 +207,7 @@ function createSessionsManagementService(session: ISession, disposables: ReturnT
 	instantiationService.stub(IChatWidgetHistoryService, new class extends mock<IChatWidgetHistoryService>() {
 		override moveHistory(): void { }
 	});
+	instantiationService.stub(IWorkspaceTrustManagementService, workspaceTrustManagementService);
 
 	const service = disposables.add(instantiationService.createInstance(SessionsManagementService));
 	const view = createView(instantiationService, service, disposables);
@@ -915,6 +931,63 @@ suite('SessionsManagementService', () => {
 		// The request was sent, but the user's view was not navigated into the session.
 		assert.strictEqual(sendRequestStarted, true);
 		assert.strictEqual(view.activeSession.get(), undefined);
+	});
+
+	test('createAndSendNewChatRequest refuses an untrusted required workspace before creating a session', async () => {
+		const chat: IChat = { ...stubChat, resource: URI.parse('test:///chat') };
+		const session = stubSession({
+			sessionId: 's1',
+			providerId: 'test',
+			chats: constObservable([chat]),
+			mainChat: constObservable(chat),
+		});
+		const folderUri = URI.parse('test:///folder');
+		let resolveCount = 0;
+		let createCount = 0;
+		let sendCount = 0;
+		const provider = new class extends TestSessionsProvider {
+			override resolveWorkspace(uri: URI): ISessionWorkspace {
+				resolveCount++;
+				return {
+					uri,
+					label: 'Test',
+					icon: Codicon.folder,
+					folders: [],
+					requiresWorkspaceTrust: true,
+					isVirtualWorkspace: false,
+				};
+			}
+			override createNewSession(): ISession {
+				createCount++;
+				return session;
+			}
+			override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> {
+				sendCount++;
+				return session;
+			}
+		}(session);
+		const workspaceTrustManagementService = new TestWorkspaceTrustManagementService();
+		workspaceTrustManagementService.trusted = false;
+		const { service } = createSessionsManagementService(session, disposables, provider, workspaceTrustManagementService);
+
+		await assert.rejects(
+			service.createAndSendNewChatRequest(folderUri, { query: 'hi' }),
+			WorkspaceNotTrustedError,
+		);
+		workspaceTrustManagementService.trusted = true;
+		await service.createAndSendNewChatRequest(folderUri, { query: 'hi' });
+
+		assert.deepStrictEqual({
+			requestedUris: workspaceTrustManagementService.requestedUris.map(uri => uri.toString()),
+			resolveCount,
+			createCount,
+			sendCount,
+		}, {
+			requestedUris: [folderUri.toString(), folderUri.toString()],
+			resolveCount: 2,
+			createCount: 1,
+			sendCount: 1,
+		});
 	});
 
 	test('target availability requires the requested provider and session type to be advertised', () => {


### PR DESCRIPTION
## Summary

- Check workspace trust before `createAndSendNewChatRequest` creates an unattended session.
- Reject untrusted required workspaces with `WorkspaceNotTrustedError` before provider code can load workspace configuration or run commands.
- Prevent Claude sessions from starting when their working directory or additional directories are untrusted. cc @TylerLeonhardt 

## Testing

- Added focused sessions management coverage for trusted and untrusted workspaces.
- Added Claude coverage for untrusted primary and additional directories.
- Ran client type checking, built-in extension compilation, layer validation, hygiene, pre-commit checks, and targeted unit tests.