### PR TITLE
Restore user/workspace terminal bash auto-approve actions for Agent Host Copilot

### DIFF
--- a/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
@@ -48,11 +48,11 @@ export interface IToolCallMeta {
 	readonly autoApproveBySetting?: boolean;
 	/**
 	 * Set by the host's side-effect layer on a shell tool call's pending
-	 * confirmation when the command was evaluated by the rule-based
-	 * auto-approver (`permissionKind === 'shell'` without a sandbox bypass),
-	 * so the client knows that configuring terminal auto-approve rules can
-	 * suppress future prompts like this one. Absent on confirmations rules
-	 * can never satisfy (e.g. sandbox-bypass prompts).
+	 * confirmation when adding a persistent terminal auto-approve rule could
+	 * suppress prompts like this one: the command parsed successfully, matched
+	 * no deny rule, has no unapproved write redirect, and only lacks a
+	 * matching allow rule. Absent on confirmations no rule can satisfy —
+	 * managed approvals, sandbox-bypass prompts, denials, and parser failures.
 	 */
 	readonly autoApproveRulesApply?: boolean;
 	/** Transient runtime corpus for the local client tool-search invocation. */

--- a/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
@@ -46,15 +46,8 @@ export interface IToolCallMeta {
 	 * explicit user action), so the client can render it as setting-driven.
 	 */
 	readonly autoApproveBySetting?: boolean;
-	/**
-	 * Set by the host's side-effect layer on a shell tool call's pending
-	 * confirmation when adding a persistent terminal auto-approve rule could
-	 * suppress prompts like this one: the command parsed successfully, matched
-	 * no deny rule, has no unapproved write redirect, and only lacks a
-	 * matching allow rule. Absent on confirmations no rule can satisfy —
-	 * managed approvals, sandbox-bypass prompts, denials, and parser failures.
-	 */
-	readonly autoApproveRulesApply?: boolean;
+	/** Whether adding a persistent terminal auto-approve rule can suppress future prompts for this confirmation. */
+	readonly autoApproveRuleResolvable?: boolean;
 	/** Transient runtime corpus for the local client tool-search invocation. */
 	readonly toolSearchCandidates?: readonly IToolSearchCandidate[];
 }
@@ -142,7 +135,7 @@ export function readToolCallMeta(source: IHasToolCallMeta): IToolCallMeta {
 	if (typeof meta['mcpServerName'] === 'string') { result.mcpServerName = meta['mcpServerName']; }
 	if (typeof meta['mcpToolName'] === 'string') { result.mcpToolName = meta['mcpToolName']; }
 	if (typeof meta['autoApproveBySetting'] === 'boolean') { result.autoApproveBySetting = meta['autoApproveBySetting']; }
-	if (typeof meta['autoApproveRulesApply'] === 'boolean') { result.autoApproveRulesApply = meta['autoApproveRulesApply']; }
+	if (typeof meta['autoApproveRuleResolvable'] === 'boolean') { result.autoApproveRuleResolvable = meta['autoApproveRuleResolvable']; }
 	const toolSearchCandidates = readToolSearchCandidates(meta['toolSearchCandidates']);
 	if (toolSearchCandidates) { result.toolSearchCandidates = toolSearchCandidates; }
 	const ui = readToolCallUiMeta(meta['ui']);

--- a/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
@@ -46,6 +46,15 @@ export interface IToolCallMeta {
 	 * explicit user action), so the client can render it as setting-driven.
 	 */
 	readonly autoApproveBySetting?: boolean;
+	/**
+	 * Set by the host's side-effect layer on a shell tool call's pending
+	 * confirmation when the command was evaluated by the rule-based
+	 * auto-approver (`permissionKind === 'shell'` without a sandbox bypass),
+	 * so the client knows that configuring terminal auto-approve rules can
+	 * suppress future prompts like this one. Absent on confirmations rules
+	 * can never satisfy (e.g. sandbox-bypass prompts).
+	 */
+	readonly autoApproveRulesApply?: boolean;
 	/** Transient runtime corpus for the local client tool-search invocation. */
 	readonly toolSearchCandidates?: readonly IToolSearchCandidate[];
 }
@@ -133,6 +142,7 @@ export function readToolCallMeta(source: IHasToolCallMeta): IToolCallMeta {
 	if (typeof meta['mcpServerName'] === 'string') { result.mcpServerName = meta['mcpServerName']; }
 	if (typeof meta['mcpToolName'] === 'string') { result.mcpToolName = meta['mcpToolName']; }
 	if (typeof meta['autoApproveBySetting'] === 'boolean') { result.autoApproveBySetting = meta['autoApproveBySetting']; }
+	if (typeof meta['autoApproveRulesApply'] === 'boolean') { result.autoApproveRulesApply = meta['autoApproveRulesApply']; }
 	const toolSearchCandidates = readToolSearchCandidates(meta['toolSearchCandidates']);
 	if (toolSearchCandidates) { result.toolSearchCandidates = toolSearchCandidates; }
 	const ui = readToolCallUiMeta(meta['ui']);

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1151,6 +1151,14 @@ export class AgentSideEffects extends Disposable {
 			// Make sure the agent is registered for the eventual `ChatToolCallConfirmed` response.
 			this._toolCallAgents.set(toolCallKey, agent.id);
 		}
+		if (e.permissionKind === 'shell' && !e.requestSandboxBypass) {
+			// Mark confirmations the rule-based auto-approver evaluated so the
+			// client knows terminal auto-approve rules can suppress future
+			// prompts like this one. Sandbox-bypass prompts are deliberately
+			// left unmarked: rules can never satisfy them (see the
+			// `requestSandboxBypass` early-return in `getAutoApproval`).
+			effective = { ...effective, state: { ...effective.state, _meta: { ...toolCall?._meta, ...effective.state._meta, ...toToolCallMeta({ autoApproveRulesApply: true }) } } };
+		}
 		this._stateManager.dispatchServerAction(
 			sessionKey,
 			this._permissionManager.createToolReadyAction(effective, sessionKey, turnId)

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1151,13 +1151,9 @@ export class AgentSideEffects extends Disposable {
 			// Make sure the agent is registered for the eventual `ChatToolCallConfirmed` response.
 			this._toolCallAgents.set(toolCallKey, agent.id);
 		}
-		if (autoApproval === undefined && !e.managedApprovalRequired && this._permissionManager.canFutureRuleSuppressPrompt(approvalEvent, sessionKey)) {
-			// Mark shell confirmations whose only blocker is a missing allow
-			// rule, so the client can offer rule-creating actions that will
-			// genuinely suppress future prompts. Managed approvals,
-			// sandbox-bypass prompts, denials, parser failures, and unapproved
-			// write redirects stay unmarked: no rule can satisfy them.
-			effective = { ...effective, state: { ...effective.state, _meta: { ...toolCall?._meta, ...effective.state._meta, ...toToolCallMeta({ autoApproveRulesApply: true }) } } };
+		if (autoApproval === undefined && !e.managedApprovalRequired && this._permissionManager.isAutoApproveRuleResolvable(approvalEvent, sessionKey)) {
+			// Mark confirmations where a persistent allow rule can suppress the next equivalent prompt.
+			effective = { ...effective, state: { ...effective.state, _meta: { ...toolCall?._meta, ...effective.state._meta, ...toToolCallMeta({ autoApproveRuleResolvable: true }) } } };
 		}
 		this._stateManager.dispatchServerAction(
 			sessionKey,

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1151,12 +1151,12 @@ export class AgentSideEffects extends Disposable {
 			// Make sure the agent is registered for the eventual `ChatToolCallConfirmed` response.
 			this._toolCallAgents.set(toolCallKey, agent.id);
 		}
-		if (e.permissionKind === 'shell' && !e.requestSandboxBypass) {
-			// Mark confirmations the rule-based auto-approver evaluated so the
-			// client knows terminal auto-approve rules can suppress future
-			// prompts like this one. Sandbox-bypass prompts are deliberately
-			// left unmarked: rules can never satisfy them (see the
-			// `requestSandboxBypass` early-return in `getAutoApproval`).
+		if (autoApproval === undefined && !e.managedApprovalRequired && this._permissionManager.canFutureRuleSuppressPrompt(approvalEvent, sessionKey)) {
+			// Mark shell confirmations whose only blocker is a missing allow
+			// rule, so the client can offer rule-creating actions that will
+			// genuinely suppress future prompts. Managed approvals,
+			// sandbox-bypass prompts, denials, parser failures, and unapproved
+			// write redirects stay unmarked: no rule can satisfy them.
 			effective = { ...effective, state: { ...effective.state, _meta: { ...toolCall?._meta, ...effective.state._meta, ...toToolCallMeta({ autoApproveRulesApply: true }) } } };
 		}
 		this._stateManager.dispatchServerAction(

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -91,15 +91,8 @@ export type CommandApprovalResult = 'approved' | 'denied' | 'noMatch';
 export interface ICommandApprovalEvaluation {
 	/** Final approval outcome, identical to {@link CommandAutoApprover.shouldAutoApprove}. */
 	readonly result: CommandApprovalResult;
-	/**
-	 * Whether adding a persistent auto-approve rule could turn this outcome
-	 * into an approval: the command parsed successfully, nothing matched a
-	 * deny rule, every write-redirect destination is approved, and the only
-	 * blocker is a missing allow rule. False for approved results (nothing
-	 * left to resolve), denials, parser failures, and unapproved write
-	 * redirects — prompts no rule can suppress.
-	 */
-	readonly ruleResolvable: boolean;
+	/** Whether a missing allow rule is the only reason confirmation is required. */
+	readonly autoApproveRuleResolvable: boolean;
 }
 
 /** Options for {@link CommandAutoApprover.shouldAutoApprove}. */
@@ -190,15 +183,11 @@ export class CommandAutoApprover extends Disposable {
 		return this.evaluate(commandLine, options).result;
 	}
 
-	/**
-	 * Like {@link shouldAutoApprove}, but also reports whether the outcome is
-	 * resolvable by adding a persistent auto-approve rule (see
-	 * {@link ICommandApprovalEvaluation.ruleResolvable}).
-	 */
+	/** Evaluates the command and reports whether adding a persistent allow rule could resolve the result. */
 	evaluate(commandLine: string, options?: IShouldAutoApproveOptions): ICommandApprovalEvaluation {
 		const trimmed = commandLine.trimStart();
 		if (trimmed.length === 0) {
-			return { result: 'approved', ruleResolvable: false };
+			return { result: 'approved', autoApproveRuleResolvable: false };
 		}
 
 		const rules = this._compileRules(options?.autoApproveRules);
@@ -206,11 +195,11 @@ export class CommandAutoApprover extends Disposable {
 		const parsed = this._extractSubCommands(trimmed);
 		if (!parsed) {
 			this._logService.trace('[CommandAutoApprover] Tree-sitter unavailable, requiring confirmation');
-			return { result: 'noMatch', ruleResolvable: false };
+			return { result: 'noMatch', autoApproveRuleResolvable: false };
 		}
 
 		if (this._matchesRule(trimmed, rules.denyCommandLineRules)) {
-			return { result: 'denied', ruleResolvable: false };
+			return { result: 'denied', autoApproveRuleResolvable: false };
 		}
 
 		const hasUnapprovedRedirect = () => parsed.unsafeWriteDests.some(dest => dest === undefined || !options?.isWriteDestApproved?.(dest));
@@ -221,11 +210,9 @@ export class CommandAutoApprover extends Disposable {
 		}
 		if (result === 'approved' && hasUnapprovedRedirect()) {
 			this._logService.trace('[CommandAutoApprover] Write redirection to non-approved destination, requiring confirmation');
-			return { result: 'noMatch', ruleResolvable: false };
+			return { result: 'noMatch', autoApproveRuleResolvable: false };
 		}
-		// A `noMatch` blocked only by missing allow rules is rule-resolvable;
-		// one that an unapproved write redirect would still block is not.
-		return { result, ruleResolvable: result === 'noMatch' && !hasUnapprovedRedirect() };
+		return { result, autoApproveRuleResolvable: result === 'noMatch' && !hasUnapprovedRedirect() };
 	}
 
 	private _matchSubCommands(subCommands: string[], rules: IAutoApproveRules): CommandApprovalResult {

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -87,6 +87,21 @@ function classifyFileRedirect(redirectText: string): FileRedirectClassification 
  */
 export type CommandApprovalResult = 'approved' | 'denied' | 'noMatch';
 
+/** Structured outcome of {@link CommandAutoApprover.evaluate}. */
+export interface ICommandApprovalEvaluation {
+	/** Final approval outcome, identical to {@link CommandAutoApprover.shouldAutoApprove}. */
+	readonly result: CommandApprovalResult;
+	/**
+	 * Whether adding a persistent auto-approve rule could turn this outcome
+	 * into an approval: the command parsed successfully, nothing matched a
+	 * deny rule, every write-redirect destination is approved, and the only
+	 * blocker is a missing allow rule. False for approved results (nothing
+	 * left to resolve), denials, parser failures, and unapproved write
+	 * redirects — prompts no rule can suppress.
+	 */
+	readonly ruleResolvable: boolean;
+}
+
 /** Options for {@link CommandAutoApprover.shouldAutoApprove}. */
 export interface IShouldAutoApproveOptions {
 	/**
@@ -172,9 +187,18 @@ export class CommandAutoApprover extends Disposable {
 	 * predicate, write redirections do not block auto-approval.
 	 */
 	shouldAutoApprove(commandLine: string, options?: IShouldAutoApproveOptions): CommandApprovalResult {
+		return this.evaluate(commandLine, options).result;
+	}
+
+	/**
+	 * Like {@link shouldAutoApprove}, but also reports whether the outcome is
+	 * resolvable by adding a persistent auto-approve rule (see
+	 * {@link ICommandApprovalEvaluation.ruleResolvable}).
+	 */
+	evaluate(commandLine: string, options?: IShouldAutoApproveOptions): ICommandApprovalEvaluation {
 		const trimmed = commandLine.trimStart();
 		if (trimmed.length === 0) {
-			return 'approved';
+			return { result: 'approved', ruleResolvable: false };
 		}
 
 		const rules = this._compileRules(options?.autoApproveRules);
@@ -182,26 +206,26 @@ export class CommandAutoApprover extends Disposable {
 		const parsed = this._extractSubCommands(trimmed);
 		if (!parsed) {
 			this._logService.trace('[CommandAutoApprover] Tree-sitter unavailable, requiring confirmation');
-			return 'noMatch';
+			return { result: 'noMatch', ruleResolvable: false };
 		}
 
 		if (this._matchesRule(trimmed, rules.denyCommandLineRules)) {
-			return 'denied';
+			return { result: 'denied', ruleResolvable: false };
 		}
+
+		const hasUnapprovedRedirect = () => parsed.unsafeWriteDests.some(dest => dest === undefined || !options?.isWriteDestApproved?.(dest));
 
 		let result = this._matchSubCommands(parsed.subCommands, rules);
 		if (result !== 'denied' && this._matchesRule(trimmed, rules.allowCommandLineRules)) {
 			result = 'approved';
 		}
-		if (result === 'approved' && parsed.unsafeWriteDests.length > 0) {
-			for (const dest of parsed.unsafeWriteDests) {
-				if (dest === undefined || !options?.isWriteDestApproved?.(dest)) {
-					this._logService.trace('[CommandAutoApprover] Write redirection to non-approved destination, requiring confirmation');
-					return 'noMatch';
-				}
-			}
+		if (result === 'approved' && hasUnapprovedRedirect()) {
+			this._logService.trace('[CommandAutoApprover] Write redirection to non-approved destination, requiring confirmation');
+			return { result: 'noMatch', ruleResolvable: false };
 		}
-		return result;
+		// A `noMatch` blocked only by missing allow rules is rule-resolvable;
+		// one that an unapproved write redirect would still block is not.
+		return { result, ruleResolvable: result === 'noMatch' && !hasUnapprovedRedirect() };
 	}
 
 	private _matchSubCommands(subCommands: string[], rules: IAutoApproveRules): CommandApprovalResult {

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -328,6 +328,30 @@ export class SessionPermissionManager extends Disposable {
 	}
 
 	/**
+	 * Whether adding a persistent terminal auto-approve rule would suppress
+	 * future prompts like this shell event (the current event still prompts):
+	 * the command parsed, matched no deny rule, has no unapproved write
+	 * redirect, and only lacks a matching allow rule. False for non-shell
+	 * events, sandbox-bypass prompts, and disabled auto-approve. Re-parses
+	 * the command (cheap, rules are cached) so {@link getAutoApproval} stays
+	 * untouched.
+	 */
+	canFutureRuleSuppressPrompt(e: IToolApprovalEvent, sessionKey: ProtocolURI): boolean {
+		if (e.permissionKind !== 'shell' || !e.toolInput || e.requestSandboxBypass) {
+			return false;
+		}
+		if (this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveEnabledConfigKey) === false) {
+			return false;
+		}
+		const workDirs = this._configService.getEffectiveWorkingDirectories(sessionKey);
+		const workingDirectories = workDirs?.map(d => URI.parse(d));
+		return this._commandAutoApprover.evaluate(e.toolInput, {
+			autoApproveRules: this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveRulesConfigKey),
+			isWriteDestApproved: dest => this._isShellWriteDestApproved(dest, workingDirectories),
+		}).ruleResolvable;
+	}
+
+	/**
 	 * Returns whether VS Code's global auto-approve setting (`chat.tools.global.autoApprove`) is enabled.
 	 * When enabled, every tool call is auto-approved without changing the session's approval level in the permissions picker.
 	 */

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -327,16 +327,8 @@ export class SessionPermissionManager extends Disposable {
 		return undefined;
 	}
 
-	/**
-	 * Whether adding a persistent terminal auto-approve rule would suppress
-	 * future prompts like this shell event (the current event still prompts):
-	 * the command parsed, matched no deny rule, has no unapproved write
-	 * redirect, and only lacks a matching allow rule. False for non-shell
-	 * events, sandbox-bypass prompts, and disabled auto-approve. Re-parses
-	 * the command (cheap, rules are cached) so {@link getAutoApproval} stays
-	 * untouched.
-	 */
-	canFutureRuleSuppressPrompt(e: IToolApprovalEvent, sessionKey: ProtocolURI): boolean {
+	/** Whether adding a persistent terminal auto-approve rule can suppress future prompts for this shell event. */
+	isAutoApproveRuleResolvable(e: IToolApprovalEvent, sessionKey: ProtocolURI): boolean {
 		if (e.permissionKind !== 'shell' || !e.toolInput || e.requestSandboxBypass) {
 			return false;
 		}
@@ -348,7 +340,7 @@ export class SessionPermissionManager extends Disposable {
 		return this._commandAutoApprover.evaluate(e.toolInput, {
 			autoApproveRules: this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveRulesConfigKey),
 			isWriteDestApproved: dest => this._isShellWriteDestApproved(dest, workingDirectories),
-		}).ruleResolvable;
+		}).autoApproveRuleResolvable;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -2887,6 +2887,43 @@ suite('AgentSideEffects', () => {
 				'tool call should advance to PendingConfirmation for permission-gated tool_ready');
 		});
 
+		test('tool_ready for a shell permission marks autoApproveRulesApply, except when sandbox bypass is requested', async () => {
+			setupSession();
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			for (const [toolCallId, requestSandboxBypass] of [['tc-shell-rules-1', false], ['tc-shell-rules-2', true]] as const) {
+				agent.fireProgress({
+					kind: 'action', resource: URI.parse(defaultChatUri),
+					action: {
+						type: ActionType.ChatToolCallStart, turnId: 'turn-1',
+						toolCallId, toolName: 'shell', displayName: 'Shell', contributor: { kind: ToolCallContributorKind.Client, clientId: 'test-client' },
+						_meta: { toolKind: undefined, language: undefined },
+					},
+				});
+				agent.fireProgress({
+					kind: 'pending_confirmation', chat: URI.parse(defaultChatUri),
+					state: {
+						status: ToolCallStatus.PendingConfirmation,
+						toolCallId, toolName: '', displayName: '',
+						invocationMessage: 'Run command', toolInput: 'foo --bar',
+						confirmationTitle: 'Run in terminal?', edits: undefined,
+					},
+					permissionKind: 'shell', permissionPath: undefined, requestSandboxBypass,
+				});
+			}
+
+			const state = await waitForState(stateManager, () => {
+				const s = stateManager.getSessionState(sessionUri.toString());
+				const parts = s?.activeTurn?.responseParts;
+				return parts?.length === 2 && parts.every(p => p.kind === ResponsePartKind.ToolCall && p.toolCall.status === ToolCallStatus.PendingConfirmation) ? s : undefined;
+			});
+			assert.deepStrictEqual(
+				state.activeTurn?.responseParts.map(p => p.kind === ResponsePartKind.ToolCall ? p.toolCall._meta?.['autoApproveRulesApply'] : undefined),
+				[true, undefined],
+				'rule-evaluated shell confirmation is marked; sandbox-bypass confirmation is not');
+		});
+
 		test('tool_ready is dropped when the tool completes while permission lookup is pending', async () => {
 			setupSession();
 			startTurn('turn-1');

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -2887,12 +2887,19 @@ suite('AgentSideEffects', () => {
 				'tool call should advance to PendingConfirmation for permission-gated tool_ready');
 		});
 
-		test('tool_ready for a shell permission marks autoApproveRulesApply, except when sandbox bypass is requested', async () => {
+		test('tool_ready for a shell permission marks autoApproveRulesApply, except for sandbox-bypass and managed confirmations', async () => {
 			setupSession();
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
+			// Rule resolvability requires a successful tree-sitter parse.
+			await sideEffects.initialize();
 
-			for (const [toolCallId, requestSandboxBypass] of [['tc-shell-rules-1', false], ['tc-shell-rules-2', true]] as const) {
+			const cases = [
+				['tc-shell-rules-1', { requestSandboxBypass: false }],
+				['tc-shell-rules-2', { requestSandboxBypass: true }],
+				['tc-shell-rules-3', { managedApprovalRequired: true }],
+			] as const;
+			for (const [toolCallId, signalOverrides] of cases) {
 				agent.fireProgress({
 					kind: 'action', resource: URI.parse(defaultChatUri),
 					action: {
@@ -2909,19 +2916,20 @@ suite('AgentSideEffects', () => {
 						invocationMessage: 'Run command', toolInput: 'foo --bar',
 						confirmationTitle: 'Run in terminal?', edits: undefined,
 					},
-					permissionKind: 'shell', permissionPath: undefined, requestSandboxBypass,
+					permissionKind: 'shell', permissionPath: undefined,
+					...signalOverrides,
 				});
 			}
 
 			const state = await waitForState(stateManager, () => {
 				const s = stateManager.getSessionState(sessionUri.toString());
 				const parts = s?.activeTurn?.responseParts;
-				return parts?.length === 2 && parts.every(p => p.kind === ResponsePartKind.ToolCall && p.toolCall.status === ToolCallStatus.PendingConfirmation) ? s : undefined;
+				return parts?.length === cases.length && parts.every(p => p.kind === ResponsePartKind.ToolCall && p.toolCall.status === ToolCallStatus.PendingConfirmation) ? s : undefined;
 			});
 			assert.deepStrictEqual(
 				state.activeTurn?.responseParts.map(p => p.kind === ResponsePartKind.ToolCall ? p.toolCall._meta?.['autoApproveRulesApply'] : undefined),
-				[true, undefined],
-				'rule-evaluated shell confirmation is marked; sandbox-bypass confirmation is not');
+				[true, undefined, undefined],
+				'only the rule-resolvable shell confirmation is marked; sandbox-bypass and managed confirmations are not');
 		});
 
 		test('tool_ready is dropped when the tool completes while permission lookup is pending', async () => {

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -2887,7 +2887,7 @@ suite('AgentSideEffects', () => {
 				'tool call should advance to PendingConfirmation for permission-gated tool_ready');
 		});
 
-		test('tool_ready for a shell permission marks autoApproveRulesApply, except for sandbox-bypass and managed confirmations', async () => {
+		test('tool_ready marks autoApproveRuleResolvable only for eligible shell confirmations', async () => {
 			setupSession();
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -2927,7 +2927,7 @@ suite('AgentSideEffects', () => {
 				return parts?.length === cases.length && parts.every(p => p.kind === ResponsePartKind.ToolCall && p.toolCall.status === ToolCallStatus.PendingConfirmation) ? s : undefined;
 			});
 			assert.deepStrictEqual(
-				state.activeTurn?.responseParts.map(p => p.kind === ResponsePartKind.ToolCall ? p.toolCall._meta?.['autoApproveRulesApply'] : undefined),
+				state.activeTurn?.responseParts.map(p => p.kind === ResponsePartKind.ToolCall ? p.toolCall._meta?.['autoApproveRuleResolvable'] : undefined),
 				[true, undefined, undefined],
 				'only the rule-resolvable shell confirmation is marked; sandbox-bypass and managed confirmations are not');
 		});

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -257,6 +257,8 @@ suite('CommandAutoApprover', () => {
 				['rm file.txt', { result: 'denied', ruleResolvable: false }],
 				// Unknown command blocked only by a missing allow rule.
 				['my-custom-script', { result: 'noMatch', ruleResolvable: true }],
+				// Transient env-var assignments are denied outright.
+				['FOO=bar my-custom-script', { result: 'denied', ruleResolvable: false }],
 				// Unapproved write redirects block regardless of rules, whether
 				// the command itself is approved or unmatched.
 				['echo hi > /etc/passwd', { result: 'noMatch', ruleResolvable: false }],

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -253,25 +253,25 @@ suite('CommandAutoApprover', () => {
 		test('reports whether a persistent rule could resolve the outcome', () => {
 			const cases: [commandLine: string, expected: ICommandApprovalEvaluation][] = [
 				// Approved and denied outcomes leave nothing for a rule to resolve.
-				['ls', { result: 'approved', ruleResolvable: false }],
-				['rm file.txt', { result: 'denied', ruleResolvable: false }],
+				['ls', { result: 'approved', autoApproveRuleResolvable: false }],
+				['rm file.txt', { result: 'denied', autoApproveRuleResolvable: false }],
 				// Unknown command blocked only by a missing allow rule.
-				['my-custom-script', { result: 'noMatch', ruleResolvable: true }],
+				['my-custom-script', { result: 'noMatch', autoApproveRuleResolvable: true }],
 				// Transient env-var assignments are denied outright.
-				['FOO=bar my-custom-script', { result: 'denied', ruleResolvable: false }],
+				['FOO=bar my-custom-script', { result: 'denied', autoApproveRuleResolvable: false }],
 				// Unapproved write redirects block regardless of rules, whether
 				// the command itself is approved or unmatched.
-				['echo hi > /etc/passwd', { result: 'noMatch', ruleResolvable: false }],
-				['my-custom-script > /etc/passwd', { result: 'noMatch', ruleResolvable: false }],
+				['echo hi > /etc/passwd', { result: 'noMatch', autoApproveRuleResolvable: false }],
+				['my-custom-script > /etc/passwd', { result: 'noMatch', autoApproveRuleResolvable: false }],
 				// Safe sinks do not block.
-				['echo hi > /dev/null', { result: 'approved', ruleResolvable: false }],
+				['echo hi > /dev/null', { result: 'approved', autoApproveRuleResolvable: false }],
 			];
 			assert.deepStrictEqual(cases.map(([commandLine]) => approver.evaluate(commandLine)), cases.map(([, expected]) => expected));
 		});
 
 		test('is not rule-resolvable while the parser is unavailable', () => {
 			const uninitialized = disposables.add(new CommandAutoApprover(new NullLogService()));
-			assert.deepStrictEqual(uninitialized.evaluate('ls'), { result: 'noMatch', ruleResolvable: false });
+			assert.deepStrictEqual(uninitialized.evaluate('ls'), { result: 'noMatch', autoApproveRuleResolvable: false });
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
-import { CommandAutoApprover } from '../../node/commandAutoApprover.js';
+import { CommandAutoApprover, type ICommandApprovalEvaluation } from '../../node/commandAutoApprover.js';
 
 suite('CommandAutoApprover', () => {
 
@@ -245,6 +245,31 @@ suite('CommandAutoApprover', () => {
 			seen.length = 0;
 			assert.strictEqual(approver.shouldAutoApprove('echo hi > /dev/null 2>&1', opts), 'approved');
 			assert.deepStrictEqual(seen, []);
+		});
+	});
+
+	suite('evaluate', () => {
+
+		test('reports whether a persistent rule could resolve the outcome', () => {
+			const cases: [commandLine: string, expected: ICommandApprovalEvaluation][] = [
+				// Approved and denied outcomes leave nothing for a rule to resolve.
+				['ls', { result: 'approved', ruleResolvable: false }],
+				['rm file.txt', { result: 'denied', ruleResolvable: false }],
+				// Unknown command blocked only by a missing allow rule.
+				['my-custom-script', { result: 'noMatch', ruleResolvable: true }],
+				// Unapproved write redirects block regardless of rules, whether
+				// the command itself is approved or unmatched.
+				['echo hi > /etc/passwd', { result: 'noMatch', ruleResolvable: false }],
+				['my-custom-script > /etc/passwd', { result: 'noMatch', ruleResolvable: false }],
+				// Safe sinks do not block.
+				['echo hi > /dev/null', { result: 'approved', ruleResolvable: false }],
+			];
+			assert.deepStrictEqual(cases.map(([commandLine]) => approver.evaluate(commandLine)), cases.map(([, expected]) => expected));
+		});
+
+		test('is not rule-resolvable while the parser is unavailable', () => {
+			const uninitialized = disposables.add(new CommandAutoApprover(new NullLogService()));
+			assert.deepStrictEqual(uninitialized.evaluate('ls'), { result: 'noMatch', ruleResolvable: false });
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -266,6 +266,25 @@ suite('SessionPermissionManager', () => {
 		assert.strictEqual(result, undefined);
 	});
 
+	test('canFutureRuleSuppressPrompt is true only when a missing allow rule is the sole blocker', () => {
+		const cases: [name: string, event: IToolApprovalEvent, expected: boolean][] = [
+			['unknown command', shellEvent('my-custom-script'), true],
+			['already approved', shellEvent('echo hello'), false],
+			['denied', shellEvent('rm file.txt'), false],
+			['unapproved write redirect', shellEvent('my-custom-script > /etc/passwd'), false],
+			['sandbox bypass', { ...shellEvent('my-custom-script'), requestSandboxBypass: true }, false],
+			['non-shell', writeEvent('/outside/app.ts'), false],
+		];
+		assert.deepStrictEqual(
+			cases.map(([name, e]) => `${name}=${permissions.canFutureRuleSuppressPrompt(e, sessionUri)}`),
+			cases.map(([name, , expected]) => `${name}=${expected}`));
+	});
+
+	test('canFutureRuleSuppressPrompt is false when terminal auto-approve is disabled', () => {
+		configService.updateRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: false });
+		assert.strictEqual(permissions.canFutureRuleSuppressPrompt(shellEvent('my-custom-script'), sessionUri), false);
+	});
+
 	test('does not affect session bypass permission mode when terminal auto-approve is disabled', async () => {
 		configService.updateRootConfig({
 			[AgentHostTerminalAutoApproveEnabledConfigKey]: false,

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -266,7 +266,7 @@ suite('SessionPermissionManager', () => {
 		assert.strictEqual(result, undefined);
 	});
 
-	test('canFutureRuleSuppressPrompt is true only when a missing allow rule is the sole blocker', () => {
+	test('isAutoApproveRuleResolvable is true only when a missing allow rule is the sole blocker', () => {
 		const cases: [name: string, event: IToolApprovalEvent, expected: boolean][] = [
 			['unknown command', shellEvent('my-custom-script'), true],
 			['already approved', shellEvent('echo hello'), false],
@@ -276,13 +276,13 @@ suite('SessionPermissionManager', () => {
 			['non-shell', writeEvent('/outside/app.ts'), false],
 		];
 		assert.deepStrictEqual(
-			cases.map(([name, e]) => `${name}=${permissions.canFutureRuleSuppressPrompt(e, sessionUri)}`),
+			cases.map(([name, e]) => `${name}=${permissions.isAutoApproveRuleResolvable(e, sessionUri)}`),
 			cases.map(([name, , expected]) => `${name}=${expected}`));
 	});
 
-	test('canFutureRuleSuppressPrompt is false when terminal auto-approve is disabled', () => {
+	test('isAutoApproveRuleResolvable is false when terminal auto-approve is disabled', () => {
 		configService.updateRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: false });
-		assert.strictEqual(permissions.canFutureRuleSuppressPrompt(shellEvent('my-custom-script'), sessionUri), false);
+		assert.strictEqual(permissions.isAutoApproveRuleResolvable(shellEvent('my-custom-script'), sessionUri), false);
 	});
 
 	test('does not affect session bypass permission mode when terminal auto-approve is disabled', async () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -1357,6 +1357,7 @@ function buildTerminalToolSpecificData(
 		commandLine,
 		intention: tc.intention ?? existing?.intention,
 		language: existing?.language ?? getTerminalLanguage(tc),
+		autoApproveRulesApply: readToolCallMeta(tc).autoApproveRulesApply ?? existing?.autoApproveRulesApply,
 		terminalToolSessionId: terminalContentUri
 			? makeAhpTerminalToolSessionId(terminalContentUri, sessionResource)
 			: existing?.terminalToolSessionId,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -1357,7 +1357,7 @@ function buildTerminalToolSpecificData(
 		commandLine,
 		intention: tc.intention ?? existing?.intention,
 		language: existing?.language ?? getTerminalLanguage(tc),
-		autoApproveRulesApply: readToolCallMeta(tc).autoApproveRulesApply ?? existing?.autoApproveRulesApply,
+		autoApproveRuleResolvable: readToolCallMeta(tc).autoApproveRuleResolvable ?? existing?.autoApproveRuleResolvable,
 		terminalToolSessionId: terminalContentUri
 			? makeAhpTerminalToolSessionId(terminalContentUri, sessionResource)
 			: existing?.terminalToolSessionId,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatConfirmationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatConfirmationWidget.ts
@@ -322,6 +322,7 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 	}
 
 	private _buttonsDomNode: HTMLElement;
+	private _buttons: { readonly label: string; readonly widget: IButton }[] = [];
 
 	setShowButtons(showButton: boolean): void {
 		this.domNode.classList.toggle('hideButtons', !showButton);
@@ -424,9 +425,14 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 	}
 
 	updateButtons(buttons: IChatConfirmationButton<T>[]) {
+		const focusedButton = this._buttons.find(button => button.widget.hasFocus());
+		const focusedDropdown = focusedButton?.widget instanceof ButtonWithDropdown && focusedButton.widget.dropdownButton.hasFocus();
+		this._buttons = [];
+
 		while (this._buttonsDomNode.children.length > 0) {
 			this._buttonsDomNode.children[0].remove();
 		}
+
 		for (const buttonData of buttons) {
 			const buttonOptions: IButtonOptions = { ...defaultButtonStyles, small: true, secondary: buttonData.isSecondary, title: buttonData.tooltip, disabled: buttonData.disabled };
 
@@ -457,11 +463,19 @@ abstract class BaseChatConfirmationWidget<T> extends Disposable {
 			}
 
 			this._register(button);
+			this._buttons.push({ label: buttonData.label, widget: button });
 			button.label = buttonData.label;
 			this._register(button.onDidClick(event => this._onDidClick.fire({ button: buttonData, isTouchClick: !!event && event.type === TouchEventType.Tap })));
 			if (buttonData.onDidChangeDisablement) {
 				this._register(buttonData.onDidChangeDisablement(disabled => button.enabled = !disabled));
 			}
+		}
+
+		const buttonToFocus = focusedButton && this._buttons.find(button => button.label === focusedButton.label)?.widget;
+		if (focusedDropdown && buttonToFocus instanceof ButtonWithDropdown) {
+			buttonToFocus.dropdownButton.focus();
+		} else {
+			buttonToFocus?.focus();
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -29,6 +29,8 @@ import { ITerminalChatService } from '../../../../../terminal/browser/terminal.j
 import { TerminalContribCommandId, TerminalContribSettingId } from '../../../../../terminal/terminalContribExports.js';
 import { ChatContextKeys } from '../../../../common/actions/chatContextKeys.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../../../common/chat.js';
+import { localChatSessionType } from '../../../../common/chatSessionsService.js';
+import { getChatSessionType } from '../../../../common/model/chatUri.js';
 import { IChatToolInvocation, ToolConfirmKind, type IChatTerminalToolInvocationData, type ILegacyChatTerminalToolInvocationData } from '../../../../common/chatService/chatService.js';
 import { ILanguageModelToolsService } from '../../../../common/tools/languageModelToolsService.js';
 import { AcceptToolConfirmationActionId, SkipToolConfirmationActionId } from '../../../actions/chatToolActions.js';
@@ -109,10 +111,17 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 		const isReadOnly = !!terminalData.presentationOverrides;
 
 		const autoApproveEnabled = this.configurationService.getValue(TerminalContribSettingId.EnableAutoApprove) === true;
-		const autoApproveWarningAccepted = this.storageService.getBoolean(TerminalToolConfirmationStorageKeys.TerminalAutoApproveWarningAccepted, StorageScope.APPLICATION, false);
-		let moreActions: (IChatConfirmationButton<TerminalNewAutoApproveButtonData> | Separator)[] | undefined = undefined;
-		if (autoApproveEnabled) {
-			moreActions = [];
+		// Custom actions typically come pre-computed from the run in terminal tool, but they can
+		// also be generated asynchronously for confirmations that arrive without them (eg. agent
+		// host sessions), so track them in a mutable local shared by the builder below and the
+		// button click handler.
+		let customActions = terminalCustomActions;
+		const buildMoreActions = (): (IChatConfirmationButton<TerminalNewAutoApproveButtonData> | Separator)[] | undefined => {
+			if (!autoApproveEnabled) {
+				return undefined;
+			}
+			const autoApproveWarningAccepted = this.storageService.getBoolean(TerminalToolConfirmationStorageKeys.TerminalAutoApproveWarningAccepted, StorageScope.APPLICATION, false);
+			const moreActions: (IChatConfirmationButton<TerminalNewAutoApproveButtonData> | Separator)[] = [];
 			if (!autoApproveWarningAccepted) {
 				moreActions.push({
 					label: localize('autoApprove.enable', 'Enable Auto Approve...'),
@@ -121,21 +130,19 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 					}
 				});
 				moreActions.push(new Separator());
-				if (terminalCustomActions) {
-					for (const action of terminalCustomActions) {
+				if (customActions) {
+					for (const action of customActions) {
 						if (!(action instanceof Separator)) {
 							action.disabled = true;
 						}
 					}
 				}
 			}
-			if (terminalCustomActions) {
-				moreActions.push(...terminalCustomActions);
+			if (customActions) {
+				moreActions.push(...customActions);
 			}
-			if (moreActions.length === 0) {
-				moreActions = undefined;
-			}
-		}
+			return moreActions.length === 0 ? undefined : moreActions;
+		};
 
 		const codeBlockRenderOptions: ICodeBlockRenderOptions = {
 			hideToolbar: true,
@@ -201,9 +208,27 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 				icon: Codicon.terminal,
 				message: elements.root,
 				footerBanner: riskBadge?.domNode,
-				buttons: this._createButtons(moreActions)
+				buttons: this._createButtons(buildMoreActions())
 			},
 		));
+
+		// Confirmations for sessions whose approval is decided outside the built-in run in
+		// terminal tool (eg. agent host sessions) arrive without pre-computed actions. Generate
+		// them from the command line so the same rule-creating options are offered.
+		if (autoApproveEnabled && !customActions && getChatSessionType(this.context.element.sessionResource) !== localChatSessionType) {
+			const commandForAnalysis = terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
+			const analysisLanguage = terminalData.language === 'powershell' ? 'powershell' : 'shellscript';
+			this.terminalChatService.getAutoApproveActions(commandForAnalysis, analysisLanguage, this.context.element.sessionResource).then(actions => {
+				if (this._store.isDisposed || !actions?.length || customActions) {
+					return;
+				}
+				if (toolInvocation.state.get().type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
+					return;
+				}
+				customActions = actions;
+				confirmWidget.updateButtons(this._createButtons(buildMoreActions()));
+			});
+		}
 
 		// Build the unsandboxed-execution reason and disclaimer markdown. When
 		// the risk badge is shown, surface them via its details hover (with
@@ -321,14 +346,16 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 							}
 							// If this would not have been auto approved, enable the options and
 							// do not complete
-							else if (terminalCustomActions) {
-								for (const action of terminalCustomActions) {
-									if (!(action instanceof Separator)) {
-										action.disabled = false;
+							else {
+								if (customActions) {
+									for (const action of customActions) {
+										if (!(action instanceof Separator)) {
+											action.disabled = false;
+										}
 									}
 								}
 
-								confirmWidget.updateButtons(this._createButtons(terminalCustomActions));
+								confirmWidget.updateButtons(this._createButtons(buildMoreActions()));
 								doComplete = false;
 							}
 						} else {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -9,7 +9,7 @@ import { HoverPosition } from '../../../../../../../base/browser/ui/hover/hoverW
 import { Separator } from '../../../../../../../base/common/actions.js';
 import { asArray } from '../../../../../../../base/common/arrays.js';
 import { Codicon } from '../../../../../../../base/common/codicons.js';
-import { ErrorNoTelemetry } from '../../../../../../../base/common/errors.js';
+import { ErrorNoTelemetry, onUnexpectedError } from '../../../../../../../base/common/errors.js';
 import { createCommandUri, escapeMarkdownSyntaxTokens, MarkdownString, type IMarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { toDisposable } from '../../../../../../../base/common/lifecycle.js';
 import Severity from '../../../../../../../base/common/severity.js';
@@ -29,7 +29,7 @@ import { ITerminalChatService } from '../../../../../terminal/browser/terminal.j
 import { TerminalContribCommandId, TerminalContribSettingId } from '../../../../../terminal/terminalContribExports.js';
 import { ChatContextKeys } from '../../../../common/actions/chatContextKeys.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../../../common/chat.js';
-import { localChatSessionType } from '../../../../common/chatSessionsService.js';
+import { SessionType } from '../../../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../../../common/model/chatUri.js';
 import { IChatToolInvocation, ToolConfirmKind, type IChatTerminalToolInvocationData, type ILegacyChatTerminalToolInvocationData } from '../../../../common/chatService/chatService.js';
 import { ILanguageModelToolsService } from '../../../../common/tools/languageModelToolsService.js';
@@ -212,10 +212,14 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 			},
 		));
 
-		// Confirmations for sessions whose approval is decided outside the built-in run in
-		// terminal tool (eg. agent host sessions) arrive without pre-computed actions. Generate
-		// them from the command line so the same rule-creating options are offered.
-		if (autoApproveEnabled && !customActions && getChatSessionType(this.context.element.sessionResource) !== localChatSessionType) {
+		// Confirmations for Agent Host Copilot sessions arrive without pre-computed actions, so
+		// generate the same rule-creating options the built-in run in terminal tool offers. Only
+		// do this when the backend marked the confirmation as evaluated by its rule-based
+		// auto-approver (`autoApproveRulesApply`) — other confirmations (e.g. sandbox-bypass
+		// prompts) can never be suppressed by a rule, so offering one would be misleading. Other
+		// session types (agent-host-claude/codex, remote agent hosts, extension-contributed
+		// sessions) are deliberately excluded: they don't consume the resulting setting.
+		if (autoApproveEnabled && !customActions && terminalData.autoApproveRulesApply && getChatSessionType(this.context.element.sessionResource) === SessionType.AgentHostCopilot) {
 			const commandForAnalysis = terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
 			const analysisLanguage = terminalData.language === 'powershell' ? 'powershell' : 'shellscript';
 			this.terminalChatService.getAutoApproveActions(commandForAnalysis, analysisLanguage, this.context.element.sessionResource).then(actions => {
@@ -227,7 +231,7 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 				}
 				customActions = actions;
 				confirmWidget.updateButtons(this._createButtons(buildMoreActions()));
-			});
+			}, onUnexpectedError);
 		}
 
 		// Build the unsandboxed-execution reason and disclaimer markdown. When

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -212,14 +212,8 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 			},
 		));
 
-		// Confirmations for Agent Host Copilot sessions arrive without pre-computed actions, so
-		// generate the same rule-creating options the built-in run in terminal tool offers. Only
-		// do this when the backend marked the confirmation as evaluated by its rule-based
-		// auto-approver (`autoApproveRulesApply`) — other confirmations (e.g. sandbox-bypass
-		// prompts) can never be suppressed by a rule, so offering one would be misleading. Other
-		// session types (agent-host-claude/codex, remote agent hosts, extension-contributed
-		// sessions) are deliberately excluded: they don't consume the resulting setting.
-		if (autoApproveEnabled && !customActions && terminalData.autoApproveRulesApply && getChatSessionType(this.context.element.sessionResource) === SessionType.AgentHostCopilot) {
+		// Agent Host Copilot confirmations need client-generated persistent rule actions.
+		if (autoApproveEnabled && !customActions && terminalData.autoApproveRuleResolvable && getChatSessionType(this.context.element.sessionResource) === SessionType.AgentHostCopilot) {
 			const commandForAnalysis = terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
 			const analysisLanguage = terminalData.language === 'powershell' ? 'powershell' : 'shellscript';
 			this.terminalChatService.getAutoApproveActions(commandForAnalysis, analysisLanguage).then(actions => {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -222,7 +222,7 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 		if (autoApproveEnabled && !customActions && terminalData.autoApproveRulesApply && getChatSessionType(this.context.element.sessionResource) === SessionType.AgentHostCopilot) {
 			const commandForAnalysis = terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
 			const analysisLanguage = terminalData.language === 'powershell' ? 'powershell' : 'shellscript';
-			this.terminalChatService.getAutoApproveActions(commandForAnalysis, analysisLanguage, this.context.element.sessionResource).then(actions => {
+			this.terminalChatService.getAutoApproveActions(commandForAnalysis, analysisLanguage).then(actions => {
 				if (this._store.isDisposed || !actions?.length || customActions) {
 					return;
 				}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -223,7 +223,7 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 			const commandForAnalysis = terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
 			const analysisLanguage = terminalData.language === 'powershell' ? 'powershell' : 'shellscript';
 			this.terminalChatService.getAutoApproveActions(commandForAnalysis, analysisLanguage).then(actions => {
-				if (this._store.isDisposed || !actions?.length || customActions) {
+				if (this._store.isDisposed || !actions?.length) {
 					return;
 				}
 				if (toolInvocation.state.get().type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -631,6 +631,13 @@ export interface IChatTerminalToolInvocationData {
 	terminalCommandId?: string;
 	/** Whether the terminal command was started as a background execution */
 	isBackground?: boolean;
+	/**
+	 * Whether the backend evaluated this command against the configured
+	 * terminal auto-approve rules, meaning rule-creating confirmation actions
+	 * can suppress future prompts. Set by the Agent Host; the built-in
+	 * terminal tool computes its actions up front and leaves this unset.
+	 */
+	autoApproveRulesApply?: boolean;
 	/** Whether the command was explicitly approved to run outside the sandbox */
 	requestUnsandboxedExecution?: boolean;
 	/** The model-provided reason for requesting sandbox bypass */

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -631,14 +631,8 @@ export interface IChatTerminalToolInvocationData {
 	terminalCommandId?: string;
 	/** Whether the terminal command was started as a background execution */
 	isBackground?: boolean;
-	/**
-	 * Whether adding a persistent terminal auto-approve rule can suppress
-	 * prompts like this confirmation — the backend parsed the command and
-	 * found a missing allow rule to be the only blocker. Set by the Agent
-	 * Host; the built-in terminal tool computes its actions up front and
-	 * leaves this unset.
-	 */
-	autoApproveRulesApply?: boolean;
+	/** Whether adding a persistent terminal auto-approve rule can suppress future prompts for this confirmation. */
+	autoApproveRuleResolvable?: boolean;
 	/** Whether the command was explicitly approved to run outside the sandbox */
 	requestUnsandboxedExecution?: boolean;
 	/** The model-provided reason for requesting sandbox bypass */

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -632,10 +632,11 @@ export interface IChatTerminalToolInvocationData {
 	/** Whether the terminal command was started as a background execution */
 	isBackground?: boolean;
 	/**
-	 * Whether the backend evaluated this command against the configured
-	 * terminal auto-approve rules, meaning rule-creating confirmation actions
-	 * can suppress future prompts. Set by the Agent Host; the built-in
-	 * terminal tool computes its actions up front and leaves this unset.
+	 * Whether adding a persistent terminal auto-approve rule can suppress
+	 * prompts like this confirmation — the backend parsed the command and
+	 * found a missing allow rule to be the only blocker. Set by the Agent
+	 * Host; the built-in terminal tool computes its actions up front and
+	 * leaves this unset.
 	 */
 	autoApproveRulesApply?: boolean;
 	/** Whether the command was explicitly approved to run outside the sandbox */

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -538,14 +538,14 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandState.exitCode, 0);
 		});
 
-		test('terminal tool call in history carries autoApproveRulesApply only when stamped', () => {
+		test('terminal tool call in history carries autoApproveRuleResolvable only when stamped', () => {
 			const turn = createTurn({
 				responseParts: [
 					{
 						kind: ResponsePartKind.ToolCall, toolCall: createCompletedToolCall({
 							toolCallId: 'tc-marked',
 							toolInput: 'my-custom-script',
-							_meta: { toolKind: 'terminal', autoApproveRulesApply: true },
+							_meta: { toolKind: 'terminal', autoApproveRuleResolvable: true },
 							content: [{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal:///marked', title: 'Terminal' }],
 							success: true,
 						})
@@ -566,7 +566,7 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(response.type, 'response');
 			if (response.type !== 'response') { return; }
 			assert.deepStrictEqual(
-				response.parts.map(part => getSerializedTerminalData(part as IChatToolInvocationSerialized).autoApproveRulesApply),
+				response.parts.map(part => getSerializedTerminalData(part as IChatToolInvocationSerialized).autoApproveRuleResolvable),
 				[true, undefined],
 				'flag is copied from tool call meta and absent otherwise');
 		});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -538,6 +538,39 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandState.exitCode, 0);
 		});
 
+		test('terminal tool call in history carries autoApproveRulesApply only when stamped', () => {
+			const turn = createTurn({
+				responseParts: [
+					{
+						kind: ResponsePartKind.ToolCall, toolCall: createCompletedToolCall({
+							toolCallId: 'tc-marked',
+							toolInput: 'my-custom-script',
+							_meta: { toolKind: 'terminal', autoApproveRulesApply: true },
+							content: [{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal:///marked', title: 'Terminal' }],
+							success: true,
+						})
+					} as ToolCallResponsePart,
+					{
+						kind: ResponsePartKind.ToolCall, toolCall: createCompletedToolCall({
+							toolCallId: 'tc-unmarked',
+							toolInput: 'echo hello',
+							content: [{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal:///unmarked', title: 'Terminal' }],
+							success: true,
+						})
+					} as ToolCallResponsePart,
+				],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			assert.deepStrictEqual(
+				response.parts.map(part => getSerializedTerminalData(part as IChatToolInvocationSerialized).autoApproveRulesApply),
+				[true, undefined],
+				'flag is copied from tool call meta and absent otherwise');
+		});
+
 		test('terminal tool call in history carries the LM intention', () => {
 			const turn = createTurn({
 				responseParts: [{

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatConfirmationWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatConfirmationWidget.test.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { mainWindow } from '../../../../../../../base/browser/window.js';
+import { toDisposable } from '../../../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
+import { ChatCustomConfirmationWidget, type IChatConfirmationButton } from '../../../../browser/widget/chatContentParts/chatConfirmationWidget.js';
+import type { IChatContentPartRenderContext } from '../../../../browser/widget/chatContentParts/chatContentParts.js';
+
+suite('ChatCustomConfirmationWidget', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createWidget(buttons: IChatConfirmationButton<boolean>[]): ChatCustomConfirmationWidget<boolean> {
+		const instantiationService = workbenchInstantiationService(undefined, store);
+		const message = mainWindow.document.createElement('div');
+		const widget = store.add(instantiationService.createInstance(
+			ChatCustomConfirmationWidget<boolean>,
+			{} as IChatContentPartRenderContext,
+			{ title: 'Confirm', message, buttons }
+		));
+		mainWindow.document.body.appendChild(widget.domNode);
+		store.add(toDisposable(() => widget.domNode.remove()));
+		return widget;
+	}
+
+	function button(label: string, moreActions?: IChatConfirmationButton<boolean>[]): IChatConfirmationButton<boolean> {
+		return { label, data: true, moreActions };
+	}
+
+	test('preserves focused button when buttons reorder', () => {
+		const widget = createWidget([button('Allow'), button('Skip')]);
+		const initialButtons = widget.domNode.querySelectorAll<HTMLElement>('.monaco-button');
+		initialButtons[1].focus();
+
+		const updatedButtons = [button('Skip'), button('Allow', [button('Always Allow')])];
+		widget.updateButtons(updatedButtons);
+		const renderedButtons = widget.domNode.querySelectorAll<HTMLElement>('.monaco-button');
+		assert.strictEqual(mainWindow.document.activeElement, renderedButtons[0]);
+	});
+
+	test('preserves focus on dropdown control', () => {
+		const widget = createWidget([button('Allow', [button('Always Allow')]), button('Skip')]);
+		let renderedButtons = widget.domNode.querySelectorAll<HTMLElement>('.monaco-button');
+		renderedButtons[1].focus();
+
+		widget.updateButtons([button('Skip'), button('Allow', [button('Always Allow')])]);
+		renderedButtons = widget.domNode.querySelectorAll<HTMLElement>('.monaco-button');
+		assert.strictEqual(mainWindow.document.activeElement, renderedButtons[2]);
+	});
+
+	test('does not move focus when focused button is removed', () => {
+		const widget = createWidget([button('Allow'), button('Skip')]);
+		const initialButtons = widget.domNode.querySelectorAll<HTMLElement>('.monaco-button');
+		initialButtons[1].focus();
+
+		widget.updateButtons([button('Allow')]);
+		const renderedButton = widget.domNode.querySelector<HTMLElement>('.monaco-button');
+		assert.notStrictEqual(mainWindow.document.activeElement, renderedButton);
+	});
+
+	test('does not move focus from outside the widget', () => {
+		const widget = createWidget([button('Allow'), button('Skip')]);
+		const externalButton = mainWindow.document.createElement('button');
+		mainWindow.document.body.appendChild(externalButton);
+		store.add(toDisposable(() => externalButton.remove()));
+		externalButton.focus();
+
+		widget.updateButtons([button('Skip'), button('Allow')]);
+		assert.strictEqual(mainWindow.document.activeElement, externalButton);
+	});
+});

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -277,15 +277,15 @@ export interface ITerminalChatService {
 	 * Generate auto-approve rule actions for a command line that was not evaluated by the
 	 * built-in run in terminal tool, such as terminal confirmations surfaced by agent host
 	 * sessions. The command line is parsed into sub-commands and evaluated against the
-	 * configured auto-approve rules to produce the same rule suggestions the built-in tool
+	 * persisted configuration rules only (never workbench session rules, which agent hosts
+	 * do not consume) to produce the same persistent-rule suggestions the built-in tool
 	 * offers.
 	 * @param commandLine The full command line being confirmed
 	 * @param language The language to parse the command line with
-	 * @param chatSessionResource The chat session resource URI
 	 * @returns The actions to show in the confirmation dropdown, or undefined if the command
 	 * line could not be analyzed
 	 */
-	getAutoApproveActions(commandLine: string, language: 'shellscript' | 'powershell', chatSessionResource: URI): Promise<ToolConfirmationAction[] | undefined>;
+	getAutoApproveActions(commandLine: string, language: 'shellscript' | 'powershell'): Promise<ToolConfirmationAction[] | undefined>;
 
 	/**
 	 * Signal that a foreground terminal tool invocation should continue in the background.

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -35,6 +35,7 @@ import type { IEditorOptions } from '../../../../platform/editor/common/editor.j
 import type { TerminalEditorInput } from './terminalEditorInput.js';
 import type { MaybePromise } from '../../../../base/common/async.js';
 import { isNumber, type SingleOrMany } from '../../../../base/common/types.js';
+import type { ToolConfirmationAction } from '../../chat/common/tools/languageModelToolsService.js';
 
 export const ITerminalService = createDecorator<ITerminalService>('terminalService');
 export const ITerminalConfigurationService = createDecorator<ITerminalConfigurationService>('terminalConfigurationService');
@@ -271,6 +272,20 @@ export interface ITerminalChatService {
 	 * @returns A record of all session-scoped auto-approve rules for the session
 	 */
 	getSessionAutoApproveRules(chatSessionResource: URI): Readonly<Record<string, boolean | { approve: boolean; matchCommandLine?: boolean }>>;
+
+	/**
+	 * Generate auto-approve rule actions for a command line that was not evaluated by the
+	 * built-in run in terminal tool, such as terminal confirmations surfaced by agent host
+	 * sessions. The command line is parsed into sub-commands and evaluated against the
+	 * configured auto-approve rules to produce the same rule suggestions the built-in tool
+	 * offers.
+	 * @param commandLine The full command line being confirmed
+	 * @param language The language to parse the command line with
+	 * @param chatSessionResource The chat session resource URI
+	 * @returns The actions to show in the confirmation dropdown, or undefined if the command
+	 * line could not be analyzed
+	 */
+	getAutoApproveActions(commandLine: string, language: 'shellscript' | 'powershell', chatSessionResource: URI): Promise<ToolConfirmationAction[] | undefined>;
 
 	/**
 	 * Signal that a foreground terminal tool invocation should continue in the background.

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -6,12 +6,18 @@
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
+import { OS } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IAhpTerminalCommandSource, IChatTerminalOutputSource, IChatTerminalToolProgressPart, ITerminalChatService, ITerminalInstance, ITerminalService } from '../../../terminal/browser/terminal.js';
 import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IChatService } from '../../../chat/common/chatService/chatService.js';
+import type { ToolConfirmationAction } from '../../../chat/common/tools/languageModelToolsService.js';
+import { generateAutoApproveActions } from '../../chatAgentTools/browser/runInTerminalHelpers.js';
+import { TreeSitterCommandParser, TreeSitterCommandParserLanguage } from '../../chatAgentTools/browser/treeSitterCommandParser.js';
+import { CommandLineAutoApprover } from '../../chatAgentTools/browser/tools/commandLineAnalyzer/autoApprove/commandLineAutoApprover.js';
 import { TerminalChatContextKeys } from './terminalChat.js';
 import { LocalChatSessionUri } from '../../../chat/common/model/chatUri.js';
 import { isNumber, isString } from '../../../../../base/common/types.js';
@@ -71,12 +77,21 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 	 */
 	private readonly _sessionAutoApproveRules = new ResourceMap<Record<string, boolean | { approve: boolean; matchCommandLine?: boolean }>>();
 
+	/**
+	 * Lazily created analysis helpers backing {@link getAutoApproveActions}. These are only
+	 * needed for confirmations that arrive without pre-computed actions (eg. agent host
+	 * sessions), so avoid paying for tree-sitter until first use.
+	 */
+	private _autoApproveCommandParser: TreeSitterCommandParser | undefined;
+	private _autoApproveEvaluator: CommandLineAutoApprover | undefined;
+
 	constructor(
 		@ILogService private readonly _logService: ILogService,
 		@ITerminalService private readonly _terminalService: ITerminalService,
 		@IStorageService private readonly _storageService: IStorageService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IChatService private readonly _chatService: IChatService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
 
@@ -414,6 +429,33 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 
 	getSessionAutoApproveRules(chatSessionResource: URI): Readonly<Record<string, boolean | { approve: boolean; matchCommandLine?: boolean }>> {
 		return this._sessionAutoApproveRules.get(chatSessionResource) ?? {};
+	}
+
+	async getAutoApproveActions(commandLine: string, language: 'shellscript' | 'powershell', chatSessionResource: URI): Promise<ToolConfirmationAction[] | undefined> {
+		const trimmedCommandLine = commandLine.trimStart();
+		if (trimmedCommandLine.length === 0) {
+			return undefined;
+		}
+		this._autoApproveCommandParser ??= this._register(this._instantiationService.createInstance(TreeSitterCommandParser));
+		this._autoApproveEvaluator ??= this._register(this._instantiationService.createInstance(CommandLineAutoApprover));
+		const treeSitterLanguage = language === 'powershell' ? TreeSitterCommandParserLanguage.PowerShell : TreeSitterCommandParserLanguage.Bash;
+		let subCommands: string[];
+		try {
+			subCommands = await this._autoApproveCommandParser.extractSubCommands(treeSitterLanguage, trimmedCommandLine);
+		} catch (e) {
+			this._logService.warn('Failed to parse sub-commands when generating auto approve actions', e);
+			return undefined;
+		}
+		if (subCommands.length === 0) {
+			return undefined;
+		}
+		const shell = language === 'powershell' ? 'pwsh' : 'bash';
+		const evaluator = this._autoApproveEvaluator;
+		const subCommandResults = await Promise.all(subCommands.map(e => evaluator.isCommandAutoApproved(e, shell, OS, undefined, chatSessionResource)));
+		const commandLineResult = evaluator.isCommandLineAutoApproved(trimmedCommandLine, chatSessionResource);
+		// Session-scoped approvals are not forwarded to the agent host yet, so offering them
+		// here would appear to work while later commands still prompt
+		return generateAutoApproveActions(trimmedCommandLine, subCommands, { subCommandResults, commandLineResult }, { skipSessionScoped: true });
 	}
 
 	continueInBackground(terminalToolSessionId: string): void {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -431,13 +431,12 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 		return this._sessionAutoApproveRules.get(chatSessionResource) ?? {};
 	}
 
-	async getAutoApproveActions(commandLine: string, language: 'shellscript' | 'powershell', chatSessionResource: URI): Promise<ToolConfirmationAction[] | undefined> {
+	async getAutoApproveActions(commandLine: string, language: 'shellscript' | 'powershell'): Promise<ToolConfirmationAction[] | undefined> {
 		const trimmedCommandLine = commandLine.trimStart();
 		if (trimmedCommandLine.length === 0) {
 			return undefined;
 		}
 		this._autoApproveCommandParser ??= this._register(this._instantiationService.createInstance(TreeSitterCommandParser));
-		this._autoApproveEvaluator ??= this._register(this._instantiationService.createInstance(CommandLineAutoApprover));
 		const treeSitterLanguage = language === 'powershell' ? TreeSitterCommandParserLanguage.PowerShell : TreeSitterCommandParserLanguage.Bash;
 		let subCommands: string[];
 		try {
@@ -450,11 +449,15 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 			return undefined;
 		}
 		const shell = language === 'powershell' ? 'pwsh' : 'bash';
-		const evaluator = this._autoApproveEvaluator;
-		const subCommandResults = await Promise.all(subCommands.map(e => evaluator.isCommandAutoApproved(e, shell, OS, undefined, chatSessionResource)));
-		const commandLineResult = evaluator.isCommandLineAutoApproved(trimmedCommandLine, chatSessionResource);
-		// Session-scoped approvals are not forwarded to the agent host yet, so offering them
-		// here would appear to work while later commands still prompt
+		const evaluator = this._autoApproveEvaluator ??= this._register(this._instantiationService.createInstance(CommandLineAutoApprover));
+		// Evaluate against persisted configuration rules only — deliberately no
+		// chat session resource, so workbench session rules (which the agent
+		// host does not consume) neither suppress suggestions nor get offered
+		// (`skipSessionScoped`). Session rules are not forwarded to the agent
+		// host yet, so anything session-scoped would appear to work while
+		// later commands still prompt.
+		const subCommandResults = await Promise.all(subCommands.map(e => evaluator.isCommandAutoApproved(e, shell, OS, undefined)));
+		const commandLineResult = evaluator.isCommandLineAutoApproved(trimmedCommandLine);
 		return generateAutoApproveActions(trimmedCommandLine, subCommands, { subCommandResults, commandLineResult }, { skipSessionScoped: true });
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chat/test/browser/terminalChatService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/test/browser/terminalChatService.test.ts
@@ -14,6 +14,7 @@ import { IContextKeyService } from '../../../../../../platform/contextkey/common
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { ITreeSitterLibraryService } from '../../../../../../editor/common/services/treeSitter/treeSitterLibraryService.js';
 import { InMemoryStorageService, IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { IChatService } from '../../../../chat/common/chatService/chatService.js';
 import { IAhpTerminalCommandSource, ITerminalInstance, ITerminalService } from '../../../../terminal/browser/terminal.js';
@@ -31,12 +32,13 @@ function listenerCount(emitter: Emitter<any>): number {
 suite('TerminalChatService', () => {
 	const store = new DisposableStore();
 	let service: TerminalChatService;
+	let instantiationService: TestInstantiationService;
 	let onDidDisposeSessionEmitter: Emitter<{ readonly sessionResources: readonly URI[]; readonly reason: 'cleared' }>;
 
 	setup(() => {
 		onDidDisposeSessionEmitter = store.add(new Emitter());
 
-		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService = store.add(new TestInstantiationService());
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
 		instantiationService.stub(IContextKeyService, new MockContextKeyService());
@@ -144,5 +146,23 @@ suite('TerminalChatService', () => {
 		await pendingTerminal.error(new Error('terminal creation failed'));
 
 		assert.strictEqual(await lookup, undefined);
+	});
+
+	suite('getAutoApproveActions', () => {
+
+		test('returns undefined for empty command lines without touching the analysis collaborators', async () => {
+			// No ITreeSitterLibraryService stub is installed, so reaching the
+			// parser would throw — passing proves the early return.
+			assert.strictEqual(await service.getAutoApproveActions('   ', 'shellscript'), undefined);
+		});
+
+		test('returns undefined when sub-command parsing fails', async () => {
+			instantiationService.stub(ITreeSitterLibraryService, new class extends mock<ITreeSitterLibraryService>() {
+				override getParserClass(): Promise<typeof import('@vscode/tree-sitter-wasm').Parser> {
+					return Promise.reject(new Error('tree-sitter unavailable in tests'));
+				}
+			});
+			assert.strictEqual(await service.getAutoApproveActions('foo && bar', 'shellscript'), undefined);
+		});
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
@@ -104,7 +104,7 @@ export function isMultilineCommand(command: string): boolean {
 	return /(?<!\\)\n/.test(normalized);
 }
 
-export function generateAutoApproveActions(commandLine: string, subCommands: string[], autoApproveResult: { subCommandResults: ICommandApprovalResultWithReason[]; commandLineResult: ICommandApprovalResultWithReason }): ToolConfirmationAction[] {
+export function generateAutoApproveActions(commandLine: string, subCommands: string[], autoApproveResult: { subCommandResults: ICommandApprovalResultWithReason[]; commandLineResult: ICommandApprovalResultWithReason }, options?: { skipSessionScoped?: boolean }): ToolConfirmationAction[] {
 	const actions: ToolConfirmationAction[] = [];
 
 	// We shouldn't offer configuring rules for commands that are explicitly denied since it
@@ -199,17 +199,19 @@ export function generateAutoApproveActions(commandLine: string, subCommands: str
 				subCommandLabel = `Commands ${subCommandsToSuggest.map(e => `\`${e} \u2026\``).join(', ')}`;
 			}
 
-			actions.push({
-				label: `Allow ${subCommandLabel} in this Session`,
-				data: {
-					type: 'newRule',
-					rule: subCommandsToSuggest.map(key => ({
-						key,
-						value: true,
-						scope: 'session'
-					}))
-				} satisfies TerminalNewAutoApproveButtonData
-			});
+			if (!options?.skipSessionScoped) {
+				actions.push({
+					label: `Allow ${subCommandLabel} in this Session`,
+					data: {
+						type: 'newRule',
+						rule: subCommandsToSuggest.map(key => ({
+							key,
+							value: true,
+							scope: 'session'
+						}))
+					} satisfies TerminalNewAutoApproveButtonData
+				});
+			}
 			actions.push({
 				label: `Allow ${subCommandLabel} in this Workspace`,
 				data: {
@@ -246,20 +248,22 @@ export function generateAutoApproveActions(commandLine: string, subCommands: str
 			!commandsWithSubcommands.has(commandLine) &&
 			!commandsWithSubSubCommands.has(commandLine)
 		) {
-			actions.push({
-				label: localize('autoApprove.exactCommand1', 'Allow Exact Command Line in this Session'),
-				data: {
-					type: 'newRule',
-					rule: {
-						key: `/^${escapeRegExpCharacters(commandLine)}$/`,
-						value: {
-							approve: true,
-							matchCommandLine: true
-						},
-						scope: 'session'
-					}
-				} satisfies TerminalNewAutoApproveButtonData
-			});
+			if (!options?.skipSessionScoped) {
+				actions.push({
+					label: localize('autoApprove.exactCommand1', 'Allow Exact Command Line in this Session'),
+					data: {
+						type: 'newRule',
+						rule: {
+							key: `/^${escapeRegExpCharacters(commandLine)}$/`,
+							value: {
+								approve: true,
+								matchCommandLine: true
+							},
+							scope: 'session'
+						}
+					} satisfies TerminalNewAutoApproveButtonData
+				});
+			}
 			actions.push({
 				label: localize('autoApprove.exactCommand2', 'Allow Exact Command Line in this Workspace'),
 				data: {
@@ -297,15 +301,17 @@ export function generateAutoApproveActions(commandLine: string, subCommands: str
 
 
 	// Allow all commands for this session
-	actions.push({
-		label: localize('allowSession', 'Allow All Commands in this Session'),
-		tooltip: localize('allowSessionTooltip', 'Allow this tool to run in this session without confirmation.'),
-		data: {
-			type: 'sessionApproval'
-		} satisfies TerminalNewAutoApproveButtonData
-	});
+	if (!options?.skipSessionScoped) {
+		actions.push({
+			label: localize('allowSession', 'Allow All Commands in this Session'),
+			tooltip: localize('allowSessionTooltip', 'Allow this tool to run in this session without confirmation.'),
+			data: {
+				type: 'sessionApproval'
+			} satisfies TerminalNewAutoApproveButtonData
+		});
 
-	actions.push(new Separator());
+		actions.push(new Separator());
+	}
 
 	// Always show configure option
 	actions.push({

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ok, strictEqual } from 'assert';
+import { deepStrictEqual, ok, strictEqual } from 'assert';
+import { Separator } from '../../../../../../base/common/actions.js';
 import * as marked from '../../../../../../base/common/marked/marked.js';
 import { appendEscapedMarkdownInlineCode } from '../../../../../../base/common/htmlContent.js';
 import { generateAutoApproveActions, TRUNCATION_MESSAGE, dedupeRules, isPowerShell, truncateOutputKeepingTail, extractCdPrefix, normalizeTerminalCommandForDisplay, normalizeCommandForExecution, isMultilineCommand, buildCommandDisplayText } from '../../browser/runInTerminalHelpers.js';
@@ -474,6 +475,26 @@ suite('generateAutoApproveActions', () => {
 		const actions = generateAutoApproveActions(commandLine, subCommands, autoApproveResult);
 		const subCommandAction = actions.find(action => action.label.includes('mvn -DskipIT test') && action.label.includes('Always Allow Command:'));
 		strictEqual(subCommandAction, undefined, 'Should not suggest approval for already approved commands');
+	});
+
+	test('should not include session-scoped actions when skipSessionScoped is set', () => {
+		const commandLine = 'mvn test';
+		const subCommands = ['mvn test'];
+		const autoApproveResult = {
+			subCommandResults: [createMockResult('noMatch', 'not approved')],
+			commandLineResult: createMockResult('noMatch', 'not approved')
+		};
+
+		const actions = generateAutoApproveActions(commandLine, subCommands, autoApproveResult, { skipSessionScoped: true });
+		deepStrictEqual(actions.map(action => action instanceof Separator ? '---' : action.label), [
+			'Allow `mvn test …` in this Workspace',
+			'Always Allow `mvn test …`',
+			'---',
+			'Allow Exact Command Line in this Workspace',
+			'Always Allow Exact Command Line',
+			'---',
+			'Configure Auto Approve...',
+		]);
 	});
 });
 


### PR DESCRIPTION
Part of: https://github.com/microsoft/vscode/issues/324136

- Generate the run-in-terminal auto-approve dropdown actions ("Allow `<cmd>` in this Workspace", "Always Allow `<cmd>`", exact-command-line variants) for Agent Host Copilot terminal confirmations, which arrive without pre-computed actions.
- Add `ITerminalChatService.getAutoApproveActions`: parse the command with `TreeSitterCommandParser`, evaluate sub-commands with `CommandLineAutoApprover` against persisted configuration rules only (never workbench session rules — the agent host does not consume them), and reuse `generateAutoApproveActions` so suggestions match the built-in tool.
- Stamp `autoApproveRulesApply` tool-call metadata in the Agent Host via `SessionPermissionManager.canFutureRuleSuppressPrompt`, only when a missing allow rule is the sole blocker: the command parsed, matched no deny rule, and has no unapproved write redirect. Managed approvals, sandbox-bypass prompts, denials, and unparseable commands are never marked, so the dropdown never offers a rule that could not suppress future prompts.
- Keep `getAutoApproval` untouched: eligibility re-evaluates the command instead of restructuring the approval path's return type (parse is sub-millisecond, compiled rules are cached).
- Only generate actions for `agent-host-copilotcli` sessions when `chat.tools.terminal.enableAutoApprove` is on, and update the confirmation buttons in place when actions arrive asynchronously, guarded against disposal and already-resolved confirmations.
- Skip all session-scoped actions (`skipSessionScoped`): workbench session rules are not forwarded to the Agent Host yet, so offering them would appear to work while later commands still prompt. That half of #324136 stays open.
- Known limitation: the Agent Host approver parses with the bash grammar only. For the SDK's `powershell` tool, PowerShell-specific syntax can yield a suggested rule the bash-grammar enforcement won't match; follow-up is loading `tree-sitter-powershell.wasm` (already shipped in the same package) in the approver. ----> https://github.com/microsoft/vscode/issues/328052 
- Tests: `evaluate()` outcome table (approved, denied, unknown command, transient env-var, unsafe redirects, parser unavailable), `_meta` stamping for plain vs sandbox-bypass vs managed confirmations, `canFutureRuleSuppressPrompt` gates, adapter meta-to-tool-data copy, `getAutoApproveActions` empty/parse-failure paths, and the `skipSessionScoped` action snapshot. Follow-up: an electron-browser integration test with real tree-sitter parsing (browser unit suites cannot load the wasm).

-----------------------------------------
Inspirations from:

- The action-generation input shape (`{ subCommandResults, commandLineResult }`) and the "only when not auto-approved and auto-approve is enabled" condition come from the built-in tool's call site in [`commandLineAutoApproveAnalyzer.ts`](https://github.com/microsoft/vscode/blob/e4bde2ca4429c861bfe8c28c0658d7c78103b6ce/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts#L198-L200).
- The suggestion labels and rule construction are reused directly from [`generateAutoApproveActions`](https://github.com/microsoft/vscode/blob/e4bde2ca4429c861bfe8c28c0658d7c78103b6ce/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts#L107) rather than reimplemented; this PR only adds the `skipSessionScoped` option to it.
- The `_meta` well-known-key producer pattern (merge into the outgoing state via `toToolCallMeta`) comes from the existing `autoApproveBySetting` stamp in [`agentSideEffects.ts`](https://github.com/microsoft/vscode/blob/e4bde2ca4429c861bfe8c28c0658d7c78103b6ce/src/vs/platform/agentHost/node/agentSideEffects.ts#L1143).
- The policy that auto-approve rules never satisfy sandbox-bypass confirmations comes from the `requestSandboxBypass` early return in [`SessionPermissionManager.getAutoApproval`](https://github.com/microsoft/vscode/blob/e4bde2ca4429c861bfe8c28c0658d7c78103b6ce/src/vs/platform/agentHost/node/sessionPermissions.ts#L268-L273) and the intentional omission of `permissionKind: 'shell'` for unsandboxed-command confirmations in [`copilotAgentSession.ts`](https://github.com/microsoft/vscode/blob/e4bde2ca4429c861bfe8c28c0658d7c78103b6ce/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts#L2773-L2778).
