### PR TITLE
agentHost: fix Claude sessions replaying as an empty chat

### DIFF
--- a/src/vs/platform/agentHost/node/claude/CONTEXT.md
+++ b/src/vs/platform/agentHost/node/claude/CONTEXT.md
@@ -921,6 +921,12 @@ For each SessionMessage in order:
       'tool_use'  → push ToolCallResponsePart (open; awaits tool_result);
                     record tool_use_id → Turn.id in the attribution map
       empty       → skip
+      NOTE: with no Turn open, the assistant envelope STARTS one, keyed on
+        its own uuid. Two cases: a subagent transcript (no spawning prompt
+        exists, userMessage.text = '') and a parent transcript the SDK
+        truncated mid-turn (userMessage.text = a placeholder). Dropping
+        instead would empty the whole chat when the slice holds no user
+        message at all — see "Truncated transcripts" below.
   ('system', subtype === 'compact_boundary'):
       → push SystemNotificationResponsePart (compact metadata)
   ('system', other allowlisted subtypes):
@@ -928,6 +934,15 @@ For each SessionMessage in order:
   ('system', other):
       → drop
 ```
+
+**Truncated transcripts.** For transcripts over ~5 MB the SDK's
+`getSessionMessages` returns only the bytes AFTER the last compact
+boundary, so the slice can begin mid-turn or contain no `user` envelope
+at all. The host opts out via `CLAUDE_CODE_DISABLE_PRECOMPACT_SKIP=1`
+(set in [claudeAgentSdkService.ts](./claudeAgentSdkService.ts)), and the
+mapper additionally recovers promptless leading turns so a slice that
+still arrives truncated degrades to a placeholder prompt rather than an
+empty chat.
 
 **Turn-level fields on replay.**
 - `state` is `'completed'` for any Turn that's followed by a later

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -1703,6 +1703,10 @@ export class ClaudeAgent extends Disposable implements IAgent {
 
 		const sess = context.target;
 		if (sess && !sess.isPipelineReady) {
+			// Provisional session: the SDK chat has never been materialized, so
+			// there is no on-disk transcript to read. Logged because an empty
+			// transcript is otherwise indistinguishable from a failed read.
+			this._logService.info(`[Claude] getSessionMessages: chat ${chat.toString()} is not materialized yet; returning no turns`);
 			return [];
 		}
 		// Default chat: its SDK chat id is the session id.
@@ -1733,6 +1737,12 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			// blow up the entire transcript read.
 			this._logService.warn(`[Claude] replay mapper threw for ${sdkSessionId}`, err);
 			return [];
+		}
+		// Always a bug: the SDK handed back a transcript but replay produced
+		// nothing, which surfaces to the user as a chat that opens completely
+		// empty. Warn so the next report is diagnosable from the log alone.
+		if (turns.length === 0 && messages.length > 0) {
+			this._logService.warn(`[Claude] replay produced no turns from ${messages.length} transcript message(s) for ${sdkSessionId}; chat will render empty`);
 		}
 		// A bug in `primeFromTranscript` MUST NOT break an otherwise-successful
 		// transcript read.

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
@@ -27,6 +27,16 @@ export const ClaudeSdkPackage: IAgentSdkPackage = {
 	hasSeparateMuslLinuxPackage: true,
 };
 
+/**
+ * SDK escape hatch for its "precompact skip" optimization. Above a ~5 MB
+ * transcript the SDK reads back only the bytes AFTER the last compact
+ * boundary, which silently truncates the history `getSessionMessages`
+ * returns — the slice can begin mid-turn, or contain no user prompt at all.
+ * Replay then reconstructs a partial (or empty) conversation, so we opt out
+ * and pay the full read. Read by the SDK from `process.env` on every call.
+ */
+const ClaudeDisablePrecompactSkipEnvVar = 'CLAUDE_CODE_DISABLE_PRECOMPACT_SKIP';
+
 export const IClaudeAgentSdkService = createDecorator<IClaudeAgentSdkService>('claudeAgentSdkService');
 
 /**
@@ -138,7 +148,14 @@ export class ClaudeAgentSdkService implements IClaudeAgentSdkService {
 	constructor(
 		@ILogService private readonly _logService: ILogService,
 		@IAgentSdkDownloader private readonly _downloader: IAgentSdkDownloader,
-	) { }
+	) {
+		// Set before any SDK call so full transcripts are always read back.
+		// An explicit value from the environment wins so the optimization can
+		// still be re-enabled from outside.
+		if (process.env[ClaudeDisablePrecompactSkipEnvVar] === undefined) {
+			process.env[ClaudeDisablePrecompactSkipEnvVar] = '1';
+		}
+	}
 
 	async listSessions(): Promise<readonly SDKSessionInfo[]> {
 		const sdk = await this._getSdk();

--- a/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
@@ -228,8 +228,8 @@ const CLI_ECHO_MARKER_PATTERN = /^<(command-name|command-message|command-args|lo
  * recovered assistant content under a placeholder prompt is strictly better
  * than dropping the turn — dropping can silently empty an entire session.
  */
-function missingPromptPlaceholder(): string {
-	return localize('claude.replay.missingPrompt', "<Message content could not be retrieved>");
+export function missingPromptPlaceholder(): string {
+	return localize('claude.replay.missingPrompt', "Message content could not be retrieved");
 }
 
 interface InProgressTurn {

--- a/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
@@ -5,6 +5,7 @@
 
 import type { SessionMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
 import type { ILogService } from '../../../log/common/log.js';
 import {
 	ResponsePartKind,
@@ -68,6 +69,7 @@ export function mapSessionMessagesToTurns(
  * {@link ReplayBuilder}; always returns an envelope `uuid`, never a `msg_…` id.
  */
 export function resolveForkAnchorUuid(messages: readonly SessionMessage[], turnId: string): string | undefined {
+	let turnOpen = false;
 	let seenTarget = false;
 	let lastAssistantUuid: string | undefined;
 	for (const msg of messages) {
@@ -80,11 +82,25 @@ export function resolveForkAnchorUuid(messages: readonly SessionMessage[], turnI
 				// First genuine user-text after turn N started → turn N is over.
 				break;
 			}
+			turnOpen = true;
 			if (parsed.uuid === turnId) {
 				seenTarget = true;
 			}
-		} else if (parsed.kind === 'assistant' && seenTarget) {
-			lastAssistantUuid = parsed.uuid;
+		} else if (parsed.kind === 'assistant') {
+			if (!turnOpen) {
+				// Mirrors {@link ReplayBuilder._consumeAssistant}: an assistant
+				// envelope with no turn open starts one keyed on its own uuid
+				// (subagent transcript, or a truncated slice that lost its
+				// prompt). Without this the resolver can't anchor a fork on
+				// such a turn.
+				turnOpen = true;
+				if (parsed.uuid === turnId) {
+					seenTarget = true;
+				}
+			}
+			if (seenTarget) {
+				lastAssistantUuid = parsed.uuid;
+			}
 		}
 		// 'user-tool-results' / 'system-notification' never flip the turn.
 	}
@@ -204,6 +220,18 @@ const ALLOWED_SYSTEM_SUBTYPES: ReadonlySet<string> = new Set([
  */
 const CLI_ECHO_MARKER_PATTERN = /^<(command-name|command-message|command-args|local-command-stdout|local-command-stderr|local-command-caveat)>/;
 
+/**
+ * Stand-in prompt for a turn whose user message is not present in the
+ * transcript slice we were handed. This happens when the SDK truncates a
+ * large transcript (it returns only the bytes after the last compact
+ * boundary), which cuts the opening prompt off mid-turn. Showing the
+ * recovered assistant content under a placeholder prompt is strictly better
+ * than dropping the turn — dropping can silently empty an entire session.
+ */
+function missingPromptPlaceholder(): string {
+	return localize('claude.replay.missingPrompt', "<Message content could not be retrieved>");
+}
+
 interface InProgressTurn {
 	readonly id: string;
 	readonly userText: string;
@@ -239,6 +267,12 @@ class ReplayBuilder {
 	 *   the `tool_use` block).
 	 */
 	private readonly _toolUses = new Map<string, { readonly turnId: string; readonly parsedInput: Record<string, unknown> | undefined }>();
+
+	/** Turns opened from a leading assistant envelope because the prompt was missing. Reported once by {@link finish}. */
+	private _recoveredPromptlessTurns = 0;
+
+	/** `tool_result` blocks whose announcing `tool_use` was not in the slice. Reported once by {@link finish}. */
+	private _orphanToolResults = 0;
 
 	constructor(private readonly _session: URI, private readonly _logService: ILogService) { }
 
@@ -286,26 +320,36 @@ class ReplayBuilder {
 
 	finish(): readonly Turn[] {
 		this._closeActive();
+		// One summary line per replay instead of one warn per envelope: a
+		// truncated transcript produces these by the hundred, and the
+		// per-envelope form drowned out the fact that the whole session had
+		// been reduced to nothing.
+		if (this._recoveredPromptlessTurns > 0 || this._orphanToolResults > 0) {
+			this._logService.warn(`[claudeReplayMapper] incomplete transcript for ${this._session.toString()}: ${this._recoveredPromptlessTurns} turn(s) recovered without their prompt, ${this._orphanToolResults} orphaned tool_result(s)`);
+		}
 		return this._turns;
 	}
 
 	private _consumeAssistant(msg: ParsedSessionMessage & { kind: 'assistant' }): void {
 		if (this._active === undefined) {
+			// Two ways a transcript legitimately opens with an assistant
+			// envelope:
+			// - Subagent transcript (`isInner`): every envelope carries
+			//   `parent_tool_use_id` and the SDK omits the synthetic spawning
+			//   prompt, so there is genuinely no prompt to show.
+			// - Truncated parent transcript: the SDK drops everything before
+			//   the last compact boundary for transcripts over its size
+			//   threshold, which can cut the prompt off mid-turn.
+			// Either way, synthesize a turn to hold the reply. Dropping would
+			// discard the assistant content — and when the truncated slice
+			// contains no user message at all (one long agentic turn), that
+			// means discarding the entire session.
 			if (!msg.isInner) {
-				// Top-level assistant envelope without a preceding user message —
-				// anomalous; synthesizing an empty user turn would be wrong, so
-				// drop with a warn.
-				this._logService.warn(`[claudeReplayMapper] assistant envelope ${msg.uuid} arrived before any user message; dropping`);
-				return;
+				this._recoveredPromptlessTurns++;
 			}
-			// Subagent transcript: every envelope carries `parent_tool_use_id`
-			// and the SDK omits the synthetic spawning prompt, so the transcript
-			// legitimately opens with an assistant message. Synthesize an
-			// empty-prompt turn to hold the subagent's reply instead of dropping
-			// it (which would lose the entire subagent transcript on replay).
 			this._active = {
 				id: msg.uuid,
-				userText: '',
+				userText: msg.isInner ? '' : missingPromptPlaceholder(),
 				startedAt: msg.timestamp,
 				responseParts: [],
 				pendingToolUseIds: new Set(),
@@ -372,7 +416,7 @@ class ReplayBuilder {
 	private _attachToolResult(block: UserToolResultBlock): string | undefined {
 		const entry = this._toolUses.get(block.tool_use_id);
 		if (entry === undefined) {
-			this._logService.warn(`[claudeReplayMapper] tool_result for unknown tool_use_id ${block.tool_use_id}`);
+			this._orphanToolResults++;
 			return undefined;
 		}
 		const announcingTurnId = entry.turnId;

--- a/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
@@ -362,20 +362,41 @@ suite('claudeReplayMapper', () => {
 			'inner Bash tool call must be reconstructed as Completed');
 	});
 
-	test('Fixture 10b: top-level assistant before any user message is still dropped', () => {
-		// Guard the narrow behavior: a top-level (non-inner) assistant envelope
-		// arriving before any user message remains anomalous and is dropped, so
-		// the synthesize-on-open path is scoped strictly to subagent transcripts.
+	test('Fixture 10b: top-level assistant before any user message is recovered under a placeholder prompt', () => {
+		// A truncated transcript slice (the SDK returns only the bytes after
+		// the last compact boundary for large sessions) can open mid-turn,
+		// with the user prompt cut off. The reply must still be recovered —
+		// dropping it empties the whole chat when the slice contains no user
+		// message at all.
 		const messages: SessionMessage[] = [
-			makeAssistantText('a1', 'orphan reply'),
+			makeAssistantText('a1', 'promptless reply'),
 			makeUser('u1', 'hello'),
 			makeAssistantText('a2', 'world'),
 		];
 
 		const turns = mapSessionMessagesToTurns(messages, session, logService);
 
-		assert.strictEqual(turns.length, 1, 'the orphan top-level assistant must NOT synthesize a turn');
-		assert.strictEqual(turns[0].id, 'u1');
+		assert.deepStrictEqual(turns.map(turn => ({ id: turn.id, text: turn.message.text })), [
+			{ id: 'a1', text: '<Message content could not be retrieved>' },
+			{ id: 'u1', text: 'hello' },
+		]);
+	});
+
+	test('a transcript slice with no user message at all still yields turns', () => {
+		// The reported failure mode: every envelope in the slice belonged to
+		// one long agentic turn whose prompt was truncated away, so the whole
+		// session replayed as zero turns and the chat rendered empty.
+		const messages: SessionMessage[] = [
+			makeAssistantToolUse('a1', 'tu1', 'Bash', { command: 'ls' }),
+			makeUserToolResult('r1', 'tu1', 'file.txt'),
+			makeAssistantText('a2', 'done'),
+		];
+
+		const turns = mapSessionMessagesToTurns(messages, session, logService);
+
+		assert.strictEqual(turns.length, 1);
+		assert.strictEqual(turns[0].message.text, '<Message content could not be retrieved>');
+		assert.strictEqual(turns[0].state, TurnState.Complete);
 	});
 });
 
@@ -501,6 +522,18 @@ suite('resolveForkAnchorUuid', () => {
 
 	test('turnId not found → undefined', () => {
 		assert.strictEqual(resolveForkAnchorUuid(threeTurns, 'nope'), undefined);
+	});
+
+	test('a promptless leading turn is anchorable, mirroring the replay builder', () => {
+		// The builder opens a turn keyed on the leading assistant envelope when
+		// the prompt is missing from the slice; the resolver must agree or a
+		// fork from that turn cannot be anchored.
+		const messages: SessionMessage[] = [
+			makeAssistantText('a1', 'promptless reply'),
+			makeUser('u1', 'next'),
+			makeAssistantText('a2', 'ok'),
+		];
+		assert.strictEqual(resolveForkAnchorUuid(messages, 'a1'), 'a1');
 	});
 
 	test('empty transcript → undefined', () => {

--- a/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
@@ -9,7 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { URI } from '../../../../base/common/uri.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { ResponsePartKind, ToolCallStatus, ToolResultContentType, TurnState } from '../../common/state/protocol/state.js';
-import { mapSessionMessagesToTurns, resolveForkAnchorUuid } from '../../node/claude/claudeReplayMapper.js';
+import { mapSessionMessagesToTurns, missingPromptPlaceholder, resolveForkAnchorUuid } from '../../node/claude/claudeReplayMapper.js';
 
 suite('claudeReplayMapper', () => {
 
@@ -377,7 +377,7 @@ suite('claudeReplayMapper', () => {
 		const turns = mapSessionMessagesToTurns(messages, session, logService);
 
 		assert.deepStrictEqual(turns.map(turn => ({ id: turn.id, text: turn.message.text })), [
-			{ id: 'a1', text: '<Message content could not be retrieved>' },
+			{ id: 'a1', text: missingPromptPlaceholder() },
 			{ id: 'u1', text: 'hello' },
 		]);
 	});
@@ -395,7 +395,7 @@ suite('claudeReplayMapper', () => {
 		const turns = mapSessionMessagesToTurns(messages, session, logService);
 
 		assert.strictEqual(turns.length, 1);
-		assert.strictEqual(turns[0].message.text, '<Message content could not be retrieved>');
+		assert.strictEqual(turns[0].message.text, missingPromptPlaceholder());
 		assert.strictEqual(turns[0].state, TurnState.Complete);
 	});
 });


### PR DESCRIPTION
Fixes Claude sessions that reopen as a completely empty chat.

## Symptom

Two `ah-logs` bundles from @TylerLeonhardt showed the same thing: opening a Claude session rendered no chat content at all. This is server-side — the AHP `subscribe` result for `ahp-chat://default/…` literally returns `"turns": []` while the rest of the session state (title, `_meta.git`, draft, changesets) is fully populated.

| Time (UTC) | Session | Chat snapshot |
|---|---|---|
| 17:20:33 | `claude:/07d946b4…` | `turns: []` |
| 18:08:39 | `claude:/07d946b4…` | `turns: []` |
| 18:28:31 | `claude:/24b9b582…` | `turns: []` — had **32 turns** at 18:21:47 |

## Root cause

Two behaviors on the transcript-replay path interacting:

1. **The SDK silently truncates large transcripts.** In `@anthropic-ai/claude-agent-sdk`, `getSessionMessages` reads back only the bytes *after* the last compact boundary once a transcript exceeds ~5 MB, unless `CLAUDE_CODE_DISABLE_PRECOMPACT_SKIP` is set (we never set it). That slice can begin mid-conversation, with the opening user prompt cut off.

2. **The replay mapper then threw the rest away.** `ReplayBuilder._consumeAssistant` dropped any top-level `assistant` envelope arriving with no preceding user message. When the truncated slice was one long agentic turn (assistant → tool_use → tool_result, repeatedly), *every* message was dropped:

```
[warning] [claudeReplayMapper] assistant envelope db5e2b0f… arrived before any user message; dropping   (x42)
[warning] [claudeReplayMapper] tool_result for unknown tool_use_id toolu_01UK4Yx…                      (x25)
[trace]   [AgentHostStateManager] Restored session: claude:/07d946b4… (0 turns)
[info]    [AgentService] Restored session claude:/07d946b4… with 0 turns
```

This was **not** limited to the two total-loss cases — the same warning fires on essentially every Claude restore, silently eating the *leading* turns (196 dropped envelopes across two sessions in one restore that still ended up with 26 and 12 turns). Total loss is just the tail of that distribution.

Session eviction (`_maybeEvictIdleSession` drops cached state on last-unsubscribe) is what makes this user-visible on any session revisit, not only after a host restart. Live turns go through a different mapper, which is why the session works fine again as soon as you send a message.

## Changes

**Recover promptless turns instead of dropping them** — `claudeReplayMapper.ts`

A leading top-level assistant envelope now opens a turn, exactly as it already did for subagent transcripts, using a localized `<Message content could not be retrieved>` placeholder prompt. A truncated slice now replays as a full turn with all its tool calls and text instead of nothing. `resolveForkAnchorUuid` is kept in sync with the new turn-boundary rule so a fork or side chat anchored on a recovered turn resolves instead of failing with "turn not found"; there's a test guarding that the two agree.

**Log once per replay, not per envelope** — same file

The two per-envelope warnings become counters, summarized in `finish()`:

```
[claudeReplayMapper] incomplete transcript for claude:/07d946b4…: 5 turn(s) recovered without their prompt, 25 orphaned tool_result(s)
```

In the reported incident that's 67 lines replaced by 1.

**Opt out of the SDK truncation** — `claudeAgentSdkService.ts`

Sets `CLAUDE_CODE_DISABLE_PRECOMPACT_SKIP=1` before any SDK call, respecting an explicit value already in the environment so the fast path can be re-enabled from outside. This addresses the root cause; the mapper change is the safety net for any slice that still arrives truncated.

**Make an empty transcript diagnosable** — `claudeAgent.ts`

- `_reconstructTurns` warns when the SDK returned messages but replay produced no turns — the exact signature of this bug, previously visible only as a `trace` line.
- The `!isPipelineReady` early return now logs, so a provisional-session empty result is distinguishable from a failed read. (These two paths were previously indistinguishable in a log bundle.)

**Docs** — updated the M7 grouping rules in `CONTEXT.md` with the new turn-opening rule and a "Truncated transcripts" note.

## Notes for reviewers

- Fixture 10b previously asserted the drop behavior and is rewritten; there's also a new test for the exact reported shape (a slice with no user message at all).
- The placeholder is localized. It contains angle brackets but isn't a valid HTML tag name, so markdown renders it literally.
- Trade-off on the env var: transcripts over 5 MB now cost a full file read on restore instead of a partial one. Correctness over the optimization, and it only applies to that size class.

## Validation

- `claudeReplayMapper.test.ts`, `claudeAgent.test.ts`, `claudeSubagentResolver.test.ts`, `claudeSdkOptions.test.ts`, `claudeSdkPipeline.test.ts` — 242 passing
- `tsc --project ./src/tsconfig.json --noEmit`, eslint, and `build/hygiene.ts` all clean

<sub>🤖 Generated with [Copilot CLI](https://github.com/features/copilot/cli)</sub>
