### PR TITLE
Fix agent host simple attachment transport

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAttachmentUtils.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAttachmentUtils.ts
@@ -6,12 +6,13 @@
 import type { SimpleMessageAttachment } from '../../common/state/protocol/state.js';
 
 const attachmentDisplayKindParameter = 'x-vscode-display-kind=';
+const simpleAttachmentMimeType = 'text/x-vscode-simple-attachment';
 
 export function addSimpleAttachmentDisplayKindToMimeType(attachment: SimpleMessageAttachment): string {
 	if (attachment.displayKind === undefined) {
 		return 'text/plain';
 	}
-	return `text/plain; ${attachmentDisplayKindParameter}${encodeURIComponent(attachment.displayKind)}`;
+	return `${simpleAttachmentMimeType}; ${attachmentDisplayKindParameter}${encodeURIComponent(attachment.displayKind)}`;
 }
 
 export function readSimpleAttachmentDisplayKindFromMimeType(mimeType: string): string | undefined {

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -709,13 +709,13 @@ function sdkAttachmentToProtocol(
 			if (typeof attachment.data !== 'string') {
 				return undefined;
 			}
-			if (attachment.mimeType.startsWith('text/plain')) {
-				const displayKind = readSimpleAttachmentDisplayKindFromMimeType(attachment.mimeType);
+			const simpleDisplayKind = readSimpleAttachmentDisplayKindFromMimeType(attachment.mimeType);
+			if (attachment.mimeType.startsWith('text/plain') || simpleDisplayKind !== undefined) {
 				return {
 					type: MessageAttachmentKind.Simple,
 					label: attachment.displayName ?? 'attachment',
 					modelRepresentation: decodeBase64(attachment.data ?? '').toString(),
-					...(displayKind !== undefined ? { displayKind } : {}),
+					...(simpleDisplayKind !== undefined ? { displayKind: simpleDisplayKind } : {}),
 				};
 			}
 			const displayKind = attachment.mimeType.startsWith('image/') ? 'image' : undefined;

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -881,7 +881,7 @@ suite('CopilotAgentSession', () => {
 		}]);
 	});
 
-	test('preserves simple attachment display kind through SDK blobs', async () => {
+	test('sends display-kind simple attachments as inline text SDK blobs', async () => {
 		const { session, mockSession } = await createAgentSession(disposables);
 		const attachment = {
 			type: MessageAttachmentKind.Simple,
@@ -894,7 +894,7 @@ suite('CopilotAgentSession', () => {
 		const sdkAttachment = {
 			type: 'blob' as const,
 			data: encodeBase64(VSBuffer.fromString(attachment.modelRepresentation)),
-			mimeType: 'text/plain; x-vscode-display-kind=workspace',
+			mimeType: 'text/x-vscode-simple-attachment; x-vscode-display-kind=workspace',
 			displayName: attachment.label,
 		};
 		assert.deepStrictEqual(mockSession.sendRequests, [{
@@ -978,7 +978,7 @@ suite('CopilotAgentSession', () => {
 			attachments: [{
 				type: 'blob',
 				data: encodeBase64(VSBuffer.fromString('Transcript text')),
-				mimeType: 'text/plain; x-vscode-display-kind=paste',
+				mimeType: 'text/x-vscode-simple-attachment; x-vscode-display-kind=paste',
 				displayName: 'Previous conversation',
 			}],
 		}]);
@@ -994,7 +994,7 @@ suite('CopilotAgentSession', () => {
 				attachments: [{
 					type: 'blob',
 					data: encodeBase64(VSBuffer.fromString('Transcript text')),
-					mimeType: 'text/plain; x-vscode-display-kind=paste',
+					mimeType: 'text/x-vscode-simple-attachment; x-vscode-display-kind=paste',
 					displayName: 'Previous conversation',
 				}],
 			},

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -910,7 +910,10 @@ suite('CopilotAgentSession', () => {
 			data: {
 				interactionId: 'message-1',
 				content: 'hello',
-				attachments: [sdkAttachment],
+				attachments: [{
+					...sdkAttachment,
+					mimeType: 'text/plain; x-vscode-display-kind=workspace',
+				}],
 			},
 		}];
 


### PR DESCRIPTION
## Summary

- keep display-kind simple attachments on the Copilot SDK inline-text path
- preserve display-kind reconstruction for both legacy `text/plain` history and the new private text subtype
- cover Browser Pages and paste attachment round trips

## Root cause

Agent-host encoded synthetic text context such as **Browser Pages** as `text/plain; x-vscode-display-kind=workspace`. The SDK normalized that to `text/plain`, treated it as a native document, and some CAPI model paths rejected the upload with `400 The file type you uploaded is not supported. Please try again with a pdf`.

Using `text/x-vscode-simple-attachment` preserves text fallback semantics and avoids native-document transport while retaining the display-kind MIME parameter.

Related: #324450

## Validation

- RED: new regression failed with `text/plain; x-vscode-display-kind=workspace`
- focused `CopilotAgentSession` suite: 243 passing
- `npm run tsec-compile-check`
- pre-commit hygiene