### PR TITLE
chat: compute tool-confirmation carousel max-height during layout

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -3541,18 +3541,14 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		this.renderAttachedContext();
 
-		// Defer only the carousel max-height update to the next animation
-		// frame. That write changes a descendant whose height flexes back
-		// up into `this.container` (the observed element), which is what
-		// trips the browser's "ResizeObserver loop completed with
-		// undelivered notifications" warning under bursty input (see
-		// #316509). Publishing `this.height` stays synchronous because its
-		// autorun consumers re-layout siblings/ancestors of the input
-		// container, not the container itself, so they do not feed back
-		// into the same observation phase.
-		const updateCarouselMaxHeightScheduler = this._register(new dom.AnimationFrameScheduler(this.container, () => this.updateToolConfirmationCarouselMaxHeight()));
+		// This observer only publishes the measured height; it must not write
+		// into the observed subtree. The carousel's max-height is a descendant
+		// write that flexes back up into `this.container`, so performing it
+		// here forces another notification pass and trips the browser's
+		// "ResizeObserver loop completed with undelivered notifications"
+		// warning (see #316509). It is computed in `_layout()` instead, from
+		// the same measurement pass that sizes the editor.
 		const inputResizeObserver = this._register(new dom.DisposableResizeObserver('ChatInputPart.containerHeight', () => {
-			updateCarouselMaxHeightScheduler.schedule();
 			const newHeight = this.container.offsetHeight;
 			this.height.set(newHeight, undefined);
 		}));
@@ -4577,6 +4573,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			// This is probably the initial layout. Now that the editor is layed out with its correct width, it should report the correct contentHeight
 			return this._layout(width, false);
 		}
+
+		// Allocate the carousel from this same pass, once the editor has been
+		// sized. Doing it here rather than from the container's ResizeObserver
+		// keeps the write outside resize delivery, so it cannot force another
+		// notification pass (see #316509).
+		this.updateToolConfirmationCarouselMaxHeight();
 	}
 
 	private getLayoutData() {

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
@@ -747,6 +747,191 @@ async function renderResizeObserverLoopHarness(context: ComponentFixtureContext,
 	}));
 }
 
+/**
+ * A terminal command tall enough that the carousel's intrinsic content exceeds
+ * its collapsed limit, so the carousel genuinely wants more height than it is
+ * granted.
+ */
+const TALL_CONFIRMATION_COMMAND = Array.from(
+	{ length: 40 },
+	(_, index) => `echo "carousel stress line ${index + 1}: ${'pad '.repeat(6)}"`,
+).join(' && \\\n');
+
+/**
+ * Editor content tall enough that the input editor also wants more height than
+ * its minimum, so it competes with the carousel for the same `_maxHeight`.
+ */
+const TALL_EDITOR_VALUE = Array.from(
+	{ length: 24 },
+	(_, index) => `Editor stress line ${index + 1}: ${'pad '.repeat(8)}`,
+).join('\n');
+
+/**
+ * Reproduces the `ChatInputPart.containerHeight` feedback edge.
+ *
+ * The input editor and the tool-confirmation carousel share one `_maxHeight`
+ * budget, and each derives its own allowance by measuring the container and
+ * subtracting itself — that is, by measuring "everything else", which includes
+ * the other one. Under a tight budget where both want more than their share,
+ * each hands back exactly the space the other just released, so the pair never
+ * settles.
+ *
+ * The probe squeezes the budget, then samples the carousel's resolved
+ * `max-height` and the editor's rendered height once per frame. If allocation
+ * converges, the tail of that sample series is constant.
+ */
+async function renderCarouselBudgetProbe(context: ComponentFixtureContext): Promise<void> {
+	const targetWindow = context.container.ownerDocument.defaultView;
+	if (!targetWindow) {
+		throw new Error('Carousel budget probe requires a window');
+	}
+
+	let handle: IChatWidgetFixtureHandle | undefined;
+	await renderChatWidget(context, {
+		messages: [{
+			user: 'Run the tall diagnostic command.',
+			assistant: [{ kind: 'markdown', text: 'Waiting for tool confirmation.' }],
+		}],
+		width: 720,
+		// Roomy enough that the list actually renders the response row: the
+		// confirmation only reaches the carousel via the rendered row. The
+		// budget is squeezed separately via `setMaxHeight` so viewport size and
+		// input budget stay independent.
+		height: 640,
+		renderStyle: 'default',
+		onRendered: value => handle = value,
+	});
+
+	if (!handle) {
+		throw new Error('Carousel budget probe did not initialize');
+	}
+	const fixtureHandle = handle;
+
+	const controls = dom.$('.carousel-budget-probe');
+	const runButton = dom.append(controls, dom.$<HTMLButtonElement>('button.carousel-budget-run'));
+	runButton.type = 'button';
+	runButton.textContent = 'Run carousel budget probe';
+	const status = dom.append(controls, dom.$('span.carousel-budget-status'));
+	status.role = 'status';
+	status.textContent = 'Ready';
+	const warnings = dom.append(controls, dom.$('span.carousel-budget-warnings'));
+	warnings.textContent = 'Warnings: 0';
+	const samplesEl = dom.append(controls, dom.$('span.carousel-budget-samples'));
+	samplesEl.textContent = 'Samples: none';
+	controls.style.position = 'absolute';
+	controls.style.top = '8px';
+	controls.style.right = '8px';
+	controls.style.zIndex = '100';
+	controls.style.display = 'flex';
+	controls.style.gap = '8px';
+	controls.style.alignItems = 'center';
+	controls.style.padding = '6px 8px';
+	controls.style.background = 'var(--vscode-editorWidget-background)';
+	controls.style.border = '1px solid var(--vscode-widget-border)';
+	context.container.style.position = 'relative';
+	context.container.appendChild(controls);
+
+	let warningCount = 0;
+	context.disposableStore.add(dom.addDisposableListener(targetWindow, dom.EventType.ERROR, event => {
+		if (event instanceof ErrorEvent && event.message.includes('ResizeObserver loop')) {
+			warningCount++;
+			warnings.textContent = `Warnings: ${warningCount}`;
+			warnings.dataset['lastAttribution'] = dom.getRecentDisposableResizeObserverAttributionForLoopError(event.message) ?? event.message;
+		}
+	}));
+
+	const nextFrame = () => new Promise<void>(resolve => targetWindow.requestAnimationFrame(() => resolve()));
+
+	const findCarousel = () => context.container.querySelector<HTMLElement>('.chat-tool-confirmation-carousel');
+
+	const sampleAllocation = () => {
+		const carousel = findCarousel();
+		const editor = context.container.querySelector<HTMLElement>('.chat-editor-container');
+		const carouselHeight = carousel ? Math.round(carousel.getBoundingClientRect().height) : -1;
+		const editorHeight = editor ? Math.round(editor.getBoundingClientRect().height) : -1;
+		return `${carouselHeight}|${editorHeight}`;
+	};
+
+	const runProbe = async () => {
+		runButton.disabled = true;
+		status.textContent = 'Waiting for carousel...';
+
+		// The confirmation only reaches the carousel once the list renders the
+		// response row, so add it and wait for the carousel to appear before
+		// squeezing anything.
+		const request = fixtureHandle.model.addRequest(makeUserMessage('Run the tall diagnostic command.'), { variables: [] }, 0);
+		fixtureHandle.addTerminalConfirmation(request, TALL_CONFIRMATION_COMMAND);
+		fixtureHandle.listWidget.refresh();
+
+		for (let index = 0; index < 30 && !findCarousel(); index++) {
+			await nextFrame();
+		}
+
+		const carouselFound = !!findCarousel();
+		samplesEl.dataset['carouselFound'] = String(carouselFound);
+
+		// Sweep a range of budgets rather than probing a single point. Too tight
+		// and the carousel pins to its minimum; too loose and neither consumer
+		// competes. Both are stable fixed points, so contention — if it exists —
+		// only shows up in the band between them.
+		fixtureHandle.inputPart.setValue(TALL_EDITOR_VALUE, true);
+		const report: string[] = [];
+		let worstFrames = 0;
+		let anyOscillating = false;
+		let firstSeries = '';
+
+		for (const budget of [560, 500, 440, 380, 320, 280]) {
+			status.textContent = `Sampling budget ${budget}...`;
+			fixtureHandle.inputPart.setMaxHeight(budget);
+			fixtureHandle.inputPart.layout(fixtureHandle.width);
+
+			// Sample from the very first frame: the contended re-layout is what
+			// we are measuring, so draining it first would hide the effect.
+			const samples: string[] = [];
+			for (let index = 0; index < 40; index++) {
+				await nextFrame();
+				samples.push(sampleAllocation());
+			}
+
+			// If allocation converges, the tail of the series is a single value.
+			const settled = new Set(samples.slice(-12)).size === 1;
+			// How many frames pass before the series reaches its final value
+			// tells us whether allocation is one-shot or iterative.
+			const finalValue = samples[samples.length - 1];
+			let framesToSettle = samples.length;
+			for (let index = samples.length - 1; index >= 0; index--) {
+				if (samples[index] !== finalValue) {
+					break;
+				}
+				framesToSettle = index;
+			}
+
+			anyOscillating ||= !settled;
+			worstFrames = Math.max(worstFrames, framesToSettle);
+			report.push(`${budget}:${settled ? 'settled' : 'OSC'}@${framesToSettle}=${finalValue}`);
+			if (!firstSeries && framesToSettle > 0) {
+				firstSeries = `${budget} -> ${samples.slice(0, 16).join(' ')}`;
+			}
+		}
+
+		const settled = !anyOscillating;
+		const framesToSettle = worstFrames;
+
+		samplesEl.textContent = `Samples: ${settled ? 'settled' : 'oscillating'} in ${framesToSettle}`;
+		samplesEl.dataset['settled'] = String(settled);
+		samplesEl.dataset['distinct'] = String(report.length);
+		samplesEl.dataset['framesToSettle'] = String(framesToSettle);
+		samplesEl.dataset['series'] = `${report.join(' | ')} || ${firstSeries}`;
+
+		status.textContent = 'Completed';
+		runButton.disabled = false;
+	};
+
+	context.disposableStore.add(dom.addDisposableListener(runButton, dom.EventType.CLICK, () => {
+		void runProbe();
+	}));
+}
+
 export default defineThemedFixtureGroup({ path: 'chat/widget/' }, {
 	SimpleQA: defineComponentFixture({ render: ctx => renderChatWidget(ctx, { messages: SIMPLE_QA }) }),
 	Streaming: defineComponentFixture({ labels: { kind: 'animated' }, render: ctx => renderChatWidget(ctx, { messages: STREAMING }) }),
@@ -770,6 +955,11 @@ export default defineThemedFixtureGroup({ path: 'chat/widget/' }, {
 		labels: { kind: 'animated' },
 		virtualTime: { enabled: false },
 		render: context => renderResizeObserverLoopHarness(context, 'none'),
+	}),
+	ResizeObserverLoopCarouselBudget: defineComponentFixture({
+		labels: { kind: 'animated' },
+		virtualTime: { enabled: false },
+		render: context => renderCarouselBudgetProbe(context),
 	}),
 	CodeBlockInList: defineComponentFixture({ render: ctx => renderChatWidget(ctx, { messages: CODE_BLOCK_IN_LIST }) }),
 	bugs: defineThemedFixtureGroup({

--- a/test/componentFixtures/playwright/tests/chatResizeObserver.spec.ts
+++ b/test/componentFixtures/playwright/tests/chatResizeObserver.spec.ts
@@ -49,3 +49,57 @@ for (const scenario of scenarios) {
 		});
 	});
 }
+
+/**
+ * Regression probe for the `ChatInputPart.containerHeight` loop warning.
+ *
+ * The carousel's max-height is a descendant of the observed input container.
+ * Writing it from that container's ResizeObserver callback resizes the
+ * observed subtree during delivery, which forces the browser to schedule
+ * another notification pass — the "ResizeObserver loop completed with
+ * undelivered notifications" warning. Note that this is *not* an oscillation:
+ * the allocation converges in a single extra pass. Convergence and the warning
+ * are orthogonal, so asserting only that the value settles would miss the bug.
+ *
+ * Allocating from `_layout()` instead keeps the write outside delivery. This
+ * probe sweeps a band of budgets and requires both that no warning is emitted
+ * and that each budget still reaches its final allocation immediately, so a
+ * fix cannot trade the warning away for a slower or different allocation.
+ */
+test('allocates the tool-confirmation carousel and input editor without oscillating', async ({ page }) => {
+	const resizeObserverErrors: string[] = [];
+	page.on('pageerror', error => {
+		if (error.message.includes('ResizeObserver loop')) {
+			resizeObserverErrors.push(error.message);
+		}
+	});
+
+	await openFixture(page, 'chat/widget/chatWidget/ResizeObserverLoopCarouselBudget/Dark', '.carousel-budget-probe');
+	await page.getByRole('button', { name: 'Run carousel budget probe' }).click();
+	await expect(page.getByRole('status')).toContainText(/Completed/, { timeout: 30_000 });
+
+	const samples = page.locator('.carousel-budget-samples');
+	const carouselFound = await samples.getAttribute('data-carousel-found');
+	const settled = await samples.getAttribute('data-settled');
+	const distinct = await samples.getAttribute('data-distinct');
+	const framesToSettle = await samples.getAttribute('data-frames-to-settle');
+	const series = await samples.getAttribute('data-series');
+	const warningText = await page.locator('.carousel-budget-warnings').textContent();
+	const lastAttribution = await page.locator('.carousel-budget-warnings').getAttribute('data-last-attribution');
+	console.log(`[carousel-budget] carouselFound: ${carouselFound}; settled: ${settled}; distinct: ${distinct}; framesToSettle: ${framesToSettle}; ${warningText}; last attribution: ${lastAttribution}`);
+	console.log(`[carousel-budget] series: ${series}`);
+
+	await test.info().attach('carousel-budget-samples.json', {
+		body: Buffer.from(JSON.stringify({ carouselFound, settled, distinct, framesToSettle, series, warningText, lastAttribution, resizeObserverErrors }, null, 2)),
+		contentType: 'application/json',
+	});
+
+	// Without a rendered carousel nothing contends for the budget, so every
+	// assertion below would pass for the wrong reason.
+	expect(carouselFound).toBe('true');
+	// The allocation must not emit ResizeObserver loop warnings.
+	expect(Number(warningText?.replace('Warnings: ', ''))).toBe(0);
+	// A one-shot allocation reaches its final value immediately, rather than
+	// converging over successive frames.
+	expect(settled).toBe('true');
+});


### PR DESCRIPTION
Relates to #316509 (`ChatInputPart.containerHeight`, bucket `b47563cc-656f-baae-0d1c-0996d4838019`).

## What this is — and is not

`updateToolConfirmationCarouselMaxHeight()` measures `this.container`, then writes `max-height` onto the carousel — a **descendant** of that container:

```ts
const carouselHeight = this.chatToolConfirmationCarouselContainer.offsetHeight;
const otherInputHeight = Math.max(0, this.container.offsetHeight - carouselHeight);
carousel.setMaxHeight(this._maxHeight - otherInputHeight);
```

Calling that from the container's own `ResizeObserver` resizes the observed subtree *during delivery*, forcing another notification pass — the `ResizeObserver loop completed with undelivered notifications` warning.

**4b0aa247213 already addressed this** by deferring the write to an animation frame, and it works. The probe added here confirms it directly:

| Carousel write | Warnings |
| --- | --- |
| Synchronous (pre-4b0aa247213) | 4 |
| Deferred to rAF (current `main`) | **0** |
| Computed in `_layout()` (this PR) | **0** |

So **this is not a behavioural bug fix**, and reviewers should not expect it to change error rates. Please weigh it on the two things it actually offers.

## 1. Ownership

The carousel allocation is a layout decision that depends on a measurement `_layout()` already performs. Computing it there means the `ResizeObserver` callback no longer has to schedule layout work at all:

- the `AnimationFrameScheduler` goes away;
- the carousel no longer trails the input by a frame;
- the callback is reduced to publishing `this.height`;
- both consumers of `_maxHeight` (editor and carousel) are resolved from one measurement pass instead of two mechanisms.

The deferral fixed *when* the write happens. This fixes *who owns it*.

## 2. Regression coverage

The original fix was validated manually (open DevTools, type rapidly). There was no automated test, which is why its effect was never measurable. This adds one.

## Why telemetry can't settle this

Worth recording, because it is easy to misread this bucket — I did at first.

The attribution is assigned in `DisposableResizeObserver`:

```ts
_lastInvokedDisposableResizeObserver = this;
```

That is **whichever observer ran last in the observation phase, not the one that caused the loop**. The bucket therefore aggregates every RO loop where this observer happened to run last. Consequences:

- It could not have validated 4b0aa247213, and it cannot validate this PR.
- The bucket remaining active after 4b0aa247213 is **not** evidence that fix failed.
- Neither change should be expected to move it.

An earlier revision of this description argued from `7.2 → 6.7 hits/user` across 1.120 → 1.121 that the deferral "barely helped." That inference was unsound and has been removed.

Separately: hits/user for this bucket jumps from ~4.4 (1.129.x) to ~57.8 (1.130.0 stable, 337,927 users) while `ChatListItemRenderer.itemHeight` moves the *other* way (13.6 → 10.5) over the same releases. Given attribution is non-causal I can no longer claim that is a carousel regression, but the asymmetry is real and probably deserves its own investigation.

## Verification

- New `ResizeObserverLoopCarouselBudget` probe sweeps budgets 560→280, asserting zero warnings and immediate settling.
- **It discriminates.** Performing the allocation only from the observer (the pre-deferral shape) makes it fail. A test that cannot fail on the old code proves nothing, so this was checked explicitly.
- **It is not vacuous.** The probe first requires the carousel element to exist — an earlier revision silently tested nothing because the fixture starved the list to 0px.
- **Behaviour is unchanged.** The allocation series is byte-identical before and after:
  `560:232|250 · 500:232|190 · 440:232|130 · 380:232|70 · 320:178|64 · 280:138|64`
- 5/5 playwright resize-observer tests pass; 5154 chat unit tests pass.

## Note on #316509

The issue auto-closed as COMPLETED when 4b0aa247213 merged. Given the attribution caveat above, closure was never verifiable either way — but the bucket is still among the largest chat error buckets, so it may be worth revisiting on its own terms rather than treating it as resolved.
