### PR TITLE
Use mic download icon for standalone dictation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -172,7 +172,7 @@ export class ChatSpeechToTextPreparingAction extends Action2 {
 			title: localize2('chat.speechToText.preparing', "Preparing Speech to Text Model…"),
 			category: CHAT_CATEGORY,
 			f1: false,
-			icon: Codicon.cloudDownload,
+			icon: Codicon.micDownload,
 			precondition: ChatSpeechToTextPreparing,
 			menu: [{
 				id: MenuId.ChatExecute,

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadActionViewItem.ts
@@ -77,7 +77,7 @@ export class DictationDownloadActionViewItem extends MenuEntryActionViewItem {
 		if (this._speechToTextService.currentBackend !== 'mai' || !this.label) {
 			return;
 		}
-		this.label.classList.remove(...ThemeIcon.asClassNameArray(Codicon.cloudDownload));
+		this.label.classList.remove(...ThemeIcon.asClassNameArray(Codicon.micDownload));
 		this.label.classList.add(...ThemeIcon.asClassNameArray(Codicon.loading));
 	}
 


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8629

## Summary
- use the mic-download icon while the on-device dictation model prepares without Voice Mode enabled
- keep the MAI backend icon replacement aligned with the new base icon

## Testing
- configure Nemotron dictation with Voice Mode disabled and start dictation
- verify the mic-download icon appears while the model prepares
- `npm run eslint -- --no-warn-ignored src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadActionViewItem.ts`