### PR TITLE
Add .mpp and .mxx extensions to C++

### DIFF
--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -47,6 +47,8 @@
           ".inl",
           ".ipp",
           ".ixx",
+          ".mpp",
+          ".mxx",
           ".tpp",
           ".txx",
           ".hpp.in",


### PR DESCRIPTION
Adds `.mpp` and `.mxx` as recognized C++ file extensions. These are common C++20 module extensions and are the defaults used by xmake (`.mpp`) and build2 (`.mxx`).

This reapplies #286872. The original change was contributed by @damster101, and the replayed commit preserves Damian Höster as its Git author so the contribution remains attributed.

Validation: parsed `extensions/cpp/package.json` and ran `git diff --check`.