### PR TITLE
chat: merge duplicate Copilot sections in the model picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives.ts
@@ -40,15 +40,9 @@ function getUpdateHoverContent(updateState: StateType): MarkdownString {
 	return hoverContent;
 }
 
-export type ProviderGroupKey = string;
-
 export interface IProviderGroupInfo {
 	readonly vendor: string;
 	readonly groupName: string;
-}
-
-export function getProviderGroupKey(vendor: string, groupName: string): ProviderGroupKey {
-	return `${vendor}\u0000${groupName}`;
 }
 
 function getVendorDisplayName(languageModelsService: ILanguageModelsService, vendor: string): string {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
@@ -158,8 +158,7 @@ function createGroupedContext(options: IBuildModelPickerItemsOptions): IGroupedC
 		placed,
 		showGroupLabel: new Set(options.models.map(model => {
 			const group = getProviderGroupForModel(model, modelToGroup, options.languageModelsService);
-			// Key by visible section title so sources that share a label (e.g. Chat
-			// vendor `copilot` and agent-host `copilotcli` both → "Copilot") count as one.
+			// Same display name → same section (e.g. Copilot Chat + CLI).
 			return group.groupName;
 		})).size > 1,
 		makePinAction: model => options.actions.onTogglePin
@@ -330,8 +329,7 @@ function appendOtherModels(context: IGroupedContext): boolean {
 	const groups = new Map<string, IProviderGroupBucket>();
 	for (const model of otherModels) {
 		const info = getProviderGroupForModel(model, context.modelToGroup, options.languageModelsService);
-		// Bucket by display name so Chat (`copilot`) and agent-host CLI (`copilotcli` →
-		// "Copilot") share one Other Models section instead of duplicate headers (#327644).
+		// By display name — avoids duplicate "Copilot" headers (#327644).
 		const key = info.groupName;
 		const bucket = groups.get(key) ?? { vendor: info.vendor, groupName: info.groupName, models: [] };
 		if (info.vendor === 'copilot') {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
@@ -12,7 +12,7 @@ import { ActionListItemKind, IActionListItem } from '../../../../../../../platfo
 import { IActionWidgetDropdownAction } from '../../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
 import { ChatEntitlement } from '../../../../../../services/chat/common/chatEntitlementService.js';
 import { IModelControlEntry, ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier } from '../../../../common/languageModels.js';
-import { buildModelToProviderGroupMap, createModelAction, createModelItem, createPinAction, createUnavailableModelItem, getProviderGroupForModel, getProviderGroupKey, getUnavailableReason, isVersionAtLeast, ProviderGroupKey } from './modelPickerItemPrimitives.js';
+import { buildModelToProviderGroupMap, createModelAction, createModelItem, createPinAction, createUnavailableModelItem, getProviderGroupForModel, getUnavailableReason, isVersionAtLeast } from './modelPickerItemPrimitives.js';
 import type { IBuildModelPickerItemsOptions } from './modelPickerItemTypes.js';
 import { isAutoModel } from './modelPickerPresentation.js';
 
@@ -158,7 +158,9 @@ function createGroupedContext(options: IBuildModelPickerItemsOptions): IGroupedC
 		placed,
 		showGroupLabel: new Set(options.models.map(model => {
 			const group = getProviderGroupForModel(model, modelToGroup, options.languageModelsService);
-			return getProviderGroupKey(group.vendor, group.groupName);
+			// Key by visible section title so sources that share a label (e.g. Chat
+			// vendor `copilot` and agent-host `copilotcli` both → "Copilot") count as one.
+			return group.groupName;
 		})).size > 1,
 		makePinAction: model => options.actions.onTogglePin
 			? createPinAction(model.identifier, options.pinnedModelIds.includes(model.identifier), options.actions.onTogglePin)
@@ -325,11 +327,16 @@ function appendOtherModels(context: IGroupedContext): boolean {
 		className: 'chat-model-picker-section-toggle',
 	});
 	interface IProviderGroupBucket { vendor: string; groupName: string; models: ILanguageModelChatMetadataAndIdentifier[] }
-	const groups = new Map<ProviderGroupKey, IProviderGroupBucket>();
+	const groups = new Map<string, IProviderGroupBucket>();
 	for (const model of otherModels) {
 		const info = getProviderGroupForModel(model, context.modelToGroup, options.languageModelsService);
-		const key = getProviderGroupKey(info.vendor, info.groupName);
+		// Bucket by display name so Chat (`copilot`) and agent-host CLI (`copilotcli` →
+		// "Copilot") share one Other Models section instead of duplicate headers (#327644).
+		const key = info.groupName;
 		const bucket = groups.get(key) ?? { vendor: info.vendor, groupName: info.groupName, models: [] };
+		if (info.vendor === 'copilot') {
+			bucket.vendor = 'copilot';
+		}
 		bucket.models.push(model);
 		groups.set(key, bucket);
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
@@ -945,9 +945,6 @@ suite('buildModelPickerItems', () => {
 	});
 
 	test('Other Models merges Chat and agent-host CLI into one Copilot section (#327644)', () => {
-		// Chat models use vendor `copilot` (displayName "Copilot"). Agent-host CLI models
-		// use modelGroup `copilotcli`, which the picker also labels "Copilot". Bucketing by
-		// (vendor, groupName) produced two identical "Copilot" headers with different models.
 		const auto = createAutoModel();
 		const chatModel = createModel('gpt-4o', 'GPT-4o', 'copilot');
 		const cliModel = createAgentHostModel('claude-haiku-4.5', 'Claude Haiku 4.5', { id: 'copilotcli' });

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
@@ -944,6 +944,30 @@ suite('buildModelPickerItems', () => {
 		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['Copilot', 'Hugging Face', 'OpenAI']);
 	});
 
+	test('Other Models merges Chat and agent-host CLI into one Copilot section (#327644)', () => {
+		// Chat models use vendor `copilot` (displayName "Copilot"). Agent-host CLI models
+		// use modelGroup `copilotcli`, which the picker also labels "Copilot". Bucketing by
+		// (vendor, groupName) produced two identical "Copilot" headers with different models.
+		const auto = createAutoModel();
+		const chatModel = createModel('gpt-4o', 'GPT-4o', 'copilot');
+		const cliModel = createAgentHostModel('claude-haiku-4.5', 'Claude Haiku 4.5', { id: 'copilotcli' });
+		const openai = createAgentHostModel('openai/gpt-5-nano', 'GPT-5 nano', { id: 'openai' });
+		const service = createLanguageModelsServiceStub([
+			{ vendor: 'copilot', displayName: 'Copilot', groups: [] },
+			{ vendor: 'copilotcli', displayName: 'Copilot CLI', groups: [] },
+			{ vendor: 'openai', displayName: 'OpenAI', groups: [] },
+		]);
+		const items = callBuild([auto, chatModel, cliModel, openai], { languageModelsService: service });
+		const labelledSeparators = items.filter(i => i.kind === ActionListItemKind.Separator && i.label);
+		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['Copilot', 'OpenAI']);
+		const otherSectionStart = items.findIndex(i => i.kind === ActionListItemKind.Action && i.isSectionToggle && i.label === 'Other Models');
+		assert.ok(otherSectionStart >= 0);
+		const otherLabels = getActionItems(items.slice(otherSectionStart + 1)).map(a => a.label);
+		assert.ok(otherLabels.includes('GPT-4o'));
+		assert.ok(otherLabels.includes('Claude Haiku 4.5'));
+		assert.ok(otherLabels.includes('GPT-5 nano'));
+	});
+
 	test('Other Models keeps a single section when agent-host models share one modelGroup', () => {
 		const auto = createAutoModel();
 		const a = createAgentHostModel('claude-haiku-4.5', 'Claude Haiku 4.5', { id: 'copilotcli' });


### PR DESCRIPTION
## Summary
- Fixes #327644 — Other Models could show two headers both labeled **Copilot**, with different models under each (e.g. Auto only in one of them).
- That happened because Chat models use vendor `copilot`, while agent-host CLI models use `modelGroup: copilotcli`, which we also display as "Copilot". Bucketing by `(vendor, groupName)` treated them as separate sections even though the UI text was identical.
- Other Models (and the “show group label” check) now key off the visible section title, so those sources land in one Copilot group. Distinct labels like OpenAI / Hugging Face still get their own sections; BYOK multi-group setups are unchanged.

## Test plan
- [x] Unit: `Other Models merges Chat and agent-host CLI into one Copilot section (#327644)`
- [x] Full `buildModelPickerItems` suite — 88 passing
- [ ] Open the chat model picker in a setup with both Copilot Chat models and agent-host / CLI models → only one **Copilot** section under Other Models
- [ ] Confirm Auto / featured models still behave as before at the top of the picker
- [ ] Smoke BYOK with multiple named groups under one vendor — still separate sections