### PR TITLE
fix: style SSH known_hosts git messages as warnings

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -14,7 +14,7 @@ import { Model } from './model';
 import { GitResourceGroup, Repository, Resource, ResourceGroupType } from './repository';
 import { DiffEditorSelectionHunkToolbarContext, LineChange, applyLineChanges, getIndexDiffInformation, getModifiedRange, getWorkingTreeDiffInformation, intersectDiffWithRange, invertLineChange, toLineChanges, toLineRanges, compareLineChanges } from './staging';
 import { fromGitUri, toGitUri, isGitUri, toMergeUris, toMultiFileDiffEditorUris } from './uri';
-import { coalesce, DiagnosticSeverityConfig, dispose, fromNow, getHistoryItemDisplayName, getStashDescription, grep, isDefined, isDescendant, isLinuxSnap, isRemote, isWindows, pathEquals, relativePath, subject, toDiagnosticSeverity, truncate } from './util';
+import { coalesce, DiagnosticSeverityConfig, dispose, fromNow, getGitErrorHintSelection, getHistoryItemDisplayName, getStashDescription, grep, isDefined, isDescendant, isLinuxSnap, isRemote, isWindows, pathEquals, relativePath, subject, toDiagnosticSeverity, truncate } from './util';
 import { GitTimelineItem } from './timelineProvider';
 import { ApiRepository } from './api/api1';
 import { getRemoteSourceActions, pickRemoteSource } from './remoteSource';
@@ -5644,15 +5644,16 @@ export class CommandCenter {
 						options.modal = false;
 						break;
 					default: {
-						const hintLines = (err.stderr || err.stdout || err.message || String(err))
-							.replace(/^error: /mi, '')
-							.replace(/^> husky.*$/mi, '')
-							.split(/[\r\n]/)
-							.filter((line: string) => !!line);
+						const { hintLines, severity } = getGitErrorHintSelection(err.stderr, err.stdout, err.message || String(err));
 
 						message = hintLines.length > 0
 							? l10n.t('Git: {0}', err.stdout ? hintLines[hintLines.length - 1] : hintLines[0])
 							: l10n.t('Git error');
+
+						if (severity === 'warning') {
+							type = 'warning';
+							options.modal = false;
+						}
 
 						break;
 					}

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -6,7 +6,7 @@
 import 'mocha';
 import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
 import * as assert from 'assert';
-import { splitInChunks } from '../util';
+import { getGitErrorHintSelection, isNonActionableGitStderrLine, splitInChunks } from '../util';
 
 suite('git', () => {
 	suite('GitStatusParser', () => {
@@ -715,6 +715,43 @@ suite('git', () => {
 				[...splitInChunks(['0', '01', '012', '0', '01', '012', '0', '01', '012'], 9)],
 				[['0', '01', '012', '0', '01'], ['012', '0', '01', '012']]
 			);
+		});
+	});
+
+	suite('getGitErrorHintSelection', () => {
+		test('detects SSH known_hosts noise', () => {
+			assert.strictEqual(
+				isNonActionableGitStderrLine("Warning: Permanently added 'gitlab.com' (ED25519) to the list of known hosts."),
+				true
+			);
+			assert.strictEqual(
+				isNonActionableGitStderrLine("warning: permanently added 'github.com' (RSA) to the list of known hosts"),
+				true
+			);
+			assert.strictEqual(isNonActionableGitStderrLine('fatal: Authentication failed'), false);
+		});
+
+		test('prefers fatal error over known_hosts warning', () => {
+			const stderr = [
+				"Warning: Permanently added 'gitlab.com' (ED25519) to the list of known hosts.",
+				"fatal: Could not read from remote repository.",
+			].join('\n');
+			const selection = getGitErrorHintSelection(stderr, undefined, undefined);
+			assert.strictEqual(selection.severity, 'error');
+			assert.deepStrictEqual(selection.hintLines, ['fatal: Could not read from remote repository.']);
+		});
+
+		test('known_hosts-only stderr uses warning severity', () => {
+			const stderr = "Warning: Permanently added 'gitlab.com' (ED25519) to the list of known hosts.";
+			const selection = getGitErrorHintSelection(stderr, undefined, undefined);
+			assert.strictEqual(selection.severity, 'warning');
+			assert.deepStrictEqual(selection.hintLines, [stderr]);
+		});
+
+		test('other warning-only stderr uses warning severity', () => {
+			const other = getGitErrorHintSelection('warning: refname is ambiguous', undefined, undefined);
+			assert.strictEqual(other.severity, 'warning');
+			assert.deepStrictEqual(other.hintLines, ['warning: refname is ambiguous']);
 		});
 	});
 });

--- a/extensions/git/src/util.ts
+++ b/extensions/git/src/util.ts
@@ -870,3 +870,54 @@ export function getStashDescription(stash: Stash): string | undefined {
 export function isCopilotWorktreeFolder(path: string): boolean {
 	return basename(path).startsWith('copilot-') || basename(path).startsWith('agents-');
 }
+
+/**
+ * SSH first-connect noise often lands on stderr alongside a later fatal error.
+ * Drop those lines so the UI does not surface them as the primary git failure.
+ * See https://github.com/microsoft/vscode/issues/280834
+ */
+const NON_ACTIONABLE_GIT_STDERR_LINE = /^(warning:\s*)?permanently added .+ to the list of known hosts\.?$/i;
+
+export function isNonActionableGitStderrLine(line: string): boolean {
+	return NON_ACTIONABLE_GIT_STDERR_LINE.test(line.trim());
+}
+
+export interface GitErrorHintSelection {
+	readonly hintLines: string[];
+	/**
+	 * Preferred notification severity for the selected lines.
+	 * `warning` when only warning-level text remains after noise filtering.
+	 */
+	readonly severity: 'error' | 'warning';
+}
+
+/**
+ * Choose which stderr/stdout lines to show for a failed git command.
+ * Prefers non-warning lines; falls back to warnings (with warning severity).
+ */
+export function getGitErrorHintSelection(
+	stderr: string | undefined,
+	stdout: string | undefined,
+	message: string | undefined
+): GitErrorHintSelection {
+	const raw = stderr || stdout || message || '';
+	const allLines = raw
+		.replace(/^error: /mi, '')
+		.replace(/^> husky.*$/mi, '')
+		.split(/[\r\n]/)
+		.map(line => line.trim())
+		.filter(line => !!line);
+
+	const actionable = allLines.filter(line => !isNonActionableGitStderrLine(line));
+	const nonWarningLines = actionable.filter(line => !/^warning:\s/i.test(line));
+	if (nonWarningLines.length > 0) {
+		return { hintLines: nonWarningLines, severity: 'error' };
+	}
+	if (actionable.length > 0) {
+		return { hintLines: actionable, severity: 'warning' };
+	}
+	if (allLines.length > 0) {
+		return { hintLines: allLines, severity: 'warning' };
+	}
+	return { hintLines: [], severity: 'error' };
+}


### PR DESCRIPTION
## Summary

Fixes #280834.

When SSH first connects to a host it prints:

```text
Warning: Permanently added 'gitlab.com' (ED25519) to the list of known hosts.
```

on stderr. The git extension's command-error path defaulted to `showErrorMessage`, so that informational line was shown with red error chrome — often as the primary message even when a later `fatal:` line was the real failure (or when it was the only stderr content).

### Changes

In `extensions/git`:

1. **`util.ts`** — `getGitErrorHintSelection()` / `isNonActionableGitStderrLine()`:
   - Prefer non-`warning:` lines for the notification text
   - Recognize SSH known_hosts lines as non-actionable noise when a real error is also present
   - If only warning-level text remains, report `severity: 'warning'`
2. **`commands.ts`** — default git error handler uses that helper; warning severity → `showWarningMessage` (non-modal)
3. **`git.test.ts`** — unit coverage for known_hosts-only, mixed fatal+known_hosts, and generic warning lines

### Behavior

| stderr | UI |
|---|---|
| only `Warning: Permanently added ... known hosts` | **Warning** (yellow), not error |
| known_hosts + `fatal: ...` | **Error** showing the fatal line |
| other `warning: ...` only | **Warning** |

## Test plan

- [x] Unit tests added for `getGitErrorHintSelection`
- [ ] Manually: first SSH git push/fetch to a new host → notification is warning-styled if that is the only message
- [ ] Manually: failed push that also emits known_hosts noise → still shows the real fatal/error line as error

Thanks!