### PR TITLE
Fix package.json hover metadata broken in npm 12+

### DIFF
--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -327,7 +327,10 @@ export class PackageJSONContribution implements IJSONContribution {
 		const stdout = await this.runNpmCommand(npmCommandPath, args, resource);
 		if (stdout) {
 			try {
-				const content = JSON.parse(stdout);
+				let content = JSON.parse(stdout);
+				if (Array.isArray(content)) {
+					content = content[0]; // In npm 12+, 'npm view --json' always returns an array, even for a single package
+				}
 				const version = content['dist-tags.latest'] || content['version'];
 				return {
 					description: content['description'],


### PR DESCRIPTION
Fixes #327228

### Description
npm 12 changed npm view --json to always return an array [{...}] instead of {...}. Handle both formats by checking Array.isArray.

### Validation
Manually tested by building VS Code from source and hovering over package.json dependencies:
- With npm 11: all metadata (description, latest version, homepage) displayed correctly
<img width="557" height="271" alt="image" src="https://github.com/user-attachments/assets/563df825-fc58-4a81-b6e7-08b5fd67592d" />

- With npm 12: same, all metadata now displays correctly
<img width="542" height="266" alt="image" src="https://github.com/user-attachments/assets/8c6e3fd3-5cc5-497e-8526-47d2d3752049" />

Both versions work after the fix.