### PR TITLE
Sessions: Preserve archive action behavior

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -100,7 +100,7 @@
 
 	/* Pinned but not hovered/focused: show only the unpin action */
 	.monaco-list-row:not(:hover):not(.focused):has(.session-item.pinned) {
-		.session-title-toolbar {
+		.session-item:not(.session-archive-animation) .session-title-toolbar {
 			display: block;
 
 			.action-item:not(:last-child) {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -106,6 +106,11 @@ export const SessionSectionTypeContext = new RawContextKey<string>('sessionSecti
 export const SessionGroupHasVisibleSessionsContext = new RawContextKey<boolean>('sessionGroup.hasVisibleSessions', false);
 export const SessionGroupIsEmptyContext = new RawContextKey<boolean>('sessionGroup.isEmpty', false);
 
+/** Whether an inline archive action should animate instead of running immediately. */
+export function shouldAnimateArchiveAction(actionId: string, sessionCount: number, motionReduced: boolean): boolean {
+	return actionId === ARCHIVE_SESSION_COMMAND_ID && sessionCount === 1 && !motionReduced;
+}
+
 //#region Types
 
 export enum SessionsGrouping {
@@ -2837,11 +2842,11 @@ export class SessionsList extends Disposable implements ISessionsList {
 	}
 
 	private async handleToolbarAction(action: IAction, session: ISession): Promise<boolean> {
-		if (action.id !== ARCHIVE_SESSION_COMMAND_ID || this.accessibilityService.isMotionReduced()) {
+		const sessions = this.getMultiSelectedSessions(session);
+		if (!shouldAnimateArchiveAction(action.id, sessions.length, this.accessibilityService.isMotionReduced())) {
 			return false;
 		}
 
-		const sessions = this.getMultiSelectedSessions(session);
 		const sessionResources = sessions.map(session => session.resource.toString());
 		if (sessionResources.some(resource => this._archiveActionsInProgress.has(resource))) {
 			return true;

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
@@ -9,7 +9,8 @@ import { constObservable, observableValue } from '../../../../../base/common/obs
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { computeReorderSortChanges, groupByDate, groupByWorkspace, groupSessionsForList, limitSessionsForList, sortSessions, SessionsGrouping, SessionsSorting } from '../../browser/views/sessionsList.js';
+import { computeReorderSortChanges, groupByDate, groupByWorkspace, groupSessionsForList, limitSessionsForList, shouldAnimateArchiveAction, sortSessions, SessionsGrouping, SessionsSorting } from '../../browser/views/sessionsList.js';
+import { ARCHIVE_SESSION_COMMAND_ID } from '../../../../common/sessionCommands.js';
 
 function createSession(id: string, opts: {
 	workspaceLabel?: string;
@@ -56,6 +57,20 @@ function createSession(id: string, opts: {
 suite('Sessions - SessionsList Helpers', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('animates only a single-session inline archive action with motion enabled', () => {
+		assert.deepStrictEqual({
+			singleArchive: shouldAnimateArchiveAction(ARCHIVE_SESSION_COMMAND_ID, 1, false),
+			multiArchive: shouldAnimateArchiveAction(ARCHIVE_SESSION_COMMAND_ID, 2, false),
+			reducedMotion: shouldAnimateArchiveAction(ARCHIVE_SESSION_COMMAND_ID, 1, true),
+			otherAction: shouldAnimateArchiveAction('sessionsViewPane.pinSession', 1, false),
+		}, {
+			singleArchive: true,
+			multiArchive: false,
+			reducedMotion: false,
+			otherAction: false,
+		});
+	});
 
 	suite('groupByWorkspace', () => {
 


### PR DESCRIPTION
## Summary

Follow-up to #327871 based on post-merge review feedback.

- keep multi-selected bulk archive actions immediate instead of delaying them behind one row animation
- keep the Archive affordance visible while a pinned row folds toward it
- add regression coverage for action eligibility

## Testing

- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/sessions/contrib/sessions/test/browser/sessionArchiveAnimation.test.ts --run src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts` (33 passing)
- `NODE_OPTIONS=--max-old-space-size=8192 npm run valid-layers-check`
- targeted hygiene check on changed files
- live CSS-state verification for pinned rows at rest and during animation