### PR TITLE
agentHost: Make MCP token authentication idempotent

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostAuthenticationService.ts
+++ b/src/vs/platform/agentHost/node/agentHostAuthenticationService.ts
@@ -37,11 +37,13 @@ export class AgentHostAuthenticationService {
 			matching.map(p => p.authenticate(params.resource, params.token)),
 		);
 		let authenticated = false;
+		let rejected = false;
 		for (let i = 0; i < settled.length; i++) {
 			const result = settled[i];
 			if (result.status === 'fulfilled') {
 				authenticated ||= result.value;
 			} else {
+				rejected = true;
 				this._logService.error(
 					result.reason,
 					`[AgentHostAuthenticationService] Provider '${matching[i].id}' authenticate threw for resource=${params.resource}`,
@@ -57,14 +59,18 @@ export class AgentHostAuthenticationService {
 			if (result.status === 'fulfilled') {
 				authenticated ||= result.value;
 			} else {
+				rejected = true;
 				this._logService.error(
 					result.reason,
 					`[AgentHostAuthenticationService] Provider '${sessionResourceHandlers[i].id}' handleAuthenticationToken threw for resource=${params.resource}`,
 				);
 			}
 		}
+		const scopes = this._normalizeScopes(params.scopes);
+		if (!authenticated && !rejected) {
+			authenticated = this._tokens.get(this._key(params.resource, scopes))?.token === params.token;
+		}
 		if (authenticated) {
-			const scopes = this._normalizeScopes(params.scopes);
 			this._tokens.set(this._key(params.resource, scopes), { resource: params.resource, scopes, token: params.token });
 		}
 		return { authenticated };

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -2231,6 +2231,50 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('accepts an already handled MCP token after retrying session handlers', async () => {
+			const mcpAgent = new MockAgent();
+			disposables.add(toDisposable(() => mcpAgent.dispose()));
+			const mcpAgentContract: IAgent = mcpAgent;
+			let handlerCalls = 0;
+			mcpAgentContract.handleAuthenticationToken = async () => ++handlerCalls === 1;
+			service.registerProvider(mcpAgentContract);
+
+			const first = await service.authenticate({ resource: 'https://mcp.example.com', scopes: ['write', 'read'], token: 'token-1' });
+			const duplicate = await service.authenticate({ resource: 'https://mcp.example.com', scopes: ['read', 'write'], token: 'token-1' });
+			const replacement = await service.authenticate({ resource: 'https://mcp.example.com', scopes: ['read', 'write'], token: 'token-2' });
+
+			assert.deepStrictEqual({ first, duplicate, replacement, handlerCalls }, {
+				first: { authenticated: true },
+				duplicate: { authenticated: true },
+				replacement: { authenticated: false },
+				handlerCalls: 3,
+			});
+		});
+
+		test('does not hide a session handler rejection with an accepted token', async () => {
+			const mcpAgent = new MockAgent();
+			disposables.add(toDisposable(() => mcpAgent.dispose()));
+			const mcpAgentContract: IAgent = mcpAgent;
+			let handlerCalls = 0;
+			mcpAgentContract.handleAuthenticationToken = async () => {
+				handlerCalls++;
+				if (handlerCalls === 1) {
+					return true;
+				}
+				throw new Error('failed');
+			};
+			service.registerProvider(mcpAgentContract);
+
+			const first = await service.authenticate({ resource: 'https://mcp.example.com', token: 'token-1' });
+			const duplicate = await service.authenticate({ resource: 'https://mcp.example.com', token: 'token-1' });
+
+			assert.deepStrictEqual({ first, duplicate, handlerCalls }, {
+				first: { authenticated: true },
+				duplicate: { authenticated: false },
+				handlerCalls: 2,
+			});
+		});
+
 		test('fans out to every provider that owns the resource', async () => {
 			// Two providers share the same protected resource (the real
 			// motivating example: both Copilot CLI and Claude consume the


### PR DESCRIPTION
## Summary

- treat repeated exact MCP token handoffs as idempotent after provider and session-handler fan-out
- preserve live pending-request handling and suppress cached fallback whenever any handler rejects
- cover sequential duplicates, normalized scopes, replacement tokens, and handler failures

## Root cause

The workbench can probe the same MCP `AuthRequired` state more than once. The first Agent Host request consumes the pending MCP authentication callback. A later, non-overlapping duplicate finds no pending consumer and returned `authenticated: false`, which the protocol surfaced as `AHP_AUTH_REQUIRED` even though the accepted token brought the server to `Ready`.

## Fix

`AgentHostAuthenticationService` now checks its exact accepted-token cache only after all provider and session-handler fan-out completes. This keeps every authentication side effect intact. The fallback is disabled if any fan-out operation rejected, so a genuine handler failure cannot be masked.

## Testing

- AgentService authentication unit suite
- client TypeScript check
- source layer validation
- changed-file and pre-commit hygiene

Fixes #327824