### PR TITLE
Emit Agent Host session titles in OTel

### DIFF
--- a/src/vs/platform/agentHost/OTEL.md
+++ b/src/vs/platform/agentHost/OTEL.md
@@ -18,7 +18,7 @@ This doc lives next to the code (`IAgentHostOTelService` in [node/otel/agentHost
 
 | Mode | Trigger | Behavior |
 |---|---|---|
-| **Pass-through** | `chat.agentHost.otel.enabled` is `true` and `dbSpanExporter.enabled` is `false` | The SDK exports directly to the user-configured exporter (OTLP/HTTP, OTLP/gRPC, file, or console). No process-local interception. |
+| **Pass-through** | `chat.agentHost.otel.enabled` is `true` and `dbSpanExporter.enabled` is `false` | The SDK exports directly to the user-configured exporter (OTLP/HTTP, OTLP/gRPC, file, or console). SDK spans are not intercepted; host-produced session-title metadata uses the matching JSON/file/console forwarder. |
 | **DB mode** | `chat.agentHost.otel.dbSpanExporter.enabled` is `true` (implicitly enables OTel) | The SDK is pointed at a loopback OTLP/HTTP receiver inside the agent host. Spans are decoded and written to a local SQLite database. If `otlpEndpoint` is **also** configured, the receiver fans the raw OTLP body out to it — so an external collector keeps receiving traces alongside the local DB. |
 
 ```
@@ -49,8 +49,20 @@ This doc lives next to the code (`IAgentHostOTelService` in [node/otel/agentHost
                  └─────────────────────────────────────────────────────────────────┘
 ```
 
-- **Pass-through mode** (default when only `otlpEndpoint` is configured): the SDK is constructed with the user's exporter settings unmodified and exports directly. The agent host does not intercept span data.
+- **Pass-through mode** (default when only `otlpEndpoint` is configured): the SDK is constructed with the user's exporter settings unmodified and exports directly. SDK span data is not intercepted; the agent host additionally emits the session-title metadata span described below through the configured exporter.
 - **DB mode** (`COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED=true`): `AgentHostOTelService` starts a `LocalOtlpHttpReceiver` on `127.0.0.1` with an ephemeral port, then constructs the SDK pointing at that loopback URL. For each batch the receiver decodes the OTLP-JSON body and inserts spans into `OTelSqliteStore` (`onSpans`). If an external `otlpEndpoint` is also configured, the receiver fans the **raw** OTLP body out to an `OtlpHttpForwarder` (`onForward`) so the user's collector keeps receiving traces alongside the local DB.
+
+## Session Title Metadata
+
+When content capture is enabled, the agent host emits a zero-duration `vscode.agent_host.session.title_changed` span whenever the authoritative Copilot session title changes. This includes fallback, generated, refined, and manually renamed titles; assigning the same title again does not emit another span. Downstream consumers can use the latest span for a conversation to display its current title.
+
+| Attribute | Description |
+|---|---|
+| `gen_ai.conversation.id` | Copilot SDK conversation ID used to correlate the metadata with SDK spans. |
+| `vscode.agent_host.session.title` | Latest session title, bounded to 200 characters. |
+| `vscode.agent_host.session.uri` | Agent Host protocol URI for the session. |
+
+Title text is user-derived content, so these spans are emitted only when `chat.agentHost.otel.captureContent` is enabled. Host-produced title spans copy `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` so collectors group them with the SDK telemetry. They are persisted in DB mode and use the configured OTLP, file, or console forwarder. Synthetic OTLP forwarding currently uses OTLP/HTTP JSON; when `http/protobuf` or gRPC is configured, title spans remain available in DB mode but are not sent to that external endpoint.
 
 ## VS Code Settings
 

--- a/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
@@ -21,6 +21,11 @@ import { createDecorator } from '../../../instantiation/common/instantiation.js'
  * in other layers) can import it without pulling in the node-only concrete
  * implementation and its transitive native dependencies (`node:sqlite`).
  */
+export const AgentHostSessionTitleSpanName = 'vscode.agent_host.session.title_changed';
+
+export const AgentHostSessionTitleAttribute = 'vscode.agent_host.session.title';
+export const AgentHostSessionUriAttribute = 'vscode.agent_host.session.uri';
+
 export interface IAgentHostOTelService {
 	readonly _serviceBrand: undefined;
 
@@ -35,6 +40,13 @@ export interface IAgentHostOTelService {
 	 * Path of the SQLite span store, or `undefined` when DB mode is off.
 	 */
 	getSpansDbPath(): URI | undefined;
+
+	/**
+	 * Emits a standalone metadata span carrying the latest title for a Copilot
+	 * SDK conversation. No span is emitted when telemetry or content capture is
+	 * disabled.
+	 */
+	emitSessionTitleChanged(conversationId: string, sessionUri: string, title: string): void;
 
 	/**
 	 * Drain any in-flight outbound forwarding. Safe to call concurrently with

--- a/src/vs/platform/agentHost/node/agentHostStateManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostStateManager.ts
@@ -241,6 +241,9 @@ export class AgentHostStateManager extends Disposable {
 	private readonly _onDidChangeSessionActiveTurn = this._register(new Emitter<{ session: string; active: boolean }>());
 	readonly onDidChangeSessionActiveTurn: Event<{ session: string; active: boolean }> = this._onDidChangeSessionActiveTurn.event;
 
+	private readonly _onDidChangeSessionTitle = this._register(new Emitter<{ session: string; title: string }>());
+	readonly onDidChangeSessionTitle: Event<{ session: string; title: string }> = this._onDidChangeSessionTitle.event;
+
 	constructor(
 		@ILogService private readonly _logService: ILogService,
 		options: IAgentHostStateManagerOptions = {},
@@ -1190,9 +1193,14 @@ export class AgentHostStateManager extends Disposable {
 			const key = channel;
 			const entry = this._sessionStates.get(key);
 			if (entry) {
-				const newState = sessionReducer(entry.state, sessionAction, this._log);
-				const summaryChanged = !this._summaryFieldsEqual(entry.state, newState);
+				const previousState = entry.state;
+				const newState = sessionReducer(previousState, sessionAction, this._log);
+				const summaryChanged = !this._summaryFieldsEqual(previousState, newState);
 				entry.state = newState;
+
+				if (previousState.title !== newState.title) {
+					this._onDidChangeSessionTitle.fire({ session: key, title: newState.title });
+				}
 
 				// When the reducer touched a summary-relevant field, notify
 				// root-channel clients of the derived-summary delta.

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -454,6 +454,11 @@ export class CopilotAgent extends Disposable implements IAgent {
 			? new AgentHostGitHubTelemetryRouter(this._telemetryService)
 			: undefined;
 		this.onDidCustomizationsChange = this._plugins.onDidChange;
+		this._register(this._stateManager.onDidChangeSessionTitle(({ session, title }) => {
+			if (AgentSession.provider(session) === this.id) {
+				this._otelService.emitSessionTitleChanged(AgentSession.id(session), session, title);
+			}
+		}));
 		// Mirror the sub-agent fan-out signals onto the first-class spawned-
 		// chat channel so the orchestrator manages sub-agent chats
 		// through the same membership path as user-driven chats.

--- a/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
@@ -343,12 +343,12 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		const attributes = Object.entries(span.attributes)
 			.filter(([key]) => !resourceAttributeKeys.has(key) || key === GenAiAttr.CONVERSATION_ID || key.startsWith('vscode.agent_host.'))
 			.map(([key, value]) => ({
-			key,
-			value: typeof value === 'string' ? { stringValue: value }
-				: typeof value === 'number' ? { doubleValue: value }
-					: typeof value === 'boolean' ? { boolValue: value }
-						: { arrayValue: { values: value.map(item => ({ stringValue: item })) } },
-		}));
+				key,
+				value: typeof value === 'string' ? { stringValue: value }
+					: typeof value === 'number' ? { doubleValue: value }
+						: typeof value === 'boolean' ? { boolValue: value }
+							: { arrayValue: { values: value.map(item => ({ stringValue: item })) } },
+			}));
 		const resourceAttributes = Object.entries(this._config.resourceAttributes).map(([key, value]) => ({ key, value: { stringValue: value } }));
 		return Buffer.from(JSON.stringify({
 			resourceSpans: [{

--- a/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
@@ -8,6 +8,7 @@ import { dirname, join } from '../../../../base/common/path.js';
 import type { TelemetryConfig } from '@github/copilot-sdk';
 import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 import { INativeEnvironmentService } from '../../../environment/common/environment.js';
 import { ILogService } from '../../../log/common/log.js';
 import { startLocalOtlpHttpReceiver, type ILocalOtlpHttpReceiver } from '../../../otel/node/otlp/localOtlpReceiver.js';
@@ -18,9 +19,11 @@ import {
 	OtlpHttpForwarder,
 	type IOutboundForwarder,
 } from '../../../otel/node/otlp/outboundForwarder.js';
+import { GenAiAttr } from '../../../otel/common/genAiAttributes.js';
+import { ICompletedSpanData, SpanStatusCode } from '../../../otel/common/spanData.js';
 import { OTelSqliteStore } from '../../../otel/node/sqlite/otelSqliteStore.js';
 import { AgentHostOTelSpansDbSubPath } from '../../common/agentService.js';
-import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
+import { AgentHostSessionTitleAttribute, AgentHostSessionTitleSpanName, AgentHostSessionUriAttribute, IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 
 /** Sub-path under the user data directory where the span DB lives. */
 const SPANS_DB_SUBPATH = AgentHostOTelSpansDbSubPath;
@@ -118,8 +121,10 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 	private readonly _spansDbPath: string;
 
 	private _receiver: ILocalOtlpHttpReceiver | undefined;
+	private _spanStore: OTelSqliteStore | undefined;
 	private _forwarder: IOutboundForwarder | undefined;
 	private _startPromise: Promise<void> | undefined;
+	private _titleExportQueue = Promise.resolve();
 
 	constructor(
 		private readonly _fetchFn: typeof globalThis.fetch | undefined,
@@ -156,7 +161,18 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		return this._config.dbSpanExporter ? URI.file(this._spansDbPath) : undefined;
 	}
 
+	emitSessionTitleChanged(conversationId: string, sessionUri: string, title: string): void {
+		if (!this._config.enabled || this._config.captureContent !== true || !conversationId || !title) {
+			return;
+		}
+
+		this._titleExportQueue = this._titleExportQueue
+			.then(() => this._emitSessionTitleSpan(conversationId, sessionUri, title))
+			.catch(err => this._logService.warn('[agentHost.otel] failed to emit session title span', err));
+	}
+
 	async flush(): Promise<void> {
+		await this._titleExportQueue;
 		await this._startPromise;
 		if (this._forwarder) {
 			await this._forwarder.flush();
@@ -203,7 +219,11 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		// 1. Persistent SQLite store.
 		await mkdir(dirname(this._spansDbPath), { recursive: true });
 		const store = new OTelSqliteStore(this._spansDbPath);
-		this._register(toDisposable(() => store.close()));
+		this._spanStore = store;
+		this._register(toDisposable(() => {
+			store.close();
+			this._spanStore = undefined;
+		}));
 
 		// 2. Optional outbound forwarder when the user *also* wants an external sink.
 		this._forwarder = this._buildOutboundForwarder();
@@ -237,6 +257,66 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		}
 
 		this._logService.info(`[agentHost.otel] loopback receiver at ${receiver.baseUrl}, db ${this._spansDbPath}`);
+	}
+
+	private async _emitSessionTitleSpan(conversationId: string, sessionUri: string, title: string): Promise<void> {
+		if (this._config.dbSpanExporter) {
+			await this._ensureStarted();
+		} else if (!this._forwarder) {
+			this._forwarder = this._buildOutboundForwarder();
+			if (this._forwarder) {
+				this._register(this._forwarder);
+			}
+		}
+
+		const now = Date.now();
+		const traceId = generateUuid().replaceAll('-', '');
+		const span: ICompletedSpanData = {
+			name: AgentHostSessionTitleSpanName,
+			traceId,
+			spanId: generateUuid().replaceAll('-', '').slice(0, 16),
+			startTime: now,
+			endTime: now,
+			status: { code: SpanStatusCode.OK },
+			attributes: {
+				[GenAiAttr.CONVERSATION_ID]: conversationId,
+				[AgentHostSessionTitleAttribute]: title,
+				[AgentHostSessionUriAttribute]: sessionUri,
+			},
+			events: [],
+		};
+
+		this._spanStore?.insertSpan(span);
+		const result = { spans: [span], rejected: 0, errors: [] };
+		this._forwarder?.forwardSpans?.(result);
+		this._forwarder?.forwardRaw?.(this._encodeOtlpSpan(span), 'application/json');
+	}
+
+	private _encodeOtlpSpan(span: ICompletedSpanData): Buffer {
+		const attributes = Object.entries(span.attributes).map(([key, value]) => ({
+			key,
+			value: typeof value === 'string' ? { stringValue: value }
+				: typeof value === 'number' ? { doubleValue: value }
+					: typeof value === 'boolean' ? { boolValue: value }
+						: { arrayValue: { values: value.map(item => ({ stringValue: item })) } },
+		}));
+		return Buffer.from(JSON.stringify({
+			resourceSpans: [{
+				scopeSpans: [{
+					scope: { name: this._config.sourceName ?? 'vscode.agent-host' },
+					spans: [{
+						traceId: span.traceId,
+						spanId: span.spanId,
+						name: span.name,
+						kind: 1,
+						startTimeUnixNano: `${span.startTime}000000`,
+						endTimeUnixNano: `${span.endTime}000000`,
+						attributes,
+						status: { code: 1 },
+					}],
+				}],
+			}],
+		}), 'utf8');
 	}
 
 	private _buildOutboundForwarder(): IOutboundForwarder | undefined {

--- a/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
@@ -50,6 +50,10 @@ interface ResolvedConfig {
 	readonly captureContent: boolean | undefined;
 	/** Parsed OTEL_EXPORTER_OTLP_HEADERS for outbound forwarding. */
 	readonly headers: Record<string, string> | undefined;
+	/** Effective OTLP protocol configured for the SDK runtime. */
+	readonly otlpProtocol: string;
+	/** Resource attributes applied to host-produced metadata spans. */
+	readonly resourceAttributes: Record<string, string>;
 }
 
 function isTruthy(v: string | undefined): boolean {
@@ -77,6 +81,29 @@ function parseOtlpHeaders(raw: string | undefined): Record<string, string> | und
 		}
 	}
 	return Object.keys(out).length ? out : undefined;
+}
+
+function parseResourceAttributes(raw: string | undefined, serviceName: string | undefined): Record<string, string> {
+	const attributes: Record<string, string> = {};
+	for (const pair of raw?.split(',') ?? []) {
+		const eq = pair.indexOf('=');
+		if (eq <= 0) {
+			continue;
+		}
+		const key = pair.slice(0, eq).trim();
+		const value = pair.slice(eq + 1).trim();
+		if (key) {
+			try {
+				attributes[key] = decodeURIComponent(value);
+			} catch {
+				attributes[key] = value;
+			}
+		}
+	}
+	if (serviceName) {
+		attributes['service.name'] = serviceName;
+	}
+	return attributes;
 }
 
 export function readAgentHostOTelEnv(env: NodeJS.ProcessEnv): ResolvedConfig {
@@ -110,6 +137,8 @@ export function readAgentHostOTelEnv(env: NodeJS.ProcessEnv): ResolvedConfig {
 			? undefined
 			: isTruthy(env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT),
 		headers: parseOtlpHeaders(env.OTEL_EXPORTER_OTLP_HEADERS),
+		otlpProtocol: protocol,
+		resourceAttributes: parseResourceAttributes(env.OTEL_RESOURCE_ATTRIBUTES, env.OTEL_SERVICE_NAME),
 	};
 }
 
@@ -165,9 +194,13 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		if (!this._config.enabled || this._config.captureContent !== true || !conversationId || !title) {
 			return;
 		}
+		if (!this._config.dbSpanExporter && !this._canForwardSyntheticSpan()) {
+			return;
+		}
 
+		const boundedTitle = title.slice(0, 200);
 		this._titleExportQueue = this._titleExportQueue
-			.then(() => this._emitSessionTitleSpan(conversationId, sessionUri, title))
+			.then(() => this._emitSessionTitleSpan(conversationId, sessionUri, boundedTitle))
 			.catch(err => this._logService.warn('[agentHost.otel] failed to emit session title span', err));
 	}
 
@@ -279,6 +312,7 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 			endTime: now,
 			status: { code: SpanStatusCode.OK },
 			attributes: {
+				...this._config.resourceAttributes,
 				[GenAiAttr.CONVERSATION_ID]: conversationId,
 				[AgentHostSessionTitleAttribute]: title,
 				[AgentHostSessionUriAttribute]: sessionUri,
@@ -286,22 +320,39 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 			events: [],
 		};
 
-		this._spanStore?.insertSpan(span);
+		try {
+			this._spanStore?.insertSpan(span);
+		} catch (err) {
+			this._logService.warn('[agentHost.otel] failed to persist session title span', err);
+		}
 		const result = { spans: [span], rejected: 0, errors: [] };
 		this._forwarder?.forwardSpans?.(result);
-		this._forwarder?.forwardRaw?.(this._encodeOtlpSpan(span), 'application/json');
+		if (this._canForwardSyntheticSpan()) {
+			this._forwarder?.forwardRaw?.(this._encodeOtlpSpan(span), 'application/json');
+		}
+	}
+
+	private _canForwardSyntheticSpan(): boolean {
+		return this._config.exporterType === 'file'
+			|| this._config.exporterType === 'console'
+			|| (this._config.exporterType === 'otlp-http' && this._config.otlpProtocol !== 'http/protobuf');
 	}
 
 	private _encodeOtlpSpan(span: ICompletedSpanData): Buffer {
-		const attributes = Object.entries(span.attributes).map(([key, value]) => ({
+		const resourceAttributeKeys = new Set(Object.keys(this._config.resourceAttributes));
+		const attributes = Object.entries(span.attributes)
+			.filter(([key]) => !resourceAttributeKeys.has(key) || key === GenAiAttr.CONVERSATION_ID || key.startsWith('vscode.agent_host.'))
+			.map(([key, value]) => ({
 			key,
 			value: typeof value === 'string' ? { stringValue: value }
 				: typeof value === 'number' ? { doubleValue: value }
 					: typeof value === 'boolean' ? { boolValue: value }
 						: { arrayValue: { values: value.map(item => ({ stringValue: item })) } },
 		}));
+		const resourceAttributes = Object.entries(this._config.resourceAttributes).map(([key, value]) => ({ key, value: { stringValue: value } }));
 		return Buffer.from(JSON.stringify({
 			resourceSpans: [{
+				...(resourceAttributes.length ? { resource: { attributes: resourceAttributes } } : {}),
 				scopeSpans: [{
 					scope: { name: this._config.sourceName ?? 'vscode.agent-host' },
 					spans: [{

--- a/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
@@ -110,6 +110,18 @@ suite('AgentHostStateManager', () => {
 		assert.strictEqual(envelopes[0].origin, undefined);
 	});
 
+	test('emits session title changes and suppresses no-op assignments', () => {
+		manager.createSession(makeSessionSummary());
+
+		const changes: Array<{ session: string; title: string }> = [];
+		disposables.add(manager.onDidChangeSessionTitle(e => changes.push(e)));
+
+		manager.dispatchServerAction(sessionUri, { type: ActionType.SessionTitleChanged, title: 'Updated' });
+		manager.dispatchServerAction(sessionUri, { type: ActionType.SessionTitleChanged, title: 'Updated' });
+
+		assert.deepStrictEqual(changes, [{ session: sessionUri, title: 'Updated' }]);
+	});
+
 	test('serverSeq increments monotonically', () => {
 		manager.createSession(makeSessionSummary());
 

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -472,6 +472,7 @@ class MockAgentHostOTelService implements IAgentHostOTelService {
 	getSpansDbPath() {
 		return undefined;
 	}
+	emitSessionTitleChanged() { }
 	async flush() {
 		//
 	}
@@ -615,6 +616,7 @@ function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, optio
 		_serviceBrand: undefined,
 		getSdkTelemetryConfig: async () => undefined,
 		getSpansDbPath: () => undefined,
+		emitSessionTitleChanged: () => { },
 		flush: async () => undefined,
 	});
 	services.set(IAgentHostCompletions, disposables.add(new AgentHostCompletions(logService)));

--- a/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
@@ -107,6 +107,8 @@ const OTEL_ENV_KEYS = [
 	'OTEL_EXPORTER_OTLP_PROTOCOL',
 	'OTEL_EXPORTER_OTLP_HEADERS',
 	'OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT',
+	'OTEL_RESOURCE_ATTRIBUTES',
+	'OTEL_SERVICE_NAME',
 ] as const;
 
 function saveEnv(): ISavedEnv {
@@ -158,12 +160,21 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 		strictEqual(cfg.exporterType, 'otlp-grpc');
 	});
 
-	test('readAgentHostOTelEnv: parses OTEL_EXPORTER_OTLP_HEADERS into key-value map', () => {
+	test('readAgentHostOTelEnv: parses headers and resource attributes', () => {
 		const cfg = readAgentHostOTelEnv({
 			COPILOT_OTEL_ENABLED: 'true',
 			OTEL_EXPORTER_OTLP_HEADERS: 'authorization=Bearer xyz,x-tenant=acme',
+			OTEL_RESOURCE_ATTRIBUTES: 'deployment.environment.name=dev,custom=value%20with%20spaces,service.name=ignored',
+			OTEL_SERVICE_NAME: 'agent-host',
 		});
-		deepStrictEqual(cfg.headers, { authorization: 'Bearer xyz', 'x-tenant': 'acme' });
+		deepStrictEqual({ headers: cfg.headers, resourceAttributes: cfg.resourceAttributes }, {
+			headers: { authorization: 'Bearer xyz', 'x-tenant': 'acme' },
+			resourceAttributes: {
+				'deployment.environment.name': 'dev',
+				custom: 'value with spaces',
+				'service.name': 'agent-host',
+			},
+		});
 	});
 
 	test('getSdkTelemetryConfig: returns undefined when fully disabled', async () => {
@@ -277,6 +288,7 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 		try {
 			process.env.COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED = 'true';
 			process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'true';
+			process.env.OTEL_SERVICE_NAME = 'agent-host-test';
 
 			const di = store.add(new TestInstantiationService());
 			di.set(ILogService, new NullLogService());
@@ -284,7 +296,7 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 			const svc = store.add(di.createInstance(AgentHostOTelService, undefined));
 
 			await svc.getSdkTelemetryConfig();
-			svc.emitSessionTitleChanged('conv-title', 'copilotcli:/conv-title', 'Updated title');
+			svc.emitSessionTitleChanged('conv-title', 'copilotcli:/conv-title', `Updated title ${'x'.repeat(300)}`);
 			await svc.flush();
 
 			const dbPath = svc.getSpansDbPath();
@@ -294,8 +306,9 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 				const spans = reader.getSpansByConversationId('conv-title');
 				strictEqual(spans.length, 1);
 				strictEqual(spans[0].name, AgentHostSessionTitleSpanName);
-				strictEqual(reader.getSpanAttribute(spans[0].span_id, AgentHostSessionTitleAttribute), 'Updated title');
+				strictEqual(reader.getSpanAttribute(spans[0].span_id, AgentHostSessionTitleAttribute)?.length, 200);
 				strictEqual(reader.getSpanAttribute(spans[0].span_id, AgentHostSessionUriAttribute), 'copilotcli:/conv-title');
+				strictEqual(reader.getSpanAttribute(spans[0].span_id, 'service.name'), 'agent-host-test');
 			} finally {
 				reader.close();
 			}

--- a/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
@@ -18,7 +18,7 @@ import {
 	IOtlpExportTraceServiceRequest,
 	OtlpSpanKind,
 } from '../../../../otel/node/otlp/otlpJsonTypes.js';
-import { IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
+import { AgentHostSessionTitleAttribute, AgentHostSessionTitleSpanName, AgentHostSessionUriAttribute, IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
 import { AgentHostOTelService, readAgentHostOTelEnv } from '../../../node/otel/agentHostOTelService.js';
 import { AgentHostOTelSpansDbSubPath } from '../../../common/agentService.js';
 
@@ -261,6 +261,41 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 				const operationNames = persisted.map(s => s.operation_name);
 				ok(operationNames.every(op => op === 'invoke_agent'));
 				notStrictEqual(persisted[0].request_model, null);
+			} finally {
+				reader.close();
+			}
+		} finally {
+			restoreEnv(saved);
+			await cleanup();
+		}
+	});
+
+	test('DB mode: emits session title metadata spans when content capture is enabled', async () => {
+		const saved = saveEnv();
+		const tmp = await mkdtemp(join(tmpdir(), 'vscode-otel-svc-'));
+		const cleanup = () => rm(tmp, { recursive: true, force: true }).catch(() => undefined);
+		try {
+			process.env.COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED = 'true';
+			process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'true';
+
+			const di = store.add(new TestInstantiationService());
+			di.set(ILogService, new NullLogService());
+			di.set(INativeEnvironmentService, makeEnvService(tmp));
+			const svc = store.add(di.createInstance(AgentHostOTelService, undefined));
+
+			await svc.getSdkTelemetryConfig();
+			svc.emitSessionTitleChanged('conv-title', 'copilotcli:/conv-title', 'Updated title');
+			await svc.flush();
+
+			const dbPath = svc.getSpansDbPath();
+			ok(dbPath);
+			const reader = new OTelSqliteStore(dbPath!.fsPath);
+			try {
+				const spans = reader.getSpansByConversationId('conv-title');
+				strictEqual(spans.length, 1);
+				strictEqual(spans[0].name, AgentHostSessionTitleSpanName);
+				strictEqual(reader.getSpanAttribute(spans[0].span_id, AgentHostSessionTitleAttribute), 'Updated title');
+				strictEqual(reader.getSpanAttribute(spans[0].span_id, AgentHostSessionUriAttribute), 'copilotcli:/conv-title');
 			} finally {
 				reader.close();
 			}


### PR DESCRIPTION
## Summary

Emits a standalone `vscode.agent_host.session.title_changed` span whenever the authoritative Copilot Agent Host session title changes. The span is correlated with SDK telemetry through `gen_ai.conversation.id` and carries:

- `vscode.agent_host.session.title`
- `vscode.agent_host.session.uri`

Title emission is gated by Agent Host OTel enablement and GenAI content capture. The state-manager hook covers fallback, generated, refined, and manually renamed titles while suppressing no-op assignments. The synthetic spans work with the existing SQLite, OTLP, file, and console exporters.

This gives downstream consumers such as OTelux a small last-write-wins metadata signal for updating session titles without mutating completed SDK spans.

## Validation

- `npm run eslint -- <changed files>`
- `npm run typecheck-client`
- Targeted Mocha tests:
  - `AgentHostStateManager` title-change event
  - `AgentHostOTelService` title metadata persistence

The standard gulp compile could not run in the isolated clone because the shared dependency installation does not contain `gulp-merge-json`; direct TypeScript compilation completed successfully.