### PR TITLE
agentHost: fix Claude side chats during active turns

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
@@ -63,8 +63,8 @@ export function mapSessionMessagesToTurns(
  * Phase 6.5 — translate a protocol `turnId` (the last KEPT turn N) into the
  * SDK envelope `uuid` that `forkSession({ upToMessageId })` accepts
  * (INCLUSIVE). Returns the `uuid` of turn N's last `'assistant'` envelope,
- * or `turnId` itself when turn N has no assistant reply (still a valid
- * inclusive anchor), or `undefined` when `turnId` is not in the transcript.
+ * or `undefined` when `turnId` is not in the transcript or the turn has no
+ * assistant envelope yet. AHP request turn IDs are not valid SDK fork UUIDs.
  * Reuses {@link parseSessionMessage} so the turn-boundary rule matches
  * {@link ReplayBuilder}; always returns an envelope `uuid`, never a `msg_…` id.
  */
@@ -107,7 +107,7 @@ export function resolveForkAnchorUuid(messages: readonly SessionMessage[], turnI
 	if (!seenTarget) {
 		return undefined;
 	}
-	return lastAssistantUuid ?? turnId;
+	return lastAssistantUuid;
 }
 
 // #region Parsed message union — narrow-at-the-seam adapter

--- a/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
@@ -64,7 +64,7 @@ export function mapSessionMessagesToTurns(
  * SDK envelope `uuid` that `forkSession({ upToMessageId })` accepts
  * (INCLUSIVE). Returns the `uuid` of turn N's last `'assistant'` envelope,
  * or `undefined` when `turnId` is not in the transcript or the turn has no
- * assistant envelope yet. AHP request turn IDs are not valid SDK fork UUIDs.
+ * assistant envelope yet. Agent Host Protocol request turn IDs are not valid SDK fork UUIDs.
  * Reuses {@link parseSessionMessage} so the turn-boundary rule matches
  * {@link ReplayBuilder}; always returns an envelope `uuid`, never a `msg_…` id.
  */

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -6933,10 +6933,11 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 		const result = await agent.chats.createChat(chatUri, {
 			sideChat: { source: sourceChat, turnId, sourceContext },
 		});
+		assert.ok(result?.providerData);
 
 		assert.deepStrictEqual({
 			forked: sdk.forkSessionCalls.length,
-			sideChat: result ? JSON.parse(result.providerData!).sideChat : undefined,
+			sideChat: JSON.parse(result.providerData).sideChat,
 		}, {
 			forked: 0,
 			sideChat: {

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -6911,6 +6911,43 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 		});
 	});
 
+	test('createChat({ sideChat }) falls back to injected source context while the source turn is awaiting its first response', async () => {
+		const { agent, sdk } = createTestContext(disposables);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+		const created = await agent.createSession({ workingDirectories: [URI.file('/work')] });
+		const parentId = AgentSession.id(created.session);
+		const sourceChat = defaultChatUri(created.session);
+		const turnId = 'request_31bb16da-2a24-4312-8adb-04781b463d41';
+		const sourceContext = 'User request:\nsource question';
+		sdk.sessionMessagesById.set(parentId, [{
+			type: 'user',
+			uuid: turnId,
+			session_id: parentId,
+			parent_tool_use_id: null,
+			parent_agent_id: null,
+			message: { role: 'user', content: [{ type: 'text', text: 'source question' }] },
+		}]);
+		sdk.forkSessionRejection = new Error(`Invalid upToMessageId: ${turnId}`);
+
+		const chatUri = URI.parse(buildChatUri(created.session.toString(), 'chat-side-active'));
+		const result = await agent.chats.createChat(chatUri, {
+			sideChat: { source: sourceChat, turnId, sourceContext },
+		});
+
+		assert.deepStrictEqual({
+			forked: sdk.forkSessionCalls.length,
+			sideChat: result ? JSON.parse(result.providerData!).sideChat : undefined,
+		}, {
+			forked: 0,
+			sideChat: {
+				source: sourceChat.toString(),
+				turnId,
+				inheritedTurnCount: 0,
+				context: sourceContext,
+			},
+		});
+	});
+
 	test('createChat({ sideChat }) preserves a local source turn id while forking from the concrete provider anchor', async () => {
 		const { agent, sdk } = createTestContext(disposables);
 		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');

--- a/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
@@ -523,13 +523,13 @@ suite('resolveForkAnchorUuid', () => {
 		assert.strictEqual(resolveForkAnchorUuid(messages, 'u1'), 'a1', 'system notification must not end the turn');
 	});
 
-	test('user-only target turn (no assistant) falls back to the user-text uuid', () => {
+	test('user-only target turn (no assistant) has no valid fork anchor', () => {
 		const messages: SessionMessage[] = [
 			makeUser('u1', 'apple'),
 			makeAssistantText('a1', 'apple!'),
 			makeUser('u2', 'unanswered'),
 		];
-		assert.strictEqual(resolveForkAnchorUuid(messages, 'u2'), 'u2', 'fall back to the user-text envelope uuid');
+		assert.strictEqual(resolveForkAnchorUuid(messages, 'u2'), undefined);
 	});
 
 	test('turnId not found → undefined', () => {


### PR DESCRIPTION
- Prevents active AHP request IDs from being passed to Claude as fork anchors, because the SDK only accepts persisted assistant message UUIDs.
- Preserves the quick /btw workflow by falling back to captured source context until Claude has produced a forkable response.
- Adds regression coverage for creating a side chat before the source response begins.

Fixes #327701

(Commit message generated by Copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>