### PR TITLE
Allow custom image previews to hide the SVG preview action

### DIFF
--- a/extensions/media-preview/package.json
+++ b/extensions/media-preview/package.json
@@ -122,7 +122,7 @@
         },
         {
           "command": "imagePreview.reopenAsPreview",
-          "when": "activeEditor == workbench.editors.files.textFileEditor && resourceExtname == '.svg'",
+          "when": "activeEditor == workbench.editors.files.textFileEditor && resourceExtname == '.svg' && !hasCustomImagePreview",
           "group": "navigation"
         },
         {
@@ -140,7 +140,7 @@
       "editor/title": [
         {
           "command": "imagePreview.reopenAsPreview",
-          "when": "editorFocus && resourceExtname == '.svg'",
+          "when": "editorFocus && resourceExtname == '.svg' && !hasCustomImagePreview",
           "group": "navigation"
         },
         {


### PR DESCRIPTION
Adds a `!hasCustomImagePreview` context guard to the built-in media preview extension's `imagePreview.reopenAsPreview` menu contributions for SVG files.

This gives custom SVG/image preview extensions an opt-in integration point similar to `hasCustomMarkdownPreview`, without overriding built-in commands or changing editor associations.

This reapplies #324864. The original change was contributed by @cesaryuan, and the replayed commit preserves `cesaryuan` as its Git author so the contribution remains attributed.

Fixes #324863

Validation: parsed `extensions/media-preview/package.json` and ran `git diff --check`.