### PR TITLE
Suppress unsupported OSC color queries in agent host terminals

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -33,7 +33,26 @@ const WAIT_FOR_PROMPT_TIMEOUT = 10_000;
 const HEADLESS_TERMINAL_SCROLLBACK = 0;
 const DSR_CURSOR_POSITION_QUERY = '\x1b[6n';
 const DEC_DSR_CURSOR_POSITION_QUERY = '\x1b[?6n';
-const SERVER_HANDLED_QUERY_PREFIXES = ['\x1b[?6', '\x1b[?', '\x1b[6', '\x1b[', '\x1b'];
+const OSC_FOREGROUND_COLOR_QUERY_ST = '\x1b]10;?\x1b\\';
+const OSC_FOREGROUND_COLOR_QUERY_BEL = '\x1b]10;?\x07';
+const OSC_BACKGROUND_COLOR_QUERY_ST = '\x1b]11;?\x1b\\';
+const OSC_BACKGROUND_COLOR_QUERY_BEL = '\x1b]11;?\x07';
+const TERMINAL_QUERIES_SUPPRESSED_FROM_CLIENT = [
+	DEC_DSR_CURSOR_POSITION_QUERY,
+	DSR_CURSOR_POSITION_QUERY,
+	OSC_FOREGROUND_COLOR_QUERY_ST,
+	OSC_FOREGROUND_COLOR_QUERY_BEL,
+	OSC_BACKGROUND_COLOR_QUERY_ST,
+	OSC_BACKGROUND_COLOR_QUERY_BEL,
+];
+const TERMINAL_QUERY_SUPPRESSION_REGEX = /\x1b(?:\[\??6n|\]1[01];\?(?:\x07|\x1b\\))/g;
+const TERMINAL_QUERY_PREFIXES_SUPPRESSED_FROM_CLIENT = [...new Set(TERMINAL_QUERIES_SUPPRESSED_FROM_CLIENT.flatMap(query => {
+	const prefixes: string[] = [];
+	for (let i = 1; i < query.length; i++) {
+		prefixes.push(query.substring(0, i));
+	}
+	return prefixes;
+}))].sort((a, b) => b.length - a.length);
 
 export const IAgentHostTerminalManager = createDecorator<IAgentHostTerminalManager>('agentHostTerminalManager');
 
@@ -62,30 +81,21 @@ export interface IFormatTerminalTextOptions {
 	forceBracketedPasteMode?: boolean;
 }
 
-export function removeServerHandledTerminalQueries(data: string, state: ITerminalQueryFilterState): string {
-	if (
-		!state.pendingData
-		&& !data.includes(DSR_CURSOR_POSITION_QUERY)
-		&& !data.includes(DEC_DSR_CURSOR_POSITION_QUERY)
-		&& !getServerHandledTerminalQueryPrefix(data)
-	) {
+// Return immediately when no partial query is buffered and this chunk contains no escape character.
+export function removeTerminalQueriesSuppressedFromClient(data: string, state: ITerminalQueryFilterState): string {
+	if (!state.pendingData && !data.includes('\x1b')) {
 		return data;
 	}
 
 	const combinedData = state.pendingData + data;
-	const pendingData = getServerHandledTerminalQueryPrefix(combinedData);
+	const pendingData = getTerminalQueryPrefixSuppressedFromClient(combinedData);
 	const dataToFilter = pendingData ? combinedData.substring(0, combinedData.length - pendingData.length) : combinedData;
 	state.pendingData = pendingData;
-	if (!dataToFilter.includes(DSR_CURSOR_POSITION_QUERY) && !dataToFilter.includes(DEC_DSR_CURSOR_POSITION_QUERY)) {
-		return dataToFilter;
-	}
-	return dataToFilter
-		.replaceAll(DEC_DSR_CURSOR_POSITION_QUERY, '')
-		.replaceAll(DSR_CURSOR_POSITION_QUERY, '');
+	return dataToFilter.replace(TERMINAL_QUERY_SUPPRESSION_REGEX, '');
 }
 
-function getServerHandledTerminalQueryPrefix(data: string): string {
-	for (const prefix of SERVER_HANDLED_QUERY_PREFIXES) {
+function getTerminalQueryPrefixSuppressedFromClient(data: string): string {
+	for (const prefix of TERMINAL_QUERY_PREFIXES_SUPPRESSED_FROM_CLIENT) {
 		if (data.endsWith(prefix)) {
 			return prefix;
 		}
@@ -658,10 +668,10 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 				continue;
 			}
 
-			// Agent Host's server-side headless terminal answers CPR so terminals
-			// work without an attached client. Hide those queries from client xterms
-			// to avoid a second CPR response flowing back through AgentHostPty.input.
-			const cleanedData = removeServerHandledTerminalQueries(segment.data, managed.terminalQueryFilterState);
+			// Agent Host's server-side headless terminal answers CPR but cannot answer
+			// OSC color queries. Hide both from client xterms so terminal responses
+			// cannot flow back out of order through AgentHostPty.input.
+			const cleanedData = removeTerminalQueriesSuppressedFromClient(segment.data, managed.terminalQueryFilterState);
 			if (cleanedData.length > 0) {
 				this._appendToContent(managed, cleanedData);
 				pendingClientData += cleanedData;

--- a/src/vs/platform/agentHost/test/node/agentHostHeadlessTerminal.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostHeadlessTerminal.test.ts
@@ -62,6 +62,17 @@ suite('AgentHostHeadlessTerminal', () => {
 		assert.deepStrictEqual(responses, []);
 	});
 
+	test('does not answer OSC color queries', async () => {
+		const terminal = createTerminal();
+		const responses: string[] = [];
+		disposables.add(terminal.onResponseData(data => responses.push(data)));
+
+		await terminal.writePtyData('\x1b]10;?\x1b\\');
+		await terminal.writePtyData('\x1b]11;?\x1b\\');
+
+		assert.deepStrictEqual(responses, []);
+	});
+
 	test('does not emit response data for normal terminal output', async () => {
 		const terminal = createTerminal();
 		const responses: string[] = [];

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -15,7 +15,7 @@ import { ActionType, StateAction } from '../../common/state/protocol/actions.js'
 import { TerminalClaimKind, TerminalContentPart, type TerminalClaim } from '../../common/state/protocol/state.js';
 import { AgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
-import { AgentHostTerminalManager, formatTerminalText, removeServerHandledTerminalQueries, type ITerminalQueryFilterState } from '../../node/agentHostTerminalManager.js';
+import { AgentHostTerminalManager, formatTerminalText, removeTerminalQueriesSuppressedFromClient, type ITerminalQueryFilterState } from '../../node/agentHostTerminalManager.js';
 import { Osc633Event, Osc633EventType, Osc633Parser } from '../../node/osc633Parser.js';
 
 /**
@@ -82,7 +82,7 @@ class TestTerminalDataHandler {
 				continue;
 			}
 
-			const cleanedData = removeServerHandledTerminalQueries(segment.data, this._terminalQueryFilterState);
+			const cleanedData = removeTerminalQueriesSuppressedFromClient(segment.data, this._terminalQueryFilterState);
 			if (cleanedData.length > 0) {
 				this._appendToContent(cleanedData);
 				pendingClientData += cleanedData;
@@ -436,6 +436,39 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		assert.deepStrictEqual(pty.writes, ['\x1b[1;4R']);
 	});
 
+	test('swallows OSC color queries while preserving headless CPR responses', async () => {
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
+		const pty = new TestPty();
+		const manager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, pty));
+		const uri = 'agenthost-terminal://test/color-query';
+		const clientData: string[] = [];
+
+		const createTerminal = manager.createTerminal({
+			channel: uri,
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/bash' });
+
+		await pty.dataListenerRegistered.p;
+		disposables.add(manager.onData(uri, data => clientData.push(data)));
+		pty.fireData('before\x1b]10;?\x1b\\\x1b[6nmid\x1b]11;?\x07\x1b[6nafter');
+		await createTerminal;
+		await waitForWrites(pty, 2);
+
+		assert.deepStrictEqual({
+			clientData,
+			ptyWrites: pty.writes,
+		}, {
+			clientData: ['beforemidafter'],
+			ptyWrites: ['\x1b[1;7R', '\x1b[1;10R'],
+		});
+	});
+
 	test('resolves alt-buffer promise from headless terminal data', async () => {
 		const logService = new NullLogService();
 		const stateManager = disposables.add(new AgentHostStateManager(logService));
@@ -497,29 +530,44 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		assert.strictEqual(didEnterAltBuffer, false);
 	});
 
-	test('server-handled CPR queries are stripped from client-facing data', () => {
+	test('client-suppressed terminal queries are stripped from client-facing data', () => {
 		function filter(data: string): string {
-			return removeServerHandledTerminalQueries(data, { pendingData: '' });
+			return removeTerminalQueriesSuppressedFromClient(data, { pendingData: '' });
 		}
 
 		assert.strictEqual(filter('before \x1b[6n after'), 'before  after');
 		assert.strictEqual(filter('before \x1b[?6n after'), 'before  after');
+		assert.strictEqual(filter('before \x1b]10;?\x1b\\ after'), 'before  after');
+		assert.strictEqual(filter('before \x1b]10;?\x07 after'), 'before  after');
+		assert.strictEqual(filter('before \x1b]11;?\x1b\\ after'), 'before  after');
+		assert.strictEqual(filter('before \x1b]11;?\x07 after'), 'before  after');
 		assert.strictEqual(filter('\x1b[5n\x1b[c\x1b[0c\x1b[>c\x1b[>0c'), '\x1b[5n\x1b[c\x1b[0c\x1b[>c\x1b[>0c');
+		assert.strictEqual(filter('\x1b]10;#ffffff\x1b\\\x1b]11;rgb:0000/0000/0000\x07'), '\x1b]10;#ffffff\x1b\\\x1b]11;rgb:0000/0000/0000\x07');
+		assert.strictEqual(filter('\x1b]10;?;#ffffff\x1b\\\x1b]12;?\x1b\\\x1b]4;0;?\x1b\\'), '\x1b]10;?;#ffffff\x1b\\\x1b]12;?\x1b\\\x1b]4;0;?\x1b\\');
 		assert.strictEqual(filter('normal output\r\n'), 'normal output\r\n');
 	});
 
-	test('server-handled CPR queries are stripped across data chunks', () => {
+	test('client-suppressed terminal queries are stripped across data chunks', () => {
 		let state: ITerminalQueryFilterState = { pendingData: '' };
-		assert.strictEqual(removeServerHandledTerminalQueries('before \x1b[', state), 'before ');
-		assert.strictEqual(removeServerHandledTerminalQueries('6n after', state), ' after');
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('before \x1b[', state), 'before ');
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('6n after', state), ' after');
 
 		state = { pendingData: '' };
-		assert.strictEqual(removeServerHandledTerminalQueries('before \x1b[?', state), 'before ');
-		assert.strictEqual(removeServerHandledTerminalQueries('6n after', state), ' after');
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('before \x1b[?', state), 'before ');
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('6n after', state), ' after');
 
 		state = { pendingData: '' };
-		assert.strictEqual(removeServerHandledTerminalQueries('before \x1b[', state), 'before ');
-		assert.strictEqual(removeServerHandledTerminalQueries('K after', state), '\x1b[K after');
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('before \x1b[', state), 'before ');
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('K after', state), '\x1b[K after');
+
+		state = { pendingData: '' };
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('before \x1b]10;', state), 'before ');
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('?\x1b', state), '');
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('\\ after', state), ' after');
+
+		state = { pendingData: '' };
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('before \x1b]11;', state), 'before ');
+		assert.strictEqual(removeTerminalQueriesSuppressedFromClient('?\x07 after', state), ' after');
 	});
 
 	test('manager data path strips CPR queries while preserving surrounding output', () => {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/327721

- Suppress exact OSC 10 and OSC 11 color queries before forwarding Agent Host terminal data to the client xterm.
- Keep existing server-side CPR handling while swallowing color queries that xterm-headless cannot answer accurately.
- Support ST and BEL terminators and queries split across PTY data chunks.
- Preserve OSC color setters, mixed payloads, OSC 4, OSC 12, and unrelated terminal sequences.
- Keep plain terminal output on a fast path and remove complete queries with one regex pass.
- Add regression coverage for OSC 10 → CPR → OSC 11 → CPR ordering and confirm xterm-headless does not answer color queries.

-----------------------------------------
Inspirations from:

- Server-side terminal response ownership comes from [`AgentHostHeadlessTerminal`](https://github.com/microsoft/vscode/blob/46441fde3c9252e94d426e7b7f35c45e932d7cb4/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts#L25-L57), which forwards CPR responses and drops unsupported xterm responses.
- Split-chunk buffering and suppressing server-owned CPR queries before client dispatch comes from [`removeServerHandledTerminalQueries`](https://github.com/microsoft/vscode/blob/46441fde3c9252e94d426e7b7f35c45e932d7cb4/src/vs/platform/agentHost/node/agentHostTerminalManager.ts#L44-L77) and its use in [`_handlePtyData`](https://github.com/microsoft/vscode/blob/46441fde3c9252e94d426e7b7f35c45e932d7cb4/src/vs/platform/agentHost/node/agentHostTerminalManager.ts#L539-L570).
- The delayed-response loop follows workbench xterm responses through [`TerminalInstance._handleOnData`](https://github.com/microsoft/vscode/blob/9b51cf9b8ca8c8ae09c409d9a9f3adf91019fb34/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L671-L674) and back to Agent Host through [`AgentHostPty.input`](https://github.com/microsoft/vscode/blob/9b51cf9b8ca8c8ae09c409d9a9f3adf91019fb34/src/vs/workbench/contrib/terminal/browser/agentHostPty.ts#L303-L313).