### PR TITLE
chat: add "Ask in Side Chat" to the message queue picker

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/btwSlashCommand.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/btwSlashCommand.contribution.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as dom from '../../../../base/browser/dom.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
@@ -15,32 +14,14 @@ import { IWorkbenchEnvironmentService } from '../../../../workbench/services/env
 import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/constants.js';
 import { IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSlashCommandService } from '../../../../workbench/contrib/chat/common/participants/chatSlashCommands.js';
+import { captureSideChatSelection } from '../../../../workbench/contrib/chat/browser/chatSideChat.js';
 import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { SessionIsArchivedContext, SessionIsCreatedContext, SessionSupportsSideChatContext } from '../../../common/contextkeys.js';
-import { ISideChatSelection, SessionStatus } from '../../../services/sessions/common/session.js';
+import { SessionStatus } from '../../../services/sessions/common/session.js';
 import { openAndSendSideChat } from './sideChatOrchestration.js';
 
-function captureSideChatSelection(widget: IChatWidgetService['lastFocusedWidget']): ISideChatSelection | undefined {
-	if (!widget) {
-		return undefined;
-	}
-	const nativeSelection = dom.getActiveWindow().getSelection();
-	const selectedText = nativeSelection?.toString();
-	if (!nativeSelection || !selectedText || !selectedText.trim()) {
-		return undefined;
-	}
-	const { anchorNode, focusNode } = nativeSelection;
-	if (!anchorNode || !focusNode || !dom.isAncestor(anchorNode, widget.domNode) || !dom.isAncestor(focusNode, widget.domNode)) {
-		return undefined;
-	}
-	const inputEditorDomNode = widget.inputEditor.getDomNode();
-	if (inputEditorDomNode && (dom.isAncestor(anchorNode, inputEditorDomNode) || dom.isAncestor(focusNode, inputEditorDomNode))) {
-		return undefined;
-	}
-	return { text: selectedText };
-}
 
 export class BtwSlashCommandContribution extends Disposable implements IWorkbenchContribution {
 

--- a/src/vs/sessions/contrib/chat/browser/sideChatProvider.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/sideChatProvider.contribution.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatSideChatProvider, IChatSideChatSelection, IChatSideChatService } from '../../../../workbench/contrib/chat/common/chatSideChatService.js';
+import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { SessionStatus } from '../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { createAndSendSideChat } from './sideChatOrchestration.js';
+
+/**
+ * Backs the workbench's "Ask in Side Chat" affordance with the Agents window's
+ * side chat implementation. The workbench owns the action and its presentation;
+ * this provider owns branching a chat from a session turn, which only this layer
+ * can do today.
+ */
+export class SessionsSideChatProviderContribution extends Disposable implements IWorkbenchContribution, IChatSideChatProvider {
+
+	static readonly ID = 'sessions.contrib.sideChatProvider';
+
+	constructor(
+		@IChatSideChatService sideChatService: IChatSideChatService,
+		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
+		@ISessionsService private readonly sessionsService: ISessionsService,
+		@IChatService private readonly chatService: IChatService,
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+	) {
+		super();
+
+		if (!environmentService.isSessionsWindow) {
+			return;
+		}
+
+		this._register(sideChatService.registerProvider(this));
+	}
+
+	canAskInSideChat(sessionResource: URI): boolean {
+		return !!this._resolveSource(sessionResource);
+	}
+
+	async askInSideChat(sessionResource: URI, query: string, selection?: IChatSideChatSelection): Promise<void> {
+		const source = this._resolveSource(sessionResource);
+		if (!source) {
+			throw new Error(`Side chats are not supported for ${sessionResource.toString()}`);
+		}
+		const { session, chatResource, turnId } = source;
+		await createAndSendSideChat(this.sessionsManagementService, this.sessionsService, session, chatResource, turnId, query, selection);
+	}
+
+	/**
+	 * Resolves the session, chat and turn a side chat would branch from, or
+	 * `undefined` when this conversation cannot produce one — it is untitled,
+	 * archived, its provider lacks side chat support, or nothing has been sent
+	 * yet so there is no turn to anchor to.
+	 */
+	private _resolveSource(sessionResource: URI) {
+		const found = this.sessionsManagementService.getSessionForChatResource(sessionResource);
+		if (!found) {
+			return undefined;
+		}
+		const { session, chat } = found;
+		if (session.status.get() === SessionStatus.Untitled || session.isArchived.get() || !session.capabilities.get().supportsSideChat) {
+			return undefined;
+		}
+		const sourceTurn = this.chatService.getSession(chat.resource)?.getRequests().at(-1);
+		if (!sourceTurn) {
+			return undefined;
+		}
+		return { session, chatResource: chat.resource, turnId: sourceTurn.id };
+	}
+}
+
+registerWorkbenchContribution2(SessionsSideChatProviderContribution.ID, SessionsSideChatProviderContribution, WorkbenchPhase.BlockRestore);

--- a/src/vs/sessions/contrib/chat/test/browser/sideChatProvider.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sideChatProvider.test.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { constObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatSideChatProvider, IChatSideChatService } from '../../../../../workbench/contrib/chat/common/chatSideChatService.js';
+import { IChatModel, IChatRequestModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
+import { IWorkbenchEnvironmentService } from '../../../../../workbench/services/environment/common/environmentService.js';
+import { SessionsSideChatProviderContribution } from '../../browser/sideChatProvider.contribution.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+
+suite('SessionsSideChatProviderContribution', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	const sourceChat = upcastPartial<IChat>({ resource: URI.parse('test:///chat/source') });
+	const sideChat = upcastPartial<IChat>({ resource: URI.parse('test:///chat/side') });
+
+	function setup(options: {
+		status?: SessionStatus;
+		isArchived?: boolean;
+		supportsSideChat?: boolean;
+		hasTurn?: boolean;
+		isSessionsWindow?: boolean;
+	} = {}) {
+		const store = disposables.add(new DisposableStore());
+		const instantiationService = store.add(new TestInstantiationService());
+
+		const session = upcastPartial<ISession>({
+			sessionId: 'session',
+			resource: URI.parse('test:///session'),
+			status: constObservable(options.status ?? SessionStatus.Completed),
+			isArchived: constObservable(options.isArchived ?? false),
+			capabilities: constObservable({ supportsMultipleChats: true, supportsSideChat: options.supportsSideChat ?? true }),
+		});
+
+		let registered: IChatSideChatProvider | undefined;
+		instantiationService.stub(IChatSideChatService, upcastPartial<IChatSideChatService>({
+			registerProvider: provider => {
+				registered = provider;
+				return toDisposable(() => { registered = undefined; });
+			},
+		}));
+		instantiationService.stub(IChatService, upcastPartial<IChatService>({
+			getSession: () => upcastPartial<IChatModel>({
+				getRequests: () => (options.hasTurn ?? true) ? [upcastPartial<IChatRequestModel>({ id: 'turn-1' })] : [],
+			}),
+		}));
+
+		const callOrder: string[] = [];
+		instantiationService.stub(ISessionsManagementService, upcastPartial<ISessionsManagementService>({
+			getSessionForChatResource: resource => resource.toString() === sourceChat.resource.toString() ? { session, chat: sourceChat } : undefined,
+			createSideChatInSession: async (_session, _sourceChat, turnId, selection) => {
+				callOrder.push(`create:${turnId}:${selection?.text ?? ''}`);
+				return sideChat;
+			},
+			sendRequest: async (_session, chat, requestOptions) => {
+				callOrder.push(`send:${chat.resource.toString()}:${requestOptions.query}`);
+			},
+		}));
+		instantiationService.stub(ISessionsService, upcastPartial<ISessionsService>({
+			openChat: async (_session, chatUri) => {
+				callOrder.push(`open:${chatUri.toString()}`);
+			},
+		}));
+		instantiationService.stub(IWorkbenchEnvironmentService, upcastPartial<IWorkbenchEnvironmentService>({
+			isSessionsWindow: options.isSessionsWindow ?? true,
+		}));
+
+		store.add(instantiationService.createInstance(SessionsSideChatProviderContribution));
+		return { provider: () => registered, callOrder };
+	}
+
+	test('registers a provider that branches, opens, then sends on the side chat', async () => {
+		const { provider, callOrder } = setup();
+
+		await provider()!.askInSideChat(sourceChat.resource, 'what about this?', { text: 'selected text' });
+
+		assert.deepStrictEqual(callOrder, [
+			'create:turn-1:selected text',
+			`open:${sideChat.resource.toString()}`,
+			`send:${sideChat.resource.toString()}:what about this?`,
+		]);
+	});
+
+	test('reports capability only for conversations that can actually branch', () => {
+		const capability = (options: Parameters<typeof setup>[0]) => {
+			const { provider } = setup(options);
+			return provider()!.canAskInSideChat(sourceChat.resource);
+		};
+
+		assert.deepStrictEqual({
+			supported: capability({}),
+			unknownChat: (() => setup({}).provider()!.canAskInSideChat(URI.parse('test:///chat/other')))(),
+			untitled: capability({ status: SessionStatus.Untitled }),
+			archived: capability({ isArchived: true }),
+			noSideChatSupport: capability({ supportsSideChat: false }),
+			noTurnYet: capability({ hasTurn: false }),
+		}, {
+			supported: true,
+			unknownChat: false,
+			untitled: false,
+			archived: false,
+			noSideChatSupport: false,
+			noTurnYet: false,
+		});
+	});
+
+	test('does not register outside the Agents window', () => {
+		const { provider } = setup({ isSessionsWindow: false });
+
+		assert.strictEqual(provider(), undefined);
+	});
+});

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -462,6 +462,7 @@ import './contrib/accountMenu/browser/account.contribution.js';
 import './contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.js';
 import './contrib/chat/browser/chat.contribution.js';
 import './contrib/chat/browser/btwSlashCommand.contribution.js';
+import './contrib/chat/browser/sideChatProvider.contribution.js';
 import './contrib/promptTimeline/browser/promptTimeline.contribution.js';
 import './contrib/providers/agentHost/browser/exportDebugLogsAction.js';
 import './contrib/providers/agentHost/browser/agentHostSessionConfigPicker.js';

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
@@ -11,11 +11,15 @@ import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatRequestQueueKind, IChatService } from '../../common/chatService/chatService.js';
+import { IChatSideChatService } from '../../common/chatSideChatService.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { isRequestVM } from '../../common/model/chatViewModel.js';
 import { IChatWidgetService } from '../chat.js';
+import { captureSideChatSelection } from '../chatSideChat.js';
 import { CHAT_CATEGORY } from './chatActions.js';
 
 const editingQueue = ChatContextKeys.editingRequestType.isEqualTo(ChatContextKeys.EditingRequestType.Queue);
@@ -159,6 +163,60 @@ export class ChatSteerWithMessageAction extends Action2 {
 		}
 
 		widget.acceptInput(undefined, { queue: ChatRequestQueueKind.Steering });
+	}
+}
+
+export class ChatAskInSideChatAction extends Action2 {
+	static readonly ID = 'workbench.action.chat.askInSideChat';
+
+	constructor() {
+		super({
+			id: ChatAskInSideChatAction.ID,
+			title: localize2('chat.askInSideChat', "Ask in Side Chat"),
+			tooltip: localize('chat.askInSideChat.tooltip', "Ask this question in a side chat without adding it to this conversation"),
+			icon: Codicon.commentDiscussion,
+			f1: false,
+			category: CHAT_CATEGORY,
+			precondition: ChatContextKeys.inputHasText,
+		});
+	}
+
+	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+		const widgetService = accessor.get(IChatWidgetService);
+		const sideChatService = accessor.get(IChatSideChatService);
+		const notificationService = accessor.get(INotificationService);
+		const logService = accessor.get(ILogService);
+
+		const widget = widgetService.lastFocusedWidget;
+		const sessionResource = widget?.viewModel?.model.sessionResource;
+		if (!widget || !sessionResource) {
+			return;
+		}
+
+		const query = widget.getInput().trim();
+		if (!query) {
+			return;
+		}
+
+		if (!sideChatService.canAskInSideChat(sessionResource)) {
+			notificationService.warn(localize('chat.askInSideChat.unsupported', "This conversation does not support side chats."));
+			return;
+		}
+
+		const selection = captureSideChatSelection(widget);
+
+		// Clear optimistically so the composer behaves like the queue/steer
+		// actions; the text is restored below if the side chat cannot be created.
+		widget.setInput('');
+		try {
+			await sideChatService.askInSideChat(sessionResource, query, selection);
+		} catch (err) {
+			logService.error('[askInSideChat] Failed to create side chat', err);
+			notificationService.error(localize('chat.askInSideChat.createFailed', "The side chat could not be created."));
+			if (!widget.getInput()) {
+				widget.setInput(query);
+			}
+		}
 	}
 }
 
@@ -311,6 +369,7 @@ export class ChatRemoveAllPendingRequestsAction extends Action2 {
 export function registerChatQueueActions(): void {
 	registerAction2(ChatQueueMessageAction);
 	registerAction2(ChatSteerWithMessageAction);
+	registerAction2(ChatAskInSideChatAction);
 	registerAction2(ChatRemovePendingRequestAction);
 	registerAction2(ChatEditPendingRequestAction);
 	registerAction2(ChatSendPendingImmediatelyAction);

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -52,6 +52,7 @@ import { IChatLayoutService } from '../common/widget/chatLayoutService.js';
 import { ChatModeService, IChatMode, IChatModeService, IChatModes } from '../common/chatModes.js';
 import { ChatResponseResourceFileSystemProvider, ChatResponseResourceWorkbenchContribution, IChatResponseResourceFileSystemProvider } from '../common/widget/chatResponseResourceFileSystemProvider.js';
 import { IChatService } from '../common/chatService/chatService.js';
+import { ChatSideChatService, IChatSideChatService } from '../common/chatSideChatService.js';
 import { ChatService } from '../common/chatService/chatServiceImpl.js';
 import { IChatSessionsService } from '../common/chatSessionsService.js';
 import { ChatSlashCommandService, IChatSlashCommandService } from '../common/participants/chatSlashCommands.js';
@@ -2901,6 +2902,7 @@ registerSingleton(IChatSpeechToTextService, ChatSpeechToTextService, Instantiati
 registerSingleton(IChatTransferService, ChatTransferService, InstantiationType.Delayed);
 registerSingleton(IChatService, ChatService, InstantiationType.Delayed);
 registerSingleton(IChatWidgetService, ChatWidgetService, InstantiationType.Delayed);
+registerSingleton(IChatSideChatService, ChatSideChatService, InstantiationType.Delayed);
 registerSingleton(IChatPetService, ChatPetService, InstantiationType.Delayed);
 registerSingleton(IQuickChatService, QuickChatService, InstantiationType.Delayed);
 registerSingleton(IChatAccessibilityService, ChatAccessibilityService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/chatSideChat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSideChat.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { IChatSideChatSelection } from '../common/chatSideChatService.js';
+import { IChatWidget } from './chat.js';
+
+/**
+ * Captures the user's current text selection within `widget`'s transcript so a
+ * side chat can be anchored to it. Returns `undefined` when there is no
+ * meaningful selection, when it falls outside the widget, or when it lives in
+ * the input editor (which holds the question being asked, not the source text).
+ */
+export function captureSideChatSelection(widget: IChatWidget | undefined): IChatSideChatSelection | undefined {
+	if (!widget) {
+		return undefined;
+	}
+	const nativeSelection = dom.getActiveWindow().getSelection();
+	const selectedText = nativeSelection?.toString();
+	if (!nativeSelection || !selectedText || !selectedText.trim()) {
+		return undefined;
+	}
+	const { anchorNode, focusNode } = nativeSelection;
+	if (!anchorNode || !focusNode || !dom.isAncestor(anchorNode, widget.domNode) || !dom.isAncestor(focusNode, widget.domNode)) {
+		return undefined;
+	}
+	const inputEditorDomNode = widget.inputEditor.getDomNode();
+	if (inputEditorDomNode && (dom.isAncestor(anchorNode, inputEditorDomNode) || dom.isAncestor(focusNode, inputEditorDomNode))) {
+		return undefined;
+	}
+	return { text: selectedText };
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -7,6 +7,7 @@ import { $, addDisposableListener, append, EventType, ModifierKeyEmitter } from 
 import { StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEvent.js';
 import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { Action, IAction } from '../../../../../../base/common/actions.js';
+import { coalesce } from '../../../../../../base/common/arrays.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -24,9 +25,11 @@ import { IKeybindingService } from '../../../../../../platform/keybinding/common
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
+import { IChatSideChatService } from '../../../common/chatSideChatService.js';
 import { ChatConfiguration } from '../../../common/constants.js';
+import { IChatWidgetService } from '../../chat.js';
 import { ChatSubmitAction, type IChatExecuteActionContext } from '../../actions/chatExecuteActions.js';
-import { ChatQueueMessageAction, ChatSteerWithMessageAction } from '../../actions/chatQueueActions.js';
+import { ChatAskInSideChatAction, ChatQueueMessageAction, ChatSteerWithMessageAction } from '../../actions/chatQueueActions.js';
 
 /**
  * Split-button action view item for the queue/steer picker in the chat execute toolbar.
@@ -53,6 +56,8 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@ITelemetryService telemetryService: ITelemetryService,
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+		@IChatSideChatService private readonly chatSideChatService: IChatSideChatService,
 	) {
 		super(undefined, action);
 
@@ -243,7 +248,32 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			}
 		};
 
-		return [sendAction, queueAction, steerAction];
+		const askInSideChatAction: IActionWidgetDropdownAction | undefined = this._canAskInSideChat() ? {
+			id: ChatAskInSideChatAction.ID,
+			label: localize('chat.askInSideChat', "Ask in Side Chat"),
+			tooltip: '',
+			enabled: true,
+			icon: Codicon.commentDiscussion,
+			class: undefined,
+			hover: {
+				content: localize('chat.askInSideChat.hover', "Ask this question in a side chat. The current response continues uninterrupted and the question is answered alongside it, without being added to this conversation."),
+			},
+			run: () => {
+				this.commandService.executeCommand(ChatAskInSideChatAction.ID);
+			}
+		} : undefined;
+
+		return coalesce([sendAction, queueAction, steerAction, askInSideChatAction]);
+	}
+
+	/**
+	 * Side chats are provided by the layer hosting the conversation (today the
+	 * Agents window), so the entry is offered only once a provider reports the
+	 * current conversation can branch one.
+	 */
+	private _canAskInSideChat(): boolean {
+		const sessionResource = this.chatWidgetService.lastFocusedWidget?.viewModel?.model.sessionResource;
+		return !!sessionResource && this.chatSideChatService.canAskInSideChat(sessionResource);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatSideChatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSideChatService.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+
+/**
+ * Source text a side chat is anchored to, so the side chat can be given the
+ * excerpt the question is about.
+ */
+export interface IChatSideChatSelection {
+	readonly text: string;
+}
+
+/**
+ * Supplies the ability to branch a conversation into a side chat — a question
+ * answered alongside the conversation without being added to it.
+ *
+ * Implemented today by the Agents window (`vs/sessions`), which owns side chat
+ * creation. The workbench declares the capability so chat UI can offer it
+ * without depending on that layer; when the workbench gains native side chats it
+ * registers a provider of its own.
+ */
+export interface IChatSideChatProvider {
+	/**
+	 * Whether a side chat can be branched from `sessionResource` right now, e.g.
+	 * the conversation supports side chats and has a turn to branch from.
+	 */
+	canAskInSideChat(sessionResource: URI): boolean;
+
+	/**
+	 * Branches a side chat from the conversation's latest turn, reveals it, and
+	 * sends `query` on it. Rejects if the side chat could not be created.
+	 */
+	askInSideChat(sessionResource: URI, query: string, selection?: IChatSideChatSelection): Promise<void>;
+}
+
+export const IChatSideChatService = createDecorator<IChatSideChatService>('chatSideChatService');
+
+export interface IChatSideChatService {
+	readonly _serviceBrand: undefined;
+
+	registerProvider(provider: IChatSideChatProvider): IDisposable;
+
+	/** @see IChatSideChatProvider.canAskInSideChat */
+	canAskInSideChat(sessionResource: URI): boolean;
+
+	/** @see IChatSideChatProvider.askInSideChat */
+	askInSideChat(sessionResource: URI, query: string, selection?: IChatSideChatSelection): Promise<void>;
+}
+
+export class ChatSideChatService extends Disposable implements IChatSideChatService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _providers = new Set<IChatSideChatProvider>();
+
+	registerProvider(provider: IChatSideChatProvider): IDisposable {
+		this._providers.add(provider);
+		return toDisposable(() => this._providers.delete(provider));
+	}
+
+	canAskInSideChat(sessionResource: URI): boolean {
+		return !!this._findProvider(sessionResource);
+	}
+
+	async askInSideChat(sessionResource: URI, query: string, selection?: IChatSideChatSelection): Promise<void> {
+		const provider = this._findProvider(sessionResource);
+		if (!provider) {
+			throw new Error(`No side chat provider for ${sessionResource.toString()}`);
+		}
+		await provider.askInSideChat(sessionResource, query, selection);
+	}
+
+	private _findProvider(sessionResource: URI): IChatSideChatProvider | undefined {
+		for (const provider of this._providers) {
+			if (provider.canAskInSideChat(sessionResource)) {
+				return provider;
+			}
+		}
+		return undefined;
+	}
+}

--- a/src/vs/workbench/contrib/chat/test/browser/actions/chatQueueActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/actions/chatQueueActions.test.ts
@@ -4,17 +4,30 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { getActiveDocument } from '../../../../../../base/browser/dom.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { OS } from '../../../../../../base/common/platform.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ICodeEditor } from '../../../../../../editor/browser/editorBrowser.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ContextKeyService } from '../../../../../../platform/contextkey/browser/contextKeyService.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { KeybindingsRegistry } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeybindingResolver } from '../../../../../../platform/keybinding/common/keybindingResolver.js';
 import { ResolvedKeybindingItem } from '../../../../../../platform/keybinding/common/resolvedKeybindingItem.js';
 import { USLayoutResolvedKeybinding } from '../../../../../../platform/keybinding/common/usLayoutResolvedKeybinding.js';
-import { ChatQueueMessageAction, ChatSteerWithMessageAction, registerChatQueueActions } from '../../../browser/actions/chatQueueActions.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { TestNotificationService } from '../../../../../../platform/notification/test/common/testNotificationService.js';
+import { IChatWidget, IChatWidgetService } from '../../../browser/chat.js';
+import { ChatAskInSideChatAction, ChatQueueMessageAction, ChatSteerWithMessageAction, registerChatQueueActions } from '../../../browser/actions/chatQueueActions.js';
 import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
+import { IChatSideChatService } from '../../../common/chatSideChatService.js';
 import { ChatConfiguration } from '../../../common/constants.js';
+import { IChatModel } from '../../../common/model/chatModel.js';
+import { IChatViewModel } from '../../../common/model/chatViewModel.js';
 
 // Register actions once so the keybindings appear in KeybindingsRegistry.
 registerChatQueueActions();
@@ -70,5 +83,81 @@ suite('Queue/Steer keybinding resolution', () => {
 		} finally {
 			dispose();
 		}
+	});
+});
+
+suite('ChatAskInSideChatAction', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function setup(options: { canAsk?: boolean; askFails?: boolean } = {}) {
+		const store = disposables.add(new DisposableStore());
+		const instantiationService = store.add(new TestInstantiationService());
+		const sessionResource = URI.parse('test:///chat/source');
+
+		let input = 'what about this?';
+		instantiationService.stub(IChatWidgetService, upcastPartial<IChatWidgetService>({
+			lastFocusedWidget: upcastPartial<IChatWidget>({
+				domNode: getActiveDocument().createElement('div'),
+				inputEditor: { getDomNode: () => null } as ICodeEditor,
+				getInput: () => input,
+				setInput: (value?: string) => { input = value ?? ''; },
+				viewModel: upcastPartial<IChatViewModel>({ model: upcastPartial<IChatModel>({ sessionResource }) }),
+			}),
+		}));
+
+		const asked: string[] = [];
+		instantiationService.stub(IChatSideChatService, upcastPartial<IChatSideChatService>({
+			canAskInSideChat: () => options.canAsk ?? true,
+			askInSideChat: async (resource, query) => {
+				if (options.askFails) {
+					asked.push('failed');
+					throw new Error('nope');
+				}
+				asked.push(`${resource.toString()}:${query}`);
+			},
+		}));
+		instantiationService.stub(INotificationService, new TestNotificationService());
+		instantiationService.stub(ILogService, new NullLogService());
+
+		const action = new ChatAskInSideChatAction();
+		return {
+			run: () => instantiationService.invokeFunction(accessor => action.run(accessor)),
+			asked,
+			sessionResource,
+			getInput: () => input,
+		};
+	}
+
+	test('delegates the composed message to the side chat service and clears the input', async () => {
+		const { run, asked, sessionResource, getInput } = setup();
+
+		await run();
+
+		assert.deepStrictEqual({ asked, input: getInput() }, {
+			asked: [`${sessionResource.toString()}:what about this?`],
+			input: '',
+		});
+	});
+
+	test('restores the composed message when the side chat cannot be created', async () => {
+		const { run, asked, getInput } = setup({ askFails: true });
+
+		await run();
+
+		assert.deepStrictEqual({ asked, input: getInput() }, {
+			asked: ['failed'],
+			input: 'what about this?',
+		});
+	});
+
+	test('does nothing but warn when no provider supports the conversation', async () => {
+		const { run, asked, getInput } = setup({ canAsk: false });
+
+		await run();
+
+		assert.deepStrictEqual({ asked, input: getInput() }, {
+			asked: [],
+			input: 'what about this?',
+		});
 	});
 });


### PR DESCRIPTION
- The queue picker offered "Stop and Send", "Add to Queue" and "Steer with
  Message", all of which interrupt or defer the composed message. Side chats
  (already reachable via /btw) answer a question alongside the conversation
  without adding it, so the picker is the natural place to offer them while a
  request is in flight.
- Adds IChatSideChatService, a provider registry in the workbench chat layer.
  Side chat creation is only implemented by the Agents window today, but
  vs/workbench cannot import vs/sessions, so the capability is declared in the
  workbench and vs/sessions registers a provider for it. This keeps the action
  and its presentation in the layer that will eventually support side chats
  natively -- at that point the workbench registers its own provider and
  nothing else moves.
- A provider registry is used rather than overriding the service singleton
  from vs/sessions, since registerSingleton is last-write-wins by import order
  and would have made the wiring silently order-dependent.
- Moves captureSideChatSelection into the workbench so both the new action and
  the existing /btw command anchor side chats to the same selection.

(Commit message generated by Copilot)