### PR TITLE
Prevent hidden harnesses from seeding new editor chats

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -37,7 +37,7 @@ import product from '../../../../../platform/product/common/product.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { IWorkspace, IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { ActiveEditorContext } from '../../../../common/contextkeys.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../../common/views.js';
@@ -1783,10 +1783,12 @@ export interface IClearEditingSessionConfirmationOptions {
  * Clears the current chat session and starts a new one using the shared
  * new-session harness resolver.
  */
-export async function clearChatSessionPreservingType(widget: IChatWidget, viewsService: IViewsService, sessionType: string | undefined, configurationService: IConfigurationService, chatSessionsService: IChatSessionsService, storageService: IStorageService, workspace: IWorkspace, agentHostEnabled: boolean): Promise<void> {
+export async function clearChatSessionPreservingType(accessor: ServicesAccessor, widget: IChatWidget, sessionType: string | undefined): Promise<void> {
+	const viewsService = accessor.get(IViewsService);
+	const storageService = accessor.get(IStorageService);
 	const currentResource = widget.viewModel?.model.sessionResource;
 	const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
-	const { sessionType: newSessionType, isPreferCopilotHarnessSwap } = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, agentHostEnabled, { explicitOverride: sessionType, currentSessionType });
+	const { sessionType: newSessionType, isPreferCopilotHarnessSwap } = resolveDefaultNewChatSessionType(accessor, { explicitOverride: sessionType, currentSessionType });
 	if (isIChatViewViewContext(widget.viewContext)) {
 		const view = await viewsService.openView(ChatViewId) as ChatViewPane;
 		if (newSessionType !== localChatSessionType) {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
@@ -3,29 +3,27 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Schemas } from '../../../../../base/common/network.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
-import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
-import { IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
-import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
-import { getDefaultNewChatSessionResource, resolveDefaultNewChatSessionType } from '../../common/constants.js';
+import { localChatSessionType } from '../../common/chatSessionsService.js';
+import { resolveDefaultNewChatSessionType } from '../../common/constants.js';
 import { markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
 import { getChatSessionType, LocalChatSessionUri } from '../../common/model/chatUri.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
 
+function getNewChatSessionResource(sessionType: string): URI {
+	return sessionType === localChatSessionType
+		? LocalChatSessionUri.getNewSessionUri()
+		: URI.from({ scheme: sessionType, path: `/untitled-${generateUuid()}` });
+}
+
 export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInput?: ChatEditorInput, targetSessionType?: string): Promise<void> {
 	const editorService = accessor.get(IEditorService);
-	const configurationService = accessor.get(IConfigurationService);
-	const chatSessionsService = accessor.get(IChatSessionsService);
 	const storageService = accessor.get(IStorageService);
-	const workspaceContextService = accessor.get(IWorkspaceContextService);
-	const agentHostEnablementService = accessor.get(IAgentHostEnablementService);
 
 	if (!chatEditorInput) {
 		const editorInput = editorService.activeEditor;
@@ -33,33 +31,16 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 	}
 
 	if (chatEditorInput instanceof ChatEditorInput) {
-		let resource: URI;
-		if (targetSessionType !== undefined) {
-			// The caller already resolved the target type (honoring an explicit
-			// request, session preservation, or the preferCopilotHarness swap and
-			// its marker); apply it directly instead of recomputing the default.
-			resource = targetSessionType === localChatSessionType
-				? LocalChatSessionUri.getNewSessionUri()
-				: URI.from({ scheme: targetSessionType, path: `/untitled-${generateUuid()}` });
-		} else {
-			const currentResource = chatEditorInput.sessionResource;
-			if (currentResource && currentResource.scheme !== Schemas.vscodeLocalChatSession) {
-				// Contributed/non-local session: keep the same type for the new session.
-				resource = currentResource.with({ path: `/untitled-${generateUuid()}` });
-			} else {
-				// Local (or brand-new) session. Honor the one-time preferCopilotHarness
-				// swap, consuming the migration marker only here where it is applied.
-				// Otherwise fall back to the computed default.
-				const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
-				const resolved = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled, { currentSessionType });
-				if (resolved.isPreferCopilotHarnessSwap) {
-					markPreferredCopilotHarness(storageService);
-					resource = URI.from({ scheme: resolved.sessionType, path: `/untitled-${generateUuid()}` });
-				} else {
-					resource = getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled);
-				}
-			}
+		const currentResource = chatEditorInput.sessionResource;
+		const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
+		const resolved = resolveDefaultNewChatSessionType(accessor, {
+			explicitOverride: targetSessionType,
+			currentSessionType,
+		});
+		if (resolved.isPreferCopilotHarnessSwap) {
+			markPreferredCopilotHarness(storageService);
 		}
+		const resource = getNewChatSessionResource(resolved.sessionType);
 
 		// A chat editor can only be open in one group
 		const identifier = editorService.findEditors(chatEditorInput.resource)[0];

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -21,11 +21,7 @@ import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.j
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
-import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
-import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { getModeNameForTelemetry, buildCustomAgentHandoffsInfo, getHandoffId, IChatMode, IChatModeService, IChatModes } from '../../common/chatModes.js';
@@ -904,14 +900,9 @@ class SendToNewChatAction extends Action2 {
 		const context = args[0] as IChatExecuteActionContext | undefined;
 
 		const widgetService = accessor.get(IChatWidgetService);
-		const viewsService = accessor.get(IViewsService);
 		const dialogService = accessor.get(IDialogService);
 		const chatService = accessor.get(IChatService);
-		const configurationService = accessor.get(IConfigurationService);
-		const chatSessionsService = accessor.get(IChatSessionsService);
-		const storageService = accessor.get(IStorageService);
-		const workspaceContextService = accessor.get(IWorkspaceContextService);
-		const agentHostEnablementService = accessor.get(IAgentHostEnablementService);
+		const instantiationService = accessor.get(IInstantiationService);
 		const widget = context?.widget ?? widgetService.lastFocusedWidget;
 		if (!widget) {
 			return;
@@ -933,7 +924,7 @@ class SendToNewChatAction extends Action2 {
 		// Clear the input from the current session before creating a new one
 		widget.setInput('');
 
-		await clearChatSessionPreservingType(widget, viewsService, undefined, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled);
+		await instantiationService.invokeFunction(clearChatSessionPreservingType, widget, undefined);
 
 		widget.acceptInput(inputBeforeClear, { storeToHistory: true });
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
@@ -12,8 +12,8 @@ import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../../p
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { ChatContextKeyExprs, ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatEditingSession } from '../../common/editing/chatEditingService.js';
@@ -25,10 +25,6 @@ import { EditingSessionAction, EditingSessionActionContext, getEditingSessionCon
 import { ACTION_ID_NEW_CHAT, ACTION_ID_NEW_EDIT_SESSION, CHAT_CATEGORY, clearChatSessionPreservingType, handleCurrentEditingSession } from './chatActions.js';
 import { clearChatEditor } from './chatClear.js';
 import { AgentSessionProviders, AgentSessionsViewerOrientation } from '../agentSessions/agentSessions.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { IChatSessionsService } from '../../common/chatSessionsService.js';
-import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
-import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 
 export interface INewEditSessionActionContext {
 
@@ -331,12 +327,7 @@ async function runNewChatAction(
 	sessionType?: AgentSessionProviders
 ) {
 	const accessibilityService = accessor.get(IAccessibilityService);
-	const viewsService = accessor.get(IViewsService);
-	const configurationService = accessor.get(IConfigurationService);
-	const chatSessionsService = accessor.get(IChatSessionsService);
-	const storageService = accessor.get(IStorageService);
-	const workspaceContextService = accessor.get(IWorkspaceContextService);
-	const agentHostEnablementService = accessor.get(IAgentHostEnablementService);
+	const instantiationService = accessor.get(IInstantiationService);
 
 	const { editingSession, chatWidget: widget } = context ?? {};
 	if (!widget) {
@@ -353,7 +344,7 @@ async function runNewChatAction(
 	await editingSession?.stop();
 
 	// Create a new session, preserving the session type (or using the specified one)
-	await clearChatSessionPreservingType(widget, viewsService, sessionType, configurationService, chatSessionsService, storageService, workspaceContextService.getWorkspace(), agentHostEnablementService.enabled);
+	await instantiationService.invokeFunction(clearChatSessionPreservingType, widget, sessionType);
 
 	widget.attachmentModel.clear(true);
 	widget.focusInput();

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -7,7 +7,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { IChatSessionsService, isAgentHostTarget, localChatSessionType, SessionType } from './chatSessionsService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
-import { IWorkspace } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkspace, IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { isVirtualWorkspace } from '../../../../platform/workspace/common/virtualWorkspace.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
@@ -17,6 +17,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { LocalChatSessionUri } from './model/chatUri.js';
 import { clearUserSelectedSessionType, getRememberedSessionType, hasPreferredCopilotHarness, storeUserSelectedSessionType } from './chatSessionTypePreference.js';
+import { IAgentHostEnablementService } from '../../../../platform/agentHost/common/agentHostEnablementService.js';
 
 export const enum BYOKUtilityModelDefault {
 	None = 'none',
@@ -323,7 +324,7 @@ export function getComputedDefaultSessionResource(
 		: URI.from({ scheme: defaultType, path: `/untitled-${generateUuid()}` });
 }
 
-export function isRememberedSessionTypeUsable(
+export function isNewChatSessionTypeUsable(
 	sessionType: string,
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
@@ -335,7 +336,7 @@ export function isRememberedSessionTypeUsable(
 	if (isAgentHostTarget(sessionType)) {
 		return true;
 	}
-	return !!chatSessionsService.getChatSessionContribution(sessionType);
+	return isVisibleEditorChatSessionType(sessionType, configurationService, chatSessionsService, workspace);
 }
 
 export interface IDefaultNewChatSessionTypeOptions {
@@ -372,7 +373,7 @@ export function getDefaultNewChatSessionType(
 		return remembered;
 	}
 
-	if (options?.currentSessionType) {
+	if (options?.currentSessionType && isNewChatSessionTypeUsable(options.currentSessionType, configurationService, chatSessionsService, workspace)) {
 		return options.currentSessionType;
 	}
 
@@ -380,13 +381,15 @@ export function getDefaultNewChatSessionType(
 }
 
 export function resolveDefaultNewChatSessionType(
-	configurationService: IConfigurationService,
-	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
-	storageService: IStorageService,
-	workspace: IWorkspace,
-	agentHostEnabled: boolean,
+	accessor: ServicesAccessor,
 	options?: IDefaultNewChatSessionTypeOptions
 ): IResolvedNewChatSessionType {
+	const configurationService = accessor.get(IConfigurationService);
+	const chatSessionsService = accessor.get(IChatSessionsService);
+	const storageService = accessor.get(IStorageService);
+	const workspace = accessor.get(IWorkspaceContextService).getWorkspace();
+	const agentHostEnabled = accessor.get(IAgentHostEnablementService).enabled;
+
 	if (options?.explicitOverride) {
 		return { sessionType: options.explicitOverride, isPreferCopilotHarnessSwap: false };
 	}
@@ -420,7 +423,7 @@ function getUsableRememberedSessionType(
 	workspace: IWorkspace
 ): string | undefined {
 	const remembered = getRememberedSessionType(storageService);
-	return remembered && isRememberedSessionTypeUsable(remembered, configurationService, chatSessionsService, workspace) ? remembered : undefined;
+	return remembered && isNewChatSessionTypeUsable(remembered, configurationService, chatSessionsService, workspace) ? remembered : undefined;
 }
 
 export function getDefaultNewChatSessionResource(

--- a/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
@@ -5,25 +5,33 @@
 
 import assert from 'assert';
 import { Event } from '../../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IDialogService } from '../../../../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
-import { NullLogService } from '../../../../../../../platform/log/common/log.js';
+import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService } from '../../../../../../../platform/workspace/common/workspace.js';
+import { isResourceEditorInput } from '../../../../../../common/editor.js';
+import { IEditorService } from '../../../../../../services/editor/common/editorService.js';
+import { clearChatEditor } from '../../../../browser/actions/chatClear.js';
 import { ChatEditorInput } from '../../../../browser/widgetHosts/editor/chatEditorInput.js';
 import { IAgentHostEnablementService } from '../../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IChatService, IChatSessionStartOptions } from '../../../../common/chatService/chatService.js';
-import { IChatSessionsService, localChatSessionType } from '../../../../common/chatSessionsService.js';
-import { ChatAgentLocation } from '../../../../common/constants.js';
+import { IChatSessionsService, localChatSessionType, SessionType } from '../../../../common/chatSessionsService.js';
+import { ChatAgentLocation, ChatConfiguration } from '../../../../common/constants.js';
 import { IChatModel } from '../../../../common/model/chatModel.js';
-import { LocalChatSessionUri } from '../../../../common/model/chatUri.js';
-import { TestContextService } from '../../../../../../test/common/workbenchTestServices.js';
+import { getChatSessionType, LocalChatSessionUri } from '../../../../common/model/chatUri.js';
+import { MockChatSessionsService } from '../../../common/mockChatSessionsService.js';
+import { TestContextService, TestStorageService } from '../../../../../../test/common/workbenchTestServices.js';
 
 suite('ChatEditorInput', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('explicit local session type starts local session for generic editor URI', async () => {
 		const sessionResource = LocalChatSessionUri.forSession('explicit-local');
@@ -129,6 +137,61 @@ suite('ChatEditorInput', () => {
 			});
 		} finally {
 			input.dispose();
+		}
+	});
+
+	test('new chat replaces a hidden current Copilot CLI harness', async () => {
+		const store = disposables.add(new DisposableStore());
+		const instantiationService = store.add(new TestInstantiationService());
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.CopilotCliHideExtensionHostEditor]: true,
+		});
+		const chatSessionsService = new MockChatSessionsService();
+		chatSessionsService.setContributions([{
+			type: SessionType.CopilotCLI,
+			name: 'Copilot CLI',
+			displayName: 'Copilot CLI',
+			description: 'Copilot CLI',
+		}]);
+		const storageService = store.add(new TestStorageService());
+		const workspaceContextService = new TestContextService();
+		const agentHostEnablementService = { _serviceBrand: undefined, enabled: true } satisfies IAgentHostEnablementService;
+
+		instantiationService.stub(IChatService, {});
+		instantiationService.stub(IDialogService, {});
+		instantiationService.set(IConfigurationService, configurationService);
+		instantiationService.set(IChatSessionsService, chatSessionsService);
+		instantiationService.set(IStorageService, storageService);
+		instantiationService.set(ILogService, new NullLogService());
+		instantiationService.set(IWorkspaceContextService, workspaceContextService);
+		instantiationService.set(IAgentHostEnablementService, agentHostEnablementService);
+
+		const input = store.add(instantiationService.createInstance(
+			ChatEditorInput,
+			URI.from({ scheme: SessionType.CopilotCLI, path: '/session' }),
+			{},
+		));
+		let replacementResource: URI | undefined;
+		instantiationService.stub(IEditorService, {
+			findEditors: () => [{ editor: input, groupId: 1 }],
+			replaceEditors: async replacements => {
+				const replacement = replacements[0].replacement;
+				replacementResource = isResourceEditorInput(replacement) ? replacement.resource : undefined;
+			},
+		});
+
+		try {
+			await instantiationService.invokeFunction(clearChatEditor, input);
+
+			assert.deepStrictEqual({
+				currentSessionType: input.sessionResource ? getChatSessionType(input.sessionResource) : undefined,
+				replacementSessionType: replacementResource ? getChatSessionType(replacementResource) : undefined,
+			}, {
+				currentSessionType: SessionType.CopilotCLI,
+				replacementSessionType: localChatSessionType,
+			});
+		} finally {
+			store.dispose();
 		}
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -6,12 +6,16 @@
 import assert from 'assert';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IWorkspace, toWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
-import { ChatConfiguration, ChatPermissionLevel, getChatPermissionLevelFromDefaultConfiguration, getComputedDefaultSessionResource, getComputedDefaultSessionType, getDefaultNewChatSessionResource, getDefaultNewChatSessionType, isEditorLocalAgentEnabled, isRememberedSessionTypeUsable, isVisibleEditorChatSessionType, recordUserSelectedSessionType, resolveDefaultNewChatSessionType } from '../../common/constants.js';
-import { localChatSessionType, SessionType, IChatSessionsExtensionPoint } from '../../common/chatSessionsService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService, Workspace, toWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
+import { ChatConfiguration, ChatPermissionLevel, getChatPermissionLevelFromDefaultConfiguration, getComputedDefaultSessionResource, getComputedDefaultSessionType, getDefaultNewChatSessionResource, getDefaultNewChatSessionType, IDefaultNewChatSessionTypeOptions, isEditorLocalAgentEnabled, isNewChatSessionTypeUsable, isVisibleEditorChatSessionType, recordUserSelectedSessionType, resolveDefaultNewChatSessionType } from '../../common/constants.js';
+import { localChatSessionType, SessionType, IChatSessionsExtensionPoint, IChatSessionsService } from '../../common/chatSessionsService.js';
 import { MockChatSessionsService } from './mockChatSessionsService.js';
-import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { TestContextService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
 import { getRememberedSessionType, hasPreferredCopilotHarness, markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 
@@ -20,11 +24,14 @@ suite('ChatConfiguration defaults', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 	const localWorkspace = createWorkspace(URI.file('/workspace'));
 
-	function createWorkspace(...resources: URI[]): IWorkspace {
-		return {
-			id: resources.map(resource => resource.toString()).join(','),
-			folders: resources.map(toWorkspaceFolder),
-		};
+	function createWorkspace(...resources: URI[]): Workspace {
+		return new Workspace(
+			resources.map(resource => resource.toString()).join(','),
+			resources.map(toWorkspaceFolder),
+			false,
+			null,
+			() => false,
+		);
 	}
 
 	function createChatSessionsService(...types: string[]): MockChatSessionsService {
@@ -36,6 +43,23 @@ suite('ChatConfiguration defaults', () => {
 			description: type,
 		} satisfies IChatSessionsExtensionPoint)));
 		return service;
+	}
+
+	function resolveSessionType(
+		configurationService: IConfigurationService,
+		chatSessionsService: IChatSessionsService,
+		storageService: IStorageService,
+		workspace: Workspace,
+		agentHostEnabled: boolean,
+		options?: IDefaultNewChatSessionTypeOptions,
+	) {
+		const accessor = disposables.add(new TestInstantiationService());
+		accessor.set(IConfigurationService, configurationService);
+		accessor.set(IChatSessionsService, chatSessionsService);
+		accessor.set(IStorageService, storageService);
+		accessor.set(IWorkspaceContextService, new TestContextService(workspace));
+		accessor.set(IAgentHostEnablementService, { _serviceBrand: undefined, enabled: agentHostEnabled });
+		return resolveDefaultNewChatSessionType(accessor, options);
 	}
 
 	test('default permission configuration maps Allow All to the Agent Host value', () => {
@@ -142,6 +166,51 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
+	test('hidden remembered extension host Copilot CLI falls back for a new chat', async () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.CopilotCLI, SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.CopilotCLI, true);
+		await configurationService.setUserConfiguration(ChatConfiguration.CopilotCliHideExtensionHostEditor, true);
+
+		assert.deepStrictEqual({
+			remembered: getRememberedSessionType(storageService),
+			rememberedUsable: isNewChatSessionTypeUsable(SessionType.CopilotCLI, configurationService, chatSessionsService, localWorkspace),
+			newSessionType: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true),
+		}, {
+			remembered: SessionType.CopilotCLI,
+			rememberedUsable: false,
+			newSessionType: localChatSessionType,
+		});
+	});
+
+	test('hidden current extension host Copilot CLI is not inherited by a new chat', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.CopilotCliHideExtensionHostEditor]: true,
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.CopilotCLI, SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		assert.deepStrictEqual(
+			resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: SessionType.CopilotCLI }),
+			{ sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false }
+		);
+	});
+
+	test('visible current extension host Copilot CLI is inherited by a new chat', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.DefaultToCopilotHarness]: true,
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.CopilotCLI, SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
+
+		assert.deepStrictEqual(
+			resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: SessionType.CopilotCLI }),
+			{ sessionType: SessionType.CopilotCLI, isPreferCopilotHarnessSwap: false }
+		);
+	});
+
 	test('editor default keeps local as last resort when local is disabled without any provider', () => {
 		const configurationService = new TestConfigurationService({
 			[ChatConfiguration.EditorLocalAgentEnabled]: false,
@@ -172,7 +241,7 @@ suite('ChatConfiguration defaults', () => {
 		assert.deepStrictEqual({
 			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, localWorkspace, true),
 			remembered: getRememberedSessionType(storageService),
-			rememberedAware: resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
+			rememberedAware: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
 		}, {
 			computed: SessionType.AgentHostCopilot,
 			remembered: SessionType.AgentHostClaude,
@@ -228,13 +297,13 @@ suite('ChatConfiguration defaults', () => {
 
 		// Resolving does not consume the marker on its own: repeated resolves keep
 		// returning the swap until the caller applies it and marks it.
-		const firstResolve = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+		const firstResolve = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
 		const markerBeforeApply = hasPreferredCopilotHarness(storageService);
-		const secondResolveBeforeApply = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+		const secondResolveBeforeApply = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
 
 		// The caller applies the swap and marks it; further resolves no longer swap.
 		markPreferredCopilotHarness(storageService);
-		const afterApply = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+		const afterApply = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
 
 		assert.deepStrictEqual({
 			firstResolve,
@@ -262,7 +331,7 @@ suite('ChatConfiguration defaults', () => {
 
 		// With the agent host disabled (e.g. on web) the swap must not fire, so it
 		// neither returns an unresolvable Copilot type nor marks the transition.
-		const resolved = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { currentSessionType: localChatSessionType });
+		const resolved = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { currentSessionType: localChatSessionType });
 
 		assert.deepStrictEqual({
 			resolved,
@@ -328,7 +397,7 @@ suite('ChatConfiguration defaults', () => {
 		// The `remembered !== local` guard lets the one-time swap replace the
 		// remembered local, even though the computed default is already Copilot.
 		// The resolver reports the swap but does not mark it (the caller does).
-		const swapped = resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+		const swapped = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
 
 		assert.deepStrictEqual({
 			swapped,
@@ -349,7 +418,7 @@ suite('ChatConfiguration defaults', () => {
 		// No remembered selection and no preferred-harness setting: the current
 		// session type wins over the Copilot computed default (session preservation).
 		assert.deepStrictEqual({
-			resolved: resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
+			resolved: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
 			preferenceApplied: hasPreferredCopilotHarness(storageService),
 		}, {
 			resolved: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
@@ -368,7 +437,7 @@ suite('ChatConfiguration defaults', () => {
 		// override outranks both the current session type and the computed default,
 		// so the clear path opens a local session instead of dropping the request.
 		assert.deepStrictEqual({
-			resolved: resolveDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { explicitOverride: localChatSessionType, currentSessionType: SessionType.AgentHostCopilot }),
+			resolved: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { explicitOverride: localChatSessionType, currentSessionType: SessionType.AgentHostCopilot }),
 		}, {
 			resolved: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
 		});
@@ -407,7 +476,7 @@ suite('ChatConfiguration defaults', () => {
 			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, workspace, true),
 			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, true),
 			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, workspace),
-			localRememberedUsable: isRememberedSessionTypeUsable(localChatSessionType, configurationService, chatSessionsService, workspace),
+			localRememberedUsable: isNewChatSessionTypeUsable(localChatSessionType, configurationService, chatSessionsService, workspace),
 		}, {
 			computed: localChatSessionType,
 			rememberedAware: localChatSessionType,
@@ -419,12 +488,15 @@ suite('ChatConfiguration defaults', () => {
 	test('remembered agent host is usable before contribution registers', () => {
 		const configurationService = new TestConfigurationService();
 		const chatSessionsService = createChatSessionsService();
+		const storageService = disposables.add(new TestStorageService());
 
 		assert.deepStrictEqual({
-			agentHost: isRememberedSessionTypeUsable(SessionType.AgentHostClaude, configurationService, chatSessionsService, localWorkspace),
-			extensionContributed: isRememberedSessionTypeUsable('my-extension-agent', configurationService, chatSessionsService, localWorkspace),
+			agentHost: isNewChatSessionTypeUsable(SessionType.AgentHostClaude, configurationService, chatSessionsService, localWorkspace),
+			agentHostCurrent: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: SessionType.AgentHostClaude }),
+			extensionContributed: isNewChatSessionTypeUsable('my-extension-agent', configurationService, chatSessionsService, localWorkspace),
 		}, {
 			agentHost: true,
+			agentHostCurrent: { sessionType: SessionType.AgentHostClaude, isPreferCopilotHarnessSwap: false },
 			extensionContributed: false,
 		});
 	});
@@ -465,7 +537,7 @@ suite('ChatConfiguration defaults', () => {
 			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, workspace, false),
 			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, false),
 			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, workspace),
-			localRememberedUsable: isRememberedSessionTypeUsable(localChatSessionType, configurationService, chatSessionsService, workspace),
+			localRememberedUsable: isNewChatSessionTypeUsable(localChatSessionType, configurationService, chatSessionsService, workspace),
 		}, {
 			computed: localChatSessionType,
 			rememberedAware: localChatSessionType,


### PR DESCRIPTION
## Problem

The editor chat harness picker hides Extension Host Copilot CLI when `chat.editor.copilotCli.hideExtensionHost` is enabled, but a previously selected or currently open Copilot CLI session could still seed a new chat with that hidden harness.

This is the editor-window counterpart to [#327428](https://github.com/microsoft/vscode/pull/327428). Existing committed chats should continue showing the harness they actually run on; the setting only affects targets offered for new chats.

## Changes

- Validate remembered and inherited editor session types against the targets available for new chats.
- Preserve Agent Host targets before their contribution registers, maintaining late-startup behavior.
- Route all editor New Chat paths through the shared session-type resolver instead of directly copying a non-local session URI.
- Make `resolveDefaultNewChatSessionType` obtain its dependencies from a `ServicesAccessor` and remove redundant service plumbing from action call sites.
- Add resolver-level and editor-action regression coverage.

## Compatibility

The one-time Local to Agent Host Copilot migration from [#326178](https://github.com/microsoft/vscode/pull/326178) is preserved: the resolver remains pure, remains gated on Agent Host enablement and the persisted marker, and callers still mark the migration only when applying the resolved swap.

## Validation

- `npm run gulp compile-client`
- Focused chat constants and editor-input tests: 29 passing
- Staged pre-commit hygiene checks

Fixes microsoft/vscode-internalbacklog#8634

(Written by Copilot)
