### PR TITLE
chat: enforce managed customization lockdown

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -111,57 +111,6 @@
             ]
         },
         {
-            "key": "chat.mcp.allowedServers",
-            "name": "ChatAllowedMcpServers",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.130",
-            "localization": {
-                "description": {
-                    "key": "chat.mcp.allowedServers.policy",
-                    "value": "Allowlist of Model Context Protocol servers. When set, only servers matching an entry may be installed or run; omit entirely to allow all servers (subject to the deny list)."
-                }
-            },
-            "type": [
-                "array",
-                "null"
-            ],
-            "default": null,
-            "included": false
-        },
-        {
-            "key": "chat.mcp.deniedServers",
-            "name": "ChatDeniedMcpServers",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.130",
-            "localization": {
-                "description": {
-                    "key": "chat.mcp.deniedServers.policy",
-                    "value": "Denylist of Model Context Protocol servers. Servers matching any entry are blocked from being installed or run, even if they also match the allow list; deny rules always take precedence."
-                }
-            },
-            "type": [
-                "array",
-                "null"
-            ],
-            "default": null,
-            "included": false
-        },
-        {
-            "key": "chat.mcp.allowManagedServersOnly",
-            "name": "ChatAllowManagedMcpServersOnly",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.132",
-            "localization": {
-                "description": {
-                    "key": "chat.mcp.allowManagedServersOnly.policy",
-                    "value": "Use only the enterprise-managed MCP allowlist when deciding which servers may run."
-                }
-            },
-            "type": "boolean",
-            "default": false,
-            "included": false
-        },
-        {
             "key": "mcp.enterpriseManagedAuth.idp",
             "name": "McpEnterpriseManagedAuthIdp",
             "category": "InteractiveSession",
@@ -189,36 +138,6 @@
             },
             "type": "object",
             "default": {},
-            "included": false
-        },
-        {
-            "key": "chat.customizations.strictPluginOnlyCustomization",
-            "name": "ChatStrictPluginOnlyCustomization",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.132",
-            "localization": {
-                "description": {
-                    "key": "chat.customizations.strictPluginOnlyCustomization.policy",
-                    "value": "Blocks standalone user and workspace skills, agents, hooks, and MCP servers while keeping eligible plugin customizations available."
-                }
-            },
-            "type": "boolean",
-            "default": false,
-            "included": false
-        },
-        {
-            "key": "chat.hooks.allowManagedOnly",
-            "name": "ChatAllowManagedHooksOnly",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.132",
-            "localization": {
-                "description": {
-                    "key": "chat.hooks.allowManagedOnly.policy",
-                    "value": "Allows hooks only from enterprise-managed sources and plugins force-enabled by policy."
-                }
-            },
-            "type": "boolean",
-            "default": false,
             "included": false
         },
         {
@@ -444,21 +363,6 @@
             ]
         },
         {
-            "key": "dictation.enabled",
-            "name": "DictationEnabled",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.131",
-            "localization": {
-                "description": {
-                    "key": "dictation.enabled.policy",
-                    "value": "Controls whether dictation is available across the product (chat input, editor, and terminal)."
-                }
-            },
-            "type": "boolean",
-            "default": true,
-            "included": true
-        },
-        {
             "key": "chat.defaultModel",
             "name": "ChatDefaultModel",
             "category": "InteractiveSession",
@@ -553,6 +457,57 @@
             "included": true
         },
         {
+            "key": "chat.mcp.allowedServers",
+            "name": "ChatAllowedMcpServers",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.130",
+            "localization": {
+                "description": {
+                    "key": "chat.mcp.allowedServers.policy",
+                    "value": "Allowlist of Model Context Protocol servers. When set, only servers matching an entry may be installed or run; omit entirely to allow all servers (subject to the deny list)."
+                }
+            },
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "included": false
+        },
+        {
+            "key": "chat.mcp.deniedServers",
+            "name": "ChatDeniedMcpServers",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.130",
+            "localization": {
+                "description": {
+                    "key": "chat.mcp.deniedServers.policy",
+                    "value": "Denylist of Model Context Protocol servers. Servers matching any entry are blocked from being installed or run, even if they also match the allow list; deny rules always take precedence."
+                }
+            },
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "included": false
+        },
+        {
+            "key": "chat.mcp.allowManagedServersOnly",
+            "name": "ChatAllowManagedMcpServersOnly",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.132",
+            "localization": {
+                "description": {
+                    "key": "chat.mcp.allowManagedServersOnly.policy",
+                    "value": "Use only the enterprise-managed MCP allowlist when deciding which servers may run."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": false
+        },
+        {
             "key": "chat.extensionTools.enabled",
             "name": "ChatAgentExtensionTools",
             "category": "InteractiveSession",
@@ -614,6 +569,36 @@
             ],
             "default": null,
             "included": true
+        },
+        {
+            "key": "chat.customizations.strictPluginOnlyCustomization",
+            "name": "ChatStrictPluginOnlyCustomization",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.132",
+            "localization": {
+                "description": {
+                    "key": "chat.customizations.strictPluginOnlyCustomization.policy",
+                    "value": "Blocks standalone user and workspace skills, agents, hooks, and MCP servers while keeping eligible plugin customizations available."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": false
+        },
+        {
+            "key": "chat.hooks.allowManagedOnly",
+            "name": "ChatAllowManagedHooksOnly",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.132",
+            "localization": {
+                "description": {
+                    "key": "chat.hooks.allowManagedOnly.policy",
+                    "value": "Allows hooks only from enterprise-managed sources and plugins force-enabled by policy."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": false
         },
         {
             "key": "chat.agent.enabled",
@@ -970,6 +955,21 @@
                 "description": {
                     "key": "github.copilot.chat.reviewAgent.enabled",
                     "value": "Enables the code review agent."
+                }
+            },
+            "type": "boolean",
+            "default": true,
+            "included": true
+        },
+        {
+            "key": "dictation.enabled",
+            "name": "DictationEnabled",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.131",
+            "localization": {
+                "description": {
+                    "key": "dictation.enabled.policy",
+                    "value": "Controls whether dictation is available across the product (chat input, editor, and terminal)."
                 }
             },
             "type": "boolean",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -111,6 +111,57 @@
             ]
         },
         {
+            "key": "chat.mcp.allowedServers",
+            "name": "ChatAllowedMcpServers",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.130",
+            "localization": {
+                "description": {
+                    "key": "chat.mcp.allowedServers.policy",
+                    "value": "Allowlist of Model Context Protocol servers. When set, only servers matching an entry may be installed or run; omit entirely to allow all servers (subject to the deny list)."
+                }
+            },
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "included": false
+        },
+        {
+            "key": "chat.mcp.deniedServers",
+            "name": "ChatDeniedMcpServers",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.130",
+            "localization": {
+                "description": {
+                    "key": "chat.mcp.deniedServers.policy",
+                    "value": "Denylist of Model Context Protocol servers. Servers matching any entry are blocked from being installed or run, even if they also match the allow list; deny rules always take precedence."
+                }
+            },
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "included": false
+        },
+        {
+            "key": "chat.mcp.allowManagedServersOnly",
+            "name": "ChatAllowManagedMcpServersOnly",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.132",
+            "localization": {
+                "description": {
+                    "key": "chat.mcp.allowManagedServersOnly.policy",
+                    "value": "Use only the enterprise-managed MCP allowlist when deciding which servers may run."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": false
+        },
+        {
             "key": "mcp.enterpriseManagedAuth.idp",
             "name": "McpEnterpriseManagedAuthIdp",
             "category": "InteractiveSession",
@@ -138,6 +189,40 @@
             },
             "type": "object",
             "default": {},
+            "included": false
+        },
+        {
+            "key": "chat.customizations.strictPluginOnlyCustomization",
+            "name": "ChatStrictPluginOnlyCustomization",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.132",
+            "localization": {
+                "description": {
+                    "key": "chat.customizations.strictPluginOnlyCustomization.policy",
+                    "value": "Blocks standalone user and workspace customizations for all or selected surfaces while keeping eligible plugin customizations available."
+                }
+            },
+            "type": [
+                "boolean",
+                "array",
+                "null"
+            ],
+            "default": null,
+            "included": false
+        },
+        {
+            "key": "chat.hooks.allowManagedOnly",
+            "name": "ChatAllowManagedHooksOnly",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.132",
+            "localization": {
+                "description": {
+                    "key": "chat.hooks.allowManagedOnly.policy",
+                    "value": "Allows hooks only from enterprise-managed sources and plugins force-enabled by policy."
+                }
+            },
+            "type": "boolean",
+            "default": false,
             "included": false
         },
         {
@@ -363,6 +448,21 @@
             ]
         },
         {
+            "key": "dictation.enabled",
+            "name": "DictationEnabled",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.131",
+            "localization": {
+                "description": {
+                    "key": "dictation.enabled.policy",
+                    "value": "Controls whether dictation is available across the product (chat input, editor, and terminal)."
+                }
+            },
+            "type": "boolean",
+            "default": true,
+            "included": true
+        },
+        {
             "key": "chat.defaultModel",
             "name": "ChatDefaultModel",
             "category": "InteractiveSession",
@@ -455,42 +555,6 @@
                 "all"
             ],
             "included": true
-        },
-        {
-            "key": "chat.mcp.allowedServers",
-            "name": "ChatAllowedMcpServers",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.130",
-            "localization": {
-                "description": {
-                    "key": "chat.mcp.allowedServers.policy",
-                    "value": "Allowlist of Model Context Protocol servers. When set, only servers matching an entry may be installed or run; omit entirely to allow all servers (subject to the deny list)."
-                }
-            },
-            "type": [
-                "array",
-                "null"
-            ],
-            "default": null,
-            "included": false
-        },
-        {
-            "key": "chat.mcp.deniedServers",
-            "name": "ChatDeniedMcpServers",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.130",
-            "localization": {
-                "description": {
-                    "key": "chat.mcp.deniedServers.policy",
-                    "value": "Denylist of Model Context Protocol servers. Servers matching any entry are blocked from being installed or run, even if they also match the allow list; deny rules always take precedence."
-                }
-            },
-            "type": [
-                "array",
-                "null"
-            ],
-            "default": null,
-            "included": false
         },
         {
             "key": "chat.extensionTools.enabled",
@@ -623,7 +687,7 @@
             "localization": {
                 "description": {
                     "key": "chat.useHooks.description",
-                    "value": "Controls whether chat hooks are executed at strategic points during an agent's workflow. Hooks are loaded from the files configured in `#chat.hookFilesLocations#`."
+                    "value": "Controls whether chat hooks are executed at strategic points during an agent's workflow. Hooks are loaded from the files configured in `#chat.hookFilesLocations#`. This setting is only used by the Local agent harness."
                 }
             },
             "type": "boolean",
@@ -910,21 +974,6 @@
                 "description": {
                     "key": "github.copilot.chat.reviewAgent.enabled",
                     "value": "Enables the code review agent."
-                }
-            },
-            "type": "boolean",
-            "default": true,
-            "included": true
-        },
-        {
-            "key": "dictation.enabled",
-            "name": "DictationEnabled",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.131",
-            "localization": {
-                "description": {
-                    "key": "dictation.enabled.policy",
-                    "value": "Controls whether dictation is available across the product (chat input, editor, and terminal)."
                 }
             },
             "type": "boolean",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -578,7 +578,7 @@
             "localization": {
                 "description": {
                     "key": "chat.customizations.strictPluginOnlyCustomization.policy",
-                    "value": "Blocks standalone user and workspace skills, agents, hooks, and MCP servers while keeping eligible plugin customizations available."
+                    "value": "Blocks standalone user and workspace skills, agents, hooks, instructions, and MCP servers while keeping eligible plugin customizations available."
                 }
             },
             "type": "boolean",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -199,15 +199,11 @@
             "localization": {
                 "description": {
                     "key": "chat.customizations.strictPluginOnlyCustomization.policy",
-                    "value": "Blocks standalone user and workspace customizations for all or selected surfaces while keeping eligible plugin customizations available."
+                    "value": "Blocks standalone user and workspace skills, agents, hooks, and MCP servers while keeping eligible plugin customizations available."
                 }
             },
-            "type": [
-                "boolean",
-                "array",
-                "null"
-            ],
-            "default": null,
+            "type": "boolean",
+            "default": false,
             "included": false
         },
         {

--- a/src/vs/platform/mcp/common/allowedMcpServersService.ts
+++ b/src/vs/platform/mcp/common/allowedMcpServersService.ts
@@ -9,9 +9,10 @@ import { createCommandUri, IMarkdownString, MarkdownString } from '../../../base
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { Emitter } from '../../../base/common/event.js';
 import { hasKey } from '../../../base/common/types.js';
-import { checkMcpServerAllowed, getMcpServerMatchers, IMcpServerIdentity, McpServerAllowResult } from './allowedMcpServers.js';
+import { checkMcpServerAllowed, getMcpServerMatchers, IMcpServerIdentity, IMcpServerMatcher, McpServerAllowResult } from './allowedMcpServers.js';
 import { IAllowedMcpServersService, IGalleryMcpServer, IInstallableMcpServer, ILocalMcpServer, mcpAccessConfig, mcpAllowedServersConfig, mcpDeniedServersConfig, McpAccessValue } from './mcpManagement.js';
 import { McpServerType } from './mcpPlatformTypes.js';
+import { COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_CONFIG } from '../../policy/common/copilotManagedSettings.js';
 
 export class AllowedMcpServersService extends Disposable implements IAllowedMcpServersService {
 
@@ -25,7 +26,7 @@ export class AllowedMcpServersService extends Disposable implements IAllowedMcpS
 	) {
 		super();
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(mcpAccessConfig) || e.affectsConfiguration(mcpAllowedServersConfig) || e.affectsConfiguration(mcpDeniedServersConfig)) {
+			if (e.affectsConfiguration(mcpAccessConfig) || e.affectsConfiguration(mcpAllowedServersConfig) || e.affectsConfiguration(mcpDeniedServersConfig) || e.affectsConfiguration(COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_CONFIG)) {
 				this._onDidChangeAllowedMcpServers.fire();
 			}
 		}));
@@ -41,8 +42,13 @@ export class AllowedMcpServersService extends Disposable implements IAllowedMcpS
 			return new MarkdownString(nls.localize('mcp servers are not allowed', "Model Context Protocol servers are disabled in the Editor. Please check your [settings]({0}).", settingsCommandLink));
 		}
 
-		const allowlist = getMcpServerMatchers(this.configurationService.getValue(mcpAllowedServersConfig));
-		const denylist = getMcpServerMatchers(this.configurationService.getValue(mcpDeniedServersConfig));
+		const managedOnly = this.configurationService.getValue<boolean>(COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_CONFIG) === true;
+		const allowlist = managedOnly
+			? getMcpServerMatchers(this.configurationService.inspect<readonly IMcpServerMatcher[]>(mcpAllowedServersConfig).policyValue) ?? []
+			: getMcpServerMatchers(this.configurationService.getValue(mcpAllowedServersConfig));
+		const denylist = managedOnly
+			? this.getAllConfiguredMatchers(mcpDeniedServersConfig)
+			: getMcpServerMatchers(this.configurationService.getValue(mcpDeniedServersConfig));
 		switch (checkMcpServerAllowed(allowlist, denylist, identity)) {
 			case McpServerAllowResult.Denied:
 				return new MarkdownString(nls.localize('mcp server is denied', "This Model Context Protocol server is blocked by your organization's policy. Please contact your administrator for more information."));
@@ -51,6 +57,20 @@ export class AllowedMcpServersService extends Disposable implements IAllowedMcpS
 		}
 
 		return true;
+	}
+
+	private getAllConfiguredMatchers(key: string): IMcpServerMatcher[] {
+		const inspected = this.configurationService.inspect<readonly IMcpServerMatcher[]>(key);
+		return [
+			inspected.applicationValue,
+			inspected.userValue,
+			inspected.userLocalValue,
+			inspected.userRemoteValue,
+			inspected.workspaceValue,
+			inspected.workspaceFolderValue,
+			inspected.memoryValue,
+			inspected.policyValue,
+		].flatMap(value => getMcpServerMatchers(value) ?? []);
 	}
 
 	private toIdentity(mcpServer: IGalleryMcpServer | ILocalMcpServer | IInstallableMcpServer): IMcpServerIdentity {

--- a/src/vs/platform/mcp/test/common/allowedMcpServersService.test.ts
+++ b/src/vs/platform/mcp/test/common/allowedMcpServersService.test.ts
@@ -9,13 +9,20 @@ import { TestConfigurationService } from '../../../configuration/test/common/tes
 import { AllowedMcpServersService } from '../../common/allowedMcpServersService.js';
 import { IInstallableMcpServer, mcpAccessConfig, mcpAllowedServersConfig, mcpDeniedServersConfig, McpAccessValue } from '../../common/mcpManagement.js';
 import { McpServerType } from '../../common/mcpPlatformTypes.js';
+import { COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_CONFIG } from '../../../policy/common/copilotManagedSettings.js';
+import { IConfigurationValue } from '../../../configuration/common/configuration.js';
 
 suite('AllowedMcpServersService', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createService(config: Record<string, unknown>): AllowedMcpServersService {
+	function createService(config: Record<string, unknown>, policy: Record<string, unknown> = {}): AllowedMcpServersService {
 		const configurationService = new TestConfigurationService(config);
+		const inspect = configurationService.inspect.bind(configurationService);
+		configurationService.inspect = <T>(key: string): IConfigurationValue<T> => ({
+			...inspect<T>(key),
+			policyValue: policy[key] as T | undefined,
+		});
 		return disposables.add(new AllowedMcpServersService(configurationService));
 	}
 
@@ -76,5 +83,29 @@ suite('AllowedMcpServersService', () => {
 
 		const blocked: IInstallableMcpServer = { name: 'anything', config: { type: McpServerType.REMOTE, url: 'https://other.example.org/api' } };
 		assert.notStrictEqual(service.isAllowed(blocked), true);
+	});
+
+	test('managed-only mode ignores user allow entries and uses the policy allowlist', () => {
+		const service = createService({
+			[COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_CONFIG]: true,
+			[mcpAllowedServersConfig]: [{ serverName: 'user-server' }],
+		}, {
+			[mcpAllowedServersConfig]: [{ serverName: 'managed-server' }],
+		});
+
+		assert.strictEqual(service.isServerAllowed({ name: 'managed-server' }), true);
+		assert.notStrictEqual(service.isServerAllowed({ name: 'user-server' }), true);
+	});
+
+	test('managed-only mode blocks all when no managed allowlist exists and preserves lower-layer denies', () => {
+		const service = createService({
+			[COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_CONFIG]: true,
+			[mcpDeniedServersConfig]: [{ serverName: 'denied' }],
+		});
+
+		const denied = service.isServerAllowed({ name: 'denied' });
+		assert.notStrictEqual(denied, true);
+		assert.ok(denied !== true && denied.value.includes('blocked by your organization'));
+		assert.notStrictEqual(service.isServerAllowed({ name: 'other' }), true);
 	});
 });

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -43,7 +43,7 @@ export const COPILOT_ALLOWED_MCP_SERVERS_KEY = 'allowedMcpServers';
 /** Managed-settings key for the per-server MCP denylist (carried as a JSON-encoded array of matcher entries; deny always takes precedence over allow). */
 export const COPILOT_DENIED_MCP_SERVERS_KEY = 'deniedMcpServers';
 
-/** Managed-settings key that blocks standalone user/workspace customizations for all or selected surfaces. */
+/** Managed-settings key that blocks standalone user/workspace customizations. */
 export const COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY = 'strictPluginOnlyCustomization';
 
 /** Managed-settings key that makes the enterprise MCP allowlist authoritative. */
@@ -436,21 +436,6 @@ function encodeArray(value: unknown): unknown[] | undefined {
 	return Array.isArray(value) ? value : undefined;
 }
 
-const STRICT_PLUGIN_ONLY_CUSTOMIZATION_SURFACES = new Set(['skills', 'agents', 'hooks', 'mcpServers']);
-
-function encodeStrictPluginOnlyCustomization(value: unknown, onWarn?: (msg: string) => void): boolean | readonly string[] | undefined {
-	if (typeof value === 'boolean') {
-		return value;
-	}
-	if (Array.isArray(value) && value.every(entry => isString(entry) && STRICT_PLUGIN_ONLY_CUSTOMIZATION_SURFACES.has(entry))) {
-		return value;
-	}
-	if (value !== undefined) {
-		onWarn?.('Ignoring managed setting "strictPluginOnlyCustomization": expected a boolean or an array containing skills, agents, hooks, and/or mcpServers');
-	}
-	return undefined;
-}
-
 /**
  * Encode the schema's `{ [id]: { source } }` marketplace map into the canonical
  * `{ [name]: url-or-shorthand }` dict; drops malformed entries (with an optional warning) and omits
@@ -476,10 +461,6 @@ const STRUCTURED_MANAGED_SETTINGS: readonly IStructuredManagedSetting[] = [
 	{
 		key: COPILOT_DENIED_MCP_SERVERS_KEY,
 		encode: encodeArray,
-	},
-	{
-		key: COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY,
-		encode: encodeStrictPluginOnlyCustomization,
 	},
 	{
 		key: COPILOT_EXTRA_MARKETPLACES_KEY,

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -43,6 +43,24 @@ export const COPILOT_ALLOWED_MCP_SERVERS_KEY = 'allowedMcpServers';
 /** Managed-settings key for the per-server MCP denylist (carried as a JSON-encoded array of matcher entries; deny always takes precedence over allow). */
 export const COPILOT_DENIED_MCP_SERVERS_KEY = 'deniedMcpServers';
 
+/** Managed-settings key that blocks standalone user/workspace customizations for all or selected surfaces. */
+export const COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY = 'strictPluginOnlyCustomization';
+
+/** Managed-settings key that makes the enterprise MCP allowlist authoritative. */
+export const COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY = 'allowManagedMcpServersOnly';
+
+/** Managed-settings key that allows hooks only from managed sources. */
+export const COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY = 'allowManagedHooksOnly';
+
+/** Policy-only configuration delivery slot for {@link COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY}. */
+export const COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG = 'chat.customizations.strictPluginOnlyCustomization';
+
+/** Policy-only configuration delivery slot for {@link COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY}. */
+export const COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_CONFIG = 'chat.mcp.allowManagedServersOnly';
+
+/** Policy-only configuration delivery slot for {@link COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY}. */
+export const COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG = 'chat.hooks.allowManagedOnly';
+
 /**
  * Managed-settings key for the default chat model (carried as a plain string: `auto`, a model
  * family name, or a full model id). Nested under `permissions` in the managed-settings schema
@@ -418,6 +436,21 @@ function encodeArray(value: unknown): unknown[] | undefined {
 	return Array.isArray(value) ? value : undefined;
 }
 
+const STRICT_PLUGIN_ONLY_CUSTOMIZATION_SURFACES = new Set(['skills', 'agents', 'hooks', 'mcpServers']);
+
+function encodeStrictPluginOnlyCustomization(value: unknown, onWarn?: (msg: string) => void): boolean | readonly string[] | undefined {
+	if (typeof value === 'boolean') {
+		return value;
+	}
+	if (Array.isArray(value) && value.every(entry => isString(entry) && STRICT_PLUGIN_ONLY_CUSTOMIZATION_SURFACES.has(entry))) {
+		return value;
+	}
+	if (value !== undefined) {
+		onWarn?.('Ignoring managed setting "strictPluginOnlyCustomization": expected a boolean or an array containing skills, agents, hooks, and/or mcpServers');
+	}
+	return undefined;
+}
+
 /**
  * Encode the schema's `{ [id]: { source } }` marketplace map into the canonical
  * `{ [name]: url-or-shorthand }` dict; drops malformed entries (with an optional warning) and omits
@@ -443,6 +476,10 @@ const STRUCTURED_MANAGED_SETTINGS: readonly IStructuredManagedSetting[] = [
 	{
 		key: COPILOT_DENIED_MCP_SERVERS_KEY,
 		encode: encodeArray,
+	},
+	{
+		key: COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY,
+		encode: encodeStrictPluginOnlyCustomization,
 	},
 	{
 		key: COPILOT_EXTRA_MARKETPLACES_KEY,

--- a/src/vs/platform/policy/test/common/fileManagedSettingsService.test.ts
+++ b/src/vs/platform/policy/test/common/fileManagedSettingsService.test.ts
@@ -15,7 +15,7 @@ import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesy
 import { NullLogService } from '../../../log/common/log.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
-import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, managedModelValue, normalizeManagedSettings, RawManagedSettingsData } from '../../common/copilotManagedSettings.js';
+import { COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY, COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY, COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY, managedModelValue, normalizeManagedSettings, RawManagedSettingsData } from '../../common/copilotManagedSettings.js';
 import { FileManagedSettingsService } from '../../common/fileManagedSettingsService.js';
 import { FileManagedSettingsChannelClient } from '../../common/fileManagedSettingsIpc.js';
 
@@ -42,6 +42,32 @@ suite('normalizeManagedSettings', () => {
 		assert.deepStrictEqual(result, {
 			[COPILOT_ENABLED_PLUGINS_KEY]: JSON.stringify(plugins)
 		});
+	});
+
+	test('normalizes customization lockdown controls', () => {
+		assert.deepStrictEqual(normalizeManagedSettings({
+			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: ['skills', 'hooks'],
+			[COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY]: true,
+			[COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY]: false,
+		}), {
+			[COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY]: true,
+			[COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY]: false,
+			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: '["skills","hooks"]',
+		});
+	});
+
+	test('normalizes boolean strictPluginOnlyCustomization and rejects malformed arrays', () => {
+		assert.deepStrictEqual(normalizeManagedSettings({
+			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: true,
+		}), {
+			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: 'true',
+		});
+
+		const warnings: string[] = [];
+		assert.deepStrictEqual(normalizeManagedSettings({
+			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: ['skills', 'unknown'],
+		}, message => warnings.push(message)), {});
+		assert.strictEqual(warnings.length, 1);
 	});
 
 	test('normalizes extraKnownMarketplaces from schema format to config dict', () => {

--- a/src/vs/platform/policy/test/common/fileManagedSettingsService.test.ts
+++ b/src/vs/platform/policy/test/common/fileManagedSettingsService.test.ts
@@ -46,28 +46,20 @@ suite('normalizeManagedSettings', () => {
 
 	test('normalizes customization lockdown controls', () => {
 		assert.deepStrictEqual(normalizeManagedSettings({
-			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: ['skills', 'hooks'],
+			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: true,
 			[COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY]: true,
 			[COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY]: false,
 		}), {
+			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: true,
 			[COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY]: true,
 			[COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY]: false,
-			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: '["skills","hooks"]',
 		});
 	});
 
-	test('normalizes boolean strictPluginOnlyCustomization and rejects malformed arrays', () => {
-		assert.deepStrictEqual(normalizeManagedSettings({
-			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: true,
-		}), {
-			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: 'true',
-		});
-
-		const warnings: string[] = [];
+	test('drops a non-boolean strictPluginOnlyCustomization value', () => {
 		assert.deepStrictEqual(normalizeManagedSettings({
 			[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: ['skills', 'unknown'],
-		}, message => warnings.push(message)), {});
-		assert.strictEqual(warnings.length, 1);
+		}), {});
 	});
 
 	test('normalizes extraKnownMarketplaces from schema format to config dict', () => {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1339,7 +1339,7 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
-			description: nls.localize('chat.customizations.strictPluginOnlyCustomization', "Blocks standalone user and workspace skills, agents, hooks, and MCP servers while keeping eligible plugin customizations available."),
+			description: nls.localize('chat.customizations.strictPluginOnlyCustomization', "Blocks standalone user and workspace skills, agents, hooks, instructions, and MCP servers while keeping eligible plugin customizations available."),
 			policy: {
 				name: 'ChatStrictPluginOnlyCustomization',
 				category: PolicyCategory.InteractiveSession,
@@ -1351,7 +1351,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.customizations.strictPluginOnlyCustomization.policy',
-						value: nls.localize('chat.customizations.strictPluginOnlyCustomization.policy', "Blocks standalone user and workspace skills, agents, hooks, and MCP servers while keeping eligible plugin customizations available.")
+						value: nls.localize('chat.customizations.strictPluginOnlyCustomization.policy', "Blocks standalone user and workspace skills, agents, hooks, instructions, and MCP servers while keeping eligible plugin customizations available.")
 					}
 				},
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1335,27 +1335,23 @@ configurationRegistry.registerConfiguration({
 			},
 		},
 		[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG]: {
-			type: ['boolean', 'array', 'null'],
-			items: {
-				type: 'string',
-				enum: ['skills', 'agents', 'hooks', 'mcpServers'],
-			},
-			default: null,
+			type: 'boolean',
+			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
-			description: nls.localize('chat.customizations.strictPluginOnlyCustomization', "Blocks standalone user and workspace customizations for all or selected surfaces while keeping eligible plugin customizations available."),
+			description: nls.localize('chat.customizations.strictPluginOnlyCustomization', "Blocks standalone user and workspace skills, agents, hooks, and MCP servers while keeping eligible plugin customizations available."),
 			policy: {
 				name: 'ChatStrictPluginOnlyCustomization',
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.132',
 				value: managedSettingValue(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY),
 				managedSettings: {
-					[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: { type: 'string' },
+					[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: { type: 'boolean' },
 				},
 				localization: {
 					description: {
 						key: 'chat.customizations.strictPluginOnlyCustomization.policy',
-						value: nls.localize('chat.customizations.strictPluginOnlyCustomization.policy', "Blocks standalone user and workspace customizations for all or selected surfaces while keeping eligible plugin customizations available.")
+						value: nls.localize('chat.customizations.strictPluginOnlyCustomization.policy', "Blocks standalone user and workspace skills, agents, hooks, and MCP servers while keeping eligible plugin customizations available.")
 					}
 				},
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -16,7 +16,7 @@ import { AgentHostAhpJsonlLoggingSettingId, AgentHostSdkSandboxEnabledSettingId,
 import { AgentHostCopilotSdkLogLevelSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, AgentHostToolSearchEnabledSettingId, copilotSdkLogLevelSettingValues } from '../../../../platform/agentHost/common/copilotCliConfig.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
-import { COPILOT_ALLOWED_MCP_SERVERS_KEY, COPILOT_DENIED_MCP_SERVERS_KEY, COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, COPILOT_STRICT_MARKETPLACES_KEY, managedModelValue, managedSettingValue } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_ALLOWED_MCP_SERVERS_KEY, COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG, COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY, COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_CONFIG, COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY, COPILOT_DENIED_MCP_SERVERS_KEY, COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, COPILOT_STRICT_MARKETPLACES_KEY, COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY, managedModelValue, managedSettingValue } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../platform/sandbox/common/settings.js';
 import { ChatSessionArchiveActionWordingSettingId } from '../../../../platform/chat/common/sessionArchiveActions.js';
 import { registerEditorFeature } from '../../../../editor/common/editorFeatures.js';
@@ -1059,6 +1059,28 @@ configurationRegistry.registerConfiguration({
 				},
 			}
 		},
+		[COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_CONFIG]: {
+			type: 'boolean',
+			default: false,
+			scope: ConfigurationScope.APPLICATION,
+			included: false,
+			description: nls.localize('chat.mcp.allowManagedServersOnly', "Use only the enterprise-managed MCP allowlist when deciding which servers may run."),
+			policy: {
+				name: 'ChatAllowManagedMcpServersOnly',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.132',
+				value: managedSettingValue(COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY),
+				managedSettings: {
+					[COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY]: { type: 'boolean' },
+				},
+				localization: {
+					description: {
+						key: 'chat.mcp.allowManagedServersOnly.policy',
+						value: nls.localize('chat.mcp.allowManagedServersOnly.policy', "Use only the enterprise-managed MCP allowlist when deciding which servers may run.")
+					}
+				},
+			}
+		},
 		[mcpAutoStartConfig]: {
 			type: 'string',
 			description: nls.localize('chat.mcp.autostart', "Controls whether MCP servers should be automatically started when the chat messages are submitted."),
@@ -1311,6 +1333,54 @@ configurationRegistry.registerConfiguration({
 					}
 				},
 			},
+		},
+		[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG]: {
+			type: ['boolean', 'array', 'null'],
+			items: {
+				type: 'string',
+				enum: ['skills', 'agents', 'hooks', 'mcpServers'],
+			},
+			default: null,
+			scope: ConfigurationScope.APPLICATION,
+			included: false,
+			description: nls.localize('chat.customizations.strictPluginOnlyCustomization', "Blocks standalone user and workspace customizations for all or selected surfaces while keeping eligible plugin customizations available."),
+			policy: {
+				name: 'ChatStrictPluginOnlyCustomization',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.132',
+				value: managedSettingValue(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY),
+				managedSettings: {
+					[COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY]: { type: 'string' },
+				},
+				localization: {
+					description: {
+						key: 'chat.customizations.strictPluginOnlyCustomization.policy',
+						value: nls.localize('chat.customizations.strictPluginOnlyCustomization.policy', "Blocks standalone user and workspace customizations for all or selected surfaces while keeping eligible plugin customizations available.")
+					}
+				},
+			}
+		},
+		[COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG]: {
+			type: 'boolean',
+			default: false,
+			scope: ConfigurationScope.APPLICATION,
+			included: false,
+			description: nls.localize('chat.hooks.allowManagedOnly', "Allows hooks only from enterprise-managed sources and plugins force-enabled by policy."),
+			policy: {
+				name: 'ChatAllowManagedHooksOnly',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.132',
+				value: managedSettingValue(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY),
+				managedSettings: {
+					[COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY]: { type: 'boolean' },
+				},
+				localization: {
+					description: {
+						key: 'chat.hooks.allowManagedOnly.policy',
+						value: nls.localize('chat.hooks.allowManagedOnly.policy', "Allows hooks only from enterprise-managed sources and plugins force-enabled by policy.")
+					}
+				},
+			}
 		},
 		[ChatConfiguration.AgentEnabled]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/common/customizationLockdown.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationLockdown.ts
@@ -16,6 +16,7 @@ export function isPromptTypeBlocked(value: StrictPluginOnlyCustomization, type: 
 		case PromptsType.skill:
 		case PromptsType.agent:
 		case PromptsType.hook:
+		case PromptsType.instructions:
 			return isStrictPluginOnlyCustomizationEnabled(value);
 		default:
 			return false;

--- a/src/vs/workbench/contrib/chat/common/customizationLockdown.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationLockdown.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptsType } from './promptSyntax/promptTypes.js';
+
+export type CustomizationLockdownSurface = 'skills' | 'agents' | 'hooks' | 'mcpServers';
+export type StrictPluginOnlyCustomization = boolean | readonly CustomizationLockdownSurface[] | null | undefined;
+
+export function isCustomizationSurfaceBlocked(value: StrictPluginOnlyCustomization, surface: CustomizationLockdownSurface): boolean {
+	return value === true || (Array.isArray(value) && value.includes(surface));
+}
+
+export function isPromptTypeBlocked(value: StrictPluginOnlyCustomization, type: PromptsType): boolean {
+	switch (type) {
+		case PromptsType.skill:
+			return isCustomizationSurfaceBlocked(value, 'skills');
+		case PromptsType.agent:
+			return isCustomizationSurfaceBlocked(value, 'agents');
+		case PromptsType.hook:
+			return isCustomizationSurfaceBlocked(value, 'hooks');
+		default:
+			return false;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/customizationLockdown.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationLockdown.ts
@@ -5,21 +5,18 @@
 
 import { PromptsType } from './promptSyntax/promptTypes.js';
 
-export type CustomizationLockdownSurface = 'skills' | 'agents' | 'hooks' | 'mcpServers';
-export type StrictPluginOnlyCustomization = boolean | readonly CustomizationLockdownSurface[] | null | undefined;
+export type StrictPluginOnlyCustomization = boolean | null | undefined;
 
-export function isCustomizationSurfaceBlocked(value: StrictPluginOnlyCustomization, surface: CustomizationLockdownSurface): boolean {
-	return value === true || (Array.isArray(value) && value.includes(surface));
+export function isStrictPluginOnlyCustomizationEnabled(value: StrictPluginOnlyCustomization): boolean {
+	return value === true;
 }
 
 export function isPromptTypeBlocked(value: StrictPluginOnlyCustomization, type: PromptsType): boolean {
 	switch (type) {
 		case PromptsType.skill:
-			return isCustomizationSurfaceBlocked(value, 'skills');
 		case PromptsType.agent:
-			return isCustomizationSurfaceBlocked(value, 'agents');
 		case PromptsType.hook:
-			return isCustomizationSurfaceBlocked(value, 'hooks');
+			return isStrictPluginOnlyCustomizationEnabled(value);
 		default:
 			return false;
 	}

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -176,7 +176,7 @@ Each `PluginSourceKind` has a strategy that knows how to compute cache paths, pr
 The managed customization controls are complementary:
 
 - `strictKnownMarketplaces` restricts which marketplace sources may provide plugins.
-- `strictPluginOnlyCustomization` blocks standalone user and workspace skills, agents, hooks, and MCP servers. Eligible plugin contributions remain available.
+- `strictPluginOnlyCustomization` blocks standalone user and workspace skills, agents, hooks, instructions, and MCP servers. Eligible plugin contributions remain available.
 - `allowManagedMcpServersOnly` makes the managed MCP allowlist authoritative; lower-layer allow entries cannot broaden it and deny entries remain restrictive.
 - `allowManagedHooksOnly` permits plugin hooks only when managed `enabledPlugins` force-enables the plugin. User/workspace hooks and hooks from otherwise user-enabled plugins do not load.
 

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -176,7 +176,7 @@ Each `PluginSourceKind` has a strategy that knows how to compute cache paths, pr
 The managed customization controls are complementary:
 
 - `strictKnownMarketplaces` restricts which marketplace sources may provide plugins.
-- `strictPluginOnlyCustomization` blocks standalone user and workspace skills, agents, hooks, and MCP servers for all or selected surfaces. Eligible plugin contributions remain available.
+- `strictPluginOnlyCustomization` blocks standalone user and workspace skills, agents, hooks, and MCP servers. Eligible plugin contributions remain available.
 - `allowManagedMcpServersOnly` makes the managed MCP allowlist authoritative; lower-layer allow entries cannot broaden it and deny entries remain restrictive.
 - `allowManagedHooksOnly` permits plugin hooks only when managed `enabledPlugins` force-enables the plugin. User/workspace hooks and hooks from otherwise user-enabled plugins do not load.
 

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -171,6 +171,17 @@ Each `PluginSourceKind` has a strategy that knows how to compute cache paths, pr
 | `chat.pluginLocations` | `Record<string, boolean>` | `{}` | Local plugin directories to discover |
 | `chat.pluginMarketplaces` | `string[]` | `[]` | Marketplace references to fetch from |
 
+### Enterprise customization lockdown
+
+The managed customization controls are complementary:
+
+- `strictKnownMarketplaces` restricts which marketplace sources may provide plugins.
+- `strictPluginOnlyCustomization` blocks standalone user and workspace skills, agents, hooks, and MCP servers for all or selected surfaces. Eligible plugin contributions remain available.
+- `allowManagedMcpServersOnly` makes the managed MCP allowlist authoritative; lower-layer allow entries cannot broaden it and deny entries remain restrictive.
+- `allowManagedHooksOnly` permits plugin hooks only when managed `enabledPlugins` force-enables the plugin. User/workspace hooks and hooks from otherwise user-enabled plugins do not load.
+
+`strictPluginOnlyCustomization` does not replace strict marketplace enforcement. Hardened deployments apply both controls when plugin source and standalone customization provenance must both be constrained.
+
 ### Storage (ApplicationScope, MachineTarget)
 | Key | Description |
 |-----|-------------|

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginEnablement.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginEnablement.ts
@@ -85,6 +85,14 @@ export function isAgentPluginBlockedByPolicy(
 	return pluginId !== undefined && enabledPluginsPolicy?.[pluginId] === false;
 }
 
+export function isAgentPluginForceEnabledByPolicy(
+	plugin: IAgentPlugin,
+	enabledPluginsPolicy: Record<string, boolean> | undefined,
+): boolean {
+	const pluginId = getAgentPluginPolicyId(plugin);
+	return pluginId !== undefined && enabledPluginsPolicy?.[pluginId] === true;
+}
+
 export function getAgentPluginPolicyId(plugin: IAgentPlugin): string | undefined {
 	const identity = getPolicyIdentity(plugin);
 	return identity ? `${identity.name}@${identity.marketplace}` : undefined;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -10,7 +10,7 @@ import { ParseError, parse as parseJSONC } from '../../../../../../base/common/j
 import { getParseErrorMessage } from '../../../../../../base/common/jsonErrorMessages.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../../../../base/common/stopwatch.js';
-import { autorun, IReader } from '../../../../../../base/common/observable.js';
+import { autorun, IReader, observableFromEvent } from '../../../../../../base/common/observable.js';
 import { ResourceMap, ResourceSet } from '../../../../../../base/common/map.js';
 import { basename, dirname, isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -48,6 +48,10 @@ import { getCanonicalPluginCommandId, IAgentPlugin, IAgentPluginService } from '
 import { isContributionEnabled } from '../../enablement.js';
 import { assertNever } from '../../../../../../base/common/assert.js';
 import { ExtensionPromptFileService } from './extensionPromptFileService.js';
+import { COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG, COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG } from '../../../../../../platform/policy/common/copilotManagedSettings.js';
+import { isPromptTypeBlocked, StrictPluginOnlyCustomization } from '../../customizationLockdown.js';
+import { isAgentPluginForceEnabledByPolicy } from '../../plugins/agentPluginEnablement.js';
+import { ChatConfiguration } from '../../constants.js';
 
 /**
  * Provides prompt services.
@@ -159,6 +163,8 @@ export class PromptsService extends Disposable implements IPromptsService {
 
 		this.extensionPromptFiles = this._register(this.instantiationService.createInstance(ExtensionPromptFileService));
 		const onDidChangeExtensionPromptFiles = this.extensionPromptFiles.onDidChange;
+		const onDidChangeCustomizationLockdown = Event.filter(this.configurationService.onDidChangeConfiguration,
+			e => e.affectsConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG) || e.affectsConfiguration(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG));
 
 		// Invalidate the cached file location list whenever an extension contribution
 		// or provider for the same type changes (or its `when` re-evaluates).
@@ -175,6 +181,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 				Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(PromptsConfig.USE_CHAT_HOOKS)),
 				Event.filter(onDidChangeExtensionPromptFiles, e => e.type === PromptsType.agent),
 				Event.filter(this._onDidPluginPromptFilesChange.event, t => t === PromptsType.agent),
+				onDidChangeCustomizationLockdown,
 				this.workspaceTrustService.onDidChangeTrust,
 			)
 		));
@@ -187,7 +194,8 @@ export class PromptsService extends Disposable implements IPromptsService {
 				Event.filter(modelChangeEvent, e => e.promptType === PromptsType.prompt),
 				Event.filter(modelChangeEvent, e => e.promptType === PromptsType.skill),
 				Event.filter(onDidChangeExtensionPromptFiles, e => e.type === PromptsType.prompt || e.type === PromptsType.skill),
-				Event.filter(this._onDidPluginPromptFilesChange.event, t => t === PromptsType.prompt || t === PromptsType.skill)),
+				Event.filter(this._onDidPluginPromptFilesChange.event, t => t === PromptsType.prompt || t === PromptsType.skill),
+				onDidChangeCustomizationLockdown),
 		));
 
 		this.cachedSkills = this._register(new CachedPromise(
@@ -196,7 +204,8 @@ export class PromptsService extends Disposable implements IPromptsService {
 				this.getFileLocatorEvent(PromptsType.skill),
 				Event.filter(modelChangeEvent, e => e.promptType === PromptsType.skill),
 				Event.filter(onDidChangeExtensionPromptFiles, e => e.type === PromptsType.skill),
-				Event.filter(this._onDidPluginPromptFilesChange.event, t => t === PromptsType.skill))
+				Event.filter(this._onDidPluginPromptFilesChange.event, t => t === PromptsType.skill),
+				onDidChangeCustomizationLockdown)
 		));
 
 		this.cachedHooks = this._register(new CachedPromise(
@@ -204,6 +213,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 			() => Event.any(
 				this.getFileLocatorEvent(PromptsType.hook),
 				Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(PromptsConfig.USE_CHAT_HOOKS) || e.affectsConfiguration(PromptsConfig.USE_CLAUDE_HOOKS)),
+				onDidChangeCustomizationLockdown,
 				this._onDidPluginHooksChange.event,
 				this.workspaceTrustService.onDidChangeTrust,
 			)
@@ -235,11 +245,20 @@ export class PromptsService extends Disposable implements IPromptsService {
 			(plugin, reader) => plugin.instructions.read(reader),
 		));
 
+		const managedHooksOnly = observableFromEvent(this, onDidChangeCustomizationLockdown,
+			() => this.configurationService.getValue<boolean>(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG) === true);
+		const enabledPluginsPolicy = observableFromEvent(this,
+			Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(ChatConfiguration.EnabledPlugins)),
+			() => this.configurationService.inspect<Record<string, boolean>>(ChatConfiguration.EnabledPlugins).policyValue);
+
 		this._register(autorun(reader => {
 			const plugins = this.agentPluginService.plugins.read(reader);
+			const managedHooksOnlyValue = managedHooksOnly.read(reader);
+			const enabledPluginsPolicyValue = enabledPluginsPolicy.read(reader);
 			const hookFiles: IPluginPromptPath[] = [];
 			for (const plugin of plugins) {
-				if (isContributionEnabled(plugin.enablement.read(reader))) {
+				if (isContributionEnabled(plugin.enablement.read(reader))
+					&& (!managedHooksOnlyValue || isAgentPluginForceEnabledByPolicy(plugin, enabledPluginsPolicyValue))) {
 					for (const hook of plugin.hooks.read(reader)) {
 						hookFiles.push({
 							uri: hook.uri,
@@ -332,9 +351,10 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	private async computeListPromptFiles(type: PromptsType, token: CancellationToken): Promise<readonly IPromptPath[]> {
+		const allowStandalone = !this.areStandalonePromptFilesBlocked(type);
 		const prompts = await Promise.all([
-			this.fileLocator.listFiles(type, PromptsStorage.user, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.user, type } satisfies IUserPromptPath))),
-			this.fileLocator.listFiles(type, PromptsStorage.local, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.local, type } satisfies ILocalPromptPath))),
+			allowStandalone ? this.fileLocator.listFiles(type, PromptsStorage.user, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.user, type } satisfies IUserPromptPath))) : [],
+			allowStandalone ? this.fileLocator.listFiles(type, PromptsStorage.local, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.local, type } satisfies ILocalPromptPath))) : [],
 			this.getExtensionPromptFiles(type, token),
 			this._pluginPromptFilesByType.get(type) ?? [],
 			this.getBuiltinPromptFiles(type, token),
@@ -347,6 +367,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 	 * Collects diagnostic information about which source folders were searched for display in the debug panel.
 	 */
 	private async _collectSourceFolderDiagnostics(type: PromptsType): Promise<IPromptSourceFolderResult[]> {
+		if (this.areStandalonePromptFilesBlocked(type)) {
+			return [];
+		}
 		const resolvedFolders = await this.fileLocator.getSourceFoldersInDiscoveryOrder(type);
 		return resolvedFolders.map(folder => ({
 			uri: folder.uri,
@@ -375,10 +398,10 @@ export class PromptsService extends Disposable implements IPromptsService {
 				promptPaths = await this.getExtensionPromptFiles(type, token);
 				break;
 			case PromptsStorage.local:
-				promptPaths = await this.fileLocator.listFiles(type, PromptsStorage.local, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.local, type } satisfies ILocalPromptPath)));
+				promptPaths = this.areStandalonePromptFilesBlocked(type) ? [] : await this.fileLocator.listFiles(type, PromptsStorage.local, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.local, type } satisfies ILocalPromptPath)));
 				break;
 			case PromptsStorage.user:
-				promptPaths = await this.fileLocator.listFiles(type, PromptsStorage.user, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.user, type } satisfies IUserPromptPath)));
+				promptPaths = this.areStandalonePromptFilesBlocked(type) ? [] : await this.fileLocator.listFiles(type, PromptsStorage.user, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.user, type } satisfies IUserPromptPath)));
 				break;
 			case PromptsStorage.plugin:
 				promptPaths = this._pluginPromptFilesByType.get(type) ?? [];
@@ -407,6 +430,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	public async getSourceFolders(type: PromptsType): Promise<readonly IPromptPath[]> {
+		if (this.areStandalonePromptFilesBlocked(type)) {
+			return [];
+		}
 		const result: IPromptPath[] = [];
 
 		if (type === PromptsType.hook) {
@@ -432,7 +458,16 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	public async getResolvedSourceFolders(type: PromptsType): Promise<readonly IResolvedPromptSourceFolder[]> {
+		if (this.areStandalonePromptFilesBlocked(type)) {
+			return [];
+		}
 		return this.fileLocator.getResolvedSourceFolders(type);
+	}
+
+	private areStandalonePromptFilesBlocked(type: PromptsType): boolean {
+		const strictPluginOnly = this.configurationService.getValue<StrictPluginOnlyCustomization>(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG);
+		return isPromptTypeBlocked(strictPluginOnly, type)
+			|| (type === PromptsType.hook && this.configurationService.getValue<boolean>(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG) === true);
 	}
 
 	// slash prompt commands
@@ -676,7 +711,10 @@ export class PromptsService extends Disposable implements IPromptsService {
 				// Parse hooks from the frontmatter if present
 				let hooks: ChatRequestHooks | undefined;
 				const hooksRaw = ast.header?.hooksRaw;
-				if (useChatHooks && isWorkspaceTrusted && hooksRaw) {
+				const strictPluginOnly = this.configurationService.getValue<StrictPluginOnlyCustomization>(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG);
+				const standaloneHooksBlocked = isPromptTypeBlocked(strictPluginOnly, PromptsType.hook)
+					&& (promptPath.storage === PromptsStorage.local || promptPath.storage === PromptsStorage.user);
+				if (useChatHooks && isWorkspaceTrusted && hooksRaw && !standaloneHooksBlocked && this.configurationService.getValue<boolean>(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG) !== true) {
 					const hookWorkspaceFolder = this.workspaceService.getWorkspaceFolder(uri) ?? defaultFolder;
 					const workspaceRootUri = hookWorkspaceFolder?.uri;
 					const target = getTarget(PromptsType.agent, ast.header ?? promptPath.uri);
@@ -1272,8 +1310,11 @@ export class PromptsService extends Disposable implements IPromptsService {
 
 		// Collect hooks from agent plugins
 		const plugins = this.agentPluginService.plugins.get();
+		const managedHooksOnlyValue = this.configurationService.getValue<boolean>(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG) === true;
+		const enabledPluginsPolicyValue = this.configurationService.inspect<Record<string, boolean>>(ChatConfiguration.EnabledPlugins).policyValue;
 		for (const plugin of plugins) {
-			if (!isContributionEnabled(plugin.enablement.get())) {
+			if (!isContributionEnabled(plugin.enablement.get())
+				|| (managedHooksOnlyValue && !isAgentPluginForceEnabledByPolicy(plugin, enabledPluginsPolicyValue))) {
 				continue;
 			}
 			for (const hook of plugin.hooks.get()) {
@@ -1337,8 +1378,11 @@ export class PromptsService extends Disposable implements IPromptsService {
 
 		// Collect all skills with their metadata for sorting
 		const allSkills: Array<IPromptPath> = [];
+		const standaloneSkills = this.areStandalonePromptFilesBlocked(PromptsType.skill)
+			? []
+			: await this.fileLocator.findAgentSkills(token);
 		const skills = await Promise.all([
-			this.fileLocator.findAgentSkills(token),
+			Promise.resolve(standaloneSkills),
 			this.getExtensionPromptFiles(PromptsType.skill, token),
 			Promise.resolve(this._pluginPromptFilesByType.get(PromptsType.skill) ?? []),
 			this.getBuiltinPromptFiles(PromptsType.skill, token)

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -165,6 +165,11 @@ export class PromptsService extends Disposable implements IPromptsService {
 		const onDidChangeExtensionPromptFiles = this.extensionPromptFiles.onDidChange;
 		const onDidChangeCustomizationLockdown = Event.filter(this.configurationService.onDidChangeConfiguration,
 			e => e.affectsConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG) || e.affectsConfiguration(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG));
+		this._register(onDidChangeCustomizationLockdown(() => {
+			this.cachedFileLocations[PromptsType.agent] = undefined;
+			this.cachedFileLocations[PromptsType.skill] = undefined;
+			this.cachedFileLocations[PromptsType.hook] = undefined;
+		}));
 
 		// Invalidate the cached file location list whenever an extension contribution
 		// or provider for the same type changes (or its `when` re-evaluates).
@@ -470,6 +475,21 @@ export class PromptsService extends Disposable implements IPromptsService {
 			|| (type === PromptsType.hook && this.configurationService.getValue<boolean>(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG) === true);
 	}
 
+	private areAgentHooksAllowed(promptPath: IPromptPath): boolean {
+		if (this.configurationService.getValue<boolean>(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG) === true) {
+			if (promptPath.storage !== PromptsStorage.plugin || !promptPath.pluginUri) {
+				return false;
+			}
+			const plugin = this.agentPluginService.plugins.get().find(candidate => isEqual(candidate.uri, promptPath.pluginUri));
+			const enabledPluginsPolicy = this.configurationService.inspect<Record<string, boolean>>(ChatConfiguration.EnabledPlugins).policyValue;
+			return plugin !== undefined && isAgentPluginForceEnabledByPolicy(plugin, enabledPluginsPolicy);
+		}
+
+		const strictPluginOnly = this.configurationService.getValue<StrictPluginOnlyCustomization>(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG);
+		return !isPromptTypeBlocked(strictPluginOnly, PromptsType.hook)
+			|| (promptPath.storage !== PromptsStorage.local && promptPath.storage !== PromptsStorage.user);
+	}
+
 	// slash prompt commands
 
 	/**
@@ -711,10 +731,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 				// Parse hooks from the frontmatter if present
 				let hooks: ChatRequestHooks | undefined;
 				const hooksRaw = ast.header?.hooksRaw;
-				const strictPluginOnly = this.configurationService.getValue<StrictPluginOnlyCustomization>(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG);
-				const standaloneHooksBlocked = isPromptTypeBlocked(strictPluginOnly, PromptsType.hook)
-					&& (promptPath.storage === PromptsStorage.local || promptPath.storage === PromptsStorage.user);
-				if (useChatHooks && isWorkspaceTrusted && hooksRaw && !standaloneHooksBlocked && this.configurationService.getValue<boolean>(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG) !== true) {
+				if (useChatHooks && isWorkspaceTrusted && hooksRaw && this.areAgentHooksAllowed(promptPath)) {
 					const hookWorkspaceFolder = this.workspaceService.getWorkspaceFolder(uri) ?? defaultFolder;
 					const workspaceRootUri = hookWorkspaceFolder?.uri;
 					const target = getTarget(PromptsType.agent, ast.header ?? promptPath.uri);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -169,6 +169,8 @@ export class PromptsService extends Disposable implements IPromptsService {
 			this.cachedFileLocations[PromptsType.agent] = undefined;
 			this.cachedFileLocations[PromptsType.skill] = undefined;
 			this.cachedFileLocations[PromptsType.hook] = undefined;
+			this.cachedFileLocations[PromptsType.instructions] = undefined;
+			this._onDidChangeAgentInstructions.fire();
 		}));
 
 		// Invalidate the cached file location list whenever an extension contribution
@@ -230,6 +232,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 				this.getFileLocatorEvent(PromptsType.instructions),
 				Event.filter(onDidChangeExtensionPromptFiles, e => e.type === PromptsType.instructions),
 				Event.filter(this._onDidPluginPromptFilesChange.event, t => t === PromptsType.instructions),
+				onDidChangeCustomizationLockdown,
 			)
 		));
 
@@ -801,6 +804,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	public async listNestedAgentMDs(token: CancellationToken): Promise<IAgentInstructionFile[]> {
+		if (this.areStandalonePromptFilesBlocked(PromptsType.instructions)) {
+			return [];
+		}
 		const useAgentMD = this.configurationService.getValue(PromptsConfig.USE_AGENT_MD);
 		if (!useAgentMD) {
 			return [];
@@ -813,6 +819,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	public async listAgentInstructions(token: CancellationToken, logger: Logger | undefined): Promise<IAgentInstructionFile[]> {
+		if (this.areStandalonePromptFilesBlocked(PromptsType.instructions)) {
+			return [];
+		}
 		const resolvedAgentFiles: IAgentInstructionFile[] = [];
 		const promises: Promise<IAgentInstructionFile[]>[] = [];
 

--- a/src/vs/workbench/contrib/chat/test/common/customizationLockdown.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/customizationLockdown.test.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { isCustomizationSurfaceBlocked, isPromptTypeBlocked } from '../../common/customizationLockdown.js';
+import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+
+suite('Customization lockdown', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('undefined and false preserve existing behavior', () => {
+		assert.strictEqual(isCustomizationSurfaceBlocked(undefined, 'skills'), false);
+		assert.strictEqual(isCustomizationSurfaceBlocked(false, 'hooks'), false);
+	});
+
+	test('true blocks every covered surface', () => {
+		assert.strictEqual(isCustomizationSurfaceBlocked(true, 'skills'), true);
+		assert.strictEqual(isCustomizationSurfaceBlocked(true, 'agents'), true);
+		assert.strictEqual(isCustomizationSurfaceBlocked(true, 'hooks'), true);
+		assert.strictEqual(isCustomizationSurfaceBlocked(true, 'mcpServers'), true);
+	});
+
+	test('array form blocks only selected surfaces', () => {
+		const value = ['skills', 'hooks'] as const;
+		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.skill), true);
+		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.hook), true);
+		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.agent), false);
+		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.prompt), false);
+		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.instructions), false);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/customizationLockdown.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/customizationLockdown.test.ts
@@ -21,7 +21,7 @@ suite('Customization lockdown', () => {
 		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.skill), true);
 		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.agent), true);
 		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.hook), true);
+		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.instructions), true);
 		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.prompt), false);
-		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.instructions), false);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/customizationLockdown.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/customizationLockdown.test.ts
@@ -5,30 +5,23 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { isCustomizationSurfaceBlocked, isPromptTypeBlocked } from '../../common/customizationLockdown.js';
+import { isPromptTypeBlocked, isStrictPluginOnlyCustomizationEnabled } from '../../common/customizationLockdown.js';
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
 
 suite('Customization lockdown', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('undefined and false preserve existing behavior', () => {
-		assert.strictEqual(isCustomizationSurfaceBlocked(undefined, 'skills'), false);
-		assert.strictEqual(isCustomizationSurfaceBlocked(false, 'hooks'), false);
+		assert.strictEqual(isStrictPluginOnlyCustomizationEnabled(undefined), false);
+		assert.strictEqual(isStrictPluginOnlyCustomizationEnabled(false), false);
 	});
 
-	test('true blocks every covered surface', () => {
-		assert.strictEqual(isCustomizationSurfaceBlocked(true, 'skills'), true);
-		assert.strictEqual(isCustomizationSurfaceBlocked(true, 'agents'), true);
-		assert.strictEqual(isCustomizationSurfaceBlocked(true, 'hooks'), true);
-		assert.strictEqual(isCustomizationSurfaceBlocked(true, 'mcpServers'), true);
-	});
-
-	test('array form blocks only selected surfaces', () => {
-		const value = ['skills', 'hooks'] as const;
-		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.skill), true);
-		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.hook), true);
-		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.agent), false);
-		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.prompt), false);
-		assert.strictEqual(isPromptTypeBlocked(value, PromptsType.instructions), false);
+	test('true blocks every covered prompt surface', () => {
+		assert.strictEqual(isStrictPluginOnlyCustomizationEnabled(true), true);
+		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.skill), true);
+		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.agent), true);
+		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.hook), true);
+		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.prompt), false);
+		assert.strictEqual(isPromptTypeBlocked(true, PromptsType.instructions), false);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginEnablement.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginEnablement.test.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { PluginFormat } from '../../../../../../platform/agentPlugins/common/pluginParsers.js';
 import { ContributionEnablementState, IEnablementModel, isContributionEnabled } from '../../../common/enablement.js';
-import { AgentPluginCollisionEnablementModel, getCanonicalAgentPluginCollisionGroups, getSortedAgentPlugins, IDiscoveredAgentPlugins, isAgentPluginBlockedByPolicy } from '../../../common/plugins/agentPluginEnablement.js';
+import { AgentPluginCollisionEnablementModel, getCanonicalAgentPluginCollisionGroups, getSortedAgentPlugins, IDiscoveredAgentPlugins, isAgentPluginBlockedByPolicy, isAgentPluginForceEnabledByPolicy } from '../../../common/plugins/agentPluginEnablement.js';
 import { AgentPluginDiscoveryPriority, IAgentPlugin } from '../../../common/plugins/agentPluginService.js';
 import { IMarketplacePlugin, MarketplaceType, parseMarketplaceReference, PluginSourceKind } from '../../../common/plugins/pluginMarketplaceService.js';
 
@@ -175,6 +175,25 @@ suite('AgentPlugin enablement', () => {
 		test('a plugin without a policy identity is never blocked', () => {
 			const plugin = makePlugin(URI.file('/Users/test/local-plugins/my-plugin'), 'my-plugin');
 			assert.strictEqual(isAgentPluginBlockedByPolicy(plugin, { [policyId]: false }), false);
+		});
+
+		suite('isAgentPluginForceEnabledByPolicy', () => {
+			test('requires an explicit managed true entry for the plugin identity', () => {
+				const plugin = makePlugin(
+					URI.file('/Users/test/.vscode-insiders/agent-plugins/github.com/microsoft/vscode-team-kit/model-council'),
+					'model-council',
+					makeMarketplacePlugin(),
+				);
+
+				assert.strictEqual(isAgentPluginForceEnabledByPolicy(plugin, undefined), false);
+				assert.strictEqual(isAgentPluginForceEnabledByPolicy(plugin, { 'model-council@microsoft/vscode-team-kit': false }), false);
+				assert.strictEqual(isAgentPluginForceEnabledByPolicy(plugin, { 'model-council@microsoft/vscode-team-kit': true }), true);
+			});
+
+			test('sideloaded plugins without a managed identity are not force-enabled', () => {
+				const plugin = makePlugin(URI.file('/Users/test/local-plugins/model-council'), 'model-council');
+				assert.strictEqual(isAgentPluginForceEnabledByPolicy(plugin, { 'model-council@microsoft/vscode-team-kit': true }), false);
+			});
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -18,7 +18,7 @@ import { Range } from '../../../../../../../editor/common/core/range.js';
 import { ILanguageService } from '../../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../../editor/common/services/model.js';
 import { ModelService } from '../../../../../../../editor/common/services/modelService.js';
-import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { IConfigurationChangeEvent, IConfigurationOverrides, IConfigurationService, IConfigurationValue } from '../../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ExtensionIdentifier, IExtensionDescription } from '../../../../../../../platform/extensions/common/extensions.js';
 import { IFileService } from '../../../../../../../platform/files/common/files.js';
@@ -49,7 +49,7 @@ import { IPathService } from '../../../../../../services/path/common/pathService
 import { IFileMatch, IFileQuery, ISearchService } from '../../../../../../services/search/common/search.js';
 import { IExtensionService } from '../../../../../../services/extensions/common/extensions.js';
 import { IRemoteAgentService } from '../../../../../../services/remote/common/remoteAgentService.js';
-import { ChatModeKind } from '../../../../common/constants.js';
+import { ChatConfiguration, ChatModeKind } from '../../../../common/constants.js';
 import { HookType } from '../../../../common/promptSyntax/hookTypes.js';
 import { IContextKeyChangeEvent, IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
@@ -4536,6 +4536,22 @@ suite('PromptsService', () => {
 	});
 
 	suite('customization lockdown', () => {
+		test('policy changes invalidate cached standalone agent locations', async () => {
+			const rootFolderUri = URI.file('/dynamic-agent-lockdown');
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+			await mockFiles(fileService, [{
+				path: '/dynamic-agent-lockdown/.github/agents/reviewer.agent.md',
+				contents: ['---', 'description: "Review code"', '---'],
+			}]);
+
+			assert.strictEqual((await service.getCustomAgents(CancellationToken.None)).length, 1);
+
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['agents']);
+			fireConfigChange(testConfigService, COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG);
+
+			assert.deepStrictEqual(await service.getCustomAgents(CancellationToken.None), []);
+		});
+
 		test('selective agent lockdown filters workspace agents without affecting prompts', async () => {
 			const rootFolderUri = URI.file('/lockdown-agents');
 			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
@@ -4610,6 +4626,52 @@ suite('PromptsService', () => {
 			const agents = await service.getCustomAgents(CancellationToken.None);
 			assert.strictEqual(agents.length, 1);
 			assert.strictEqual(agents[0].hooks, undefined);
+		});
+
+		test('managed-only hooks preserve frontmatter hooks from force-enabled plugin agents', async () => {
+			testConfigService.setUserConfiguration(PromptsConfig.USE_CHAT_HOOKS, true);
+			testConfigService.setUserConfiguration(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG, true);
+			const pluginUri = URI.file('/home/user/.copilot/installed-plugins/managed-marketplace/managed-plugin');
+			const agentUri = URI.joinPath(pluginUri, 'agents', 'reviewer.agent.md');
+			await mockFiles(fileService, [{
+				path: agentUri.path,
+				contents: [
+					'---',
+					'description: "Review code"',
+					'hooks:',
+					'  PreToolUse:',
+					'    - type: command',
+					'      command: "echo managed"',
+					'---',
+				],
+			}]);
+
+			const originalInspect = testConfigService.inspect.bind(testConfigService);
+			testConfigService.inspect = <T>(key: string, overrides?: IConfigurationOverrides): IConfigurationValue<T> => {
+				const inspected = originalInspect<T>(key, overrides);
+				return key === ChatConfiguration.EnabledPlugins
+					? { ...inspected, policyValue: { 'managed-plugin@managed-marketplace': true } as T }
+					: inspected;
+			};
+
+			const plugin: IAgentPlugin = {
+				uri: pluginUri,
+				format: PluginFormat.Copilot,
+				label: 'managed-plugin',
+				enablement: observableValue('managedPluginEnablement', 2 /* ContributionEnablementState.EnabledProfile */),
+				hooks: observableValue('managedPluginHooks', []),
+				commands: observableValue('managedPluginCommands', []),
+				skills: observableValue('managedPluginSkills', []),
+				agents: observableValue<readonly IAgentPluginAgent[]>('managedPluginAgents', [{ uri: agentUri, name: 'reviewer' }]),
+				instructions: observableValue('managedPluginInstructions', []),
+				mcpServerDefinitions: observableValue('managedPluginMcpServers', []),
+			};
+			testPluginsObservable.set([plugin], undefined);
+			fireConfigChange(testConfigService, COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG, ChatConfiguration.EnabledPlugins);
+
+			const agents = await service.getCustomAgents(CancellationToken.None);
+			assert.strictEqual(agents.length, 1);
+			assert.strictEqual(agents[0].hooks?.[HookType.PreToolUse]?.[0].command, 'echo managed');
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -4546,16 +4546,16 @@ suite('PromptsService', () => {
 
 			assert.strictEqual((await service.getCustomAgents(CancellationToken.None)).length, 1);
 
-			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['agents']);
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, true);
 			fireConfigChange(testConfigService, COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG);
 
 			assert.deepStrictEqual(await service.getCustomAgents(CancellationToken.None), []);
 		});
 
-		test('selective agent lockdown filters workspace agents without affecting prompts', async () => {
+		test('plugin-only lockdown filters workspace agents without affecting prompts', async () => {
 			const rootFolderUri = URI.file('/lockdown-agents');
 			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
-			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['agents']);
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, true);
 
 			await mockFiles(fileService, [
 				{
@@ -4574,7 +4574,7 @@ suite('PromptsService', () => {
 
 		test('skill lockdown filters standalone skills before discovery and preserves plugin skills', async () => {
 			testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_SKILLS, true);
-			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['skills']);
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, true);
 			const rootFolderUri = URI.file('/lockdown-skills');
 			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
 			await mockFiles(fileService, [{
@@ -4605,9 +4605,9 @@ suite('PromptsService', () => {
 			]);
 		});
 
-		test('hook lockdown removes hooks embedded in standalone agents', async () => {
+		test('plugin-only lockdown removes standalone agents with embedded hooks', async () => {
 			testConfigService.setUserConfiguration(PromptsConfig.USE_CHAT_HOOKS, true);
-			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['hooks']);
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, true);
 			const rootFolderUri = URI.file('/lockdown-agent-hooks');
 			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
 			await mockFiles(fileService, [{
@@ -4624,8 +4624,7 @@ suite('PromptsService', () => {
 			}]);
 
 			const agents = await service.getCustomAgents(CancellationToken.None);
-			assert.strictEqual(agents.length, 1);
-			assert.strictEqual(agents[0].hooks, undefined);
+			assert.deepStrictEqual(agents, []);
 		});
 
 		test('managed-only hooks preserve frontmatter hooks from force-enabled plugin agents', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -4605,6 +4605,61 @@ suite('PromptsService', () => {
 			]);
 		});
 
+		test('plugin-only lockdown filters standalone instructions and preserves plugin instructions', async () => {
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, true);
+			const rootFolderUri = URI.file('/lockdown-instructions');
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+			const workspaceInstructionUri = URI.joinPath(rootFolderUri, '.github', 'instructions', 'workspace.instructions.md');
+			const pluginUri = URI.file('/plugins/managed');
+			const pluginInstructionUri = URI.joinPath(pluginUri, 'rules', 'plugin.instructions.md');
+			await mockFiles(fileService, [{
+				path: workspaceInstructionUri.path,
+				contents: ['---', 'description: "Workspace"', '---'],
+			}, {
+				path: pluginInstructionUri.path,
+				contents: ['---', 'description: "Plugin"', '---'],
+			}]);
+
+			const plugin: IAgentPlugin = {
+				uri: pluginUri,
+				format: PluginFormat.Copilot,
+				label: 'managed',
+				enablement: observableValue('lockdownInstructionPluginEnablement', 2 /* ContributionEnablementState.EnabledProfile */),
+				hooks: observableValue('lockdownInstructionPluginHooks', []),
+				commands: observableValue('lockdownInstructionPluginCommands', []),
+				skills: observableValue('lockdownInstructionPluginSkills', []),
+				agents: observableValue('lockdownInstructionPluginAgents', []),
+				instructions: observableValue<readonly IAgentPluginInstruction[]>('lockdownPluginInstructions', [{ uri: pluginInstructionUri, name: 'plugin' }]),
+				mcpServerDefinitions: observableValue('lockdownInstructionPluginMcpServers', []),
+			};
+			testPluginsObservable.set([plugin], undefined);
+
+			const instructions = await service.listPromptFiles(PromptsType.instructions, CancellationToken.None);
+			assert.deepStrictEqual(instructions.map(instruction => ({
+				uri: instruction.uri.toString(),
+				storage: instruction.storage,
+			})), [{
+				uri: pluginInstructionUri.toString(),
+				storage: PromptsStorage.plugin,
+			}]);
+		});
+
+		test('plugin-only lockdown filters workspace agent instruction files', async () => {
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, true);
+			const rootFolderUri = URI.file('/lockdown-agent-instructions');
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+			await mockFiles(fileService, [{
+				path: URI.joinPath(rootFolderUri, 'AGENTS.md').path,
+				contents: ['Workspace agent instructions'],
+			}, {
+				path: URI.joinPath(rootFolderUri, 'CLAUDE.md').path,
+				contents: ['Workspace Claude instructions'],
+			}]);
+
+			assert.deepStrictEqual(await service.listAgentInstructions(CancellationToken.None, undefined), []);
+			assert.deepStrictEqual(await service.listNestedAgentMDs(CancellationToken.None), []);
+		});
+
 		test('plugin-only lockdown removes standalone agents with embedded hooks', async () => {
 			testConfigService.setUserConfiguration(PromptsConfig.USE_CHAT_HOOKS, true);
 			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, true);

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -56,6 +56,7 @@ import { MockContextKeyService } from '../../../../../../../platform/keybinding/
 import { IAgentPlugin, IAgentPluginAgent, IAgentPluginCommand, IAgentPluginHook, IAgentPluginInstruction, IAgentPluginMcpServerDefinition, IAgentPluginService, IAgentPluginSkill } from '../../../../common/plugins/agentPluginService.js';
 import { PluginFormat } from '../../../../../../../platform/agentPlugins/common/pluginParsers.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../../platform/workspace/common/workspaceTrust.js';
+import { COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG, COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG } from '../../../../../../../platform/policy/common/copilotManagedSettings.js';
 
 class TestPromptContextKeyService extends MockContextKeyService {
 	private readonly _onDidChangeContextEmitter = new Emitter<IContextKeyChangeEvent>();
@@ -4534,6 +4535,84 @@ suite('PromptsService', () => {
 		});
 	});
 
+	suite('customization lockdown', () => {
+		test('selective agent lockdown filters workspace agents without affecting prompts', async () => {
+			const rootFolderUri = URI.file('/lockdown-agents');
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['agents']);
+
+			await mockFiles(fileService, [
+				{
+					path: '/lockdown-agents/.github/agents/reviewer.agent.md',
+					contents: ['---', 'description: "Review code"', '---'],
+				},
+				{
+					path: '/lockdown-agents/.github/prompts/review.prompt.md',
+					contents: ['---', 'description: "Review prompt"', '---'],
+				},
+			]);
+
+			assert.deepStrictEqual(await service.getCustomAgents(CancellationToken.None), []);
+			assert.strictEqual((await service.listPromptFiles(PromptsType.prompt, CancellationToken.None)).length, 1);
+		});
+
+		test('skill lockdown filters standalone skills before discovery and preserves plugin skills', async () => {
+			testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_SKILLS, true);
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['skills']);
+			const rootFolderUri = URI.file('/lockdown-skills');
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+			await mockFiles(fileService, [{
+				path: '/lockdown-skills/.github/skills/workspace-skill/SKILL.md',
+				contents: ['---', 'name: "workspace-skill"', 'description: "Workspace"', '---'],
+			}, {
+				path: '/plugins/managed/skills/plugin-skill/SKILL.md',
+				contents: ['---', 'name: "plugin-skill"', 'description: "Plugin"', '---'],
+			}]);
+
+			const plugin: IAgentPlugin = {
+				uri: URI.file('/plugins/managed'),
+				format: PluginFormat.Copilot,
+				label: 'managed',
+				enablement: observableValue('lockdownPluginEnablement', 2 /* ContributionEnablementState.EnabledProfile */),
+				hooks: observableValue('lockdownPluginHooks', []),
+				commands: observableValue('lockdownPluginCommands', []),
+				skills: observableValue<readonly IAgentPluginSkill[]>('lockdownPluginSkills', [{ uri: URI.file('/plugins/managed/skills/plugin-skill/SKILL.md'), name: 'plugin-skill' }]),
+				agents: observableValue('lockdownPluginAgents', []),
+				instructions: observableValue('lockdownPluginInstructions', []),
+				mcpServerDefinitions: observableValue('lockdownPluginMcpServers', []),
+			};
+			testPluginsObservable.set([plugin], undefined);
+
+			const skills = await service.findAgentSkills(CancellationToken.None);
+			assert.deepStrictEqual(skills?.map(skill => ({ name: skill.name, storage: skill.storage })), [
+				{ name: 'plugin-skill', storage: PromptsStorage.plugin },
+			]);
+		});
+
+		test('hook lockdown removes hooks embedded in standalone agents', async () => {
+			testConfigService.setUserConfiguration(PromptsConfig.USE_CHAT_HOOKS, true);
+			testConfigService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['hooks']);
+			const rootFolderUri = URI.file('/lockdown-agent-hooks');
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+			await mockFiles(fileService, [{
+				path: '/lockdown-agent-hooks/.github/agents/reviewer.agent.md',
+				contents: [
+					'---',
+					'description: "Review code"',
+					'hooks:',
+					'  PreToolUse:',
+					'    - type: command',
+					'      command: "echo blocked"',
+					'---',
+				],
+			}]);
+
+			const agents = await service.getCustomAgents(CancellationToken.None);
+			assert.strictEqual(agents.length, 1);
+			assert.strictEqual(agents[0].hooks, undefined);
+		});
+	});
+
 	suite('hooks', () => {
 		const createTestPlugin = (path: string, initialHooks: readonly IAgentPluginHook[]): { plugin: IAgentPlugin; hooks: ISettableObservable<readonly IAgentPluginHook[]> } => {
 			const enablement = observableValue('testPluginEnablement', 2 /* ContributionEnablementState.EnabledProfile */);
@@ -4633,6 +4712,30 @@ suite('PromptsService', () => {
 				command: 'echo from-plugin',
 				sourceUri: URI.file('/plugins/test-plugin/hooks.json'),
 			}], 'Expected plugin hooks to be included in computed hooks');
+		});
+
+		test('managed-only hooks block standalone and unmanaged plugin hooks', async function () {
+			const rootFolderUri = URI.file('/managed-hooks-only');
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+			testConfigService.setUserConfiguration(PromptsConfig.USE_CHAT_HOOKS, true);
+			testConfigService.setUserConfiguration(PromptsConfig.HOOKS_LOCATION_KEY, { [HOOKS_SOURCE_FOLDER]: true });
+			testConfigService.setUserConfiguration(COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG, true);
+			fireConfigChange(testConfigService, COPILOT_ALLOW_MANAGED_HOOKS_ONLY_CONFIG);
+			await mockFiles(fileService, [{
+				path: '/managed-hooks-only/.github/hooks/hooks.json',
+				contents: [JSON.stringify({ hooks: { [HookType.PreToolUse]: [{ type: 'command', command: 'echo workspace' }] } })],
+			}]);
+
+			const { plugin } = createTestPlugin('/plugins/unmanaged', [{
+				type: HookType.PreToolUse,
+				originalId: 'plugin-hook',
+				hooks: [{ command: 'echo plugin' }],
+				uri: URI.file('/plugins/unmanaged/hooks.json'),
+			}]);
+			testPluginsObservable.set([plugin], undefined);
+
+			assert.strictEqual(await service.getHooks(CancellationToken.None), undefined);
+			assert.deepStrictEqual(await service.listPromptFiles(PromptsType.hook, CancellationToken.None), []);
 		});
 
 		test('recomputes hooks when agent plugin hooks change', async function () {

--- a/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
@@ -20,7 +20,7 @@ import {
 } from '../../../chat/common/plugins/agentPluginService.js';
 import { isContributionEnabled } from '../../../chat/common/enablement.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
-import { McpCollectionSortOrder, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust } from '../mcpTypes.js';
+import { MCP_PLUGIN_COLLECTION_ID_PREFIX, McpCollectionProvenance, McpCollectionSortOrder, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
 
 /**
@@ -29,7 +29,7 @@ import { IMcpDiscovery } from './mcpDiscovery.js';
  * the plugin's URI. Consumers can use this to tell plugin-sourced MCP servers
  * apart from servers configured directly in VS Code.
  */
-export const MCP_PLUGIN_COLLECTION_ID_PREFIX = 'plugin.';
+export { MCP_PLUGIN_COLLECTION_ID_PREFIX } from '../mcpTypes.js';
 
 export class PluginMcpDiscovery extends Disposable implements IMcpDiscovery {
 	readonly fromGallery = false;
@@ -78,6 +78,7 @@ export class PluginMcpDiscovery extends Disposable implements IMcpDiscovery {
 		const collectionId = `${MCP_PLUGIN_COLLECTION_ID_PREFIX}${plugin.uri}`;
 		return this._mcpRegistry.registerCollection({
 			id: collectionId,
+			provenance: McpCollectionProvenance.Plugin,
 			label: `${plugin.label} (Agent Plugin)`,
 			remoteAuthority: plugin.uri.scheme === Schemas.vscodeRemote ? plugin.uri.authority : null,
 			configTarget: ConfigurationTarget.USER,

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -35,7 +35,9 @@ import { McpRegistryInputStorage } from './mcpRegistryInputStorage.js';
 import { IMcpHostDelegate, IMcpRegistry, IMcpResolveConnectionOptions } from './mcpRegistryTypes.js';
 import { IMcpSandboxService } from './mcpSandboxService.js';
 import { McpServerConnection } from './mcpServerConnection.js';
-import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpDefinitionReference, McpServerDefinition, McpServerLaunch, McpServerTrust, McpStartServerInteraction, UserInteractionRequiredError } from './mcpTypes.js';
+import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpCollectionProvenance, McpDefinitionReference, McpServerDefinition, McpServerLaunch, McpServerTrust, McpStartServerInteraction, UserInteractionRequiredError } from './mcpTypes.js';
+import { COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { isCustomizationSurfaceBlocked, StrictPluginOnlyCustomization } from '../../chat/common/customizationLockdown.js';
 
 const notTrustedNonce = '__vscode_not_trusted';
 
@@ -45,11 +47,13 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 	private readonly _collections = observableValue<readonly McpCollectionDefinition[]>('collections', []);
 	private readonly _delegates = observableValue<readonly IMcpHostDelegate[]>('delegates', []);
 	private readonly _mcpAccessValue: IObservable<string>;
+	private readonly _strictPluginOnlyCustomization: IObservable<StrictPluginOnlyCustomization>;
 	public readonly collections: IObservable<readonly McpCollectionDefinition[]> = derived(reader => {
 		if (this._mcpAccessValue.read(reader) === McpAccessValue.None) {
 			return [];
 		}
-		return this._collections.read(reader);
+		const strictPluginOnly = this._strictPluginOnlyCustomization.read(reader);
+		return this._collections.read(reader).filter(collection => this.isCollectionAllowed(collection, strictPluginOnly));
 	});
 
 	private readonly _workspaceStorage = new Lazy(() => this._register(this._instantiationService.createInstance(McpRegistryInputStorage, StorageScope.WORKSPACE, StorageTarget.USER)));
@@ -65,7 +69,8 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		if (this._ongoingLazyActivations.read(reader) > 0) {
 			return { state: LazyCollectionState.LoadingUnknown, collections: [] };
 		}
-		const collections = this._collections.read(reader);
+		const strictPluginOnly = this._strictPluginOnlyCustomization.read(reader);
+		const collections = this._collections.read(reader).filter(collection => this.isCollectionAllowed(collection, strictPluginOnly));
 		const hasUnknown = collections.some(c => c.lazy && c.lazy.isCached === false);
 		return hasUnknown ? { state: LazyCollectionState.HasUnknown, collections: collections.filter(c => c.lazy && c.lazy.isCached === false) } : { state: LazyCollectionState.AllKnown, collections: [] };
 	});
@@ -93,6 +98,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 	) {
 		super();
 		this._mcpAccessValue = observableConfigValue(mcpAccessConfig, McpAccessValue.All, configurationService);
+		this._strictPluginOnlyCustomization = observableConfigValue(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, undefined, configurationService);
 	}
 
 	public registerDelegate(delegate: IMcpHostDelegate): IDisposable {
@@ -134,13 +140,17 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 	public getServerDefinition(collectionRef: McpDefinitionReference, definitionRef: McpDefinitionReference): IObservable<{ server: McpServerDefinition | undefined; collection: McpCollectionDefinition | undefined }> {
 		const collectionObs = this._collections.map(cols => cols.find(c => c.id === collectionRef.id));
 		return collectionObs.map((collection, reader) => {
+			if (collection && !this.isCollectionAllowed(collection, this._strictPluginOnlyCustomization.read(reader))) {
+				return { collection: undefined, server: undefined };
+			}
 			const server = collection?.serverDefinitions.read(reader).find(s => s.id === definitionRef.id);
 			return { collection, server };
 		});
 	}
 
 	public async discoverCollections(): Promise<McpCollectionDefinition[]> {
-		const toDiscover = this._collections.get().filter(c => c.lazy && !c.lazy.isCached);
+		const strictPluginOnly = this._strictPluginOnlyCustomization.get();
+		const toDiscover = this._collections.get().filter(c => this.isCollectionAllowed(c, strictPluginOnly) && c.lazy && !c.lazy.isCached);
 
 		this._ongoingLazyActivations.set(this._ongoingLazyActivations.get() + 1, undefined);
 		await Promise.all(toDiscover.map(c => c.lazy?.load())).finally(() => {
@@ -484,12 +494,20 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		return await this._configurationResolverService.resolveAsync(folder, expr);
 	}
 
+	private isCollectionAllowed(collection: McpCollectionDefinition, strictPluginOnly: StrictPluginOnlyCustomization): boolean {
+		return !isCustomizationSurfaceBlocked(strictPluginOnly, 'mcpServers')
+			|| collection.provenance === McpCollectionProvenance.Plugin;
+	}
+
 	public async resolveConnection(opts: IMcpResolveConnectionOptions): Promise<IMcpServerConnection | undefined> {
 		const { collectionRef, definitionRef, interaction, logger, debug } = opts;
 		let collection = this._collections.get().find(c => c.id === collectionRef.id);
 		if (collection?.lazy) {
 			await collection.lazy.load();
 			collection = this._collections.get().find(c => c.id === collectionRef.id);
+		}
+		if (collection && !this.isCollectionAllowed(collection, this._strictPluginOnlyCustomization.get())) {
+			throw new Error(`MCP collection ${collectionRef.id} is blocked by enterprise customization policy`);
 		}
 
 		const definition = collection?.serverDefinitions.get().find(s => s.id === definitionRef.id);

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -37,7 +37,7 @@ import { IMcpSandboxService } from './mcpSandboxService.js';
 import { McpServerConnection } from './mcpServerConnection.js';
 import { IMcpServerConnection, LazyCollectionState, McpCollectionDefinition, McpCollectionProvenance, McpDefinitionReference, McpServerDefinition, McpServerLaunch, McpServerTrust, McpStartServerInteraction, UserInteractionRequiredError } from './mcpTypes.js';
 import { COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG } from '../../../../platform/policy/common/copilotManagedSettings.js';
-import { isCustomizationSurfaceBlocked, StrictPluginOnlyCustomization } from '../../chat/common/customizationLockdown.js';
+import { isStrictPluginOnlyCustomizationEnabled, StrictPluginOnlyCustomization } from '../../chat/common/customizationLockdown.js';
 
 const notTrustedNonce = '__vscode_not_trusted';
 
@@ -495,7 +495,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 	}
 
 	private isCollectionAllowed(collection: McpCollectionDefinition, strictPluginOnly: StrictPluginOnlyCustomization): boolean {
-		return !isCustomizationSurfaceBlocked(strictPluginOnly, 'mcpServers')
+		return !isStrictPluginOnlyCustomizationEnabled(strictPluginOnly)
 			|| collection.provenance === McpCollectionProvenance.Plugin;
 	}
 

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -502,6 +502,9 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 	public async resolveConnection(opts: IMcpResolveConnectionOptions): Promise<IMcpServerConnection | undefined> {
 		const { collectionRef, definitionRef, interaction, logger, debug } = opts;
 		let collection = this._collections.get().find(c => c.id === collectionRef.id);
+		if (collection && !this.isCollectionAllowed(collection, this._strictPluginOnlyCustomization.get())) {
+			throw new Error(`MCP collection ${collectionRef.id} is blocked by enterprise customization policy`);
+		}
 		if (collection?.lazy) {
 			await collection.lazy.load();
 			collection = this._collections.get().find(c => c.id === collectionRef.id);

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -44,6 +44,11 @@ export const extensionMcpCollectionPrefix = 'ext.';
  * {@link IMcpConfigPath.id} of the originating config path.
  */
 export const MCP_CONFIGURATION_COLLECTION_ID_PREFIX = 'mcp.config.';
+export const MCP_PLUGIN_COLLECTION_ID_PREFIX = 'plugin.';
+
+export const enum McpCollectionProvenance {
+	Plugin = 'plugin',
+}
 
 export function extensionPrefixedIdentifier(identifier: ExtensionIdentifier, id: string): string {
 	return ExtensionIdentifier.toKey(identifier) + '/' + id;
@@ -58,6 +63,7 @@ export interface McpCollectionDefinition {
 	readonly remoteAuthority: string | null;
 	/** Globally-unique, stable ID for this definition */
 	readonly id: string;
+	readonly provenance?: McpCollectionProvenance;
 	/** Human-readable label for the definition */
 	readonly label: string;
 	/** Definitions this collection contains. */

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -542,6 +542,28 @@ suite('Workbench - MCP - Registry', () => {
 			assert.strictEqual(removedCalled, true);
 		});
 
+		test('blocked lazy collection is rejected before activation', async () => {
+			let loadCalled = false;
+			lazyCollection = {
+				...lazyCollection,
+				lazy: {
+					...lazyCollection.lazy!,
+					load: async () => { loadCalled = true; },
+				},
+			};
+			store.add(registry.registerCollection(lazyCollection));
+			configurationService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['mcpServers']);
+			configurationService.onDidChangeConfigurationEmitter.fire({
+				affectsConfiguration: (key: string) => key === COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG,
+			} as unknown as IConfigurationChangeEvent);
+
+			await assert.rejects(
+				registry.resolveConnection({ collectionRef: lazyCollection, definitionRef: baseDefinition, logger, trustNonceBearer, taskManager }),
+				/blocked by enterprise customization policy/,
+			);
+			assert.strictEqual(loadCalled, false);
+		});
+
 		test('cached lazy collections are tracked correctly', () => {
 			lazyCollection.lazy!.isCached = true;
 			store.add(registry.registerCollection(lazyCollection));

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -277,7 +277,7 @@ suite('Workbench - MCP - Registry', () => {
 		};
 		store.add(registry.registerCollection(spoofedCollection));
 
-		configurationService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['mcpServers']);
+		configurationService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, true);
 		configurationService.onDidChangeConfigurationEmitter.fire({
 			affectsConfiguration: (key: string) => key === COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG,
 		} as unknown as IConfigurationChangeEvent);
@@ -552,7 +552,7 @@ suite('Workbench - MCP - Registry', () => {
 				},
 			};
 			store.add(registry.registerCollection(lazyCollection));
-			configurationService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['mcpServers']);
+			configurationService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, true);
 			configurationService.onDidChangeConfigurationEmitter.fire({
 				affectsConfiguration: (key: string) => key === COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG,
 			} as unknown as IConfigurationChangeEvent);

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -39,8 +39,9 @@ import { IMcpSandboxService } from '../../common/mcpSandboxService.js';
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
 import { McpCollisionEnablementModel } from '../../common/mcpService.js';
 import { McpTaskManager } from '../../common/mcpTaskManager.js';
-import { IMcpPotentialSandboxBlock, LazyCollectionState, McpCollectionDefinition, McpServerDefinition, McpServerLaunch, McpServerTransportStdio, McpServerTransportType, McpServerTrust, McpStartServerInteraction } from '../../common/mcpTypes.js';
+import { IMcpPotentialSandboxBlock, LazyCollectionState, MCP_PLUGIN_COLLECTION_ID_PREFIX, McpCollectionDefinition, McpCollectionProvenance, McpServerDefinition, McpServerLaunch, McpServerTransportStdio, McpServerTransportType, McpServerTrust, McpStartServerInteraction } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
+import { COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG } from '../../../../../platform/policy/common/copilotManagedSettings.js';
 
 class TestConfigurationResolverService {
 	declare readonly _serviceBrand: undefined;
@@ -258,6 +259,33 @@ suite('Workbench - MCP - Registry', () => {
 
 		disposable.dispose();
 		assert.strictEqual(registry.collections.get().length, 0);
+	});
+
+	test('strict plugin-only customization hides non-plugin MCP collections and blocks direct lookup', () => {
+		store.add(registry.registerCollection(testCollection));
+		const pluginCollection = {
+			...testCollection,
+			id: `${MCP_PLUGIN_COLLECTION_ID_PREFIX}test`,
+			provenance: McpCollectionProvenance.Plugin,
+			serverDefinitions: observableValue<McpServerDefinition[]>('pluginDefinitions', [baseDefinition]),
+		};
+		store.add(registry.registerCollection(pluginCollection));
+		const spoofedCollection = {
+			...testCollection,
+			id: `${MCP_PLUGIN_COLLECTION_ID_PREFIX}spoofed-extension/collection`,
+			serverDefinitions: observableValue<McpServerDefinition[]>('spoofedDefinitions', [baseDefinition]),
+		};
+		store.add(registry.registerCollection(spoofedCollection));
+
+		configurationService.setUserConfiguration(COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG, ['mcpServers']);
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: (key: string) => key === COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG,
+		} as unknown as IConfigurationChangeEvent);
+
+		assert.deepStrictEqual(registry.collections.get().map(collection => collection.id), [pluginCollection.id]);
+		assert.deepStrictEqual(registry.getServerDefinition(testCollection, baseDefinition).get(), { collection: undefined, server: undefined });
+		assert.deepStrictEqual(registry.getServerDefinition(spoofedCollection, baseDefinition).get(), { collection: undefined, server: undefined });
+		assert.strictEqual(registry.getServerDefinition(pluginCollection, baseDefinition).get().server, baseDefinition);
 	});
 
 	test('collections are not visible when not enabled', () => {

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -40,6 +40,9 @@ export interface IManagedSettingsResponse {
 	readonly strictKnownMarketplaces?: readonly unknown[];
 	readonly allowedMcpServers?: ReadonlyArray<IManagedMcpServerMatcher>;
 	readonly deniedMcpServers?: ReadonlyArray<IManagedMcpServerMatcher>;
+	readonly strictPluginOnlyCustomization?: boolean | readonly ('skills' | 'agents' | 'hooks' | 'mcpServers')[];
+	readonly allowManagedMcpServersOnly?: boolean;
+	readonly allowManagedHooksOnly?: boolean;
 	readonly telemetry?: {
 		readonly enabled?: boolean;
 		readonly endpoint?: string;

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -40,7 +40,7 @@ export interface IManagedSettingsResponse {
 	readonly strictKnownMarketplaces?: readonly unknown[];
 	readonly allowedMcpServers?: ReadonlyArray<IManagedMcpServerMatcher>;
 	readonly deniedMcpServers?: ReadonlyArray<IManagedMcpServerMatcher>;
-	readonly strictPluginOnlyCustomization?: boolean | readonly ('skills' | 'agents' | 'hooks' | 'mcpServers')[];
+	readonly strictPluginOnlyCustomization?: boolean;
 	readonly allowManagedMcpServersOnly?: boolean;
 	readonly allowManagedHooksOnly?: boolean;
 	readonly telemetry?: {

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -92,14 +92,14 @@ suite('adaptManagedSettings', () => {
 
 	test('carries customization lockdown controls', () => {
 		assert.deepStrictEqual(adaptManagedSettings({
-			strictPluginOnlyCustomization: ['skills', 'agents'],
+			strictPluginOnlyCustomization: true,
 			allowManagedMcpServersOnly: true,
 			allowManagedHooksOnly: true,
 		}), {
 			managedSettings: {
+				strictPluginOnlyCustomization: true,
 				allowManagedMcpServersOnly: true,
 				allowManagedHooksOnly: true,
-				strictPluginOnlyCustomization: '["skills","agents"]',
 			},
 		});
 	});

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -90,6 +90,20 @@ suite('adaptManagedSettings', () => {
 		});
 	});
 
+	test('carries customization lockdown controls', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
+			strictPluginOnlyCustomization: ['skills', 'agents'],
+			allowManagedMcpServersOnly: true,
+			allowManagedHooksOnly: true,
+		}), {
+			managedSettings: {
+				allowManagedMcpServersOnly: true,
+				allowManagedHooksOnly: true,
+				strictPluginOnlyCustomization: '["skills","agents"]',
+			},
+		});
+	});
+
 	test('flattens scalar telemetry leaves and carries resourceAttributes and headers as single JSON keys', () => {
 		assert.deepStrictEqual(adaptManagedSettings({
 			telemetry: {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8464

## Summary

Adds VS Code-native enforcement for exactly three boolean managed-settings controls:

- `strictPluginOnlyCustomization`
- `allowManagedMcpServersOnly`
- `allowManagedHooksOnly`

`allowedMcpServers` and `deniedMcpServers` are pre-existing managed-settings data. This change does not add them as controls; `allowManagedMcpServersOnly` only changes which existing allowlist layer is authoritative.

## Code changes

- Registers the three boolean managed-settings keys in the existing policy pipeline and adds hidden policy-backed configuration delivery slots.
- Blocks standalone user/workspace skills, agents, hooks, and MCP collections when `strictPluginOnlyCustomization` is true, while preserving eligible plugin contributions.
- Prevents blocked standalone hook files and custom-agent frontmatter hooks from reaching execution.
- Under `allowManagedHooksOnly`, accepts plugin hooks only when managed `enabledPlugins` explicitly force-enables that plugin.
- Under `allowManagedMcpServersOnly`, uses only the policy-provided existing MCP allowlist as the positive allow source, while continuing to compose deny entries restrictively.
- Uses explicit MCP collection provenance so extension collection IDs cannot spoof plugin origin.
- Regenerates the policy catalog and adds regression coverage for provenance, dynamic policy updates, and bypass paths.

This PR intentionally covers VS Code-native enforcement only; it does not forward these settings into Copilot CLI or SDK sessions.

## Validation

- `npm run typecheck-client`
- `npm run gulp compile-client`
- 201 targeted policy, prompt, plugin, hook, and MCP unit tests
- changed-file hygiene checks
- clean-profile policy export