### PR TITLE
chat: keep the response selection intact for the Ask Question widget

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/responseSelectionResolver.ts
+++ b/src/vs/sessions/contrib/chat/browser/responseSelectionResolver.ts
@@ -10,6 +10,8 @@ import { IChatResponseViewModel, isResponseVM } from '../../../../workbench/cont
 export interface IResolvedResponseSelection {
 	readonly response: IChatResponseViewModel;
 	readonly text: string;
+	/** Snapshot of the selected range, used to position and re-paint the affordance after the native selection is gone. */
+	readonly range: Range;
 }
 
 /** Ancestor of a valid selection endpoint: rendered assistant markdown. */
@@ -30,6 +32,42 @@ function isAssistantMarkdownEndpoint(node: Node, widgetDomNode: HTMLElement): bo
 }
 
 /**
+ * Returns the first and last text nodes that actually contribute characters to
+ * `range`. Browsers routinely park a selection boundary at offset 0 of the node
+ * *following* the selected text — notably a triple-click, which selects a whole
+ * line and ends at the start of the next block, landing outside the response's
+ * markdown when the line is the last one — so the raw anchor/focus nodes are
+ * not usable endpoints on their own.
+ */
+function contributingTextEndpoints(range: Range): { first: Text; last: Text } | undefined {
+	const container = range.commonAncestorContainer;
+	const scope = container.nodeType === Node.TEXT_NODE ? container.parentNode : container;
+	const doc = scope?.ownerDocument;
+	if (!scope || !doc) {
+		return undefined;
+	}
+
+	const walker = doc.createTreeWalker(scope, NodeFilter.SHOW_TEXT);
+	let first: Text | undefined;
+	let last: Text | undefined;
+	for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+		const text = node as Text;
+		if (!range.intersectsNode(text)) {
+			continue;
+		}
+		const start = text === range.startContainer ? range.startOffset : 0;
+		const end = text === range.endContainer ? range.endOffset : text.data.length;
+		if (!text.data.slice(start, end).trim()) {
+			continue;
+		}
+		first ??= text;
+		last = text;
+	}
+
+	return first && last ? { first, last } : undefined;
+}
+
+/**
  * Resolves the widget's current native DOM selection to the single assistant
  * response it lies entirely within, scoped to rendered markdown only (embedded
  * code editors and tool-invocation UI are excluded). Returns `undefined` for an
@@ -38,28 +76,30 @@ function isAssistantMarkdownEndpoint(node: Node, widgetDomNode: HTMLElement): bo
  */
 export function resolveResponseSelection(widget: IChatWidget): IResolvedResponseSelection | undefined {
 	const nativeSelection = dom.getWindow(widget.domNode).getSelection();
-	const text = nativeSelection?.toString();
-	if (!nativeSelection || nativeSelection.isCollapsed || !text?.trim()) {
+	if (!nativeSelection || nativeSelection.isCollapsed || !nativeSelection.rangeCount || !nativeSelection.toString().trim()) {
 		return undefined;
 	}
 
-	const { anchorNode, focusNode } = nativeSelection;
-	if (!anchorNode || !focusNode
-		|| !isAssistantMarkdownEndpoint(anchorNode, widget.domNode)
-		|| !isAssistantMarkdownEndpoint(focusNode, widget.domNode)) {
+	const range = nativeSelection.getRangeAt(0);
+	const endpoints = contributingTextEndpoints(range);
+	if (!endpoints
+		|| !isAssistantMarkdownEndpoint(endpoints.first, widget.domNode)
+		|| !isAssistantMarkdownEndpoint(endpoints.last, widget.domNode)) {
 		return undefined;
 	}
 
-	const anchorElement = closestElement(anchorNode);
-	const focusElement = closestElement(focusNode);
-	if (!anchorElement || !focusElement) {
+	const firstElement = closestElement(endpoints.first);
+	const lastElement = closestElement(endpoints.last);
+	if (!firstElement || !lastElement) {
 		return undefined;
 	}
-	const anchorItem = widget.getElementFromNode(anchorElement);
-	const focusItem = widget.getElementFromNode(focusElement);
-	if (!anchorItem || anchorItem !== focusItem || !isResponseVM(anchorItem)) {
+	const firstItem = widget.getElementFromNode(firstElement);
+	const lastItem = widget.getElementFromNode(lastElement);
+	if (!firstItem || firstItem !== lastItem || !isResponseVM(firstItem)) {
 		return undefined;
 	}
 
-	return { response: anchorItem, text };
+	// Trailing newlines are an artifact of how browsers extend line selections
+	// past the block they belong to; they add nothing to the quoted snippet.
+	return { response: firstItem, text: nativeSelection.toString().trim(), range: range.cloneRange() };
 }

--- a/src/vs/sessions/contrib/chat/browser/responseSelectionSideChatController.ts
+++ b/src/vs/sessions/contrib/chat/browser/responseSelectionSideChatController.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { editorSelectionBackground, editorSelectionForeground } from '../../../../platform/theme/common/colors/editorColors.js';
+import { registerThemingParticipant } from '../../../../platform/theme/common/themeService.js';
 import { IChatWidget } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { FeedbackInputWidget } from '../../agentFeedback/browser/feedbackInputWidget.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
@@ -17,6 +19,71 @@ import { IChat, SessionStatus } from '../../../services/sessions/common/session.
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { IResolvedResponseSelection, resolveResponseSelection } from './responseSelectionResolver.js';
 import { createAndSendSideChat } from './sideChatOrchestration.js';
+
+/**
+ * Name of the CSS custom highlight that stands in for the native selection
+ * once the browser collapses it.
+ */
+const selectionHighlightName = 'chat-response-selection';
+
+// Highlight pseudo-elements inherit custom properties from the root element
+// only, so they cannot see the `--vscode-*` theme variables (which are scoped
+// to `.monaco-workbench`); the color has to be baked into the rule instead.
+registerThemingParticipant((theme, collector) => {
+	const background = theme.getColor(editorSelectionBackground);
+	if (!background) {
+		return;
+	}
+	// High contrast themes select with an opaque background and rely on the
+	// paired foreground to keep the text readable.
+	const foreground = theme.getColor(editorSelectionForeground);
+	collector.addRule(`::highlight(${selectionHighlightName}) {
+		background-color: ${background};
+		${foreground ? `color: ${foreground};` : ''}
+	}`);
+});
+
+/**
+ * The highlight registry is per-window and shared by every chat view in it, so
+ * all controllers contribute ranges to one registered {@link Highlight} rather
+ * than overwriting each other's entry.
+ */
+function getSelectionHighlight(targetWindow: Window & typeof globalThis): Highlight | undefined {
+	const registry = targetWindow.CSS?.highlights;
+	if (!registry) {
+		return undefined; // CSS Custom Highlight API unavailable
+	}
+	let highlight = registry.get(selectionHighlightName);
+	if (!highlight) {
+		highlight = new targetWindow.Highlight();
+		registry.set(selectionHighlightName, highlight);
+	}
+	return highlight;
+}
+
+/**
+ * Bounding box of the range's *visible* line boxes. `Range.getBoundingClientRect`
+ * includes the empty box a line selection leaves at the start of the following
+ * block, which would push the affordance a line too far down.
+ */
+function getVisibleBoundingRect(range: Range): { top: number; bottom: number; left: number } | undefined {
+	let top = Number.POSITIVE_INFINITY;
+	let bottom = Number.NEGATIVE_INFINITY;
+	let left = Number.POSITIVE_INFINITY;
+	for (const rect of range.getClientRects()) {
+		if (rect.width === 0 || rect.height === 0) {
+			continue;
+		}
+		top = Math.min(top, rect.top);
+		bottom = Math.max(bottom, rect.bottom);
+		left = Math.min(left, rect.left);
+	}
+	if (bottom === Number.NEGATIVE_INFINITY) {
+		const fallback = range.getBoundingClientRect();
+		return fallback.width || fallback.height ? fallback : undefined;
+	}
+	return { top, bottom, left };
+}
 
 /**
  * Agents-window-only controller that shows an "Ask Question" input (reusing
@@ -29,6 +96,8 @@ export class ResponseSelectionSideChatController extends Disposable {
 
 	private readonly _input: FeedbackInputWidget;
 	private _resolved: IResolvedResponseSelection | undefined;
+	/** Range currently painted via the CSS custom highlight, if any. */
+	private _paintedRange: Range | undefined;
 	private _chat: IChat | undefined;
 	/** Bumped on a genuine chat navigation/force-dismiss so a stale submission's completion/error handler can no-op. */
 	private _generation = 0;
@@ -84,6 +153,7 @@ export class ResponseSelectionSideChatController extends Disposable {
 		this._register(dom.addDisposableListener(window.document, 'selectionchange', () => this._onSelectionChange()));
 		// Scrolling the transcript invalidates the widget's pinned position; hide rather than drift.
 		this._register(dom.addDisposableListener(this._widget.domNode, 'scroll', () => this._dismiss(), true));
+		this._register(toDisposable(() => this._paintHighlight(undefined)));
 	}
 
 	/**
@@ -107,12 +177,14 @@ export class ResponseSelectionSideChatController extends Disposable {
 		// captured; a real outside invalidation is handled once focus
 		// actually leaves (the next selectionchange runs with focus outside).
 		if (dom.isAncestorOfActiveElement(this._input.domNode)) {
+			this._syncHighlight();
 			return;
 		}
 		// A pending submission owns the overlay until the view changes (see
 		// `_dismiss`); don't let an incidental selection change reposition or
 		// swap the captured selection out from under it.
 		if (this._input.isBusy) {
+			this._syncHighlight();
 			return;
 		}
 		const resolved = resolveResponseSelection(this._widget);
@@ -124,18 +196,48 @@ export class ResponseSelectionSideChatController extends Disposable {
 		this._showFor(resolved);
 	}
 
-	private _showFor(resolved: IResolvedResponseSelection): void {
+	/**
+	 * Keeps the captured selection visible. The native selection disappears as
+	 * soon as focus moves into the "Ask Question" input, so a CSS custom
+	 * highlight takes over painting the range for as long as the affordance is
+	 * open; while the native selection still covers it the browser paints it
+	 * and the highlight stays off so the two never stack.
+	 */
+	private _syncHighlight(): void {
+		const range = this._resolved?.range;
 		const nativeSelection = dom.getWindow(this._widget.domNode).getSelection();
-		const range = nativeSelection?.rangeCount ? nativeSelection.getRangeAt(0) : undefined;
-		if (!range) {
+		const paintedNatively = !!nativeSelection && !nativeSelection.isCollapsed && !!nativeSelection.toString().trim();
+		this._paintHighlight(range && !paintedNatively ? range : undefined);
+	}
+
+	private _paintHighlight(range: Range | undefined): void {
+		if (this._paintedRange === range) {
 			return;
 		}
-		const selectionRect = range.getBoundingClientRect();
+		const highlight = getSelectionHighlight(dom.getWindow(this._widget.domNode));
+		if (!highlight) {
+			return;
+		}
+		if (this._paintedRange) {
+			highlight.delete(this._paintedRange);
+		}
+		if (range) {
+			highlight.add(range);
+		}
+		this._paintedRange = range;
+	}
+
+	private _showFor(resolved: IResolvedResponseSelection): void {
+		const selectionRect = getVisibleBoundingRect(resolved.range);
+		if (!selectionRect) {
+			return;
+		}
 		const containerRect = this._widget.domNode.getBoundingClientRect();
 
 		this._input.show();
 		this._input.autoSize();
 		this._input.updateActionEnabled();
+		this._syncHighlight();
 
 		const gap = 4;
 		const inputWidth = this._input.domNode.offsetWidth;
@@ -177,6 +279,7 @@ export class ResponseSelectionSideChatController extends Disposable {
 		}
 		const hadFocus = dom.isAncestorOfActiveElement(this._input.domNode);
 		this._resolved = undefined;
+		this._paintHighlight(undefined);
 		this._input.setBusy(false);
 		this._input.hide();
 		this._input.clearInput();

--- a/src/vs/sessions/contrib/chat/test/browser/responseSelectionResolver.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/responseSelectionResolver.test.ts
@@ -16,17 +16,23 @@ function makeResponse(requestId: string): IChatResponseViewModel {
 	return upcastPartial<IChatResponseViewModel>({ requestId, setVote: () => undefined });
 }
 
-function stubSelection(store: DisposableStore, anchorNode: Node, focusNode: Node, text: string): void {
+function stubSelection(store: DisposableStore, anchorNode: Node, focusNode: Node, text: string, focusOffset?: number): void {
+	const doc = anchorNode.ownerDocument!;
+	const range = doc.createRange();
+	range.setStart(anchorNode, 0);
+	range.setEnd(focusNode, focusOffset ?? (focusNode.nodeType === Node.TEXT_NODE ? (focusNode as Text).data.length : focusNode.childNodes.length));
+
 	const targetWindow = dom.getWindow(anchorNode);
 	const original = targetWindow.getSelection.bind(targetWindow);
 	const mutableWindow = targetWindow as typeof targetWindow & { getSelection: () => Selection | null };
-	mutableWindow.getSelection = () => ({
+	mutableWindow.getSelection = () => upcastPartial<Selection>({
 		toString: () => text,
 		isCollapsed: text.length === 0,
 		anchorNode,
 		focusNode,
 		rangeCount: 1,
-	} as Selection);
+		getRangeAt: () => range,
+	});
 	store.add(toDisposable(() => { mutableWindow.getSelection = original; }));
 }
 
@@ -61,6 +67,56 @@ suite('resolveResponseSelection', () => {
 		assert.ok(resolved);
 		assert.strictEqual(resolved!.response, response);
 		assert.strictEqual(resolved!.text, 'hello world');
+	});
+
+	test('resolves a line selection that ends at the start of the element after the markdown', () => {
+		// A triple-click selects the whole line and parks the selection's focus
+		// at offset 0 of the *next* block, which for the last line of a
+		// response lands outside the markdown part entirely.
+		const { store, doc, widgetDomNode } = setup();
+		const markdown = doc.createElement('div');
+		markdown.classList.add('chat-markdown-part');
+		const paragraph = doc.createElement('p');
+		const textNode = doc.createTextNode('hello world');
+		paragraph.appendChild(textNode);
+		markdown.appendChild(paragraph);
+		const footer = doc.createElement('div');
+		footer.appendChild(doc.createTextNode('response toolbar'));
+		widgetDomNode.appendChild(markdown);
+		widgetDomNode.appendChild(footer);
+
+		const response = makeResponse('turn-1');
+		stubSelection(store, textNode, footer, 'hello world\n', 0);
+		const widget = upcastPartial<IChatWidget>({
+			domNode: widgetDomNode,
+			getElementFromNode: () => response,
+		});
+
+		const resolved = resolveResponseSelection(widget);
+		assert.ok(resolved);
+		assert.strictEqual(resolved!.response, response);
+		assert.strictEqual(resolved!.text, 'hello world');
+	});
+
+	test('rejects a selection that genuinely extends into content after the markdown', () => {
+		const { store, doc, widgetDomNode } = setup();
+		const markdown = doc.createElement('div');
+		markdown.classList.add('chat-markdown-part');
+		const textNode = doc.createTextNode('hello world');
+		markdown.appendChild(textNode);
+		const footer = doc.createElement('div');
+		const footerText = doc.createTextNode('response toolbar');
+		footer.appendChild(footerText);
+		widgetDomNode.appendChild(markdown);
+		widgetDomNode.appendChild(footer);
+
+		stubSelection(store, textNode, footerText, 'hello world response toolbar');
+		const widget = upcastPartial<IChatWidget>({
+			domNode: widgetDomNode,
+			getElementFromNode: () => makeResponse('turn-1'),
+		});
+
+		assert.strictEqual(resolveResponseSelection(widget), undefined);
 	});
 
 	test('rejects a collapsed (empty) selection', () => {

--- a/src/vs/sessions/contrib/chat/test/browser/responseSelectionSideChatController.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/responseSelectionSideChatController.test.ts
@@ -49,6 +49,11 @@ suite('ResponseSelectionSideChatController', () => {
 
 		const markdown = doc.createElement('div');
 		markdown.classList.add('chat-markdown-part');
+		// Positioned so the selection's real client rects (the controller
+		// measures the range itself) land at known coordinates.
+		markdown.style.position = 'absolute';
+		markdown.style.top = '0px';
+		markdown.style.left = '0px';
 		const textNode = doc.createTextNode('hello world');
 		markdown.appendChild(textNode);
 		widgetDomNode.appendChild(markdown);
@@ -68,27 +73,28 @@ suite('ResponseSelectionSideChatController', () => {
 		const originalGetSelection = targetWindow.getSelection.bind(targetWindow);
 		const mutableWindow = targetWindow as typeof targetWindow & { getSelection: () => Selection | null };
 		let selectionText = '';
-		let rangeRect: Partial<DOMRect> = { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0 };
-		mutableWindow.getSelection = () => ({
+		const range = doc.createRange();
+		range.setStart(textNode, 0);
+		range.setEnd(textNode, textNode.data.length);
+		mutableWindow.getSelection = () => upcastPartial<Selection>({
 			toString: () => selectionText,
 			isCollapsed: selectionText.length === 0,
 			anchorNode: textNode,
 			focusNode: textNode,
 			rangeCount: 1,
-			getRangeAt: () => ({
-				getBoundingClientRect: () => rangeRect as DOMRect,
-			}),
-		} as unknown as Selection);
+			getRangeAt: () => range,
+		});
 		store.add(toDisposable(() => { mutableWindow.getSelection = originalGetSelection; }));
 
-		const setSelection = (text: string, rect?: Partial<DOMRect>) => {
+		const setSelection = (text: string, selectionTop?: number) => {
 			selectionText = text;
-			if (rect) {
-				rangeRect = rect;
+			if (selectionTop !== undefined) {
+				markdown.style.top = `${selectionTop}px`;
 			}
 			doc.dispatchEvent(new Event('selectionchange'));
 		};
 		const setContainerRect = (rect: Partial<DOMRect>) => { containerRect = rect; };
+		const highlightedRanges = () => targetWindow.CSS.highlights?.get('chat-response-selection')?.size ?? 0;
 
 		const sideChat = upcastPartial<IChat>({ resource: URI.parse('test:///chat/side') });
 		const chat = upcastPartial<IChat>({ resource: URI.parse('test:///chat/source') });
@@ -123,7 +129,7 @@ suite('ResponseSelectionSideChatController', () => {
 		const controller = store.add(instantiationService.createInstance(ResponseSelectionSideChatController, widget));
 		controller.setChat(chat);
 
-		return { controller, setSelection, setContainerRect, callOrder, doc, chat, sideChat, focusResponseItemCalls, notificationService };
+		return { controller, setSelection, setContainerRect, callOrder, doc, chat, sideChat, focusResponseItemCalls, notificationService, highlightedRanges };
 	}
 
 	function inputDomNode(controller: ResponseSelectionSideChatController): HTMLElement {
@@ -249,11 +255,39 @@ suite('ResponseSelectionSideChatController', () => {
 		// A container far shorter than any realistic widget height forces the
 		// vertical clamp to floor the overlay at the top.
 		setContainerRect({ top: 0, left: 0, width: 600, height: 20 });
-		setSelection('hello world', { top: 10, bottom: 15, left: 0, right: 10, width: 10, height: 5 });
+		setSelection('hello world', 10);
 
 		const style = inputDomNode(controller).style;
 		assert.notStrictEqual(style.display, 'none');
 		assert.strictEqual(parseFloat(style.top), 0);
+	});
+
+	test('paints the captured selection with a custom highlight once the native selection is gone', () => {
+		const { controller, setSelection, highlightedRanges } = setup();
+		setSelection('hello world');
+		assert.strictEqual(highlightedRanges(), 0, 'the browser still paints the live native selection');
+
+		// Focusing the textarea collapses the native selection; the highlight
+		// takes over so the user can still see what they selected.
+		inputTextArea(controller).focus();
+		setSelection('');
+		assert.strictEqual(highlightedRanges(), 1);
+
+		inputTextArea(controller).blur();
+		setSelection('');
+		assert.strictEqual(inputDomNode(controller).style.display, 'none');
+		assert.strictEqual(highlightedRanges(), 0, 'dismissing must clear the highlight');
+	});
+
+	test('clears the highlight when the controller is disposed', () => {
+		const { controller, setSelection, highlightedRanges } = setup();
+		setSelection('hello world');
+		inputTextArea(controller).focus();
+		setSelection('');
+		assert.strictEqual(highlightedRanges(), 1);
+
+		controller.dispose();
+		assert.strictEqual(highlightedRanges(), 0);
 	});
 
 	test('stays visible with a busy state while the request is pending, then clears once it settles', async () => {


### PR DESCRIPTION
- Resolves the selected response from the text nodes that actually
  contribute characters rather than the raw anchor/focus nodes. Browsers
  park a line selection's endpoint at offset 0 of the *next* block, which
  for the last line of a response lands outside the markdown part
  entirely, so a triple-click (the natural way to select a whole line)
  looked like an out-of-scope selection and dismissed the widget.
- Paints the captured range with a CSS custom highlight once the native
  selection is gone. Focusing the textarea collapses the document
  selection as a browser side effect, so the text the question is about
  visually disappeared the moment the user clicked in to type it.
- Sources the highlight color from a theming participant instead of a
  stylesheet, because highlight pseudo-elements only inherit custom
  properties from the root element and cannot see the `--vscode-*`
  variables scoped to `.monaco-workbench`.
- Positions the widget from the range's visible line boxes, so the empty
  box a line selection leaves in the following block no longer pushes it
  a line too low.

Fixes #327706
Fixes #327707
