### PR TITLE
Recover Agent Host GitHub authentication for pull requests

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitStateService.ts
@@ -45,4 +45,19 @@ export interface IAgentHostGitStateService {
 	 * @param sessionKey The key of the session for which to check the GitHub pull request.
 	 */
 	attachSessionGitHubPullRequest(sessionKey: string): Promise<void>;
+
+	/**
+	 * Retries pull-request lookups that were blocked by an invalid token.
+	 */
+	handleAuthenticationTokenUpdated(resource: string): Promise<void>;
+
+	/**
+	 * Whether GitHub rejected this token for the current repository resource.
+	 */
+	isAuthenticationTokenRejected(resource: string, token: string): boolean;
+
+	/**
+	 * Records a GitHub 401 for the current repository token and requests replacement authentication.
+	 */
+	rejectAuthenticationToken(sessionKey: string, resource: string, token: string): boolean;
 }

--- a/src/vs/platform/agentHost/common/state/sessionProtocol.ts
+++ b/src/vs/platform/agentHost/common/state/sessionProtocol.ts
@@ -102,6 +102,7 @@ export const AHP_TURN_IN_PROGRESS = -32004 as const;
 export const AHP_UNSUPPORTED_PROTOCOL_VERSION = -32005 as const;
 export const AHP_CONTENT_NOT_FOUND = -32006 as const;
 export const AHP_AUTH_REQUIRED = -32007 as const;
+export const AHP_AUTH_REQUIRED_ERROR_NAME = 'AHPAuthRequiredError';
 
 // ---- Type guards -----------------------------------------------------------
 

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -45,7 +45,7 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 	private readonly _gitStateRefreshThrottler = this._register(new ThrottlerByKey<string>());
 	private readonly _gitStateRefreshCancellationTokenSource = new CancellationTokenSource();
 	private readonly _pullRequestLookupSequencer = new SequencerByKey<string>();
-	private readonly _rejectedAuthTokens = new Map<string, string>();
+	private readonly _rejectedAuthTokens = new Map<string, Set<string>>();
 	private readonly _pendingPullRequestSessions = new Map<string, Set<string>>();
 
 	constructor(
@@ -104,11 +104,10 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 			if (!authToken) {
 				return;
 			}
-			if (this._rejectedAuthTokens.get(repoResource.resource) === authToken) {
+			if (this._rejectedAuthTokens.get(repoResource.resource)?.has(authToken)) {
 				this._addPendingPullRequestSession(repoResource.resource, sessionKey);
 				return;
 			}
-			this._rejectedAuthTokens.delete(repoResource.resource);
 
 			try {
 				const pr = await this._findPullRequestWithRetry(
@@ -151,7 +150,6 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		if (resource !== this._gitHubEndpointService.getRepoResource().resource) {
 			return;
 		}
-		this._rejectedAuthTokens.delete(resource);
 		const pendingSessions = this._pendingPullRequestSessions.get(resource);
 		if (!pendingSessions) {
 			return;
@@ -166,7 +164,7 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 
 	isAuthenticationTokenRejected(resource: string, token: string): boolean {
 		return resource === this._gitHubEndpointService.getRepoResource().resource
-			&& this._rejectedAuthTokens.get(resource) === token;
+			&& this._rejectedAuthTokens.get(resource)?.has(token) === true;
 	}
 
 	rejectAuthenticationToken(sessionKey: string, resource: string, token: string): boolean {
@@ -181,7 +179,12 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		if (currentToken && currentToken !== token) {
 			return false;
 		}
-		this._rejectedAuthTokens.set(resource, token);
+		let rejectedTokens = this._rejectedAuthTokens.get(resource);
+		if (!rejectedTokens) {
+			rejectedTokens = new Set();
+			this._rejectedAuthTokens.set(resource, rejectedTokens);
+		}
+		rejectedTokens.add(token);
 		this._addPendingPullRequestSession(resource, sessionKey);
 		this._stateManager.emitAuthRequired({
 			resource,

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -12,13 +12,29 @@ import { ISessionGitHubState, readSessionGitHubState, readSessionGitState, Sessi
 import { IAgentHostGitService } from '../common/agentHostGitService.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
-import { IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
+import { AgentHostGitHubApiError, IAgentHostOctoKitService, type CreatedPullRequest } from './shared/agentHostOctoKitService.js';
 import { IAgentService } from '../common/agentService.js';
 import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
-import { ThrottlerByKey, timeout } from '../../../base/common/async.js';
+import { SequencerByKey, ThrottlerByKey, timeout } from '../../../base/common/async.js';
 import { isCancellationError } from '../../../base/common/errors.js';
+import { AuthRequiredReason } from '../common/state/sessionActions.js';
+
+const PULL_REQUEST_LOOKUP_MAX_ATTEMPTS = 3;
+const PULL_REQUEST_LOOKUP_RETRY_BASE_DELAY_MS = 1_000;
+const PULL_REQUEST_LOOKUP_RETRY_MAX_DELAY_MS = 30_000;
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === 'AbortError';
+}
+
+interface IPullRequestEndpointSnapshot {
+	readonly resource: string;
+	readonly apiBaseUri: string;
+}
+
+class PullRequestEndpointChangedError extends Error { }
 
 export class AgentHostGitStateService extends Disposable implements IAgentHostGitStateService {
 	declare readonly _serviceBrand: undefined;
@@ -28,6 +44,9 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 
 	private readonly _gitStateRefreshThrottler = this._register(new ThrottlerByKey<string>());
 	private readonly _gitStateRefreshCancellationTokenSource = new CancellationTokenSource();
+	private readonly _pullRequestLookupSequencer = new SequencerByKey<string>();
+	private readonly _rejectedAuthTokens = new Map<string, string>();
+	private readonly _pendingPullRequestSessions = new Map<string, Set<string>>();
 
 	constructor(
 		@IAgentHostStateManager private readonly _stateManager: AgentHostStateManager,
@@ -41,33 +60,43 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		super();
 
 		this._register(toDisposable(() => this._gitStateRefreshCancellationTokenSource.dispose(true)));
+		this._register(this._gitHubEndpointService.onDidChange(() => this._handleGitHubEndpointChanged()));
+		this._register(this._stateManager.onDidEmitNotification(notification => {
+			if (notification.type === 'root/sessionRemoved') {
+				for (const resource of this._pendingPullRequestSessions.keys()) {
+					this._removePendingPullRequestSession(resource, notification.session);
+				}
+			}
+		}));
 	}
 
 	async attachSessionGitHubPullRequest(sessionKey: string): Promise<void> {
-		const state = this._stateManager.getSessionState(sessionKey);
-		if (!state) {
-			return;
-		}
-
-		// New session
-		if (state.lifecycle !== SessionLifecycle.Ready) {
-			return;
-		}
-
-		// GitHub state
-		const gitHubState = readSessionGitHubState(this._stateManager.getSessionState(sessionKey)?._meta);
-		if (!gitHubState?.owner || !gitHubState?.repo || gitHubState?.pullRequestUrl) {
-			return;
-		}
-
-		// Git state
-		const gitState = readSessionGitState(state._meta);
-		if (!gitState?.branchName || (gitState.branchName === gitState.baseBranchName)) {
-			return;
-		}
-
-		try {
+		const queuedResource = this._gitHubEndpointService.getRepoResource().resource;
+		await this._pullRequestLookupSequencer.queue(queuedResource, async () => {
 			const repoResource = this._gitHubEndpointService.getRepoResource();
+			const endpoint: IPullRequestEndpointSnapshot = {
+				resource: repoResource.resource,
+				apiBaseUri: this._gitHubEndpointService.getApiBaseUri(),
+			};
+			if (endpoint.resource !== queuedResource) {
+				this._retryOrPendForCurrentEndpoint(sessionKey);
+				return;
+			}
+			const state = this._stateManager.getSessionState(sessionKey);
+			if (!state || state.lifecycle !== SessionLifecycle.Ready) {
+				return;
+			}
+
+			const gitHubState = readSessionGitHubState(state._meta);
+			if (!gitHubState?.owner || !gitHubState.repo || gitHubState.pullRequestUrl) {
+				return;
+			}
+
+			const gitState = readSessionGitState(state._meta);
+			if (!gitState?.branchName || gitState.branchName === gitState.baseBranchName) {
+				return;
+			}
+
 			const authToken = this._agentService.getAuthToken({
 				resource: repoResource.resource,
 				scopes: repoResource.scopes_supported,
@@ -75,22 +104,90 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 			if (!authToken) {
 				return;
 			}
-
-			const signal = new AbortController().signal;
-			const pr = await this._octoKitService.findPullRequestByHeadBranch(
-				gitHubState.owner, gitHubState.repo, gitState.branchName, authToken, signal);
-			if (!pr?.url) {
+			if (this._rejectedAuthTokens.get(repoResource.resource) === authToken) {
+				this._addPendingPullRequestSession(repoResource.resource, sessionKey);
 				return;
 			}
+			this._rejectedAuthTokens.delete(repoResource.resource);
 
-			this.setSessionGitHubState(sessionKey, {
-				owner: gitHubState.owner,
-				repo: gitHubState.repo,
-				pullRequestUrl: pr.url
-			} satisfies ISessionGitHubState);
-		} catch (error) {
-			this._logService.warn(`[AgentHostGitStateService][attachSessionGitHubPullRequest] Failed to find pull request for ${sessionKey}`, error);
+			try {
+				const pr = await this._findPullRequestWithRetry(
+					gitHubState.owner,
+					gitHubState.repo,
+					gitState.branchName,
+					authToken,
+					endpoint,
+				);
+				if (!pr?.url) {
+					return;
+				}
+
+				await this.setSessionGitHubState(sessionKey, {
+					owner: gitHubState.owner,
+					repo: gitHubState.repo,
+					pullRequestUrl: pr.url
+				} satisfies ISessionGitHubState);
+				this._removePendingPullRequestSession(repoResource.resource, sessionKey);
+			} catch (error) {
+				if (error instanceof AgentHostGitHubApiError && error.statusCode === 401) {
+					if (!this.rejectAuthenticationToken(sessionKey, repoResource.resource, authToken)) {
+						void this.attachSessionGitHubPullRequest(sessionKey);
+					}
+					return;
+				}
+				if (error instanceof PullRequestEndpointChangedError) {
+					this._removePendingPullRequestSession(endpoint.resource, sessionKey);
+					this._retryOrPendForCurrentEndpoint(sessionKey);
+					return;
+				}
+				if (!isCancellationError(error) && !isAbortError(error)) {
+					this._logService.warn(`[AgentHostGitStateService][attachSessionGitHubPullRequest] Failed to find pull request for ${sessionKey}`, error);
+				}
+			}
+		});
+	}
+
+	async handleAuthenticationTokenUpdated(resource: string): Promise<void> {
+		if (resource !== this._gitHubEndpointService.getRepoResource().resource) {
+			return;
 		}
+		this._rejectedAuthTokens.delete(resource);
+		const pendingSessions = this._pendingPullRequestSessions.get(resource);
+		if (!pendingSessions) {
+			return;
+		}
+		this._pendingPullRequestSessions.delete(resource);
+		for (const sessionKey of pendingSessions) {
+			if (this._stateManager.getSessionState(sessionKey)) {
+				await this.attachSessionGitHubPullRequest(sessionKey);
+			}
+		}
+	}
+
+	isAuthenticationTokenRejected(resource: string, token: string): boolean {
+		return resource === this._gitHubEndpointService.getRepoResource().resource
+			&& this._rejectedAuthTokens.get(resource) === token;
+	}
+
+	rejectAuthenticationToken(sessionKey: string, resource: string, token: string): boolean {
+		const repoResource = this._gitHubEndpointService.getRepoResource();
+		if (resource !== repoResource.resource) {
+			return false;
+		}
+		const currentToken = this._agentService.getAuthToken({
+			resource: repoResource.resource,
+			scopes: repoResource.scopes_supported,
+		});
+		if (currentToken && currentToken !== token) {
+			return false;
+		}
+		this._rejectedAuthTokens.set(resource, token);
+		this._addPendingPullRequestSession(resource, sessionKey);
+		this._stateManager.emitAuthRequired({
+			resource,
+			reason: AuthRequiredReason.Expired,
+		});
+		return true;
 	}
 
 	async refreshSessionGitState(sessionKey: string, workingDirectory: URI | undefined): Promise<void> {
@@ -174,6 +271,121 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 
 		// Update session database
 		await this._saveSessionState(sessionKey, META_GIT_STATE, JSON.stringify(gitState));
+	}
+
+	private async _findPullRequestWithRetry(owner: string, repo: string, branch: string, authToken: string, endpoint: IPullRequestEndpointSnapshot): Promise<CreatedPullRequest | undefined> {
+		const controller = new AbortController();
+		const cancellationListener = this._gitStateRefreshCancellationTokenSource.token.onCancellationRequested(() => controller.abort());
+		try {
+			for (let attempt = 0; attempt < PULL_REQUEST_LOOKUP_MAX_ATTEMPTS; attempt++) {
+				try {
+					this._throwIfEndpointChanged(endpoint);
+					const result = await this._octoKitService.findPullRequestByHeadBranch(
+						owner,
+						repo,
+						branch,
+						authToken,
+						controller.signal,
+						endpoint.apiBaseUri,
+					);
+					this._throwIfEndpointChanged(endpoint);
+					return result;
+				} catch (error) {
+					this._throwIfEndpointChanged(endpoint);
+					const isLastAttempt = attempt + 1 === PULL_REQUEST_LOOKUP_MAX_ATTEMPTS;
+					if (isLastAttempt || !this._isRetryablePullRequestLookupError(error)) {
+						throw error;
+					}
+					const delay = Math.min(
+						error.retryAfterMs ?? this._pullRequestLookupRetryDelay(attempt),
+						PULL_REQUEST_LOOKUP_RETRY_MAX_DELAY_MS,
+					);
+					this._logService.warn(`[AgentHostGitStateService][attachSessionGitHubPullRequest] Pull request lookup failed (attempt ${attempt + 1}), retrying in ${delay}ms`, error);
+					await timeout(delay, this._gitStateRefreshCancellationTokenSource.token);
+				}
+			}
+
+			return undefined;
+		} finally {
+			cancellationListener.dispose();
+		}
+	}
+
+	private _throwIfEndpointChanged(endpoint: IPullRequestEndpointSnapshot): void {
+		if (
+			this._gitHubEndpointService.getRepoResource().resource !== endpoint.resource
+			|| this._gitHubEndpointService.getApiBaseUri() !== endpoint.apiBaseUri
+		) {
+			throw new PullRequestEndpointChangedError();
+		}
+	}
+
+	private _isRetryablePullRequestLookupError(error: unknown): error is AgentHostGitHubApiError {
+		if (!(error instanceof AgentHostGitHubApiError)) {
+			return false;
+		}
+		return error.statusCode === undefined
+			|| error.statusCode === 408
+			|| error.statusCode === 429
+			|| (error.statusCode === 403 && error.retryAfterMs !== undefined)
+			|| error.statusCode >= 500;
+	}
+
+	private _handleGitHubEndpointChanged(): void {
+		const sessionKeys = new Set<string>();
+		for (const pendingSessions of this._pendingPullRequestSessions.values()) {
+			for (const sessionKey of pendingSessions) {
+				if (this._stateManager.getSessionState(sessionKey)) {
+					sessionKeys.add(sessionKey);
+				}
+			}
+		}
+		this._pendingPullRequestSessions.clear();
+		this._rejectedAuthTokens.clear();
+		for (const sessionKey of sessionKeys) {
+			this._retryOrPendForCurrentEndpoint(sessionKey);
+		}
+	}
+
+	private _retryOrPendForCurrentEndpoint(sessionKey: string): void {
+		const resource = this._gitHubEndpointService.getRepoResource();
+		const token = this._agentService.getAuthToken({
+			resource: resource.resource,
+			scopes: resource.scopes_supported,
+		});
+		if (token && !this.isAuthenticationTokenRejected(resource.resource, token)) {
+			void this.attachSessionGitHubPullRequest(sessionKey);
+		} else {
+			this._addPendingPullRequestSession(resource.resource, sessionKey);
+		}
+	}
+
+	protected _pullRequestLookupRetryDelay(attempt: number): number {
+		const exponentialDelay = Math.min(
+			PULL_REQUEST_LOOKUP_RETRY_MAX_DELAY_MS,
+			PULL_REQUEST_LOOKUP_RETRY_BASE_DELAY_MS * 2 ** attempt,
+		);
+		return Math.round(exponentialDelay / 2 + Math.random() * exponentialDelay / 2);
+	}
+
+	private _addPendingPullRequestSession(resource: string, sessionKey: string): void {
+		if (!this._stateManager.getSessionState(sessionKey)) {
+			return;
+		}
+		let sessions = this._pendingPullRequestSessions.get(resource);
+		if (!sessions) {
+			sessions = new Set();
+			this._pendingPullRequestSessions.set(resource, sessions);
+		}
+		sessions.add(sessionKey);
+	}
+
+	private _removePendingPullRequestSession(resource: string, sessionKey: string): void {
+		const sessions = this._pendingPullRequestSessions.get(resource);
+		sessions?.delete(sessionKey);
+		if (sessions?.size === 0) {
+			this._pendingPullRequestSessions.delete(resource);
+		}
 	}
 
 	private async _saveSessionState(sessionKey: string, key: string, value: string): Promise<void> {

--- a/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
+++ b/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
@@ -9,15 +9,17 @@ import { localize } from '../../../nls.js';
 import { IAgentService } from '../common/agentService.js';
 import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { parseChangesetUri } from '../common/changesetUri.js';
-import { AHP_AUTH_REQUIRED, AHP_SESSION_NOT_FOUND, JsonRpcErrorCodes, ProtocolError } from '../common/state/sessionProtocol.js';
+import { AHP_AUTH_REQUIRED, AHP_AUTH_REQUIRED_ERROR_NAME, AHP_SESSION_NOT_FOUND, JsonRpcErrorCodes, ProtocolError } from '../common/state/sessionProtocol.js';
 import { readSessionGitHubState, readSessionGitState, type ChangesetOperationFollowUp, type ISessionFileDiff, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
 import { ILogService } from '../../log/common/log.js';
 import { IAgentHostGitService } from '../common/agentHostGitService.js';
+import { IAgentHostGitStateService } from '../common/agentHostGitStateService.js';
 import { type IChangesetOperationHandler } from '../common/agentHostChangesetOperationService.js';
-import { type AutoMergeMethod, type CreatedPullRequest, IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
+import { AgentHostGitHubApiError, type AutoMergeMethod, type CreatedPullRequest, IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../common/state/protocol/channels-changeset/commands.js';
 import { ICopilotApiService, type ICopilotUtilityChatMessage } from './shared/copilotApiService.js';
 import { buildConversationContext } from '../common/agentHostConversationContext.js';
+import type { ProtectedResourceMetadata } from '../common/state/protocol/state.js';
 
 /**
  * Soft upper bound, in characters, for the conversation context fed to the
@@ -72,6 +74,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		private readonly _onPullRequestCreated: (event: PullRequestCreatedEvent) => void,
 		@IAgentService private readonly _agentService: IAgentService,
 		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
+		@IAgentHostGitStateService private readonly _gitStateService: IAgentHostGitStateService,
 		@IAgentHostOctoKitService private readonly _octoKitService: IAgentHostOctoKitService,
 		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
@@ -131,13 +134,14 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		const base = baseBranchName;
 
 		const repoResource = this._gitHubEndpointService.getRepoResource();
+		const apiBaseUri = this._gitHubEndpointService.getApiBaseUri();
+		const graphQlUri = this._gitHubEndpointService.getGraphQlUri();
 		const authToken = this._agentService.getAuthToken({
 			resource: repoResource.resource,
 			scopes: repoResource.scopes_supported,
 		});
 		if (!authToken) {
-			throw new ProtocolError(
-				AHP_AUTH_REQUIRED,
+			throw this._createAuthRequiredError(
 				localize('agentHost.changeset.pr.authRequired', "Sign in to GitHub with repository access to create a pull request."),
 				[repoResource],
 			);
@@ -176,10 +180,17 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		}
 		this._throwIfCancelled(token);
 
-		const existing = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal);
+		let existing: CreatedPullRequest | undefined;
+		try {
+			this._throwIfGitHubEndpointChanged(apiBaseUri, repoResource);
+			existing = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal, apiBaseUri);
+		} catch (error) {
+			this._throwIfGitHubAuthenticationFailure(error, sessionUri, repoResource, authToken);
+			throw error;
+		}
 		if (existing) {
 			this._throwIfCancelled(token);
-			return await this._finalize(existing, true, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token);
+			return await this._finalize(existing, true, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token, graphQlUri);
 		}
 		this._throwIfCancelled(token);
 
@@ -191,6 +202,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		this._logService.info(`[AgentHostPullRequestOperationHandler] Creating ${this._draft ? 'draft ' : ''}PR ${gitHubState.owner}/${gitHubState.repo} ${branchName} -> ${base}`);
 		let created: CreatedPullRequest;
 		try {
+			this._throwIfGitHubEndpointChanged(apiBaseUri, repoResource);
 			created = await this._octoKitService.createPullRequest(
 				gitHubState.owner,
 				gitHubState.repo,
@@ -201,24 +213,59 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 				this._draft,
 				authToken,
 				signal,
+				apiBaseUri,
 			);
 		} catch (err) {
 			this._throwIfCancelled(token);
+			this._throwIfGitHubAuthenticationFailure(err, sessionUri, repoResource, authToken);
 			let foundAfterFailure: CreatedPullRequest | undefined;
 			try {
-				foundAfterFailure = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal);
-			} catch {
+				this._throwIfGitHubEndpointChanged(apiBaseUri, repoResource);
+				foundAfterFailure = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal, apiBaseUri);
+			} catch (findError) {
 				this._throwIfCancelled(token);
+				this._throwIfGitHubAuthenticationFailure(findError, sessionUri, repoResource, authToken);
 				throw err;
 			}
 			if (foundAfterFailure) {
 				this._throwIfCancelled(token);
-				return await this._finalize(foundAfterFailure, true, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token);
+				return await this._finalize(foundAfterFailure, true, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token, graphQlUri);
 			}
 			throw err;
 		}
 		this._throwIfCancelled(token);
-		return await this._finalize(created, false, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token);
+		return await this._finalize(created, false, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token, graphQlUri);
+	}
+
+	private _throwIfGitHubEndpointChanged(apiBaseUri: string, resource: ProtectedResourceMetadata): void {
+		if (
+			this._gitHubEndpointService.getApiBaseUri() === apiBaseUri
+			&& this._gitHubEndpointService.getRepoResource().resource === resource.resource
+		) {
+			return;
+		}
+		const currentResource = this._gitHubEndpointService.getRepoResource();
+		throw this._createAuthRequiredError(
+			localize('agentHost.changeset.pr.endpointChanged', "GitHub configuration changed. Authenticate again to create the pull request."),
+			[currentResource],
+		);
+	}
+
+	private _throwIfGitHubAuthenticationFailure(error: unknown, sessionUri: string, resource: ProtectedResourceMetadata, token: string): void {
+		if (!(error instanceof AgentHostGitHubApiError) || error.statusCode !== 401) {
+			return;
+		}
+		this._gitStateService.rejectAuthenticationToken(sessionUri, resource.resource, token);
+		throw this._createAuthRequiredError(
+			localize('agentHost.changeset.pr.authExpired', "GitHub authentication expired. Sign in again to create the pull request."),
+			[resource],
+		);
+	}
+
+	private _createAuthRequiredError(message: string, resources: readonly ProtectedResourceMetadata[]): ProtocolError {
+		const error = new ProtocolError(AHP_AUTH_REQUIRED, message, { resources });
+		error.name = AHP_AUTH_REQUIRED_ERROR_NAME;
+		return error;
 	}
 
 	/**
@@ -236,6 +283,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		authToken: string,
 		signal: AbortSignal,
 		token: CancellationToken,
+		graphQlUri: string,
 	): Promise<InvokeChangesetOperationResult> {
 		if (!this._autoMergeMethod) {
 			// No auto-merge configured
@@ -248,7 +296,10 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 
 		if (pr.nodeId) {
 			try {
-				await this._octoKitService.enablePullRequestAutoMerge(pr.nodeId, this._autoMergeMethod, authToken, signal);
+				if (this._gitHubEndpointService.getGraphQlUri() !== graphQlUri) {
+					throw new Error('GitHub endpoint changed before auto-merge could be enabled');
+				}
+				await this._octoKitService.enablePullRequestAutoMerge(pr.nodeId, this._autoMergeMethod, authToken, signal, graphQlUri);
 				autoMergeOutcome = 'enabled';
 			} catch (err) {
 				this._throwIfCancelled(token);

--- a/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
+++ b/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
@@ -35,6 +35,8 @@ const MAX_PR_CONVERSATION_CONTEXT_CHARS = 12_000;
  */
 const MAX_PR_CHANGE_SUMMARY_CHARS = 4_000;
 
+class PullRequestAuthenticationChangedError extends Error { }
+
 export interface PullRequestCreatedEvent {
 	readonly sessionKey: string;
 	readonly pullRequestUrl: string;
@@ -88,7 +90,15 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		}
 		const cancellationListener = token.onCancellationRequested(() => abortController.abort());
 		try {
-			return await this._invoke(params, token, abortController.signal);
+			try {
+				return await this._invoke(params, token, abortController.signal);
+			} catch (error) {
+				if (!(error instanceof PullRequestAuthenticationChangedError)) {
+					throw error;
+				}
+				this._throwIfCancelled(token);
+				return await this._invoke(params, token, abortController.signal);
+			}
 		} finally {
 			cancellationListener.dispose();
 		}
@@ -255,7 +265,9 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		if (!(error instanceof AgentHostGitHubApiError) || error.statusCode !== 401) {
 			return;
 		}
-		this._gitStateService.rejectAuthenticationToken(sessionUri, resource.resource, token);
+		if (!this._gitStateService.rejectAuthenticationToken(sessionUri, resource.resource, token)) {
+			throw new PullRequestAuthenticationChangedError();
+		}
 		throw this._createAuthRequiredError(
 			localize('agentHost.changeset.pr.authExpired', "GitHub authentication expired. Sign in again to create the pull request."),
 			[resource],

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -5,7 +5,7 @@
 
 import { open, unlink, type FileHandle } from 'fs/promises';
 import { decodeBase64, VSBuffer } from '../../../base/common/buffer.js';
-import { DeferredPromise, disposableTimeout, ResourceQueue } from '../../../base/common/async.js';
+import { DeferredPromise, disposableTimeout, ResourceQueue, SequencerByKey } from '../../../base/common/async.js';
 import { toErrorMessage } from '../../../base/common/errorMessage.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
@@ -261,6 +261,7 @@ export class AgentService extends Disposable implements IAgentService {
 	 */
 	private readonly _peerChatCatalogWrites = new Map<string, Promise<void>>();
 	private readonly _authService: AgentHostAuthenticationService;
+	private readonly _authenticationSequencer = new SequencerByKey<string>();
 	/** Default provider used when no explicit provider is specified. */
 	private _defaultProvider: AgentProvider | undefined;
 	/** Observable registered agents, drives `root/agentsChanged` via {@link AgentSideEffects}. */
@@ -430,15 +431,19 @@ export class AgentService extends Disposable implements IAgentService {
 		const instantiationService = this._register(new InstantiationService(services, /*strict*/ true));
 		this._gitHubEndpointService = this._register(instantiationService.createInstance(AgentHostGitHubEndpointService));
 		services.set(IAgentHostGitHubEndpointService, this._gitHubEndpointService);
-		// A GitHub Enterprise URI change repoints every agent's GitHub resource
-		// identity to a different authorization server, so the client must obtain a
-		// token for the new resource. One root-channel `auth/required` covers all
-		// agents (the URI is host-level config).
+		// Publish the new resources before requesting tokens so clients can resolve
+		// each notification against the updated root state.
 		this._register(this._gitHubEndpointService.onDidChange(() => {
-			this._stateManager.emitAuthRequired({
-				resource: this._gitHubEndpointService.getCopilotResource().resource,
-				reason: AuthRequiredReason.Required,
-			});
+			this._sideEffects?.refreshAgentInfos();
+			for (const resource of [
+				this._gitHubEndpointService.getCopilotResource(),
+				this._gitHubEndpointService.getRepoResource(),
+			]) {
+				this._stateManager.emitAuthRequired({
+					resource: resource.resource,
+					reason: AuthRequiredReason.Required,
+				});
+			}
 		}));
 		const agentHostOctoKitService = instantiationService.createInstance(AgentHostOctoKitService, fetchFn);
 		services.set(IAgentHostOctoKitService, agentHostOctoKitService);
@@ -720,7 +725,17 @@ export class AgentService extends Disposable implements IAgentService {
 	// ---- auth ---------------------------------------------------------------
 
 	async authenticate(params: AuthenticateParams): Promise<AuthenticateResult> {
-		return this._authService.authenticate(params, this._providers.values());
+		return this._authenticationSequencer.queue(params.resource, async () => {
+			const repoResource = this._gitHubEndpointService.getRepoResource();
+			if (this._gitStateService.isAuthenticationTokenRejected(params.resource, params.token)) {
+				return { authenticated: false };
+			}
+			const result = await this._authService.authenticate(params, this._providers.values());
+			if (result.authenticated && params.resource === repoResource.resource) {
+				void this._gitStateService.handleAuthenticationTokenUpdated(params.resource);
+			}
+			return result;
+		});
 	}
 
 	getAuthToken(request: IAgentHostAuthTokenRequest): string | undefined {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -247,6 +247,10 @@ export class AgentSideEffects extends Disposable {
 		}));
 	}
 
+	refreshAgentInfos(): void {
+		this._publishAgentInfos(this._options.agents.get());
+	}
+
 	/**
 	 * Publishes agent descriptors using the last known model lists.
 	 */

--- a/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
@@ -35,6 +35,11 @@ interface GitHubPullRequestResponseItem {
 	readonly node_id?: unknown;
 }
 
+interface ICachedPullRequestSearch {
+	readonly etag: string;
+	readonly pullRequest: CreatedPullRequest | undefined;
+}
+
 export interface IGitHubApiResponse<T> {
 	readonly data: T | undefined;
 	readonly statusCode: number;
@@ -76,10 +81,11 @@ export interface IAgentHostOctoKitService {
 		draft: boolean,
 		token: string,
 		signal: AbortSignal,
+		apiBaseUri?: string,
 	): Promise<CreatedPullRequest>;
 
 	/** Finds the most recently updated pull request for `owner:branch`, if any. */
-	findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal): Promise<CreatedPullRequest | undefined>;
+	findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal, apiBaseUri?: string): Promise<CreatedPullRequest | undefined>;
 
 	/**
 	 * Enables auto-merge on a pull request so GitHub merges it automatically
@@ -91,13 +97,25 @@ export interface IAgentHostOctoKitService {
 	 * including when the repository does not allow the requested merge method or
 	 * auto-merge is not enabled for the repository.
 	 */
-	enablePullRequestAutoMerge(pullRequestId: string, mergeMethod: AutoMergeMethod, token: string, signal: AbortSignal): Promise<void>;
+	enablePullRequestAutoMerge(pullRequestId: string, mergeMethod: AutoMergeMethod, token: string, signal: AbortSignal, graphQlUri?: string): Promise<void>;
 }
 
 export const IAgentHostOctoKitService = createDecorator<IAgentHostOctoKitService>('agentHostOctoKitService');
 
 const GITHUB_API_VERSION = '2022-11-28';
 const MAX_ERROR_RESPONSE_BODY_LENGTH = 500;
+
+export class AgentHostGitHubApiError extends Error {
+	constructor(
+		message: string,
+		readonly statusCode: number | undefined,
+		readonly retryAfterMs: number | undefined,
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.name = 'AgentHostGitHubApiError';
+	}
+}
 
 const ENABLE_AUTO_MERGE_MUTATION = `mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
 	enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) {
@@ -114,7 +132,7 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 	/**
 	 * A cache of ETags for pull request search results.
 	 */
-	private readonly pullRequestSearchEtags = new LRUCache<string, string>(100);
+	private readonly pullRequestSearchCache = new LRUCache<string, ICachedPullRequestSearch>(100);
 
 	constructor(
 		fetchFn: FetchFunction | undefined,
@@ -134,6 +152,7 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 		draft: boolean,
 		token: string,
 		signal: AbortSignal,
+		apiBaseUri?: string,
 	): Promise<CreatedPullRequest> {
 		const response = await this._makeGHAPIRequest<GitHubPullRequestResponseItem>(
 			`repos/${owner}/${repo}/pulls`,
@@ -141,6 +160,8 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 			token,
 			signal,
 			{ title, body, head, base, draft },
+			undefined,
+			apiBaseUri,
 		);
 
 		const number = response.data?.number;
@@ -153,21 +174,21 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 		return { url: html_url, number, nodeId: typeof node_id === 'string' ? node_id : undefined };
 	}
 
-	async findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal): Promise<CreatedPullRequest | undefined> {
+	async findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal, apiBaseUri?: string): Promise<CreatedPullRequest | undefined> {
 		const routeSlug = `repos/${owner}/${repo}/pulls?head=${encodeURIComponent(`${owner}:${branch}`)}&state=all&sort=updated&direction=desc&per_page=1`;
+		const effectiveApiBaseUri = apiBaseUri ?? this._endpoint.getApiBaseUri();
+		const etagKey = `${effectiveApiBaseUri}\0${routeSlug}`;
 
-		const etag = this.pullRequestSearchEtags.get(routeSlug);
-		const response = await this._makeGHAPIRequest<GitHubPullRequestResponseItem[]>(routeSlug, 'GET', token, signal, undefined, etag);
+		const cached = this.pullRequestSearchCache.get(etagKey);
+		const response = await this._makeGHAPIRequest<GitHubPullRequestResponseItem[]>(routeSlug, 'GET', token, signal, undefined, cached?.etag, effectiveApiBaseUri);
 
-		if (response.etag) {
-			this.pullRequestSearchEtags.set(routeSlug, response.etag);
+		if (response.statusCode === 304) {
+			return cached?.pullRequest;
 		}
-
-		if (
-			response.statusCode === 304 ||
-			!Array.isArray(response.data) ||
-			response.data.length === 0
-		) {
+		if (!Array.isArray(response.data) || response.data.length === 0) {
+			if (response.etag) {
+				this.pullRequestSearchCache.set(etagKey, { etag: response.etag, pullRequest: undefined });
+			}
 			return undefined;
 		}
 
@@ -175,7 +196,7 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 		const html_url = first?.html_url;
 		const number = first?.number;
 		const node_id = first?.node_id;
-		return typeof html_url === 'string' && typeof number === 'number'
+		const pullRequest = typeof html_url === 'string' && typeof number === 'number'
 			? {
 				number,
 				url: html_url,
@@ -184,10 +205,14 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 					: undefined
 			}
 			: undefined;
+		if (response.etag) {
+			this.pullRequestSearchCache.set(etagKey, { etag: response.etag, pullRequest });
+		}
+		return pullRequest;
 	}
 
-	async enablePullRequestAutoMerge(pullRequestId: string, mergeMethod: AutoMergeMethod, token: string, signal: AbortSignal): Promise<void> {
-		await this._makeGraphQLRequest(ENABLE_AUTO_MERGE_MUTATION, { pullRequestId, mergeMethod }, token, signal);
+	async enablePullRequestAutoMerge(pullRequestId: string, mergeMethod: AutoMergeMethod, token: string, signal: AbortSignal, graphQlUri?: string): Promise<void> {
+		await this._makeGraphQLRequest(ENABLE_AUTO_MERGE_MUTATION, { pullRequestId, mergeMethod }, token, signal, graphQlUri);
 	}
 
 	private async _makeGHAPIRequest<T>(
@@ -196,9 +221,10 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 		token: string,
 		signal: AbortSignal,
 		body?: Record<string, unknown>,
-		etag?: string
+		etag?: string,
+		apiBaseUri?: string,
 	): Promise<IGitHubApiResponse<T>> {
-		const url = `${this._endpoint.getApiBaseUri()}/${routeSlug}`;
+		const url = `${apiBaseUri ?? this._endpoint.getApiBaseUri()}/${routeSlug}`;
 		const headers: Record<string, string> = {
 			'Accept': 'application/vnd.github+json',
 			'Authorization': `Bearer ${token}`,
@@ -224,7 +250,12 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 				throw err;
 			}
 			this._logService.error(`[AgentHostOctoKit] ${method} ${url} - Network error`, err);
-			throw err;
+			throw new AgentHostGitHubApiError(
+				`GitHub API request failed: ${method} ${routeSlug} - Network error`,
+				undefined,
+				undefined,
+				{ cause: err },
+			);
 		}
 
 		// Inspect rate limit header
@@ -250,7 +281,11 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 			const errorText = await response.text().catch(() => undefined);
 			const errorDetail = this._formatErrorResponseBody(errorText);
 			this._logService.error(`[AgentHostOctoKit] ${method} ${url} - Status: ${response.status}${errorDetail ? ` - ${errorDetail}` : ''}`);
-			throw new Error(`GitHub API request failed: ${method} ${routeSlug} - ${response.status} ${response.statusText}${errorDetail ? ` - ${errorDetail}` : ''}`);
+			throw new AgentHostGitHubApiError(
+				`GitHub API request failed: ${method} ${routeSlug} - ${response.status} ${response.statusText}${errorDetail ? ` - ${errorDetail}` : ''}`,
+				response.status,
+				parseRetryAfterHeader(response.headers.get('retry-after')),
+			);
 		}
 
 		try {
@@ -267,8 +302,9 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 		variables: Record<string, unknown>,
 		token: string,
 		signal: AbortSignal,
+		graphQlUri?: string,
 	): Promise<unknown> {
-		const url = this._endpoint.getGraphQlUri();
+		const url = graphQlUri ?? this._endpoint.getGraphQlUri();
 		const headers: Record<string, string> = {
 			'Accept': 'application/json',
 			'Authorization': `Bearer ${token}`,
@@ -339,4 +375,12 @@ function parseRateLimitHeader(value: string | string[] | undefined): number | un
 	const str = Array.isArray(value) ? value[0] : value;
 	const parsed = parseInt(str, 10);
 	return isNaN(parsed) ? undefined : parsed;
+}
+
+function parseRetryAfterHeader(value: string | null): number | undefined {
+	if (!value) {
+		return undefined;
+	}
+	const seconds = Number(value);
+	return Number.isFinite(seconds) && seconds > 0 ? seconds * 1_000 : undefined;
 }

--- a/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
@@ -375,6 +375,9 @@ class TestGitStateService extends Disposable implements IAgentHostGitStateServic
 	}
 	async setSessionGitHubState(_sessionKey: string, _state: ISessionGitHubState): Promise<void> { }
 	async attachSessionGitHubPullRequest(_sessionKey: string): Promise<void> { }
+	async handleAuthenticationTokenUpdated(_resource: string): Promise<void> { }
+	isAuthenticationTokenRejected(_resource: string, _token: string): boolean { return false; }
+	rejectAuthenticationToken(_sessionKey: string, _resource: string, _token: string): boolean { return false; }
 }
 
 class TestFileMonitorService extends Disposable implements IAgentHostFileMonitorService {

--- a/src/vs/platform/agentHost/test/node/agentHostChangesetOperationService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostChangesetOperationService.test.ts
@@ -75,6 +75,12 @@ class TestGitStateService implements IAgentHostGitStateService {
 	async setSessionGitHubState(_sessionKey: string, _state: ISessionGitHubState): Promise<void> { }
 
 	async attachSessionGitHubPullRequest(_sessionKey: string): Promise<void> { }
+
+	async handleAuthenticationTokenUpdated(_resource: string): Promise<void> { }
+
+	isAuthenticationTokenRejected(_resource: string, _token: string): boolean { return false; }
+
+	rejectAuthenticationToken(_sessionKey: string, _resource: string, _token: string): boolean { return false; }
 }
 
 suite('AgentHostChangesetOperationService', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -303,6 +303,7 @@ suite('AgentHostGitStateService', () => {
 			authRequired: h.notifications.filter(notification => notification.type === 'auth/required'),
 			gitHubState: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
 			rejectedBeforeReplacement,
+			oldTokenRejectedAfterReplacement: h.service.isAuthenticationTokenRejected('https://api.github.com/repos', 'rejected-token'),
 			rejectedAfterReplacement: h.service.isAuthenticationTokenRejected('https://api.github.com/repos', 'fresh-token'),
 		}, {
 			pullRequestCalls: [
@@ -321,6 +322,7 @@ suite('AgentHostGitStateService', () => {
 				pullRequestUrl: 'https://github.com/microsoft/vscode/pull/42',
 			},
 			rejectedBeforeReplacement: true,
+			oldTokenRejectedAfterReplacement: true,
 			rejectedAfterReplacement: false,
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -4,19 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { Emitter } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
+import { mock } from '../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
+import { deriveGitHubEndpoints, gitHubCopilotResource, gitHubRepoResource } from '../../common/githubEndpoints.js';
 import type { IAgentService } from '../../common/agentService.js';
-import { readSessionGitHubState, readSessionGitState, withSessionGitState, SessionStatus, type ISessionGitState, type SessionSummary } from '../../common/state/sessionState.js';
+import { readSessionGitHubState, readSessionGitState, withSessionGitHubState, withSessionGitState, SessionStatus, type ISessionGitHubState, type ISessionGitState, type SessionSummary } from '../../common/state/sessionState.js';
 import { META_GIT_STATE } from '../../common/agentHostGitStateService.js';
 import { AgentHostGitStateService } from '../../node/agentHostGitStateService.js';
-import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
+import type { IAgentHostGitHubEndpointService } from '../../node/agentHostGitHubEndpointService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
-import type { IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
+import { AgentHostGitHubApiError, type CreatedPullRequest, type IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
 import { TestSessionDatabase, createNoopGitService, createSessionDataService } from '../common/sessionTestHelpers.js';
+import type { INotification } from '../../common/state/sessionActions.js';
 
 const SESSION = 'mock:/session-1';
 const WORKING_DIRECTORY = 'file:///wd';
@@ -24,6 +28,12 @@ const WORKING_DIRECTORY = 'file:///wd';
 suite('AgentHostGitStateService', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	class TestAgentHostGitStateService extends AgentHostGitStateService {
+		protected override _pullRequestLookupRetryDelay(): number {
+			return 0;
+		}
+	}
 
 	function createHarness() {
 		const stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
@@ -44,20 +54,59 @@ suite('AgentHostGitStateService', () => {
 			},
 		};
 
-		// The octokit and agent services are only used by the GitHub
-		// pull-request flow, which `refreshSessionGitState` does not touch.
-		const service = disposables.add(new AgentHostGitStateService(
+		const authTokens = new Map<string, string>();
+		const agentService = new class extends mock<IAgentService>() {
+			override getAuthToken(request: { resource: string }): string | undefined {
+				return authTokens.get(request.resource);
+			}
+		}();
+		let enterpriseUri: string | undefined;
+		const endpointChangeEmitter = disposables.add(new Emitter<void>());
+		const endpointService: IAgentHostGitHubEndpointService = {
+			_serviceBrand: undefined,
+			onDidChange: endpointChangeEmitter.event,
+			getApiBaseUri: () => deriveGitHubEndpoints(enterpriseUri).apiBaseUri,
+			getGraphQlUri: () => deriveGitHubEndpoints(enterpriseUri).graphQlUri,
+			getEnterpriseHost: () => deriveGitHubEndpoints(enterpriseUri).enterpriseHost,
+			getEnterpriseUri: () => enterpriseUri,
+			getCopilotResource: () => gitHubCopilotResource(deriveGitHubEndpoints(enterpriseUri)),
+			getRepoResource: () => gitHubRepoResource(deriveGitHubEndpoints(enterpriseUri)),
+		};
+		const pullRequestCalls: Array<{ owner: string; repo: string; branch: string; token: string; apiBaseUri: string | undefined }> = [];
+		let pullRequestResults: Array<CreatedPullRequest | Error | undefined> = [];
+		let beforePullRequestResult: (() => void) | undefined;
+		const octoKitService: IAgentHostOctoKitService = {
+			_serviceBrand: undefined,
+			async createPullRequest() {
+				throw new Error('Unexpected createPullRequest call');
+			},
+			async findPullRequestByHeadBranch(owner, repo, branch, token, _signal, apiBaseUri) {
+				pullRequestCalls.push({ owner, repo, branch, token, apiBaseUri });
+				const result = pullRequestResults.shift();
+				beforePullRequestResult?.();
+				if (result instanceof Error) {
+					throw result;
+				}
+				return result;
+			},
+			async enablePullRequestAutoMerge() {
+				throw new Error('Unexpected enablePullRequestAutoMerge call');
+			},
+		};
+		const service = disposables.add(new TestAgentHostGitStateService(
 			stateManager,
 			gitService,
-			{} as unknown as IAgentHostOctoKitService,
-			{} as unknown as IAgentService,
-			createTestGitHubEndpointService(),
+			octoKitService,
+			agentService,
+			endpointService,
 			new NullLogService(),
 			sessionDataService,
 		));
 
 		const runEvents: string[] = [];
+		const notifications: INotification[] = [];
 		disposables.add(service.onDidRefreshSessionGitState(key => runEvents.push(key)));
+		disposables.add(stateManager.onDidEmitNotification(notification => notifications.push(notification)));
 
 		return {
 			stateManager,
@@ -65,12 +114,30 @@ suite('AgentHostGitStateService', () => {
 			service,
 			gitCalls,
 			runEvents,
+			pullRequestCalls,
+			notifications,
 			setGitResult: (state: ISessionGitState | undefined) => { gitResult = state; },
 			setGitError: (error: Error) => { gitError = error; },
+			setAuthToken: (token: string | undefined) => {
+				const resource = endpointService.getRepoResource().resource;
+				if (token === undefined) {
+					authTokens.delete(resource);
+				} else {
+					authTokens.set(resource, token);
+				}
+			},
+			setEnterpriseUri: (uri: string | undefined, fire = true) => {
+				enterpriseUri = uri;
+				if (fire) {
+					endpointChangeEmitter.fire();
+				}
+			},
+			setBeforePullRequestResult: (callback: (() => void) | undefined) => { beforePullRequestResult = callback; },
+			setPullRequestResults: (...results: Array<CreatedPullRequest | Error | undefined>) => { pullRequestResults = results; },
 		};
 	}
 
-	function seedSession(stateManager: AgentHostStateManager, options?: { workingDirectory?: string; gitState?: ISessionGitState }): void {
+	function seedSession(stateManager: AgentHostStateManager, options?: { workingDirectory?: string; gitState?: ISessionGitState; gitHubState?: ISessionGitHubState }): void {
 		const summary: SessionSummary = {
 			resource: SESSION,
 			provider: 'mock',
@@ -83,8 +150,12 @@ suite('AgentHostGitStateService', () => {
 		// `restoreSession` materializes the session in `ready` lifecycle so the
 		// persistence path (which skips `creating` sessions) actually runs.
 		stateManager.restoreSession(summary, []);
-		if (options?.gitState) {
-			stateManager.setSessionMeta(SESSION, withSessionGitState(undefined, options.gitState));
+		let metadata = options?.gitState ? withSessionGitState(undefined, options.gitState) : undefined;
+		if (options?.gitHubState) {
+			metadata = withSessionGitHubState(metadata, options.gitHubState);
+		}
+		if (metadata) {
+			stateManager.setSessionMeta(SESSION, metadata);
 		}
 	}
 
@@ -206,6 +277,196 @@ suite('AgentHostGitStateService', () => {
 				github: { owner: 'microsoft', repo: 'vscode' },
 				persistedGit: JSON.stringify(next),
 			});
+		});
+	});
+
+	test('circuit-breaks a rejected token and retries pending sessions after token replacement', async () => {
+		const h = createHarness();
+		seedSession(h.stateManager, {
+			workingDirectory: WORKING_DIRECTORY,
+			gitState: { branchName: 'feature', baseBranchName: 'main' },
+			gitHubState: { owner: 'microsoft', repo: 'vscode' },
+		});
+		h.setAuthToken('rejected-token');
+		h.setPullRequestResults(new AgentHostGitHubApiError('Bad credentials', 401, undefined));
+
+		await h.service.attachSessionGitHubPullRequest(SESSION);
+		await h.service.attachSessionGitHubPullRequest(SESSION);
+		const rejectedBeforeReplacement = h.service.isAuthenticationTokenRejected('https://api.github.com/repos', 'rejected-token');
+
+		h.setAuthToken('fresh-token');
+		h.setPullRequestResults({ number: 42, url: 'https://github.com/microsoft/vscode/pull/42' });
+		await h.service.handleAuthenticationTokenUpdated('https://api.github.com/repos');
+
+		assert.deepStrictEqual({
+			pullRequestCalls: h.pullRequestCalls,
+			authRequired: h.notifications.filter(notification => notification.type === 'auth/required'),
+			gitHubState: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			rejectedBeforeReplacement,
+			rejectedAfterReplacement: h.service.isAuthenticationTokenRejected('https://api.github.com/repos', 'fresh-token'),
+		}, {
+			pullRequestCalls: [
+				{ owner: 'microsoft', repo: 'vscode', branch: 'feature', token: 'rejected-token', apiBaseUri: 'https://api.github.com' },
+				{ owner: 'microsoft', repo: 'vscode', branch: 'feature', token: 'fresh-token', apiBaseUri: 'https://api.github.com' },
+			],
+			authRequired: [{
+				type: 'auth/required',
+				channel: 'ahp-root://',
+				resource: 'https://api.github.com/repos',
+				reason: 'expired',
+			}],
+			gitHubState: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrl: 'https://github.com/microsoft/vscode/pull/42',
+			},
+			rejectedBeforeReplacement: true,
+			rejectedAfterReplacement: false,
+		});
+	});
+
+	test('keeps each lookup bound to one GitHub endpoint snapshot', async () => {
+		const h = createHarness();
+		seedSession(h.stateManager, {
+			workingDirectory: WORKING_DIRECTORY,
+			gitState: { branchName: 'feature', baseBranchName: 'main' },
+			gitHubState: { owner: 'microsoft', repo: 'vscode' },
+		});
+		h.setAuthToken('github-token');
+		h.setPullRequestResults(new AgentHostGitHubApiError('Bad credentials', 401, undefined));
+		h.setBeforePullRequestResult(() => {
+			h.setBeforePullRequestResult(undefined);
+			h.setEnterpriseUri('https://ghe.example.com', false);
+		});
+
+		await h.service.attachSessionGitHubPullRequest(SESSION);
+
+		const enterpriseEndpoints = deriveGitHubEndpoints('https://ghe.example.com');
+		const enterpriseResource = gitHubRepoResource(enterpriseEndpoints).resource;
+		h.setAuthToken('enterprise-token');
+		h.setPullRequestResults({ number: 42, url: 'https://ghe.example.com/microsoft/vscode/pull/42' });
+		await h.service.handleAuthenticationTokenUpdated(enterpriseResource);
+
+		assert.deepStrictEqual({
+			pullRequestCalls: h.pullRequestCalls,
+			gitHubState: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+		}, {
+			pullRequestCalls: [
+				{ owner: 'microsoft', repo: 'vscode', branch: 'feature', token: 'github-token', apiBaseUri: 'https://api.github.com' },
+				{ owner: 'microsoft', repo: 'vscode', branch: 'feature', token: 'enterprise-token', apiBaseUri: 'https://ghe.example.com/api/v3' },
+			],
+			gitHubState: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrl: 'https://ghe.example.com/microsoft/vscode/pull/42',
+			},
+		});
+	});
+
+	test('retries when the new endpoint token arrives before the old lookup settles', async () => {
+		const h = createHarness();
+		seedSession(h.stateManager, {
+			workingDirectory: WORKING_DIRECTORY,
+			gitState: { branchName: 'feature', baseBranchName: 'main' },
+			gitHubState: { owner: 'microsoft', repo: 'vscode' },
+		});
+		h.setAuthToken('github-token');
+		h.setPullRequestResults(
+			new AgentHostGitHubApiError('Bad credentials', 401, undefined),
+			{ number: 42, url: 'https://ghe.example.com/microsoft/vscode/pull/42' },
+		);
+		h.setBeforePullRequestResult(() => {
+			h.setBeforePullRequestResult(undefined);
+			h.setEnterpriseUri('https://ghe.example.com');
+			h.setAuthToken('enterprise-token');
+			void h.service.handleAuthenticationTokenUpdated(
+				gitHubRepoResource(deriveGitHubEndpoints('https://ghe.example.com')).resource,
+			);
+		});
+
+		await h.service.attachSessionGitHubPullRequest(SESSION);
+		await h.service.attachSessionGitHubPullRequest(SESSION);
+
+		assert.deepStrictEqual({
+			pullRequestCalls: h.pullRequestCalls,
+			gitHubState: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+		}, {
+			pullRequestCalls: [
+				{ owner: 'microsoft', repo: 'vscode', branch: 'feature', token: 'github-token', apiBaseUri: 'https://api.github.com' },
+				{ owner: 'microsoft', repo: 'vscode', branch: 'feature', token: 'enterprise-token', apiBaseUri: 'https://ghe.example.com/api/v3' },
+			],
+			gitHubState: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrl: 'https://ghe.example.com/microsoft/vscode/pull/42',
+			},
+		});
+	});
+
+	test('ignores a stale 401 after a newer token is accepted', async () => {
+		const h = createHarness();
+		seedSession(h.stateManager, {
+			workingDirectory: WORKING_DIRECTORY,
+			gitState: { branchName: 'feature', baseBranchName: 'main' },
+			gitHubState: { owner: 'microsoft', repo: 'vscode' },
+		});
+		h.setAuthToken('old-token');
+		h.setPullRequestResults(
+			new AgentHostGitHubApiError('Bad credentials', 401, undefined),
+			{ number: 42, url: 'https://github.com/microsoft/vscode/pull/42' },
+		);
+		h.setBeforePullRequestResult(() => {
+			h.setBeforePullRequestResult(undefined);
+			h.setAuthToken('new-token');
+		});
+
+		await h.service.attachSessionGitHubPullRequest(SESSION);
+		await h.service.attachSessionGitHubPullRequest(SESSION);
+
+		assert.deepStrictEqual({
+			pullRequestCalls: h.pullRequestCalls,
+			authRequired: h.notifications.filter(notification => notification.type === 'auth/required'),
+			gitHubState: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+		}, {
+			pullRequestCalls: [
+				{ owner: 'microsoft', repo: 'vscode', branch: 'feature', token: 'old-token', apiBaseUri: 'https://api.github.com' },
+				{ owner: 'microsoft', repo: 'vscode', branch: 'feature', token: 'new-token', apiBaseUri: 'https://api.github.com' },
+			],
+			authRequired: [],
+			gitHubState: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrl: 'https://github.com/microsoft/vscode/pull/42',
+			},
+		});
+	});
+
+	test('retries transient pull request lookup failures at most three times', async () => {
+		const h = createHarness();
+		seedSession(h.stateManager, {
+			workingDirectory: WORKING_DIRECTORY,
+			gitState: { branchName: 'feature', baseBranchName: 'main' },
+			gitHubState: { owner: 'microsoft', repo: 'vscode' },
+		});
+		h.setAuthToken('fresh-token');
+		h.setPullRequestResults(
+			new AgentHostGitHubApiError('Secondary rate limit', 403, 0),
+			new AgentHostGitHubApiError('Unavailable', 503, undefined),
+			{ number: 42, url: 'https://github.com/microsoft/vscode/pull/42' },
+		);
+
+		await h.service.attachSessionGitHubPullRequest(SESSION);
+
+		assert.deepStrictEqual({
+			attempts: h.pullRequestCalls.length,
+			gitHubState: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+		}, {
+			attempts: 3,
+			gitHubState: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrl: 'https://github.com/microsoft/vscode/pull/42',
+			},
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
@@ -140,7 +140,9 @@ class TestOctoKitService implements IAgentHostOctoKitService {
 			return this.existingAfterCreateFailure;
 		}
 		if (this.findError) {
-			throw this.findError;
+			const error = this.findError;
+			this.findError = undefined;
+			throw error;
 		}
 		return this.existing;
 	}
@@ -156,6 +158,7 @@ class TestGitStateService implements IAgentHostGitStateService {
 	declare readonly _serviceBrand: undefined;
 	readonly onDidRefreshSessionGitState = Event.None;
 	readonly rejectedTokens: Array<{ sessionKey: string; resource: string; token: string }> = [];
+	rejectResult = true;
 
 	async refreshSessionGitState(): Promise<void> { }
 	async setSessionGitHubState(): Promise<void> { }
@@ -164,7 +167,7 @@ class TestGitStateService implements IAgentHostGitStateService {
 	isAuthenticationTokenRejected(): boolean { return false; }
 	rejectAuthenticationToken(sessionKey: string, resource: string, token: string): boolean {
 		this.rejectedTokens.push({ sessionKey, resource, token });
-		return true;
+		return this.rejectResult;
 	}
 }
 
@@ -310,6 +313,36 @@ suite('AgentHostPullRequestOperationHandler', () => {
 			resource: GITHUB_REPO_PROTECTED_RESOURCE.resource,
 			token: 'gh-token',
 		}]);
+	});
+
+	test('retries once when a stale 401 arrives after authentication changes', async () => {
+		const gitService = new TestGitService();
+		const octoKitService = new TestOctoKitService();
+		octoKitService.findError = new AgentHostGitHubApiError('Bad credentials', 401, undefined);
+		const { handler, session, gitStateService, createdEvents } = setup(disposables, gitService, octoKitService);
+		gitStateService.rejectResult = false;
+
+		const result = await handler.invoke({ channel: buildSessionChangesetUri(session.toString()), operationId: AgentHostPullRequestOperationHandler.OPERATION_CREATE_PR }, CancellationToken.None);
+
+		assert.deepStrictEqual({
+			message: result.message,
+			rejectedTokens: gitStateService.rejectedTokens,
+			octoCalls: octoKitService.calls,
+			createdEvents,
+		}, {
+			message: { markdown: 'Created pull request [#123](https://github.com/microsoft/vscode/pull/123).' },
+			rejectedTokens: [{
+				sessionKey: session.toString(),
+				resource: GITHUB_REPO_PROTECTED_RESOURCE.resource,
+				token: 'gh-token',
+			}],
+			octoCalls: [
+				'findPullRequestByHeadBranch:feature/test',
+				'findPullRequestByHeadBranch:feature/test',
+				'createPullRequest:false',
+			],
+			createdEvents: ['agent:/session:https://github.com/microsoft/vscode/pull/123'],
+		});
 	});
 
 	// A visible PR button can race with refreshed git state. If the backend

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
@@ -5,18 +5,21 @@
 
 import assert from 'assert';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { Event } from '../../../../base/common/event.js';
 import type { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, type IAgentService } from '../../common/agentService.js';
 import { buildSessionChangesetUri } from '../../common/changesetUri.js';
+import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { withSessionGitHubState, withSessionGitState, type ISessionFileDiff, MessageKind, ResponsePartKind, SessionStatus, TurnState, type Turn } from '../../common/state/sessionState.js';
 import type { IAgentHostGitService, IBranch, IDefaultBranch, IPushOptions } from '../../common/agentHostGitService.js';
+import type { IAgentHostGitStateService } from '../../common/agentHostGitStateService.js';
 import { AgentHostPullRequestOperationHandler } from '../../node/agentHostPullRequestOperationHandler.js';
 import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
-import type { AutoMergeMethod, CreatedPullRequest, IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
+import { AgentHostGitHubApiError, type AutoMergeMethod, type CreatedPullRequest, type IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
 import type { ICopilotApiService, ICopilotApiServiceRequestOptions, ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
 import type Anthropic from '@anthropic-ai/sdk';
 import type { CCAModel } from '@vscode/copilot-api';
@@ -111,6 +114,7 @@ class TestOctoKitService implements IAgentHostOctoKitService {
 	readonly calls: string[] = [];
 	existing: CreatedPullRequest | undefined;
 	existingAfterCreateFailure: CreatedPullRequest | undefined;
+	findError: Error | undefined;
 	createError: Error | undefined;
 	findAfterCreateError: Error | undefined;
 	autoMergeError: Error | undefined;
@@ -135,6 +139,9 @@ class TestOctoKitService implements IAgentHostOctoKitService {
 			}
 			return this.existingAfterCreateFailure;
 		}
+		if (this.findError) {
+			throw this.findError;
+		}
 		return this.existing;
 	}
 	async enablePullRequestAutoMerge(pullRequestId: string, mergeMethod: AutoMergeMethod, _token: string, _signal: AbortSignal): Promise<void> {
@@ -142,6 +149,22 @@ class TestOctoKitService implements IAgentHostOctoKitService {
 		if (this.autoMergeError) {
 			throw this.autoMergeError;
 		}
+	}
+}
+
+class TestGitStateService implements IAgentHostGitStateService {
+	declare readonly _serviceBrand: undefined;
+	readonly onDidRefreshSessionGitState = Event.None;
+	readonly rejectedTokens: Array<{ sessionKey: string; resource: string; token: string }> = [];
+
+	async refreshSessionGitState(): Promise<void> { }
+	async setSessionGitHubState(): Promise<void> { }
+	async attachSessionGitHubPullRequest(): Promise<void> { }
+	async handleAuthenticationTokenUpdated(): Promise<void> { }
+	isAuthenticationTokenRejected(): boolean { return false; }
+	rejectAuthenticationToken(sessionKey: string, resource: string, token: string): boolean {
+		this.rejectedTokens.push({ sessionKey, resource, token });
+		return true;
 	}
 }
 
@@ -159,7 +182,7 @@ function createAgentService(withCopilotToken = false): IAgentService {
 	} as IAgentService;
 }
 
-function setup(disposables: Pick<DisposableStore, 'add'>, gitService: TestGitService, octoKitService: TestOctoKitService, options?: { copilotApiService?: TestCopilotApiService; withCopilotToken?: boolean; turns?: Turn[]; draft?: boolean; autoMergeMethod?: AutoMergeMethod }): { handler: AgentHostPullRequestOperationHandler; session: URI; createdEvents: string[]; copilotApiService: TestCopilotApiService } {
+function setup(disposables: Pick<DisposableStore, 'add'>, gitService: TestGitService, octoKitService: TestOctoKitService, options?: { copilotApiService?: TestCopilotApiService; withCopilotToken?: boolean; turns?: Turn[]; draft?: boolean; autoMergeMethod?: AutoMergeMethod }): { handler: AgentHostPullRequestOperationHandler; session: URI; createdEvents: string[]; copilotApiService: TestCopilotApiService; gitStateService: TestGitStateService } {
 	const stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
 	const session = URI.parse('agent:/session');
 	const createdEvents: string[] = [];
@@ -185,6 +208,7 @@ function setup(disposables: Pick<DisposableStore, 'add'>, gitService: TestGitSer
 	});
 	stateManager.setSessionMeta(session.toString(), sessionMeta);
 	const copilotApiService = options?.copilotApiService ?? new TestCopilotApiService();
+	const gitStateService = new TestGitStateService();
 	return {
 		handler: new AgentHostPullRequestOperationHandler(
 			options?.draft ?? false,
@@ -197,10 +221,11 @@ function setup(disposables: Pick<DisposableStore, 'add'>, gitService: TestGitSer
 				return state;
 			},
 			event => createdEvents.push(`${event.sessionKey}:${event.pullRequestUrl}`),
-			createAgentService(options?.withCopilotToken), gitService, octoKitService, createTestGitHubEndpointService(), copilotApiService, new NullLogService()),
+			createAgentService(options?.withCopilotToken), gitService, gitStateService, octoKitService, createTestGitHubEndpointService(), copilotApiService, new NullLogService()),
 		session,
 		createdEvents,
 		copilotApiService,
+		gitStateService,
 	};
 }
 
@@ -262,6 +287,29 @@ suite('AgentHostPullRequestOperationHandler', () => {
 			followUp: { content: { uri: 'https://github.com/microsoft/vscode/pull/7', contentType: 'text/html' }, external: true },
 			createdEvents: ['agent:/session:https://github.com/microsoft/vscode/pull/7'],
 		});
+	});
+
+	test('maps a rejected repository token to auth-required recovery', async () => {
+		const gitService = new TestGitService();
+		const octoKitService = new TestOctoKitService();
+		octoKitService.findError = new AgentHostGitHubApiError('Bad credentials', 401, undefined);
+		const { handler, session, gitStateService } = setup(disposables, gitService, octoKitService);
+
+		await assert.rejects(
+			() => handler.invoke({ channel: buildSessionChangesetUri(session.toString()), operationId: AgentHostPullRequestOperationHandler.OPERATION_CREATE_PR }, CancellationToken.None),
+			error => {
+				if (!(error instanceof ProtocolError) || error.code !== AHP_AUTH_REQUIRED || typeof error.data !== 'object' || error.data === null) {
+					return false;
+				}
+				return Array.isArray(Object.getOwnPropertyDescriptor(error.data, 'resources')?.value);
+			},
+		);
+
+		assert.deepStrictEqual(gitStateService.rejectedTokens, [{
+			sessionKey: session.toString(),
+			resource: GITHUB_REPO_PROTECTED_RESOURCE.resource,
+			token: 'gh-token',
+		}]);
 	});
 
 	// A visible PR button can race with refreshed git state. If the backend

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationProvider.test.ts
@@ -21,6 +21,9 @@ const nullGitStateService = new class implements IAgentHostGitStateService {
 	async getSessionGitHubState(): Promise<ISessionGitHubState | undefined> { return undefined; }
 	async setSessionGitHubState(): Promise<void> { }
 	async attachSessionGitHubPullRequest(): Promise<void> { }
+	async handleAuthenticationTokenUpdated(_resource: string): Promise<void> { }
+	isAuthenticationTokenRejected(): boolean { return false; }
+	rejectAuthenticationToken(): boolean { return false; }
 };
 
 const githubBranchWithUncommittedChanges: ISessionGitState = {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -22,7 +22,7 @@ import { hasKey } from '../../../../base/common/types.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { FileService } from '../../../files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
-import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, IConnectionTrackerService, IRestoredSubagentSession, SubagentChatSignal, type IAgent, type IAgentChatDataChange, type IAgentChats, type IAgentCreateChatForkSource, type IAgentCreateChatOptions, type IAgentCreateChatResult, type IAgentCreateSessionConfig, type IAgentCreateSessionResult, type IAgentLegacyChat, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
+import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, IConnectionTrackerService, IRestoredSubagentSession, SubagentChatSignal, type IAgent, type IAgentChatDataChange, type IAgentChats, type IAgentCreateChatForkSource, type IAgentCreateChatOptions, type IAgentCreateChatResult, type IAgentCreateSessionConfig, type IAgentCreateSessionResult, type IAgentLegacyChat, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
@@ -2228,6 +2228,49 @@ suite('AgentService (node dispatcher)', () => {
 				readToken: 'read-token',
 				profileToken: 'profile-token',
 				supersetToken: 'profile-token',
+			});
+		});
+
+		test('serializes authentication so an older request cannot overwrite a newer token', async () => {
+			const oldAuthenticationStarted = new DeferredPromise<void>();
+			const releaseOldAuthentication = new DeferredPromise<void>();
+			copilotAgent.getProtectedResources = () => [GITHUB_REPO_PROTECTED_RESOURCE];
+			copilotAgent.authenticate = async (resource, token) => {
+				copilotAgent.authenticateCalls.push({ resource, token });
+				if (token === 'old-token') {
+					oldAuthenticationStarted.complete();
+					await releaseOldAuthentication.p;
+				}
+				return true;
+			};
+			service.registerProvider(copilotAgent);
+
+			const oldAuthentication = service.authenticate({
+				resource: GITHUB_REPO_PROTECTED_RESOURCE.resource,
+				scopes: GITHUB_REPO_PROTECTED_RESOURCE.scopes_supported,
+				token: 'old-token',
+			});
+			await oldAuthenticationStarted.p;
+			const newAuthentication = service.authenticate({
+				resource: GITHUB_REPO_PROTECTED_RESOURCE.resource,
+				scopes: GITHUB_REPO_PROTECTED_RESOURCE.scopes_supported,
+				token: 'new-token',
+			});
+			releaseOldAuthentication.complete();
+			await Promise.all([oldAuthentication, newAuthentication]);
+
+			assert.deepStrictEqual({
+				token: service.getAuthToken({
+					resource: GITHUB_REPO_PROTECTED_RESOURCE.resource,
+					scopes: GITHUB_REPO_PROTECTED_RESOURCE.scopes_supported,
+				}),
+				calls: copilotAgent.authenticateCalls,
+			}, {
+				token: 'new-token',
+				calls: [
+					{ resource: GITHUB_REPO_PROTECTED_RESOURCE.resource, token: 'old-token' },
+					{ resource: GITHUB_REPO_PROTECTED_RESOURCE.resource, token: 'new-token' },
+				],
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../log/common/log.js';
-import { AgentHostOctoKitService, type FetchFunction } from '../../../node/shared/agentHostOctoKitService.js';
+import { AgentHostGitHubApiError, AgentHostOctoKitService, type FetchFunction } from '../../../node/shared/agentHostOctoKitService.js';
 import { createTestGitHubEndpointService } from '../testGitHubEndpointService.js';
 
 type Captured = { url: string; init: RequestInit | undefined };
@@ -104,6 +104,59 @@ suite('AgentHostOctoKitService', () => {
 			result: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: 'PR_node_9' },
 			url: 'https://api.github.com/repos/o/r/pulls?head=o%3Afeature%2Ftest&state=all&sort=updated&direction=desc&per_page=1',
 			method: 'GET',
+		});
+	});
+
+	test('findPullRequestByHeadBranch exposes status and retry-after on failure', async () => {
+		const service = makeService(capturingFetch(new Response('{"message":"Bad credentials"}', {
+			status: 401,
+			statusText: 'Unauthorized',
+			headers: { 'Retry-After': '7' },
+		})).fetch);
+
+		await assert.rejects(
+			() => service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal()),
+			error => {
+				assert.deepStrictEqual(error instanceof AgentHostGitHubApiError ? {
+					statusCode: error.statusCode,
+					retryAfterMs: error.retryAfterMs,
+					message: error.message,
+				} : undefined, {
+					statusCode: 401,
+					retryAfterMs: 7_000,
+					message: 'GitHub API request failed: GET repos/o/r/pulls?head=o%3Afeature&state=all&sort=updated&direction=desc&per_page=1 - 401 Unauthorized - {"message":"Bad credentials"}',
+				});
+				return true;
+			},
+		);
+	});
+
+	test('findPullRequestByHeadBranch returns the cached pull request on 304', async () => {
+		const responses = [
+			new Response(JSON.stringify([{ html_url: 'https://github.com/o/r/pull/9', number: 9 }]), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json', ETag: '"pr-9"' },
+			}),
+			new Response(undefined, { status: 304 }),
+		];
+		const requestHeaders: Array<Record<string, string>> = [];
+		const fetch: FetchFunction = async (_input, init) => {
+			requestHeaders.push(init?.headers as Record<string, string>);
+			return responses.shift()!;
+		};
+		const service = makeService(fetch);
+
+		const first = await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
+		const second = await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
+
+		assert.deepStrictEqual({
+			first,
+			second,
+			ifNoneMatch: requestHeaders[1]?.['If-None-Match'],
+		}, {
+			first: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: undefined },
+			second: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: undefined },
+			ifNoneMatch: '"pr-9"',
 		});
 	});
 

--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -30,6 +30,7 @@ Registered by `LocalAgentHostContribution` in `browser/localAgentHost.contributi
 - The enablement bit is read once through the sessions-layer `AgentHostEnablementService`; the contribution does not subscribe to config changes.
 - Creates `LocalAgentHostSessionsProvider` via `IInstantiationService` and registers it through `ISessionsProvidersService.registerProvider`.
 - Registers a per-session-type **working-directory resolver** (`IAgentHostSessionWorkingDirectoryResolver`) for each `agent-host-${sessionType.id}` scheme, refreshed on `onDidChangeSessionTypes`.
+- Handles root `auth/required` notifications in either the editor or Agents window; the focused window owns interactive recovery to avoid duplicate sign-in flows. An expired token is replaced once for the same account and scopes, forwarding is retried at most three times with exponential backoff, and repeated rejection surfaces one notification.
 - The same module also wires the heavy lifting from the workbench chat layer at `WorkbenchPhase.AfterRestored`:
   - `AgentHostContribution` — agent discovery, session-handler registration, language-model providers, customization harness (via `IChatSessionsService`).
   - `AgentHostTerminalContribution` — terminal integration for agent host sessions.

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
@@ -9,15 +9,19 @@ import { constObservable, derived, derivedObservableWithCache, derivedOpts, IObs
 import { basename, isEqual } from '../../../../../base/common/resources.js';
 import { format } from '../../../../../base/common/strings.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
-import { isDefined } from '../../../../../base/common/types.js';
+import { isDefined, isObject } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
-import { ChangesetOperationTargetKind } from '../../../../../platform/agentHost/common/state/protocol/channels-changeset/commands.js';
-import { ChangesetOperation, ChangesetOperationScope, type ChangesetFile, ChangesetOperationStatus } from '../../../../../platform/agentHost/common/state/protocol/state.js';
-import { ActionType } from '../../../../../platform/agentHost/common/state/sessionActions.js';
+import { ChangesetOperationTargetKind, type InvokeChangesetOperationParams } from '../../../../../platform/agentHost/common/state/protocol/channels-changeset/commands.js';
+import { ChangesetOperation, ChangesetOperationScope, type ChangesetFile, ChangesetOperationStatus, type ProtectedResourceMetadata } from '../../../../../platform/agentHost/common/state/protocol/state.js';
+import { ActionType, AuthRequiredReason } from '../../../../../platform/agentHost/common/state/sessionActions.js';
+import { AHP_AUTH_REQUIRED, AHP_AUTH_REQUIRED_ERROR_NAME, ProtocolError } from '../../../../../platform/agentHost/common/state/sessionProtocol.js';
 import { buildDefaultChatUri, ChangesetStatus, Changeset, StateComponents, type ChangesetState, type ChatState, type ChatSummary, type SessionState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { ISessionChangeset, ISessionChangesetCapabilities, ISessionChangesetOperation, ISessionChangesetOperationTarget, ISessionFileChange, SessionChangesetOperationScope, SessionChangesetOperationStatus, sessionFileChangesEqual } from '../../../../services/sessions/common/session.js';
+import { IAgentHostAuthenticationRecoveryService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.js';
+import type { IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
+
 import { changesetFileToChange } from './agentHostDiffs.js';
 import { IAgentHostAdapterOptions } from './baseAgentHostSessionsProvider.js';
 
@@ -160,6 +164,53 @@ function toSessionChangesetOperation(operation: ChangesetOperation): ISessionCha
 	};
 }
 
+function getAuthRequiredResources(error: unknown, connection: IAgentConnection): readonly ProtectedResourceMetadata[] | undefined {
+	if (error instanceof ProtocolError && error.code === AHP_AUTH_REQUIRED) {
+		const resources = Array.isArray(error.data)
+			? error.data
+			: isObject(error.data)
+				? Object.getOwnPropertyDescriptor(error.data, 'resources')?.value
+				: undefined;
+		return Array.isArray(resources) && resources.every(isProtectedResourceMetadata) ? resources : undefined;
+	}
+	if (!(error instanceof Error) || error.name !== AHP_AUTH_REQUIRED_ERROR_NAME) {
+		return undefined;
+	}
+	const rootState = connection.rootState.value;
+	if (!rootState || rootState instanceof Error) {
+		return undefined;
+	}
+	const resources = new Map<string, ProtectedResourceMetadata>();
+	for (const agent of rootState.agents) {
+		for (const resource of agent.protectedResources ?? []) {
+			if (resource.scopes_supported?.includes('repo')) {
+				resources.set(resource.resource, resource);
+			}
+		}
+	}
+	return [...resources.values()];
+}
+
+function isProtectedResourceMetadata(value: unknown): value is ProtectedResourceMetadata {
+	return isObject(value) && typeof Object.getOwnPropertyDescriptor(value, 'resource')?.value === 'string';
+}
+
+export async function invokeChangesetOperationWithAuthenticationRecovery(
+	connection: IAgentConnection,
+	params: InvokeChangesetOperationParams,
+	authenticationRecoveryService: IAgentHostAuthenticationRecoveryService,
+): Promise<void> {
+	try {
+		await connection.invokeChangesetOperation(params);
+	} catch (error) {
+		const resources = getAuthRequiredResources(error, connection);
+		if (!resources || !await authenticationRecoveryService.recover(connection, resources, AuthRequiredReason.Expired)) {
+			throw error;
+		}
+		await connection.invokeChangesetOperation(params);
+	}
+}
+
 abstract class AbstractAgentHostChangeset implements ISessionChangeset {
 	abstract readonly id: string;
 	abstract readonly label: string;
@@ -185,6 +236,7 @@ abstract class AbstractAgentHostChangeset implements ISessionChangeset {
 		changeset: Changeset,
 		private readonly _options: IAgentHostAdapterOptions,
 		private readonly _dialogService: IDialogService,
+		private readonly _authenticationRecoveryService: IAgentHostAuthenticationRecoveryService,
 	) {
 		this.capabilities = {
 			review: changeset.capabilities?.review !== undefined
@@ -297,7 +349,7 @@ abstract class AbstractAgentHostChangeset implements ISessionChangeset {
 			}
 		}
 
-		await connection.invokeChangesetOperation({
+		const params: InvokeChangesetOperationParams = {
 			operationId,
 			channel: channel.toString(),
 			target: target?.kind === 'resource'
@@ -306,7 +358,8 @@ abstract class AbstractAgentHostChangeset implements ISessionChangeset {
 					resource: target.resource.toString()
 				}
 				: undefined,
-		});
+		};
+		await invokeChangesetOperationWithAuthenticationRecovery(connection, params, this._authenticationRecoveryService);
 	}
 
 	setReviewState(resources: readonly URI[], reviewed: boolean): void {
@@ -363,8 +416,9 @@ class AgentHostChangeset extends AbstractAgentHostChangeset {
 		isActiveSessionObs: IObservable<boolean>,
 		changesetSummary: Changeset & { isDefault: boolean },
 		@IDialogService dialogService: IDialogService,
+		@IAgentHostAuthenticationRecoveryService authenticationRecoveryService: IAgentHostAuthenticationRecoveryService,
 	) {
-		super(changesetSummary, options, dialogService);
+		super(changesetSummary, options, dialogService, authenticationRecoveryService);
 
 		this.channelUriObs = constObservable(URI.parse(changesetSummary.uriTemplate));
 
@@ -400,8 +454,9 @@ class AgentHostLastTurnChangeset extends AbstractAgentHostChangeset {
 		isActiveSessionObs: IObservable<boolean>,
 		changesetSummary: Changeset & { isDefault: boolean },
 		@IDialogService dialogService: IDialogService,
+		@IAgentHostAuthenticationRecoveryService authenticationRecoveryService: IAgentHostAuthenticationRecoveryService,
 	) {
-		super(changesetSummary, options, dialogService);
+		super(changesetSummary, options, dialogService, authenticationRecoveryService);
 
 		this.id = changesetSummary.changeKind;
 

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSessionChangesets.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSessionChangesets.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../../base/common/event.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { GITHUB_REPO_PROTECTED_RESOURCE, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AHP_AUTH_REQUIRED_ERROR_NAME } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
+import type { InvokeChangesetOperationParams } from '../../../../../../platform/agentHost/common/state/protocol/channels-changeset/commands.js';
+import { AuthRequiredReason } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
+import type { IAgentHostAuthenticationRecoveryService } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.js';
+import { invokeChangesetOperationWithAuthenticationRecovery } from '../../browser/agentHostSessionChangesets.js';
+
+suite('AgentHostSessionChangesets', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('recovers authentication and retries a create pull request operation once', async () => {
+		const params: InvokeChangesetOperationParams = {
+			channel: 'agent:///session/changeset/session',
+			operationId: 'create-pr',
+		};
+		const connection = new class extends mock<IAgentConnection>() {
+			calls = 0;
+			private readonly _rootState = {
+				agents: [{
+					provider: 'copilot',
+					displayName: 'Copilot',
+					description: '',
+					models: [],
+					protectedResources: [GITHUB_REPO_PROTECTED_RESOURCE],
+				}]
+			};
+			override readonly rootState = {
+				value: this._rootState,
+				verifiedValue: this._rootState,
+				onDidChange: Event.None,
+				onWillApplyAction: Event.None,
+				onDidApplyAction: Event.None,
+			};
+			override async invokeChangesetOperation(): Promise<{}> {
+				this.calls++;
+				if (this.calls === 1) {
+					const error = new Error('Authentication required');
+					error.name = AHP_AUTH_REQUIRED_ERROR_NAME;
+					throw error;
+				}
+				return {};
+			}
+		}();
+		const recoveryCalls: Array<{ resources: readonly string[]; reason: AuthRequiredReason }> = [];
+		const recoveryService: IAgentHostAuthenticationRecoveryService = {
+			_serviceBrand: undefined,
+			register: () => ({ dispose() { } }),
+			recover: async (_connection, resources, reason) => {
+				recoveryCalls.push({ resources: resources.map(resource => resource.resource), reason });
+				return true;
+			},
+		};
+
+		await invokeChangesetOperationWithAuthenticationRecovery(connection, params, recoveryService);
+
+		assert.deepStrictEqual({
+			operationCalls: connection.calls,
+			recoveryCalls,
+		}, {
+			operationCalls: 2,
+			recoveryCalls: [{
+				resources: [GITHUB_REPO_PROTECTED_RESOURCE.resource],
+				reason: AuthRequiredReason.Expired,
+			}],
+		});
+	});
+});

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
@@ -75,7 +75,7 @@ Decoupling these allows copilot sessions from different providers (local CLI, re
 - `clearConnection()` — Clears the connection when the host disconnects
 - Handles session notifications (`notify/sessionAdded`, `notify/sessionRemoved`) and state changes
 - Fires `onDidChangeSessionTypes` when the host's agent list changes
-- Missing Copilot credentials open the standard product sign-in dialog before tokens are forwarded to the remote host. Authentication and transport failures propagate to the pending request; `false` is reserved for canceled or unavailable authentication.
+- Missing Copilot credentials open the standard product sign-in dialog before tokens are forwarded to the remote host. Root `auth/required` notifications replace an expired token once the owning window is focused; forwarding is retried at most three times with exponential backoff, while repeated rejection reports one error instead of reopening the sign-in flow.
 - Remote-host management options do not expose an IPC output channel; remote diagnostics use the host's forwarded logs when available.
 - SSH connection progress notifications are closed when the connect promise settles; keyboard-interactive prompt cancellation rejects the connect promise as cancellation and does not show an error notification.
 - SSH config host connections use resolved `IdentityFile` and `IdentityAgent` values from `ssh -G`; encrypted private keys are prompted for a passphrase through the same quick-input bridge as keyboard-interactive auth.

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -15,6 +15,7 @@ import { type AgentProvider, type IAgentConnection } from '../../../../../platfo
 import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, type IRemoteAgentHostSSHConnection, RemoteAgentHostAutoConnectSettingId, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, getEntryAddress } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TunnelAgentHostsSettingId } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { PROTOCOL_VERSION } from '../../../../../platform/agentHost/common/state/protocol/version/registry.js';
+import { AuthRequiredReason, NotificationType } from '../../../../../platform/agentHost/common/state/sessionActions.js';
 import { AgentHostLocalFilePermissionsSettingId } from '../../../../../platform/agentHost/common/agentHostResourceService.js';
 import { type ProtectedResourceMetadata } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { type AgentInfo, type RootState } from '../../../../../platform/agentHost/common/state/sessionState.js';
@@ -28,7 +29,7 @@ import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
 import { registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { OpenSessionEventsFileAction } from '../../agentHost/browser/openSessionEventsFileActions.js';
-import { authenticateProtectedResources, AgentHostAuthTokenCache, resolveAuthenticationInteractively } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.js';
+import { authenticateProtectedResources, AgentHostAuthenticationRecovery, AgentHostAuthTokenCache, findProtectedResource, IAgentHostAuthenticationRecoveryService, resolveAuthenticationInteractively } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.js';
 import { AgentHostLanguageModelProvider, agentHostProviderSupportsAutoModel } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.js';
 import { AgentHostSessionHandler } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.js';
 import { IAgentHostActiveClientService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
@@ -223,12 +224,40 @@ class ConnectionState extends Disposable {
 	readonly modelProviders = new Map<AgentProvider, AgentHostLanguageModelProvider>();
 	/** Dedupes redundant `authenticate` RPCs when the resolved token hasn't changed. */
 	readonly authTokenCache = new AgentHostAuthTokenCache();
+	readonly authenticationRecovery: AgentHostAuthenticationRecovery;
+	private readonly _pendingAuthenticationRequests = new Map<string, AuthRequiredReason>();
 
 	constructor(
 		readonly name: string | undefined,
 		readonly connection: IAgentConnection,
+		recoveryKey: string,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IAgentHostAuthenticationRecoveryService authenticationRecoveryService: IAgentHostAuthenticationRecoveryService,
 	) {
 		super();
+		this.authenticationRecovery = this._register(instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			authTokenCache: this.authTokenCache,
+			logPrefix: '[RemoteAgentHost]',
+			recoveryKey,
+			authenticate: request => this.connection.authenticate(request),
+		}));
+		this._register(authenticationRecoveryService.register(this.connection, this.authenticationRecovery));
+	}
+
+	handleRootState(rootState: RootState): void {
+		for (const [resource, reason] of this._pendingAuthenticationRequests) {
+			this.handleAuthenticationRequired(resource, reason, rootState);
+		}
+	}
+
+	handleAuthenticationRequired(resource: string, reason: AuthRequiredReason, rootState: RootState | undefined): void {
+		const protectedResource = rootState ? findProtectedResource(rootState.agents, resource) : undefined;
+		if (!protectedResource) {
+			this._pendingAuthenticationRequests.set(resource, reason);
+			return;
+		}
+		this._pendingAuthenticationRequests.delete(resource);
+		void this.authenticationRecovery.recover(protectedResource, reason);
 	}
 }
 
@@ -743,7 +772,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		}
 
 		const { address, name } = connectionInfo;
-		const connState = this._instantiationService.createInstance(ConnectionState, name, connection);
+		const connState = this._instantiationService.createInstance(ConnectionState, name, connection, address);
 		this._connections.set(address, connState);
 		const store = connState.store;
 
@@ -767,12 +796,25 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 
 		// React to root state changes (agent discovery)
 		store.add(connection.rootState.onDidChange(rootState => {
+			connState.handleRootState(rootState);
 			this._handleRootStateChange(address, connection, rootState);
+		}));
+		store.add(connection.onDidNotification(notification => {
+			if (notification.type !== NotificationType.AuthRequired) {
+				return;
+			}
+			const rootState = connection.rootState.value;
+			connState.handleAuthenticationRequired(
+				notification.resource,
+				notification.reason ?? AuthRequiredReason.Required,
+				rootState && !(rootState instanceof Error) ? rootState : undefined,
+			);
 		}));
 
 		// If root state is already available, process it immediately
 		const initialRootState = connection.rootState.value;
 		if (initialRootState && !(initialRootState instanceof Error)) {
+			connState.handleRootState(initialRootState);
 			this._handleRootStateChange(address, connection, initialRootState);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
@@ -4,23 +4,37 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { fetchAuthorizationServerMetadata } from '../../../../../../base/common/oauth.js';
-import { SequencerByKey } from '../../../../../../base/common/async.js';
-import { CancellationError } from '../../../../../../base/common/errors.js';
+import { SequencerByKey, timeout } from '../../../../../../base/common/async.js';
+import { CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
+import { CancellationError, isCancellationError } from '../../../../../../base/common/errors.js';
+import { Disposable, toDisposable, type IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { type McpOAuthClient, type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { AuthRequiredReason } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
+import { AHP_AUTH_REQUIRED, ProtocolError } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
+import { type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { type AgentInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
-import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { createDecorator, ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { localize } from '../../../../../../nls.js';
 import { IAuthenticationMcpAccessService } from '../../../../../services/authentication/browser/authenticationMcpAccessService.js';
 import { IAuthenticationMcpService } from '../../../../../services/authentication/browser/authenticationMcpService.js';
 import { IAuthenticationMcpUsageService } from '../../../../../services/authentication/browser/authenticationMcpUsageService.js';
 import { AuthenticationSession, getDynamicAuthenticationProviderId, IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
 import { IDynamicAuthenticationProviderStorageService } from '../../../../../services/authentication/common/dynamicAuthenticationProviderStorage.js';
+import { IHostService } from '../../../../../services/host/browser/host.js';
 import { CHAT_SETUP_ACTION_ID } from '../../actions/chatActions.js';
 import { IChatSetupResult } from '../../chatSetup/chatSetup.js';
+
+const AUTHENTICATION_RECOVERY_MAX_ATTEMPTS = 3;
+const AUTHENTICATION_RECOVERY_RETRY_BASE_DELAY_MS = 500;
+const AUTHENTICATION_RECOVERY_RETRY_MAX_DELAY_MS = 5_000;
+const AUTHENTICATION_REPROMPT_COOLDOWN_MS = 5 * 60_000;
 
 /**
  * Stable identity for an agent-host MCP server, used as the key for
@@ -125,12 +139,17 @@ export class AgentHostAuthTokenCache {
 					this._pendingAuthentications.delete(key);
 				}
 			}
+
 		} else {
 			this._globalGeneration++;
 			this._completedTokens.clear();
 			this._pendingAuthentications.clear();
 			this._keyGenerations.clear();
 		}
+	}
+
+	get(resource: string, scopes: readonly string[] | undefined): string | undefined {
+		return this._completedTokens.get(this._key(resource, scopes));
 	}
 
 	private _invalidateKey(key: string): void {
@@ -144,6 +163,365 @@ export class AgentHostAuthTokenCache {
 	private _key(resource: string, scopes: readonly string[] | undefined): string {
 		return `${resource}\x00${scopes ? [...new Set(scopes)].sort().join('\x00') : ''}`;
 	}
+}
+
+export function findProtectedResource(agents: readonly AgentInfo[], resource: string): ProtectedResourceMetadata | undefined {
+	for (const agent of agents) {
+		const protectedResource = agent.protectedResources?.find(candidate => candidate.resource === resource);
+		if (protectedResource) {
+			return protectedResource;
+		}
+	}
+	return undefined;
+}
+
+export interface IAgentHostAuthenticationRecoveryOptions extends IAgentHostAuthenticationOptions {
+	readonly now?: () => number;
+	readonly recoveryKey: string;
+	readonly retryDelay?: (attempt: number) => number;
+}
+
+interface IPendingInteractiveRecovery {
+	readonly protectedResource: ProtectedResourceMetadata;
+	readonly reason: AuthRequiredReason;
+	readonly currentToken: string | undefined;
+	readonly forwardedToken: string | undefined;
+	readonly reportOnFocus: boolean;
+}
+
+export class AgentHostAuthenticationRecovery extends Disposable {
+	private readonly _sequencer = new SequencerByKey<string>();
+	private readonly _inFlightRecoveries = new Map<string, Promise<boolean>>();
+	private readonly _recentSuccessfulRecoveries = new Map<string, { readonly token: string; readonly completedAt: number }>();
+	private readonly _pendingInteractiveRecoveries = new Map<string, IPendingInteractiveRecovery>();
+	private readonly _reportedFailures = new Set<string>();
+	private readonly _cancellationTokenSource = new CancellationTokenSource();
+	private readonly _now: () => number;
+
+	constructor(
+		private readonly _options: IAgentHostAuthenticationRecoveryOptions,
+		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
+		@INotificationService private readonly _notificationService: INotificationService,
+		@ILogService private readonly _logService: ILogService,
+		@IHostService private readonly _hostService: IHostService,
+		@IStorageService private readonly _storageService: IStorageService,
+	) {
+		super();
+		this._now = _options.now ?? Date.now;
+		this._register(toDisposable(() => this._cancellationTokenSource.dispose(true)));
+		this._register(this._hostService.onDidChangeFocus(focused => {
+			if (focused) {
+				this._resumePendingInteractiveRecoveries();
+			}
+		}));
+	}
+
+	reset(): void {
+		this._pendingInteractiveRecoveries.clear();
+		this._recentSuccessfulRecoveries.clear();
+		this._reportedFailures.clear();
+	}
+
+	recover(protectedResource: ProtectedResourceMetadata, reason = AuthRequiredReason.Required, acceptRecentSuccess = false): Promise<boolean> {
+		if (this._cancellationTokenSource.token.isCancellationRequested) {
+			return Promise.resolve(false);
+		}
+		const inFlight = this._inFlightRecoveries.get(protectedResource.resource);
+		if (inFlight) {
+			return inFlight;
+		}
+		if (acceptRecentSuccess && this._hasRecentSuccessfulRecovery(protectedResource)) {
+			return Promise.resolve(true);
+		}
+		const recovery = this._sequencer.queue(protectedResource.resource, () => this._recover(protectedResource, reason))
+			.finally(() => {
+				if (this._inFlightRecoveries.get(protectedResource.resource) === recovery) {
+					this._inFlightRecoveries.delete(protectedResource.resource);
+				}
+			});
+		this._inFlightRecoveries.set(protectedResource.resource, recovery);
+		return recovery;
+	}
+
+	private async _recover(protectedResource: ProtectedResourceMetadata, reason: AuthRequiredReason, deferredRecovery?: IPendingInteractiveRecovery): Promise<boolean> {
+		let currentToken: string | undefined;
+		let forwardedToken: string | undefined;
+		try {
+			if (this._cancellationTokenSource.token.isCancellationRequested) {
+				return false;
+			}
+			const scopes = protectedResource.scopes_supported ?? [];
+			currentToken = await resolveTokenForResource(
+				URI.parse(protectedResource.resource),
+				protectedResource.authorization_servers ?? [],
+				scopes,
+				this._authenticationService,
+				this._logService,
+				this._options.logPrefix,
+			);
+			forwardedToken = this._options.authTokenCache?.get(protectedResource.resource, scopes);
+			if (deferredRecovery) {
+				if (forwardedToken && forwardedToken !== deferredRecovery.forwardedToken) {
+					this._recordSuccessfulRecovery(protectedResource.resource, forwardedToken);
+					return true;
+				}
+				if (currentToken && currentToken !== deferredRecovery.currentToken) {
+					this._options.authTokenCache?.clear(protectedResource.resource, scopes);
+					await this._forwardWithRetry(protectedResource, currentToken);
+					this._recordSuccessfulRecovery(protectedResource.resource, currentToken);
+					return true;
+				}
+			}
+			if (reason !== AuthRequiredReason.Expired) {
+				this._options.authTokenCache?.clear(protectedResource.resource, scopes);
+				if (currentToken) {
+					await this._forwardWithRetry(protectedResource, currentToken);
+					this._recordSuccessfulRecovery(protectedResource.resource, currentToken);
+					return true;
+				}
+			} else {
+				if (forwardedToken && currentToken && forwardedToken !== currentToken) {
+					this._options.authTokenCache?.clear(protectedResource.resource, scopes);
+					await this._forwardWithRetry(protectedResource, currentToken);
+					this._recordSuccessfulRecovery(protectedResource.resource, currentToken);
+					return true;
+				}
+			}
+
+			if (this._wasRecentlyPrompted(protectedResource.resource)) {
+				if (deferredRecovery && !deferredRecovery.reportOnFocus) {
+					return false;
+				}
+				if (this._hostService.hasFocus) {
+					this._reportFailure(protectedResource);
+				} else {
+					this._deferInteractiveRecovery(protectedResource, reason, currentToken, forwardedToken, true);
+				}
+				return false;
+			}
+			if (!this._hostService.hasFocus) {
+				this._deferInteractiveRecovery(protectedResource, reason, currentToken, forwardedToken);
+				return false;
+			}
+			this._pendingInteractiveRecoveries.delete(protectedResource.resource);
+			if (reason === AuthRequiredReason.Expired) {
+				this._options.authTokenCache?.clear(protectedResource.resource, scopes);
+			}
+			const session = await createFreshAuthenticationSessionForResource(
+				protectedResource,
+				this._authenticationService,
+				this._logService,
+				this._options.logPrefix,
+				() => {
+					if (!this._hostService.hasFocus || this._cancellationTokenSource.token.isCancellationRequested) {
+						return false;
+					}
+					this._markPrompted(protectedResource.resource);
+					return true;
+				},
+			);
+			if (!session) {
+				this._reportFailure(protectedResource);
+				return false;
+			}
+			if (this._cancellationTokenSource.token.isCancellationRequested) {
+				return false;
+			}
+			await this._forwardWithRetry(protectedResource, session.accessToken);
+			this._recordSuccessfulRecovery(protectedResource.resource, session.accessToken);
+			return true;
+		} catch (error) {
+			if (isCancellationError(error) || this._cancellationTokenSource.token.isCancellationRequested) {
+				return false;
+			}
+			if (error instanceof AuthenticationInteractionDeferredError) {
+				this._deferInteractiveRecovery(protectedResource, reason, currentToken, forwardedToken);
+				return false;
+			}
+			this._logService.warn(`${this._options.logPrefix} Failed to refresh authentication for ${protectedResource.resource}`, error);
+			this._reportFailure(protectedResource);
+			return false;
+		}
+	}
+
+	private _resumePendingInteractiveRecoveries(): void {
+		const pending = [...this._pendingInteractiveRecoveries.values()];
+		this._pendingInteractiveRecoveries.clear();
+		for (const recovery of pending) {
+			if (this._inFlightRecoveries.has(recovery.protectedResource.resource)) {
+				continue;
+			}
+			const inFlight = this._sequencer.queue(
+				recovery.protectedResource.resource,
+				() => this._recover(recovery.protectedResource, recovery.reason, recovery),
+			).finally(() => {
+				if (this._inFlightRecoveries.get(recovery.protectedResource.resource) === inFlight) {
+					this._inFlightRecoveries.delete(recovery.protectedResource.resource);
+				}
+			});
+			this._inFlightRecoveries.set(recovery.protectedResource.resource, inFlight);
+			void inFlight;
+		}
+	}
+
+	private _deferInteractiveRecovery(protectedResource: ProtectedResourceMetadata, reason: AuthRequiredReason, currentToken: string | undefined, forwardedToken: string | undefined, reportOnFocus = false): void {
+		this._pendingInteractiveRecoveries.set(protectedResource.resource, {
+			protectedResource,
+			reason,
+			currentToken,
+			forwardedToken,
+			reportOnFocus,
+		});
+	}
+
+	private _recordSuccessfulRecovery(resource: string, token: string): void {
+		this._recentSuccessfulRecoveries.set(resource, { token, completedAt: this._now() });
+		this._reportedFailures.delete(resource);
+	}
+
+	private _hasRecentSuccessfulRecovery(resource: ProtectedResourceMetadata): boolean {
+		const successful = this._recentSuccessfulRecoveries.get(resource.resource);
+		return !!successful
+			&& this._now() - successful.completedAt <= AUTHENTICATION_REPROMPT_COOLDOWN_MS
+			&& this._options.authTokenCache?.get(resource.resource, resource.scopes_supported) === successful.token;
+	}
+
+	private async _forwardWithRetry(protectedResource: ProtectedResourceMetadata, token: string): Promise<void> {
+		const scopes = protectedResource.scopes_supported ?? [];
+		const authenticate = () => this._authenticateWithRetry({
+			resource: protectedResource.resource,
+			scopes,
+			token,
+		});
+		if (this._options.authTokenCache) {
+			await this._options.authTokenCache.authenticate(protectedResource.resource, scopes, token, authenticate);
+		} else {
+			await authenticate();
+		}
+	}
+
+	private async _authenticateWithRetry(request: IAgentHostAuthenticateRequest): Promise<void> {
+		for (let attempt = 0; attempt < AUTHENTICATION_RECOVERY_MAX_ATTEMPTS; attempt++) {
+			try {
+				const result = await this._options.authenticate(request);
+				if (isRejectedAuthenticationResult(result)) {
+					throw new AuthenticationRejectedError();
+				}
+				return;
+			} catch (error) {
+				if (error instanceof ProtocolError && error.code === AHP_AUTH_REQUIRED) {
+					throw new AuthenticationRejectedError();
+				}
+				const isLastAttempt = attempt + 1 === AUTHENTICATION_RECOVERY_MAX_ATTEMPTS;
+				if (isLastAttempt || error instanceof AuthenticationRejectedError) {
+					throw error;
+				}
+				const delay = this._options.retryDelay?.(attempt) ?? authenticationRecoveryRetryDelay(attempt);
+				this._logService.warn(`${this._options.logPrefix} Failed to forward refreshed authentication (attempt ${attempt + 1}), retrying in ${delay}ms`, error);
+				await timeout(delay, this._cancellationTokenSource.token);
+			}
+		}
+	}
+
+	private _wasRecentlyPrompted(resource: string): boolean {
+		try {
+			const promptedAt = Number(this._storageService.get(this._promptStorageKey(resource), StorageScope.APPLICATION_SHARED));
+			return Number.isFinite(promptedAt) && this._now() - promptedAt <= AUTHENTICATION_REPROMPT_COOLDOWN_MS;
+		} catch (error) {
+			this._logService.warn(`${this._options.logPrefix} Failed to read authentication recovery backoff`, error);
+			return false;
+		}
+	}
+
+	private _markPrompted(resource: string): void {
+		try {
+			this._storageService.store(
+				this._promptStorageKey(resource),
+				this._now(),
+				StorageScope.APPLICATION_SHARED,
+				StorageTarget.MACHINE,
+			);
+		} catch (error) {
+			this._logService.warn(`${this._options.logPrefix} Failed to store authentication recovery backoff`, error);
+		}
+	}
+
+	private _promptStorageKey(resource: string): string {
+		return `agentHost.authenticationRecoveryPrompt.${encodeURIComponent(this._options.recoveryKey)}.${encodeURIComponent(resource)}`;
+	}
+
+	private _reportFailure(protectedResource: ProtectedResourceMetadata): void {
+		if (this._reportedFailures.has(protectedResource.resource)) {
+			return;
+		}
+		this._reportedFailures.add(protectedResource.resource);
+		this._notificationService.error(localize(
+			'agentHost.authenticationRecoveryFailed',
+			"Agent Host authentication for {0} could not be refreshed. Sign in again to continue.",
+			protectedResource.resource_name ?? protectedResource.resource,
+		));
+	}
+}
+
+export const IAgentHostAuthenticationRecoveryService = createDecorator<IAgentHostAuthenticationRecoveryService>('agentHostAuthenticationRecoveryService');
+
+export interface IAgentHostAuthenticationRecoveryService {
+	readonly _serviceBrand: undefined;
+	register(connection: IAgentConnection, recovery: AgentHostAuthenticationRecovery): IDisposable;
+	recover(connection: IAgentConnection, resources: readonly ProtectedResourceMetadata[], reason: AuthRequiredReason): Promise<boolean>;
+}
+
+class AgentHostAuthenticationRecoveryService implements IAgentHostAuthenticationRecoveryService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _recoveries = new Map<IAgentConnection, AgentHostAuthenticationRecovery>();
+
+	register(connection: IAgentConnection, recovery: AgentHostAuthenticationRecovery): IDisposable {
+		this._recoveries.set(connection, recovery);
+		return toDisposable(() => {
+			if (this._recoveries.get(connection) === recovery) {
+				this._recoveries.delete(connection);
+			}
+		});
+	}
+
+	async recover(connection: IAgentConnection, resources: readonly ProtectedResourceMetadata[], reason: AuthRequiredReason): Promise<boolean> {
+		const recovery = this._recoveries.get(connection);
+		if (!recovery) {
+			return false;
+		}
+		for (const resource of resources) {
+			if (await recovery.recover(resource, reason, true)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+registerSingleton(IAgentHostAuthenticationRecoveryService, AgentHostAuthenticationRecoveryService, InstantiationType.Delayed);
+
+class AuthenticationRejectedError extends Error {
+	constructor() {
+		super('Agent Host rejected the refreshed authentication token');
+		this.name = 'AuthenticationRejectedError';
+	}
+}
+
+class AuthenticationInteractionDeferredError extends Error { }
+
+function isRejectedAuthenticationResult(result: unknown): boolean {
+	return typeof result === 'object'
+		&& result !== null
+		&& Object.getOwnPropertyDescriptor(result, 'authenticated')?.value === false;
+}
+
+function authenticationRecoveryRetryDelay(attempt: number): number {
+	const exponentialDelay = Math.min(
+		AUTHENTICATION_RECOVERY_RETRY_MAX_DELAY_MS,
+		AUTHENTICATION_RECOVERY_RETRY_BASE_DELAY_MS * 2 ** attempt,
+	);
+	return Math.round(exponentialDelay / 2 + Math.random() * exponentialDelay / 2);
 }
 
 /**
@@ -160,6 +538,24 @@ export async function resolveTokenForResource(
 	logService: ILogService,
 	logPrefix: string,
 ): Promise<string | undefined> {
+	return (await resolveSessionForResource(
+		resourceServer,
+		authorizationServers,
+		scopes,
+		authenticationService,
+		logService,
+		logPrefix,
+	))?.accessToken;
+}
+
+async function resolveSessionForResource(
+	resourceServer: URI,
+	authorizationServers: readonly string[],
+	scopes: readonly string[],
+	authenticationService: IAuthenticationService,
+	logService: ILogService,
+	logPrefix: string,
+): Promise<AuthenticationSession | undefined> {
 	for (const server of authorizationServers) {
 		const serverUri = URI.parse(server);
 		const providerId = await authenticationService.getOrActivateProviderIdForServer(serverUri, resourceServer);
@@ -172,13 +568,13 @@ export async function resolveTokenForResource(
 		// Try exact scope match first
 		const sessions = await authenticationService.getSessions(providerId, [...scopes], { authorizationServer: serverUri }, true);
 		if (sessions.length > 0) {
-			return sessions[0].accessToken;
+			return sessions[0];
 		}
 
 		// Fall back: get all sessions and find the narrowest superset of requested scopes
 		const allSessions = await authenticationService.getSessions(providerId, undefined, { authorizationServer: serverUri }, true);
 		const requestedSet = new Set(scopes);
-		let bestToken: string | undefined;
+		let bestSession: AuthenticationSession | undefined;
 		let bestExtraScopes = Infinity;
 		for (const session of allSessions) {
 			const sessionScopes = new Set(session.scopes);
@@ -193,13 +589,53 @@ export async function resolveTokenForResource(
 				const extraScopes = sessionScopes.size - requestedSet.size;
 				if (extraScopes < bestExtraScopes) {
 					bestExtraScopes = extraScopes;
-					bestToken = session.accessToken;
+					bestSession = session;
 				}
 			}
 		}
-		if (bestToken) {
-			return bestToken;
+		if (bestSession) {
+			return bestSession;
 		}
+	}
+	return undefined;
+}
+
+async function createFreshAuthenticationSessionForResource(
+	protectedResource: ProtectedResourceMetadata,
+	authenticationService: IAuthenticationService,
+	logService: ILogService,
+	logPrefix: string,
+	canInteract: () => boolean,
+): Promise<AuthenticationSession | undefined> {
+	const resourceUri = URI.parse(protectedResource.resource);
+	const scopes = protectedResource.scopes_supported ?? [];
+	for (const server of protectedResource.authorization_servers ?? []) {
+		const serverUri = URI.parse(server);
+		const providerId = await authenticationService.getOrActivateProviderIdForServer(serverUri, resourceUri);
+		if (!providerId) {
+			continue;
+		}
+		const existingSession = await resolveSessionForResource(
+			resourceUri,
+			[server],
+			scopes,
+			authenticationService,
+			logService,
+			logPrefix,
+		);
+		if (!canInteract()) {
+			throw new AuthenticationInteractionDeferredError();
+		}
+		const session = await authenticationService.createSession(providerId, [...scopes], {
+			account: existingSession?.account,
+			authorizationServer: serverUri,
+			resource: protectedResource.resource,
+			activateImmediate: true,
+		});
+		if (session.accessToken === existingSession?.accessToken) {
+			throw new Error('Authentication provider returned the rejected token');
+		}
+		return session;
 	}
 	return undefined;
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -383,15 +383,20 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 	private async _resolveAuthenticationInteractively(protectedResources: ProtectedResourceMetadata[]): Promise<boolean> {
 		const testToken = this._getScenarioAutomationToken();
 		if (testToken !== undefined) {
+			let authenticated = false;
 			for (const resource of protectedResources) {
+				if (resource.required === false) {
+					continue;
+				}
 				await this._authTokenCache.authenticate(
 					resource.resource,
 					resource.scopes_supported,
 					testToken,
-					() => this._agentHostService.authenticate({ resource: resource.resource, token: testToken }),
+					() => this._agentHostService.authenticate({ resource: resource.resource, scopes: resource.scopes_supported, token: testToken }),
 				);
+				authenticated = true;
 			}
-			return protectedResources.length > 0;
+			return authenticated;
 		}
 		return this._instantiationService.invokeFunction(resolveAuthenticationInteractively, protectedResources, {
 			authTokenCache: this._authTokenCache,
@@ -403,11 +408,14 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 	private async _seedTestToken(agents: readonly AgentInfo[], token: string): Promise<void> {
 		for (const agent of agents) {
 			for (const resource of agent.protectedResources ?? []) {
+				if (resource.required === false) {
+					continue;
+				}
 				await this._authTokenCache.authenticate(
 					resource.resource,
 					resource.scopes_supported,
 					token,
-					() => this._agentHostService.authenticate({ resource: resource.resource, token }),
+					() => this._agentHostService.authenticate({ resource: resource.resource, scopes: resource.scopes_supported, token }),
 				);
 			}
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -13,7 +13,7 @@ import { localize } from '../../../../../../nls.js';
 import { affectsAgentHostProviderPreference, IAgentHostService, shouldSurfaceLocalAgentHostProvider, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
 import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
-import { NotificationType } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
+import { AuthRequiredReason, NotificationType } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { type AgentInfo, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
@@ -30,7 +30,7 @@ import { ILanguageModelsService } from '../../../common/languageModels.js';
 import { Target } from '../../../common/promptSyntax/promptTypes.js';
 import { AgentCustomizationItemProvider } from './agentCustomizationItemProvider.js';
 import { AgentHostDownloadProgress } from './agentHostDownloadProgress.js';
-import { authenticateProtectedResources, AgentHostAuthTokenCache, resolveAuthenticationInteractively } from './agentHostAuth.js';
+import { authenticateProtectedResources, AgentHostAuthenticationRecovery, AgentHostAuthTokenCache, findProtectedResource, IAgentHostAuthenticationRecoveryService, resolveAuthenticationInteractively } from './agentHostAuth.js';
 import { AgentHostLanguageModelProvider, agentHostProviderSupportsAutoModel } from './agentHostLanguageModelProvider.js';
 import { AgentHostSessionHandler } from './agentHostSessionHandler.js';
 import { AgentHostPromptCacheNotification } from './agentHostPromptCacheNotification.js';
@@ -103,6 +103,8 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 
 	/** Dedupes redundant `authenticate` RPCs when the resolved token hasn't changed. */
 	private readonly _authTokenCache = new AgentHostAuthTokenCache();
+	private readonly _authenticationRecovery: AgentHostAuthenticationRecovery | undefined;
+	private readonly _pendingAuthenticationRequests = new Map<string, AuthRequiredReason>();
 
 	private readonly _isSessionsWindow: boolean;
 	private readonly _enableSmokeTestDriver: boolean;
@@ -124,6 +126,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 		@IAgentHostActiveClientService private readonly _activeClientService: IAgentHostActiveClientService,
 		@IAgentHostEnablementService agentHostEnablementService: IAgentHostEnablementService,
+		@IAgentHostAuthenticationRecoveryService private readonly _authenticationRecoveryService: IAgentHostAuthenticationRecoveryService,
 	) {
 		super();
 		this._isSessionsWindow = environmentService.isSessionsWindow;
@@ -142,6 +145,14 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		}
 		this._initialized = true;
 		this._promptCacheNotification = this._register(this._instantiationService.createInstance(AgentHostPromptCacheNotification));
+		const authenticationRecovery = this._register(this._instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			authTokenCache: this._authTokenCache,
+			logPrefix: '[AgentHost]',
+			recoveryKey: 'local',
+			authenticate: request => this._agentHostService.authenticate(request),
+		}));
+		this._authenticationRecovery = authenticationRecovery;
+		this._register(this._authenticationRecoveryService.register(this._agentHostService, authenticationRecovery));
 		this._register(this._agentHostFileSystemService.registerAuthority('local', this._agentHostService));
 
 		// React to root state changes (agent discovery / removal)
@@ -153,22 +164,24 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		// first post-restart authenticate RPC is never skipped as "unchanged".
 		this._register(this._agentHostService.onAgentHostStart(() => {
 			this._authTokenCache.clear();
+			this._authenticationRecovery?.reset();
 		}));
 
-		// Surface the agent host's lazy, first-use SDK download as a progress
-		// notification. The Agents window renders this via its own sessions
-		// provider (`BaseAgentHostSessionsProvider`), so only wire it up here
-		// for regular editor windows to avoid duplicate notifications (this
-		// contribution runs in both windows). The matching `createSession`
-		// opt-in (`progressToken`) lives in the editor-window session handlers.
-		if (!this._isSessionsWindow) {
-			const downloadProgress = this._register(this._instantiationService.createInstance(AgentHostDownloadProgress));
-			this._register(this._agentHostService.onDidNotification(n => {
-				if (n.type === NotificationType.Progress) {
-					downloadProgress.handleProgress(n);
-				}
-			}));
-		}
+		const downloadProgress = !this._isSessionsWindow
+			? this._register(this._instantiationService.createInstance(AgentHostDownloadProgress))
+			: undefined;
+		this._register(this._agentHostService.onDidNotification(notification => {
+			if (notification.type === NotificationType.AuthRequired) {
+				const rootState = this._agentHostService.rootState.value;
+				this._handleAuthenticationRequired(
+					notification.resource,
+					notification.reason ?? AuthRequiredReason.Required,
+					rootState && !(rootState instanceof Error) ? rootState : undefined,
+				);
+			} else if (notification.type === NotificationType.Progress) {
+				downloadProgress?.handleProgress(notification);
+			}
+		}));
 
 		// Process initial root state if already available
 		const initialRootState = this._agentHostService.rootState.value;
@@ -192,6 +205,9 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 	}
 
 	private _handleRootStateChange(rootState: RootState): void {
+		for (const [resource, reason] of this._pendingAuthenticationRequests) {
+			this._handleAuthenticationRequired(resource, reason, rootState);
+		}
 		const allowed = rootState.agents.filter(a => this._shouldRegisterAgent(a.provider));
 		const incoming = new Set(allowed.map(a => a.provider));
 
@@ -220,6 +236,16 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 				modelProvider?.updateModels(agent.models);
 			}
 		}
+	}
+
+	private _handleAuthenticationRequired(resource: string, reason: AuthRequiredReason, rootState: RootState | undefined): void {
+		const protectedResource = rootState ? findProtectedResource(rootState.agents, resource) : undefined;
+		if (!protectedResource) {
+			this._pendingAuthenticationRequests.set(resource, reason);
+			return;
+		}
+		this._pendingAuthenticationRequests.delete(resource);
+		void this._authenticationRecovery?.recover(protectedResource, reason);
 	}
 
 	private _registerAgent(agent: AgentInfo): void {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -103,7 +103,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 
 	/** Dedupes redundant `authenticate` RPCs when the resolved token hasn't changed. */
 	private readonly _authTokenCache = new AgentHostAuthTokenCache();
-	private readonly _authenticationRecovery: AgentHostAuthenticationRecovery | undefined;
+	private _authenticationRecovery: AgentHostAuthenticationRecovery | undefined;
 	private readonly _pendingAuthenticationRequests = new Map<string, AuthRequiredReason>();
 
 	private readonly _isSessionsWindow: boolean;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
@@ -4,24 +4,29 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { DeferredPromise } from '../../../../../../base/common/async.js';
-import { Event } from '../../../../../../base/common/event.js';
+import { DeferredPromise, timeout } from '../../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { AuthRequiredReason } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { type AgentInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { TestNotificationService } from '../../../../../../platform/notification/test/common/testNotificationService.js';
+import { IStorageService, InMemoryStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { IAuthenticationMcpAccessService } from '../../../../../services/authentication/browser/authenticationMcpAccessService.js';
 import { IAuthenticationMcpService } from '../../../../../services/authentication/browser/authenticationMcpService.js';
 import { IAuthenticationMcpUsageService } from '../../../../../services/authentication/browser/authenticationMcpUsageService.js';
 import { IAuthenticationService, type IAuthenticationProvider } from '../../../../../services/authentication/common/authentication.js';
 import { IDynamicAuthenticationProviderStorageService } from '../../../../../services/authentication/common/dynamicAuthenticationProviderStorage.js';
+import { IHostService } from '../../../../../services/host/browser/host.js';
 import { CHAT_SETUP_ACTION_ID } from '../../../browser/actions/chatActions.js';
-import { authenticateProtectedResources, resolveAuthenticationInteractively, resolveTokenForResource, AgentHostAuthTokenCache, agentHostMcpServerId, resolveMcpServerAuthentication, type IAgentHostAuthenticationOptions } from '../../../browser/agentSessions/agentHost/agentHostAuth.js';
+import { authenticateProtectedResources, resolveAuthenticationInteractively, resolveTokenForResource, AgentHostAuthenticationRecovery, AgentHostAuthTokenCache, agentHostMcpServerId, resolveMcpServerAuthentication, type IAgentHostAuthenticationOptions } from '../../../browser/agentSessions/agentHost/agentHostAuth.js';
 
 class TestCommandService extends mock<ICommandService>() {
 	readonly calls: { commandId: string; args: unknown[] }[] = [];
@@ -35,12 +40,35 @@ class TestCommandService extends mock<ICommandService>() {
 	}
 }
 
-function createAuthInstantiationService(disposables: Pick<DisposableStore, 'add'>, authenticationService: IAuthenticationService, commandService = new TestCommandService()): TestInstantiationService {
+function createAuthInstantiationService(disposables: Pick<DisposableStore, 'add'>, authenticationService: IAuthenticationService, commandService = new TestCommandService(), notificationService: INotificationService = new TestNotificationService(), hostService: IHostService = createHostService(true), storageService?: IStorageService): TestInstantiationService {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	instantiationService.stub(IAuthenticationService, authenticationService);
 	instantiationService.stub(ICommandService, commandService);
 	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(INotificationService, notificationService);
+	instantiationService.stub(IHostService, hostService);
+	instantiationService.stub(IStorageService, storageService ?? disposables.add(new InMemoryStorageService()));
 	return instantiationService;
+}
+
+function createHostService(hasFocus: boolean): IHostService {
+	return new class extends mock<IHostService>() {
+		override readonly hasFocus = hasFocus;
+		override readonly onDidChangeFocus = Event.None;
+
+		override async hadLastFocus(): Promise<boolean> {
+			return hasFocus;
+		}
+	}();
+}
+
+class RecordingNotificationService extends TestNotificationService {
+	readonly errors: Array<string | Error> = [];
+
+	override error(error: string | Error) {
+		this.errors.push(error);
+		return super.error(error);
+	}
 }
 
 function createMockAuthService(overrides: {
@@ -366,6 +394,370 @@ suite('AgentHostAuthTokenCache', () => {
 		await cache.authenticate('https://other.example.com', ['read'], 'tok2', authenticate);
 
 		assert.strictEqual(authenticateCalls, 4);
+	});
+});
+
+suite('AgentHostAuthenticationRecovery', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	const protectedResource: ProtectedResourceMetadata = {
+		resource: 'https://api.github.com/repos',
+		resource_name: 'GitHub Repository',
+		authorization_servers: ['https://github.com/login/oauth'],
+		scopes_supported: ['repo'],
+	};
+
+	test('forwards an existing token when authentication is required', async () => {
+		let createSessionCalls = 0;
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: async () => 'github',
+			getSessions: async () => [{ scopes: ['repo'], accessToken: 'existing-token' }],
+			createSession: async () => {
+				createSessionCalls++;
+				return { accessToken: 'unexpected-token' };
+			},
+		});
+		const instantiationService = createAuthInstantiationService(disposables, authService);
+		const authenticateCalls: string[] = [];
+		const recovery = disposables.add(instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			logPrefix: '[AgentHost]',
+			recoveryKey: 'required-test',
+			authenticate: async request => {
+				authenticateCalls.push(request.token);
+				return { authenticated: true };
+			},
+		}));
+
+		await recovery.recover(protectedResource, AuthRequiredReason.Required);
+
+		assert.deepStrictEqual({
+			createSessionCalls,
+			authenticateCalls,
+		}, {
+			createSessionCalls: 0,
+			authenticateCalls: ['existing-token'],
+		});
+	});
+
+	test('defers interactive recovery until the window is focused', async () => {
+		const focusEmitter = disposables.add(new Emitter<boolean>());
+		let focused = false;
+		const hostService = new class extends mock<IHostService>() {
+			override readonly onDidChangeFocus = focusEmitter.event;
+			override get hasFocus(): boolean {
+				return focused;
+			}
+			override async hadLastFocus(): Promise<boolean> {
+				return focused;
+			}
+		}();
+		let createSessionCalls = 0;
+		const sessionCreated = new DeferredPromise<void>();
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: async () => 'github',
+			getSessions: async () => [{ scopes: ['repo'], accessToken: 'rejected-token' }],
+			createSession: async () => {
+				createSessionCalls++;
+				sessionCreated.complete();
+				return { accessToken: 'fresh-token' };
+			},
+		});
+		const instantiationService = createAuthInstantiationService(disposables, authService, undefined, undefined, hostService);
+		const recovery = disposables.add(instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			logPrefix: '[AgentHost]',
+			recoveryKey: 'focus-test',
+			authenticate: async () => ({ authenticated: true }),
+		}));
+
+		await recovery.recover(protectedResource, AuthRequiredReason.Expired);
+		const callsBeforeFocus = createSessionCalls;
+		focused = true;
+		focusEmitter.fire(true);
+		await sessionCreated.p;
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			callsBeforeFocus,
+			callsAfterFocus: createSessionCalls,
+		}, {
+			callsBeforeFocus: 0,
+			callsAfterFocus: 1,
+		});
+	});
+
+	test('drops deferred recovery after a fresh token is forwarded in the background', async () => {
+		const focusEmitter = disposables.add(new Emitter<boolean>());
+		let focused = false;
+		const hostService = new class extends mock<IHostService>() {
+			override readonly onDidChangeFocus = focusEmitter.event;
+			override get hasFocus(): boolean {
+				return focused;
+			}
+		}();
+		let currentToken = 'rejected-token';
+		let createSessionCalls = 0;
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: async () => 'github',
+			getSessions: async () => [{ scopes: ['repo'], accessToken: currentToken }],
+			createSession: async () => {
+				createSessionCalls++;
+				return { accessToken: 'unexpected-token' };
+			},
+		});
+		const cache = new AgentHostAuthTokenCache();
+		const instantiationService = createAuthInstantiationService(disposables, authService, undefined, undefined, hostService);
+		let recoveryAuthenticateCalls = 0;
+		const recovery = disposables.add(instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			authTokenCache: cache,
+			logPrefix: '[AgentHost]',
+			recoveryKey: 'background-token-test',
+			authenticate: async () => {
+				recoveryAuthenticateCalls++;
+				return { authenticated: true };
+			},
+		}));
+
+		await recovery.recover(protectedResource, AuthRequiredReason.Expired);
+		currentToken = 'fresh-token';
+		await cache.authenticate(protectedResource.resource, protectedResource.scopes_supported, currentToken, async () => { });
+		focused = true;
+		focusEmitter.fire(true);
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			createSessionCalls,
+			recoveryAuthenticateCalls,
+		}, {
+			createSessionCalls: 0,
+			recoveryAuthenticateCalls: 0,
+		});
+	});
+
+	test('shares the prompt cooldown across windows', async () => {
+		const sharedStorage = disposables.add(new InMemoryStorageService());
+		let createSessionCalls = 0;
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: async () => 'github',
+			getSessions: async () => [{ scopes: ['repo'], accessToken: 'rejected-token' }],
+			createSession: async () => {
+				createSessionCalls++;
+				return { accessToken: 'fresh-token' };
+			},
+		});
+		const firstInstantiationService = createAuthInstantiationService(disposables, authService, undefined, undefined, createHostService(true), sharedStorage);
+		const secondInstantiationService = createAuthInstantiationService(disposables, authService, undefined, undefined, createHostService(true), sharedStorage);
+		const authenticateCalls: string[] = [];
+		const options = {
+			logPrefix: '[AgentHost]',
+			recoveryKey: 'shared-host',
+			authenticate: async (request: { token: string }) => {
+				authenticateCalls.push(request.token);
+				return { authenticated: true };
+			},
+		};
+		const first = disposables.add(firstInstantiationService.createInstance(AgentHostAuthenticationRecovery, options));
+		const second = disposables.add(secondInstantiationService.createInstance(AgentHostAuthenticationRecovery, options));
+
+		await first.recover(protectedResource, AuthRequiredReason.Expired);
+		await second.recover(protectedResource, AuthRequiredReason.Expired);
+
+		assert.deepStrictEqual({
+			createSessionCalls,
+			authenticateCalls,
+		}, {
+			createSessionCalls: 1,
+			authenticateCalls: ['fresh-token'],
+		});
+	});
+
+	test('joins concurrent recovery and lets an operation accept the completed result', async () => {
+		const releaseSession = new DeferredPromise<{ accessToken: string }>();
+		const createSessionStarted = new DeferredPromise<void>();
+		let createSessionCalls = 0;
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: async () => 'github',
+			getSessions: async () => [{ scopes: ['repo'], accessToken: 'rejected-token' }],
+			createSession: async () => {
+				createSessionCalls++;
+				createSessionStarted.complete();
+				return releaseSession.p;
+			},
+		});
+		const cache = new AgentHostAuthTokenCache();
+		const instantiationService = createAuthInstantiationService(disposables, authService);
+		const recovery = disposables.add(instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			authTokenCache: cache,
+			logPrefix: '[AgentHost]',
+			recoveryKey: 'joined-recovery-test',
+			authenticate: async () => ({ authenticated: true }),
+		}));
+
+		const notificationRecovery = recovery.recover(protectedResource, AuthRequiredReason.Expired);
+		await createSessionStarted.p;
+		const operationRecovery = recovery.recover(protectedResource, AuthRequiredReason.Expired, true);
+		releaseSession.complete({ accessToken: 'fresh-token' });
+		const joinedResults = await Promise.all([notificationRecovery, operationRecovery]);
+		const completedResult = await recovery.recover(protectedResource, AuthRequiredReason.Expired, true);
+
+		assert.deepStrictEqual({
+			createSessionCalls,
+			joinedResults,
+			completedResult,
+		}, {
+			createSessionCalls: 1,
+			joinedResults: [true, true],
+			completedResult: true,
+		});
+	});
+
+	test('replaces the rejected session and retries forwarding with backoff', async () => {
+		const account = { id: '1', label: 'octocat' };
+		let createSessionOptions: Parameters<IAuthenticationService['createSession']>[2];
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: async () => 'github',
+			getSessions: async () => [{ scopes: ['repo'], accessToken: 'rejected-token', account }],
+			createSession: async (_providerId, _scopes, options) => {
+				createSessionOptions = options;
+				return { accessToken: 'fresh-token' };
+			},
+		});
+		const notifications = new RecordingNotificationService();
+		const instantiationService = createAuthInstantiationService(disposables, authService, undefined, notifications);
+		const authenticateCalls: string[] = [];
+		const recovery = disposables.add(instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			authTokenCache: new AgentHostAuthTokenCache(),
+			logPrefix: '[AgentHost]',
+			recoveryKey: 'backoff-test',
+			retryDelay: () => 0,
+			authenticate: async request => {
+				authenticateCalls.push(request.token);
+				if (authenticateCalls.length < 3) {
+					throw new Error('connection unavailable');
+				}
+				return { authenticated: true };
+			},
+		}));
+
+		await recovery.recover(protectedResource, AuthRequiredReason.Expired);
+
+		assert.deepStrictEqual({
+			createSessionOptions,
+			authenticateCalls,
+			errors: notifications.errors,
+		}, {
+			createSessionOptions: {
+				account,
+				authorizationServer: URI.parse('https://github.com/login/oauth'),
+				resource: protectedResource.resource,
+				activateImmediate: true,
+			},
+			authenticateCalls: ['fresh-token', 'fresh-token', 'fresh-token'],
+			errors: [],
+		});
+	});
+
+	test('reports failure after three forwarding attempts', async () => {
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: async () => 'github',
+			getSessions: async () => [{ scopes: ['repo'], accessToken: 'rejected-token' }],
+			createSession: async () => ({ accessToken: 'fresh-token' }),
+		});
+		const notifications = new RecordingNotificationService();
+		const instantiationService = createAuthInstantiationService(disposables, authService, undefined, notifications);
+		let authenticateCalls = 0;
+		const recovery = disposables.add(instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			logPrefix: '[AgentHost]',
+			recoveryKey: 'failure-test',
+			retryDelay: () => 0,
+			authenticate: async () => {
+				authenticateCalls++;
+				throw new Error('connection unavailable');
+			},
+		}));
+
+		await recovery.recover(protectedResource, AuthRequiredReason.Expired);
+
+		assert.deepStrictEqual({
+			authenticateCalls,
+			errors: notifications.errors.map(String),
+		}, {
+			authenticateCalls: 3,
+			errors: ['Agent Host authentication for GitHub Repository could not be refreshed. Sign in again to continue.'],
+		});
+	});
+
+	test('does not prompt again when the replacement token is rejected', async () => {
+		let currentToken = 'rejected-token';
+		let createSessionCalls = 0;
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: async () => 'github',
+			getSessions: async () => [{ scopes: ['repo'], accessToken: currentToken }],
+			createSession: async () => {
+				createSessionCalls++;
+				currentToken = 'fresh-token';
+				return { accessToken: currentToken };
+			},
+		});
+		const notifications = new RecordingNotificationService();
+		const instantiationService = createAuthInstantiationService(disposables, authService, undefined, notifications);
+		const recovery = disposables.add(instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			logPrefix: '[AgentHost]',
+			recoveryKey: 'replacement-test',
+			authenticate: async () => ({ authenticated: true }),
+		}));
+
+		await recovery.recover(protectedResource, AuthRequiredReason.Expired);
+		await recovery.recover(protectedResource, AuthRequiredReason.Expired);
+		await recovery.recover(protectedResource, AuthRequiredReason.Expired);
+
+		assert.deepStrictEqual({
+			createSessionCalls,
+			errors: notifications.errors.map(String),
+		}, {
+			createSessionCalls: 1,
+			errors: ['Agent Host authentication for GitHub Repository could not be refreshed. Sign in again to continue.'],
+		});
+	});
+
+	test('can replace a recovered token after the prompt cooldown', async () => {
+		let now = 0;
+		let currentToken = 'rejected-token';
+		let createSessionCalls = 0;
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: async () => 'github',
+			getSessions: async () => [{ scopes: ['repo'], accessToken: currentToken }],
+			createSession: async () => {
+				createSessionCalls++;
+				currentToken = `fresh-token-${createSessionCalls}`;
+				return { accessToken: currentToken };
+			},
+		});
+		const notifications = new RecordingNotificationService();
+		const instantiationService = createAuthInstantiationService(disposables, authService, undefined, notifications);
+		const authenticateCalls: string[] = [];
+		const recovery = disposables.add(instantiationService.createInstance(AgentHostAuthenticationRecovery, {
+			logPrefix: '[AgentHost]',
+			now: () => now,
+			recoveryKey: 'cooldown-test',
+			authenticate: async request => {
+				authenticateCalls.push(request.token);
+				return { authenticated: true };
+			},
+		}));
+
+		await recovery.recover(protectedResource, AuthRequiredReason.Expired);
+		now = 5 * 60_000 + 1;
+		await recovery.recover(protectedResource, AuthRequiredReason.Expired);
+
+		assert.deepStrictEqual({
+			createSessionCalls,
+			authenticateCalls,
+			errors: notifications.errors,
+		}, {
+			createSessionCalls: 2,
+			authenticateCalls: ['fresh-token-1', 'fresh-token-2'],
+			errors: [],
+		});
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -21,13 +21,15 @@ import { ITextModel } from '../../../../../../editor/common/model.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { createTextModel } from '../../../../../../editor/test/common/testTextModel.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { TestNotificationService } from '../../../../../../platform/notification/test/common/testNotificationService.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IAgentCreateSessionConfig, IAgentHostService, IAgentSessionMetadata, AgentSession } from '../../../../../../platform/agentHost/common/agentService.js';
 import type { ChatInputRequestWithPlanReview } from '../../../../../../platform/agentHost/common/agentHostPlanReview.js';
 import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
 import { getElementAttachmentCorrelationId } from '../../../../../../platform/agentHost/common/meta/agentElementAttachments.js';
 import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
-import { ActionType, isSessionAction, isChatAction, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type ChatAction as AgentHostChatAction, type TerminalAction, type INotification, type IToolCallConfirmedAction, type ITurnStartedAction, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
+import { ActionType, AuthRequiredReason, isSessionAction, isChatAction, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type ChatAction as AgentHostChatAction, type TerminalAction, type INotification, type IToolCallConfirmedAction, type ITurnStartedAction, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { ProtocolError, type IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
 import { ChatInteractivity, ConfirmationOptionKind, CustomizationType, McpAuthRequiredReason, McpServerStatus, type ClientPluginCustomization, type ProtectedResourceMetadata, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ChatOriginKind, SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, createSessionState, createChatState, createDefaultChatSummary, buildChatUri, buildDefaultChatUri, parseDefaultChatUri, isAhpChatChannel, createActiveTurn, isAhpRootChannel, PolicyState, ResponsePartKind, ROOT_STATE_URI, StateComponents, buildSubagentChatUri, ToolResultContentType, MessageAttachmentKind, MessageKind, PendingMessageKind, type SessionState, type SessionSummary, type ChatState, type ISessionWithDefaultChat, RootState, type ToolCallState, type AgentInfo, type MessageAttachment, type MessageChatAttachment } from '../../../../../../platform/agentHost/common/state/sessionState.js';
@@ -42,6 +44,7 @@ import { IAuthenticationService } from '../../../../../services/authentication/c
 import { IAuthenticationMcpAccessService } from '../../../../../services/authentication/browser/authenticationMcpAccessService.js';
 import { IAuthenticationMcpService } from '../../../../../services/authentication/browser/authenticationMcpService.js';
 import { IAuthenticationMcpUsageService } from '../../../../../services/authentication/browser/authenticationMcpUsageService.js';
+import { IHostService } from '../../../../../services/host/browser/host.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatAgentData, IChatAgentImplementation, IChatAgentRequest, IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ChatAIDisabledSettingId, ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../../common/constants.js';
@@ -60,6 +63,7 @@ import { IOutputService } from '../../../../../services/output/common/output.js'
 import { IWorkspaceContextService, WorkbenchState } from '../../../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceTrustRequestService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 import { AgentHostContribution, AgentHostSessionHandler } from '../../../browser/agentSessions/agentHost/agentHostChatContribution.js';
+import { IAgentHostAuthenticationRecoveryService } from '../../../browser/agentSessions/agentHost/agentHostAuth.js';
 import { AgentHostLanguageModelProvider } from '../../../browser/agentSessions/agentHost/agentHostLanguageModelProvider.js';
 import { AgentHostSessionListContribution } from '../../../browser/agentSessions/agentHost/agentHostSessionListContribution.js';
 import { AgentHostSessionListController } from '../../../browser/agentSessions/agentHost/agentHostSessionListController.js';
@@ -676,6 +680,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 
 	instantiationService.stub(IAgentHostService, agentHostService);
 	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(INotificationService, new TestNotificationService());
 	instantiationService.stub(IProductService, { quality: 'insider' });
 	instantiationService.stub(ITelemetryService, NullTelemetryService);
 	instantiationService.stub(IChatEntitlementService, { entitlement: ChatEntitlement.Free, quotas: {} } as Partial<IChatEntitlementService> as IChatEntitlementService);
@@ -730,6 +735,18 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	const commandService = new MockCommandService();
 	instantiationService.stub(ICommandService, commandService);
 	instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None, ...authServiceOverride });
+	instantiationService.stub(IAgentHostAuthenticationRecoveryService, {
+		register: () => toDisposable(() => { }),
+		recover: async () => false,
+	});
+	instantiationService.stub(IHostService, new class extends mock<IHostService>() {
+		override readonly hasFocus = true;
+		override readonly onDidChangeFocus = Event.None;
+
+		override async hadLastFocus(): Promise<boolean> {
+			return true;
+		}
+	}());
 	instantiationService.stub(ILanguageModelsService, {
 		deltaLanguageModelChatProviderDescriptors: () => { },
 		registerLanguageModelProvider: () => toDisposable(() => { }),
@@ -10117,6 +10134,55 @@ suite('AgentHostChatContribution', () => {
 				}) as unknown as IAuthenticationService['getSessions'],
 			};
 		}
+
+		test('sessions window replaces an expired token from auth/required', async () => {
+			const account = { id: '1', label: 'octocat' };
+			let token = 'rejected-token';
+			let createSessionCalls = 0;
+			const authService: Partial<IAuthenticationService> = {
+				onDidChangeSessions: Event.None,
+				getOrActivateProviderIdForServer: async () => 'github',
+				getSessions: async (_providerId, scopes) => !Array.isArray(scopes) ? [] : [{
+					id: 'github-session',
+					account,
+					scopes: [...scopes],
+					accessToken: token,
+				}],
+				createSession: async (_providerId, scopes) => {
+					createSessionCalls++;
+					token = 'fresh-token';
+					return {
+						id: 'fresh-github-session',
+						account,
+						scopes: Array.isArray(scopes) ? [...scopes] : [],
+						accessToken: token,
+					};
+				},
+			};
+			const { instantiationService, agentHostService } = createTestServices(disposables, undefined, authService, undefined, undefined, true);
+			disposables.add(instantiationService.createInstance(AgentHostContribution));
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 0 });
+			await timeout(0);
+
+			agentHostService.fireNotification({
+				type: 'auth/required',
+				channel: 'ahp-root://root',
+				resource: 'https://api.github.com',
+				reason: AuthRequiredReason.Expired,
+			});
+			await timeout(0);
+
+			assert.deepStrictEqual({
+				createSessionCalls,
+				authenticateCalls: agentHostService.authenticateCalls,
+			}, {
+				createSessionCalls: 1,
+				authenticateCalls: [
+					{ resource: 'https://api.github.com', scopes: ['read:user'], token: 'rejected-token' },
+					{ resource: 'https://api.github.com', scopes: ['read:user'], token: 'fresh-token' },
+				],
+			});
+		});
 
 		test('does not re-authenticate when token unchanged across rootState changes', async () => {
 			const tokenRef = { current: 'tok-1' };

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -944,8 +944,11 @@ function createSessionListController(disposables: DisposableStore, instantiation
 	return disposables.add(instantiationService.createInstance(AgentHostSessionListController, sessionType, provider, sessionListStore, description, 'local'));
 }
 
-function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }; languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>; provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>; languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>; configOverrides?: Record<string, unknown>; provider?: string; chatSessionsServiceOverride?: Partial<IChatSessionsService>; chatDebugServiceOverride?: Partial<IChatDebugService>; remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService>; customizationServiceOverride?: IAgentHostCustomizationService; agentHostTerminalServiceOverride?: Partial<IAgentHostTerminalService> }) {
+function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }; languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>; provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>; languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>; configOverrides?: Record<string, unknown>; provider?: string; chatSessionsServiceOverride?: Partial<IChatSessionsService>; chatDebugServiceOverride?: Partial<IChatDebugService>; remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService>; customizationServiceOverride?: IAgentHostCustomizationService; agentHostTerminalServiceOverride?: Partial<IAgentHostTerminalService>; enableSmokeTestDriver?: boolean }) {
 	const { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, trustController, modelService, workingCopyService } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride, opts?.languageModels, opts?.provisionalServiceOverride, false, opts?.languageModelToolsServiceOverride, opts?.configOverrides, opts?.chatSessionsServiceOverride, opts?.chatDebugServiceOverride, opts?.remoteAgentHostServiceOverride, opts?.customizationServiceOverride, opts?.agentHostTerminalServiceOverride);
+	if (opts?.enableSmokeTestDriver) {
+		instantiationService.stub(IWorkbenchEnvironmentService, { isSessionsWindow: false, enableSmokeTestDriver: true } as Partial<IWorkbenchEnvironmentService>);
+	}
 
 	const listController = createSessionListController(disposables, instantiationService, agentHostService);
 	const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
@@ -10239,6 +10242,36 @@ suite('AgentHostChatContribution', () => {
 			await timeout(0);
 
 			assert.deepStrictEqual(agentHostService.authenticateCalls, []);
+		});
+
+		test('scenario automation token skips optional protected resources', async () => {
+			const { agentHostService } = createContribution(disposables, {
+				enableSmokeTestDriver: true,
+				configOverrides: { 'chat.agentHost.unsafeTestToken': 'scenario-token' },
+			});
+			agentHostService.setRootState({
+				agents: [{
+					...protectedAgents()[0],
+					protectedResources: [
+						...protectedAgents()[0].protectedResources!,
+						{
+							resource: 'https://api.github.com/repos',
+							resource_name: 'GitHub Repository',
+							authorization_servers: ['https://github.com/login/oauth'],
+							scopes_supported: ['repo'],
+							required: false,
+						},
+					],
+				}],
+				activeSessions: 0,
+			});
+			await timeout(0);
+
+			assert.deepStrictEqual(agentHostService.authenticateCalls, [{
+				resource: 'https://api.github.com',
+				scopes: ['read:user'],
+				token: 'scenario-token',
+			}]);
 		});
 
 		test('propagates interactive authentication errors for eager-created sessions', async () => {


### PR DESCRIPTION
Fixes #327788

## Summary

Recover Agent Host pull-request detection and creation when GitHub rejects the repository-scoped OAuth token with `401 Bad credentials`.

Previously, the Agent Host accepted and cached a token for the `https://api.github.com/repos` protected resource, but a later REST request could discover that GitHub had revoked or invalidated it. The 401 was treated as a generic lookup failure: the exact bad token remained cached, subsequent checks reused it, the Agents window continued reporting `hasPullRequest: false`, and signing out/in of Copilot did not necessarily replace the separate `repo`-scoped authentication session.

This change makes authentication recovery an explicit, bounded state machine shared by background PR detection and the user-triggered Create Pull Request operation, for both local and remote Agent Host connections.

## Behavior after this change

1. GitHub REST failures carry structured status and `Retry-After` information.
2. A 401 marks the exact repository token as rejected; the host refuses to accept or call GitHub with that token again.
3. The host emits `auth/required` with reason `expired` for the repository resource.
4. The focused client resolves a replacement `repo`-scoped session for the same account, forwards only a different token, and bounds transient forwarding failures to three backoff attempts.
5. The host serializes authentication by protected resource, preventing a late older request from overwriting a newer token.
6. Pending PR detections retry after the replacement token is accepted.
7. Create Pull Request surfaces a transport-safe auth-required marker, joins the same recovery, and retries the operation exactly once. This works across local `ProxyChannel` IPC and remote JSON-RPC.
8. If recovery cannot make progress, it stops and shows one actionable error instead of repeatedly prompting or retrying.

## Review guide

Reviewing in this order follows the dependency hierarchy and makes the diff easier to reason about.

### 1. Protocol and host authentication boundary

Start with:

- `src/vs/platform/agentHost/common/state/sessionProtocol.ts`
- `src/vs/platform/agentHost/common/agentHostGitStateService.ts`
- `src/vs/platform/agentHost/node/agentService.ts`

These define the transport-safe auth-required marker, extend the git-state recovery contract, reject known-bad tokens before provider mutation, and serialize authentication per protected resource.

Key invariant: once GitHub rejects token `T1`, no later client RPC can reinstall `T1`, and an older in-flight auth request cannot overwrite accepted token `T2`.

### 2. GitHub REST client and background PR detection

Then review:

- `src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts`
- `src/vs/platform/agentHost/node/agentHostGitStateService.ts`
- `src/vs/platform/agentHost/node/agentSideEffects.ts`

This layer classifies GitHub failures, retries transient failures only, retains affected sessions, republishes endpoint-derived protected resources, and retries detection after authentication changes.

Safety properties:

- Three attempts maximum for transient network/408/429/5xx and `403 + Retry-After` failures.
- Equal-jitter exponential backoff with server `Retry-After` capped at 30 seconds.
- No retry with a token already rejected by GitHub.
- Each request is bound to one GitHub API endpoint snapshot; an Enterprise endpoint change cannot send an old host's token to a new host.
- ETag cache entries include the parsed PR result, so `304 Not Modified` still returns the PR.
- Removed sessions are pruned from pending recovery state.

### 3. User-triggered Create Pull Request recovery

Next review:

- `src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts`
- `src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts`

The server maps PR lookup/create 401s to `AHP_AUTH_REQUIRED`, records the rejected token, and attaches a stable error name that survives local IPC's error serialization. The client resolves resources from structured remote error data or, for local IPC, from the current root-state repository resources. After recovery succeeds, it retries the operation once and never loops.

### 4. Client recovery orchestration and local/remote wiring

Then review:

- `src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts`
- `src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts`
- `src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts`

This owns token resolution, fresh-session creation, forwarding retries, focus deferral, cross-window prompt cooldown, in-flight recovery joining, and connection-scoped registration.

The editor and Agents windows may both observe the same notification. Non-interactive forwarding remains safe and idempotent; only a focused window can initiate interactive sign-in, and an application-shared cooldown prevents duplicate prompts. Operation callers join notification-driven recovery and inherit its successful result.

### 5. Tests and specifications

Finally review the focused tests and provider specifications listed below. They cover token races, endpoint ordering in both directions, local IPC error degradation, remote structured errors, create-operation retry, transient retry bounds, ETag 304 behavior, and recovery deduplication.

## Per-file changes and rationale

| File | Change | Why |
|---|---|---|
| `src/vs/platform/agentHost/common/agentHostGitStateService.ts` | Extends the git-state service contract with token rejection, token-update handling, and rejected-token queries. | Makes one host-owned service the source of truth for PR-related GitHub auth state. |
| `src/vs/platform/agentHost/common/state/sessionProtocol.ts` | Adds a stable auth-required error name. | Local `ProxyChannel` preserves error name/message/stack but drops custom `code` and `data`; the name is the transport-safe discriminator. |
| `src/vs/platform/agentHost/node/agentHostGitStateService.ts` | Adds rejected-token circuit breaking, pending-session retention, transient retry/backoff, endpoint snapshots/migration, stale-401 suppression, and session cleanup. | Converts background PR detection from a log-only failure into bounded, recoverable behavior without token or endpoint races. |
| `src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts` | Maps GitHub 401s to auth-required errors, binds REST/GraphQL calls to endpoint snapshots, and marks rejected tokens. | Gives Create Pull Request the same recovery semantics as background detection while preserving idempotency and one retry. |
| `src/vs/platform/agentHost/node/agentService.ts` | Serializes authentication per resource, gates rejected tokens, republishes endpoint-derived resources, and requests both Copilot and repository authentication after endpoint changes. | Prevents old/new auth races and ensures clients know the current Enterprise resource before resolving a token. |
| `src/vs/platform/agentHost/node/agentSideEffects.ts` | Exposes agent-info republishing. | Endpoint changes alter protected-resource identifiers without changing the agents observable; clients need refreshed root metadata before auth notifications. |
| `src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts` | Adds typed GitHub API errors, Retry-After parsing, endpoint overrides, and ETag+result caching. | Enables reliable error classification, endpoint-safe requests, bounded retry policy, and correct `304` behavior. |
| `src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts` | Detects auth-required operation failures, recovers via the connection registry, and retries once. Includes local IPC resource fallback. | Makes the visible Create Pull Request action recover automatically on local and remote Agent Hosts. |
| `src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSessionChangesets.test.ts` | Adds focused operation retry coverage using the local transport-safe marker. | Locks in exactly-one retry and recovery-resource resolution. |
| `src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts` | Adds connection-scoped recovery, fresh session creation, retry policy, focus deferral, shared prompt cooldown, in-flight joining, and recovery registry. | Centralizes client auth recovery and prevents duplicate prompts or notification/operation recovery collisions. |
| `src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts` | Registers local recovery and routes root `auth/required` notifications, buffering unknown resources until root state updates. | Wires recovery for both editor and Agents windows without assuming notification/root-state ordering. |
| `src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts` | Registers per-connection remote recovery and buffers auth notifications until matching protected resources are published. | Keeps remote behavior symmetric with local recovery while preserving connection isolation. |
| `src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md` | Documents local recovery ownership, focus behavior, retries, and failure handling. | Keeps the provider specification aligned with implementation. |
| `src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md` | Documents remote expired-token recovery and focused interaction. | Keeps remote architecture documentation current. |
| `src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts` | Covers rejected tokens, fresh-token retry, stale 401s, transient retries, endpoint snapshots, and both endpoint/token orderings. | Exercises the host recovery state machine and race handling. |
| `src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts` | Covers conversion of repository-token 401s into auth-required operation failures. | Ensures Create Pull Request enters recovery instead of returning a generic error. |
| `src/vs/platform/agentHost/test/node/agentService.test.ts` | Adds concurrent old/new authentication ordering coverage. | Proves the final stored token is the newest request and provider mutation is serialized. |
| `src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts` | Covers typed status/Retry-After errors and cached PR return on 304. | Locks in the REST client's recovery metadata and cache semantics. |
| `src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts` | Covers required vs expired behavior, fresh token replacement, three forwarding attempts, focus deferral, background token changes, cross-window cooldown, and concurrent recovery joining. | Tests the client recovery state machine and prompt deduplication. |
| `src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts` | Covers local root-notification recovery wiring and test service registration. | Verifies the local contribution reacts to host auth requirements in the Agents window path. |
| `src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts` | Updates the git-state test double for the expanded recovery contract. | Keeps coordinator tests type-safe against the shared service interface. |
| `src/vs/platform/agentHost/test/node/agentHostChangesetOperationService.test.ts` | Updates the git-state test double for the expanded recovery contract. | Keeps operation-service tests isolated while satisfying the real interface. |
| `src/vs/platform/agentHost/test/node/agentHostPullRequestOperationProvider.test.ts` | Updates the null git-state service for the expanded recovery contract. | Keeps provider registration tests focused on operation contribution behavior. |

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- Pre-commit hygiene hook
- `git diff --check`
- Focused unit suites: **523 passing, 17 pending**
  - Agent Host OctoKit service
  - Agent Host git-state service
  - Agent Host pull-request operation handler
  - Agent Service authentication ordering
  - Agent Host authentication recovery
  - Agent Host chat contribution
  - Agent Host changeset operation recovery

## Review history

The fix received independent architecture, implementation, engineering, decision, and adversarial correctness reviews. Follow-up review findings addressed in this revision include:

- Create Pull Request 401 recovery and one retry.
- Host-side old/new token ordering.
- Endpoint/token reverse-order races.
- Local IPC loss of structured error fields.
- Notification-driven vs operation-driven recovery collision.
- Retry-After queue starvation and GitHub secondary-rate-limit 403s.
- ETag 304 result loss.
- Pending state for disposed sessions.