### PR TITLE
Support custom tool calls in BYOK Agent Host

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostByokLm.ts
+++ b/src/vs/platform/agentHost/common/agentHostByokLm.ts
@@ -26,7 +26,7 @@ export interface IByokLmToolCall {
 	readonly id: string;
 	/** Tool/function name. */
 	readonly name: string;
-	/** JSON-encoded arguments object. */
+	/** JSON-encoded tool input, which may be an object or a freeform string. */
 	readonly argumentsJson: string;
 }
 

--- a/src/vs/platform/agentHost/node/copilot/byokOpenAiTranslation.ts
+++ b/src/vs/platform/agentHost/node/copilot/byokOpenAiTranslation.ts
@@ -26,14 +26,25 @@ interface IOpenAiTextContentPart {
 
 type IOpenAiContentPart = IOpenAiTextContentPart | { readonly type: string;[k: string]: unknown };
 
-interface IOpenAiToolCall {
+interface IOpenAiFunctionToolCall {
 	readonly id?: string;
-	readonly type?: string;
+	readonly type?: 'function';
 	readonly function?: {
 		readonly name?: string;
 		readonly arguments?: string;
 	};
 }
+
+interface IOpenAiCustomToolCall {
+	readonly id?: string;
+	readonly type: 'custom';
+	readonly custom?: {
+		readonly name?: string;
+		readonly input?: string;
+	};
+}
+
+type IOpenAiToolCall = IOpenAiFunctionToolCall | IOpenAiCustomToolCall;
 
 interface IOpenAiRequestMessage {
 	readonly role?: string;
@@ -104,11 +115,21 @@ function toBridgeToolCalls(toolCalls: IOpenAiToolCall[] | undefined): IByokLmToo
 	const mapped: IByokLmToolCall[] = [];
 	for (let i = 0; i < toolCalls.length; i++) {
 		const call = toolCalls[i];
+		if (call.type === 'custom') {
+			const name = call.custom?.name;
+			if (!name) {
+				throw new OpenAiTranslationError(`tool_calls[${i}].custom.name is required`);
+			}
+			mapped.push({
+				id: call.id ?? `call_${i}`,
+				name,
+				argumentsJson: JSON.stringify({ input: call.custom?.input ?? '' }),
+			});
+			continue;
+		}
+
 		const name = call.function?.name;
 		if (!name) {
-			// A tool call without a function name is malformed: reject at the
-			// boundary (→ 400) rather than forwarding an invalid `tool_use` part
-			// that would fail later, deeper in the renderer.
 			throw new OpenAiTranslationError(`tool_calls[${i}].function.name is required`);
 		}
 		mapped.push({

--- a/src/vs/platform/agentHost/test/node/byokLmProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/byokLmProxyService.test.ts
@@ -139,6 +139,44 @@ suite('ByokLmProxyService', () => {
 		assert.deepStrictEqual(captured?.messages, [{ role: 'user', content: 'hi', toolCalls: undefined, toolCallId: undefined }]);
 	});
 
+	test('forwards custom tool call history with freeform input', async () => {
+		let captured: IByokLmChatRequest | undefined;
+		await withProxy(
+			async (request) => {
+				captured = request;
+				return { content: 'done' };
+			},
+			async (handle) => {
+				const response = await fetch(chatUrl(handle, 'acme'), {
+					method: 'POST',
+					headers: authHeaders(handle),
+					body: JSON.stringify({
+						model: 'm',
+						messages: [
+							{
+								role: 'assistant',
+								content: '',
+								tool_calls: [{ id: 'call_1', type: 'custom', custom: { name: 'apply_patch', input: '*** Begin Patch\n*** End Patch' } }],
+							},
+							{ role: 'tool', tool_call_id: 'call_1', content: 'Done!' },
+						],
+					}),
+				});
+				assert.strictEqual(response.status, 200);
+				await response.text();
+			},
+		);
+		assert.deepStrictEqual(captured?.messages, [
+			{
+				role: 'assistant',
+				content: '',
+				toolCalls: [{ id: 'call_1', name: 'apply_patch', argumentsJson: '{"input":"*** Begin Patch\\n*** End Patch"}' }],
+				toolCallId: undefined,
+			},
+			{ role: 'tool', content: 'Done!', toolCalls: undefined, toolCallId: 'call_1' },
+		]);
+	});
+
 	test('decodes a url-encoded vendor path segment', async () => {
 		let captured: IByokLmChatRequest | undefined;
 		await withProxy(

--- a/src/vs/platform/agentHost/test/node/byokOpenAiTranslation.test.ts
+++ b/src/vs/platform/agentHost/test/node/byokOpenAiTranslation.test.ts
@@ -64,6 +64,44 @@ suite('byokOpenAiTranslation', () => {
 			}), OpenAiTranslationError);
 		});
 
+		test('maps a custom assistant tool call with freeform input', () => {
+			const result = openAiRequestToBridge('acme', {
+				model: 'm',
+				messages: [
+					{
+						role: 'assistant',
+						content: '',
+						tool_calls: [{ id: 'call_1', type: 'custom', custom: { name: 'apply_patch', input: '*** Begin Patch\n*** End Patch' } }],
+					},
+				],
+			});
+
+			assert.deepStrictEqual(result.messages, [{
+				role: 'assistant',
+				content: '',
+				toolCalls: [{ id: 'call_1', name: 'apply_patch', argumentsJson: '{"input":"*** Begin Patch\\n*** End Patch"}' }],
+				toolCallId: undefined,
+			}]);
+		});
+
+		test('throws when a custom assistant tool call is missing its name', () => {
+			assert.throws(() => openAiRequestToBridge('acme', {
+				model: 'm',
+				messages: [{ role: 'assistant', content: '', tool_calls: [{ id: 'call_1', type: 'custom', custom: { input: 'patch' } }] }],
+			}), OpenAiTranslationError);
+		});
+
+		test('treats an omitted tool call type as a function call', () => {
+			const result = openAiRequestToBridge('acme', {
+				model: 'm',
+				messages: [{ role: 'assistant', content: '', tool_calls: [{ id: 'call_1', function: { name: 'getWeather', arguments: '{}' } }] }],
+			});
+
+			assert.deepStrictEqual(result.messages[0].toolCalls, [
+				{ id: 'call_1', name: 'getWeather', argumentsJson: '{}' },
+			]);
+		});
+
 		test('omits tools and options when absent', () => {
 			const result = openAiRequestToBridge('acme', { model: 'm', messages: [{ role: 'user', content: 'hello' }] });
 			assert.strictEqual(result.tools, undefined);


### PR DESCRIPTION
## Summary

Support OpenAI custom tool calls when replaying tool-call history through the local Agent Host BYOK proxy.

Custom tools such as `apply_patch` use `custom.name` and freeform `custom.input` instead of the function-call shape. Model the two wire variants as a discriminated union and normalize custom input for the VS Code language model bridge, while preserving the default function behavior when `type` is omitted.

## Testing

- `npm run gulp compile-client`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/byokOpenAiTranslation.test.ts --run src/vs/platform/agentHost/test/node/byokLmProxyService.test.ts`
- 25 tests passing
