### PR TITLE
feat: add greeting command and startup log to vscode-extras

### DIFF
--- a/.vscode/extensions/vscode-extras/src/extension.ts
+++ b/.vscode/extensions/vscode-extras/src/extension.ts
@@ -10,12 +10,22 @@ export class Extension extends vscode.Disposable {
 	private readonly _output: vscode.LogOutputChannel;
 	private _npmFeature: NpmUpToDateFeature | undefined;
 
-	constructor(_context: vscode.ExtensionContext) {
+	constructor(context: vscode.ExtensionContext) {
 		const disposables: vscode.Disposable[] = [];
 		super(() => disposables.forEach(d => d.dispose()));
 
 		this._output = vscode.window.createOutputChannel('VS Code Extras', { log: true });
 		disposables.push(this._output);
+
+		
+		this._output.info('The VS Code Extras extension has been successfully started and is active!');
+
+		
+		disposables.push(
+			vscode.commands.registerCommand('vscode-extras.sayHello', () => {
+				vscode.window.showInformationMessage('Hey friend! VS Code Extras is online..');
+			})
+		);
 
 		this._updateNpmFeature();
 

--- a/.vscode/extensions/vscode-extras/src/extension.ts
+++ b/.vscode/extensions/vscode-extras/src/extension.ts
@@ -10,20 +10,17 @@ export class Extension extends vscode.Disposable {
 	private readonly _output: vscode.LogOutputChannel;
 	private _npmFeature: NpmUpToDateFeature | undefined;
 
-	constructor(context: vscode.ExtensionContext) {
+	constructor(_context: vscode.ExtensionContext) {
 		const disposables: vscode.Disposable[] = [];
 		super(() => disposables.forEach(d => d.dispose()));
 
 		this._output = vscode.window.createOutputChannel('VS Code Extras', { log: true });
 		disposables.push(this._output);
-
-		
 		this._output.info('The VS Code Extras extension has been successfully started and is active!');
 
-		
 		disposables.push(
 			vscode.commands.registerCommand('vscode-extras.sayHello', () => {
-				vscode.window.showInformationMessage('Hey friend! VS Code Extras is online..');
+				vscode.window.showInformationMessage('Hey friend! VS Code Extras is online.');
 			})
 		);
 
@@ -53,7 +50,8 @@ let extension: Extension | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
 	extension = new Extension(context);
-	context.subscriptions.push(extension);
+    // context parametresini burada kullanıyoruz
+    context.subscriptions.push(extension);
 }
 
 export function deactivate() {


### PR DESCRIPTION
The `sayHello` command—executable from the command palette—and a startup log channel message have been added to the extension.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
