### PR TITLE
Don't replay a signed thinking block onto rounds that never had one

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -264,9 +264,7 @@ class ConversationHistory extends PromptElement<SummarizedAgentHistoryProps> {
 			// Reverse the tool call rounds so they are in chronological order
 			toolCallRounds.reverse();
 
-			// For Anthropic models with thinking enabled, set the thinking on the first round
-			// so it gets rendered as the first thinking block after summarization
-			if (isAnthropicFamily(this.props.endpoint) && thinkingForFirstRoundAfterSummarization && toolCallRounds.length > 0 && !toolCallRounds[0].thinking) {
+			if (requiresLeadingThinkingBlock(this.props.endpoint) && thinkingForFirstRoundAfterSummarization && toolCallRounds.length > 0 && !toolCallRounds[0].thinking) {
 				toolCallRounds[0].thinking = thinkingForFirstRoundAfterSummarization;
 			}
 
@@ -539,7 +537,10 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 		const round = this.props.promptContext.toolCallRounds?.find(round => round.id === toolCallRoundId);
 		if (round) {
 			round.summary = summary;
-			round.thinking = thinking;
+			// Only ever overwrite: clearing would drop a signed block the round is still replayed with.
+			if (thinking) {
+				round.thinking = thinking;
+			}
 			return;
 		}
 
@@ -549,11 +550,22 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 			const round = turn.rounds.find(round => round.id === toolCallRoundId);
 			if (round) {
 				round.summary = summary;
-				round.thinking = thinking;
+				if (thinking) {
+					round.thinking = thinking;
+				}
 				break;
 			}
 		}
 	}
+}
+
+/**
+ * Only Anthropic's manual thinking mode (`type: "enabled"`) requires an assistant message to open
+ * with a thinking block. Adaptive thinking accepts history as-is, so carrying a signed block onto
+ * a round that never produced one is a pointless edit of a message the API returned.
+ */
+function requiresLeadingThinkingBlock(endpoint: IChatEndpoint): boolean {
+	return isAnthropicFamily(endpoint) && !endpoint.supportsAdaptiveThinking;
 }
 
 enum SummaryMode {
@@ -1069,10 +1081,7 @@ export class SummarizedConversationHistoryPropsBuilder {
 			return undefined;
 		}
 
-		// For Anthropic models with thinking enabled, find the last assistant message with thinking
-		// from all rounds being summarized (both current toolCallRounds and history).
-		// This thinking will be used as the first thinking block after summarization.
-		const summarizedThinking = isAnthropicFamily(props.endpoint) ? this.findLastThinking(props) : undefined;
+		const summarizedThinking = requiresLeadingThinkingBlock(props.endpoint) ? this.findLastThinking(props) : undefined;
 		const promptContext = {
 			...props.promptContext,
 			toolCallRounds,

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -10,12 +10,14 @@ import { ChatLocation } from '../../../../../platform/chat/common/commonTypes';
 import { ISessionTranscriptService, NullSessionTranscriptService } from '../../../../../platform/chat/common/sessionTranscriptService';
 import { StaticChatMLFetcher } from '../../../../../platform/chat/test/common/staticChatMLFetcher';
 import { CodeGenerationTextInstruction, ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
+import { rawPartAsThinkingData } from '../../../../../platform/endpoint/common/thinkingDataContainer';
 import { MockEndpoint } from '../../../../../platform/endpoint/test/node/mockEndpoint';
 import { messageToMarkdown } from '../../../../../platform/log/common/messageStringify';
 import { IResponseDelta } from '../../../../../platform/networking/common/fetch';
 import { IMakeChatRequestOptions } from '../../../../../platform/networking/common/networking';
 import { ITestingServicesAccessor } from '../../../../../platform/test/node/services';
 import { TestWorkspaceService } from '../../../../../platform/test/node/testWorkspaceService';
+import { ThinkingData } from '../../../../../platform/thinking/common/thinking';
 import { ITokenizerProvider } from '../../../../../platform/tokenizer/node/tokenizer';
 import { IWorkspaceService } from '../../../../../platform/workspace/common/workspaceService';
 import { createTextDocumentData } from '../../../../../util/common/test/shims/textDocument';
@@ -602,6 +604,71 @@ suite('Agent Summarization', () => {
 		for (const round of toolCallRounds) {
 			expect(round.summary).toBeUndefined();
 		}
+	});
+
+	async function renderThinkingAfterSummarization(supportsAdaptiveThinking: boolean) {
+		chatResponse[0] = 'summarized successfully!';
+		const instaService = accessor.get(IInstantiationService);
+		const endpoint = instaService.createInstance(MockEndpoint, undefined);
+		(endpoint as { model: string }).model = 'claude-opus-5';
+		(endpoint as { family: string }).family = 'claude-opus-5';
+		(endpoint as { supportsAdaptiveThinking?: boolean }).supportsAdaptiveThinking = supportsAdaptiveThinking;
+
+		const makeRound = (response: string, idx: number, thinking?: ThinkingData) => ToolCallRound.create({
+			response,
+			toolCalls: [createEditFileToolCall(idx)],
+			toolInputRetry: 0,
+			modelId: 'claude-opus-5',
+			thinking,
+		});
+		const toolCallRounds = [
+			makeRound('ok', 1, { id: 'th1', text: 'thoughts 1', encrypted: 'sig-1' }),
+			makeRound('ok 2', 2, { id: 'th2', text: 'thoughts 2', encrypted: 'sig-2' }),
+			makeRound('ok 3', 3),
+		];
+
+		const renderer = PromptRenderer.create(instaService, endpoint, SummarizedConversationHistory, {
+			priority: 1,
+			endpoint,
+			location: ChatLocation.Panel,
+			promptContext: {
+				chatVariables: new ChatVariablesCollection([{ id: 'vscode.file', name: 'file', value: fileTsUri }]),
+				history: [],
+				query: 'edit this file',
+				toolCallRounds,
+				toolCallResults: createEditFileToolResult(1, 2, 3),
+				tools,
+				conversation: new Conversation('sessionId', [new Turn('turnId', { type: 'user', message: 'hello' })]),
+			},
+			maxToolResultLength: Infinity,
+			enableCacheBreakpoints: true,
+			triggerSummarize: true,
+		});
+		const result = await renderer.render();
+
+		return {
+			thinkingParts: result.messages
+				.flatMap(m => Array.isArray(m.content) ? m.content : [])
+				.map(c => c.type === Raw.ChatCompletionContentPartKind.Opaque ? rawPartAsThinkingData(c) : undefined)
+				.filter(t => !!t),
+			toolCallRounds,
+		};
+	}
+
+	test('manual-mode thinking carries onto the first round after the summary', async () => {
+		const { thinkingParts } = await renderThinkingAfterSummarization(false);
+		expect(thinkingParts).toEqual([{ id: 'th2', text: 'thoughts 2', encrypted: 'sig-2' }]);
+	});
+
+	test('adaptive-mode thinking is not replayed on a round that never had it (#327646)', async () => {
+		const { thinkingParts, toolCallRounds } = await renderThinkingAfterSummarization(true);
+		expect(thinkingParts).toEqual([]);
+		expect(toolCallRounds[2].thinking).toBeUndefined();
+	});
+
+	test('summarization does not clear the summarized round\'s own thinking', async () => {
+		const { toolCallRounds } = await renderThinkingAfterSummarization(true);
+		expect(toolCallRounds[1].thinking).toEqual({ id: 'th2', text: 'thoughts 2', encrypted: 'sig-2' });
 	});
 
 	test('simple mode summarization with small token budget renders zero messages (repro for No messages provided)', async () => {


### PR DESCRIPTION
Removes an edit to a signed assistant message that we shouldn't be making on models that don't require it.

### What was happening

After summarization, `SummarizedConversationHistory` did two things to `round.thinking`:

1. **Carry-over** — the last thinking block from the summarized rounds was copied onto the first tool call round after the summary, for *every* Anthropic model.
2. **Clearing** — `setSummaryAndThinking` assigned `round.thinking = thinking` unconditionally, so a call without a thinking block wiped whatever was already on the round.

Both operate on a block that carries a server-issued signature (`encrypted`), on a message the API handed back to us.

### Why it's wrong

Only Anthropic's **manual** thinking mode (`thinking: { type: "enabled" }`) requires an assistant message to open with a thinking block — that's the constraint the carry-over was written for. **Adaptive** thinking (`type: "adaptive"`) accepts history as-is and has no such requirement.

So on adaptive models we were attaching a signature from round N onto round N+1, which never produced one. That's a rewrite of signed content for no benefit.

### The change

- New `requiresLeadingThinkingBlock(endpoint)` = `isAnthropicFamily(endpoint) && !endpoint.supportsAdaptiveThinking`, gating both the carry-over and the `findLastThinking` lookup that feeds it.
- `setSummaryAndThinking` now only ever *overwrites* — `if (thinking)` — so summarization can't strip a signature off a round that is still replayed.


### On #327646

This is a **plausible but unconfirmed** explanation for #327646, and I'd rather not have it auto-close.

What supports it: this is the only code path that rewrites a signed assistant message, and it fits the preconditions in all three reports.

Refs #327646

