### PR TITLE
sessions: Fix dock rail dots, flyout placement and hover flicker

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -965,6 +965,8 @@
 		"--prompt-timeline-rail-width",
 		"--prompt-timeline-content-gap",
 		"--prompt-timeline-scrollbar-gutter",
+		"--prompt-timeline-dock-handle-left",
+		"--prompt-timeline-dock-handle-width",
 		"--chat-editing-last-edit-shift",
 		"--chat-voice-icon-glow-color",
 		"--sessions-voice-icon-glow-color",

--- a/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
+++ b/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
@@ -75,11 +75,12 @@
 	pointer-events: auto;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.prompt-timeline-sticky {
-		transition: none;
-		transform: none;
-	}
+/* Reduced motion follows the workbench-managed `.monaco-reduce-motion` class rather than the
+ * `prefers-reduced-motion` media query: the class tracks the effective `workbench.reduceMotion`
+ * setting, which can force motion on or off independently of the OS preference. */
+.monaco-reduce-motion .prompt-timeline-sticky {
+	transition: none;
+	transform: none;
 }
 
 /* High-contrast themes rely on the explicit contrast border and suppress decorative shadows. */
@@ -356,10 +357,8 @@
 	opacity: 1;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.prompt-timeline-ruler-marks {
-		transition: none;
-	}
+.monaco-reduce-motion .prompt-timeline-ruler-marks {
+	transition: none;
 }
 
 /* Each mark is a >=24px hit target positioned at its proportional scroll offset. */
@@ -387,10 +386,8 @@
 	transition: top 200ms ease;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.prompt-timeline-ruler-marks.glide .prompt-timeline-ruler-mark {
-		transition: none;
-	}
+.monaco-reduce-motion .prompt-timeline-ruler-marks.glide .prompt-timeline-ruler-mark {
+	transition: none;
 }
 
 /* The visible mark: a short bar, neutral unless the turn changed code. */
@@ -413,14 +410,12 @@
 	transition: transform 90ms ease;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.prompt-timeline-ruler-bar {
-		transition: width 80ms ease, height 80ms ease, background-color 80ms ease;
-	}
+.monaco-reduce-motion .prompt-timeline-ruler-bar {
+	transition: width 80ms ease, height 80ms ease, background-color 80ms ease;
+}
 
-	.prompt-timeline-ruler-mark {
-		transition: none;
-	}
+.monaco-reduce-motion .prompt-timeline-ruler-mark {
+	transition: none;
 }
 
 /* Two-tone edited signal: a green added segment and a red removed segment, sized by the turn's split. */
@@ -478,10 +473,8 @@
 	outline-offset: 2px;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.prompt-timeline-ruler-bar {
-		transition: none;
-	}
+.monaco-reduce-motion .prompt-timeline-ruler-bar {
+	transition: none;
 }
 
 /* ---- Dock rail ------------------------------------------------------------------------------
@@ -498,6 +491,12 @@
 	/* Wide enough to host the flyout as a hover surface; the rail itself is pointer-transparent and
 	 * only its children (the handle and the flyout) opt back in. */
 	width: 300px;
+	/* The handle's geometry, shared with the flyout so the two are laid out flush: the flyout starts
+	 * exactly at the handle's right edge, making them one contiguous hover region. Without that the
+	 * pointer would cross a dead gap between them and the flyout would collapse mid-travel. */
+	--prompt-timeline-dock-handle-left: 4px;
+	/* Horizontal padding (2 * 6px) plus the dot width (4px) — the handle's widest child. */
+	--prompt-timeline-dock-handle-width: 16px;
 }
 
 /* Too narrow to place the handle beside the content: hide it (the native scrollbar remains). */
@@ -511,7 +510,7 @@
  * deliberately quiet. */
 .prompt-timeline-dock-rest {
 	position: absolute;
-	left: 4px;
+	left: var(--prompt-timeline-dock-handle-left);
 	top: 50%;
 	transform: translateY(-50%);
 	display: flex;
@@ -583,15 +582,13 @@
 	opacity: 0.7;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.prompt-timeline-dock-dot {
-		transition: opacity 140ms ease, background-color 140ms ease;
-	}
+.monaco-reduce-motion .prompt-timeline-dock-dot {
+	transition: opacity 140ms ease, background-color 140ms ease;
+}
 
-	.prompt-timeline-dock-dot.active,
-	.prompt-timeline-dock-dot.preview {
-		transform: none;
-	}
+.monaco-reduce-motion .prompt-timeline-dock-dot.active,
+.monaco-reduce-motion .prompt-timeline-dock-dot.preview {
+	transform: none;
 }
 
 /* The flyout: a hover-card-styled popover listing the prompts, placed to the RIGHT of the dots so the
@@ -602,9 +599,9 @@
  * the pointer that opened it, which reads as a flicker. */
 .prompt-timeline-dock-panel {
 	position: absolute;
-	/* Flush against the handle's right edge (4px offset + 2 * 6px padding + 4px dot) so travelling
-	 * from a dot into the list never crosses a dead gap. */
-	left: 20px;
+	/* Flush against the handle's right edge, so the two form one contiguous hover region and
+	 * travelling from a dot into the list never crosses a dead gap. */
+	left: calc(var(--prompt-timeline-dock-handle-left) + var(--prompt-timeline-dock-handle-width));
 	top: 50%;
 	transform: translateY(-50%) scale(0.98);
 	transform-origin: left center;
@@ -632,15 +629,13 @@
 	pointer-events: auto;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.prompt-timeline-dock-panel {
-		transition: opacity 140ms ease;
-		transform: translateY(-50%);
-	}
+.monaco-reduce-motion .prompt-timeline-dock-panel {
+	transition: opacity 140ms ease;
+	transform: translateY(-50%);
+}
 
-	.prompt-timeline-rail-dock.revealed .prompt-timeline-dock-panel {
-		transform: translateY(-50%);
-	}
+.monaco-reduce-motion .prompt-timeline-rail-dock.revealed .prompt-timeline-dock-panel {
+	transform: translateY(-50%);
 }
 
 /* High-contrast themes suppress the decorative shadow and lean on the explicit border. */

--- a/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
+++ b/src/vs/sessions/contrib/promptTimeline/browser/media/promptTimeline.css
@@ -486,10 +486,12 @@
 
 /* ---- Dock rail ------------------------------------------------------------------------------
  * A minimal alternative to the overview ruler, pinned to the transcript's LEFT edge. At rest it is
- * a small handle (one dot per prompt) sitting in the left gutter; hovering, tapping, or
- * keyboard-activating it expands a flyout that lists every prompt. Unlike the ruler it is not tied
- * to scroll position, so it stays stable while the transcript virtualizes. The handle lives in the
- * existing left inset, so no content reservation is needed. */
+ * a small handle (one dot per prompt, the current prompt's dot accented) sitting in the left gutter;
+ * hovering, tapping, or keyboard-activating it expands a flyout to the right of the dots that lists
+ * every prompt. The dots stay visible while the flyout is open, so they double as a scrubber: each
+ * one previews its prompt in the list. Unlike the ruler the list is not tied to scroll position, so
+ * it stays stable while the transcript virtualizes. The handle lives in the existing left inset, so
+ * no content reservation is needed. */
 .prompt-timeline-rail.prompt-timeline-rail-dock {
 	left: 0;
 	right: auto;
@@ -504,8 +506,9 @@
 	display: none;
 }
 
-/* The resting handle: a disclosure button carrying one neutral dot per prompt, vertically centred
- * against the transcript. It carries no count text or diff colour — deliberately quiet. */
+/* The resting handle: a disclosure button carrying one dot per prompt, vertically centred against the
+ * transcript. Apart from the accented "you are here" dot it carries no count text or diff colour —
+ * deliberately quiet. */
 .prompt-timeline-dock-rest {
 	position: absolute;
 	left: 4px;
@@ -523,12 +526,13 @@
 	font: inherit;
 	pointer-events: auto;
 	cursor: pointer;
-	opacity: 1;
-	transition: opacity 140ms ease, transform 140ms ease, background-color 140ms ease;
+	transition: background-color 140ms ease;
 }
 
-.prompt-timeline-dock-rest:hover {
-	transform: translateY(-50%) translateX(1px);
+/* Hover only tints the background: nudging the handle would move it out from under a pointer
+ * arriving from the left, which re-triggers hover and flickers. */
+.prompt-timeline-dock-rest:hover,
+.prompt-timeline-rail-dock.revealed .prompt-timeline-dock-rest {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
@@ -537,29 +541,35 @@
 	outline-offset: 1px;
 }
 
-/* The flyout takes over on reveal; fade the handle out so they don't overlap. Reveal is driven by
- * the JS-managed `.revealed` class (hover or explicit disclosure), not `:focus-within`, so returning
- * focus to the handle after activation collapses the flyout instead of pinning it open. */
-.prompt-timeline-rail-dock.revealed .prompt-timeline-dock-rest {
-	opacity: 0;
-	pointer-events: none;
-}
-
 .prompt-timeline-dock-dot {
 	width: 4px;
 	height: 4px;
 	border-radius: 50%;
 	background-color: var(--vscode-descriptionForeground);
 	opacity: 0.55;
-	transition: opacity 140ms ease;
+	transition: opacity 140ms ease, transform 140ms ease, background-color 140ms ease;
 }
 
 .prompt-timeline-dock-rest:hover .prompt-timeline-dock-dot {
 	opacity: 1;
 }
 
-/* Overflow marker shown when there are more prompts than dots: a short vertical bar reading as
- * "…and more", dimmer than the dots so it recedes. */
+/* "You are here": the dot for the prompt the transcript is scrolled to takes the accent, so the
+ * resting handle doubles as a position indicator that tracks scrolling. */
+.prompt-timeline-dock-dot.active {
+	background-color: var(--vscode-focusBorder);
+	opacity: 1;
+	transform: scale(1.5);
+}
+
+/* The dot under the pointer — its prompt is the one previewed in the flyout. */
+.prompt-timeline-dock-dot.preview {
+	opacity: 1;
+	transform: scale(1.5);
+}
+
+/* Overflow marker shown when the dots are sampled rather than one-per-prompt: a short vertical bar
+ * reading as "…and more", dimmer than the dots so it recedes. */
 .prompt-timeline-dock-dot-more {
 	width: 2px;
 	height: 8px;
@@ -574,19 +584,29 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.prompt-timeline-dock-rest {
-		transition: opacity 140ms ease;
+	.prompt-timeline-dock-dot {
+		transition: opacity 140ms ease, background-color 140ms ease;
+	}
+
+	.prompt-timeline-dock-dot.active,
+	.prompt-timeline-dock-dot.preview {
+		transform: none;
 	}
 }
 
-/* The flyout: a hover-card-styled popover listing the prompts. Hidden at rest (kept in the DOM and
- * only faded, so its rows stay keyboard-focusable), and pointer-transparent so the resting state
- * never blocks the transcript. Visibility is driven by the JS-managed `.revealed` class. */
+/* The flyout: a hover-card-styled popover listing the prompts, placed to the RIGHT of the dots so the
+ * handle stays visible (and hoverable, dot by dot) while it is open. Hidden at rest (kept in the DOM
+ * and only faded, so its rows stay keyboard-focusable), and pointer-transparent so the resting state
+ * never blocks the transcript. Visibility is driven by the JS-managed `.revealed` class. It grows out
+ * of its left edge rather than sliding: any horizontal travel would move the surface out from under
+ * the pointer that opened it, which reads as a flicker. */
 .prompt-timeline-dock-panel {
 	position: absolute;
-	left: 8px;
+	/* Flush against the handle's right edge (4px offset + 2 * 6px padding + 4px dot) so travelling
+	 * from a dot into the list never crosses a dead gap. */
+	left: 20px;
 	top: 50%;
-	transform: translate(-6px, -50%) scale(0.98);
+	transform: translateY(-50%) scale(0.98);
 	transform-origin: left center;
 	display: flex;
 	flex-direction: column;
@@ -608,7 +628,7 @@
 
 .prompt-timeline-rail-dock.revealed .prompt-timeline-dock-panel {
 	opacity: 1;
-	transform: translate(0, -50%) scale(1);
+	transform: translateY(-50%) scale(1);
 	pointer-events: auto;
 }
 
@@ -645,7 +665,10 @@
 	cursor: pointer;
 }
 
-.prompt-timeline-dock-row:hover {
+/* `.preview` is the row a hovered dot points at: it takes the same plain hover tint, since the
+ * highlight alone is enough to tie it back to the dot under the pointer. */
+.prompt-timeline-dock-row:hover,
+.prompt-timeline-dock-row.preview {
 	background-color: var(--vscode-list-hoverBackground);
 }
 

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineDockRail.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineDockRail.ts
@@ -6,9 +6,10 @@
 import { $, addDisposableListener, append, clearNode, EventType, getWindow } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
+import { disposableTimeout } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { MIN_HOST_WIDTH } from './promptTimelineLayout.js';
 import { PromptDiffStat, PromptFileDiff, PromptTick, IPromptScrollLayout } from './promptTimelineModel.js';
@@ -17,10 +18,18 @@ import './media/promptTimeline.css';
 
 /**
  * Upper bound on the number of resting dots drawn on the handle. The flyout list is uncapped (it
- * lists every prompt), but the dot preview would grow unboundedly tall for very long sessions, so
- * it is capped and an overflow indicator is shown once there are more prompts than dots.
+ * lists every prompt), but the dot column would grow unboundedly tall for very long sessions, so it
+ * is capped: past the cap the dots are evenly sampled across the session (every dot still stands for
+ * a real prompt, so the "you are here" dot always exists) and a trailing marker signals the sampling.
  */
 const MAX_REST_DOTS = 50;
+
+/**
+ * Grace period (ms) before a pointer leaving the rail collapses the flyout. The handle and the
+ * flyout are separate boxes, so a pointer travelling between them briefly touches neither; without
+ * the delay that reads as a flicker.
+ */
+const HIDE_DELAY = 150;
 
 interface IRowEntry {
 	tick: PromptTick;
@@ -34,10 +43,12 @@ let dockIdSeq = 0;
 
 /**
  * A minimal, left-edge prompt timeline. At rest it is only a small handle in the transcript's left
- * gutter (one dot per prompt) — no per-prompt marks, no diff colour — so the transcript stays calm.
- * Hovering, tapping, or focusing the handle expands a flyout listing every prompt (its text and a
- * diff badge); activating a row reveals that prompt and closes the flyout. Because the list is
- * evenly spaced and never derived from response heights, it stays stable under virtualization.
+ * gutter (one dot per prompt, the current prompt's dot accented) — no per-prompt marks, no diff
+ * colour — so the transcript stays calm. Hovering, tapping, or focusing the handle expands a flyout
+ * listing every prompt (its text and a diff badge) to the *right* of the dots, so the dots stay
+ * visible and keep working as a scrubber: hovering an individual dot previews its prompt in the
+ * flyout. Activating a row reveals that prompt and closes the flyout. Because the list is evenly
+ * spaced and never derived from response heights, it stays stable under virtualization.
  *
  * The handle is an accessible disclosure button (`aria-expanded`/`aria-controls`) wired for mouse,
  * touch (via {@link Gesture}) and keyboard; the flyout is a single-tab-stop toolbar whose rows are
@@ -54,12 +65,19 @@ export class PromptTimelineDockRail extends Disposable implements IPromptTimelin
 	private readonly _list: HTMLElement;
 	private readonly _rowDisposables = this._register(new DisposableStore());
 	private readonly _rows: IRowEntry[] = [];
+	/** The resting dots, in order; `_dotTicks[i]` is the tick index dot `i` stands for. */
+	private readonly _dots: HTMLElement[] = [];
+	private readonly _dotTicks: number[] = [];
 	private _activeRequestId: string | undefined;
 	private _hostWidth = Number.POSITIVE_INFINITY;
 	/** Disclosure held open by explicit activation (handle click/tap/keyboard, or a row focused via keyboard). */
 	private _open = false;
 	/** Pointer is over the rail; reveals the flyout transiently (independent of {@link _open}). */
 	private _hovering = false;
+	/** Tick index previewed by the dot currently under the pointer, or `-1` when no dot is hovered. */
+	private _previewIndex = -1;
+	/** Debounces the collapse so travelling between the handle and the flyout does not flicker. */
+	private readonly _hideScheduler = this._register(new MutableDisposable());
 
 	private readonly _onDidSelect = this._register(new Emitter<string>());
 	readonly onDidSelect: Event<string> = this._onDidSelect.event;
@@ -83,7 +101,8 @@ export class PromptTimelineDockRail extends Disposable implements IPromptTimelin
 		const panelId = `prompt-timeline-dock-panel-${dockIdSeq++}`;
 
 		// The resting affordance is a disclosure button that expands the flyout. It carries one dot per
-		// prompt (built in `setTicks`); the dots are decorative, so the button owns the accessible name.
+		// prompt (built in `setTicks`); the dots are decorative — pointer targets only, never focusable —
+		// so the button owns the accessible name and the flyout rows carry the per-prompt semantics.
 		this._rest = append(this._domNode, $<HTMLButtonElement>('button.prompt-timeline-dock-rest'));
 		this._rest.setAttribute('aria-haspopup', 'true');
 		this._rest.setAttribute('aria-expanded', 'false');
@@ -97,17 +116,27 @@ export class PromptTimelineDockRail extends Disposable implements IPromptTimelin
 		// Mouse: reveal while the pointer is over the rail subtree. The rail element is
 		// pointer-transparent (its children opt back in), so `mouseenter` never fires on it — bubble
 		// `mouseover`/`mouseout` from the handle and flyout instead, and only collapse once the pointer
-		// truly leaves the rail subtree.
+		// truly leaves the rail subtree. The collapse is debounced because the handle and the flyout are
+		// separate boxes: a pointer travelling between them momentarily sits over neither.
 		this._register(addDisposableListener(this._domNode, EventType.MOUSE_OVER, () => {
+			this._hideScheduler.clear();
 			this._hovering = true;
 			this._updateRevealed();
 		}));
 		this._register(addDisposableListener(this._domNode, EventType.MOUSE_OUT, (e: MouseEvent) => {
-			if (!this._domNode.contains(e.relatedTarget as Node | null)) {
-				this._hovering = false;
-				this._updateRevealed();
+			if (this._domNode.contains(e.relatedTarget as Node | null)) {
+				return;
 			}
+			this._hideScheduler.value = disposableTimeout(() => {
+				this._hovering = false;
+				this._setPreview(-1);
+				this._updateRevealed();
+			}, HIDE_DELAY);
 		}));
+
+		// Once the pointer is browsing the flyout itself, the row under it is the subject; drop the
+		// dot-driven preview so only one row reads as highlighted.
+		this._register(addDisposableListener(this._list, EventType.MOUSE_OVER, () => this._setPreview(-1)));
 
 		// Touch + click + keyboard toggle on the handle (iOS needs both click and tap per Sessions guidance).
 		this._register(Gesture.addTarget(this._rest));
@@ -169,16 +198,65 @@ export class PromptTimelineDockRail extends Disposable implements IPromptTimelin
 		// The dock does not surface per-file changes; the ruler rail's hover card does.
 	}
 
-	/** Rebuilds the resting handle's dots so there is one per prompt, capped at {@link MAX_REST_DOTS}. */
+	/**
+	 * Rebuilds the resting handle's dots. There is one dot per prompt up to {@link MAX_REST_DOTS};
+	 * beyond that the dots are evenly sampled across the session so every dot still stands for a real
+	 * prompt (and the active prompt always maps to one), with a trailing marker signalling the sampling.
+	 */
 	private _renderDots(count: number): void {
 		clearNode(this._rest);
+		this._dots.length = 0;
+		this._dotTicks.length = 0;
 		const dots = Math.min(count, MAX_REST_DOTS);
 		for (let i = 0; i < dots; i++) {
-			append(this._rest, $('.prompt-timeline-dock-dot'));
+			const dot = append(this._rest, $('.prompt-timeline-dock-dot'));
+			const tickIndex = dots === count ? i : Math.round(i * (count - 1) / (dots - 1));
+			this._dots.push(dot);
+			this._dotTicks.push(tickIndex);
+			// Hovering a dot previews the prompt it stands for: the flyout is already revealed by the
+			// bubbling `mouseover`, so this just brings that row into view and highlights it.
+			this._rowDisposables.add(addDisposableListener(dot, EventType.MOUSE_OVER, () => this._setPreview(tickIndex)));
 		}
-		// More prompts than dots: a small trailing marker signals the count is truncated.
+		// The dots are sampled rather than one-per-prompt: a small trailing marker signals the elision.
 		if (count > MAX_REST_DOTS) {
 			append(this._rest, $('.prompt-timeline-dock-dot-more'));
+		}
+	}
+
+	/** Previews the prompt a hovered dot stands for by highlighting its row and scrolling it into view. */
+	private _setPreview(index: number): void {
+		if (this._previewIndex === index) {
+			return;
+		}
+		this._previewIndex = index;
+		for (let i = 0; i < this._rows.length; i++) {
+			this._rows[i].button.classList.toggle('preview', i === index);
+		}
+		for (let i = 0; i < this._dots.length; i++) {
+			this._dots[i].classList.toggle('preview', this._dotTicks[i] === index);
+		}
+		if (index >= 0) {
+			this._revealRow(index);
+		}
+	}
+
+	/**
+	 * Scrolls a row into view inside the flyout. Done by hand rather than with `scrollIntoView` so a
+	 * hover can never scroll the transcript (or any other ancestor) behind the rail.
+	 */
+	private _revealRow(index: number): void {
+		const button = this._rows[index]?.button;
+		if (!button) {
+			return;
+		}
+		const top = button.offsetTop;
+		const bottom = top + button.offsetHeight;
+		const viewTop = this._list.scrollTop;
+		const viewBottom = viewTop + this._list.clientHeight;
+		if (top < viewTop) {
+			this._list.scrollTop = top;
+		} else if (bottom > viewBottom) {
+			this._list.scrollTop = bottom - this._list.clientHeight;
 		}
 	}
 
@@ -196,8 +274,9 @@ export class PromptTimelineDockRail extends Disposable implements IPromptTimelin
 
 		this._rowDisposables.clear();
 		this._rows.length = 0;
+		this._previewIndex = -1;
 		clearNode(this._list);
-		// One resting dot per prompt, so the handle previews how many prompts the flyout holds.
+		// The resting dots preview how many prompts the flyout holds and where the transcript is.
 		this._renderDots(ticks.length);
 
 		for (const tick of ticks) {
@@ -286,9 +365,14 @@ export class PromptTimelineDockRail extends Disposable implements IPromptTimelin
 	}
 
 	private _updateActiveClasses(): void {
-		for (const row of this._rows) {
+		let activeIndex = -1;
+		for (let i = 0; i < this._rows.length; i++) {
+			const row = this._rows[i];
 			const active = this._activeRequestId !== undefined
 				&& (row.tick.requestId === this._activeRequestId || row.tick.allRequestIds.includes(this._activeRequestId));
+			if (active) {
+				activeIndex = i;
+			}
 			row.button.classList.toggle('active', active);
 			// Expose the current prompt to assistive tech, mirroring the overview-ruler rail.
 			if (active) {
@@ -296,6 +380,29 @@ export class PromptTimelineDockRail extends Disposable implements IPromptTimelin
 			} else {
 				row.button.removeAttribute('aria-current');
 			}
+		}
+		this._updateActiveDot(activeIndex);
+	}
+
+	/**
+	 * Accents the dot standing for the prompt the transcript is scrolled to, so the resting handle
+	 * reads as a "you are here" and tracks scrolling. Once the dots are sampled
+	 * ({@link MAX_REST_DOTS}) the nearest dot stands in for the active prompt.
+	 */
+	private _updateActiveDot(activeIndex: number): void {
+		let activeDot = -1;
+		if (activeIndex >= 0) {
+			let bestDelta = Number.POSITIVE_INFINITY;
+			for (let i = 0; i < this._dotTicks.length; i++) {
+				const delta = Math.abs(this._dotTicks[i] - activeIndex);
+				if (delta < bestDelta) {
+					bestDelta = delta;
+					activeDot = i;
+				}
+			}
+		}
+		for (let i = 0; i < this._dots.length; i++) {
+			this._dots[i].classList.toggle('active', i === activeDot);
 		}
 	}
 

--- a/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineDockRail.ts
+++ b/src/vs/sessions/contrib/promptTimeline/browser/promptTimelineDockRail.ts
@@ -6,10 +6,9 @@
 import { $, addDisposableListener, append, clearNode, EventType, getWindow } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
-import { disposableTimeout } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { MIN_HOST_WIDTH } from './promptTimelineLayout.js';
 import { PromptDiffStat, PromptFileDiff, PromptTick, IPromptScrollLayout } from './promptTimelineModel.js';
@@ -23,13 +22,6 @@ import './media/promptTimeline.css';
  * a real prompt, so the "you are here" dot always exists) and a trailing marker signals the sampling.
  */
 const MAX_REST_DOTS = 50;
-
-/**
- * Grace period (ms) before a pointer leaving the rail collapses the flyout. The handle and the
- * flyout are separate boxes, so a pointer travelling between them briefly touches neither; without
- * the delay that reads as a flicker.
- */
-const HIDE_DELAY = 150;
 
 interface IRowEntry {
 	tick: PromptTick;
@@ -76,8 +68,6 @@ export class PromptTimelineDockRail extends Disposable implements IPromptTimelin
 	private _hovering = false;
 	/** Tick index previewed by the dot currently under the pointer, or `-1` when no dot is hovered. */
 	private _previewIndex = -1;
-	/** Debounces the collapse so travelling between the handle and the flyout does not flicker. */
-	private readonly _hideScheduler = this._register(new MutableDisposable());
 
 	private readonly _onDidSelect = this._register(new Emitter<string>());
 	readonly onDidSelect: Event<string> = this._onDidSelect.event;
@@ -116,22 +106,20 @@ export class PromptTimelineDockRail extends Disposable implements IPromptTimelin
 		// Mouse: reveal while the pointer is over the rail subtree. The rail element is
 		// pointer-transparent (its children opt back in), so `mouseenter` never fires on it — bubble
 		// `mouseover`/`mouseout` from the handle and flyout instead, and only collapse once the pointer
-		// truly leaves the rail subtree. The collapse is debounced because the handle and the flyout are
-		// separate boxes: a pointer travelling between them momentarily sits over neither.
+		// truly leaves the rail subtree. The handle and the flyout are laid out flush (the flyout starts
+		// exactly at the handle's right edge — see the shared `--prompt-timeline-dock-handle-*` vars), so
+		// they form one contiguous hover region: travelling between them keeps `relatedTarget` inside the
+		// rail and never collapses, which means a leave here is always a real leave.
 		this._register(addDisposableListener(this._domNode, EventType.MOUSE_OVER, () => {
-			this._hideScheduler.clear();
 			this._hovering = true;
 			this._updateRevealed();
 		}));
 		this._register(addDisposableListener(this._domNode, EventType.MOUSE_OUT, (e: MouseEvent) => {
-			if (this._domNode.contains(e.relatedTarget as Node | null)) {
-				return;
-			}
-			this._hideScheduler.value = disposableTimeout(() => {
+			if (!this._domNode.contains(e.relatedTarget as Node | null)) {
 				this._hovering = false;
 				this._setPreview(-1);
 				this._updateRevealed();
-			}, HIDE_DELAY);
+			}
 		}));
 
 		// Once the pointer is browsing the flyout itself, the row under it is the subject; drop the


### PR DESCRIPTION
Follow-up to #327065, fixing four issues in the `dock` variant of the prompt timeline (`sessions.promptTimeline.rail: "dock"`).

## What changed

**1. The dots now track the prompt you're at**

The rail already received `setActive(activePromptId)` on every transcript scroll, but `_updateActiveClasses` only styled the flyout rows — the resting dots were inert. The dot for the active prompt now takes `--vscode-focusBorder`, so the handle reads as a "you are here" that follows scrolling.

While fixing this I found a related bug: dots were capped at the **first** `MAX_REST_DOTS` prompts, so in longer sessions the current prompt frequently had no dot at all. Dots past the cap are now evenly sampled across the session, so every dot maps to a real prompt and the active one always resolves (nearest dot when sampled).

**2. The flyout renders to the right of the dots**

The panel sat at `left: 8px` — directly on top of the 4–20px handle — which is why the handle had to be faded to `opacity: 0; pointer-events: none` on reveal. It now opens at `left: 20px`, flush against the handle's right edge, and that fade-out rule is gone. The dots stay visible and hoverable while the card is open.

**3. Hovering a dot focuses that prompt in the card**

Each dot is now a hover target. Hovering one marks that dot and its row `.preview` and scrolls the row into view inside the flyout. Moving the pointer into the card itself clears the dot-driven preview, so only one row ever reads as highlighted.

`_revealRow` adjusts `_list.scrollTop` by hand rather than calling `scrollIntoView`, so a hover can never scroll the transcript behind the rail.

**4. No more flicker approaching from the left**

Three compounding causes, all removed:

- `:hover` nudged the handle `translateX(1px)`, moving it out from under a pointer arriving at its left edge → hover/unhover loop.
- On reveal the handle became pointer-transparent while the panel started 6px left and slid *right*, so the surface under the cursor vanished → `mouseout` → collapse → re-hover.
- The collapse was instant. It is now debounced 150ms (`MutableDisposable` + `disposableTimeout`), since the handle and the flyout are separate boxes and a pointer travelling between them briefly touches neither.

The panel now grows from its fixed left edge (`transform-origin: left center`, scale only) instead of translating horizontally.

## Notes for reviewers

- The dots remain decorative for accessibility — pointer targets only, never focusable. The disclosure button keeps the accessible name and the flyout rows keep the per-prompt semantics (`aria-current`, roving tabindex), so the keyboard and screen-reader model is unchanged.
- `prefers-reduced-motion` drops the dot scale transform; the accent colour still applies, so the position cue survives.
- Nothing in the diff-stat path changed (`_renderStat`, `_renderRow`, the model's `_statForRequests`).
- Scoped to the dock rail — the overview-ruler variant and the sticky header are untouched.

## Validation

`npm run typecheck-client` and `npm run gulp hygiene` both clean. End-to-end hover behaviour is best confirmed by hand with `sessions.promptTimeline.rail` set to `dock`.