### PR TITLE
Increase layer checker heap limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "monaco-compile-check": "tsc --project src/tsconfig.monaco.json --noEmit",
     "tsec-compile-check": "node --max-old-space-size=8192 node_modules/tsec/bin/tsec -p src/tsconfig.tsec.json",
     "vscode-dts-compile-check": "tsc --project src/tsconfig.vscode-dts.json && tsc --project src/tsconfig.vscode-proposed-dts.json",
-    "valid-layers-check": "node build/checker/layersChecker.ts && tsc --project build/checker/tsconfig.browser.json && tsc --project build/checker/tsconfig.worker.json && tsc --project build/checker/tsconfig.node.json && tsc --project build/checker/tsconfig.electron-browser.json && tsc --project build/checker/tsconfig.electron-main.json && tsc --project build/checker/tsconfig.electron-utility.json",
+    "valid-layers-check": "node --max-old-space-size=8192 build/checker/layersChecker.ts && tsc --project build/checker/tsconfig.browser.json && tsc --project build/checker/tsconfig.worker.json && tsc --project build/checker/tsconfig.node.json && tsc --project build/checker/tsconfig.electron-browser.json && tsc --project build/checker/tsconfig.electron-main.json && tsc --project build/checker/tsconfig.electron-utility.json",
     "define-class-fields-check": "node build/lib/propertyInitOrderChecker.ts && tsc --project src/tsconfig.defineClassFields.json",
     "update-distro": "node build/npm/update-distro.ts",
     "export-policy-data": "node build/lib/policies/exportPolicyData.ts",


### PR DESCRIPTION
## Summary

Increase the V8 heap limit for the custom layer checker to 8 GB, matching the existing `gulp` and `tsec` script limits.

## Investigation

The failed [build investigation](https://github.com/microsoft/vscode-engineering/actions/runs/30411858269) reported a `valid-layers-check` OOM at the default ~4 GB old-space ceiling. Running the commands separately showed that `node build/checker/layersChecker.ts` fails before any of the six `tsc` passes:

- default heap: OOM after 40.7s at 4.54 GB peak RSS
- 8 GB heap: success after 31.2s at 4.72 GB peak RSS

A newer main build succeeded unchanged, so the failure is threshold-sensitive rather than a deterministic compile error. The checker has effectively no headroom under the default heap limit, which makes it flaky as the source tree grows.

## Validation

- `npm run valid-layers-check`
- `npm run precommit`

(Written by Copilot)
