### PR TITLE
agentHost: only report MCP servers as starting once they are

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1756,7 +1756,6 @@ export class CopilotAgentSession extends Disposable {
 		await this.syncPermissionMode('turn-start');
 		await this._applyEffectiveSandboxConfig();
 		await this._reconcileMcpServerEnablement();
-		this._markEnabledMcpServersStarting();
 		await this._wrapper.session.send({ prompt, attachments: sdkAttachments?.length ? sdkAttachments : undefined });
 		this._logService.info(`[Copilot:${this.sessionId}] session.send() returned`);
 	}
@@ -2119,16 +2118,14 @@ export class CopilotAgentSession extends Disposable {
 		}
 		// stopServer leaves inline session MCP servers not_configured; disable->enable is the validated restart path.
 		await this._disableMcpServer(serverName);
-		// The SDK reconnects in the background on enable with no live "starting"
-		// event, so surface Starting optimistically until the seed below settles it.
-		this._mcpCustomizations.markStarting([serverName]);
 		try {
 			await this._wrapper.session.rpc.mcp.enable({ serverName });
 			await this._wrapper.session.rpc.mcp.listTools({ serverName });
 		} finally {
-			// Always reconcile against the SDK's real state -- on success this
-			// settles Starting -> Ready/AuthRequired, and on failure it clears the
-			// optimistic Starting instead of leaving the UI stuck.
+			// Reconcile against the SDK's real state. The live
+			// `session.mcp_server_status_changed` stream already reports the
+			// connect (`pending` -> `connected`/`failed`); this covers the case
+			// where the enable rejects before any status is emitted.
 			this._seedMcpServersFromRpc();
 		}
 	}
@@ -2148,12 +2145,11 @@ export class CopilotAgentSession extends Disposable {
 			}
 			try {
 				if (desired) {
-					// Re-enabling restarts the server. The SDK connects it in the
-					// background with no live "starting" event, so surface Starting
-					// optimistically. Mark `changed` now (before the enable) so the
-					// trailing refresh always runs and settles/clears this optimistic
-					// Starting even if the enable rejects.
-					this._mcpCustomizations.markStarting([server.serverName]);
+					// Re-enabling restarts the server. The SDK reports the
+					// connect live (`pending` -> `connected`/`failed`), so no
+					// optimistic state is written here. Mark `changed` now
+					// (before the enable) so the trailing refresh always runs
+					// even if the enable rejects.
 					changed = true;
 					await this._wrapper.session.rpc.mcp.enable({ serverName: server.serverName });
 				} else {
@@ -2166,23 +2162,6 @@ export class CopilotAgentSession extends Disposable {
 		}
 		if (changed) {
 			await this._refreshMcpServersFromRpc();
-		}
-	}
-
-	/**
-	 * Optimistically marks the session's enabled MCP servers as Starting for the
-	 * turn that is about to begin. Sending a message makes the SDK connect
-	 * enabled servers in the background with no live "starting" event, so without
-	 * this a connecting server would read as its last settled state (e.g. the
-	 * seeded Stopped) until the connection resolves. Already-running servers are
-	 * left untouched by the controller; the subsequent SDK status settles each
-	 * server.
-	 */
-	private _markEnabledMcpServersStarting(): void {
-		const customizations = this._stateManager.getSessionState(this.sessionUri.toString())?.customizations ?? [];
-		const enabled = getEffectiveMcpServerCustomizations(customizations).filter(server => server.enabled);
-		if (enabled.length > 0) {
-			this._mcpCustomizations.markStarting(enabled.map(server => server.name));
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/shared/mcpCustomizationController.ts
+++ b/src/vs/platform/agentHost/node/shared/mcpCustomizationController.ts
@@ -276,33 +276,6 @@ export class McpCustomizationController extends Disposable {
 		transaction(tx => this._applyOne(server, tx));
 	}
 
-	/**
-	 * Optimistically transitions the named servers to
-	 * {@link McpServerStatus.Starting}, skipping any that are already
-	 * {@link McpServerStatus.Ready} (nothing to (re)start), blocked on
-	 * {@link McpServerStatus.AuthRequired} (needs the user, not a background
-	 * start), or already {@link McpServerStatus.Starting}.
-	 *
-	 * The SDK connects enabled servers in the background — on an explicit
-	 * start or when a turn begins — but emits no live "starting" event, so
-	 * without this a connecting server would read as its last settled state
-	 * (e.g. `Stopped`) until it resolves. Callers invoke this immediately
-	 * before the (blocking) connect so clients see the transient `Starting`
-	 * state; the subsequent SDK status settles each server. Batched in a
-	 * single transaction so {@link runtimeStates} observers see one update.
-	 */
-	markStarting(serverNames: Iterable<string>): void {
-		transaction(tx => {
-			for (const name of serverNames) {
-				const previous = this._live.get().get(name)?.state.kind;
-				if (previous === McpServerStatus.Ready || previous === McpServerStatus.AuthRequired || previous === McpServerStatus.Starting) {
-					continue;
-				}
-				this._applyOne({ name, state: { kind: McpServerStatus.Starting } }, tx);
-			}
-		});
-	}
-
 	private _applyOne(server: ISdkMcpServer, tx: ITransaction): void {
 		const previous = this._live.get().get(server.name);
 		const state = this._stateForUpdate(previous?.state, server.state);

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -207,6 +207,9 @@ class MockCopilotSession {
 			},
 			enable: async (params: { serverName: string }) => {
 				this.mcpEnableCalls.push(params);
+				if (this.mcpEnableError !== undefined) {
+					throw this.mcpEnableError;
+				}
 				this.mcpListResult = {
 					servers: this.mcpListResult.servers.map(server => server.name === params.serverName ? { ...server, status: 'pending' } : server),
 				};
@@ -253,6 +256,7 @@ class MockCopilotSession {
 
 	mcpListResult: { servers: ReadonlyArray<{ name: string; status: 'connected' | 'failed' | 'needs-auth' | 'pending' | 'disabled' | 'not_configured'; error?: string }> } = { servers: [] };
 	mcpListError: unknown = undefined;
+	mcpEnableError: unknown = undefined;
 }
 
 class TestCopilotApiService implements ICopilotApiService {
@@ -6533,7 +6537,7 @@ suite('CopilotAgentSession', () => {
 			});
 		});
 
-		test('sending a message optimistically marks an enabled server as Starting', async () => {
+		test('sending a message does not mark an enabled server as Starting', async () => {
 			const serverName = 'db';
 			const id = 'mcp-top-level:copilot:test-session-1:db';
 			const { session } = await createAgentSession(disposables, {
@@ -6545,8 +6549,9 @@ suite('CopilotAgentSession', () => {
 					enabled: true,
 					state: { kind: McpServerStatus.Stopped },
 				}],
-				// The server is settled (failed) before the turn; the SDK reconnects
-				// enabled servers in the background on send without a live event.
+				// The server is settled (failed) before the turn. Sending does not
+				// reconnect it, so its state must stay put until the SDK reports a
+				// live `pending` of its own.
 				configureMockSession: mock => { mock.mcpListResult = { servers: [{ name: serverName, status: 'failed', error: 'boom' }] }; },
 			});
 
@@ -6556,14 +6561,14 @@ suite('CopilotAgentSession', () => {
 
 			assert.deepStrictEqual({ beforeSend, afterSend }, {
 				beforeSend: { kind: McpServerStatus.Error, error: { errorType: 'mcp-server-failed', message: 'boom' } },
-				afterSend: { kind: McpServerStatus.Starting },
+				afterSend: { kind: McpServerStatus.Error, error: { errorType: 'mcp-server-failed', message: 'boom' } },
 			});
 		});
 
-		test('startMcpServer optimistically marks the server Starting before the blocking reconnect', async () => {
+		test('startMcpServer reports Starting only once the SDK reports the reconnect', async () => {
 			const serverName = 'db';
 			const id = 'mcp-top-level:copilot:test-session-1:db';
-			const { session } = await createAgentSession(disposables, {
+			const { session, mockSession } = await createAgentSession(disposables, {
 				sessionCustomizations: () => [{
 					type: CustomizationType.McpServer,
 					id,
@@ -6572,20 +6577,31 @@ suite('CopilotAgentSession', () => {
 					enabled: true,
 					state: { kind: McpServerStatus.Stopped },
 				}],
-				// Settled (failed) before the explicit restart; the disable->enable
-				// reconnect is a background SDK operation with no live "starting" event.
-				configureMockSession: mock => { mock.mcpListResult = { servers: [{ name: serverName, status: 'failed', error: 'boom' }] }; },
+				// Settled (failed) before the explicit restart, and the enable
+				// rejects, so the SDK never reports a connect attempt.
+				configureMockSession: mock => {
+					mock.mcpListResult = { servers: [{ name: serverName, status: 'failed', error: 'boom' }] };
+					mock.mcpEnableError = new Error('enable failed');
+				},
 			});
 
 			const beforeStart = session.topLevelMcpCustomizations()[0]?.state;
-			await session.startMcpServer(id);
-			// The trailing inventory refresh is fire-and-forget, so right after the
-			// awaited enable the optimistic Starting is observable.
-			const afterStart = session.topLevelMcpCustomizations()[0]?.state;
+			await session.startMcpServer(id).catch(() => { });
+			// Let the fire-and-forget inventory refresh settle: the disable
+			// landed but the enable rejected, so the server reads as stopped
+			// rather than optimistically Starting.
+			await timeout(0);
+			const afterFailedStart = session.topLevelMcpCustomizations()[0]?.state;
+			mockSession.fire('session.mcp_server_status_changed', {
+				serverName,
+				status: 'pending',
+			} as SessionEventPayload<'session.mcp_server_status_changed'>['data']);
+			const afterSdkPending = session.topLevelMcpCustomizations()[0]?.state;
 
-			assert.deepStrictEqual({ beforeStart, afterStart }, {
+			assert.deepStrictEqual({ beforeStart, afterFailedStart, afterSdkPending }, {
 				beforeStart: { kind: McpServerStatus.Error, error: { errorType: 'mcp-server-failed', message: 'boom' } },
-				afterStart: { kind: McpServerStatus.Starting },
+				afterFailedStart: { kind: McpServerStatus.Stopped },
+				afterSdkPending: { kind: McpServerStatus.Starting },
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/shared/mcpCustomizationController.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/mcpCustomizationController.test.ts
@@ -313,35 +313,6 @@ suite('McpCustomizationController', () => {
 		]);
 	});
 
-	test('markStarting transitions non-ready servers to Starting, skipping ready/auth-required/starting', () => {
-		const { controller, actions } = harness(store, { customizations: PLUGIN_CUSTOMIZATIONS });
-		store.add(controller);
-
-		controller.applyOne(server('fs', stopped()));
-		controller.applyOne(server('search', ready()));
-		controller.applyOne(server('mail', authRequired()));
-		const before = actions.length;
-
-		// `unknown` has no live entry yet; it should be created as Starting.
-		controller.markStarting(['fs', 'search', 'mail', 'unknown']);
-
-		const summarized = actions.slice(before).map(a => {
-			if (a.type === ActionType.SessionMcpServerStateChanged) {
-				return { type: a.type, id: a.id, state: a.state };
-			}
-			if (a.type === ActionType.SessionCustomizationUpdated && a.customization.type === CustomizationType.McpServer) {
-				return { type: a.type, id: a.customization.id, state: a.customization.state };
-			}
-			return { type: a.type, id: undefined, state: undefined };
-		});
-		assert.deepStrictEqual(summarized, [
-			// fs (Stopped) -> Starting via its plugin child id
-			{ type: ActionType.SessionMcpServerStateChanged, id: 'mcp-child:demo:fs', state: { kind: McpServerStatus.Starting } },
-			// unknown (no entry) -> Starting as a bare top-level customization
-			{ type: ActionType.SessionCustomizationUpdated, id: 'mcp-top-level:copilot:session-1:unknown', state: { kind: McpServerStatus.Starting } },
-		]);
-	});
-
 	test('parseMcpChannelUri round-trips the controller-minted channel URI', () => {
 		const channel = 'mcp://copilot/session-1/fs';
 		assert.deepStrictEqual(parseMcpChannelUri(channel), {


### PR DESCRIPTION
The Copilot provider assumed MCP servers were starting when they weren't. It optimistically forced every enabled MCP server into `Starting` in three places — on every turn (`_markEnabledMcpServersStarting`), on `startMcpServer`, and during enablement reconciliation — on the premise that:

> The SDK connects enabled servers in the background — on an explicit start or when a turn begins — but emits no live "starting" event.

That premise is wrong. I verified against the repo's `@github/copilot-sdk@1.0.8` using a POC that drives the SDK and prints the live `session.mcp_server_status_changed` stream:

| Trigger | Live events observed |
| --- | --- |
| `createSession({ mcpServers })` | `pending` → `connected` |
| `rpc.mcp.startServer` | `pending` → `connected` / `failed` |
| `rpc.mcp.disable` | `disabled` |
| `rpc.mcp.enable` | `not_configured` → `pending` → `connected` |
| `rpc.mcp.stopServer` | `not_configured` |
| `session.send()` on a stopped server | **nothing** — stays `not_configured` |

The SDK emits `pending` for every connect it attempts, and `pending` already maps to `Starting` in `_translateSdkMcpStatus`. What it does *not* do is reconnect a stopped server when a turn begins — so the optimistic mark on send left such servers spinning at `Starting` indefinitely.

## Changes

- Removed `McpCustomizationController.markStarting()` and all three call sites.
- `pending` → `Starting` is now the only source of `Starting`. Servers hold their last settled state (`Stopped` / `Error` / `Ready`) until the SDK actually reports a connect attempt.
- Kept the fire-and-forget `_seedMcpServersFromRpc()` in `startMcpServer`'s `finally` as the safety net for an `enable` that rejects before any status is emitted.
- `needs-auth` → `Starting` is unchanged.

## Validation

`npm run typecheck-client`, ESLint on the changed files, and the agentHost node suites (410 tests) all pass. Tests that asserted the optimistic behavior were rewritten to assert the settled-state behavior instead, including a new `mcpEnableError` hook on the mock session covering the "enable rejects → reads `Stopped`, not `Starting`" path.

## Note for follow-up

Claude's `deriveMcpState` in `claudeMcpScan.ts` has the same anti-pattern — `default: → Starting`, so a `failed` server renders as "starting". Left alone here since it's a different provider.
