### PR TITLE
sessions: add Split Right for chat tabs

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -189,6 +189,8 @@ Read-only is honored on both rendering paths: `SessionView` only routes an `Unti
 
 The active session (`IActiveSession`) extends `ISession` with an `activeChat` observable that tracks which chat the user is viewing.
 
+**Split Right** opens a tab's chat in a transient adjacent leaf. Its synthetic session id gives that leaf independent grid and active-chat state. Detached leaves are not persisted, cannot be dragged, and close when their source session or chat disappears.
+
 Chat input history in the Agents Window is scoped by `ISession.sessionId`. Pressing Up/Down in a chat input only navigates prompts previously submitted in the same session, including across multiple chats in that session. Users can disable `chat.agentSessions.scopedInputHistory` to restore shared input history across sessions. When a provider replaces a temporary untitled session with a committed session after the first send, history is moved from the temporary session id to the committed session id.
 
 ### Workspaces and Folders

--- a/src/vs/sessions/browser/parts/chatCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/chatCompositeBar.ts
@@ -12,7 +12,7 @@ import { ScrollableElement } from '../../../base/browser/ui/scrollbar/scrollable
 import { ScrollbarVisibility } from '../../../base/common/scrollable.js';
 import { autorun } from '../../../base/common/observable.js';
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
-import { Action } from '../../../base/common/actions.js';
+import { Action, Separator } from '../../../base/common/actions.js';
 import { ActionBar } from '../../../base/browser/ui/actionbar/actionbar.js';
 import { InputBox } from '../../../base/browser/ui/inputbox/inputBox.js';
 import { defaultInputBoxStyles } from '../../../platform/theme/browser/defaultStyles.js';
@@ -390,6 +390,12 @@ export class ChatCompositeBar extends Disposable {
 			this._startTabEditing(chatTab);
 		}));
 
+		const splitRightAction = this._tabDisposables.add(new Action('sessionCompositeBar.splitChatRight', localize('splitChatRight', "Split Right"), undefined, true, async () => {
+			if (session) {
+				this._sessionsService.splitChat(session, chat, 'right');
+			}
+		}));
+
 		// Delete permanently removes the chat (destructive). Only non-main chats
 		// can be deleted; the main chat lives and dies with its session.
 		const deleteAction = this._tabDisposables.add(new Action('sessionCompositeBar.deleteChat', localize('deleteChat', "Delete Chat"), undefined, true, async () => {
@@ -422,6 +428,15 @@ export class ChatCompositeBar extends Disposable {
 				getActions: () => {
 					const capabilities = getChatCapabilities(chat, session, undefined);
 					const actions = [];
+					const canSplit = !!session
+						&& session.isCreated.get()
+						&& session.chats.get().some(candidate => candidate.resource.toString() === chat.resource.toString());
+					if (canSplit) {
+						actions.push(splitRightAction);
+					}
+					if (canSplit && (capabilities.canRename || capabilities.canDelete)) {
+						actions.push(new Separator());
+					}
 					if (capabilities.canRename) {
 						actions.push(renameAction);
 					}

--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -238,11 +238,11 @@ export class SessionHeader extends Disposable {
 	}
 
 	private _registerDragSource(): void {
-		this._container.draggable = true;
+		this._container.draggable = false;
 
 		this._register(addDisposableListener(this._container, EventType.DRAG_START, (e: DragEvent) => {
 			const session = this._session;
-			if (!session || !e.dataTransfer) {
+			if (!session || session.detachedChat || !e.dataTransfer) {
 				e.preventDefault();
 				return;
 			}
@@ -291,6 +291,7 @@ export class SessionHeader extends Disposable {
 		// Cancel any in-flight rename when switching sessions.
 		this._cancelTitleEditing();
 		this._session = session;
+		this._container.draggable = !!session && !session.detachedChat;
 		this._toolbar.context = session;
 		this._metaToolbar.context = session;
 		this._statusIcon.reset();

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -462,43 +462,46 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	}
 
 	async createNewChatInSession(session: ISession, options?: ICreateNewChatInSessionOptions): Promise<IChat | undefined> {
-		const provider = this._getProvider(session);
+		const live = this._resolveLiveSession(session);
+		const provider = this._getProvider(live);
 		if (!provider) {
-			this.logService.warn(`[SessionsManagement] createNewChatInSession: provider '${session.providerId}' not found`);
+			this.logService.warn(`[SessionsManagement] createNewChatInSession: provider '${live.providerId}' not found`);
 			return undefined;
 		}
 		// `forceNew` skips reuse so callers can reset the composer right after
 		// sending a chat (which may still transiently report `Untitled`).
 		if (!options?.forceNew) {
-			const existingUntitled = session.chats.get().find(c => c.status.get() === SessionStatus.Untitled);
+			const existingUntitled = live.chats.get().find(c => c.status.get() === SessionStatus.Untitled);
 			if (existingUntitled) {
 				return existingUntitled;
 			}
 		}
-		const created = await provider.createNewChat(session.sessionId);
+		const created = await provider.createNewChat(live.sessionId);
 		return created;
 	}
 
 	async forkChatInSession(session: ISession, sourceChat: URI, turnId: string): Promise<IChat> {
-		const provider = this._getProvider(session);
+		const live = this._resolveLiveSession(session);
+		const provider = this._getProvider(live);
 		if (!provider) {
-			throw new Error(`Provider '${session.providerId}' not found for session '${session.sessionId}'`);
+			throw new Error(`Provider '${live.providerId}' not found for session '${live.sessionId}'`);
 		}
-		if (!session.capabilities.get().supportsMultipleChats) {
-			throw new Error(`Session '${session.sessionId}' does not support forking into a chat`);
+		if (!live.capabilities.get().supportsMultipleChats) {
+			throw new Error(`Session '${live.sessionId}' does not support forking into a chat`);
 		}
-		return provider.forkChat(session.sessionId, sourceChat, turnId);
+		return provider.forkChat(live.sessionId, sourceChat, turnId);
 	}
 
 	async createSideChatInSession(session: ISession, sourceChat: URI, turnId: string, selection?: ISideChatSelection): Promise<IChat> {
-		const provider = this._getProvider(session);
+		const live = this._resolveLiveSession(session);
+		const provider = this._getProvider(live);
 		if (!provider) {
-			throw new Error(`Provider '${session.providerId}' not found for session '${session.sessionId}'`);
+			throw new Error(`Provider '${live.providerId}' not found for session '${live.sessionId}'`);
 		}
-		if (!session.capabilities.get().supportsSideChat) {
-			throw new Error(`Session '${session.sessionId}' does not support side chats`);
+		if (!live.capabilities.get().supportsSideChat) {
+			throw new Error(`Session '${live.sessionId}' does not support side chats`);
 		}
-		return provider.createSideChat(session.sessionId, sourceChat, turnId, selection);
+		return provider.createSideChat(live.sessionId, sourceChat, turnId, selection);
 	}
 
 	/**
@@ -808,20 +811,21 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	}
 
 	async sendRequest(session: ISession, chat: IChat, options: ISendRequestOptions): Promise<void> {
+		const live = this._resolveLiveSession(session);
 		// Sending into an existing session abandons any in-progress new session,
 		// so dispose it to release its eager backend session.
 		this.discardNewSession();
 
-		const provider = this._getProvider(session);
+		const provider = this._getProvider(live);
 		if (!provider) {
-			throw new Error(`Sessions provider '${session.providerId}' not found`);
+			throw new Error(`Sessions provider '${live.providerId}' not found`);
 		}
 
 		if (options.background) {
 			// Fire-and-forget so the composer can reset immediately. Unlike the
 			// foreground path this skips `_onWillSendRequest` so the view's
 			// send-follow does not navigate the visible slot into the sent chat.
-			this._sendRequestInBackground(provider, session, chat, options).catch(e => {
+			this._sendRequestInBackground(provider, live, chat, options).catch(e => {
 				this.logService.error('[SessionsManagement] Failed to send background request:', e);
 			});
 			return;
@@ -831,19 +835,19 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		// can use this to prewarm caches whose result is consumed when
 		// `onDidSendRequest` fires below. The view service observes the will/did
 		// send pair to keep the sent chat active in the visible slot.
-		this._onWillSendRequest.fire(session);
+		this._onWillSendRequest.fire(live);
 
-		const sendOptions = this._augmentOptionsForTroubleshoot(session, options);
+		const sendOptions = this._augmentOptionsForTroubleshoot(live, options);
 		const chatResourceKey = chat.resource.toString();
 		this._pendingSendChatResources.add(chatResourceKey);
 		let updatedSession: ISession;
 		try {
-			updatedSession = await provider.sendRequest(session.sessionId, chat.resource, sendOptions);
+			updatedSession = await provider.sendRequest(live.sessionId, chat.resource, sendOptions);
 		} finally {
 			this._pendingSendChatResources.delete(chatResourceKey);
 		}
-		if (updatedSession.sessionId !== session.sessionId) {
-			this.logService.info(`[SessionsManagement] sendRequest: active session replaced: ${session.sessionId} -> ${updatedSession.sessionId}`);
+		if (updatedSession.sessionId !== live.sessionId) {
+			this.logService.info(`[SessionsManagement] sendRequest: active session replaced: ${live.sessionId} -> ${updatedSession.sessionId}`);
 		}
 
 		this._onDidSendRequest.fire({ session: updatedSession, chat, isNewSession: false, isNewChat: true, options });
@@ -878,18 +882,32 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return this.sessionsProvidersService.getProviders().find(p => p.id === session.providerId);
 	}
 
+	/**
+	 * Resolve a view adapter back to the provider-owned session for model operations.
+	 * View-layer adapters such as `DetachedChatSession` carry a synthetic
+	 * `sessionId` to own an independent grid slot, but provider calls need the
+	 * real id. This is a no-op for provider-owned sessions.
+	 */
+	private _resolveLiveSession(session: ISession): ISession {
+		const live = this.getSession(session.resource);
+		return live?.providerId === session.providerId ? live : session;
+	}
+
 	async archiveSession(session: ISession): Promise<void> {
-		await this._getProvider(session)?.archiveSession(session.sessionId);
-		this._onDidArchiveSession.fire(session);
+		const live = this._resolveLiveSession(session);
+		await this._getProvider(live)?.archiveSession(live.sessionId);
+		this._onDidArchiveSession.fire(live);
 	}
 
 	async unarchiveSession(session: ISession): Promise<void> {
-		await this._getProvider(session)?.unarchiveSession(session.sessionId);
-		this._onDidUnarchiveSession.fire(session);
+		const live = this._resolveLiveSession(session);
+		await this._getProvider(live)?.unarchiveSession(live.sessionId);
+		this._onDidUnarchiveSession.fire(live);
 	}
 
 	async setSessionReadState(session: ISession, isRead: boolean): Promise<void> {
-		await this._getProvider(session)?.setSessionReadState(session.sessionId, isRead);
+		const live = this._resolveLiveSession(session);
+		await this._getProvider(live)?.setSessionReadState(live.sessionId, isRead);
 	}
 
 	markRead(session: ISession): Promise<void> {
@@ -905,22 +923,24 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	}
 
 	async deleteSession(session: ISession): Promise<void> {
-		await this._getProvider(session)?.deleteSession(session.sessionId);
-		this._onDidDeleteSession.fire(session);
+		const live = this._resolveLiveSession(session);
+		await this._getProvider(live)?.deleteSession(live.sessionId);
+		this._onDidDeleteSession.fire(live);
 	}
 
 	async deleteSessions(sessions: readonly ISession[]): Promise<void> {
 		const byProvider = new Map<ISessionsProvider, ISession[]>();
 		for (const session of sessions) {
-			const provider = this._getProvider(session);
+			const live = this._resolveLiveSession(session);
+			const provider = this._getProvider(live);
 			if (!provider) {
 				continue;
 			}
 			const group = byProvider.get(provider);
 			if (group) {
-				group.push(session);
+				group.push(live);
 			} else {
-				byProvider.set(provider, [session]);
+				byProvider.set(provider, [live]);
 			}
 		}
 
@@ -942,20 +962,23 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	}
 
 	async deleteChat(session: ISession, chatUri: URI, options?: IDeleteChatOptions): Promise<void> {
-		const deleted = await this._getProvider(session)?.deleteChat(session.sessionId, chatUri, options);
+		const live = this._resolveLiveSession(session);
+		const deleted = await this._getProvider(live)?.deleteChat(live.sessionId, chatUri, options);
 		if (deleted) {
-			this._onDidDeleteChat.fire(session);
+			this._onDidDeleteChat.fire(live);
 		}
 	}
 
 	async renameChat(session: ISession, chatUri: URI, title: string): Promise<void> {
-		await this._getProvider(session)?.renameChat(session.sessionId, chatUri, title);
-		this._onDidRenameChat.fire(session);
+		const live = this._resolveLiveSession(session);
+		await this._getProvider(live)?.renameChat(live.sessionId, chatUri, title);
+		this._onDidRenameChat.fire(live);
 	}
 
 	async renameSession(session: ISession, title: string): Promise<void> {
-		await this._getProvider(session)?.renameSession(session.sessionId, title);
-		this._onDidRenameSession.fire(session);
+		const live = this._resolveLiveSession(session);
+		await this._getProvider(live)?.renameSession(live.sessionId, title);
+		this._onDidRenameSession.fire(live);
 	}
 }
 

--- a/src/vs/sessions/services/sessions/browser/sessionsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsService.ts
@@ -18,6 +18,7 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { localize } from '../../../../nls.js';
 import { ChatInteractivity, ChatOriginKind, IChat, ISession, SessionStatus } from '../common/session.js';
+import { DetachedChatSession } from '../common/detachedChatSession.js';
 import { IActiveSession, ICreateNewChatInSessionOptions, ICreateNewSessionOptions, inheritableSessionTarget, IRecentlyOpenedSessions, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
 import { ISessionsProvidersService } from './sessionsProvidersService.js';
 import { SessionsNavigation } from './sessionNavigation.js';
@@ -210,6 +211,11 @@ export interface ISessionsService {
 	insertAt(session: ISession, targetSessionId: string, side: 'left' | 'right', activate?: boolean): void;
 
 	/**
+	 * Open one chat in an adjacent transient leaf while leaving its session visible.
+	 */
+	splitChat(session: ISession, chat: IChat, side: 'left' | 'right'): void;
+
+	/**
 	 * Toggle a session's stickiness in the grid. The session keeps its grid
 	 * slot when toggled. If the session is not currently visible, it is
 	 * appended to the grid as sticky.
@@ -392,6 +398,17 @@ export class SessionsService extends Disposable implements ISessionsService {
 		// one disappears.
 		this._register(this.sessionsManagementService.onDidChangeSessions(e => this._onDidChangeSessions(e)));
 
+		// removeMany feeds back into this autorun, but its transactional refresh leaves no matching slots for the next pass.
+		this._register(autorun(reader => {
+			const detachedSessionIds = this.visibleSessions.read(reader)
+				.filter((session): session is IActiveSession => !!session?.detachedChat)
+				.filter(session => !session.chats.read(reader).some(chat => this.uriIdentityService.extUri.isEqual(chat.resource, session.detachedChat!.resource)))
+				.map(session => session.sessionId);
+			if (detachedSessionIds.length > 0) {
+				this._visibility.removeMany(detachedSessionIds);
+			}
+		}));
+
 		// Reflect provider session replacement (e.g. a draft graduating into a
 		// committed session) onto the grid slot.
 		this._register(this.sessionsManagementService.onDidReplaceSession(({ from, to }) => this._onDidReplaceSession(from, to)));
@@ -437,6 +454,13 @@ export class SessionsService extends Disposable implements ISessionsService {
 	}
 
 	private _onDidReplaceSession(from: ISession, to: ISession): void {
+		const detachedSessionIds = this._visibility.visibleSessions.get()
+			.filter((session): session is IActiveSession => !!session?.detachedChat)
+			.filter(session =>
+				session.providerId === from.providerId
+				&& this.uriIdentityService.extUri.isEqual(session.resource, from.resource))
+			.map(session => session.sessionId);
+		this._visibility.removeMany(detachedSessionIds);
 		this._visibility.updateSession(from, to);
 	}
 
@@ -501,6 +525,18 @@ export class SessionsService extends Disposable implements ISessionsService {
 
 	private _onDidChangeSessions(e: ISessionsChangeEvent): void {
 		const currentActive = this._visibility.activeSession.get();
+		const removedDetachedSessionIds = this._visibility.visibleSessions.get()
+			.filter((session): session is IActiveSession => !!session?.detachedChat)
+			.filter(session => e.removed.some(removed =>
+				removed.providerId === session.providerId
+				&& this.uriIdentityService.extUri.isEqual(removed.resource, session.resource)))
+			.map(session => session.sessionId);
+		const activeSessionWasRemoved = !!currentActive && (
+			e.removed.some(removed => removed.sessionId === currentActive.sessionId)
+			|| (currentActive.detachedChat !== undefined && e.removed.some(removed =>
+				removed.providerId === currentActive.providerId
+				&& this.uriIdentityService.extUri.isEqual(removed.resource, currentActive.resource)))
+		);
 
 		// Clean removed sessions out of the visibility model (drops their grid
 		// slot and disposes their wrapper). If the active session is among the
@@ -511,14 +547,14 @@ export class SessionsService extends Disposable implements ISessionsService {
 			for (const session of e.removed) {
 				this._sessionStates.delete(session.resource);
 			}
-			this._visibility.removeMany(e.removed.map(r => r.sessionId));
+			this._visibility.removeMany([...e.removed.map(r => r.sessionId), ...removedDetachedSessionIds]);
 		}
 
 		if (!currentActive) {
 			return;
 		}
 
-		if (e.removed.length && e.removed.some(r => r.sessionId === currentActive.sessionId)) {
+		if (e.removed.length && activeSessionWasRemoved) {
 			const fallback = this._visibility.activeSession.get();
 			if (fallback && this.sessionsManagementService.getSession(fallback.resource)) {
 				this.openSession(fallback.resource);
@@ -835,6 +871,14 @@ export class SessionsService extends Disposable implements ISessionsService {
 		this._visibility.insertAt(session, targetSessionId, side, activate);
 	}
 
+	splitChat(session: ISession, chat: IChat, side: 'left' | 'right'): void {
+		if (session.status.get() === SessionStatus.Untitled
+			|| !session.chats.get().some(candidate => this.uriIdentityService.extUri.isEqual(candidate.resource, chat.resource))) {
+			return;
+		}
+		this._visibility.insertAt(new DetachedChatSession(session, chat), session.sessionId, side, true);
+	}
+
 	closeSession(session: ISession | undefined): void {
 		const sessionId = session?.sessionId;
 		const visible = this._visibility.visibleSessions.get();
@@ -991,6 +1035,11 @@ export class SessionsService extends Disposable implements ISessionsService {
 		const entries: ISessionState[] = [];
 		visible.forEach((session, index) => {
 			if (!session) {
+				return;
+			}
+
+			// Detached leaves share their source resource and must remain transient.
+			if (session.detachedChat) {
 				return;
 			}
 

--- a/src/vs/sessions/services/sessions/browser/visibleSessions.ts
+++ b/src/vs/sessions/services/sessions/browser/visibleSessions.ts
@@ -9,6 +9,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IActiveSession } from '../common/sessionsManagement.js';
 import { ChatInteractivity, ChatOriginKind, IChat, ISession, SessionStatus } from '../common/session.js';
+import { isDetachedChatSession } from '../common/detachedChatSession.js';
 
 /**
  * Wraps an {@link ISession} with an active chat observable to form an
@@ -219,6 +220,10 @@ export class VisibleSession extends Disposable implements IActiveSession {
 			}
 		}
 		return undefined;
+	}
+
+	get detachedChat(): IChat | undefined {
+		return isDetachedChatSession(this._session) ? this._session.chat : undefined;
 	}
 
 	setSticky(value: boolean): void {

--- a/src/vs/sessions/services/sessions/common/detachedChatSession.ts
+++ b/src/vs/sessions/services/sessions/common/detachedChatSession.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { constObservable, derived, IObservable } from '../../../../base/common/observable.js';
+import { IChat, ISession } from './session.js';
+
+/**
+ * Returns the stable synthetic session id used by a detached chat grid slot.
+ */
+export function getDetachedChatSessionId(session: ISession, chat: IChat): string {
+	return `${session.sessionId}::detached::${chat.resource.toString()}`;
+}
+
+/**
+ * Presents one chat from another session as an independent, transient session.
+ */
+export class DetachedChatSession implements ISession {
+
+	readonly sessionId: string;
+	readonly chats: IObservable<readonly IChat[]>;
+	readonly mainChat: IObservable<IChat>;
+
+	constructor(
+		readonly session: ISession,
+		readonly chat: IChat,
+	) {
+		this.sessionId = getDetachedChatSessionId(session, chat);
+		this.chats = derived(this, reader => {
+			const currentChat = this.session.chats.read(reader).find(candidate => candidate.resource.toString() === this.chat.resource.toString());
+			return currentChat ? [currentChat] : [];
+		});
+		this.mainChat = constObservable(chat);
+	}
+
+	get resource() { return this.session.resource; }
+	get providerId() { return this.session.providerId; }
+	get sessionType() { return this.session.sessionType; }
+	get icon() { return this.session.icon; }
+	get createdAt() { return this.session.createdAt; }
+	get workspace() { return this.session.workspace; }
+	get hasGitRepository() { return this.session.hasGitRepository; }
+	get worktreePending() { return this.session.worktreePending; }
+	get isQuickChat() { return this.session.isQuickChat; }
+	get title() { return this.session.title; }
+	get updatedAt() { return this.session.updatedAt; }
+	get status() { return this.session.status; }
+	get changesSummary() { return this.session.changesSummary; }
+	get changes() { return this.session.changes; }
+	get changesets() { return this.session.changesets; }
+	get externalChanges() { return this.session.externalChanges; }
+	get modelId() { return this.session.modelId; }
+	get mode() { return this.session.mode; }
+	get loading() { return this.session.loading; }
+	get isArchived() { return this.session.isArchived; }
+	get isRead() { return this.session.isRead; }
+	get description() { return this.session.description; }
+	get lastTurnEnd() { return this.session.lastTurnEnd; }
+	get capabilities() { return this.session.capabilities; }
+}
+
+/** Returns whether a session is a transient detached chat view. */
+export function isDetachedChatSession(session: ISession): session is DetachedChatSession {
+	return session instanceof DetachedChatSession;
+}

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -147,6 +147,9 @@ export interface IActiveSession extends ISession {
 	/** The currently active chat within this session. */
 	readonly activeChat: IObservable<IChat>;
 
+	/** Set when this slot is a detached single-chat view of another session's chat. */
+	readonly detachedChat?: IChat;
+
 	readonly isCreated: IObservable<boolean>;
 
 	/** Whether this session is sticky in the sessions part's grid. */

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -257,6 +257,61 @@ suite('SessionsManagementService', () => {
 		assert.deepStrictEqual({ resolved }, { resolved: true });
 	});
 
+	test('splitChat opens one chat in a transient leaf without duplicating it', async () => {
+		const splitChat = { ...stubChat, resource: URI.parse('test:///split') };
+		const session = stubSession({
+			sessionId: 'split',
+			providerId: 'test',
+			status: constObservable(SessionStatus.Completed),
+			chats: constObservable([stubChat, splitChat]),
+			mainChat: constObservable(stubChat),
+		});
+		const { view } = createSessionsManagementService(session, disposables);
+
+		await view.openSession(session.resource);
+		view.splitChat(session, splitChat, 'right');
+		view.splitChat(session, splitChat, 'right');
+
+		const afterSplit = {
+			visible: view.visibleSessions.get().map(activeSession => ({
+				sessionId: activeSession?.sessionId,
+				activeChat: activeSession?.activeChat.get().resource.toString(),
+			})),
+			active: view.activeSession.get()?.sessionId,
+		};
+		view.closeSession(view.activeSession.get());
+
+		assert.deepStrictEqual({ afterSplit, afterClose: view.visibleSessions.get().map(activeSession => activeSession?.sessionId) }, {
+			afterSplit: {
+				visible: [
+					{ sessionId: session.sessionId, activeChat: stubChat.resource.toString() },
+					{ sessionId: `${session.sessionId}::detached::${splitChat.resource.toString()}`, activeChat: splitChat.resource.toString() },
+				],
+				active: `${session.sessionId}::detached::${splitChat.resource.toString()}`,
+			},
+			afterClose: [session.sessionId],
+		});
+	});
+
+	test('splitChat closes the detached leaf when its chat is removed', async () => {
+		const splitChat = { ...stubChat, resource: URI.parse('test:///split-removed') };
+		const chats = observableValue<readonly IChat[]>('splitChats', [stubChat, splitChat]);
+		const session = stubSession({
+			sessionId: 'split-removed',
+			providerId: 'test',
+			status: constObservable(SessionStatus.Completed),
+			chats,
+			mainChat: constObservable(stubChat),
+		});
+		const { view } = createSessionsManagementService(session, disposables);
+
+		await view.openSession(session.resource);
+		view.splitChat(session, splitChat, 'right');
+		chats.set([stubChat], undefined);
+
+		assert.deepStrictEqual(view.visibleSessions.get().map(activeSession => activeSession?.sessionId), [session.sessionId]);
+	});
+
 	test('marks the active session as read via its provider even when its provider state was unread', async () => {
 		const isRead = observableValue('isRead', false);
 		const session = stubSession({ sessionId: 'unread', providerId: 'test', isRead });

--- a/src/vs/sessions/services/sessions/test/browser/visibleSessions.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/visibleSessions.test.ts
@@ -12,6 +12,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { VisibleSession, VisibleSessions } from '../../browser/visibleSessions.js';
+import { DetachedChatSession, getDetachedChatSessionId } from '../../common/detachedChatSession.js';
 import { ChatInteractivity, ChatOriginKind, IChat, ISession, SessionStatus } from '../../common/session.js';
 
 const stubChat: IChat = {
@@ -97,6 +98,31 @@ suite('VisibleSessions', () => {
 		}, {
 			visible: true,
 			resourceOverride: true,
+		});
+	});
+
+	test('detached chat adapter has an independent id and exposes only its chat', () => {
+		const detachedChat = { ...stubChat, resource: URI.parse('test:///detached') };
+		const chats = observableValue<readonly IChat[]>('chats', [stubChat, detachedChat]);
+		const session = { ...stubSession('A'), chats };
+		const detached = new DetachedChatSession(session, detachedChat);
+
+		const beforeRemoval = {
+			sessionId: detached.sessionId,
+			resource: detached.resource.toString(),
+			chats: detached.chats.get().map(chat => chat.resource.toString()),
+			mainChat: detached.mainChat.get().resource.toString(),
+		};
+		chats.set([stubChat], undefined);
+
+		assert.deepStrictEqual({ beforeRemoval, afterRemoval: detached.chats.get().map(chat => chat.resource.toString()) }, {
+			beforeRemoval: {
+				sessionId: getDetachedChatSessionId(session, detachedChat),
+				resource: session.resource.toString(),
+				chats: [detachedChat.resource.toString()],
+				mainChat: detachedChat.resource.toString(),
+			},
+			afterRemoval: [],
 		});
 	});
 
@@ -362,6 +388,43 @@ suite('VisibleSessions', () => {
 	});
 
 	suite('insertAt', () => {
+
+		test('shows a detached chat beside its source with an independent active chat and does not duplicate it', () => {
+			const model = createModel();
+			const splitChat = { ...stubChat, resource: URI.parse('test:///split') };
+			const otherChat = { ...stubChat, resource: URI.parse('test:///other') };
+			const session = { ...stubSession('A'), chats: constObservable([stubChat, splitChat, otherChat]) };
+			const detached = new DetachedChatSession(session, splitChat);
+
+			model.setActive(session);
+			model.insertAt(detached, session.sessionId, 'right');
+			model.insertAt(new DetachedChatSession(session, splitChat), session.sessionId, 'right');
+
+			const visible = model.visibleSessions.get().filter((session): session is NonNullable<typeof session> => !!session);
+			assert.deepStrictEqual({
+				visible: visible.map(session => ({
+					sessionId: session.sessionId,
+					activeChat: session.activeChat.get().resource.toString(),
+					hasTabs: session.shouldShowChatTabs.get(),
+				})),
+				active: model.activeSession.get()?.sessionId,
+			}, {
+				visible: [
+					{ sessionId: session.sessionId, activeChat: stubChat.resource.toString(), hasTabs: true },
+					{ sessionId: detached.sessionId, activeChat: splitChat.resource.toString(), hasTabs: false },
+				],
+				active: detached.sessionId,
+			});
+
+			model.setActiveChat(session, otherChat);
+			assert.deepStrictEqual(visible.map(session => ({
+				sessionId: session.sessionId,
+				activeChat: session.activeChat.get().resource.toString(),
+			})), [
+				{ sessionId: session.sessionId, activeChat: otherChat.resource.toString() },
+				{ sessionId: detached.sessionId, activeChat: splitChat.resource.toString() },
+			]);
+		});
 
 		test('inserts a not-yet-visible session to the left of a target as non-sticky and activates it', () => {
 			const model = createModel();


### PR DESCRIPTION
Adds a **Split Right** action to the chat tab context menu in the Agents window. Right-clicking a chat tab and choosing Split Right opens that chat in its own grid leaf beside its session, so two chats of the *same* session can be viewed side by side.

Today side-by-side in the Agents window is session-scoped only — dragging a session into the grid works, but chats within a session are mutually exclusive tabs.

Drag-and-drop of chat tabs is intentionally out of scope here.

## The constraint

The sessions grid keys every leaf by **session id** (`IGridSlot.boundSessionId`, and both `_visibleList` / `_wrappers` in `VisibleSessions`), and each `VisibleSession` wrapper owns exactly one `activeChat` observable. So one session cannot occupy two leaves.

Re-keying the visibility model to be chat-scoped would touch persistence, stickiness, restore and navigation — too broad for this change.

## Approach

A `DetachedChatSession` adapter, following the existing `ResourceOverrideSession` precedent in the same file:

- reports a **synthetic `sessionId`** (`<sessionId>::detached::<chatResource>`) → earns its own grid slot, its own wrapper, and therefore its own `activeChat`
- delegates **`resource` / `providerId` / everything else** to the real session, so model lookups keep resolving
- narrows `chats` / `mainChat` to the detached chat → the leaf renders with no tab strip, for free

`ISessionsService.splitChat(session, chat, side)` is then a thin wrapper over the existing `insertAt`, which already handles positioning, activation, and the already-visible case (so re-splitting reveals rather than duplicates).

`IActiveSession.detachedChat` is added as an explicit typed signal, so consumers never sniff the synthetic id — per the layer's "DOM Traversal & Intent" rule.

## Model-side normalization

Provider calls are made with `session.sessionId`, which the adapter overrides. `SessionsManagementService._resolveLiveSession` now normalizes an adapter back to the provider-owned session before dispatching, matching on both resource **and** provider. It's a no-op for provider-owned sessions.

This is done defensively in the model service rather than by unwrapping at each call site, since adapters reach it from the header toolbar, the tab menu, and anywhere else handing an `IActiveSession` to the management service.

## Transience

Detached leaves are view state only:

- **Not persisted** — they share the source session's `resource`, so an entry would collide in the `_sessionStates` `ResourceMap`, and restore would block for `RESTORE_SESSION_WAIT_TIMEOUT` waiting on a session that can never appear.
- **Not draggable** — the header drag fills a `DraggedSessionIdentifier` that is looked up by resource on drop, so dragging a detached header would move the *original* slot.
- **Self-closing** — removed when the source session is removed or replaced, or when the chat leaves `session.chats`.

## Validation

| Check | Result |
|---|---|
| `npm run typecheck-client` | clean |
| `npm run valid-layers-check` | clean |
| `./scripts/test.sh --glob "**/vs/sessions/**/*.test.js"` | 1780 passing |
| `npm run hygiene` | clean |

New tests cover the adapter's identity/narrowing, coexistence of both leaves with independent active chats, no duplication on re-split, and cleanup when the chat is removed.

## Follow-ups

- Dragging a chat tab into the grid
- Split Left / Up / Down
- Persisting detached leaves across reload
- The tab strip only renders when a session has more than one visible chat, so single-chat sessions have no tab to right-click. The session header's Conversations menu would be the natural second entry point.
