### PR TITLE
Enhance branch picker ordering in agent host

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitService.ts
@@ -340,22 +340,22 @@ export interface IAgentHostGitService {
 	getDiffPatchBetweenRefs(workingDirectory: URI, options: { readonly fromRef: string; readonly toRef: string; readonly paths: readonly string[]; readonly maxBuffer: number }): Promise<IDiffPatchResult | undefined>;
 }
 
-function getCommonBranchPriority(branch: string): number {
-	if (branch === 'main') {
+function getBranchPriority(branch: string, currentBranch: string | undefined, defaultBranch: string | undefined): number {
+	if (branch === currentBranch) {
 		return 0;
 	}
-	if (branch === 'master') {
+	if (branch === defaultBranch) {
 		return 1;
 	}
 	return 2;
 }
 
-export function getBranchCompletions(branches: readonly string[], options?: { readonly query?: string; readonly limit?: number }): string[] {
+export function getBranchCompletions(branches: readonly string[], options?: { readonly currentBranch?: string; readonly defaultBranch?: string; readonly query?: string; readonly limit?: number }): string[] {
 	const normalizedQuery = options?.query?.toLowerCase();
 	const filtered = normalizedQuery
 		? branches.filter(branch => branch.toLowerCase().includes(normalizedQuery))
 		: [...branches];
 
-	filtered.sort((a, b) => getCommonBranchPriority(a) - getCommonBranchPriority(b));
+	filtered.sort((a, b) => getBranchPriority(a, options?.currentBranch, options?.defaultBranch) - getBranchPriority(b, options?.currentBranch, options?.defaultBranch));
 	return options?.limit ? filtered.slice(0, options.limit) : filtered;
 }

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -382,8 +382,17 @@ export class WorktreeIsolation extends Disposable {
 		if (!workingDirectory) {
 			return { items: [] };
 		}
-		const branches = await this._gitService.getBranches(workingDirectory, { pattern: ['refs/heads'], sort: 'committerdate' });
-		const branchCompletions = getBranchCompletions(branches.map(branch => branch.name), { query, limit: BRANCH_COMPLETION_LIMIT });
+		const [branches, currentBranch, defaultBranch] = await Promise.all([
+			this._gitService.getBranches(workingDirectory, { pattern: ['refs/heads'], sort: 'committerdate' }),
+			this._gitService.getCurrentBranch(workingDirectory),
+			this._gitService.getDefaultBranch(workingDirectory),
+		]);
+		const branchCompletions = getBranchCompletions(branches.map(branch => branch.name), {
+			currentBranch,
+			defaultBranch: defaultBranch?.name,
+			query,
+			limit: BRANCH_COMPLETION_LIMIT,
+		});
 
 		return { items: branchCompletions.map(branch => ({ value: branch, label: branch })) };
 	}

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
@@ -13,24 +13,33 @@ import { EMPTY_TREE_OBJECT, getBranchCompletions, resolveDiffBaseBranchName } fr
 suite('AgentHostGitService', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('sorts common branch names to the top before applying limit', () => {
+	test('sorts the current and default branches before recent branches and applying the limit', () => {
 		assert.deepStrictEqual(
-			getBranchCompletions(['feature/recent', 'release', 'master', 'main', 'feature/older'], { limit: 3 }),
-			['main', 'master', 'feature/recent'],
+			getBranchCompletions(
+				['feature/recent', 'dev', 'feature/current', 'main', 'feature/older'],
+				{ currentBranch: 'feature/current', defaultBranch: 'dev', limit: 3 },
+			),
+			['feature/current', 'dev', 'feature/recent'],
 		);
 	});
 
-	test('preserves git order for non-common branches', () => {
+	test('preserves git order for branches other than the current and default branches', () => {
 		assert.deepStrictEqual(
-			getBranchCompletions(['feature/recent', 'release', 'feature/older']),
+			getBranchCompletions(
+				['feature/recent', 'release', 'feature/older'],
+				{ currentBranch: 'other', defaultBranch: 'main' },
+			),
 			['feature/recent', 'release', 'feature/older'],
 		);
 	});
 
-	test('filters before sorting common branch names', () => {
+	test('filters before prioritizing the current and default branches', () => {
 		assert.deepStrictEqual(
-			getBranchCompletions(['feature/recent', 'master', 'main', 'maintenance'], { query: 'ma' }),
-			['main', 'master', 'maintenance'],
+			getBranchCompletions(
+				['feature/recent', 'maintenance', 'main', 'feature/current'],
+				{ currentBranch: 'feature/current', defaultBranch: 'maintenance', query: 'ma' },
+			),
+			['maintenance', 'main'],
 		);
 	});
 

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -166,13 +166,13 @@ suite('WorktreeIsolation', () => {
 		});
 	});
 
-	test('branchCompletions returns git branches, empty without a working directory', async () => {
+	test('branchCompletions returns current then default then recent git branches, empty without a working directory', async () => {
 		const isolation = createIsolation(disposables);
 		assert.deepStrictEqual({
 			withDir: await isolation.branchCompletions(repoRoot),
 			noDir: await isolation.branchCompletions(undefined),
 		}, {
-			withDir: { items: [{ value: 'main', label: 'main' }, { value: 'feature', label: 'feature' }] },
+			withDir: { items: [{ value: 'feature', label: 'feature' }, { value: 'main', label: 'main' }] },
 			noDir: { items: [] },
 		});
 	});


### PR DESCRIPTION
This pull request improves the ordering of branches in the branch picker of the agent host. The new order prioritizes the current branch first, followed by the repository's default branch (e.g., `main`, `dev`), and then lists the remaining branches based on their recent commit dates. 

### Changes made:
- Updated the branch ordering logic in `agentHostGitService.ts` to implement the new prioritization.
- Modified `worktreeIsolation.ts` to ensure the completion logic aligns with the new branch ordering.
- Added tests in `agentHostGitService.test.ts` to validate the new ordering behavior.
- Adjusted existing tests in `worktreeIsolation.test.ts` to accommodate the changes.

Validation has been completed successfully with all tests passing.