### PR TITLE
chat: reduce latest response reserved height

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -457,13 +457,6 @@ export class ChatListWidget extends Disposable {
 
 		this._register(this._renderer.onDidChangeItemHeight(e => {
 			this._updateElementHeight(e.element, e.height);
-
-			// If the second-to-last item's height changed, update the last item's min height
-			const secondToLastItem = this._viewModel?.getItems().at(-2);
-			if (e.element.id === secondToLastItem?.id) {
-				this.updateLastItemMinHeight();
-			}
-
 			this._onDidChangeItemHeight.fire(e);
 		}));
 
@@ -689,8 +682,6 @@ export class ChatListWidget extends Disposable {
 		const items = this._viewModel.getItems();
 		this._lastItem = items.at(-1);
 		this._lastItemIdContextKey.set(this._lastItem ? [this._lastItem.id] : []);
-		const previousItem = items.at(-2);
-		const needsInitialPreviousItemHeight = (isRequestVM(previousItem) || isResponseVM(previousItem)) && previousItem.currentRenderedHeight === undefined;
 
 		const treeItems: ITreeElement<ChatTreeItem>[] = items.map(item => ({
 			element: item,
@@ -732,10 +723,6 @@ export class ChatListWidget extends Disposable {
 				}
 			});
 		});
-
-		if (needsInitialPreviousItemHeight) {
-			this.updateLastItemMinHeight();
-		}
 	}
 
 	/**
@@ -1080,17 +1067,10 @@ export class ChatListWidget extends Disposable {
 			return;
 		}
 
-		const contentHeight = this._bodyDimension.height;
 		if (this._renderStyle === 'compact' || this._renderStyle === 'minimal') {
 			this._container.style.removeProperty('--chat-current-response-min-height');
 		} else {
-			const secondToLastItem = this._viewModel?.getItems().at(-2);
-			const maxRequestShownHeight = 200;
-			const secondToLastItemHeight = Math.min(
-				(isRequestVM(secondToLastItem) || isResponseVM(secondToLastItem)) ?
-					secondToLastItem.currentRenderedHeight ?? this._delegate.getMeasuredHeight(secondToLastItem) ?? 150 : 150,
-				maxRequestShownHeight);
-			const lastItemMinHeight = Math.max(contentHeight - (secondToLastItemHeight + 10), 0);
+			const lastItemMinHeight = this._bodyDimension.height / 4;
 			this._container.style.setProperty('--chat-current-response-min-height', lastItemMinHeight + 'px');
 			if (lastItemMinHeight !== this._previousLastItemMinHeight) {
 				this._previousLastItemMinHeight = lastItemMinHeight;


### PR DESCRIPTION
## What changed

- Reserve one-fourth of the chat list height as the minimum height for the latest response.
- Remove the preceding request height measurement and related refresh logic.

## Why

Sending a message should reveal the latest response without scrolling the preceding request all the way to the top of the viewport. A direct minimum height is simpler and keeps more conversation context visible.

## Validation

- `npm run compile`
- Focused `ChatListWidget` unit tests
- Hygiene check

(Written by Copilot)