### PR TITLE
Fix model picker deduplication to prevent identifier collision issues

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
@@ -142,7 +142,7 @@ interface IGroupedContext {
 	readonly placed: Set<string>;
 	readonly showGroupLabel: boolean;
 	readonly makePinAction: (model: ILanguageModelChatMetadataAndIdentifier) => ReturnType<typeof createPinAction> | undefined;
-	markPlaced(identifierOrId: string, metadataId?: string): void;
+	markPlaced(identifierOrId: string): void;
 }
 
 function createGroupedContext(options: IBuildModelPickerItemsOptions): IGroupedContext {
@@ -163,12 +163,7 @@ function createGroupedContext(options: IBuildModelPickerItemsOptions): IGroupedC
 		makePinAction: model => options.actions.onTogglePin
 			? createPinAction(model.identifier, options.pinnedModelIds.includes(model.identifier), options.actions.onTogglePin)
 			: undefined,
-		markPlaced: (identifierOrId, metadataId) => {
-			placed.add(identifierOrId);
-			if (metadataId) {
-				placed.add(metadataId);
-			}
-		},
+		markPlaced: identifierOrId => placed.add(identifierOrId),
 	};
 }
 
@@ -179,13 +174,13 @@ function appendLeadingModels(context: IGroupedContext): ILanguageModelChatMetada
 		items.push(createSyntheticAutoItem());
 	}
 	if (autoModel) {
-		context.markPlaced(autoModel.identifier, autoModel.metadata.id);
+		context.markPlaced(autoModel.identifier);
 		const { action, ariaDescription } = createModelAction(autoModel, options.selectedModelId, options.actions.onSelect);
 		items.push(createModelItem(action, autoModel, options.openerService, undefined, options.presentation.isUBB, ariaDescription));
 	}
 	for (const model of options.models) {
-		if (!context.placed.has(model.identifier) && !context.placed.has(model.metadata.id) && ILanguageModelChatMetadata.hasPromoDiscount(model.metadata)) {
-			context.markPlaced(model.identifier, model.metadata.id);
+		if (!context.placed.has(model.identifier) && ILanguageModelChatMetadata.hasPromoDiscount(model.metadata)) {
+			context.markPlaced(model.identifier);
 			const { action, ariaDescription } = createModelAction(model, options.selectedModelId, options.actions.onSelect);
 			items.push(createModelItem(action, model, options.openerService, undefined, options.presentation.isUBB, ariaDescription));
 		}
@@ -200,7 +195,7 @@ function appendPinnedModels(context: IGroupedContext): Set<string> {
 	for (const id of options.pinnedModelIds) {
 		const model = context.resolveModel(id);
 		if (!context.placed.has(id) && model && !context.placed.has(model.identifier)) {
-			context.markPlaced(model.identifier, model.metadata.id);
+			context.markPlaced(model.identifier);
 			pinnedModels.push(model);
 		}
 	}
@@ -233,7 +228,7 @@ function appendPromotedModels(context: IGroupedContext, autoModel: ILanguageMode
 		}
 		const model = context.resolveModel(id);
 		if (model && !context.placed.has(model.identifier)) {
-			context.markPlaced(model.identifier, model.metadata.id);
+			context.markPlaced(model.identifier);
 			const entry = options.controlModels[model.metadata.id];
 			if (entry?.minVSCodeVersion && !isVersionAtLeast(options.currentVSCodeVersion, entry.minVSCodeVersion)) {
 				promoted.push({ kind: 'unavailable', id: model.metadata.id, entry, reason: 'update' });
@@ -270,11 +265,11 @@ function appendPromotedModels(context: IGroupedContext, autoModel: ILanguageMode
 			if (model && !context.placed.has(model.identifier)) {
 				if (entry.minVSCodeVersion && !isVersionAtLeast(options.currentVSCodeVersion, entry.minVSCodeVersion)) {
 					if (options.presentation.showUnavailableFeatured) {
-						context.markPlaced(model.identifier, model.metadata.id);
+						context.markPlaced(model.identifier);
 						promoted.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
 					}
 				} else {
-					context.markPlaced(model.identifier, model.metadata.id);
+					context.markPlaced(model.identifier);
 					promoted.push({ kind: 'available', model });
 				}
 			} else if (!model && !entry.exists && options.presentation.showUnavailableFeatured) {
@@ -308,7 +303,7 @@ function appendPromotedModels(context: IGroupedContext, autoModel: ILanguageMode
 
 function appendOtherModels(context: IGroupedContext): boolean {
 	const { options, items } = context;
-	const otherModels = options.models.filter(model => !context.placed.has(model.identifier) && !context.placed.has(model.metadata.id));
+	const otherModels = options.models.filter(model => !context.placed.has(model.identifier));
 	if (otherModels.length === 0) {
 		return false;
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
@@ -433,6 +433,39 @@ suite('buildModelPickerItems', () => {
 		assert.strictEqual(actions[1].label, 'Claude');
 	});
 
+	test('model variants sharing metadata ids remain visible across promoted and other sections', () => {
+		const auto = createAutoModel();
+		const copilotSol = createModel('gpt-5.6-sol', 'GPT-5.6 Sol');
+		const copilotTerra = createModel('gpt-5.6-terra', 'GPT-5.6 Terra');
+		const byokSol = createModel('gpt-5.6-sol', 'GPT-5.6 Sol', 'openai');
+		const byokTerra = createModel('gpt-5.6-terra', 'GPT-5.6 Terra', 'openai');
+		const copilotOther = createModel('gpt-5.5', 'GPT-5.5');
+		const byokOther = createModel('gpt-5.5', 'GPT-5.5', 'openai');
+		const languageModelsService = createLanguageModelsServiceStub([
+			{ vendor: 'copilot', displayName: 'Copilot', groups: [] },
+			{
+				vendor: 'openai',
+				displayName: 'OpenAI',
+				groups: [{ name: 'OpenAI (Work)', modelIdentifiers: [byokSol.identifier, byokTerra.identifier, byokOther.identifier] }],
+			},
+		]);
+		const items = callBuild([auto, copilotSol, copilotTerra, copilotOther, byokSol, byokTerra, byokOther], {
+			recentModelIds: [copilotSol.identifier, byokSol.identifier, copilotTerra.identifier, byokTerra.identifier],
+			languageModelsService,
+		});
+
+		assert.deepStrictEqual(getActionItems(items)
+			.filter(item => !item.isSectionToggle && item.label !== 'Auto' && item.item?.id !== 'manageModels')
+			.map(item => ({ id: item.item?.id, section: item.section, provider: item.badge })), [
+			{ id: copilotSol.identifier, section: undefined, provider: 'Copilot' },
+			{ id: byokSol.identifier, section: undefined, provider: 'OpenAI (Work)' },
+			{ id: copilotTerra.identifier, section: undefined, provider: 'Copilot' },
+			{ id: copilotOther.identifier, section: 'other', provider: undefined },
+			{ id: byokOther.identifier, section: 'other', provider: undefined },
+			{ id: byokTerra.identifier, section: 'other', provider: undefined },
+		]);
+	});
+
 	test('recently used model not in models list but in controlModels shows as unavailable (upgrade for free user)', () => {
 		const auto = createAutoModel();
 		const items = callBuild([auto], {


### PR DESCRIPTION
This pull request addresses an issue in the model picker where certain models were disappearing due to identifier collisions caused by the use of `metadata.id` for deduplication. 

### Changes made:
- Updated the deduplication logic in `modelPickerItemSections.ts` to only use the globally unique `model.identifier` for marking placed models.
- Adjusted the filtering logic in the "Other Models" section to prevent models from being incorrectly excluded based on shared `metadata.id`.
- Enhanced the regression test in `modelPickerItems.test.ts` to include realistic scenarios with multiple models from different providers, ensuring that the fourth model remains visible under "Other Models."

### Rationale:
- The previous implementation led to models being hidden when they shared a `metadata.id`, even if they had distinct identifiers. This fix ensures that all models are correctly displayed while maintaining the intended three-item cap for promoted models. 
- The changes have been validated with all tests passing, confirming that the fix resolves the issue without introducing new problems.