### PR TITLE
fix: show Modern UI hover on panel and secondary side bar tabs

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -303,6 +303,22 @@
 }
 
 /*
+ * Hover pill on `.action-item` for panel and secondary side bar composite tabs.
+ * Side-bar hover paints `.active-item-indicator`, but that path does not work
+ * here: icon tabs hide the indicator, and the side-bar hover selector only
+ * matches `.icon` (panel text tabs never hit it). Active state already uses
+ * `.action-item.checked`, so hover belongs on the same element. Skip while
+ * dragging so drop indicators stay clear. Uses list-hoverBackground (same as
+ * the side bar); checked still uses a foreground color-mix until themed
+ * (#327267). See https://github.com/microsoft/vscode/issues/327676
+ */
+.style-override .part.panel > .title > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover,
+.style-override .part.auxiliarybar > .title > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover,
+.style-override .part.auxiliarybar > .header-or-footer > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover {
+	background-color: var(--vscode-list-hoverBackground);
+}
+
+/*
  * Drop the underline active indicator in favour of the pill background. The
  * base rules (auxiliaryBarPart.css / paneCompositePart.css) paint the indicator
  * with `!important` from `.part.auxiliarybar` selectors, so match their

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -302,16 +302,7 @@
 	background-color: color-mix(in srgb, var(--vscode-foreground) 10%, transparent) !important;
 }
 
-/*
- * Hover pill on `.action-item` for panel and secondary side bar composite tabs.
- * Side-bar hover paints `.active-item-indicator`, but that path does not work
- * here: icon tabs hide the indicator, and the side-bar hover selector only
- * matches `.icon` (panel text tabs never hit it). Active state already uses
- * `.action-item.checked`, so hover belongs on the same element. Skip while
- * dragging so drop indicators stay clear. Uses list-hoverBackground (same as
- * the side bar); checked still uses a foreground color-mix until themed
- * (#327267). See https://github.com/microsoft/vscode/issues/327676
- */
+/* Skip hover while dragging so drop indicators stay clear. */
 .style-override .part.panel > .title > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover,
 .style-override .part.auxiliarybar > .title > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover,
 .style-override .part.auxiliarybar > .header-or-footer > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover {


### PR DESCRIPTION
## Summary
- Fixes #327676: with Modern UI and the activity bar on top, panel and secondary side bar composite tabs showed no hover background while primary side bar tabs did.
- Active state already paints a pill on `.action-item`, but hover still targeted `.active-item-indicator` (hidden for icon tabs; side-bar hover also requires `.icon`, so panel text tabs never matched).
- Paint `var(--vscode-list-hoverBackground)` on `.action-item:not(.checked):hover` for panel `.title` and auxiliary bar `.title` / `.header-or-footer`, with the same drag-over guards as the side bar.
- Checked tabs keep the existing foreground `color-mix` pill (theming that separately is #327267).

## Test plan
- [x] Enable `workbench.experimental.modernUI` and set `workbench.activityBar.location` to `top`
- [x] Primary side bar icon tabs: hover pill still appears (no regression; still via indicator)
- [x] Panel tabs (Problems / Output / Terminal): hover background on unchecked tabs; checked tab unchanged
- [x] Secondary side bar header composite tabs: hover background on unchecked tabs; checked unchanged
- [x] Modern UI off: `.style-override` absent; these hover rules do not apply
- [ ] Manual: drag a composite tab — hover pill should not fight drop indicators