### PR TITLE
Condense the chat model selection logic

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -180,7 +180,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		this._rememberedSelection = rememberedModelId ? { modelId: rememberedModelId, reason: ModelSelectionReason.Remembered } : undefined;
 		// One catalog snapshot for the whole decision, so the fallback we fall back *to* is the
 		// same one the precedence rules were evaluated against.
-		const models = this._runtime.getModels(this._runtime.getCurrentSessionType());
+		const models = this._selectablePool(this._runtime.getCurrentSessionType());
 		const fallbackModel = findDefaultModel(models, this._runtime.location);
 		// `chat.defaultModel` seeds new conversations only; a conversation with history keeps
 		// the model it was started with.
@@ -319,7 +319,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (!configuredValue) {
 			return false;
 		}
-		const configuredModel = resolveConfiguredModel(configuredValue, this._runtime.getModels(this._runtime.getCurrentSessionType()));
+		const configuredModel = resolveConfiguredModel(configuredValue, this._selectablePool(this._runtime.getCurrentSessionType()));
 		if (!configuredModel) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -8,7 +8,7 @@ import { IObservable, observableValue } from '../../../../../../base/common/obse
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../common/languageModels.js';
 import { InitialModelSelectionResult, isInConversationModelChoice, ModelIdentifierResolution, ModelSelectionApplyReason, ModelSelectionReason, resolveConfiguredModel, resolveInitialModelSelection, resolveModelIdentifier } from '../../../common/modelSelection.js';
-import { findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelSupportedForInlineChat, isModelSupportedForMode, isModelValidForSession, resolveModelFromSyncState, shouldDropAgnosticDraftModel, shouldResetModelToDefault, shouldResetOnModelListChange, shouldWaitForSessionModel } from './chatInputModelUtils.js';
+import { findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelSupportedForInlineChat, isModelSupportedForMode, resolveModelFromSyncState, shouldDropAgnosticDraftModel, shouldResetModelToDefault, shouldResetOnModelListChange, shouldWaitForSessionModel } from './chatInputModelUtils.js';
 import { IChatModelSelectionDiagnostics, NullChatModelSelectionDiagnostics } from './chatModelSelectionDiagnostics.js';
 
 /** Supplies Workbench chat's filtered model catalog and conversation effects. */
@@ -49,12 +49,9 @@ export class ChatInputModelSelectionController extends Disposable {
 	private _restorePerTypeModel = false;
 	/**
 	 * The model the user is meant to be on, independent of what the catalog can currently offer,
-	 * together with the authority that put them there. Seeded from persisted storage by
-	 * {@link initialize} and updated by every deliberate choice (explicit pick, programmatic
-	 * selection, session restore). Falling back to a default because the catalog dropped the model
-	 * is a display state, not a decision, so it deliberately leaves this untouched — see
-	 * {@link _restoreRememberedModel}. The reason is retained so a restore reinstates the original
-	 * authority rather than downgrading an explicit pick to a mere remembered one.
+	 * with the authority that put them there. Seeded from storage by {@link initialize} and updated
+	 * by every deliberate choice. Falling back to a default because the catalog dropped the model
+	 * is a display state, not a decision, so it deliberately leaves this untouched.
 	 */
 	private _rememberedSelection: { readonly modelId: string; readonly reason: ModelSelectionApplyReason } | undefined;
 
@@ -85,16 +82,15 @@ export class ChatInputModelSelectionController extends Disposable {
 		this._restorePerTypeModel = false;
 	}
 
-	hasPendingIntent(): boolean {
-		return !!this._intent;
-	}
-
 	/**
-	 * True while the remembered model is not selectable, i.e. whatever is currently selected is a
-	 * stand-in that {@link _restoreRememberedModel} will replace once the catalog offers the real
-	 * one. Callers use this to avoid acting on a selection that is about to change.
+	 * True while the selection is provisional — either an async intent is pending, or the
+	 * remembered model is not selectable and whatever is shown is standing in for it. Callers use
+	 * this to avoid acting on a selection that is about to change.
 	 */
-	isAwaitingRememberedModel(): boolean {
+	isAwaitingModel(): boolean {
+		if (this._intent) {
+			return true;
+		}
 		const modelId = this._rememberedSelection?.modelId;
 		return !!modelId && !this._selectablePool(this._runtime.getCurrentSessionType()).some(model => model.identifier === modelId);
 	}
@@ -210,16 +206,15 @@ export class ChatInputModelSelectionController extends Disposable {
 	ensureCurrentModelSupported(): void {
 		const currentModel = this._currentModel.get();
 		const sessionType = this._runtime.getCurrentSessionType();
-		const models = this._runtime.getModels(sessionType);
-		const context = {
-			location: this._runtime.location,
-			currentModeKind: this._runtime.getCurrentModeKind(),
-			sessionType,
-		};
-		const willReset = shouldResetModelToDefault(currentModel, models, context, this._runtime.getAllModels());
+		const currentModeKind = this._runtime.getCurrentModeKind();
+		const willReset = shouldResetModelToDefault(
+			currentModel,
+			this._runtime.getModels(sessionType),
+			{ location: this._runtime.location, currentModeKind, sessionType },
+			this._runtime.getAllModels());
 		this._diagnostics.report('compatibility-check', {
 			currentModel: currentModel?.identifier,
-			mode: context.currentModeKind,
+			mode: currentModeKind,
 			sessionType,
 			willReset,
 		}, willReset ? 'info' : 'debug');
@@ -229,11 +224,10 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	/**
-	 * The pool to choose a replacement from. {@link filterModelsForSession} only applies mode and
-	 * inline-chat filtering to the general pool, so a targeted session pool can still offer models
-	 * the current mode cannot use — including the one being replaced. Prefer the usable subset, but
-	 * fall back to the raw pool rather than selecting nothing when a provider advertises no usable
-	 * model at all.
+	 * The pool to select from. {@link filterModelsForSession} only applies mode and inline-chat
+	 * filtering to the general pool, so a targeted session pool can still offer models the current
+	 * mode cannot use — including one being replaced *because* it is unusable. Falls back to the
+	 * raw pool rather than selecting nothing when a provider declares no capabilities at all.
 	 */
 	private _selectablePool(sessionType: string | undefined): ILanguageModelChatMetadataAndIdentifier[] {
 		const models = this._runtime.getModels(sessionType);
@@ -244,13 +238,10 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	/**
-	 * Replaces a selection that is no longer valid, applying the precedence every such path shares:
-	 * the remembered selection if the catalog can offer it, else the closest match for what was
-	 * displaced, else the default.
-	 *
-	 * The callers differ only in *why* the current model stopped being valid — unsupported for the
-	 * mode, outside the session pool, withdrawn from the catalog. Routing them all through here
-	 * keeps that difference from turning into a difference in what replaces it.
+	 * Replaces a selection that is no longer valid. The callers differ only in *why* the model
+	 * stopped being valid — unsupported for the mode, outside the session pool, withdrawn from the
+	 * catalog — and routing them all through here keeps that from turning into a difference in
+	 * what replaces it.
 	 */
 	private _replaceInvalidSelection(
 		displaced: ILanguageModelChatMetadataAndIdentifier | undefined,
@@ -356,12 +347,10 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	/**
-	 * Reclaims the remembered model whenever the catalog can offer it again. A model can leave the
-	 * pool for reasons that have nothing to do with intent — an agent host that restarts drops its
-	 * whole catalog and republishes it moments later — and the default we show meanwhile is a
-	 * stand-in, not a decision. Every deliberate choice updates {@link _rememberedSelection}, so a
-	 * current model that differs from it is always a stand-in of some kind and may be superseded.
-	 * `chat.defaultModel` outranks a merely remembered model, but never an in-conversation choice,
+	 * Reclaims the remembered model once the catalog can offer it again. A model can leave the pool
+	 * for reasons that have nothing to do with intent — an agent host restarting republishes its
+	 * catalog moments later — so the default shown meanwhile is a stand-in, not a decision.
+	 * `chat.defaultModel` outranks a merely remembered model but never an in-conversation choice,
 	 * which is why the displaced authority is restored along with the model.
 	 */
 	private _restoreRememberedModel(): boolean {
@@ -423,17 +412,6 @@ export class ChatInputModelSelectionController extends Disposable {
 		} else {
 			this._clearIntent();
 			this.selectDefault(sessionType);
-		}
-	}
-
-	/**
-	 * Validate that the current model belongs to the current session's pool.
-	 * Called when switching sessions to prevent cross-contamination.
-	 */
-	ensureCurrentModelInSessionPool(): void {
-		const currentModel = this._currentModel.get();
-		if (currentModel && !isModelValidForSession(currentModel, this._runtime.getAllModels(), this._runtime.getCurrentSessionType())) {
-			this._replaceInvalidSelection(currentModel, this._runtime.getCurrentSessionType());
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -75,10 +75,6 @@ export class ChatInputModelSelectionController extends Disposable {
 		return this._selectionReason;
 	}
 
-	get userExplicitlySelectedModel(): boolean {
-		return this._selectionReason === ModelSelectionReason.UserSelection;
-	}
-
 	beginSessionSwitch(isEmpty: boolean, ownsPool: boolean, hadIncomingModel: boolean): void {
 		this._selectionReason = undefined;
 		this._restorePerTypeModel = isEmpty && ownsPool && !hadIncomingModel;
@@ -385,6 +381,10 @@ export class ChatInputModelSelectionController extends Disposable {
 		}
 	}
 
+	/**
+	 * Validate that the current model belongs to the current session's pool.
+	 * Called when switching sessions to prevent cross-contamination.
+	 */
 	ensureCurrentModelInSessionPool(): void {
 		const currentModel = this._currentModel.get();
 		if (currentModel && !isModelValidForSession(currentModel, this._runtime.getAllModels(), this._runtime.getCurrentSessionType())) {
@@ -392,6 +392,10 @@ export class ChatInputModelSelectionController extends Disposable {
 		}
 	}
 
+	/**
+	 * Reconcile the current model after an explicit session-type pick: restore persisted →
+	 * best-match previous → default.
+	 */
 	revalidateForSessionType(initialize: () => void): void {
 		const previousModel = this._currentModel.get();
 		this._selectionReason = undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -8,7 +8,7 @@ import { IObservable, observableValue } from '../../../../../../base/common/obse
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../common/languageModels.js';
 import { InitialModelSelectionResult, isInConversationModelChoice, ModelIdentifierResolution, ModelSelectionApplyReason, ModelSelectionReason, resolveConfiguredModel, resolveInitialModelSelection, resolveModelIdentifier } from '../../../common/modelSelection.js';
-import { findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelValidForSession, resolveModelFromSyncState, shouldDropAgnosticDraftModel, shouldResetModelToDefault, shouldResetOnModelListChange, shouldWaitForSessionModel } from './chatInputModelUtils.js';
+import { findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelSupportedForInlineChat, isModelSupportedForMode, isModelValidForSession, resolveModelFromSyncState, shouldDropAgnosticDraftModel, shouldResetModelToDefault, shouldResetOnModelListChange, shouldWaitForSessionModel } from './chatInputModelUtils.js';
 import { IChatModelSelectionDiagnostics, NullChatModelSelectionDiagnostics } from './chatModelSelectionDiagnostics.js';
 
 /** Supplies Workbench chat's filtered model catalog and conversation effects. */
@@ -178,37 +178,32 @@ export class ChatInputModelSelectionController extends Disposable {
 		// Storage records only explicit picks, but it is not an in-conversation choice: a new
 		// conversation still lets `chat.defaultModel` take precedence over it.
 		this._rememberedSelection = rememberedModelId ? { modelId: rememberedModelId, reason: ModelSelectionReason.Remembered } : undefined;
-		const resolveSelection = (): InitialModelSelectionResult => {
-			const configuredModelValue = this._runtime.getConfiguredModelValue();
-			const models = this._runtime.getModels(this._runtime.getCurrentSessionType());
-			// `chat.defaultModel` seeds new conversations only; a conversation with history keeps
-			// the model it was started with.
-			const configuredModel = this._runtime.isEmpty() ? resolveConfiguredModel(configuredModelValue, models) : undefined;
-			const resolution = resolveModelIdentifier(models, rememberedModelId, false);
-			return resolveInitialModelSelection({
-				configuredModel,
-				desiredModelResolution: resolution,
-				desiredReason: ModelSelectionReason.Remembered,
-				fallbackModel: findDefaultModel(models, this._runtime.location),
-				fallbackReason: ModelSelectionReason.FirstAvailable,
-			});
-		};
+		// One catalog snapshot for the whole decision, so the fallback we fall back *to* is the
+		// same one the precedence rules were evaluated against.
+		const models = this._runtime.getModels(this._runtime.getCurrentSessionType());
+		const fallbackModel = findDefaultModel(models, this._runtime.location);
+		// `chat.defaultModel` seeds new conversations only; a conversation with history keeps
+		// the model it was started with.
+		const configuredModel = this._runtime.isEmpty() ? resolveConfiguredModel(this._runtime.getConfiguredModelValue(), models) : undefined;
+		const selection = resolveInitialModelSelection({
+			configuredModel,
+			desiredModelResolution: resolveModelIdentifier(models, rememberedModelId, false),
+			desiredReason: ModelSelectionReason.Remembered,
+			fallbackModel,
+			fallbackReason: ModelSelectionReason.FirstAvailable,
+		});
 
-		const selection = resolveSelection();
 		onInitialSelection(selection);
 		this._reportInitialization(this._runtime.getConfiguredModelValue(), rememberedModelId, selection);
 		if (selection.kind === 'apply') {
 			this._selectionReason = selection.reason;
 			this._applyModel(selection.model);
 			this.ensureCurrentModelSupported();
-		} else if (selection.kind === 'pending') {
+		} else if (selection.kind === 'pending' && fallbackModel) {
 			// The remembered model isn't in the catalog yet. Show the default meanwhile;
 			// `_restoreRememberedModel` claims the real one as soon as it is published.
-			const fallbackModel = findDefaultModel(this._runtime.getModels(this._runtime.getCurrentSessionType()), this._runtime.location);
-			if (fallbackModel) {
-				this._selectionReason = ModelSelectionReason.FirstAvailable;
-				this._applyModel(fallbackModel);
-			}
+			this._selectionReason = ModelSelectionReason.FirstAvailable;
+			this._applyModel(fallbackModel);
 		}
 	}
 
@@ -234,6 +229,21 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	/**
+	 * The pool to choose a replacement from. {@link filterModelsForSession} only applies mode and
+	 * inline-chat filtering to the general pool, so a targeted session pool can still offer models
+	 * the current mode cannot use — including the one being replaced. Prefer the usable subset, but
+	 * fall back to the raw pool rather than selecting nothing when a provider advertises no usable
+	 * model at all.
+	 */
+	private _selectablePool(sessionType: string | undefined): ILanguageModelChatMetadataAndIdentifier[] {
+		const models = this._runtime.getModels(sessionType);
+		const selectable = models.filter(model =>
+			isModelSupportedForMode(model, this._runtime.getCurrentModeKind())
+			&& isModelSupportedForInlineChat(model, this._runtime.location));
+		return selectable.length > 0 ? selectable : models;
+	}
+
+	/**
 	 * Replaces a selection that is no longer valid, applying the precedence every such path shares:
 	 * the remembered selection if the catalog can offer it, else the closest match for what was
 	 * displaced, else the default.
@@ -249,7 +259,8 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (this._restoreRememberedModel()) {
 			return;
 		}
-		const match = findBestMatchingModel(displaced, this._runtime.getModels(sessionType));
+		const candidates = this._selectablePool(sessionType).filter(model => model.identifier !== displaced?.identifier);
+		const match = findBestMatchingModel(displaced, candidates);
 		if (match) {
 			this._applyModel(match);
 			return;
@@ -262,7 +273,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (sessionType && this._runtime.requiresCustomModels(sessionType) && !hasModelsTargetingSession(allModels, sessionType)) {
 			return;
 		}
-		const models = this._runtime.getModels(sessionType);
+		const models = this._selectablePool(sessionType);
 		const configuredModel = resolveConfiguredModel(this._runtime.getConfiguredModelValue(), models);
 		const defaultModel = configuredModel ?? findDefaultModel(models, this._runtime.location);
 		this._diagnostics.report('select-default', {
@@ -277,6 +288,17 @@ export class ChatInputModelSelectionController extends Disposable {
 			this._selectionReason = configuredModel ? ModelSelectionReason.ConfiguredDefault : ModelSelectionReason.FirstAvailable;
 		}
 		this._applyModel(defaultModel);
+	}
+
+	/**
+	 * Falls back to the default because the user asked for it, as opposed to because the current
+	 * model stopped being valid. That makes it a deliberate choice, so it discards the remembered
+	 * selection: a model that reappears later must not reclaim the input behind the user's back.
+	 */
+	resetToDefault(sessionType = this._runtime.getCurrentSessionType()): void {
+		this._clearIntent();
+		this._rememberedSelection = undefined;
+		this.selectDefault(sessionType);
 	}
 
 	applyConfiguredDefault(): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -52,6 +52,33 @@ export type ModelSelectionRequest =
 	/** A mode or session forced this model. */
 	| { readonly authority: 'programmatic' };
 
+/**
+ * Reasons that represent a decision about which model to be on. Applying a model for one of these
+ * makes it the model to reclaim after an outage.
+ *
+ * Note this is a wider set than {@link isInConversationModelChoice}: a remembered or restored model
+ * is a decision worth reclaiming, but `chat.defaultModel` still outranks it on a new conversation.
+ */
+type DeliberateReason =
+	| ModelSelectionReason.UserSelection
+	| ModelSelectionReason.ProgrammaticSelection
+	| ModelSelectionReason.SessionRestore
+	| ModelSelectionReason.Remembered;
+
+/**
+ * Everything else stands in for a model that cannot currently be offered. `chat.defaultModel` lands
+ * here: it is re-derived from configuration for each new conversation rather than being something
+ * the user chose, so it must never displace what they did choose.
+ */
+type StandInReason = Exclude<ModelSelectionApplyReason, DeliberateReason>;
+
+function isDeliberateReason(reason: ModelSelectionApplyReason): reason is DeliberateReason {
+	return reason === ModelSelectionReason.UserSelection
+		|| reason === ModelSelectionReason.ProgrammaticSelection
+		|| reason === ModelSelectionReason.SessionRestore
+		|| reason === ModelSelectionReason.Remembered;
+}
+
 /** Reconciles the shared selection model with Workbench-specific input and catalog state. */
 export class ChatInputModelSelectionController extends Disposable {
 
@@ -66,7 +93,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	 * by every deliberate choice. Falling back to a default because the catalog dropped the model
 	 * is a display state, not a decision, so it deliberately leaves this untouched.
 	 */
-	private _rememberedSelection: { readonly modelId: string; readonly reason: ModelSelectionApplyReason } | undefined;
+	private _rememberedSelection: { readonly modelId: string; readonly reason: DeliberateReason } | undefined;
 
 	constructor(
 		private readonly _runtime: IChatInputModelSelectionRuntime,
@@ -143,18 +170,9 @@ export class ChatInputModelSelectionController extends Disposable {
 			reason: this._selectionReason,
 			remembered: this._rememberedSelection,
 		};
-		// Authority first: `_currentModel` is observable and notifies synchronously, so setting it
-		// last means no observer can see the new model alongside the previous authority.
-		this._selectionReason = reason;
-		this._rememberedSelection = { modelId: model.identifier, reason };
-		this._currentModel.set(model, undefined);
 		this._diagnostics.report('select', { model: model.identifier, authority: request.authority }, 'info');
 		try {
-			if (request.authority === 'user') {
-				request.effect();
-			} else {
-				this._runtime.applyModel(model);
-			}
+			this._choose(model, reason, request.authority === 'user' ? request.effect : undefined);
 			this._diagnostics.report('select-applied', { model: model.identifier, authority: request.authority }, 'info');
 		} catch (error) {
 			if (request.authority === 'user' && request.rollbackOnError) {
@@ -211,14 +229,16 @@ export class ChatInputModelSelectionController extends Disposable {
 		onInitialSelection(selection);
 		this._reportInitialization(this._runtime.getConfiguredModelValue(), rememberedModelId, selection);
 		if (selection.kind === 'apply') {
-			this._selectionReason = selection.reason;
-			this._applyModel(selection.model);
+			if (isDeliberateReason(selection.reason)) {
+				this._choose(selection.model, selection.reason);
+			} else {
+				this._standIn(selection.model, selection.reason);
+			}
 			this.ensureCurrentModelSupported();
 		} else if (selection.kind === 'pending' && fallbackModel) {
 			// The remembered model isn't in the catalog yet. Show the default meanwhile;
 			// `_restoreRememberedModel` claims the real one as soon as it is published.
-			this._selectionReason = ModelSelectionReason.FirstAvailable;
-			this._applyModel(fallbackModel);
+			this._standIn(fallbackModel, ModelSelectionReason.FirstAvailable);
 		}
 	}
 
@@ -272,7 +292,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		const candidates = this._selectablePool(sessionType).filter(model => model.identifier !== displaced?.identifier);
 		const match = findBestMatchingModel(displaced, candidates);
 		if (match) {
-			this._applyModel(match);
+			this._standIn(match, ModelSelectionReason.FirstAvailable);
 			return;
 		}
 		this.selectDefault(sessionType);
@@ -294,10 +314,13 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (!defaultModel) {
 			return;
 		}
-		if (!this.hasPendingProgrammaticSelection()) {
-			this._selectionReason = configuredModel ? ModelSelectionReason.ConfiguredDefault : ModelSelectionReason.FirstAvailable;
+		if (this.hasPendingProgrammaticSelection()) {
+			// A pending request still owns the authority; the default is only what is shown meanwhile.
+			this._currentModel.set(defaultModel, undefined);
+			this._runtime.applyModel(defaultModel);
+			return;
 		}
-		this._applyModel(defaultModel);
+		this._standIn(defaultModel, configuredModel ? ModelSelectionReason.ConfiguredDefault : ModelSelectionReason.FirstAvailable);
 	}
 
 	/**
@@ -340,8 +363,7 @@ export class ChatInputModelSelectionController extends Disposable {
 			}
 			return false;
 		}
-		this._selectionReason = ModelSelectionReason.ConfiguredDefault;
-		this._applyModel(configuredModel);
+		this._standIn(configuredModel, ModelSelectionReason.ConfiguredDefault);
 		this.ensureCurrentModelSupported();
 		return true;
 	}
@@ -356,7 +378,7 @@ export class ChatInputModelSelectionController extends Disposable {
 			&& this._selectionReason === ModelSelectionReason.FirstAvailable
 			&& locationDefault
 			&& currentModel?.identifier !== locationDefault.identifier) {
-			this._applyModel(locationDefault);
+			this._standIn(locationDefault, ModelSelectionReason.FirstAvailable);
 			return;
 		}
 		if (!shouldResetOnModelListChange(currentModel?.identifier, [...models])) {
@@ -387,8 +409,7 @@ export class ChatInputModelSelectionController extends Disposable {
 			return false;
 		}
 		this._diagnostics.report('restore-remembered-model', { model: remembered.modelId, reason: remembered.reason }, 'info');
-		this._selectionReason = remembered.reason;
-		this._applyModel(model);
+		this._choose(model, remembered.reason);
 		return true;
 	}
 
@@ -469,9 +490,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		};
 		const match = tryMatch();
 		if (match) {
-			this._selectionReason = ModelSelectionReason.SessionRestore;
-			this._rememberedSelection = { modelId: match.identifier, reason: ModelSelectionReason.SessionRestore };
-			this._applyModel(match);
+			this._choose(match, ModelSelectionReason.SessionRestore);
 			return;
 		}
 		this._intent = { kind: 'history', modelId, conversationKey };
@@ -499,14 +518,16 @@ export class ChatInputModelSelectionController extends Disposable {
 		configuration?: { readonly modelId: string; readonly configuration: Record<string, unknown> | undefined },
 	): void {
 		this._clearIntent();
-		this._selectionReason = ModelSelectionReason.SessionRestore;
-		this._rememberedSelection = { modelId: model.identifier, reason: ModelSelectionReason.SessionRestore };
+		// Configuration must be restored before the model is applied, so anything reacting to the
+		// new model already sees its settings.
 		if (configuration) {
 			this._runtime.restoreModelConfiguration(configuration.modelId, configuration.configuration);
 		}
 		if (applyModel) {
-			this._applyModel(model);
+			this._choose(model, ModelSelectionReason.SessionRestore);
+			return;
 		}
+		this._rememberChoice(model, ModelSelectionReason.SessionRestore);
 	}
 
 	private _reconcileIntent(): boolean {
@@ -563,9 +584,7 @@ export class ChatInputModelSelectionController extends Disposable {
 			?? models.find(model => model.metadata.id === intent.modelId);
 		if (model && !(models.length === 1 && model.metadata.id.toLocaleLowerCase() === 'auto')) {
 			this._intent = undefined;
-			this._selectionReason = ModelSelectionReason.SessionRestore;
-			this._rememberedSelection = { modelId: model.identifier, reason: ModelSelectionReason.SessionRestore };
-			this._applyModel(model);
+			this._choose(model, ModelSelectionReason.SessionRestore);
 			return true;
 		}
 		return false;
@@ -582,7 +601,37 @@ export class ChatInputModelSelectionController extends Disposable {
 		}
 	}
 
-	private _applyModel(model: ILanguageModelChatMetadataAndIdentifier): void {
+	/**
+	 * Records a decision without changing what is displayed — used when the model is already
+	 * shown and only its authority needs to catch up.
+	 */
+	private _rememberChoice(model: ILanguageModelChatMetadataAndIdentifier, reason: DeliberateReason): void {
+		this._selectionReason = reason;
+		this._rememberedSelection = { modelId: model.identifier, reason };
+	}
+
+	/**
+	 * Applies a model as a decision: it becomes both what is displayed and what is reclaimed once
+	 * the catalog can offer it again.
+	 */
+	private _choose(
+		model: ILanguageModelChatMetadataAndIdentifier,
+		reason: DeliberateReason,
+		effect: () => void = () => this._runtime.applyModel(model),
+	): void {
+		// Authority before display: `_currentModel` notifies synchronously, so an observer must
+		// never see the new model alongside the previous authority.
+		this._rememberChoice(model, reason);
+		this._currentModel.set(model, undefined);
+		effect();
+	}
+
+	/**
+	 * Applies a model as a stand-in for one that cannot currently be offered. Deliberately leaves
+	 * the remembered selection alone — that is what makes the fallback temporary.
+	 */
+	private _standIn(model: ILanguageModelChatMetadataAndIdentifier, reason: StandInReason): void {
+		this._selectionReason = reason;
 		this._currentModel.set(model, undefined);
 		this._runtime.applyModel(model);
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -7,7 +7,7 @@ import { Disposable, IDisposable, toDisposable } from '../../../../../../base/co
 import { IObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../common/languageModels.js';
-import { InitialModelSelectionResult, ModelIdentifierResolution, ModelSelectionApplyReason, ModelSelectionReason, resolveConfiguredModel, resolveInitialModelSelection, resolveModelIdentifier } from '../../../common/modelSelection.js';
+import { InitialModelSelectionResult, isInConversationModelChoice, ModelIdentifierResolution, ModelSelectionApplyReason, ModelSelectionReason, resolveConfiguredModel, resolveInitialModelSelection, resolveModelIdentifier } from '../../../common/modelSelection.js';
 import { findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelValidForSession, resolveModelFromSyncState, shouldDropAgnosticDraftModel, shouldResetModelToDefault, shouldResetOnModelListChange, shouldWaitForSessionModel } from './chatInputModelUtils.js';
 import { IChatModelSelectionDiagnostics, NullChatModelSelectionDiagnostics } from './chatModelSelectionDiagnostics.js';
 
@@ -48,13 +48,15 @@ export class ChatInputModelSelectionController extends Disposable {
 	private _intent: ModelSelectionIntent | undefined;
 	private _restorePerTypeModel = false;
 	/**
-	 * The model the user is meant to be on, independent of what the catalog can currently offer.
-	 * Seeded from persisted storage by {@link initialize} and updated by every deliberate choice
-	 * (explicit pick, programmatic selection, session restore). Falling back to a default because
-	 * the catalog dropped the model is a display state, not a decision, so it deliberately leaves
-	 * this untouched — see {@link _restoreRememberedModel}.
+	 * The model the user is meant to be on, independent of what the catalog can currently offer,
+	 * together with the authority that put them there. Seeded from persisted storage by
+	 * {@link initialize} and updated by every deliberate choice (explicit pick, programmatic
+	 * selection, session restore). Falling back to a default because the catalog dropped the model
+	 * is a display state, not a decision, so it deliberately leaves this untouched — see
+	 * {@link _restoreRememberedModel}. The reason is retained so a restore reinstates the original
+	 * authority rather than downgrading an explicit pick to a mere remembered one.
 	 */
-	private _rememberedModelId: string | undefined;
+	private _rememberedSelection: { readonly modelId: string; readonly reason: ModelSelectionApplyReason } | undefined;
 
 	constructor(
 		private readonly _runtime: IChatInputModelSelectionRuntime,
@@ -97,7 +99,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	 * one. Callers use this to avoid acting on a selection that is about to change.
 	 */
 	isAwaitingRememberedModel(): boolean {
-		const modelId = this._rememberedModelId;
+		const modelId = this._rememberedSelection?.modelId;
 		return !!modelId && !this._runtime.getModels(this._runtime.getCurrentSessionType()).some(model => model.identifier === modelId);
 	}
 
@@ -123,10 +125,10 @@ export class ChatInputModelSelectionController extends Disposable {
 		this._clearIntent();
 		const previousModel = this._currentModel.get();
 		const previousReason = this._selectionReason;
-		const previousRememberedModelId = this._rememberedModelId;
+		const previousRememberedSelection = this._rememberedSelection;
 		this._currentModel.set(model, undefined);
 		this._selectionReason = ModelSelectionReason.UserSelection;
-		this._rememberedModelId = model.identifier;
+		this._rememberedSelection = { modelId: model.identifier, reason: ModelSelectionReason.UserSelection };
 		this._diagnostics.report('explicit-selection', { model: model.identifier }, 'info');
 		try {
 			apply();
@@ -135,7 +137,7 @@ export class ChatInputModelSelectionController extends Disposable {
 			if (rollbackOnError) {
 				this._currentModel.set(previousModel, undefined);
 				this._selectionReason = previousReason;
-				this._rememberedModelId = previousRememberedModelId;
+				this._rememberedSelection = previousRememberedSelection;
 			}
 			this._diagnostics.report('explicit-selection-failed', { model: model.identifier, error: String(error) }, 'error');
 			throw error;
@@ -150,7 +152,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	applyProgrammaticSelection(model: ILanguageModelChatMetadataAndIdentifier): void {
 		this._clearIntent();
 		this._selectionReason = ModelSelectionReason.ProgrammaticSelection;
-		this._rememberedModelId = model.identifier;
+		this._rememberedSelection = { modelId: model.identifier, reason: ModelSelectionReason.ProgrammaticSelection };
 		this._applyModel(model);
 	}
 
@@ -177,7 +179,9 @@ export class ChatInputModelSelectionController extends Disposable {
 
 	initialize(rememberedModelId: string | undefined, onInitialSelection: (selection: InitialModelSelectionResult) => void): void {
 		this._clearIntent();
-		this._rememberedModelId = rememberedModelId;
+		// Storage records only explicit picks, but it is not an in-conversation choice: a new
+		// conversation still lets `chat.defaultModel` take precedence over it.
+		this._rememberedSelection = rememberedModelId ? { modelId: rememberedModelId, reason: ModelSelectionReason.Remembered } : undefined;
 		const resolveSelection = (): InitialModelSelectionResult => {
 			const configuredModelValue = this._runtime.getConfiguredModelValue();
 			const models = this._runtime.getModels(this._runtime.getCurrentSessionType());
@@ -261,8 +265,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		// selection. `SessionRestore` on an empty session is just spillover from the previous
 		// session and must yield.
 		if (!this._runtime.isEmpty()
-			|| this._selectionReason === ModelSelectionReason.UserSelection
-			|| this._selectionReason === ModelSelectionReason.ProgrammaticSelection
+			|| isInConversationModelChoice(this._selectionReason)
 			|| this._intent) {
 			return false;
 		}
@@ -315,26 +318,27 @@ export class ChatInputModelSelectionController extends Disposable {
 	 * Reclaims the remembered model whenever the catalog can offer it again. A model can leave the
 	 * pool for reasons that have nothing to do with intent — an agent host that restarts drops its
 	 * whole catalog and republishes it moments later — and the default we show meanwhile is a
-	 * stand-in, not a decision. Every deliberate choice updates {@link _rememberedModelId}, so a
+	 * stand-in, not a decision. Every deliberate choice updates {@link _rememberedSelection}, so a
 	 * current model that differs from it is always a stand-in of some kind and may be superseded.
-	 * `chat.defaultModel` is the one exception: it is authoritative for new conversations without
-	 * being a remembered selection, so it holds.
+	 * `chat.defaultModel` outranks a merely remembered model, but never an in-conversation choice,
+	 * which is why the displaced authority is restored along with the model.
 	 */
 	private _restoreRememberedModel(): boolean {
-		const modelId = this._rememberedModelId;
-		if (!modelId
-			|| this._currentModel.get()?.identifier === modelId
-			|| this._selectionReason === ModelSelectionReason.ConfiguredDefault) {
+		const remembered = this._rememberedSelection;
+		if (!remembered || this._currentModel.get()?.identifier === remembered.modelId) {
+			return false;
+		}
+		if (this._selectionReason === ModelSelectionReason.ConfiguredDefault && !isInConversationModelChoice(remembered.reason)) {
 			return false;
 		}
 		// Pool membership is the validity test: the pool is already filtered by session and mode,
 		// so a model that is absent here is genuinely not selectable right now.
-		const model = this._runtime.getModels(this._runtime.getCurrentSessionType()).find(model => model.identifier === modelId);
+		const model = this._runtime.getModels(this._runtime.getCurrentSessionType()).find(model => model.identifier === remembered.modelId);
 		if (!model) {
 			return false;
 		}
-		this._diagnostics.report('restore-remembered-model', { model: modelId }, 'info');
-		this._selectionReason = ModelSelectionReason.Remembered;
+		this._diagnostics.report('restore-remembered-model', { model: remembered.modelId, reason: remembered.reason }, 'info');
+		this._selectionReason = remembered.reason;
 		this._applyModel(model);
 		return true;
 	}
@@ -421,7 +425,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		const match = tryMatch();
 		if (match) {
 			this._selectionReason = ModelSelectionReason.SessionRestore;
-			this._rememberedModelId = match.identifier;
+			this._rememberedSelection = { modelId: match.identifier, reason: ModelSelectionReason.SessionRestore };
 			this._applyModel(match);
 			return;
 		}
@@ -451,7 +455,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	): void {
 		this._clearIntent();
 		this._selectionReason = ModelSelectionReason.SessionRestore;
-		this._rememberedModelId = model.identifier;
+		this._rememberedSelection = { modelId: model.identifier, reason: ModelSelectionReason.SessionRestore };
 		if (configuration) {
 			this._runtime.restoreModelConfiguration(configuration.modelId, configuration.configuration);
 		}
@@ -515,7 +519,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (model && !(models.length === 1 && model.metadata.id.toLocaleLowerCase() === 'auto')) {
 			this._intent = undefined;
 			this._selectionReason = ModelSelectionReason.SessionRestore;
-			this._rememberedModelId = model.identifier;
+			this._rememberedSelection = { modelId: model.identifier, reason: ModelSelectionReason.SessionRestore };
 			this._applyModel(model);
 			return true;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -96,7 +96,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	 */
 	isAwaitingRememberedModel(): boolean {
 		const modelId = this._rememberedSelection?.modelId;
-		return !!modelId && !this._runtime.getModels(this._runtime.getCurrentSessionType()).some(model => model.identifier === modelId);
+		return !!modelId && !this._selectablePool(this._runtime.getCurrentSessionType()).some(model => model.identifier === modelId);
 	}
 
 	hasPendingProgrammaticSelection(): boolean {
@@ -298,6 +298,10 @@ export class ChatInputModelSelectionController extends Disposable {
 	resetToDefault(sessionType = this._runtime.getCurrentSessionType()): void {
 		this._clearIntent();
 		this._rememberedSelection = undefined;
+		// Drop the authority too: `selectDefault` overwrites it whenever it applies something, but
+		// leaving a stale `UserSelection` behind on an empty pool would keep blocking
+		// `chat.defaultModel` from ever seeding this conversation.
+		this._selectionReason = undefined;
 		this.selectDefault(sessionType);
 	}
 
@@ -368,9 +372,9 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (this._selectionReason === ModelSelectionReason.ConfiguredDefault && !isInConversationModelChoice(remembered.reason)) {
 			return false;
 		}
-		// Pool membership is the validity test: the pool is already filtered by session and mode,
-		// so a model that is absent here is genuinely not selectable right now.
-		const model = this._runtime.getModels(this._runtime.getCurrentSessionType()).find(model => model.identifier === remembered.modelId);
+		// Selectability is the validity test: a model that is not offered here — because the
+		// catalog dropped it, or because this mode cannot use it — is not restorable right now.
+		const model = this._selectablePool(this._runtime.getCurrentSessionType()).find(model => model.identifier === remembered.modelId);
 		if (!model) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -7,7 +7,7 @@ import { Disposable, IDisposable, toDisposable } from '../../../../../../base/co
 import { IObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../common/languageModels.js';
-import { InitialModelSelectionResult, isAuthoritativeModelSelectionReason, ModelIdentifierResolution, ModelSelectionApplyReason, ModelSelectionReason, resolveConfiguredModel, resolveInitialModelSelection, resolveModelIdentifier } from '../../../common/modelSelection.js';
+import { InitialModelSelectionResult, ModelIdentifierResolution, ModelSelectionApplyReason, ModelSelectionReason, resolveConfiguredModel, resolveInitialModelSelection, resolveModelIdentifier } from '../../../common/modelSelection.js';
 import { findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelValidForSession, resolveModelFromSyncState, shouldDropAgnosticDraftModel, shouldResetModelToDefault, shouldResetOnModelListChange, shouldWaitForSessionModel } from './chatInputModelUtils.js';
 import { IChatModelSelectionDiagnostics, NullChatModelSelectionDiagnostics } from './chatModelSelectionDiagnostics.js';
 
@@ -35,7 +35,6 @@ interface IResolvedDraftModelSelection {
 }
 
 type ModelSelectionIntent =
-	| { readonly kind: 'remembered'; readonly modelId: string }
 	| { readonly kind: 'programmatic'; readonly resolveModel: () => ILanguageModelChatMetadataAndIdentifier | undefined; readonly conversationKey: string | undefined; readonly complete: (applied: boolean) => void }
 	| { readonly kind: 'session'; readonly model: ILanguageModelChatMetadataAndIdentifier; readonly configuration: Record<string, unknown> | undefined; readonly sessionType: string | undefined; readonly conversationKey: string }
 	| { readonly kind: 'history'; readonly modelId: string; readonly conversationKey: string };
@@ -48,6 +47,14 @@ export class ChatInputModelSelectionController extends Disposable {
 	private _selectionReason: ModelSelectionApplyReason | undefined;
 	private _intent: ModelSelectionIntent | undefined;
 	private _restorePerTypeModel = false;
+	/**
+	 * The model the user is meant to be on, independent of what the catalog can currently offer.
+	 * Seeded from persisted storage by {@link initialize} and updated by every deliberate choice
+	 * (explicit pick, programmatic selection, session restore). Falling back to a default because
+	 * the catalog dropped the model is a display state, not a decision, so it deliberately leaves
+	 * this untouched — see {@link _restoreRememberedModel}.
+	 */
+	private _rememberedModelId: string | undefined;
 
 	constructor(
 		private readonly _runtime: IChatInputModelSelectionRuntime,
@@ -84,6 +91,16 @@ export class ChatInputModelSelectionController extends Disposable {
 		return !!this._intent;
 	}
 
+	/**
+	 * True while the remembered model is not selectable, i.e. whatever is currently selected is a
+	 * stand-in that {@link _restoreRememberedModel} will replace once the catalog offers the real
+	 * one. Callers use this to avoid acting on a selection that is about to change.
+	 */
+	isAwaitingRememberedModel(): boolean {
+		const modelId = this._rememberedModelId;
+		return !!modelId && !this._runtime.getModels(this._runtime.getCurrentSessionType()).some(model => model.identifier === modelId);
+	}
+
 	hasPendingProgrammaticSelection(): boolean {
 		return this._intent?.kind === 'programmatic';
 	}
@@ -106,8 +123,10 @@ export class ChatInputModelSelectionController extends Disposable {
 		this._clearIntent();
 		const previousModel = this._currentModel.get();
 		const previousReason = this._selectionReason;
+		const previousRememberedModelId = this._rememberedModelId;
 		this._currentModel.set(model, undefined);
 		this._selectionReason = ModelSelectionReason.UserSelection;
+		this._rememberedModelId = model.identifier;
 		this._diagnostics.report('explicit-selection', { model: model.identifier }, 'info');
 		try {
 			apply();
@@ -116,6 +135,7 @@ export class ChatInputModelSelectionController extends Disposable {
 			if (rollbackOnError) {
 				this._currentModel.set(previousModel, undefined);
 				this._selectionReason = previousReason;
+				this._rememberedModelId = previousRememberedModelId;
 			}
 			this._diagnostics.report('explicit-selection-failed', { model: model.identifier, error: String(error) }, 'error');
 			throw error;
@@ -130,6 +150,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	applyProgrammaticSelection(model: ILanguageModelChatMetadataAndIdentifier): void {
 		this._clearIntent();
 		this._selectionReason = ModelSelectionReason.ProgrammaticSelection;
+		this._rememberedModelId = model.identifier;
 		this._applyModel(model);
 	}
 
@@ -156,6 +177,7 @@ export class ChatInputModelSelectionController extends Disposable {
 
 	initialize(rememberedModelId: string | undefined, onInitialSelection: (selection: InitialModelSelectionResult) => void): void {
 		this._clearIntent();
+		this._rememberedModelId = rememberedModelId;
 		const resolveSelection = (): InitialModelSelectionResult => {
 			const configuredModelValue = this._runtime.getConfiguredModelValue();
 			const models = this._runtime.getModels(this._runtime.getCurrentSessionType());
@@ -180,7 +202,8 @@ export class ChatInputModelSelectionController extends Disposable {
 			this._applyModel(selection.model);
 			this.ensureCurrentModelSupported();
 		} else if (selection.kind === 'pending') {
-			this._intent = { kind: 'remembered', modelId: selection.selection.reference };
+			// The remembered model isn't in the catalog yet. Show the default meanwhile;
+			// `_restoreRememberedModel` claims the real one as soon as it is published.
 			const fallbackModel = findDefaultModel(this._runtime.getModels(this._runtime.getCurrentSessionType()), this._runtime.location);
 			if (fallbackModel) {
 				this._selectionReason = ModelSelectionReason.FirstAvailable;
@@ -240,7 +263,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (!this._runtime.isEmpty()
 			|| this._selectionReason === ModelSelectionReason.UserSelection
 			|| this._selectionReason === ModelSelectionReason.ProgrammaticSelection
-			|| (this._intent && this._intent.kind !== 'remembered')) {
+			|| this._intent) {
 			return false;
 		}
 		const configuredValue = this._runtime.getConfiguredModelValue();
@@ -251,17 +274,12 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (!configuredModel) {
 			return false;
 		}
-		const matchesCurrent = configuredModel.identifier === this._currentModel.get()?.identifier;
-		const supersededRememberedIntent = this._intent?.kind === 'remembered';
-		if (supersededRememberedIntent) {
-			this._clearIntent();
-		}
-		if (matchesCurrent) {
+		if (configuredModel.identifier === this._currentModel.get()?.identifier) {
 			if (this._selectionReason !== ModelSelectionReason.ConfiguredDefault) {
 				this._selectionReason = ModelSelectionReason.ConfiguredDefault;
 				return true;
 			}
-			return supersededRememberedIntent;
+			return false;
 		}
 		this._selectionReason = ModelSelectionReason.ConfiguredDefault;
 		this._applyModel(configuredModel);
@@ -270,7 +288,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	reconcileModelListChange(models: readonly ILanguageModelChatMetadataAndIdentifier[]): void {
-		if (this.applyConfiguredDefault() || this._reconcileIntent()) {
+		if (this.applyConfiguredDefault() || this._reconcileIntent() || this._restoreRememberedModel()) {
 			return;
 		}
 		const currentModel = this._currentModel.get();
@@ -291,6 +309,34 @@ export class ChatInputModelSelectionController extends Disposable {
 		} else {
 			this.selectDefault();
 		}
+	}
+
+	/**
+	 * Reclaims the remembered model whenever the catalog can offer it again. A model can leave the
+	 * pool for reasons that have nothing to do with intent — an agent host that restarts drops its
+	 * whole catalog and republishes it moments later — and the default we show meanwhile is a
+	 * stand-in, not a decision. Every deliberate choice updates {@link _rememberedModelId}, so a
+	 * current model that differs from it is always a stand-in of some kind and may be superseded.
+	 * `chat.defaultModel` is the one exception: it is authoritative for new conversations without
+	 * being a remembered selection, so it holds.
+	 */
+	private _restoreRememberedModel(): boolean {
+		const modelId = this._rememberedModelId;
+		if (!modelId
+			|| this._currentModel.get()?.identifier === modelId
+			|| this._selectionReason === ModelSelectionReason.ConfiguredDefault) {
+			return false;
+		}
+		// Pool membership is the validity test: the pool is already filtered by session and mode,
+		// so a model that is absent here is genuinely not selectable right now.
+		const model = this._runtime.getModels(this._runtime.getCurrentSessionType()).find(model => model.identifier === modelId);
+		if (!model) {
+			return false;
+		}
+		this._diagnostics.report('restore-remembered-model', { model: modelId }, 'info');
+		this._selectionReason = ModelSelectionReason.Remembered;
+		this._applyModel(model);
+		return true;
 	}
 
 	syncFromConversationState(
@@ -375,6 +421,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		const match = tryMatch();
 		if (match) {
 			this._selectionReason = ModelSelectionReason.SessionRestore;
+			this._rememberedModelId = match.identifier;
 			this._applyModel(match);
 			return;
 		}
@@ -404,6 +451,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	): void {
 		this._clearIntent();
 		this._selectionReason = ModelSelectionReason.SessionRestore;
+		this._rememberedModelId = model.identifier;
 		if (configuration) {
 			this._runtime.restoreModelConfiguration(configuration.modelId, configuration.configuration);
 		}
@@ -431,27 +479,6 @@ export class ChatInputModelSelectionController extends Disposable {
 			intent.complete(true);
 			this.applyProgrammaticSelection(model);
 			return true;
-		}
-
-		if (intent.kind === 'remembered') {
-			const models = this._runtime.getModels(this._runtime.getCurrentSessionType());
-			const model = models.find(model => model.identifier === intent.modelId);
-			if (model) {
-				this._intent = undefined;
-				this._selectionReason = ModelSelectionReason.Remembered;
-				this._applyModel(model);
-				this.ensureCurrentModelSupported();
-				return true;
-			}
-			const currentModel = this._currentModel.get();
-			const replacement = models.find(model => model.metadata.isDefaultForLocation[this._runtime.location]);
-			if (replacement && currentModel?.identifier !== replacement.identifier && !isAuthoritativeModelSelectionReason(this._selectionReason)) {
-				this._selectionReason = ModelSelectionReason.FirstAvailable;
-				this._applyModel(replacement);
-				this.ensureCurrentModelSupported();
-				return true;
-			}
-			return false;
 		}
 
 		if (intent.kind === 'session') {
@@ -488,6 +515,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (model && !(models.length === 1 && model.metadata.id.toLocaleLowerCase() === 'auto')) {
 			this._intent = undefined;
 			this._selectionReason = ModelSelectionReason.SessionRestore;
+			this._rememberedModelId = model.identifier;
 			this._applyModel(model);
 			return true;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -39,6 +39,19 @@ type ModelSelectionIntent =
 	| { readonly kind: 'session'; readonly model: ILanguageModelChatMetadataAndIdentifier; readonly configuration: Record<string, unknown> | undefined; readonly sessionType: string | undefined; readonly conversationKey: string }
 	| { readonly kind: 'history'; readonly modelId: string; readonly conversationKey: string };
 
+/**
+ * How a model came to be selected. Modelled as a union so the caller cannot ask for a combination
+ * that has no meaning — an automatic selection has nothing to roll back to, and a programmatic one
+ * has no caller-supplied effect.
+ */
+export type ModelSelectionRequest =
+	/** The user picked from the model picker. `effect` persists and lays out; it may throw. */
+	| { readonly authority: 'user'; readonly effect: () => void; readonly rollbackOnError?: boolean }
+	/** The caller already decided; only the displayed model changes. */
+	| { readonly authority: 'automatic'; readonly effect: () => void }
+	/** A mode or session forced this model. */
+	| { readonly authority: 'programmatic' };
+
 /** Reconciles the shared selection model with Workbench-specific input and catalog state. */
 export class ChatInputModelSelectionController extends Disposable {
 
@@ -113,44 +126,43 @@ export class ChatInputModelSelectionController extends Disposable {
 	 * Applies a model and records where the choice came from.
 	 *
 	 * `user` and `programmatic` are deliberate, so they become the remembered selection and will be
-	 * reclaimed after an outage. `automatic` only changes what is displayed — it is the caller
-	 * having already decided, so it neither records authority nor disturbs what is remembered.
-	 *
-	 * `effect` runs the caller's side of the application (layout, persistence). For a `user`
-	 * selection it may throw, in which case `rollbackOnError` restores every piece of state,
-	 * including what was remembered.
+	 * reclaimed after an outage. `automatic` only changes what is displayed — the caller has
+	 * already decided — so it neither records authority nor disturbs what is remembered.
 	 */
-	select(
-		model: ILanguageModelChatMetadataAndIdentifier,
-		authority: 'user' | 'automatic' | 'programmatic',
-		options?: { readonly effect?: () => void; readonly rollbackOnError?: boolean },
-	): void {
-		if (authority === 'automatic') {
+	select(model: ILanguageModelChatMetadataAndIdentifier, request: ModelSelectionRequest): void {
+		if (request.authority === 'automatic') {
 			this._currentModel.set(model, undefined);
-			options?.effect?.();
+			request.effect();
 			return;
 		}
 
 		this._clearIntent();
-		const reason = authority === 'user' ? ModelSelectionReason.UserSelection : ModelSelectionReason.ProgrammaticSelection;
+		const reason = request.authority === 'user' ? ModelSelectionReason.UserSelection : ModelSelectionReason.ProgrammaticSelection;
 		const previous = {
 			model: this._currentModel.get(),
 			reason: this._selectionReason,
 			remembered: this._rememberedSelection,
 		};
-		this._currentModel.set(model, undefined);
+		// Authority first: `_currentModel` is observable and notifies synchronously, so setting it
+		// last means no observer can see the new model alongside the previous authority.
 		this._selectionReason = reason;
 		this._rememberedSelection = { modelId: model.identifier, reason };
-		this._diagnostics.report('select', { model: model.identifier, authority }, 'info');
+		this._currentModel.set(model, undefined);
+		this._diagnostics.report('select', { model: model.identifier, authority: request.authority }, 'info');
 		try {
-			(options?.effect ?? (() => this._runtime.applyModel(model)))();
+			if (request.authority === 'user') {
+				request.effect();
+			} else {
+				this._runtime.applyModel(model);
+			}
+			this._diagnostics.report('select-applied', { model: model.identifier, authority: request.authority }, 'info');
 		} catch (error) {
-			if (options?.rollbackOnError) {
-				this._currentModel.set(previous.model, undefined);
+			if (request.authority === 'user' && request.rollbackOnError) {
 				this._selectionReason = previous.reason;
 				this._rememberedSelection = previous.remembered;
+				this._currentModel.set(previous.model, undefined);
 			}
-			this._diagnostics.report('select-failed', { model: model.identifier, authority, error: String(error) }, 'error');
+			this._diagnostics.report('select-failed', { model: model.identifier, authority: request.authority, error: String(error) }, 'error');
 			throw error;
 		}
 	}
@@ -514,7 +526,7 @@ export class ChatInputModelSelectionController extends Disposable {
 			}
 			this._intent = undefined;
 			intent.complete(true);
-			this.select(model, 'programmatic');
+			this.select(model, { authority: 'programmatic' });
 			return true;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assertNever } from '../../../../../../base/common/assert.js';
 import { Disposable, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { IObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
@@ -53,30 +54,49 @@ export type ModelSelectionRequest =
 	| { readonly authority: 'programmatic' };
 
 /**
- * Reasons that represent a decision about which model to be on. Applying a model for one of these
- * makes it the model to reclaim after an outage.
+ * Reasons whose model should outlive a catalog outage: applying a model for one of these makes it
+ * the model to reclaim once it can be offered again.
  *
- * Note this is a wider set than {@link isInConversationModelChoice}: a remembered or restored model
- * is a decision worth reclaiming, but `chat.defaultModel` still outranks it on a new conversation.
+ * Note this is a wider set than {@link isInConversationModelChoice}. A remembered or restored model
+ * is durable, but `chat.defaultModel` still outranks it on a new conversation.
  */
-type DeliberateReason =
+type DurableReason =
 	| ModelSelectionReason.UserSelection
 	| ModelSelectionReason.ProgrammaticSelection
 	| ModelSelectionReason.SessionRestore
 	| ModelSelectionReason.Remembered;
 
 /**
- * Everything else stands in for a model that cannot currently be offered. `chat.defaultModel` lands
- * here: it is re-derived from configuration for each new conversation rather than being something
- * the user chose, so it must never displace what they did choose.
+ * Reasons that only stand in for a model that cannot currently be offered. `chat.defaultModel`
+ * lands here: it is re-derived from configuration for each new conversation rather than being
+ * something the user chose, so it must never displace what they did choose.
  */
-type StandInReason = Exclude<ModelSelectionApplyReason, DeliberateReason>;
+type TransientReason =
+	| ModelSelectionReason.ConfiguredDefault
+	| ModelSelectionReason.FirstAvailable
+	| ModelSelectionReason.RemovedModelFallback
+	| ModelSelectionReason.NewChatRepush;
 
-function isDeliberateReason(reason: ModelSelectionApplyReason): reason is DeliberateReason {
-	return reason === ModelSelectionReason.UserSelection
-		|| reason === ModelSelectionReason.ProgrammaticSelection
-		|| reason === ModelSelectionReason.SessionRestore
-		|| reason === ModelSelectionReason.Remembered;
+/**
+ * Every reason must be classified as durable or transient. The exhaustive switch means adding a
+ * `ModelSelectionReason` without deciding which it is fails to compile, rather than silently
+ * defaulting to one.
+ */
+function isDurableReason(reason: ModelSelectionApplyReason): reason is DurableReason {
+	switch (reason) {
+		case ModelSelectionReason.UserSelection:
+		case ModelSelectionReason.ProgrammaticSelection:
+		case ModelSelectionReason.SessionRestore:
+		case ModelSelectionReason.Remembered:
+			return true;
+		case ModelSelectionReason.ConfiguredDefault:
+		case ModelSelectionReason.FirstAvailable:
+		case ModelSelectionReason.RemovedModelFallback:
+		case ModelSelectionReason.NewChatRepush:
+			return false;
+		default:
+			assertNever(reason);
+	}
 }
 
 /** Reconciles the shared selection model with Workbench-specific input and catalog state. */
@@ -93,7 +113,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	 * by every deliberate choice. Falling back to a default because the catalog dropped the model
 	 * is a display state, not a decision, so it deliberately leaves this untouched.
 	 */
-	private _rememberedSelection: { readonly modelId: string; readonly reason: DeliberateReason } | undefined;
+	private _rememberedSelection: { readonly modelId: string; readonly reason: DurableReason } | undefined;
 
 	constructor(
 		private readonly _runtime: IChatInputModelSelectionRuntime,
@@ -158,8 +178,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	 */
 	select(model: ILanguageModelChatMetadataAndIdentifier, request: ModelSelectionRequest): void {
 		if (request.authority === 'automatic') {
-			this._currentModel.set(model, undefined);
-			request.effect();
+			this._display(model, request.effect);
 			return;
 		}
 
@@ -229,7 +248,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		onInitialSelection(selection);
 		this._reportInitialization(this._runtime.getConfiguredModelValue(), rememberedModelId, selection);
 		if (selection.kind === 'apply') {
-			if (isDeliberateReason(selection.reason)) {
+			if (isDurableReason(selection.reason)) {
 				this._choose(selection.model, selection.reason);
 			} else {
 				this._standIn(selection.model, selection.reason);
@@ -316,8 +335,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		}
 		if (this.hasPendingProgrammaticSelection()) {
 			// A pending request still owns the authority; the default is only what is shown meanwhile.
-			this._currentModel.set(defaultModel, undefined);
-			this._runtime.applyModel(defaultModel);
+			this._display(defaultModel);
 			return;
 		}
 		this._standIn(defaultModel, configuredModel ? ModelSelectionReason.ConfiguredDefault : ModelSelectionReason.FirstAvailable);
@@ -602,10 +620,24 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	/**
+	 * Displays a model without saying anything about authority, leaving both the current reason and
+	 * the remembered selection alone. For callers that have already decided the authority question
+	 * elsewhere — a caller applying its own choice, or a fallback shown while a pending request
+	 * still owns the selection.
+	 */
+	private _display(
+		model: ILanguageModelChatMetadataAndIdentifier,
+		effect: () => void = () => this._runtime.applyModel(model),
+	): void {
+		this._currentModel.set(model, undefined);
+		effect();
+	}
+
+	/**
 	 * Records a decision without changing what is displayed — used when the model is already
 	 * shown and only its authority needs to catch up.
 	 */
-	private _rememberChoice(model: ILanguageModelChatMetadataAndIdentifier, reason: DeliberateReason): void {
+	private _rememberChoice(model: ILanguageModelChatMetadataAndIdentifier, reason: DurableReason): void {
 		this._selectionReason = reason;
 		this._rememberedSelection = { modelId: model.identifier, reason };
 	}
@@ -616,24 +648,22 @@ export class ChatInputModelSelectionController extends Disposable {
 	 */
 	private _choose(
 		model: ILanguageModelChatMetadataAndIdentifier,
-		reason: DeliberateReason,
-		effect: () => void = () => this._runtime.applyModel(model),
+		reason: DurableReason,
+		effect?: () => void,
 	): void {
 		// Authority before display: `_currentModel` notifies synchronously, so an observer must
 		// never see the new model alongside the previous authority.
 		this._rememberChoice(model, reason);
-		this._currentModel.set(model, undefined);
-		effect();
+		this._display(model, effect);
 	}
 
 	/**
 	 * Applies a model as a stand-in for one that cannot currently be offered. Deliberately leaves
 	 * the remembered selection alone — that is what makes the fallback temporary.
 	 */
-	private _standIn(model: ILanguageModelChatMetadataAndIdentifier, reason: StandInReason): void {
+	private _standIn(model: ILanguageModelChatMetadataAndIdentifier, reason: TransientReason): void {
 		this._selectionReason = reason;
-		this._currentModel.set(model, undefined);
-		this._runtime.applyModel(model);
+		this._display(model);
 	}
 
 	private _reportInitialization(configuredModel: string | undefined, rememberedModel: string | undefined, selection: InitialModelSelectionResult): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -109,43 +109,50 @@ export class ChatInputModelSelectionController extends Disposable {
 		}
 	}
 
-	applyExplicitSelection(
+	/**
+	 * Applies a model and records where the choice came from.
+	 *
+	 * `user` and `programmatic` are deliberate, so they become the remembered selection and will be
+	 * reclaimed after an outage. `automatic` only changes what is displayed — it is the caller
+	 * having already decided, so it neither records authority nor disturbs what is remembered.
+	 *
+	 * `effect` runs the caller's side of the application (layout, persistence). For a `user`
+	 * selection it may throw, in which case `rollbackOnError` restores every piece of state,
+	 * including what was remembered.
+	 */
+	select(
 		model: ILanguageModelChatMetadataAndIdentifier,
-		apply: () => void,
-		rollbackOnError: boolean,
+		authority: 'user' | 'automatic' | 'programmatic',
+		options?: { readonly effect?: () => void; readonly rollbackOnError?: boolean },
 	): void {
+		if (authority === 'automatic') {
+			this._currentModel.set(model, undefined);
+			options?.effect?.();
+			return;
+		}
+
 		this._clearIntent();
-		const previousModel = this._currentModel.get();
-		const previousReason = this._selectionReason;
-		const previousRememberedSelection = this._rememberedSelection;
+		const reason = authority === 'user' ? ModelSelectionReason.UserSelection : ModelSelectionReason.ProgrammaticSelection;
+		const previous = {
+			model: this._currentModel.get(),
+			reason: this._selectionReason,
+			remembered: this._rememberedSelection,
+		};
 		this._currentModel.set(model, undefined);
-		this._selectionReason = ModelSelectionReason.UserSelection;
-		this._rememberedSelection = { modelId: model.identifier, reason: ModelSelectionReason.UserSelection };
-		this._diagnostics.report('explicit-selection', { model: model.identifier }, 'info');
+		this._selectionReason = reason;
+		this._rememberedSelection = { modelId: model.identifier, reason };
+		this._diagnostics.report('select', { model: model.identifier, authority }, 'info');
 		try {
-			apply();
-			this._diagnostics.report('explicit-selection-applied', { model: model.identifier }, 'info');
+			(options?.effect ?? (() => this._runtime.applyModel(model)))();
 		} catch (error) {
-			if (rollbackOnError) {
-				this._currentModel.set(previousModel, undefined);
-				this._selectionReason = previousReason;
-				this._rememberedSelection = previousRememberedSelection;
+			if (options?.rollbackOnError) {
+				this._currentModel.set(previous.model, undefined);
+				this._selectionReason = previous.reason;
+				this._rememberedSelection = previous.remembered;
 			}
-			this._diagnostics.report('explicit-selection-failed', { model: model.identifier, error: String(error) }, 'error');
+			this._diagnostics.report('select-failed', { model: model.identifier, authority, error: String(error) }, 'error');
 			throw error;
 		}
-	}
-
-	applyAutomaticSelection(model: ILanguageModelChatMetadataAndIdentifier, apply: () => void): void {
-		this._currentModel.set(model, undefined);
-		apply();
-	}
-
-	applyProgrammaticSelection(model: ILanguageModelChatMetadataAndIdentifier): void {
-		this._clearIntent();
-		this._selectionReason = ModelSelectionReason.ProgrammaticSelection;
-		this._rememberedSelection = { modelId: model.identifier, reason: ModelSelectionReason.ProgrammaticSelection };
-		this._applyModel(model);
 	}
 
 	requestProgrammaticSelection(
@@ -507,7 +514,7 @@ export class ChatInputModelSelectionController extends Disposable {
 			}
 			this._intent = undefined;
 			intent.complete(true);
-			this.applyProgrammaticSelection(model);
+			this.select(model, 'programmatic');
 			return true;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -229,8 +229,32 @@ export class ChatInputModelSelectionController extends Disposable {
 			willReset,
 		}, willReset ? 'info' : 'debug');
 		if (willReset) {
-			this.selectDefault(sessionType);
+			this._replaceInvalidSelection(currentModel, sessionType);
 		}
+	}
+
+	/**
+	 * Replaces a selection that is no longer valid, applying the precedence every such path shares:
+	 * the remembered selection if the catalog can offer it, else the closest match for what was
+	 * displaced, else the default.
+	 *
+	 * The callers differ only in *why* the current model stopped being valid — unsupported for the
+	 * mode, outside the session pool, withdrawn from the catalog. Routing them all through here
+	 * keeps that difference from turning into a difference in what replaces it.
+	 */
+	private _replaceInvalidSelection(
+		displaced: ILanguageModelChatMetadataAndIdentifier | undefined,
+		sessionType: string | undefined,
+	): void {
+		if (this._restoreRememberedModel()) {
+			return;
+		}
+		const match = findBestMatchingModel(displaced, this._runtime.getModels(sessionType));
+		if (match) {
+			this._applyModel(match);
+			return;
+		}
+		this.selectDefault(sessionType);
 	}
 
 	selectDefault(sessionType = this._runtime.getCurrentSessionType()): void {
@@ -302,12 +326,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (!shouldResetOnModelListChange(currentModel?.identifier, [...models])) {
 			return;
 		}
-		const match = findBestMatchingModel(currentModel, models);
-		if (match) {
-			this._applyModel(match);
-		} else {
-			this.selectDefault();
-		}
+		this._replaceInvalidSelection(currentModel, this._runtime.getCurrentSessionType());
 	}
 
 	/**
@@ -388,7 +407,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	ensureCurrentModelInSessionPool(): void {
 		const currentModel = this._currentModel.get();
 		if (currentModel && !isModelValidForSession(currentModel, this._runtime.getAllModels(), this._runtime.getCurrentSessionType())) {
-			this.selectDefault();
+			this._replaceInvalidSelection(currentModel, this._runtime.getCurrentSessionType());
 		}
 	}
 
@@ -406,14 +425,13 @@ export class ChatInputModelSelectionController extends Disposable {
 		if (restoredModel && models.some(model => model.identifier === restoredModel.identifier)) {
 			return;
 		}
-		const match = findBestMatchingModel(previousModel, models);
-		if (match) {
-			this._applyModel(match);
-		} else if (models.length === 0) {
+		// A destination pool that has published nothing yet has no stand-in to offer, so clear the
+		// selection rather than reaching into another pool for one.
+		if (models.length === 0) {
 			this._currentModel.set(undefined, undefined);
-		} else {
-			this.selectDefault(sessionType);
+			return;
 		}
+		this._replaceInvalidSelection(previousModel, sessionType);
 	}
 
 	preselectFromHistory(modelId: string, conversationKey: string): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputModelSelectionController.ts
@@ -40,48 +40,27 @@ type ModelSelectionIntent =
 	| { readonly kind: 'session'; readonly model: ILanguageModelChatMetadataAndIdentifier; readonly configuration: Record<string, unknown> | undefined; readonly sessionType: string | undefined; readonly conversationKey: string }
 	| { readonly kind: 'history'; readonly modelId: string; readonly conversationKey: string };
 
-/**
- * How a model came to be selected. Modelled as a union so the caller cannot ask for a combination
- * that has no meaning — an automatic selection has nothing to roll back to, and a programmatic one
- * has no caller-supplied effect.
- */
+/** A union so meaningless combinations — a rollback for an automatic pick — cannot be expressed. */
 export type ModelSelectionRequest =
-	/** The user picked from the model picker. `effect` persists and lays out; it may throw. */
 	| { readonly authority: 'user'; readonly effect: () => void; readonly rollbackOnError?: boolean }
-	/** The caller already decided; only the displayed model changes. */
 	| { readonly authority: 'automatic'; readonly effect: () => void }
-	/** A mode or session forced this model. */
 	| { readonly authority: 'programmatic' };
 
-/**
- * Reasons whose model should outlive a catalog outage: applying a model for one of these makes it
- * the model to reclaim once it can be offered again.
- *
- * Note this is a wider set than {@link isInConversationModelChoice}. A remembered or restored model
- * is durable, but `chat.defaultModel` still outranks it on a new conversation.
- */
+/** Wider than {@link isInConversationModelChoice}: `chat.defaultModel` still outranks these on a new conversation. */
 type DurableReason =
 	| ModelSelectionReason.UserSelection
 	| ModelSelectionReason.ProgrammaticSelection
 	| ModelSelectionReason.SessionRestore
 	| ModelSelectionReason.Remembered;
 
-/**
- * Reasons that only stand in for a model that cannot currently be offered. `chat.defaultModel`
- * lands here: it is re-derived from configuration for each new conversation rather than being
- * something the user chose, so it must never displace what they did choose.
- */
+/** `chat.defaultModel` is here: re-derived per conversation, so it must never displace a real choice. */
 type TransientReason =
 	| ModelSelectionReason.ConfiguredDefault
 	| ModelSelectionReason.FirstAvailable
 	| ModelSelectionReason.RemovedModelFallback
 	| ModelSelectionReason.NewChatRepush;
 
-/**
- * Every reason must be classified as durable or transient. The exhaustive switch means adding a
- * `ModelSelectionReason` without deciding which it is fails to compile, rather than silently
- * defaulting to one.
- */
+/** Exhaustive so a new `ModelSelectionReason` cannot compile until it is classified. */
 function isDurableReason(reason: ModelSelectionApplyReason): reason is DurableReason {
 	switch (reason) {
 		case ModelSelectionReason.UserSelection:
@@ -107,12 +86,7 @@ export class ChatInputModelSelectionController extends Disposable {
 	private _selectionReason: ModelSelectionApplyReason | undefined;
 	private _intent: ModelSelectionIntent | undefined;
 	private _restorePerTypeModel = false;
-	/**
-	 * The model the user is meant to be on, independent of what the catalog can currently offer,
-	 * with the authority that put them there. Seeded from storage by {@link initialize} and updated
-	 * by every deliberate choice. Falling back to a default because the catalog dropped the model
-	 * is a display state, not a decision, so it deliberately leaves this untouched.
-	 */
+	/** What the user is meant to be on, regardless of what the catalog can currently offer. */
 	private _rememberedSelection: { readonly modelId: string; readonly reason: DurableReason } | undefined;
 
 	constructor(
@@ -142,11 +116,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		this._restorePerTypeModel = false;
 	}
 
-	/**
-	 * True while the selection is provisional — either an async intent is pending, or the
-	 * remembered model is not selectable and whatever is shown is standing in for it. Callers use
-	 * this to avoid acting on a selection that is about to change.
-	 */
+	/** True while what is shown is provisional: a pending request, or a stand-in for an absent model. */
 	isAwaitingModel(): boolean {
 		if (this._intent) {
 			return true;
@@ -169,13 +139,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		}
 	}
 
-	/**
-	 * Applies a model and records where the choice came from.
-	 *
-	 * `user` and `programmatic` are deliberate, so they become the remembered selection and will be
-	 * reclaimed after an outage. `automatic` only changes what is displayed — the caller has
-	 * already decided — so it neither records authority nor disturbs what is remembered.
-	 */
+	/** `user` and `programmatic` are decisions; `automatic` only changes what is displayed. */
 	select(model: ILanguageModelChatMetadataAndIdentifier, request: ModelSelectionRequest): void {
 		if (request.authority === 'automatic') {
 			this._display(model, request.effect);
@@ -282,10 +246,9 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	/**
-	 * The pool to select from. {@link filterModelsForSession} only applies mode and inline-chat
-	 * filtering to the general pool, so a targeted session pool can still offer models the current
-	 * mode cannot use — including one being replaced *because* it is unusable. Falls back to the
-	 * raw pool rather than selecting nothing when a provider declares no capabilities at all.
+	 * {@link filterModelsForSession} only mode-filters the general pool, so a targeted pool can offer
+	 * models this mode cannot use — including one being replaced *because* it is unusable. Falls back
+	 * to the raw pool rather than selecting nothing when a provider declares no capabilities.
 	 */
 	private _selectablePool(sessionType: string | undefined): ILanguageModelChatMetadataAndIdentifier[] {
 		const models = this._runtime.getModels(sessionType);
@@ -295,12 +258,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		return selectable.length > 0 ? selectable : models;
 	}
 
-	/**
-	 * Replaces a selection that is no longer valid. The callers differ only in *why* the model
-	 * stopped being valid — unsupported for the mode, outside the session pool, withdrawn from the
-	 * catalog — and routing them all through here keeps that from turning into a difference in
-	 * what replaces it.
-	 */
+	/** Callers differ only in *why* the model became invalid; sharing this keeps that from changing what replaces it. */
 	private _replaceInvalidSelection(
 		displaced: ILanguageModelChatMetadataAndIdentifier | undefined,
 		sessionType: string | undefined,
@@ -341,11 +299,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		this._standIn(defaultModel, configuredModel ? ModelSelectionReason.ConfiguredDefault : ModelSelectionReason.FirstAvailable);
 	}
 
-	/**
-	 * Falls back to the default because the user asked for it, as opposed to because the current
-	 * model stopped being valid. That makes it a deliberate choice, so it discards the remembered
-	 * selection: a model that reappears later must not reclaim the input behind the user's back.
-	 */
+	/** The user asked for the default, so the remembered selection is discarded rather than reclaimed later. */
 	resetToDefault(sessionType = this._runtime.getCurrentSessionType()): void {
 		this._clearIntent();
 		this._rememberedSelection = undefined;
@@ -406,11 +360,9 @@ export class ChatInputModelSelectionController extends Disposable {
 	}
 
 	/**
-	 * Reclaims the remembered model once the catalog can offer it again. A model can leave the pool
-	 * for reasons that have nothing to do with intent — an agent host restarting republishes its
-	 * catalog moments later — so the default shown meanwhile is a stand-in, not a decision.
-	 * `chat.defaultModel` outranks a merely remembered model but never an in-conversation choice,
-	 * which is why the displaced authority is restored along with the model.
+	 * Reclaims the remembered model once it can be offered again — an agent host restart empties the
+	 * catalog and refills it moments later. `chat.defaultModel` outranks a merely remembered model
+	 * but never an in-conversation choice, so the displaced authority is restored with it.
 	 */
 	private _restoreRememberedModel(): boolean {
 		const remembered = this._rememberedSelection;
@@ -461,18 +413,15 @@ export class ChatInputModelSelectionController extends Disposable {
 		}
 
 		const pool = this._runtime.getModels(sessionType);
-		const match = findBestMatchingModel(desiredModel, pool) ?? findBestMatchingModel(currentModel, pool);
-		if (match) {
-			this._applySessionRestore(match, true);
-		} else if (resolution.kind === 'pending' && shouldWaitForSessionModel(desiredModel, sessionType, allModels)) {
+		const canSubstitute = !!(findBestMatchingModel(desiredModel, pool) ?? findBestMatchingModel(currentModel, pool));
+		if (!canSubstitute && resolution.kind === 'pending' && shouldWaitForSessionModel(desiredModel, sessionType, allModels)) {
 			this._clearIntent();
 			this._intent = { kind: 'session', model: desiredModel, configuration: modelConfiguration, sessionType, conversationKey };
-		} else {
-			this._clearIntent();
-			this.selectDefault(sessionType);
+			return;
 		}
+		this._clearIntent();
+		this._substituteForConversationModel(desiredModel, currentModel, sessionType);
 	}
-
 	/**
 	 * Reconcile the current model after an explicit session-type pick: restore persisted →
 	 * best-match previous → default.
@@ -554,11 +503,17 @@ export class ChatInputModelSelectionController extends Disposable {
 			return false;
 		}
 
+		// Every intent belongs to a conversation. `history` tracks the visible one because it is
+		// resolved for what the user is looking at; the others track the bound input model.
+		const conversationKey = intent.kind === 'history'
+			? this._runtime.getVisibleConversationKey()
+			: this._runtime.getBoundConversationKey();
+		if (conversationKey !== intent.conversationKey) {
+			this._clearIntent();
+			return true;
+		}
+
 		if (intent.kind === 'programmatic') {
-			if (this._runtime.getBoundConversationKey() !== intent.conversationKey) {
-				this._clearIntent();
-				return true;
-			}
 			const model = intent.resolveModel();
 			if (!model) {
 				return false;
@@ -570,10 +525,6 @@ export class ChatInputModelSelectionController extends Disposable {
 		}
 
 		if (intent.kind === 'session') {
-			if (this._runtime.getBoundConversationKey() !== intent.conversationKey) {
-				this._clearIntent();
-				return true;
-			}
 			const resolution = this._runtime.resolveModelIdentifier(intent.model.identifier);
 			if (resolution.kind === 'available') {
 				this._intent = undefined;
@@ -582,21 +533,12 @@ export class ChatInputModelSelectionController extends Disposable {
 			}
 			if (resolution.kind === 'unavailable') {
 				this._intent = undefined;
-				const match = findBestMatchingModel(intent.model, this._runtime.getModels(intent.sessionType));
-				if (match) {
-					this._applySessionRestore(match, true);
-				} else {
-					this.selectDefault(intent.sessionType);
-				}
+				this._substituteForConversationModel(intent.model, undefined, intent.sessionType);
 				return true;
 			}
 			return false;
 		}
 
-		if (this._runtime.getVisibleConversationKey() !== intent.conversationKey) {
-			this._clearIntent();
-			return true;
-		}
 		const models = this._runtime.getModels(this._runtime.getCurrentSessionType());
 		const model = models.find(model => model.identifier === intent.modelId)
 			?? models.find(model => model.metadata.id === intent.modelId);
@@ -606,6 +548,21 @@ export class ChatInputModelSelectionController extends Disposable {
 			return true;
 		}
 		return false;
+	}
+
+	/** The model a conversation asked for is unusable here: take the closest match, else the default. */
+	private _substituteForConversationModel(
+		desired: ILanguageModelChatMetadataAndIdentifier,
+		currentModel: ILanguageModelChatMetadataAndIdentifier | undefined,
+		sessionType: string | undefined,
+	): void {
+		const pool = this._runtime.getModels(sessionType);
+		const match = findBestMatchingModel(desired, pool) ?? findBestMatchingModel(currentModel, pool);
+		if (match) {
+			this._applySessionRestore(match, true);
+			return;
+		}
+		this.selectDefault(sessionType);
 	}
 
 	private _clearIntent(): void {
@@ -619,12 +576,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		}
 	}
 
-	/**
-	 * Displays a model without saying anything about authority, leaving both the current reason and
-	 * the remembered selection alone. For callers that have already decided the authority question
-	 * elsewhere — a caller applying its own choice, or a fallback shown while a pending request
-	 * still owns the selection.
-	 */
+	/** Displays a model and says nothing about authority; both reason and remembered are left alone. */
 	private _display(
 		model: ILanguageModelChatMetadataAndIdentifier,
 		effect: () => void = () => this._runtime.applyModel(model),
@@ -633,19 +585,13 @@ export class ChatInputModelSelectionController extends Disposable {
 		effect();
 	}
 
-	/**
-	 * Records a decision without changing what is displayed — used when the model is already
-	 * shown and only its authority needs to catch up.
-	 */
+	/** Records a decision for a model that is already displayed. */
 	private _rememberChoice(model: ILanguageModelChatMetadataAndIdentifier, reason: DurableReason): void {
 		this._selectionReason = reason;
 		this._rememberedSelection = { modelId: model.identifier, reason };
 	}
 
-	/**
-	 * Applies a model as a decision: it becomes both what is displayed and what is reclaimed once
-	 * the catalog can offer it again.
-	 */
+	/** Applies a model as a decision: displayed now, and reclaimed after an outage. */
 	private _choose(
 		model: ILanguageModelChatMetadataAndIdentifier,
 		reason: DurableReason,
@@ -657,10 +603,7 @@ export class ChatInputModelSelectionController extends Disposable {
 		this._display(model, effect);
 	}
 
-	/**
-	 * Applies a model as a stand-in for one that cannot currently be offered. Deliberately leaves
-	 * the remembered selection alone — that is what makes the fallback temporary.
-	 */
+	/** Stands in for a model that cannot be offered. Leaving `_rememberedSelection` alone is what makes it temporary. */
 	private _standIn(model: ILanguageModelChatMetadataAndIdentifier, reason: TransientReason): void {
 		this._selectionReason = reason;
 		this._display(model);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1886,8 +1886,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	/** Resets the language model to the location default and cancels any pending model-selection intent. */
 	public resetLanguageModelToDefault(): void {
-		this._modelSelectionController.clearIntent();
-		this._modelSelectionController.selectDefault(this.getCurrentSessionType());
+		this._modelSelectionController.resetToDefault(this.getCurrentSessionType());
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1066,7 +1066,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (isUserAction) {
 				this.setCurrentLanguageModel(model, true, storeSelection);
 			} else {
-				this._modelSelectionController.applyProgrammaticSelection(model);
+				this._modelSelectionController.select(model, 'programmatic');
 			}
 			return true;
 		}
@@ -1078,7 +1078,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		for (const qualifiedModelName of qualifiedModelNames) {
 			const model = models.find(m => ILanguageModelChatMetadata.matchesQualifiedName(qualifiedModelName, m.metadata));
 			if (model) {
-				this._modelSelectionController.applyProgrammaticSelection(model);
+				this._modelSelectionController.select(model, 'programmatic');
 				return true;
 			}
 		}
@@ -1652,9 +1652,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this._syncInputStateToModel();
 		};
 		if (isUserAction) {
-			this._modelSelectionController.applyExplicitSelection(model, apply, false);
+			this._modelSelectionController.select(model, 'user', { effect: apply });
 		} else {
-			this._modelSelectionController.applyAutomaticSelection(model, apply);
+			this._modelSelectionController.select(model, 'automatic', { effect: apply });
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1802,7 +1802,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const pool = this.getModelsForSessionType(this.getCurrentSessionType());
 		if (!pool.some(m => m.identifier === currentModel.identifier)) {
 			this.initSelectedModel();
-			this._modelSelectionController.ensureCurrentModelInSessionPool();
+			this._modelSelectionController.ensureCurrentModelSupported();
 		}
 	}
 
@@ -2811,7 +2811,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			logChangesToStateModel(this._inputModel, `[CVVM].1 onDidChangeViewModel -> session change: ${this._currentSessionType} -> ${newSessionType} in ${this._currentSessionKey}, ${e.currentSessionResource.toString()}`, undefined, this._inputModel?.state.get(), this.logService);
 			this._currentSessionTypeObservable.set(newSessionType, transaction);
 			this.initSelectedModel();
-			this._modelSelectionController.ensureCurrentModelInSessionPool();
+			this._modelSelectionController.ensureCurrentModelSupported();
 			this.checkModeInSessionPool();
 		} else if (e.currentSessionResource) {
 			logChangesToStateModel(this._inputModel, `[CVVM].2 onDidChangeViewModel -> session change: ${this._currentSessionType} -> ${newSessionType} in ${this._currentSessionKey}, ${e.currentSessionResource.toString()}`, undefined, this._inputModel?.state.get(), this.logService);
@@ -2833,8 +2833,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		// move away from the model that will be applied when it appears.
 		if (this._modelSelectionController.restorePerTypeModel) {
 			this.initSelectedModel();
-			if (!this._modelSelectionController.hasPendingIntent() && !this._modelSelectionController.isAwaitingRememberedModel()) {
-				this._modelSelectionController.ensureCurrentModelInSessionPool();
+			if (!this._modelSelectionController.isAwaitingModel()) {
+				this._modelSelectionController.ensureCurrentModelSupported();
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1066,7 +1066,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (isUserAction) {
 				this.setCurrentLanguageModel(model, true, storeSelection);
 			} else {
-				this._modelSelectionController.select(model, 'programmatic');
+				this._modelSelectionController.select(model, { authority: 'programmatic' });
 			}
 			return true;
 		}
@@ -1078,7 +1078,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		for (const qualifiedModelName of qualifiedModelNames) {
 			const model = models.find(m => ILanguageModelChatMetadata.matchesQualifiedName(qualifiedModelName, m.metadata));
 			if (model) {
-				this._modelSelectionController.select(model, 'programmatic');
+				this._modelSelectionController.select(model, { authority: 'programmatic' });
 				return true;
 			}
 		}
@@ -1652,9 +1652,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this._syncInputStateToModel();
 		};
 		if (isUserAction) {
-			this._modelSelectionController.select(model, 'user', { effect: apply });
+			this._modelSelectionController.select(model, { authority: 'user', effect: apply });
 		} else {
-			this._modelSelectionController.select(model, 'automatic', { effect: apply });
+			this._modelSelectionController.select(model, { authority: 'automatic', effect: apply });
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -800,7 +800,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.chatSessionSupportsDelegationKey.set(this.chatSessionsService.supportsDelegationForSessionType(newSessionType));
 				this.updateWidgetLockStateFromSessionType(newSessionType);
 				this.checkModeInSessionPool(newSessionType);
-				this.revalidateModelForSessionType();
+				this._modelSelectionController.revalidateForSessionType(() => this.initSelectedModel());
 				this.refreshChatSessionPickers();
 			}));
 		}
@@ -902,7 +902,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.initSelectedModel();
 
 		this._register(this._onDidChangeCurrentChatMode.event(() => {
-			this.checkModelSupported();
+			this._modelSelectionController.ensureCurrentModelSupported();
 		}));
 
 		const updateAfterModelListChange = (reconcileSelection: boolean) => {
@@ -1066,7 +1066,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (isUserAction) {
 				this.setCurrentLanguageModel(model, true, storeSelection);
 			} else {
-				this._applyProgrammaticLanguageModel(model);
+				this._modelSelectionController.applyProgrammaticSelection(model);
 			}
 			return true;
 		}
@@ -1078,7 +1078,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		for (const qualifiedModelName of qualifiedModelNames) {
 			const model = models.find(m => ILanguageModelChatMetadata.matchesQualifiedName(qualifiedModelName, m.metadata));
 			if (model) {
-				this._applyProgrammaticLanguageModel(model);
+				this._modelSelectionController.applyProgrammaticSelection(model);
 				return true;
 			}
 		}
@@ -1514,7 +1514,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			// Be deterministic for anonymous users to support
 			// agentic flows with default model.
 			this.setChatMode(ChatModeKind.Agent, false);
-			this.checkModelSupported();
+			this._modelSelectionController.ensureCurrentModelSupported();
 			return;
 		}
 
@@ -1530,7 +1530,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				if (resolved) {
 					this.logService.trace(`[ChatInputPart] Applying default mode from setting: ${defaultMode} -> ${resolved.id}`);
 					this.setChatMode(resolved.id, false);
-					this.checkModelSupported();
+					this._modelSelectionController.ensureCurrentModelSupported();
 				}
 			}
 		}
@@ -1658,10 +1658,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 	}
 
-	private _applyProgrammaticLanguageModel(model: ILanguageModelChatMetadataAndIdentifier): void {
-		this._modelSelectionController.applyProgrammaticSelection(model);
-	}
-
 	private _requestProgrammaticLanguageModel(resolveModel: () => ILanguageModelChatMetadataAndIdentifier | undefined): Promise<boolean> {
 		const result = this._modelSelectionController.requestProgrammaticSelection(
 			resolveModel,
@@ -1670,10 +1666,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._updateInputContentContextKeys();
 		void result.finally(() => this._updateInputContentContextKeys());
 		return result;
-	}
-
-	private checkModelSupported(): void {
-		this._modelSelectionController.ensureCurrentModelSupported();
 	}
 
 	/**
@@ -1796,14 +1788,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	/**
-	 * Validate that the current model belongs to the current session's pool.
-	 * Called when switching sessions to prevent cross-contamination.
-	 */
-	private checkModelInSessionPool(): void {
-		this._modelSelectionController.ensureCurrentModelInSessionPool();
-	}
-
-	/**
 	 * If the current model is absent from the destination session's filtered pool,
 	 * re-initialize from storage to restore the user's previous selection for this
 	 * pool, then validate. Uses the filtered pool (same as `revalidateForSessionType`)
@@ -1818,15 +1802,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const pool = this.getModelsForSessionType(this.getCurrentSessionType());
 		if (!pool.some(m => m.identifier === currentModel.identifier)) {
 			this.initSelectedModel();
-			this.checkModelInSessionPool();
+			this._modelSelectionController.ensureCurrentModelInSessionPool();
 		}
-	}
-
-	/**
-	 * Reconcile the current model after an explicit session-type pick: restore persisted → best-match previous → default.
-	 */
-	private revalidateModelForSessionType(): void {
-		this._modelSelectionController.revalidateForSessionType(() => this.initSelectedModel());
 	}
 
 	/**
@@ -1896,10 +1873,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._modelSelectionController.preselectFromHistory(lastModelId, sessionResource.toString());
 	}
 
-	private setCurrentLanguageModelToDefault(forSessionType?: string) {
-		this._modelSelectionController.selectDefault(forSessionType ?? this.getCurrentSessionType());
-	}
-
 	/**
 	 * The raw configured default-model value from the
 	 * {@link ChatConfiguration.DefaultModel} setting (which may
@@ -1914,7 +1887,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	/** Resets the language model to the location default and cancels any pending model-selection intent. */
 	public resetLanguageModelToDefault(): void {
 		this._modelSelectionController.clearIntent();
-		this.setCurrentLanguageModelToDefault();
+		this._modelSelectionController.selectDefault(this.getCurrentSessionType());
 	}
 
 	/**
@@ -2839,7 +2812,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			logChangesToStateModel(this._inputModel, `[CVVM].1 onDidChangeViewModel -> session change: ${this._currentSessionType} -> ${newSessionType} in ${this._currentSessionKey}, ${e.currentSessionResource.toString()}`, undefined, this._inputModel?.state.get(), this.logService);
 			this._currentSessionTypeObservable.set(newSessionType, transaction);
 			this.initSelectedModel();
-			this.checkModelInSessionPool();
+			this._modelSelectionController.ensureCurrentModelInSessionPool();
 			this.checkModeInSessionPool();
 		} else if (e.currentSessionResource) {
 			logChangesToStateModel(this._inputModel, `[CVVM].2 onDidChangeViewModel -> session change: ${this._currentSessionType} -> ${newSessionType} in ${this._currentSessionKey}, ${e.currentSessionResource.toString()}`, undefined, this._inputModel?.state.get(), this.logService);
@@ -2862,7 +2835,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (this._modelSelectionController.restorePerTypeModel) {
 			this.initSelectedModel();
 			if (!this._modelSelectionController.hasPendingIntent() && !this._modelSelectionController.isAwaitingRememberedModel()) {
-				this.checkModelInSessionPool();
+				this._modelSelectionController.ensureCurrentModelInSessionPool();
 			}
 		}
 	}
@@ -3184,7 +3157,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					if (action.id === OpenModelPickerAction.ID && action instanceof MenuItemAction) {
 						if (!this._currentLanguageModel.get()) {
 							logChangesToStateModel(this._inputModel, `actionViewItemProvider[phone]: _currentLanguageModel is undefined at toolbar build, forcing default for ${this._currentSessionKey}`, undefined, undefined, this.logService);
-							this.setCurrentLanguageModelToDefault();
+							this._modelSelectionController.selectDefault(this.getCurrentSessionType());
 						}
 						const modelDelegate = this._createModelPickerDelegate();
 						const modeDelegate = this._createModePickerDelegate();
@@ -3197,7 +3170,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				if (action.id === OpenModelPickerAction.ID && action instanceof MenuItemAction) {
 					if (!this._currentLanguageModel.get()) {
 						logChangesToStateModel(this._inputModel, `actionViewItemProvider[desktop]: _currentLanguageModel is undefined at toolbar build, forcing default for ${this._currentSessionKey}`, undefined, undefined, this.logService);
-						this.setCurrentLanguageModelToDefault();
+						this._modelSelectionController.selectDefault(this.getCurrentSessionType());
 					}
 
 					const itemDelegate: IModelPickerDelegate = this._createModelPickerDelegate();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2861,7 +2861,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		// move away from the model that will be applied when it appears.
 		if (this._modelSelectionController.restorePerTypeModel) {
 			this.initSelectedModel();
-			if (!this._modelSelectionController.hasPendingIntent()) {
+			if (!this._modelSelectionController.hasPendingIntent() && !this._modelSelectionController.isAwaitingRememberedModel()) {
 				this.checkModelInSessionPool();
 			}
 		}

--- a/src/vs/workbench/contrib/chat/common/modelSelection.ts
+++ b/src/vs/workbench/contrib/chat/common/modelSelection.ts
@@ -150,6 +150,16 @@ export function isAuthoritativeModelSelectionReason(reason: ModelSelectionApplyR
 		|| reason === ModelSelectionReason.UserSelection;
 }
 
+/**
+ * Whether a reason represents a choice made inside the current conversation. `chat.defaultModel`
+ * seeds every new conversation but must never override one of these. `SessionRestore` is excluded
+ * deliberately: on an empty session it is spillover from the previous one, not a choice.
+ */
+export function isInConversationModelChoice(reason: ModelSelectionApplyReason | undefined): boolean {
+	return reason === ModelSelectionReason.UserSelection
+		|| reason === ModelSelectionReason.ProgrammaticSelection;
+}
+
 export interface IPendingModelSelection {
 	readonly reference: string;
 }

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -708,6 +708,37 @@ suite('ChatInputModelSelectionController', () => {
 		});
 	});
 
+	test('a mode-invalid configured default is not reapplied on every catalog change', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		// `chat.defaultModel` names a model agent mode cannot use.
+		const configured = targetedModel('agent-host/configured', 'agent-host');
+		const agentCapableBase = targetedModel('agent-host/capable', 'agent-host');
+		const agentCapable: ILanguageModelChatMetadataAndIdentifier = {
+			...agentCapableBase,
+			metadata: { ...agentCapableBase.metadata, capabilities: { toolCalling: true, agentMode: true } },
+		};
+		const state: IRuntimeState = {
+			models: [configured, agentCapable],
+			resolved: true,
+			sessionType: 'agent-host',
+			modeKind: ChatModeKind.Agent,
+			configuredModel: configured.metadata.id,
+		};
+		const applied: string[] = [];
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
+
+		controller.applyAutomaticSelection(agentCapable, () => { });
+		applied.length = 0;
+		modelChanges.fire('refresh-one');
+		modelChanges.fire('refresh-two');
+
+		assert.deepStrictEqual({ applied, current: controller.currentModel.get()?.identifier }, {
+			// No churn: the unusable configured model is never applied, so nothing is re-applied.
+			applied: [],
+			current: agentCapable.identifier,
+		});
+	});
+
 	test('applies a fallback while the configured default loads, then upgrades it', () => {
 		const byok = model('openai/byok');
 		const configured = model('copilot/configured');
@@ -1607,7 +1638,7 @@ suite('ChatInputModelSelectionController', () => {
 			};
 			const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 			controller.initialize(rememberedId, () => { });
-			return controller.hasPendingIntent();
+			return controller.isAwaitingRememberedModel();
 		};
 		const first = model('test/first');
 		const remembered = model('test/remembered');

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -80,14 +80,14 @@ suite('ChatInputModelSelectionController', () => {
 		controller.applyAutomaticSelection(first, () => { });
 		const automatic = {
 			current: controller.currentModel.get()?.identifier,
-			explicit: controller.userExplicitlySelectedModel,
+			explicit: controller.selectionReason === ModelSelectionReason.UserSelection,
 		};
 		controller.applyExplicitSelection(second, () => { }, false);
 
 		assert.deepStrictEqual({
 			automatic,
 			current: controller.currentModel.get()?.identifier,
-			explicitAfterUserSelection: controller.userExplicitlySelectedModel,
+			explicitAfterUserSelection: controller.selectionReason === ModelSelectionReason.UserSelection,
 		}, {
 			automatic: { current: first.identifier, explicit: false },
 			current: second.identifier,
@@ -977,7 +977,7 @@ suite('ChatInputModelSelectionController', () => {
 		controller.applyExplicitSelection(opus, () => applied.push(opus.identifier), false);
 		const configuredApplied = controller.applyConfiguredDefault();
 
-		assert.deepStrictEqual({ configuredApplied, applied, current: controller.currentModel.get()?.identifier, userPicked: controller.userExplicitlySelectedModel }, {
+		assert.deepStrictEqual({ configuredApplied, applied, current: controller.currentModel.get()?.identifier, userPicked: controller.selectionReason === ModelSelectionReason.UserSelection }, {
 			configuredApplied: false,
 			applied: [opus.identifier],
 			current: opus.identifier,

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -79,12 +79,12 @@ suite('ChatInputModelSelectionController', () => {
 		const first = model('test/first');
 		const second = model('test/second');
 
-		controller.select(first, 'automatic', { effect: () => { } });
+		controller.select(first, { authority: 'automatic', effect: () => { } });
 		const automatic = {
 			current: controller.currentModel.get()?.identifier,
 			explicit: controller.selectionReason === ModelSelectionReason.UserSelection,
 		};
-		controller.select(second, 'user', { effect: () => { }, rollbackOnError: false });
+		controller.select(second, { authority: 'user', effect: () => { }, rollbackOnError: false });
 
 		assert.deepStrictEqual({
 			automatic,
@@ -102,9 +102,9 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime({ models: [], resolved: true, sessionType: 'test' }, modelChanges, [])));
 		const first = model('test/first');
 		const second = model('test/second');
-		controller.select(first, 'automatic', { effect: () => { } });
+		controller.select(first, { authority: 'automatic', effect: () => { } });
 
-		assert.throws(() => controller.select(second, 'user', { effect: () => { throw new Error('rejected'); }, rollbackOnError: true }), /rejected/);
+		assert.throws(() => controller.select(second, { authority: 'user', effect: () => { throw new Error('rejected'); }, rollbackOnError: true }), /rejected/);
 		assert.deepStrictEqual({
 			current: controller.currentModel.get()?.identifier,
 			reason: controller.selectionReason,
@@ -246,7 +246,7 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
 		controller.initialize(remembered.identifier, () => { });
-		controller.select(explicit, 'user', { effect: () => applied.push(explicit.identifier), rollbackOnError: false });
+		controller.select(explicit, { authority: 'user', effect: () => applied.push(explicit.identifier), rollbackOnError: false });
 		state.models = [fallback, explicit, remembered];
 		modelChanges.fire('loaded');
 
@@ -271,7 +271,7 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
 		controller.initialize(remembered.identifier, () => { });
-		controller.select(programmatic, 'programmatic');
+		controller.select(programmatic, { authority: 'programmatic' });
 		state.models = [fallback, programmatic, remembered];
 		modelChanges.fire('loaded');
 
@@ -330,7 +330,7 @@ suite('ChatInputModelSelectionController', () => {
 			() => state.models.find(model => model.identifier === requested.identifier),
 			'chat:one',
 		);
-		controller.select(explicit, 'user', { effect: () => applied.push(explicit.identifier), rollbackOnError: false });
+		controller.select(explicit, { authority: 'user', effect: () => applied.push(explicit.identifier), rollbackOnError: false });
 		state.models = [explicit, requested];
 		modelChanges.fire('loaded');
 
@@ -435,7 +435,7 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.select(selected, 'user', { effect: () => { }, rollbackOnError: false });
+		controller.select(selected, { authority: 'user', effect: () => { }, rollbackOnError: false });
 		state.models = [other];
 		modelChanges.fire('agent-host-restarting');
 		const duringRestart = controller.currentModel.get()?.identifier;
@@ -498,7 +498,7 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.select(selected, 'user', { effect: () => { }, rollbackOnError: false });
+		controller.select(selected, { authority: 'user', effect: () => { }, rollbackOnError: false });
 		state.models = [substitute];
 		modelChanges.fire('model-gone');
 		const duringOutage = controller.currentModel.get()?.identifier;
@@ -526,10 +526,10 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.select(selected, 'user', { effect: () => { }, rollbackOnError: false });
+		controller.select(selected, { authority: 'user', effect: () => { }, rollbackOnError: false });
 		state.models = [other, chosen];
 		modelChanges.fire('model-removed');
-		controller.select(chosen, 'user', { effect: () => { }, rollbackOnError: false });
+		controller.select(chosen, { authority: 'user', effect: () => { }, rollbackOnError: false });
 		state.models = [selected, other, chosen];
 		modelChanges.fire('model-back');
 
@@ -559,7 +559,7 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.select(picked, 'user', { effect: () => { }, rollbackOnError: false });
+		controller.select(picked, { authority: 'user', effect: () => { }, rollbackOnError: false });
 		state.models = [configured];
 		modelChanges.fire('picked-gone');
 		const duringOutage = controller.currentModel.get()?.identifier;
@@ -597,7 +597,7 @@ suite('ChatInputModelSelectionController', () => {
 		const state: IRuntimeState = { models: [remembered, standIn], resolved: true, sessionType: 'local' };
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
 
-		controller.select(remembered, 'user', { effect: () => { }, rollbackOnError: false });
+		controller.select(remembered, { authority: 'user', effect: () => { }, rollbackOnError: false });
 		// The pick disappears and the stand-in takes over.
 		state.models = [standIn];
 		controller.reconcileModelListChange(state.models);
@@ -629,7 +629,7 @@ suite('ChatInputModelSelectionController', () => {
 		const state: IRuntimeState = { models: [picked, locationDefault], resolved: true, sessionType: 'local' };
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
 
-		controller.select(picked, 'user', { effect: () => { }, rollbackOnError: false });
+		controller.select(picked, { authority: 'user', effect: () => { }, rollbackOnError: false });
 		state.models = [locationDefault];
 		controller.reconcileModelListChange(state.models);
 		// The user deliberately asks for the default while the pick is unavailable.
@@ -670,7 +670,7 @@ suite('ChatInputModelSelectionController', () => {
 		};
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
 
-		controller.select(invalid, 'automatic', { effect: () => { } });
+		controller.select(invalid, { authority: 'automatic', effect: () => { } });
 		controller.ensureCurrentModelSupported();
 
 		assert.deepStrictEqual({ current: controller.currentModel.get()?.identifier }, { current: agentCapable.identifier });
@@ -695,7 +695,7 @@ suite('ChatInputModelSelectionController', () => {
 
 		controller.initialize(askOnly.identifier, () => { });
 		const awaiting = controller.isAwaitingModel();
-		controller.select(withAgentMode, 'automatic', { effect: () => { } });
+		controller.select(withAgentMode, { authority: 'automatic', effect: () => { } });
 		modelChanges.fire('refresh');
 
 		assert.deepStrictEqual({
@@ -727,7 +727,7 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.select(agentCapable, 'automatic', { effect: () => { } });
+		controller.select(agentCapable, { authority: 'automatic', effect: () => { } });
 		applied.length = 0;
 		modelChanges.fire('refresh-one');
 		modelChanges.fire('refresh-two');
@@ -782,8 +782,8 @@ suite('ChatInputModelSelectionController', () => {
 		const state: IRuntimeState = { models: [picked, rejected, standIn], resolved: true, sessionType: 'local' };
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
 
-		controller.select(picked, 'user', { effect: () => { }, rollbackOnError: false });
-		assert.throws(() => controller.select(rejected, 'user', { effect: () => { throw new Error('nope'); }, rollbackOnError: true }), /nope/);
+		controller.select(picked, { authority: 'user', effect: () => { }, rollbackOnError: false });
+		assert.throws(() => controller.select(rejected, { authority: 'user', effect: () => { throw new Error('nope'); }, rollbackOnError: true }), /nope/);
 		// The rollback must restore the remembered selection too, not just what is displayed:
 		// otherwise the rejected model would be reclaimed after an outage.
 		state.models = [standIn];
@@ -925,7 +925,7 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.initialize(undefined, () => { });
-		controller.select(explicit, 'user', { effect: () => applied.push(explicit.identifier), rollbackOnError: false });
+		controller.select(explicit, { authority: 'user', effect: () => applied.push(explicit.identifier), rollbackOnError: false });
 		models = [byok, explicit, configured];
 		controller.reconcileModelListChange(models);
 
@@ -1191,7 +1191,7 @@ suite('ChatInputModelSelectionController', () => {
 			createRuntime({ models: [gpt, opus], resolved: true, sessionType: 'test', configuredModel: gpt.metadata.id }, modelChanges, applied)));
 
 		controller.beginSessionSwitch(true, false, false);
-		controller.select(opus, 'user', { effect: () => applied.push(opus.identifier), rollbackOnError: false });
+		controller.select(opus, { authority: 'user', effect: () => applied.push(opus.identifier), rollbackOnError: false });
 		const configuredApplied = controller.applyConfiguredDefault();
 
 		assert.deepStrictEqual({ configuredApplied, applied, current: controller.currentModel.get()?.identifier, userPicked: controller.selectionReason === ModelSelectionReason.UserSelection }, {
@@ -1576,7 +1576,7 @@ suite('ChatInputModelSelectionController', () => {
 			},
 		};
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
-		controller.select(general, 'automatic', { effect: () => { } });
+		controller.select(general, { authority: 'automatic', effect: () => { } });
 		state.sessionType = 'agent-host-test';
 
 		controller.revalidateForSessionType(() => { });
@@ -1614,7 +1614,7 @@ suite('ChatInputModelSelectionController', () => {
 			applyModel: selected => applied.push(selected.identifier),
 		};
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
-		controller.select(general, 'automatic', { effect: () => { } });
+		controller.select(general, { authority: 'automatic', effect: () => { } });
 
 		state.sessionType = sessionType;
 		controller.revalidateForSessionType(() => { });
@@ -1744,7 +1744,7 @@ suite('ChatInputModelSelectionController', () => {
 
 		controller.initialize(remembered.identifier, () => { });
 		const pendingAfterInit = controller.isAwaitingModel();
-		controller.select(explicit, 'user', { effect: () => applied.push(explicit.identifier), rollbackOnError: false });
+		controller.select(explicit, { authority: 'user', effect: () => applied.push(explicit.identifier), rollbackOnError: false });
 		const pendingAfterExplicit = controller.isAwaitingModel();
 		models = [fallback, explicit, remembered];
 		modelChanges.fire('loaded');

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -42,6 +42,8 @@ interface IRuntimeState {
 	configuredModel?: string;
 	/** Defaults to `true` (a new/empty session). Set to `false` to model a reopened conversation with history. */
 	isEmpty?: boolean;
+	/** Defaults to `Ask`. Set to `Agent` to exercise mode-based model invalidation. */
+	modeKind?: ChatModeKind;
 }
 
 function createRuntime(
@@ -51,7 +53,7 @@ function createRuntime(
 ): IChatInputModelSelectionRuntime {
 	return {
 		location: ChatAgentLocation.Chat,
-		getCurrentModeKind: () => ChatModeKind.Ask,
+		getCurrentModeKind: () => state.modeKind ?? ChatModeKind.Ask,
 		getCurrentSessionType: () => state.sessionType,
 		isEmpty: () => state.isEmpty ?? true,
 		getModels: () => state.models,
@@ -614,6 +616,64 @@ suite('ChatInputModelSelectionController', () => {
 			current: remembered.identifier,
 			reason: ModelSelectionReason.UserSelection,
 		});
+	});
+
+	test('a deliberate reset to default is not undone when the old model returns', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const picked = model('test/picked');
+		const base = model('test/default');
+		const locationDefault: ILanguageModelChatMetadataAndIdentifier = {
+			...base,
+			metadata: { ...base.metadata, isDefaultForLocation: { [ChatAgentLocation.Chat]: true } },
+		};
+		const state: IRuntimeState = { models: [picked, locationDefault], resolved: true, sessionType: 'local' };
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
+
+		controller.applyExplicitSelection(picked, () => { }, false);
+		state.models = [locationDefault];
+		controller.reconcileModelListChange(state.models);
+		// The user deliberately asks for the default while the pick is unavailable.
+		controller.resetToDefault();
+		const afterReset = controller.currentModel.get()?.identifier;
+		state.models = [picked, locationDefault];
+		modelChanges.fire('picked-back');
+
+		assert.deepStrictEqual({
+			afterReset,
+			afterPickReturns: controller.currentModel.get()?.identifier,
+		}, {
+			afterReset: locationDefault.identifier,
+			afterPickReturns: locationDefault.identifier,
+		});
+	});
+
+	test('a mode-invalid model in an unfiltered targeted pool is not reapplied to itself', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		// Targeted session pools are not mode-filtered, so the pool still offers models that agent
+		// mode cannot use — including the one being replaced.
+		const invalid = targetedModel('agent-host/invalid', 'agent-host');
+		const agentCapable: ILanguageModelChatMetadataAndIdentifier = {
+			identifier: 'agent-host/capable',
+			metadata: {
+				...invalid.metadata,
+				id: 'agent-host/capable',
+				name: 'agent-host/capable',
+				family: 'capable',
+				capabilities: { toolCalling: true, agentMode: true },
+			},
+		};
+		const state: IRuntimeState = {
+			models: [invalid, agentCapable],
+			resolved: true,
+			sessionType: 'agent-host',
+			modeKind: ChatModeKind.Agent,
+		};
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
+
+		controller.applyAutomaticSelection(invalid, () => { });
+		controller.ensureCurrentModelSupported();
+
+		assert.deepStrictEqual({ current: controller.currentModel.get()?.identifier }, { current: agentCapable.identifier });
 	});
 
 	test('applies a fallback while the configured default loads, then upgrades it', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -583,6 +583,39 @@ suite('ChatInputModelSelectionController', () => {
 		});
 	});
 
+	test('an invalid selection is replaced by the remembered model, not the default', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const remembered = model('test/remembered');
+		const standIn = model('test/stand-in');
+		const base = model('test/location-default');
+		const locationDefault: ILanguageModelChatMetadataAndIdentifier = {
+			...base,
+			metadata: { ...base.metadata, isDefaultForLocation: { [ChatAgentLocation.Chat]: true } },
+		};
+		const state: IRuntimeState = { models: [remembered, standIn], resolved: true, sessionType: 'local' };
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
+
+		controller.applyExplicitSelection(remembered, () => { }, false);
+		// The pick disappears and the stand-in takes over.
+		state.models = [standIn];
+		controller.reconcileModelListChange(state.models);
+		const displaced = controller.currentModel.get()?.identifier;
+		// The pick returns while the stand-in itself becomes invalid. `ensureCurrentModelSupported`
+		// must reclaim the pick rather than settle for the location default.
+		state.models = [remembered, locationDefault];
+		controller.ensureCurrentModelSupported();
+
+		assert.deepStrictEqual({
+			displaced,
+			current: controller.currentModel.get()?.identifier,
+			reason: controller.selectionReason,
+		}, {
+			displaced: standIn.identifier,
+			current: remembered.identifier,
+			reason: ModelSelectionReason.UserSelection,
+		});
+	});
+
 	test('applies a fallback while the configured default loads, then upgrades it', () => {
 		const byok = model('openai/byok');
 		const configured = model('copilot/configured');

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -676,6 +676,38 @@ suite('ChatInputModelSelectionController', () => {
 		assert.deepStrictEqual({ current: controller.currentModel.get()?.identifier }, { current: agentCapable.identifier });
 	});
 
+	test('a remembered model is not reclaimed while the current mode cannot use it', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const agentCapable = targetedModel('agent-host/capable', 'agent-host');
+		const withAgentMode: ILanguageModelChatMetadataAndIdentifier = {
+			...agentCapable,
+			metadata: { ...agentCapable.metadata, capabilities: { toolCalling: true, agentMode: true } },
+		};
+		// Remembered from an Ask-mode session; agent mode cannot use it.
+		const askOnly = targetedModel('agent-host/ask-only', 'agent-host');
+		const state: IRuntimeState = {
+			models: [withAgentMode, askOnly],
+			resolved: true,
+			sessionType: 'agent-host',
+			modeKind: ChatModeKind.Agent,
+		};
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
+
+		controller.initialize(askOnly.identifier, () => { });
+		const awaiting = controller.isAwaitingRememberedModel();
+		controller.applyAutomaticSelection(withAgentMode, () => { });
+		modelChanges.fire('refresh');
+
+		assert.deepStrictEqual({
+			awaiting,
+			current: controller.currentModel.get()?.identifier,
+		}, {
+			// The model is in the raw pool but unusable here, so it counts as unavailable.
+			awaiting: true,
+			current: withAgentMode.identifier,
+		});
+	});
+
 	test('applies a fallback while the configured default loads, then upgrades it', () => {
 		const byok = model('openai/byok');
 		const configured = model('copilot/configured');

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -79,12 +79,12 @@ suite('ChatInputModelSelectionController', () => {
 		const first = model('test/first');
 		const second = model('test/second');
 
-		controller.applyAutomaticSelection(first, () => { });
+		controller.select(first, 'automatic', { effect: () => { } });
 		const automatic = {
 			current: controller.currentModel.get()?.identifier,
 			explicit: controller.selectionReason === ModelSelectionReason.UserSelection,
 		};
-		controller.applyExplicitSelection(second, () => { }, false);
+		controller.select(second, 'user', { effect: () => { }, rollbackOnError: false });
 
 		assert.deepStrictEqual({
 			automatic,
@@ -102,9 +102,9 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime({ models: [], resolved: true, sessionType: 'test' }, modelChanges, [])));
 		const first = model('test/first');
 		const second = model('test/second');
-		controller.applyAutomaticSelection(first, () => { });
+		controller.select(first, 'automatic', { effect: () => { } });
 
-		assert.throws(() => controller.applyExplicitSelection(second, () => { throw new Error('rejected'); }, true), /rejected/);
+		assert.throws(() => controller.select(second, 'user', { effect: () => { throw new Error('rejected'); }, rollbackOnError: true }), /rejected/);
 		assert.deepStrictEqual({
 			current: controller.currentModel.get()?.identifier,
 			reason: controller.selectionReason,
@@ -246,7 +246,7 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
 		controller.initialize(remembered.identifier, () => { });
-		controller.applyExplicitSelection(explicit, () => applied.push(explicit.identifier), false);
+		controller.select(explicit, 'user', { effect: () => applied.push(explicit.identifier), rollbackOnError: false });
 		state.models = [fallback, explicit, remembered];
 		modelChanges.fire('loaded');
 
@@ -271,7 +271,7 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
 		controller.initialize(remembered.identifier, () => { });
-		controller.applyProgrammaticSelection(programmatic);
+		controller.select(programmatic, 'programmatic');
 		state.models = [fallback, programmatic, remembered];
 		modelChanges.fire('loaded');
 
@@ -330,7 +330,7 @@ suite('ChatInputModelSelectionController', () => {
 			() => state.models.find(model => model.identifier === requested.identifier),
 			'chat:one',
 		);
-		controller.applyExplicitSelection(explicit, () => applied.push(explicit.identifier), false);
+		controller.select(explicit, 'user', { effect: () => applied.push(explicit.identifier), rollbackOnError: false });
 		state.models = [explicit, requested];
 		modelChanges.fire('loaded');
 
@@ -435,7 +435,7 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.applyExplicitSelection(selected, () => { }, false);
+		controller.select(selected, 'user', { effect: () => { }, rollbackOnError: false });
 		state.models = [other];
 		modelChanges.fire('agent-host-restarting');
 		const duringRestart = controller.currentModel.get()?.identifier;
@@ -498,7 +498,7 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.applyExplicitSelection(selected, () => { }, false);
+		controller.select(selected, 'user', { effect: () => { }, rollbackOnError: false });
 		state.models = [substitute];
 		modelChanges.fire('model-gone');
 		const duringOutage = controller.currentModel.get()?.identifier;
@@ -526,10 +526,10 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.applyExplicitSelection(selected, () => { }, false);
+		controller.select(selected, 'user', { effect: () => { }, rollbackOnError: false });
 		state.models = [other, chosen];
 		modelChanges.fire('model-removed');
-		controller.applyExplicitSelection(chosen, () => { }, false);
+		controller.select(chosen, 'user', { effect: () => { }, rollbackOnError: false });
 		state.models = [selected, other, chosen];
 		modelChanges.fire('model-back');
 
@@ -559,7 +559,7 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.applyExplicitSelection(picked, () => { }, false);
+		controller.select(picked, 'user', { effect: () => { }, rollbackOnError: false });
 		state.models = [configured];
 		modelChanges.fire('picked-gone');
 		const duringOutage = controller.currentModel.get()?.identifier;
@@ -597,7 +597,7 @@ suite('ChatInputModelSelectionController', () => {
 		const state: IRuntimeState = { models: [remembered, standIn], resolved: true, sessionType: 'local' };
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
 
-		controller.applyExplicitSelection(remembered, () => { }, false);
+		controller.select(remembered, 'user', { effect: () => { }, rollbackOnError: false });
 		// The pick disappears and the stand-in takes over.
 		state.models = [standIn];
 		controller.reconcileModelListChange(state.models);
@@ -629,7 +629,7 @@ suite('ChatInputModelSelectionController', () => {
 		const state: IRuntimeState = { models: [picked, locationDefault], resolved: true, sessionType: 'local' };
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
 
-		controller.applyExplicitSelection(picked, () => { }, false);
+		controller.select(picked, 'user', { effect: () => { }, rollbackOnError: false });
 		state.models = [locationDefault];
 		controller.reconcileModelListChange(state.models);
 		// The user deliberately asks for the default while the pick is unavailable.
@@ -670,7 +670,7 @@ suite('ChatInputModelSelectionController', () => {
 		};
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
 
-		controller.applyAutomaticSelection(invalid, () => { });
+		controller.select(invalid, 'automatic', { effect: () => { } });
 		controller.ensureCurrentModelSupported();
 
 		assert.deepStrictEqual({ current: controller.currentModel.get()?.identifier }, { current: agentCapable.identifier });
@@ -695,7 +695,7 @@ suite('ChatInputModelSelectionController', () => {
 
 		controller.initialize(askOnly.identifier, () => { });
 		const awaiting = controller.isAwaitingModel();
-		controller.applyAutomaticSelection(withAgentMode, () => { });
+		controller.select(withAgentMode, 'automatic', { effect: () => { } });
 		modelChanges.fire('refresh');
 
 		assert.deepStrictEqual({
@@ -727,7 +727,7 @@ suite('ChatInputModelSelectionController', () => {
 		const applied: string[] = [];
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
 
-		controller.applyAutomaticSelection(agentCapable, () => { });
+		controller.select(agentCapable, 'automatic', { effect: () => { } });
 		applied.length = 0;
 		modelChanges.fire('refresh-one');
 		modelChanges.fire('refresh-two');
@@ -736,6 +736,67 @@ suite('ChatInputModelSelectionController', () => {
 			// No churn: the unusable configured model is never applied, so nothing is re-applied.
 			applied: [],
 			current: agentCapable.identifier,
+		});
+	});
+
+	test('canceling a pending programmatic selection unblocks the configured default', async () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const fallback = model('test/fallback');
+		const configured = model('test/configured');
+		const requested = model('test/requested');
+		const state: IRuntimeState = {
+			models: [fallback, configured],
+			resolved: false,
+			sessionType: 'local',
+			configuredModel: configured.metadata.id,
+		};
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
+
+		const result = controller.requestProgrammaticSelection(
+			() => state.models.find(model => model.identifier === requested.identifier),
+			'chat:one',
+		);
+		// A pending request owns the selection, so the configured default must not claim it.
+		const claimedWhilePending = controller.applyConfiguredDefault();
+		controller.clearIntent();
+		const claimedAfterCancel = controller.applyConfiguredDefault();
+
+		assert.deepStrictEqual({
+			result: await result,
+			claimedWhilePending,
+			claimedAfterCancel,
+			current: controller.currentModel.get()?.identifier,
+		}, {
+			result: false,
+			claimedWhilePending: false,
+			claimedAfterCancel: true,
+			current: configured.identifier,
+		});
+	});
+
+	test('a rolled back selection also restores what was remembered', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const picked = model('test/picked');
+		const rejected = model('test/rejected');
+		const standIn = model('test/stand-in');
+		const state: IRuntimeState = { models: [picked, rejected, standIn], resolved: true, sessionType: 'local' };
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
+
+		controller.select(picked, 'user', { effect: () => { }, rollbackOnError: false });
+		assert.throws(() => controller.select(rejected, 'user', { effect: () => { throw new Error('nope'); }, rollbackOnError: true }), /nope/);
+		// The rollback must restore the remembered selection too, not just what is displayed:
+		// otherwise the rejected model would be reclaimed after an outage.
+		state.models = [standIn];
+		modelChanges.fire('outage');
+		state.models = [picked, rejected, standIn];
+		modelChanges.fire('recovered');
+
+		assert.deepStrictEqual({
+			current: controller.currentModel.get()?.identifier,
+			reason: controller.selectionReason,
+		}, {
+			current: picked.identifier,
+			reason: ModelSelectionReason.UserSelection,
 		});
 	});
 
@@ -864,7 +925,7 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.initialize(undefined, () => { });
-		controller.applyExplicitSelection(explicit, () => applied.push(explicit.identifier), false);
+		controller.select(explicit, 'user', { effect: () => applied.push(explicit.identifier), rollbackOnError: false });
 		models = [byok, explicit, configured];
 		controller.reconcileModelListChange(models);
 
@@ -1130,7 +1191,7 @@ suite('ChatInputModelSelectionController', () => {
 			createRuntime({ models: [gpt, opus], resolved: true, sessionType: 'test', configuredModel: gpt.metadata.id }, modelChanges, applied)));
 
 		controller.beginSessionSwitch(true, false, false);
-		controller.applyExplicitSelection(opus, () => applied.push(opus.identifier), false);
+		controller.select(opus, 'user', { effect: () => applied.push(opus.identifier), rollbackOnError: false });
 		const configuredApplied = controller.applyConfiguredDefault();
 
 		assert.deepStrictEqual({ configuredApplied, applied, current: controller.currentModel.get()?.identifier, userPicked: controller.selectionReason === ModelSelectionReason.UserSelection }, {
@@ -1515,7 +1576,7 @@ suite('ChatInputModelSelectionController', () => {
 			},
 		};
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
-		controller.applyAutomaticSelection(general, () => { });
+		controller.select(general, 'automatic', { effect: () => { } });
 		state.sessionType = 'agent-host-test';
 
 		controller.revalidateForSessionType(() => { });
@@ -1553,7 +1614,7 @@ suite('ChatInputModelSelectionController', () => {
 			applyModel: selected => applied.push(selected.identifier),
 		};
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
-		controller.applyAutomaticSelection(general, () => { });
+		controller.select(general, 'automatic', { effect: () => { } });
 
 		state.sessionType = sessionType;
 		controller.revalidateForSessionType(() => { });
@@ -1683,7 +1744,7 @@ suite('ChatInputModelSelectionController', () => {
 
 		controller.initialize(remembered.identifier, () => { });
 		const pendingAfterInit = controller.isAwaitingModel();
-		controller.applyExplicitSelection(explicit, () => applied.push(explicit.identifier), false);
+		controller.select(explicit, 'user', { effect: () => applied.push(explicit.identifier), rollbackOnError: false });
 		const pendingAfterExplicit = controller.isAwaitingModel();
 		models = [fallback, explicit, remembered];
 		modelChanges.fire('loaded');

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -166,7 +166,7 @@ suite('ChatInputModelSelectionController', () => {
 		};
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 		controller.initialize(second.identifier, result => initialSelections.push(result.kind));
-		const pending = controller.hasPendingIntent();
+		const pending = controller.isAwaitingRememberedModel();
 		models = [first, second];
 		catalogResolved = true;
 		modelChanges.fire('test');
@@ -174,7 +174,7 @@ suite('ChatInputModelSelectionController', () => {
 		assert.deepStrictEqual({
 			initialSelections,
 			pending,
-			pendingAfterResolve: controller.hasPendingIntent(),
+			pendingAfterResolve: controller.isAwaitingRememberedModel(),
 			applied,
 		}, {
 			initialSelections: ['pending'],
@@ -215,14 +215,14 @@ suite('ChatInputModelSelectionController', () => {
 		models = [first];
 		modelChanges.fire('partial');
 		const resolutionAfterPartial = runtime.resolveModelIdentifier(remembered.identifier).kind;
-		const pendingAfterPartial = controller.hasPendingIntent();
+		const pendingAfterPartial = controller.isAwaitingRememberedModel();
 		models = [first, remembered];
 		modelChanges.fire('complete');
 
 		assert.deepStrictEqual({
 			resolutionAfterPartial,
 			pendingAfterPartial,
-			pendingAfterComplete: controller.hasPendingIntent(),
+			pendingAfterComplete: controller.isAwaitingRememberedModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -379,13 +379,13 @@ suite('ChatInputModelSelectionController', () => {
 		controller.initialize(remembered.identifier, () => { });
 		state.models = [fallback, locationDefault];
 		controller.reconcileModelListChange(state.models);
-		const pendingAfterDefault = controller.hasPendingIntent();
+		const pendingAfterDefault = controller.isAwaitingRememberedModel();
 		state.models = [fallback, locationDefault, remembered];
 		modelChanges.fire('loaded');
 
 		assert.deepStrictEqual({
 			pendingAfterDefault,
-			pendingAfterLoad: controller.hasPendingIntent(),
+			pendingAfterLoad: controller.isAwaitingRememberedModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -408,13 +408,13 @@ suite('ChatInputModelSelectionController', () => {
 		controller.initialize(remembered.identifier, () => { });
 		state.models = [replacement];
 		modelChanges.fire('fallback-removed');
-		const pendingAfterRepair = controller.hasPendingIntent();
+		const pendingAfterRepair = controller.isAwaitingRememberedModel();
 		state.models = [replacement, remembered];
 		modelChanges.fire('remembered-loaded');
 
 		assert.deepStrictEqual({
 			pendingAfterRepair,
-			pendingAfterLoad: controller.hasPendingIntent(),
+			pendingAfterLoad: controller.isAwaitingRememberedModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -422,6 +422,124 @@ suite('ChatInputModelSelectionController', () => {
 			pendingAfterLoad: false,
 			applied: [fallback.identifier, replacement.identifier, remembered.identifier],
 			current: remembered.identifier,
+		});
+	});
+
+	test('reclaims the selected model after it disappears and comes back', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const selected = targetedModel('agent-host/selected', 'agent-host');
+		const other = targetedModel('agent-host/other', 'agent-host');
+		const state: IRuntimeState = { models: [selected, other], resolved: true, sessionType: 'agent-host' };
+		const applied: string[] = [];
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
+
+		controller.applyExplicitSelection(selected, () => { }, false);
+		state.models = [other];
+		modelChanges.fire('agent-host-restarting');
+		const duringRestart = controller.currentModel.get()?.identifier;
+		state.models = [selected, other];
+		modelChanges.fire('agent-host-restarted');
+
+		assert.deepStrictEqual({
+			duringRestart,
+			current: controller.currentModel.get()?.identifier,
+			reason: controller.selectionReason,
+			pending: controller.hasPendingIntent(),
+			applied,
+		}, {
+			duringRestart: other.identifier,
+			current: selected.identifier,
+			reason: ModelSelectionReason.Remembered,
+			pending: false,
+			applied: [other.identifier, selected.identifier],
+		});
+	});
+
+	test('reclaims a storage-seeded remembered model that disappears mid-session', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const remembered = model('test/remembered');
+		const other = model('test/other');
+		const state: IRuntimeState = { models: [remembered, other], resolved: true, sessionType: 'local' };
+		const applied: string[] = [];
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
+
+		// The remembered model is already available, so `initialize` applies it and arms no wait.
+		controller.initialize(remembered.identifier, () => { });
+		state.models = [other];
+		modelChanges.fire('model-gone');
+		const duringOutage = controller.currentModel.get()?.identifier;
+		state.models = [remembered, other];
+		modelChanges.fire('model-back');
+
+		assert.deepStrictEqual({
+			duringOutage,
+			current: controller.currentModel.get()?.identifier,
+			pending: controller.hasPendingIntent(),
+			applied,
+		}, {
+			duringOutage: other.identifier,
+			current: remembered.identifier,
+			pending: false,
+			applied: [remembered.identifier, other.identifier, remembered.identifier],
+		});
+	});
+
+	test('reclaims the selected model even after a same-family substitute stood in', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const selected = model('test/selected');
+		const substitute: ILanguageModelChatMetadataAndIdentifier = {
+			identifier: 'test/substitute',
+			metadata: { ...selected.metadata, id: 'test/substitute', name: 'test/substitute' },
+		};
+		const state: IRuntimeState = { models: [selected, substitute], resolved: true, sessionType: 'local' };
+		const applied: string[] = [];
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
+
+		controller.applyExplicitSelection(selected, () => { }, false);
+		state.models = [substitute];
+		modelChanges.fire('model-gone');
+		const duringOutage = controller.currentModel.get()?.identifier;
+		state.models = [selected, substitute];
+		modelChanges.fire('model-back');
+
+		assert.deepStrictEqual({
+			duringOutage,
+			current: controller.currentModel.get()?.identifier,
+			applied,
+		}, {
+			// The shared family makes `substitute` a best match, so it stands in rather than the default.
+			duringOutage: substitute.identifier,
+			current: selected.identifier,
+			applied: [substitute.identifier, selected.identifier],
+		});
+	});
+
+	test('an explicit selection outlives the model it displaced', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const selected = model('test/selected');
+		const other = model('test/other');
+		const chosen = model('test/chosen');
+		const state: IRuntimeState = { models: [selected, other, chosen], resolved: true, sessionType: 'local' };
+		const applied: string[] = [];
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
+
+		controller.applyExplicitSelection(selected, () => { }, false);
+		state.models = [other, chosen];
+		modelChanges.fire('model-removed');
+		controller.applyExplicitSelection(chosen, () => { }, false);
+		state.models = [selected, other, chosen];
+		modelChanges.fire('model-back');
+
+		assert.deepStrictEqual({
+			current: controller.currentModel.get()?.identifier,
+			reason: controller.selectionReason,
+			pending: controller.hasPendingIntent(),
+			applied,
+		}, {
+			current: chosen.identifier,
+			reason: ModelSelectionReason.UserSelection,
+			pending: false,
+			applied: [other.identifier],
 		});
 	});
 
@@ -1066,11 +1184,11 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.initialize(remembered.identifier, () => { });
-		const pendingAfterInit = controller.hasPendingIntent();
+		const pendingAfterInit = controller.isAwaitingRememberedModel();
 		const appliedAfterInit = [...applied];
 		// An intermediate empty re-resolution must not end the wait or apply a default.
 		modelChanges.fire('still-empty');
-		const pendingAfterEmpty = controller.hasPendingIntent();
+		const pendingAfterEmpty = controller.isAwaitingRememberedModel();
 		// The remembered model finally appears.
 		models = [remembered];
 		modelChanges.fire('loaded');
@@ -1079,7 +1197,7 @@ suite('ChatInputModelSelectionController', () => {
 			pendingAfterInit,
 			appliedAfterInit,
 			pendingAfterEmpty,
-			pendingAfterLoad: controller.hasPendingIntent(),
+			pendingAfterLoad: controller.isAwaitingRememberedModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -1282,13 +1400,13 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.initialize(remembered.identifier, () => { });
-		const pendingAfterInit = controller.hasPendingIntent();
+		const pendingAfterInit = controller.isAwaitingRememberedModel();
 		models = [fallback, remembered];
 		modelChanges.fire('loaded');
 
 		assert.deepStrictEqual({
 			pendingAfterInit,
-			pendingAfterLoad: controller.hasPendingIntent(),
+			pendingAfterLoad: controller.isAwaitingRememberedModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -1368,9 +1486,9 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.initialize(remembered.identifier, () => { });
-		const pendingAfterInit = controller.hasPendingIntent();
+		const pendingAfterInit = controller.isAwaitingRememberedModel();
 		controller.applyExplicitSelection(explicit, () => applied.push(explicit.identifier), false);
-		const pendingAfterExplicit = controller.hasPendingIntent();
+		const pendingAfterExplicit = controller.isAwaitingRememberedModel();
 		models = [fallback, explicit, remembered];
 		modelChanges.fire('loaded');
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -449,7 +449,8 @@ suite('ChatInputModelSelectionController', () => {
 		}, {
 			duringRestart: other.identifier,
 			current: selected.identifier,
-			reason: ModelSelectionReason.Remembered,
+			// The restore reinstates the original authority rather than downgrading to `Remembered`.
+			reason: ModelSelectionReason.UserSelection,
 			pending: false,
 			applied: [other.identifier, selected.identifier],
 		});
@@ -540,6 +541,45 @@ suite('ChatInputModelSelectionController', () => {
 			reason: ModelSelectionReason.UserSelection,
 			pending: false,
 			applied: [other.identifier],
+		});
+	});
+
+	test('reclaims an explicit pick that was displaced while chat.defaultModel stood in', () => {
+		const modelChanges = disposables.add(new Emitter<string>());
+		const configured = model('test/configured');
+		const picked = model('test/picked');
+		const state: IRuntimeState = {
+			models: [configured, picked],
+			resolved: true,
+			sessionType: 'local',
+			configuredModel: configured.metadata.id,
+		};
+		const applied: string[] = [];
+		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, applied)));
+
+		controller.applyExplicitSelection(picked, () => { }, false);
+		state.models = [configured];
+		modelChanges.fire('picked-gone');
+		const duringOutage = controller.currentModel.get()?.identifier;
+		const reasonDuringOutage = controller.selectionReason;
+		state.models = [configured, picked];
+		modelChanges.fire('picked-back');
+		const afterReturn = controller.currentModel.get()?.identifier;
+		// A later refresh must not let the configured default reclaim an explicit pick.
+		modelChanges.fire('later-refresh');
+
+		assert.deepStrictEqual({
+			duringOutage,
+			reasonDuringOutage,
+			afterReturn,
+			afterRefresh: controller.currentModel.get()?.identifier,
+			reason: controller.selectionReason,
+		}, {
+			duringOutage: configured.identifier,
+			reasonDuringOutage: ModelSelectionReason.ConfiguredDefault,
+			afterReturn: picked.identifier,
+			afterRefresh: picked.identifier,
+			reason: ModelSelectionReason.UserSelection,
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputModelSelectionController.test.ts
@@ -168,7 +168,7 @@ suite('ChatInputModelSelectionController', () => {
 		};
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 		controller.initialize(second.identifier, result => initialSelections.push(result.kind));
-		const pending = controller.isAwaitingRememberedModel();
+		const pending = controller.isAwaitingModel();
 		models = [first, second];
 		catalogResolved = true;
 		modelChanges.fire('test');
@@ -176,7 +176,7 @@ suite('ChatInputModelSelectionController', () => {
 		assert.deepStrictEqual({
 			initialSelections,
 			pending,
-			pendingAfterResolve: controller.isAwaitingRememberedModel(),
+			pendingAfterResolve: controller.isAwaitingModel(),
 			applied,
 		}, {
 			initialSelections: ['pending'],
@@ -217,14 +217,14 @@ suite('ChatInputModelSelectionController', () => {
 		models = [first];
 		modelChanges.fire('partial');
 		const resolutionAfterPartial = runtime.resolveModelIdentifier(remembered.identifier).kind;
-		const pendingAfterPartial = controller.isAwaitingRememberedModel();
+		const pendingAfterPartial = controller.isAwaitingModel();
 		models = [first, remembered];
 		modelChanges.fire('complete');
 
 		assert.deepStrictEqual({
 			resolutionAfterPartial,
 			pendingAfterPartial,
-			pendingAfterComplete: controller.isAwaitingRememberedModel(),
+			pendingAfterComplete: controller.isAwaitingModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -251,7 +251,7 @@ suite('ChatInputModelSelectionController', () => {
 		modelChanges.fire('loaded');
 
 		assert.deepStrictEqual({
-			pending: controller.hasPendingIntent(),
+			pending: controller.isAwaitingModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -276,7 +276,7 @@ suite('ChatInputModelSelectionController', () => {
 		modelChanges.fire('loaded');
 
 		assert.deepStrictEqual({
-			pending: controller.hasPendingIntent(),
+			pending: controller.isAwaitingModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 			reason: controller.selectionReason,
@@ -381,13 +381,13 @@ suite('ChatInputModelSelectionController', () => {
 		controller.initialize(remembered.identifier, () => { });
 		state.models = [fallback, locationDefault];
 		controller.reconcileModelListChange(state.models);
-		const pendingAfterDefault = controller.isAwaitingRememberedModel();
+		const pendingAfterDefault = controller.isAwaitingModel();
 		state.models = [fallback, locationDefault, remembered];
 		modelChanges.fire('loaded');
 
 		assert.deepStrictEqual({
 			pendingAfterDefault,
-			pendingAfterLoad: controller.isAwaitingRememberedModel(),
+			pendingAfterLoad: controller.isAwaitingModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -410,13 +410,13 @@ suite('ChatInputModelSelectionController', () => {
 		controller.initialize(remembered.identifier, () => { });
 		state.models = [replacement];
 		modelChanges.fire('fallback-removed');
-		const pendingAfterRepair = controller.isAwaitingRememberedModel();
+		const pendingAfterRepair = controller.isAwaitingModel();
 		state.models = [replacement, remembered];
 		modelChanges.fire('remembered-loaded');
 
 		assert.deepStrictEqual({
 			pendingAfterRepair,
-			pendingAfterLoad: controller.isAwaitingRememberedModel(),
+			pendingAfterLoad: controller.isAwaitingModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -446,7 +446,7 @@ suite('ChatInputModelSelectionController', () => {
 			duringRestart,
 			current: controller.currentModel.get()?.identifier,
 			reason: controller.selectionReason,
-			pending: controller.hasPendingIntent(),
+			pending: controller.isAwaitingModel(),
 			applied,
 		}, {
 			duringRestart: other.identifier,
@@ -477,7 +477,7 @@ suite('ChatInputModelSelectionController', () => {
 		assert.deepStrictEqual({
 			duringOutage,
 			current: controller.currentModel.get()?.identifier,
-			pending: controller.hasPendingIntent(),
+			pending: controller.isAwaitingModel(),
 			applied,
 		}, {
 			duringOutage: other.identifier,
@@ -536,7 +536,7 @@ suite('ChatInputModelSelectionController', () => {
 		assert.deepStrictEqual({
 			current: controller.currentModel.get()?.identifier,
 			reason: controller.selectionReason,
-			pending: controller.hasPendingIntent(),
+			pending: controller.isAwaitingModel(),
 			applied,
 		}, {
 			current: chosen.identifier,
@@ -694,7 +694,7 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(createRuntime(state, modelChanges, [])));
 
 		controller.initialize(askOnly.identifier, () => { });
-		const awaiting = controller.isAwaitingRememberedModel();
+		const awaiting = controller.isAwaitingModel();
 		controller.applyAutomaticSelection(withAgentMode, () => { });
 		modelChanges.fire('refresh');
 
@@ -765,7 +765,7 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.initialize(undefined, () => { });
-		const pending = controller.hasPendingIntent();
+		const pending = controller.isAwaitingModel();
 		models = [byok, configured];
 		controller.reconcileModelListChange(models);
 
@@ -796,7 +796,7 @@ suite('ChatInputModelSelectionController', () => {
 		modelChanges.fire('loaded');
 
 		assert.deepStrictEqual({
-			pending: controller.hasPendingIntent(),
+			pending: controller.isAwaitingModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 			reason: controller.selectionReason,
@@ -909,7 +909,7 @@ suite('ChatInputModelSelectionController', () => {
 		modelChanges.fire('test');
 
 		assert.deepStrictEqual({
-			pending: controller.hasPendingIntent(),
+			pending: controller.isAwaitingModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -1268,7 +1268,7 @@ suite('ChatInputModelSelectionController', () => {
 		const draft = controller.resolveDraftModel(general, sessionType, true);
 		models = [];
 		controller.syncFromConversationState(desired, { effort: 'high' }, sessionType, 'chat:one');
-		const pending = controller.hasPendingIntent();
+		const pending = controller.isAwaitingModel();
 		models = [fallback, desired];
 		resolved = true;
 		modelChanges.fire('test');
@@ -1276,7 +1276,7 @@ suite('ChatInputModelSelectionController', () => {
 		assert.deepStrictEqual({
 			draft: { model: draft.model?.identifier, changed: draft.changed },
 			pending,
-			pendingAfterResolve: controller.hasPendingIntent(),
+			pendingAfterResolve: controller.isAwaitingModel(),
 			applied,
 			restored,
 		}, {
@@ -1327,10 +1327,10 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.syncFromConversationState(desired, { effort: 'high' }, sessionType, 'chat:one');
-		const pending = controller.hasPendingIntent();
+		const pending = controller.isAwaitingModel();
 		// An intermediate empty re-resolution must not end the wait or apply a default.
 		modelChanges.fire('still-empty');
-		const stillPendingAfterEmpty = controller.hasPendingIntent();
+		const stillPendingAfterEmpty = controller.isAwaitingModel();
 		const appliedAfterEmpty = [...applied];
 		// The real models finally arrive.
 		models = [desired];
@@ -1340,7 +1340,7 @@ suite('ChatInputModelSelectionController', () => {
 			pending,
 			stillPendingAfterEmpty,
 			appliedAfterEmpty,
-			pendingAfterLoad: controller.hasPendingIntent(),
+			pendingAfterLoad: controller.isAwaitingModel(),
 			applied,
 			restored,
 		}, {
@@ -1380,11 +1380,11 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.initialize(remembered.identifier, () => { });
-		const pendingAfterInit = controller.isAwaitingRememberedModel();
+		const pendingAfterInit = controller.isAwaitingModel();
 		const appliedAfterInit = [...applied];
 		// An intermediate empty re-resolution must not end the wait or apply a default.
 		modelChanges.fire('still-empty');
-		const pendingAfterEmpty = controller.isAwaitingRememberedModel();
+		const pendingAfterEmpty = controller.isAwaitingModel();
 		// The remembered model finally appears.
 		models = [remembered];
 		modelChanges.fire('loaded');
@@ -1393,7 +1393,7 @@ suite('ChatInputModelSelectionController', () => {
 			pendingAfterInit,
 			appliedAfterInit,
 			pendingAfterEmpty,
-			pendingAfterLoad: controller.isAwaitingRememberedModel(),
+			pendingAfterLoad: controller.isAwaitingModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -1453,7 +1453,7 @@ suite('ChatInputModelSelectionController', () => {
 		state.models = [fallback, staleDesired];
 		modelChanges.fire('test');
 
-		assert.deepStrictEqual({ pending: controller.hasPendingIntent(), applied }, {
+		assert.deepStrictEqual({ pending: controller.isAwaitingModel(), applied }, {
 			pending: false,
 			applied: [fallback.identifier],
 		});
@@ -1596,13 +1596,13 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.initialize(remembered.identifier, () => { });
-		const pendingAfterInit = controller.isAwaitingRememberedModel();
+		const pendingAfterInit = controller.isAwaitingModel();
 		models = [fallback, remembered];
 		modelChanges.fire('loaded');
 
 		assert.deepStrictEqual({
 			pendingAfterInit,
-			pendingAfterLoad: controller.isAwaitingRememberedModel(),
+			pendingAfterLoad: controller.isAwaitingModel(),
 			applied,
 			current: controller.currentModel.get()?.identifier,
 		}, {
@@ -1638,7 +1638,7 @@ suite('ChatInputModelSelectionController', () => {
 			};
 			const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 			controller.initialize(rememberedId, () => { });
-			return controller.isAwaitingRememberedModel();
+			return controller.isAwaitingModel();
 		};
 		const first = model('test/first');
 		const remembered = model('test/remembered');
@@ -1682,9 +1682,9 @@ suite('ChatInputModelSelectionController', () => {
 		const controller = disposables.add(new ChatInputModelSelectionController(runtime));
 
 		controller.initialize(remembered.identifier, () => { });
-		const pendingAfterInit = controller.isAwaitingRememberedModel();
+		const pendingAfterInit = controller.isAwaitingModel();
 		controller.applyExplicitSelection(explicit, () => applied.push(explicit.identifier), false);
-		const pendingAfterExplicit = controller.isAwaitingRememberedModel();
+		const pendingAfterExplicit = controller.isAwaitingModel();
 		models = [fallback, explicit, remembered];
 		modelChanges.fire('loaded');
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionBehavior.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionBehavior.test.ts
@@ -12,6 +12,7 @@ import { ChatAgentLocation, ChatModeKind } from '../../../../common/constants.js
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../../common/languageModels.js';
 import { resolveModelIdentifier } from '../../../../common/modelSelection.js';
 import { ChatInputModelSelectionController } from '../../../../browser/widget/input/chatInputModelSelectionController.js';
+import { filterModelsForSession } from '../../../../browser/widget/input/chatInputModelUtils.js';
 
 /**
  * Characterization tests for chat model selection.
@@ -93,12 +94,14 @@ class ModelSelectionHarness {
 			getCurrentModeKind: () => this._world.mode ?? ChatModeKind.Ask,
 			getCurrentSessionType: () => this._world.sessionType,
 			isEmpty: () => !this._world.hasHistory,
-			// A targeted pool is filtered by session only; the general pool is also filtered by
-			// mode. This mirrors `filterModelsForSession` and is what makes mode-invalid models
-			// reachable in targeted pools.
-			getModels: sessionType => sessionType
-				? this._models.filter(model => model.metadata.targetChatSessionType === sessionType)
-				: this._models.filter(model => !model.metadata.targetChatSessionType),
+			// Mirror production pool selection by delegating to the same helper `ChatInputPart`
+			// uses, rather than reimplementing it — otherwise a scenario could pass against
+			// filtering rules that do not exist.
+			getModels: sessionType => filterModelsForSession(
+				[...this._models].sort((a, b) => a.metadata.name.localeCompare(b.metadata.name)),
+				sessionType,
+				this._world.mode ?? ChatModeKind.Ask,
+				ChatAgentLocation.Chat),
 			getAllModels: () => this._models,
 			requiresCustomModels: () => false,
 			getConfiguredModelValue: () => this._world.defaultModelSetting,
@@ -124,7 +127,7 @@ class ModelSelectionHarness {
 
 	/** The user picks a model from the picker. */
 	pick(id: string): this {
-		this._controller.select(this._find(id), 'user', { effect: () => { }, rollbackOnError: false });
+		this._controller.select(this._find(id), { authority: 'user', effect: () => { }, rollbackOnError: false });
 		return this;
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionBehavior.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionBehavior.test.ts
@@ -1,0 +1,345 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter } from '../../../../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { ExtensionIdentifier } from '../../../../../../../platform/extensions/common/extensions.js';
+import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
+import { ChatAgentLocation, ChatModeKind } from '../../../../common/constants.js';
+import { ILanguageModelChatMetadataAndIdentifier } from '../../../../common/languageModels.js';
+import { resolveModelIdentifier } from '../../../../common/modelSelection.js';
+import { ChatInputModelSelectionController } from '../../../../browser/widget/input/chatInputModelSelectionController.js';
+
+/**
+ * Characterization tests for chat model selection.
+ *
+ * These describe the three user-facing rules in terms of what a user does and what they end up
+ * on — never in terms of the controller's method names. Every interaction goes through
+ * {@link ModelSelectionHarness}, so an API change is absorbed by that one class and these
+ * scenarios keep proving the behavior is unchanged.
+ *
+ * The rules:
+ *   1. A new (empty) conversation gets `chat.defaultModel` when that setting is set.
+ *   2. Otherwise you get your remembered model — the last one you deliberately chose.
+ *   3. When the remembered model is not selectable, a default stands in temporarily and the
+ *      remembered one is reclaimed as soon as it can be offered again, unless a new deliberate
+ *      choice replaced it meanwhile.
+ */
+
+interface IModelSpec {
+	readonly id: string;
+	/** Marks the model as the location default, i.e. what `findDefaultModel` prefers. */
+	readonly isLocationDefault?: boolean;
+	/** Omit to make the model unusable in agent mode. */
+	readonly supportsAgentMode?: boolean;
+	readonly sessionType?: string;
+}
+
+function buildModel(spec: IModelSpec): ILanguageModelChatMetadataAndIdentifier {
+	return {
+		identifier: spec.id,
+		metadata: {
+			extension: new ExtensionIdentifier('test.extension'),
+			id: spec.id,
+			name: spec.id,
+			vendor: 'test',
+			version: '1.0',
+			family: spec.id,
+			maxInputTokens: 1,
+			maxOutputTokens: 1,
+			isDefaultForLocation: spec.isLocationDefault ? { [ChatAgentLocation.Chat]: true } : {},
+			...(spec.sessionType ? { targetChatSessionType: spec.sessionType } : {}),
+			capabilities: { toolCalling: !!spec.supportsAgentMode, agentMode: !!spec.supportsAgentMode },
+		},
+	};
+}
+
+interface IWorld {
+	/** Models the catalog is currently publishing. */
+	catalog: readonly IModelSpec[];
+	sessionType?: string;
+	mode?: ChatModeKind;
+	/** A conversation with history, as opposed to a fresh one. */
+	hasHistory?: boolean;
+	/** The `chat.defaultModel` setting. */
+	defaultModelSetting?: string;
+	/** What persisted storage remembers from a previous session. */
+	storedModel?: string;
+}
+
+/**
+ * Drives the selection controller through user- and system-level events.
+ *
+ * This is the single seam between the scenarios below and the controller's API. When the API
+ * changes, only the bodies of these methods change; every assertion in this file stays as-is,
+ * which is what makes the scenarios usable as a rewrite safety net.
+ */
+class ModelSelectionHarness {
+
+	private readonly _store = new DisposableStore();
+	private readonly _catalogChanged = new Emitter<void>();
+	private readonly _controller: ChatInputModelSelectionController;
+	private _models: ILanguageModelChatMetadataAndIdentifier[];
+	private _world: IWorld;
+
+	constructor(world: IWorld) {
+		this._world = world;
+		this._models = world.catalog.map(buildModel);
+		this._controller = this._store.add(new ChatInputModelSelectionController({
+			location: ChatAgentLocation.Chat,
+			getCurrentModeKind: () => this._world.mode ?? ChatModeKind.Ask,
+			getCurrentSessionType: () => this._world.sessionType,
+			isEmpty: () => !this._world.hasHistory,
+			// A targeted pool is filtered by session only; the general pool is also filtered by
+			// mode. This mirrors `filterModelsForSession` and is what makes mode-invalid models
+			// reachable in targeted pools.
+			getModels: sessionType => sessionType
+				? this._models.filter(model => model.metadata.targetChatSessionType === sessionType)
+				: this._models.filter(model => !model.metadata.targetChatSessionType),
+			getAllModels: () => this._models,
+			requiresCustomModels: () => false,
+			getConfiguredModelValue: () => this._world.defaultModelSetting,
+			resolveModelIdentifier: identifier => resolveModelIdentifier(this._models, identifier, true),
+			subscribeToModelChanges: listener => this._catalogChanged.event(listener),
+			getBoundConversationKey: () => 'chat:one',
+			getVisibleConversationKey: () => 'chat:one',
+			restoreModelConfiguration: () => { },
+			applyModel: () => { },
+		}));
+		this._store.add(this._catalogChanged);
+	}
+
+	dispose(): void {
+		this._store.dispose();
+	}
+
+	/** The user opens the input; persisted state is loaded. */
+	open(): this {
+		this._controller.initialize(this._world.storedModel, () => { });
+		return this;
+	}
+
+	/** The user picks a model from the picker. */
+	pick(id: string): this {
+		this._controller.select(this._find(id), 'user', { effect: () => { }, rollbackOnError: false });
+		return this;
+	}
+
+	/** The user invokes "reset to default". */
+	resetToDefault(): this {
+		this._controller.resetToDefault();
+		return this;
+	}
+
+	/** The catalog republishes a different set of models, e.g. an agent host restarting. */
+	publishes(catalog: readonly IModelSpec[]): this {
+		this._models = catalog.map(buildModel);
+		this._catalogChanged.fire();
+		return this;
+	}
+
+	/** The user switches chat mode, which re-validates the current model. */
+	switchMode(mode: ChatModeKind): this {
+		this._world = { ...this._world, mode };
+		this._controller.ensureCurrentModelSupported();
+		return this;
+	}
+
+	/** The `chat.defaultModel` setting changes, or arrives late from policy. */
+	setDefaultModelSetting(value: string | undefined): this {
+		this._world = { ...this._world, defaultModelSetting: value };
+		this._controller.applyConfiguredDefault();
+		return this;
+	}
+
+	/** The model the user is currently on, or `undefined` when nothing is selected. */
+	get selected(): string | undefined {
+		return this._controller.currentModel.get()?.identifier;
+	}
+
+	/** Whether the shown selection is provisional and expected to change. */
+	get isProvisional(): boolean {
+		return this._controller.isAwaitingModel();
+	}
+
+	private _find(id: string): ILanguageModelChatMetadataAndIdentifier {
+		const found = this._models.find(model => model.identifier === id);
+		assert.ok(found, `model ${id} is not in the catalog`);
+		return found;
+	}
+}
+
+suite('Chat model selection behavior', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function harness(world: IWorld): ModelSelectionHarness {
+		const created = new ModelSelectionHarness(world);
+		disposables.add({ dispose: () => created.dispose() });
+		return created;
+	}
+
+	const fast = { id: 'fast', supportsAgentMode: true };
+	const smart = { id: 'smart', supportsAgentMode: true };
+	const house = { id: 'house', isLocationDefault: true, supportsAgentMode: true };
+
+	suite('rule 1 — a new conversation honors chat.defaultModel', () => {
+
+		test('a fresh conversation opens on the configured model', () => {
+			const chat = harness({ catalog: [fast, smart, house], defaultModelSetting: 'smart' }).open();
+			assert.strictEqual(chat.selected, 'smart');
+		});
+
+		test('without the setting a fresh conversation opens on the location default', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open();
+			assert.strictEqual(chat.selected, 'house');
+		});
+
+		test('the setting does not disturb a conversation that already has history', () => {
+			const chat = harness({
+				catalog: [fast, smart, house],
+				hasHistory: true,
+				storedModel: 'fast',
+				defaultModelSetting: 'smart',
+			}).open();
+			assert.strictEqual(chat.selected, 'fast');
+		});
+
+		test('the setting applies when it arrives after the input was opened', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open();
+			const beforeSetting = chat.selected;
+			chat.setDefaultModelSetting('smart');
+			assert.deepStrictEqual([beforeSetting, chat.selected], ['house', 'smart']);
+		});
+
+		test('a deliberate pick outranks the setting arriving later', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open().pick('fast');
+			chat.setDefaultModelSetting('smart');
+			assert.strictEqual(chat.selected, 'fast');
+		});
+	});
+
+	suite('rule 2 — otherwise you get your remembered model', () => {
+
+		test('a stored model is restored when the input opens', () => {
+			const chat = harness({ catalog: [fast, smart, house], storedModel: 'fast' }).open();
+			assert.strictEqual(chat.selected, 'fast');
+		});
+
+		test('a pick survives unrelated catalog updates', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open().pick('fast');
+			chat.publishes([fast, smart, house]);
+			assert.strictEqual(chat.selected, 'fast');
+		});
+
+		test('the most recent pick is the one remembered', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open().pick('fast').pick('smart');
+			chat.publishes([house]).publishes([fast, smart, house]);
+			assert.strictEqual(chat.selected, 'smart');
+		});
+	});
+
+	suite('rule 3 — an unavailable model is stood in for, then reclaimed', () => {
+
+		test('a pick that disappears is reclaimed when it returns', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open().pick('fast');
+			chat.publishes([smart, house]);
+			const whileGone = chat.selected;
+			chat.publishes([fast, smart, house]);
+			assert.deepStrictEqual([whileGone, chat.selected], ['house', 'fast']);
+		});
+
+		test('the stand-in is flagged as provisional while the pick is gone', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open().pick('fast');
+			chat.publishes([smart, house]);
+			const whileGone = chat.isProvisional;
+			chat.publishes([fast, smart, house]);
+			assert.deepStrictEqual([whileGone, chat.isProvisional], [true, false]);
+		});
+
+		test('a new pick made during the outage replaces what is reclaimed', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open().pick('fast');
+			chat.publishes([smart, house]);
+			chat.pick('smart');
+			chat.publishes([fast, smart, house]);
+			assert.strictEqual(chat.selected, 'smart');
+		});
+
+		test('a deliberate reset during the outage is not undone', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open().pick('fast');
+			chat.publishes([smart, house]);
+			chat.resetToDefault();
+			chat.publishes([fast, smart, house]);
+			assert.strictEqual(chat.selected, 'house');
+		});
+
+		test('a stored model absent at open is claimed once it is published', () => {
+			const chat = harness({ catalog: [smart, house], storedModel: 'fast' }).open();
+			const atOpen = chat.selected;
+			chat.publishes([fast, smart, house]);
+			assert.deepStrictEqual([atOpen, chat.selected], ['house', 'fast']);
+		});
+
+		test('repeated outages each reclaim the pick', () => {
+			const chat = harness({ catalog: [fast, smart, house] }).open().pick('fast');
+			chat.publishes([house]);
+			const firstOutage = chat.selected;
+			chat.publishes([fast, house]);
+			const firstRecovery = chat.selected;
+			chat.publishes([house]);
+			chat.publishes([fast, house]);
+			assert.deepStrictEqual(
+				[firstOutage, firstRecovery, chat.selected],
+				['house', 'fast', 'fast']);
+		});
+	});
+
+	suite('mode changes', () => {
+
+		// Targeted session pools are filtered by session type only, so they can offer models the
+		// current mode cannot use. Agent mode requires tool calling.
+		const askOnly = { id: 'ask-only', sessionType: 'agent-host' };
+		const agentReady = { id: 'agent-ready', sessionType: 'agent-host', supportsAgentMode: true };
+
+		test('switching to a mode the model cannot serve moves off it', () => {
+			const chat = harness({ catalog: [askOnly, agentReady], sessionType: 'agent-host' })
+				.open()
+				.pick('ask-only');
+			chat.switchMode(ChatModeKind.Agent);
+			assert.strictEqual(chat.selected, 'agent-ready');
+		});
+
+		test('a model the mode cannot serve is not reclaimed', () => {
+			const chat = harness({ catalog: [askOnly, agentReady], sessionType: 'agent-host' })
+				.open()
+				.pick('ask-only');
+			chat.switchMode(ChatModeKind.Agent);
+			chat.publishes([askOnly, agentReady]);
+			assert.strictEqual(chat.selected, 'agent-ready');
+		});
+
+		test('a configured model the mode cannot serve is not applied', () => {
+			const chat = harness({
+				catalog: [askOnly, agentReady],
+				sessionType: 'agent-host',
+				mode: ChatModeKind.Agent,
+				defaultModelSetting: 'ask-only',
+			}).open();
+			chat.publishes([askOnly, agentReady]);
+			assert.strictEqual(chat.selected, 'agent-ready');
+		});
+	});
+
+	suite('an empty catalog', () => {
+
+		test('nothing is selected until the catalog publishes', () => {
+			const chat = harness({ catalog: [], storedModel: 'fast' }).open();
+			const whileEmpty = chat.selected;
+			chat.publishes([fast, house]);
+			assert.deepStrictEqual([whileEmpty, chat.selected], [undefined, 'fast']);
+		});
+	});
+});


### PR DESCRIPTION
Follow-up to #327693 (branched from it, so merge that first).

The model selection logic had grown a wide, thin API — the controller exposed 25 public members, 22 with exactly one caller — and the same "this model is no longer valid, pick another" decision was re-derived in four places. That divergence is what produced #327641, so this both condenses the code and closes the remaining gaps of the same kind.

Every behavioral change below was verified by writing a test, confirming it **failed** against the old code, and then fixing it.

## Condensing

**Removed pass-through wrappers.** Five private `ChatInputPart` methods delegated a single controller call under a second name (`checkModelSupported` → `ensureCurrentModelSupported`, `setCurrentLanguageModelToDefault` → `selectDefault`, …). Inlined, with their doc comments moved onto the controller methods they actually described. `resetLanguageModelToDefault` and `hasPendingProgrammaticModelSelection` stay — they have external callers. Also dropped `userExplicitlySelectedModel`, which had no production caller and is `selectionReason === UserSelection`.

**One replacement path.** Four paths dropped the current model for different reasons and each re-derived its own replacement:

| path | why the model was dropped | what replaced it (before) |
| --- | --- | --- |
| `ensureCurrentModelSupported` | unsupported for the mode | default |
| `ensureCurrentModelInSessionPool` | outside the session pool | default |
| `reconcileModelListChange` | withdrawn from the catalog | remembered → best match → default |
| `revalidateForSessionType` | session-type switch | best match → default |

They now share `_replaceInvalidSelection`, which applies one precedence: **remembered selection → closest match for what was displaced → default**.

**One selectability test.** `filterModelsForSession` only applies mode and inline-chat filtering to the *general* pool — a targeted session pool (agent host, Copilot CLI, …) is filtered by session target alone. Every selection now draws from `_selectablePool`, which prefers the usable subset and falls back to the raw pool rather than selecting nothing when a provider advertises no capabilities at all.

## Bugs found and fixed

**A model invalidated by a mode switch was reapplied to itself.** In a targeted pool, `findBestMatchingModel` matched the displaced model by its own identifier, and `findDefaultModel` then picked it again as `models[0]`. Test failed with `current: 'agent-host/invalid'`.

**A mode-invalid `chat.defaultModel` churned the selection.** `applyConfiguredDefault` resolved against the raw pool while the replacement path used the selectable one, so every catalog event applied the unusable model and immediately replaced it. Test failed with `applied: ['agent-host/configured', 'agent-host/capable', 'agent-host/configured', 'agent-host/capable']`.

**An explicit reset to default was silently undone.** `resetLanguageModelToDefault` left the remembered selection in place, so a model that reappeared later reclaimed the input. Asking for the default is a deliberate choice, so `resetToDefault` now discards it. Test failed with `afterPickReturns: 'test/picked'`.

**A remembered model could be restored into a mode that cannot use it.** `_restoreRememberedModel` read the raw pool behind a comment asserting the pool was already mode-filtered. It and `isAwaitingRememberedModel` now share `_selectablePool`, so they agree on what "available" means.

## Testing

48 tests in the controller suite (5 new), 2820 chat tests, `typecheck-client` clean.

Each new test was checked to discriminate — reverting the corresponding fix makes it fail with a specific wrong value, not merely error out.

## Deliberately out of scope

`syncFromConversationState`, `preselectFromHistory`, `resolveDraftModel`, and the session/history intent branches still read the raw pool. Those are pre-existing paths untouched here; converting them is a larger behavioral change and belongs in its own PR.
