### PR TITLE
Remove unwanted margin-right on chat turn pills file-changes label

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -3004,7 +3004,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 /* The pill header already spaces its children with `gap`, so the label's own
 	margin-right (needed in the standalone checkpoint summary) is redundant here
 	and leaves unwanted trailing space. */
-.interactive-session .chat-turn-pills-part .chat-file-changes-label {
+.interactive-session .chat-turn-pills-part .checkpoint-file-changes-summary-header .chat-file-changes-label {
 	margin-right: 0;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -3001,6 +3001,13 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	outline-offset: calc(-1 * var(--vscode-strokeThickness));
 }
 
+/* The pill header already spaces its children with `gap`, so the label's own
+	margin-right (needed in the standalone checkpoint summary) is redundant here
+	and leaves unwanted trailing space. */
+.interactive-session .chat-turn-pills-part .chat-file-changes-label {
+	margin-right: 0;
+}
+
 .interactive-session .chat-turn-pills-part .chat-turn-preview {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Removes the redundant .chat-file-changes-label margin-right within .chat-turn-pills-part. The pill header already spaces its children via flex gap, so the label's own margin-right (needed for the standalone checkpoint summary) left unwanted trailing space in the turn pills.