### PR TITLE
Automations: Cap empty-state button width

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -87,6 +87,8 @@ For Agent Host client tools, a call made while the SDK is in **Allow all** mode 
 
 Automation rows use dynamic heights. The management editor propagates both editor-pane and section visibility to the Automations widget; while hidden, the widget updates its view model but defers list splices and layout. Revealing the section commits the latest entries and forces a fresh row measurement so `display:none` cannot cache zero-height rows.
 
+The Automations empty-state CTA is centered and capped to the explanatory copy column while retaining the shared button's responsive width below that cap. A CI-blocking wide management-editor fixture covers this empty state in dark and light themes.
+
 ### IAICustomizationWorkspaceService
 
 The `IAICustomizationWorkspaceService` interface controls per-window behavior:

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -2070,6 +2070,7 @@ pane is first mounted. View switches inside the modal are not animated. */
 .automations-list-widget .automations-empty-state .automations-empty-cta {
 	margin-top: 16px;
 	min-width: 160px;
+	max-width: 320px;
 	align-self: center;
 }
 

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -28,7 +28,8 @@ import { IQuickInputService } from '../../../../../platform/quickinput/common/qu
 import { IRequestService } from '../../../../../platform/request/common/request.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
 import { IWorkspace, IWorkspaceContextService, WorkbenchState } from '../../../../../platform/workspace/common/workspace.js';
-import { IEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
+import { IEditorGroup, IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { IChatWidgetService } from '../../../../contrib/chat/browser/chat.js';
@@ -64,6 +65,10 @@ import { TestConfigurationService } from '../../../../../platform/configuration/
 import { mcpAccessConfig, McpAccessValue } from '../../../../../platform/mcp/common/mcpManagement.js';
 import { McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { ChatConfiguration } from '../../../../contrib/chat/common/constants.js';
+import { IAutomationDialogService } from '../../../../contrib/chat/common/automations/automationDialogService.js';
+import { IAutomationRunner } from '../../../../contrib/chat/common/automations/automationRunner.js';
+import { IAutomationService } from '../../../../contrib/chat/common/automations/automationService.js';
+import { CHAT_AUTOMATIONS_ENABLED_SETTING } from '../../../../contrib/chat/common/automations/automationsEnabled.js';
 import { IMcpWorkbenchService, IWorkbenchMcpServer, IMcpService, McpConnectionState, McpServerInstallState } from '../../../../contrib/mcp/common/mcpTypes.js';
 import { IMcpRegistry } from '../../../../contrib/mcp/common/mcpRegistryTypes.js';
 import { IWorkbenchLocalMcpServer, LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
@@ -578,6 +583,7 @@ interface IRenderEditorOptions {
 	readonly openItemLabel?: string;
 	readonly editorDisplayMode?: 'preview' | 'raw';
 	readonly showPromptMigrationPage?: boolean;
+	readonly automationsEnabled?: boolean;
 }
 
 function renderFixtureMarkdown(markdown: string): HTMLElement {
@@ -691,6 +697,7 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 			reg.defineInstance(IConfigurationService, new TestConfigurationService({
 				[ChatConfiguration.ChatCustomizationsStructuredPreviewEnabled]: true,
 				[ChatConfiguration.ChatCustomizationsPromptMigrationEnabled]: true,
+				[CHAT_AUTOMATIONS_ENABLED_SETTING]: options.automationsEnabled === true,
 			}));
 			reg.define(IListService, ListService);
 			reg.defineInstance(ITextModelService, new class extends mock<ITextModelService>() {
@@ -759,6 +766,17 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 				override getRegisteredChatSessionItemProviders() { return []; }
 				override hasCustomizationsProvider() { return false; }
 			}());
+			reg.defineInstance(IAutomationService, new class extends mock<IAutomationService>() {
+				override readonly automations = constObservable([]);
+				override readonly runs = constObservable([]);
+				override runsFor() { return constObservable([]); }
+			}());
+			reg.defineInstance(IAutomationRunner, new class extends mock<IAutomationRunner>() { }());
+			reg.defineInstance(IAutomationDialogService, new class extends mock<IAutomationDialogService>() {
+				override async showAutomationDialog() { return undefined; }
+			}());
+			reg.defineInstance(IEditorService, new class extends mock<IEditorService>() { }());
+			reg.defineInstance(IEditorGroupsService, new class extends mock<IEditorGroupsService>() { }());
 			reg.defineInstance(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() {
 				override readonly onDidChangeWorkspaceFolders = Event.None;
 				override getWorkspace(): IWorkspace { return { id: 'test', folders: [] }; }
@@ -1441,6 +1459,26 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 				AICustomizationManagementSection.Instructions,
 				AICustomizationManagementSection.Prompts,
 				AICustomizationManagementSection.Hooks,
+				AICustomizationManagementSection.McpServers,
+				AICustomizationManagementSection.Plugins,
+			],
+		}),
+	}),
+
+	AutomationsTab: defineComponentFixture({
+		labels: { kind: 'screenshot', blocksCi: true },
+		render: ctx => renderEditor(ctx, {
+			sessionResource: localSessionResource,
+			selectedSection: AICustomizationManagementSection.Automations,
+			automationsEnabled: true,
+			width: 1200,
+			managementSections: [
+				AICustomizationManagementSection.Agents,
+				AICustomizationManagementSection.Skills,
+				AICustomizationManagementSection.Instructions,
+				AICustomizationManagementSection.Hooks,
+				AICustomizationManagementSection.Prompts,
+				AICustomizationManagementSection.Automations,
 				AICustomizationManagementSection.McpServers,
 				AICustomizationManagementSection.Plugins,
 			],

--- a/test/componentFixtures/blocks-ci-screenshots.md
+++ b/test/componentFixtures/blocks-ci-screenshots.md
@@ -6,6 +6,12 @@
 #### chat/aiCustomizations/aiCustomizationManagementEditor/AgentHostPromptMigration/Light
 ![screenshot](https://hediet-screenshots.azurewebsites.net/images/70c9ac164e5358815b96da4db49b7a4d661be4d57b797e282a459142634e3fd3)
 
+#### chat/aiCustomizations/aiCustomizationManagementEditor/AutomationsTab/Dark
+![screenshot](https://hediet-screenshots.azurewebsites.net/images/f37dd6e9e0898eac8e3a6a94374dd79ad1de0efd5b2770729d1be56f43b501c8)
+
+#### chat/aiCustomizations/aiCustomizationManagementEditor/AutomationsTab/Light
+![screenshot](https://hediet-screenshots.azurewebsites.net/images/2885b375f57c0ef67b1259b7b4c54a8267da48f17207c1c1df2d74ff425ce121)
+
 #### editor/codeEditor/CodeEditor/Dark
 ![screenshot](https://hediet-screenshots.azurewebsites.net/images/af3df9d90346c8473e8576c2aab60a9cab514ed0a130a2208fa72851e4884852)
 


### PR DESCRIPTION
## Summary

- cap the empty-state **Create automation** button to the explanatory copy width while preserving responsive shrinking
- add a CI-blocking wide Automations component fixture in dark and light themes
- document the empty-state layout contract

## Validation

- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/automations/automationsListWidget.test.ts` (25 passing)
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `npm run precommit`
- rendered `AutomationsTab` component fixtures in dark and light themes

Fixes #327772