### PR TITLE
chat: Default Remote Repositories chats to Local

### DIFF
--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -368,6 +368,10 @@ export function getDefaultNewChatSessionType(
 		return options.explicitOverride;
 	}
 
+	if (isVirtualWorkspace(workspace)) {
+		return localChatSessionType;
+	}
+
 	const remembered = getUsableRememberedSessionType(storageService, configurationService, chatSessionsService, workspace);
 	if (remembered) {
 		return remembered;
@@ -392,6 +396,10 @@ export function resolveDefaultNewChatSessionType(
 
 	if (options?.explicitOverride) {
 		return { sessionType: options.explicitOverride, isPreferCopilotHarnessSwap: false };
+	}
+
+	if (isVirtualWorkspace(workspace)) {
+		return { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false };
 	}
 
 	const remembered = getUsableRememberedSessionType(storageService, configurationService, chatSessionsService, workspace);

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -463,23 +463,38 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('virtual workspace defaults to local when the agent host default is enabled', () => {
+	test('virtual workspace defaults implicit new chats to local', () => {
 		const configurationService = new TestConfigurationService({
 			[ChatConfiguration.DefaultToCopilotHarness]: true,
 			[ChatConfiguration.EditorLocalAgentEnabled]: false,
+			[ChatConfiguration.EditorPreferCopilotHarness]: true,
 		});
-		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
-		const storageService = disposables.add(new TestStorageService());
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
+		const rememberedStorageService = disposables.add(new TestStorageService());
+		const currentStorageService = disposables.add(new TestStorageService());
 		const workspace = createWorkspace(URI.parse('vscode-vfs://github/microsoft/vscode'));
+		recordUserSelectedSessionType(rememberedStorageService, configurationService, chatSessionsService, workspace, SessionType.AgentHostClaude, true);
 
 		assert.deepStrictEqual({
 			computed: getComputedDefaultSessionType(configurationService, chatSessionsService, workspace, true),
-			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, true),
+			remembered: getRememberedSessionType(rememberedStorageService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, rememberedStorageService, workspace, true),
+			currentAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, currentStorageService, workspace, true, { currentSessionType: SessionType.AgentHostCopilot }),
+			resolvedRemembered: resolveSessionType(configurationService, chatSessionsService, rememberedStorageService, workspace, true, { currentSessionType: SessionType.AgentHostCopilot }),
+			resolvedCurrent: resolveSessionType(configurationService, chatSessionsService, currentStorageService, workspace, true, { currentSessionType: SessionType.AgentHostCopilot }),
+			resolvedPreferMigration: resolveSessionType(configurationService, chatSessionsService, currentStorageService, workspace, true, { currentSessionType: localChatSessionType }),
+			explicitOverride: resolveSessionType(configurationService, chatSessionsService, currentStorageService, workspace, true, { explicitOverride: SessionType.AgentHostClaude }),
 			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService, workspace),
 			localRememberedUsable: isNewChatSessionTypeUsable(localChatSessionType, configurationService, chatSessionsService, workspace),
 		}, {
 			computed: localChatSessionType,
+			remembered: SessionType.AgentHostClaude,
 			rememberedAware: localChatSessionType,
+			currentAware: localChatSessionType,
+			resolvedRemembered: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
+			resolvedCurrent: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
+			resolvedPreferMigration: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
+			explicitOverride: { sessionType: SessionType.AgentHostClaude, isPreferCopilotHarnessSwap: false },
 			localVisible: true,
 			localRememberedUsable: true,
 		});


### PR DESCRIPTION
## Summary

- make Local override remembered and inherited harnesses for implicit new chats in fully virtual workspaces
- prevent the one-time Copilot harness migration from overriding Local in Remote Repositories
- preserve explicit harness selections
- expand regression coverage across every implicit selection path

Fixes #326464

## Validation

- `npm run compile-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/common/constants.test.ts`
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/common/constants.ts src/vs/workbench/contrib/chat/test/common/constants.test.ts`
- pre-commit hygiene hook

(Written by Copilot)