### PR TITLE
nes: fix: share in-flight speculative requests across concurrent calls

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -12,7 +12,7 @@ import { RootedLineEdit } from '../../../platform/inlineEdits/common/dataTypes/r
 import { SpeculativeRequestsAutoExpandEditWindowLines, SpeculativeRequestsCursorPlacement, SpeculativeRequestsEnablement } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { InlineEditRequestLogContext, type MarkdownLoggable } from '../../../platform/inlineEdits/common/inlineEditLogContext';
 import { IObservableDocument, ObservableWorkspace } from '../../../platform/inlineEdits/common/observableWorkspace';
-import { IStatelessNextEditModelTelemetry, IStatelessNextEditProvider, IStatelessNextEditTelemetry, NoNextEditReason, StatelessNextEditDocument, StatelessNextEditRequest, StatelessNextEditResult, StreamedEdit } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
+import { IStatelessNextEditModelTelemetry, IStatelessNextEditProvider, IStatelessNextEditTelemetry, NoNextEditReason, StatelessNextEditDocument, StatelessNextEditRequest, StatelessNextEditResult, StatelessNextEditTelemetryBuilder, StreamedEdit } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { autorunWithChanges } from '../../../platform/inlineEdits/common/utils/observable';
 import { DocumentHistory, HistoryContext, IHistoryContextProvider } from '../../../platform/inlineEdits/common/workspaceEditTracker/historyContextProvider';
 import { IXtabHistoryEditEntry, IXtabHistoryEntry, NesXtabHistoryTracker } from '../../../platform/inlineEdits/common/workspaceEditTracker/nesXtabHistoryTracker';
@@ -46,7 +46,7 @@ import { INesConfigs } from './nesConfigs';
 import { CachedEdit, CachedOrRebasedEdit, NextEditCache } from './nextEditCache';
 import { LlmNESTelemetryBuilder, ReusedRequestKind } from './nextEditProviderTelemetry';
 import { INextEditResult, NextEditResult } from './nextEditResult';
-import { SpeculativeCancelReason, SpeculativeRequestManager } from './speculativeRequestManager';
+import { SpeculativeCancelReason, SpeculativePendingRequest, SpeculativeRequestManager } from './speculativeRequestManager';
 
 /**
  * Computes a reduced window range that encompasses both the original window (shrunk by one line
@@ -659,13 +659,21 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			&& !this._pendingStatelessNextEditRequest?.cancellationTokenSource.token.isCancellationRequested
 			&& this._pendingStatelessNextEditRequest || undefined;
 
-		// Check if we can reuse the speculative pending request (from when a suggestion was shown)
-		const specPending = this._specManager.pending;
-		const speculativeRequestMatches = specPending?.docId === curDocId
-			&& specPending?.postEditContent === documentAtInvocationTime.value
-			&& !specPending.request.cancellationTokenSource.token.isCancellationRequested
-			&& cursorInRequestEditWindow(specPending.request);
-		const speculativeRequest = speculativeRequestMatches ? specPending?.request : undefined;
+		// Check if we can reuse a speculative request (from when a suggestion was shown).
+		// Falls back to already-claimed speculatives so that concurrent `getNextEdit` calls
+		// for the same post-edit state join the in-flight request instead of duplicating it.
+		const speculativeMatches = (spec: SpeculativePendingRequest | null | undefined) =>
+			!!spec
+			&& spec.docId === curDocId
+			&& spec.postEditContent === documentAtInvocationTime.value
+			&& !spec.request.cancellationTokenSource.token.isCancellationRequested
+			&& cursorInRequestEditWindow(spec.request);
+
+		const pendingSpec = this._specManager.pending;
+		const matchedSpec = speculativeMatches(pendingSpec)
+			? pendingSpec
+			: this._specManager.findClaimed(speculativeMatches);
+		const speculativeRequest = matchedSpec?.request;
 
 		// Prefer speculative request if it matches (it was specifically created for this post-edit state)
 		const requestToReuse = speculativeRequest ?? existingNextEditRequest;
@@ -674,14 +682,16 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			// Nice! No need to make another request, we can reuse the result from a pending request.
 			if (speculativeRequest) {
 				logger.trace(`reusing speculative pending request (opportunityId=${speculativeRequest.opportunityId}, headerRequestId=${speculativeRequest.headerRequestId})`);
-				// Detach the speculative — caller is consuming it now.
-				this._specManager.consumePending();
+				if (matchedSpec === pendingSpec) {
+					// Detach the speculative — caller is consuming it now.
+					this._specManager.claimPending();
+				}
 			} else {
 				logger.trace(`reusing in-flight pending request (opportunityId=${requestToReuse.opportunityId}, headerRequestId=${requestToReuse.headerRequestId})`);
 			}
 
 			const requestStillCurrent = speculativeRequest
-				? speculativeRequestMatches // For speculative, we already checked it matches
+				? true // For speculative, we already checked it matches
 				: pendingRequestStillCurrent;
 
 			const reusedRequestKind = speculativeRequest ? ReusedRequestKind.Speculative : ReusedRequestKind.Async;
@@ -1234,9 +1244,14 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			return;
 		}
 
-		// Check if we already have a speculative request for this post-edit state
+		// Check if we already have a live speculative request for this post-edit state.
+		// A cancelled one doesn't count — it will never produce a result to reuse.
+		const matchesPostEditState = (spec: SpeculativePendingRequest) =>
+			spec.docId === docId
+			&& spec.postEditContent === postEditContent
+			&& !spec.request.cancellationTokenSource.token.isCancellationRequested;
 		const existingSpec = this._specManager.pending;
-		if (existingSpec?.docId === docId && existingSpec?.postEditContent === postEditContent) {
+		if ((existingSpec && matchesPostEditState(existingSpec)) || this._specManager.findClaimed(matchesPostEditState)) {
 			logger.trace('already have speculative request for post-edit state');
 			return;
 		}
@@ -1533,6 +1548,19 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			logger.trace(`speculative request completed with ${ithEdit + 1} edits`);
 		} catch (e) {
 			logger.trace(`speculative provider call error: ${ErrorUtils.toString(e)}`);
+			// Settle the request so that anyone reusing it (see `fetchNextEdit`) doesn't await
+			// forever. The detached streaming loop settles these itself, so this only covers
+			// failures thrown before the first edit was streamed. Note we complete with an error
+			// result rather than rejecting, since a speculative may have no consumer at all.
+			if (!nextEditRequest.firstEdit.isSettled) {
+				const reason = new NoNextEditReason.Unexpected(ErrorUtils.fromUnknown(e));
+				const result = Result.error(reason);
+				nextEditRequest.firstEdit.complete(result);
+				nextEditRequest.setResult(new StatelessNextEditResult(
+					result,
+					new StatelessNextEditTelemetryBuilder(nextEditRequest.headerRequestId).build(result)
+				));
+			}
 		}
 	}
 
@@ -1628,6 +1656,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		// Any in-flight speculative would land its result into a cache that's
 		// meant to be empty (and may be based on a now-stale model/auth/prompt).
 		this._specManager.cancelAll(SpeculativeCancelReason.CacheCleared);
+		this._specManager.invalidateClaimed(SpeculativeCancelReason.CacheCleared);
 	}
 }
 

--- a/extensions/copilot/src/extension/inlineEdits/node/speculativeRequestManager.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/speculativeRequestManager.ts
@@ -65,6 +65,8 @@ export interface ScheduledSpeculativeRequest {
  * Owns the lifecycle of NES speculative requests:
  *
  * - the in-flight `pending` speculative (the bet on a specific post-accept document state)
+ * - the `claimed` speculatives, already picked up by a `getNextEdit` caller but kept
+ *   discoverable so concurrent callers join them instead of duplicating the request
  * - the `scheduled` speculative deferred until its originating stream completes
  *
  * Centralizes cancellation with typed reasons so every triggered cancellation
@@ -75,6 +77,16 @@ export class SpeculativeRequestManager extends Disposable {
 
 	private _pending: SpeculativePendingRequest | null = null;
 	private _scheduled: ScheduledSpeculativeRequest | null = null;
+
+	/**
+	 * Speculatives that a `getNextEdit` caller has claimed and is awaiting.
+	 *
+	 * They stay discoverable here until they settle so that *concurrent* callers for the
+	 * same post-edit state join the same request instead of issuing a duplicate one. Keyed
+	 * by request identity: several may be in flight at once (e.g. one per document), and
+	 * evicting one on the arrival of another would reintroduce the duplicate-request bug.
+	 */
+	private readonly _claimed = new Map<StatelessNextEditRequest<CachedOrRebasedEdit>, SpeculativePendingRequest>();
 
 	constructor(private readonly _logger: ILogger) {
 		super();
@@ -92,9 +104,39 @@ export class SpeculativeRequestManager extends Disposable {
 		this._pending = req;
 	}
 
-	/** Detaches the pending speculative without cancelling — caller is consuming it. */
-	consumePending(): void {
+	/**
+	 * Detaches the pending speculative without cancelling — the caller is consuming it —
+	 * and keeps it discoverable via {@link findClaimed} until it settles.
+	 */
+	claimPending(): void {
+		const p = this._pending;
+		if (!p) {
+			return;
+		}
 		this._pending = null;
+		this._claimed.set(p.request, p);
+		// Release once the request settles, whatever the outcome.
+		//
+		// Deliberately `then(fn, fn)` and not `finally(fn)`: `setResultError` rejects
+		// `result`, and `finally` returns a *derived* promise that re-raises that rejection.
+		// Nothing holds that derived promise, so it would surface as an unhandled rejection
+		// even though the joining caller already awaits (and handles) `result` itself.
+		// `then(fn, fn)` consumes the rejection instead.
+		p.request.result.then(() => this._releaseClaimed(p), () => this._releaseClaimed(p));
+	}
+
+	/** Returns the first claimed speculative matching `predicate`, if any. */
+	findClaimed(predicate: (req: SpeculativePendingRequest) => boolean): SpeculativePendingRequest | undefined {
+		for (const claimed of this._claimed.values()) {
+			if (predicate(claimed)) {
+				return claimed;
+			}
+		}
+		return undefined;
+	}
+
+	private _releaseClaimed(req: SpeculativePendingRequest): void {
+		this._claimed.delete(req.request);
 	}
 
 	schedule(s: ScheduledSpeculativeRequest): void {
@@ -139,6 +181,7 @@ export class SpeculativeRequestManager extends Disposable {
 		if (this._pending?.docId === docId) {
 			this._cancelPending(SpeculativeCancelReason.DocumentClosed);
 		}
+		this.invalidateClaimed(SpeculativeCancelReason.DocumentClosed, req => req.docId === docId);
 	}
 
 	/**
@@ -181,6 +224,32 @@ export class SpeculativeRequestManager extends Disposable {
 			return;
 		}
 		this._pending = null;
+		this._cancelRequest(p, reason);
+	}
+
+	/**
+	 * Hard invalidation for claimed speculatives.
+	 *
+	 * Claimed speculatives deliberately survive the "nobody will want this anymore" reasons
+	 * ({@link SpeculativeCancelReason.Replaced}, `Superseded`, `Rejected`, `IgnoredDismissed`,
+	 * trajectory divergence): they have a live consumer awaiting them, and their lifetime is
+	 * already governed by `liveDependentants` plus that consumer's cancellation token.
+	 *
+	 * They must not survive reasons that invalidate the *result itself* — a cleared cache, a
+	 * closed document, or disposal — since a later caller could otherwise join a request built
+	 * on now-stale state.
+	 */
+	invalidateClaimed(reason: SpeculativeCancelReason, filter?: (req: SpeculativePendingRequest) => boolean): void {
+		for (const claimed of [...this._claimed.values()]) {
+			if (filter && !filter(claimed)) {
+				continue;
+			}
+			this._claimed.delete(claimed.request);
+			this._cancelRequest(claimed, reason);
+		}
+	}
+
+	private _cancelRequest(p: SpeculativePendingRequest, reason: SpeculativeCancelReason): void {
 		const headerRequestId = p.request.headerRequestId;
 		this._logger.trace(`cancelling speculative request: ${reason} (headerRequestId=${headerRequestId})`);
 		p.request.logContext.addLog(`speculative request cancelled: ${reason}`);
@@ -194,6 +263,7 @@ export class SpeculativeRequestManager extends Disposable {
 
 	override dispose(): void {
 		this.cancelAll(SpeculativeCancelReason.Disposed);
+		this.invalidateClaimed(SpeculativeCancelReason.Disposed);
 		super.dispose();
 	}
 }

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
@@ -72,6 +72,10 @@ type ProviderBehavior =
 		startSignal: DeferredPromise<void>;
 	}
 	| {
+		kind: 'throwBeforeFirstYield';
+		error: Error;
+	}
+	| {
 		kind: 'waitForCancellation';
 	};
 
@@ -167,6 +171,12 @@ class TestStatelessNextEditProvider implements IStatelessNextEditProvider {
 				}
 				const noSuggestions = new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, streamedEditWindow);
 				return new WithStatelessProviderTelemetry(noSuggestions, telemetryBuilder.build(Result.error(noSuggestions)));
+			}
+
+			if (behavior.kind === 'throwBeforeFirstYield') {
+				// Fails the stream before anything is yielded, so `firstEdit`/`result` are only
+				// settled by `_runSpeculativeProviderCall`'s outer catch.
+				throw behavior.error;
 			}
 
 			if (behavior.kind === 'waitThenYieldEditThenNoSuggestions') {
@@ -1672,6 +1682,48 @@ describe('NextEditProvider speculative requests', () => {
 			await claimed;
 
 			expect(statelessProvider.calls[1].wasCancelled).toBe(true);
+		});
+
+		it('settles a speculative that throws before its first yield instead of hanging its joiner', async () => {
+			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequests, SpeculativeRequestsEnablement.On);
+
+			const statelessProvider = new TestStatelessNextEditProvider();
+			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(1, 'const value = 2;') });
+			statelessProvider.enqueueBehavior({ kind: 'throwBeforeFirstYield', error: new Error('provider exploded') });
+			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(2, 'console.log(value + 1);') });
+			const { nextEditProvider, workspace } = createProviderAndWorkspace(statelessProvider);
+
+			const doc = workspace.addDocument({
+				id: DocumentId.create(URI.file('/test/spec-throws-before-yield.ts').toString()),
+				initialValue: 'const value = 1;\nconsole.log(value);',
+			});
+			doc.setSelection([new OffsetRange(0, 0)], undefined);
+
+			const suggestion = await getNextEdit(nextEditProvider, doc.id);
+			assert(suggestion.result?.edit);
+			nextEditProvider.handleShown(suggestion);
+			await statelessProvider.waitForCall(2);
+			await statelessProvider.calls[1].completed.p;
+
+			nextEditProvider.handleAcceptance(doc.id, suggestion);
+			doc.applyEdit(suggestion.result.edit.toEdit());
+
+			// Claims the failed speculative. Before the outer catch settled `firstEdit`/`result`
+			// this awaited forever; now the failure surfaces as `NoNextEditReason.Unexpected`,
+			// which `getNextEdit` rethrows as the underlying provider error.
+			await expect(getNextEdit(nextEditProvider, doc.id)).rejects.toThrow('provider exploded');
+
+			// The claimed entry must have been released, so the next call issues a fresh request
+			// rather than reusing (or re-failing on) the dead speculative.
+			const afterFailure = await getNextEdit(nextEditProvider, doc.id);
+
+			expect({
+				providerCalls: statelessProvider.calls.length,
+				recoveredEdit: afterFailure.result?.edit?.newText,
+			}).toEqual({
+				providerCalls: 3,
+				recoveredEdit: 'console.log(value + 1);',
+			});
 		});
 	});
 });

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
@@ -27,7 +27,7 @@ import { TestWorkspaceService } from '../../../../platform/test/node/testWorkspa
 import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
 import { Result } from '../../../../util/common/result';
 import { DeferredPromise } from '../../../../util/vs/base/common/async';
-import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import { CancellationToken, CancellationTokenSource } from '../../../../util/vs/base/common/cancellation';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { URI } from '../../../../util/vs/base/common/uri';
 import { generateUuid } from '../../../../util/vs/base/common/uuid';
@@ -65,6 +65,11 @@ type ProviderBehavior =
 		firstEdit: LineReplacement;
 		continueSignal: DeferredPromise<void>;
 		remainingEdits: readonly LineReplacement[];
+	}
+	| {
+		kind: 'waitThenYieldEditThenNoSuggestions';
+		edit: LineReplacement;
+		startSignal: DeferredPromise<void>;
 	}
 	| {
 		kind: 'waitForCancellation';
@@ -164,6 +169,18 @@ class TestStatelessNextEditProvider implements IStatelessNextEditProvider {
 				return new WithStatelessProviderTelemetry(noSuggestions, telemetryBuilder.build(Result.error(noSuggestions)));
 			}
 
+			if (behavior.kind === 'waitThenYieldEditThenNoSuggestions') {
+				// Blocks *before* the first yield, so the request stays unsettled while the
+				// test attaches multiple joiners. `yieldEditThenWait` can't do this: its first
+				// edit settles `firstEdit`/`result` and so releases the claim immediately.
+				await Promise.race([behavior.startSignal.p, cancellationRequested.p]);
+				if (!call.wasCancelled) {
+					yield new WithStatelessProviderTelemetry({ edit: behavior.edit, isFromCursorJump: false, targetDocument: activeDocId, window: streamedEditWindow, originalWindow: streamedOriginalWindow }, telemetryBuilder.build(Result.ok(undefined)));
+				}
+				const noSuggestions = new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, streamedEditWindow);
+				return new WithStatelessProviderTelemetry(noSuggestions, telemetryBuilder.build(Result.error(noSuggestions)));
+			}
+
 			yield new WithStatelessProviderTelemetry({ edit: behavior.edit, isFromCursorJump: false, targetDocument: activeDocId, window: streamedEditWindow, originalWindow: streamedOriginalWindow }, telemetryBuilder.build(Result.ok(undefined)));
 
 			if (behavior.kind === 'yieldEditThenWait') {
@@ -256,12 +273,12 @@ describe('NextEditProvider speculative requests', () => {
 		}
 	}
 
-	async function getNextEditWithTelemetry(nextEditProvider: NextEditProvider, docId: DocumentId): Promise<{ suggestion: Awaited<ReturnType<typeof getNextEdit>>; telemetry: ILlmNESTelemetry }> {
+	async function getNextEditWithTelemetry(nextEditProvider: NextEditProvider, docId: DocumentId, token: CancellationToken = CancellationToken.None): Promise<{ suggestion: Awaited<ReturnType<typeof getNextEdit>>; telemetry: ILlmNESTelemetry }> {
 		const context = createInlineContext();
 		const logContext = new InlineEditRequestLogContext(docId.toString(), 1, context);
 		const telemetryBuilder = new NextEditProviderTelemetryBuilder(gitExtensionService, mockNotebookService, workspaceService, nextEditProvider.ID, undefined);
 		try {
-			const suggestion = await nextEditProvider.getNextEdit(docId, context, logContext, CancellationToken.None, telemetryBuilder.nesBuilder);
+			const suggestion = await nextEditProvider.getNextEdit(docId, context, logContext, token, telemetryBuilder.nesBuilder);
 			const telemetry = telemetryBuilder.nesBuilder.build(false);
 			return { suggestion, telemetry };
 		} finally {
@@ -1460,6 +1477,199 @@ describe('NextEditProvider speculative requests', () => {
 
 			nextEditProvider.dispose();
 			await statelessProvider.calls[1].cancellationRequested.p;
+
+			expect(statelessProvider.calls[1].wasCancelled).toBe(true);
+		});
+	});
+
+	describe('concurrent reuse of a claimed speculative', () => {
+
+		/**
+		 * Drives a document to the point where its speculative request is in flight, gated
+		 * before its first yield, and the originating suggestion has been accepted+applied —
+		 * i.e. the next `getNextEdit` will claim the speculative.
+		 */
+		async function acceptSuggestionWithGatedSpeculative(
+			nextEditProvider: NextEditProvider,
+			statelessProvider: TestStatelessNextEditProvider,
+			doc: ReturnType<MutableObservableWorkspace['addDocument']>,
+			expectedCallCount: number
+		): Promise<void> {
+			const suggestion = await getNextEdit(nextEditProvider, doc.id);
+			assert(suggestion.result?.edit);
+			nextEditProvider.handleShown(suggestion);
+			await statelessProvider.waitForCall(expectedCallCount);
+
+			nextEditProvider.handleAcceptance(doc.id, suggestion);
+			doc.applyEdit(suggestion.result.edit.toEdit());
+		}
+
+		it('two concurrent calls share one in-flight speculative instead of duplicating it', async () => {
+			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequests, SpeculativeRequestsEnablement.On);
+
+			const startSignal = new DeferredPromise<void>();
+			const statelessProvider = new TestStatelessNextEditProvider();
+			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(1, 'const value = 2;') });
+			statelessProvider.enqueueBehavior({ kind: 'waitThenYieldEditThenNoSuggestions', edit: lineReplacement(2, 'console.log(value + 1);'), startSignal });
+			const { nextEditProvider, workspace } = createProviderAndWorkspace(statelessProvider);
+
+			const doc = workspace.addDocument({
+				id: DocumentId.create(URI.file('/test/spec-shared.ts').toString()),
+				initialValue: 'const value = 1;\nconsole.log(value);',
+			});
+			doc.setSelection([new OffsetRange(0, 0)], undefined);
+
+			await acceptSuggestionWithGatedSpeculative(nextEditProvider, statelessProvider, doc, 2);
+
+			// Both callers arrive while the speculative is still in flight: the first claims it,
+			// the second must find the claimed request rather than issuing a duplicate.
+			const first = getNextEditWithTelemetry(nextEditProvider, doc.id);
+			const second = getNextEditWithTelemetry(nextEditProvider, doc.id);
+			await flushMicrotasks();
+
+			startSignal.complete();
+			const [a, b] = await Promise.all([first, second]);
+
+			expect({
+				providerCalls: statelessProvider.calls.length,
+				firstEdit: a.suggestion.result?.edit?.newText,
+				secondEdit: b.suggestion.result?.edit?.newText,
+				firstReusedRequest: a.telemetry.reusedRequest,
+				secondReusedRequest: b.telemetry.reusedRequest,
+			}).toEqual({
+				providerCalls: 2,
+				firstEdit: 'console.log(value + 1);',
+				secondEdit: 'console.log(value + 1);',
+				firstReusedRequest: ReusedRequestKind.Speculative,
+				secondReusedRequest: ReusedRequestKind.Speculative,
+			});
+		});
+
+		it('keeps a shared speculative alive when only one of two joiners is cancelled', async () => {
+			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequests, SpeculativeRequestsEnablement.On);
+
+			const startSignal = new DeferredPromise<void>();
+			const statelessProvider = new TestStatelessNextEditProvider();
+			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(1, 'const value = 2;') });
+			statelessProvider.enqueueBehavior({ kind: 'waitThenYieldEditThenNoSuggestions', edit: lineReplacement(2, 'console.log(value + 1);'), startSignal });
+			const { nextEditProvider, workspace } = createProviderAndWorkspace(statelessProvider);
+
+			const doc = workspace.addDocument({
+				id: DocumentId.create(URI.file('/test/spec-shared-cancel.ts').toString()),
+				initialValue: 'const value = 1;\nconsole.log(value);',
+			});
+			doc.setSelection([new OffsetRange(0, 0)], undefined);
+
+			await acceptSuggestionWithGatedSpeculative(nextEditProvider, statelessProvider, doc, 2);
+
+			const firstCts = disposables.add(new CancellationTokenSource());
+			const first = getNextEditWithTelemetry(nextEditProvider, doc.id, firstCts.token);
+			const second = getNextEditWithTelemetry(nextEditProvider, doc.id);
+			await flushMicrotasks();
+
+			// The second joiner still depends on the request, so `liveDependentants` must keep
+			// it alive despite the first joiner going away.
+			firstCts.cancel();
+			await flushMicrotasks();
+
+			startSignal.complete();
+			const b = await second;
+			await first.catch(() => { /* the cancelled caller's outcome is irrelevant here */ });
+
+			expect({
+				providerCalls: statelessProvider.calls.length,
+				speculativeCancelled: statelessProvider.calls[1].wasCancelled,
+				secondEdit: b.suggestion.result?.edit?.newText,
+				secondReusedRequest: b.telemetry.reusedRequest,
+			}).toEqual({
+				providerCalls: 2,
+				speculativeCancelled: false,
+				secondEdit: 'console.log(value + 1);',
+				secondReusedRequest: ReusedRequestKind.Speculative,
+			});
+		});
+
+		it('keeps claimed speculatives for several documents discoverable at once', async () => {
+			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequests, SpeculativeRequestsEnablement.On);
+
+			const startSignal1 = new DeferredPromise<void>();
+			const startSignal2 = new DeferredPromise<void>();
+			const statelessProvider = new TestStatelessNextEditProvider();
+			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(1, 'const value = 2;') });
+			statelessProvider.enqueueBehavior({ kind: 'waitThenYieldEditThenNoSuggestions', edit: lineReplacement(2, 'console.log(value + 1);'), startSignal: startSignal1 });
+			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(1, 'const other = 2;') });
+			statelessProvider.enqueueBehavior({ kind: 'waitThenYieldEditThenNoSuggestions', edit: lineReplacement(2, 'console.log(other + 1);'), startSignal: startSignal2 });
+			const { nextEditProvider, workspace } = createProviderAndWorkspace(statelessProvider);
+
+			const doc1 = workspace.addDocument({
+				id: DocumentId.create(URI.file('/test/spec-multi-1.ts').toString()),
+				initialValue: 'const value = 1;\nconsole.log(value);',
+			});
+			doc1.setSelection([new OffsetRange(0, 0)], undefined);
+			const doc2 = workspace.addDocument({
+				id: DocumentId.create(URI.file('/test/spec-multi-2.ts').toString()),
+				initialValue: 'const other = 1;\nconsole.log(other);',
+			});
+			doc2.setSelection([new OffsetRange(0, 0)], undefined);
+
+			await acceptSuggestionWithGatedSpeculative(nextEditProvider, statelessProvider, doc1, 2);
+			const claim1 = getNextEditWithTelemetry(nextEditProvider, doc1.id);
+			await flushMicrotasks();
+
+			await acceptSuggestionWithGatedSpeculative(nextEditProvider, statelessProvider, doc2, 4);
+			const claim2 = getNextEditWithTelemetry(nextEditProvider, doc2.id);
+			await flushMicrotasks();
+
+			// doc1's speculative was claimed before doc2's; claiming doc2's must not evict it.
+			const secondClaim1 = getNextEditWithTelemetry(nextEditProvider, doc1.id);
+			await flushMicrotasks();
+
+			startSignal1.complete();
+			startSignal2.complete();
+			const [a, b, c] = await Promise.all([claim1, claim2, secondClaim1]);
+
+			expect({
+				providerCalls: statelessProvider.calls.length,
+				doc1Edit: a.suggestion.result?.edit?.newText,
+				doc2Edit: b.suggestion.result?.edit?.newText,
+				doc1SecondEdit: c.suggestion.result?.edit?.newText,
+				doc1SecondReusedRequest: c.telemetry.reusedRequest,
+			}).toEqual({
+				providerCalls: 4,
+				doc1Edit: 'console.log(value + 1);',
+				doc2Edit: 'console.log(other + 1);',
+				doc1SecondEdit: 'console.log(value + 1);',
+				doc1SecondReusedRequest: ReusedRequestKind.Speculative,
+			});
+		});
+
+		it('cancels an already-claimed speculative when clearCache() is called', async () => {
+			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequests, SpeculativeRequestsEnablement.On);
+
+			const startSignal = new DeferredPromise<void>();
+			const statelessProvider = new TestStatelessNextEditProvider();
+			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(1, 'const value = 2;') });
+			statelessProvider.enqueueBehavior({ kind: 'waitThenYieldEditThenNoSuggestions', edit: lineReplacement(2, 'console.log(value + 1);'), startSignal });
+			const { nextEditProvider, workspace } = createProviderAndWorkspace(statelessProvider);
+
+			const doc = workspace.addDocument({
+				id: DocumentId.create(URI.file('/test/spec-claimed-clear-cache.ts').toString()),
+				initialValue: 'const value = 1;\nconsole.log(value);',
+			});
+			doc.setSelection([new OffsetRange(0, 0)], undefined);
+
+			await acceptSuggestionWithGatedSpeculative(nextEditProvider, statelessProvider, doc, 2);
+
+			const claimed = getNextEditWithTelemetry(nextEditProvider, doc.id);
+			await flushMicrotasks();
+
+			// The speculative is claimed, so it is no longer reachable via `pending` — hard
+			// invalidation must still reach it, otherwise it could repopulate the cleared cache.
+			nextEditProvider.clearCache();
+			await statelessProvider.calls[1].cancellationRequested.p;
+
+			startSignal.complete();
+			await claimed;
 
 			expect(statelessProvider.calls[1].wasCancelled).toBe(true);
 		});


### PR DESCRIPTION
## Problem

NES fires a **speculative request** when a suggestion is shown, betting on the document state that results if the user accepts it.

`SpeculativeRequestManager.consumePending()` nulled the pending slot as soon as the first `getNextEdit` caller claimed the request. From that moment the request was reachable only through that caller's local variable, so a second overlapping `getNextEdit` for the same post-edit state found nothing in `pending` (nulled) and nothing in `_pendingStatelessNextEditRequest` (speculatives are never installed there — only `_executeNewNextEditRequest` assigns it, always with `isSpeculative: false`).

It therefore issued a **duplicate model request**, and:

1. two model requests ran for the same document state;
2. the second caller lost the speculative latency win, the `ReusedRequestKind.Speculative` telemetry, and the `speculativeRequestDelay` path in `computeMinimumResponseDelay`;
3. `liveDependentants` sharing — which exists precisely to keep a joined request alive for multiple dependants — never engaged for speculatives.

## Fix

`consumePending()` → `claimPending()`, which moves the request into a **claimed map** instead of dropping it. Claimed entries stay discoverable until their `result` settles, so concurrent callers join the in-flight request. `findClaimed()` does the lookup; `fetchNextEdit` prefers `pending` and falls back to claimed.

A map rather than a single slot: several speculatives can be claimed at once (e.g. one per document), and evicting one on the arrival of another would reintroduce the very bug being fixed.

**Cancellation is split by intent.** Claimed requests deliberately survive the "nobody will want this anymore" reasons (`Replaced`, `Superseded`, `Rejected`, `IgnoredDismissed`, trajectory divergence) — they have a live consumer, and their lifetime is already governed by `liveDependentants` plus that consumer's token. This is safe because a claim implies the suggestion was accepted, and accept/reject/ignore are mutually exclusive outcomes for the same suggestion. `invalidateClaimed()` still cancels them for reasons that invalidate the *result itself*: `CacheCleared`, `DocumentClosed`, `Disposed`.

### Prerequisite bug fix

`_runSpeculativeProviderCall`'s outer `catch` only logged, so a throw at the first `editStream.next()` left `firstEdit`/`result` **permanently unsettled** — any caller reusing that request would await forever. Pre-existing, but the claimed map would widen the window and leak the entry, so it's fixed here. It completes with an error `Result` rather than rejecting, since a speculative may have no consumer at all.

## Behavior when the feature is off

Unchanged, and verified rather than assumed. The claimed map is only populated via `_triggerSpeculativeRequest`, whose two call sites both sit inside `if (enablement === SpeculativeRequestsEnablement.On)`. The enum is exactly `On | Off` (default `Off`), so that check is a complete gate. Every new lookup degenerates to an empty-map no-op, leaving `requestToReuse` / `requestStillCurrent` / `reusedRequestKind` exactly as before.

To confirm this empirically I temporarily armed hard assertions (throw in `claimPending`; throw in `findClaimed`/`invalidateClaimed` if the map was ever non-empty) and ran the full `inlineEdits` + `xtab` suites with the speculative spec excluded: **1043 tests, zero probe hits**. Re-running the speculative spec with the same probes armed fired them 14 times, confirming the probes were live and not vacuous.

## Tests

Four new cases, each verified to **fail without the fix** (I disabled `findClaimed` → the 3 sharing tests failed; disabled the `clearCache` invalidation → the 4th timed out):

- two concurrent calls share one in-flight speculative instead of duplicating it
- a shared speculative stays alive when only one of two joiners is cancelled (`liveDependentants`)
- claimed speculatives for several documents stay discoverable at once (guards the map-vs-single-slot regression)
- `clearCache()` cancels an already-claimed speculative

This needed a new `waitThenYieldEditThenNoSuggestions` harness behavior that blocks *before* the first yield. The existing `yieldEditThenWait` yields first, which settles `firstEdit`/`result` and releases the claim immediately, making an overlap test racy.

## Validation

- Typecheck clean.
- Speculative spec: 37 passed, 2 skipped.
- Full `inlineEdits` + `xtab`: 1068 passed. The 11 failures (`ignoreImportChanges.spec.ts`, `xtabProvider.spec.ts`) are **pre-existing** — identical failures on a stashed baseline (1064 passed, the delta being exactly these 4 new tests).

## Known limitation (out of scope)

Manager cancellation only signals/disposes the CTS, and the speculative stream loop caches each edit without re-checking cancellation. A provider racing cancellation can therefore still write into a cleared cache. This change closes the *discovery* path but not the *write* path; fully closing it needs a generation guard at the cache-write site.
