### PR TITLE
Address important dictation feedback

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -85,6 +85,7 @@ import { IChatStatusItemService } from '../../../../workbench/contrib/chat/brows
 import { handleTerminalCommandPaste, isTerminalCommandInput } from '../../../../workbench/contrib/chat/browser/chatTerminalCommandPaste.js';
 import { getChatSessionType } from '../../../../workbench/contrib/chat/common/model/chatUri.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from '../../../../workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.js';
+import { setupDictationMicGlow } from '../../../../workbench/contrib/chat/browser/speechToText/dictationMicGlow.js';
 import { ChatVoiceInputModeAction, VoiceInputModeActionViewItem } from '../../../../workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.js';
 import { IVoiceInputModeService } from '../../../../workbench/contrib/chat/browser/voiceInputMode/voiceInputMode.js';
 import { toAction } from '../../../../base/common/actions.js';
@@ -346,6 +347,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		@ICommandService private readonly commandService: ICommandService,
 		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
 		@IVoiceInputModeService private readonly voiceInputModeService: IVoiceInputModeService,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 	) {
 		super();
 		this._sessionModelSelectionModel = this._register(this.instantiationService.createInstance(SessionModelSelectionModel, this.options.session));
@@ -880,6 +882,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		renderState();
 		this._register(sttService.onDidChangeState(renderState));
 		this._register(sttService.onDidChangePreparingModel(renderState));
+		this._register(setupDictationMicGlow(button, sttService, this.configurationService, this.accessibilityService));
 
 		const updateVisibility = () => {
 			// Mirror the `MenuId.ChatExecute` dictation gate: hide while

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -93,7 +93,7 @@ import { runDictationShortcut } from '../../../../workbench/contrib/chat/browser
 import { notifyDictationSubmitted } from '../../../../workbench/contrib/chat/browser/speechToText/dictationSession.js';
 import { combineVoiceInput } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceInputUtils.js';
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
-import { DictationDownloadRing, getDictationPreparingLabel } from '../../../../workbench/contrib/chat/browser/speechToText/dictationDownloadRing.js';
+import { DictationDownloadRing, getDictationDownloadHoverMarkdown, getDictationPreparingLabel } from '../../../../workbench/contrib/chat/browser/speechToText/dictationDownloadRing.js';
 import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
 import { ChatPetWidget } from '../../../../workbench/contrib/chat/browser/widget/chatPetWidget.js';
 
@@ -842,11 +842,16 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		button.role = 'button';
 		const micLabel = localize('sessionsStt.dictate', "Dictate (Speech to Text)");
 		const stopLabel = localize('sessionsStt.stop', "Stop Dictation");
-		this._register(this.hoverService.setupDelayedHover(button, {
-			content: micLabel,
+		this._register(this.hoverService.setupDelayedHover(button, () => ({
+			// While the model prepares, surface the download/connecting hover
+			// (which invites the user to click to cancel) so this composer matches
+			// the main chat toolbar affordance.
+			content: sttService.isPreparingModel
+				? getDictationDownloadHoverMarkdown(sttService)
+				: (sttService.state !== ChatSpeechToTextState.Idle ? stopLabel : micLabel),
 			position: { hoverPosition: HoverPosition.BELOW },
 			appearance: { showPointer: true }
-		}));
+		})));
 
 		const downloadRing = this._register(new MutableDisposable<DictationDownloadRing>());
 		const renderState = () => {

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -887,7 +887,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		renderState();
 		this._register(sttService.onDidChangeState(renderState));
 		this._register(sttService.onDidChangePreparingModel(renderState));
-		this._register(setupDictationMicGlow(button, sttService, this.configurationService, this.accessibilityService));
+		this._register(setupDictationMicGlow(button, sttService, this.accessibilityService));
 
 		const updateVisibility = () => {
 			// Mirror the `MenuId.ChatExecute` dictation gate: hide while

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -172,7 +172,7 @@ export class ChatSpeechToTextPreparingAction extends Action2 {
 			title: localize2('chat.speechToText.preparing', "Preparing Speech to Text Model…"),
 			category: CHAT_CATEGORY,
 			f1: false,
-			icon: Codicon.cloudDownload,
+			icon: Codicon.micDownload,
 			precondition: ChatSpeechToTextPreparing,
 			menu: [{
 				id: MenuId.ChatExecute,

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -293,6 +293,12 @@ configurationRegistry.registerConfiguration({
 			default: 'nemotron-speech-streaming-en-0.6b',
 			tags: ['experimental']
 		},
+		'dictation.showTranscript': {
+			type: 'boolean',
+			markdownDescription: nls.localize('dictation.showTranscript', "Controls whether the transcript is shown while dictating. The final transcript is inserted when dictation ends."),
+			default: false,
+			tags: ['experimental']
+		},
 		'dictation.experimental.llmCleanup': {
 			type: 'boolean',
 			markdownDescription: nls.localize('dictation.experimental.llmCleanup', "Experimental: periodically refine finalized text while dictating, then pass the final transcript through a small language model to restore punctuation, capitalization, paragraphs, and lists. Requires Copilot to be enabled; the transcript is sent to the language model for cleanup. Falls back to the raw transcript when no model is available."),

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -105,7 +105,7 @@ import { registerChatExecuteActions } from './actions/chatExecuteActions.js';
 import { ChatVoiceInputModeAction, ChatVoiceInputModeToggleListenAction, registerVoiceInputModeSimulateActions } from './voiceInputMode/voiceInputModeActionViewItem.js';
 import './voiceInputMode/voiceInputMode.js';
 import { registerChatSpeechToTextActions } from './actions/chatSpeechToTextActions.js';
-import { ChatSpeechToTextService, IChatSpeechToTextService } from './speechToText/chatSpeechToTextService.js';
+import { ChatSpeechToTextService, DictationSettingId, IChatSpeechToTextService } from './speechToText/chatSpeechToTextService.js';
 import { registerChatFileTreeActions } from './actions/chatFileTreeActions.js';
 import { ChatGettingStartedContribution } from './actions/chatGettingStarted.js';
 import { registerChatExportActions } from './actions/chatImportExport.js';
@@ -293,7 +293,7 @@ configurationRegistry.registerConfiguration({
 			default: 'nemotron-speech-streaming-en-0.6b',
 			tags: ['experimental']
 		},
-		'dictation.showTranscript': {
+		[DictationSettingId.ShowTranscript]: {
 			type: 'boolean',
 			markdownDescription: nls.localize('dictation.showTranscript', "Controls whether the transcript is shown while dictating. The final transcript is inserted when dictation ends."),
 			default: false,

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -296,7 +296,7 @@ configurationRegistry.registerConfiguration({
 		[DictationSettingId.ShowTranscript]: {
 			type: 'boolean',
 			markdownDescription: nls.localize('dictation.showTranscript', "Controls whether the transcript is shown while dictating. The final transcript is inserted when dictation ends."),
-			default: false,
+			default: true,
 			tags: ['experimental']
 		},
 		'dictation.experimental.llmCleanup': {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -194,8 +194,9 @@ const ENABLED_SETTING = 'dictation.enabled';
  */
 const MODEL_SETTING = 'dictation.model';
 
-/** Controls whether interim transcript text is rendered while dictating. */
-export const SHOW_TRANSCRIPT_SETTING = 'dictation.showTranscript';
+export const enum DictationSettingId {
+	ShowTranscript = 'dictation.showTranscript',
+}
 
 /** `dictation.model` sentinel selecting the cloud voice backend used by Voice Mode. */
 const MAI_MODEL_ID = 'mai';
@@ -521,7 +522,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	}
 
 	get showTranscriptWhileDictating(): boolean {
-		return this._configurationService.getValue<boolean>(SHOW_TRANSCRIPT_SETTING) === true;
+		return this._configurationService.getValue<boolean>(DictationSettingId.ShowTranscript) === true;
 	}
 
 	get analyserNode(): AnalyserNode | undefined {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -194,6 +194,9 @@ const ENABLED_SETTING = 'dictation.enabled';
  */
 const MODEL_SETTING = 'dictation.model';
 
+/** Controls whether interim transcript text is rendered while dictating. */
+export const SHOW_TRANSCRIPT_SETTING = 'dictation.showTranscript';
+
 /** `dictation.model` sentinel selecting the cloud voice backend used by Voice Mode. */
 const MAI_MODEL_ID = 'mai';
 
@@ -370,6 +373,12 @@ export interface IChatSpeechToTextService {
 	 */
 	readonly onDidUpdateTranscript: Event<IChatDictationTranscript>;
 
+	/** Whether interim transcript text should be rendered while recording. */
+	readonly showTranscriptWhileDictating: boolean;
+
+	/** Analyser for the active microphone capture, used for audio-reactive feedback. */
+	readonly analyserNode: AnalyserNode | undefined;
+
 	/**
 	 * Whether on-device speech-to-text is available on this platform. Callers
 	 * gate the dictation UI on this.
@@ -476,6 +485,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	private _mediaStream: MediaStream | undefined;
 	private _audioContext: AudioContext | undefined;
 	private _sourceNode: MediaStreamAudioSourceNode | undefined;
+	private _analyserNode: AnalyserNode | undefined;
 	private _workletNode: AudioWorkletNode | undefined;
 
 	private readonly _localSessionDisposables = this._register(new DisposableStore());
@@ -508,6 +518,14 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		// on first use. It is only unavailable where the platform lacks native
 		// inference support (e.g. web).
 		return this._localTranscription.isSupported;
+	}
+
+	get showTranscriptWhileDictating(): boolean {
+		return this._configurationService.getValue<boolean>(SHOW_TRANSCRIPT_SETTING) === true;
+	}
+
+	get analyserNode(): AnalyserNode | undefined {
+		return this._analyserNode;
 	}
 
 	/** Finalized (committed) utterances, space-joined. */
@@ -1535,7 +1553,12 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		}
 
 		this._workletNode = node;
-		source.connect(node);
+		const analyser = ctx.createAnalyser();
+		analyser.fftSize = 256;
+		analyser.smoothingTimeConstant = 0.75;
+		this._analyserNode = analyser;
+		source.connect(analyser);
+		analyser.connect(node);
 		node.connect(ctx.destination);
 	}
 
@@ -1561,6 +1584,8 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 			try { this._workletNode.disconnect(); } catch { /* ignore */ }
 			this._workletNode = undefined;
 		}
+		try { this._analyserNode?.disconnect(); } catch { /* ignore */ }
+		this._analyserNode = undefined;
 		try { this._sourceNode?.disconnect(); } catch { /* ignore */ }
 		this._sourceNode = undefined;
 		this._audioContext?.close().catch(() => { /* ignore */ });

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationActionViewItem.ts
@@ -13,6 +13,8 @@ import { IContextMenuService } from '../../../../../platform/contextview/browser
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { IChatSpeechToTextService } from './chatSpeechToTextService.js';
+import { setupDictationMicGlow } from './dictationMicGlow.js';
 import { addMicButtonContextMenuListener, getDictationContextMenuActions } from './micButtonMenuActions.js';
 
 /**
@@ -34,9 +36,10 @@ export class DictationActionViewItem extends MenuEntryActionViewItem {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IThemeService themeService: IThemeService,
 		@IContextMenuService contextMenuService: IContextMenuService,
-		@IAccessibilityService accessibilityService: IAccessibilityService,
+		@IAccessibilityService private readonly _dictationAccessibilityService: IAccessibilityService,
+		@IChatSpeechToTextService private readonly _speechToTextService: IChatSpeechToTextService,
 	) {
-		super(action, options, keybindingService, notificationService, contextKeyService, themeService, contextMenuService, accessibilityService);
+		super(action, options, keybindingService, notificationService, contextKeyService, themeService, contextMenuService, _dictationAccessibilityService);
 	}
 
 	override render(container: HTMLElement): void {
@@ -47,5 +50,6 @@ export class DictationActionViewItem extends MenuEntryActionViewItem {
 			() => getDictationContextMenuActions(this._commandService, this._configurationService, this._keybindingService, this._action.id),
 			this._contextMenuService,
 		));
+		this._register(setupDictationMicGlow(container, this._speechToTextService, this._configurationService, this._dictationAccessibilityService));
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationActionViewItem.ts
@@ -50,6 +50,6 @@ export class DictationActionViewItem extends MenuEntryActionViewItem {
 			() => getDictationContextMenuActions(this._commandService, this._configurationService, this._keybindingService, this._action.id),
 			this._contextMenuService,
 		));
-		this._register(setupDictationMicGlow(container, this._speechToTextService, this._configurationService, this._dictationAccessibilityService));
+		this._register(setupDictationMicGlow(container, this._speechToTextService, this._dictationAccessibilityService));
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadActionViewItem.ts
@@ -77,7 +77,7 @@ export class DictationDownloadActionViewItem extends MenuEntryActionViewItem {
 		if (this._speechToTextService.currentBackend !== 'mai' || !this.label) {
 			return;
 		}
-		this.label.classList.remove(...ThemeIcon.asClassNameArray(Codicon.cloudDownload));
+		this.label.classList.remove(...ThemeIcon.asClassNameArray(Codicon.micDownload));
 		this.label.classList.add(...ThemeIcon.asClassNameArray(Codicon.loading));
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadRing.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadRing.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IManagedHoverContent } from '../../../../../base/browser/ui/hover/hover.js';
-import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../nls.js';
 import { IChatSpeechToTextService } from './chatSpeechToTextService.js';
@@ -75,21 +75,32 @@ export class DictationDownloadRing extends Disposable {
 }
 
 /**
- * Static hover explaining what the mic is doing while it prepares. The on-device
- * backend downloads a model; the cloud backend connects. The ring conveys live
- * progress/activity, so the hover stays fixed to avoid churning on every tick.
+ * Markdown describing what the mic is doing while it prepares, for use as hover
+ * content. The on-device backend downloads a local model; the cloud backend
+ * connects. Both are cancelled by clicking the affordance, so the hover invites
+ * the user to click to cancel. The ring conveys live progress/activity, so the
+ * text stays fixed to avoid churning on every tick.
  */
-export function getDictationDownloadHoverContent(service: IChatSpeechToTextService): IManagedHoverContent {
+export function getDictationDownloadHoverMarkdown(service: IChatSpeechToTextService): IMarkdownString {
 	const markdown = new MarkdownString('', { supportThemeIcons: true });
 	if (service.currentBackend === 'mai') {
 		markdown.appendMarkdown(localize('chatStt.hover.connectingTitle', "**Connecting to dictation service**"));
 		markdown.appendMarkdown('\n\n');
-		markdown.appendMarkdown(localize('chatStt.hover.connecting', "Establishing a connection. This happens each time you start cloud dictation."));
-		return { markdown, markdownNotSupportedFallback: markdown.value };
+		markdown.appendMarkdown(localize('chatStt.hover.connecting', "Establishing a connection. This happens each time you start cloud dictation. Click to cancel."));
+		return markdown;
 	}
-	markdown.appendMarkdown(localize('chatStt.hover.title', "**Downloading speech-to-text model**"));
+	markdown.appendMarkdown(localize('chatStt.hover.title', "**Downloading local model**"));
 	markdown.appendMarkdown('\n\n');
-	markdown.appendMarkdown(localize('chatStt.hover.preparing', "Preparing the on-device model. This happens only the first time you dictate."));
+	markdown.appendMarkdown(localize('chatStt.hover.preparing', "This happens only the first time you dictate. Click to cancel."));
+	return markdown;
+}
+
+/**
+ * Static hover explaining what the mic is doing while it prepares, wrapped as
+ * managed hover content for toolbar affordances.
+ */
+export function getDictationDownloadHoverContent(service: IChatSpeechToTextService): IManagedHoverContent {
+	const markdown = getDictationDownloadHoverMarkdown(service);
 	return { markdown, markdownNotSupportedFallback: markdown.value };
 }
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationMicGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationMicGlow.ts
@@ -7,9 +7,8 @@ import './media/dictationMicGlow.css';
 import { getWindow } from '../../../../../base/browser/dom.js';
 import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { readVoiceGlowIntensity } from '../voiceClient/voiceGlow.js';
-import { ChatSpeechToTextState, DictationSettingId, IChatSpeechToTextService } from './chatSpeechToTextService.js';
+import { ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
 
 const SPEAKING_THRESHOLD = 0.08;
 const GLOW_LEVEL_CLASSES = [
@@ -20,12 +19,11 @@ const GLOW_LEVEL_CLASSES = [
 ] as const;
 
 /**
- * Adds audio-reactive feedback to a dictation microphone when the live transcript is hidden.
+ * Adds audio-reactive feedback to a dictation microphone while recording.
  */
 export function setupDictationMicGlow(
 	target: HTMLElement,
 	service: IChatSpeechToTextService,
-	configurationService: IConfigurationService,
 	accessibilityService: IAccessibilityService,
 ): IDisposable {
 	const store = new DisposableStore();
@@ -56,8 +54,7 @@ export function setupDictationMicGlow(
 	};
 
 	const update = () => {
-		const active = service.state === ChatSpeechToTextState.Recording
-			&& !service.showTranscriptWhileDictating;
+		const active = service.state === ChatSpeechToTextState.Recording;
 		target.classList.toggle('dictation-mic-active', active);
 		if (!active) {
 			stopAnimation();
@@ -74,11 +71,6 @@ export function setupDictationMicGlow(
 	};
 
 	store.add(service.onDidChangeState(update));
-	store.add(configurationService.onDidChangeConfiguration(event => {
-		if (event.affectsConfiguration(DictationSettingId.ShowTranscript)) {
-			update();
-		}
-	}));
 	store.add(accessibilityService.onDidChangeReducedMotion(update));
 	store.add(toDisposable(() => {
 		stopAnimation();

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationMicGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationMicGlow.ts
@@ -9,7 +9,7 @@ import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { readVoiceGlowIntensity } from '../voiceClient/voiceGlow.js';
-import { ChatSpeechToTextState, IChatSpeechToTextService, SHOW_TRANSCRIPT_SETTING } from './chatSpeechToTextService.js';
+import { ChatSpeechToTextState, DictationSettingId, IChatSpeechToTextService } from './chatSpeechToTextService.js';
 
 const SPEAKING_THRESHOLD = 0.08;
 const GLOW_LEVEL_CLASSES = [
@@ -75,7 +75,7 @@ export function setupDictationMicGlow(
 
 	store.add(service.onDidChangeState(update));
 	store.add(configurationService.onDidChangeConfiguration(event => {
-		if (event.affectsConfiguration(SHOW_TRANSCRIPT_SETTING)) {
+		if (event.affectsConfiguration(DictationSettingId.ShowTranscript)) {
 			update();
 		}
 	}));

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationMicGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationMicGlow.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './media/dictationMicGlow.css';
+import { getWindow } from '../../../../../base/browser/dom.js';
+import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { readVoiceGlowIntensity } from '../voiceClient/voiceGlow.js';
+import { ChatSpeechToTextState, IChatSpeechToTextService, SHOW_TRANSCRIPT_SETTING } from './chatSpeechToTextService.js';
+
+const SPEAKING_THRESHOLD = 0.08;
+const GLOW_LEVEL_CLASSES = [
+	'dictation-mic-glow-level-1',
+	'dictation-mic-glow-level-2',
+	'dictation-mic-glow-level-3',
+	'dictation-mic-glow-level-4',
+] as const;
+
+/**
+ * Adds audio-reactive feedback to a dictation microphone when the live transcript is hidden.
+ */
+export function setupDictationMicGlow(
+	target: HTMLElement,
+	service: IChatSpeechToTextService,
+	configurationService: IConfigurationService,
+	accessibilityService: IAccessibilityService,
+): IDisposable {
+	const store = new DisposableStore();
+	const window = getWindow(target);
+	const dataArray = { value: undefined as Uint8Array | undefined };
+	let animationFrame: number | undefined;
+
+	const setGlowLevel = (level: number) => {
+		for (let index = 0; index < GLOW_LEVEL_CLASSES.length; index++) {
+			target.classList.toggle(GLOW_LEVEL_CLASSES[index], index === level - 1);
+		}
+		target.classList.toggle('dictation-mic-speaking', level > 0);
+	};
+
+	const stopAnimation = () => {
+		if (animationFrame !== undefined) {
+			window.cancelAnimationFrame(animationFrame);
+			animationFrame = undefined;
+		}
+		setGlowLevel(0);
+	};
+
+	const animate = () => {
+		animationFrame = window.requestAnimationFrame(animate);
+		const intensity = readVoiceGlowIntensity(service.analyserNode ?? null, dataArray);
+		const speakingIntensity = Math.max(0, Math.min(1, (intensity - SPEAKING_THRESHOLD) / (1 - SPEAKING_THRESHOLD)));
+		setGlowLevel(speakingIntensity === 0 ? 0 : Math.min(GLOW_LEVEL_CLASSES.length, Math.ceil(speakingIntensity * GLOW_LEVEL_CLASSES.length)));
+	};
+
+	const update = () => {
+		const active = service.state === ChatSpeechToTextState.Recording
+			&& !service.showTranscriptWhileDictating;
+		target.classList.toggle('dictation-mic-active', active);
+		if (!active) {
+			stopAnimation();
+			return;
+		}
+		if (accessibilityService.isMotionReduced()) {
+			stopAnimation();
+			setGlowLevel(2);
+			return;
+		}
+		if (animationFrame === undefined) {
+			animationFrame = window.requestAnimationFrame(animate);
+		}
+	};
+
+	store.add(service.onDidChangeState(update));
+	store.add(configurationService.onDidChangeConfiguration(event => {
+		if (event.affectsConfiguration(SHOW_TRANSCRIPT_SETTING)) {
+			update();
+		}
+	}));
+	store.add(accessibilityService.onDidChangeReducedMotion(update));
+	store.add(toDisposable(() => {
+		stopAnimation();
+		target.classList.remove('dictation-mic-active');
+	}));
+	update();
+
+	return store;
+}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -17,7 +17,6 @@ import { IModelContentChangedEvent } from '../../../../../editor/common/textMode
 import { localize } from '../../../../../nls.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ChatDictationSurface, ChatSpeechToTextState, IChatSpeechToTextService } from './chatSpeechToTextService.js';
-import { getDictationPreparingLabel } from './dictationDownloadRing.js';
 
 /**
  * Inline decoration class for the still-processing tail of not-yet-finalized
@@ -356,27 +355,29 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	const HIDE_CURSOR_CLASS = 'dictation-hide-cursor';
 	editor.getDomNode()?.classList.add(HIDE_CURSOR_CLASS);
 	disposables.add(toDisposable(() => editor.getDomNode()?.classList.remove(HIDE_CURSOR_CLASS)));
-	// Show a "Listening…" placeholder once the session is actually connected
-	// and recording, i.e. the service is in the Recording state and the
-	// on-device model has finished preparing. While the model is still being
-	// prepared on first use (downloading/loading, which can take a while), show
-	// a "Preparing…/Downloading… X%" placeholder instead so the user knows why
-	// dictation has not started yet rather than staring at an idle editor. The
-	// placeholder must not appear during microphone acquisition. It remains
-	// visible until transcript text is inserted, and is restored to its
-	// previous value when the session ends.
+	// Show a "Listening…" placeholder once the session is actually connected,
+	// recording, and the on-device model has finished preparing. While the model
+	// is still being prepared on first use (downloading/loading, which can take a
+	// while), the toolbar mic shows a determinate download spinner
+	// (DictationDownloadRing), so the placeholder stays on its previous value
+	// instead of churning through "Downloading… X%" text. The placeholder must
+	// not appear during microphone acquisition. It remains visible until
+	// transcript text is inserted, and is restored to its previous value when the
+	// session ends.
 	const previousPlaceholder = editor.getOption(EditorOption.placeholder);
 	const listeningPlaceholder = localize('chatStt.listening', "Listening…");
-	// The placeholder we last applied (listening or a preparing label), so we
-	// only ever restore the previous placeholder when it was ours to restore.
+	// The placeholder we last applied, so we only ever restore the previous
+	// placeholder when it was ours to restore.
 	let appliedPlaceholder: string | undefined;
 	const applyPlaceholder = () => {
 		if (!editor.getModel()) {
 			return;
 		}
 		const recording = service.state === ChatSpeechToTextState.Recording;
-		const desired = recording
-			? (service.isPreparingModel ? getDictationPreparingLabel(service) : listeningPlaceholder)
+		// Only surface "Listening…" once the model is ready; while it prepares the
+		// mic icon spinner conveys download/load progress.
+		const desired = recording && !service.isPreparingModel
+			? listeningPlaceholder
 			: undefined;
 		if (desired !== undefined) {
 			if (appliedPlaceholder !== desired) {
@@ -417,8 +418,6 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	}));
 	disposables.add(editor.onDidChangeModelContent(event => inserter.onDidChangeModelContent(event)));
 	disposables.add(service.onDidChangePreparingModel(() => applyPlaceholder()));
-	// Refresh the "Downloading… X%" placeholder as the download progresses.
-	disposables.add(service.onDidChangeModelDownloadProgress(() => applyPlaceholder()));
 	disposables.add(service.onDidChangeState(state => {
 		logService.trace(`${LOG_PREFIX} onDidChangeState ${state}`);
 		if (state === ChatSpeechToTextState.Idle && _active?.service === service) {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -348,7 +348,6 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 		return;
 	}
 	const inserter = new LiveTranscriptInserter(editor, logService);
-	const showTranscriptWhileDictating = service.showTranscriptWhileDictating;
 	const disposables = new DisposableStore();
 	// Hide the editor's blinking caret for the duration of the dictation
 	// session. During dictation the caret is parked at the start of the dictated
@@ -402,7 +401,13 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	const idleSettle = disposables.add(new MutableDisposable());
 	disposables.add(service.onDidUpdateTranscript(update => {
 		logService.trace(`${LOG_PREFIX} onDidUpdateTranscript len=${update.text.length} finalized=${update.finalizedText.length} state=${service.state}`);
-		if (!showTranscriptWhileDictating) {
+		if (!service.showTranscriptWhileDictating) {
+			// The setting is read live (not snapshotted) so transcript rendering
+			// and the hidden-transcript mic glow always react to configuration
+			// changes together. If the transcript is hidden mid-session, drop any
+			// lingering interim shimmer so hidden mode renders no transcript at all.
+			inserter.clearShimmer();
+			idleSettle.clear();
 			return;
 		}
 		inserter.update(update.text, true, update.finalizedText);

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -348,6 +348,7 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 		return;
 	}
 	const inserter = new LiveTranscriptInserter(editor, logService);
+	const showTranscriptWhileDictating = service.showTranscriptWhileDictating;
 	const disposables = new DisposableStore();
 	// Hide the editor's blinking caret for the duration of the dictation
 	// session. During dictation the caret is parked at the start of the dictated
@@ -401,6 +402,9 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 	const idleSettle = disposables.add(new MutableDisposable());
 	disposables.add(service.onDidUpdateTranscript(update => {
 		logService.trace(`${LOG_PREFIX} onDidUpdateTranscript len=${update.text.length} finalized=${update.finalizedText.length} state=${service.state}`);
+		if (!showTranscriptWhileDictating) {
+			return;
+		}
 		inserter.update(update.text, true, update.finalizedText);
 		// Restart the idle timer: if no further transcript arrives, the user has
 		// paused, so stop shimmering the trailing (still-interim) words.

--- a/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationMicGlow.css
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationMicGlow.css
@@ -12,7 +12,7 @@
 	position: absolute;
 	inset: var(--vscode-spacing-size20);
 	border-radius: var(--vscode-cornerRadius-circle);
-	box-shadow: 0 0 var(--vscode-spacing-size80) var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+	box-shadow: 0 0 var(--vscode-spacing-size80) var(--vscode-focusBorder);
 	pointer-events: none;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationMicGlow.css
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationMicGlow.css
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.dictation-mic-active {
+	position: relative;
+}
+
+.dictation-mic-speaking::after {
+	content: '';
+	position: absolute;
+	inset: var(--vscode-spacing-size20);
+	border-radius: var(--vscode-cornerRadius-circle);
+	box-shadow: 0 0 var(--vscode-spacing-size80) var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+	pointer-events: none;
+}
+
+.dictation-mic-glow-level-1::after {
+	opacity: 0.3;
+}
+
+.dictation-mic-glow-level-2::after {
+	opacity: 0.5;
+}
+
+.dictation-mic-glow-level-3::after {
+	opacity: 0.7;
+}
+
+.dictation-mic-glow-level-4::after {
+	opacity: 0.9;
+}
+
+.hc-black .dictation-mic-speaking::after,
+.hc-light .dictation-mic-speaking::after {
+	box-shadow: none;
+	outline: var(--vscode-strokeThickness) solid var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
+}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationMicGlow.css
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationMicGlow.css
@@ -34,6 +34,10 @@
 
 .hc-black .dictation-mic-speaking::after,
 .hc-light .dictation-mic-speaking::after {
+	/* The high-contrast fallback replaces the soft glow with a solid outline, so
+	force full opacity: the glow-level opacities (0.3 to 0.9) would otherwise make
+	the contrast border faint, especially at the lower levels. */
+	opacity: 1;
 	box-shadow: none;
 	outline: var(--vscode-strokeThickness) solid var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
 }

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
@@ -33,6 +33,7 @@ import { IVoiceSessionController } from '../voiceClient/voiceSessionController.j
 import { IMicCaptureService } from '../voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../voiceClient/ttsPlaybackService.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from '../speechToText/chatSpeechToTextService.js';
+import { setupDictationMicGlow } from '../speechToText/dictationMicGlow.js';
 import { getDictationPreparingLabel } from '../speechToText/dictationDownloadRing.js';
 import { addMicButtonContextMenuListener, getDictationContextMenuActions, getVoiceModeContextMenuActions } from '../speechToText/micButtonMenuActions.js';
 import { IVoiceInputModeService, SimulatedVoiceState, VoiceInputMode, VoiceWalkthroughVersion } from './voiceInputMode.js';
@@ -364,6 +365,7 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 			() => getDictationContextMenuActions(this.commandService, this.configurationService, this.keybindingService, DICTATION_TOGGLE_COMMAND_ID),
 			this.contextMenuService,
 		));
+		this._register(setupDictationMicGlow(this._dictationCell, this.chatSpeechToTextService, this.configurationService, this.accessibilityService));
 
 		// --- Voice cell: a single waveform that transforms across states (no glyph). ---
 		this._voiceCell = dom.append(this._reel, dom.$('button.monaco-segmented-icon-toggle-cell.chat-voice-input-mode-cell.voice'));

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
@@ -365,7 +365,7 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 			() => getDictationContextMenuActions(this.commandService, this.configurationService, this.keybindingService, DICTATION_TOGGLE_COMMAND_ID),
 			this.contextMenuService,
 		));
-		this._register(setupDictationMicGlow(this._dictationCell, this.chatSpeechToTextService, this.configurationService, this.accessibilityService));
+		this._register(setupDictationMicGlow(this._dictationCell, this.chatSpeechToTextService, this.accessibilityService));
 
 		// --- Voice cell: a single waveform that transforms across states (no glyph). ---
 		this._voiceCell = dom.append(this._reel, dom.$('button.monaco-segmented-icon-toggle-cell.chat-voice-input-mode-cell.voice'));

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPlaceholderRotation.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPlaceholderRotation.ts
@@ -9,6 +9,7 @@ import { localize } from '../../../../../../nls.js';
 import { ICodeEditor } from '../../../../../../editor/browser/editorBrowser.js';
 import { EditorOption } from '../../../../../../editor/common/config/editorOptions.js';
 import { PlaceholderTextContribution } from '../../../../../../editor/contrib/placeholderText/browser/placeholderTextContribution.js';
+import { activeDictationEditor } from '../../speechToText/dictationSession.js';
 
 /**
  * Friendly placeholders shared by empty Agents window and agent host chat inputs.
@@ -72,6 +73,13 @@ export function installRotatingChatPlaceholder(editor: ICodeEditor, options?: IR
 		index = Math.floor(Math.random() * placeholders.length);
 	}
 	store.add(disposableWindowInterval(getWindow(editor.getDomNode()), () => {
+		// While this editor is being dictated into, the dictation session owns the
+		// placeholder ("Listening", or the preserved value while the model
+		// prepares - progress is conveyed by the mic download spinner). Skip
+		// rotating so we don't clobber it; rotation resumes once dictation ends.
+		if (activeDictationEditor() === editor) {
+			return;
+		}
 		index = (index + 1) % placeholders.length;
 		editor.updateOptions({ placeholder: placeholders[index] });
 	}, intervalMs));

--- a/src/vs/workbench/contrib/chat/test/browser/dictationSession.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationSession.test.ts
@@ -30,6 +30,8 @@ suite('DictationSession', () => {
 			onDidChangePreparingModel: store.add(new Emitter<boolean>()).event,
 			onDidChangeModelDownloadProgress: store.add(new Emitter<void>()).event,
 			get state() { return state; },
+			get showTranscriptWhileDictating() { return true; },
+			get analyserNode() { return undefined; },
 			get isConfigured() { return true; },
 			get isPreparingModel() { return false; },
 			get modelDownloadProgress() { return undefined; },
@@ -55,5 +57,46 @@ suite('DictationSession', () => {
 		await stopDictation();
 
 		assert.strictEqual(editor.getValue(), '');
+	});
+
+	test('hides interim transcript and inserts final transcript when stopped', async () => {
+		const transcript = 'hello world';
+		const onDidUpdateTranscript = store.add(new Emitter<IChatDictationTranscript>());
+		const onDidChangeState = store.add(new Emitter<ChatSpeechToTextState>());
+		let state = ChatSpeechToTextState.Idle;
+		const service: IChatSpeechToTextService = {
+			_serviceBrand: undefined,
+			onDidUpdateTranscript: onDidUpdateTranscript.event,
+			onDidChangeState: onDidChangeState.event,
+			onDidChangePreparingModel: store.add(new Emitter<boolean>()).event,
+			onDidChangeModelDownloadProgress: store.add(new Emitter<void>()).event,
+			get state() { return state; },
+			get showTranscriptWhileDictating() { return false; },
+			get analyserNode() { return undefined; },
+			get isConfigured() { return true; },
+			get isPreparingModel() { return false; },
+			get modelDownloadProgress() { return undefined; },
+			get currentBackend() { return 'mai' as const; },
+			async start() {
+				state = ChatSpeechToTextState.Recording;
+				onDidChangeState.fire(state);
+			},
+			async stopAndTranscribe() {
+				state = ChatSpeechToTextState.Idle;
+				onDidChangeState.fire(state);
+				return transcript;
+			},
+			cancel() { },
+			logDictationAccuracy() { },
+		};
+		const model = store.add(createTextModel(''));
+		const editor = store.add(createTestCodeEditor(model));
+
+		await startDictation(service, editor, mainWindow, new NullLogService());
+		onDidUpdateTranscript.fire({ text: transcript, finalizedText: '' });
+		const interimValue = editor.getValue();
+		await stopDictation();
+
+		assert.deepStrictEqual([interimValue, editor.getValue()], ['', transcript]);
 	});
 });


### PR DESCRIPTION
https://github.com/user-attachments/assets/5e53b993-c8ea-44af-8cb7-b4a20343255f

## Summary

Improves dictation feedback and first-use polish across the Chat and Agents composer surfaces.

### Transcript visibility
- Add a `dictation.showTranscript` setting (default on) controlling whether interim dictation text is shown while dictating.
- When the transcript is hidden, still insert the final transcript when dictation ends, so nothing is lost.

### Microphone feedback
- Add an audio-reactive microphone glow while recording (regardless of transcript visibility), using the focus border color.
- Respect reduced-motion and high-contrast preferences (visible outline, no animation).

### Model download / connect state
- Show the mic download icon (not the cloud icon) while the on-device model downloads.
- Convey download/load progress via the mic icon spinner/ring instead of placeholder progress text, and keep the previous placeholder until the model is ready.
- Pause chat input placeholder rotation during dictation so the dictation placeholder is not clobbered (Chat and Agents window).
- Add a "Downloading local model, click to cancel" hover on the dictation download affordance; clicking cancels the pending download/connect (Chat and Agents window).

All changes apply to both the main Chat composer and the Agents window composer.

## Testing

- targeted `DictationSession` unit tests
- client typecheck
- layer validation
- compile
- precommit hygiene

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8607
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8609
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8629
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8601
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8632