### PR TITLE
Fix automation pill label overflowing the button

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAutomationConfiguredResultSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAutomationConfiguredResultSubPart.ts
@@ -39,9 +39,7 @@ export class ChatAutomationConfiguredResultSubPart extends BaseChatToolInvocatio
 		const label = data.operation === 'created'
 			? localize('automationConfigured.created', "Created an automation: {0}", data.automationName)
 			: localize('automationConfigured.updated', "Edited an automation: {0}", data.automationName);
-		// `ButtonWithIcon` renders the icon into its own child span. A plain `Button`
-		// would put the `codicon-*` classes on the button root, applying the 16px
-		// codicon font to the label text and overflowing the pill.
+		// `ButtonWithIcon` keeps the `codicon-*` classes off the button root, where they would restyle the label text.
 		const button = this._register(new ButtonWithIcon(this.domNode, {
 			...defaultButtonStyles,
 			secondary: true,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAutomationConfiguredResultSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAutomationConfiguredResultSubPart.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../../../base/browser/dom.js';
-import { Button } from '../../../../../../../base/browser/ui/button/button.js';
+import { ButtonWithIcon } from '../../../../../../../base/browser/ui/button/button.js';
 import { Codicon } from '../../../../../../../base/common/codicons.js';
 import { localize } from '../../../../../../../nls.js';
 import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
@@ -39,7 +39,10 @@ export class ChatAutomationConfiguredResultSubPart extends BaseChatToolInvocatio
 		const label = data.operation === 'created'
 			? localize('automationConfigured.created', "Created an automation: {0}", data.automationName)
 			: localize('automationConfigured.updated', "Edited an automation: {0}", data.automationName);
-		const button = this._register(new Button(this.domNode, {
+		// `ButtonWithIcon` renders the icon into its own child span. A plain `Button`
+		// would put the `codicon-*` classes on the button root, applying the 16px
+		// codicon font to the label text and overflowing the pill.
+		const button = this._register(new ButtonWithIcon(this.domNode, {
 			...defaultButtonStyles,
 			secondary: true,
 			title: localize('automationConfigured.open', "Open automation {0}", data.automationName),

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatToolProgressPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatToolProgressPart.test.ts
@@ -307,8 +307,7 @@ suite('ChatToolProgressSubPart', () => {
 				ariaLabel: button?.getAttribute('aria-label'),
 				tabIndex: button?.tabIndex,
 				watchIconIsChild: !!button?.querySelector('.codicon-watch'),
-				// A `codicon-*` class on the button root would apply the 16px codicon
-				// font to the label text, which falls back to serif and overflows.
+				// `codicon-*` on the root would restyle the label text.
 				rootCarriesCodiconClass: button?.classList.contains('codicon'),
 				injectedIcons: [...button?.querySelectorAll('.codicon') ?? []]
 					.flatMap(el => [...el.classList]).filter(c => c.startsWith('codicon-')),

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatToolProgressPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatToolProgressPart.test.ts
@@ -292,35 +292,47 @@ suite('ChatToolProgressSubPart', () => {
 		assert.strictEqual(createInstanceStub.firstCall.args[0], ChatAutomationConfiguredResultSubPart);
 	});
 
-	test('renders codicon syntax in an automation name as literal accessible text', () => {
-		const data: IChatAutomationConfiguredData = {
-			kind: 'automationConfigured',
-			automationId: 'automation-1',
-			automationName: '$(error)',
-			operation: 'created',
+	test('renders codicon syntax in an automation name as literal text', () => {
+		const render = (automationName: string) => {
+			const part = disposables.add(instantiationService.createInstance(
+				ChatAutomationConfiguredResultSubPart,
+				createSerializedToolInvocation({ isComplete: true }),
+				{ kind: 'automationConfigured', automationId: 'automation-1', automationName, operation: 'created' } satisfies IChatAutomationConfiguredData,
+				createRenderContext(),
+				mockMarkdownRenderer,
+			));
+			const button = part.domNode.querySelector<HTMLElement>('.chat-open-session-button');
+			return {
+				text: button?.textContent,
+				ariaLabel: button?.getAttribute('aria-label'),
+				tabIndex: button?.tabIndex,
+				watchIconIsChild: !!button?.querySelector('.codicon-watch'),
+				// A `codicon-*` class on the button root would apply the 16px codicon
+				// font to the label text, which falls back to serif and overflows.
+				rootCarriesCodiconClass: button?.classList.contains('codicon'),
+				injectedIcons: [...button?.querySelectorAll('.codicon') ?? []]
+					.flatMap(el => [...el.classList]).filter(c => c.startsWith('codicon-')),
+			};
 		};
-		const part = disposables.add(instantiationService.createInstance(
-			ChatAutomationConfiguredResultSubPart,
-			createSerializedToolInvocation({ isComplete: true }),
-			data,
-			createRenderContext(),
-			mockMarkdownRenderer,
-		));
-		const button = part.domNode.querySelector<HTMLElement>('.chat-open-session-button');
 
-		assert.deepStrictEqual({
-			text: button?.textContent,
-			ariaLabel: button?.getAttribute('aria-label'),
-			tabIndex: button?.tabIndex,
-			hasWatchIcon: button?.classList.contains('codicon-watch'),
-			hasInjectedErrorIcon: button?.classList.contains('codicon-error') || !!button?.querySelector('.codicon-error'),
-		}, {
-			text: 'Created an automation: $(error)',
-			ariaLabel: 'Open automation $(error)',
-			tabIndex: 0,
-			hasWatchIcon: true,
-			hasInjectedErrorIcon: false,
-		});
+		assert.deepStrictEqual([render('$(error)'), render('a \\$(error) b')], [
+			{
+				text: 'Created an automation: $(error)',
+				ariaLabel: 'Open automation $(error)',
+				tabIndex: 0,
+				watchIconIsChild: true,
+				rootCarriesCodiconClass: false,
+				injectedIcons: ['codicon-watch'],
+			},
+			{
+				text: 'Created an automation: a \\$(error) b',
+				ariaLabel: 'Open automation a \\$(error) b',
+				tabIndex: 0,
+				watchIconIsChild: true,
+				rootCarriesCodiconClass: false,
+				injectedIcons: ['codicon-watch'],
+			},
+		]);
 	});
 
 	test('rerenders when terminal metadata changes without changing data kind', () => {


### PR DESCRIPTION
### Problem

The pill rendered after creating or editing an automation ("Created an automation: Daily Hello") drew its text in an oversized serif font that visually spilled outside the pill's rounded border.

### Root cause

`ChatAutomationConfiguredResultSubPart` used a plain `Button` and set both `label` and `icon`:

```ts
button.label = label;          // bare text node on the button root
button.icon = Codicon.watch;   // adds `codicon codicon-watch` to that SAME element
```

`Button`'s icon setter does not create a child element, it stamps the codicon classes onto the button root. `codicon.css` then applies `font: normal normal normal 16px/1 codicon` to that element. Because the label is a bare text node of the same element, it inherited the 16px codicon font and fell back to a serif face. The `font` shorthand plus `display: inline-block` also knocked out the button's `display: flex` centering.

This is why the combination only misbehaves here: every other `Button.icon` call site in the codebase is icon-only or uses a blank label, so nothing else has text sharing the element with the codicon classes.

### Fix

Switch to `ButtonWithIcon`, which exists for exactly this case. It renders the icon into a dedicated child span and the label into its own element, so neither can clobber the other's font. The call site is otherwise unchanged:

```ts
const button = this._register(new ButtonWithIcon(this.domNode, { ... }));
button.label = label;
button.icon = Codicon.watch;
```

The label still goes through `textContent`, so a `$(...)` sequence in an automation name stays literal without needing to be escaped, and HTML injection is not possible.

### Notes for reviewers

I considered fixing `Button.icon` itself, since setting an icon alongside a label is a footgun. I decided against it for this PR: root codicon classes are intentionally consumed by CSS elsewhere (for example `inlineChat.css`), and a child-span implementation would also require reworking the `label` setter. That felt like too broad a change for a visual bug fix, but the API is worth revisiting separately.

There is a pre-existing, unrelated residual: the pill keeps `overflow-wrap: normal`, so a very long unbroken automation name could still overflow. Not addressed here.

### Testing

Updated the existing test in `chatToolProgressPart.test.ts` so it guards the actual regression: it asserts the watch icon is a child element and that the button root carries no `codicon` class. I verified the guard by temporarily reverting the source, which flips `rootCarriesCodiconClass` to `true` and `watchIconIsChild` to `false` and fails the test.

The test also now covers backslash preservation (`a \$(error) b`) alongside the existing `$(error)` case, confirming names are reproduced verbatim.

Validated with `scripts/test.sh` (automation, chat tool progress, accessible view and button suites), `npm run typecheck-client`, and eslint on the changed files.

To verify manually: ask an agent to create an automation and confirm the resulting pill renders its label in the normal 12px UI font, fully inside the pill, with the watch icon to its left.