### PR TITLE
fix(linux): convert StartupWMClass template values to lowercase

### DIFF
--- a/build/gulpfile.vscode.linux.ts
+++ b/build/gulpfile.vscode.linux.ts
@@ -49,7 +49,7 @@ function prepareDebPackage(arch: string) {
 
 		const desktops = es.merge(desktop, desktopUrlHandler)
 			.pipe(replace('@@NAME_LONG@@', product.nameLong))
-			.pipe(replace('@@NAME_SHORT@@', product.nameShort.toLowerCase().replace(/ /g, '-')))
+			.pipe(replace('@@NAME_SHORT@@', product.applicationName))
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(replace('@@EXEC@@', `/usr/share/${product.applicationName}/${product.applicationName}`))
 			.pipe(replace('@@ICON@@', product.linuxIconName))

--- a/build/gulpfile.vscode.linux.ts
+++ b/build/gulpfile.vscode.linux.ts
@@ -49,7 +49,7 @@ function prepareDebPackage(arch: string) {
 
 		const desktops = es.merge(desktop, desktopUrlHandler)
 			.pipe(replace('@@NAME_LONG@@', product.nameLong))
-			.pipe(replace('@@NAME_SHORT@@', product.nameShort))
+			.pipe(replace('@@NAME_SHORT@@', product.nameShort.toLowerCase().replace(/ /g, '-')))
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(replace('@@EXEC@@', `/usr/share/${product.applicationName}/${product.applicationName}`))
 			.pipe(replace('@@ICON@@', product.linuxIconName))
@@ -159,7 +159,7 @@ function prepareRpmPackage(arch: string) {
 
 		const desktops = es.merge(desktop, desktopUrlHandler)
 			.pipe(replace('@@NAME_LONG@@', product.nameLong))
-			.pipe(replace('@@NAME_SHORT@@', product.nameShort))
+			.pipe(replace('@@NAME_SHORT@@', product.nameShort.toLowerCase().replace(/ /g, '-')))
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(replace('@@EXEC@@', `/usr/share/${product.applicationName}/${product.applicationName}`))
 			.pipe(replace('@@ICON@@', product.linuxIconName))
@@ -246,7 +246,7 @@ function prepareSnapPackage(arch: string) {
 
 		const desktops = es.merge(desktop, desktopUrlHandler)
 			.pipe(replace('@@NAME_LONG@@', product.nameLong))
-			.pipe(replace('@@NAME_SHORT@@', product.nameShort))
+			.pipe(replace('@@NAME_SHORT@@', product.nameShort.toLowerCase().replace(/ /g, '-')))
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(replace('@@EXEC@@', `${product.applicationName} --force-user-env`))
 			.pipe(replace('@@ICON@@', `\${SNAP}/meta/gui/${product.linuxIconName}.png`))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Linux .deb installer creates duplicate desktop shortcuts leading to startup crash loops and orphaned crashpad handlers on Ubuntu MATE
 #327088

When VS Code or VS Code Insiders compiles on Linux, it sets StartupWMClass using standard camel-case names, but the underlying runtime engine launches as low-case code or code-insiders, breaking taskbar icon-grouping window mappings on Linux panels like Ubuntu MATE.

Whenever a new version of code or code-insiders is downloaded for me, it opens up the URL handler desktop instead of the main desktop.  With this change, it should no longer happen.  I've gone into the code.desktop / code-insiders.desktop folder and updated it to code or code-insiders and it no longer exhibits that behaviour.
