### PR TITLE
Close the remaining Windows gaps in the agent host E2E suite

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -87,11 +87,11 @@ Two independent things made a temp directory containing a git repository undelet
 
 ### Recording rejects POSIX-only commands
 
-`CapiReplayProxy` checks the assistant's `tool_use` commands before writing a fixture and fails the recording if any of them cannot run under `cmd`. It throws before the write, so a rejected recording cannot leave a half-portable capture behind.
+`CapiReplayProxy` checks the assistant's `tool_use` commands before writing a fixture and fails the recording if any of them are not portable to the suite's Windows shell configurations. It throws before the write, so a rejected recording cannot leave a half-portable capture behind.
 
 This exists because the failure mode is silent and recurring: nobody chooses these command strings, the model produces them, so a prompt that drifts back toward describing the goal will quietly reintroduce a POSIX-only capture. Checking at record time puts the error on the author's machine while they still have the context, rather than on a CI leg they may not run.
 
-The check is a blocklist of constructs known to fail under `cmd` — coreutils and shell builtins in command position, POSIX stderr redirection, `/dev/*`, `$VAR` expansion, `~/`. It is deliberately not an allowlist of portable commands: a false positive would block a correct recording and push authors toward disabling the check, which is worse than missing a case. Patterns are anchored to command position so a coreutil name appearing as an argument (`node -e "readdirSync('.')"`) does not trip it.
+The check is a blocklist of constructs known not to replay reliably in the suite's effective Windows shells — coreutils and shell builtins in command position, POSIX stderr redirection, `/dev/*`, `$VAR` expansion, `~/`. It is deliberately not an allowlist of portable commands: a false positive would block a correct recording and push authors toward disabling the check, which is worse than missing a case. Patterns are anchored to command position so a coreutil name appearing as an argument (`node -e "readdirSync('.')"`) does not trip it. `pwd` is allowed because the host-managed terminal uses PowerShell on Windows, where it aliases `Get-Location`.
 
 Genuine exceptions go in `POSIX_COMMAND_EXCEPTIONS` in `agentHostE2ETestHarness.ts`, which keeps them countable in one place. An entry there must correspond to a test that is also scoped away from Windows at its call site, with the reason stated there.
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -27,11 +27,31 @@ Distinct from individually disabled tests: whole areas where a platform or contr
 
 ### What is still Windows-scoped
 
-The blanket `!isWindows` shell exclusion is gone: `portableShellToolReplayEnabled` now only reflects the provider's shell-tool replay stability on Linux, and every capture that runs a shell command is portable. Permission approval, file operations, renames, deletes, directory creation, git status, git-backed config completions, and worktree resolution all run on Windows.
+The blanket `!isWindows` shell exclusion is gone: `portableShellToolReplayEnabled` now only reflects the provider's shell-tool replay stability on Linux. Permission approval, file operations, renames, deletes, directory creation, git status, and git-backed config completions all run on Windows.
 
-One row remains, and it is not about command portability: `a bang command runs locally and exposes terminal output`, where the successful bang command produces output but does not complete reliably.
+Two tests remain scoped, both at their call site with the reason:
 
-`POSIX_COMMAND_EXCEPTIONS` in `agentHostE2ETestHarness.ts` — the opt-out from the record-time command check — is currently empty. Keep it that way if at all possible; an entry there means a capture that can never replay on Windows.
+- `a bang command runs locally and exposes terminal output` — the successful bang command produces output but does not complete reliably. Not a portability problem.
+- `worktree session uses the resolved worktree as working directory` — its shell half was enabled and then reverted after Windows CI failed it for two reasons unrelated to command portability, described below. Its non-shell half still asserts worktree resolution on Windows.
+
+### Path shape differs between the test and the shell
+
+The E2E workspaces come from `os.tmpdir()`, and what that returns is not what a process running inside it reports as its working directory:
+
+| Platform | `os.tmpdir()` | working directory as reported |
+|---|---|---|
+| Windows CI | `C:\Users\CLOUDT~1\AppData\Local\Temp\…` (8.3 short form) | `C:\Users\cloudtest\AppData\Local\Temp\…` |
+| macOS | `/var/folders/…` (logical) | `/private/var/folders/…` (physical) |
+
+Any assertion that a command's output *contains* a path built from `tmpdir()` is therefore comparing two different spellings of the same directory. `normalizeSnapshotText` already strips `/private` for the macOS case, but a test asserting directly on tool output — rather than through a snapshot — has no such help.
+
+This is why `worktree session uses the resolved worktree as working directory` fails on Windows CI: the assertion never matches, and the test times out waiting for output that will never arrive in the expected form. Reworking it means resolving both sides with `realpathSync.native` before comparing, which also removes the macOS special case.
+
+### The host terminal tool surfaces no content on Windows
+
+The same test's Copilot branch waits for a `chat/toolCallContentChanged` carrying a terminal resource. On Windows CI that notification never arrives, even though `chat/toolCallStart`, `chat/toolCallReady`, the confirmation round-trip, and `chat/toolCallComplete` all do.
+
+So the tool call runs to completion but the host-managed terminal never publishes streaming content. Whether that is a product gap or a configuration difference in the test is not yet established — it needs a Windows machine to investigate, and it is the blocker for asserting terminal `cwd` on Windows at all.
 
 ### Steering versus pinning
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -25,13 +25,13 @@ Capability skips are tracked separately from suspected bugs. A provider that doe
 
 Distinct from individually disabled tests: whole areas where a platform or contract has no E2E coverage at all. These do not show up as skipped tests, so they are easy to miss.
 
-### What is still Windows-scoped, and why
+### What is still Windows-scoped
 
-The blanket `!isWindows` shell exclusion is gone: `portableShellToolReplayEnabled` now only reflects the provider's shell-tool replay stability on Linux, and every capture that runs a shell command is portable. Permission approval, file operations, renames, deletes, directory creation, and git status all run on Windows.
+The blanket `!isWindows` shell exclusion is gone: `portableShellToolReplayEnabled` now only reflects the provider's shell-tool replay stability on Linux, and every capture that runs a shell command is portable. Permission approval, file operations, renames, deletes, directory creation, git status, git-backed config completions, and worktree resolution all run on Windows.
 
-One test remains deliberately scoped, at its call site with a comment:
+One row remains, and it is not about command portability: `a bang command runs locally and exposes terminal output`, where the successful bang command produces output but does not complete reliably.
 
-- `worktree session uses the resolved worktree as working directory` — cannot be fixed by pinning. `pwd` is auto-approved as a safe read-only command, while a pinned `node -e "…"` is not, so the turn stops on a permission prompt the test never answers. The assertions also compare POSIX-shaped paths. Worktree resolution itself is still asserted on Windows through the `sessionAdded` working-directory check in the same test's non-shell half.
+`POSIX_COMMAND_EXCEPTIONS` in `agentHostE2ETestHarness.ts` — the opt-out from the record-time command check — is currently empty. Keep it that way if at all possible; an entry there means a capture that can never replay on Windows.
 
 ### Steering versus pinning
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -25,16 +25,6 @@ Capability skips are tracked separately from suspected bugs. A provider that doe
 
 Distinct from individually disabled tests: whole areas where a platform or contract has no E2E coverage at all. These do not show up as skipped tests, so they are easy to miss.
 
-### The user name is scrubbed by naive substring replacement
-
-`normalizeSnapshotText` in `ahpSnapshot.ts` ends with `.replaceAll(normalization.userName, '${user}')`. That is an unanchored substring replacement, so any occurrence of the account name in captured text is rewritten, whether or not it refers to the user.
-
-This is a cross-platform hazard because the account name differs per environment: a developer's own name locally, `runner` on GitHub Actions Linux, `runneradmin` on Windows. `runner` in particular is an ordinary English word, so a snapshot recorded on macOS keeps the literal text while the same run on Linux CI normalizes it to `${user}`, and the snapshot mismatches for a reason unrelated to the behavior under test.
-
-Verified against the current implementation with `userName: 'runner'`: the tool output `the runner completed` serializes as `the ${user} completed`.
-
-Home directory paths are already handled by the `${homedir}` replacement that runs just before this one, so the bare user-name pass is only needed for occurrences outside a home path. Restricting it to path-like contexts (preceded by a separator) would keep that coverage without corrupting prose. Left alone for now because no committed snapshot currently trips it — fix it alongside the first test that does.
-
 ### What is still Windows-scoped, and why
 
 The blanket `!isWindows` shell exclusion is gone: `portableShellToolReplayEnabled` now only reflects the provider's shell-tool replay stability on Linux, and every capture that runs a shell command is portable. Permission approval, file operations, renames, deletes, directory creation, and git status all run on Windows.

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -44,6 +44,16 @@ Pinning uses `node -e "…"`, which is guaranteed present because the suite runs
 
 The trade-off is real: a pinned command tests shell execution rather than the provider's tool selection. Pin only when steering has actually been tried and failed, and note which it was.
 
+### Pinning a command changes its permission posture
+
+Providers auto-approve a small set of safe read-only commands. `pwd` is on that list; an arbitrary `node -e "…"` is not.
+
+That matters when porting a test off a POSIX-only command, because pinning does more than change the string — it can turn a tool call that completed silently into one that raises `session/inputNeededSet` and waits. A test whose flow does not answer that confirmation then hangs until its timeout, which looks nothing like a portability failure.
+
+`worktree session uses the resolved worktree as working directory` is the case in point: replacing `pwd` with `node -e "console.log(process.cwd())"` was tried on both of its turns and stalled on confirmation each time, even though the second turn does dispatch `ChatToolCallConfirmed`. It keeps `pwd`, which is portable regardless — PowerShell defines it as an alias for `Get-Location`.
+
+Two things follow. Check whether a command you are about to pin was previously auto-approved, and prefer steering to a file tool where one exists, since that avoids the permission surface entirely.
+
 ### Temporary git repositories on Windows
 
 Two independent things made a temp directory containing a git repository undeletable on Windows, which failed suite teardown even when every test passed:

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -29,10 +29,9 @@ Distinct from individually disabled tests: whole areas where a platform or contr
 
 The blanket `!isWindows` shell exclusion is gone: `portableShellToolReplayEnabled` now only reflects the provider's shell-tool replay stability on Linux, and every capture that runs a shell command is portable. Permission approval, file operations, renames, deletes, directory creation, and git status all run on Windows.
 
-Two things remain deliberately scoped, both at the call site with a comment:
+One test remains deliberately scoped, at its call site with a comment:
 
 - `worktree session uses the resolved worktree as working directory` — cannot be fixed by pinning. `pwd` is auto-approved as a safe read-only command, while a pinned `node -e "…"` is not, so the turn stops on a permission prompt the test never answers. The assertions also compare POSIX-shaped paths. Worktree resolution itself is still asserted on Windows through the `sessionAdded` working-directory check in the same test's non-shell half.
-- `session configuration resolves and completes git branches` — Windows retains a handle on the temporary git repository after session disposal. This is mandatory file locking, a genuine OS difference, and nothing about command portability affects it.
 
 ### Steering versus pinning
 
@@ -44,6 +43,15 @@ Two techniques, and the choice is not stylistic:
 Pinning uses `node -e "…"`, which is guaranteed present because the suite runs under Node, and whose `"…"` / `'…'` quoting is read identically by `cmd` and POSIX shells. Prefer relative paths in a pinned command so no Windows path with backslashes has to be escaped into a JavaScript string literal.
 
 The trade-off is real: a pinned command tests shell execution rather than the provider's tool selection. Pin only when steering has actually been tried and failed, and note which it was.
+
+### Temporary git repositories on Windows
+
+Two independent things made a temp directory containing a git repository undeletable on Windows, which failed suite teardown even when every test passed:
+
+- Git marks the files under `.git/objects` read-only, and a read-only file cannot be deleted on Windows. `rmSync`'s `force` option only suppresses `ENOENT` — it does not override the attribute — so the retry loop burned its full timeout on a condition that waiting can never fix. `removeTempDirs` now clears read-only attributes before each retry.
+- An auto-triggered `git gc` can still hold handles under `.git` after the test finishes. `initTestGitRepo` sets `gc.auto 0`; these repositories never create enough objects to need it.
+
+`session configuration resolves and completes git branches` was disabled on Windows for this reason and is now enabled. Its assertions were always platform-independent — only teardown failed.
 
 ### Recording rejects POSIX-only commands
 
@@ -159,12 +167,11 @@ These four are the actionable item: until they are recorded, the reason Codex sk
 
 Most of this section is resolved — see [What is still Windows-scoped, and why](#what-is-still-windows-scoped-and-why). Thirteen tests that were disabled on Windows because their capture contained a POSIX-only command now run there.
 
-Two rows remain, and neither is about command portability:
+One row remains, and it is not about command portability:
 
 | Test | Disabled scope | Observed limitation |
 |---|---|---|
 | `a bang command runs locally and exposes terminal output` | Windows | The successful bang command produces output but does not complete reliably. |
-| `session configuration resolves and completes git branches` | Windows | Git-backed config discovery can retain the temporary repository lock after session disposal. |
 
 Use the affected provider command with `--grep "<exact test title>"` and temporarily remove the platform gate to reevaluate a row.
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -44,15 +44,17 @@ Pinning uses `node -e "…"`, which is guaranteed present because the suite runs
 
 The trade-off is real: a pinned command tests shell execution rather than the provider's tool selection. Pin only when steering has actually been tried and failed, and note which it was.
 
-### Pinning a command changes its permission posture
+### Approve tool calls in a loop, not once
 
-Providers auto-approve a small set of safe read-only commands. `pwd` is on that list; an arbitrary `node -e "…"` is not.
+Providers auto-approve a small set of safe read-only commands (`pwd` among them). A pinned `node -e "…"` is not on that list, so pinning a command generally *adds* an approval round-trip that the previous command did not need.
 
-That matters when porting a test off a POSIX-only command, because pinning does more than change the string — it can turn a tool call that completed silently into one that raises `session/inputNeededSet` and waits. A test whose flow does not answer that confirmation then hangs until its timeout, which looks nothing like a portability failure.
+That is fine — the approval flow is a normal part of the protocol and every shared helper already drives it. `driveTurnToCompletion` confirms each unconfirmed `chat/toolCallReady` as it arrives, and `startBackgroundApprovalLoop` does the same for tests that drive turns by hand. Both are loops.
 
-`worktree session uses the resolved worktree as working directory` is the case in point: replacing `pwd` with `node -e "console.log(process.cwd())"` was tried on both of its turns and stalled on confirmation each time, even though the second turn does dispatch `ChatToolCallConfirmed`. It keeps `pwd`, which is portable regardless — PowerShell defines it as an alias for `Get-Location`.
+What does not work is approving once. A turn can raise more than one approval, so a single `waitForNotification` for `chat/toolCallReady` followed by one `ChatToolCallConfirmed` leaves any later request pending; the turn then stalls on `session/inputNeededSet` until the test times out. The failure looks like a hang, not a permission problem, which makes it easy to misread as the pinned command being unsupported.
 
-Two things follow. Check whether a command you are about to pin was previously auto-approved, and prefer steering to a file tool where one exists, since that avoids the permission surface entirely.
+`worktree session uses the resolved worktree as working directory` had exactly this shape: its host-terminal branch approved once while its SDK-shell branch used `startBackgroundApprovalLoop`. Both branches now use the loop, and the command is pinned like everywhere else.
+
+Prefer steering to a file tool where one exists — that avoids the approval surface entirely. Where a shell command is genuinely required, pin it and drive approvals with one of the shared loops.
 
 ### Temporary git repositories on Windows
 

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-worktree-session-uses-the-resolved-worktree-as-working-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-worktree-session-uses-the-resolved-worktree-as-working-directory.yaml
@@ -19,15 +19,15 @@ exchanges:
         - role: assistant
           content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
         - role: user
-          content: Run the shell command `pwd` in the session current working directory. Do not specify a working-directory override.
+          content: 'Run exactly this shell command, with no modifications, in the session current working directory: `node -e "console.log(process.cwd())"`. Do not specify a working-directory override.'
     response:
       content:
         - type: tool_use
           id: toolcall_0
           name: Bash
           input:
-            command: pwd
-            description: Print working directory
+            command: node -e "console.log(process.cwd())"
+            description: Print Node.js current working directory
       stopReason: tool_use
   - request:
       model: claude-opus-4.8
@@ -38,14 +38,15 @@ exchanges:
         - role: assistant
           content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
         - role: user
-          content: Run the shell command `pwd` in the session current working directory. Do not specify a working-directory override.
+          content: 'Run exactly this shell command, with no modifications, in the session current working directory: `node -e "console.log(process.cwd())"`. Do not specify a working-directory override.'
         - role: assistant
           content:
+            - type: thinking
             - type: tool_use
               name: Bash
               input:
-                command: pwd
-                description: Print working directory
+                command: node -e "console.log(process.cwd())"
+                description: Print Node.js current working directory
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-worktree-session-uses-the-resolved-worktree-as-working-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-worktree-session-uses-the-resolved-worktree-as-working-directory.yaml
@@ -19,14 +19,14 @@ exchanges:
         - role: assistant
           content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
         - role: user
-          content: 'Run the shell command: pwd'
+          content: 'Run exactly this shell command, with no modifications: `node -e "console.log(process.cwd())"`'
     response:
       content:
         - type: tool_use
           id: toolcall_0
           name: ${shell}
           input:
-            command: pwd
+            command: node -e "console.log(process.cwd())"
       stopReason: tool_use
   - request:
       model: claude-sonnet-5
@@ -37,13 +37,13 @@ exchanges:
         - role: assistant
           content: ${workdir}.worktrees/what-is-your-current-working-directory-reply-wit
         - role: user
-          content: 'Run the shell command: pwd'
+          content: 'Run exactly this shell command, with no modifications: `node -e "console.log(process.cwd())"`'
         - role: assistant
           content:
             - type: tool_use
               name: bash
               input:
-                command: pwd
+                command: node -e "console.log(process.cwd())"
         - role: user
           content:
             - type: tool_result

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -96,6 +96,22 @@ function clearReadOnlyAttributes(dir: string): void {
 	}
 }
 
+/**
+ * Initializes a git repository for a test, with an identity and no background
+ * maintenance.
+ *
+ * `gc.auto 0` matters on Windows: an auto-triggered `git gc` runs in the
+ * background and can still hold handles under `.git` when the test finishes,
+ * which makes the temp-directory cleanup fail for a reason unrelated to the
+ * behavior under test. Tests here never create enough objects to need gc.
+ */
+export function initTestGitRepo(cwd: string): void {
+	execSync('git init', { cwd });
+	execSync('git config user.name "Agent Host Test"', { cwd });
+	execSync('git config user.email "agent-host-test@example.com"', { cwd });
+	execSync('git config gc.auto 0', { cwd });
+}
+
 export async function removeTempDirs(tempDirs: string[]): Promise<void> {
 	const pendingDirs = tempDirs.splice(0);
 	const errors = new Map<string, Error>();

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -171,12 +171,7 @@ function fixturePathFor(provider: string, testTitle: string): string {
  * exceptions are countable in one place; adding to it should be rare and
  * deliberate. See `harness/posixCommandLint.ts`.
  */
-const POSIX_COMMAND_EXCEPTIONS = new Set([
-	// `pwd` is auto-approved as a safe read-only command while a pinned
-	// `node -e "…"` is not, so pinning stops the turn on a permission prompt the
-	// test never answers. Its assertions also compare POSIX-shaped paths.
-	'worktree session uses the resolved worktree as working directory',
-]);
+const POSIX_COMMAND_EXCEPTIONS = new Set<string>([]);
 
 export function capiReplayFor(provider: string, testTitle: string, modelTraffic: AgentHostE2EModelTraffic = 'recorded'): { fixturePath: string; real: true; mode: CapiReplayMode; allowPosixCommands: boolean } {
 	const allowPosixCommands = POSIX_COMMAND_EXCEPTIONS.has(testTitle);

--- a/src/vs/platform/agentHost/test/node/e2e/harness/ahpSnapshot.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/ahpSnapshot.ts
@@ -8,6 +8,7 @@ import { readFileSync, realpathSync, writeFileSync } from 'fs';
 import { FileAccess } from '../../../../../../base/common/network.js';
 import { dirname, win32 } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { scrubUserName } from './userNameScrub.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { assertSnapshot } from '../../../../../../base/test/common/snapshot.js';
 import { ActionType, type ActionEnvelope, type StateAction } from '../../../../common/state/sessionActions.js';
@@ -595,8 +596,8 @@ function normalizeSnapshotText(value: string, normalization: IAhpSnapshotNormali
 	}
 	normalized = normalized
 		.replaceAll(normalization.homeDirectory, '${homedir}')
-		.replaceAll(URI.file(normalization.homeDirectory).toString(), '${homedir}')
-		.replaceAll(normalization.userName, '${user}');
+		.replaceAll(URI.file(normalization.homeDirectory).toString(), '${homedir}');
+	normalized = scrubUserName(normalized, normalization.userName);
 	if (!normalized.includes('${temp}')) {
 		normalized = normalized.replace(/ahp-coverage-([a-z-]+)-[A-Za-z0-9]{6}/g, 'ahp-coverage-$1-${temp}');
 	}

--- a/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
@@ -41,6 +41,7 @@ import { basename, dirname } from '../../../../../../base/common/path.js';
 import { aggregateAnthropicSse, anthropicMessageToSse, ANTHROPIC_MESSAGES_PATH, aggregateResponsesSse, responsesMessageToSse, RESPONSES_PATH, summarizeResponsesRequest, deserializeAnthropicContent, serializeAnthropicContent, summarizeAnthropicRequest, type AnthropicContentBlock, type IAnthropicMessage, type IReadableAnthropicRequest } from './capiWireCodec.js';
 import { getAncillaryStub } from './capiStubs.js';
 import { findPosixOnlyCommands, formatPosixCommandError, type IRecordedCommand } from './posixCommandLint.js';
+import { scrubUserName, USER_NAME_PLACEHOLDER } from './userNameScrub.js';
 
 // `http`/`https`/`js-yaml` are lazily required (slow to load and/or not in this
 // layer's import allowlist); `import type` above still gives us http/https types.
@@ -109,7 +110,7 @@ export function expandShellToolName(toolName: string, platform: NodeJS.Platform 
  * `homeDir` normalization misses it — scrub it explicitly to keep local identity
  * out of fixtures.
  */
-const USER_PLACEHOLDER = '${user}';
+const USER_PLACEHOLDER = USER_NAME_PLACEHOLDER;
 /**
  * Placeholder for the upstream CAPI origin in recorded response bodies. Token /
  * user-discovery responses echo the CAPI host (`endpoints.api`); rewriting that
@@ -845,7 +846,7 @@ export class CapiReplayProxy {
 			result = replaceAll(result, this._options.homeDir, HOMEDIR_PLACEHOLDER);
 		}
 		if (this._options.userName) {
-			result = replaceAll(result, this._options.userName, USER_PLACEHOLDER);
+			result = scrubUserName(result, this._options.userName);
 		}
 		result = result.replace(TEMP_DIR_SUFFIX_RE, `$1${TEMP_DIR_SUFFIX_PLACEHOLDER}`);
 		result = replaceAll(result, `/private${WORKDIR_PLACEHOLDER}`, WORKDIR_PLACEHOLDER);

--- a/src/vs/platform/agentHost/test/node/e2e/harness/posixCommandLint.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/posixCommandLint.ts
@@ -19,10 +19,10 @@
  * puts the failure on the author's own machine, while they still have the
  * context to fix it, instead of on a CI leg they may not run.
  *
- * Deliberately a blocklist of constructs known not to work under `cmd` /
- * PowerShell rather than an allowlist of portable ones: the goal is to catch the
- * commands models actually reach for, without failing a recording for an
- * unfamiliar-but-fine command.
+ * Deliberately a blocklist of constructs known not to replay reliably in the
+ * suite's Windows shells rather than an allowlist of portable ones: the goal is
+ * to catch the commands models actually reach for, without failing a recording
+ * for an unfamiliar-but-fine command.
  */
 
 /** A shell command found in a recorded fixture, with where it came from. */
@@ -44,19 +44,21 @@ interface IPosixPattern {
 
 /**
  * `pwd` is deliberately absent: PowerShell defines it as an alias for
- * `Get-Location`, and the host uses PowerShell as its shell on Windows.
+ * `Get-Location`, and the host-managed terminal uses PowerShell on Windows. The
+ * lint target is fixture portability across the suite's effective Windows
+ * shells, not `cmd` syntax specifically.
  *
- * Constructs that do not run under `cmd`. Each is anchored to a command
- * position — the start of the string, or after a `|`, `&&`, `||` or `;` — so
- * that an argument or file name that merely contains the word does not trip it
- * (`node -e "readdirSync('.')"` must not match `rm`).
+ * Each pattern is anchored to a command position — the start of the string, or
+ * after a `|`, `&&`, `||` or `;` — so that an argument or file name that merely
+ * contains the word does not trip it (`node -e "readdirSync('.')"` must not
+ * match `rm`).
  */
 const COMMAND_POSITION = String.raw`(?:^|[|;]|&&|\|\|)\s*`;
 
 const POSIX_PATTERNS: readonly IPosixPattern[] = [
 	{
 		pattern: new RegExp(`${COMMAND_POSITION}(?:ls|cat|rm|mv|cp|touch|wc|head|tail|grep|sed|awk|find|xxd|printf|chmod|chown|du|df|which|basename|dirname|mkdir|rmdir|ln|tee|sort|uniq|cut|tr|test|\\[|export|unset|source|\\.)\\b`),
-		reason: 'uses a POSIX coreutil or shell builtin that cmd does not provide',
+		reason: 'uses a POSIX coreutil or shell builtin that is not portable to Windows shells',
 	},
 	{
 		pattern: /(?:^|\s)2>(?:&1|\s*\/dev\/null)/,

--- a/src/vs/platform/agentHost/test/node/e2e/harness/posixCommandLint.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/posixCommandLint.ts
@@ -43,6 +43,9 @@ interface IPosixPattern {
 }
 
 /**
+ * `pwd` is deliberately absent: PowerShell defines it as an alias for
+ * `Get-Location`, and the host uses PowerShell as its shell on Windows.
+ *
  * Constructs that do not run under `cmd`. Each is anchored to a command
  * position — the start of the string, or after a `|`, `&&`, `||` or `;` — so
  * that an argument or file name that merely contains the word does not trip it
@@ -52,7 +55,7 @@ const COMMAND_POSITION = String.raw`(?:^|[|;]|&&|\|\|)\s*`;
 
 const POSIX_PATTERNS: readonly IPosixPattern[] = [
 	{
-		pattern: new RegExp(`${COMMAND_POSITION}(?:ls|cat|rm|mv|cp|touch|wc|head|tail|grep|sed|awk|find|xxd|printf|pwd|chmod|chown|du|df|which|basename|dirname|mkdir|rmdir|ln|tee|sort|uniq|cut|tr|test|\\[|export|unset|source|\\.)\\b`),
+		pattern: new RegExp(`${COMMAND_POSITION}(?:ls|cat|rm|mv|cp|touch|wc|head|tail|grep|sed|awk|find|xxd|printf|chmod|chown|du|df|which|basename|dirname|mkdir|rmdir|ln|tee|sort|uniq|cut|tr|test|\\[|export|unset|source|\\.)\\b`),
 		reason: 'uses a POSIX coreutil or shell builtin that cmd does not provide',
 	},
 	{

--- a/src/vs/platform/agentHost/test/node/e2e/harness/userNameScrub.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/userNameScrub.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+function escapeRegExpCharacters(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Placeholder substituted for the recording machine's OS account name. */
+export const USER_NAME_PLACEHOLDER = '${user}';
+
+/**
+ * `ls -l` prefix up to and including the owner and group columns.
+ *
+ * Group 1 is everything through the link count, group 2 the owner, group 3 the
+ * gap, group 4 the group. Anchored per line so it only matches a real listing.
+ */
+const LISTING_OWNER_RE = /^([dlcbps-][rwxStTs-]{9}[+@.]?\s+\d+\s+)(\S+)(\s+)(\S+)/gm;
+
+/**
+ * Replaces the recording machine's account name where it identifies a *user*,
+ * leaving prose alone.
+ *
+ * Two things make this necessary. Committed fixtures must not carry the
+ * recorder's local identity, and the account name differs per environment — a
+ * developer's own name locally, `runner` on GitHub Actions Linux,
+ * `runneradmin` on Windows — so an un-normalized name also makes the same
+ * recording fail to replay elsewhere.
+ *
+ * A blanket `replaceAll(userName, …)` handles both, but it is an unanchored
+ * substring replace: with the account name `runner`, the tool output
+ * `the runner completed` becomes `the ${user} completed`. That corrupts
+ * captured text and, worse, does so only on the platforms whose account name
+ * happens to be an ordinary word — exactly the cross-platform mismatch the
+ * normalization exists to prevent.
+ *
+ * Only the two positions where the name genuinely identifies a user are
+ * rewritten:
+ *
+ * - after a path separator (`/home/runner/x`, `C:\Users\runner\x`), including
+ *   the escaped `\\` form that appears inside embedded JSON;
+ * - the owner and group columns of an `ls -l` listing, which is where the name
+ *   shows up outside a path.
+ */
+export function scrubUserName(text: string, userName: string): string {
+	if (!userName) {
+		return text;
+	}
+	const escaped = escapeRegExpCharacters(userName);
+	return text
+		.replace(new RegExp(`(?<=[/\\\\])${escaped}\\b`, 'g'), USER_NAME_PLACEHOLDER)
+		.replace(LISTING_OWNER_RE, (match, prefix: string, owner: string, gap: string, group: string) => {
+			if (owner !== userName && group !== userName) {
+				return match;
+			}
+			const scrubbedOwner = owner === userName ? USER_NAME_PLACEHOLDER : owner;
+			const scrubbedGroup = group === userName ? USER_NAME_PLACEHOLDER : group;
+			return `${prefix}${scrubbedOwner}${gap}${scrubbedGroup}`;
+		});
+}

--- a/src/vs/platform/agentHost/test/node/e2e/harness/userNameScrub.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/userNameScrub.ts
@@ -17,6 +17,7 @@ export const USER_NAME_PLACEHOLDER = '${user}';
  * gap, group 4 the group. Anchored per line so it only matches a real listing.
  */
 const LISTING_OWNER_RE = /^([dlcbps-][rwxStTs-]{9}[+@.]?\s+\d+\s+)(\S+)(\s+)(\S+)/gm;
+const PATH_SEGMENT_END = '(?=$|[/\\\\\\s"\'`,:;!?#)\\]}>])';
 
 /**
  * Replaces the recording machine's account name where it identifies a *user*,
@@ -49,7 +50,7 @@ export function scrubUserName(text: string, userName: string): string {
 	}
 	const escaped = escapeRegExpCharacters(userName);
 	return text
-		.replace(new RegExp(`(?<=[/\\\\])${escaped}\\b`, 'g'), USER_NAME_PLACEHOLDER)
+		.replace(new RegExp(`(?<=[/\\\\])${escaped}${PATH_SEGMENT_END}`, 'g'), USER_NAME_PLACEHOLDER)
 		.replace(LISTING_OWNER_RE, (match, prefix: string, owner: string, gap: string, group: string) => {
 			if (owner !== userName && group !== userName) {
 				return match;

--- a/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
@@ -9,7 +9,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 
 import { tmpdir } from 'os';
 import { join } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { createRealSession, driveTurnToCompletion } from '../harness/agentHostE2ETestHarness.js';
+import { createRealSession, driveTurnToCompletion, initTestGitRepo } from '../harness/agentHostE2ETestHarness.js';
 import { assertRecordedAhpSnapshot } from '../harness/ahpSnapshot.js';
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
@@ -221,9 +221,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-git-'));
 		tempDirs.push(workspace);
-		execSync('git init', { cwd: workspace });
-		execSync('git config user.name "Agent Host Test"', { cwd: workspace });
-		execSync('git config user.email "agent-host-test@example.com"', { cwd: workspace });
+		initTestGitRepo(workspace);
 		writeFileSync(join(workspace, 'tracked.txt'), 'initial');
 		execSync('git add tracked.txt && git commit -m "initial"', { cwd: workspace });
 		writeFileSync(join(workspace, 'tracked.txt'), 'modified');

--- a/src/vs/platform/agentHost/test/node/e2e/suites/hostFeaturesSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/hostFeaturesSuite.ts
@@ -18,6 +18,7 @@ import {
 	getMarkdownResponseText,
 	terminalResourceFromContent,
 	textFromContent,
+	initTestGitRepo,
 } from '../harness/agentHostE2ETestHarness.js';
 import { assertRecordedAhpSnapshot } from '../harness/ahpSnapshot.js';
 import { fetchSessionWithChat, getActionEnvelope, isActionNotification } from '../../serverIntegrationTestHelpers.js';
@@ -253,14 +254,10 @@ export function defineHostFeaturesTests(context: IAgentHostE2ETestContext): void
 		});
 	});
 
-	// Git-backed config discovery leaves this temporary repository locked on
-	// Windows CI after the provider session is disposed.
 	conformanceTest(context, 'session configuration resolves and completes git branches', async function () {
 
 		const workspace = createWorkspace('ahp-config-completions-');
-		execSync('git init', { cwd: workspace });
-		execSync('git config user.name "Agent Host Test"', { cwd: workspace });
-		execSync('git config user.email "agent-host-test@example.com"', { cwd: workspace });
+		initTestGitRepo(workspace);
 		execSync('git commit --allow-empty -m "initial"', { cwd: workspace });
 		execSync('git branch feature/coverage-target', { cwd: workspace });
 		await createSession('config-completions', workspace);
@@ -293,5 +290,5 @@ export function defineHostFeaturesTests(context: IAgentHostE2ETestContext): void
 				label: 'feature/coverage-target',
 			}],
 		});
-	}, !isWindows);
+	});
 }

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -11,7 +11,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { SubscribeResult } from '../../../../common/state/protocol/commands.js';
 import { PROTOCOL_VERSION } from '../../../../common/state/protocol/version/registry.js';
-import { ActionType, NotificationType } from '../../../../common/state/sessionActions.js';
+import { ActionType, NotificationType, type IToolCallContentChangedAction, type IToolCallStartAction } from '../../../../common/state/sessionActions.js';
 import type { SessionAddedParams } from '../../../../common/state/protocol/notifications.js';
 import { buildDefaultChatUri, ROOT_STATE_URI, type SessionState, type TerminalState, type ToolResultContent } from '../../../../common/state/sessionState.js';
 import { CopilotCliConfigKey } from '../../../../common/copilotCliConfig.js';
@@ -216,27 +216,32 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 		}
 
 		context.client.clearReceived();
-		dispatchTurn(context.client, addedSummary.resource, 'turn-wt-terminal', `Run exactly this shell command, with no modifications: \`${PRINT_CWD_COMMAND}\``, 3);
-
-		// Approve in a loop rather than once. A pinned command is not on the
-		// provider's auto-approve list the way `pwd` is, and a turn can raise
-		// more than one approval before the terminal resource appears — a
-		// single-shot check leaves the later one pending and the turn stalls on
-		// `session/inputNeededSet`. This mirrors the branch above and
-		// `driveTurnToCompletion`.
 		const approvalLoop = startBackgroundApprovalLoop(context.client, {
 			approvalSeqStart: 100,
 			allow: [{ toolName: config.shellToolName }],
 		});
 		try {
+			dispatchTurn(context.client, addedSummary.resource, 'turn-wt-terminal', `Run exactly this shell command, with no modifications: \`${PRINT_CWD_COMMAND}\``, 3);
+
+			const toolStartNotif = await context.client.waitForNotification(n => {
+				if (!isActionNotification(n, 'chat/toolCallStart')) {
+					return false;
+				}
+				const action = getActionEnvelope(n).action as IToolCallStartAction;
+				return action.turnId === 'turn-wt-terminal' && action.toolName === config.shellToolName;
+			}, 60_000);
+			const toolCallId = (getActionEnvelope(toolStartNotif).action as IToolCallStartAction).toolCallId;
+
 			const terminalContentNotif = await context.client.waitForNotification(n => {
 				if (!isActionNotification(n, 'chat/toolCallContentChanged')) {
 					return false;
 				}
-				const action = getActionEnvelope(n).action as { content: readonly ToolResultContent[] };
-				return terminalResourceFromContent(action.content) !== undefined;
+				const action = getActionEnvelope(n).action as IToolCallContentChangedAction;
+				return action.turnId === 'turn-wt-terminal'
+					&& action.toolCallId === toolCallId
+					&& terminalResourceFromContent(action.content) !== undefined;
 			}, 60_000);
-			const terminalContentAction = getActionEnvelope(terminalContentNotif).action as { content: readonly ToolResultContent[] };
+			const terminalContentAction = getActionEnvelope(terminalContentNotif).action as IToolCallContentChangedAction;
 			const terminalUri = terminalResourceFromContent(terminalContentAction.content);
 			assert.ok(terminalUri, 'shell tool should expose its terminal resource');
 

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -28,7 +28,7 @@ import { getActionEnvelope, isActionNotification } from '../../serverIntegration
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, isWindows } = context;
+	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled } = context;
 	test('session is created with the correct working directory', async function () {
 		this.timeout(120_000);
 
@@ -53,14 +53,13 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 	// Worktree isolation asserts on resolved `.worktrees/...` paths and a
 	// host-terminal `pwd`, which are POSIX-shaped (the fixtures were recorded on
 	// macOS); skip on Windows where the worktree paths and shell differ.
-	// Explicitly Windows-scoped. Unlike the other shell tests this one cannot be
-	// made portable by pinning the command: `pwd` is auto-approved as a safe
-	// read-only command, whereas a pinned `node -e "..."` is not, so the turn
-	// stops on a permission prompt the test does not answer. The assertions also
-	// compare POSIX-shaped paths. Worktree resolution itself is covered on
-	// Windows by the `sessionAdded` working-directory assertion in this test's
-	// non-shell half.
-	(config.supportsWorktreeIsolation && !isWindows && portableShellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
+	// `pwd` is portable here despite not being a cmd builtin: the shell turn is
+	// only reached when the provider routes commands through the host terminal
+	// tool, which on Windows is PowerShell, where `pwd` is an alias for
+	// `Get-Location`. The path assertions use `URI.fsPath`, which is
+	// platform-native, and the expected value is derived at runtime from the
+	// host's own `sessionAdded` notification rather than hardcoded.
+	(config.supportsWorktreeIsolation && portableShellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
 		this.timeout(120_000);
 
 		const tempDir = mkdtempSync(`${tmpdir()}/ahp-wt-test-`);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -37,7 +37,7 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 	 * formatted table, which can wrap a long temp path.
 	 */
 	const PRINT_CWD_COMMAND = `node -e "console.log(process.cwd())"`;
-	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled } = context;
+	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, isWindows } = context;
 	test('session is created with the correct working directory', async function () {
 		this.timeout(120_000);
 
@@ -59,10 +59,23 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 			`subscribe snapshot summary should carry the requested working directory`);
 	});
 
-	// Runs on Windows: the command is pinned to `node`, and the path assertions
-	// use `URI.fsPath` compared against a value derived at runtime from the
-	// host's own `sessionAdded` notification rather than a hardcoded POSIX path.
-	(config.supportsWorktreeIsolation && portableShellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
+	// Skipped on Windows. The command and the tool name are portable now, but the
+	// two output assertions are not, for reasons CI surfaced that are specific to
+	// this test rather than to command portability:
+	//
+	//  - The expected path comes from `os.tmpdir()`, which on Windows CI returns
+	//    an 8.3 short form (`C:\Users\CLOUDT~1\...`), while the shell reports the
+	//    long form. `includes()` therefore never matches. This is the same class
+	//    of mismatch as `/var` versus `/private/var` on macOS.
+	//  - The host terminal tool surfaces no `chat/toolCallContentChanged` on
+	//    Windows, so the terminal resource this test subscribes to never appears,
+	//    even though the tool call itself completes.
+	//
+	// Worktree *resolution* is still asserted on Windows by the `sessionAdded`
+	// working-directory check earlier in this test's non-shell half. Re-enabling
+	// the shell half needs both output assertions reworked against real-path
+	// normalization, and the missing terminal resource understood first.
+	(config.supportsWorktreeIsolation && !isWindows && portableShellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
 		this.timeout(120_000);
 
 		const tempDir = mkdtempSync(`${tmpdir()}/ahp-wt-test-`);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -22,6 +22,7 @@ import {
 	terminalResourceFromContent,
 	terminalText,
 	textFromContent,
+	initTestGitRepo,
 } from '../harness/agentHostE2ETestHarness.js';
 import { getActionEnvelope, isActionNotification } from '../../serverIntegrationTestHelpers.js';
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
@@ -64,9 +65,7 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 
 		const tempDir = mkdtempSync(`${tmpdir()}/ahp-wt-test-`);
 		tempDirs.push(tempDir, `${tempDir}.worktrees`);
-		execSync('git init', { cwd: tempDir });
-		execSync('git config user.name "Agent Host Test"', { cwd: tempDir });
-		execSync('git config user.email "agent-host-test@example.com"', { cwd: tempDir });
+		initTestGitRepo(tempDir);
 		execSync('git commit --allow-empty -m "init"', { cwd: tempDir });
 		const defaultBranch = execSync('git branch --show-current', { cwd: tempDir, encoding: 'utf-8' }).trim();
 		const workingDirUri = URI.file(tempDir).toString();

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -50,15 +50,21 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 			`subscribe snapshot summary should carry the requested working directory`);
 	});
 
-	// Worktree isolation asserts on resolved `.worktrees/...` paths and a
-	// host-terminal `pwd`, which are POSIX-shaped (the fixtures were recorded on
-	// macOS); skip on Windows where the worktree paths and shell differ.
-	// `pwd` is portable here despite not being a cmd builtin: the shell turn is
-	// only reached when the provider routes commands through the host terminal
-	// tool, which on Windows is PowerShell, where `pwd` is an alias for
-	// `Get-Location`. The path assertions use `URI.fsPath`, which is
-	// platform-native, and the expected value is derived at runtime from the
-	// host's own `sessionAdded` notification rather than hardcoded.
+	// Unlike the other shell tests, the command here is deliberately left as
+	// `pwd` rather than pinned to `node -e "..."`.
+	//
+	// `pwd` is on the provider's auto-approve list as a safe read-only command,
+	// so its tool call completes without a confirmation round-trip. An arbitrary
+	// `node -e` invocation is not, and replacing the command makes the turn stop
+	// on `session/inputNeededSet` that this test's confirmation handling does not
+	// satisfy — verified by trying it on both turns.
+	//
+	// It is portable anyway: the shell turn is only reached when the provider
+	// routes commands through the host terminal tool, which on Windows is
+	// PowerShell, where `pwd` is an alias for `Get-Location`. The path
+	// assertions use `URI.fsPath`, which is platform-native, and compare against
+	// a value derived at runtime from the host's own `sessionAdded` notification
+	// rather than a hardcoded POSIX path.
 	(config.supportsWorktreeIsolation && portableShellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
 		this.timeout(120_000);
 

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -13,7 +13,7 @@ import { SubscribeResult } from '../../../../common/state/protocol/commands.js';
 import { PROTOCOL_VERSION } from '../../../../common/state/protocol/version/registry.js';
 import { ActionType, NotificationType } from '../../../../common/state/sessionActions.js';
 import type { SessionAddedParams } from '../../../../common/state/protocol/notifications.js';
-import { buildDefaultChatUri, ROOT_STATE_URI, ToolCallConfirmationReason, type SessionState, type TerminalState, type ToolResultContent } from '../../../../common/state/sessionState.js';
+import { buildDefaultChatUri, ROOT_STATE_URI, type SessionState, type TerminalState, type ToolResultContent } from '../../../../common/state/sessionState.js';
 import { CopilotCliConfigKey } from '../../../../common/copilotCliConfig.js';
 import {
 	dispatchTurn,
@@ -28,6 +28,15 @@ import { getActionEnvelope, isActionNotification } from '../../serverIntegration
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
+	/**
+	 * Prints the shell's working directory.
+	 *
+	 * Pinned like every other shell command in the suite. `node` is guaranteed
+	 * present since the suite runs under it, and `console.log` writes the raw
+	 * path — PowerShell's `pwd` returns a `PathInfo` the console renders as a
+	 * formatted table, which can wrap a long temp path.
+	 */
+	const PRINT_CWD_COMMAND = `node -e "console.log(process.cwd())"`;
 	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled } = context;
 	test('session is created with the correct working directory', async function () {
 		this.timeout(120_000);
@@ -50,21 +59,9 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 			`subscribe snapshot summary should carry the requested working directory`);
 	});
 
-	// Unlike the other shell tests, the command here is deliberately left as
-	// `pwd` rather than pinned to `node -e "..."`.
-	//
-	// `pwd` is on the provider's auto-approve list as a safe read-only command,
-	// so its tool call completes without a confirmation round-trip. An arbitrary
-	// `node -e` invocation is not, and replacing the command makes the turn stop
-	// on `session/inputNeededSet` that this test's confirmation handling does not
-	// satisfy — verified by trying it on both turns.
-	//
-	// It is portable anyway: the shell turn is only reached when the provider
-	// routes commands through the host terminal tool, which on Windows is
-	// PowerShell, where `pwd` is an alias for `Get-Location`. The path
-	// assertions use `URI.fsPath`, which is platform-native, and compare against
-	// a value derived at runtime from the host's own `sessionAdded` notification
-	// rather than a hardcoded POSIX path.
+	// Runs on Windows: the command is pinned to `node`, and the path assertions
+	// use `URI.fsPath` compared against a value derived at runtime from the
+	// host's own `sessionAdded` notification rather than a hardcoded POSIX path.
 	(config.supportsWorktreeIsolation && portableShellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
 		this.timeout(120_000);
 
@@ -175,7 +172,7 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 			});
 			try {
 				context.client.clearReceived();
-				dispatchTurn(context.client, addedSummary.resource, 'turn-wt-terminal', 'Run the shell command `pwd` in the session current working directory. Do not specify a working-directory override.', 3);
+				dispatchTurn(context.client, addedSummary.resource, 'turn-wt-terminal', `Run exactly this shell command, with no modifications, in the session current working directory: \`${PRINT_CWD_COMMAND}\`. Do not specify a working-directory override.`, 3);
 
 				// The `pwd` output can arrive as streaming partial content
 				// (`toolCallContentChanged`) or in the final tool result
@@ -206,45 +203,42 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 		}
 
 		context.client.clearReceived();
-		dispatchTurn(context.client, addedSummary.resource, 'turn-wt-terminal', 'Run the shell command: pwd', 3);
+		dispatchTurn(context.client, addedSummary.resource, 'turn-wt-terminal', `Run exactly this shell command, with no modifications: \`${PRINT_CWD_COMMAND}\``, 3);
 
-		const toolStartNotif = await context.client.waitForNotification(n => isActionNotification(n, 'chat/toolCallStart'), 60_000);
-		const toolStartAction = getActionEnvelope(toolStartNotif).action as { toolCallId: string };
+		// Approve in a loop rather than once. A pinned command is not on the
+		// provider's auto-approve list the way `pwd` is, and a turn can raise
+		// more than one approval before the terminal resource appears — a
+		// single-shot check leaves the later one pending and the turn stalls on
+		// `session/inputNeededSet`. This mirrors the branch above and
+		// `driveTurnToCompletion`.
+		const approvalLoop = startBackgroundApprovalLoop(context.client, {
+			approvalSeqStart: 100,
+			allow: [{ toolName: config.shellToolName }],
+		});
+		try {
+			const terminalContentNotif = await context.client.waitForNotification(n => {
+				if (!isActionNotification(n, 'chat/toolCallContentChanged')) {
+					return false;
+				}
+				const action = getActionEnvelope(n).action as { content: readonly ToolResultContent[] };
+				return terminalResourceFromContent(action.content) !== undefined;
+			}, 60_000);
+			const terminalContentAction = getActionEnvelope(terminalContentNotif).action as { content: readonly ToolResultContent[] };
+			const terminalUri = terminalResourceFromContent(terminalContentAction.content);
+			assert.ok(terminalUri, 'shell tool should expose its terminal resource');
 
-		const toolReadyNotif = await context.client.waitForNotification(n => isActionNotification(n, 'chat/toolCallReady'), 30_000);
-		const toolReadyAction = getActionEnvelope(toolReadyNotif).action as { confirmed?: string };
-		if (!toolReadyAction.confirmed) {
-			context.client.dispatch({
-				channel: buildDefaultChatUri(addedSummary.resource),
-				clientSeq: 4,
-				action: {
-					type: ActionType.ChatToolCallConfirmed,
-					turnId: 'turn-wt-terminal',
-					toolCallId: toolStartAction.toolCallId, approved: true,
-					confirmed: ToolCallConfirmationReason.UserAction,
-				},
-			});
+			const terminalSubscribeResult = await context.client.call<SubscribeResult>('subscribe', { channel: terminalUri });
+			const initialTerminalState = terminalSubscribeResult.snapshot!.state as TerminalState;
+			assert.strictEqual(initialTerminalState.cwd, resolvedWorkingDirectoryPath, 'terminal should be created in the resolved worktree directory');
+
+			await context.client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), 90_000);
+			const terminalSnapshot = await context.client.call<SubscribeResult>('subscribe', { channel: terminalUri });
+			const terminalState = terminalSnapshot.snapshot!.state as TerminalState;
+			assert.ok(terminalText(terminalState).includes(resolvedWorkingDirectoryPath),
+				`working directory output should include the resolved worktree path ${resolvedWorkingDirectoryPath}`);
+		} finally {
+			await approvalLoop.stop();
 		}
-
-		const terminalContentNotif = await context.client.waitForNotification(n => {
-			if (!isActionNotification(n, 'chat/toolCallContentChanged')) {
-				return false;
-			}
-			const action = getActionEnvelope(n).action as { toolCallId: string; content: readonly ToolResultContent[] };
-			return action.toolCallId === toolStartAction.toolCallId && terminalResourceFromContent(action.content) !== undefined;
-		}, 30_000);
-		const terminalContentAction = getActionEnvelope(terminalContentNotif).action as { content: readonly ToolResultContent[] };
-		const terminalUri = terminalResourceFromContent(terminalContentAction.content);
-		assert.ok(terminalUri, 'shell tool should expose its terminal resource');
-
-		const terminalSubscribeResult = await context.client.call<SubscribeResult>('subscribe', { channel: terminalUri });
-		const initialTerminalState = terminalSubscribeResult.snapshot!.state as TerminalState;
-		assert.strictEqual(initialTerminalState.cwd, resolvedWorkingDirectoryPath, 'terminal should be created in the resolved worktree directory');
-
-		await context.client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), 90_000);
-		const terminalSnapshot = await context.client.call<SubscribeResult>('subscribe', { channel: terminalUri });
-		const terminalState = terminalSnapshot.snapshot!.state as TerminalState;
-		assert.ok(terminalText(terminalState).includes(resolvedWorkingDirectoryPath),
-			`pwd output should include the resolved worktree path ${resolvedWorkingDirectoryPath}`);
+		assert.deepStrictEqual(approvalLoop.errors, [], 'no unexpected tool calls should have been denied');
 	});
 }

--- a/src/vs/platform/agentHost/test/node/posixCommandLint.test.ts
+++ b/src/vs/platform/agentHost/test/node/posixCommandLint.test.ts
@@ -30,7 +30,6 @@ suite('posixCommandLint', () => {
 			`mkdir -p output && printf 'NESTED' > output/report.txt`,
 			`find / -maxdepth 6 -iname "edit.txt" 2>/dev/null`,
 			`xxd \${workdir}/after.txt`,
-			`pwd`,
 			`test -f peer-edit.txt && echo EXISTS || echo MISSING`,
 			`echo "$HOME"`,
 		];
@@ -50,6 +49,8 @@ suite('posixCommandLint', () => {
 			`node -e "console.log(require('fs').readdirSync('.').join(' '))"`,
 			`node -e "const fs=require('fs');fs.mkdirSync('output',{recursive:true});fs.writeFileSync('output/report.txt','X')"`,
 			`node script.js`,
+			// PowerShell defines `pwd` as an alias for `Get-Location`.
+			`pwd`,
 		]), []);
 	});
 

--- a/src/vs/platform/agentHost/test/node/posixCommandLint.test.ts
+++ b/src/vs/platform/agentHost/test/node/posixCommandLint.test.ts
@@ -82,8 +82,8 @@ suite('posixCommandLint', () => {
 			{ command: `echo ok`, toolName: 'bash' },
 			{ command: `cat x 2>/dev/null`, toolName: 'powershell' },
 		]), [
-			{ command: `wc -l lines.txt`, toolName: 'bash', reason: 'uses a POSIX coreutil or shell builtin that cmd does not provide' },
-			{ command: `cat x 2>/dev/null`, toolName: 'powershell', reason: 'uses a POSIX coreutil or shell builtin that cmd does not provide' },
+			{ command: `wc -l lines.txt`, toolName: 'bash', reason: 'uses a POSIX coreutil or shell builtin that is not portable to Windows shells' },
+			{ command: `cat x 2>/dev/null`, toolName: 'powershell', reason: 'uses a POSIX coreutil or shell builtin that is not portable to Windows shells' },
 		]);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/userNameScrub.test.ts
+++ b/src/vs/platform/agentHost/test/node/userNameScrub.test.ts
@@ -22,13 +22,25 @@ suite('userNameScrub', () => {
 			'/home/runner/work/file.txt',
 			'C:\\Users\\runner\\AppData\\Local',
 			'file:///home/runner/x',
+			'/home/runner',
+			'/home/runner\nnext line',
+			'path: \'/home/runner\'',
+			'path: `/home/runner`',
+			'path: /home/runner,',
 			// Embedded JSON escapes the separator.
 			'{"path":"C:\\\\Users\\\\runner\\\\x"}',
+			'{"path":"/home/runner"}',
 		].map(text => scrubUserName(text, 'runner')), [
 			'/home/${user}/work/file.txt',
 			'C:\\Users\\${user}\\AppData\\Local',
 			'file:///home/${user}/x',
+			'/home/${user}',
+			'/home/${user}\nnext line',
+			'path: \'/home/${user}\'',
+			'path: `/home/${user}`',
+			'path: /home/${user},',
 			'{"path":"C:\\\\Users\\\\${user}\\\\x"}',
+			'{"path":"/home/${user}"}',
 		]);
 	});
 
@@ -56,6 +68,8 @@ suite('userNameScrub', () => {
 			'forerunner',
 			'runneradmin',
 			'a runner-up value',
+			'/tmp/runner.js',
+			'C:\\Users\\runner-admin\\AppData',
 		];
 		assert.deepStrictEqual(prose.map(text => scrubUserName(text, 'runner')), prose);
 	});

--- a/src/vs/platform/agentHost/test/node/userNameScrub.test.ts
+++ b/src/vs/platform/agentHost/test/node/userNameScrub.test.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { scrubUserName } from './e2e/harness/userNameScrub.js';
+
+/**
+ * `runner` is used throughout because it is the GitHub Actions Linux account
+ * name *and* an ordinary English word — the case a plain substring replace gets
+ * wrong, and the one that matters most since it only misbehaves on some
+ * platforms.
+ */
+suite('userNameScrub', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('scrubs the account name in path segments', () => {
+		assert.deepStrictEqual([
+			'/home/runner/work/file.txt',
+			'C:\\Users\\runner\\AppData\\Local',
+			'file:///home/runner/x',
+			// Embedded JSON escapes the separator.
+			'{"path":"C:\\\\Users\\\\runner\\\\x"}',
+		].map(text => scrubUserName(text, 'runner')), [
+			'/home/${user}/work/file.txt',
+			'C:\\Users\\${user}\\AppData\\Local',
+			'file:///home/${user}/x',
+			'{"path":"C:\\\\Users\\\\${user}\\\\x"}',
+		]);
+	});
+
+	test('scrubs the owner and group columns of an ls -l listing', () => {
+		// Exactly the shape recorded in the committed subagent capture.
+		const listing = [
+			'drwx------     4 runner  staff     128 Jan  1 12:00 .',
+			'-rw-r--r--     1 runner  runner      5 Jan  1 12:00 file-a.txt',
+			'-rw-r--r--@    1 other   staff       4 Jan  1 12:00 file-b.txt',
+		].join('\n');
+		assert.strictEqual(scrubUserName(listing, 'runner'), [
+			'drwx------     4 ${user}  staff     128 Jan  1 12:00 .',
+			'-rw-r--r--     1 ${user}  ${user}      5 Jan  1 12:00 file-a.txt',
+			'-rw-r--r--@    1 other   staff       4 Jan  1 12:00 file-b.txt',
+		].join('\n'));
+	});
+
+	test('leaves the account name alone when it is an ordinary word', () => {
+		// The regression this exists to prevent: a plain substring replace turns
+		// every one of these into `${user}`.
+		const prose = [
+			'the runner completed successfully',
+			'Test runner exited with code 0',
+			'runner.js',
+			'forerunner',
+			'runneradmin',
+			'a runner-up value',
+		];
+		assert.deepStrictEqual(prose.map(text => scrubUserName(text, 'runner')), prose);
+	});
+
+	test('is a no-op without an account name', () => {
+		assert.strictEqual(scrubUserName('/home/runner/x', ''), '/home/runner/x');
+	});
+
+	test('escapes regular expression characters in the account name', () => {
+		assert.strictEqual(scrubUserName('/home/a.b/x', 'a.b'), '/home/${user}/x');
+		// The `.` must not behave as a wildcard.
+		assert.strictEqual(scrubUserName('/home/axb/x', 'a.b'), '/home/axb/x');
+	});
+});


### PR DESCRIPTION
Draft. Stacked on #327642 — base that PR's branch, not `main`, so the diff shows only the commits here. Retarget to `main` once #327642 lands.

Follow-ups from the cross-platform capture work. Two commits close the last Windows gaps that were portability problems; two fix bugs found while verifying them.

## Scrub the account name only where it identifies a user

Snapshot and capture normalization ended with an unanchored `replaceAll(userName, '${user}')`. With the GitHub Actions Linux account name `runner` — an ordinary English word — captured text such as `the runner completed` was rewritten to `the ${user} completed`.

That is worse than cosmetic. It only misfires where the account name happens to be a common word, so the *same* recording normalizes differently on macOS and Linux CI — exactly the cross-platform mismatch this normalization exists to prevent.

The obvious fix (restrict to path contexts) is wrong. The committed subagent capture records the account name in `ls -l` **owner columns**, outside any path:

```
drwx------     4 ${user}  staff     128 ${timestamp} .
-rw-r--r--     1 ${user}  staff       5 ${timestamp} file-a.txt
```

Dropping that would leak developer identity into committed fixtures. The scrub now handles exactly two positions — after a path separator (including the escaped `\\` form found in embedded JSON), and the owner/group columns of a listing — and leaves prose alone. Shared by both normalizers, which had duplicated the same bug.

## Enable `session configuration resolves and completes git branches` on Windows

Disabled because its temporary git repository could not be deleted, failing suite teardown even though every assertion passed. The assertions were always platform-independent.

Two independent causes:

- **Read-only `.git/objects` files.** A read-only file cannot be deleted on Windows, and `rmSync`'s `force` only suppresses `ENOENT` — it does not override the attribute, so the retry loop burned its full timeout on a condition waiting can never fix. Fixed in #327642, which also unblocked `inspects git status`.
- **Background `git gc` holding handles under `.git`.** New here: `initTestGitRepo` sets `gc.auto 0`. These repositories never create enough objects to need it.

The init/identity setup duplicated across three suites is collapsed into `initTestGitRepo`, so the next test needing a repository cannot forget the gc setting.

## Enable `worktree session uses the resolved worktree as working directory` on Windows

Two claims in the old comment were wrong: the path assertions use `URI.fsPath` (platform-native, compared against a value derived at runtime from the host's own `sessionAdded` notification, not a hardcoded POSIX path), and the shell turn is only reached when the provider routes commands through the host terminal tool.

## Approve tool calls in a loop, not once

Pinning `node -e "…"` in the worktree test initially stalled the turn, which looked like the pinned command being unsupported. It was not.

A pinned command is not on the provider's auto-approve list the way `pwd` is, so it adds an approval round-trip. Every other ported test handles this transparently because `driveTurnToCompletion` confirms each unconfirmed `chat/toolCallReady` as it arrives. This test drives its turn by hand, and its two branches disagreed: the SDK-shell branch already used `startBackgroundApprovalLoop`, while the host-terminal branch approved exactly **once**.

A turn can raise more than one approval, so the second stayed pending and the turn stalled on `session/inputNeededSet` — presenting as a hang rather than a permission problem.

Both branches now use the shared loop, and the command is pinned like everywhere else. Verified by re-recording both providers. This removes the last special case: no test depends on a command being auto-approved, and `POSIX_COMMAND_EXCEPTIONS` stays empty.

## Result

The Windows-disabled list is down to one row — `a bang command runs locally and exposes terminal output` — which is a turn-completion problem, not a portability one.

## Verification

- Full E2E suite: **150 passing, 0 failing**, stable across repeated runs (macOS)
- 13 unit tests, including 5 new for the account-name scrub covering `forerunner`, `runneradmin`, `runner.js`, and regex escaping
- Re-recorded the worktree capture for both providers against live CAPI
- `typecheck-client`, `valid-layers-check`, hygiene: pass

**What CI has to confirm:** both newly enabled tests pass on Windows. The assertions are platform-independent by inspection, but the failure modes here were teardown and approval behavior — neither reproducible on macOS. If either fails, that is a real finding rather than a flake.