### PR TITLE
Auto-open model picker in session onboarding

### DIFF
--- a/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewV2Tour.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewV2Tour.ts
@@ -54,7 +54,7 @@ const newSessionViewV2Payload: ISpotlightPayload = {
 			description: localize('sessions.onboarding.newSessionViewV2.model.description', "The model powers your agent's reasoning. Choose one based on the balance of speed and capability your task needs."),
 			placement: 'below',
 			missingTarget: WAIT_FOR_PICKER,
-			openTarget: false,
+			openTarget: true,
 			allowTargetInteraction: true,
 		},
 	],

--- a/src/vs/sessions/contrib/onboardingTours/test/browser/newSessionViewV2Tour.test.ts
+++ b/src/vs/sessions/contrib/onboardingTours/test/browser/newSessionViewV2Tour.test.ts
@@ -62,7 +62,7 @@ suite('NewSessionViewV2Tour', () => {
 					id: 'modelPicker',
 					targetId: 'sessions.newSession.modelPicker',
 					missingTarget: { kind: 'wait', timeoutMs: 5_000 },
-					openTarget: false,
+					openTarget: true,
 					allowTargetInteraction: true,
 					advanceWhenWorkspaceSelected: false,
 				},


### PR DESCRIPTION
## Summary
- auto-open the model picker during the session view v2 onboarding tour
- keep the harness picker closed and preserve workspace picker auto-open behavior
- update the focused tour expectation

## Testing
- Not run (per request)