### PR TITLE
agentHost: Forward the resolved shell SSH agent

### DIFF
--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -40,6 +40,8 @@ export interface ISSHAgentHostConfig {
 	readonly privateKeyPath?: string;
 	/** Raw IdentityAgent value from resolved SSH config; may be a socket path, `none`, `SSH_AUTH_SOCK`, or an environment reference. */
 	readonly identityAgent?: string;
+	/** Local SSH agent socket resolved from the renderer's shell environment. */
+	readonly agentSocket?: string;
 	/** Password string (when {@link authMethod} is Password). */
 	readonly password?: string;
 	/** Display name for this connection. */
@@ -57,7 +59,7 @@ export interface ISSHAgentHostConfig {
  * (password, private key path). Exposed on active connections so
  * consumers can inspect connection metadata without accessing credentials.
  */
-export type ISSHAgentHostConfigSanitized = Omit<ISSHAgentHostConfig, 'password' | 'privateKeyPath'>;
+export type ISSHAgentHostConfigSanitized = Omit<ISSHAgentHostConfig, 'password' | 'privateKeyPath' | 'agentSocket'>;
 
 export interface ISSHAgentHostConnection extends IDisposable {
 	/** The SSH config used to establish this connection (secrets stripped). */
@@ -281,5 +283,5 @@ export interface ISSHRemoteAgentHostMainService {
 	 * Resolves the SSH config alias, connects, and returns fresh
 	 * connection info with a new local forwarded port.
 	 */
-	reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string, agentForward?: boolean): Promise<ISSHConnectResult>;
+	reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string, agentForward?: boolean, agentSocket?: string): Promise<ISSHConnectResult>;
 }

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -11,6 +11,7 @@ import { localize } from '../../../nls.js';
 import { ILogService } from '../../log/common/log.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
+import { IShellEnvironmentService } from '../../environment/common/shellEnvironmentService.js';
 import { ISharedProcessService } from '../../ipc/electron-browser/services.js';
 import { ProxyChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId } from '../common/remoteAgentHostService.js';
@@ -85,6 +86,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ISSHRelayClientFactory private readonly _relayClientFactory: ISSHRelayClientFactory,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
+		@IShellEnvironmentService private readonly _shellEnvironmentService: IShellEnvironmentService,
 	) {
 		super();
 
@@ -140,7 +142,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 			throw new Error('Remote agent host connections are not enabled.');
 		}
 
-		const augmentedConfig = this._augmentConfig(config);
+		const augmentedConfig = await this._augmentConfig(config);
 		this._logService.info(`[SSHRemoteAgentHost] Connecting to ${config.host}`);
 		const result = await this._mainService.connect(augmentedConfig);
 		this._logService.trace(`[SSHRemoteAgentHost] SSH tunnel established, connectionId=${result.connectionId}`);
@@ -174,8 +176,9 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 
 		const commandOverride = this._getRemoteAgentHostCommand();
 		const agentForward = this._isSSHAgentForwardingEnabled();
+		const agentSocket = agentForward ? await this._getSSHAgentSocket() : undefined;
 		this._logService.info(`[SSHRemoteAgentHost] Reconnecting to ${sshConfigHost}`);
-		const result = await this._mainService.reconnect(sshConfigHost, name, commandOverride, agentForward);
+		const result = await this._mainService.reconnect(sshConfigHost, name, commandOverride, agentForward, agentSocket);
 		return this._setupConnection(result);
 	}
 
@@ -303,7 +306,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		return this._relayClientFactory.createClient(this._mainService, result.connectionId, result.address);
 	}
 
-	private _augmentConfig(config: ISSHAgentHostConfig): ISSHAgentHostConfig {
+	private async _augmentConfig(config: ISSHAgentHostConfig): Promise<ISSHAgentHostConfig> {
 		const result = { ...config };
 		const commandOverride = this._getRemoteAgentHostCommand();
 		if (commandOverride) {
@@ -311,9 +314,8 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		}
 		// Agent forwarding requires both the global setting (security opt-in)
 		// and the per-host SSH config `ForwardAgent yes` to be enabled.
-		if (this._isSSHAgentForwardingEnabled() && config.agentForward) {
-			result.agentForward = true;
-		}
+		result.agentForward = this._isSSHAgentForwardingEnabled() && config.agentForward ? true : undefined;
+		result.agentSocket = result.agentForward ? await this._getSSHAgentSocket() : undefined;
 		return result;
 	}
 
@@ -321,8 +323,12 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		return this._configurationService.getValue<string>('chat.sshRemoteAgentHostCommand') || undefined;
 	}
 
-	private _isSSHAgentForwardingEnabled(): boolean | undefined {
-		return this._configurationService.getValue<boolean>('chat.agentHost.forwardSSHAgent') || undefined;
+	private _isSSHAgentForwardingEnabled(): boolean {
+		return !!this._configurationService.getValue<boolean>('chat.agentHost.forwardSSHAgent');
+	}
+
+	private async _getSSHAgentSocket(): Promise<string | undefined> {
+		return (await this._shellEnvironmentService.getShellEnv())['SSH_AUTH_SOCK'];
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -466,7 +466,7 @@ function createWebSocketRelay(
 }
 
 function sanitizeConfig(config: ISSHAgentHostConfig): ISSHAgentHostConfigSanitized {
-	const { password: _p, privateKeyPath: _k, ...sanitized } = config;
+	const { password: _p, privateKeyPath: _k, agentSocket: _a, ...sanitized } = config;
 	return sanitized;
 }
 
@@ -868,7 +868,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		}
 	}
 
-	async reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string, agentForward?: boolean): Promise<ISSHConnectResult> {
+	async reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string, agentForward?: boolean, agentSocket?: string): Promise<ISSHConnectResult> {
 		this._logService.info(`${LOG_PREFIX} Reconnecting via SSH config host: ${sshConfigHost}`);
 		const resolved = await this.resolveSSHConfig(sshConfigHost);
 
@@ -893,6 +893,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			sshConfigHost,
 			remoteAgentHostCommand,
 			agentForward: agentForward && resolved.forwardAgent ? true : undefined,
+			agentSocket,
 		}, /* replaceRelay */ true);
 	}
 
@@ -1256,18 +1257,18 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 	protected _getAgentSocket(config: ISSHAgentHostConfig): string | undefined {
 		if (config.identityAgent !== undefined) {
-			return this._resolveIdentityAgent(config.identityAgent);
+			return this._resolveIdentityAgent(config.identityAgent, config.agentSocket);
 		}
-		return this._isAgentAvailable();
+		return config.agentSocket ?? this._isAgentAvailable();
 	}
 
-	private _resolveIdentityAgent(identityAgent: string): string | undefined {
+	private _resolveIdentityAgent(identityAgent: string, agentSocket: string | undefined): string | undefined {
 		const trimmed = identityAgent.trim();
 		if (!trimmed || trimmed.toLowerCase() === 'none') {
 			return undefined;
 		}
 		if (trimmed === 'SSH_AUTH_SOCK') {
-			return this._isAgentAvailable();
+			return agentSocket ?? this._isAgentAvailable();
 		}
 		if (trimmed.startsWith('$')) {
 			const envMatch = /^\$\{(?<braced>[A-Za-z_][A-Za-z0-9_]*)\}$|^\$(?<plain>[A-Za-z_][A-Za-z0-9_]*)$/.exec(trimmed);

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -871,6 +871,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	async reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string, agentForward?: boolean, agentSocket?: string): Promise<ISSHConnectResult> {
 		this._logService.info(`${LOG_PREFIX} Reconnecting via SSH config host: ${sshConfigHost}`);
 		const resolved = await this.resolveSSHConfig(sshConfigHost);
+		const enableAgentForwarding = agentForward && resolved.forwardAgent;
 
 		// Always use Agent auth — the auth handler will walk through the SSH
 		// agent and any default identities. If the user pinned a non-default
@@ -892,8 +893,8 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			name,
 			sshConfigHost,
 			remoteAgentHostCommand,
-			agentForward: agentForward && resolved.forwardAgent ? true : undefined,
-			agentSocket,
+			agentForward: enableAgentForwarding ? true : undefined,
+			agentSocket: enableAgentForwarding ? agentSocket : undefined,
 		}, /* replaceRelay */ true);
 	}
 
@@ -1267,7 +1268,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		if (!trimmed || trimmed.toLowerCase() === 'none') {
 			return undefined;
 		}
-		if (trimmed === 'SSH_AUTH_SOCK') {
+		if (trimmed === 'SSH_AUTH_SOCK' || trimmed === '$SSH_AUTH_SOCK' || trimmed === '${SSH_AUTH_SOCK}') {
 			return agentSocket ?? this._isAgentAvailable();
 		}
 		if (trimmed.startsWith('$')) {

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -13,6 +13,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IConfigurationService } from '../../../configuration/common/configuration.js';
+import { IShellEnvironmentService } from '../../../environment/common/shellEnvironmentService.js';
 
 import { ISharedProcessService } from '../../../ipc/electron-browser/services.js';
 import { IQuickInputService } from '../../../quickinput/common/quickInput.js';
@@ -66,7 +67,7 @@ class MockSSHMainService {
 
 	readonly disconnectCalls: string[] = [];
 	readonly connectCalls: ISSHAgentHostConfig[] = [];
-	readonly reconnectCalls: Array<{ sshConfigHost: string; name: string }> = [];
+	readonly reconnectCalls: Array<{ sshConfigHost: string; name: string; remoteAgentHostCommand: string | undefined; agentForward: boolean | undefined; agentSocket: string | undefined }> = [];
 	private _nextConnectionId = 1;
 
 	connectResult: Partial<ISSHConnectResult> | undefined;
@@ -84,8 +85,8 @@ class MockSSHMainService {
 		};
 	}
 
-	async reconnect(sshConfigHost: string, name: string): Promise<ISSHConnectResult> {
-		this.reconnectCalls.push({ sshConfigHost, name });
+	async reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string, agentForward?: boolean, agentSocket?: string): Promise<ISSHConnectResult> {
+		this.reconnectCalls.push({ sshConfigHost, name, remoteAgentHostCommand, agentForward, agentSocket });
 		return {
 			connectionId: this.connectResult?.connectionId ?? `conn-${this._nextConnectionId++}`,
 			address: this.connectResult?.address ?? `ssh:${sshConfigHost}`,
@@ -218,9 +219,18 @@ class MockProtocolClient extends Disposable {
 
 class TestConfigurationService {
 	readonly onDidChangeConfiguration = Event.None;
-	constructor(private _remoteAgentHostsEnabled = true) { }
-	getValue(key?: string): unknown { return key === RemoteAgentHostsEnabledSettingId ? this._remoteAgentHostsEnabled : undefined; }
+	constructor(private _remoteAgentHostsEnabled = true, private _forwardSSHAgent = false) { }
+	getValue(key?: string): unknown {
+		if (key === RemoteAgentHostsEnabledSettingId) {
+			return this._remoteAgentHostsEnabled;
+		}
+		if (key === 'chat.agentHost.forwardSSHAgent') {
+			return this._forwardSSHAgent;
+		}
+		return undefined;
+	}
 	setRemoteAgentHostsEnabled(enabled: boolean): void { this._remoteAgentHostsEnabled = enabled; }
+	setForwardSSHAgent(enabled: boolean): void { this._forwardSSHAgent = enabled; }
 }
 
 suite('SSHRemoteAgentHostService (renderer)', () => {
@@ -250,6 +260,9 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 		instantiationService.stub(IQuickInputService, {} as Partial<IQuickInputService>);
 		instantiationService.stub(ISharedProcessService, sharedProcessService as ISharedProcessService);
 		instantiationService.stub(IRemoteAgentHostService, remoteAgentHostService as Partial<IRemoteAgentHostService>);
+		instantiationService.stub(IShellEnvironmentService, {
+			getShellEnv: async () => ({ SSH_AUTH_SOCK: '/tmp/shell-agent.sock' }),
+		});
 
 		const clientWaiters: DeferredPromise<MockProtocolClient>[] = [];
 		waitForClient = (index: number): Promise<MockProtocolClient> => {
@@ -301,6 +314,50 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 		assert.ok(remoteAgentHostService.added[0].transport, 'a transport disposable is passed so removal can tear down the SSH tunnel');
 		assert.strictEqual(service.connections.length, 1);
 		assert.strictEqual(handle.localAddress, 'ssh:remote.example');
+	});
+
+	test('connect forwards the SSH agent from the shell environment when both opt-ins are enabled', async () => {
+		configurationService.setForwardSSHAgent(true);
+		const connectPromise = service.connect({ ...sampleConfig, agentForward: true });
+		await awaitClientThenResolve(0);
+		await connectPromise;
+
+		assert.deepStrictEqual({
+			agentForward: mainService.connectCalls[0].agentForward,
+			agentSocket: mainService.connectCalls[0].agentSocket,
+		}, {
+			agentForward: true,
+			agentSocket: '/tmp/shell-agent.sock',
+		});
+	});
+
+	test('connect strips agent forwarding when the global opt-in is disabled', async () => {
+		const connectPromise = service.connect({ ...sampleConfig, agentForward: true, agentSocket: '/tmp/caller-agent.sock' });
+		await awaitClientThenResolve(0);
+		await connectPromise;
+
+		assert.deepStrictEqual({
+			agentForward: mainService.connectCalls[0].agentForward,
+			agentSocket: mainService.connectCalls[0].agentSocket,
+		}, {
+			agentForward: undefined,
+			agentSocket: undefined,
+		});
+	});
+
+	test('reconnect forwards the SSH agent from the shell environment', async () => {
+		configurationService.setForwardSSHAgent(true);
+		const reconnectPromise = service.reconnect('remote.example', 'My Remote');
+		await awaitClientThenResolve(0);
+		await reconnectPromise;
+
+		assert.deepStrictEqual(mainService.reconnectCalls, [{
+			sshConfigHost: 'remote.example',
+			name: 'My Remote',
+			remoteAgentHostCommand: undefined,
+			agentForward: true,
+			agentSocket: '/tmp/shell-agent.sock',
+		}]);
 	});
 
 	test('incompatible handshake keeps SSH tunnel registered for server upgrade', async () => {

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -12,7 +12,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { NullLogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { createRemoteAgentHostState } from '../../common/remoteAgentHostMetadata.js';
-import { SSHAuthMethod, type ISSHAgentHostConfig, type ISSHConnectProgress, type ISSHKeyboardInteractivePrompt, type ISSHKeyboardInteractiveRequest } from '../../common/sshRemoteAgentHost.js';
+import { SSHAuthMethod, type ISSHAgentHostConfig, type ISSHConnectProgress, type ISSHConnectResult, type ISSHKeyboardInteractivePrompt, type ISSHKeyboardInteractiveRequest } from '../../common/sshRemoteAgentHost.js';
 import { SSHRemoteAgentHostMainService, makeAuthHandler, type SSHAuthAttempt } from '../../node/sshRemoteAgentHostService.js';
 import type { AnyAuthMethod, AuthenticationType, ConnectConfig } from 'ssh2';
 
@@ -416,6 +416,33 @@ class AgentForwardingConnectTestService extends SSHRemoteAgentHostMainService {
 	}
 }
 
+class ReconnectConfigTestService extends SSHRemoteAgentHostMainService {
+	connectConfig: ISSHAgentHostConfig | undefined;
+
+	override async resolveSSHConfig() {
+		return {
+			hostname: '10.0.0.1',
+			port: 22,
+			user: 'testuser',
+			identityFile: [],
+			identityAgent: undefined,
+			forwardAgent: false,
+		};
+	}
+
+	override async connect(config: ISSHAgentHostConfig): Promise<ISSHConnectResult> {
+		this.connectConfig = config;
+		return {
+			connectionId: 'ssh:test-host',
+			address: 'ssh:test-host',
+			name: config.name,
+			connectionToken: undefined,
+			config,
+			sshConfigHost: config.sshConfigHost,
+		};
+	}
+}
+
 suite('SSHRemoteAgentHostMainService - connect flow', () => {
 
 	const disposables = new DisposableStore();
@@ -488,6 +515,27 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 		assert.strictEqual(result2.connectionToken, result1.connectionToken);
 		assert.strictEqual(service.startCalled, 1); // no restart
 		assert.strictEqual(service.relayCalled, 2); // fresh relay
+	});
+
+	test('reconnect omits the renderer agent socket when the host disables agent forwarding', async () => {
+		const reconnectService = disposables.add(new ReconnectConfigTestService(
+			new NullLogService(),
+			{
+				_serviceBrand: undefined,
+				quality,
+				dataFolderName,
+			} as IProductService,
+		));
+
+		await reconnectService.reconnect('myalias', 'test-agent', undefined, true, '/tmp/shell-agent.sock');
+
+		assert.deepStrictEqual({
+			agentForward: reconnectService.connectConfig?.agentForward,
+			agentSocket: reconnectService.connectConfig?.agentSocket,
+		}, {
+			agentForward: undefined,
+			agentSocket: undefined,
+		});
 	});
 
 	test('reconnect does not fire onDidRelayClose for superseded relay', async () => {
@@ -1577,18 +1625,40 @@ suite('SSHRemoteAgentHostMainService - _buildAuthAttempts', () => {
 		]);
 	});
 
-	test('Agent + IdentityAgent SSH_AUTH_SOCK uses the default agent endpoint', async () => {
+	test('Agent + IdentityAgent SSH_AUTH_SOCK references use the renderer-resolved agent endpoint', async () => {
 		service.agentSock = '/tmp/shared-process-agent.sock';
 
-		const attempts = await service.testBuildAuthAttempts(makeConfig({
-			authMethod: SSHAuthMethod.Agent,
-			identityAgent: 'SSH_AUTH_SOCK',
-			agentSocket: '/tmp/shell-agent.sock',
-		}));
+		const results = await Promise.all(['SSH_AUTH_SOCK', '$SSH_AUTH_SOCK', '${SSH_AUTH_SOCK}'].map(async identityAgent => ({
+			identityAgent,
+			attempts: await service.testBuildAuthAttempts(makeConfig({
+				authMethod: SSHAuthMethod.Agent,
+				identityAgent,
+				agentSocket: '/tmp/shell-agent.sock',
+			})),
+		})));
 
-		assert.deepStrictEqual(attempts, [
-			{ type: 'agent', username: 'testuser', agent: '/tmp/shell-agent.sock' },
-			{ type: 'keyboard-interactive', username: 'testuser' },
+		assert.deepStrictEqual(results, [
+			{
+				identityAgent: 'SSH_AUTH_SOCK',
+				attempts: [
+					{ type: 'agent', username: 'testuser', agent: '/tmp/shell-agent.sock' },
+					{ type: 'keyboard-interactive', username: 'testuser' },
+				],
+			},
+			{
+				identityAgent: '$SSH_AUTH_SOCK',
+				attempts: [
+					{ type: 'agent', username: 'testuser', agent: '/tmp/shell-agent.sock' },
+					{ type: 'keyboard-interactive', username: 'testuser' },
+				],
+			},
+			{
+				identityAgent: '${SSH_AUTH_SOCK}',
+				attempts: [
+					{ type: 'agent', username: 'testuser', agent: '/tmp/shell-agent.sock' },
+					{ type: 'keyboard-interactive', username: 'testuser' },
+				],
+			},
 		]);
 	});
 

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -188,6 +188,35 @@ class KeyboardInteractiveMockSSHClient {
 	}
 }
 
+class AgentForwardingMockSSHClient {
+	connectConfig: ConnectConfig | undefined;
+	private readonly _readyListeners: Array<() => void> = [];
+
+	on(event: 'ready' | 'close', listener: () => void): this;
+	on(event: 'error', listener: (err: Error) => void): this;
+	on(event: string, listener: ((err: Error) => void) | (() => void)): this {
+		if (event === 'ready') {
+			this._readyListeners.push(listener as () => void);
+		}
+		return this;
+	}
+
+	removeListener(_event: string, _listener: (...args: never[]) => void): this {
+		return this;
+	}
+
+	connect(config: ConnectConfig): void {
+		this.connectConfig = config;
+		queueMicrotask(() => {
+			for (const listener of this._readyListeners) {
+				listener();
+			}
+		});
+	}
+
+	end(): void { }
+}
+
 function makeConfig(overrides?: Partial<ISSHAgentHostConfig>): ISSHAgentHostConfig {
 	return {
 		host: '10.0.0.1',
@@ -371,6 +400,22 @@ class KeyboardInteractiveConnectTestService extends SSHRemoteAgentHostMainServic
 	}
 }
 
+class AgentForwardingConnectTestService extends SSHRemoteAgentHostMainService {
+	readonly client = new AgentForwardingMockSSHClient();
+
+	protected override async _createSSHClient() {
+		return this.client as never;
+	}
+
+	protected override async _buildAuthAttempts(): Promise<SSHAuthAttempt[]> {
+		return [];
+	}
+
+	connectSSHForTest(config: ISSHAgentHostConfig) {
+		return this._connectSSH(config, 'ssh:test-host');
+	}
+}
+
 suite('SSHRemoteAgentHostMainService - connect flow', () => {
 
 	const disposables = new DisposableStore();
@@ -404,10 +449,11 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 			{ stdout: '', code: 0 },               // echo state file (write)
 		];
 
-		const config = makeConfig({ sshConfigHost: 'myalias' });
+		const config = makeConfig({ sshConfigHost: 'myalias', agentSocket: '/tmp/shell-agent.sock' });
 		const result1 = await service.connect(config);
 		assert.strictEqual(result1.connectionId, 'ssh:myalias');
 		assert.strictEqual(result1.sshConfigHost, 'myalias');
+		assert.strictEqual(Object.keys(result1.config).includes('agentSocket'), false);
 		assert.strictEqual(service.startCalled, 1);
 		assert.strictEqual(service.relayCalled, 1);
 
@@ -975,6 +1021,30 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 		});
 	});
 
+	test('agent forwarding uses the renderer-resolved SSH agent socket', async () => {
+		const forwardingService = disposables.add(new AgentForwardingConnectTestService(
+			new NullLogService(),
+			{
+				_serviceBrand: undefined,
+				quality,
+				dataFolderName,
+			} as IProductService,
+		));
+
+		await forwardingService.connectSSHForTest(makeConfig({
+			agentForward: true,
+			agentSocket: '/tmp/shell-agent.sock',
+		}));
+
+		assert.deepStrictEqual({
+			agent: forwardingService.client.connectConfig?.agent,
+			agentForward: forwardingService.client.connectConfig?.agentForward,
+		}, {
+			agent: '/tmp/shell-agent.sock',
+			agentForward: true,
+		});
+	});
+
 	test('responding to keyboard-interactive prompt does not cancel connection attempt', async () => {
 		let finished: readonly string[] | undefined;
 		let cancelled = false;
@@ -1478,6 +1548,19 @@ suite('SSHRemoteAgentHostMainService - _buildAuthAttempts', () => {
 		]);
 	});
 
+	test('Agent + renderer-resolved SSH_AUTH_SOCK uses it instead of the shared-process environment', async () => {
+		service.agentSock = '/tmp/shared-process-agent.sock';
+
+		const attempts = await service.testBuildAuthAttempts(makeConfig({
+			agentSocket: '/tmp/shell-agent.sock',
+		}));
+
+		assert.deepStrictEqual(attempts, [
+			{ type: 'agent', username: 'testuser', agent: '/tmp/shell-agent.sock' },
+			{ type: 'keyboard-interactive', username: 'testuser' },
+		]);
+	});
+
 	test('Agent + IdentityAgent uses configured agent endpoint before default keys', async () => {
 		service.agentSock = '/tmp/ssh-agent.sock';
 		service.keyFiles.set('~/.ssh/id_rsa', RSA);
@@ -1495,15 +1578,16 @@ suite('SSHRemoteAgentHostMainService - _buildAuthAttempts', () => {
 	});
 
 	test('Agent + IdentityAgent SSH_AUTH_SOCK uses the default agent endpoint', async () => {
-		service.agentSock = '/tmp/ssh-agent.sock';
+		service.agentSock = '/tmp/shared-process-agent.sock';
 
 		const attempts = await service.testBuildAuthAttempts(makeConfig({
 			authMethod: SSHAuthMethod.Agent,
 			identityAgent: 'SSH_AUTH_SOCK',
+			agentSocket: '/tmp/shell-agent.sock',
 		}));
 
 		assert.deepStrictEqual(attempts, [
-			{ type: 'agent', username: 'testuser', agent: '/tmp/ssh-agent.sock' },
+			{ type: 'agent', username: 'testuser', agent: '/tmp/shell-agent.sock' },
 			{ type: 'keyboard-interactive', username: 'testuser' },
 		]);
 	});

--- a/src/vs/platform/environment/common/shellEnvironmentService.ts
+++ b/src/vs/platform/environment/common/shellEnvironmentService.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IProcessEnvironment } from '../../../base/common/platform.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+
+export const IShellEnvironmentService = createDecorator<IShellEnvironmentService>('shellEnvironmentService');
+
+export interface IShellEnvironmentService {
+	readonly _serviceBrand: undefined;
+	getShellEnv(): Promise<IProcessEnvironment>;
+}

--- a/src/vs/workbench/services/environment/electron-browser/shellEnvironmentService.ts
+++ b/src/vs/workbench/services/environment/electron-browser/shellEnvironmentService.ts
@@ -3,19 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { IProcessEnvironment } from '../../../../base/common/platform.js';
 import { process } from '../../../../base/parts/sandbox/electron-browser/globals.js';
+import { IProcessEnvironment } from '../../../../base/common/platform.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IShellEnvironmentService } from '../../../../platform/environment/common/shellEnvironmentService.js';
 
-export const IShellEnvironmentService = createDecorator<IShellEnvironmentService>('shellEnvironmentService');
-
-export interface IShellEnvironmentService {
-
-	readonly _serviceBrand: undefined;
-
-	getShellEnv(): Promise<IProcessEnvironment>;
-}
+export { IShellEnvironmentService } from '../../../../platform/environment/common/shellEnvironmentService.js';
 
 export class ShellEnvironmentService implements IShellEnvironmentService {
 


### PR DESCRIPTION
## Summary

- resolve `SSH_AUTH_SOCK` from VS Code's merged shell environment before opening SSH agent-host connections
- pass the resolved socket through initial connections and reconnects while preserving the existing global and per-host forwarding opt-ins
- exclude the local agent socket path from sanitized connection metadata
- add regression coverage for renderer configuration, socket selection, forwarding setup, reconnects, and sanitization

## Validation

- `npm run compile-client`
- `npm run valid-layers-check`
- `npm run precommit`
- `npm run test-node -- --run src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts --run src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts` (75 passing)