### PR TITLE
copilot: stop monitoring sessions when editor CLI is hidden

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -57,7 +57,7 @@ import { ICopilotCLIMCPHandler, McpServerMappings, remapCustomAgentTools } from 
 const COPILOT_CLI_WORKSPACE_JSON_FILE_KEY = 'github.copilot.cli.workspaceSessionFile';
 const AGENT_HOST_ENABLED_SETTING_ID = 'chat.agentHost.enabled';
 const AGENT_HOST_DEFAULT_SESSIONS_PROVIDER_SETTING_ID = 'chat.agentHost.defaultSessionsProvider';
-const DEFAULT_TO_COPILOT_HARNESS_SETTING_ID = 'chat.defaultToCopilotHarness';
+const COPILOT_CLI_HIDE_EXTENSION_HOST_EDITOR_SETTING_ID = 'chat.editor.copilotCli.hideExtensionHost';
 const AGENT_HOST_COPILOT_CLIENT_NAME = 'vscode-agent-host';
 export const COPILOT_CLI_CHAT_PANEL_SYSTEM_MESSAGE = 'You are an AI assistant using Copilot CLI runtime in VS Code. You help users with software engineering tasks. When asked about your identity, you must state that you are an AI assistant using Copilot CLI runtime in VS Code.';
 
@@ -191,7 +191,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 			if (e.affectsConfiguration(ConfigKey.Advanced.CLIShowExternalSessions.fullyQualifiedId)) {
 				this.showExternalSessions = this.configurationService.getConfig(ConfigKey.Advanced.CLIShowExternalSessions);
 			}
-			if (e.affectsConfiguration(AGENT_HOST_ENABLED_SETTING_ID) || e.affectsConfiguration(this.defaultSessionsProviderSettingId)) {
+			if (e.affectsConfiguration(AGENT_HOST_ENABLED_SETTING_ID) || e.affectsConfiguration(this.sessionFileMonitoringDisabledSettingId)) {
 				this.updateSessionFileMonitoring();
 			}
 		}));
@@ -244,13 +244,13 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 			return true;
 		}
 
-		return this.configurationService.getNonExtensionConfig<boolean>(this.defaultSessionsProviderSettingId) !== true;
+		return this.configurationService.getNonExtensionConfig<boolean>(this.sessionFileMonitoringDisabledSettingId) !== true;
 	}
 
-	private get defaultSessionsProviderSettingId(): string {
+	private get sessionFileMonitoringDisabledSettingId(): string {
 		return this._agentSessionsWorkspace.isAgentSessionsWorkspace
 			? AGENT_HOST_DEFAULT_SESSIONS_PROVIDER_SETTING_ID
-			: DEFAULT_TO_COPILOT_HARNESS_SETTING_ID;
+			: COPILOT_CLI_HIDE_EXTENSION_HOST_EDITOR_SETTING_ID;
 	}
 
 	private updateSessionFileMonitoring(): void {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
@@ -260,14 +260,15 @@ describe('CopilotCLISessionService', () => {
 	// --- Tests ----------------------------------------------------------------------------------
 
 	describe('session file monitoring', () => {
-		it('skips the watcher when Agent Host is the default for the current window', async () => {
+		it('skips the watcher when the Extension Host Copilot CLI is inactive for the current window', async () => {
 			const cases = [
-				{ name: 'Agents window Agent Host default', isAgentSessionsWorkspace: true, agentHostEnabled: true, agentsDefault: true, editorDefault: false, expectedWatcherCount: 0 },
-				{ name: 'editor window Agent Host default', isAgentSessionsWorkspace: false, agentHostEnabled: true, agentsDefault: false, editorDefault: true, expectedWatcherCount: 0 },
-				{ name: 'Agents window Agent Host disabled', isAgentSessionsWorkspace: true, agentHostEnabled: false, agentsDefault: true, editorDefault: false, expectedWatcherCount: 1 },
-				{ name: 'editor window Agent Host disabled', isAgentSessionsWorkspace: false, agentHostEnabled: false, agentsDefault: false, editorDefault: true, expectedWatcherCount: 1 },
-				{ name: 'Agents window editor default only', isAgentSessionsWorkspace: true, agentHostEnabled: true, agentsDefault: false, editorDefault: true, expectedWatcherCount: 1 },
-				{ name: 'editor window Agents default only', isAgentSessionsWorkspace: false, agentHostEnabled: true, agentsDefault: true, editorDefault: false, expectedWatcherCount: 1 },
+				{ name: 'Agents window Agent Host default', isAgentSessionsWorkspace: true, agentHostEnabled: true, agentsDefault: true, editorHidden: false, editorDefault: false, expectedWatcherCount: 0 },
+				{ name: 'editor window Extension Host hidden', isAgentSessionsWorkspace: false, agentHostEnabled: true, agentsDefault: false, editorHidden: true, editorDefault: false, expectedWatcherCount: 0 },
+				{ name: 'Agents window Agent Host disabled', isAgentSessionsWorkspace: true, agentHostEnabled: false, agentsDefault: true, editorHidden: false, editorDefault: false, expectedWatcherCount: 1 },
+				{ name: 'editor window Agent Host disabled', isAgentSessionsWorkspace: false, agentHostEnabled: false, agentsDefault: false, editorHidden: true, editorDefault: false, expectedWatcherCount: 1 },
+				{ name: 'Agents window editor hidden only', isAgentSessionsWorkspace: true, agentHostEnabled: true, agentsDefault: false, editorHidden: true, editorDefault: false, expectedWatcherCount: 1 },
+				{ name: 'editor window Agents default only', isAgentSessionsWorkspace: false, agentHostEnabled: true, agentsDefault: true, editorHidden: false, editorDefault: false, expectedWatcherCount: 1 },
+				{ name: 'editor window Agent Host default only', isAgentSessionsWorkspace: false, agentHostEnabled: true, agentsDefault: false, editorHidden: false, editorDefault: true, expectedWatcherCount: 1 },
 			];
 
 			const results = [];
@@ -276,6 +277,7 @@ describe('CopilotCLISessionService', () => {
 				await Promise.all([
 					testConfiguration.setNonExtensionConfig('chat.agentHost.enabled', testCase.agentHostEnabled),
 					testConfiguration.setNonExtensionConfig('chat.agentHost.defaultSessionsProvider', testCase.agentsDefault),
+					testConfiguration.setNonExtensionConfig('chat.editor.copilotCli.hideExtensionHost', testCase.editorHidden),
 					testConfiguration.setNonExtensionConfig('chat.defaultToCopilotHarness', testCase.editorDefault),
 				]);
 				const fileSystem = new TrackingFileSystemService();
@@ -308,6 +310,37 @@ describe('CopilotCLISessionService', () => {
 			states.push({ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount });
 
 			await testConfiguration.setNonExtensionConfig('chat.agentHost.defaultSessionsProvider', false);
+			states.push({ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount });
+
+			sessionService.dispose();
+			states.push({ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount });
+
+			expect(states).toEqual([
+				{ created: 1, disposed: 0 },
+				{ created: 1, disposed: 1 },
+				{ created: 2, disposed: 1 },
+				{ created: 2, disposed: 2 },
+			]);
+		});
+
+		it('updates monitoring when the Extension Host Copilot CLI is hidden in the editor window', async () => {
+			const testConfiguration = disposables.add(new InMemoryConfigurationService(configurationService));
+			await Promise.all([
+				testConfiguration.setNonExtensionConfig('chat.agentHost.enabled', true),
+				testConfiguration.setNonExtensionConfig('chat.editor.copilotCli.hideExtensionHost', false),
+			]);
+			const fileSystem = new TrackingFileSystemService();
+			const sessionService = disposables.add(createSessionService({
+				configurationService: testConfiguration,
+				fileSystem,
+				isAgentSessionsWorkspace: false,
+			}));
+			const states = [{ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount }];
+
+			await testConfiguration.setNonExtensionConfig('chat.editor.copilotCli.hideExtensionHost', true);
+			states.push({ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount });
+
+			await testConfiguration.setNonExtensionConfig('chat.editor.copilotCli.hideExtensionHost', false);
 			states.push({ created: fileSystem.createFileSystemWatcherCallCount, disposed: fileSystem.disposeFileSystemWatcherCallCount });
 
 			sessionService.dispose();


### PR DESCRIPTION
## What changed

- use `chat.editor.copilotCli.hideExtensionHost` to control the extension-host Copilot CLI session-state watcher in editor windows
- preserve the existing Agent Host default-provider behavior in the Agents window
- cover startup and live configuration changes with focused unit tests

## Why

The previous editor-window gate used `chat.defaultToCopilotHarness`, which only selects the default provider. When the extension-host Copilot CLI was hidden in favor of Agent Host but was not the default, VS Code still recursively watched the shared `~/.copilot/session-state` tree.

## Validation

- `cd extensions/copilot && npm run compile`
- focused `CopilotCLISessionService` unit tests: 50 passed, 1 skipped
- targeted hygiene checks and pre-commit hygiene hook

(Written by Copilot)