### PR TITLE
chore: bump @anthropic-ai/claude-agent-sdk to 0.3.220

### DIFF
--- a/build/agent-sdk/agents/claude/package-lock.json
+++ b/build/agent-sdk/agents/claude/package-lock.json
@@ -6,26 +6,26 @@
 		"": {
 			"name": "agent-sdk-claude",
 			"dependencies": {
-				"@anthropic-ai/claude-agent-sdk": "0.3.198"
+				"@anthropic-ai/claude-agent-sdk": "0.3.220"
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.3.198",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.198.tgz",
-			"integrity": "sha512-xt469sSCyclTPtzpLAg0Aschy665GiRMgZKabSmESbGUA5/H56HcILVOiFxclXswkeMUk2fQxfHJUY9UZfiTnA==",
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+			"integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
 			"license": "SEE LICENSE IN README.md",
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
-				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.198",
-				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.198",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.198",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.198",
-				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.198",
-				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.198",
-				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.198",
-				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.198"
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
 			},
 			"peerDependencies": {
 				"@anthropic-ai/sdk": ">=0.93.0",
@@ -34,9 +34,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-			"version": "0.3.198",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.198.tgz",
-			"integrity": "sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw==",
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+			"integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -47,9 +47,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-			"version": "0.3.198",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.198.tgz",
-			"integrity": "sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw==",
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+			"integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
 			"cpu": [
 				"x64"
 			],
@@ -60,9 +60,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-			"version": "0.3.198",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.198.tgz",
-			"integrity": "sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q==",
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+			"integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
 			"cpu": [
 				"arm64"
 			],
@@ -76,9 +76,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-			"version": "0.3.198",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.198.tgz",
-			"integrity": "sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw==",
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+			"integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -92,9 +92,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-			"version": "0.3.198",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.198.tgz",
-			"integrity": "sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ==",
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+			"integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
 			"cpu": [
 				"x64"
 			],
@@ -108,9 +108,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-			"version": "0.3.198",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.198.tgz",
-			"integrity": "sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ==",
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+			"integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
 			"cpu": [
 				"x64"
 			],
@@ -124,9 +124,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-			"version": "0.3.198",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.198.tgz",
-			"integrity": "sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ==",
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+			"integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
 			"cpu": [
 				"arm64"
 			],
@@ -137,9 +137,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-			"version": "0.3.198",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.198.tgz",
-			"integrity": "sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg==",
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+			"integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
 			"cpu": [
 				"x64"
 			],

--- a/build/agent-sdk/agents/claude/package.json
+++ b/build/agent-sdk/agents/claude/package.json
@@ -3,6 +3,6 @@
 	"private": true,
 	"comment": "Pinned dependency set for the build/agent-sdk claude tarball. The package-lock.json alongside is the source of truth for transitive deps — produce.ts runs `npm ci` against this directory to get byte-deterministic output across pipeline runs.",
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.198"
+		"@anthropic-ai/claude-agent-sdk": "0.3.220"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk": "0.3.220",
         "@openai/codex": "0.142.0",
         "@playwright/cli": "^0.1.9",
         "@playwright/test": "^1.61.1",
@@ -191,23 +191,23 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.198.tgz",
-      "integrity": "sha512-xt469sSCyclTPtzpLAg0Aschy665GiRMgZKabSmESbGUA5/H56HcILVOiFxclXswkeMUk2fQxfHJUY9UZfiTnA==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.198"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -216,9 +216,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.198.tgz",
-      "integrity": "sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
       "cpu": [
         "arm64"
       ],
@@ -230,9 +230,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.198.tgz",
-      "integrity": "sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
       "cpu": [
         "x64"
       ],
@@ -244,9 +244,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.198.tgz",
-      "integrity": "sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
       "cpu": [
         "arm64"
       ],
@@ -261,9 +261,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.198.tgz",
-      "integrity": "sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
       "cpu": [
         "arm64"
       ],
@@ -278,9 +278,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.198.tgz",
-      "integrity": "sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
       "cpu": [
         "x64"
       ],
@@ -295,9 +295,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.198.tgz",
-      "integrity": "sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
       "cpu": [
         "x64"
       ],
@@ -312,9 +312,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.198.tgz",
-      "integrity": "sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
       "cpu": [
         "arm64"
       ],
@@ -326,9 +326,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.198.tgz",
-      "integrity": "sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.198",
+    "@anthropic-ai/claude-agent-sdk": "0.3.220",
     "@openai/codex": "0.142.0",
     "@playwright/cli": "^0.1.9",
     "@playwright/test": "^1.61.1",

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -34,7 +34,7 @@
  */
 
 import type Anthropic from '@anthropic-ai/sdk';
-import type { GetSessionMessagesOptions, Options, PermissionResult, Query, SDKMessage, SDKResultSuccess, SDKSessionInfo, SDKSystemMessage, SDKUserMessage, SessionMessage, WarmQuery } from '@anthropic-ai/claude-agent-sdk';
+import type { GetSessionMessagesOptions, Options, PermissionResult, Query, SDKControlInterruptResponse, SDKMessage, SDKResultSuccess, SDKSessionInfo, SDKSystemMessage, SDKUserMessage, SessionMessage, WarmQuery } from '@anthropic-ai/claude-agent-sdk';
 import type { CCAModel } from '@vscode/copilot-api';
 import assert from 'assert';
 import type * as http from 'http';
@@ -363,7 +363,7 @@ class ProxyRoundTripSdkService implements IClaudeAgentSdkService {
 	queryMessages: QueryStreamItem[] = [];
 
 	/** Records the {@link PermissionResult} returned by each `canUseTool` invocation in {@link queryMessages} order. */
-	readonly canUseToolResults: PermissionResult[] = [];
+	readonly canUseToolResults: (PermissionResult | null)[] = [];
 	readonly elicitationResults: Awaited<ReturnType<NonNullable<Options['onElicitation']>>>[] = [];
 
 	readonly warmQueries: RoundTripWarmQuery[] = [];
@@ -482,6 +482,7 @@ class RoundTripQuery implements AsyncGenerator<SDKMessage, void> {
 				const result = await startup.canUseTool(item.toolName, item.input, {
 					signal: new AbortController().signal,
 					toolUseID: item.toolUseID,
+					requestId: item.toolUseID,
 				});
 				this._sdk.canUseToolResults.push(result);
 				continue;
@@ -509,7 +510,7 @@ class RoundTripQuery implements AsyncGenerator<SDKMessage, void> {
 		throw err;
 	}
 
-	async interrupt(): Promise<void> { /* not used */ }
+	async interrupt(): Promise<SDKControlInterruptResponse | undefined> { return undefined; }
 
 	setPermissionMode(): never { throw new Error('not modeled'); }
 	setMcpPermissionModeOverride(): never { throw new Error('not modeled'); }

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type Anthropic from '@anthropic-ai/sdk';
-import type { AgentInfo, ForkSessionOptions, ForkSessionResult, GetSessionMessagesOptions, McpSdkServerConfigWithInstance, McpServerStatus, ModelInfo, Options, PermissionMode, Query, SDKMessage, SDKSessionInfo, SDKUserMessage, SdkMcpToolDefinition, SessionMessage, SessionMutationOptions, Settings, SlashCommand, WarmQuery } from '@anthropic-ai/claude-agent-sdk';
+import type { AgentInfo, ForkSessionOptions, ForkSessionResult, GetSessionMessagesOptions, McpSdkServerConfigWithInstance, McpServerStatus, ModelInfo, Options, PermissionMode, Query, SDKControlInterruptResponse, SDKMessage, SDKSessionInfo, SDKUserMessage, SdkMcpToolDefinition, SessionMessage, SessionMutationOptions, Settings, SlashCommand, WarmQuery } from '@anthropic-ai/claude-agent-sdk';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { CCAModel } from '@vscode/copilot-api';
 
@@ -587,8 +587,9 @@ class FakeQuery implements AsyncGenerator<SDKMessage, void> {
 		throw err;
 	}
 
-	async interrupt(): Promise<void> {
+	async interrupt(): Promise<SDKControlInterruptResponse | undefined> {
 		this.interruptCount++;
+		return undefined;
 	}
 
 	// Phase 6 doesn't exercise the rest of the Query control surface; if a
@@ -848,10 +849,10 @@ function tick(): Promise<void> {
  */
 function forkSourceMessages(sourceId: string): SessionMessage[] {
 	return [
-		{ type: 'user', uuid: 'u1', session_id: sourceId, parent_tool_use_id: null, message: { role: 'user', content: [{ type: 'text', text: 'apple' }] } },
-		{ type: 'assistant', uuid: 'a1', session_id: sourceId, parent_tool_use_id: null, message: { id: 'msg_a1', role: 'assistant', content: [{ type: 'text', text: 'apple!' }] } },
-		{ type: 'user', uuid: 'u2', session_id: sourceId, parent_tool_use_id: null, message: { role: 'user', content: [{ type: 'text', text: 'banana' }] } },
-		{ type: 'assistant', uuid: 'a2', session_id: sourceId, parent_tool_use_id: null, message: { id: 'msg_a2', role: 'assistant', content: [{ type: 'text', text: 'banana!' }] } },
+		{ type: 'user', uuid: 'u1', session_id: sourceId, parent_tool_use_id: null, parent_agent_id: null, message: { role: 'user', content: [{ type: 'text', text: 'apple' }] } },
+		{ type: 'assistant', uuid: 'a1', session_id: sourceId, parent_tool_use_id: null, parent_agent_id: null, message: { id: 'msg_a1', role: 'assistant', content: [{ type: 'text', text: 'apple!' }] } },
+		{ type: 'user', uuid: 'u2', session_id: sourceId, parent_tool_use_id: null, parent_agent_id: null, message: { role: 'user', content: [{ type: 'text', text: 'banana' }] } },
+		{ type: 'assistant', uuid: 'a2', session_id: sourceId, parent_tool_use_id: null, parent_agent_id: null, message: { id: 'msg_a2', role: 'assistant', content: [{ type: 'text', text: 'banana!' }] } },
 	];
 }
 
@@ -4892,6 +4893,7 @@ suite('ClaudeAgent (Phase 7 §3.4 — _handleCanUseTool)', () => {
 		return {
 			signal: new AbortController().signal,
 			toolUseID,
+			requestId: toolUseID,
 			...(overrides?.blockedPath !== undefined ? { blockedPath: overrides.blockedPath } : {}),
 		};
 	}
@@ -4996,6 +4998,7 @@ suite('ClaudeAgent (Phase 7 §3.4 — _handleCanUseTool)', () => {
 		const options: Parameters<NonNullable<Options['canUseTool']>>[2] = {
 			signal: ac.signal,
 			toolUseID: 'tu_aborted',
+			requestId: 'tu_aborted',
 		};
 
 		const promise = canUseTool('Read', { file_path: '/tmp/x' }, options);
@@ -5018,6 +5021,7 @@ suite('ClaudeAgent (Phase 7 §3.4 — _handleCanUseTool)', () => {
 		const result = await canUseTool('Read', { file_path: '/tmp/y' }, {
 			signal: ac.signal,
 			toolUseID: 'tu_pre_aborted',
+			requestId: 'tu_pre_aborted',
 		});
 
 		assert.deepStrictEqual(result, { behavior: 'deny', message: 'SDK aborted the tool request' });
@@ -5173,7 +5177,7 @@ suite('ClaudeAgent (Phase 7 §3.5 — INTERACTIVE_CLAUDE_TOOLS)', () => {
 				question: 'Pick one?',
 				options: [{ label: 'Apple' }, { label: 'Banana' }],
 			}],
-		}, { signal: new AbortController().signal, toolUseID: 'tu_ask' });
+		}, { signal: new AbortController().signal, toolUseID: 'tu_ask', requestId: 'tu_ask' });
 		await tick();
 
 		const inputRequest = inputRequests.at(-1)!;
@@ -5211,7 +5215,7 @@ suite('ClaudeAgent (Phase 7 §3.5 — INTERACTIVE_CLAUDE_TOOLS)', () => {
 
 		const promise = canUseTool('AskUserQuestion', {
 			questions: [{ header: 'q1', question: 'Pick one?', options: [{ label: 'Apple' }] }],
-		}, { signal: new AbortController().signal, toolUseID: 'tu_ask_cancel' });
+		}, { signal: new AbortController().signal, toolUseID: 'tu_ask_cancel', requestId: 'tu_ask_cancel' });
 		await tick();
 
 		ctx.agent.respondToUserInputRequest('tu_ask_cancel', ChatInputResponseKind.Cancel);
@@ -5236,6 +5240,7 @@ suite('ClaudeAgent (Phase 7 §3.5 — INTERACTIVE_CLAUDE_TOOLS)', () => {
 		const promise = canUseTool('ExitPlanMode', { plan: '1. Read foo\n2. Edit foo' }, {
 			signal: new AbortController().signal,
 			toolUseID: 'tu_plan_ok',
+			requestId: 'tu_plan_ok',
 		});
 		await tick();
 
@@ -5281,6 +5286,7 @@ suite('ClaudeAgent (Phase 7 §3.5 — INTERACTIVE_CLAUDE_TOOLS)', () => {
 		const promise = canUseTool('ExitPlanMode', { plan: 'just plan' }, {
 			signal: new AbortController().signal,
 			toolUseID: 'tu_plan_deny',
+			requestId: 'tu_plan_deny',
 		});
 		await tick();
 
@@ -5314,6 +5320,7 @@ suite('ClaudeAgent (Phase 7 §3.5 — INTERACTIVE_CLAUDE_TOOLS)', () => {
 		const result = await canUseTool('ExitPlanMode', { plan: 'sync test' }, {
 			signal: new AbortController().signal,
 			toolUseID: 'tu_plan_race',
+			requestId: 'tu_plan_race',
 		});
 		assert.deepStrictEqual(result, { behavior: 'allow', updatedInput: { plan: 'sync test' } });
 	});
@@ -5850,6 +5857,7 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 		const permissionPromise = canUseTool('Read', { file_path: '/tmp/foo.txt' }, {
 			signal: new AbortController().signal,
 			toolUseID: 'tu_pending',
+			requestId: 'tu_pending',
 		});
 		await tick();
 
@@ -6040,6 +6048,7 @@ suite('ClaudeAgent (Phase 13 — getSessionMessages)', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { role: 'user', content: [{ type: 'text', text }] },
 		};
 	}
@@ -6050,6 +6059,7 @@ suite('ClaudeAgent (Phase 13 — getSessionMessages)', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { id: `msg_${uuid}`, role: 'assistant', content: [{ type: 'text', text }] },
 		};
 	}
@@ -6846,8 +6856,8 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 			: sentContent?.filter(block => block.type === 'text').map(block => block.text).join('\n');
 		sdk.sessionMessagesById.set('side-1', [
 			...forkSourceMessages('side-1').slice(0, 2),
-			{ type: 'user', uuid: 'turn-side', session_id: 'side-1', parent_tool_use_id: null, message: { role: 'user', content: [{ type: 'text', text: injectedPrompt }] } },
-			{ type: 'assistant', uuid: 'a3', session_id: 'side-1', parent_tool_use_id: null, message: { id: 'msg_a3', role: 'assistant', content: [{ type: 'text', text: 'side answer' }] } },
+			{ type: 'user', uuid: 'turn-side', session_id: 'side-1', parent_tool_use_id: null, parent_agent_id: null, message: { role: 'user', content: [{ type: 'text', text: injectedPrompt }] } },
+			{ type: 'assistant', uuid: 'a3', session_id: 'side-1', parent_tool_use_id: null, parent_agent_id: null, message: { id: 'msg_a3', role: 'assistant', content: [{ type: 'text', text: 'side answer' }] } },
 		]);
 		await agent.chats.changeModel(chatUri, { id: 'claude-opus-4-6' });
 		const turns = await agent.chats.getMessages(chatUri);
@@ -6930,8 +6940,8 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 			: sentContent?.filter(block => block.type === 'text').map(block => block.text).join('\n');
 		sdk.sessionMessagesById.set('side-local-1', [
 			...forkSourceMessages('side-local-1').slice(0, 2),
-			{ type: 'user', uuid: 'turn-side-local', session_id: 'side-local-1', parent_tool_use_id: null, message: { role: 'user', content: [{ type: 'text', text: injectedPrompt }] } },
-			{ type: 'assistant', uuid: 'a3', session_id: 'side-local-1', parent_tool_use_id: null, message: { id: 'msg_a3', role: 'assistant', content: [{ type: 'text', text: 'side answer' }] } },
+			{ type: 'user', uuid: 'turn-side-local', session_id: 'side-local-1', parent_tool_use_id: null, parent_agent_id: null, message: { role: 'user', content: [{ type: 'text', text: injectedPrompt }] } },
+			{ type: 'assistant', uuid: 'a3', session_id: 'side-local-1', parent_tool_use_id: null, parent_agent_id: null, message: { id: 'msg_a3', role: 'assistant', content: [{ type: 'text', text: 'side answer' }] } },
 		]);
 		const turns = await agent.chats.getMessages(chatUri);
 

--- a/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
@@ -25,6 +25,7 @@ suite('claudeReplayMapper', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { role: 'user', content: [{ type: 'text', text }] },
 			timestamp,
 		};
@@ -36,6 +37,7 @@ suite('claudeReplayMapper', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { id: `msg_${uuid}`, role: 'assistant', content: [{ type: 'text', text }] },
 			timestamp,
 		};
@@ -47,6 +49,7 @@ suite('claudeReplayMapper', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: {
 				id: `msg_${uuid}`,
 				role: 'assistant',
@@ -62,6 +65,7 @@ suite('claudeReplayMapper', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: {
 				role: 'user',
 				content: [{ type: 'tool_result', tool_use_id: toolUseId, content: text, ...(isError ? { is_error: true } : {}) }],
@@ -76,6 +80,7 @@ suite('claudeReplayMapper', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { subtype, ...(text !== undefined ? { text } : {}) },
 		};
 	}
@@ -299,6 +304,7 @@ suite('claudeReplayMapper', () => {
 				uuid: 'echo-1',
 				session_id: 'sess-1',
 				parent_tool_use_id: null,
+				parent_agent_id: null,
 				message: { role: 'user', content: '<command-name>/model</command-name>\n            <command-message>model</command-message>\n            <command-args>claude-opus-4.7</command-args>' },
 			},
 			{
@@ -306,6 +312,7 @@ suite('claudeReplayMapper', () => {
 				uuid: 'echo-2',
 				session_id: 'sess-1',
 				parent_tool_use_id: null,
+				parent_agent_id: null,
 				message: { role: 'user', content: '<local-command-stdout>Set model to claude-opus-4.7</local-command-stdout>' },
 			},
 			makeUser('u2', 'how about now'),
@@ -331,19 +338,19 @@ suite('claudeReplayMapper', () => {
 		const parent = 'toolu_parent';
 		const messages: SessionMessage[] = [
 			{
-				type: 'assistant', uuid: 'sa1', session_id: 'sess-1', parent_tool_use_id: parent,
+				type: 'assistant', uuid: 'sa1', session_id: 'sess-1', parent_tool_use_id: parent, parent_agent_id: null,
 				message: { id: 'msg_sa1', role: 'assistant', content: [{ type: 'thinking', thinking: 'planning', signature: 'sig' }] },
 			},
 			{
-				type: 'assistant', uuid: 'sa2', session_id: 'sess-1', parent_tool_use_id: parent,
+				type: 'assistant', uuid: 'sa2', session_id: 'sess-1', parent_tool_use_id: parent, parent_agent_id: null,
 				message: { id: 'msg_sa2', role: 'assistant', content: [{ type: 'tool_use', id: 'tu_inner', name: 'Bash', input: { command: 'ls' } }] },
 			},
 			{
-				type: 'user', uuid: 'sa3', session_id: 'sess-1', parent_tool_use_id: parent,
+				type: 'user', uuid: 'sa3', session_id: 'sess-1', parent_tool_use_id: parent, parent_agent_id: null,
 				message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu_inner', content: 'file-a.txt\nfile-b.txt' }] },
 			},
 			{
-				type: 'assistant', uuid: 'sa4', session_id: 'sess-1', parent_tool_use_id: parent,
+				type: 'assistant', uuid: 'sa4', session_id: 'sess-1', parent_tool_use_id: parent, parent_agent_id: null,
 				message: { id: 'msg_sa4', role: 'assistant', content: [{ type: 'text', text: 'Done. SUBAGENT_ONLY_MARKER_xyz' }] },
 			},
 		];
@@ -410,6 +417,7 @@ suite('resolveForkAnchorUuid', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { role: 'user', content: [{ type: 'text', text }] },
 		};
 	}
@@ -420,6 +428,7 @@ suite('resolveForkAnchorUuid', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { id: `msg_${uuid}`, role: 'assistant', content: [{ type: 'text', text }] },
 		};
 	}
@@ -430,6 +439,7 @@ suite('resolveForkAnchorUuid', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { id: `msg_${uuid}`, role: 'assistant', content: [{ type: 'tool_use', id: toolUseId, name, input }] },
 		};
 	}
@@ -440,6 +450,7 @@ suite('resolveForkAnchorUuid', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUseId, content: text }] },
 		};
 	}
@@ -450,6 +461,7 @@ suite('resolveForkAnchorUuid', () => {
 			uuid,
 			session_id: 'sess-1',
 			parent_tool_use_id: null,
+			parent_agent_id: null,
 			message: { subtype, ...(text !== undefined ? { text } : {}) },
 		};
 	}
@@ -548,6 +560,7 @@ suite('resolveForkAnchorUuid', () => {
 				uuid: 'echo-1',
 				session_id: 'sess-1',
 				parent_tool_use_id: null,
+				parent_agent_id: null,
 				message: { role: 'user', content: '<command-name>/model</command-name>' },
 			},
 			makeAssistantText('a1', 'opus'),

--- a/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Query, SDKMessage, SDKUserMessage, WarmQuery } from '@anthropic-ai/claude-agent-sdk';
+import type { Query, SDKControlInterruptResponse, SDKMessage, SDKUserMessage, WarmQuery } from '@anthropic-ai/claude-agent-sdk';
 
 import assert from 'assert';
 import { DeferredPromise } from '../../../../base/common/async.js';
@@ -60,7 +60,7 @@ class ImmediatelyDoneQuery implements Query {
 	async applyFlagSettings(_settings: Parameters<Query['applyFlagSettings']>[0]): Promise<void> { /* not exercised here */ }
 	async setPermissionMode(): Promise<void> { /* not exercised here */ }
 	async setMcpPermissionModeOverride(): Promise<{ warning?: string }> { return {}; }
-	async interrupt(): Promise<void> { /* not exercised here */ }
+	async interrupt(): Promise<SDKControlInterruptResponse | undefined> { return undefined; }
 	streamInput(): never { throw new Error('not modeled'); }
 	stopTask(): never { throw new Error('not modeled'); }
 	reloadSkills(): never { throw new Error('not modeled'); }


### PR DESCRIPTION
Bumps the Claude Agent SDK from `0.3.198` to [`0.3.220`](https://github.com/anthropics/claude-agent-sdk-typescript/releases/tag/v0.3.220).

## Changes

- **Version pins**: runtime pin in repo-root `devDependencies`, build pin in `build/agent-sdk/agents/claude/package.json` (source of truth for the deterministic tarball), and both lockfiles.
- **Test updates**: `0.3.220` tightens three test-facing SDK types, so the agent host test doubles and transcript fixtures were updated to match:
  - `Query.interrupt()` now returns `Promise<SDKControlInterruptResponse | undefined>` (was `Promise<void>`)
  - `canUseTool` options now require `requestId`
  - `SessionMessage` now requires `parent_agent_id`

No production code changed — all type breakages were in test infrastructure.

## No fixture re-recording needed

The committed replay captures already replay green against the new SDK, so no `captures/*.yaml` or AHP snapshots are touched here.

I did verify this against **real CAPI** rather than assuming. A live recording run drifted only on things unrelated to the bump — the CAPI default model moving `claude-opus-4.8` → `claude-opus-5`, plus model prose/formatting variance — so that churn was deliberately discarded to keep this PR minimal.

Notably, `can abort a running turn` (a record-only test that never runs in replay) **passed live**. That's the test that exercises `Query.interrupt()`, whose signature changed in this bump.

## Validation

| Check | Result |
|---|---|
| `typecheck-client` | 0 errors |
| Agent host unit + integration tests (4 affected files) | 246 passing |
| Claude E2E replay suite | 44 passing, 6 pending |
| Agent SDK version-sync test | passing |
| Hygiene | passing |

### Manual smoke test (Agents window, Code OSS from sources)

- Claude agent registered and selected by default
- Model enumeration returned 7 models (opus 4.6/4.7/4.8/5, sonnet 4.6/5, haiku 4.5)
- Plain turn completed and returned the exact requested output
- **Tool calling** round-tripped: rendered a `Read package.json` tool call and returned the correct `name` value — this is the path exercising the new required `requestId` on permission options

## Note for reviewers

Unrelated to this PR, but found while validating: a full live re-record of the Claude fixtures currently can't complete. The model reaches for `ls -la` in the rename and subagent scenarios, which trips the POSIX portability lint at fixture-write time — and because that fires in an `afterEach` hook, it aborts the remaining Mocha tests and silently truncates the re-record. Those prompts need portable commands pinned before the next re-record.
