### PR TITLE
Fix Copilot CLI session monitor startup race

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -371,7 +371,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 			}));
 		} catch (error) {
 			disposables.dispose();
-			this.logService.error(`Failed to monitor Copilot CLI session files: ${error}`);
+			this.logService.error('Failed to monitor Copilot CLI session files:', error);
 			return;
 		}
 		this._sessionFileMonitor.value = disposables;

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -29,7 +29,7 @@ import { disposableTimeout, raceCancellation, raceCancellationError, SequencerBy
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { Emitter, Event } from '../../../../util/vs/base/common/event';
 import { Lazy } from '../../../../util/vs/base/common/lazy';
-import { Disposable, DisposableMap, IDisposable, IReference, RefCountedDisposable, toDisposable } from '../../../../util/vs/base/common/lifecycle';
+import { Disposable, DisposableMap, DisposableStore, IDisposable, IReference, MutableDisposable, RefCountedDisposable, toDisposable } from '../../../../util/vs/base/common/lifecycle';
 import { basename, dirname, joinPath } from '../../../../util/vs/base/common/resources';
 import { URI } from '../../../../util/vs/base/common/uri';
 import { generateUuid } from '../../../../util/vs/base/common/uuid';
@@ -148,6 +148,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 	private readonly _sessionTracker: CopilotCLISessionWorkspaceTracker;
 	private readonly _sessionWorkingDirectories = new Map<string, Uri | undefined>();
 	private readonly _onDidChangeSessionsThrottler = this._register(new ThrottledDelayer<void>(500));
+	private readonly _sessionFileMonitor = this._register(new MutableDisposable<IDisposable>());
 	private readonly _cachedSessionItems = new Map<string, ICopilotCLISessionItem>();
 	private readonly _sessionsBeingCreatedViaFork = new Set<string>();
 	private readonly _newSessionIds = new Set<string>();
@@ -190,6 +191,9 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 			if (e.affectsConfiguration(ConfigKey.Advanced.CLIShowExternalSessions.fullyQualifiedId)) {
 				this.showExternalSessions = this.configurationService.getConfig(ConfigKey.Advanced.CLIShowExternalSessions);
 			}
+			if (e.affectsConfiguration(AGENT_HOST_ENABLED_SETTING_ID) || e.affectsConfiguration(this.defaultSessionsProviderSettingId)) {
+				this.updateSessionFileMonitoring();
+			}
 		}));
 		this._register(this._promptsService.onDidChangeCustomAgents(() => {
 			this._customAgentLookupChanged = true;
@@ -197,9 +201,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 				void this.createCustomAgentLookup();
 			}
 		}));
-		if (this.shouldMonitorSessionFiles()) {
-			this.monitorSessionFiles();
-		}
+		this.updateSessionFileMonitoring();
 		this._sessionManager = new Lazy<Promise<internal.LocalSessionManager>>(async () => {
 			try {
 				const sdkPackage = await this.getSDKPackage();
@@ -242,10 +244,25 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 			return true;
 		}
 
-		const defaultProviderSettingId = this._agentSessionsWorkspace.isAgentSessionsWorkspace
+		return this.configurationService.getNonExtensionConfig<boolean>(this.defaultSessionsProviderSettingId) !== true;
+	}
+
+	private get defaultSessionsProviderSettingId(): string {
+		return this._agentSessionsWorkspace.isAgentSessionsWorkspace
 			? AGENT_HOST_DEFAULT_SESSIONS_PROVIDER_SETTING_ID
 			: DEFAULT_TO_COPILOT_HARNESS_SETTING_ID;
-		return this.configurationService.getNonExtensionConfig<boolean>(defaultProviderSettingId) !== true;
+	}
+
+	private updateSessionFileMonitoring(): void {
+		const shouldMonitor = this.shouldMonitorSessionFiles();
+		if (shouldMonitor === !!this._sessionFileMonitor.value) {
+			return;
+		}
+		if (shouldMonitor) {
+			this.monitorSessionFiles();
+		} else {
+			this._sessionFileMonitor.clear();
+		}
 	}
 
 	private async getSDKPackage(): Promise<SDKPackage> {
@@ -308,11 +325,12 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 		return this._newSessionIds.has(sessionId);
 	}
 
-	protected monitorSessionFiles() {
+	protected monitorSessionFiles(): void {
+		const disposables = new DisposableStore();
 		try {
 			const sessionDir = joinPath(this.nativeEnv.userHome, '.copilot', 'session-state');
-			const watcher = this._register(this.fileSystem.createFileSystemWatcher(new RelativePattern(sessionDir, '**/*.jsonl')));
-			this._register(watcher.onDidCreate(async (e) => {
+			const watcher = disposables.add(this.fileSystem.createFileSystemWatcher(new RelativePattern(sessionDir, '**/*.jsonl')));
+			disposables.add(watcher.onDidCreate(async (e) => {
 				const sessionId = extractSessionIdFromEventPath(sessionDir, e);
 				if (sessionId && this._sessionsBeingCreatedViaFork.has(sessionId)) {
 					return;
@@ -323,7 +341,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 					this._onDidChangeSession.fire(sessionItem);
 				}
 			}));
-			this._register(watcher.onDidDelete(e => {
+			disposables.add(watcher.onDidDelete(e => {
 				const sessionId = extractSessionIdFromEventPath(sessionDir, e);
 				if (sessionId) {
 					this._cachedSessionItems.delete(sessionId);
@@ -331,7 +349,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 				}
 				this.triggerSessionsChangeEvent();
 			}));
-			this._register(watcher.onDidChange((e) => {
+			disposables.add(watcher.onDidChange((e) => {
 				// If we're busy fetching sessions, then do not trigger change event as we'll trigger one after we're done fetching sessions.
 				if (this._isGettingSessions > 0) {
 					return;
@@ -352,8 +370,11 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 				this.triggerSessionsChangeEvent();
 			}));
 		} catch (error) {
+			disposables.dispose();
 			this.logService.error(`Failed to monitor Copilot CLI session files: ${error}`);
+			return;
 		}
+		this._sessionFileMonitor.value = disposables;
 	}
 	async getSessionManager() {
 		return this._sessionManager.value;

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
@@ -78,16 +78,22 @@ class TestFileSystemWatcher implements FileSystemWatcher {
 	readonly onDidCreate = emptyFileSystemEvent;
 	readonly onDidChange = emptyFileSystemEvent;
 	readonly onDidDelete = emptyFileSystemEvent;
-	dispose(): void { }
+
+	constructor(private readonly onDispose: () => void) { }
+
+	dispose(): void {
+		this.onDispose();
+	}
 }
 
 class TrackingFileSystemService extends MockFileSystemService {
 	createFileSystemWatcherCallCount = 0;
+	disposeFileSystemWatcherCallCount = 0;
 	readDirectoryCallCount = 0;
 
 	override createFileSystemWatcher(): FileSystemWatcher {
 		this.createFileSystemWatcherCallCount++;
-		return new TestFileSystemWatcher();
+		return new TestFileSystemWatcher(() => this.disposeFileSystemWatcherCallCount++);
 	}
 
 	override async readDirectory(uri: URI): Promise<[string, FileType][]> {
@@ -282,6 +288,33 @@ describe('CopilotCLISessionService', () => {
 			}
 
 			expect(results).toEqual(cases.map(testCase => ({ name: testCase.name, watcherCount: testCase.expectedWatcherCount })));
+		});
+
+		it('stops monitoring when the Agents window Agent Host default resolves after construction', async () => {
+			const testConfiguration = disposables.add(new InMemoryConfigurationService(configurationService));
+			await Promise.all([
+				testConfiguration.setNonExtensionConfig('chat.agentHost.enabled', true),
+				testConfiguration.setNonExtensionConfig('chat.agentHost.defaultSessionsProvider', false),
+			]);
+			const fileSystem = new TrackingFileSystemService();
+			disposables.add(createSessionService({
+				configurationService: testConfiguration,
+				fileSystem,
+				isAgentSessionsWorkspace: true,
+			}));
+			const states = [{ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount }];
+
+			await testConfiguration.setNonExtensionConfig('chat.agentHost.defaultSessionsProvider', true);
+			states.push({ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount });
+
+			await testConfiguration.setNonExtensionConfig('chat.agentHost.defaultSessionsProvider', false);
+			states.push({ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount });
+
+			expect(states).toEqual([
+				{ created: 1, disposed: 0 },
+				{ created: 1, disposed: 1 },
+				{ created: 2, disposed: 1 },
+			]);
 		});
 	});
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
@@ -297,7 +297,7 @@ describe('CopilotCLISessionService', () => {
 				testConfiguration.setNonExtensionConfig('chat.agentHost.defaultSessionsProvider', false),
 			]);
 			const fileSystem = new TrackingFileSystemService();
-			disposables.add(createSessionService({
+			const sessionService = disposables.add(createSessionService({
 				configurationService: testConfiguration,
 				fileSystem,
 				isAgentSessionsWorkspace: true,
@@ -310,10 +310,14 @@ describe('CopilotCLISessionService', () => {
 			await testConfiguration.setNonExtensionConfig('chat.agentHost.defaultSessionsProvider', false);
 			states.push({ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount });
 
+			sessionService.dispose();
+			states.push({ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount });
+
 			expect(states).toEqual([
 				{ created: 1, disposed: 0 },
 				{ created: 1, disposed: 1 },
 				{ created: 2, disposed: 1 },
+				{ created: 2, disposed: 2 },
 			]);
 		});
 	});


### PR DESCRIPTION
## Summary

- make the extension-host Copilot CLI session-file monitor react to effective Agent Host ownership settings
- dispose a watcher started before the Agents window experimental default resolves
- restore monitoring if ownership later moves back to the extension-host provider
- add regression coverage for the delayed configuration transition

## Validation

- `npm run test:unit -- src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts` (49 passed, 1 skipped)
- `npx tsc --noEmit --project tsconfig.json`
- targeted ESLint and repository hygiene checks

(Written by Copilot)