### PR TITLE
Filter worktree folders from session workspace recents

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -195,7 +195,7 @@ Chat input history in the Agents Window is scoped by `ISession.sessionId`. Press
 
 Each session operates on an **`ISessionWorkspace`** containing one or more **`ISessionFolder`** instances. Folders encapsulate a working directory and optional git repository information (`ISessionGitRepository`), including branch state, upstream tracking, and GitHub PR info.
 
-Workspaces carry a `group` label (e.g., `"Local"`, `"Remote"`) used by the workspace picker to organize entries into tabs via the `SESSION_WORKSPACE_GROUP_LOCAL` / `SESSION_WORKSPACE_GROUP_REMOTE` constants.
+Workspaces carry a `group` label (e.g., `"Local"`, `"Remote"`) used by the workspace picker to organize entries into tabs via the `SESSION_WORKSPACE_GROUP_LOCAL` / `SESSION_WORKSPACE_GROUP_REMOTE` constants. The picker supplements its own history with VS Code's recently opened folders, excluding folders below a path segment ending in `.worktrees`; explicitly picked session workspace history remains available.
 
 Tasks with `runOptions.runOn === "worktreeCreated"` are dispatched client-side only for sessions that this window has just started. `SessionsManagementService` emits `onDidStartSession` from `sendNewChatRequest` after `provider.sendRequest(...)` commits, and `WorktreeCreatedTaskDispatcher` tracks only those sessions until they report a concrete `gitRepository.workTreeUri`. Restored/synced catalog sessions and runtimes that declare `capabilities.runsWorktreeCreatedTasks` are skipped so setup tasks are not re-run on window open or double-run with server-side provisioning.
 

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -419,6 +419,38 @@ suite('WorkspacePicker - Connection Status', () => {
 		assert.strictEqual(picker.selectedFolderUri, undefined, 'restore selects nothing when there is no owned history to restore from');
 	});
 
+	test('filters worktree checkout folders from VS Code global recents only', async () => {
+		const provider = createMockProvider('provider');
+		providersService.setProviders([provider]);
+
+		const ownWorktreeUri = URI.file('/code/owned.worktrees/feature');
+		const globalWorktreeUri = URI.file('/code/vscode.worktrees/feature');
+		const globalUppercaseWorktreeUri = URI.file('/code/VSCode.WORKTREES/other-feature');
+		const globalSimilarUri = URI.file('/code/vscode.worktrees-backup/feature');
+		const globalRegularUri = URI.file('/code/vscode/feature');
+		const storage = disposables.add(new TestStorageService());
+		seedStorage(storage, [{ uri: ownWorktreeUri, providerId: 'provider', checked: false }]);
+
+		const workspacesService = {
+			getRecentlyOpened: async () => ({
+				workspaces: [
+					{ folderUri: globalWorktreeUri },
+					{ folderUri: globalUppercaseWorktreeUri },
+					{ folderUri: globalSimilarUri },
+					{ folderUri: globalRegularUri },
+				],
+				files: [],
+			}),
+			onDidChangeRecentlyOpened: Event.None,
+		} as unknown as IWorkspacesService;
+		const recentWorkspacesService = await createResolvedRecentWorkspacesService(disposables, storage, providersService, workspacesService);
+
+		assert.deepStrictEqual(
+			recentWorkspacesService.getRecentWorkspaces().map(recent => recent.workspace.uri.toString()),
+			[ownWorktreeUri, globalSimilarUri, globalRegularUri].map(uri => uri.toString()),
+		);
+	});
+
 	test('restored remote that never connects falls back after grace period', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
 		// The provider is registered as Disconnected and never transitions —
 		// e.g. SSH host is unreachable and the status was set before the picker

--- a/src/vs/sessions/services/sessions/browser/sessionsRecentWorkspacesService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsRecentWorkspacesService.ts
@@ -19,6 +19,10 @@ const STORAGE_KEY_RECENT_WORKSPACES = 'sessions.recentlyPickedWorkspaces';
 const MAX_RECENT_WORKSPACES = 10;
 const MAX_VSCODE_RECENT_WORKSPACES = 10;
 
+function hasWorktreesPathSegment(uri: URI): boolean {
+	return uri.path.split('/').some(segment => segment.toLowerCase().endsWith('.worktrees'));
+}
+
 /** A recently used folder, resolved to its workspace. `checked` marks the currently selected folder in the new-session workspace picker. */
 export interface IRecentWorkspace {
 	readonly workspace: ISessionWorkspace;
@@ -168,6 +172,7 @@ export class SessionsRecentWorkspacesService extends Disposable implements ISess
 			.filter(isRecentFolder)
 			.map(f => f.folderUri)
 			.filter(uri => !basename(uri).startsWith('copilot-'))
+			.filter(uri => !hasWorktreesPathSegment(uri))
 			.slice(0, MAX_VSCODE_RECENT_WORKSPACES);
 		this._onDidChangeRecentWorkspaces.fire();
 	}


### PR DESCRIPTION
## Summary
- filter VS Code recently opened folders containing a `.worktrees` path segment from the Sessions workspace picker
- preserve explicitly picked Sessions workspace history
- add regression coverage and update the Sessions specification

## Testing
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `scripts\test.bat --run src\vs\sessions\contrib\chat\test\browser\sessionWorkspacePicker.test.ts --grep "filters worktree checkout folders"`