### PR TITLE
agentHost: track edit attribution telemetry

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -37,7 +37,7 @@ import { encodeBase64 } from '../../../base/common/buffer.js';
 import { ILoadEstimator, LoadEstimator } from '../../../base/parts/ipc/common/ipc.net.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, AUTO_REPLY_SETTING_ID, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, getAgentHostTerminalAutoApproveRulesConfig, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, AUTO_REPLY_SETTING_ID, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, EDIT_TELEMETRY_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import type { OtlpExportLogsParams } from '../common/state/protocol/channels-otlp/notifications.js';
 import type { TelemetryCapabilities } from '../common/state/protocol/channels-otlp/state.js';
 import type { Implementation, InitializeResult } from '../common/state/protocol/common/commands.js';
@@ -342,6 +342,12 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 					return;
 				}
 				this._updateTelemetryLevel();
+			}
+			if (e.affectsConfiguration(EDIT_TELEMETRY_ENABLED_SETTING_ID)) {
+				if (this._state.kind !== AgentHostClientState.Connected) {
+					return;
+				}
+				this._updateEditTelemetryEnabled();
 			}
 			if (e.affectsConfiguration(SESSION_SYNC_ENABLED_SETTING_ID)) {
 				if (this._state.kind !== AgentHostClientState.Connected) {
@@ -687,6 +693,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			this._defaultDirectory = typeof directory === 'string' ? URI.parse(directory).path : URI.revive(directory).path;
 		}
 		this._updateTelemetryLevel();
+		this._updateEditTelemetryEnabled();
 		this._updateSessionSyncEnabled();
 		this._updateTerminalAutoApproveEnabled();
 		this._updateGlobalAutoApproveEnabled();
@@ -1481,6 +1488,13 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this.dispatchAction(ROOT_STATE_URI, {
 			type: ActionType.RootConfigChanged,
 			config: { [AgentHostTelemetryLevelConfigKey]: telemetryLevelToAgentHostConfigValue(getTelemetryLevel(this._configurationService)) },
+		}, this._clientId, 0);
+	}
+
+	private _updateEditTelemetryEnabled(): void {
+		this.dispatchAction(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [AgentHostEditTelemetryEnabledConfigKey]: this._configurationService.getValue<boolean>(EDIT_TELEMETRY_ENABLED_SETTING_ID) !== false },
 		}, this._clientId, 0);
 	}
 

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -387,6 +387,12 @@ export function migrateLegacyAutopilotConfig<T extends Record<string, unknown> |
  */
 export const AgentHostTelemetryLevelConfigKey = 'telemetryLevel';
 
+/** Whether Agent Host edit attribution telemetry is enabled. */
+export const AgentHostEditTelemetryEnabledConfigKey = 'editTelemetryEnabled';
+
+/** VS Code setting forwarded into {@link AgentHostEditTelemetryEnabledConfigKey}. */
+export const EDIT_TELEMETRY_ENABLED_SETTING_ID = 'telemetry.editStats.enabled';
+
 /** Legacy Copilot Chat debug switch that disables `request.repoInfo` collection. */
 export const AgentHostDisableRepoInfoTelemetryConfigKey = 'disableRepoInfoTelemetry';
 
@@ -681,6 +687,12 @@ export const platformRootSchema = createSchema({
 		description: localize('agentHost.config.telemetryLevel.description', "Most restrictive telemetry level requested by connected clients."),
 		enum: [TelemetryConfiguration.ON, TelemetryConfiguration.ERROR, TelemetryConfiguration.CRASH, TelemetryConfiguration.OFF],
 		default: TelemetryConfiguration.ON,
+	}),
+	[AgentHostEditTelemetryEnabledConfigKey]: schemaProperty<boolean>({
+		type: 'boolean',
+		title: localize('agentHost.config.editTelemetryEnabled.title', "Edit Telemetry"),
+		description: localize('agentHost.config.editTelemetryEnabled.description', "Whether edit attribution telemetry is enabled for Agent Host sessions."),
+		default: true,
 	}),
 	[AgentHostSessionSyncEnabledConfigKey]: schemaProperty<boolean>({
 		type: 'boolean',

--- a/src/vs/platform/agentHost/common/diffComputeService.ts
+++ b/src/vs/platform/agentHost/common/diffComputeService.ts
@@ -8,6 +8,13 @@ import { createDecorator } from '../../instantiation/common/instantiation.js';
 export interface IDiffCountResult {
 	added: number;
 	removed: number;
+	changes: readonly IOffsetEdit[];
+}
+
+export interface IOffsetEdit {
+	startOffset: number;
+	endOffsetExclusive: number;
+	newText: string;
 }
 
 export const IDiffComputeService = createDecorator<IDiffComputeService>('diffComputeService');
@@ -24,7 +31,7 @@ export interface IDiffComputeService {
 	readonly _serviceBrand: undefined;
 
 	/**
-	 * Computes line-level diff counts between two text strings.
+	 * Computes line-level diff counts and character edits between two text strings.
 	 * @param original - The original text.
 	 * @param modified - The modified text to compare against the original.
 	 * @param timeoutMs - Maximum time in milliseconds before aborting. Defaults to {@link DEFAULT_DIFF_TIMEOUT_MS}.

--- a/src/vs/platform/agentHost/common/fileEditAttribution.ts
+++ b/src/vs/platform/agentHost/common/fileEditAttribution.ts
@@ -55,6 +55,7 @@ export const IAgentEditAttributionService = createDecorator<IAgentEditAttributio
 
 export interface IAgentEditAttributionService {
 	readonly _serviceBrand: undefined;
+	/** Disabling attribution is permanent for the lifetime of the service. */
 	setEnabled(enabled: boolean): void;
 	recordEdit(edit: IAgentEditAttribution): Promise<IFileEditAttributionMarker | undefined>;
 	flushSession(sessionUri: string): Promise<void>;
@@ -90,6 +91,7 @@ export interface IPrepareEditAttributionFlushParams {
 export interface IPreparedEditAttributionFlush {
 	readonly flushToken: string;
 	readonly agentModifiedCount: number;
+	readonly lastSequence?: number;
 }
 
 export interface ICommitEditAttributionFlushParams {

--- a/src/vs/platform/agentHost/common/fileEditAttribution.ts
+++ b/src/vs/platform/agentHost/common/fileEditAttribution.ts
@@ -1,0 +1,206 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { stringHash } from '../../../base/common/hash.js';
+import { IOffsetEdit } from './diffComputeService.js';
+import { ToolResultFileEditContent } from './state/sessionState.js';
+import { URI } from '../../../base/common/uri.js';
+import { EditTelemetryTrigger } from '../../telemetry/common/editTelemetry.js';
+
+export const FILE_EDIT_ATTRIBUTION_PROPERTY = '_vscodeEditAttribution';
+const EDIT_ATTRIBUTION_RESOURCE_SCHEME = 'agent-edit-attribution';
+
+export interface IFileEditAttributionMarker {
+	readonly version: 1;
+	readonly editId: string;
+	readonly sequence: number;
+	readonly beforeDigest: string;
+	readonly afterDigest: string;
+}
+
+export type AttributedToolResultFileEditContent = ToolResultFileEditContent & {
+	readonly [FILE_EDIT_ATTRIBUTION_PROPERTY]: IFileEditAttributionMarker;
+};
+
+export interface IAgentEditAttribution {
+	readonly sessionUri: string;
+	readonly turnId: string;
+	readonly toolCallId: string;
+	readonly filePath: string;
+	readonly beforeText: string;
+	readonly afterText: string;
+	readonly changes: readonly IOffsetEdit[];
+	readonly modelId: string | undefined;
+	readonly toolName: string;
+}
+
+export const IAgentEditAttributionService = createDecorator<IAgentEditAttributionService>('agentEditAttributionService');
+
+export interface IAgentEditAttributionService {
+	readonly _serviceBrand: undefined;
+	setEnabled(enabled: boolean): void;
+	recordEdit(edit: IAgentEditAttribution): Promise<IFileEditAttributionMarker | undefined>;
+	flushSession(sessionUri: string): Promise<void>;
+	prepareFlush(params: IPrepareEditAttributionFlushParams): Promise<IPreparedEditAttributionFlush | undefined>;
+	commitFlush(params: ICommitEditAttributionFlushParams): Promise<IEditAttributionFlushResult>;
+	cancelFlush(params: ICancelEditAttributionFlushParams): Promise<IEditAttributionFlushResult>;
+}
+
+export class NullAgentEditAttributionService implements IAgentEditAttributionService {
+	declare readonly _serviceBrand: undefined;
+
+	setEnabled(_enabled: boolean): void { }
+
+	async recordEdit(_edit: IAgentEditAttribution): Promise<IFileEditAttributionMarker | undefined> {
+		return undefined;
+	}
+
+	async flushSession(_sessionUri: string): Promise<void> { }
+	async prepareFlush(_params: IPrepareEditAttributionFlushParams): Promise<IPreparedEditAttributionFlush | undefined> { return undefined; }
+	async commitFlush(_params: ICommitEditAttributionFlushParams): Promise<IEditAttributionFlushResult> { return { outcome: 'missing', agentModifiedCount: 0 }; }
+	async cancelFlush(_params: ICancelEditAttributionFlushParams): Promise<IEditAttributionFlushResult> { return { outcome: 'missing', agentModifiedCount: 0 }; }
+}
+
+export interface IPrepareEditAttributionFlushParams {
+	readonly resource: URI;
+	readonly trigger: EditTelemetryTrigger;
+	readonly statsUuid: string;
+	readonly isDirty: boolean;
+	readonly flushToken: string;
+	readonly languageId: string;
+}
+
+export interface IPreparedEditAttributionFlush {
+	readonly flushToken: string;
+	readonly agentModifiedCount: number;
+}
+
+export interface ICommitEditAttributionFlushParams {
+	readonly flushToken: string;
+	readonly totalModifiedCount: number;
+}
+
+export interface ICancelEditAttributionFlushParams {
+	readonly flushToken: string;
+}
+
+export type EditAttributionFlushOutcome = 'committed' | 'cancelled' | 'missing';
+
+export interface IEditAttributionFlushResult {
+	readonly outcome: EditAttributionFlushOutcome;
+	readonly agentModifiedCount: number;
+}
+
+export function getFileEditAttributionMarker(content: ToolResultFileEditContent): IFileEditAttributionMarker | undefined {
+	const marker = (content as Partial<AttributedToolResultFileEditContent>)[FILE_EDIT_ATTRIBUTION_PROPERTY];
+	if (
+		marker?.version !== 1 ||
+		typeof marker.editId !== 'string' ||
+		typeof marker.sequence !== 'number' ||
+		typeof marker.beforeDigest !== 'string' ||
+		typeof marker.afterDigest !== 'string'
+	) {
+		return undefined;
+	}
+	return marker;
+}
+
+export function createFileEditContentDigest(content: string): string {
+	return `${content.length}:${stringHash(content, 0)}:${stringHash(content, 5381)}`;
+}
+
+export function buildPrepareEditAttributionResource(params: IPrepareEditAttributionFlushParams): URI {
+	return buildEditAttributionResource('prepare', {
+		resource: params.resource.toString(),
+		trigger: params.trigger,
+		statsUuid: params.statsUuid,
+		isDirty: params.isDirty,
+		flushToken: params.flushToken,
+		languageId: params.languageId,
+	});
+}
+
+export function buildCommitEditAttributionResource(params: ICommitEditAttributionFlushParams): URI {
+	return buildEditAttributionResource('commit', params);
+}
+
+export function buildCancelEditAttributionResource(params: ICancelEditAttributionFlushParams): URI {
+	return buildEditAttributionResource('cancel', params);
+}
+
+export type EditAttributionResourceRequest =
+	| { readonly kind: 'prepare'; readonly params: IPrepareEditAttributionFlushParams }
+	| { readonly kind: 'commit'; readonly params: ICommitEditAttributionFlushParams }
+	| { readonly kind: 'cancel'; readonly params: ICancelEditAttributionFlushParams };
+
+export function parseEditAttributionResource(resource: URI): EditAttributionResourceRequest | undefined {
+	if (resource.scheme !== EDIT_ATTRIBUTION_RESOURCE_SCHEME) {
+		return undefined;
+	}
+	const kind = resource.path.substring(1);
+	const payload = new URLSearchParams(resource.query).get('payload');
+	if (!payload) {
+		return undefined;
+	}
+	try {
+		const value = JSON.parse(payload) as Record<string, string | number | boolean>;
+		if (
+			kind === 'prepare' &&
+			typeof value.resource === 'string' &&
+			isEditTelemetryTrigger(value.trigger) &&
+			typeof value.statsUuid === 'string' &&
+			typeof value.isDirty === 'boolean' &&
+			typeof value.flushToken === 'string' &&
+			typeof value.languageId === 'string'
+		) {
+			return {
+				kind,
+				params: {
+					resource: URI.parse(value.resource),
+					trigger: value.trigger,
+					statsUuid: value.statsUuid,
+					isDirty: value.isDirty,
+					flushToken: value.flushToken,
+					languageId: value.languageId,
+				},
+			};
+		}
+		if (kind === 'commit' && typeof value.flushToken === 'string' && typeof value.totalModifiedCount === 'number') {
+			return {
+				kind,
+				params: {
+					flushToken: value.flushToken,
+					totalModifiedCount: value.totalModifiedCount,
+				},
+			};
+		}
+		if (kind === 'cancel' && typeof value.flushToken === 'string') {
+			return {
+				kind,
+				params: {
+					flushToken: value.flushToken,
+				},
+			};
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
+}
+
+function buildEditAttributionResource(kind: EditAttributionResourceRequest['kind'], value: object): URI {
+	const params = new URLSearchParams();
+	params.set('payload', JSON.stringify(value));
+	return URI.from({
+		scheme: EDIT_ATTRIBUTION_RESOURCE_SCHEME,
+		path: `/${kind}`,
+		query: params.toString(),
+	});
+}
+
+function isEditTelemetryTrigger(value: string | number | boolean | undefined): value is EditTelemetryTrigger {
+	return value === '10hours' || value === 'hashChange' || value === 'branchChange' || value === 'closed' || value === 'time';
+}

--- a/src/vs/platform/agentHost/common/fileEditAttribution.ts
+++ b/src/vs/platform/agentHost/common/fileEditAttribution.ts
@@ -11,15 +11,29 @@ import { URI } from '../../../base/common/uri.js';
 import { EditTelemetryTrigger } from '../../telemetry/common/editTelemetry.js';
 
 export const FILE_EDIT_ATTRIBUTION_PROPERTY = '_vscodeEditAttribution';
+// Workbench edit-source tracking reports a coverage gap when Agent Host attribution exceeds this cap.
+export const MAX_EDIT_ATTRIBUTION_FILE_SIZE = 5 * 1024 * 1024;
 const EDIT_ATTRIBUTION_RESOURCE_SCHEME = 'agent-edit-attribution';
 
-export interface IFileEditAttributionMarker {
+interface IFileEditAttributionMarkerBase {
 	readonly version: 1;
 	readonly editId: string;
 	readonly sequence: number;
+}
+
+export interface ITrackedFileEditAttributionMarker extends IFileEditAttributionMarkerBase {
+	readonly status?: 'tracked';
 	readonly beforeDigest: string;
 	readonly afterDigest: string;
 }
+
+export interface ISkippedFileEditAttributionMarker extends IFileEditAttributionMarkerBase {
+	readonly status: 'skipped';
+	readonly reason: 'fileTooLarge';
+	readonly insertedCount: number;
+}
+
+export type IFileEditAttributionMarker = ITrackedFileEditAttributionMarker | ISkippedFileEditAttributionMarker;
 
 export type AttributedToolResultFileEditContent = ToolResultFileEditContent & {
 	readonly [FILE_EDIT_ATTRIBUTION_PROPERTY]: IFileEditAttributionMarker;
@@ -99,13 +113,18 @@ export function getFileEditAttributionMarker(content: ToolResultFileEditContent)
 	if (
 		marker?.version !== 1 ||
 		typeof marker.editId !== 'string' ||
-		typeof marker.sequence !== 'number' ||
-		typeof marker.beforeDigest !== 'string' ||
-		typeof marker.afterDigest !== 'string'
+		!Number.isSafeInteger(marker.sequence) ||
+		marker.sequence < 0
 	) {
 		return undefined;
 	}
-	return marker;
+	if (marker.status === 'skipped') {
+		return marker.reason === 'fileTooLarge' && Number.isSafeInteger(marker.insertedCount) && marker.insertedCount >= 0 ? marker : undefined;
+	}
+	if (marker.status !== undefined && marker.status !== 'tracked') {
+		return undefined;
+	}
+	return typeof marker.beforeDigest === 'string' && typeof marker.afterDigest === 'string' ? marker : undefined;
 }
 
 export function createFileEditContentDigest(content: string): string {

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -73,7 +73,9 @@ import { IWindowsMxcTerminalSandboxRuntime, WindowsMxcTerminalSandboxRuntime } f
 import { ISandboxHelperService } from '../../sandbox/common/sandboxHelperService.js';
 import { SandboxHelperService } from '../../sandbox/node/sandboxHelper.js';
 import { IDiffComputeService } from '../common/diffComputeService.js';
+import { IAgentEditAttributionService } from '../common/fileEditAttribution.js';
 import { NodeWorkerDiffComputeService } from './diffComputeService.js';
+import { AgentEditAttributionService } from './shared/agentEditAttributionService.js';
 import { IEditSurvivalReporterFactory, EditSurvivalReporterFactory } from './shared/editSurvivalReporter.js';
 import { AgentHostClientFileSystemProvider } from '../common/agentHostClientFileSystemProvider.js';
 import { AGENT_CLIENT_SCHEME } from '../common/agentClientUri.js';
@@ -217,6 +219,9 @@ async function startAgentHost(): Promise<void> {
 		diServices.set(IAgentPluginManager, pluginManager);
 		const diffComputeService = disposables.add(new NodeWorkerDiffComputeService(logService));
 		diServices.set(IDiffComputeService, diffComputeService);
+		const editAttributionService = disposables.add(instantiationService.createInstance(AgentEditAttributionService, undefined, undefined));
+		diServices.set(IAgentEditAttributionService, editAttributionService);
+		agentService.setEditAttributionService(editAttributionService);
 		diServices.set(IEditSurvivalReporterFactory, instantiationService.createInstance(EditSurvivalReporterFactory));
 
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -66,7 +66,9 @@ import { DiskFileSystemProvider } from '../../files/node/diskFileSystemProvider.
 import { Schemas } from '../../../base/common/network.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
 import { IDiffComputeService } from '../common/diffComputeService.js';
+import { IAgentEditAttributionService } from '../common/fileEditAttribution.js';
 import { NodeWorkerDiffComputeService } from './diffComputeService.js';
+import { AgentEditAttributionService } from './shared/agentEditAttributionService.js';
 import { IEditSurvivalReporterFactory, EditSurvivalReporterFactory } from './shared/editSurvivalReporter.js';
 import { SessionDataService } from './sessionDataService.js';
 import { IWindowsMxcTerminalSandboxRuntime, WindowsMxcTerminalSandboxRuntime } from '../../sandbox/common/terminalSandboxMxcRuntime.js';
@@ -270,6 +272,9 @@ async function main(): Promise<void> {
 		const pluginManager = new AgentPluginManager(URI.file(environmentService.userDataPath), fileService, logService);
 		diServices.set(IAgentPluginManager, pluginManager);
 		diServices.set(IDiffComputeService, disposables.add(new NodeWorkerDiffComputeService(logService)));
+		const editAttributionService = disposables.add(instantiationService.createInstance(AgentEditAttributionService, undefined, undefined));
+		diServices.set(IAgentEditAttributionService, editAttributionService);
+		agentService.setEditAttributionService(editAttributionService);
 		diServices.set(IEditSurvivalReporterFactory, instantiationService.createInstance(EditSurvivalReporterFactory));
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
 		diServices.set(IAgentConfigurationService, agentService.configurationService);

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -24,6 +24,7 @@ import { ServiceCollection } from '../../instantiation/common/serviceCollection.
 import { ILogService } from '../../log/common/log.js';
 import { AgentProvider, AgentSession, AgentSignal, AgentHostSessionReleaseGraceMsEnvVar, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateChatSideChatSelection, IAgentCreateChatSideChatSource, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkEndpoint, IAgentHostNetworkFetchResult, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
 import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
+import { IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommitEditAttributionFlushParams, IEditAttributionFlushResult, IPrepareEditAttributionFlushParams, IPreparedEditAttributionFlush, parseEditAttributionResource } from '../common/fileEditAttribution.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import type { IAgentCustomizationSettingsRegistration } from '../common/agentCustomizationSettings.js';
 import { parseChangesetUri } from '../common/changesetUri.js';
@@ -72,6 +73,7 @@ import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { AgentHostAuthenticationService } from './agentHostAuthenticationService.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
+import { AgentHostEditTelemetryEnabledConfigKey } from '../common/agentHostSchema.js';
 import { AgentHostOctoKitService, IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
 import { IAgentHostChangesetService, CHANGESET_DB_METADATA_KEYS, META_CHANGES_SUMMARY } from '../common/agentHostChangesetService.js';
 import { IAgentHostChangesetSubscriptionService } from '../common/agentHostChangesetSubscriptionService.js';
@@ -298,6 +300,7 @@ export class AgentService extends Disposable implements IAgentService {
 	private _skillCompletionProviderRegistered = false;
 	/** Backs {@link getNetworkDiagnosticsInfo} / {@link diagnosticsFetch}; wired via {@link setNetworkDiagnosticsService}. */
 	private _networkDiagnostics: INetworkDiagnosticsService | undefined;
+	private _editAttributionService: IAgentEditAttributionService | undefined;
 
 	/**
 	 * Authoritative server-side per-resource subscription refcount, keyed by
@@ -2265,6 +2268,10 @@ export class AgentService extends Disposable implements IAgentService {
 		this._stateManager.dispatchClientAction(channel, action, origin);
 		if (action.type === ActionType.RootConfigChanged) {
 			this._configurationService.persistRootConfig();
+			const editTelemetryEnabled = action.config[AgentHostEditTelemetryEnabledConfigKey];
+			if (typeof editTelemetryEnabled === 'boolean') {
+				this._editAttributionService?.setEnabled(editTelemetryEnabled);
+			}
 		}
 		this._sideEffects.handleAction(channel, action, clientId, clientType);
 	}
@@ -3158,6 +3165,32 @@ export class AgentService extends Disposable implements IAgentService {
 	}
 
 	async resourceRead(uri: URI): Promise<ResourceReadResult> {
+		const editAttributionRequest = parseEditAttributionResource(uri);
+		if (editAttributionRequest?.kind === 'prepare') {
+			const prepared = await this.prepareEditAttributionFlush(editAttributionRequest.params);
+			return {
+				data: JSON.stringify(prepared ?? null),
+				encoding: ContentEncoding.Utf8,
+				contentType: 'application/json',
+			};
+		}
+		if (editAttributionRequest?.kind === 'commit') {
+			const result = await this.commitEditAttributionFlush(editAttributionRequest.params);
+			return {
+				data: JSON.stringify(result),
+				encoding: ContentEncoding.Utf8,
+				contentType: 'application/json',
+			};
+		}
+		if (editAttributionRequest?.kind === 'cancel') {
+			const result = await this.cancelEditAttributionFlush(editAttributionRequest.params);
+			return {
+				data: JSON.stringify(result),
+				encoding: ContentEncoding.Utf8,
+				contentType: 'application/json',
+			};
+		}
+
 		// Handle session-db: URIs that reference file-edit content stored
 		// in a per-session SQLite database.
 		const dbFields = parseSessionDbUri(uri.toString());
@@ -3192,6 +3225,18 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 			throw new ProtocolError(JSON_RPC_INTERNAL_ERROR, `Failed to read content: ${uri.toString()}: ${toErrorMessage(error)}`);
 		}
+	}
+
+	prepareEditAttributionFlush(params: IPrepareEditAttributionFlushParams): Promise<IPreparedEditAttributionFlush | undefined> {
+		return this._editAttributionService?.prepareFlush(params) ?? Promise.resolve(undefined);
+	}
+
+	commitEditAttributionFlush(params: ICommitEditAttributionFlushParams): Promise<IEditAttributionFlushResult> {
+		return this._editAttributionService?.commitFlush(params) ?? Promise.resolve({ outcome: 'missing', agentModifiedCount: 0 });
+	}
+
+	cancelEditAttributionFlush(params: ICancelEditAttributionFlushParams): Promise<IEditAttributionFlushResult> {
+		return this._editAttributionService?.cancelFlush(params) ?? Promise.resolve({ outcome: 'missing', agentModifiedCount: 0 });
 	}
 
 	async resourceWrite(params: ResourceWriteParams): Promise<ResourceWriteResult> {
@@ -3620,6 +3665,11 @@ export class AgentService extends Disposable implements IAgentService {
 	 */
 	setNetworkDiagnosticsService(service: INetworkDiagnosticsService): void {
 		this._networkDiagnostics = service;
+	}
+
+	setEditAttributionService(service: IAgentEditAttributionService): void {
+		this._editAttributionService = service;
+		service.setEnabled(this._stateManager.rootState.config?.values[AgentHostEditTelemetryEnabledConfigKey] !== false);
 	}
 
 	async getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> {

--- a/src/vs/platform/agentHost/node/claude/claudeFileEditObserver.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeFileEditObserver.ts
@@ -139,4 +139,11 @@ export class ClaudeFileEditObserver extends Disposable {
 			}
 		}
 	}
+
+	override dispose(): void {
+		void this._editTracker.flushAttribution().catch(error => {
+			this._logService.warn(`[ClaudeFileEditObserver] Failed to flush edit attribution: ${error}`);
+		});
+		super.dispose();
+	}
 }

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2040,6 +2040,9 @@ export class CopilotAgentSession extends Disposable {
 	 * backstop, since {@link _beginAbort} no-ops when already aborted.
 	 */
 	override dispose(): void {
+		void this._editTracker.flushAttribution().catch(error => {
+			this._logService.warn(`[Copilot:${this.sessionId}] Failed to flush edit attribution: ${error}`);
+		});
 		this._beginAbort();
 		super.dispose();
 	}
@@ -2051,6 +2054,11 @@ export class CopilotAgentSession extends Disposable {
 	 * truncation or fork operations that modify the session files).
 	 */
 	async destroySession(): Promise<void> {
+		try {
+			await this._editTracker.flushAttribution();
+		} catch (error) {
+			this._logService.warn(`[Copilot:${this.sessionId}] Failed to flush edit attribution: ${error}`);
+		}
 		await this._wrapper.session.disconnect();
 	}
 

--- a/src/vs/platform/agentHost/node/diffWorkerMain.ts
+++ b/src/vs/platform/agentHost/node/diffWorkerMain.ts
@@ -26,7 +26,43 @@ export function computeDiffCounts(originalText: string, modifiedText: string, ti
 		added += change.modified.length;
 	}
 
-	return { added, removed };
+	const originalLineStarts = getLineStarts(originalText);
+	const modifiedLineStarts = getLineStarts(modifiedText);
+	const changes = result.changes.flatMap(change => {
+		const rangeMappings = change.innerChanges ?? [change.toRangeMapping2(originalLines, modifiedLines)];
+		return rangeMappings.map(mapping => ({
+			startOffset: getOffset(mapping.originalRange, originalLineStarts, false),
+			endOffsetExclusive: getOffset(mapping.originalRange, originalLineStarts, true),
+			newText: modifiedText.substring(
+				getOffset(mapping.modifiedRange, modifiedLineStarts, false),
+				getOffset(mapping.modifiedRange, modifiedLineStarts, true),
+			),
+		}));
+	});
+	return { added, removed, changes };
+}
+
+function getLineStarts(content: string): number[] {
+	const result = [0];
+	for (let index = 0; index < content.length; index++) {
+		const charCode = content.charCodeAt(index);
+		if (charCode === 13) {
+			if (content.charCodeAt(index + 1) === 10) {
+				index++;
+			}
+			result.push(index + 1);
+		} else if (charCode === 10) {
+			result.push(index + 1);
+		}
+	}
+	return result;
+}
+
+function getOffset(range: { readonly startLineNumber: number; readonly startColumn: number; readonly endLineNumber: number; readonly endColumn: number }, lineStarts: readonly number[], end: boolean): number {
+	const lineNumber = end ? range.endLineNumber : range.startLineNumber;
+	const column = end ? range.endColumn : range.startColumn;
+	const lineStart = lineStarts[Math.min(lineNumber - 1, lineStarts.length - 1)];
+	return lineStart + column - 1;
 }
 
 function main() {
@@ -51,4 +87,6 @@ function main() {
 	});
 }
 
-main();
+if (parentPort) {
+	main();
+}

--- a/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
@@ -17,12 +17,10 @@ import { EditTelemetryTrigger, sendEditSourcesDetailsTelemetry } from '../../../
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { AgentSession } from '../../common/agentService.js';
 import { IDiffComputeService, IOffsetEdit } from '../../common/diffComputeService.js';
-import { createFileEditContentDigest, IAgentEditAttribution, IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommitEditAttributionFlushParams, IEditAttributionFlushResult, IFileEditAttributionMarker, IPrepareEditAttributionFlushParams, IPreparedEditAttributionFlush } from '../../common/fileEditAttribution.js';
+import { createFileEditContentDigest, IAgentEditAttribution, IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommitEditAttributionFlushParams, IEditAttributionFlushResult, IFileEditAttributionMarker, IPrepareEditAttributionFlushParams, IPreparedEditAttributionFlush, MAX_EDIT_ATTRIBUTION_FILE_SIZE } from '../../common/fileEditAttribution.js';
 import { IAgentHostTelemetryService } from '../agentHostTelemetryService.js';
 
-// Keep aligned with TextModel._MODEL_SYNC_LIMIT in vs/editor/common/model/textModel.ts.
-const MAX_TRACKED_FILE_SIZE = 50 * 1024 * 1024;
-const MAX_TOTAL_TRACKED_TEXT = MAX_TRACKED_FILE_SIZE;
+const MAX_TOTAL_TRACKED_TEXT = 20 * 1024 * 1024;
 const MAX_TRACKED_RESOURCES = 100;
 const MAX_INTERVALS_PER_RESOURCE = 10_000;
 const MAX_SETTLED_FLUSHES = 1_000;
@@ -129,10 +127,19 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 	async recordEdit(edit: IAgentEditAttribution): Promise<IFileEditAttributionMarker | undefined> {
 		if (
 			!this._enabled ||
-			this._telemetryService.telemetryLevel < TelemetryLevel.USAGE ||
-			Math.max(edit.beforeText.length, edit.afterText.length) > MAX_TRACKED_FILE_SIZE
+			this._telemetryService.telemetryLevel < TelemetryLevel.USAGE
 		) {
 			return undefined;
+		}
+		if (Math.max(edit.beforeText.length, edit.afterText.length) > MAX_EDIT_ATTRIBUTION_FILE_SIZE) {
+			return {
+				version: 1,
+				editId: generateUuid(),
+				sequence: ++this._sequence,
+				status: 'skipped',
+				reason: 'fileTooLarge',
+				insertedCount: edit.changes.reduce((sum, change) => sum + change.newText.length, 0),
+			};
 		}
 
 		const key = resourceKey(edit.sessionUri, edit.filePath);

--- a/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
@@ -1,0 +1,732 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { IntervalTimer } from '../../../../base/common/async.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { dirname } from '../../../../base/common/path.js';
+import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { FileOperationResult, IFileService, toFileOperationResult } from '../../../files/common/files.js';
+import { ILogService } from '../../../log/common/log.js';
+import { EditTelemetryTrigger, sendEditSourcesDetailsTelemetry } from '../../../telemetry/common/editTelemetry.js';
+import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { AgentSession } from '../../common/agentService.js';
+import { IDiffComputeService, IOffsetEdit } from '../../common/diffComputeService.js';
+import { createFileEditContentDigest, IAgentEditAttribution, IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommitEditAttributionFlushParams, IEditAttributionFlushResult, IFileEditAttributionMarker, IPrepareEditAttributionFlushParams, IPreparedEditAttributionFlush } from '../../common/fileEditAttribution.js';
+import { IAgentHostTelemetryService } from '../agentHostTelemetryService.js';
+
+// Keep aligned with TextModel._MODEL_SYNC_LIMIT in vs/editor/common/model/textModel.ts.
+const MAX_TRACKED_FILE_SIZE = 50 * 1024 * 1024;
+const MAX_TOTAL_TRACKED_TEXT = MAX_TRACKED_FILE_SIZE;
+const MAX_TRACKED_RESOURCES = 100;
+const MAX_INTERVALS_PER_RESOURCE = 10_000;
+const MAX_SETTLED_FLUSHES = 1_000;
+const MAX_STANDALONE_OWNERSHIP = 1_000;
+const PREPARED_FLUSH_TTL = 5 * 60 * 1000;
+const SETTLED_FLUSH_TTL = 10 * 60 * 1000;
+const STANDALONE_OWNERSHIP_TTL = 10 * 60 * 60 * 1000;
+const GIT_STATE_POLL_INTERVAL = 30_000;
+const execFileAsync = promisify(execFile);
+
+interface IAttributedInterval {
+	readonly start: number;
+	readonly endExclusive: number;
+	readonly sourceKey: string;
+}
+
+interface ISourceStatistics {
+	readonly sourceKey: string;
+	readonly sourceKeyCleaned: string;
+	readonly modelId: string | undefined;
+	readonly conversationId: string;
+	readonly requestId: string;
+	readonly harness: string;
+	insertedCount: number;
+}
+
+interface ITrackedResource {
+	readonly key: string;
+	readonly sessionUri: string;
+	readonly filePath: string;
+	currentContent: string;
+	intervals: IAttributedInterval[];
+	readonly sources: Map<string, ISourceStatistics>;
+	repositoryRoot: string | undefined;
+}
+
+export interface IAgentEditAttributionGitState {
+	readonly root: string;
+	branch: string;
+	head: string;
+}
+
+export type AgentEditAttributionGitStateReader = (workingDirectory: string) => Promise<IAgentEditAttributionGitState | undefined>;
+
+interface IPreparedFlush {
+	readonly token: string;
+	readonly trigger: EditTelemetryTrigger;
+	readonly statsUuid: string;
+	readonly languageId: string | undefined;
+	readonly sources: readonly ISourceStatistics[];
+	readonly retainedBySource: ReadonlyMap<string, number>;
+	readonly agentModifiedCount: number;
+	readonly resources: readonly ITrackedResource[];
+	readonly standaloneOwnershipKeys: readonly string[];
+	readonly timestamp: number;
+}
+
+export class AgentEditAttributionService extends Disposable implements IAgentEditAttributionService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _resources = new Map<string, ITrackedResource>();
+	private readonly _preparedFlushes = new Map<string, IPreparedFlush>();
+	private readonly _settledFlushes = new Map<string, { readonly result: IEditAttributionFlushResult; readonly timestamp: number }>();
+	private readonly _standaloneOwnership = new Map<string, { readonly timestamp: number; readonly agentModifiedCount: number }>();
+	private readonly _repositories = new Map<string, IAgentEditAttributionGitState>();
+	private readonly _nonRepositoryDirectories = new Set<string>();
+	private _trackedTextLength = 0;
+	private _sequence = 0;
+	private _enabled = true;
+
+	constructor(
+		private readonly _gitStateReader: AgentEditAttributionGitStateReader = readGitState,
+		private readonly _now: () => number = Date.now,
+		@IFileService private readonly _fileService: IFileService,
+		@IDiffComputeService private readonly _diffComputeService: IDiffComputeService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+		this._register(new IntervalTimer()).cancelAndSet(() => {
+			void this._flushAll('10hours');
+		}, 10 * 60 * 60 * 1000);
+		this._register(new IntervalTimer()).cancelAndSet(() => {
+			void this.checkGitState();
+		}, GIT_STATE_POLL_INTERVAL);
+	}
+
+	setEnabled(enabled: boolean): void {
+		if (this._enabled === enabled) {
+			return;
+		}
+		this._enabled = enabled;
+		if (!enabled) {
+			this._resources.clear();
+			this._preparedFlushes.clear();
+			this._settledFlushes.clear();
+			this._standaloneOwnership.clear();
+			this._repositories.clear();
+			this._nonRepositoryDirectories.clear();
+			this._trackedTextLength = 0;
+		}
+	}
+
+	async recordEdit(edit: IAgentEditAttribution): Promise<IFileEditAttributionMarker | undefined> {
+		if (
+			!this._enabled ||
+			this._telemetryService.telemetryLevel < TelemetryLevel.USAGE ||
+			Math.max(edit.beforeText.length, edit.afterText.length) > MAX_TRACKED_FILE_SIZE
+		) {
+			return undefined;
+		}
+
+		const key = resourceKey(edit.sessionUri, edit.filePath);
+		await this._ensureCapacity(key, edit.afterText.length);
+		let resource = this._resources.get(key);
+		const repository = resource?.repositoryRoot
+			? this._repositories.get(resource.repositoryRoot)
+			: await this._getOrCreateRepository(edit.filePath);
+		if (!resource) {
+			resource = {
+				key,
+				sessionUri: edit.sessionUri,
+				filePath: edit.filePath,
+				currentContent: edit.beforeText,
+				intervals: [],
+				sources: new Map(),
+				repositoryRoot: repository?.root,
+			};
+			this._resources.set(key, resource);
+			this._trackedTextLength += edit.beforeText.length;
+		} else {
+			resource.repositoryRoot = repository?.root;
+			this._resources.delete(key);
+			this._resources.set(key, resource);
+		}
+
+		if (resource.currentContent !== edit.beforeText) {
+			const bridge = await this._diffComputeService.computeDiffCounts(resource.currentContent, edit.beforeText);
+			this._applyChanges(resource, bridge.changes, undefined, edit.beforeText);
+		}
+
+		const provider = AgentSession.provider(edit.sessionUri) ?? 'unknown';
+		const modelSegment = edit.modelId ? `-$modelId:${edit.modelId}` : '';
+		const sourceKey = `source:Chat.applyEdits${modelSegment}-$harness:${provider}-$origin:agentHost`;
+		let source = resource.sources.get(sourceKey);
+		if (!source) {
+			source = {
+				sourceKey,
+				sourceKeyCleaned: `source:Chat.applyEdits-$harness:${provider}-$origin:agentHost`,
+				modelId: edit.modelId,
+				conversationId: AgentSession.id(edit.sessionUri),
+				requestId: edit.turnId,
+				harness: provider,
+				insertedCount: 0,
+			};
+			resource.sources.set(sourceKey, source);
+		}
+		this._applyChanges(resource, edit.changes, source, edit.afterText);
+		if (resource.intervals.length > MAX_INTERVALS_PER_RESOURCE) {
+			await this._flushStandalone(resource, 'closed');
+			return undefined;
+		}
+
+		return {
+			version: 1,
+			editId: generateUuid(),
+			sequence: ++this._sequence,
+			beforeDigest: createFileEditContentDigest(edit.beforeText),
+			afterDigest: createFileEditContentDigest(edit.afterText),
+		};
+	}
+
+	async flushSession(sessionUri: string): Promise<void> {
+		const resources = Array.from(this._resources.values()).filter(resource => resource.sessionUri === sessionUri);
+		await Promise.all(resources.map(resource => this._flushStandalone(resource, 'closed')));
+	}
+
+	async prepareFlush(params: IPrepareEditAttributionFlushParams): Promise<IPreparedEditAttributionFlush | undefined> {
+		this._expireFlushState();
+		if (params.isDirty) {
+			return undefined;
+		}
+		const existing = this._preparedFlushes.get(params.flushToken);
+		if (existing) {
+			return {
+				flushToken: existing.token,
+				agentModifiedCount: existing.agentModifiedCount,
+			};
+		}
+		if (this._settledFlushes.has(params.flushToken)) {
+			return undefined;
+		}
+		const standaloneOwnershipKey = this._filePathKey(params.resource.fsPath);
+		const standaloneOwnership = this._standaloneOwnership.get(standaloneOwnershipKey);
+		const resources = Array.from(this._resources.values()).filter(resource => extUriBiasedIgnorePathCase.isEqual(URI.file(resource.filePath), params.resource));
+		if (resources.length === 0 && !standaloneOwnership) {
+			return undefined;
+		}
+		const preparedResources: IPreparedFlush[] = [];
+		try {
+			for (const resource of resources) {
+				const prepared = await this._prepareResource(resource, params.trigger, params.statsUuid);
+				if (prepared) {
+					preparedResources.push(prepared);
+				}
+			}
+		} catch (error) {
+			for (const prepared of preparedResources) {
+				this._restoreResources(prepared.resources);
+			}
+			throw error;
+		}
+		const prepared = combinePreparedFlushes(
+			preparedResources,
+			params.trigger,
+			params.statsUuid,
+			params.flushToken,
+			params.languageId,
+			standaloneOwnership ? [standaloneOwnershipKey] : [],
+			standaloneOwnership?.agentModifiedCount ?? 0,
+			this._now(),
+		);
+		this._preparedFlushes.set(prepared.token, prepared);
+		return {
+			flushToken: prepared.token,
+			agentModifiedCount: prepared.agentModifiedCount,
+		};
+	}
+
+	async commitFlush(params: ICommitEditAttributionFlushParams): Promise<IEditAttributionFlushResult> {
+		this._expireFlushState();
+		const prepared = this._preparedFlushes.get(params.flushToken);
+		if (!prepared) {
+			return this._settledFlushes.get(params.flushToken)?.result ?? { outcome: 'missing', agentModifiedCount: 0 };
+		}
+		this._preparedFlushes.delete(params.flushToken);
+		this._emitTelemetry(prepared, params.totalModifiedCount);
+		for (const ownershipKey of prepared.standaloneOwnershipKeys) {
+			this._standaloneOwnership.delete(ownershipKey);
+		}
+		const result = { outcome: 'committed', agentModifiedCount: prepared.agentModifiedCount } as const;
+		this._recordSettledFlush(params.flushToken, result);
+		this._cleanupRepositories(prepared.resources);
+		return result;
+	}
+
+	async cancelFlush(params: ICancelEditAttributionFlushParams): Promise<IEditAttributionFlushResult> {
+		this._expireFlushState();
+		const settled = this._settledFlushes.get(params.flushToken);
+		if (settled) {
+			return settled.result;
+		}
+		const prepared = this._preparedFlushes.get(params.flushToken);
+		if (!prepared) {
+			const result = { outcome: 'cancelled', agentModifiedCount: 0 } as const;
+			this._recordSettledFlush(params.flushToken, result);
+			return result;
+		}
+		this._preparedFlushes.delete(params.flushToken);
+		if (prepared.resources.some(resource => this._resources.has(resource.key))) {
+			this._emitTelemetry(prepared, prepared.agentModifiedCount);
+			for (const ownershipKey of prepared.standaloneOwnershipKeys) {
+				this._standaloneOwnership.delete(ownershipKey);
+			}
+			const result = { outcome: 'committed', agentModifiedCount: prepared.agentModifiedCount } as const;
+			this._recordSettledFlush(params.flushToken, result);
+			this._cleanupRepositories(prepared.resources);
+			return result;
+		} else {
+			this._restoreResources(prepared.resources);
+		}
+		const result = { outcome: 'cancelled', agentModifiedCount: 0 } as const;
+		this._recordSettledFlush(params.flushToken, result);
+		this._cleanupRepositories(prepared.resources);
+		return result;
+	}
+
+	private async _ensureCapacity(key: string, nextLength: number): Promise<void> {
+		const existingLength = this._resources.get(key)?.currentContent.length ?? 0;
+		while (
+			this._resources.size >= MAX_TRACKED_RESOURCES ||
+			this._trackedTextLength - existingLength + nextLength > MAX_TOTAL_TRACKED_TEXT
+		) {
+			const oldest = this._resources.values().next().value;
+			if (!oldest) {
+				return;
+			}
+			await this._flushStandalone(oldest, 'closed');
+		}
+	}
+
+	private _applyChanges(resource: ITrackedResource, changes: readonly IOffsetEdit[], source: ISourceStatistics | undefined, afterText: string, updateTrackedTextLength = true): void {
+		const normalizedChanges = validateChanges(resource.currentContent, afterText, changes)
+			? changes
+			: [createMinimalChange(resource.currentContent, afterText)];
+		const intervals = transformIntervals(resource.intervals, normalizedChanges);
+		let delta = 0;
+		for (const change of normalizedChanges) {
+			if (source && change.newText.length > 0) {
+				const start = change.startOffset + delta;
+				intervals.push({
+					start,
+					endExclusive: start + change.newText.length,
+					sourceKey: source.sourceKey,
+				});
+				source.insertedCount += change.newText.length;
+			}
+			delta += change.newText.length - (change.endOffsetExclusive - change.startOffset);
+		}
+		intervals.sort((a, b) => a.start - b.start);
+		resource.intervals = mergeIntervals(intervals);
+		if (updateTrackedTextLength) {
+			this._trackedTextLength += afterText.length - resource.currentContent.length;
+		}
+		resource.currentContent = afterText;
+	}
+
+	private async _flushAll(trigger: EditTelemetryTrigger): Promise<void> {
+		await Promise.all(Array.from(this._resources.values(), resource => this._flushStandalone(resource, trigger)));
+	}
+
+	async checkGitState(): Promise<void> {
+		this._expireFlushState();
+		for (const repository of Array.from(this._repositories.values())) {
+			const current = await this._gitStateReader(repository.root);
+			if (!current) {
+				continue;
+			}
+			const trigger = current.branch !== repository.branch
+				? 'branchChange'
+				: current.head !== repository.head
+					? 'hashChange'
+					: undefined;
+			repository.branch = current.branch;
+			repository.head = current.head;
+			if (!trigger) {
+				continue;
+			}
+			const resources = Array.from(this._resources.values()).filter(resource => resource.repositoryRoot === repository.root);
+			await Promise.all(resources.map(resource => this._flushStandalone(resource, trigger)));
+		}
+	}
+
+	private async _getOrCreateRepository(filePath: string): Promise<IAgentEditAttributionGitState | undefined> {
+		const workingDirectory = dirname(filePath);
+		if (this._nonRepositoryDirectories.has(workingDirectory)) {
+			return undefined;
+		}
+		const current = await this._gitStateReader(workingDirectory);
+		if (!current) {
+			this._nonRepositoryDirectories.add(workingDirectory);
+			return undefined;
+		}
+		const existing = this._repositories.get(current.root);
+		if (existing) {
+			return existing;
+		}
+		this._repositories.set(current.root, current);
+		return current;
+	}
+
+	private async _flushStandalone(resource: ITrackedResource, trigger: EditTelemetryTrigger): Promise<void> {
+		const prepared = await this._prepareResource(resource, trigger, generateUuid());
+		if (!prepared) {
+			return;
+		}
+		this._preparedFlushes.set(prepared.token, prepared);
+		await this.commitFlush({
+			flushToken: prepared.token,
+			totalModifiedCount: prepared.agentModifiedCount,
+		});
+		this._recordStandaloneOwnership(resource.filePath, prepared.agentModifiedCount);
+	}
+
+	private async _prepareResource(resource: ITrackedResource, trigger: EditTelemetryTrigger, statsUuid: string): Promise<IPreparedFlush | undefined> {
+		if (this._resources.get(resource.key) !== resource) {
+			return undefined;
+		}
+		this._resources.delete(resource.key);
+		this._trackedTextLength -= resource.currentContent.length;
+		try {
+			const currentContent = await this._readCurrentContent(resource.filePath);
+			if (currentContent !== resource.currentContent) {
+				const diff = await this._diffComputeService.computeDiffCounts(resource.currentContent, currentContent);
+				this._applyChanges(resource, diff.changes, undefined, currentContent, false);
+			}
+			const retainedBySource = new Map<string, number>();
+			for (const interval of resource.intervals) {
+				retainedBySource.set(interval.sourceKey, (retainedBySource.get(interval.sourceKey) ?? 0) + interval.endExclusive - interval.start);
+			}
+			const prepared: IPreparedFlush = {
+				token: generateUuid(),
+				trigger,
+				statsUuid,
+				languageId: undefined,
+				sources: Array.from(resource.sources.values())
+					.toSorted((a, b) => (retainedBySource.get(b.sourceKey) ?? 0) - (retainedBySource.get(a.sourceKey) ?? 0))
+					.slice(0, 30),
+				retainedBySource,
+				agentModifiedCount: Array.from(retainedBySource.values()).reduce((sum, value) => sum + value, 0),
+				resources: [resource],
+				standaloneOwnershipKeys: [],
+				timestamp: this._now(),
+			};
+			return prepared;
+		} catch (error) {
+			this._logService.warn(`[AgentEditAttributionService] Failed to flush ${resource.filePath}: ${error}`);
+			if (!this._resources.has(resource.key)) {
+				this._resources.set(resource.key, resource);
+				this._trackedTextLength += resource.currentContent.length;
+			}
+			throw error;
+		}
+	}
+
+	private _emitTelemetry(prepared: IPreparedFlush, totalModifiedCount: number): void {
+		for (const source of prepared.sources) {
+			const data = {
+				mode: 'longterm',
+				sourceKey: source.sourceKey,
+				sourceKeyCleaned: source.sourceKeyCleaned,
+				extensionId: undefined,
+				extensionVersion: undefined,
+				modelId: source.modelId,
+				trigger: prepared.trigger,
+				languageId: prepared.languageId,
+				statsUuid: prepared.statsUuid,
+				conversationId: source.conversationId,
+				requestId: source.requestId,
+				origin: 'agentHost',
+				harness: source.harness,
+				modifiedCount: prepared.retainedBySource.get(source.sourceKey) ?? 0,
+				deltaModifiedCount: source.insertedCount,
+				totalModifiedCount,
+			} as const;
+			sendEditSourcesDetailsTelemetry(this._telemetryService, data);
+			const agentHostTelemetryService = this._telemetryService as Partial<IAgentHostTelemetryService>;
+			agentHostTelemetryService.sendGHTelemetryEvent?.('editTelemetry.editSources.details', {
+				mode: data.mode,
+				sourceKey: data.sourceKey,
+				sourceKeyCleaned: data.sourceKeyCleaned,
+				extensionId: '',
+				extensionVersion: '',
+				modelId: data.modelId ?? '',
+				trigger: data.trigger,
+				languageId: data.languageId ?? '',
+				statsUuid: data.statsUuid,
+				conversationId: data.conversationId,
+				requestId: data.requestId,
+				origin: data.origin,
+				harness: data.harness,
+			}, {
+				modifiedCount: data.modifiedCount,
+				deltaModifiedCount: data.deltaModifiedCount,
+				totalModifiedCount: data.totalModifiedCount,
+			});
+		}
+	}
+
+	private async _readCurrentContent(filePath: string): Promise<string> {
+		try {
+			return (await this._fileService.readFile(URI.file(filePath))).value.toString();
+		} catch (error) {
+			if (toFileOperationResult(error) === FileOperationResult.FILE_NOT_FOUND) {
+				return '';
+			}
+			throw error;
+		}
+	}
+
+	private _restoreResources(resources: readonly ITrackedResource[]): void {
+		for (const resource of resources) {
+			if (!this._resources.has(resource.key)) {
+				this._resources.set(resource.key, resource);
+				this._trackedTextLength += resource.currentContent.length;
+			}
+		}
+	}
+
+	private _cleanupRepositories(resources: readonly ITrackedResource[]): void {
+		for (const resource of resources) {
+			const repositoryRoot = resource.repositoryRoot;
+			if (
+				repositoryRoot &&
+				!Array.from(this._resources.values()).some(candidate => candidate.repositoryRoot === repositoryRoot) &&
+				!Array.from(this._preparedFlushes.values()).some(prepared => prepared.resources.some(candidate => candidate.repositoryRoot === repositoryRoot))
+			) {
+				this._repositories.delete(repositoryRoot);
+			}
+		}
+	}
+
+	private _recordSettledFlush(flushToken: string, result: IEditAttributionFlushResult): void {
+		this._settledFlushes.delete(flushToken);
+		this._settledFlushes.set(flushToken, { result, timestamp: this._now() });
+		while (this._settledFlushes.size > MAX_SETTLED_FLUSHES) {
+			const oldestToken = this._settledFlushes.keys().next().value;
+			if (oldestToken === undefined) {
+				break;
+			}
+			this._settledFlushes.delete(oldestToken);
+		}
+	}
+
+	private _recordStandaloneOwnership(filePath: string, agentModifiedCount: number): void {
+		const key = this._filePathKey(filePath);
+		const existing = this._standaloneOwnership.get(key);
+		this._standaloneOwnership.delete(key);
+		this._standaloneOwnership.set(key, {
+			timestamp: this._now(),
+			agentModifiedCount: (existing?.agentModifiedCount ?? 0) + agentModifiedCount,
+		});
+		while (this._standaloneOwnership.size > MAX_STANDALONE_OWNERSHIP) {
+			const oldestKey = this._standaloneOwnership.keys().next().value;
+			if (oldestKey === undefined) {
+				break;
+			}
+			this._standaloneOwnership.delete(oldestKey);
+		}
+	}
+
+	private _filePathKey(filePath: string): string {
+		return extUriBiasedIgnorePathCase.getComparisonKey(URI.file(filePath));
+	}
+
+	private _expireFlushState(): void {
+		const now = this._now();
+		for (const [flushToken, prepared] of this._preparedFlushes) {
+			if (prepared.timestamp < now - PREPARED_FLUSH_TTL) {
+				this._preparedFlushes.delete(flushToken);
+				if (prepared.resources.some(resource => this._resources.has(resource.key))) {
+					this._emitTelemetry(prepared, prepared.agentModifiedCount);
+					this._recordSettledFlush(flushToken, { outcome: 'committed', agentModifiedCount: prepared.agentModifiedCount });
+				} else {
+					this._restoreResources(prepared.resources);
+					this._recordSettledFlush(flushToken, { outcome: 'cancelled', agentModifiedCount: 0 });
+				}
+				this._cleanupRepositories(prepared.resources);
+			}
+		}
+		for (const [flushToken, settled] of this._settledFlushes) {
+			if (settled.timestamp < now - SETTLED_FLUSH_TTL) {
+				this._settledFlushes.delete(flushToken);
+			}
+		}
+		for (const [resourceKey, ownership] of this._standaloneOwnership) {
+			if (ownership.timestamp < now - STANDALONE_OWNERSHIP_TTL) {
+				this._standaloneOwnership.delete(resourceKey);
+			}
+		}
+	}
+
+	override dispose(): void {
+		void this._flushAll('closed');
+		super.dispose();
+	}
+}
+
+function resourceKey(sessionUri: string, filePath: string): string {
+	return `${sessionUri}\0${filePath}`;
+}
+
+function combinePreparedFlushes(
+	flushes: readonly IPreparedFlush[],
+	trigger: EditTelemetryTrigger,
+	statsUuid: string,
+	flushToken: string,
+	languageId: string,
+	standaloneOwnershipKeys: readonly string[],
+	standaloneAgentModifiedCount: number,
+	timestamp: number,
+): IPreparedFlush {
+	const retainedBySource = new Map<string, number>();
+	const sources = new Map<string, ISourceStatistics>();
+	for (const flush of flushes) {
+		for (const [sourceKey, retainedCount] of flush.retainedBySource) {
+			retainedBySource.set(sourceKey, (retainedBySource.get(sourceKey) ?? 0) + retainedCount);
+		}
+		for (const source of flush.sources) {
+			const existing = sources.get(source.sourceKey);
+			if (existing) {
+				existing.insertedCount += source.insertedCount;
+			} else {
+				sources.set(source.sourceKey, { ...source });
+			}
+		}
+	}
+	return {
+		token: flushToken,
+		trigger,
+		statsUuid,
+		languageId,
+		sources: Array.from(sources.values())
+			.toSorted((a, b) => (retainedBySource.get(b.sourceKey) ?? 0) - (retainedBySource.get(a.sourceKey) ?? 0))
+			.slice(0, 30),
+		retainedBySource,
+		agentModifiedCount: standaloneAgentModifiedCount + Array.from(retainedBySource.values()).reduce((sum, value) => sum + value, 0),
+		resources: flushes.flatMap(flush => flush.resources),
+		standaloneOwnershipKeys,
+		timestamp,
+	};
+}
+
+function validateChanges(before: string, after: string, changes: readonly IOffsetEdit[]): boolean {
+	let result = '';
+	let lastOffset = 0;
+	for (const change of changes) {
+		if (change.startOffset < lastOffset || change.endOffsetExclusive < change.startOffset || change.endOffsetExclusive > before.length) {
+			return false;
+		}
+		result += before.substring(lastOffset, change.startOffset);
+		result += change.newText;
+		lastOffset = change.endOffsetExclusive;
+	}
+	return result + before.substring(lastOffset) === after;
+}
+
+function createMinimalChange(before: string, after: string): IOffsetEdit {
+	let prefixLength = 0;
+	while (prefixLength < before.length && prefixLength < after.length && before.charCodeAt(prefixLength) === after.charCodeAt(prefixLength)) {
+		prefixLength++;
+	}
+	let suffixLength = 0;
+	while (
+		suffixLength < before.length - prefixLength &&
+		suffixLength < after.length - prefixLength &&
+		before.charCodeAt(before.length - suffixLength - 1) === after.charCodeAt(after.length - suffixLength - 1)
+	) {
+		suffixLength++;
+	}
+	return {
+		startOffset: prefixLength,
+		endOffsetExclusive: before.length - suffixLength,
+		newText: after.substring(prefixLength, after.length - suffixLength),
+	};
+}
+
+function transformIntervals(intervals: readonly IAttributedInterval[], changes: readonly IOffsetEdit[]): IAttributedInterval[] {
+	const result: IAttributedInterval[] = [];
+	for (const interval of intervals) {
+		let cursor = interval.start;
+		let delta = 0;
+		for (const change of changes) {
+			if (change.endOffsetExclusive <= cursor) {
+				delta += change.newText.length - (change.endOffsetExclusive - change.startOffset);
+				continue;
+			}
+			if (change.startOffset >= interval.endExclusive) {
+				break;
+			}
+			if (cursor < change.startOffset) {
+				result.push({
+					start: cursor + delta,
+					endExclusive: Math.min(interval.endExclusive, change.startOffset) + delta,
+					sourceKey: interval.sourceKey,
+				});
+			}
+			cursor = Math.max(cursor, change.endOffsetExclusive);
+			delta += change.newText.length - (change.endOffsetExclusive - change.startOffset);
+		}
+		if (cursor < interval.endExclusive) {
+			result.push({
+				start: cursor + delta,
+				endExclusive: interval.endExclusive + delta,
+				sourceKey: interval.sourceKey,
+			});
+		}
+	}
+	return result;
+}
+
+function mergeIntervals(intervals: readonly IAttributedInterval[]): IAttributedInterval[] {
+	const result: IAttributedInterval[] = [];
+	for (const interval of intervals) {
+		if (interval.start === interval.endExclusive) {
+			continue;
+		}
+		const previous = result[result.length - 1];
+		if (previous?.sourceKey === interval.sourceKey && previous.endExclusive === interval.start) {
+			result[result.length - 1] = {
+				start: previous.start,
+				endExclusive: interval.endExclusive,
+				sourceKey: interval.sourceKey,
+			};
+		} else {
+			result.push(interval);
+		}
+	}
+	return result;
+}
+
+async function readGitState(workingDirectory: string): Promise<IAgentEditAttributionGitState | undefined> {
+	try {
+		const [{ stdout: rootOutput }, { stdout: headOutput }, branchResult] = await Promise.all([
+			execFileAsync('git', ['rev-parse', '--show-toplevel'], { cwd: workingDirectory }),
+			execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: workingDirectory }),
+			execFileAsync('git', ['symbolic-ref', '--short', '-q', 'HEAD'], { cwd: workingDirectory }).catch(() => ({ stdout: '' })),
+		]);
+		return {
+			root: rootOutput.trim(),
+			head: headOutput.trim(),
+			branch: branchResult.stdout.trim(),
+		};
+	} catch {
+		return undefined;
+	}
+}

--- a/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
@@ -5,7 +5,7 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { IntervalTimer } from '../../../../base/common/async.js';
+import { IntervalTimer, SequencerByKey } from '../../../../base/common/async.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { dirname } from '../../../../base/common/path.js';
 import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
@@ -77,6 +77,7 @@ export type AgentEditAttributionGitStateReader = (workingDirectory: string) => P
 
 interface IPreparedFlush {
 	readonly token: string;
+	readonly fileKey: string;
 	readonly trigger: EditTelemetryTrigger;
 	readonly statsUuid: string;
 	readonly languageId: string | undefined;
@@ -94,6 +95,8 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 
 	private readonly _resources = new Map<string, ITrackedResource>();
 	private readonly _claimedResources = new Set<ITrackedResource>();
+	private readonly _recordingEdits = new Set<IAgentEditAttribution>();
+	private readonly _fileSequencer = new SequencerByKey<string>();
 	private readonly _preparedFlushes = new Map<string, IPreparedFlush>();
 	private readonly _preparingFlushes = new Map<string, Promise<IPreparedEditAttributionFlush | undefined>>();
 	private readonly _settledFlushes = new Map<string, { readonly result: IEditAttributionFlushResult; readonly timestamp: number }>();
@@ -130,6 +133,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		this._generation++;
 		this._resources.clear();
 		this._claimedResources.clear();
+		this._recordingEdits.clear();
 		this._preparedFlushes.clear();
 		this._preparingFlushes.clear();
 		this._settledFlushes.clear();
@@ -157,9 +161,18 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			};
 		}
 
-		const generation = this._generation;
+		this._recordingEdits.add(edit);
+		try {
+			const fileKey = this._filePathKey(edit.filePath);
+			return await this._fileSequencer.queue(fileKey, () => this._recordEdit(edit, this._generation, fileKey));
+		} finally {
+			this._recordingEdits.delete(edit);
+		}
+	}
+
+	private async _recordEdit(edit: IAgentEditAttribution, generation: number, fileKey: string): Promise<IFileEditAttributionMarker | undefined> {
 		const key = resourceKey(edit.sessionUri, edit.filePath);
-		await this._ensureCapacity(key, edit.afterText.length, generation);
+		await this._ensureCapacity(key, edit.afterText.length, generation, fileKey);
 		if (!this._isCurrentGeneration(generation)) {
 			return undefined;
 		}
@@ -223,7 +236,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		};
 		resource.lastSequence = marker.sequence;
 		if (resource.intervals.length > MAX_INTERVALS_PER_RESOURCE) {
-			await this._flushStandalone(resource, 'closed', generation);
+			await this._flushStandalone(resource, 'closed', generation, true);
 			return this._isCurrentGeneration(generation) ? marker : undefined;
 		}
 
@@ -244,7 +257,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		if (!this._isCurrentGeneration(generation)) {
 			return undefined;
 		}
-		this._expireFlushState();
+		await this._expireFlushState();
 		if (params.isDirty) {
 			return undefined;
 		}
@@ -275,8 +288,12 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 	}
 
 	private async _prepareFlush(params: IPrepareEditAttributionFlushParams, generation: number): Promise<IPreparedEditAttributionFlush | undefined> {
+		return this._fileSequencer.queue(this._filePathKey(params.resource.fsPath), () => this._prepareFlushLocked(params, generation));
+	}
+
+	private async _prepareFlushLocked(params: IPrepareEditAttributionFlushParams, generation: number): Promise<IPreparedEditAttributionFlush | undefined> {
 		const standaloneOwnershipKey = this._filePathKey(params.resource.fsPath);
-		const standaloneOwnership = this._standaloneOwnership.get(standaloneOwnershipKey);
+		let standaloneOwnership = this._standaloneOwnership.get(standaloneOwnershipKey);
 		if (standaloneOwnership) {
 			this._standaloneOwnership.delete(standaloneOwnershipKey);
 		}
@@ -287,7 +304,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		const preparedResources: IPreparedFlush[] = [];
 		try {
 			for (const resource of resources) {
-				const prepared = await this._prepareResource(resource, params.trigger, params.statsUuid, generation);
+				const prepared = await this._prepareResourceNow(resource, params.trigger, params.statsUuid, generation);
 				if (!this._isCurrentGeneration(generation)) {
 					return undefined;
 				}
@@ -304,8 +321,18 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			}
 			throw error;
 		}
+		if (!standaloneOwnership) {
+			standaloneOwnership = this._standaloneOwnership.get(standaloneOwnershipKey);
+			if (standaloneOwnership) {
+				this._standaloneOwnership.delete(standaloneOwnershipKey);
+			}
+		}
+		if (preparedResources.length === 0 && !standaloneOwnership) {
+			return undefined;
+		}
 		const prepared = combinePreparedFlushes(
 			preparedResources,
+			standaloneOwnershipKey,
 			params.trigger,
 			params.statsUuid,
 			params.flushToken,
@@ -333,7 +360,18 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		if (!this._enabled) {
 			return { outcome: 'missing', agentModifiedCount: 0 };
 		}
-		this._expireFlushState();
+		await this._expireFlushState();
+		const prepared = this._preparedFlushes.get(params.flushToken);
+		if (!prepared) {
+			return this._settledFlushes.get(params.flushToken)?.result ?? { outcome: 'missing', agentModifiedCount: 0 };
+		}
+		return this._fileSequencer.queue(prepared.fileKey, async () => this._commitFlushNow(params));
+	}
+
+	private _commitFlushNow(params: ICommitEditAttributionFlushParams): IEditAttributionFlushResult {
+		if (!this._enabled) {
+			return { outcome: 'missing', agentModifiedCount: 0 };
+		}
 		const prepared = this._preparedFlushes.get(params.flushToken);
 		if (!prepared) {
 			return this._settledFlushes.get(params.flushToken)?.result ?? { outcome: 'missing', agentModifiedCount: 0 };
@@ -359,7 +397,24 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		if (!this._enabled) {
 			return { outcome: 'missing', agentModifiedCount: 0 };
 		}
-		this._expireFlushState();
+		await this._expireFlushState();
+		const settled = this._settledFlushes.get(params.flushToken);
+		if (settled) {
+			return settled.result;
+		}
+		const prepared = this._preparedFlushes.get(params.flushToken);
+		if (!prepared) {
+			const result = { outcome: 'cancelled', agentModifiedCount: 0 } as const;
+			this._recordSettledFlush(params.flushToken, result);
+			return result;
+		}
+		return this._fileSequencer.queue(prepared.fileKey, async () => this._cancelFlushNow(params));
+	}
+
+	private _cancelFlushNow(params: ICancelEditAttributionFlushParams): IEditAttributionFlushResult {
+		if (!this._enabled) {
+			return { outcome: 'missing', agentModifiedCount: 0 };
+		}
 		const settled = this._settledFlushes.get(params.flushToken);
 		if (settled) {
 			return settled.result;
@@ -388,20 +443,19 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		return result;
 	}
 
-	private async _ensureCapacity(key: string, nextLength: number, generation: number): Promise<void> {
-		const existingLength = this._resources.get(key)?.currentContent.length ?? 0;
-		while (
-			this._isCurrentGeneration(generation) &&
-			(
-				this._resources.size >= MAX_TRACKED_RESOURCES ||
-				this._trackedTextLength - existingLength + nextLength > MAX_TOTAL_TRACKED_TEXT
-			)
-		) {
-			const oldest = this._resources.values().next().value;
-			if (!oldest) {
+	private async _ensureCapacity(key: string, nextLength: number, generation: number, lockedFileKey: string): Promise<void> {
+		while (this._isCurrentGeneration(generation)) {
+			const existing = this._resources.get(key);
+			const projectedTextLength = this._trackedTextLength - (existing?.currentContent.length ?? 0) + nextLength;
+			if (this._resources.size < MAX_TRACKED_RESOURCES && projectedTextLength <= MAX_TOTAL_TRACKED_TEXT) {
 				return;
 			}
-			await this._flushStandalone(oldest, 'closed', generation);
+			const sameFileResource = Array.from(this._resources.values()).find(resource => this._filePathKey(resource.filePath) === lockedFileKey);
+			const resource = existing ?? sameFileResource ?? this._resources.values().next().value;
+			if (!resource) {
+				return;
+			}
+			await this._flushStandalone(resource, 'closed', generation, this._filePathKey(resource.filePath) === lockedFileKey);
 		}
 	}
 
@@ -444,7 +498,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		if (!this._isCurrentGeneration(generation)) {
 			return;
 		}
-		this._expireFlushState();
+		await this._expireFlushState();
 		for (const repository of Array.from(this._repositories.values())) {
 			let current: IAgentEditAttributionGitState | undefined;
 			try {
@@ -467,11 +521,12 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			if (!trigger) {
 				continue;
 			}
-			const resources = Array.from(this._resources.values()).filter(resource => resource.repositoryRoot === repository.root);
+			const resources = Array.from(this._resources.values()).filter(resource => resource.repositoryRoot === repository.root && !this._isRecordingFile(resource.filePath));
 			const results = await Promise.allSettled(resources.map(resource => this._flushStandalone(resource, trigger, generation)));
 			const hasPendingResources = Array.from(this._resources.values()).some(resource => resource.repositoryRoot === repository.root);
 			const hasClaimedResources = Array.from(this._claimedResources).some(resource => resource.repositoryRoot === repository.root);
-			if (this._isCurrentGeneration(generation) && results.every(result => result.status === 'fulfilled') && !hasPendingResources && !hasClaimedResources) {
+			const hasRecordingEdits = Array.from(this._recordingEdits).some(edit => extUriBiasedIgnorePathCase.isEqualOrParent(URI.file(edit.filePath), URI.file(repository.root)));
+			if (this._isCurrentGeneration(generation) && results.every(result => result.status === 'fulfilled') && !hasPendingResources && !hasClaimedResources && !hasRecordingEdits) {
 				repository.branch = current.branch;
 				repository.head = current.head;
 			}
@@ -501,13 +556,16 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		return current;
 	}
 
-	private async _flushStandalone(resource: ITrackedResource, trigger: EditTelemetryTrigger, generation: number): Promise<void> {
-		const prepared = await this._prepareResource(resource, trigger, generateUuid(), generation);
+	private async _flushStandalone(resource: ITrackedResource, trigger: EditTelemetryTrigger, generation: number, fileLockHeld = false): Promise<void> {
+		if (!fileLockHeld) {
+			return this._fileSequencer.queue(this._filePathKey(resource.filePath), () => this._flushStandalone(resource, trigger, generation, true));
+		}
+		const prepared = await this._prepareResourceNow(resource, trigger, generateUuid(), generation);
 		if (!prepared || !this._isCurrentGeneration(generation)) {
 			return;
 		}
 		this._preparedFlushes.set(prepared.token, prepared);
-		await this.commitFlush({
+		this._commitFlushNow({
 			flushToken: prepared.token,
 			totalModifiedCount: prepared.agentModifiedCount,
 		});
@@ -516,7 +574,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		}
 	}
 
-	private async _prepareResource(resource: ITrackedResource, trigger: EditTelemetryTrigger, statsUuid: string, generation: number): Promise<IPreparedFlush | undefined> {
+	private async _prepareResourceNow(resource: ITrackedResource, trigger: EditTelemetryTrigger, statsUuid: string, generation: number): Promise<IPreparedFlush | undefined> {
 		if (!this._isCurrentGeneration(generation) || this._resources.get(resource.key) !== resource) {
 			return undefined;
 		}
@@ -541,6 +599,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			}
 			const prepared: IPreparedFlush = {
 				token: generateUuid(),
+				fileKey: this._filePathKey(resource.filePath),
 				trigger,
 				statsUuid,
 				languageId: undefined,
@@ -560,10 +619,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 				return undefined;
 			}
 			this._logService.warn(`[AgentEditAttributionService] Failed to flush ${resource.filePath}: ${error}`);
-			if (!this._resources.has(resource.key)) {
-				this._resources.set(resource.key, resource);
-				this._trackedTextLength += resource.currentContent.length;
-			}
+			this._restoreResources([resource]);
 			throw error;
 		}
 	}
@@ -649,6 +705,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 				repositoryRoot &&
 				!Array.from(this._resources.values()).some(candidate => candidate.repositoryRoot === repositoryRoot) &&
 				!Array.from(this._claimedResources).some(candidate => candidate.repositoryRoot === repositoryRoot) &&
+				!Array.from(this._recordingEdits).some(edit => extUriBiasedIgnorePathCase.isEqualOrParent(URI.file(edit.filePath), URI.file(repositoryRoot))) &&
 				!Array.from(this._preparedFlushes.values()).some(prepared => prepared.resources.some(candidate => candidate.repositoryRoot === repositoryRoot))
 			) {
 				this._repositories.delete(repositoryRoot);
@@ -724,23 +781,20 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		return extUriBiasedIgnorePathCase.getComparisonKey(URI.file(filePath));
 	}
 
-	private _expireFlushState(): void {
+	private _isRecordingFile(filePath: string): boolean {
+		const resource = URI.file(filePath);
+		return Array.from(this._recordingEdits).some(edit => extUriBiasedIgnorePathCase.isEqual(URI.file(edit.filePath), resource));
+	}
+
+	private async _expireFlushState(): Promise<void> {
 		const now = this._now();
+		const expirations: Promise<void>[] = [];
 		for (const [flushToken, prepared] of this._preparedFlushes) {
 			if (prepared.timestamp < now - PREPARED_FLUSH_TTL) {
-				this._preparedFlushes.delete(flushToken);
-				if (prepared.resources.some(resource => this._resources.has(resource.key))) {
-					this._releaseResourceClaims(prepared.resources);
-					this._emitTelemetry(prepared, prepared.agentModifiedCount);
-					this._recordSettledFlush(flushToken, { outcome: 'committed', agentModifiedCount: prepared.agentModifiedCount });
-				} else {
-					this._restoreResources(prepared.resources);
-					this._restoreStandaloneOwnership(prepared.standaloneOwnership);
-					this._recordSettledFlush(flushToken, { outcome: 'cancelled', agentModifiedCount: 0 });
-				}
-				this._cleanupRepositories(prepared.resources);
+				expirations.push(this._fileSequencer.queue(prepared.fileKey, async () => this._expirePreparedFlush(flushToken, prepared, now)));
 			}
 		}
+		await Promise.allSettled(expirations);
 		for (const [flushToken, settled] of this._settledFlushes) {
 			if (settled.timestamp < now - SETTLED_FLUSH_TTL) {
 				this._settledFlushes.delete(flushToken);
@@ -751,6 +805,23 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 				this._standaloneOwnership.delete(resourceKey);
 			}
 		}
+	}
+
+	private _expirePreparedFlush(flushToken: string, prepared: IPreparedFlush, now: number): void {
+		if (this._preparedFlushes.get(flushToken) !== prepared || prepared.timestamp >= now - PREPARED_FLUSH_TTL) {
+			return;
+		}
+		this._preparedFlushes.delete(flushToken);
+		if (prepared.resources.some(resource => this._resources.has(resource.key))) {
+			this._releaseResourceClaims(prepared.resources);
+			this._emitTelemetry(prepared, prepared.agentModifiedCount);
+			this._recordSettledFlush(flushToken, { outcome: 'committed', agentModifiedCount: prepared.agentModifiedCount });
+		} else {
+			this._restoreResources(prepared.resources);
+			this._restoreStandaloneOwnership(prepared.standaloneOwnership);
+			this._recordSettledFlush(flushToken, { outcome: 'cancelled', agentModifiedCount: 0 });
+		}
+		this._cleanupRepositories(prepared.resources);
 	}
 
 	override dispose(): void {
@@ -765,6 +836,7 @@ function resourceKey(sessionUri: string, filePath: string): string {
 
 function combinePreparedFlushes(
 	flushes: readonly IPreparedFlush[],
+	fileKey: string,
 	trigger: EditTelemetryTrigger,
 	statsUuid: string,
 	flushToken: string,
@@ -789,6 +861,7 @@ function combinePreparedFlushes(
 	}
 	return {
 		token: flushToken,
+		fileKey,
 		trigger,
 		statsUuid,
 		languageId,

--- a/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
@@ -25,10 +25,13 @@ const MAX_TRACKED_RESOURCES = 100;
 const MAX_INTERVALS_PER_RESOURCE = 10_000;
 const MAX_SETTLED_FLUSHES = 1_000;
 const MAX_STANDALONE_OWNERSHIP = 1_000;
+const MAX_NON_REPOSITORY_DIRECTORIES = 1_000;
 const PREPARED_FLUSH_TTL = 5 * 60 * 1000;
 const SETTLED_FLUSH_TTL = 10 * 60 * 1000;
 const STANDALONE_OWNERSHIP_TTL = 10 * 60 * 60 * 1000;
+const NON_REPOSITORY_DIRECTORY_TTL = 10 * 60 * 1000;
 const GIT_STATE_POLL_INTERVAL = 30_000;
+const GIT_STATE_TIMEOUT = 10_000;
 const execFileAsync = promisify(execFile);
 
 interface IAttributedInterval {
@@ -47,6 +50,12 @@ interface ISourceStatistics {
 	insertedCount: number;
 }
 
+interface IStandaloneOwnership {
+	readonly timestamp: number;
+	readonly agentModifiedCount: number;
+	readonly lastSequence: number;
+}
+
 interface ITrackedResource {
 	readonly key: string;
 	readonly sessionUri: string;
@@ -55,6 +64,7 @@ interface ITrackedResource {
 	intervals: IAttributedInterval[];
 	readonly sources: Map<string, ISourceStatistics>;
 	repositoryRoot: string | undefined;
+	lastSequence: number;
 }
 
 export interface IAgentEditAttributionGitState {
@@ -73,8 +83,9 @@ interface IPreparedFlush {
 	readonly sources: readonly ISourceStatistics[];
 	readonly retainedBySource: ReadonlyMap<string, number>;
 	readonly agentModifiedCount: number;
+	readonly lastSequence: number;
 	readonly resources: readonly ITrackedResource[];
-	readonly standaloneOwnershipKeys: readonly string[];
+	readonly standaloneOwnership: readonly (readonly [string, IStandaloneOwnership])[];
 	readonly timestamp: number;
 }
 
@@ -82,13 +93,16 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _resources = new Map<string, ITrackedResource>();
+	private readonly _claimedResources = new Set<ITrackedResource>();
 	private readonly _preparedFlushes = new Map<string, IPreparedFlush>();
+	private readonly _preparingFlushes = new Map<string, Promise<IPreparedEditAttributionFlush | undefined>>();
 	private readonly _settledFlushes = new Map<string, { readonly result: IEditAttributionFlushResult; readonly timestamp: number }>();
-	private readonly _standaloneOwnership = new Map<string, { readonly timestamp: number; readonly agentModifiedCount: number }>();
+	private readonly _standaloneOwnership = new Map<string, IStandaloneOwnership>();
 	private readonly _repositories = new Map<string, IAgentEditAttributionGitState>();
-	private readonly _nonRepositoryDirectories = new Set<string>();
+	private readonly _nonRepositoryDirectories = new Map<string, number>();
 	private _trackedTextLength = 0;
 	private _sequence = 0;
+	private _generation = 0;
 	private _enabled = true;
 
 	constructor(
@@ -109,19 +123,20 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 	}
 
 	setEnabled(enabled: boolean): void {
-		if (this._enabled === enabled) {
+		if (!this._enabled || enabled) {
 			return;
 		}
-		this._enabled = enabled;
-		if (!enabled) {
-			this._resources.clear();
-			this._preparedFlushes.clear();
-			this._settledFlushes.clear();
-			this._standaloneOwnership.clear();
-			this._repositories.clear();
-			this._nonRepositoryDirectories.clear();
-			this._trackedTextLength = 0;
-		}
+		this._enabled = false;
+		this._generation++;
+		this._resources.clear();
+		this._claimedResources.clear();
+		this._preparedFlushes.clear();
+		this._preparingFlushes.clear();
+		this._settledFlushes.clear();
+		this._standaloneOwnership.clear();
+		this._repositories.clear();
+		this._nonRepositoryDirectories.clear();
+		this._trackedTextLength = 0;
 	}
 
 	async recordEdit(edit: IAgentEditAttribution): Promise<IFileEditAttributionMarker | undefined> {
@@ -142,12 +157,19 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			};
 		}
 
+		const generation = this._generation;
 		const key = resourceKey(edit.sessionUri, edit.filePath);
-		await this._ensureCapacity(key, edit.afterText.length);
+		await this._ensureCapacity(key, edit.afterText.length, generation);
+		if (!this._isCurrentGeneration(generation)) {
+			return undefined;
+		}
 		let resource = this._resources.get(key);
 		const repository = resource?.repositoryRoot
 			? this._repositories.get(resource.repositoryRoot)
-			: await this._getOrCreateRepository(edit.filePath);
+			: await this._getOrCreateRepository(edit.filePath, generation);
+		if (!this._isCurrentGeneration(generation)) {
+			return undefined;
+		}
 		if (!resource) {
 			resource = {
 				key,
@@ -157,6 +179,7 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 				intervals: [],
 				sources: new Map(),
 				repositoryRoot: repository?.root,
+				lastSequence: 0,
 			};
 			this._resources.set(key, resource);
 			this._trackedTextLength += edit.beforeText.length;
@@ -168,6 +191,9 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 
 		if (resource.currentContent !== edit.beforeText) {
 			const bridge = await this._diffComputeService.computeDiffCounts(resource.currentContent, edit.beforeText);
+			if (!this._isCurrentGeneration(generation)) {
+				return undefined;
+			}
 			this._applyChanges(resource, bridge.changes, undefined, edit.beforeText);
 		}
 
@@ -188,42 +214,72 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			resource.sources.set(sourceKey, source);
 		}
 		this._applyChanges(resource, edit.changes, source, edit.afterText);
-		if (resource.intervals.length > MAX_INTERVALS_PER_RESOURCE) {
-			await this._flushStandalone(resource, 'closed');
-			return undefined;
-		}
-
-		return {
+		const marker: IFileEditAttributionMarker = {
 			version: 1,
 			editId: generateUuid(),
 			sequence: ++this._sequence,
 			beforeDigest: createFileEditContentDigest(edit.beforeText),
 			afterDigest: createFileEditContentDigest(edit.afterText),
 		};
+		resource.lastSequence = marker.sequence;
+		if (resource.intervals.length > MAX_INTERVALS_PER_RESOURCE) {
+			await this._flushStandalone(resource, 'closed', generation);
+			return this._isCurrentGeneration(generation) ? marker : undefined;
+		}
+
+		return marker;
 	}
 
 	async flushSession(sessionUri: string): Promise<void> {
+		const generation = this._generation;
+		if (!this._isCurrentGeneration(generation)) {
+			return;
+		}
 		const resources = Array.from(this._resources.values()).filter(resource => resource.sessionUri === sessionUri);
-		await Promise.all(resources.map(resource => this._flushStandalone(resource, 'closed')));
+		await Promise.allSettled(resources.map(resource => this._flushStandalone(resource, 'closed', generation)));
 	}
 
 	async prepareFlush(params: IPrepareEditAttributionFlushParams): Promise<IPreparedEditAttributionFlush | undefined> {
+		const generation = this._generation;
+		if (!this._isCurrentGeneration(generation)) {
+			return undefined;
+		}
 		this._expireFlushState();
 		if (params.isDirty) {
 			return undefined;
+		}
+		const preparing = this._preparingFlushes.get(params.flushToken);
+		if (preparing) {
+			return preparing;
 		}
 		const existing = this._preparedFlushes.get(params.flushToken);
 		if (existing) {
 			return {
 				flushToken: existing.token,
 				agentModifiedCount: existing.agentModifiedCount,
+				lastSequence: existing.lastSequence,
 			};
 		}
 		if (this._settledFlushes.has(params.flushToken)) {
 			return undefined;
 		}
+		const prepare = this._prepareFlush(params, generation);
+		this._preparingFlushes.set(params.flushToken, prepare);
+		try {
+			return await prepare;
+		} finally {
+			if (this._preparingFlushes.get(params.flushToken) === prepare) {
+				this._preparingFlushes.delete(params.flushToken);
+			}
+		}
+	}
+
+	private async _prepareFlush(params: IPrepareEditAttributionFlushParams, generation: number): Promise<IPreparedEditAttributionFlush | undefined> {
 		const standaloneOwnershipKey = this._filePathKey(params.resource.fsPath);
 		const standaloneOwnership = this._standaloneOwnership.get(standaloneOwnershipKey);
+		if (standaloneOwnership) {
+			this._standaloneOwnership.delete(standaloneOwnershipKey);
+		}
 		const resources = Array.from(this._resources.values()).filter(resource => extUriBiasedIgnorePathCase.isEqual(URI.file(resource.filePath), params.resource));
 		if (resources.length === 0 && !standaloneOwnership) {
 			return undefined;
@@ -231,7 +287,10 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		const preparedResources: IPreparedFlush[] = [];
 		try {
 			for (const resource of resources) {
-				const prepared = await this._prepareResource(resource, params.trigger, params.statsUuid);
+				const prepared = await this._prepareResource(resource, params.trigger, params.statsUuid, generation);
+				if (!this._isCurrentGeneration(generation)) {
+					return undefined;
+				}
 				if (prepared) {
 					preparedResources.push(prepared);
 				}
@@ -239,6 +298,9 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		} catch (error) {
 			for (const prepared of preparedResources) {
 				this._restoreResources(prepared.resources);
+			}
+			if (standaloneOwnership) {
+				this._restoreStandaloneOwnership([[standaloneOwnershipKey, standaloneOwnership]]);
 			}
 			throw error;
 		}
@@ -248,28 +310,37 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			params.statsUuid,
 			params.flushToken,
 			params.languageId,
-			standaloneOwnership ? [standaloneOwnershipKey] : [],
-			standaloneOwnership?.agentModifiedCount ?? 0,
+			standaloneOwnership ? [[standaloneOwnershipKey, standaloneOwnership]] : [],
 			this._now(),
 		);
+		if (!this._isCurrentGeneration(generation)) {
+			return undefined;
+		}
+		if (this._settledFlushes.has(params.flushToken)) {
+			this._restoreResources(prepared.resources);
+			this._restoreStandaloneOwnership(prepared.standaloneOwnership);
+			return undefined;
+		}
 		this._preparedFlushes.set(prepared.token, prepared);
 		return {
 			flushToken: prepared.token,
 			agentModifiedCount: prepared.agentModifiedCount,
+			lastSequence: prepared.lastSequence,
 		};
 	}
 
 	async commitFlush(params: ICommitEditAttributionFlushParams): Promise<IEditAttributionFlushResult> {
+		if (!this._enabled) {
+			return { outcome: 'missing', agentModifiedCount: 0 };
+		}
 		this._expireFlushState();
 		const prepared = this._preparedFlushes.get(params.flushToken);
 		if (!prepared) {
 			return this._settledFlushes.get(params.flushToken)?.result ?? { outcome: 'missing', agentModifiedCount: 0 };
 		}
 		this._preparedFlushes.delete(params.flushToken);
+		this._releaseResourceClaims(prepared.resources);
 		this._emitTelemetry(prepared, params.totalModifiedCount);
-		for (const ownershipKey of prepared.standaloneOwnershipKeys) {
-			this._standaloneOwnership.delete(ownershipKey);
-		}
 		const result = { outcome: 'committed', agentModifiedCount: prepared.agentModifiedCount } as const;
 		this._recordSettledFlush(params.flushToken, result);
 		this._cleanupRepositories(prepared.resources);
@@ -277,6 +348,17 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 	}
 
 	async cancelFlush(params: ICancelEditAttributionFlushParams): Promise<IEditAttributionFlushResult> {
+		const preparing = this._preparingFlushes.get(params.flushToken);
+		if (preparing) {
+			try {
+				await preparing;
+			} catch {
+				// The prepare path restores its own resources before rejecting.
+			}
+		}
+		if (!this._enabled) {
+			return { outcome: 'missing', agentModifiedCount: 0 };
+		}
 		this._expireFlushState();
 		const settled = this._settledFlushes.get(params.flushToken);
 		if (settled) {
@@ -290,16 +372,15 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		}
 		this._preparedFlushes.delete(params.flushToken);
 		if (prepared.resources.some(resource => this._resources.has(resource.key))) {
+			this._releaseResourceClaims(prepared.resources);
 			this._emitTelemetry(prepared, prepared.agentModifiedCount);
-			for (const ownershipKey of prepared.standaloneOwnershipKeys) {
-				this._standaloneOwnership.delete(ownershipKey);
-			}
 			const result = { outcome: 'committed', agentModifiedCount: prepared.agentModifiedCount } as const;
 			this._recordSettledFlush(params.flushToken, result);
 			this._cleanupRepositories(prepared.resources);
 			return result;
 		} else {
 			this._restoreResources(prepared.resources);
+			this._restoreStandaloneOwnership(prepared.standaloneOwnership);
 		}
 		const result = { outcome: 'cancelled', agentModifiedCount: 0 } as const;
 		this._recordSettledFlush(params.flushToken, result);
@@ -307,17 +388,20 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		return result;
 	}
 
-	private async _ensureCapacity(key: string, nextLength: number): Promise<void> {
+	private async _ensureCapacity(key: string, nextLength: number, generation: number): Promise<void> {
 		const existingLength = this._resources.get(key)?.currentContent.length ?? 0;
 		while (
-			this._resources.size >= MAX_TRACKED_RESOURCES ||
-			this._trackedTextLength - existingLength + nextLength > MAX_TOTAL_TRACKED_TEXT
+			this._isCurrentGeneration(generation) &&
+			(
+				this._resources.size >= MAX_TRACKED_RESOURCES ||
+				this._trackedTextLength - existingLength + nextLength > MAX_TOTAL_TRACKED_TEXT
+			)
 		) {
 			const oldest = this._resources.values().next().value;
 			if (!oldest) {
 				return;
 			}
-			await this._flushStandalone(oldest, 'closed');
+			await this._flushStandalone(oldest, 'closed', generation);
 		}
 	}
 
@@ -348,13 +432,30 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 	}
 
 	private async _flushAll(trigger: EditTelemetryTrigger): Promise<void> {
-		await Promise.all(Array.from(this._resources.values(), resource => this._flushStandalone(resource, trigger)));
+		const generation = this._generation;
+		if (!this._isCurrentGeneration(generation)) {
+			return;
+		}
+		await Promise.allSettled(Array.from(this._resources.values(), resource => this._flushStandalone(resource, trigger, generation)));
 	}
 
 	async checkGitState(): Promise<void> {
+		const generation = this._generation;
+		if (!this._isCurrentGeneration(generation)) {
+			return;
+		}
 		this._expireFlushState();
 		for (const repository of Array.from(this._repositories.values())) {
-			const current = await this._gitStateReader(repository.root);
+			let current: IAgentEditAttributionGitState | undefined;
+			try {
+				current = await this._gitStateReader(repository.root);
+			} catch (error) {
+				this._logService.warn(`[AgentEditAttributionService] Failed to read Git state for ${repository.root}: ${error}`);
+				continue;
+			}
+			if (!this._isCurrentGeneration(generation)) {
+				return;
+			}
 			if (!current) {
 				continue;
 			}
@@ -363,24 +464,33 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 				: current.head !== repository.head
 					? 'hashChange'
 					: undefined;
-			repository.branch = current.branch;
-			repository.head = current.head;
 			if (!trigger) {
 				continue;
 			}
 			const resources = Array.from(this._resources.values()).filter(resource => resource.repositoryRoot === repository.root);
-			await Promise.all(resources.map(resource => this._flushStandalone(resource, trigger)));
+			const results = await Promise.allSettled(resources.map(resource => this._flushStandalone(resource, trigger, generation)));
+			const hasPendingResources = Array.from(this._resources.values()).some(resource => resource.repositoryRoot === repository.root);
+			const hasClaimedResources = Array.from(this._claimedResources).some(resource => resource.repositoryRoot === repository.root);
+			if (this._isCurrentGeneration(generation) && results.every(result => result.status === 'fulfilled') && !hasPendingResources && !hasClaimedResources) {
+				repository.branch = current.branch;
+				repository.head = current.head;
+			}
 		}
 	}
 
-	private async _getOrCreateRepository(filePath: string): Promise<IAgentEditAttributionGitState | undefined> {
+	private async _getOrCreateRepository(filePath: string, generation: number): Promise<IAgentEditAttributionGitState | undefined> {
 		const workingDirectory = dirname(filePath);
-		if (this._nonRepositoryDirectories.has(workingDirectory)) {
+		const nonRepositoryTimestamp = this._nonRepositoryDirectories.get(workingDirectory);
+		if (nonRepositoryTimestamp !== undefined && nonRepositoryTimestamp >= this._now() - NON_REPOSITORY_DIRECTORY_TTL) {
 			return undefined;
 		}
+		this._nonRepositoryDirectories.delete(workingDirectory);
 		const current = await this._gitStateReader(workingDirectory);
+		if (!this._isCurrentGeneration(generation)) {
+			return undefined;
+		}
 		if (!current) {
-			this._nonRepositoryDirectories.add(workingDirectory);
+			this._recordNonRepositoryDirectory(workingDirectory);
 			return undefined;
 		}
 		const existing = this._repositories.get(current.root);
@@ -391,9 +501,9 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		return current;
 	}
 
-	private async _flushStandalone(resource: ITrackedResource, trigger: EditTelemetryTrigger): Promise<void> {
-		const prepared = await this._prepareResource(resource, trigger, generateUuid());
-		if (!prepared) {
+	private async _flushStandalone(resource: ITrackedResource, trigger: EditTelemetryTrigger, generation: number): Promise<void> {
+		const prepared = await this._prepareResource(resource, trigger, generateUuid(), generation);
+		if (!prepared || !this._isCurrentGeneration(generation)) {
 			return;
 		}
 		this._preparedFlushes.set(prepared.token, prepared);
@@ -401,19 +511,28 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			flushToken: prepared.token,
 			totalModifiedCount: prepared.agentModifiedCount,
 		});
-		this._recordStandaloneOwnership(resource.filePath, prepared.agentModifiedCount);
+		if (this._isCurrentGeneration(generation)) {
+			this._recordStandaloneOwnership(resource.filePath, prepared.agentModifiedCount, prepared.lastSequence);
+		}
 	}
 
-	private async _prepareResource(resource: ITrackedResource, trigger: EditTelemetryTrigger, statsUuid: string): Promise<IPreparedFlush | undefined> {
-		if (this._resources.get(resource.key) !== resource) {
+	private async _prepareResource(resource: ITrackedResource, trigger: EditTelemetryTrigger, statsUuid: string, generation: number): Promise<IPreparedFlush | undefined> {
+		if (!this._isCurrentGeneration(generation) || this._resources.get(resource.key) !== resource) {
 			return undefined;
 		}
 		this._resources.delete(resource.key);
+		this._claimedResources.add(resource);
 		this._trackedTextLength -= resource.currentContent.length;
 		try {
 			const currentContent = await this._readCurrentContent(resource.filePath);
+			if (!this._isCurrentGeneration(generation)) {
+				return undefined;
+			}
 			if (currentContent !== resource.currentContent) {
 				const diff = await this._diffComputeService.computeDiffCounts(resource.currentContent, currentContent);
+				if (!this._isCurrentGeneration(generation)) {
+					return undefined;
+				}
 				this._applyChanges(resource, diff.changes, undefined, currentContent, false);
 			}
 			const retainedBySource = new Map<string, number>();
@@ -430,12 +549,16 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 					.slice(0, 30),
 				retainedBySource,
 				agentModifiedCount: Array.from(retainedBySource.values()).reduce((sum, value) => sum + value, 0),
+				lastSequence: resource.lastSequence,
 				resources: [resource],
-				standaloneOwnershipKeys: [],
+				standaloneOwnership: [],
 				timestamp: this._now(),
 			};
 			return prepared;
 		} catch (error) {
+			if (!this._isCurrentGeneration(generation)) {
+				return undefined;
+			}
 			this._logService.warn(`[AgentEditAttributionService] Failed to flush ${resource.filePath}: ${error}`);
 			if (!this._resources.has(resource.key)) {
 				this._resources.set(resource.key, resource);
@@ -446,6 +569,9 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 	}
 
 	private _emitTelemetry(prepared: IPreparedFlush, totalModifiedCount: number): void {
+		if (!this._enabled) {
+			return;
+		}
 		for (const source of prepared.sources) {
 			const data = {
 				mode: 'longterm',
@@ -502,10 +628,17 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 
 	private _restoreResources(resources: readonly ITrackedResource[]): void {
 		for (const resource of resources) {
+			this._claimedResources.delete(resource);
 			if (!this._resources.has(resource.key)) {
 				this._resources.set(resource.key, resource);
 				this._trackedTextLength += resource.currentContent.length;
 			}
+		}
+	}
+
+	private _releaseResourceClaims(resources: readonly ITrackedResource[]): void {
+		for (const resource of resources) {
+			this._claimedResources.delete(resource);
 		}
 	}
 
@@ -515,11 +648,36 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			if (
 				repositoryRoot &&
 				!Array.from(this._resources.values()).some(candidate => candidate.repositoryRoot === repositoryRoot) &&
+				!Array.from(this._claimedResources).some(candidate => candidate.repositoryRoot === repositoryRoot) &&
 				!Array.from(this._preparedFlushes.values()).some(prepared => prepared.resources.some(candidate => candidate.repositoryRoot === repositoryRoot))
 			) {
 				this._repositories.delete(repositoryRoot);
 			}
+			const workingDirectory = dirname(resource.filePath);
+			if (
+				!Array.from(this._resources.values()).some(candidate => dirname(candidate.filePath) === workingDirectory) &&
+				!Array.from(this._claimedResources).some(candidate => dirname(candidate.filePath) === workingDirectory) &&
+				!Array.from(this._preparedFlushes.values()).some(prepared => prepared.resources.some(candidate => dirname(candidate.filePath) === workingDirectory))
+			) {
+				this._nonRepositoryDirectories.delete(workingDirectory);
+			}
 		}
+	}
+
+	private _recordNonRepositoryDirectory(workingDirectory: string): void {
+		this._nonRepositoryDirectories.delete(workingDirectory);
+		this._nonRepositoryDirectories.set(workingDirectory, this._now());
+		while (this._nonRepositoryDirectories.size > MAX_NON_REPOSITORY_DIRECTORIES) {
+			const oldestDirectory = this._nonRepositoryDirectories.keys().next().value;
+			if (oldestDirectory === undefined) {
+				break;
+			}
+			this._nonRepositoryDirectories.delete(oldestDirectory);
+		}
+	}
+
+	private _isCurrentGeneration(generation: number): boolean {
+		return this._enabled && generation === this._generation;
 	}
 
 	private _recordSettledFlush(flushToken: string, result: IEditAttributionFlushResult): void {
@@ -534,14 +692,25 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 		}
 	}
 
-	private _recordStandaloneOwnership(filePath: string, agentModifiedCount: number): void {
+	private _recordStandaloneOwnership(filePath: string, agentModifiedCount: number, lastSequence: number): void {
 		const key = this._filePathKey(filePath);
-		const existing = this._standaloneOwnership.get(key);
-		this._standaloneOwnership.delete(key);
-		this._standaloneOwnership.set(key, {
+		this._restoreStandaloneOwnership([[key, {
 			timestamp: this._now(),
-			agentModifiedCount: (existing?.agentModifiedCount ?? 0) + agentModifiedCount,
-		});
+			agentModifiedCount,
+			lastSequence,
+		}]]);
+	}
+
+	private _restoreStandaloneOwnership(ownership: readonly (readonly [string, IStandaloneOwnership])[]): void {
+		for (const [key, value] of ownership) {
+			const existing = this._standaloneOwnership.get(key);
+			this._standaloneOwnership.delete(key);
+			this._standaloneOwnership.set(key, {
+				timestamp: Math.max(existing?.timestamp ?? 0, value.timestamp),
+				agentModifiedCount: (existing?.agentModifiedCount ?? 0) + value.agentModifiedCount,
+				lastSequence: Math.max(existing?.lastSequence ?? 0, value.lastSequence),
+			});
+		}
 		while (this._standaloneOwnership.size > MAX_STANDALONE_OWNERSHIP) {
 			const oldestKey = this._standaloneOwnership.keys().next().value;
 			if (oldestKey === undefined) {
@@ -561,10 +730,12 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			if (prepared.timestamp < now - PREPARED_FLUSH_TTL) {
 				this._preparedFlushes.delete(flushToken);
 				if (prepared.resources.some(resource => this._resources.has(resource.key))) {
+					this._releaseResourceClaims(prepared.resources);
 					this._emitTelemetry(prepared, prepared.agentModifiedCount);
 					this._recordSettledFlush(flushToken, { outcome: 'committed', agentModifiedCount: prepared.agentModifiedCount });
 				} else {
 					this._restoreResources(prepared.resources);
+					this._restoreStandaloneOwnership(prepared.standaloneOwnership);
 					this._recordSettledFlush(flushToken, { outcome: 'cancelled', agentModifiedCount: 0 });
 				}
 				this._cleanupRepositories(prepared.resources);
@@ -598,8 +769,7 @@ function combinePreparedFlushes(
 	statsUuid: string,
 	flushToken: string,
 	languageId: string,
-	standaloneOwnershipKeys: readonly string[],
-	standaloneAgentModifiedCount: number,
+	standaloneOwnership: readonly (readonly [string, IStandaloneOwnership])[],
 	timestamp: number,
 ): IPreparedFlush {
 	const retainedBySource = new Map<string, number>();
@@ -626,9 +796,14 @@ function combinePreparedFlushes(
 			.toSorted((a, b) => (retainedBySource.get(b.sourceKey) ?? 0) - (retainedBySource.get(a.sourceKey) ?? 0))
 			.slice(0, 30),
 		retainedBySource,
-		agentModifiedCount: standaloneAgentModifiedCount + Array.from(retainedBySource.values()).reduce((sum, value) => sum + value, 0),
+		agentModifiedCount: standaloneOwnership.reduce((sum, [, value]) => sum + value.agentModifiedCount, 0) + Array.from(retainedBySource.values()).reduce((sum, value) => sum + value, 0),
+		lastSequence: Math.max(
+			0,
+			...flushes.map(flush => flush.lastSequence),
+			...standaloneOwnership.map(([, value]) => value.lastSequence),
+		),
 		resources: flushes.flatMap(flush => flush.resources),
-		standaloneOwnershipKeys,
+		standaloneOwnership,
 		timestamp,
 	};
 }
@@ -723,15 +898,18 @@ function mergeIntervals(intervals: readonly IAttributedInterval[]): IAttributedI
 
 async function readGitState(workingDirectory: string): Promise<IAgentEditAttributionGitState | undefined> {
 	try {
-		const [{ stdout: rootOutput }, { stdout: headOutput }, branchResult] = await Promise.all([
-			execFileAsync('git', ['rev-parse', '--show-toplevel'], { cwd: workingDirectory }),
-			execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: workingDirectory }),
-			execFileAsync('git', ['symbolic-ref', '--short', '-q', 'HEAD'], { cwd: workingDirectory }).catch(() => ({ stdout: '' })),
-		]);
+		const { stdout } = await execFileAsync('git', ['rev-parse', '--show-toplevel', 'HEAD', '--abbrev-ref', 'HEAD'], {
+			cwd: workingDirectory,
+			timeout: GIT_STATE_TIMEOUT,
+		});
+		const [root, head, branch] = stdout.trim().split(/\r?\n/);
+		if (!root || !head || !branch) {
+			return undefined;
+		}
 		return {
-			root: rootOutput.trim(),
-			head: headOutput.trim(),
-			branch: branchResult.stdout.trim(),
+			root,
+			head,
+			branch: branch === 'HEAD' ? '' : branch,
 		};
 	} catch {
 		return undefined;

--- a/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
+++ b/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
@@ -8,7 +8,8 @@ import { basename } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IFileService } from '../../../files/common/files.js';
 import { ILogService } from '../../../log/common/log.js';
-import { IDiffComputeService } from '../../common/diffComputeService.js';
+import { IDiffComputeService, IOffsetEdit } from '../../common/diffComputeService.js';
+import { AttributedToolResultFileEditContent, FILE_EDIT_ATTRIBUTION_PROPERTY, IAgentEditAttributionService, IFileEditAttributionMarker } from '../../common/fileEditAttribution.js';
 import { ISessionDatabase } from '../../common/sessionDataService.js';
 import { FileEditKind, ToolResultContentType, type ToolResultFileEditContent } from '../../common/state/sessionState.js';
 import { extractAiChunks } from './editChunkExtractor.js';
@@ -89,6 +90,7 @@ export class FileEditTracker {
 		@ILogService private readonly _logService: ILogService,
 		@IDiffComputeService private readonly _diffComputeService: IDiffComputeService,
 		@IEditSurvivalReporterFactory private readonly _editSurvivalReporterFactory: IEditSurvivalReporterFactory,
+		@IAgentEditAttributionService private readonly _editAttributionService: IAgentEditAttributionService,
 	) { }
 
 	/**
@@ -167,10 +169,12 @@ export class FileEditTracker {
 
 		let addedLines: number | undefined;
 		let removedLines: number | undefined;
+		let changes: readonly IOffsetEdit[] = [];
 		try {
 			const counts = await this._diffComputeService.computeDiffCounts(beforeText, afterText);
 			addedLines = counts.added;
 			removedLines = isCreate ? 0 : counts.removed;
+			changes = counts.changes;
 		} catch (err) {
 			this._logService.warn(`[FileEditTracker] Failed to compute diff counts: ${filePath}`, err);
 		}
@@ -203,7 +207,7 @@ export class FileEditTracker {
 			aiChunks: extractAiChunks(toolName, toolInput, filePath),
 		});
 
-		return {
+		const content: ToolResultFileEditContent = {
 			type: ToolResultContentType.FileEdit,
 			before: {
 				uri: URI.file(filePath).toString(),
@@ -215,6 +219,34 @@ export class FileEditTracker {
 			},
 			diff: addedLines !== undefined ? { added: addedLines, removed: removedLines } : undefined,
 		};
+		let marker: IFileEditAttributionMarker | undefined;
+		try {
+			marker = await this._editAttributionService.recordEdit({
+				sessionUri: this._sessionUri,
+				turnId,
+				toolCallId,
+				filePath,
+				beforeText,
+				afterText,
+				changes,
+				modelId,
+				toolName,
+			});
+		} catch (error) {
+			this._logService.warn(`[FileEditTracker] Failed to record edit attribution for ${filePath}: ${error}`);
+		}
+		if (!marker) {
+			return content;
+		}
+		const attributedContent: AttributedToolResultFileEditContent = {
+			...content,
+			[FILE_EDIT_ATTRIBUTION_PROPERTY]: marker,
+		};
+		return attributedContent;
+	}
+
+	async flushAttribution(): Promise<void> {
+		await this._editAttributionService.flushSession(this._sessionUri);
 	}
 
 	private async _readFile(filePath: string): Promise<VSBuffer> {

--- a/src/vs/platform/agentHost/test/common/fileEditAttribution.test.ts
+++ b/src/vs/platform/agentHost/test/common/fileEditAttribution.test.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { buildCancelEditAttributionResource, buildCommitEditAttributionResource, buildPrepareEditAttributionResource, parseEditAttributionResource } from '../../common/fileEditAttribution.js';
+
+suite('File Edit Attribution', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('round-trips prepare and commit resource requests', () => {
+		const prepare = {
+			resource: URI.file('C:\\repo\\file.ts'),
+			trigger: 'hashChange',
+			statsUuid: 'stats-1',
+			isDirty: false,
+			flushToken: 'flush-1',
+			languageId: 'typescript',
+		} as const;
+		const commit = {
+			flushToken: 'flush-1',
+			totalModifiedCount: 42,
+		};
+		const cancel = { flushToken: 'flush-1' };
+
+		const parsedPrepare = parseEditAttributionResource(buildPrepareEditAttributionResource(prepare));
+		assert.deepStrictEqual({
+			prepare: parsedPrepare?.kind === 'prepare' ? {
+				kind: parsedPrepare.kind,
+				resource: parsedPrepare.params.resource.toString(),
+				trigger: parsedPrepare.params.trigger,
+				statsUuid: parsedPrepare.params.statsUuid,
+				isDirty: parsedPrepare.params.isDirty,
+				flushToken: parsedPrepare.params.flushToken,
+				languageId: parsedPrepare.params.languageId,
+			} : parsedPrepare,
+			commit: parseEditAttributionResource(buildCommitEditAttributionResource(commit)),
+			cancel: parseEditAttributionResource(buildCancelEditAttributionResource(cancel)),
+		}, {
+			prepare: {
+				kind: 'prepare',
+				resource: prepare.resource.toString(),
+				trigger: prepare.trigger,
+				statsUuid: prepare.statsUuid,
+				isDirty: prepare.isDirty,
+				flushToken: prepare.flushToken,
+				languageId: prepare.languageId,
+			},
+			commit: { kind: 'commit', params: commit },
+			cancel: { kind: 'cancel', params: cancel },
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -191,12 +191,17 @@ export class TestDiffComputeService implements IDiffComputeService {
 		return {
 			added: Math.max(0, modifiedLines.length - originalLines.length),
 			removed: Math.max(0, originalLines.length - modifiedLines.length),
+			changes: original === modified ? [] : [{
+				startOffset: 0,
+				endOffsetExclusive: original.length,
+				newText: modified,
+			}],
 		};
 	}
 }
 
 export function createZeroDiffComputeService(): IDiffComputeService {
-	return new TestDiffComputeService({ added: 0, removed: 0 });
+	return new TestDiffComputeService({ added: 0, removed: 0, changes: [] });
 }
 
 export function createSessionDataService(database: ISessionDatabase = new TestSessionDatabase()): ISessionDataService {

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -30,7 +30,7 @@ import type { IClientTransport, IProtocolTransport } from '../../common/state/se
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { AgentHostCodexAgentEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId } from '../../common/agentService.js';
-import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
 import type { Implementation } from '../../common/state/protocol/common/commands.js';
 import { agentsWindowAgentHostClientInfo } from '../../common/agentHostClientInfo.js';
 
@@ -815,6 +815,19 @@ suite('RemoteAgentHostProtocolClient', () => {
 				action: {
 					type: ActionType.RootConfigChanged,
 					config: { [AgentHostTelemetryLevelConfigKey]: telemetryLevelToAgentHostConfigValue(TelemetryLevel.USAGE) },
+				},
+			},
+		});
+		const editTelemetryEnabled = findRootConfigNotification(transport.sentMessages, AgentHostEditTelemetryEnabledConfigKey);
+		assert.deepStrictEqual(editTelemetryEnabled, {
+			jsonrpc: '2.0',
+			method: 'dispatchAction',
+			params: {
+				channel: ROOT_STATE_URI,
+				clientSeq: 0,
+				action: {
+					type: ActionType.RootConfigChanged,
+					config: { [AgentHostEditTelemetryEnabledConfigKey]: true },
 				},
 			},
 		});

--- a/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DeferredPromise } from '../../../../base/common/async.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { isWindows } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -274,6 +275,71 @@ suite('Agent Edit Attribution Service', () => {
 		assert.deepStrictEqual(triggers, ['hashChange', 'branchChange']);
 	});
 
+	test('continues a Git-triggered flush after one resource fails', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		const provider = disposables.add(new class extends InMemoryFileSystemProvider {
+			failPath: string | undefined;
+
+			override async readFile(resource: URI): Promise<Uint8Array> {
+				if (resource.path === this.failPath) {
+					throw new Error('Read failed');
+				}
+				return super.readFile(resource);
+			}
+		}());
+		disposables.add(fileService.registerProvider('file', provider));
+		const failingResource = URI.file('/workspace/failing.ts');
+		const successfulResource = URI.file('/workspace/successful.ts');
+		await fileService.writeFile(failingResource, VSBuffer.fromString('ab'));
+		await fileService.writeFile(successfulResource, VSBuffer.fromString('ab'));
+
+		let branch = 'main';
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => ({
+			root: '/workspace',
+			branch,
+			head: 'head-1',
+		}), undefined));
+		for (const [toolCallId, resource] of [['tool-failing', failingResource], ['tool-successful', successfulResource]] as const) {
+			await service.recordEdit({
+				sessionUri: 'copilot:/session-1',
+				turnId: 'turn-1',
+				toolCallId,
+				filePath: resource.fsPath,
+				beforeText: 'a',
+				afterText: 'ab',
+				changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+				modelId: 'model',
+				toolName: 'edit',
+			});
+		}
+		provider.failPath = failingResource.path;
+		branch = 'feature';
+
+		await service.checkGitState();
+		const eventCountAfterFailure = eventCount;
+		provider.failPath = undefined;
+		await service.checkGitState();
+
+		assert.deepStrictEqual({
+			eventCountAfterFailure,
+			eventCountAfterRetry: eventCount,
+		}, {
+			eventCountAfterFailure: 1,
+			eventCountAfterRetry: 2,
+		});
+	});
+
 	test('does not retain attribution when usage telemetry is disabled', async () => {
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(IFileService, disposables.add(new FileService(new NullLogService())));
@@ -344,6 +410,48 @@ suite('Agent Edit Attribution Service', () => {
 		assert.deepStrictEqual({ marker, eventCount }, { marker: undefined, eventCount: 0 });
 	});
 
+	test('fences in-flight attribution after edit telemetry is disabled', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		const repositoryReadStarted = new DeferredPromise<void>();
+		const repositoryRead = new DeferredPromise<undefined>();
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => {
+			repositoryReadStarted.complete();
+			return repositoryRead.p;
+		}, undefined));
+
+		const recordEdit = service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: '/workspace/file.ts',
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await repositoryReadStarted.p;
+		service.setEnabled(false);
+		service.setEnabled(true);
+		repositoryRead.complete(undefined);
+
+		const marker = await recordEdit;
+		await service.flushSession('copilot:/session-1');
+
+		assert.deepStrictEqual({ marker, eventCount }, { marker: undefined, eventCount: 0 });
+	});
+
 	test('signals files larger than the five MB attribution limit', async () => {
 		const fileService = disposables.add(new FileService(new NullLogService()));
 		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
@@ -384,6 +492,104 @@ suite('Agent Edit Attribution Service', () => {
 			reason: 'fileTooLarge',
 			insertedCount: 1,
 		});
+	});
+
+	test('returns a marker when the interval safety limit flushes the resource', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		const characters = Array.from('a'.repeat(20_001));
+		const changes = [];
+		for (let offset = 0; offset < characters.length; offset += 2) {
+			characters[offset] = 'b';
+			changes.push({ startOffset: offset, endOffsetExclusive: offset + 1, newText: 'b' });
+		}
+		const afterText = characters.join('');
+		await fileService.writeFile(resource, VSBuffer.fromString(afterText));
+
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+
+		const marker = await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a'.repeat(20_001),
+			afterText,
+			changes,
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		assert.deepStrictEqual({
+			status: marker?.status,
+			eventCount,
+		}, {
+			status: undefined,
+			eventCount: 1,
+		});
+	});
+
+	test('retries expired non-repository lookups', async () => {
+		let now = 0;
+		let repositoryReadCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, disposables.add(new FileService(new NullLogService())));
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, { telemetryLevel: TelemetryLevel.USAGE });
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => {
+			repositoryReadCount++;
+			return undefined;
+		}, () => now));
+
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: '/workspace/file.ts',
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-2',
+			toolCallId: 'tool-2',
+			filePath: '/workspace/file.ts',
+			beforeText: 'ab',
+			afterText: 'abc',
+			changes: [{ startOffset: 2, endOffsetExclusive: 2, newText: 'c' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		now = 10 * 60 * 1000 + 1;
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-3',
+			toolCallId: 'tool-3',
+			filePath: '/workspace/file.ts',
+			beforeText: 'abc',
+			afterText: 'abcd',
+			changes: [{ startOffset: 3, endOffsetExclusive: 3, newText: 'd' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		assert.strictEqual(repositoryReadCount, 2);
 	});
 
 	test('flushes only the closing session when sessions edit the same file', async () => {
@@ -570,7 +776,10 @@ suite('Agent Edit Attribution Service', () => {
 		instantiationService.stub(IFileService, fileService);
 		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
 		instantiationService.stub(ILogService, new NullLogService());
-		instantiationService.stub(ITelemetryService, { telemetryLevel: TelemetryLevel.USAGE });
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() { },
+		});
 		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
 		await service.recordEdit({
 			sessionUri: 'copilot:/session-1',
@@ -644,6 +853,142 @@ suite('Agent Edit Attribution Service', () => {
 		await service.flushSession('copilot:/session-1');
 
 		assert.strictEqual(eventCount, 1);
+	});
+
+	test('waits for an in-flight prepare before cancelling it', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		const readStarted = new DeferredPromise<void>();
+		const readResult = new DeferredPromise<Uint8Array>();
+		const provider = disposables.add(new class extends InMemoryFileSystemProvider {
+			blockReads = false;
+
+			override async readFile(resource: URI): Promise<Uint8Array> {
+				if (this.blockReads) {
+					readStarted.complete();
+					return readResult.p;
+				}
+				return super.readFile(resource);
+			}
+		}());
+		disposables.add(fileService.registerProvider('file', provider));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		provider.blockReads = true;
+
+		const prepare = service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-1',
+			isDirty: false,
+			flushToken: 'flush-1',
+			languageId: 'typescript',
+		});
+		await readStarted.p;
+		const cancel = service.cancelFlush({ flushToken: 'flush-1' });
+		readResult.complete(VSBuffer.fromString('ab').buffer);
+		const [prepared, cancelOutcome] = await Promise.all([prepare, cancel]);
+		provider.blockReads = false;
+		await service.flushSession('copilot:/session-1');
+
+		assert.deepStrictEqual({
+			prepared: prepared?.agentModifiedCount,
+			cancelOutcome,
+			eventCount,
+		}, {
+			prepared: 1,
+			cancelOutcome: { outcome: 'cancelled', agentModifiedCount: 0 },
+			eventCount: 1,
+		});
+	});
+
+	test('reserves standalone ownership for one prepared flush', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() { },
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.flushSession('copilot:/session-1');
+
+		const first = await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-1',
+			isDirty: false,
+			flushToken: 'flush-1',
+			languageId: 'typescript',
+		});
+		const duplicate = await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-2',
+			isDirty: false,
+			flushToken: 'flush-2',
+			languageId: 'typescript',
+		});
+		await service.cancelFlush({ flushToken: 'flush-1' });
+		const restored = await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-3',
+			isDirty: false,
+			flushToken: 'flush-3',
+			languageId: 'typescript',
+		});
+		await service.cancelFlush({ flushToken: 'flush-3' });
+
+		assert.deepStrictEqual({
+			first: first?.agentModifiedCount,
+			duplicate,
+			restored: restored?.agentModifiedCount,
+		}, {
+			first: 1,
+			duplicate: undefined,
+			restored: 1,
+		});
 	});
 
 	test('makes commit and cancellation idempotent after telemetry is emitted', async () => {

--- a/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
@@ -1,0 +1,792 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { isWindows } from '../../../../base/common/platform.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { FileService } from '../../../files/common/fileService.js';
+import { IFileService } from '../../../files/common/files.js';
+import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
+import { ILogService, NullLogService } from '../../../log/common/log.js';
+import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
+import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { IDiffComputeService } from '../../common/diffComputeService.js';
+import { createFileEditContentDigest } from '../../common/fileEditAttribution.js';
+import { AgentEditAttributionService } from '../../node/shared/agentEditAttributionService.js';
+import { computeDiffCounts } from '../../node/diffWorkerMain.js';
+import { TestDiffComputeService } from '../common/sessionTestHelpers.js';
+
+suite('Agent Edit Attribution Service', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('emits retained Agent characters from disjoint edits', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('aBcdeF'));
+
+		const events: { eventName: string; data: Record<string, string | number | undefined> }[] = [];
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, {
+			computeDiffCounts: async (original, modified, timeoutMs) => computeDiffCounts(original, modified, timeoutMs ?? 5_000),
+		});
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2(eventName, data) {
+				events.push({ eventName, data: data as Record<string, string | number | undefined> });
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, undefined, undefined));
+
+		const marker = await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'abcdef',
+			afterText: 'aBcdeF',
+			changes: [
+				{ startOffset: 1, endOffsetExclusive: 2, newText: 'B' },
+				{ startOffset: 5, endOffsetExclusive: 6, newText: 'F' },
+			],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.flushSession('copilot:/session-1');
+		const acknowledged = await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-2',
+			isDirty: false,
+			flushToken: 'flush-standalone',
+			languageId: 'typescript',
+		});
+		const acknowledgedOutcome = await service.commitFlush({
+			flushToken: acknowledged!.flushToken,
+			totalModifiedCount: 0,
+		});
+
+		assert.deepStrictEqual({
+			marker: marker && {
+				version: marker.version,
+				sequence: marker.sequence,
+				editIdLength: marker.editId.length,
+				beforeDigest: marker.beforeDigest,
+				afterDigest: marker.afterDigest,
+			},
+			events: events.map(event => ({
+				eventName: event.eventName,
+				sourceKey: event.data.sourceKey,
+				modifiedCount: event.data.modifiedCount,
+				deltaModifiedCount: event.data.deltaModifiedCount,
+				totalModifiedCount: event.data.totalModifiedCount,
+				origin: event.data.origin,
+				harness: event.data.harness,
+			})),
+			acknowledged: acknowledged && {
+				agentModifiedCount: acknowledged.agentModifiedCount,
+				outcome: acknowledgedOutcome,
+			},
+		}, {
+			marker: {
+				version: 1,
+				sequence: 1,
+				editIdLength: 36,
+				beforeDigest: createFileEditContentDigest('abcdef'),
+				afterDigest: createFileEditContentDigest('aBcdeF'),
+			},
+			events: [{
+				eventName: 'editTelemetry.editSources.details',
+				sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilot-$origin:agentHost',
+				modifiedCount: 2,
+				deltaModifiedCount: 2,
+				totalModifiedCount: 2,
+				origin: 'agentHost',
+				harness: 'copilot',
+			}],
+			acknowledged: {
+				agentModifiedCount: 2,
+				outcome: {
+					outcome: 'committed',
+					agentModifiedCount: 2,
+				},
+			},
+		});
+	});
+
+	test('preserves Agent attribution across later external disk edits', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('axb'));
+
+		const events: Record<string, string | number | undefined>[] = [];
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, {
+			computeDiffCounts: async (original, modified, timeoutMs) => computeDiffCounts(original, modified, timeoutMs ?? 5_000),
+		});
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2(_eventName, data) {
+				events.push(data as Record<string, string | number | undefined>);
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, undefined, undefined));
+
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.flushSession('copilot:/session-1');
+
+		assert.deepStrictEqual(events.map(event => ({
+			modifiedCount: event.modifiedCount,
+			deltaModifiedCount: event.deltaModifiedCount,
+			totalModifiedCount: event.totalModifiedCount,
+		})), [{
+			modifiedCount: 1,
+			deltaModifiedCount: 1,
+			totalModifiedCount: 1,
+		}]);
+	});
+
+	test('tracks creates and removes retained attribution after deletion', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString(''));
+
+		const events: Record<string, string | number | undefined>[] = [];
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2(_eventName, data) {
+				events.push(data as Record<string, string | number | undefined>);
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, undefined, undefined));
+		const baseEdit = {
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			filePath: resource.fsPath,
+			modelId: 'model',
+			toolName: 'edit',
+		};
+
+		await service.recordEdit({
+			...baseEdit,
+			toolCallId: 'tool-create',
+			beforeText: '',
+			afterText: 'abc',
+			changes: [{ startOffset: 0, endOffsetExclusive: 0, newText: 'abc' }],
+		});
+		await service.recordEdit({
+			...baseEdit,
+			toolCallId: 'tool-delete',
+			beforeText: 'abc',
+			afterText: '',
+			changes: [{ startOffset: 0, endOffsetExclusive: 3, newText: '' }],
+		});
+		await service.flushSession('copilot:/session-1');
+
+		assert.deepStrictEqual(events.map(event => ({
+			modifiedCount: event.modifiedCount,
+			deltaModifiedCount: event.deltaModifiedCount,
+			totalModifiedCount: event.totalModifiedCount,
+		})), [{
+			modifiedCount: 0,
+			deltaModifiedCount: 3,
+			totalModifiedCount: 0,
+		}]);
+	});
+
+	test('flushes Agent-only resources when HEAD changes', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		const triggers: string[] = [];
+		let head = 'head-1';
+		let branch = 'main';
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2(_eventName, data) {
+				triggers.push((data as { trigger: string }).trigger);
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => ({
+			root: '/workspace',
+			branch,
+			head,
+		}), undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		head = 'head-2';
+		await service.checkGitState();
+		await fileService.writeFile(resource, VSBuffer.fromString('abc'));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-2',
+			toolCallId: 'tool-2',
+			filePath: resource.fsPath,
+			beforeText: 'ab',
+			afterText: 'abc',
+			changes: [{ startOffset: 2, endOffsetExclusive: 2, newText: 'c' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		branch = 'feature';
+		await service.checkGitState();
+
+		assert.deepStrictEqual(triggers, ['hashChange', 'branchChange']);
+	});
+
+	test('does not retain attribution when usage telemetry is disabled', async () => {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, disposables.add(new FileService(new NullLogService())));
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, { telemetryLevel: TelemetryLevel.NONE });
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, undefined, undefined));
+
+		const marker = await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: '/workspace/file.ts',
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		assert.strictEqual(marker, undefined);
+	});
+
+	test('discards attribution when edit telemetry is disabled', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		service.setEnabled(false);
+		const marker = await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-2',
+			toolCallId: 'tool-2',
+			filePath: resource.fsPath,
+			beforeText: 'ab',
+			afterText: 'abc',
+			changes: [{ startOffset: 2, endOffsetExclusive: 2, newText: 'c' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.flushSession('copilot:/session-1');
+
+		assert.deepStrictEqual({ marker, eventCount }, { marker: undefined, eventCount: 0 });
+	});
+
+	test('tracks files larger than the previous five MB limit', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/large.ts');
+		const beforeText = 'a'.repeat(6 * 1024 * 1024);
+		const afterText = `${beforeText}b`;
+		await fileService.writeFile(resource, VSBuffer.fromString(afterText));
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() { },
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+
+		const marker = await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText,
+			afterText,
+			changes: [{ startOffset: beforeText.length, endOffsetExclusive: beforeText.length, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.flushSession('copilot:/session-1');
+
+		assert.strictEqual(marker?.version, 1);
+	});
+
+	test('flushes only the closing session when sessions edit the same file', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('abc'));
+
+		const events: Record<string, string | number | undefined>[] = [];
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, {
+			computeDiffCounts: async (original, modified, timeoutMs) => computeDiffCounts(original, modified, timeoutMs ?? 5_000),
+		});
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2(_eventName, data) {
+				events.push(data as Record<string, string | number | undefined>);
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-a',
+			turnId: 'turn-a',
+			toolCallId: 'tool-a',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-b',
+			turnId: 'turn-b',
+			toolCallId: 'tool-b',
+			filePath: resource.fsPath,
+			beforeText: 'ab',
+			afterText: 'abc',
+			changes: [{ startOffset: 2, endOffsetExclusive: 2, newText: 'c' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		await service.flushSession('copilot:/session-a');
+		const afterFirstFlush = events.map(event => event.conversationId);
+		await service.flushSession('copilot:/session-b');
+
+		assert.deepStrictEqual({
+			afterFirstFlush,
+			allEvents: events.map(event => ({
+				conversationId: event.conversationId,
+				modifiedCount: event.modifiedCount,
+				deltaModifiedCount: event.deltaModifiedCount,
+			})),
+		}, {
+			afterFirstFlush: ['session-a'],
+			allEvents: [
+				{ conversationId: 'session-a', modifiedCount: 1, deltaModifiedCount: 1 },
+				{ conversationId: 'session-b', modifiedCount: 1, deltaModifiedCount: 1 },
+			],
+		});
+	});
+
+	test('coordinates a live session after another session flushed the same file', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('abc'));
+
+		const events: Record<string, string | number | undefined>[] = [];
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2(_eventName, data) {
+				events.push(data as Record<string, string | number | undefined>);
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-a',
+			turnId: 'turn-a',
+			toolCallId: 'tool-a',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-b',
+			turnId: 'turn-b',
+			toolCallId: 'tool-b',
+			filePath: resource.fsPath,
+			beforeText: 'ab',
+			afterText: 'abc',
+			changes: [{ startOffset: 2, endOffsetExclusive: 2, newText: 'c' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.flushSession('copilot:/session-a');
+
+		const prepared = await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-1',
+			isDirty: false,
+			flushToken: 'flush-1',
+			languageId: 'typescript',
+		});
+		await service.commitFlush({ flushToken: prepared!.flushToken, totalModifiedCount: prepared!.agentModifiedCount });
+
+		assert.deepStrictEqual(events.map(event => ({
+			conversationId: event.conversationId,
+			modifiedCount: event.modifiedCount,
+		})), [
+			{ conversationId: 'session-a', modifiedCount: 0 },
+			{ conversationId: 'session-b', modifiedCount: 1 },
+		]);
+	});
+
+	test('claims a resource once when flush triggers race', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		const [_, prepared] = await Promise.all([
+			service.flushSession('copilot:/session-1'),
+			service.prepareFlush({
+				resource,
+				trigger: 'closed',
+				statsUuid: 'stats-1',
+				isDirty: false,
+				flushToken: 'flush-1',
+				languageId: 'typescript',
+			}),
+		]);
+
+		assert.deepStrictEqual({ prepared, eventCount }, { prepared: undefined, eventCount: 1 });
+	});
+
+	test('coordinates Windows resources when path casing differs', async () => {
+		if (!isWindows) {
+			return;
+		}
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		const filePath = URI.file('/Workspace/file.ts').fsPath;
+		await fileService.createFolder(URI.file('/Workspace'));
+		await fileService.writeFile(URI.file(filePath), VSBuffer.fromString('ab'));
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, { telemetryLevel: TelemetryLevel.USAGE });
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		const prepared = await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-1',
+			isDirty: false,
+			flushToken: 'flush-1',
+			languageId: 'typescript',
+		});
+
+		assert.deepStrictEqual(prepared && {
+			flushToken: prepared.flushToken,
+			agentModifiedCount: prepared.agentModifiedCount,
+		}, {
+			flushToken: 'flush-1',
+			agentModifiedCount: 1,
+		});
+	});
+
+	test('restores prepared resources when a coordinated flush is cancelled', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		const prepared = await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-1',
+			isDirty: false,
+			flushToken: 'flush-1',
+			languageId: 'typescript',
+		});
+
+		await service.cancelFlush({ flushToken: prepared!.flushToken });
+		await service.flushSession('copilot:/session-1');
+
+		assert.strictEqual(eventCount, 1);
+	});
+
+	test('makes commit and cancellation idempotent after telemetry is emitted', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-1',
+			isDirty: false,
+			flushToken: 'flush-1',
+			languageId: 'typescript',
+		});
+
+		const outcomes = [
+			await service.commitFlush({ flushToken: 'flush-1', totalModifiedCount: 1 }),
+			await service.commitFlush({ flushToken: 'flush-1', totalModifiedCount: 1 }),
+			await service.cancelFlush({ flushToken: 'flush-1' }),
+		];
+
+		assert.deepStrictEqual({ outcomes, eventCount }, {
+			outcomes: [
+				{ outcome: 'committed', agentModifiedCount: 1 },
+				{ outcome: 'committed', agentModifiedCount: 1 },
+				{ outcome: 'committed', agentModifiedCount: 1 },
+			],
+			eventCount: 1,
+		});
+	});
+
+	test('restores an unclaimed prepared flush after its timeout', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		let now = 0;
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, () => now));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-1',
+			isDirty: false,
+			flushToken: 'flush-1',
+			languageId: 'typescript',
+		});
+
+		now = 5 * 60 * 1000 + 1;
+		await service.checkGitState();
+		const commitOutcome = await service.commitFlush({ flushToken: 'flush-1', totalModifiedCount: 1 });
+		await service.flushSession('copilot:/session-1');
+
+		assert.deepStrictEqual({ commitOutcome, eventCount }, {
+			commitOutcome: { outcome: 'cancelled', agentModifiedCount: 0 },
+			eventCount: 1,
+		});
+	});
+
+	test('fences a prepare request that arrives after cancellation', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		const cancelOutcome = await service.cancelFlush({ flushToken: 'flush-1' });
+		const prepared = await service.prepareFlush({
+			resource,
+			trigger: 'closed',
+			statsUuid: 'stats-1',
+			isDirty: false,
+			flushToken: 'flush-1',
+			languageId: 'typescript',
+		});
+		await service.flushSession('copilot:/session-1');
+
+		assert.deepStrictEqual({ cancelOutcome, prepared, eventCount }, {
+			cancelOutcome: { outcome: 'cancelled', agentModifiedCount: 0 },
+			prepared: undefined,
+			eventCount: 1,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
@@ -73,13 +73,13 @@ suite('Agent Edit Attribution Service', () => {
 		});
 
 		assert.deepStrictEqual({
-			marker: marker && {
+			marker: marker?.status !== 'skipped' && marker ? {
 				version: marker.version,
 				sequence: marker.sequence,
 				editIdLength: marker.editId.length,
 				beforeDigest: marker.beforeDigest,
 				afterDigest: marker.afterDigest,
-			},
+			} : marker,
 			events: events.map(event => ({
 				eventName: event.eventName,
 				sourceKey: event.data.sourceKey,
@@ -344,7 +344,7 @@ suite('Agent Edit Attribution Service', () => {
 		assert.deepStrictEqual({ marker, eventCount }, { marker: undefined, eventCount: 0 });
 	});
 
-	test('tracks files larger than the previous five MB limit', async () => {
+	test('signals files larger than the five MB attribution limit', async () => {
 		const fileService = disposables.add(new FileService(new NullLogService()));
 		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
 		const resource = URI.file('/workspace/large.ts');
@@ -375,7 +375,15 @@ suite('Agent Edit Attribution Service', () => {
 		});
 		await service.flushSession('copilot:/session-1');
 
-		assert.strictEqual(marker?.version, 1);
+		assert.deepStrictEqual(marker && {
+			status: marker.status,
+			reason: marker.status === 'skipped' ? marker.reason : undefined,
+			insertedCount: marker.status === 'skipped' ? marker.insertedCount : undefined,
+		}, {
+			status: 'skipped',
+			reason: 'fileTooLarge',
+			insertedCount: 1,
+		});
 	});
 
 	test('flushes only the closing session when sessions edit the same file', async () => {

--- a/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
@@ -340,6 +340,153 @@ suite('Agent Edit Attribution Service', () => {
 		});
 	});
 
+	test('keeps a Git boundary pending while an edit is being recorded', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		const bridgeStarted = new DeferredPromise<void>();
+		const bridgeResult = new DeferredPromise<ReturnType<typeof computeDiffCounts>>();
+		let branch = 'main';
+		let eventCount = 0;
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, {
+			async computeDiffCounts(original, modified, timeoutMs) {
+				if (original === 'ab' && modified === 'ac') {
+					bridgeStarted.complete();
+					return bridgeResult.p;
+				}
+				return computeDiffCounts(original, modified, timeoutMs ?? 5_000);
+			},
+		});
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2() {
+				eventCount++;
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => ({
+			root: '/workspace',
+			branch,
+			head: 'head-1',
+		}), undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		const recording = service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-2',
+			toolCallId: 'tool-2',
+			filePath: resource.fsPath,
+			beforeText: 'ac',
+			afterText: 'acd',
+			changes: [{ startOffset: 2, endOffsetExclusive: 2, newText: 'd' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await bridgeStarted.p;
+		await fileService.writeFile(resource, VSBuffer.fromString('acd'));
+		branch = 'feature';
+		await service.checkGitState();
+		const eventCountWhileRecording = eventCount;
+		bridgeResult.complete(computeDiffCounts('ab', 'ac', 5_000));
+		await recording;
+		await service.checkGitState();
+
+		assert.deepStrictEqual({
+			eventCountWhileRecording,
+			eventCountAfterRecording: eventCount,
+		}, {
+			eventCountWhileRecording: 0,
+			eventCountAfterRecording: 1,
+		});
+	});
+
+	test('serializes a new edit behind a failing Git flush', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		const readStarted = new DeferredPromise<void>();
+		const readResult = new DeferredPromise<Uint8Array>();
+		const provider = disposables.add(new class extends InMemoryFileSystemProvider {
+			blockReads = false;
+
+			override async readFile(resource: URI): Promise<Uint8Array> {
+				if (this.blockReads) {
+					readStarted.complete();
+					return readResult.p;
+				}
+				return super.readFile(resource);
+			}
+		}());
+		disposables.add(fileService.registerProvider('file', provider));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('ab'));
+
+		let branch = 'main';
+		const retainedCounts: number[] = [];
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2(_eventName, data) {
+				retainedCounts.push((data as { modifiedCount: number }).modifiedCount);
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => ({
+			root: '/workspace',
+			branch,
+			head: 'head-1',
+		}), undefined));
+		await service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		provider.blockReads = true;
+		branch = 'feature';
+
+		const boundaryFlush = service.checkGitState();
+		await readStarted.p;
+		await fileService.writeFile(resource, VSBuffer.fromString('abc'));
+		const recording = service.recordEdit({
+			sessionUri: 'copilot:/session-1',
+			turnId: 'turn-2',
+			toolCallId: 'tool-2',
+			filePath: resource.fsPath,
+			beforeText: 'ab',
+			afterText: 'abc',
+			changes: [{ startOffset: 2, endOffsetExclusive: 2, newText: 'c' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		await readResult.error(new Error('Read failed'));
+		await boundaryFlush;
+		await recording;
+		provider.blockReads = false;
+		await service.checkGitState();
+
+		assert.deepStrictEqual(retainedCounts, [2]);
+	});
+
 	test('does not retain attribution when usage telemetry is disabled', async () => {
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(IFileService, disposables.add(new FileService(new NullLogService())));
@@ -758,7 +905,19 @@ suite('Agent Edit Attribution Service', () => {
 			}),
 		]);
 
-		assert.deepStrictEqual({ prepared, eventCount }, { prepared: undefined, eventCount: 1 });
+		assert.deepStrictEqual({
+			prepared: prepared && {
+				agentModifiedCount: prepared.agentModifiedCount,
+				lastSequence: prepared.lastSequence,
+			},
+			eventCount,
+		}, {
+			prepared: {
+				agentModifiedCount: 1,
+				lastSequence: 1,
+			},
+			eventCount: 1,
+		});
 	});
 
 	test('coordinates Windows resources when path casing differs', async () => {

--- a/src/vs/platform/agentHost/test/node/claudeFileEditObserver.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeFileEditObserver.test.ts
@@ -18,6 +18,7 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
+import { IAgentEditAttributionService, NullAgentEditAttributionService } from '../../common/fileEditAttribution.js';
 import { ISessionDatabase } from '../../common/sessionDataService.js';
 import { ToolResultContentType } from '../../common/state/sessionState.js';
 import { ClaudeFileEditObserver } from '../../node/claude/claudeFileEditObserver.js';
@@ -44,6 +45,7 @@ function createObserver(disposables: Pick<import('../../../../base/common/lifecy
 		[ILogService, new NullLogService()],
 		[IFileService, fileService],
 		[IDiffComputeService, createZeroDiffComputeService()],
+		[IAgentEditAttributionService, new NullAgentEditAttributionService()],
 		[IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory()],
 	);
 	const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));

--- a/src/vs/platform/agentHost/test/node/diffWorkerMain.test.ts
+++ b/src/vs/platform/agentHost/test/node/diffWorkerMain.test.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { computeDiffCounts } from '../../node/diffWorkerMain.js';
+
+suite('Agent Host Diff Worker', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns line counts and character edits from one diff', () => {
+		const result = computeDiffCounts('alpha\nbeta\ngamma', 'alpha\nBETA\ngamma\nomega', 5_000);
+
+		assert.deepStrictEqual({
+			added: result.added,
+			removed: result.removed,
+			applied: applyChanges('alpha\nbeta\ngamma', result.changes),
+			changeCount: result.changes.length,
+		}, {
+			added: 2,
+			removed: 1,
+			applied: 'alpha\nBETA\ngamma\nomega',
+			changeCount: 2,
+		});
+	});
+});
+
+function applyChanges(content: string, changes: readonly { startOffset: number; endOffsetExclusive: number; newText: string }[]): string {
+	let result = '';
+	let lastOffset = 0;
+	for (const change of changes) {
+		result += content.substring(lastOffset, change.startOffset);
+		result += change.newText;
+		lastOffset = change.endOffsetExclusive;
+	}
+	return result + content.substring(lastOffset);
+}

--- a/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
@@ -16,8 +16,9 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
+import { createFileEditContentDigest, getFileEditAttributionMarker, IAgentEditAttributionService, NullAgentEditAttributionService } from '../../common/fileEditAttribution.js';
 import { ToolResultContentType } from '../../common/state/sessionState.js';
-import { createZeroDiffComputeService, TestDiffComputeService } from '../common/sessionTestHelpers.js';
+import { TestDiffComputeService } from '../common/sessionTestHelpers.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { IEditSurvivalReporterFactory, NullEditSurvivalReporterFactory } from '../../node/shared/editSurvivalReporter.js';
 import { FileEditTracker, buildSessionDbUri, parseSessionDbUri } from '../../node/shared/fileEditTracker.js';
@@ -28,6 +29,7 @@ suite('FileEditTracker', () => {
 	let fileService: FileService;
 	let db: SessionDatabase;
 	let tracker: FileEditTracker;
+	let diffComputeService: TestDiffComputeService;
 
 	setup(async () => {
 		fileService = disposables.add(new FileService(new NullLogService()));
@@ -40,7 +42,9 @@ suite('FileEditTracker', () => {
 		const services = new ServiceCollection();
 		services.set(ILogService, new NullLogService());
 		services.set(IFileService, fileService);
-		services.set(IDiffComputeService, createZeroDiffComputeService());
+		diffComputeService = new TestDiffComputeService();
+		services.set(IDiffComputeService, diffComputeService);
+		services.set(IAgentEditAttributionService, new NullAgentEditAttributionService());
 		services.set(IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory());
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		tracker = instantiationService.createInstance(FileEditTracker, 'copilot:/test-session', db);
@@ -62,6 +66,7 @@ suite('FileEditTracker', () => {
 		const fileEdit = await tracker.takeCompletedEdit('turn-1', 'tc-1', '/workspace/test.txt', '', undefined, undefined);
 		assert.ok(fileEdit);
 		assert.strictEqual(fileEdit.type, ToolResultContentType.FileEdit);
+		assert.strictEqual(diffComputeService.callCount, 1);
 
 		// URIs are parseable session-db: URIs
 		const beforeFields = parseSessionDbUri(fileEdit.before!.content.uri);
@@ -106,6 +111,80 @@ suite('FileEditTracker', () => {
 		assert.strictEqual(result, undefined);
 	});
 
+	test('attaches Agent attribution marker to the file edit result', async () => {
+		const services = new ServiceCollection();
+		services.set(ILogService, new NullLogService());
+		services.set(IFileService, fileService);
+		services.set(IDiffComputeService, new TestDiffComputeService());
+		services.set(IAgentEditAttributionService, {
+			_serviceBrand: undefined,
+			setEnabled: () => { },
+			recordEdit: async edit => ({
+				version: 1,
+				editId: 'edit-1',
+				sequence: 1,
+				beforeDigest: createFileEditContentDigest(edit.beforeText),
+				afterDigest: createFileEditContentDigest(edit.afterText),
+			}),
+			flushSession: async () => { },
+			prepareFlush: async () => undefined,
+			commitFlush: async () => ({ outcome: 'missing', agentModifiedCount: 0 }),
+			cancelFlush: async () => ({ outcome: 'missing', agentModifiedCount: 0 }),
+		});
+		services.set(IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory());
+		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
+		const localTracker = instantiationService.createInstance(FileEditTracker, 'copilot:/test-session', db);
+		await fileService.writeFile(URI.file('/workspace/marker.txt'), VSBuffer.fromString('before'));
+
+		await localTracker.trackEditStart('/workspace/marker.txt');
+		await fileService.writeFile(URI.file('/workspace/marker.txt'), VSBuffer.fromString('after'));
+		await localTracker.completeEdit('/workspace/marker.txt');
+		const result = await localTracker.takeCompletedEdit('turn-1', 'tc-marker', '/workspace/marker.txt', 'edit', undefined, 'model');
+
+		assert.deepStrictEqual(result && getFileEditAttributionMarker(result), {
+			version: 1,
+			editId: 'edit-1',
+			sequence: 1,
+			beforeDigest: createFileEditContentDigest('before'),
+			afterDigest: createFileEditContentDigest('after'),
+		});
+	});
+
+	test('returns the file edit result when attribution fails', async () => {
+		const services = new ServiceCollection();
+		services.set(ILogService, new NullLogService());
+		services.set(IFileService, fileService);
+		services.set(IDiffComputeService, new TestDiffComputeService());
+		services.set(IAgentEditAttributionService, {
+			_serviceBrand: undefined,
+			setEnabled: () => { },
+			recordEdit: async () => {
+				throw new Error('Attribution failed');
+			},
+			flushSession: async () => { },
+			prepareFlush: async () => undefined,
+			commitFlush: async () => ({ outcome: 'missing', agentModifiedCount: 0 }),
+			cancelFlush: async () => ({ outcome: 'missing', agentModifiedCount: 0 }),
+		});
+		services.set(IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory());
+		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
+		const localTracker = instantiationService.createInstance(FileEditTracker, 'copilot:/test-session', db);
+		await fileService.writeFile(URI.file('/workspace/fallback.txt'), VSBuffer.fromString('before'));
+
+		await localTracker.trackEditStart('/workspace/fallback.txt');
+		await fileService.writeFile(URI.file('/workspace/fallback.txt'), VSBuffer.fromString('after'));
+		await localTracker.completeEdit('/workspace/fallback.txt');
+		const result = await localTracker.takeCompletedEdit('turn-1', 'tc-fallback', '/workspace/fallback.txt', 'edit', undefined, 'model');
+
+		assert.deepStrictEqual({
+			type: result?.type,
+			marker: result && getFileEditAttributionMarker(result),
+		}, {
+			type: ToolResultContentType.FileEdit,
+			marker: undefined,
+		});
+	});
+
 	test('Write to non-existent file records kind=create with removed=0', async () => {
 		// When a file did not exist before the edit, the tracker clamps
 		// `removed` to 0 (the differ otherwise reports 1 for an empty
@@ -115,7 +194,8 @@ suite('FileEditTracker', () => {
 		const services = new ServiceCollection();
 		services.set(ILogService, new NullLogService());
 		services.set(IFileService, fileService);
-		services.set(IDiffComputeService, new TestDiffComputeService({ added: 1, removed: 1 }));
+		services.set(IDiffComputeService, new TestDiffComputeService({ added: 1, removed: 1, changes: [] }));
+		services.set(IAgentEditAttributionService, new NullAgentEditAttributionService());
 		services.set(IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory());
 		const inst: IInstantiationService = disposables.add(new InstantiationService(services));
 		const localTracker = inst.createInstance(FileEditTracker, 'copilot:/test-session', db);

--- a/src/vs/platform/telemetry/common/editTelemetry.ts
+++ b/src/vs/platform/telemetry/common/editTelemetry.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITelemetryService } from './telemetry.js';
+
+export type EditTelemetryMode = 'longterm' | '10minFocusWindow' | '20minFocusWindow';
+export type EditTelemetryTrigger = '10hours' | 'hashChange' | 'branchChange' | 'closed' | 'time';
+
+export interface IEditSourcesDetailsTelemetryData {
+	mode: EditTelemetryMode;
+	sourceKey: string;
+	sourceKeyCleaned: string;
+	extensionId: string | undefined;
+	extensionVersion: string | undefined;
+	modelId: string | undefined;
+	trigger: EditTelemetryTrigger;
+	languageId: string | undefined;
+	statsUuid: string;
+	conversationId: string | undefined;
+	requestId: string | undefined;
+	origin: string | undefined;
+	harness: string | undefined;
+	modifiedCount: number;
+	deltaModifiedCount: number;
+	totalModifiedCount: number;
+}
+
+type EditSourcesDetailsTelemetryClassification = {
+	owner: 'hediet';
+	comment: 'Provides detailed character count breakdown for individual edit sources (typing, paste, inline completions, NES, etc.) within a session. Reports the top 10-30 sources per session with granular metadata including extension IDs and model IDs for AI edits. Sessions are scoped to either 10-minute or 20-minute focus time windows for visible documents, or longer periods ending on branch changes, commits, or 10-hour intervals. Focus time is computed as the accumulated time where VS Code has focus and there was recent user activity (within the last minute). This event complements editSources.stats by providing source-specific details. @sentToGitHub';
+	mode: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Describes the session mode. Is either longterm, 10minFocusWindow, or 20minFocusWindow.' };
+	sourceKey: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'A description of the source of the edit.' };
+	sourceKeyCleaned: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The source of the edit with some properties (such as extensionId, extensionVersion and modelId) removed.' };
+	extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension id.' };
+	extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension.' };
+	modelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The LLM id.' };
+	languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language id of the document.' };
+	statsUuid: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The unique identifier of the session for which stats are reported. The sourceKey is unique in this session.' };
+	conversationId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat conversation identifier when the edit source comes from chat. Sourced from the chat edit session id.' };
+	requestId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat request identifier when the edit source comes from chat.' };
+	origin: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The process or subsystem that observed the edit source.' };
+	harness: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The Agent Host provider that produced the edit.' };
+	trigger: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Indicates why the session ended.' };
+	modifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by the given edit source during the session that are still in the text document at the end of the session.'; isMeasurement: true };
+	deltaModifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by the given edit source during the session.'; isMeasurement: true };
+	totalModifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by any edit source during the session that are still in the text document at the end of the session.'; isMeasurement: true };
+};
+
+export function sendEditSourcesDetailsTelemetry(telemetryService: ITelemetryService, data: IEditSourcesDetailsTelemetryData): void {
+	telemetryService.publicLog2<IEditSourcesDetailsTelemetryData, EditSourcesDetailsTelemetryClassification>('editTelemetry.editSources.details', data);
+}

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
@@ -13,7 +13,7 @@ import { ActionType } from '../../../../../platform/agentHost/common/state/proto
 import { ToolResultContentType } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IAgentHostConnectionsService } from '../../../../../platform/agentHost/common/agentHostConnectionsService.js';
 import { toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
-import { buildCancelEditAttributionResource, buildCommitEditAttributionResource, buildPrepareEditAttributionResource, createFileEditContentDigest, getFileEditAttributionMarker, IEditAttributionFlushResult, IFileEditAttributionMarker, IPreparedEditAttributionFlush } from '../../../../../platform/agentHost/common/fileEditAttribution.js';
+import { buildCancelEditAttributionResource, buildCommitEditAttributionResource, buildPrepareEditAttributionResource, createFileEditContentDigest, getFileEditAttributionMarker, IEditAttributionFlushResult, IPreparedEditAttributionFlush, ITrackedFileEditAttributionMarker } from '../../../../../platform/agentHost/common/fileEditAttribution.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
 import { EditTelemetryTrigger } from '../../../../../platform/telemetry/common/editTelemetry.js';
@@ -25,8 +25,13 @@ const MAX_OBSERVATIONS_PER_RESOURCE = 128;
 const MAX_ROUTES = 1_000;
 const COORDINATION_TIMEOUT = 15_000;
 
-interface IRecentMarker extends IFileEditAttributionMarker {
+interface IRecentMarker extends ITrackedFileEditAttributionMarker {
 	readonly timestamp: number;
+}
+
+export interface IAgentHostEditAttributionCoverageGap {
+	readonly editCount: number;
+	readonly insertedCount: number;
 }
 
 interface IExternalObservation {
@@ -58,6 +63,7 @@ export class AgentHostEditAttributionUnknownOutcomeError extends Error {
 
 export interface IAgentHostEditMarkerService {
 	createCorrelation(resource: URI): IExternalEditCorrelation;
+	takeCoverageGap?(resource: URI): IAgentHostEditAttributionCoverageGap | undefined;
 	prepareFlush(resource: URI, trigger: EditTelemetryTrigger, statsUuid: string, isDirty: boolean, languageId?: string): Promise<IPreparedAgentHostEditAttributionFlush | undefined>;
 }
 
@@ -73,6 +79,7 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 	private readonly _markers = new Map<string, IRecentMarker[]>();
 	private readonly _observations = new Map<string, IExternalObservation[]>();
 	private readonly _routes = new Map<string, IAgentHostResourceRoute>();
+	private readonly _coverageGaps = new Map<string, IAgentHostEditAttributionCoverageGap & { readonly timestamp: number }>();
 	private readonly _onDidSuppress = this._register(new Emitter<string>());
 	private readonly _onDidInvalidate = this._register(new Emitter<string>());
 	private readonly _connectionListeners = this._register(new DisposableStore());
@@ -94,6 +101,22 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 			register: (before, after) => this._registerObservation(resourceKey, before, after),
 			isSuppressed: id => this._observations.get(resourceKey)?.some(observation => observation.id === id && observation.suppressed) ?? false,
 			release: id => this._releaseObservation(resourceKey, id),
+		};
+	}
+
+	takeCoverageGap(resource: URI): IAgentHostEditAttributionCoverageGap | undefined {
+		const resourceKey = this._key(resource);
+		const coverageGap = this._coverageGaps.get(resourceKey);
+		if (!coverageGap) {
+			return undefined;
+		}
+		this._coverageGaps.delete(resourceKey);
+		if (coverageGap.timestamp < Date.now() - ROUTE_TTL) {
+			return undefined;
+		}
+		return {
+			editCount: coverageGap.editCount,
+			insertedCount: coverageGap.insertedCount,
 		};
 	}
 
@@ -238,9 +261,30 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 						this._invalidateObservations(oldestKey);
 						this._routes.delete(oldestKey);
 					}
-					this._recordMarker(resourceKey, marker);
+					if (marker.status === 'skipped') {
+						this._recordCoverageGap(resourceKey, marker.insertedCount);
+					} else {
+						this._recordMarker(resourceKey, marker);
+					}
 				}
 			}));
+		}
+	}
+
+	private _recordCoverageGap(resourceKey: string, insertedCount: number): void {
+		const existing = this._coverageGaps.get(resourceKey);
+		this._coverageGaps.delete(resourceKey);
+		this._coverageGaps.set(resourceKey, {
+			editCount: (existing?.editCount ?? 0) + 1,
+			insertedCount: (existing?.insertedCount ?? 0) + insertedCount,
+			timestamp: Date.now(),
+		});
+		while (this._coverageGaps.size > MAX_ROUTES) {
+			const oldestKey = this._coverageGaps.keys().next().value;
+			if (oldestKey === undefined) {
+				break;
+			}
+			this._coverageGaps.delete(oldestKey);
 		}
 	}
 
@@ -266,7 +310,7 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 		return observation.id;
 	}
 
-	private _recordMarker(resourceKey: string, marker: IFileEditAttributionMarker): void {
+	private _recordMarker(resourceKey: string, marker: ITrackedFileEditAttributionMarker): void {
 		this._prune(resourceKey);
 		const markers = this._markers.get(resourceKey) ?? [];
 		if (!markers.some(candidate => candidate.editId === marker.editId)) {
@@ -374,6 +418,9 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 		if ((this._routes.get(resourceKey)?.timestamp ?? now) < now - ROUTE_TTL) {
 			this._invalidateObservations(resourceKey);
 			this._routes.delete(resourceKey);
+		}
+		if ((this._coverageGaps.get(resourceKey)?.timestamp ?? now) < now - ROUTE_TTL) {
+			this._coverageGaps.delete(resourceKey);
 		}
 	}
 

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
@@ -61,6 +61,12 @@ export class AgentHostEditAttributionUnknownOutcomeError extends Error {
 	}
 }
 
+export class AgentHostEditAttributionDeferredError extends Error {
+	constructor(cause: unknown) {
+		super('The Agent Host edit attribution was deferred', { cause });
+	}
+}
+
 export interface IAgentHostEditMarkerService {
 	createCorrelation(resource: URI): IExternalEditCorrelation;
 	takeCoverageGap?(resource: URI): IAgentHostEditAttributionCoverageGap | undefined;
@@ -82,6 +88,7 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 	private readonly _coverageGaps = new Map<string, IAgentHostEditAttributionCoverageGap & { readonly timestamp: number }>();
 	private readonly _onDidSuppress = this._register(new Emitter<string>());
 	private readonly _onDidInvalidate = this._register(new Emitter<string>());
+	private readonly _onDidReceiveMarker = this._register(new Emitter<{ readonly resourceKey: string; readonly connection: IAgentConnection; readonly sequence: number }>());
 	private readonly _connectionListeners = this._register(new DisposableStore());
 
 	constructor(
@@ -121,14 +128,15 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 	}
 
 	async prepareFlush(resource: URI, trigger: EditTelemetryTrigger, statsUuid: string, isDirty: boolean, languageId = 'plaintext'): Promise<IPreparedAgentHostEditAttributionFlush | undefined> {
-		const route = this._routes.get(this._key(resource));
+		const resourceKey = this._key(resource);
+		this._prune(resourceKey);
+		const route = this._routes.get(resourceKey);
 		if (!route) {
 			return undefined;
 		}
 		const flushToken = generateUuid();
-		let result;
 		try {
-			result = await this._resourceRead(route.connection, buildPrepareEditAttributionResource({
+			const result = await this._resourceRead(route.connection, buildPrepareEditAttributionResource({
 				resource: route.resource,
 				trigger,
 				statsUuid,
@@ -136,57 +144,94 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 				flushToken,
 				languageId,
 			}));
-		} catch (prepareError) {
-			try {
-				const result = await this._readOutcome(route.connection, buildCancelEditAttributionResource({ flushToken }));
-				if (result.outcome === 'committed') {
-					return {
-						flushToken,
-						agentModifiedCount: result.agentModifiedCount,
-						commit: async () => { },
-					};
-				}
-			} catch (cancelError) {
-				throw new AggregateError([prepareError, cancelError], 'Failed to prepare or cancel Agent Host edit attribution');
+			const prepared = JSON.parse(result.data) as IPreparedEditAttributionFlush | null;
+			if (
+				prepared &&
+				(
+					prepared.flushToken !== flushToken ||
+					!Number.isSafeInteger(prepared.agentModifiedCount) ||
+					prepared.agentModifiedCount < 0 ||
+					(prepared.lastSequence !== undefined && (!Number.isSafeInteger(prepared.lastSequence) || prepared.lastSequence < 0))
+				)
+			) {
+				throw new Error('Agent Host edit attribution returned an invalid prepared flush');
 			}
-			throw prepareError;
-		}
-		const prepared = JSON.parse(result.data) as IPreparedEditAttributionFlush | null;
-		if (prepared && prepared.flushToken !== flushToken) {
-			throw new Error('Agent Host edit attribution returned an unexpected flush token');
-		}
-		return prepared ? {
-			...prepared,
-			commit: async totalModifiedCount => {
-				let commitError: unknown = new Error(`Agent Host edit attribution commit failed: ${prepared.flushToken}`);
-				try {
-					const result = await this._readOutcome(route.connection, buildCommitEditAttributionResource({
-						flushToken: prepared.flushToken,
-						totalModifiedCount,
-					}));
-					if (result.outcome === 'committed') {
+			if (prepared?.lastSequence !== undefined) {
+				await this._waitForMarker(resourceKey, route.connection, prepared.lastSequence);
+			}
+			return prepared ? {
+				...prepared,
+				commit: async totalModifiedCount => {
+					let commitError: unknown = new Error(`Agent Host edit attribution commit failed: ${prepared.flushToken}`);
+					try {
+						const result = await this._readOutcome(route.connection, buildCommitEditAttributionResource({
+							flushToken: prepared.flushToken,
+							totalModifiedCount,
+						}));
+						if (result.outcome === 'committed') {
+							return;
+						}
+						commitError = new Error(`Agent Host edit attribution commit was not found: ${prepared.flushToken}`);
+					} catch (error) {
+						commitError = error;
+					}
+					let cancelResult: IEditAttributionFlushResult;
+					try {
+						cancelResult = await this._readOutcome(route.connection, buildCancelEditAttributionResource({
+							flushToken: prepared.flushToken,
+						}));
+					} catch (cancelError) {
+						throw new AgentHostEditAttributionUnknownOutcomeError(new AggregateError(
+							[commitError, cancelError],
+							'Failed to commit or cancel Agent Host edit attribution'
+						));
+					}
+					if (cancelResult.outcome === 'committed') {
 						return;
 					}
-					commitError = new Error(`Agent Host edit attribution commit was not found: ${prepared.flushToken}`);
-				} catch (error) {
-					commitError = error;
-				}
-				try {
-					const result = await this._readOutcome(route.connection, buildCancelEditAttributionResource({
-						flushToken: prepared.flushToken,
-					}));
-					if (result.outcome === 'committed') {
-						return;
-					}
-				} catch (cancelError) {
-					throw new AgentHostEditAttributionUnknownOutcomeError(new AggregateError(
-						[commitError, cancelError],
-						'Failed to commit or cancel Agent Host edit attribution'
-					));
-				}
-				throw commitError;
-			},
-		} : undefined;
+					throw new AgentHostEditAttributionDeferredError(commitError);
+				},
+			} : undefined;
+		} catch (prepareError) {
+			return this._recoverFailedPrepare(route.connection, flushToken, prepareError);
+		}
+	}
+
+	private async _recoverFailedPrepare(connection: IAgentConnection, flushToken: string, prepareError: unknown): Promise<IPreparedAgentHostEditAttributionFlush> {
+		let cancelResult: IEditAttributionFlushResult;
+		try {
+			cancelResult = await this._readOutcome(connection, buildCancelEditAttributionResource({ flushToken }));
+		} catch (cancelError) {
+			throw new AgentHostEditAttributionUnknownOutcomeError(new AggregateError(
+				[prepareError, cancelError],
+				'Failed to prepare or cancel Agent Host edit attribution'
+			));
+		}
+		if (cancelResult.outcome === 'committed') {
+			return {
+				flushToken,
+				agentModifiedCount: cancelResult.agentModifiedCount,
+				commit: async () => { },
+			};
+		}
+		throw new AgentHostEditAttributionDeferredError(prepareError);
+	}
+
+	private async _waitForMarker(resourceKey: string, connection: IAgentConnection, sequence: number): Promise<void> {
+		const isCaughtUp = () => {
+			const route = this._routes.get(resourceKey);
+			return route?.connection === connection && route.lastSequence >= sequence;
+		};
+		if (isCaughtUp()) {
+			return;
+		}
+		const marker = await raceTimeout(Event.toPromise(Event.filter(
+			this._onDidReceiveMarker.event,
+			event => event.resourceKey === resourceKey && event.connection === connection && event.sequence >= sequence
+		)), COORDINATION_TIMEOUT);
+		if (!marker && !isCaughtUp()) {
+			throw new Error(`Timed out waiting for Agent Host edit attribution marker: ${sequence}`);
+		}
 	}
 
 	private async _resourceRead(connection: IAgentConnection, resource: URI) {
@@ -253,6 +298,7 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 						timestamp: Date.now(),
 						lastSequence: marker.sequence,
 					});
+					this._onDidReceiveMarker.fire({ resourceKey, connection, sequence: marker.sequence });
 					while (this._routes.size > MAX_ROUTES) {
 						const oldestKey = this._routes.keys().next().value;
 						if (oldestKey === undefined) {

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
@@ -1,0 +1,419 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { raceTimeout } from '../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { ActionType } from '../../../../../platform/agentHost/common/state/protocol/common/actions.js';
+import { ToolResultContentType } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { IAgentHostConnectionsService } from '../../../../../platform/agentHost/common/agentHostConnectionsService.js';
+import { toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { buildCancelEditAttributionResource, buildCommitEditAttributionResource, buildPrepareEditAttributionResource, createFileEditContentDigest, getFileEditAttributionMarker, IEditAttributionFlushResult, IFileEditAttributionMarker, IPreparedEditAttributionFlush } from '../../../../../platform/agentHost/common/fileEditAttribution.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
+import { EditTelemetryTrigger } from '../../../../../platform/telemetry/common/editTelemetry.js';
+
+const MARKER_TTL = 5 * 60 * 1000;
+const ROUTE_TTL = 10 * 60 * 60 * 1000;
+const MAX_MARKERS_PER_RESOURCE = 128;
+const MAX_OBSERVATIONS_PER_RESOURCE = 128;
+const MAX_ROUTES = 1_000;
+const COORDINATION_TIMEOUT = 15_000;
+
+interface IRecentMarker extends IFileEditAttributionMarker {
+	readonly timestamp: number;
+}
+
+interface IExternalObservation {
+	readonly id: string;
+	readonly beforeDigest: string;
+	readonly afterDigest: string;
+	readonly timestamp: number;
+	suppressed: boolean;
+}
+
+interface IAgentHostResourceRoute {
+	readonly connection: IAgentConnection;
+	readonly resource: URI;
+	readonly timestamp: number;
+	readonly lastSequence: number;
+}
+
+export interface IPreparedAgentHostEditAttributionFlush {
+	readonly flushToken: string;
+	readonly agentModifiedCount: number;
+	commit(totalModifiedCount: number): Promise<void>;
+}
+
+export class AgentHostEditAttributionUnknownOutcomeError extends Error {
+	constructor(cause: unknown) {
+		super('The Agent Host edit attribution outcome is unknown', { cause });
+	}
+}
+
+export interface IAgentHostEditMarkerService {
+	createCorrelation(resource: URI): IExternalEditCorrelation;
+	prepareFlush(resource: URI, trigger: EditTelemetryTrigger, statsUuid: string, isDirty: boolean, languageId?: string): Promise<IPreparedAgentHostEditAttributionFlush | undefined>;
+}
+
+export interface IExternalEditCorrelation {
+	readonly onDidSuppress: Event<string>;
+	readonly onDidInvalidate: Event<string>;
+	register(before: string, after: string): string;
+	isSuppressed(id: string): boolean;
+	release(id: string): void;
+}
+
+export class AgentHostEditMarkerService extends Disposable implements IAgentHostEditMarkerService {
+	private readonly _markers = new Map<string, IRecentMarker[]>();
+	private readonly _observations = new Map<string, IExternalObservation[]>();
+	private readonly _routes = new Map<string, IAgentHostResourceRoute>();
+	private readonly _onDidSuppress = this._register(new Emitter<string>());
+	private readonly _onDidInvalidate = this._register(new Emitter<string>());
+	private readonly _connectionListeners = this._register(new DisposableStore());
+
+	constructor(
+		@IAgentHostConnectionsService private readonly _connectionsService: IAgentHostConnectionsService,
+		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService,
+	) {
+		super();
+		this._updateConnectionListeners();
+		this._register(this._connectionsService.onDidChangeConnections(() => this._updateConnectionListeners()));
+	}
+
+	createCorrelation(resource: URI): IExternalEditCorrelation {
+		const resourceKey = this._key(resource);
+		return {
+			onDidSuppress: this._onDidSuppress.event,
+			onDidInvalidate: this._onDidInvalidate.event,
+			register: (before, after) => this._registerObservation(resourceKey, before, after),
+			isSuppressed: id => this._observations.get(resourceKey)?.some(observation => observation.id === id && observation.suppressed) ?? false,
+			release: id => this._releaseObservation(resourceKey, id),
+		};
+	}
+
+	async prepareFlush(resource: URI, trigger: EditTelemetryTrigger, statsUuid: string, isDirty: boolean, languageId = 'plaintext'): Promise<IPreparedAgentHostEditAttributionFlush | undefined> {
+		const route = this._routes.get(this._key(resource));
+		if (!route) {
+			return undefined;
+		}
+		const flushToken = generateUuid();
+		let result;
+		try {
+			result = await this._resourceRead(route.connection, buildPrepareEditAttributionResource({
+				resource: route.resource,
+				trigger,
+				statsUuid,
+				isDirty,
+				flushToken,
+				languageId,
+			}));
+		} catch (prepareError) {
+			try {
+				const result = await this._readOutcome(route.connection, buildCancelEditAttributionResource({ flushToken }));
+				if (result.outcome === 'committed') {
+					return {
+						flushToken,
+						agentModifiedCount: result.agentModifiedCount,
+						commit: async () => { },
+					};
+				}
+			} catch (cancelError) {
+				throw new AggregateError([prepareError, cancelError], 'Failed to prepare or cancel Agent Host edit attribution');
+			}
+			throw prepareError;
+		}
+		const prepared = JSON.parse(result.data) as IPreparedEditAttributionFlush | null;
+		if (prepared && prepared.flushToken !== flushToken) {
+			throw new Error('Agent Host edit attribution returned an unexpected flush token');
+		}
+		return prepared ? {
+			...prepared,
+			commit: async totalModifiedCount => {
+				let commitError: unknown = new Error(`Agent Host edit attribution commit failed: ${prepared.flushToken}`);
+				try {
+					const result = await this._readOutcome(route.connection, buildCommitEditAttributionResource({
+						flushToken: prepared.flushToken,
+						totalModifiedCount,
+					}));
+					if (result.outcome === 'committed') {
+						return;
+					}
+					commitError = new Error(`Agent Host edit attribution commit was not found: ${prepared.flushToken}`);
+				} catch (error) {
+					commitError = error;
+				}
+				try {
+					const result = await this._readOutcome(route.connection, buildCancelEditAttributionResource({
+						flushToken: prepared.flushToken,
+					}));
+					if (result.outcome === 'committed') {
+						return;
+					}
+				} catch (cancelError) {
+					throw new AgentHostEditAttributionUnknownOutcomeError(new AggregateError(
+						[commitError, cancelError],
+						'Failed to commit or cancel Agent Host edit attribution'
+					));
+				}
+				throw commitError;
+			},
+		} : undefined;
+	}
+
+	private async _resourceRead(connection: IAgentConnection, resource: URI) {
+		const result = await raceTimeout(connection.resourceRead(resource), COORDINATION_TIMEOUT);
+		if (!result) {
+			throw new Error(`Agent Host edit attribution request timed out: ${resource.path}`);
+		}
+		return result;
+	}
+
+	private async _readOutcome(connection: IAgentConnection, resource: URI): Promise<IEditAttributionFlushResult> {
+		const result = await this._resourceRead(connection, resource);
+		const parsed = JSON.parse(result.data) as Partial<IEditAttributionFlushResult>;
+		if (
+			(parsed.outcome !== 'committed' && parsed.outcome !== 'cancelled' && parsed.outcome !== 'missing') ||
+			typeof parsed.agentModifiedCount !== 'number'
+		) {
+			throw new Error(`Invalid Agent Host edit attribution outcome: ${resource.path}`);
+		}
+		return {
+			outcome: parsed.outcome,
+			agentModifiedCount: parsed.agentModifiedCount,
+		};
+	}
+
+	private _updateConnectionListeners(): void {
+		this._connectionListeners.clear();
+		const activeConnections = new Set(this._connectionsService.connections.flatMap(info => info.connection ? [info.connection] : []));
+		for (const [resourceKey, route] of this._routes) {
+			if (!activeConnections.has(route.connection)) {
+				this._invalidateObservations(resourceKey);
+				this._routes.delete(resourceKey);
+			}
+		}
+		for (const connectionInfo of this._connectionsService.connections) {
+			const connection = connectionInfo.connection;
+			if (!connection) {
+				continue;
+			}
+			this._connectionListeners.add(connection.onDidAction(envelope => {
+				const action = envelope.action;
+				if (action.type !== ActionType.ChatToolCallComplete) {
+					return;
+				}
+				for (const content of action.result.content ?? []) {
+					if (content.type !== ToolResultContentType.FileEdit) {
+						continue;
+					}
+					const marker = getFileEditAttributionMarker(content);
+					const resourceUri = content.after?.uri ?? content.before?.uri;
+					if (!marker || !resourceUri) {
+						continue;
+					}
+					const resource = toAgentHostUri(URI.parse(resourceUri), connectionInfo.authority);
+					const resourceKey = this._key(resource);
+					const previousRoute = this._routes.get(resourceKey);
+					if (previousRoute && (previousRoute.connection !== connection || marker.sequence <= previousRoute.lastSequence)) {
+						this._invalidateObservations(resourceKey);
+					}
+					this._routes.delete(resourceKey);
+					this._routes.set(resourceKey, {
+						connection,
+						resource: URI.parse(resourceUri),
+						timestamp: Date.now(),
+						lastSequence: marker.sequence,
+					});
+					while (this._routes.size > MAX_ROUTES) {
+						const oldestKey = this._routes.keys().next().value;
+						if (oldestKey === undefined) {
+							break;
+						}
+						this._invalidateObservations(oldestKey);
+						this._routes.delete(oldestKey);
+					}
+					this._recordMarker(resourceKey, marker);
+				}
+			}));
+		}
+	}
+
+	private _registerObservation(resourceKey: string, before: string, after: string): string {
+		this._prune(resourceKey);
+		const observation: IExternalObservation = {
+			id: generateUuid(),
+			beforeDigest: createFileEditContentDigest(before),
+			afterDigest: createFileEditContentDigest(after),
+			timestamp: Date.now(),
+			suppressed: false,
+		};
+		const observations = this._observations.get(resourceKey) ?? [];
+		observations.push(observation);
+		while (observations.length > MAX_OBSERVATIONS_PER_RESOURCE) {
+			const removed = observations.shift();
+			if (removed?.suppressed) {
+				this._onDidInvalidate.fire(removed.id);
+			}
+		}
+		this._observations.set(resourceKey, observations);
+		this._trySuppress(resourceKey, observation);
+		return observation.id;
+	}
+
+	private _recordMarker(resourceKey: string, marker: IFileEditAttributionMarker): void {
+		this._prune(resourceKey);
+		const markers = this._markers.get(resourceKey) ?? [];
+		if (!markers.some(candidate => candidate.editId === marker.editId)) {
+			markers.push({ ...marker, timestamp: Date.now() });
+			markers.sort((a, b) => a.sequence - b.sequence);
+			removeCompletedCycle(markers, marker.editId);
+			while (markers.length > MAX_MARKERS_PER_RESOURCE) {
+				markers.shift();
+			}
+			this._markers.set(resourceKey, markers);
+		}
+		for (const observation of this._observations.get(resourceKey) ?? []) {
+			this._trySuppress(resourceKey, observation);
+		}
+	}
+
+	private _trySuppress(resourceKey: string, observation: IExternalObservation): void {
+		if (observation.suppressed) {
+			return;
+		}
+		const markers = this._markers.get(resourceKey);
+		if (!markers) {
+			return;
+		}
+		for (let startIndex = 0; startIndex < markers.length; startIndex++) {
+			const first = markers[startIndex];
+			if (first.beforeDigest !== observation.beforeDigest) {
+				continue;
+			}
+			const consumed = [startIndex];
+			let afterDigest = first.afterDigest;
+			let sequence = first.sequence;
+			while (afterDigest !== observation.afterDigest) {
+				const nextIndex = markers.findIndex((marker, index) =>
+					index !== startIndex &&
+					!consumed.includes(index) &&
+					marker.sequence > sequence &&
+					marker.beforeDigest === afterDigest
+				);
+				if (nextIndex < 0) {
+					break;
+				}
+				consumed.push(nextIndex);
+				afterDigest = markers[nextIndex].afterDigest;
+				sequence = markers[nextIndex].sequence;
+			}
+			if (afterDigest !== observation.afterDigest) {
+				continue;
+			}
+			observation.suppressed = true;
+			for (const index of consumed.toSorted((a, b) => b - a)) {
+				markers.splice(index, 1);
+			}
+			if (markers.length === 0) {
+				this._markers.delete(resourceKey);
+			}
+			this._onDidSuppress.fire(observation.id);
+			return;
+		}
+	}
+
+	private _releaseObservation(resourceKey: string, id: string): void {
+		const observations = this._observations.get(resourceKey);
+		if (!observations) {
+			return;
+		}
+		const index = observations.findIndex(observation => observation.id === id);
+		if (index >= 0) {
+			observations.splice(index, 1);
+		}
+		if (observations.length === 0) {
+			this._observations.delete(resourceKey);
+		}
+	}
+
+	private _invalidateObservations(resourceKey: string): void {
+		this._markers.delete(resourceKey);
+		const observations = this._observations.get(resourceKey);
+		if (!observations) {
+			return;
+		}
+		for (const observation of observations) {
+			if (observation.suppressed) {
+				this._onDidInvalidate.fire(observation.id);
+			}
+		}
+		this._observations.delete(resourceKey);
+	}
+
+	private _prune(resourceKey: string): void {
+		const now = Date.now();
+		const minimumTimestamp = now - MARKER_TTL;
+		const markers = this._markers.get(resourceKey)?.filter(marker => marker.timestamp >= minimumTimestamp);
+		if (markers?.length) {
+			this._markers.set(resourceKey, markers);
+		} else {
+			this._markers.delete(resourceKey);
+		}
+		const observations = this._observations.get(resourceKey)?.filter(observation => observation.suppressed || observation.timestamp >= minimumTimestamp);
+		if (observations?.length) {
+			this._observations.set(resourceKey, observations);
+		} else {
+			this._observations.delete(resourceKey);
+		}
+		if ((this._routes.get(resourceKey)?.timestamp ?? now) < now - ROUTE_TTL) {
+			this._invalidateObservations(resourceKey);
+			this._routes.delete(resourceKey);
+		}
+	}
+
+	private _key(resource: URI): string {
+		const normalizedResource = resource.scheme === Schemas.vscodeRemote
+			? URI.from({ scheme: Schemas.file, path: resource.path })
+			: resource;
+		return this._uriIdentityService.extUri.getComparisonKey(this._uriIdentityService.asCanonicalUri(normalizedResource));
+	}
+}
+
+function removeCompletedCycle(markers: IRecentMarker[], latestEditId: string): void {
+	const latestIndex = markers.findIndex(marker => marker.editId === latestEditId);
+	if (latestIndex < 0) {
+		return;
+	}
+	const completedDigest = markers[latestIndex].afterDigest;
+	const consumed = [latestIndex];
+	let beforeDigest = markers[latestIndex].beforeDigest;
+	let sequence = markers[latestIndex].sequence;
+	while (true) {
+		if (beforeDigest === completedDigest && consumed.length > 1) {
+			for (const index of consumed.toSorted((a, b) => b - a)) {
+				markers.splice(index, 1);
+			}
+			return;
+		}
+		let previousIndex = -1;
+		for (let index = markers.length - 1; index >= 0; index--) {
+			const marker = markers[index];
+			if (marker.sequence < sequence && marker.afterDigest === beforeDigest) {
+				previousIndex = index;
+				break;
+			}
+		}
+		if (previousIndex < 0) {
+			return;
+		}
+		consumed.push(previousIndex);
+		beforeDigest = markers[previousIndex].beforeDigest;
+		sequence = markers[previousIndex].sequence;
+	}
+}

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingFeature.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingFeature.ts
@@ -27,6 +27,7 @@ import { DataChannelForwardingTelemetryService } from '../../../../../platform/d
 import { EDIT_TELEMETRY_DETAILS_SETTING_ID, EDIT_TELEMETRY_SHOW_DECORATIONS, EDIT_TELEMETRY_SHOW_STATUS_BAR } from '../settings.js';
 import { VSCodeWorkspace } from '../helpers/vscodeObservableWorkspace.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { AgentHostEditMarkerService } from './agentHostEditMarkerService.js';
 
 export class EditTrackingFeature extends Disposable {
 
@@ -54,21 +55,22 @@ export class EditTrackingFeature extends Disposable {
 		const extensions = observableFromEvent(this._extensionService.onDidChangeExtensions, () => {
 			return this._extensionService.extensions;
 		});
-		const extensionIds = derived(reader => new Set(extensions.read(reader).map(e => e.id?.toLowerCase())));
-		function getExtensionInfoObs(extensionId: string, extensionService: IExtensionService) {
+		const extensionIds = derived(reader => new Set(extensions.read(reader).map(e => e.identifier.value.toLowerCase())));
+		function getExtensionInfoObs(extensionId: string) {
 			const extIdLowerCase = extensionId.toLowerCase();
 			return derived(reader => extensionIds.read(reader).has(extIdLowerCase));
 		}
 
-		const copilotInstalled = getExtensionInfoObs('GitHub.copilot', this._extensionService);
-		const copilotChatInstalled = getExtensionInfoObs('GitHub.copilot-chat', this._extensionService);
+		const copilotInstalled = getExtensionInfoObs('GitHub.copilot');
+		const copilotChatInstalled = getExtensionInfoObs('GitHub.copilot-chat');
 
 		const shouldSendDetails = derived(reader => editSourceDetailsEnabled.read(reader) || !!copilotInstalled.read(reader) || !!copilotChatInstalled.read(reader));
 
 		const instantiationServiceWithInterceptedTelemetry = this._instantiationService.createChild(new ServiceCollection(
 			[ITelemetryService, this._instantiationService.createInstance(DataChannelForwardingTelemetryService)]
 		));
-		const impl = this._register(instantiationServiceWithInterceptedTelemetry.createInstance(EditSourceTrackingImpl, shouldSendDetails, this._annotatedDocuments));
+		const markerService = this._register(instantiationServiceWithInterceptedTelemetry.createInstance(AgentHostEditMarkerService));
+		const impl = this._register(instantiationServiceWithInterceptedTelemetry.createInstance(EditSourceTrackingImpl, shouldSendDetails, this._annotatedDocuments, markerService));
 
 		this._register(autorun((reader) => {
 			if (!this._editSourceTrackingShowDecorations.read(reader)) {

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
@@ -195,23 +195,27 @@ class TrackedDocumentInfo extends Disposable {
 	private _sendTelemetryAndLog(mode: EditTelemetryMode, trigger: EditTelemetryTrigger, tracker: DocumentEditSourceTracker, focusTime: number, actualTime: number): void {
 		void this.sendTelemetry(mode, trigger, tracker, focusTime, actualTime).catch(error => {
 			this._logService.error(`[EditSourceTrackingImpl] Failed to send ${mode} edit telemetry: ${error}`);
+		}).finally(() => {
+			tracker.releaseExternalEditCorrelations();
 		});
 	}
 
 	async sendTelemetry(mode: EditTelemetryMode, trigger: EditTelemetryTrigger, t: DocumentEditSourceTracker, focusTime: number, actualTime: number) {
+		const coverageGap = mode === 'longterm' ? this._agentHostEditMarkerService?.takeCoverageGap?.(this._doc.document.uri) : undefined;
 		t.applyPendingExternalEdits();
 		let ranges = t.getTrackedRanges();
 		let internalKeys = t.getAllKeys();
 		let data = this.getTelemetryData(ranges);
 		const statsUuid = this._randomService.generateUuid();
 		let preparedAgentFlush: IPreparedAgentHostEditAttributionFlush | undefined;
+		const isDirty = this._textFileService.isDirty(this._doc.document.uri);
 		if (mode === 'longterm' && this._agentHostEditMarkerService) {
 			try {
 				preparedAgentFlush = await this._agentHostEditMarkerService.prepareFlush(
 					this._doc.document.uri,
 					trigger,
 					statsUuid,
-					this._textFileService.isDirty(this._doc.document.uri),
+					isDirty,
 					this._doc.document.languageId.get(),
 				);
 			} catch (error) {
@@ -228,14 +232,14 @@ class TrackedDocumentInfo extends Disposable {
 				}
 			}
 		}
-		const includeSuppressedExternal = !preparedAgentFlush && mode === 'longterm' && !!this._agentHostEditMarkerService;
+		const includeSuppressedExternal = !preparedAgentFlush && !isDirty && mode === 'longterm' && !!this._agentHostEditMarkerService;
 		if (includeSuppressedExternal) {
 			ranges = t.getTrackedRanges(undefined, true);
 			internalKeys = t.getAllKeys(true);
 			data = this.getTelemetryData(ranges);
 		}
 		const agentModifiedCount = preparedAgentFlush?.agentModifiedCount ?? 0;
-		if (internalKeys.length === 0 && agentModifiedCount === 0) {
+		if (internalKeys.length === 0 && agentModifiedCount === 0 && !coverageGap) {
 			return;
 		}
 		const totalModifiedCount = data.totalModifiedCharactersInFinalState + agentModifiedCount;
@@ -313,6 +317,9 @@ class TrackedDocumentInfo extends Disposable {
 			focusTime: number;
 			actualTime: number;
 			trigger: EditTelemetryTrigger;
+			agentHostAttributionCoverage?: 'complete' | 'partial';
+			agentHostUntrackedEditCount?: number;
+			agentHostUntrackedInsertedCount?: number;
 		}, {
 			owner: 'hediet';
 			comment: 'Aggregates character counts by edit source category (user typing, AI completions, NES, IDE actions, external changes) for each editing session. Sessions represent units of work and end when documents close, branches change, commits occur, or time limits are reached (10 or 20 minutes of focus time for visible documents, or 10 hours otherwise). Focus time is computed as accumulated 1-minute blocks where VS Code has focus and there was recent user activity. Tracks both total characters inserted and characters remaining at session end to measure retention. This high-level summary complements editSources.details which provides granular per-source breakdowns. @sentToGitHub';
@@ -334,6 +341,9 @@ class TrackedDocumentInfo extends Disposable {
 			focusTime: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The focus time in ms during the session.'; isMeasurement: true };
 			actualTime: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The actual time in ms during the session.'; isMeasurement: true };
 			trigger: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Indicates why the session ended.' };
+			agentHostAttributionCoverage?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether long-term Agent Host edit attribution was complete or skipped at least one oversized edit.' };
+			agentHostUntrackedEditCount?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Number of oversized Agent Host edits excluded from detailed attribution in this long-term window.'; isMeasurement: true };
+			agentHostUntrackedInsertedCount?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Characters inserted by oversized Agent Host edits excluded from retained-character attribution in this long-term window.'; isMeasurement: true };
 		}>('editTelemetry.editSources.stats', {
 			mode,
 			languageId: this._doc.document.languageId.get(),
@@ -351,6 +361,11 @@ class TrackedDocumentInfo extends Disposable {
 			focusTime,
 			actualTime,
 			trigger,
+			...(mode === 'longterm' ? {
+				agentHostAttributionCoverage: coverageGap ? 'partial' as const : 'complete' as const,
+				agentHostUntrackedEditCount: coverageGap?.editCount ?? 0,
+				agentHostUntrackedInsertedCount: coverageGap?.insertedCount ?? 0,
+			} : {}),
 		});
 	}
 

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
@@ -21,7 +21,7 @@ import { DocumentEditSourceTracker, TrackedEdit } from './editTracker.js';
 import { sumByCategory } from '../helpers/utils.js';
 import { IScmRepoAdapter, ScmAdapter } from './scmAdapter.js';
 import { IRandomService } from '../randomService.js';
-import { AgentHostEditAttributionUnknownOutcomeError, IAgentHostEditMarkerService, IPreparedAgentHostEditAttributionFlush } from './agentHostEditMarkerService.js';
+import { AgentHostEditAttributionDeferredError, AgentHostEditAttributionUnknownOutcomeError, IAgentHostEditMarkerService, IPreparedAgentHostEditAttributionFlush } from './agentHostEditMarkerService.js';
 
 export type EditTelemetryCategory = 'nes' | 'inlineCompletionsCopilot' | 'inlineCompletionsNES' | 'inlineCompletionsOther' | 'otherAI' | 'user' | 'ide' | 'external' | 'unknown';
 
@@ -208,6 +208,7 @@ class TrackedDocumentInfo extends Disposable {
 		let data = this.getTelemetryData(ranges);
 		const statsUuid = this._randomService.generateUuid();
 		let preparedAgentFlush: IPreparedAgentHostEditAttributionFlush | undefined;
+		let deferSuppressedExternal = false;
 		const isDirty = this._textFileService.isDirty(this._doc.document.uri);
 		if (mode === 'longterm' && this._agentHostEditMarkerService) {
 			try {
@@ -220,9 +221,14 @@ class TrackedDocumentInfo extends Disposable {
 				);
 			} catch (error) {
 				this._logService.error(`[EditSourceTrackingImpl] Failed to prepare Agent Host edit attribution: ${error}`);
+				deferSuppressedExternal = error instanceof AgentHostEditAttributionDeferredError || error instanceof AgentHostEditAttributionUnknownOutcomeError;
 			}
 		}
 		if (preparedAgentFlush) {
+			t.applyPendingExternalEdits();
+			ranges = t.getTrackedRanges();
+			internalKeys = t.getAllKeys();
+			data = this.getTelemetryData(ranges);
 			try {
 				await preparedAgentFlush.commit(data.totalModifiedCharactersInFinalState + preparedAgentFlush.agentModifiedCount);
 			} catch (error) {
@@ -230,9 +236,10 @@ class TrackedDocumentInfo extends Disposable {
 				if (!(error instanceof AgentHostEditAttributionUnknownOutcomeError)) {
 					preparedAgentFlush = undefined;
 				}
+				deferSuppressedExternal = error instanceof AgentHostEditAttributionDeferredError || error instanceof AgentHostEditAttributionUnknownOutcomeError;
 			}
 		}
-		const includeSuppressedExternal = !preparedAgentFlush && !isDirty && mode === 'longterm' && !!this._agentHostEditMarkerService;
+		const includeSuppressedExternal = !preparedAgentFlush && !deferSuppressedExternal && !isDirty && mode === 'longterm' && !!this._agentHostEditMarkerService;
 		if (includeSuppressedExternal) {
 			ranges = t.getTrackedRanges(undefined, true);
 			internalKeys = t.getAllKeys(true);

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
@@ -8,8 +8,12 @@ import { IntervalTimer } from '../../../../../base/common/async.js';
 import { toDisposable, Disposable } from '../../../../../base/common/lifecycle.js';
 import { mapObservableArrayCached, derived, IObservable, observableSignal, runOnChange, autorun } from '../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { EditTelemetryMode, EditTelemetryTrigger, sendEditSourcesDetailsTelemetry } from '../../../../../platform/telemetry/common/editTelemetry.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
 import { IUserAttentionService } from '../../../../services/userAttention/common/userAttentionService.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 import { AnnotatedDocument, IAnnotatedDocuments } from '../helpers/annotatedDocuments.js';
 import { CreateSuggestionIdForChatOrInlineChatCaller, EditTelemetryReportEditArcForChatOrInlineChatSender, EditTelemetryReportInlineEditArcSender } from './arcTelemetrySender.js';
 import { createDocWithJustReason, EditSource } from '../helpers/documentWithAnnotatedEdits.js';
@@ -17,9 +21,7 @@ import { DocumentEditSourceTracker, TrackedEdit } from './editTracker.js';
 import { sumByCategory } from '../helpers/utils.js';
 import { IScmRepoAdapter, ScmAdapter } from './scmAdapter.js';
 import { IRandomService } from '../randomService.js';
-
-type EditTelemetryMode = 'longterm' | '10minFocusWindow' | '20minFocusWindow';
-type EditTelemetryTrigger = '10hours' | 'hashChange' | 'branchChange' | 'closed' | 'time';
+import { AgentHostEditAttributionUnknownOutcomeError, IAgentHostEditMarkerService, IPreparedAgentHostEditAttributionFlush } from './agentHostEditMarkerService.js';
 
 export type EditTelemetryCategory = 'nes' | 'inlineCompletionsCopilot' | 'inlineCompletionsNES' | 'inlineCompletionsOther' | 'otherAI' | 'user' | 'ide' | 'external' | 'unknown';
 
@@ -45,13 +47,14 @@ export class EditSourceTrackingImpl extends Disposable {
 	constructor(
 		private readonly _statsEnabled: IObservable<boolean>,
 		private readonly _annotatedDocuments: IAnnotatedDocuments,
+		private readonly _agentHostEditMarkerService: IAgentHostEditMarkerService | undefined,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
 
 		const scmBridge = this._instantiationService.createInstance(ScmAdapter);
 		this._states = mapObservableArrayCached(this, this._annotatedDocuments.documents, (doc, store) => {
-			return [doc.document, store.add(this._instantiationService.createInstance(TrackedDocumentInfo, doc, scmBridge, this._statsEnabled))] as const;
+			return [doc.document, store.add(this._instantiationService.createInstance(TrackedDocumentInfo, doc, scmBridge, this._statsEnabled, this._agentHostEditMarkerService))] as const;
 		});
 		this.docsState = this._states.map((entries) => new Map(entries));
 
@@ -70,16 +73,20 @@ class TrackedDocumentInfo extends Disposable {
 		private readonly _doc: AnnotatedDocument,
 		private readonly _scm: ScmAdapter,
 		private readonly _statsEnabled: IObservable<boolean>,
+		private readonly _agentHostEditMarkerService: IAgentHostEditMarkerService | undefined,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IRandomService private readonly _randomService: IRandomService,
 		@IUserAttentionService private readonly _userAttentionService: IUserAttentionService,
+		@ITextFileService private readonly _textFileService: ITextFileService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 
 		this._repo = derived(this, reader => this._scm.getRepo(_doc.document.uri, reader));
 
 		const docWithJustReason = createDocWithJustReason(_doc.documentWithAnnotations, this._store);
+		const externalEditCorrelation = this._agentHostEditMarkerService?.createCorrelation(_doc.document.uri);
 
 		const longtermResetSignal = observableSignal('resetSignal');
 
@@ -88,14 +95,12 @@ class TrackedDocumentInfo extends Disposable {
 			if (!this._statsEnabled.read(reader)) { return undefined; }
 			longtermResetSignal.read(reader);
 
-			const t = reader.store.add(new DocumentEditSourceTracker(docWithJustReason, undefined));
+			const t = reader.store.add(new DocumentEditSourceTracker(docWithJustReason, undefined, externalEditCorrelation));
 			const startFocusTime = this._userAttentionService.totalFocusTimeMs;
 			const startTime = Date.now();
 			reader.store.add(toDisposable(() => {
 				// send long term document telemetry
-				if (!t.isEmpty()) {
-					this.sendTelemetry('longterm', longtermReason, t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
-				}
+				this._sendTelemetryAndLog('longterm', longtermReason, t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
 				t.dispose();
 			}));
 			return t;
@@ -150,7 +155,7 @@ class TrackedDocumentInfo extends Disposable {
 			const startTime = Date.now();
 			reader.store.add(toDisposable(async () => {
 				// send windowed document telemetry
-				this.sendTelemetry('10minFocusWindow', 'time', t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
+				this._sendTelemetryAndLog('10minFocusWindow', 'time', t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
 				t.dispose();
 			}));
 
@@ -178,7 +183,7 @@ class TrackedDocumentInfo extends Disposable {
 			const startTime = Date.now();
 			reader.store.add(toDisposable(async () => {
 				// send focus-windowed document telemetry
-				this.sendTelemetry('20minFocusWindow', 'time', t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
+				this._sendTelemetryAndLog('20minFocusWindow', 'time', t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
 				t.dispose();
 			}));
 
@@ -187,89 +192,105 @@ class TrackedDocumentInfo extends Disposable {
 
 	}
 
+	private _sendTelemetryAndLog(mode: EditTelemetryMode, trigger: EditTelemetryTrigger, tracker: DocumentEditSourceTracker, focusTime: number, actualTime: number): void {
+		void this.sendTelemetry(mode, trigger, tracker, focusTime, actualTime).catch(error => {
+			this._logService.error(`[EditSourceTrackingImpl] Failed to send ${mode} edit telemetry: ${error}`);
+		});
+	}
+
 	async sendTelemetry(mode: EditTelemetryMode, trigger: EditTelemetryTrigger, t: DocumentEditSourceTracker, focusTime: number, actualTime: number) {
-		const ranges = t.getTrackedRanges();
-		const keys = t.getAllKeys();
-		if (keys.length === 0) {
-			return;
-		}
-
-		const data = this.getTelemetryData(ranges);
-
+		t.applyPendingExternalEdits();
+		let ranges = t.getTrackedRanges();
+		let internalKeys = t.getAllKeys();
+		let data = this.getTelemetryData(ranges);
 		const statsUuid = this._randomService.generateUuid();
-
-		const sums = sumByCategory(ranges, r => r.range.length, r => r.sourceKey);
-		for (const key of keys) {
-			if (!sums[key]) {
-				sums[key] = 0;
+		let preparedAgentFlush: IPreparedAgentHostEditAttributionFlush | undefined;
+		if (mode === 'longterm' && this._agentHostEditMarkerService) {
+			try {
+				preparedAgentFlush = await this._agentHostEditMarkerService.prepareFlush(
+					this._doc.document.uri,
+					trigger,
+					statsUuid,
+					this._textFileService.isDirty(this._doc.document.uri),
+					this._doc.document.languageId.get(),
+				);
+			} catch (error) {
+				this._logService.error(`[EditSourceTrackingImpl] Failed to prepare Agent Host edit attribution: ${error}`);
 			}
 		}
+		if (preparedAgentFlush) {
+			try {
+				await preparedAgentFlush.commit(data.totalModifiedCharactersInFinalState + preparedAgentFlush.agentModifiedCount);
+			} catch (error) {
+				this._logService.error(`[EditSourceTrackingImpl] Failed to commit Agent Host edit attribution: ${error}`);
+				if (!(error instanceof AgentHostEditAttributionUnknownOutcomeError)) {
+					preparedAgentFlush = undefined;
+				}
+			}
+		}
+		const includeSuppressedExternal = !preparedAgentFlush && mode === 'longterm' && !!this._agentHostEditMarkerService;
+		if (includeSuppressedExternal) {
+			ranges = t.getTrackedRanges(undefined, true);
+			internalKeys = t.getAllKeys(true);
+			data = this.getTelemetryData(ranges);
+		}
+		const agentModifiedCount = preparedAgentFlush?.agentModifiedCount ?? 0;
+		if (internalKeys.length === 0 && agentModifiedCount === 0) {
+			return;
+		}
+		const totalModifiedCount = data.totalModifiedCharactersInFinalState + agentModifiedCount;
+
+		const telemetryKeys = new Map<string, {
+			readonly representative: TextModelEditSource;
+			modifiedCount: number;
+			deltaModifiedCount: number;
+		}>();
+		for (const internalKey of internalKeys) {
+			const representative = t.getRepresentative(internalKey)!;
+			const telemetryKey = representative.toKey(1);
+			const entry = telemetryKeys.get(telemetryKey) ?? {
+				representative,
+				modifiedCount: 0,
+				deltaModifiedCount: 0,
+			};
+			entry.deltaModifiedCount += t.getTotalInsertedCharactersCount(internalKey, includeSuppressedExternal);
+			telemetryKeys.set(telemetryKey, entry);
+		}
+		for (const range of ranges) {
+			const representative = t.getRepresentative(range.sourceKey)!;
+			const entry = telemetryKeys.get(representative.toKey(1));
+			if (entry) {
+				entry.modifiedCount += range.range.length;
+			}
+		}
+		const sums = Object.fromEntries(Array.from(telemetryKeys, ([key, value]) => [key, value.modifiedCount]));
 		const entries = Object.entries(sums)
 			.filter((entry): entry is [string, number] => entry[1] !== undefined)
 			.sort(reverseOrder(compareBy(([, value]) => value, numberComparator)))
 			.slice(0, mode === 'longterm' ? 30 : 10);
 
 		for (const [key, value] of entries) {
-			const repr = t.getRepresentative(key)!;
-			const deltaModifiedCount = t.getTotalInsertedCharactersCount(key);
+			const telemetryEntry = telemetryKeys.get(key)!;
+			const repr = telemetryEntry.representative;
+			const deltaModifiedCount = telemetryEntry.deltaModifiedCount;
 
-			this._telemetryService.publicLog2<{
-				mode: EditTelemetryMode;
-				sourceKey: string;
-
-				sourceKeyCleaned: string;
-				extensionId: string | undefined;
-				extensionVersion: string | undefined;
-				modelId: string | undefined;
-
-				trigger: EditTelemetryTrigger;
-				languageId: string;
-				statsUuid: string;
-				conversationId: string | undefined;
-				requestId: string | undefined;
-				modifiedCount: number;
-				deltaModifiedCount: number;
-				totalModifiedCount: number;
-			}, {
-				owner: 'hediet';
-				comment: 'Provides detailed character count breakdown for individual edit sources (typing, paste, inline completions, NES, etc.) within a session. Reports the top 10-30 sources per session with granular metadata including extension IDs and model IDs for AI edits. Sessions are scoped to either 10-minute or 20-minute focus time windows for visible documents, or longer periods ending on branch changes, commits, or 10-hour intervals. Focus time is computed as the accumulated time where VS Code has focus and there was recent user activity (within the last minute). This event complements editSources.stats by providing source-specific details. @sentToGitHub';
-
-				mode: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Describes the session mode. Is either \'longterm\', \'10minFocusWindow\', or \'20minFocusWindow\'.' };
-				sourceKey: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'A description of the source of the edit.' };
-
-				sourceKeyCleaned: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The source of the edit with some properties (such as extensionId, extensionVersion and modelId) removed.' };
-				extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension id.' };
-				extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension.' };
-				modelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The LLM id.' };
-
-				languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language id of the document.' };
-				statsUuid: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The unique identifier of the session for which stats are reported. The sourceKey is unique in this session.' };
-				conversationId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat conversation identifier when the edit source comes from chat. Sourced from the chat edit session id.' };
-				requestId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat request identifier when the edit source comes from chat.' };
-
-				trigger: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Indicates why the session ended.' };
-
-				modifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by the given edit source during the session that are still in the text document at the end of the session.'; isMeasurement: true };
-				deltaModifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by the given edit source during the session.'; isMeasurement: true };
-				totalModifiedCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The number of characters inserted by any edit source during the session that are still in the text document at the end of the session.'; isMeasurement: true };
-
-			}>('editTelemetry.editSources.details', {
+			sendEditSourcesDetailsTelemetry(this._telemetryService, {
 				mode,
 				sourceKey: key,
-
 				sourceKeyCleaned: repr.toKey(1, { $extensionId: false, $extensionVersion: false, $modelId: false }),
 				extensionId: repr.props.$extensionId,
 				extensionVersion: repr.props.$extensionVersion,
 				modelId: repr.props.$modelId,
-
 				trigger,
 				languageId: this._doc.document.languageId.get(),
 				statsUuid: statsUuid,
 				conversationId: repr.props.$$sessionId,
 				requestId: repr.props.$$requestId,
+				origin: undefined,
+				harness: undefined,
 				modifiedCount: value,
 				deltaModifiedCount: deltaModifiedCount,
-				totalModifiedCount: data.totalModifiedCharactersInFinalState,
+				totalModifiedCount,
 			});
 		}
 
@@ -320,11 +341,11 @@ class TrackedDocumentInfo extends Disposable {
 			nesModifiedCount: data.nesModifiedCount,
 			inlineCompletionsCopilotModifiedCount: data.inlineCompletionsCopilotModifiedCount,
 			inlineCompletionsNESModifiedCount: data.inlineCompletionsNESModifiedCount,
-			otherAIModifiedCount: data.otherAIModifiedCount,
+			otherAIModifiedCount: data.otherAIModifiedCount + agentModifiedCount,
 			unknownModifiedCount: data.unknownModifiedCount,
 			userModifiedCount: data.userModifiedCount,
 			ideModifiedCount: data.ideModifiedCount,
-			totalModifiedCharacters: data.totalModifiedCharactersInFinalState,
+			totalModifiedCharacters: totalModifiedCount,
 			externalModifiedCount: data.externalModifiedCount,
 			isTrackedByGit: isTrackedByGit ? 1 : 0,
 			focusTime,

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editTracker.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editTracker.ts
@@ -4,12 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { observableSignal, runOnChange, IReader } from '../../../../../base/common/observable.js';
 import { AnnotatedStringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
 import { IDocumentWithAnnotatedEdits, EditKeySourceData, EditSource } from '../helpers/documentWithAnnotatedEdits.js';
+import { IExternalEditCorrelation } from './agentHostEditMarkerService.js';
+
+const EXTERNAL_OBSERVATION_KEY_PREFIX = 'external-observation:';
 
 /**
  * Tracks a single document.
@@ -21,19 +24,36 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 	private readonly _update = observableSignal(this);
 	private readonly _representativePerKey: Map<string, TextModelEditSource> = new Map();
 	private readonly _sumAddedCharactersPerKey: Map</* key */string, number> = new Map();
+	private readonly _externalObservationIds = new Set<string>();
+	private readonly _ignoredInitialExternalObservationIds = new Set<string>();
+	private readonly _suppressedExternalObservationIds = new Set<string>();
+	private readonly _invalidatedExternalObservationIds = new Set<string>();
 
 	constructor(
 		private readonly _doc: IDocumentWithAnnotatedEdits,
 		public readonly data: T,
+		private readonly _externalEditCorrelation?: IExternalEditCorrelation,
 	) {
 		super();
 
 		this._register(runOnChange(this._doc.value, (_val, _prevVal, edits) => {
-			const eComposed = AnnotatedStringEdit.compose(edits.map(e => e.edit));
+			let eComposed = AnnotatedStringEdit.compose(edits.map(e => e.edit));
 			if (eComposed.replacements.every(e => e.data.source.category === 'external')) {
-				if (this._edits.isEmpty()) {
+				if (this._edits.isEmpty() && !this._externalEditCorrelation) {
 					// Ignore initial external edits
 				} else {
+					if (this._externalEditCorrelation) {
+						const observationId = this._externalEditCorrelation.register(_prevVal.value, _val.value);
+						this._externalObservationIds.add(observationId);
+						if (this._externalEditCorrelation.isSuppressed(observationId)) {
+							this._suppressedExternalObservationIds.add(observationId);
+						}
+						if (this._edits.isEmpty()) {
+							this._ignoredInitialExternalObservationIds.add(observationId);
+						}
+						const key = `${EXTERNAL_OBSERVATION_KEY_PREFIX}${observationId}`;
+						eComposed = eComposed.mapData(replacement => new EditKeySourceData(key, replacement.data.source, replacement.data.representative));
+					}
 					// queue pending external edits
 					this._pendingExternalEdits = this._pendingExternalEdits.compose(eComposed);
 				}
@@ -47,6 +67,26 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 
 			this._update.trigger(undefined);
 		}));
+		if (this._externalEditCorrelation) {
+			this._register(this._externalEditCorrelation.onDidSuppress(observationId => {
+				if (this._externalObservationIds.has(observationId)) {
+					this._suppressedExternalObservationIds.add(observationId);
+					this._update.trigger(undefined);
+				}
+			}));
+			this._register(this._externalEditCorrelation.onDidInvalidate(observationId => {
+				if (this._externalObservationIds.has(observationId)) {
+					this._suppressedExternalObservationIds.delete(observationId);
+					this._invalidatedExternalObservationIds.add(observationId);
+					this._update.trigger(undefined);
+				}
+			}));
+			this._register(toDisposable(() => {
+				for (const observationId of this._externalObservationIds) {
+					this._externalEditCorrelation?.release(observationId);
+				}
+			}));
+		}
 	}
 
 	private _applyEdit(e: AnnotatedStringEdit<EditKeySourceData>): void {
@@ -67,31 +107,58 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 		await this._doc.waitForQueue();
 	}
 
-	public getTotalInsertedCharactersCount(key: string): number {
+	public getTotalInsertedCharactersCount(key: string, includeSuppressed = false): number {
+		if (!this._shouldIncludeKey(key, includeSuppressed)) {
+			return 0;
+		}
 		const val = this._sumAddedCharactersPerKey.get(key);
 		return val ?? 0;
 	}
 
-	public getAllKeys(): string[] {
-		return Array.from(this._sumAddedCharactersPerKey.keys());
+	public getAllKeys(includeSuppressed = false): string[] {
+		return Array.from(this._sumAddedCharactersPerKey.keys()).filter(key => this._shouldIncludeKey(key, includeSuppressed));
 	}
 
 	public getRepresentative(key: string): TextModelEditSource | undefined {
 		return this._representativePerKey.get(key);
 	}
 
-	public getTrackedRanges(reader?: IReader): TrackedEdit[] {
+	public applyPendingExternalEdits(): void {
+		if (this._pendingExternalEdits.isEmpty()) {
+			return;
+		}
+		this._applyEdit(this._pendingExternalEdits);
+		this._pendingExternalEdits = AnnotatedStringEdit.empty;
+		this._update.trigger(undefined);
+	}
+
+	public getTrackedRanges(reader?: IReader, includeSuppressed = false): TrackedEdit[] {
 		this._update.read(reader);
 		const ranges = this._edits.getNewRanges();
 		return ranges.map((r, idx) => {
 			const e = this._edits.replacements[idx];
 			const te = new TrackedEdit(e.replaceRange, r, e.data.key, e.data.source, e.data.representative);
 			return te;
-		});
+		}).filter(edit => this._shouldIncludeKey(edit.sourceKey, includeSuppressed));
 	}
 
 	public isEmpty(): boolean {
-		return this._edits.isEmpty();
+		return this.getAllKeys().length === 0;
+	}
+
+	private _shouldIncludeKey(key: string, includeSuppressed: boolean): boolean {
+		if (!key.startsWith(EXTERNAL_OBSERVATION_KEY_PREFIX)) {
+			return true;
+		}
+		const observationId = key.substring(EXTERNAL_OBSERVATION_KEY_PREFIX.length);
+		if (this._invalidatedExternalObservationIds.has(observationId)) {
+			return true;
+		}
+		const isSuppressed = this._suppressedExternalObservationIds.has(observationId);
+		if (this._ignoredInitialExternalObservationIds.has(observationId)) {
+			return includeSuppressed && isSuppressed;
+		}
+		return includeSuppressed || !isSuppressed;
 	}
 
 	public _getDebugVisualization() {

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editTracker.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editTracker.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { Disposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { observableSignal, runOnChange, IReader } from '../../../../../base/common/observable.js';
 import { AnnotatedStringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
@@ -81,12 +81,14 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 					this._update.trigger(undefined);
 				}
 			}));
-			this._register(toDisposable(() => {
-				for (const observationId of this._externalObservationIds) {
-					this._externalEditCorrelation?.release(observationId);
-				}
-			}));
 		}
+	}
+
+	public releaseExternalEditCorrelations(): void {
+		for (const observationId of this._externalObservationIds) {
+			this._externalEditCorrelation?.release(observationId);
+		}
+		this._externalObservationIds.clear();
 	}
 
 	private _applyEdit(e: AnnotatedStringEdit<EditKeySourceData>): void {

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
@@ -1,0 +1,357 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { extUri } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
+import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { IAgentHostConnectionsService } from '../../../../../platform/agentHost/common/agentHostConnectionsService.js';
+import { toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { AttributedToolResultFileEditContent, createFileEditContentDigest, EditAttributionFlushOutcome, FILE_EDIT_ATTRIBUTION_PROPERTY, IFileEditAttributionMarker, parseEditAttributionResource } from '../../../../../platform/agentHost/common/fileEditAttribution.js';
+import { ActionType } from '../../../../../platform/agentHost/common/state/protocol/common/actions.js';
+import { ContentEncoding } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
+import { ActionEnvelope } from '../../../../../platform/agentHost/common/state/sessionActions.js';
+import { ToolResultContentType } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { AgentHostEditMarkerService } from '../../browser/telemetry/agentHostEditMarkerService.js';
+
+suite('Agent Host Edit Marker Service', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('suppresses marker-first and reload-first observations', () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+
+		context.fireMarker(marker(1, 'a', 'ab'));
+		const markerFirst = correlation.register('a', 'ab');
+		const reloadFirst = correlation.register('ab', 'abc');
+		context.fireMarker(marker(2, 'ab', 'abc'));
+
+		assert.deepStrictEqual({
+			markerFirst: correlation.isSuppressed(markerFirst),
+			reloadFirst: correlation.isSuppressed(reloadFirst),
+			suppressedIds: context.suppressedIds,
+		}, {
+			markerFirst: true,
+			reloadFirst: true,
+			suppressedIds: [markerFirst, reloadFirst],
+		});
+	});
+
+	test('matches a connected Agent marker chain to one reload', () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+		context.fireMarker(marker(2, 'ab', 'abc'));
+
+		const observation = correlation.register('a', 'abc');
+
+		assert.deepStrictEqual({
+			suppressed: correlation.isSuppressed(observation),
+			suppressedIds: context.suppressedIds,
+		}, {
+			suppressed: true,
+			suppressedIds: [observation],
+		});
+	});
+
+	test('does not reuse a completed Agent content cycle', () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+		context.fireMarker(marker(2, 'ab', 'a'));
+
+		const unrelatedObservation = correlation.register('a', 'ab');
+
+		assert.deepStrictEqual({
+			suppressed: correlation.isSuppressed(unrelatedObservation),
+			suppressedIds: context.suppressedIds,
+		}, {
+			suppressed: false,
+			suppressedIds: [],
+		});
+	});
+
+	test('invalidates old suppressions when the Agent Host sequence restarts', () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		context.fireMarker(marker(5, 'a', 'ab'));
+		const oldObservation = correlation.register('a', 'ab');
+
+		context.fireMarker(marker(1, 'ab', 'abc'));
+		const newObservation = correlation.register('ab', 'abc');
+
+		assert.deepStrictEqual({
+			oldSuppressed: correlation.isSuppressed(oldObservation),
+			newSuppressed: correlation.isSuppressed(newObservation),
+			invalidatedIds: context.invalidatedIds,
+		}, {
+			oldSuppressed: false,
+			newSuppressed: true,
+			invalidatedIds: [oldObservation],
+		});
+	});
+
+	test('does not suppress with an expired marker', () => runWithFakedTimers({}, async () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+		await timeout(5 * 60 * 1000 + 1);
+
+		const observation = correlation.register('a', 'ab');
+
+		assert.strictEqual(correlation.isSuppressed(observation), false);
+	}));
+
+	test('matches ambient remote model URIs to Agent Host file markers', () => {
+		const context = createContext();
+		const remoteResource = URI.from({
+			scheme: Schemas.vscodeRemote,
+			authority: 'ssh-remote+example',
+			path: context.resource.path,
+		});
+		const correlation = context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+
+		const observation = correlation.register('a', 'ab');
+
+		assert.strictEqual(correlation.isSuppressed(observation), true);
+	});
+
+	test('coordinates flushes through a non-ambient remote connection', async () => {
+		const context = createContext({ isAmbient: false, authority: 'remote-one' });
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+
+		const prepared = await context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+		await prepared?.commit(5);
+
+		assert.deepStrictEqual({
+			prepared: prepared && {
+				flushTokenLength: prepared.flushToken.length,
+				agentModifiedCount: prepared.agentModifiedCount,
+			},
+			resourceReads: context.resourceReads,
+		}, {
+			prepared: {
+				flushTokenLength: 36,
+				agentModifiedCount: 2,
+			},
+			resourceReads: ['/prepare', '/commit'],
+		});
+	});
+
+	test('cancels a prepared flush when the commit transport fails', async () => {
+		const context = createContext({ isAmbient: false, authority: 'remote-one', failCommit: true });
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+
+		const prepared = await context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+		await assert.rejects(() => prepared!.commit(5), /Commit failed/);
+
+		assert.deepStrictEqual(context.resourceReads, ['/prepare', '/commit', '/cancel']);
+	});
+
+	test('times out a stalled prepare request', () => runWithFakedTimers({}, async () => {
+		const context = createContext({ isAmbient: false, authority: 'remote-one', stalledResources: ['/prepare'] });
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+
+		const result = context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+		await timeout(15_001);
+
+		await assert.rejects(result, /request timed out: \/prepare/);
+		assert.deepStrictEqual(context.resourceReads, ['/prepare', '/cancel']);
+	}));
+
+	test('uses a committed cancellation result after prepare fails', async () => {
+		const context = createContext({
+			isAmbient: false,
+			authority: 'remote-one',
+			failPrepare: true,
+			cancelOutcome: 'committed',
+		});
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+
+		const prepared = await context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+		await prepared!.commit(5);
+
+		assert.deepStrictEqual({
+			agentModifiedCount: prepared?.agentModifiedCount,
+			resourceReads: context.resourceReads,
+		}, {
+			agentModifiedCount: 2,
+			resourceReads: ['/prepare', '/cancel'],
+		});
+	});
+
+	test('times out a stalled commit request and cancels the flush', () => runWithFakedTimers({}, async () => {
+		const context = createContext({ isAmbient: false, authority: 'remote-one', stalledResources: ['/commit'] });
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+		const prepared = await context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+
+		const result = prepared!.commit(5);
+		await timeout(15_001);
+
+		await assert.rejects(result, /request timed out: \/commit/);
+		assert.deepStrictEqual(context.resourceReads, ['/prepare', '/commit', '/cancel']);
+	}));
+
+	test('accepts a commit that completed before cancellation', async () => {
+		const context = createContext({ isAmbient: false, authority: 'remote-one', failCommit: true, cancelOutcome: 'committed' });
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+		const prepared = await context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+
+		await prepared!.commit(5);
+
+		assert.deepStrictEqual(context.resourceReads, ['/prepare', '/commit', '/cancel']);
+	});
+
+	test('does not fall back when commit and cancellation outcomes are unknown', () => runWithFakedTimers({}, async () => {
+		const context = createContext({
+			isAmbient: false,
+			authority: 'remote-one',
+			stalledResources: ['/commit', '/cancel'],
+		});
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+		const prepared = await context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+
+		const result = prepared!.commit(5);
+		await timeout(15_001);
+		await timeout(15_001);
+
+		await assert.rejects(result, /outcome is unknown/);
+	}));
+
+	function createContext(options: {
+		readonly isAmbient?: boolean;
+		readonly authority?: string;
+		readonly failPrepare?: boolean;
+		readonly failCommit?: boolean;
+		readonly stalledResources?: readonly string[];
+		readonly cancelOutcome?: EditAttributionFlushOutcome;
+	} = {}) {
+		const {
+			isAmbient = true,
+			authority = 'local',
+			failPrepare = false,
+			failCommit = false,
+			stalledResources = [],
+			cancelOutcome = 'cancelled',
+		} = options;
+		const actionEmitter = disposables.add(new Emitter<ActionEnvelope>());
+		const resourceReads: string[] = [];
+		const instantiationService = disposables.add(new TestInstantiationService());
+		const connection = instantiationService.stub(IAgentHostService, {
+			onDidAction: actionEmitter.event,
+			async resourceRead(resource: URI) {
+				resourceReads.push(resource.path);
+				if (stalledResources.includes(resource.path)) {
+					return new Promise<never>(() => { });
+				}
+				if (failPrepare && resource.path === '/prepare') {
+					throw new Error('Prepare failed');
+				}
+				if (failCommit && resource.path === '/commit') {
+					throw new Error('Commit failed');
+				}
+				const request = parseEditAttributionResource(resource);
+				return {
+					data: resource.path === '/prepare'
+						? JSON.stringify({
+							flushToken: request?.kind === 'prepare' ? request.params.flushToken : '',
+							agentModifiedCount: 2,
+						})
+						: JSON.stringify({
+							outcome: resource.path === '/commit' ? 'committed' : cancelOutcome,
+							agentModifiedCount: resource.path === '/commit' || cancelOutcome === 'committed' ? 2 : 0,
+						}),
+					encoding: ContentEncoding.Utf8,
+				};
+			},
+		});
+		instantiationService.stub(IAgentHostConnectionsService, {
+			onDidChangeConnections: Event.None,
+			connections: [{
+				authority,
+				address: isAmbient ? undefined : 'remote',
+				name: isAmbient ? 'Local' : 'Remote',
+				isAmbient,
+				connection,
+			}],
+		});
+		instantiationService.stub(IUriIdentityService, { extUri, asCanonicalUri: resource => resource });
+		const service = disposables.add(instantiationService.createInstance(AgentHostEditMarkerService));
+		const resource = URI.file('C:\\repo\\file.ts');
+		const suppressedIds: string[] = [];
+		const invalidatedIds: string[] = [];
+		const correlation = service.createCorrelation(resource);
+		disposables.add(correlation.onDidSuppress(id => suppressedIds.push(id)));
+		disposables.add(correlation.onDidInvalidate(id => invalidatedIds.push(id)));
+		return {
+			resource,
+			service,
+			suppressedIds,
+			invalidatedIds,
+			resourceReads,
+			fireMarker(attribution: IFileEditAttributionMarker) {
+				const content: AttributedToolResultFileEditContent = {
+					type: ToolResultContentType.FileEdit,
+					before: {
+						uri: resource.toString(),
+						content: { uri: 'session-db:/before' },
+					},
+					after: {
+						uri: resource.toString(),
+						content: { uri: 'session-db:/after' },
+					},
+					[FILE_EDIT_ATTRIBUTION_PROPERTY]: attribution,
+				};
+				actionEmitter.fire({
+					channel: 'ahp-chat:copilot%3A%2Fsession',
+					serverSeq: attribution.sequence,
+					origin: undefined,
+					action: {
+						type: ActionType.ChatToolCallComplete,
+						turnId: 'turn-1',
+						toolCallId: `tool-${attribution.sequence}`,
+						result: {
+							success: true,
+							pastTenseMessage: '',
+							content: [content],
+						},
+					},
+				});
+			},
+		};
+	}
+});
+
+function marker(sequence: number, before: string, after: string): IFileEditAttributionMarker {
+	return {
+		version: 1,
+		editId: `edit-${sequence}`,
+		sequence,
+		beforeDigest: createFileEditContentDigest(before),
+		afterDigest: createFileEditContentDigest(after),
+	};
+}

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
@@ -46,6 +46,47 @@ suite('Agent Host Edit Marker Service', () => {
 		});
 	});
 
+	test('records oversized Agent edits as coverage gaps without suppressing reloads', () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		context.fireMarker({
+			version: 1,
+			editId: 'edit-skipped',
+			sequence: 1,
+			status: 'skipped',
+			reason: 'fileTooLarge',
+			insertedCount: 42,
+		});
+
+		const observation = correlation.register('a', 'ab');
+
+		assert.deepStrictEqual({
+			suppressed: correlation.isSuppressed(observation),
+			coverageGap: context.service.takeCoverageGap(context.resource),
+		}, {
+			suppressed: false,
+			coverageGap: {
+				editCount: 1,
+				insertedCount: 42,
+			},
+		});
+	});
+
+	test('does not report expired coverage gaps', () => runWithFakedTimers({}, async () => {
+		const context = createContext();
+		context.fireMarker({
+			version: 1,
+			editId: 'edit-skipped',
+			sequence: 1,
+			status: 'skipped',
+			reason: 'fileTooLarge',
+			insertedCount: 42,
+		});
+		await timeout(10 * 60 * 60 * 1000 + 1);
+
+		assert.strictEqual(context.service.takeCoverageGap(context.resource), undefined);
+	}));
+
 	test('matches a connected Agent marker chain to one reload', () => {
 		const context = createContext();
 		const correlation = context.service.createCorrelation(context.resource);

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
@@ -21,7 +21,7 @@ import { ActionEnvelope } from '../../../../../platform/agentHost/common/state/s
 import { ToolResultContentType } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
-import { AgentHostEditMarkerService } from '../../browser/telemetry/agentHostEditMarkerService.js';
+import { AgentHostEditAttributionDeferredError, AgentHostEditMarkerService } from '../../browser/telemetry/agentHostEditMarkerService.js';
 
 suite('Agent Host Edit Marker Service', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -152,6 +152,28 @@ suite('Agent Host Edit Marker Service', () => {
 		assert.strictEqual(correlation.isSuppressed(observation), false);
 	}));
 
+	test('does not coordinate with an expired route', () => runWithFakedTimers({}, async () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+		const observation = correlation.register('a', 'ab');
+		await timeout(10 * 60 * 60 * 1000 + 1);
+
+		const prepared = await context.service.prepareFlush(context.resource, 'hashChange', 'stats-1', false);
+
+		assert.deepStrictEqual({
+			prepared,
+			suppressed: correlation.isSuppressed(observation),
+			invalidatedIds: context.invalidatedIds,
+			resourceReads: context.resourceReads,
+		}, {
+			prepared: undefined,
+			suppressed: false,
+			invalidatedIds: [observation],
+			resourceReads: [],
+		});
+	}));
+
 	test('matches ambient remote model URIs to Agent Host file markers', () => {
 		const context = createContext();
 		const remoteResource = URI.from({
@@ -191,6 +213,26 @@ suite('Agent Host Edit Marker Service', () => {
 		});
 	});
 
+	test('waits for the prepared Agent marker before coordinating', async () => {
+		const context = createContext({ isAmbient: false, authority: 'remote-one', prepareSequence: 2 });
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+
+		const prepare = context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+		await timeout(0);
+		context.fireMarker(marker(2, 'ab', 'abc'));
+		const prepared = await prepare;
+
+		assert.deepStrictEqual({
+			agentModifiedCount: prepared?.agentModifiedCount,
+			resourceReads: context.resourceReads,
+		}, {
+			agentModifiedCount: 2,
+			resourceReads: ['/prepare'],
+		});
+	});
+
 	test('cancels a prepared flush when the commit transport fails', async () => {
 		const context = createContext({ isAmbient: false, authority: 'remote-one', failCommit: true });
 		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
@@ -198,7 +240,7 @@ suite('Agent Host Edit Marker Service', () => {
 		context.fireMarker(marker(1, 'a', 'ab'));
 
 		const prepared = await context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
-		await assert.rejects(() => prepared!.commit(5), /Commit failed/);
+		await assert.rejects(() => prepared!.commit(5), error => error instanceof AgentHostEditAttributionDeferredError);
 
 		assert.deepStrictEqual(context.resourceReads, ['/prepare', '/commit', '/cancel']);
 	});
@@ -212,7 +254,7 @@ suite('Agent Host Edit Marker Service', () => {
 		const result = context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
 		await timeout(15_001);
 
-		await assert.rejects(result, /request timed out: \/prepare/);
+		await assert.rejects(result, error => error instanceof AgentHostEditAttributionDeferredError);
 		assert.deepStrictEqual(context.resourceReads, ['/prepare', '/cancel']);
 	}));
 
@@ -239,6 +281,38 @@ suite('Agent Host Edit Marker Service', () => {
 		});
 	});
 
+	test('cancels a malformed prepared response', async () => {
+		const context = createContext({
+			isAmbient: false,
+			authority: 'remote-one',
+			prepareResponse: '{',
+		});
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+
+		const result = context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+
+		await assert.rejects(result, error => error instanceof AgentHostEditAttributionDeferredError);
+		assert.deepStrictEqual(context.resourceReads, ['/prepare', '/cancel']);
+	});
+
+	test('cancels a prepared response with an unexpected token', async () => {
+		const context = createContext({
+			isAmbient: false,
+			authority: 'remote-one',
+			prepareResponse: JSON.stringify({ flushToken: 'unexpected', agentModifiedCount: 2 }),
+		});
+		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
+		context.service.createCorrelation(remoteResource);
+		context.fireMarker(marker(1, 'a', 'ab'));
+
+		const result = context.service.prepareFlush(remoteResource, 'hashChange', 'stats-1', false);
+
+		await assert.rejects(result, error => error instanceof AgentHostEditAttributionDeferredError);
+		assert.deepStrictEqual(context.resourceReads, ['/prepare', '/cancel']);
+	});
+
 	test('times out a stalled commit request and cancels the flush', () => runWithFakedTimers({}, async () => {
 		const context = createContext({ isAmbient: false, authority: 'remote-one', stalledResources: ['/commit'] });
 		const remoteResource = toAgentHostUri(context.resource, 'remote-one');
@@ -249,7 +323,7 @@ suite('Agent Host Edit Marker Service', () => {
 		const result = prepared!.commit(5);
 		await timeout(15_001);
 
-		await assert.rejects(result, /request timed out: \/commit/);
+		await assert.rejects(result, error => error instanceof AgentHostEditAttributionDeferredError);
 		assert.deepStrictEqual(context.resourceReads, ['/prepare', '/commit', '/cancel']);
 	}));
 
@@ -290,6 +364,8 @@ suite('Agent Host Edit Marker Service', () => {
 		readonly failCommit?: boolean;
 		readonly stalledResources?: readonly string[];
 		readonly cancelOutcome?: EditAttributionFlushOutcome;
+		readonly prepareResponse?: string;
+		readonly prepareSequence?: number;
 	} = {}) {
 		const {
 			isAmbient = true,
@@ -298,6 +374,8 @@ suite('Agent Host Edit Marker Service', () => {
 			failCommit = false,
 			stalledResources = [],
 			cancelOutcome = 'cancelled',
+			prepareResponse,
+			prepareSequence,
 		} = options;
 		const actionEmitter = disposables.add(new Emitter<ActionEnvelope>());
 		const resourceReads: string[] = [];
@@ -318,9 +396,10 @@ suite('Agent Host Edit Marker Service', () => {
 				const request = parseEditAttributionResource(resource);
 				return {
 					data: resource.path === '/prepare'
-						? JSON.stringify({
+						? prepareResponse ?? JSON.stringify({
 							flushToken: request?.kind === 'prepare' ? request.params.flushToken : '',
 							agentModifiedCount: 2,
+							lastSequence: prepareSequence,
 						})
 						: JSON.stringify({
 							outcome: resource.path === '/commit' ? 'committed' : cancelOutcome,

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
@@ -262,6 +262,36 @@ suite('Edit Source Tracking Windows', () => {
 		context.disposables.dispose();
 	}));
 
+	test('does not fall back matched Agent edits while the model is dirty', () => runWithFakedTimers({}, async () => {
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => true,
+				release: () => { },
+			}),
+			prepareFlush: async () => undefined,
+		};
+		const context = setup(undefined, markerService, true);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual({
+			detailCount: context.details.length,
+			statsCount: context.stats.length,
+		}, {
+			detailCount: 0,
+			statsCount: 0,
+		});
+
+		context.disposables.dispose();
+	}));
+
 	test('keeps unmatched reloads as standard external telemetry', () => runWithFakedTimers({}, async () => {
 		let observation = 0;
 		const markerService: IAgentHostEditMarkerService = {
@@ -290,6 +320,47 @@ suite('Edit Source Tracking Windows', () => {
 			sourceKeys: ['source:Chat.applyEdits', 'source:reloadFromDisk'],
 			hasInternalObservationKey: false,
 		});
+
+		context.disposables.dispose();
+	}));
+
+	test('reports partial Agent Host coverage without dropping workbench attribution', () => runWithFakedTimers({}, async () => {
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => false,
+				release: () => { },
+			}),
+			takeCoverageGap: () => ({
+				editCount: 1,
+				insertedCount: 42,
+			}),
+			prepareFlush: async () => undefined,
+		};
+		const context = setup(undefined, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'alpha', chatEdit('request-1')));
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('alpha'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual(context.stats.map(event => ({
+			externalModifiedCount: event.externalModifiedCount,
+			totalModifiedCharacters: event.totalModifiedCharacters,
+			agentHostAttributionCoverage: event.agentHostAttributionCoverage,
+			agentHostUntrackedEditCount: event.agentHostUntrackedEditCount,
+			agentHostUntrackedInsertedCount: event.agentHostUntrackedInsertedCount,
+		})), [{
+			externalModifiedCount: 8,
+			totalModifiedCharacters: 8,
+			agentHostAttributionCoverage: 'partial',
+			agentHostUntrackedEditCount: 1,
+			agentHostUntrackedInsertedCount: 42,
+		}]);
 
 		context.disposables.dispose();
 	}));
@@ -486,7 +557,15 @@ function setup(
 		isIgnored: async () => false,
 	} satisfies IScmRepoAdapter;
 	const details: Array<{ sourceKey: string; trigger: string; requestId: string | undefined; statsUuid: string; modifiedCount: number; deltaModifiedCount: number; totalModifiedCount: number }> = [];
-	const stats: Array<{ statsUuid: string; otherAIModifiedCount: number; externalModifiedCount: number; totalModifiedCharacters: number }> = [];
+	const stats: Array<{
+		statsUuid: string;
+		otherAIModifiedCount: number;
+		externalModifiedCount: number;
+		totalModifiedCharacters: number;
+		agentHostAttributionCoverage?: 'complete' | 'partial';
+		agentHostUntrackedEditCount?: number;
+		agentHostUntrackedInsertedCount?: number;
+	}> = [];
 	let uuid = 0;
 	const instantiationService = disposables.add(new TestInstantiationService(new ServiceCollection(), false, undefined, true));
 	instantiationService.stub(ITelemetryService, {

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { timeout } from '../../../../../base/common/async.js';
+import { Event } from '../../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { constObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -18,11 +19,13 @@ import { TestInstantiationService } from '../../../../../platform/instantiation/
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IUserAttentionService } from '../../../../services/userAttention/common/userAttentionService.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { AnnotatedDocuments, UriVisibilityProvider } from '../../browser/helpers/annotatedDocuments.js';
 import { DiffService } from '../../browser/helpers/documentWithAnnotatedEdits.js';
 import { StringEditWithReason } from '../../browser/helpers/observableWorkspace.js';
 import { IAiEditTelemetryService } from '../../browser/telemetry/aiEditTelemetry/aiEditTelemetryService.js';
 import { EditSourceTrackingImpl } from '../../browser/telemetry/editSourceTrackingImpl.js';
+import { AgentHostEditAttributionUnknownOutcomeError, IAgentHostEditMarkerService } from '../../browser/telemetry/agentHostEditMarkerService.js';
 import { IScmRepoAdapter, ScmAdapter } from '../../browser/telemetry/scmAdapter.js';
 import { IRandomService } from '../../browser/randomService.js';
 import { MutableObservableWorkspace } from './editTelemetry.test.js';
@@ -160,9 +163,320 @@ suite('Edit Source Tracking Windows', () => {
 
 		context.disposables.dispose();
 	}));
+
+	test('coordinates long-term totals with Agent Host attribution', () => runWithFakedTimers({}, async () => {
+		const commits: number[] = [];
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => false,
+				release: () => { },
+			}),
+			prepareFlush: async (_resource, trigger, statsUuid, isDirty) => isDirty || trigger !== 'hashChange' ? undefined : ({
+				flushToken: 'flush-1',
+				agentModifiedCount: 3,
+				commit: async totalModifiedCount => {
+					assert.strictEqual(statsUuid, 'stats-2');
+					commits.push(totalModifiedCount);
+				},
+			}),
+		};
+		const context = setup(undefined, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'alpha', chatEdit('request-1')));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual({
+			details: context.details.map(event => ({
+				statsUuid: event.statsUuid,
+				modifiedCount: event.modifiedCount,
+				totalModifiedCount: event.totalModifiedCount,
+			})),
+			stats: context.stats.map(event => ({
+				statsUuid: event.statsUuid,
+				otherAIModifiedCount: event.otherAIModifiedCount,
+				totalModifiedCharacters: event.totalModifiedCharacters,
+			})),
+			commits,
+		}, {
+			details: [{
+				statsUuid: 'stats-2',
+				modifiedCount: 5,
+				totalModifiedCount: 8,
+			}],
+			stats: [{
+				statsUuid: 'stats-2',
+				otherAIModifiedCount: 8,
+				totalModifiedCharacters: 8,
+			}],
+			commits: [8],
+		});
+
+		context.disposables.dispose();
+	}));
+
+	test('defers Agent Host attribution while the model is dirty', () => runWithFakedTimers({}, async () => {
+		const dirtyStates: boolean[] = [];
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => false,
+				release: () => { },
+			}),
+			prepareFlush: async (_resource, trigger, _statsUuid, isDirty) => {
+				if (trigger === 'hashChange') {
+					dirtyStates.push(isDirty);
+				}
+				return undefined;
+			},
+		};
+		const context = setup(undefined, markerService, true);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'alpha', chatEdit('request-1')));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual({
+			dirtyStates,
+			details: context.details.map(event => ({
+				modifiedCount: event.modifiedCount,
+				totalModifiedCount: event.totalModifiedCount,
+			})),
+		}, {
+			dirtyStates: [true],
+			details: [{
+				modifiedCount: 5,
+				totalModifiedCount: 5,
+			}],
+		});
+
+		context.disposables.dispose();
+	}));
+
+	test('keeps unmatched reloads as standard external telemetry', () => runWithFakedTimers({}, async () => {
+		let observation = 0;
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => `observation-${++observation}`,
+				isSuppressed: () => false,
+				release: () => { },
+			}),
+			prepareFlush: async () => undefined,
+		};
+		const context = setup(undefined, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'alpha', chatEdit('request-1')));
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('alpha'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual({
+			sourceKeys: context.details.map(event => event.sourceKey).sort(),
+			hasInternalObservationKey: context.details.some(event => event.sourceKey.startsWith('external-observation:')),
+		}, {
+			sourceKeys: ['source:Chat.applyEdits', 'source:reloadFromDisk'],
+			hasInternalObservationKey: false,
+		});
+
+		context.disposables.dispose();
+	}));
+
+	test('emits workbench telemetry when Agent Host coordination fails', () => runWithFakedTimers({}, async () => {
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => false,
+				release: () => { },
+			}),
+			prepareFlush: async () => {
+				throw new Error('Agent Host unavailable');
+			},
+		};
+		const context = setup(undefined, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'alpha', chatEdit('request-1')));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual(context.details.map(event => ({
+			modifiedCount: event.modifiedCount,
+			totalModifiedCount: event.totalModifiedCount,
+		})), [{
+			modifiedCount: 5,
+			totalModifiedCount: 5,
+		}]);
+
+		context.disposables.dispose();
+	}));
+
+	test('falls back to external telemetry when a matched Agent flush cannot prepare', () => runWithFakedTimers({}, async () => {
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => true,
+				release: () => { },
+			}),
+			prepareFlush: async () => {
+				throw new Error('Agent Host unavailable');
+			},
+		};
+		const context = setup(undefined, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'alpha', chatEdit('request-1')));
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('alpha'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual(context.details.map(event => event.sourceKey).sort(), [
+			'source:Chat.applyEdits',
+			'source:reloadFromDisk',
+		]);
+
+		context.disposables.dispose();
+	}));
+
+	test('falls back to a matched initial external edit when Agent Host is unavailable', () => runWithFakedTimers({}, async () => {
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => true,
+				release: () => { },
+			}),
+			prepareFlush: async () => {
+				throw new Error('Agent Host unavailable');
+			},
+		};
+		const context = setup(undefined, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual(context.details.map(event => ({
+			sourceKey: event.sourceKey,
+			modifiedCount: event.modifiedCount,
+			totalModifiedCount: event.totalModifiedCount,
+		})), [{
+			sourceKey: 'source:reloadFromDisk',
+			modifiedCount: 8,
+			totalModifiedCount: 8,
+		}]);
+
+		context.disposables.dispose();
+	}));
+
+	test('does not emit external fallback when the Agent Host commit outcome is unknown', () => runWithFakedTimers({}, async () => {
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => true,
+				release: () => { },
+			}),
+			prepareFlush: async () => ({
+				flushToken: 'flush-1',
+				agentModifiedCount: 3,
+				commit: async () => {
+					throw new AgentHostEditAttributionUnknownOutcomeError(new Error('Transport unavailable'));
+				},
+			}),
+		};
+		const context = setup(undefined, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual({
+			detailCount: context.details.length,
+			stats: context.stats.map(event => ({
+				otherAIModifiedCount: event.otherAIModifiedCount,
+				externalModifiedCount: event.externalModifiedCount,
+				totalModifiedCharacters: event.totalModifiedCharacters,
+			})),
+		}, {
+			detailCount: 0,
+			stats: [{
+				otherAIModifiedCount: 3,
+				externalModifiedCount: 0,
+				totalModifiedCharacters: 3,
+			}],
+		});
+
+		context.disposables.dispose();
+	}));
+
+	test('commits zero-retention Agent Host windows', () => runWithFakedTimers({}, async () => {
+		const commits: number[] = [];
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => false,
+				release: () => { },
+			}),
+			prepareFlush: async (_resource, trigger) => trigger === 'hashChange' ? ({
+				flushToken: 'flush-1',
+				agentModifiedCount: 0,
+				commit: async totalModifiedCount => {
+					commits.push(totalModifiedCount);
+				},
+			}) : undefined,
+		};
+		const context = setup(undefined, markerService);
+		await timeout(10);
+
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual({
+			commits,
+			detailCount: context.details.length,
+			statsCount: context.stats.length,
+		}, {
+			commits: [0],
+			detailCount: 0,
+			statsCount: 0,
+		});
+
+		context.disposables.dispose();
+	}));
 });
 
-function setup(visible: ISettableObservable<boolean> = observableValue('visible', true)) {
+function setup(
+	visible: ISettableObservable<boolean> = observableValue('visible', true),
+	markerService?: IAgentHostEditMarkerService,
+	dirty = false,
+) {
 	const disposables = new DisposableStore();
 	const headHash = observableValue('headHash', 'hash-1');
 	const branch = observableValue('branch', 'main');
@@ -171,7 +485,8 @@ function setup(visible: ISettableObservable<boolean> = observableValue('visible'
 		headBranchNameObs: branch,
 		isIgnored: async () => false,
 	} satisfies IScmRepoAdapter;
-	const details: Array<{ sourceKey: string; trigger: string; requestId: string | undefined; modifiedCount: number; deltaModifiedCount: number }> = [];
+	const details: Array<{ sourceKey: string; trigger: string; requestId: string | undefined; statsUuid: string; modifiedCount: number; deltaModifiedCount: number; totalModifiedCount: number }> = [];
+	const stats: Array<{ statsUuid: string; otherAIModifiedCount: number; externalModifiedCount: number; totalModifiedCharacters: number }> = [];
 	let uuid = 0;
 	const instantiationService = disposables.add(new TestInstantiationService(new ServiceCollection(), false, undefined, true));
 	instantiationService.stub(ITelemetryService, {
@@ -179,6 +494,8 @@ function setup(visible: ISettableObservable<boolean> = observableValue('visible'
 			const eventData = data as { mode?: string } | undefined;
 			if (eventName === 'editTelemetry.editSources.details' && eventData?.mode === 'longterm') {
 				details.push(data as typeof details[number]);
+			} else if (eventName === 'editTelemetry.editSources.stats' && eventData?.mode === 'longterm') {
+				stats.push(data as typeof stats[number]);
 			}
 		},
 	});
@@ -198,6 +515,7 @@ function setup(visible: ISettableObservable<boolean> = observableValue('visible'
 		totalFocusTimeMs: 0,
 		fireAfterGivenFocusTimePassed: () => Disposable.None,
 	});
+	instantiationService.stub(ITextFileService, { isDirty: () => dirty });
 	instantiationService.stub(IAiEditTelemetryService, {
 		_serviceBrand: undefined,
 		createSuggestionId: () => EditSuggestionId.newId(() => 'sgt-test'),
@@ -208,14 +526,14 @@ function setup(visible: ISettableObservable<boolean> = observableValue('visible'
 
 	const workspace = new MutableObservableWorkspace();
 	const annotatedDocuments = disposables.add(new AnnotatedDocuments(workspace, instantiationService));
-	const impl = disposables.add(new EditSourceTrackingImpl(constObservable(true), annotatedDocuments, instantiationService));
+	const impl = disposables.add(new EditSourceTrackingImpl(constObservable(true), annotatedDocuments, markerService, instantiationService));
 	const document = disposables.add(workspace.createDocument({
 		uri: URI.file('C:\\repo\\file.ts'),
 		initialValue: 'hello',
 		languageId: 'typescript',
 	}));
 
-	return { disposables, document, details, headHash, branch, impl };
+	return { disposables, document, details, stats, headHash, branch, impl };
 }
 
 function chatEdit(requestId: string) {

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { timeout } from '../../../../../base/common/async.js';
-import { Event } from '../../../../../base/common/event.js';
+import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { constObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -25,7 +25,7 @@ import { DiffService } from '../../browser/helpers/documentWithAnnotatedEdits.js
 import { StringEditWithReason } from '../../browser/helpers/observableWorkspace.js';
 import { IAiEditTelemetryService } from '../../browser/telemetry/aiEditTelemetry/aiEditTelemetryService.js';
 import { EditSourceTrackingImpl } from '../../browser/telemetry/editSourceTrackingImpl.js';
-import { AgentHostEditAttributionUnknownOutcomeError, IAgentHostEditMarkerService } from '../../browser/telemetry/agentHostEditMarkerService.js';
+import { AgentHostEditAttributionDeferredError, AgentHostEditAttributionUnknownOutcomeError, IAgentHostEditMarkerService } from '../../browser/telemetry/agentHostEditMarkerService.js';
 import { IScmRepoAdapter, ScmAdapter } from '../../browser/telemetry/scmAdapter.js';
 import { IRandomService } from '../../browser/randomService.js';
 import { MutableObservableWorkspace } from './editTelemetry.test.js';
@@ -215,6 +215,67 @@ suite('Edit Source Tracking Windows', () => {
 				totalModifiedCharacters: 8,
 			}],
 			commits: [8],
+		});
+
+		context.disposables.dispose();
+	}));
+
+	test('recomputes workbench totals after a late Agent marker', () => runWithFakedTimers({}, async () => {
+		const onDidSuppress = new Emitter<string>();
+		const prepareStarted = new DeferredPromise<void>();
+		const continuePrepare = new DeferredPromise<void>();
+		let suppressed = false;
+		const committedTotals: number[] = [];
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: onDidSuppress.event,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => suppressed,
+				release: () => { },
+			}),
+			prepareFlush: async (_resource, trigger) => {
+				if (trigger !== 'hashChange') {
+					return undefined;
+				}
+				prepareStarted.complete();
+				await continuePrepare.p;
+				return {
+					flushToken: 'flush-1',
+					agentModifiedCount: 3,
+					commit: async totalModifiedCount => {
+						committedTotals.push(totalModifiedCount);
+					},
+				};
+			},
+		};
+		const context = setup(undefined, markerService);
+		context.disposables.add(onDidSuppress);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await prepareStarted.p;
+		suppressed = true;
+		onDidSuppress.fire('observation');
+		continuePrepare.complete();
+		await timeout(10);
+
+		assert.deepStrictEqual({
+			committedTotals,
+			stats: context.stats.map(event => ({
+				otherAIModifiedCount: event.otherAIModifiedCount,
+				externalModifiedCount: event.externalModifiedCount,
+				totalModifiedCharacters: event.totalModifiedCharacters,
+			})),
+		}, {
+			committedTotals: [3],
+			stats: [{
+				otherAIModifiedCount: 3,
+				externalModifiedCount: 0,
+				totalModifiedCharacters: 3,
+			}],
 		});
 
 		context.disposables.dispose();
@@ -457,6 +518,38 @@ suite('Edit Source Tracking Windows', () => {
 			modifiedCount: 8,
 			totalModifiedCount: 8,
 		}]);
+
+		context.disposables.dispose();
+	}));
+
+	test('does not fall back when Agent Host attribution is deferred', () => runWithFakedTimers({}, async () => {
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => ({
+				onDidSuppress: Event.None,
+				onDidInvalidate: Event.None,
+				register: () => 'observation',
+				isSuppressed: () => true,
+				release: () => { },
+			}),
+			prepareFlush: async () => {
+				throw new AgentHostEditAttributionDeferredError(new Error('Prepare cancelled'));
+			},
+		};
+		const context = setup(undefined, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		context.headHash.set('hash-2', undefined);
+		await timeout(10);
+
+		assert.deepStrictEqual({
+			detailCount: context.details.length,
+			statsCount: context.stats.length,
+		}, {
+			detailCount: 0,
+			statsCount: 0,
+		});
 
 		context.disposables.dispose();
 	}));

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editTelemetry.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editTelemetry.test.ts
@@ -62,7 +62,7 @@ suite('Edit Telemetry', () => {
 
 		const w = new MutableObservableWorkspace();
 		const docs = disposables.add(new AnnotatedDocuments(w, instantiationService));
-		disposables.add(new EditSourceTrackingImpl(constObservable(true), docs, instantiationService));
+		disposables.add(new EditSourceTrackingImpl(constObservable(true), docs, undefined, instantiationService));
 
 		const d1 = disposables.add(w.createDocument({
 			uri: URI.parse('file:///a'), initialValue: `

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editTelemetry.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editTelemetry.test.ts
@@ -31,6 +31,7 @@ import { SyncDescriptor } from '../../../../../platform/instantiation/common/des
 import { UserAttentionService, UserAttentionServiceEnv } from '../../../../services/userAttention/browser/userAttentionBrowser.js';
 import { IUserAttentionService } from '../../../../services/userAttention/common/userAttentionService.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 
 suite('Edit Telemetry', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -59,6 +60,7 @@ suite('Edit Telemetry', () => {
 		instantiationService.stubInstance(UriVisibilityProvider, { isVisible: (uri, reader) => true, });
 		instantiationService.stub(IRandomService, new DeterministicRandomService());
 		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITextFileService, { isDirty: () => false });
 
 		const w = new MutableObservableWorkspace();
 		const docs = disposables.add(new AnnotatedDocuments(w, instantiationService));

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editTracker.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editTracker.test.ts
@@ -13,6 +13,8 @@ import { EditSources, TextModelEditSource } from '../../../../../editor/common/t
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { EditKeySourceData, EditSourceData, IDocumentWithAnnotatedEdits } from '../../browser/helpers/documentWithAnnotatedEdits.js';
 import { DocumentEditSourceTracker } from '../../browser/telemetry/editTracker.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { IExternalEditCorrelation } from '../../browser/telemetry/agentHostEditMarkerService.js';
 
 suite('DocumentEditSourceTracker', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -24,6 +26,59 @@ suite('DocumentEditSourceTracker', () => {
 		document.apply(StringEdit.replace(OffsetRange.ofLength(7), 'external'), EditSources.reloadFromDisk());
 
 		assert.deepStrictEqual(snapshot(tracker), []);
+	});
+
+	test('retains a matched initial external edit only for fallback', () => {
+		const document = disposables.add(new TestAnnotatedDocument('initial'));
+		const correlation = new TestExternalEditCorrelation();
+		const tracker = disposables.add(new DocumentEditSourceTracker(document, undefined, correlation));
+
+		document.apply(StringEdit.replace(OffsetRange.ofLength(7), 'external'), EditSources.reloadFromDisk());
+		tracker.applyPendingExternalEdits();
+		const beforeSuppression = snapshot(tracker, true);
+		correlation.suppress(correlation.lastObservationId!);
+		const fallback = snapshot(tracker, true);
+		tracker.dispose();
+
+		assert.deepStrictEqual({
+			beforeSuppression,
+			fallback,
+			afterDisposeStandard: snapshot(tracker),
+			afterDisposeFallback: snapshot(tracker, true),
+		}, {
+			beforeSuppression: [],
+			fallback: [{
+				key: 'external-observation:observation-1',
+				delta: 8,
+				retained: 8,
+				requestId: undefined,
+			}],
+			afterDisposeStandard: [],
+			afterDisposeFallback: [{
+				key: 'external-observation:observation-1',
+				delta: 8,
+				retained: 8,
+				requestId: undefined,
+			}],
+		});
+	});
+
+	test('restores external attribution when Agent Host suppression is invalidated', () => {
+		const document = disposables.add(new TestAnnotatedDocument('initial'));
+		const correlation = new TestExternalEditCorrelation();
+		const tracker = disposables.add(new DocumentEditSourceTracker(document, undefined, correlation));
+
+		document.apply(StringEdit.replace(OffsetRange.ofLength(7), 'external'), EditSources.reloadFromDisk());
+		tracker.applyPendingExternalEdits();
+		correlation.suppress(correlation.lastObservationId!);
+		correlation.invalidate(correlation.lastObservationId!);
+
+		assert.deepStrictEqual(snapshot(tracker), [{
+			key: 'external-observation:observation-1',
+			delta: 8,
+			retained: 8,
+			requestId: undefined,
+		}]);
 	});
 
 	test('applies queued external edits before the next attributed edit', () => {
@@ -93,6 +148,34 @@ suite('DocumentEditSourceTracker', () => {
 		]);
 		assert.strictEqual(gptFirst.toKey(1), gptSecond.toKey(1));
 	});
+
+	test('suppresses matched external attribution while preserving range transforms', () => {
+		const document = disposables.add(new TestAnnotatedDocument(''));
+		const correlation = new TestExternalEditCorrelation();
+		const tracker = disposables.add(new DocumentEditSourceTracker(document, undefined, correlation));
+		const ai = chatEditSource('gpt-5', 'request-1');
+		const user = EditSources.cursor({ kind: 'type' });
+
+		document.apply(StringEdit.insert(0, 'abcdef'), ai);
+		document.apply(StringEdit.delete(new OffsetRange(2, 4)), EditSources.reloadFromDisk());
+		correlation.suppress(correlation.lastObservationId!);
+		document.apply(StringEdit.insert(4, 'X'), user);
+
+		assert.deepStrictEqual(snapshot(tracker), [
+			{
+				key: ai.toKey(1),
+				delta: 6,
+				retained: 4,
+				requestId: 'request-1',
+			},
+			{
+				key: 'source:cursor-kind:type',
+				delta: 1,
+				retained: 1,
+				requestId: undefined,
+			},
+		]);
+	});
 });
 
 class TestAnnotatedDocument extends Disposable implements IDocumentWithAnnotatedEdits<EditKeySourceData> {
@@ -126,15 +209,47 @@ function chatEditSource(modelId: string, requestId: string): TextModelEditSource
 	});
 }
 
-function snapshot(tracker: DocumentEditSourceTracker): Array<{ key: string; delta: number; retained: number; requestId: string | undefined }> {
+function snapshot(tracker: DocumentEditSourceTracker, includeSuppressed = false): Array<{ key: string; delta: number; retained: number; requestId: string | undefined }> {
 	const retained = new Map<string, number>();
-	for (const range of tracker.getTrackedRanges()) {
+	for (const range of tracker.getTrackedRanges(undefined, includeSuppressed)) {
 		retained.set(range.sourceKey, (retained.get(range.sourceKey) ?? 0) + range.range.length);
 	}
-	return tracker.getAllKeys().map(key => ({
+	return tracker.getAllKeys(includeSuppressed).map(key => ({
 		key,
-		delta: tracker.getTotalInsertedCharactersCount(key),
+		delta: tracker.getTotalInsertedCharactersCount(key, includeSuppressed),
 		retained: retained.get(key) ?? 0,
 		requestId: tracker.getRepresentative(key)?.props.$$requestId,
 	})).sort((a, b) => a.key.localeCompare(b.key));
+}
+
+class TestExternalEditCorrelation implements IExternalEditCorrelation {
+	private readonly _onDidSuppress = new Emitter<string>();
+	readonly onDidSuppress: Event<string> = this._onDidSuppress.event;
+	private readonly _onDidInvalidate = new Emitter<string>();
+	readonly onDidInvalidate: Event<string> = this._onDidInvalidate.event;
+	private readonly _suppressed = new Set<string>();
+	private _sequence = 0;
+	lastObservationId: string | undefined;
+
+	register(_before: string, _after: string): string {
+		return this.lastObservationId = `observation-${++this._sequence}`;
+	}
+
+	isSuppressed(id: string): boolean {
+		return this._suppressed.has(id);
+	}
+
+	release(id: string): void {
+		this._suppressed.delete(id);
+	}
+
+	suppress(id: string): void {
+		this._suppressed.add(id);
+		this._onDidSuppress.fire(id);
+	}
+
+	invalidate(id: string): void {
+		this._suppressed.delete(id);
+		this._onDidInvalidate.fire(id);
+	}
 }


### PR DESCRIPTION
Attribute tool-driven edits in Agent Host, correlate workbench reloads so that both sources can be used together.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
