### PR TITLE
Revert invalid markdown Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
   - package-ecosystem: "npm"
     directory: "/extensions/markdown-language-features"
     schedule:
-      interval: "cron"
-      cronjob: "0 2,17 * * *"
-      timezone: "Europe/Zurich"
+      interval: "daily"
     allow:
       - dependency-name: "@vscode/markdown-editor"


### PR DESCRIPTION
## Summary
- restore the Markdown editor Dependabot entry in `.github/dependabot.yml` to `interval: "daily"`
- remove the invalid twice-daily cron schedule fields introduced by #327814

## Testing
- parsed `.github/dependabot.yml` with `python3` and verified the Markdown entry schedule is `{'interval': 'daily'}`
- compared the updated file to commit `96b7470ad17` (`Keep markdown editor updated`) and confirmed it matches

(Written by Copilot)