### PR TITLE
Update changes pill hovers and enable turn status pills by default

### DIFF
--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -34,7 +34,7 @@ import { SessionHeaderMetaActionViewItem } from './sessionHeaderMetaActionViewIt
 /**
  * An action runner for the session header toolbars that promotes the header's
  * session to be the active session before running any contributed command. This
- * ensures commands (e.g. View Changes) operate on the clicked session even when
+ * ensures commands (e.g. View All Changes) operate on the clicked session even when
  * a different session is currently active.
  */
 class SessionActivatingActionRunner extends ActionRunner {
@@ -178,7 +178,7 @@ export class SessionHeader extends Disposable {
 		// SessionHeaderMetaActionViewItem.
 		const metaToolbarContainer = $('.chat-composite-bar-meta-toolbar');
 		this._metaRow.appendChild(metaToolbarContainer);
-		// Commands contributed into the header meta toolbar (e.g. View Changes)
+		// Commands contributed into the header meta toolbar (e.g. View All Changes)
 		// operate on this view's session. Promote it to the active session before
 		// running any of them via a custom action runner, so the command always
 		// targets the clicked session even when another session is active.

--- a/src/vs/sessions/contrib/changes/browser/changesActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesActions.ts
@@ -322,8 +322,8 @@ export class ViewAllChangesActionViewItem extends SessionHeaderMetaActionViewIte
 	protected override getTooltip(): string {
 		const { branch } = this._diffStatsObs.get();
 		return branch
-			? localize('agentSessions.viewChanges.tooltip.branch', "View Changes ({0})", branch)
-			: localize('agentSessions.viewChanges.tooltip', "View Changes");
+			? localize('agentSessions.viewChanges.tooltip.branch', "View All Changes ({0})", branch)
+			: localize('agentSessions.viewChanges.tooltip', "View All Changes");
 	}
 
 	protected override getAriaLabel(): string {
@@ -331,7 +331,7 @@ export class ViewAllChangesActionViewItem extends SessionHeaderMetaActionViewIte
 		const filesLabel = files === 1
 			? localize('agentSessions.changes.file', "{0} file", files)
 			: localize('agentSessions.changes.files', "{0} files", files);
-		// e.g. "View Changes (main): 3 files, +10, -4"
+		// e.g. "View All Changes (main): 3 files, +10, -4"
 		return localize('agentSessions.viewChanges.ariaLabel', "{0}: {1}, +{2}, -{3}", this.getTooltip(), filesLabel, insertions, deletions);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -941,7 +941,7 @@ configurationRegistry.registerConfiguration({
 				},
 			],
 			markdownDescription: nls.localize('chat.turnStatusPills', "Controls whether agent status pills are shown above the chat input while a turn is in progress and inside the completed response. Only applies to agent sessions."),
-			default: false,
+			default: true,
 		},
 		[mcpAccessConfig]: {
 			type: 'string',

--- a/src/vs/workbench/contrib/chat/browser/widget/chatTurnPills.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatTurnPills.ts
@@ -132,7 +132,7 @@ export function isChatTurnStatusPillsEnabled(value: ChatTurnStatusPillsSetting |
 
 /** Observe whether agent turn status pills are enabled. */
 export function observeTurnStatusPillsEnabled(configurationService: IConfigurationService): IObservable<boolean> {
-	const value = observableConfigValue<ChatTurnStatusPillsSetting>(ChatConfiguration.TurnStatusPills, false, configurationService);
+	const value = observableConfigValue<ChatTurnStatusPillsSetting>(ChatConfiguration.TurnStatusPills, true, configurationService);
 	return derived(reader => isChatTurnStatusPillsEnabled(value.read(reader)));
 }
 
@@ -203,8 +203,8 @@ class ChangesPillActionViewItem extends BaseActionViewItem {
 			? localize('chatTurnPills.changes.file', "{0} File", files)
 			: localize('chatTurnPills.changes.files', "{0} Files", files);
 		this._filesLabel.textContent = filesLabel;
-		this._button.setTitle(localize('chatTurnPills.changes.tooltip', "View Changes"));
-		this._button.element.setAttribute('aria-label', localize('chatTurnPills.changes.ariaLabel', "View Changes: {0}, +{1}, -{2}", filesLabel, insertions, deletions));
+		this._button.setTitle(localize('chatTurnPills.changes.tooltip', "View Current Turn Changes"));
+		this._button.element.setAttribute('aria-label', localize('chatTurnPills.changes.ariaLabel', "View Current Turn Changes: {0}, +{1}, -{2}", filesLabel, insertions, deletions));
 	}
 
 	override focus(): void {
@@ -324,7 +324,7 @@ export class ChatTurnPillsWidget extends Disposable {
 		this.element = $('.chat-turn-pills.show-file-icons.hidden');
 		this._resourceLabels = this._register(this._instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
 
-		this._changesAction = this._register(new Action(CHANGES_PILL_ACTION_ID, localize('chatTurnPills.changes.tooltip', "View Changes"), undefined, true, async () => this._model.openChanges()));
+		this._changesAction = this._register(new Action(CHANGES_PILL_ACTION_ID, localize('chatTurnPills.changes.tooltip', "View Current Turn Changes"), undefined, true, async () => this._model.openChanges()));
 		this._previewAction = this._register(new Action(PREVIEW_PILL_ACTION_ID, localize('chatTurnPills.preview.label', "Open Preview"), undefined, true, async () => this._openPrimaryPreview()));
 
 		this._toolbar = this._register(new ToolBar(this.element, this._contextMenuService, {

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
@@ -159,7 +159,8 @@ async function renderChatViewWithPills(ctx: ComponentFixtureContext, mock: IMock
 	await renderChatWidget(ctx, {
 		messages,
 		decorateInputPart: (inputPart, instantiationService) => {
-			// All pills are off by default; enable them so the fixture renders.
+			// The fixture's test configuration has no product defaults, so opt in
+			// explicitly to make sure the pills render.
 			instantiationService.invokeFunction(accessor => {
 				(accessor.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, true);
 			});


### PR DESCRIPTION
- The chat turn changes pill (above the chat input and in completed responses) now reads **View Current Turn Changes** instead of `View Changes` (title + aria label).
- The changes meta action in the sessions header toolbar now reads **View All Changes** (with and without branch suffix).
- `chat.turnStatusPills` now defaults to `true`.