### PR TITLE
Nice file edit paths

### DIFF
--- a/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
+++ b/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
@@ -16,18 +16,10 @@ import { IEditSurvivalReporterFactory } from './editSurvivalReporter.js';
 const SESSION_DB_SCHEME = 'session-db';
 
 /**
- * Builds a `session-db:` URI that references a file-edit content blob
- * stored in the session database. Parsed by {@link parseSessionDbUri}.
- *
- * The URI path is the edited file's path so resource labels show a
- * recognizable path and the snapshot lines up with the working-tree side
- * in diff editors. The session URI, tool call, exact file path, and
- * snapshot part needed to fetch the blob are carried in the query.
- *
- * @param sessionUri Session the blob belongs to; used to find the database.
- * @param toolCallId Tool call whose edit produced the snapshot.
- * @param filePath Absolute path of the edited file, as recorded in the database.
- * @param part Which side of the edit the blob holds.
+ * Builds a `session-db:` URI referencing a file-edit content blob in the
+ * session database. The path is the edited file's path so resource labels
+ * show a real path; the lookup fields live in the query, where `filePath` is
+ * kept verbatim because it is part of the database key.
  */
 export function buildSessionDbUri(sessionUri: string, toolCallId: string, filePath: string, part: 'before' | 'after'): string {
 	return URI.from({
@@ -62,6 +54,10 @@ export function parseSessionDbUri(raw: string): ISessionDbUriFields | undefined 
 	return parsed.query ? parseSessionDbUriQuery(parsed.query) : parseLegacySessionDbUri(parsed);
 }
 
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === 'string' && value.length > 0;
+}
+
 function parseSessionDbUriQuery(query: string): ISessionDbUriFields | undefined {
 	let fields: Partial<ISessionDbUriFields>;
 	try {
@@ -69,8 +65,11 @@ function parseSessionDbUriQuery(query: string): ISessionDbUriFields | undefined 
 	} catch {
 		return undefined;
 	}
+	if (typeof fields !== 'object' || fields === null) {
+		return undefined;
+	}
 	const { sessionUri, toolCallId, filePath, part } = fields;
-	if (typeof sessionUri !== 'string' || typeof toolCallId !== 'string' || typeof filePath !== 'string' || (part !== 'before' && part !== 'after')) {
+	if (!isNonEmptyString(sessionUri) || !isNonEmptyString(toolCallId) || !isNonEmptyString(filePath) || (part !== 'before' && part !== 'after')) {
 		return undefined;
 	}
 	return { sessionUri, toolCallId, filePath, part };

--- a/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
+++ b/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { decodeHex, encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
-import { basename } from '../../../../base/common/path.js';
+import { decodeHex, VSBuffer } from '../../../../base/common/buffer.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IFileService } from '../../../files/common/files.js';
 import { ILogService } from '../../../log/common/log.js';
@@ -19,12 +18,22 @@ const SESSION_DB_SCHEME = 'session-db';
 /**
  * Builds a `session-db:` URI that references a file-edit content blob
  * stored in the session database. Parsed by {@link parseSessionDbUri}.
+ *
+ * The URI path is the edited file's path so resource labels show a
+ * recognizable path and the snapshot lines up with the working-tree side
+ * in diff editors. The session URI, tool call, exact file path, and
+ * snapshot part needed to fetch the blob are carried in the query.
+ *
+ * @param sessionUri Session the blob belongs to; used to find the database.
+ * @param toolCallId Tool call whose edit produced the snapshot.
+ * @param filePath Absolute path of the edited file, as recorded in the database.
+ * @param part Which side of the edit the blob holds.
  */
 export function buildSessionDbUri(sessionUri: string, toolCallId: string, filePath: string, part: 'before' | 'after'): string {
 	return URI.from({
 		scheme: SESSION_DB_SCHEME,
-		authority: encodeHex(VSBuffer.fromString(sessionUri)).toString(),
-		path: `/${encodeURIComponent(toolCallId)}/${encodeHex(VSBuffer.fromString(filePath))}/${part}/${basename(filePath)}`,
+		path: URI.file(filePath).path,
+		query: JSON.stringify({ sessionUri, toolCallId, filePath, part } satisfies ISessionDbUriFields),
 	}).toString();
 }
 
@@ -41,17 +50,45 @@ export interface ISessionDbUriFields {
  * Returns `undefined` if the URI is not a valid `session-db:` URI.
  */
 export function parseSessionDbUri(raw: string): ISessionDbUriFields | undefined {
-	const parsed = URI.parse(raw);
+	let parsed: URI;
+	try {
+		parsed = URI.parse(raw);
+	} catch {
+		return undefined;
+	}
 	if (parsed.scheme !== SESSION_DB_SCHEME) {
 		return undefined;
 	}
-	const [, toolCallId, filePath, part] = parsed.path.split('/');
+	return parsed.query ? parseSessionDbUriQuery(parsed.query) : parseLegacySessionDbUri(parsed);
+}
+
+function parseSessionDbUriQuery(query: string): ISessionDbUriFields | undefined {
+	let fields: Partial<ISessionDbUriFields>;
+	try {
+		fields = JSON.parse(query) as Partial<ISessionDbUriFields>;
+	} catch {
+		return undefined;
+	}
+	const { sessionUri, toolCallId, filePath, part } = fields;
+	if (typeof sessionUri !== 'string' || typeof toolCallId !== 'string' || typeof filePath !== 'string' || (part !== 'before' && part !== 'after')) {
+		return undefined;
+	}
+	return { sessionUri, toolCallId, filePath, part };
+}
+
+/**
+ * Parses the query-less layout used before the fields moved into the query
+ * (`session-db://<hexSessionUri>/<toolCallId>/<hexFilePath>/<part>/<basename>`),
+ * so snapshots recorded by earlier builds still resolve.
+ */
+function parseLegacySessionDbUri(uri: URI): ISessionDbUriFields | undefined {
+	const [, toolCallId, filePath, part] = uri.path.split('/');
 	if (!toolCallId || !filePath || (part !== 'before' && part !== 'after')) {
 		return undefined;
 	}
 	try {
 		return {
-			sessionUri: decodeHex(parsed.authority).toString(),
+			sessionUri: decodeHex(uri.authority).toString(),
 			toolCallId: decodeURIComponent(toolCallId),
 			filePath: decodeHex(filePath).toString(),
 			part

--- a/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { VSBuffer } from '../../../../base/common/buffer.js';
+import { encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -189,6 +189,13 @@ suite('buildSessionDbUri / parseSessionDbUri', () => {
 		assert.strictEqual(parsed.toolCallId, 'call_abc=123&x');
 	});
 
+	test('round-trips a backslashed Windows filePath, which the database lookup needs verbatim', () => {
+		const filePath = 'C:\\Code\\vscode\\src\\vs\\file.ts';
+		const parsed = parseSessionDbUri(buildSessionDbUri('copilot:/s1', 'tc-1', filePath, 'before'));
+		assert.ok(parsed);
+		assert.strictEqual(parsed.filePath, filePath);
+	});
+
 	test('parseSessionDbUri returns undefined for non-session-db URIs', () => {
 		assert.strictEqual(parseSessionDbUri('file:///foo/bar'), undefined);
 		assert.strictEqual(parseSessionDbUri('https://example.com'), undefined);
@@ -200,15 +207,29 @@ suite('buildSessionDbUri / parseSessionDbUri', () => {
 		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1?toolCallId=tc-1&filePath=/f&part=middle'), undefined);
 	});
 
-	test('URI path ends with the basename of the file', () => {
+	test('URI path is the file path, so labels show a real path', () => {
 		const uri = buildSessionDbUri('copilot:/s1', 'tc-1', '/workspace/src/index.ts', 'before');
-		const parsed = URI.parse(uri);
-		assert.ok(parsed.path.endsWith('/index.ts'));
+		assert.strictEqual(URI.parse(uri).path, '/workspace/src/index.ts');
 	});
 
-	test('URI path ends with basename for files with spaces and special chars', () => {
+	test('URI path is the file path for files with spaces and special chars', () => {
 		const uri = buildSessionDbUri('copilot:/s1', 'tc-1', '/work space/file (1).ts', 'after');
-		const parsed = URI.parse(uri);
-		assert.ok(parsed.path.endsWith('/file (1).ts'));
+		assert.strictEqual(URI.parse(uri).path, '/work space/file (1).ts');
+	});
+
+	test('parses the legacy hex-encoded layout', () => {
+		const hex = (value: string) => encodeHex(VSBuffer.fromString(value)).toString();
+		const legacy = URI.from({
+			scheme: 'session-db',
+			authority: hex('copilot:/abc-123'),
+			path: `/tc-1/${hex('/workspace/file.ts')}/before/file.ts`,
+		}).toString();
+
+		assert.deepStrictEqual(parseSessionDbUri(legacy), {
+			sessionUri: 'copilot:/abc-123',
+			toolCallId: 'tc-1',
+			filePath: '/workspace/file.ts',
+			part: 'before',
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
@@ -207,6 +207,25 @@ suite('buildSessionDbUri / parseSessionDbUri', () => {
 		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1?toolCallId=tc-1&filePath=/f&part=middle'), undefined);
 	});
 
+	test('parseSessionDbUri returns undefined for JSON queries that are not objects', () => {
+		const queries = ['null', '123', '"a string"', 'true', '[]'];
+		assert.deepStrictEqual(
+			queries.map(query => parseSessionDbUri(`session-db:/f.ts?${encodeURIComponent(query)}`)),
+			queries.map(() => undefined),
+		);
+	});
+
+	test('parseSessionDbUri rejects empty lookup keys, which would hit the database', () => {
+		const withField = (field: Partial<Record<'sessionUri' | 'toolCallId' | 'filePath', string>>) =>
+			`session-db:/f.ts?${encodeURIComponent(JSON.stringify({ sessionUri: 's', toolCallId: 't', filePath: '/f.ts', part: 'before', ...field }))}`;
+
+		assert.deepStrictEqual([
+			parseSessionDbUri(withField({ sessionUri: '' })),
+			parseSessionDbUri(withField({ toolCallId: '' })),
+			parseSessionDbUri(withField({ filePath: '' })),
+		], [undefined, undefined, undefined]);
+	});
+
 	test('URI path is the file path, so labels show a real path', () => {
 		const uri = buildSessionDbUri('copilot:/s1', 'tc-1', '/workspace/src/index.ts', 'before');
 		assert.strictEqual(URI.parse(uri).path, '/workspace/src/index.ts');


### PR DESCRIPTION
```Copilot Generated Description:``` Refactor the file edit tracking logic to improve URI handling. Update the `buildSessionDbUri` function to use the full file path in the URI and enhance the `parseSessionDbUri` function to support both new and legacy URI formats. Add tests to verify the correct parsing of Windows file paths and legacy hex-encoded layouts.

