### PR TITLE
Fix chat tips in Agents new session composer

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -83,7 +83,7 @@ focus a slot:   part.onDidFocusSession → view.setActive → updates active vis
 
 The Agents-window chat surface also registers the workbench chat pre-submit handlers. These handlers can consume provider-specific client-side commands before the normal send path, while the actual send still routes through the sessions provider model.
 
-The Agents-window composer uses the shared dictation toggle semantics: activating dictation again while the speech-to-text model is downloading or loading cancels preparation, while activating it during recording stops and transcribes.
+The Agents-window composer uses the shared dictation toggle semantics: activating dictation again while the speech-to-text model is downloading or loading cancels preparation, while activating it during recording stops and transcribes. The new-session composer also renders the shared chat-tip content above its input; because it is not an `IChatWidget`, the chat-tip service treats an Agents window with zero registered foreground chat widgets as this single composer surface.
 
 The part (interface `services/sessions/browser/sessionsPartService.ts`; concrete `browser/parts/sessionsPart.ts`) is a **passive renderer**: it injects neither the model nor the view, and only exposes `updateVisibleSessions(visible, active)`, `focusSession`, and `onDidFocusSession`. The view owns the reconcile autorun and focus and wires `part.onDidFocusSession → view.setActive`.
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -11,6 +11,18 @@
 	display: none;
 }
 
+.new-chat-widget-content > .chat-getting-started-tip-container:has(> .chat-tip-widget) {
+	margin-bottom: 0;
+}
+
+.new-chat-widget-content > .chat-getting-started-tip-container:has(> .chat-tip-widget) + .new-chat-input-container {
+	margin-top: 0;
+}
+
+.new-chat-widget-content > .chat-getting-started-tip-container:has(> .chat-tip-widget) + .new-chat-input-container .new-chat-input-area {
+	border-radius: 0 0 var(--vscode-cornerRadius-large) var(--vscode-cornerRadius-large);
+}
+
 .new-session-feedback-banners {
 	width: 100%;
 	max-width: 800px;

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -303,6 +303,12 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 	/** The underlying input editor. Exposed for component fixtures. */
 	get inputEditor(): CodeEditorWidget | undefined { return this._editor; }
 
+	/** The current model-selection state. Exposed so host widgets can react to model changes. */
+	get selectedModelState() { return this._sessionModelSelectionModel.state; }
+
+	/** Opens the model picker dropdown. */
+	openModelPicker(): void { this._newChatModelPickerService.openModelPicker(); }
+
 	// Input
 	private _editor!: CodeEditorWidget;
 	private _editorContainer!: HTMLElement;

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -311,6 +311,10 @@ export class NewChatWidget extends Disposable {
 		if (!this._chatTipContainer) {
 			return;
 		}
+		// Don't show a tip in the no-agent-host empty state — there is no usable composer.
+		if (this._chatTipContainer.parentElement?.classList.contains('no-agent-host')) {
+			return;
+		}
 		if (this.contextKeyService.getContextKeyValue<number>(ChatContextKeys.foregroundSessionCount.key) !== 0) {
 			this._isChatTipSessionInitialized = false;
 			this._clearChatTip();
@@ -554,12 +558,14 @@ export class NewChatWidget extends Disposable {
 			chatWidgetContent.classList.remove('no-agent-host');
 			dom.clearNode(pickerSlot);
 			stateDisposables.value = this._renderWorkspacePicker(pickerSlot);
+			this._renderChatTip();
 		};
 
 		const showEmptyState = () => {
 			chatWidgetContent.classList.add('no-agent-host');
 			dom.clearNode(pickerSlot);
 			stateDisposables.value = this._renderEmptyState(pickerSlot);
+			this._clearChatTip();
 		};
 
 		const filter = this.agentHostFilterService;

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -10,6 +10,7 @@ import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposa
 import { constObservable, derived, derivedObservableWithCache, autorun, IObservable, observableSignalFromEvent } from '../../../../base/common/observable.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -32,6 +33,10 @@ import { AGENT_FEEDBACK_NEW_SESSION_RESOURCE, AgentFeedbackState, IAgentFeedback
 import { buildNewSessionPrompt } from '../../agentFeedback/browser/agentFeedbackAttachmentEntry.js';
 import { SessionInputBannerWidget } from '../../sessionInputBanners/browser/sessionInputBannerWidget.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { ChatTipContentPart } from '../../../../workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.js';
+import { ChatContentMarkdownRenderer } from '../../../../workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.js';
+import { IChatTipService } from '../../../../workbench/contrib/chat/browser/chatTipService.js';
+import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 
 // #region --- New Chat Widget ---
 
@@ -39,6 +44,9 @@ export class NewChatWidget extends Disposable {
 
 	private readonly _workspacePicker: WorkspacePicker;
 	private readonly _newChatInput: NewChatInputWidget;
+	private readonly _chatTipPart = this._register(new MutableDisposable<DisposableStore>());
+	private _chatTipContainer: HTMLElement | undefined;
+	private _isChatTipSessionInitialized = false;
 	private _aquariumToggle: IMountedToggleHandle | undefined;
 
 	/** Recreates the draft once a better/late-registering provider can serve the folder (see {@link _createNewSession}). */
@@ -87,7 +95,8 @@ export class NewChatWidget extends Disposable {
 	constructor(
 		private readonly options: IChatViewOptions,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IContextKeyService contextKeyService: IContextKeyService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ILogService private readonly logService: ILogService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
@@ -95,6 +104,7 @@ export class NewChatWidget extends Disposable {
 		@IAgentHostFilterService private readonly agentHostFilterService: IAgentHostFilterService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IAgentFeedbackService private readonly agentFeedbackService: IAgentFeedbackService,
+		@IChatTipService private readonly chatTipService: IChatTipService,
 	) {
 		super();
 		this._workspacePickerVisibleKey = SessionWorkspacePickerVisibleContext.bindTo(contextKeyService);
@@ -180,6 +190,23 @@ export class NewChatWidget extends Disposable {
 			this._newChatInput.focus();
 		}));
 
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (!e.affectsConfiguration('chat.tips.enabled')) {
+				return;
+			}
+			if (this.configurationService.getValue<boolean>('chat.tips.enabled')) {
+				this._renderChatTip();
+			} else {
+				this._clearChatTip();
+			}
+		}));
+		const foregroundSessionCountContextKeys = new Set([ChatContextKeys.foregroundSessionCount.key]);
+		this._register(this.contextKeyService.onDidChangeContext(e => {
+			if (e.affectsSome(foregroundSessionCountContextKeys)) {
+				this._renderChatTip();
+			}
+		}));
+
 		// Re-sync the picker's displayed selection when the session's workspace
 		// changes externally (e.g. sessionsService.openNewSession({ folderUri })).
 		this._register(autorun(reader => {
@@ -225,6 +252,8 @@ export class NewChatWidget extends Disposable {
 		}
 
 		this._renderFeedbackBanner(chatWidgetContent);
+		this._chatTipContainer = dom.append(chatWidgetContent, dom.$('.chat-getting-started-tip-container'));
+		this._renderChatTip();
 		this._newChatInput.render(chatWidgetContent, parent);
 
 		// Quick chat composer: hide the workspace picker for workspace-less
@@ -276,6 +305,48 @@ export class NewChatWidget extends Disposable {
 		}
 
 		chatWidgetContainer.classList.add('revealed');
+	}
+
+	private _renderChatTip(): void {
+		if (!this._chatTipContainer) {
+			return;
+		}
+		if (this.contextKeyService.getContextKeyValue<number>(ChatContextKeys.foregroundSessionCount.key) !== 0) {
+			this._isChatTipSessionInitialized = false;
+			this._clearChatTip();
+			return;
+		}
+		if (!this._isChatTipSessionInitialized) {
+			this._isChatTipSessionInitialized = true;
+			this.chatTipService.resetSession();
+		}
+
+		const tip = this.chatTipService.getWelcomeTip(this.contextKeyService);
+		if (!tip) {
+			this._clearChatTip();
+			return;
+		}
+		if (this._chatTipPart.value) {
+			dom.setVisibility(true, this._chatTipContainer);
+			return;
+		}
+
+		const store = new DisposableStore();
+		const renderer = this.instantiationService.createInstance(ChatContentMarkdownRenderer);
+		const tipPart = store.add(this.instantiationService.createInstance(ChatTipContentPart, tip, renderer));
+		store.add(tipPart.onDidHide(() => this._clearChatTip()));
+		this._chatTipPart.value = store;
+		dom.clearNode(this._chatTipContainer);
+		this._chatTipContainer.appendChild(tipPart.domNode);
+		dom.setVisibility(true, this._chatTipContainer);
+	}
+
+	private _clearChatTip(): void {
+		this._chatTipPart.clear();
+		if (this._chatTipContainer) {
+			dom.clearNode(this._chatTipContainer);
+			dom.setVisibility(false, this._chatTipContainer);
+		}
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -37,6 +37,8 @@ import { ChatTipContentPart } from '../../../../workbench/contrib/chat/browser/w
 import { ChatContentMarkdownRenderer } from '../../../../workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.js';
 import { IChatTipService } from '../../../../workbench/contrib/chat/browser/chatTipService.js';
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
+import { ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 
 // #region --- New Chat Widget ---
 
@@ -105,6 +107,7 @@ export class NewChatWidget extends Disposable {
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IAgentFeedbackService private readonly agentFeedbackService: IAgentFeedbackService,
 		@IChatTipService private readonly chatTipService: IChatTipService,
+		@IOpenerService private readonly openerService: IOpenerService,
 	) {
 		super();
 		this._workspacePickerVisibleKey = SessionWorkspacePickerVisibleContext.bindTo(contextKeyService);
@@ -174,6 +177,35 @@ export class NewChatWidget extends Disposable {
 		this._register(toDisposable(() => newChatInput.saveState()));
 		this._newChatInput = this._register(newChatInput);
 
+		// Comment 3: Bind Agent mode in the scoped context so that Agent-only tips
+		// (messageQueueing, subagents, etc.) are eligible and chatModeKind-based
+		// when-clauses evaluate correctly against this composer's actual mode.
+		const chatModeKindKey = ChatContextKeys.chatModeKind.bindTo(contextKeyService);
+		chatModeKindKey.set(ChatModeKind.Agent);
+		this._register(toDisposable(() => chatModeKindKey.reset()));
+
+		// Comment 4: Route tip command links to this composer's own pickers
+		// so they do not fall through to IChatWidgetService.lastFocusedWidget
+		// (which this composer is not registered with).
+		this._register(this.openerService.registerOpener({
+			open: async (resource: URI | string): Promise<boolean> => {
+				if (!this._chatTipPart.value) {
+					return false;
+				}
+				const link = typeof resource === 'string' ? resource : resource.toString();
+				if (link === 'command:workbench.action.chat.openModelPicker') {
+					this._newChatInput.openModelPicker();
+					return true;
+				}
+				if (link === 'command:workbench.action.chat.openPlan') {
+					// Plan mode is not available in the new-session composer; consume
+					// the link without action so it does not misfire on a stale widget.
+					return true;
+				}
+				return false;
+			}
+		}));
+
 		this._register(this._workspacePicker.onDidSelectWorkspace(async folderUri => {
 			await this._onWorkspaceSelected(folderUri);
 			this._newChatInput.focus();
@@ -205,6 +237,17 @@ export class NewChatWidget extends Disposable {
 			if (e.affectsSome(foregroundSessionCountContextKeys)) {
 				this._renderChatTip();
 			}
+		}));
+
+		// Comment 2: Re-evaluate the tip when the selected model changes, because
+		// some tips (e.g. tip.switchToAuto) are only eligible for specific models.
+		let previousModelId: string | undefined;
+		this._register(autorun(reader => {
+			const modelId = this._newChatInput.selectedModelState.read(reader).currentModel?.identifier;
+			if (previousModelId !== undefined && previousModelId !== modelId) {
+				this._renderChatTip();
+			}
+			previousModelId = modelId;
 		}));
 
 		// Re-sync the picker's displayed selection when the session's workspace
@@ -338,7 +381,12 @@ export class NewChatWidget extends Disposable {
 		const store = new DisposableStore();
 		const renderer = this.instantiationService.createInstance(ChatContentMarkdownRenderer);
 		const tipPart = store.add(this.instantiationService.createInstance(ChatTipContentPart, tip, renderer));
-		store.add(tipPart.onDidHide(() => this._clearChatTip()));
+		store.add(tipPart.onDidHide(() => {
+			this._clearChatTip();
+			// Restore focus to the input after the tip DOM is removed so keyboard
+			// focus is not stranded on <body> (matches ChatWidget behaviour).
+			this.focusInput();
+		}));
 		this._chatTipPart.value = store;
 		dom.clearNode(this._chatTipContainer);
 		this._chatTipContainer.appendChild(tipPart.domNode);

--- a/src/vs/sessions/contrib/chat/test/browser/newChatWidget.fixture.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/newChatWidget.fixture.ts
@@ -5,6 +5,7 @@
 
 import * as dom from '../../../../../base/browser/dom.js';
 import { Event } from '../../../../../base/common/event.js';
+import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { constObservable, observableValue } from '../../../../../base/common/observable.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -12,6 +13,7 @@ import { Range } from '../../../../../editor/common/core/range.js';
 import { IRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { asCssVariable } from '../../../../../platform/theme/common/colorUtils.js';
+import { IChatTipService } from '../../../../../workbench/contrib/chat/browser/chatTipService.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from '../../../../../workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.js';
 import { IMicCaptureService } from '../../../../../workbench/contrib/chat/browser/voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../../../../workbench/contrib/chat/browser/voiceClient/ttsPlaybackService.js';
@@ -52,7 +54,7 @@ const HEIGHT = 360;
  * specific rules (`chatWidget.css` vs `newChatInSession.css`) that source order
  * decides between.
  */
-async function renderNewChatWidget(context: ComponentFixtureContext, commentCount: number): Promise<void> {
+async function renderNewChatWidget(context: ComponentFixtureContext, commentCount: number, showTip: boolean): Promise<void> {
 	const { container, disposableStore } = context;
 	const feedbackItems: readonly IAgentFeedback[] = Array.from({ length: commentCount }, (_, index) => ({
 		id: `feedback-${index}`,
@@ -68,6 +70,17 @@ async function renderNewChatWidget(context: ComponentFixtureContext, commentCoun
 		colorTheme: context.theme,
 		additionalServices: reg => {
 			registerChatFixtureServices(reg);
+			reg.defineInstance(IChatTipService, new class extends mock<IChatTipService>() {
+				override readonly onDidDismissTip = Event.None;
+				override readonly onDidNavigateTip = Event.None;
+				override readonly onDidHideTip = Event.None;
+				override readonly onDidDisableTips = Event.None;
+				override getWelcomeTip() {
+					return showTip ? { id: 'fixture-tip', content: new MarkdownString('**Tip:** Reference files or folders with # to give the agent more context.') } : undefined;
+				}
+				override resetSession(): void { }
+				override hasMultipleTips(): boolean { return false; }
+			}());
 			reg.defineInstance(IQuickInputService, new class extends mock<IQuickInputService>() {
 				override readonly onShow = Event.None;
 				override readonly onHide = Event.None;
@@ -181,6 +194,10 @@ async function renderNewChatWidget(context: ComponentFixtureContext, commentCoun
 export default defineThemedFixtureGroup({ path: 'sessions/chat/newWidget/' }, {
 	NewSessionComments: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: context => renderNewChatWidget(context, 3),
+		render: context => renderNewChatWidget(context, 3, false),
+	}),
+	NewSessionTip: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: context => renderNewChatWidget(context, 0, true),
 	}),
 });

--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -27,6 +27,7 @@ import { TipEligibilityTracker } from './chatTipEligibilityTracker.js';
 import { ChatTipExperiment, ChatTipTier, extractCommandIds, ITipBuildContext, ITipDefinition, TIP_CATALOG } from './chatTipCatalog.js';
 import { ChatTipStorageKeys, TipTrackingCommands } from './chatTipStorageKeys.js';
 import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';
+import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
 
 type ChatTipEvent = {
 	tipId: string;
@@ -444,9 +445,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 			return undefined;
 		}
 
-		// Only show tips when there is exactly one foreground chat session visible.
-		const foregroundSessionCount = contextKeyService.getContextKeyValue<number>(ChatContextKeys.foregroundSessionCount.key);
-		if (foregroundSessionCount !== 1) {
+		if (!this._hasSingleForegroundChatSurface(contextKeyService)) {
 			return undefined;
 		}
 
@@ -497,6 +496,12 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		const tip = this._pickTip('welcome', contextKeyService);
 
 		return tip;
+	}
+
+	private _hasSingleForegroundChatSurface(contextKeyService: IContextKeyService): boolean {
+		const foregroundSessionCount = contextKeyService.getContextKeyValue<number>(ChatContextKeys.foregroundSessionCount.key);
+		return foregroundSessionCount === 1
+			|| (foregroundSessionCount === 0 && contextKeyService.getContextKeyValue<boolean>(IsSessionsWindowContext.key) === true);
 	}
 
 	private _findNextEligibleTip(currentTipId: string, contextKeyService: IContextKeyService): ITipDefinition | undefined {

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -22,6 +22,7 @@ import { NullWorkbenchAssignmentService } from '../../../../services/assignment/
 import { ChatTipService, CREATE_AGENT_INSTRUCTIONS_TRACKING_COMMAND, CREATE_AGENT_TRACKING_COMMAND, CREATE_PROMPT_TRACKING_COMMAND, CREATE_SKILL_TRACKING_COMMAND, FORK_CONVERSATION_TRACKING_COMMAND, IChatTip, ITipDefinition, TipEligibilityTracker } from '../../browser/chatTipService.js';
 import { AgentInstructionFileType, IPromptPath, IPromptsService, IAgentInstructionFile, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { storeSelectedModel } from '../../common/chatSelectedModel.js';
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
@@ -507,6 +508,15 @@ suite('ChatTipService', () => {
 
 		const tip = service.getWelcomeTip(contextKeyService);
 		assert.strictEqual(tip, undefined, 'Should not return a tip when no foreground chat sessions are visible');
+	});
+
+	test('returns a tip for the Agents new-session composer when foreground session count is zero', () => {
+		const service = createService();
+		contextKeyService.createKey(ChatContextKeys.foregroundSessionCount.key, 0);
+		contextKeyService.createKey(IsSessionsWindowContext.key, true);
+
+		const tip = service.getWelcomeTip(contextKeyService);
+		assert.ok(tip, 'Should return a tip for the Agents new-session composer');
 	});
 
 	test('returns undefined when foreground session count is greater than one', () => {


### PR DESCRIPTION
The Agents window's default New Session surface uses `NewChatWidget` rather than the shared `ChatWidget`, so the chat-tip support from #327895 did not render there.

This change:
- renders the shared accessible chat-tip content above the New Session input
- treats the Agents composer as the single foreground chat surface when no `IChatWidget` is registered
- adds service coverage and a deterministic component fixture
- documents the New Session tip behavior

Related to #327893.

## Testing
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts --grep ChatTipService` (84 passing)
- `npm run valid-layers-check`
- targeted hygiene check
- manually launched the Agents window and verified the accessible tip region appears above the New Session input

`npm run typecheck-client` is currently blocked by unrelated existing `@anthropic-ai/claude-agent-sdk` type mismatches in agent host tests.