### PR TITLE
feat(agentHost): add support for multiple working directories in Copilot provider

### DIFF
--- a/.github/skills/sessions/SKILL.md
+++ b/.github/skills/sessions/SKILL.md
@@ -108,6 +108,10 @@ Whenever the user flags a wrong pattern, rejects an approach, or gives design/ru
 
 - **Centralize session workspace filtering behind a semantic predicate**: refresh, add-notification, and summary-update paths should call one `_isSessionInWorkspace(entry)`-style helper. Keep key construction, working-directory parsing, pending-local lookup, and provenance checks out of each caller so the high-level list flow stays readable and all paths apply identical rules.
 
+- **Feature-specific workspace storage must be gated at the storage service boundary**: Editor multi-root provenance is enabled only for a non-Sessions window with `WorkbenchState.WORKSPACE` and more than one open folder. Lazy-load it only after that gate passes; folder/empty/Agents windows must use ordinary path filtering and never read, write, refresh, or delete the persisted state.
+
+- **Keep legacy single-folder filtering explicit when adding multi-root provenance**: zero-folder windows still include all sessions, and one-folder windows still use direct any-directory path containment. Call the provenance service only when the window has multiple folders; keep its internal scope gate as defense-in-depth.
+
 - **Name semantic layout operations after the user-facing surface**: a shared operation must use the stable UI concept (`toggleSecondarySideBar()`), not the implementation term (`AuxiliaryBar`) that happens to back it in classic layouts. This keeps single-pane mappings clear and avoids leaking layout internals through the API.
 
 - **Semantic layout commands need matching visibility and focus semantics**: when a shared command maps to a different surface, expose a semantic visibility query for its toggled state and transfer focus before hiding the currently focused mapped surface. Otherwise menu labels lie about the action and keyboard users retain focus in hidden content.

--- a/.github/skills/sessions/SKILL.md
+++ b/.github/skills/sessions/SKILL.md
@@ -102,6 +102,12 @@ Whenever the user flags a wrong pattern, rejects an approach, or gives design/ru
 
 - **Shared commands must delegate behavior to the layout service, not inspect a layout implementation**: `workbench.action.toggleAuxiliaryBar` must call the semantic `IWorkbenchLayoutService.toggleSecondarySideBar()` operation. Do not branch on optional layout properties or concrete workbench shape in the shared action; each workbench owns how its secondary-sidebar affordance maps to visible parts.
 
+- **Definitive session deletion and temporary list eviction are different operations**: deletion clears durable provenance and pending state; filtering a still-existing session only removes its visible list entry. Keep the list-removal helper side-effect-free, and let each caller explicitly update its mutation generation instead of passing an "already incremented" boolean.
+
+- **Keep session-list refresh filtering linear**: when retention pruning needs the complete backend key set, collect those keys while filtering entries in the original loop, then reconcile last-seen/pruning afterward. Do not introduce a candidate-map/filter/map pipeline when one loop plus one reconciliation call expresses the lifecycle more clearly.
+
+- **Centralize session workspace filtering behind a semantic predicate**: refresh, add-notification, and summary-update paths should call one `_isSessionInWorkspace(entry)`-style helper. Keep key construction, working-directory parsing, pending-local lookup, and provenance checks out of each caller so the high-level list flow stays readable and all paths apply identical rules.
+
 - **Name semantic layout operations after the user-facing surface**: a shared operation must use the stable UI concept (`toggleSecondarySideBar()`), not the implementation term (`AuxiliaryBar`) that happens to back it in classic layouts. This keeps single-pane mappings clear and avoids leaking layout internals through the API.
 
 - **Semantic layout commands need matching visibility and focus semantics**: when a shared command maps to a different surface, expose a semantic visibility query for its toggled state and transfer focus before hiding the currently focused mapped surface. Otherwise menu labels lie about the action and keyboard users retain focus in hidden content.

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -18,7 +18,7 @@ import { generateUuid } from '../../../base/common/uuid.js';
 import { ILogService } from '../../log/common/log.js';
 import { FileSystemProviderErrorCode, toFileSystemProviderErrorCode } from '../../files/common/files.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
-import { AgentSession, AgentHostCodexAgentEnabledSettingId, AgentHostSystemProxyEnabledSettingId, IAgentConnection, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
+import { AgentSession, AgentHostCodexAgentEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId, IAgentConnection, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
 import { createRemoteWatchHandle, type IRemoteWatchHandle } from '../common/agentHostFileSystemProvider.js';
 import { AgentSubscriptionManager, type IActiveSubscriptionInfo, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import { agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../common/agentHostUri.js';
@@ -37,7 +37,7 @@ import { encodeBase64 } from '../../../base/common/buffer.js';
 import { ILoadEstimator, LoadEstimator } from '../../../base/parts/ipc/common/ipc.net.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostCodexEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, AUTO_REPLY_SETTING_ID, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, AUTO_REPLY_SETTING_ID, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import type { OtlpExportLogsParams } from '../common/state/protocol/channels-otlp/notifications.js';
 import type { TelemetryCapabilities } from '../common/state/protocol/channels-otlp/state.js';
 import type { Implementation, InitializeResult } from '../common/state/protocol/common/commands.js';
@@ -379,6 +379,12 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 				}
 				this._updateSystemProxyEnabled();
 			}
+			if (e.affectsConfiguration(AgentHostCopilotMultiRootEnabledSettingId)) {
+				if (this._state.kind !== AgentHostClientState.Connected) {
+					return;
+				}
+				this._updateCopilotMultiRootEnabled();
+			}
 			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_SETTING_ID) || e.affectsConfiguration(TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID)) {
 				if (this._state.kind !== AgentHostClientState.Connected) {
 					return;
@@ -687,6 +693,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._updateAutoReplyEnabled();
 		this._updatePreferLongContextEnabled();
 		this._updateSystemProxyEnabled();
+		this._updateCopilotMultiRootEnabled();
 		this._updateTerminalAutoApproveRules();
 		this._updateCodexEnabled();
 		this._updateDisableRepoInfoTelemetry();
@@ -1530,6 +1537,14 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this.dispatchAction(ROOT_STATE_URI, {
 			type: ActionType.RootConfigChanged,
 			config: { [AgentHostSystemProxyEnabledConfigKey]: enabled },
+		}, this._clientId, 0);
+	}
+
+	private _updateCopilotMultiRootEnabled(): void {
+		const enabled = this._configurationService.getValue<boolean>(AgentHostCopilotMultiRootEnabledSettingId) === true;
+		this.dispatchAction(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [AgentHostCopilotMultiRootEnabledConfigKey]: enabled },
 		}, this._clientId, 0);
 	}
 

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -461,6 +461,14 @@ export const PREFER_LONG_CONTEXT_SETTING_ID = 'github.copilot.chat.preferLongCon
 export const AgentHostSystemProxyEnabledConfigKey = 'systemProxyEnabled';
 
 /**
+ * Root config key forwarded from the renderer that gates multiple-working-directory
+ * support for the Copilot provider. When `true`, the Copilot provider advertises
+ * the `multipleWorkingDirectories` capability. Mirrors the hidden
+ * `chat.agentHost.copilotAgent.multiRootEnabled` VS Code setting.
+ */
+export const AgentHostCopilotMultiRootEnabledConfigKey = 'copilotMultiRootEnabled';
+
+/**
  * Root config key forwarded from the renderer when VS Code's
  * `chat.tools.terminal.autoApprove` setting changes. Holds the effective
  * terminal auto-approve rule object for agent-host shell permission checks.
@@ -715,6 +723,12 @@ export const platformRootSchema = createSchema({
 		title: localize('agentHost.config.systemProxyEnabled.title', "System Proxy Discovery"),
 		description: localize('agentHost.config.systemProxyEnabled.description', "Whether Copilot sessions automatically discover and use the operating system's proxy configuration."),
 		default: true,
+	}),
+	[AgentHostCopilotMultiRootEnabledConfigKey]: schemaProperty<boolean>({
+		type: 'boolean',
+		title: localize('agentHost.config.copilotMultiRootEnabled.title', "Copilot Multiple Working Directories"),
+		description: localize('agentHost.config.copilotMultiRootEnabled.description', "Whether the Copilot provider advertises support for multiple working directories, letting a session span every folder of a multi-root workspace."),
+		default: false,
 	}),
 	[AgentHostTerminalAutoApproveRulesConfigKey]: schemaProperty<AgentHostTerminalAutoApproveRules>({
 		type: 'object',

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -17,6 +17,7 @@ import {
 	AgentHostCodexAgentEnabledSettingId,
 	AgentHostCodexAgentSdkRootSettingId,
 	AgentHostCodexAgentCodexHomeSettingId,
+	AgentHostCopilotMultiRootEnabledSettingId,
 	AgentHostOTelCaptureContentSettingId,
 	AgentHostOTelDbSpanExporterEnabledSettingId,
 	AgentHostOTelEnabledSettingId,
@@ -91,6 +92,15 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			tags: ['experimental', 'advanced'],
 			experiment: { mode: 'startup' },
+		},
+		[AgentHostCopilotMultiRootEnabledSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.copilotAgent.multiRootEnabled', "When enabled, Copilot agent-host sessions advertise support for multiple working directories, so a session created in a multi-root workspace can span every workspace folder. Experimental; newly created sessions pick up a change without restarting the agent host."),
+			default: false,
+			// Hidden from the Settings UI while the feature is dogfooded internally.
+			// Still settable via `settings.json`; flip `default` (e.g. to
+			// `product.quality !== 'stable'`) to enable it for a build channel.
+			included: false,
 		},
 		[AgentHostClaudeAgentEnabledSettingId]: {
 			type: 'boolean',

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -53,6 +53,16 @@ export const AgentHostAhpJsonlLoggingSettingId = 'chat.agentHost.ahpJsonlLogging
 /** Configuration key controlling automatic OS system proxy discovery for agent-host Copilot sessions. */
 export const AgentHostSystemProxyEnabledSettingId = 'chat.agentHost.systemProxy.enabled';
 
+/**
+ * Configuration key gating multiple-working-directory support for the Copilot
+ * agent-host provider. When `true`, the Copilot provider advertises the
+ * `multipleWorkingDirectories` capability, so a session created in a multi-root
+ * workspace can span every workspace folder. Hidden from the Settings UI and
+ * off by default while the feature is dogfooded; the agent host re-advertises
+ * on change, so newly created sessions pick it up without a restart.
+ */
+export const AgentHostCopilotMultiRootEnabledSettingId = 'chat.agentHost.copilotAgent.multiRootEnabled';
+
 // The Copilot-CLI-specific setting IDs (`customTerminalTool`, `opus48Prompt`,
 // `reasoningEffortOverride`, `modelCapabilityOverrides`) live with their
 // root-config keys in `copilotCliConfig.ts`.

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -37,7 +37,7 @@ import { createPricingMetaFromBilling, hasLongContextSurcharge, normalizeCAPIBil
 import { createAgentModelByokMeta } from '../../common/agentModelByokMeta.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema, DEFAULT_SESSION_CUSTOMIZATION_DISCOVERY_MODE, toContainerCustomization } from '../../common/agentHostCustomizationConfig.js';
 import { CopilotCliConfigKey, copilotCliConfigSchema, type CopilotSdkLogLevelSetting } from '../../common/copilotCliConfig.js';
-import { AgentHostMcpServersConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AutoApproveLevel, SessionMode, migrateLegacyAutopilotConfig, platformRootSchema, platformSessionSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
+import { AgentHostMcpServersConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AutoApproveLevel, SessionMode, migrateLegacyAutopilotConfig, platformRootSchema, platformSessionSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSessionEntry, decodeProviderData, encodeProviderData, prepareSideChatPrompt, stripSideChatContext, type IPersistedChat } from '../agentPeerChats.js';
 import { AgentSession, AgentSignal, AuthenticateParams, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentLegacyChat, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentHostManagedSettingsSnapshot, IAgentHostNetworkEndpoint, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../../common/agentService.js';
@@ -679,8 +679,15 @@ export class CopilotAgent extends Disposable implements IAgent {
 			provider: 'copilotcli',
 			displayName: 'Copilot',
 			description: localize('copilotAgent.description', "Copilot SDK agent running in the local agent host process"),
-			capabilities: { multipleChats: { fork: true, sideChat: true } },
+			capabilities: {
+				multipleChats: { fork: true, sideChat: true },
+				...(this._isMultiRootEnabled() ? { multipleWorkingDirectories: { immutablePrimary: true } } : {}),
+			},
 		};
+	}
+
+	private _isMultiRootEnabled(): boolean {
+		return this._configurationService.getRootValue(platformRootSchema, AgentHostCopilotMultiRootEnabledConfigKey) === true;
 	}
 
 	getProtectedResources(): ProtectedResourceMetadata[] {

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -29,8 +29,8 @@ import { CustomizationType, MessageAttachmentKind, MessageKind, PendingMessageKi
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentHostCodexAgentEnabledSettingId, AgentHostSystemProxyEnabledSettingId } from '../../common/agentService.js';
-import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+import { AgentHostCodexAgentEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId } from '../../common/agentService.js';
+import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
 import type { Implementation } from '../../common/state/protocol/common/commands.js';
 import { agentsWindowAgentHostClientInfo } from '../../common/agentHostClientInfo.js';
 
@@ -910,6 +910,23 @@ suite('RemoteAgentHostProtocolClient', () => {
 
 		const updatedSystemProxyEnabled = findLastRootConfigNotification(transport.sentMessages, AgentHostSystemProxyEnabledConfigKey);
 		assert.deepStrictEqual(getRootConfig(updatedSystemProxyEnabled), { [AgentHostSystemProxyEnabledConfigKey]: false });
+	});
+
+	test('forwards Copilot multi-root enablement on connect and when the setting changes', async () => {
+		const configurationService = new TestConfigurationService({ [AgentHostCopilotMultiRootEnabledSettingId]: true });
+		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
+
+		await connectClient(client, transport);
+
+		const multiRootEnabled = findRootConfigNotification(transport.sentMessages, AgentHostCopilotMultiRootEnabledConfigKey);
+		assert.deepStrictEqual(getRootConfig(multiRootEnabled), { [AgentHostCopilotMultiRootEnabledConfigKey]: true });
+
+		transport.sentMessages.length = 0;
+		await configurationService.setUserConfiguration(AgentHostCopilotMultiRootEnabledSettingId, false);
+		fireConfigurationChange(configurationService, AgentHostCopilotMultiRootEnabledSettingId);
+
+		const updatedMultiRootEnabled = findLastRootConfigNotification(transport.sentMessages, AgentHostCopilotMultiRootEnabledConfigKey);
+		assert.deepStrictEqual(getRootConfig(updatedMultiRootEnabled), { [AgentHostCopilotMultiRootEnabledConfigKey]: false });
 	});
 
 	test('forwards auto-reply on connect and when the setting changes', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -32,11 +32,11 @@ import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../telemetry/common/telemetryUtils.js';
 import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
 import { CopilotCliConfigKey } from '../../common/copilotCliConfig.js';
-import { AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
+import { AgentHostCopilotMultiRootEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type IAgentCreateChatForkSource, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
-import { buildDefaultChatUri, buildChatUri, buildSubagentChatUri, parseRequiredSessionUriFromChatUri, CustomizationLoadStatus, MessageKind, ResponsePartKind, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, buildChatUri, buildSubagentChatUri, parseRequiredSessionUriFromChatUri, CustomizationLoadStatus, MessageKind, ResponsePartKind, ROOT_STATE_URI, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
 import { CustomizationType, SessionStatus, ToolCallContributorKind, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
 
@@ -877,6 +877,28 @@ suite('CopilotAgent', () => {
 				displayName: 'Copilot',
 				description: 'Copilot SDK agent running in the local agent host process',
 				capabilities: { multipleChats: { fork: true, sideChat: true } },
+			});
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('advertises multipleWorkingDirectories only when the hidden setting is enabled', async () => {
+		const { agent, stateManager } = createTestAgentContext(disposables);
+		try {
+			const setMultiRoot = (enabled: boolean) => stateManager.dispatchServerAction(ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [AgentHostCopilotMultiRootEnabledConfigKey]: enabled },
+			});
+			const disabledByDefault = agent.getDescriptor().capabilities?.multipleWorkingDirectories;
+			setMultiRoot(true);
+			const whenEnabled = agent.getDescriptor().capabilities?.multipleWorkingDirectories;
+			setMultiRoot(false);
+			const afterDisabling = agent.getDescriptor().capabilities?.multipleWorkingDirectories;
+			assert.deepStrictEqual({ disabledByDefault, whenEnabled, afterDisabling }, {
+				disabledByDefault: undefined,
+				whenEnabled: { immutablePrimary: true },
+				afterDisabling: undefined,
 			});
 		} finally {
 			await disposeAgent(agent);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
@@ -6,6 +6,7 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { AgentSession, type IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ActionType, type INotification, type SessionAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
@@ -268,6 +269,7 @@ export class AgentHostSessionListStore extends Disposable {
 			if (!this._isSessionInWorkspace(entry)) {
 				return;
 			}
+			this._workspaceMembership.markSeen(key);
 			this._mutationGeneration++;
 			this._entries.set(key, entry);
 			// The backend has now announced this session, so it is no longer a
@@ -299,6 +301,7 @@ export class AgentHostSessionListStore extends Disposable {
 				return;
 			}
 
+			this._workspaceMembership.markSeen(key);
 			this._mutationGeneration++;
 			this._entries.set(key, updated);
 			this._onDidChangeSessions.fire({ addedOrUpdated: [updated] });
@@ -349,9 +352,17 @@ export class AgentHostSessionListStore extends Disposable {
 		};
 	}
 
+	/** Uses legacy path containment for zero/single-folder windows and durable provenance only for multi-root workspaces. */
 	private _isSessionInWorkspace(entry: IAgentHostSessionListEntry): boolean {
-		const key = this._key(entry.provider, entry.rawId);
 		const workingDirectories = entry.summary.workingDirectories?.map(directory => URI.parse(directory)) ?? [];
+		const folders = this._workspaceContextService.getWorkspace().folders;
+		if (folders.length === 0) {
+			return true;
+		}
+		if (folders.length === 1) {
+			return workingDirectories.some(directory => extUriBiasedIgnorePathCase.isEqualOrParent(directory, folders[0].uri));
+		}
+		const key = this._key(entry.provider, entry.rawId);
 		return this._workspaceMembership.shouldInclude(key, workingDirectories, this._pendingNewSessions.has(key));
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
@@ -6,12 +6,12 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { AgentSession, type IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ActionType, type INotification, type SessionAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { SessionStatus, type SessionSummary } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IAgentHostWorkspaceSessionMembershipStore } from './agentHostWorkspaceSessionMembershipStore.js';
 
 /**
  * Minimal agent-host connection surface needed by the session list store.
@@ -84,6 +84,7 @@ export class AgentHostSessionListStore extends Disposable {
 	constructor(
 		private readonly _connection: IAgentHostSessionListConnection,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IAgentHostWorkspaceSessionMembershipStore private readonly _workspaceMembership: IAgentHostWorkspaceSessionMembershipStore,
 	) {
 		super();
 
@@ -155,8 +156,13 @@ export class AgentHostSessionListStore extends Disposable {
 		// resurrecting the just-removed session.
 		this._mutationGeneration++;
 		const key = this._key(provider, rawId);
-		// Clear any local pending marker even when there's no backend entry yet:
-		// an optimistic delete can target a session the backend never announced.
+		this._workspaceMembership.remove(key);
+		this._removeSessionFromList(provider, rawId);
+	}
+
+	private _removeSessionFromList(provider: string, rawId: string): void {
+		const key = this._key(provider, rawId);
+		// An announced or deleted session is no longer pending, even when no visible entry exists.
 		this._pendingNewSessions.delete(key);
 		const entry = this._entries.get(key);
 		if (!entry) {
@@ -212,15 +218,18 @@ export class AgentHostSessionListStore extends Disposable {
 		}
 
 		const nextEntries: IAgentHostSessionListEntry[] = [];
+		const backendSessionKeys: string[] = [];
 		for (const session of sessions) {
-			if (!this._isWorkingDirectoryInWorkspace(session.workingDirectories?.[0])) {
-				continue;
-			}
 			const entry = this._makeEntryFromMetadata(session);
 			if (entry) {
-				nextEntries.push(entry);
+				const key = this._key(entry.provider, entry.rawId);
+				backendSessionKeys.push(key);
+				if (this._isSessionInWorkspace(entry)) {
+					nextEntries.push(entry);
+				}
 			}
 		}
+		this._workspaceMembership.reconcileBackendSessions(backendSessionKeys);
 
 		this._entries.clear();
 		for (const entry of nextEntries) {
@@ -251,15 +260,15 @@ export class AgentHostSessionListStore extends Disposable {
 
 	private _onNotification(notification: INotification): void {
 		if (notification.type === 'root/sessionAdded') {
-			if (!this._isWorkingDirectoryInWorkspace(notification.summary.workingDirectories?.[0])) {
-				return;
-			}
 			const entry = this._makeEntryFromSummary(notification.summary);
 			if (!entry) {
 				return;
 			}
-			this._mutationGeneration++;
 			const key = this._key(entry.provider, entry.rawId);
+			if (!this._isSessionInWorkspace(entry)) {
+				return;
+			}
+			this._mutationGeneration++;
 			this._entries.set(key, entry);
 			// The backend has now announced this session, so it is no longer a
 			// locally-pending new session.
@@ -283,13 +292,13 @@ export class AgentHostSessionListStore extends Disposable {
 				return;
 			}
 
-			const updatedSummary = { ...cached.summary, ...notification.changes };
-			if (!this._isWorkingDirectoryInWorkspace(updatedSummary.workingDirectories?.[0])) {
-				this.removeSession(provider, rawId);
+			const updated = { provider, rawId, summary: { ...cached.summary, ...notification.changes } };
+			if (!this._isSessionInWorkspace(updated)) {
+				this._mutationGeneration++;
+				this._removeSessionFromList(provider, rawId);
 				return;
 			}
 
-			const updated = { provider, rawId, summary: updatedSummary };
 			this._mutationGeneration++;
 			this._entries.set(key, updated);
 			this._onDidChangeSessions.fire({ addedOrUpdated: [updated] });
@@ -340,25 +349,10 @@ export class AgentHostSessionListStore extends Disposable {
 		};
 	}
 
-	/**
-	 * Returns `true` if a session with the given working directory belongs
-	 * to the current VS Code workspace. When the window has no workspace
-	 * folders open (e.g. the Agents window, or an empty VS Code window),
-	 * filtering is disabled and every session is considered in-scope.
-	 *
-	 * Sessions without a working directory are excluded when a workspace
-	 * is open since they cannot be attributed to any folder.
-	 */
-	private _isWorkingDirectoryInWorkspace(workingDirectory: URI | string | undefined): boolean {
-		const folders = this._workspaceContextService.getWorkspace().folders;
-		if (folders.length === 0) {
-			return true;
-		}
-		if (!workingDirectory) {
-			return false;
-		}
-		const workingDirectoryUri = typeof workingDirectory === 'string' ? URI.parse(workingDirectory) : workingDirectory;
-		return folders.some(folder => extUriBiasedIgnorePathCase.isEqualOrParent(workingDirectoryUri, folder.uri));
+	private _isSessionInWorkspace(entry: IAgentHostSessionListEntry): boolean {
+		const key = this._key(entry.provider, entry.rawId);
+		const workingDirectories = entry.summary.workingDirectories?.map(directory => URI.parse(directory)) ?? [];
+		return this._workspaceMembership.shouldInclude(key, workingDirectories, this._pendingNewSessions.has(key));
 	}
 
 	private _toRemoval(entry: IAgentHostSessionListEntry): IAgentHostSessionListRemoval {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostWorkspaceSessionMembershipStore.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostWorkspaceSessionMembershipStore.ts
@@ -11,6 +11,7 @@ import { createDecorator } from '../../../../../../platform/instantiation/common
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../../../platform/workspace/common/workspace.js';
+import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 
 const STORAGE_KEY = 'agentHost.workspaceSessionMembership.v1';
 const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
@@ -30,51 +31,61 @@ export const IAgentHostWorkspaceSessionMembershipStore = createDecorator<IAgentH
 
 export interface IAgentHostWorkspaceSessionMembershipStore {
 	readonly _serviceBrand: undefined;
-	/** Refreshes last-seen timestamps from a complete backend snapshot and prunes memberships absent for over 30 days. */
+	/** Sets exact last-seen timestamps from a complete backend snapshot and prunes memberships absent for over 30 days. */
 	reconcileBackendSessions(sessionKeys: readonly string[]): void;
+	/** Refreshes one membership after an isolated backend notification. */
+	markSeen(key: string): void;
+	/** Returns whether a session belongs to this workspace, recording new multi-root provenance when appropriate. */
 	shouldInclude(key: string, workingDirectories: readonly URI[], isPendingLocalSession: boolean): boolean;
+	/** Removes durable provenance after the backend session is definitively deleted. */
 	remove(key: string): void;
+	/** Returns whether this eligible Editor multi-root workspace has recorded the session. */
 	has(key: string): boolean;
 }
 
-/** Persists multi-root session provenance for the current workspace. */
+/**
+ * Keeps multi-root sessions associated with the Editor Window workspace where they were first seen, even when that workspace's folders later change.
+ * Backend snapshots batch last-seen updates and stale pruning; outside Editor multi-root workspaces the storage remains dormant.
+ */
 export class AgentHostWorkspaceSessionMembershipStore implements IAgentHostWorkspaceSessionMembershipStore {
 
 	declare readonly _serviceBrand: undefined;
 	private readonly _entries = new Map<string, number>();
+	private _loaded = false;
+	private _dirty = false;
 
 	constructor(
 		@IStorageService private readonly _storageService: IStorageService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@ILogService private readonly _logService: ILogService,
-	) {
-		this._load();
-	}
+		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
+	) { }
 
 	protected now(): number {
 		return Date.now();
 	}
 
 	reconcileBackendSessions(sessionKeys: readonly string[]): void {
-		if (this._workspaceContextService.getWorkbenchState() !== WorkbenchState.WORKSPACE) {
+		if (!this._isEnabled()) {
 			return;
 		}
+		this._ensureLoaded();
 
 		const now = this.now();
 		const present = new Set(sessionKeys);
-		let didChange = false;
 		for (const key of present) {
-			didChange = this._markSeen(key, now) || didChange;
+			if (this._entries.has(key) && this._entries.get(key) !== now) {
+				this._entries.set(key, now);
+				this._dirty = true;
+			}
 		}
 		for (const [key, lastSeenAt] of this._entries) {
 			if (!present.has(key) && now - lastSeenAt > RETENTION_MS) {
 				this._entries.delete(key);
-				didChange = true;
+				this._dirty = true;
 			}
 		}
-		if (didChange) {
-			this._save();
-		}
+		this._flushIfDirty();
 	}
 
 	shouldInclude(key: string, workingDirectories: readonly URI[], isPendingLocalSession: boolean): boolean {
@@ -82,50 +93,73 @@ export class AgentHostWorkspaceSessionMembershipStore implements IAgentHostWorks
 		const pathMatches = workingDirectories.some(directory =>
 			folders.some(folder => extUriBiasedIgnorePathCase.isEqualOrParent(directory, folder.uri))
 		);
-		const isWorkspace = this._workspaceContextService.getWorkbenchState() === WorkbenchState.WORKSPACE;
 		const isMultiRootSession = workingDirectories.length > 1;
-
-		if (isWorkspace && isMultiRootSession) {
-			if (this._entries.has(key)) {
-				this._markSeenAndSave(key);
-			} else if (isPendingLocalSession || pathMatches) {
-				this._entries.set(key, this.now());
-				this._save();
-			}
-		}
 
 		if (folders.length === 0) {
 			return true;
 		}
-		if (folders.length === 1 || !isMultiRootSession || !isWorkspace) {
+		if (!this._isEnabled() || !isMultiRootSession) {
 			return pathMatches;
+		}
+		this._ensureLoaded();
+		if (!this._entries.has(key) && (isPendingLocalSession || pathMatches)) {
+			this._entries.set(key, this.now());
+			this._dirty = true;
 		}
 		return this._entries.has(key);
 	}
 
+	markSeen(key: string): void {
+		if (!this._isEnabled()) {
+			return;
+		}
+		this._ensureLoaded();
+		this._markSeen(key, this.now());
+		this._flushIfDirty();
+	}
+
 	remove(key: string): void {
+		if (!this._isEnabled()) {
+			return;
+		}
+		this._ensureLoaded();
 		if (this._entries.delete(key)) {
-			this._save();
+			this._dirty = true;
+			this._flushIfDirty();
 		}
 	}
 
 	has(key: string): boolean {
+		if (!this._isEnabled()) {
+			return false;
+		}
+		this._ensureLoaded();
 		return this._entries.has(key);
 	}
 
-	private _markSeenAndSave(key: string): void {
-		if (this._markSeen(key, this.now())) {
-			this._save();
+	/** Restricts durable provenance to Editor Windows with an actual multi-root workspace. */
+	private _isEnabled(): boolean {
+		return !this._environmentService.isSessionsWindow
+			&& this._workspaceContextService.getWorkbenchState() === WorkbenchState.WORKSPACE
+			&& this._workspaceContextService.getWorkspace().folders.length > 1;
+	}
+
+	/** Loads workspace membership lazily so ineligible windows never read this storage. */
+	private _ensureLoaded(): void {
+		if (!this._loaded) {
+			this._loaded = true;
+			this._load();
 		}
 	}
 
-	private _markSeen(key: string, now: number): boolean {
+	/** Advances notification-driven freshness only after the daily write-throttle interval. */
+	private _markSeen(key: string, now: number): void {
 		const lastSeenAt = this._entries.get(key);
 		if (lastSeenAt === undefined || now - lastSeenAt < SEEN_WRITE_INTERVAL_MS) {
-			return false;
+			return;
 		}
 		this._entries.set(key, now);
-		return true;
+		this._dirty = true;
 	}
 
 	private _load(): void {
@@ -155,16 +189,21 @@ export class AgentHostWorkspaceSessionMembershipStore implements IAgentHostWorks
 		}
 	}
 
-	private _save(): void {
-		if (this._entries.size === 0) {
-			this._storageService.remove(STORAGE_KEY, StorageScope.WORKSPACE);
+	/** Persists all accumulated membership changes in one whole-map write. */
+	private _flushIfDirty(): void {
+		if (!this._dirty) {
 			return;
 		}
-		const value: ISerializedMembership = {
-			version: 1,
-			sessions: [...this._entries].map(([key, lastSeenAt]) => ({ key, lastSeenAt })),
-		};
-		this._storageService.store(STORAGE_KEY, JSON.stringify(value), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		if (this._entries.size === 0) {
+			this._storageService.remove(STORAGE_KEY, StorageScope.WORKSPACE);
+		} else {
+			const value: ISerializedMembership = {
+				version: 1,
+				sessions: [...this._entries].map(([key, lastSeenAt]) => ({ key, lastSeenAt })),
+			};
+			this._storageService.store(STORAGE_KEY, JSON.stringify(value), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		}
+		this._dirty = false;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostWorkspaceSessionMembershipStore.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostWorkspaceSessionMembershipStore.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
+import { isObject } from '../../../../../../base/common/types.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService, WorkbenchState } from '../../../../../../platform/workspace/common/workspace.js';
+
+const STORAGE_KEY = 'agentHost.workspaceSessionMembership.v1';
+const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const SEEN_WRITE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+interface IStoredMembership {
+	readonly key: string;
+	readonly lastSeenAt: number;
+}
+
+interface ISerializedMembership {
+	readonly version: 1;
+	readonly sessions: readonly IStoredMembership[];
+}
+
+export const IAgentHostWorkspaceSessionMembershipStore = createDecorator<IAgentHostWorkspaceSessionMembershipStore>('agentHostWorkspaceSessionMembershipStore');
+
+export interface IAgentHostWorkspaceSessionMembershipStore {
+	readonly _serviceBrand: undefined;
+	/** Refreshes last-seen timestamps from a complete backend snapshot and prunes memberships absent for over 30 days. */
+	reconcileBackendSessions(sessionKeys: readonly string[]): void;
+	shouldInclude(key: string, workingDirectories: readonly URI[], isPendingLocalSession: boolean): boolean;
+	remove(key: string): void;
+	has(key: string): boolean;
+}
+
+/** Persists multi-root session provenance for the current workspace. */
+export class AgentHostWorkspaceSessionMembershipStore implements IAgentHostWorkspaceSessionMembershipStore {
+
+	declare readonly _serviceBrand: undefined;
+	private readonly _entries = new Map<string, number>();
+
+	constructor(
+		@IStorageService private readonly _storageService: IStorageService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		this._load();
+	}
+
+	protected now(): number {
+		return Date.now();
+	}
+
+	reconcileBackendSessions(sessionKeys: readonly string[]): void {
+		if (this._workspaceContextService.getWorkbenchState() !== WorkbenchState.WORKSPACE) {
+			return;
+		}
+
+		const now = this.now();
+		const present = new Set(sessionKeys);
+		let didChange = false;
+		for (const key of present) {
+			didChange = this._markSeen(key, now) || didChange;
+		}
+		for (const [key, lastSeenAt] of this._entries) {
+			if (!present.has(key) && now - lastSeenAt > RETENTION_MS) {
+				this._entries.delete(key);
+				didChange = true;
+			}
+		}
+		if (didChange) {
+			this._save();
+		}
+	}
+
+	shouldInclude(key: string, workingDirectories: readonly URI[], isPendingLocalSession: boolean): boolean {
+		const folders = this._workspaceContextService.getWorkspace().folders;
+		const pathMatches = workingDirectories.some(directory =>
+			folders.some(folder => extUriBiasedIgnorePathCase.isEqualOrParent(directory, folder.uri))
+		);
+		const isWorkspace = this._workspaceContextService.getWorkbenchState() === WorkbenchState.WORKSPACE;
+		const isMultiRootSession = workingDirectories.length > 1;
+
+		if (isWorkspace && isMultiRootSession) {
+			if (this._entries.has(key)) {
+				this._markSeenAndSave(key);
+			} else if (isPendingLocalSession || pathMatches) {
+				this._entries.set(key, this.now());
+				this._save();
+			}
+		}
+
+		if (folders.length === 0) {
+			return true;
+		}
+		if (folders.length === 1 || !isMultiRootSession || !isWorkspace) {
+			return pathMatches;
+		}
+		return this._entries.has(key);
+	}
+
+	remove(key: string): void {
+		if (this._entries.delete(key)) {
+			this._save();
+		}
+	}
+
+	has(key: string): boolean {
+		return this._entries.has(key);
+	}
+
+	private _markSeenAndSave(key: string): void {
+		if (this._markSeen(key, this.now())) {
+			this._save();
+		}
+	}
+
+	private _markSeen(key: string, now: number): boolean {
+		const lastSeenAt = this._entries.get(key);
+		if (lastSeenAt === undefined || now - lastSeenAt < SEEN_WRITE_INTERVAL_MS) {
+			return false;
+		}
+		this._entries.set(key, now);
+		return true;
+	}
+
+	private _load(): void {
+		const raw = this._storageService.get(STORAGE_KEY, StorageScope.WORKSPACE);
+		if (!raw) {
+			return;
+		}
+		try {
+			const value: unknown = JSON.parse(raw);
+			if (!isObject(value)) {
+				return;
+			}
+			const serialized = value as Record<string, unknown>;
+			if (serialized.version !== 1 || !Array.isArray(serialized.sessions)) {
+				return;
+			}
+			for (const entry of serialized.sessions) {
+				if (isObject(entry)) {
+					const membership = entry as Record<string, unknown>;
+					if (typeof membership.key === 'string' && typeof membership.lastSeenAt === 'number' && Number.isFinite(membership.lastSeenAt)) {
+						this._entries.set(membership.key, membership.lastSeenAt);
+					}
+				}
+			}
+		} catch (error) {
+			this._logService.warn('[AgentHostWorkspaceSessionMembershipStore] Failed to parse persisted membership', error);
+		}
+	}
+
+	private _save(): void {
+		if (this._entries.size === 0) {
+			this._storageService.remove(STORAGE_KEY, StorageScope.WORKSPACE);
+			return;
+		}
+		const value: ISerializedMembership = {
+			version: 1,
+			sessions: [...this._entries].map(([key, lastSeenAt]) => ({ key, lastSeenAt })),
+		};
+		this._storageService.store(STORAGE_KEY, JSON.stringify(value), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+	}
+}
+
+registerSingleton(IAgentHostWorkspaceSessionMembershipStore, AgentHostWorkspaceSessionMembershipStore, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -806,7 +806,6 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		ensureSyncedCustomizationProvider: () => { },
 	});
 	instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
-	instantiationService.stub(IAgentHostWorkspaceSessionMembershipStore, instantiationService.createInstance(AgentHostWorkspaceSessionMembershipStore));
 	instantiationService.stub(ICustomizationHarnessService, {
 		registerExternalHarness: () => toDisposable(() => { }),
 	});
@@ -843,6 +842,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		isNewSession: sessionResource => workingDirectoryResolver?.isNewSession?.(sessionResource) ?? sessionResource.path.substring(1).startsWith('new-'),
 	});
 	instantiationService.stub(IWorkbenchEnvironmentService, { isSessionsWindow } as Partial<IWorkbenchEnvironmentService>);
+	instantiationService.stub(IAgentHostWorkspaceSessionMembershipStore, instantiationService.createInstance(AgentHostWorkspaceSessionMembershipStore));
 	instantiationService.stub(IWorkbenchAssignmentService, new NullWorkbenchAssignmentService());
 	instantiationService.stub(IChatInputNotificationService, {
 		_serviceBrand: undefined,
@@ -2665,11 +2665,20 @@ suite('AgentHostChatContribution', () => {
 
 		test('summary eviction preserves workspace membership but session removal clears it', async () => {
 			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const a = URI.file('/workspace/a');
+			const b = URI.file('/workspace/b');
+			instantiationService.stub(IWorkspaceContextService, {
+				getWorkbenchState: () => WorkbenchState.WORKSPACE,
+				getWorkspace: () => ({ id: 'workspace', folders: [a, b].map((uri, index) => ({ uri, name: uri.path, index, toResource: () => uri })) }),
+				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: Event.None,
+			});
 			let include = true;
 			const removedMemberships: string[] = [];
 			const workspaceMembership: IAgentHostWorkspaceSessionMembershipStore = {
 				_serviceBrand: undefined,
 				reconcileBackendSessions: () => { },
+				markSeen: () => { },
 				shouldInclude: () => include,
 				remove: key => removedMemberships.push(key),
 				has: () => false,
@@ -2870,11 +2879,26 @@ suite('AgentHostChatContribution', () => {
 			agentHostService.addSession({ session: AgentSession.uri('copilot', 'out-ws'), startTime: 1000, modifiedTime: 2000, summary: 'Outside workspace', workingDirectories: [URI.file('/other/place')] });
 			agentHostService.addSession({ session: AgentSession.uri('copilot', 'no-wd'), startTime: 1000, modifiedTime: 2000, summary: 'No working directory' });
 
-			const listController = createSessionListController(disposables, instantiationService, agentHostService);
+			let membershipChecks = 0;
+			const workspaceMembership: IAgentHostWorkspaceSessionMembershipStore = {
+				_serviceBrand: undefined,
+				reconcileBackendSessions: () => { },
+				markSeen: () => { },
+				shouldInclude: () => { membershipChecks++; return false; },
+				remove: () => { },
+				has: () => false,
+			};
+			const listController = createSessionListController(disposables, instantiationService, agentHostService, 'agent-host-copilot', 'copilot', undefined, workspaceMembership);
 
 			await listController.refresh(CancellationToken.None);
 
-			assert.deepStrictEqual(listController.items.map(item => item.label), ['In workspace', 'Tail in workspace']);
+			assert.deepStrictEqual({
+				labels: listController.items.map(item => item.label),
+				membershipChecks,
+			}, {
+				labels: ['In workspace', 'Tail in workspace'],
+				membershipChecks: 0,
+			});
 		});
 
 		test('refresh does not filter when no workspace folders are open', async () => {
@@ -2937,7 +2961,7 @@ suite('AgentHostChatContribution', () => {
 			let folders = [a, b];
 			const onDidChangeWorkspaceFolders = disposables.add(new Emitter<{ readonly added: never[]; readonly removed: never[]; readonly changed: never[] }>());
 			instantiationService.stub(IWorkspaceContextService, {
-				getWorkbenchState: () => folders.length > 1 ? WorkbenchState.WORKSPACE : WorkbenchState.FOLDER,
+				getWorkbenchState: () => WorkbenchState.WORKSPACE,
 				getWorkspace: () => ({ id: 'workspace', folders: folders.map((uri, index) => ({ uri, name: uri.path, index, toResource: () => uri })) }),
 				getWorkspaceFolder: () => null,
 				onDidChangeWorkspaceFolders: onDidChangeWorkspaceFolders.event,
@@ -2954,6 +2978,10 @@ suite('AgentHostChatContribution', () => {
 
 			await listController.refresh(CancellationToken.None);
 			const initial = listController.items.map(item => item.label);
+			folders = [a];
+			onDidChangeWorkspaceFolders.fire({ added: [], removed: [], changed: [] });
+			await timeout(0);
+			const oneOriginalFolderRemaining = listController.items.map(item => item.label);
 			folders = [c, d];
 			onDidChangeWorkspaceFolders.fire({ added: [], removed: [], changed: [] });
 			await timeout(0);
@@ -2964,10 +2992,12 @@ suite('AgentHostChatContribution', () => {
 
 			assert.deepStrictEqual({
 				initial,
+				oneOriginalFolderRemaining,
 				changedMultiRootWorkspace,
 				singleFolderWorkspace: listController.items.map(item => item.label),
 			}, {
 				initial: ['Multi-root session'],
+				oneOriginalFolderRemaining: ['Multi-root session'],
 				changedMultiRootWorkspace: ['Multi-root session'],
 				singleFolderWorkspace: [],
 			});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -57,13 +57,14 @@ import { IOpenerService } from '../../../../../../platform/opener/common/opener.
 import { IPathService } from '../../../../../services/path/common/pathService.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IOutputService } from '../../../../../services/output/common/output.js';
-import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceContextService, WorkbenchState } from '../../../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceTrustRequestService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 import { AgentHostContribution, AgentHostSessionHandler } from '../../../browser/agentSessions/agentHost/agentHostChatContribution.js';
 import { AgentHostLanguageModelProvider } from '../../../browser/agentSessions/agentHost/agentHostLanguageModelProvider.js';
 import { AgentHostSessionListContribution } from '../../../browser/agentSessions/agentHost/agentHostSessionListContribution.js';
 import { AgentHostSessionListController } from '../../../browser/agentSessions/agentHost/agentHostSessionListController.js';
 import { AgentHostSessionListStore, type IAgentHostSessionListConnection } from '../../../browser/agentSessions/agentHost/agentHostSessionListStore.js';
+import { AgentHostWorkspaceSessionMembershipStore, IAgentHostWorkspaceSessionMembershipStore } from '../../../browser/agentSessions/agentHost/agentHostWorkspaceSessionMembershipStore.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { TestFileService } from '../../../../../test/common/workbenchTestServices.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
@@ -759,7 +760,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	instantiationService.stub(IOutputService, { getChannel: () => undefined });
 	instantiationService.stub(IAgentHostEnablementService, { _serviceBrand: undefined, enabled: true });
 	instantiationService.stub(IProgressService, { withProgress: <R,>(_options: IProgressNotificationOptions, task: (progress: IProgress<IProgressStep>) => Promise<R>) => task({ report: () => { } }) });
-	instantiationService.stub(IWorkspaceContextService, { getWorkspace: () => ({ id: '', folders: [] }), getWorkspaceFolder: () => null, onDidChangeWorkspaceFolders: Event.None });
+	instantiationService.stub(IWorkspaceContextService, { getWorkbenchState: () => WorkbenchState.EMPTY, getWorkspace: () => ({ id: '', folders: [] }), getWorkspaceFolder: () => null, onDidChangeWorkspaceFolders: Event.None });
 	const trustController: { result: boolean | undefined; workspaceTrustCalls: number; resourcesTrustCalls: number } = { result: true, workspaceTrustCalls: 0, resourcesTrustCalls: 0 };
 	instantiationService.stub(IWorkspaceTrustRequestService, new class extends mock<IWorkspaceTrustRequestService>() {
 		override async requestWorkspaceTrust(): Promise<boolean | undefined> {
@@ -805,6 +806,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		ensureSyncedCustomizationProvider: () => { },
 	});
 	instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
+	instantiationService.stub(IAgentHostWorkspaceSessionMembershipStore, instantiationService.createInstance(AgentHostWorkspaceSessionMembershipStore));
 	instantiationService.stub(ICustomizationHarnessService, {
 		registerExternalHarness: () => toDisposable(() => { }),
 	});
@@ -915,12 +917,13 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	return { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, activeClientService, seedActiveClient, chatSessionContributions, chatSessionItemControllers, newSessionFolderService, trustController, modelService, workingCopyService, commandService };
 }
 
-function createSessionListStore(disposables: DisposableStore, instantiationService: TestInstantiationService, connection: IAgentHostSessionListConnection): AgentHostSessionListStore {
+function createSessionListStore(disposables: DisposableStore, instantiationService: TestInstantiationService, connection: IAgentHostSessionListConnection, workspaceMembership?: IAgentHostWorkspaceSessionMembershipStore): AgentHostSessionListStore {
+	instantiationService.stub(IAgentHostWorkspaceSessionMembershipStore, workspaceMembership ?? instantiationService.createInstance(AgentHostWorkspaceSessionMembershipStore));
 	return disposables.add(instantiationService.createInstance(AgentHostSessionListStore, connection));
 }
 
-function createSessionListController(disposables: DisposableStore, instantiationService: TestInstantiationService, connection: IAgentHostSessionListConnection, sessionType = 'agent-host-copilot', provider = 'copilot', description: string | undefined = undefined): AgentHostSessionListController {
-	const sessionListStore = createSessionListStore(disposables, instantiationService, connection);
+function createSessionListController(disposables: DisposableStore, instantiationService: TestInstantiationService, connection: IAgentHostSessionListConnection, sessionType = 'agent-host-copilot', provider = 'copilot', description: string | undefined = undefined, workspaceMembership?: IAgentHostWorkspaceSessionMembershipStore): AgentHostSessionListController {
+	const sessionListStore = createSessionListStore(disposables, instantiationService, connection, workspaceMembership);
 	return disposables.add(instantiationService.createInstance(AgentHostSessionListController, sessionType, provider, sessionListStore, description, 'local'));
 }
 
@@ -2660,6 +2663,45 @@ suite('AgentHostChatContribution', () => {
 			});
 		});
 
+		test('summary eviction preserves workspace membership but session removal clears it', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+			let include = true;
+			const removedMemberships: string[] = [];
+			const workspaceMembership: IAgentHostWorkspaceSessionMembershipStore = {
+				_serviceBrand: undefined,
+				reconcileBackendSessions: () => { },
+				shouldInclude: () => include,
+				remove: key => removedMemberships.push(key),
+				has: () => false,
+			};
+			const session = AgentSession.uri('copilot', 'membership');
+			agentHostService.addSession({ session, startTime: 1000, modifiedTime: 2000, summary: 'Membership' });
+			const listController = createSessionListController(disposables, instantiationService, agentHostService, 'agent-host-copilot', 'copilot', undefined, workspaceMembership);
+			await listController.refresh(CancellationToken.None);
+
+			include = false;
+			agentHostService.fireNotification({
+				type: 'root/sessionSummaryChanged',
+				channel: ROOT_STATE_URI,
+				session: session.toString(),
+				changes: { workingDirectories: [URI.file('/other').toString()] },
+			} as INotification);
+			const afterSummaryEviction = listController.items.length;
+			agentHostService.fireNotification({
+				type: 'root/sessionRemoved',
+				channel: ROOT_STATE_URI,
+				session: session.toString(),
+			} as INotification);
+
+			assert.deepStrictEqual({
+				afterSummaryEviction,
+				removedMemberships,
+			}, {
+				afterSummaryEviction: 0,
+				removedMemberships: ['copilot://membership'],
+			});
+		});
+
 		test('sessionRemoved notification removes only the matching item', async () => {
 			const { instantiationService, agentHostService } = createTestServices(disposables);
 
@@ -2817,12 +2859,14 @@ suite('AgentHostChatContribution', () => {
 
 			const workspaceFolder = URI.file('/workspace/root');
 			instantiationService.stub(IWorkspaceContextService, {
+				getWorkbenchState: () => WorkbenchState.FOLDER,
 				getWorkspace: () => ({ id: '', folders: [{ uri: workspaceFolder, name: 'root', index: 0, toResource: () => workspaceFolder }] }),
 				getWorkspaceFolder: () => null,
 				onDidChangeWorkspaceFolders: Event.None,
 			});
 
 			agentHostService.addSession({ session: AgentSession.uri('copilot', 'in-ws'), startTime: 1000, modifiedTime: 2000, summary: 'In workspace', workingDirectories: [URI.file('/workspace/root/sub')] });
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'tail-in-ws'), startTime: 1000, modifiedTime: 2000, summary: 'Tail in workspace', workingDirectories: [URI.file('/other/primary'), URI.file('/workspace/root/sub')] });
 			agentHostService.addSession({ session: AgentSession.uri('copilot', 'out-ws'), startTime: 1000, modifiedTime: 2000, summary: 'Outside workspace', workingDirectories: [URI.file('/other/place')] });
 			agentHostService.addSession({ session: AgentSession.uri('copilot', 'no-wd'), startTime: 1000, modifiedTime: 2000, summary: 'No working directory' });
 
@@ -2830,7 +2874,7 @@ suite('AgentHostChatContribution', () => {
 
 			await listController.refresh(CancellationToken.None);
 
-			assert.deepStrictEqual(listController.items.map(item => item.label), ['In workspace']);
+			assert.deepStrictEqual(listController.items.map(item => item.label), ['In workspace', 'Tail in workspace']);
 		});
 
 		test('refresh does not filter when no workspace folders are open', async () => {
@@ -2851,6 +2895,7 @@ suite('AgentHostChatContribution', () => {
 			let folders: { uri: URI; name: string; index: number; toResource: () => URI }[] = [];
 			const onDidChangeWorkspaceFolders = disposables.add(new Emitter<{ readonly added: never[]; readonly removed: never[]; readonly changed: never[] }>());
 			instantiationService.stub(IWorkspaceContextService, {
+				getWorkbenchState: () => folders.length === 0 ? WorkbenchState.EMPTY : folders.length === 1 ? WorkbenchState.FOLDER : WorkbenchState.WORKSPACE,
 				getWorkspace: () => ({ id: '', folders: [...folders] }),
 				getWorkspaceFolder: () => null,
 				onDidChangeWorkspaceFolders: onDidChangeWorkspaceFolders.event,
@@ -2882,11 +2927,58 @@ suite('AgentHostChatContribution', () => {
 			});
 		});
 
+		test('multi-root workspace membership survives workspace folder changes', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			const a = URI.file('/workspace/a');
+			const b = URI.file('/workspace/b');
+			const c = URI.file('/workspace/c');
+			const d = URI.file('/workspace/d');
+			let folders = [a, b];
+			const onDidChangeWorkspaceFolders = disposables.add(new Emitter<{ readonly added: never[]; readonly removed: never[]; readonly changed: never[] }>());
+			instantiationService.stub(IWorkspaceContextService, {
+				getWorkbenchState: () => folders.length > 1 ? WorkbenchState.WORKSPACE : WorkbenchState.FOLDER,
+				getWorkspace: () => ({ id: 'workspace', folders: folders.map((uri, index) => ({ uri, name: uri.path, index, toResource: () => uri })) }),
+				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: onDidChangeWorkspaceFolders.event,
+			});
+
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'multi-root'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Multi-root session',
+				workingDirectories: [b, a],
+			});
+			const listController = createSessionListController(disposables, instantiationService, agentHostService);
+
+			await listController.refresh(CancellationToken.None);
+			const initial = listController.items.map(item => item.label);
+			folders = [c, d];
+			onDidChangeWorkspaceFolders.fire({ added: [], removed: [], changed: [] });
+			await timeout(0);
+			const changedMultiRootWorkspace = listController.items.map(item => item.label);
+			folders = [c];
+			onDidChangeWorkspaceFolders.fire({ added: [], removed: [], changed: [] });
+			await timeout(0);
+
+			assert.deepStrictEqual({
+				initial,
+				changedMultiRootWorkspace,
+				singleFolderWorkspace: listController.items.map(item => item.label),
+			}, {
+				initial: ['Multi-root session'],
+				changedMultiRootWorkspace: ['Multi-root session'],
+				singleFolderWorkspace: [],
+			});
+		});
+
 		test('sessionAdded notification filters out sessions outside the workspace', async () => {
 			const { instantiationService, agentHostService } = createTestServices(disposables);
 
 			const workspaceFolder = URI.file('/workspace/root');
 			instantiationService.stub(IWorkspaceContextService, {
+				getWorkbenchState: () => WorkbenchState.FOLDER,
 				getWorkspace: () => ({ id: '', folders: [{ uri: workspaceFolder, name: 'root', index: 0, toResource: () => workspaceFolder }] }),
 				getWorkspaceFolder: () => null,
 				onDidChangeWorkspaceFolders: Event.None,
@@ -2912,7 +3004,28 @@ suite('AgentHostChatContribution', () => {
 				},
 			} as INotification);
 
-			assert.strictEqual(listController.items.length, 0);
+			const afterForeign = listController.items.map(item => item.label);
+			agentHostService.fireNotification({
+				type: 'root/sessionAdded',
+				channel: ROOT_STATE_URI,
+				summary: {
+					resource: AgentSession.uri('copilot', 'tail-match').toString(),
+					provider: 'copilot',
+					title: 'Tail matches workspace',
+					status: SessionStatus.Idle,
+					createdAt: new Date(1000).toISOString(),
+					modifiedAt: new Date(2000).toISOString(),
+					workingDirectories: [URI.file('/other/primary').toString(), URI.file('/workspace/root/sub').toString()],
+				},
+			} as INotification);
+
+			assert.deepStrictEqual({
+				afterForeign,
+				afterTailMatch: listController.items.map(item => item.label),
+			}, {
+				afterForeign: [],
+				afterTailMatch: ['Tail matches workspace'],
+			});
 
 			// And one in our workspace should be included.
 			agentHostService.fireNotification({
@@ -2929,7 +3042,7 @@ suite('AgentHostChatContribution', () => {
 				},
 			} as INotification);
 
-			assert.deepStrictEqual(listController.items.map(item => item.label), ['Local session']);
+			assert.deepStrictEqual(listController.items.map(item => item.label), ['Tail matches workspace', 'Local session']);
 		});
 
 		test('deleteChatSessionItem disposes the corresponding backend session and removes it from the cached items', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
@@ -2983,6 +3096,7 @@ suite('AgentHostChatContribution', () => {
 
 			const workspaceFolder = URI.from({ scheme: 'file', path: '/workspace/root' });
 			instantiationService.stub(IWorkspaceContextService, {
+				getWorkbenchState: () => WorkbenchState.FOLDER,
 				getWorkspace: () => ({ id: '', folders: [{ uri: workspaceFolder, name: 'root', index: 0, toResource: () => workspaceFolder }] }),
 				getWorkspaceFolder: () => null,
 				onDidChangeWorkspaceFolders: Event.None,
@@ -3041,6 +3155,7 @@ suite('AgentHostChatContribution', () => {
 			const folderA = URI.from({ scheme: 'file', path: '/workspace/a' });
 			const folderB = URI.from({ scheme: 'file', path: '/workspace/b' });
 			instantiationService.stub(IWorkspaceContextService, {
+				getWorkbenchState: () => WorkbenchState.WORKSPACE,
 				getWorkspace: () => ({
 					id: '', folders: [
 						{ uri: folderA, name: 'a', index: 0, toResource: () => folderA },

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostWorkspaceSessionMembershipStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostWorkspaceSessionMembershipStore.test.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../../base/common/event.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { mock, upcastPartial } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import { InMemoryStorageService } from '../../../../../../platform/storage/common/storage.js';
+import { IWorkspace, IWorkspaceContextService, WorkbenchState } from '../../../../../../platform/workspace/common/workspace.js';
+import { AgentHostWorkspaceSessionMembershipStore } from '../../../browser/agentSessions/agentHost/agentHostWorkspaceSessionMembershipStore.js';
+
+suite('AgentHostWorkspaceSessionMembershipStore', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	class TestMembershipStore extends AgentHostWorkspaceSessionMembershipStore {
+		constructor(
+			private readonly _now: () => number,
+			storageService: InMemoryStorageService,
+			workspaceContextService: IWorkspaceContextService,
+		) {
+			super(storageService, workspaceContextService, new NullLogService());
+		}
+
+		protected override now(): number {
+			return this._now();
+		}
+	}
+
+	class TestWorkspaceContextService extends mock<IWorkspaceContextService>() {
+		state = WorkbenchState.WORKSPACE;
+		folders: URI[] = [];
+		override readonly onDidChangeWorkspaceFolders = Event.None;
+		override getWorkbenchState(): WorkbenchState { return this.state; }
+		override getWorkspace(): IWorkspace {
+			return upcastPartial<IWorkspace>({
+				id: 'workspace',
+				folders: this.folders.map((uri, index) => ({ uri, index, name: uri.path, toResource: path => URI.joinPath(uri, path) })),
+			});
+		}
+	}
+
+	test('workspace membership survives folder and directory-set transitions', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		const workspaceService = new TestWorkspaceContextService();
+		const a = URI.file('/workspace/a');
+		const b = URI.file('/workspace/b');
+		const c = URI.file('/workspace/c');
+		const d = URI.file('/workspace/d');
+		workspaceService.folders = [a, b];
+		const store = new TestMembershipStore(() => 1000, storageService, workspaceService);
+
+		const key = 'copilot://session';
+		const initial = store.shouldInclude(key, [a, b], false);
+		const restoredStore = new TestMembershipStore(() => 1000, storageService, workspaceService);
+		workspaceService.folders = [c, d];
+		const changedWorkspace = restoredStore.shouldInclude(key, [a, b], false);
+		workspaceService.folders = [c];
+		const singleFolder = restoredStore.shouldInclude(key, [a, b], false);
+		workspaceService.folders = [c, d];
+		const shrunkSession = restoredStore.shouldInclude(key, [a], false);
+		const expandedAgain = restoredStore.shouldInclude(key, [a, b], false);
+		restoredStore.remove(key);
+		const afterDelete = restoredStore.shouldInclude(key, [a, b], false);
+
+		assert.deepStrictEqual({
+			initial,
+			changedWorkspace,
+			singleFolder,
+			shrunkSession,
+			expandedAgain,
+			afterDelete,
+		}, {
+			initial: true,
+			changedWorkspace: true,
+			singleFolder: false,
+			shrunkSession: false,
+			expandedAgain: true,
+			afterDelete: false,
+		});
+	});
+
+	test('last-seen reconciliation retains active sessions and prunes after thirty unseen days', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		const workspaceService = new TestWorkspaceContextService();
+		const a = URI.file('/workspace/a');
+		const b = URI.file('/workspace/b');
+		workspaceService.folders = [a, b];
+		let now = 0;
+		const store = new TestMembershipStore(() => now, storageService, workspaceService);
+		const key = 'copilot://session';
+
+		store.shouldInclude(key, [a, b], false);
+		now = 20 * 24 * 60 * 60 * 1000;
+		store.reconcileBackendSessions([key]);
+		now += 29 * 24 * 60 * 60 * 1000;
+		store.reconcileBackendSessions([]);
+		const retained = store.has(key);
+		now += 2 * 24 * 60 * 60 * 1000;
+		store.reconcileBackendSessions([]);
+
+		assert.deepStrictEqual({ retained, pruned: store.has(key) }, { retained: true, pruned: false });
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostWorkspaceSessionMembershipStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostWorkspaceSessionMembershipStore.test.ts
@@ -5,12 +5,14 @@
 
 import assert from 'assert';
 import { Event } from '../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { mock, upcastPartial } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
-import { InMemoryStorageService } from '../../../../../../platform/storage/common/storage.js';
+import { InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { IWorkspace, IWorkspaceContextService, WorkbenchState } from '../../../../../../platform/workspace/common/workspace.js';
+import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { AgentHostWorkspaceSessionMembershipStore } from '../../../browser/agentSessions/agentHost/agentHostWorkspaceSessionMembershipStore.js';
 
 suite('AgentHostWorkspaceSessionMembershipStore', () => {
@@ -21,8 +23,9 @@ suite('AgentHostWorkspaceSessionMembershipStore', () => {
 			private readonly _now: () => number,
 			storageService: InMemoryStorageService,
 			workspaceContextService: IWorkspaceContextService,
+			isSessionsWindow = false,
 		) {
-			super(storageService, workspaceContextService, new NullLogService());
+			super(storageService, workspaceContextService, new NullLogService(), { isSessionsWindow } as Partial<IWorkbenchEnvironmentService> as IWorkbenchEnvironmentService);
 		}
 
 		protected override now(): number {
@@ -55,6 +58,7 @@ suite('AgentHostWorkspaceSessionMembershipStore', () => {
 
 		const key = 'copilot://session';
 		const initial = store.shouldInclude(key, [a, b], false);
+		store.reconcileBackendSessions([key]);
 		const restoredStore = new TestMembershipStore(() => 1000, storageService, workspaceService);
 		workspaceService.folders = [c, d];
 		const changedWorkspace = restoredStore.shouldInclude(key, [a, b], false);
@@ -83,6 +87,41 @@ suite('AgentHostWorkspaceSessionMembershipStore', () => {
 		});
 	});
 
+	test('records only eligible multi-root session provenance', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		const workspaceService = new TestWorkspaceContextService();
+		const a = URI.file('/workspace/a');
+		const b = URI.file('/workspace/b');
+		const c = URI.file('/workspace/c');
+		const d = URI.file('/workspace/d');
+		workspaceService.folders = [a, b];
+		const store = new TestMembershipStore(() => 1000, storageService, workspaceService);
+
+		const pathMatchKey = 'copilot://path-match';
+		const pendingKey = 'copilot://pending';
+		const noMatchKey = 'copilot://no-match';
+		const singleRootKey = 'copilot://single-root';
+		assert.deepStrictEqual({
+			pathMatch: store.shouldInclude(pathMatchKey, [c, b], false),
+			pathMatchStored: store.has(pathMatchKey),
+			pendingNoMatch: store.shouldInclude(pendingKey, [c, d], true),
+			pendingStored: store.has(pendingKey),
+			nonPendingNoMatch: store.shouldInclude(noMatchKey, [c, d], false),
+			nonPendingStored: store.has(noMatchKey),
+			singleRootPathMatch: store.shouldInclude(singleRootKey, [a], false),
+			singleRootStored: store.has(singleRootKey),
+		}, {
+			pathMatch: true,
+			pathMatchStored: true,
+			pendingNoMatch: true,
+			pendingStored: true,
+			nonPendingNoMatch: false,
+			nonPendingStored: false,
+			singleRootPathMatch: true,
+			singleRootStored: false,
+		});
+	});
+
 	test('last-seen reconciliation retains active sessions and prunes after thirty unseen days', () => {
 		const storageService = disposables.add(new InMemoryStorageService());
 		const workspaceService = new TestWorkspaceContextService();
@@ -103,5 +142,201 @@ suite('AgentHostWorkspaceSessionMembershipStore', () => {
 		store.reconcileBackendSessions([]);
 
 		assert.deepStrictEqual({ retained, pruned: store.has(key) }, { retained: true, pruned: false });
+	});
+
+	test('snapshot reconciliation batches new and retained membership writes', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		const workspaceService = new TestWorkspaceContextService();
+		const a = URI.file('/workspace/a');
+		const b = URI.file('/workspace/b');
+		workspaceService.folders = [a, b];
+		let now = 0;
+		const store = new TestMembershipStore(() => now, storageService, workspaceService);
+		const first = 'copilot://first';
+		const second = 'copilot://second';
+		const listenerStore = disposables.add(new DisposableStore());
+		let writes = 0;
+		listenerStore.add(storageService.onDidChangeValue(StorageScope.WORKSPACE, undefined, listenerStore)(() => writes++));
+		store.shouldInclude(first, [a, b], false);
+		store.shouldInclude(second, [a, b], false);
+		const beforeSnapshot = writes;
+		store.reconcileBackendSessions([first, second]);
+		const afterNewMembershipSnapshot = writes;
+		now = 2 * 24 * 60 * 60 * 1000;
+		store.reconcileBackendSessions([first, second]);
+		const afterRetainedMembershipSnapshot = writes;
+		now += 12 * 60 * 60 * 1000;
+		store.markSeen(first);
+		const afterThrottledNotification = writes;
+		now += 24 * 60 * 60 * 1000;
+		store.markSeen(first);
+
+		assert.deepStrictEqual({
+			beforeSnapshot,
+			afterNewMembershipSnapshot,
+			afterRetainedMembershipSnapshot,
+			afterThrottledNotification,
+			afterEligibleNotification: writes,
+		}, {
+			beforeSnapshot: 0,
+			afterNewMembershipSnapshot: 1,
+			afterRetainedMembershipSnapshot: 2,
+			afterThrottledNotification: 2,
+			afterEligibleNotification: 3,
+		});
+	});
+
+	test('snapshot freshness prevents pruning before thirty full days of absence', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		const workspaceService = new TestWorkspaceContextService();
+		const a = URI.file('/workspace/a');
+		const b = URI.file('/workspace/b');
+		workspaceService.folders = [a, b];
+		let now = 0;
+		const store = new TestMembershipStore(() => now, storageService, workspaceService);
+		const key = 'copilot://session';
+		store.shouldInclude(key, [a, b], false);
+		store.reconcileBackendSessions([key]);
+		now = 12 * 60 * 60 * 1000;
+		store.reconcileBackendSessions([key]);
+		now += 29 * 24 * 60 * 60 * 1000 + 23 * 60 * 60 * 1000;
+		store.reconcileBackendSessions([]);
+		const retainedBeforeThirtyDays = store.has(key);
+		now += 2 * 60 * 60 * 1000;
+		store.reconcileBackendSessions([]);
+
+		assert.deepStrictEqual({ retainedBeforeThirtyDays, prunedAfterThirtyDays: store.has(key) }, {
+			retainedBeforeThirtyDays: true,
+			prunedAfterThirtyDays: false,
+		});
+	});
+
+	test('notification path flushes a newly discovered membership', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		const workspaceService = new TestWorkspaceContextService();
+		const a = URI.file('/workspace/a');
+		const b = URI.file('/workspace/b');
+		workspaceService.folders = [a, b];
+		const key = 'copilot://session';
+		const store = new TestMembershipStore(() => 1000, storageService, workspaceService);
+		const listenerStore = disposables.add(new DisposableStore());
+		let writes = 0;
+		listenerStore.add(storageService.onDidChangeValue(StorageScope.WORKSPACE, undefined, listenerStore)(() => writes++));
+
+		store.shouldInclude(key, [a, b], false);
+		const beforeMarkSeen = writes;
+		store.markSeen(key);
+		const restoredStore = new TestMembershipStore(() => 1000, storageService, workspaceService);
+
+		assert.deepStrictEqual({ beforeMarkSeen, afterMarkSeen: writes, restored: restoredStore.has(key) }, {
+			beforeMarkSeen: 0,
+			afterMarkSeen: 1,
+			restored: true,
+		});
+	});
+
+	test('ignores malformed persisted membership', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		storageService.store('agentHost.workspaceSessionMembership.v1', '{not-json', StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		const workspaceService = new TestWorkspaceContextService();
+		workspaceService.folders = [URI.file('/workspace/a'), URI.file('/workspace/b')];
+		const store = new TestMembershipStore(() => 1000, storageService, workspaceService);
+
+		assert.deepStrictEqual({
+			hasCorruptEntry: store.has('copilot://corrupt'),
+			unmatchedSession: store.shouldInclude('copilot://unmatched', [URI.file('/other/a'), URI.file('/other/b')], false),
+		}, {
+			hasCorruptEntry: false,
+			unmatchedSession: false,
+		});
+	});
+
+	test('storage is dormant in the Agents window', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		const workspaceService = new TestWorkspaceContextService();
+		const a = URI.file('/workspace/a');
+		const b = URI.file('/workspace/b');
+		const c = URI.file('/workspace/c');
+		const d = URI.file('/workspace/d');
+		workspaceService.folders = [a, b];
+		const key = 'copilot://session';
+		const seedStore = new TestMembershipStore(() => 0, storageService, workspaceService);
+		seedStore.shouldInclude(key, [a, b], false);
+		seedStore.reconcileBackendSessions([key]);
+
+		const listenerStore = disposables.add(new DisposableStore());
+		let writes = 0;
+		listenerStore.add(storageService.onDidChangeValue(StorageScope.WORKSPACE, undefined, listenerStore)(() => writes++));
+		workspaceService.folders = [c, d];
+		const sessionsWindowStore = new TestMembershipStore(() => 2 * 24 * 60 * 60 * 1000, storageService, workspaceService, true);
+		const sessionsWindowIncluded = sessionsWindowStore.shouldInclude(key, [a, b], false);
+		sessionsWindowStore.reconcileBackendSessions([key]);
+		sessionsWindowStore.markSeen(key);
+		sessionsWindowStore.remove(key);
+		workspaceService.folders = [a, b];
+		const restoredEditorStore = new TestMembershipStore(() => 2 * 24 * 60 * 60 * 1000, storageService, workspaceService);
+
+		assert.deepStrictEqual({
+			sessionsWindowIncluded,
+			writes,
+			membershipPreserved: restoredEditorStore.has(key),
+		}, {
+			sessionsWindowIncluded: false,
+			writes: 0,
+			membershipPreserved: true,
+		});
+	});
+
+	test('storage is dormant in Editor windows without a multi-root workspace', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		const workspaceService = new TestWorkspaceContextService();
+		const a = URI.file('/workspace/a');
+		const b = URI.file('/workspace/b');
+		const c = URI.file('/workspace/c');
+		workspaceService.folders = [a, b];
+		const key = 'copilot://session';
+		const seedStore = new TestMembershipStore(() => 0, storageService, workspaceService);
+		seedStore.shouldInclude(key, [a, b], false);
+		seedStore.reconcileBackendSessions([key]);
+
+		const listenerStore = disposables.add(new DisposableStore());
+		let writes = 0;
+		listenerStore.add(storageService.onDidChangeValue(StorageScope.WORKSPACE, undefined, listenerStore)(() => writes++));
+		workspaceService.folders = [c];
+		const singleFolderWorkspaceStore = new TestMembershipStore(() => 2 * 24 * 60 * 60 * 1000, storageService, workspaceService);
+		const singleFolderWorkspaceIncluded = singleFolderWorkspaceStore.shouldInclude(key, [a, b], false);
+		singleFolderWorkspaceStore.reconcileBackendSessions([key]);
+		singleFolderWorkspaceStore.markSeen(key);
+		singleFolderWorkspaceStore.remove(key);
+		workspaceService.state = WorkbenchState.FOLDER;
+		const folderWindowStore = new TestMembershipStore(() => 2 * 24 * 60 * 60 * 1000, storageService, workspaceService);
+		const folderWindowIncluded = folderWindowStore.shouldInclude(key, [a, b], false);
+		folderWindowStore.reconcileBackendSessions([key]);
+		folderWindowStore.markSeen(key);
+		folderWindowStore.remove(key);
+		workspaceService.state = WorkbenchState.EMPTY;
+		workspaceService.folders = [];
+		const emptyWindowStore = new TestMembershipStore(() => 2 * 24 * 60 * 60 * 1000, storageService, workspaceService);
+		const emptyWindowIncluded = emptyWindowStore.shouldInclude(key, [a, b], false);
+		emptyWindowStore.reconcileBackendSessions([key]);
+		emptyWindowStore.markSeen(key);
+		emptyWindowStore.remove(key);
+		workspaceService.state = WorkbenchState.WORKSPACE;
+		workspaceService.folders = [a, b];
+		const restoredEditorStore = new TestMembershipStore(() => 2 * 24 * 60 * 60 * 1000, storageService, workspaceService);
+
+		assert.deepStrictEqual({
+			singleFolderWorkspaceIncluded,
+			folderWindowIncluded,
+			emptyWindowIncluded,
+			writes,
+			membershipPreserved: restoredEditorStore.has(key),
+		}, {
+			singleFolderWorkspaceIncluded: false,
+			folderWindowIncluded: false,
+			emptyWindowIncluded: true,
+			writes: 0,
+			membershipPreserved: true,
+		});
 	});
 });


### PR DESCRIPTION
- Introduced `AgentHostCopilotMultiRootEnabledConfigKey` to enable multiple working directory support.
- Updated `platformRootSchema` to include the new configuration key with default value set to false.
- Modified `agentHostStarter.config.contribution.ts` to register the new setting, hidden from the UI.
- Enhanced `agentService.ts` to manage the new configuration key for Copilot sessions.
- Updated `CopilotAgent` to advertise `multipleWorkingDirectories` capability based on the new setting.
- Added tests to ensure correct behavior of multiple working directories feature.
- Created `AgentHostWorkspaceSessionMembershipStore` to manage session membership in multi-root workspaces.
- Updated session list store to utilize the new membership store for filtering sessions based on workspace context.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
