### PR TITLE
Keep first message timestamp padding while editing

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -4287,7 +4287,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 
 	div[data-index="0"] .monaco-tl-contents {
-		.interactive-item-container.interactive-request:not(.editing) {
+		.interactive-item-container.interactive-request {
 			padding-top: 19px;
 		}
 


### PR DESCRIPTION
## Summary
- Fixes #327712: when editing the very first chat message (via the Edit icon or double-click), its timestamp lost the 19px top padding reserved for the first row and ended up flush against the top of the chat panel.
- Root cause: `div[data-index="0"] .monaco-tl-contents .interactive-item-container.interactive-request:not(.editing) { padding-top: 19px; }` excluded the editing state, so the `editing` class added during edit mode disqualified the row from this rule.
- Fix: drop the `:not(.editing)` condition so the padding applies regardless of edit state — one line in `chat.css`.

## Illustration
![Illustrative before/after diagram](https://gist.githubusercontent.com/srikanthananthula63053/8a538f2642a02a0bdcabd4a7f2e5ea74/raw/aaac852a3f66cb03df3205b69d94676ca2bfdc3b/issue-327712-illustration.svg)

*Note: this is a hand-built diagram illustrating the padding-top CSS values before/after the fix — not a captured screenshot of the running app.*

## Test plan
- [x] Verified the fix is the only change (`git diff` against `main` shows a single line touched in `chat.css`)
- [x] Verified via CSS specificity analysis that the restored `padding-top: 19px` isn't overridden by the pre-existing `.interactive-request.editing { padding: 0px; }` rule (our selector is more specific)
- [x] Manual verification in a running Code OSS build: sent a first chat message, clicked Edit, confirmed the timestamp keeps its top spacing instead of collapsing to the panel edge