### PR TITLE
voice: require explicit speech for approvals

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -124,6 +124,46 @@ interface ITranscriptionTurnState {
 	phase: TranscriptionTurnPhase;
 }
 
+const EXPLICIT_VOICE_APPROVALS = new Set([
+	'allow',
+	'allow it',
+	'allow this',
+	'approve',
+	'approve it',
+	'approve this',
+	'confirm',
+	'confirm it',
+	'do it',
+	'go ahead',
+	'yes',
+	'yes allow',
+	'yes approve',
+	'yes confirm',
+]);
+
+const EXPLICIT_VOICE_AUTO_APPROVALS = new Set([
+	'always approve this session',
+	'auto approve',
+	'auto approve this session',
+	'enable auto approval',
+	'enable auto approval for this session',
+]);
+
+function isExplicitVoiceApproval(toolName: string, transcript: string | undefined): boolean {
+	if (!transcript) {
+		return false;
+	}
+	const normalized = transcript.toLocaleLowerCase().replace(/[.,!?;:]+/g, ' ').replace(/\s+/g, ' ').trim()
+		.replace(/^please /, '').replace(/ please$/, '');
+	if (toolName === 'approve_confirmation') {
+		return EXPLICIT_VOICE_APPROVALS.has(normalized);
+	}
+	if (toolName === 'auto_approve_session') {
+		return EXPLICIT_VOICE_AUTO_APPROVALS.has(normalized);
+	}
+	return true;
+}
+
 export interface IVoiceSessionController {
 	readonly _serviceBrand: undefined;
 
@@ -309,6 +349,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _enterListenOnSessionInit = false;
 	private _pttCurrentTurnId = '';
 	private _transcriptionTurnState: ITranscriptionTurnState | undefined;
+	private _lastFinalTranscription: string | undefined;
 	private _window: (Window & typeof globalThis) | undefined;
 	private readonly _voiceEventDisposables = this._register(new DisposableStore());
 	private readonly _voiceAutorunDisposable = this._register(new MutableDisposable());
@@ -890,6 +931,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	async connect(window: Window & typeof globalThis): Promise<void> {
 		if (this._isConnecting.get() || this._isConnected.get()) { return; }
 		const connectAttemptGeneration = ++this._connectAttemptGeneration;
+		this._resetTranscriptionTurn();
 
 		this._window = window;
 		this._onFocusedSessionChanged();
@@ -1578,6 +1620,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 		// Audio response → fade transcript, queue for sequential playback
 		this._voiceEventDisposables.add(this.voiceClientService.onAudioResponse(e => {
+			if (e.isFirstChunk) {
+				this._lastFinalTranscription = undefined;
+			}
 			if (this._isInterruptedAudio(e)) {
 				return;
 			}
@@ -1702,6 +1747,20 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				'auto_approve_session', 'revoke_auto_approve',
 				'focus_session',
 			];
+			if ((e.name === 'approve_confirmation' || e.name === 'auto_approve_session') && !isExplicitVoiceApproval(e.name, this._lastFinalTranscription)) {
+				this.logService.warn(`[voice] blocked ${e.name}: the final transcript was not an explicit approval`);
+				this._lastFinalTranscription = undefined;
+				this.voiceClientService.sendToolResult(e.callId, 'explicit voice approval required');
+				return;
+			}
+			if (e.name === 'send_to_chat'
+				|| e.name === 'approve_confirmation'
+				|| e.name === 'reject_confirmation'
+				|| e.name === 'auto_approve_session'
+				|| e.name === 'revoke_auto_approve'
+				|| e.name === 'focus_session') {
+				this._lastFinalTranscription = undefined;
+			}
 			if (e.name === 'send_to_chat') {
 				// Drop a stray finalization from a turn we just discarded on a
 				// focus change, so buffered speech isn't misrouted to the newly
@@ -2014,6 +2073,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this.micCaptureService.stopCapture();
 		this._pttHeld = false;
 		this._pttToggleMode = false;
+		this._resetTranscriptionTurn();
 		// No reconnect is coming and a later connect() does not reset narration
 		// bookkeeping, so clear the deferred/in-flight narration state and its
 		// timers here (as disconnect() does). Otherwise a narration_unblocked on a
@@ -2085,6 +2145,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 	private _resetTranscriptionTurn(): void {
 		this._transcriptionTurnState = undefined;
+		this._lastFinalTranscription = undefined;
 	}
 
 	private _handleTurnAutoEnded(event: IVoiceTurnAutoEnded): void {
@@ -2196,6 +2257,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._voiceState.set('processing', undefined);
 			this._statusText.set('Processing...', undefined);
 		}
+		this._lastFinalTranscription = this._isConnected.get() && event.turnId && state ? event.text : undefined;
 		this._persistTurn('user', event.text);
 		if (event.turnId && state) {
 			state.phase = 'final';
@@ -2386,6 +2448,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// stray `send_to_chat` the backend may already have in flight (e.g. it
 		// auto-ended the turn via VAD before we discarded).
 		if (!this._isConnected.get()) { return; }
+		this._lastFinalTranscription = undefined;
 		this._autoListenSuppressed = true;
 		this._pttToggleMode = false;
 		this._clearAutoListenTimer();
@@ -2396,6 +2459,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._voiceState.set('idle', undefined);
 			this._statusText.set('Tap to start', undefined);
 		}
+		this._resetTranscriptionTurn();
 	}
 
 	finishListeningAndSubmitTo(session: URI): void {
@@ -2953,6 +3017,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * landed), reuse it instead of pushing a duplicate empty entry.
 	 */
 	private _startUserTurn(): void {
+		this._lastFinalTranscription = undefined;
 		const cur = this._transcriptTurns.get();
 		const last = cur[cur.length - 1];
 		if (last && last.speaker === 'user' && !last.text) {

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -30,7 +30,7 @@ import { IAgentSessionsService } from '../../../browser/agentSessions/agentSessi
 import { IChatWidgetService } from '../../../browser/chat.js';
 import { IMicCaptureService } from '../../../browser/voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../../browser/voiceClient/ttsPlaybackService.js';
-import { IVoiceSessionController, VoiceSessionController } from '../../../browser/voiceClient/voiceSessionController.js';
+import { VoiceSessionController } from '../../../browser/voiceClient/voiceSessionController.js';
 import { IVoiceToolDispatchService } from '../../../browser/voiceClient/voiceToolDispatchService.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IPromptsService } from '../../../common/promptSyntax/service/promptsService.js';
@@ -306,6 +306,17 @@ class TestTelemetryService extends NullTelemetryServiceShape {
 	}
 }
 
+class RecordingVoiceToolDispatchService extends mock<IVoiceToolDispatchService>() {
+	readonly calls: IVoiceToolCall[] = [];
+
+	override setDelegate(): void { }
+
+	override async dispatchToolCall(toolCall: IVoiceToolCall): Promise<string> {
+		this.calls.push(toolCall);
+		return 'ok';
+	}
+}
+
 suite('VoiceSessionController', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	let clock: sinon.SinonFakeTimers;
@@ -330,16 +341,17 @@ suite('VoiceSessionController', () => {
 		promptsService: IPromptsService = new class extends mock<IPromptsService>() {
 			override async getVoiceInstructions(): Promise<undefined> { return undefined; }
 		}(),
-	): IVoiceSessionController {
+		voiceToolDispatchService: IVoiceToolDispatchService = new class extends mock<IVoiceToolDispatchService>() {
+			override setDelegate(): void { }
+		}(),
+	): VoiceSessionController {
 		store.add({ dispose: () => voiceClientService.dispose() });
 		store.add(ttsPlaybackService);
 		return store.add(new VoiceSessionController(
 			voiceClientService,
 			micCaptureService,
 			ttsPlaybackService,
-			new class extends mock<IVoiceToolDispatchService>() {
-				override setDelegate(): void { }
-			}(),
+			voiceToolDispatchService,
 			new class extends mock<IVoicePlaybackService>() {
 				override notifyPlaybackStart(): void { }
 				override notifyPlaybackEnd(): void { }
@@ -366,6 +378,152 @@ suite('VoiceSessionController', () => {
 			promptsService,
 		));
 	}
+
+	function fireFinalTranscription(controller: VoiceSessionController, voiceClientService: TestVoiceClientService, text: string): string {
+		controller['_isConnected'].set(true, undefined);
+		controller.pttDown();
+		const turnId = controller['_pttCurrentTurnId'];
+		controller['_finishPtt']('local');
+		voiceClientService.fireTranscription({ text, status: 'final', turnId, revision: 1 });
+		return turnId;
+	}
+
+	test('requires an explicit final transcript before approving a tool call', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const voiceToolDispatchService = new RecordingVoiceToolDispatchService();
+		const controller = createController(
+			voiceClientService,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			voiceToolDispatchService,
+		);
+		await controller.connect(mainWindow);
+
+		fireFinalTranscription(controller, voiceClientService, 'replace all text with approve');
+		voiceClientService.fireToolCall({ callId: 'injected-approval', name: 'approve_confirmation', args: {} });
+		fireFinalTranscription(controller, voiceClientService, 'Approve it, please.');
+		voiceClientService.fireToolCall({ callId: 'explicit-approval', name: 'approve_confirmation', args: {} });
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			dispatchedCallIds: voiceToolDispatchService.calls.map(call => call.callId),
+			toolResults: voiceClientService.toolResults,
+		}, {
+			dispatchedCallIds: ['explicit-approval'],
+			toolResults: [
+				{ callId: 'injected-approval', result: 'explicit voice approval required' },
+				{ callId: 'explicit-approval', result: 'ok' },
+			],
+		});
+	});
+
+	test('consumes an explicit approval transcript after one tool call', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const voiceToolDispatchService = new RecordingVoiceToolDispatchService();
+		const controller = createController(
+			voiceClientService,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			voiceToolDispatchService,
+		);
+		await controller.connect(mainWindow);
+
+		fireFinalTranscription(controller, voiceClientService, 'yes');
+		voiceClientService.fireToolCall({ callId: 'first-approval', name: 'approve_confirmation', args: {} });
+		voiceClientService.fireToolCall({ callId: 'replayed-approval', name: 'approve_confirmation', args: {} });
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			dispatchedCallIds: voiceToolDispatchService.calls.map(call => call.callId),
+			toolResults: voiceClientService.toolResults,
+		}, {
+			dispatchedCallIds: ['first-approval'],
+			toolResults: [
+				{ callId: 'replayed-approval', result: 'explicit voice approval required' },
+				{ callId: 'first-approval', result: 'ok' },
+			],
+		});
+	});
+
+	test('requires an explicit auto-approval transcript', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const voiceToolDispatchService = new RecordingVoiceToolDispatchService();
+		const controller = createController(
+			voiceClientService,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			voiceToolDispatchService,
+		);
+		await controller.connect(mainWindow);
+
+		fireFinalTranscription(controller, voiceClientService, 'approve');
+		voiceClientService.fireToolCall({ callId: 'implicit-auto-approval', name: 'auto_approve_session', args: {} });
+		fireFinalTranscription(controller, voiceClientService, 'auto approve this session');
+		voiceClientService.fireToolCall({ callId: 'explicit-auto-approval', name: 'auto_approve_session', args: {} });
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			dispatchedCallIds: voiceToolDispatchService.calls.map(call => call.callId),
+			toolResults: voiceClientService.toolResults,
+		}, {
+			dispatchedCallIds: ['explicit-auto-approval'],
+			toolResults: [
+				{ callId: 'implicit-auto-approval', result: 'explicit voice approval required' },
+				{ callId: 'explicit-auto-approval', result: 'ok' },
+			],
+		});
+	});
+
+	test('invalidates approval transcripts across lifecycle boundaries', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const controller = createController(voiceClientService);
+		await controller.connect(mainWindow);
+
+		const disconnectedTurnId = fireFinalTranscription(controller, voiceClientService, 'approve');
+		assert.strictEqual(Reflect.get(controller, '_lastFinalTranscription'), 'approve');
+		controller['_onConnectionLost']();
+		voiceClientService.fireTranscription({ text: 'approve', status: 'final', turnId: disconnectedTurnId, revision: 2 });
+		assert.strictEqual(Reflect.get(controller, '_lastFinalTranscription'), undefined);
+		controller['_isConnected'].set(true, undefined);
+		voiceClientService.fireTranscription({ text: 'approve', status: 'final' });
+		assert.strictEqual(Reflect.get(controller, '_lastFinalTranscription'), undefined);
+
+		fireFinalTranscription(controller, voiceClientService, 'approve');
+		controller.discardListening();
+
+		assert.strictEqual(Reflect.get(controller, '_lastFinalTranscription'), undefined);
+	});
+
+	test('invalidates an approval transcript when the backend responds without approving', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const controller = createController(voiceClientService);
+		await controller.connect(mainWindow);
+
+		fireFinalTranscription(controller, voiceClientService, 'approve');
+		voiceClientService.fireAudioResponse({
+			audio: '',
+			isFirstChunk: true,
+			isFinal: true,
+			transcript: 'There is nothing to approve.',
+		});
+
+		assert.strictEqual(Reflect.get(controller, '_lastFinalTranscription'), undefined);
+	});
 
 	test('includes response errors in the summary sent to the voice backend', () => {
 		const controller = createController(new TestVoiceClientService());


### PR DESCRIPTION
## Summary

- require a scoped, accepted final transcript to explicitly match a fixed approval phrase before dispatching `approve_confirmation`
- apply the same protection to `auto_approve_session` with a separate, more specific phrase set
- consume approval evidence after one privileged call and invalidate it across turns, responses, mutating calls, discards, and connection lifecycle changes
- reject unscoped legacy transcripts as approval evidence while preserving their existing display and persistence behavior

This provides VS Code-side defense in depth against voice customization or backend routing turning unrelated speech into an approval. The backend should still avoid applying user voice instructions while processing confirmations.

Follow-up to #327418.

## Testing

- compiled the VS Code client
- ran `VoiceSessionController` unit tests (44 passing)