### PR TITLE
Dictation/Voice Mode: hover descriptions, pill sizing, compact glyphs

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1103,8 +1103,10 @@
 		"--slide-from-y"
 	],
 	"sizes": [
+		"--segmented-icon-toggle-cell-radius",
 		"--segmented-icon-toggle-cell-width",
 		"--segmented-icon-toggle-height",
+		"--segmented-icon-toggle-radius",
 		"--segmented-icon-toggle-single-width",
 		"--segmented-icon-toggle-width",
 		"--vscode-agents-fontSize-body1",

--- a/src/vs/base/browser/ui/segmentedIconToggle/segmentedIconToggle.css
+++ b/src/vs/base/browser/ui/segmentedIconToggle/segmentedIconToggle.css
@@ -15,6 +15,7 @@
  * exposed as custom properties so a host toolbar can size the pill without overriding rules.
  */
 
+/* Tunable metrics are exposed as custom properties so a host toolbar can size the pill without overriding rules. */
 .monaco-segmented-icon-toggle-container {
 	display: flex;
 	align-items: center;
@@ -28,7 +29,7 @@
 	width: var(--segmented-icon-toggle-width, 56px);
 	height: var(--segmented-icon-toggle-height, 24px);
 	border: 1px solid var(--vscode-input-border, var(--vscode-editorWidget-border));
-	border-radius: 8px;
+	border-radius: var(--segmented-icon-toggle-radius, 8px);
 }
 
 .monaco-segmented-icon-toggle-reel {
@@ -60,12 +61,12 @@
 	z-index: 1;
 }
 
-/* Hover background — a rounded-rectangle (squircle) filling the whole cell, edge-to-edge and full height, so it fully covers the housing interior with no surrounding gap. */
+/* Hover background — a rounded-rectangle (squircle) filling the whole cell, edge-to-edge and full height, so it fully covers the housing interior with no surrounding gap. Its radius nests one step inside the housing so the corners stay concentric. */
 .monaco-segmented-icon-toggle-cell::before {
 	content: '';
 	position: absolute;
 	inset: 0;
-	border-radius: 7px;
+	border-radius: var(--segmented-icon-toggle-cell-radius, 7px);
 	background: transparent;
 	transition: background 0.15s ease;
 	z-index: 0;

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -151,6 +151,18 @@
 	position: relative;
 }
 
+/* Match the send button's control tier (22×22, control radius) and the compact
+	glyph size used by the pickers, so the voice controls, the dictation mic and
+	Send all read as one row. */
+.sessions-chat-voice-toolbar .monaco-action-bar .action-item > .action-label {
+	box-sizing: border-box;
+	width: 22px;
+	height: 22px;
+	justify-content: center;
+	border-radius: var(--vscode-cornerRadius-small);
+	font-size: var(--vscode-codiconFontSize-compact);
+}
+
 /* Segmented voice/dictation pill (experimental) */
 .sessions-chat-voice-input-mode {
 	display: flex;
@@ -432,18 +444,20 @@
 	color: var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
 }
 
+/* Compact glyph, matching the model / mode picker icons in the row above. */
 .monaco-workbench .sessions-chat-stt-button .codicon[class*='codicon-'] {
-	font-size: var(--vscode-codiconFontSize, 16px);
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 }
 
 /* Determinate download ring shown over the mic while the on-device dictation
-	model downloads on first use (see DictationDownloadRing). */
+	model downloads on first use (see DictationDownloadRing). Sized to hug the
+	compact glyph rather than the full button. */
 .sessions-chat-stt-button > .dictation-download-ring {
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	width: 22px;
-	height: 22px;
+	width: 16px;
+	height: 16px;
 	transform: translate(-50%, -50%) rotate(-90deg);
 	pointer-events: none;
 }

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -163,6 +163,13 @@
 	font-size: var(--vscode-codiconFontSize-compact);
 }
 
+.monaco-workbench.monaco-enable-motion .sessions-chat-voice-toolbar .action-label.codicon-loading-compact::before,
+.monaco-workbench.monaco-enable-motion .sessions-chat-stt-button .codicon-loading-compact.codicon-modifier-spin {
+	display: inline-block;
+	transform-origin: center center;
+	animation: codicon-spin 1.5s steps(30) infinite;
+}
+
 /* Segmented voice/dictation pill (experimental) */
 .sessions-chat-voice-input-mode {
 	display: flex;

--- a/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
+++ b/src/vs/sessions/contrib/chat/browser/media/voiceChatView.css
@@ -119,24 +119,25 @@ so mirror the blue-listening / purple-speaking glow here. `voice-active` /
 	}
 }
 
-/* Blue when listening */
-.new-chat-input-area.voice-active.voice-listening .action-label.codicon-voice-mode {
+/* Blue when listening. The glow keeps the button's resting shape so the control
+never morphs between states — only its color and the pulse change. */
+.new-chat-input-area.voice-active.voice-listening .action-label.codicon-voice-mode-compact {
 	--sessions-voice-icon-glow-color: rgba(88, 166, 255, 0.65);
 	color: var(--vscode-charts-blue, #58a6ff) !important;
-	border-radius: 50%;
+	border-radius: var(--vscode-cornerRadius-small);
 }
 
-.monaco-workbench.monaco-enable-motion .new-chat-input-area.voice-active.voice-listening .action-label.codicon-voice-mode {
+.monaco-workbench.monaco-enable-motion .new-chat-input-area.voice-active.voice-listening .action-label.codicon-voice-mode-compact {
 	animation: sessionsVoiceIconGlow 1.4s ease-in-out infinite;
 }
 
 /* Purple when speaking */
-.new-chat-input-area.voice-active.voice-speaking .action-label.codicon-voice-mode {
+.new-chat-input-area.voice-active.voice-speaking .action-label.codicon-voice-mode-compact {
 	--sessions-voice-icon-glow-color: rgba(163, 113, 247, 0.65);
 	color: var(--vscode-charts-purple, #a371f7) !important;
-	border-radius: 50%;
+	border-radius: var(--vscode-cornerRadius-small);
 }
 
-.monaco-workbench.monaco-enable-motion .new-chat-input-area.voice-active.voice-speaking .action-label.codicon-voice-mode {
+.monaco-workbench.monaco-enable-motion .new-chat-input-area.voice-active.voice-speaking .action-label.codicon-voice-mode-compact {
 	animation: sessionsVoiceIconGlow 1.4s ease-in-out infinite;
 }

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -60,6 +60,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { getDictationHoverMarkdown } from '../../../../workbench/contrib/chat/browser/speechToText/micButtonHovers.js';
 import { addMicButtonContextMenuListener, getDictationContextMenuActions } from '../../../../workbench/contrib/chat/browser/speechToText/micButtonMenuActions.js';
 import { SlashCommandHandler } from './slashCommands.js';
 import { VariableCompletionHandler } from './variableCompletions.js';
@@ -845,10 +846,11 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		this._register(this.hoverService.setupDelayedHover(button, () => ({
 			// While the model prepares, surface the download/connecting hover
 			// (which invites the user to click to cancel) so this composer matches
-			// the main chat toolbar affordance.
+			// the main chat toolbar affordance. Idle gets the richer description
+			// naming the configured dictation model.
 			content: sttService.isPreparingModel
 				? getDictationDownloadHoverMarkdown(sttService)
-				: (sttService.state !== ChatSpeechToTextState.Idle ? stopLabel : micLabel),
+				: (sttService.state !== ChatSpeechToTextState.Idle ? stopLabel : getDictationHoverMarkdown(micLabel, this.configurationService)),
 			position: { hoverPosition: HoverPosition.BELOW },
 			appearance: { showPointer: true }
 		})));
@@ -869,13 +871,16 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 				// First-use only. The on-device backend downloads a model, so
 				// render a download icon wrapped by a progress ring; the cloud
 				// backend just connects, so render a plain spinner instead.
+				// Glyphs render at the compact 12px size, so use the `*Compact`
+				// variants where one exists.
 				if (sttService.currentBackend === 'mai') {
-					dom.append(button, renderIcon(ThemeIcon.modify(Codicon.loading, 'spin')));
+					dom.append(button, renderIcon(ThemeIcon.modify(Codicon.loadingCompact, 'spin')));
 				} else {
-					dom.append(button, renderIcon(Codicon.micDownload));
+					dom.append(button, renderIcon(Codicon.micDownloadCompact));
 					downloadRing.value = new DictationDownloadRing(button, sttService);
 				}
 			} else {
+				// `mic` / `micFilled` have no compact variant, so they stay as-is.
 				dom.append(button, renderIcon(recording ? Codicon.micFilled : Codicon.mic));
 			}
 			button.classList.toggle('recording', recording && !preparing);

--- a/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
@@ -116,21 +116,21 @@ const WHEN_NOT_DICTATING = ContextKeyExpr.and(
 const WHEN_NO_SEGMENTED_PILL = SegmentedVoiceInputModePillInactive;
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
-	command: { id: 'agentsVoice.connecting', title: localize('agentsVoice.connecting', "Connecting..."), icon: Codicon.loading },
+	command: { id: 'agentsVoice.connecting', title: localize('agentsVoice.connecting', "Connecting..."), icon: Codicon.loadingCompact },
 	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_CONNECTING, WHEN_INITIATED_HERE, WHEN_NO_SEGMENTED_PILL),
 	group: 'navigation',
 	order: -10,
 });
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
-	command: { id: 'agentsVoice.startVoiceInChat', title: localize('agentsVoice.startVoiceInChat', "Voice Mode"), icon: Codicon.voiceMode },
+	command: { id: 'agentsVoice.startVoiceInChat', title: localize('agentsVoice.startVoiceInChat', "Voice Mode"), icon: Codicon.voiceModeCompact },
 	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_VOICE_SURFACE, WHEN_LISTENING.negate(), WHEN_CONNECTING.negate(), WHEN_NOT_DICTATING, WHEN_NO_SEGMENTED_PILL),
 	group: 'navigation',
 	order: -10,
 });
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
-	command: { id: 'agentsVoice.pttStopInChat', title: localize('agentsVoice.pttStopInChat', "Voice Mode: Stop Recording"), icon: Codicon.voiceMode },
+	command: { id: 'agentsVoice.pttStopInChat', title: localize('agentsVoice.pttStopInChat', "Voice Mode: Stop Recording"), icon: Codicon.voiceModeCompact },
 	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_LISTENING, WHEN_INITIATED_HERE, WHEN_NO_SEGMENTED_PILL),
 	group: 'navigation',
 	order: -10,
@@ -144,7 +144,7 @@ MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
 });
 
 MenuRegistry.appendMenuItem(SessionsNewChatVoiceMenu, {
-	command: { id: 'agentsVoice.disconnect', title: localize('agentsVoice.disconnect', "Disconnect Voice Mode"), icon: Codicon.debugDisconnect },
+	command: { id: 'agentsVoice.disconnect', title: localize('agentsVoice.disconnect', "Disconnect Voice Mode"), icon: Codicon.debugDisconnectCompact },
 	when: ContextKeyExpr.and(WHEN_VOICE_ENABLED, WHEN_CONNECTED, WHEN_INITIATED_HERE, WHEN_NO_SEGMENTED_PILL),
 	group: 'navigation',
 	order: -9,

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -122,7 +122,7 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'agentsVoice.connecting',
 			title: nls.localize2('agentsVoice.connecting', "Connecting..."),
-			icon: Codicon.loading,
+			icon: Codicon.loadingCompact,
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),
 				AGENTS_VOICE_CONNECTING.isEqualTo(true),
@@ -150,7 +150,7 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'agentsVoice.startVoiceInChat',
 			title: nls.localize2('agentsVoice.startVoiceInChat', "Voice Mode"),
-			icon: Codicon.voiceMode,
+			icon: Codicon.voiceModeCompact,
 			precondition: ContextKeyExpr.equals('config.agents.voice.enabled', true),
 			menu: {
 				id: MenuId.ChatExecute,
@@ -236,7 +236,7 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'agentsVoice.pttStopInChat',
 			title: nls.localize2('agentsVoice.pttStopInChat', "Voice Mode: Stop Recording"),
-			icon: Codicon.voiceMode,
+			icon: Codicon.voiceModeCompact,
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),
 				AGENTS_VOICE_LISTENING.isEqualTo(true),
@@ -276,7 +276,7 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'agentsVoice.disconnect',
 			title: nls.localize2('agentsVoice.disconnect', "Disconnect Voice Mode"),
-			icon: Codicon.debugDisconnect,
+			icon: Codicon.debugDisconnectCompact,
 			f1: true,
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -172,7 +172,7 @@ export class ChatSpeechToTextPreparingAction extends Action2 {
 			title: localize2('chat.speechToText.preparing', "Preparing Speech to Text Model…"),
 			category: CHAT_CATEGORY,
 			f1: false,
-			icon: Codicon.micDownload,
+			icon: Codicon.micDownloadCompact,
 			precondition: ChatSpeechToTextPreparing,
 			menu: [{
 				id: MenuId.ChatExecute,
@@ -200,7 +200,7 @@ export class ChatSpeechToTextConnectingAction extends Action2 {
 			title: localize2('chat.speechToText.connecting', "Connecting to Speech to Text…"),
 			category: CHAT_CATEGORY,
 			f1: false,
-			icon: Codicon.loading,
+			icon: Codicon.loadingCompact,
 			precondition: ChatSpeechToTextPreparing,
 			menu: [{
 				id: MenuId.ChatExecute,

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -190,16 +190,16 @@ const ENABLED_SETTING = 'dictation.enabled';
 /**
  * Selects the dictation model. On-device model ids (e.g.
  * `nemotron-speech-streaming-en-0.6b`) run through {@link ILocalTranscriptionService};
- * the sentinel {@link MAI_MODEL_ID} routes to the cloud voice service instead.
+ * the sentinel {@link DICTATION_MAI_MODEL_ID} routes to the cloud voice service instead.
  */
-const MODEL_SETTING = 'dictation.model';
+export const DICTATION_MODEL_SETTING = 'dictation.model';
 
 export const enum DictationSettingId {
 	ShowTranscript = 'dictation.showTranscript',
 }
 
 /** `dictation.model` sentinel selecting the cloud voice backend used by Voice Mode. */
-const MAI_MODEL_ID = 'mai';
+export const DICTATION_MAI_MODEL_ID = 'mai';
 
 /**
  * Experimental: when enabled, the final dictation transcript is passed through a
@@ -595,7 +595,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		this._preparingContextKey = ChatContextKeys.speechToTextPreparing.bindTo(contextKeyService);
 		this._updateConfiguredContextKey();
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(ENABLED_SETTING) || e.affectsConfiguration(MODEL_SETTING)) {
+			if (e.affectsConfiguration(ENABLED_SETTING) || e.affectsConfiguration(DICTATION_MODEL_SETTING)) {
 				this._updateConfiguredContextKey();
 			}
 		}));
@@ -603,7 +603,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 
 	/** Read the configured dictation backend, derived from the selected model. */
 	private _getBackend(): DictationBackend {
-		return this._configurationService.getValue<string>(MODEL_SETTING) === MAI_MODEL_ID ? 'mai' : 'nemo';
+		return this._configurationService.getValue<string>(DICTATION_MODEL_SETTING) === DICTATION_MAI_MODEL_ID ? 'mai' : 'nemo';
 	}
 
 	get currentBackend(): string {
@@ -1141,7 +1141,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	}
 
 	private _getModelId(): string | undefined {
-		const value = this._configurationService.getValue<string>(MODEL_SETTING);
+		const value = this._configurationService.getValue<string>(DICTATION_MODEL_SETTING);
 		return value ? value.trim() || undefined : undefined;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationActionViewItem.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
+import { IManagedHoverContent } from '../../../../../base/browser/ui/hover/hover.js';
 import { MenuItemAction } from '../../../../../platform/actions/common/actions.js';
 import { IMenuEntryActionViewItemOptions, MenuEntryActionViewItem } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -15,6 +16,7 @@ import { INotificationService } from '../../../../../platform/notification/commo
 import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
 import { IChatSpeechToTextService } from './chatSpeechToTextService.js';
 import { setupDictationMicGlow } from './dictationMicGlow.js';
+import { getDictationHoverContent } from './micButtonHovers.js';
 import { addMicButtonContextMenuListener, getDictationContextMenuActions } from './micButtonMenuActions.js';
 
 /**
@@ -22,7 +24,8 @@ import { addMicButtonContextMenuListener, getDictationContextMenuActions } from 
  * normal toolbar mic (click to dictate) but adds a right-click context menu with
  * dictation-specific entries — "Configure Keybinding" (mirroring the standard
  * toolbar affordance), "Select Microphone" and "Disable Dictation" — instead of
- * the generic toolbar context menu.
+ * the generic toolbar context menu. Its hover also describes what dictation does
+ * and which model transcribes the audio.
  */
 export class DictationActionViewItem extends MenuEntryActionViewItem {
 
@@ -51,5 +54,9 @@ export class DictationActionViewItem extends MenuEntryActionViewItem {
 			this._contextMenuService,
 		));
 		this._register(setupDictationMicGlow(container, this._speechToTextService, this._dictationAccessibilityService));
+	}
+
+	protected override getHoverContents(): IManagedHoverContent {
+		return getDictationHoverContent(this.getTooltip() ?? '', this._configurationService);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationDownloadActionViewItem.ts
@@ -77,8 +77,8 @@ export class DictationDownloadActionViewItem extends MenuEntryActionViewItem {
 		if (this._speechToTextService.currentBackend !== 'mai' || !this.label) {
 			return;
 		}
-		this.label.classList.remove(...ThemeIcon.asClassNameArray(Codicon.micDownload));
-		this.label.classList.add(...ThemeIcon.asClassNameArray(Codicon.loading));
+		this.label.classList.remove(...ThemeIcon.asClassNameArray(Codicon.micDownloadCompact));
+		this.label.classList.add(...ThemeIcon.asClassNameArray(Codicon.loadingCompact));
 	}
 
 	protected override getHoverContents(): IManagedHoverContent {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonHovers.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonHovers.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IManagedHoverContent } from '../../../../../base/browser/ui/hover/hover.js';
+import { escapeMarkdownSyntaxTokens, MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { DICTATION_MAI_MODEL_ID, DICTATION_MODEL_SETTING } from './chatSpeechToTextService.js';
+
+/**
+ * Build a hover with a bold title line and a one-sentence description below it.
+ * `title` is the button's label plus keybinding, so it is escaped before being
+ * emphasized.
+ */
+function createMicButtonHover(title: string, description: string): MarkdownString {
+	const markdown = new MarkdownString('', { supportThemeIcons: true });
+	markdown.appendMarkdown(`**${escapeMarkdownSyntaxTokens(title)}**`);
+	markdown.appendMarkdown('\n\n');
+	markdown.appendMarkdown(escapeMarkdownSyntaxTokens(description));
+	return markdown;
+}
+
+/** Wrap a mic-button hover for APIs that take managed hover content. */
+function asHoverContent(title: string, description: string): IManagedHoverContent {
+	return { markdown: createMicButtonHover(title, description), markdownNotSupportedFallback: `${title}\n${description}` };
+}
+
+/**
+ * Names the model dictation actually uses, so it is obvious that `dictation.model`
+ * governs this button and not Voice Mode (see microsoft/vscode-internalbacklog#8600).
+ */
+function getDictationDescription(configurationService: IConfigurationService): string {
+	const modelId = configurationService.getValue<string>(DICTATION_MODEL_SETTING)?.trim();
+	return modelId === DICTATION_MAI_MODEL_ID
+		? localize('dictation.hover.cloud', "Types what you say into the input. Transcribes in the cloud with the MAI speech model.")
+		: localize('dictation.hover.onDevice', "Types what you say into the input. Transcribes on-device with {0}.", modelId || localize('dictation.hover.defaultModel', "the dictation model"));
+}
+
+/**
+ * Spells out that Voice Mode is a spoken conversation driven by a separate online
+ * model, so it doesn't read as another dictation entry point.
+ */
+function getVoiceModeDescription(): string {
+	return localize('voiceMode.hover', "Talk with the agent and hear it reply. Uses the online real-time voice model.");
+}
+
+/** Hover markdown for the dictation mic button. */
+export function getDictationHoverMarkdown(title: string, configurationService: IConfigurationService): MarkdownString {
+	return createMicButtonHover(title, getDictationDescription(configurationService));
+}
+
+/** Hover for the dictation mic button, for APIs that take managed hover content. */
+export function getDictationHoverContent(title: string, configurationService: IConfigurationService): IManagedHoverContent {
+	return asHoverContent(title, getDictationDescription(configurationService));
+}
+
+/** Hover for the Voice Mode button, for APIs that take managed hover content. */
+export function getVoiceModeHoverContent(title: string): IManagedHoverContent {
+	return asHoverContent(title, getVoiceModeDescription());
+}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceModeActionViewItem.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
+import { IManagedHoverContent } from '../../../../../base/browser/ui/hover/hover.js';
 import { MenuItemAction } from '../../../../../platform/actions/common/actions.js';
 import { IMenuEntryActionViewItemOptions, MenuEntryActionViewItem } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -13,6 +14,7 @@ import { IContextMenuService } from '../../../../../platform/contextview/browser
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { getVoiceModeHoverContent } from '../speechToText/micButtonHovers.js';
 import { addMicButtonContextMenuListener, getVoiceModeContextMenuActions } from '../speechToText/micButtonMenuActions.js';
 
 /**
@@ -27,7 +29,9 @@ const VOICE_START_COMMAND = 'agentsVoice.startVoiceInChat';
  * toolbar voice-mode toggle (click to start/stop) but adds a right-click context
  * menu with voice-specific entries — "Configure Keybinding" (mirroring the
  * standard toolbar affordance), "Select Microphone" and "Disable Voice Mode" —
- * instead of the generic toolbar context menu. Mirrors {@link DictationActionViewItem}.
+ * instead of the generic toolbar context menu. Its hover also explains that
+ * Voice Mode is a spoken conversation driven by its own online model, distinct
+ * from dictation. Mirrors {@link DictationActionViewItem}.
  */
 export class VoiceModeActionViewItem extends MenuEntryActionViewItem {
 
@@ -54,5 +58,9 @@ export class VoiceModeActionViewItem extends MenuEntryActionViewItem {
 			() => getVoiceModeContextMenuActions(this._commandService, this._configurationService, this._keybindingService, VOICE_START_COMMAND),
 			this._contextMenuService,
 		));
+	}
+
+	protected override getHoverContents(): IManagedHoverContent {
+		return getVoiceModeHoverContent(this.getTooltip() ?? '');
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/media/voiceInputMode.css
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/media/voiceInputMode.css
@@ -7,7 +7,18 @@
  * Built on the generic segmented-icon-toggle chrome (see
  * base/browser/ui/segmentedIconToggle/segmentedIconToggle.css) for the pill housing, reel,
  * and cell layout/hover/collapse behavior. The rules below add only the voice-specific
- * styling: the walkthrough hover preview, per-state colors, and the waveform bars. */
+ * styling: the pill's metrics, the walkthrough hover preview, per-state colors, and the
+ * waveform bars. */
+
+/* Size the housing to the same control tier as the chat input's send button — 22px tall — and
+ * round it fully so it reads as a true pill rather than a rounded box. The cell hover
+ * background uses the same full radius so it follows the housing's curved ends instead of
+ * poking square corners through them. */
+.monaco-segmented-icon-toggle-container.chat-voice-input-mode-item {
+	--segmented-icon-toggle-height: 22px;
+	--segmented-icon-toggle-radius: var(--vscode-cornerRadius-circle);
+	--segmented-icon-toggle-cell-radius: var(--vscode-cornerRadius-circle);
+}
 
 /* Walkthrough-only simulated hover mirrors the real :hover preview from the generic chrome. */
 .chat-voice-input-mode-cell.sim-hover::before {
@@ -32,43 +43,50 @@
 	color: var(--vscode-charts-purple, #a371f7);
 }
 
-.chat-voice-input-mode-icon {
-	font-size: 16px;
+/* Compact glyph size, matching the agent / model picker icons that sit beside the pill.
+ * Needs to outrank the `font` shorthand on `.codicon[class*='codicon-']`, and to drop the
+ * fixed 16px box the action bar puts on every codicon so the glyph sizes to its font. */
+.monaco-workbench .chat-voice-input-mode-icon.codicon[class*='codicon-'] {
+	font-size: var(--vscode-codiconFontSize-compact);
+	width: auto;
+	height: auto;
 }
 
-.monaco-workbench.monaco-enable-motion .chat-voice-input-mode-cell.dictation.preparing .chat-voice-input-mode-icon.codicon-loading::before {
+.monaco-workbench.monaco-enable-motion .chat-voice-input-mode-cell.dictation.preparing .chat-voice-input-mode-icon.codicon-loading-compact::before {
 	display: inline-block;
 	animation: codicon-spin 1.5s steps(30) infinite;
 }
 
-/* The Device EQ waveform lives in the voice cell and transforms per state. Thin bars = default (disconnected); thick bars = filled (connected). */
+/* The Device EQ waveform lives in the voice cell and transforms per state. Thin bars = default (disconnected); thick bars = filled (connected). Its box matches the compact glyph size of the neighbouring cells so every state of the pill reads at the same optical weight. */
 .chat-voice-input-mode-bars {
 	display: inline-flex;
 	align-items: center;
 	gap: 2px;
-	height: 16px;
+	height: 12px;
 }
 
+/* Bars are strokes, not shapes — keep them at the same visual weight as the codicon
+	glyphs in the neighbouring cells so the waveform doesn't read as bolder than the mic. */
 .chat-voice-input-mode-bar {
-	width: 1.5px;
+	width: 1px;
 	border-radius: 1px;
 	background: currentColor;
 	transform-origin: center center;
 	transition: height 0.22s cubic-bezier(0.2, 0.9, 0.2, 1);
 }
 
-/* Device EQ silhouette: symmetric center-peak (matches Device EQ.svg). Bars stay thin in every state — connected reads via a darker color, not thicker bars. */
-.chat-voice-input-mode-bar:nth-child(1) { height: 4px; }
-.chat-voice-input-mode-bar:nth-child(2) { height: 8px; }
-.chat-voice-input-mode-bar:nth-child(3) { height: 12px; }
-.chat-voice-input-mode-bar:nth-child(4) { height: 8px; }
-.chat-voice-input-mode-bar:nth-child(5) { height: 4px; }
+/* Device EQ silhouette: symmetric center-peak (matches Device EQ.svg), scaled to the 12px glyph box. Bars stay thin in every state — connected reads via a darker color, not thicker bars. */
+.chat-voice-input-mode-bar:nth-child(1) { height: 3px; }
+.chat-voice-input-mode-bar:nth-child(2) { height: 6px; }
+.chat-voice-input-mode-bar:nth-child(3) { height: 9px; }
+.chat-voice-input-mode-bar:nth-child(4) { height: 6px; }
+.chat-voice-input-mode-bar:nth-child(5) { height: 3px; }
 
 /* Hover while connected → preview disconnect: collapse to a short, even, "silent" row (no waveform, no motion). The height transition makes leaving the hover grow the bars smoothly back into the active waveform. */
 .chat-voice-input-mode-cell.voice.on:hover .chat-voice-input-mode-bar,
 .chat-voice-input-mode-cell.voice.on.sim-hover .chat-voice-input-mode-bar {
 	animation: none;
-	height: 4px;
+	height: 3px;
 }
 
 /* Connected but idle → a calm undulating wave: each bar gently grows/shrinks in height (centered scaleY) out of phase, so a soft sine ripples across the waveform to say "on, but not listening or speaking". The bars stay centered — they don't bob. */
@@ -104,6 +122,6 @@
 }
 
 @keyframes chat-voice-input-mode-eq {
-	0%, 100% { height: 3px; }
-	50% { height: 13px; }
+	0%, 100% { height: 2px; }
+	50% { height: 10px; }
 }

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
@@ -35,6 +35,7 @@ import { ITtsPlaybackService } from '../voiceClient/ttsPlaybackService.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from '../speechToText/chatSpeechToTextService.js';
 import { setupDictationMicGlow } from '../speechToText/dictationMicGlow.js';
 import { getDictationPreparingLabel } from '../speechToText/dictationDownloadRing.js';
+import { getDictationHoverContent, getVoiceModeHoverContent } from '../speechToText/micButtonHovers.js';
 import { addMicButtonContextMenuListener, getDictationContextMenuActions, getVoiceModeContextMenuActions } from '../speechToText/micButtonMenuActions.js';
 import { IVoiceInputModeService, SimulatedVoiceState, VoiceInputMode, VoiceWalkthroughVersion } from './voiceInputMode.js';
 import { SegmentedVoiceInputModePillActive } from './voiceInputModeContextKeys.js';
@@ -51,6 +52,15 @@ const VOICE_START_COMMAND_ID = 'agentsVoice.startVoiceInChat';
 
 /** Number of animated waveform bars shown in the voice segment. */
 const WAVEFORM_BAR_COUNT = 5;
+
+/**
+ * Height bounds (px) of an audio-reactive waveform bar. These mirror the
+ * `chat-voice-input-mode-eq` keyframes in `voiceInputMode.css`, which drive the bars
+ * whenever no analyser is available, so the two must be kept in sync; both are sized
+ * against the 12px waveform box.
+ */
+const WAVEFORM_BAR_MIN_HEIGHT = 2;
+const WAVEFORM_BAR_MAX_HEIGHT = 10;
 
 /**
  * Menu placeholder action for the segmented voice input mode toggle. The actual UI is
@@ -355,7 +365,7 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 		this._dictationCell.setAttribute('role', 'button');
 		this._dictationIcon = dom.append(this._dictationCell, dom.$('span.chat-voice-input-mode-icon'));
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this._dictationCell,
-			() => this._getLabelWithKeybinding(localize('voiceInputMode.dictation', "Dictation"), DICTATION_TOGGLE_COMMAND_ID)));
+			() => getDictationHoverContent(this._getLabelWithKeybinding(localize('voiceInputMode.dictation', "Dictation"), DICTATION_TOGGLE_COMMAND_ID), this.configurationService)));
 		this._register(dom.addDisposableListener(this._dictationCell, dom.EventType.CLICK, e => {
 			dom.EventHelper.stop(e, true);
 			this._onClickDictation();
@@ -378,9 +388,9 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this._voiceCell,
 			() => {
 				const connectedish = this.voiceSessionController.isConnected.get() || this.voiceSessionController.isConnecting.get() || this.voiceInputModeService.simulatedVoiceState.get() === 'idle' || this.voiceInputModeService.simulatedVoiceState.get() === 'listening' || this.voiceInputModeService.simulatedVoiceState.get() === 'speaking';
-				return connectedish
+				return getVoiceModeHoverContent(connectedish
 					? localize('voiceInputMode.disconnect', "Turn Off Voice Mode")
-					: this._getLabelWithKeybinding(localize('voiceInputMode.voice', "Voice Mode"), VOICE_START_COMMAND_ID);
+					: this._getLabelWithKeybinding(localize('voiceInputMode.voice', "Voice Mode"), VOICE_START_COMMAND_ID));
 			}));
 		// The voice button is a plain power toggle (connect / disconnect). Listening is
 		// driven by the separate listen cell in manual mode and by the auto-listen loop
@@ -512,8 +522,10 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 			this._dictationCell!.setAttribute('aria-label', dictationBusy
 				? localize('voiceInputMode.dictationPreparingCancelable', "Cancel Dictation. {0}", getDictationPreparingLabel(this.chatSpeechToTextService))
 				: localize('voiceInputMode.dictation', "Dictation"));
+			// Glyphs render at the compact 12px size, so use the `*Compact` variants
+			// wherever one exists (`mic` / `micFilled` have none and stay as-is).
 			const dictationIcon = dictationBusy
-				? this.chatSpeechToTextService.currentBackend === 'mai' ? Codicon.loading : Codicon.micDownload
+				? this.chatSpeechToTextService.currentBackend === 'mai' ? Codicon.loadingCompact : Codicon.micDownloadCompact
 				: isDictating ? Codicon.micFilled : Codicon.mic;
 			this._dictationIcon!.className = `chat-voice-input-mode-icon ${ThemeIcon.asClassName(dictationIcon)}`;
 
@@ -537,7 +549,7 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 			this._listenCell!.classList.toggle('active', listening);
 			this._listenCell!.classList.toggle('muted', !listening);
 			this._listenCell!.setAttribute('aria-pressed', String(listening));
-			this._listenIcon!.className = `chat-voice-input-mode-icon ${ThemeIcon.asClassName(listening ? Codicon.personVoiceFilled : Codicon.personVoice)}`;
+			this._listenIcon!.className = `chat-voice-input-mode-icon ${ThemeIcon.asClassName(listening ? Codicon.personVoiceFilledCompact : Codicon.personVoiceCompact)}`;
 			this._updateAriaLabels();
 
 			// Audio-reactive bars only while live (and not hovering the disconnect preview).
@@ -575,7 +587,7 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 		if (this.accessibilityService.isMotionReduced()) {
 			for (const bar of this._voiceBarEls) {
 				bar.style.animation = 'none';
-				bar.style.height = '3px';
+				bar.style.height = `${WAVEFORM_BAR_MIN_HEIGHT}px`;
 			}
 			return;
 		}
@@ -606,7 +618,7 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 					sum += this._barData[Math.min(bins - 1, i * step + j)];
 				}
 				const intensity = Math.min(1, (sum / step) / 180);
-				const heightPx = 3 + intensity * 11;
+				const heightPx = WAVEFORM_BAR_MIN_HEIGHT + intensity * (WAVEFORM_BAR_MAX_HEIGHT - WAVEFORM_BAR_MIN_HEIGHT);
 				// Disable the CSS keyframe fallback while we drive heights from live audio.
 				this._voiceBarEls[i].style.animation = 'none';
 				this._voiceBarEls[i].style.height = `${heightPx}px`;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1196,6 +1196,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	box-sizing: border-box;
 	width: 22px;
 	height: 22px;
+	/* Keep the control corner radius in both states — the enabled rule below only
+		adds the filled background, it shouldn't be what defines the shape. */
+	border-radius: var(--vscode-cornerRadius-small);
 	transition: background-color 250ms ease, color 250ms ease;
 }
 
@@ -1222,7 +1225,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button:not(.disabled) > .action-label {
 	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground) !important;
-	border-radius: var(--vscode-cornerRadius-small);
 	transition: background-color 120ms ease;
 }
 
@@ -4522,6 +4524,27 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	outline: none !important;
 }
 
+/* Standalone dictation / Voice Mode buttons (shown when the segmented voice pill
+	isn't active). Give them the same control tier as the send button they sit
+	beside — a 22×22 surface with the control corner radius — and the compact 12px
+	glyph used by the agent / model pickers, so the mic group reads as one
+	consistent row in every state: dictation idle / recording / preparing /
+	connecting, and Voice Mode idle / connecting / listening / speaking /
+	disconnect. */
+.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-mic,
+.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-mic-filled,
+.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-mic-download-compact,
+.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-voice-mode-compact,
+.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-loading-compact,
+.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-debug-disconnect-compact {
+	box-sizing: border-box;
+	width: 22px;
+	height: 22px;
+	justify-content: center;
+	border-radius: var(--vscode-cornerRadius-small);
+	font-size: var(--vscode-codiconFontSize-compact);
+}
+
 @keyframes chat-voice-icon-glow {
 	0%,
 	100% {
@@ -4533,30 +4556,32 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-/* Voice mode: blue when listening */
-.chat-input-container.voice-active.voice-listening .chat-input-toolbars .action-label.codicon-voice-mode {
+/* Voice mode: blue when listening. The glow keeps the button's resting shape —
+	only its color and the pulse change between states, so the control never
+	morphs from a rounded square into a circle mid-session. */
+.chat-input-container.voice-active.voice-listening .chat-input-toolbars .action-label.codicon-voice-mode-compact {
 	--chat-voice-icon-glow-color: rgba(88, 166, 255, 0.65);
 	color: var(--vscode-charts-blue, #58a6ff) !important;
-	border-radius: 50%;
+	border-radius: var(--vscode-cornerRadius-small);
 }
 
-.monaco-workbench.monaco-enable-motion .chat-input-container.voice-active.voice-listening .chat-input-toolbars .action-label.codicon-voice-mode {
+.monaco-workbench.monaco-enable-motion .chat-input-container.voice-active.voice-listening .chat-input-toolbars .action-label.codicon-voice-mode-compact {
 	animation: chat-voice-icon-glow 1.4s ease-in-out infinite;
 }
 
 /* Voice mode: purple when speaking */
-.chat-input-container.voice-active.voice-speaking .chat-input-toolbars .action-label.codicon-voice-mode {
+.chat-input-container.voice-active.voice-speaking .chat-input-toolbars .action-label.codicon-voice-mode-compact {
 	--chat-voice-icon-glow-color: rgba(163, 113, 247, 0.65);
 	color: var(--vscode-charts-purple, #a371f7) !important;
-	border-radius: 50%;
+	border-radius: var(--vscode-cornerRadius-small);
 }
 
-.monaco-workbench.monaco-enable-motion .chat-input-container.voice-active.voice-speaking .chat-input-toolbars .action-label.codicon-voice-mode {
+.monaco-workbench.monaco-enable-motion .chat-input-container.voice-active.voice-speaking .chat-input-toolbars .action-label.codicon-voice-mode-compact {
 	animation: chat-voice-icon-glow 1.4s ease-in-out infinite;
 }
 
 /* Voice mode: green disconnect button */
-.chat-input-container .chat-input-toolbars .codicon-debug-disconnect {
+.chat-input-container .chat-input-toolbars .codicon-debug-disconnect-compact {
 	color: var(--vscode-charts-green, #3fb950) !important;
 }
 
@@ -4565,17 +4590,20 @@ have to be updated for changes to the rules above, or to support more deeply nes
  * button. Otherwise the action-label (including its hover background) rotates
  * along with the icon.
  */
-.chat-input-container .chat-input-toolbars .action-label.codicon-loading {
+.chat-input-container .chat-input-toolbars .action-label.codicon-loading,
+.chat-input-container .chat-input-toolbars .action-label.codicon-loading-compact {
 	animation: none;
 }
 
-.chat-input-container .chat-input-toolbars .action-label.codicon-loading::before {
+.chat-input-container .chat-input-toolbars .action-label.codicon-loading::before,
+.chat-input-container .chat-input-toolbars .action-label.codicon-loading-compact::before {
 	display: inline-block;
 	transform-origin: center center;
 	animation: codicon-spin 1.5s steps(30) infinite;
 }
 
-.monaco-reduce-motion .chat-input-container .chat-input-toolbars .action-label.codicon-loading::before {
+.monaco-reduce-motion .chat-input-container .chat-input-toolbars .action-label.codicon-loading::before,
+.monaco-reduce-motion .chat-input-container .chat-input-toolbars .action-label.codicon-loading-compact::before {
 	animation: none;
 }
 
@@ -4598,8 +4626,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	width: 22px;
-	height: 22px;
+	/* Sized to hug the compact 12px download glyph rather than the full button. */
+	width: 16px;
+	height: 16px;
 	transform: translate(-50%, -50%) rotate(-90deg);
 	pointer-events: none;
 }


### PR DESCRIPTION
Three related polish fixes to the dictation and Voice Mode entry points in the chat input.

Fixes microsoft/vscode-internalbacklog#8600

### 1. Hover descriptions

It wasn't clear that dictation and Voice Mode are unrelated features, or that only dictation honors `dictation.model`. Both affordances now show a bold title plus one concise sentence:

> **Dictation (⌘I)**
> Types what you say into the input. Transcribes on-device with nemotron-speech-streaming-en-0.6b.

> **Voice Mode (⇧⌘Space)**
> Talk with the agent and hear it reply. Uses the online real-time voice model.

The dictation copy reads `dictation.model` live, so it switches to the MAI cloud wording when configured. Descriptions live in `getHoverContents()` only, so `aria-label` stays the short title plus keybinding.

Shared via a new `micButtonHovers.ts` so the chat toolbar, the segmented pill, and the Agents window composer all use the same copy. In the composer the existing state-aware hover is preserved — preparing still shows the download/connecting hover, recording still shows "Stop Dictation", and only the idle case gains the description.

### 2. Control tier

The segmented voice pill was `24px` tall with an `8px` radius, while the send button beside it is `22px` with the control radius — so the two disagreed on both height and shape. The pill is now `22px` and fully rounded (`cornerRadius-circle`), and the standalone dictation / Voice Mode buttons get the same `22×22` control surface as Send.

The housing radius is exposed as a tunable custom property on the generic segmented-icon-toggle chrome rather than hardcoding voice-specific values into shared code.

### 3. Icon ramp

The mic / Voice Mode glyphs rendered at the base **16px** codicon size while the neighbouring agent and model pickers use the compact **12px** token. Measured before/after in a running build:

| Element | before | after |
|---|---|---|
| Agent picker icon | 12px | 12px |
| Model picker icon | 12px | 12px |
| Dictation mic | **16px** | **12px** |
| Voice waveform / listen | **16px** | **12px** |

Uses the `*Compact` glyph variants where they exist (`voiceMode`, `personVoice`, `personVoiceFilled`, `loading`, `debugDisconnect`). `mic` and `micFilled` have no compact variant, so they keep the regular glyph at the compact size. The waveform bars drop `1.5px → 1px` to match the codicon stroke weight, and the download ring shrinks `22px → 16px` to hug the smaller glyph.

Because the Voice Mode affordance morphs across states, this had to be holistic — every state was checked, not just idle.

### Two related fixes that fell out of this

- The listening/speaking glow forced `border-radius: 50%`, so the standalone Voice Mode button **changed shape** from a rounded square into a circle mid-session. It now keeps its resting shape; only color and the pulse change between states.
- The send button lost its corner radius while disabled, because the radius was declared inside a `:not(.disabled)` rule — it rendered at 6px disabled and 4px enabled. Moved so the shape is state-independent and only the filled background stays conditional.

### Validation

`typecheck-client`, `stylelint`, `hygiene`, `eslint`, and `valid-layers-check` all pass.

Verified live in a running Code OSS build across every state on **both** surfaces (chat view and Agents window composer):

- dictation: idle, recording, preparing (on-device download ring), preparing (cloud spinner)
- voice mode: idle, connecting, listening, speaking, connected/disconnect
- standalone fallbacks with only one of the two features enabled

In each state the pill measures 22px tall with 12px glyphs and its shape stays constant.
