### PR TITLE
Forward worktreePending through session wrappers, improve accessibility

### DIFF
--- a/src/vs/sessions/contrib/files/browser/workspaceFolderActions.ts
+++ b/src/vs/sessions/contrib/files/browser/workspaceFolderActions.ts
@@ -103,10 +103,7 @@ export class OpenFilesViewActionViewItem extends SessionHeaderMetaActionViewItem
 			if (!workspace?.label) {
 				return undefined;
 			}
-			// Mirror the sessions list / hover icon logic: cloud for virtual
-			// workspaces, folder when the session runs in the repo checkout,
-			// worktree otherwise. Path and branch are withheld while the
-			// worktree is pending, as they still describe the checkout.
+			// Path and branch still describe the checkout while the worktree is pending, so withhold them.
 			const worktreePending = session?.worktreePending?.read(reader) ?? false;
 			const kind = getSessionWorkspaceKind(workspace, worktreePending);
 			const icon = kind === SessionWorkspaceKind.Virtual ? Codicon.cloudCompact : kind === SessionWorkspaceKind.Folder ? Codicon.folderCompact : Codicon.worktreeCompact;
@@ -144,10 +141,13 @@ export class OpenFilesViewActionViewItem extends SessionHeaderMetaActionViewItem
 	}
 
 	protected override getAriaLabel(): string {
-		const label = this._workspaceObs.get()?.label;
-		return label
-			? localize('agentSessions.openFilesView.ariaLabel', "Open Files: {0}", label)
-			: this.getTooltip();
+		const workspace = this._workspaceObs.get();
+		if (!workspace?.label) {
+			return this.getTooltip();
+		}
+		return workspace.worktreePending
+			? localize('agentSessions.openFilesView.worktreePendingAriaLabel', "Open Files: {0}, creating worktree", workspace.label)
+			: localize('agentSessions.openFilesView.ariaLabel', "Open Files: {0}", workspace.label);
 	}
 
 	protected override getHoverContents(): IManagedHoverContent {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -655,8 +655,7 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 		const initialWorkspace = this._computeWorkspace();
 		this.workspace = observableValue('workspace', initialWorkspace);
 		this.isQuickChat = this._isQuickChat;
-		// A worktree-isolated session keeps reporting the checkout it was started
-		// from until the agent host creates and reports the worktree.
+		// Until the host reports the worktree, the workspace is still the checkout it was started from.
 		this.worktreePending = derived(this, reader =>
 			this._worktreeIsolation.read(reader)
 			&& !this.workspace.read(reader)?.folders.some(folder => !!folder.gitRepository?.workTreeUri));

--- a/src/vs/sessions/contrib/sessions/browser/sessionHoverContent.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionHoverContent.ts
@@ -64,7 +64,7 @@ export function buildSessionHoverContent(
 	// Line 2: folder icon + folder path · git branch
 	const workspace = session.workspace.get();
 	const folder = workspace?.folders[0];
-	// A pending worktree still describes the checkout, so path and branch are withheld.
+	// A pending worktree still describes the checkout, so its path, branch and changes are withheld.
 	const worktreePending = session.worktreePending?.get() ?? false;
 	const branch = worktreePending ? undefined : folder?.gitRepository?.branchName?.trim();
 	let appendedDetails = false;
@@ -93,7 +93,7 @@ export function buildSessionHoverContent(
 	}
 
 	// Line 3: file count · diff stats
-	const diffStats = getSessionDiffStats(session);
+	const diffStats = worktreePending ? undefined : getSessionDiffStats(session);
 	if (diffStats) {
 		const fileText = diffStats.files === 1
 			? localize('agentSessions.fileChanged', "1 file changed")

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -17,7 +17,7 @@ import { HighlightedLabel } from '../../../../../base/browser/ui/highlightedlabe
 import { createMatches, FuzzyScore, IMatch } from '../../../../../base/common/filters.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { IObservable, IReader, autorun, observableSignalFromEvent, observableValue } from '../../../../../base/common/observable.js';
+import { IObservable, IReader, autorun, derived, observableSignalFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { fromNow } from '../../../../../base/common/date.js';
@@ -1228,7 +1228,7 @@ class SessionsAccessibilityProvider {
 		return localize('sessionsList', "Sessions");
 	}
 
-	getAriaLabel(element: SessionListItem): string | null {
+	getAriaLabel(element: SessionListItem): string | IObservable<string> | null {
 		if (isSessionGroupItem(element)) {
 			return `${element.group.name}, ${element.sessions.length}`;
 		}
@@ -1252,12 +1252,13 @@ class SessionsAccessibilityProvider {
 				? localize('sessionPlaceholderAria', "{0}. {1}", element.label, element.hover)
 				: element.label;
 		}
-		const title = element.title.get();
-		const updated = fromNow(element.updatedAt.get(), true);
-		if (element.worktreePending?.get()) {
-			return localize('sessionItemWorktreePendingAria', "{0}, creating worktree, updated {1}", title, updated);
-		}
-		return localize('sessionItemAria', "{0}, updated {1}", title, updated);
+		return derived(this, reader => {
+			const title = element.title.read(reader);
+			const updated = fromNow(element.updatedAt.read(reader), true);
+			return element.worktreePending?.read(reader)
+				? localize('sessionItemWorktreePendingAria', "{0}, creating worktree, updated {1}", title, updated)
+				: localize('sessionItemAria', "{0}, updated {1}", title, updated);
+		});
 	}
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -1254,6 +1254,9 @@ class SessionsAccessibilityProvider {
 		}
 		const title = element.title.get();
 		const updated = fromNow(element.updatedAt.get(), true);
+		if (element.worktreePending?.get()) {
+			return localize('sessionItemWorktreePendingAria', "{0}, creating worktree, updated {1}", title, updated);
+		}
 		return localize('sessionItemAria', "{0}, updated {1}", title, updated);
 	}
 }

--- a/src/vs/sessions/services/sessions/browser/visibleSessions.ts
+++ b/src/vs/sessions/services/sessions/browser/visibleSessions.ts
@@ -238,6 +238,7 @@ export class VisibleSession extends Disposable implements IActiveSession {
 	get createdAt() { return this._session.createdAt; }
 	get workspace() { return this._session.workspace; }
 	get hasGitRepository() { return this._session.hasGitRepository; }
+	get worktreePending() { return this._session.worktreePending; }
 	get isQuickChat() { return this._session.isQuickChat; }
 	get title() { return this._session.title; }
 	get updatedAt() { return this._session.updatedAt; }
@@ -280,6 +281,7 @@ class ResourceOverrideSession implements ISession {
 	get createdAt() { return this._session.createdAt; }
 	get workspace() { return this._session.workspace; }
 	get hasGitRepository() { return this._session.hasGitRepository; }
+	get worktreePending() { return this._session.worktreePending; }
 	get isQuickChat() { return this._session.isQuickChat; }
 	get title() { return this._session.title; }
 	get updatedAt() { return this._session.updatedAt; }

--- a/src/vs/sessions/services/sessions/common/sessionContextKeys.ts
+++ b/src/vs/sessions/services/sessions/common/sessionContextKeys.ts
@@ -140,8 +140,7 @@ export function setSessionContextKeys(session: ISession | undefined, contextKeyS
 	keys.workspaceIsVirtual.set(workspace?.isVirtualWorkspace ?? true);
 	keys.hasGitRepository.set(session?.hasGitRepository?.read(reader) ?? workspace?.folders.some(folder => folder.gitRepository !== undefined) ?? false);
 
-	// Mirror the changes pill: the default changeset, falling back to the session's changes.
-	// While the worktree is pending the reported changes belong to the checkout, not the session.
+	// Mirror the changes pill: the default changeset, falling back to the session's changes — but while the worktree is pending those changes belong to the checkout, not the session.
 	const worktreePending = session?.worktreePending?.read(reader) ?? false;
 	const defaultChangeset = session?.changesets.read(reader)?.find(c => c.isDefault.read(reader));
 	let insertions = 0;

--- a/src/vs/sessions/services/sessions/test/common/sessionContextKeys.test.ts
+++ b/src/vs/sessions/services/sessions/test/common/sessionContextKeys.test.ts
@@ -115,7 +115,7 @@ suite('setSessionContextKeys - changes', () => {
 
 	const change: IChatSessionFileChange = { modifiedUri: URI.parse('test:///file.ts'), insertions: 3, deletions: 1 };
 
-	test('hides changes of the checkout a session with a pending worktree was started from', () => {
+	test('hides the changes of the checkout that a session with a pending worktree was started from', () => {
 		const contextKeyService = disposables.add(new MockContextKeyService());
 		const worktreePending = observableValue('worktreePending', true);
 		const session = stubSession({ sessionId: 'a', changesets: constObservable(undefined), changes: constObservable([change]), worktreePending });


### PR DESCRIPTION
Follow-up to #327812, addressing review feedback that arrived after it auto-merged.

- **`worktreePending` was never observable by consumers.** `VisibleSession` and `ResourceOverrideSession` in [visibleSessions.ts](src/vs/sessions/services/sessions/browser/visibleSessions.ts) explicitly forward each `ISession` property, and neither forwarded the new optional observable. `SessionView` receives a `VisibleSession`, so `setActiveSessionContextKeys` and `OpenFilesViewActionViewItem` always saw `undefined` and the original bugs still reproduced. Added the delegating getters to both wrappers.
- **Hover diff summary.** `buildSessionHoverContent` hid the checkout path and branch while pending but still rendered `getSessionDiffStats(session)`, showing the parent checkout's changes as session changes right under "Creating worktree…". Now suppressed too, matching the context key.
- **Accessibility.** The pending state was conveyed by the icon alone. It is now included in the session row's aria label (`SessionsAccessibilityProvider.getAriaLabel`) and in the workspace pill's `getAriaLabel()`.
- **Comment length + grammar.** Condensed the inline comments that exceeded the one-line guideline and fixed a test name.
