### PR TITLE
Fix banner notification display in agents window

### DIFF
--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
@@ -21,8 +21,8 @@ const MAIN_AGENT_BYOK_UTILITY_MODEL_DEFAULT = 'mainAgent';
  * settings are still defaults. Some utility flows are unavailable until the
  * user points them at a BYOK model or selects the main agent model as the BYOK utility default.
  *
- * The notification hides automatically once the user signs in, BYOK models
- * disappear, both utility settings are configured, or the main agent model is the BYOK utility default.
+ * The notification is not shown in the Agents window. Elsewhere, it hides automatically once the user
+ * signs in, BYOK models disappear, both utility settings are configured, or the main agent model is the BYOK utility default.
  */
 export class ByokUtilityModelNotificationContribution extends Disposable {
 
@@ -36,6 +36,10 @@ export class ByokUtilityModelNotificationContribution extends Disposable {
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
+
+		if (vscode.workspace.isAgentSessionsWorkspace) {
+			return;
+		}
 
 		this._register(this._authService.onDidAuthenticationChange(() => this._update()));
 		this._register(vscode.lm.onDidChangeChatModels(() => this._update()));

--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/test/byokUtilityModel.contribution.spec.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/test/byokUtilityModel.contribution.spec.ts
@@ -25,6 +25,7 @@ const mockNotification = {
 
 const onDidChangeChatModelsEmitter = new Emitter<void>();
 const selectChatModelsMock = vi.fn();
+const mockWorkspace = vi.hoisted(() => ({ isAgentSessionsWorkspace: false }));
 
 vi.mock('vscode', () => ({
 	ChatInputNotificationSeverity: { Info: 1 },
@@ -36,6 +37,7 @@ vi.mock('vscode', () => ({
 		selectChatModels: (...args: unknown[]) => selectChatModelsMock(...args),
 	},
 	l10n: { t: (str: string, ...args: unknown[]) => str.replace(/\{(\d+)\}/g, (_, i) => String(args[Number(i)])) },
+	workspace: mockWorkspace,
 }));
 
 import { ByokUtilityModelNotificationContribution } from '../byokUtilityModel.contribution';
@@ -97,6 +99,7 @@ describe('ByokUtilityModelNotificationContribution', () => {
 		mockNotification.message = '';
 		mockNotification.description = '';
 		mockNotification.actions = [];
+		mockWorkspace.isAgentSessionsWorkspace = false;
 		selectChatModelsMock.mockResolvedValue([{ vendor: 'ollama', id: 'llama3' }]);
 	});
 
@@ -117,6 +120,18 @@ describe('ByokUtilityModelNotificationContribution', () => {
 		expect(mockNotification.actions).toHaveLength(1);
 		expect(mockNotification.actions[0].commandId).toBe('workbench.action.openSettings');
 		expect(mockNotification.actions[0].commandArgs).toEqual(['chat.byokUtilityModelDefault']);
+	});
+
+	test('does not show notification in the Agents window', async () => {
+		mockWorkspace.isAgentSessionsWorkspace = true;
+		const { authService } = createAuthService({ anyGitHubSession: undefined });
+		const { configService } = createConfigService();
+		contribution = new ByokUtilityModelNotificationContribution(authService, configService, noopLog);
+
+		await flushAsync();
+
+		expect(mockNotification.show).not.toHaveBeenCalled();
+		expect(selectChatModelsMock).not.toHaveBeenCalled();
 	});
 
 	test('shows notification with single action when only chat.utilityModel is unset', async () => {


### PR DESCRIPTION
This pull request addresses the issue of the BYOK utility-model banner notification appearing in the agents window when users are not signed in. The changes made include:

- **Modification of Banner Behavior**: The banner is now suppressed when the `workspace.isAgentSessionsWorkspace` condition is true, ensuring it does not display in the agents window.
- **Regression Test Addition**: A focused regression test has been added to verify the new behavior, ensuring that the fix is properly validated.

All tests have passed successfully, and the code adheres to hygiene and whitespace standards.