### PR TITLE
sessions: default the side panel to Files until the session has changes

### DIFF
--- a/src/vs/sessions/LAYOUT_CONTROLLER.md
+++ b/src/vs/sessions/LAYOUT_CONTROLLER.md
@@ -111,27 +111,31 @@ strict priority order:
    - saved state is **visible** with a still-pinned active container → reopen that container.
    - saved state is **visible** but its container is gone → fall back to the default container
      (§3.2 step 4).
-4. **Default container** (`_openDefaultAuxiliaryBarContainer`), used only when the side pane is being
-   shown (new-session default, or restoring a session the user explicitly left visible):
-   - session **is created** → open the Changes view (`CHANGES_VIEW_ID`).
+4. **Default container** (`_defaultAuxiliaryBarContainerId` / `_openDefaultAuxiliaryBarContainer`), used
+   only when the side pane is being shown (new-session default, or restoring a session the user
+   explicitly left visible):
+   - session has produced **at least one file change** in any of its chats (`sessionHasChanges`) → open
+     the Changes view (`CHANGES_VIEW_ID`).
    - otherwise → open the Files container (falling back to Changes if Files is hidden).
+   The change state is read untracked, so it is evaluated only at the moment the side pane is opened.
 
 ### 3.3 New-session submit
 
 When the active new session becomes created (either `isCreated` changes from false to true for the
 same session, or the provider replaces the draft with a new committed resource), the side pane stays
-in whatever visibility state the user left it. If it is visible, the controller switches it to Changes
-immediately. If it is hidden, the controller records Changes as that session's default active container
-so opening the side pane later shows Changes. In single-pane mode, the submit transition keeps editor
-content closed: the managed Changes tab opens under editor-auto-visibility suppression, while the
-visible side pane maps to the Changes detail.
+in whatever visibility state the user left it. If it is visible, it keeps showing the container it is
+already on. If it is hidden, the controller records no active container for that session, so opening
+the side pane later shows the default container for the session's change state at that time (§3.2
+step 4). In single-pane mode, the submit transition keeps editor content closed: the managed Changes
+tab opens under editor-auto-visibility suppression, while the visible side pane maps to the Changes
+detail.
 
 ### 3.4 No auto-reveal on changes
 
 The side pane is **not** revealed, and the active container is not changed, when a chat turn produces
-new file changes. The controller does not track pending turns or file-change counts for default
-selection; the automatic switch to Changes is driven by the created transition (§3.3). Once a session
-is created the side pane stays in whatever state the user left it.
+new file changes. The first change does make Changes the default container (§3.2 step 4), but that
+only takes effect the next time the side pane is opened — a visible side pane is never switched from
+under the user.
 
 ### 3.5 Live visibility tracking
 
@@ -140,7 +144,8 @@ Aux-bar visibility is also tracked **live** (not only on session switch) via an
 multiple sessions are visible). For a titled active session it re-runs `_captureViewState`; for an
 uncreated active session it updates the shared `_newSessionViewState` (§3.2 step 2). When a created
 session with hidden saved state is opened, the saved/default active container is restored before the
-visible state is captured, so a hidden-on-submit session opens to Changes.
+visible state is captured, so a hidden-on-submit session opens to the default container for its
+change state (§3.2 step 4).
 
 ### 3.6 Editor reveal on session switch
 

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
@@ -71,7 +71,10 @@ The side pane is restored in this order:
 - **D3c — An existing (created) session** → the side pane is **never** opened automatically on
   restore. If it was closed or has no remembered state it stays closed; if it was open and that view
   still exists it reopens; if that view is gone it falls back to the default view (D3d).
-- **D3d — Default view** → Files while the session is uncreated; Changes after the session is created.
+- **D3d — Default view** → **Files** until the session has produced at least one file change (in any of
+  its chats), **Changes** from then on. The change state is read at the moment the side pane is opened,
+  so a change landing later never switches a view you are already looking at (D6). Falls back to
+  Changes when the Files pane has been unpinned.
 
 ### Scenario: special cases that override the remembered state
 A few transitions intentionally ignore the remembered state above.
@@ -79,8 +82,9 @@ A few transitions intentionally ignore the remembered state above.
 #### D4 — Submitting a new session
 When a new session becomes created while staying active — either `isCreated` changes from false to true
 on the same resource, or the provider replaces the draft with a committed resource — the side pane stays
-as you left it: if it was open it stays open and switches to **Changes**; if it was closed it stays
-closed, but opening it later shows **Changes**. In single-pane detail-panel mode, the submit transition
+exactly as you left it: if it was open it stays open on the view it is already showing; if it was closed
+it stays closed and no view is recorded for it, so opening it later shows the default view for the
+session's change state at that time (D3d). In single-pane detail-panel mode, the submit transition
 also keeps the editor content closed and activates the Changes tab that was already shown beside Files;
 the open side pane shows the Changes detail.
 
@@ -96,7 +100,8 @@ A running session can produce new file changes at any time.
 #### D6 — New changes never open the side pane
 When a chat turn produces new file changes, the side pane is **not** opened automatically and the
 active view is not switched automatically — it stays as you left it. Only a new session opens it
-(D3b), and only the created transition switches it to Changes (D4).
+(D3b). The first change does make **Changes** the default view (D3d), but that only applies the next
+time the side pane is opened.
 
 ### Scenario: the side pane has nothing to show
 Some sessions gate off every auxiliary-bar view container — e.g. a workspace-less **quick chat**,
@@ -180,11 +185,13 @@ and hands control back once the user reopens the sessions sidebar manually.
   container is restored before capture (`_restoreSavedAuxiliaryBarContainerOnReveal`).
 - **Restore [D3]** — `_syncAuxiliaryBarVisibility(resource, hasWorkspace, isCreated)`.
   Uncreated sessions (D3b) share `_newSessionViewState`, persisted under
-  `sessions.newSessionViewState`. `_openDefaultAuxiliaryBarContainer` /
-  `_isAuxiliaryBarContainerPinned` implement D3c/D3d.
-- **New-session submit [D4]** — `_onNewSessionSubmitted` keeps the aux bar as left, switches an open one
-  to Changes, and records Changes as the active container even when hidden so opening the side pane
-  later starts on Changes. `_onSessionReplaced` applies the same state transfer when a provider commits
+  `sessions.newSessionViewState`. `_defaultAuxiliaryBarContainerId` /
+  `_openDefaultAuxiliaryBarContainer` / `_isAuxiliaryBarContainerPinned` implement D3c/D3d; the default
+  container comes from `sessionHasChanges(activeSession)`, read untracked so it is evaluated only when
+  the side pane is opened.
+- **New-session submit [D4]** — `_onNewSessionSubmitted` keeps the aux bar as left: an open one keeps
+  showing its current container, a hidden one records no container so opening the side pane later picks
+  the D3d default. `_onSessionReplaced` applies the same state transfer when a provider commits
   the draft as a new resource. In single-pane mode, the tab opens that accompany this transition are
   managed by `SinglePaneLayoutController` under editor-auto-visibility suppression, so they
   do not reveal editor content.

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -13,7 +13,7 @@ import product from '../../../../platform/product/common/product.js';
 import { StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ViewContainerLocation } from '../../../../workbench/common/views.js';
 import { Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
-import { ISession } from '../../../services/sessions/common/session.js';
+import { ISession, sessionHasChanges } from '../../../services/sessions/common/session.js';
 import { CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID } from '../../changes/common/changes.js';
 import { SESSIONS_FILES_CONTAINER_ID } from '../../files/browser/files.contribution.js';
 import { BaseLayoutController } from './baseSessionLayoutController.js';
@@ -226,14 +226,16 @@ export class LayoutController extends BaseLayoutController {
 			return;
 		}
 
+		// [D4] Carry the draft's side pane over as-is rather than forcing Changes:
+		// an open side pane keeps showing its current container, and a closed one
+		// records no container so opening it later picks the default for the
+		// session's change state at that time ([D3d]).
 		this._viewStateBySession.set(to.resource, {
 			auxiliaryBarVisible,
-			auxiliaryBarActiveViewContainerId: CHANGES_VIEW_CONTAINER_ID,
+			auxiliaryBarActiveViewContainerId: replacedSessionIsActive && auxiliaryBarVisible
+				? this._paneCompositePartService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar)?.getId()
+				: undefined,
 		});
-
-		if (replacedSessionIsActive && auxiliaryBarVisible) {
-			void this._viewsService.openView(CHANGES_VIEW_ID, false);
-		}
 	}
 
 	/**
@@ -524,19 +526,20 @@ export class LayoutController extends BaseLayoutController {
 
 	/**
 	 * [D4] When a new (uncreated) session is submitted it becomes a real session
-	 * while staying active. Keep the auxiliary bar as the user left it: if open,
-	 * keep it open and switch to the Changes view; if closed, keep it closed. The
-	 * resulting state is persisted so later syncs don't fall back to hidden.
+	 * while staying active. Keep the auxiliary bar exactly as the user left it: if
+	 * open, keep it open on the container it is already showing; if closed, keep it
+	 * closed and record no container so opening the side pane later picks the
+	 * default for the session's change state at that time ([D3d]). The resulting
+	 * state is persisted so later syncs don't fall back to hidden.
 	 */
-	private _onNewSessionSubmitted(sessionResource: URI): void | Promise<unknown> {
+	private _onNewSessionSubmitted(sessionResource: URI): void {
 		const auxiliaryBarVisible = this._layoutService.isVisible(Parts.AUXILIARYBAR_PART);
 		this._viewStateBySession.set(sessionResource, {
 			auxiliaryBarVisible,
-			auxiliaryBarActiveViewContainerId: CHANGES_VIEW_CONTAINER_ID,
+			auxiliaryBarActiveViewContainerId: auxiliaryBarVisible
+				? this._paneCompositePartService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar)?.getId()
+				: undefined,
 		});
-		if (auxiliaryBarVisible) {
-			return this._viewsService.openView(CHANGES_VIEW_ID, false);
-		}
 	}
 
 	// [D3] Restore the auxiliary bar in strict priority order.
@@ -556,7 +559,7 @@ export class LayoutController extends BaseLayoutController {
 				this._hideAuxiliaryBarForRestore();
 				return;
 			}
-			void this._openDefaultAuxiliaryBarContainer(false);
+			void this._openDefaultAuxiliaryBarContainer();
 			return;
 		}
 
@@ -575,16 +578,37 @@ export class LayoutController extends BaseLayoutController {
 			return;
 		}
 
-		void this._openDefaultAuxiliaryBarContainer(true);
+		void this._openDefaultAuxiliaryBarContainer();
 	}
 
-	/** [D3d] Prefer Changes for created sessions and Files for new sessions. */
-	private _openDefaultAuxiliaryBarContainer(isCreated: boolean): Promise<unknown> {
-		if (isCreated || !this._isAuxiliaryBarContainerPinned(SESSIONS_FILES_CONTAINER_ID)) {
-			return this._viewsService.openView(CHANGES_VIEW_ID, false);
-		} else {
-			return this._viewsService.openViewContainer(SESSIONS_FILES_CONTAINER_ID, false);
+	/**
+	 * [D3d] The container the side pane defaults to for the active session:
+	 * Changes once the session has produced at least one change (in any of its
+	 * chats), Files until then. Falls back to Changes when the user has unpinned
+	 * the Files pane, since there is nothing else to show.
+	 *
+	 * Read untracked on purpose: the default is evaluated at the moment the side
+	 * pane is opened, so a change landing later never switches a pane the user is
+	 * already looking at.
+	 */
+	private _defaultAuxiliaryBarContainerId(): string {
+		if (!this._isAuxiliaryBarContainerPinned(SESSIONS_FILES_CONTAINER_ID)) {
+			return CHANGES_VIEW_CONTAINER_ID;
 		}
+		const activeSession = this._sessionsService.activeSession.get();
+		return activeSession && sessionHasChanges(activeSession, undefined)
+			? CHANGES_VIEW_CONTAINER_ID
+			: SESSIONS_FILES_CONTAINER_ID;
+	}
+
+	/** [D3d] Opens the container chosen by {@link _defaultAuxiliaryBarContainerId}. */
+	private _openDefaultAuxiliaryBarContainer(containerId: string = this._defaultAuxiliaryBarContainerId()): Promise<unknown> {
+		// Changes is opened through its view so the view is revealed inside the
+		// container rather than leaving the container on a stale sub-view.
+		if (containerId === CHANGES_VIEW_CONTAINER_ID) {
+			return this._viewsService.openView(CHANGES_VIEW_ID, false);
+		}
+		return this._viewsService.openViewContainer(containerId, false);
 	}
 
 	private _restoreSavedAuxiliaryBarContainerOnReveal(sessionResource: URI): boolean {
@@ -598,11 +622,12 @@ export class LayoutController extends BaseLayoutController {
 			this._viewStateBySession.set(sessionResource, { ...savedState, auxiliaryBarVisible: true });
 			void this._viewsService.openViewContainer(savedContainerId, false);
 		} else {
+			const defaultContainerId = this._defaultAuxiliaryBarContainerId();
 			this._viewStateBySession.set(sessionResource, {
 				auxiliaryBarVisible: true,
-				auxiliaryBarActiveViewContainerId: CHANGES_VIEW_CONTAINER_ID,
+				auxiliaryBarActiveViewContainerId: defaultContainerId,
 			});
-			void this._openDefaultAuxiliaryBarContainer(true);
+			void this._openDefaultAuxiliaryBarContainer(defaultContainerId);
 		}
 		return true;
 	}

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -226,10 +226,7 @@ export class LayoutController extends BaseLayoutController {
 			return;
 		}
 
-		// [D4] Carry the draft's side pane over as-is rather than forcing Changes:
-		// an open side pane keeps showing its current container, and a closed one
-		// records no container so opening it later picks the default for the
-		// session's change state at that time ([D3d]).
+		// [D4] Preserve the draft's visible container; a hidden pane uses the reveal-time default.
 		this._viewStateBySession.set(to.resource, {
 			auxiliaryBarVisible,
 			auxiliaryBarActiveViewContainerId: replacedSessionIsActive && auxiliaryBarVisible

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -120,7 +120,21 @@ suite('LayoutController (desktop)', () => {
 		assert.ok(harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
 	});
 
-	test('[D3d] keeps Files as the default for an uncreated session with changes', () => {
+	test('[D3d] defaults to Files while the session has no changes', () => {
+		createController();
+		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled });
+		harness.activeSessionObs.set(session, undefined);
+
+		assert.deepStrictEqual({
+			openedFiles: harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			openedChanges: harness.openedViews.includes(CHANGES_VIEW_ID),
+		}, {
+			openedFiles: true,
+			openedChanges: false,
+		});
+	});
+
+	test('[D3d] defaults to Changes once one of the session chats has a change', () => {
 		createController();
 		const session = makeSession(URI.parse('session:1'), {
 			status: SessionStatus.Untitled,
@@ -132,7 +146,26 @@ suite('LayoutController (desktop)', () => {
 			openedFiles: harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
 			openedChanges: harness.openedViews.includes(CHANGES_VIEW_ID),
 		}, {
-			openedFiles: true,
+			openedFiles: false,
+			openedChanges: true,
+		});
+	});
+
+	test('[D3d] does not switch a side pane that is already showing Files when a change lands', () => {
+		createController();
+		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled });
+		harness.activeSessionObs.set(session, undefined);
+		harness.activePaneCompositeId = SESSIONS_FILES_CONTAINER_ID;
+
+		harness.openedViews = [];
+		harness.openedViewContainers = [];
+		(session.changes as ISettableObservable<readonly ISessionFileChange[]>).set([makeChange('/file.ts')], undefined);
+
+		assert.deepStrictEqual({
+			openedFiles: harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			openedChanges: harness.openedViews.includes(CHANGES_VIEW_ID),
+		}, {
+			openedFiles: false,
 			openedChanges: false,
 		});
 	});
@@ -718,27 +751,32 @@ suite('LayoutController (desktop)', () => {
 			'a restore-driven editor reveal must not overwrite session A\'s captured closed state');
 	});
 
-	test('[D4] keeps the open side pane and shows Changes when a new session is submitted', () => {
-		createController();
+	test('[D4] keeps the open side pane on its current view when a new session is submitted', () => {
+		const controller = createController();
 		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled, isCreated: false });
 		harness.activeSessionObs.set(session, undefined);
 
 		assert.ok(harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
 
-		// Aux bar is open on the new-session view.
+		// Aux bar is open on the new-session view, showing Files.
 		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		harness.activePaneCompositeId = SESSIONS_FILES_CONTAINER_ID;
 		harness.setPartHiddenCalls = [];
 		harness.openedViews = [];
 		(session.isCreated as ISettableObservable<boolean>).set(true, undefined);
 
-		assert.ok(
-			!harness.setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
-			'side pane should remain open after the new session is submitted'
-		);
-		assert.ok(
-			harness.openedViews.includes(CHANGES_VIEW_ID),
-			'Changes view should be shown after the new session is submitted'
-		);
+		assert.deepStrictEqual({
+			hidden: harness.setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
+			openedChanges: harness.openedViews.includes(CHANGES_VIEW_ID),
+			viewState: controller.getViewState(session.resource),
+		}, {
+			hidden: false,
+			openedChanges: false,
+			viewState: {
+				auxiliaryBarVisible: true,
+				auxiliaryBarActiveViewContainerId: SESSIONS_FILES_CONTAINER_ID,
+			},
+		});
 	});
 
 	test('[D4] keeps the side pane closed when a new session is submitted with the aux bar hidden', () => {
@@ -764,7 +802,7 @@ suite('LayoutController (desktop)', () => {
 		);
 	});
 
-	test('[D4] shows Changes when a hidden side pane is opened after the session is submitted', () => {
+	test('[D4] shows Files when a hidden side pane is opened after a change-free session is submitted', () => {
 		createController();
 		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled, isCreated: false });
 		harness.activeSessionObs.set(session, undefined);
@@ -775,17 +813,47 @@ suite('LayoutController (desktop)', () => {
 		(session.isCreated as ISettableObservable<boolean>).set(true, undefined);
 
 		harness.openedViewContainers = [];
+		harness.openedViews = [];
 		harness.activePaneCompositeId = SESSIONS_FILES_CONTAINER_ID;
 		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
 		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: true });
 
-		assert.ok(
-			harness.openedViewContainers.includes(CHANGES_VIEW_CONTAINER_ID),
-			'Changes should be the active view when the side pane is opened later'
-		);
+		assert.deepStrictEqual({
+			openedFiles: harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			openedChanges: harness.openedViews.includes(CHANGES_VIEW_ID),
+		}, {
+			openedFiles: true,
+			openedChanges: false,
+		});
 	});
 
-	test('[D4] records Changes when a hidden side pane falls back from an invalid saved container', () => {
+	test('[D4] shows Changes when a hidden side pane is opened after the session produced a change', () => {
+		createController();
+		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled, isCreated: false });
+		harness.activeSessionObs.set(session, undefined);
+
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, false);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: false });
+
+		(session.isCreated as ISettableObservable<boolean>).set(true, undefined);
+		(session.changes as ISettableObservable<readonly ISessionFileChange[]>).set([makeChange('/file.ts')], undefined);
+
+		harness.openedViewContainers = [];
+		harness.openedViews = [];
+		harness.activePaneCompositeId = SESSIONS_FILES_CONTAINER_ID;
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: true });
+
+		assert.deepStrictEqual({
+			openedFiles: harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			openedChanges: harness.openedViews.includes(CHANGES_VIEW_ID),
+		}, {
+			openedFiles: false,
+			openedChanges: true,
+		});
+	});
+
+	test('[D4] records Files when a change-free session falls back from an invalid saved container', () => {
 		const session = makeSession(URI.parse('session:1'));
 		const controller = createController({
 			layoutState: [{
@@ -799,6 +867,37 @@ suite('LayoutController (desktop)', () => {
 		harness.activeSessionObs.set(session, undefined);
 
 		harness.openedViews = [];
+		harness.openedViewContainers = [];
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: true });
+
+		assert.deepStrictEqual({
+			openedFiles: harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			viewState: controller.getViewState(session.resource),
+		}, {
+			openedFiles: true,
+			viewState: {
+				auxiliaryBarVisible: true,
+				auxiliaryBarActiveViewContainerId: SESSIONS_FILES_CONTAINER_ID,
+			},
+		});
+	});
+
+	test('[D4] records Changes when a session with changes falls back from an invalid saved container', () => {
+		const session = makeSession(URI.parse('session:1'), { changes: [makeChange('/file.ts')] });
+		const controller = createController({
+			layoutState: [{
+				sessionResource: session.resource.toString(),
+				viewState: {
+					auxiliaryBarVisible: false,
+					auxiliaryBarActiveViewContainerId: 'missing.view',
+				},
+			}],
+		});
+		harness.activeSessionObs.set(session, undefined);
+
+		harness.openedViews = [];
+		harness.openedViewContainers = [];
 		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
 		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: true });
 

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -567,8 +567,9 @@ export function sessionHasChanges(session: ISession, reader: IReader | undefined
 	if (session.chats.read(reader).some(chat => chat.changes.read(reader).length > 0)) {
 		return true;
 	}
-	if ((session.changesSummary?.read(reader)?.files ?? 0) > 0) {
-		return true;
+	const changesSummary = session.changesSummary?.read(reader);
+	if (changesSummary !== undefined) {
+		return changesSummary.files > 0;
 	}
 	return session.changes.read(reader).length > 0;
 }

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -554,15 +554,7 @@ export interface ISession {
 	readonly capabilities: IObservable<ISessionCapabilities>;
 }
 
-/**
- * Whether the session has produced at least one file change so far.
- *
- * The per-chat diff stats are the source of truth: a session counts as having
- * changes as soon as any of its chats reports a file change. Providers that
- * only report changes for the session as a whole (no per-chat attribution) are
- * covered by the session-level {@link ISession.changesSummary} /
- * {@link ISession.changes} fallbacks.
- */
+/** Returns whether any chat or session-level fallback reports file changes. */
 export function sessionHasChanges(session: ISession, reader: IReader | undefined): boolean {
 	if (session.chats.read(reader).some(chat => chat.changes.read(reader).length > 0)) {
 		return true;

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -555,6 +555,25 @@ export interface ISession {
 }
 
 /**
+ * Whether the session has produced at least one file change so far.
+ *
+ * The per-chat diff stats are the source of truth: a session counts as having
+ * changes as soon as any of its chats reports a file change. Providers that
+ * only report changes for the session as a whole (no per-chat attribution) are
+ * covered by the session-level {@link ISession.changesSummary} /
+ * {@link ISession.changes} fallbacks.
+ */
+export function sessionHasChanges(session: ISession, reader: IReader | undefined): boolean {
+	if (session.chats.read(reader).some(chat => chat.changes.read(reader).length > 0)) {
+		return true;
+	}
+	if ((session.changesSummary?.read(reader)?.files ?? 0) > 0) {
+		return true;
+	}
+	return session.changes.read(reader).length > 0;
+}
+
+/**
  * Build the canonical {@link ISession.sessionId} from a provider id and
  * session resource URI.
  *


### PR DESCRIPTION
## What

Opening the side panel in the Agents window always revealed the **Changes** view for created sessions, even when the session had not produced a single file change yet. This changes the default to the **Files** tab, and only makes **Changes** the default once the session has at least one change in one of its chats.

## Why

A brand-new session has nothing to show in Changes, so the side panel opened onto an empty view. Files is the useful default until the agent has actually touched something.

## How

- **New helper `sessionHasChanges()`** in `src/vs/sessions/services/sessions/common/session.ts`. The per-chat diff stats are the source of truth (`session.chats[].changes`), with the session-level `changesSummary.files` / `changes` observables as fallbacks for providers that don't attribute changes per chat.
- **Reworked `[D3d]`** in `desktopSessionLayoutController.ts`. The new `_defaultAuxiliaryBarContainerId()` replaces the old `isCreated`-based rule: Files while the session has no changes, Changes from the first change onward. It still falls back to Changes when the user has unpinned the Files pane.
- **Reveal-time semantics.** The default is read *untracked* on purpose, so it is evaluated at the moment the side pane is opened. A change landing while the panel is already open never yanks the user off the tab they're looking at — it only affects the next open/reveal.
- **`[D4]` no longer hard-codes Changes** on new-session submit (`_onNewSessionSubmitted`) or draft→created replacement (`_onSessionReplaced`). An open side pane is carried over on the container it is already showing; a closed one records no container so the next open picks the `[D3d]` default for the session's change state at that time.
- `_restoreSavedAuxiliaryBarContainerOnReveal` records and opens the computed default instead of always Changes.

## Notes for reviewers

- Behavior docs updated: `desktopSessionLayoutController.md` (D3d / D4 / D6 + implementation map) and `LAYOUT_CONTROLLER.md` (§3.2–3.5).
- The single-pane (`sessions.layout.singlePaneDetailPanel`, experimental / default-off) and mobile layouts are **intentionally unchanged** — `SinglePaneDetailPanelStrategy._computeDetailTarget` still uses the `isCreated`-based rule. Happy to align them in a follow-up if wanted.
- One existing test asserted the old `isCreated` semantics for a synthetic "uncreated session with changes" case and now asserts Changes. In practice uncreated/draft sessions never have changes, so the real new-session flow still shows Files.

## Validation

- `npm run typecheck-client` — clean
- `npm run precommit` (hygiene) — clean
- `scripts\test.bat --grep "LayoutController"` — **148 passing**, including new coverage for:
  - `[D3d] defaults to Files while the session has no changes`
  - `[D3d] defaults to Changes once one of the session chats has a change`
  - `[D3d] does not switch a side pane that is already showing Files when a change lands`
  - `[D4] shows Files / shows Changes when a hidden side pane is opened after submit`
  - `[D4] records Files / records Changes when falling back from an invalid saved container`