### PR TITLE
Set Responses API prompt cache mode

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -1059,7 +1059,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		}
 
 		if (this.endpoint.apiType !== 'messages') {
-			addCacheBreakpoints(result.messages);
+			addCacheBreakpoints(result.messages, this.endpoint.apiType);
 		}
 
 		if (this.request.command === 'error') {

--- a/extensions/copilot/src/extension/intents/node/cacheBreakpoints.ts
+++ b/extensions/copilot/src/extension/intents/node/cacheBreakpoints.ts
@@ -27,7 +27,13 @@ const MaxCacheBreakpoints = 4;
  * For turns with no tool calling, we will have a hit on the previous assistant message in history.
  * During the agentic loop, each request will have a hit on the previous tool result message.
  */
-export function addCacheBreakpoints(messages: Raw.ChatMessage[]) {
+export function addCacheBreakpoints(messages: Raw.ChatMessage[], apiType: string | undefined) {
+	for (const message of messages) {
+		if (!supportsCacheBreakpoint(message, apiType)) {
+			message.content = message.content.filter(part => part.type !== Raw.ChatCompletionContentPartKind.CacheBreakpoint);
+		}
+	}
+
 	// One or two cache breakpoints are already added via the prompt, assign the rest here.
 	let count = MaxCacheBreakpoints - countCacheBreakpoints(messages);
 	let isBelowCurrentUserMessage = true;
@@ -41,7 +47,7 @@ export function addCacheBreakpoints(messages: Raw.ChatMessage[]) {
 
 		const isLastToolResultInRound = msg.role === Raw.ChatRole.Tool && prevMsg?.role !== Raw.ChatRole.Tool;
 		const isAsstMsgWithNoTools = msg.role === Raw.ChatRole.Assistant && !msg.toolCalls?.length;
-		if (isBelowCurrentUserMessage && (isLastToolResultInRound || msg.role === Raw.ChatRole.User) || isAsstMsgWithNoTools) {
+		if ((isBelowCurrentUserMessage && (isLastToolResultInRound || msg.role === Raw.ChatRole.User) || isAsstMsgWithNoTools) && supportsCacheBreakpoint(msg, apiType)) {
 			count--;
 			msg.content.push({
 				type: Raw.ChatCompletionContentPartKind.CacheBreakpoint,
@@ -65,7 +71,7 @@ export function addCacheBreakpoints(messages: Raw.ChatMessage[]) {
 		}
 
 		const hasCacheBreakpoint = msg.content.some(part => part.type === Raw.ChatCompletionContentPartKind.CacheBreakpoint);
-		if ((msg.role === Raw.ChatRole.User || msg.role === Raw.ChatRole.System) && !hasCacheBreakpoint) {
+		if ((msg.role === Raw.ChatRole.User || msg.role === Raw.ChatRole.System) && !hasCacheBreakpoint && supportsCacheBreakpoint(msg, apiType)) {
 			count--;
 			msg.content.push({
 				type: Raw.ChatCompletionContentPartKind.CacheBreakpoint,
@@ -77,6 +83,36 @@ export function addCacheBreakpoints(messages: Raw.ChatMessage[]) {
 			break;
 		}
 	}
+}
+
+function supportsCacheBreakpoint(message: Raw.ChatMessage, apiType: string | undefined): boolean {
+	if (apiType === 'responses') {
+		if (message.role === Raw.ChatRole.Assistant) {
+			return false;
+		}
+
+		return message.content.some(part => {
+			if (message.role === Raw.ChatRole.Tool) {
+				return part.type === Raw.ChatCompletionContentPartKind.Image || part.type === Raw.ChatCompletionContentPartKind.Document;
+			}
+			return part.type === Raw.ChatCompletionContentPartKind.Text
+				|| part.type === Raw.ChatCompletionContentPartKind.Image
+				|| part.type === Raw.ChatCompletionContentPartKind.Document
+				|| isOpaqueBlockType(part, ['input_text', 'input_image', 'input_file']);
+		});
+	}
+
+	return message.content.some(part => part.type === Raw.ChatCompletionContentPartKind.Text
+		|| part.type === Raw.ChatCompletionContentPartKind.Image
+		|| part.type === Raw.ChatCompletionContentPartKind.Document
+		|| isOpaqueBlockType(part, ['text', 'image_url', 'input_audio', 'file', 'refusal']));
+}
+
+function isOpaqueBlockType(part: Raw.ChatCompletionContentPart, supportedTypes: readonly string[]): boolean {
+	if (part.type !== Raw.ChatCompletionContentPartKind.Opaque || typeof part.value !== 'object' || part.value === null || !('type' in part.value)) {
+		return false;
+	}
+	return supportedTypes.includes(String(part.value.type));
 }
 
 function countCacheBreakpoints(messages: Raw.ChatMessage[]) {

--- a/extensions/copilot/src/extension/intents/node/test/cacheBreakpoints.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/cacheBreakpoints.spec.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Raw } from '@vscode/prompt-tsx';
+import { describe, expect, it } from 'vitest';
+import { addCacheBreakpoints } from '../cacheBreakpoints';
+
+const text = (value = 'text'): Raw.ChatCompletionContentPart => ({ type: Raw.ChatCompletionContentPartKind.Text, text: value });
+const image = (): Raw.ChatCompletionContentPart => ({ type: Raw.ChatCompletionContentPartKind.Image, imageUrl: { url: 'image' } });
+const document = (): Raw.ChatCompletionContentPart => ({ type: Raw.ChatCompletionContentPartKind.Document, documentData: { data: 'file', mediaType: 'application/pdf' } });
+const opaque = (type: string): Raw.ChatCompletionContentPart => ({ type: Raw.ChatCompletionContentPartKind.Opaque, value: { type } });
+const cacheBreakpoint = (): Raw.ChatCompletionContentPart => ({ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint });
+const hasBreakpoint = (message: Raw.ChatMessage) => message.content.some(part => part.type === Raw.ChatCompletionContentPartKind.CacheBreakpoint);
+
+describe('addCacheBreakpoints', () => {
+	it('only marks messages that produce supported Responses API input blocks', () => {
+		const system: Raw.ChatMessage = { role: Raw.ChatRole.System, content: [text()] };
+		const assistant: Raw.ChatMessage = { role: Raw.ChatRole.Assistant, content: [text()] };
+		const textTool: Raw.ChatMessage = { role: Raw.ChatRole.Tool, toolCallId: 'text', content: [text()] };
+		const imageTool: Raw.ChatMessage = { role: Raw.ChatRole.Tool, toolCallId: 'image', content: [image()] };
+		const user: Raw.ChatMessage = { role: Raw.ChatRole.User, content: [document()] };
+
+		addCacheBreakpoints([system, assistant, user, textTool, imageTool], 'responses');
+
+		expect(hasBreakpoint(system)).toBe(true);
+		expect(hasBreakpoint(assistant)).toBe(false);
+		expect(hasBreakpoint(textTool)).toBe(false);
+		expect(hasBreakpoint(imageTool)).toBe(true);
+		expect(hasBreakpoint(user)).toBe(true);
+	});
+
+	it('removes prompt-rendered markers from unsupported Responses API messages', () => {
+		const assistant: Raw.ChatMessage = { role: Raw.ChatRole.Assistant, content: [text(), cacheBreakpoint()] };
+		const textTool: Raw.ChatMessage = { role: Raw.ChatRole.Tool, toolCallId: 'text', content: [text(), cacheBreakpoint()] };
+
+		addCacheBreakpoints([assistant, textTool], 'responses');
+
+		expect(hasBreakpoint(assistant)).toBe(false);
+		expect(hasBreakpoint(textTool)).toBe(false);
+	});
+
+	it.each(['text', 'image_url', 'input_audio', 'file', 'refusal'])('supports Chat Completions %s blocks', type => {
+		const message: Raw.ChatMessage = { role: Raw.ChatRole.Assistant, content: [opaque(type)] };
+
+		addCacheBreakpoints([message], 'chatCompletions');
+
+		expect(hasBreakpoint(message)).toBe(true);
+	});
+
+	it('does not mark unsupported Chat Completions blocks', () => {
+		const message: Raw.ChatMessage = { role: Raw.ChatRole.Assistant, content: [opaque('unsupported')] };
+
+		addCacheBreakpoints([message], 'chatCompletions');
+
+		expect(hasBreakpoint(message)).toBe(false);
+	});
+});

--- a/extensions/copilot/src/extension/prompts/node/agent/test/agentPrompt.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/agentPrompt.spec.tsx
@@ -132,7 +132,7 @@ testFamilies.forEach(family => {
 
 			const r = await renderer.render();
 			if (!isMessagesApi) {
-				addCacheBreakpoints(r.messages);
+				addCacheBreakpoints(r.messages, 'chatCompletions');
 			}
 			return r.messages
 				.map(m => messageToMarkdown(m))

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -140,7 +140,7 @@ suite('Agent Summarization', () => {
 				}
 			}
 		}
-		addCacheBreakpoints(r.messages);
+		addCacheBreakpoints(r.messages, 'chatCompletions');
 		return r.messages
 			.filter(message => message.role !== Raw.ChatRole.System)
 			.map(m => messageToMarkdown(m))

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -604,8 +604,8 @@ function hasCacheBreakpoint(message: Raw.ChatMessage): boolean {
  * Attaches a prompt-cache marker (`prompt_cache_breakpoint: { mode: 'explicit' }`) to a single
  * Responses API input item.
  *
- * The Responses API supports cache breakpoints only on `input_text`, `input_image`, and
- * `input_file` content blocks. Returns whether a marker was applied.
+ * The Responses API supports cache breakpoints only on `input_text` and `input_image` content
+ * blocks and `message` input items. Returns whether a marker was applied.
  */
 function tryApplyPromptCacheBreakpoint(item: OpenAI.Responses.ResponseInputItem): boolean {
 	const content = (item as { content?: unknown }).content;
@@ -615,10 +615,15 @@ function tryApplyPromptCacheBreakpoint(item: OpenAI.Responses.ResponseInputItem)
 
 	for (let contentIndex = content.length - 1; contentIndex >= 0; contentIndex--) {
 		const block = content[contentIndex] as { type?: string; prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint };
-		if (block.type === 'input_text' || block.type === 'input_image' || block.type === 'input_file') {
+		if (block.type === 'input_text' || block.type === 'input_image') {
 			block.prompt_cache_breakpoint = promptCacheBreakpoint;
 			return true;
 		}
+	}
+
+	if ((item as { type?: string }).type === 'message') {
+		(item as { prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint }).prompt_cache_breakpoint = promptCacheBreakpoint;
+		return true;
 	}
 
 	return false;

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -604,8 +604,8 @@ function hasCacheBreakpoint(message: Raw.ChatMessage): boolean {
  * Attaches a prompt-cache marker (`prompt_cache_breakpoint: { mode: 'explicit' }`) to a single
  * Responses API input item.
  *
- * The Responses API supports cache breakpoints only on `input_text` and `input_image` content
- * blocks and `message` input items. Returns whether a marker was applied.
+ * The Responses API supports cache breakpoints only on `input_text`, `input_image`, and
+ * `input_file` content blocks. Returns whether a marker was applied.
  */
 function tryApplyPromptCacheBreakpoint(item: OpenAI.Responses.ResponseInputItem): boolean {
 	const content = (item as { content?: unknown }).content;
@@ -615,15 +615,10 @@ function tryApplyPromptCacheBreakpoint(item: OpenAI.Responses.ResponseInputItem)
 
 	for (let contentIndex = content.length - 1; contentIndex >= 0; contentIndex--) {
 		const block = content[contentIndex] as { type?: string; prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint };
-		if (block.type === 'input_text' || block.type === 'input_image') {
+		if (block.type === 'input_text' || block.type === 'input_image' || block.type === 'input_file') {
 			block.prompt_cache_breakpoint = promptCacheBreakpoint;
 			return true;
 		}
-	}
-
-	if ((item as { type?: string }).type === 'message') {
-		(item as { prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint }).prompt_cache_breakpoint = promptCacheBreakpoint;
-		return true;
 	}
 
 	return false;

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -604,21 +604,32 @@ function hasCacheBreakpoint(message: Raw.ChatMessage): boolean {
  * Attaches a prompt-cache marker (`prompt_cache_breakpoint: { mode: 'explicit' }`) to a single
  * Responses API input item.
  *
- * The Responses API supports cache breakpoints only on `input_text`, `input_image`, and
- * `input_file` content blocks. Returns whether a marker was applied.
+ * Items that carry a non-empty `content` array (user/system/assistant messages) receive the marker
+ * on their last content block. Items without a content array (`function_call`,
+ * `function_call_output`, `tool_search_*`) receive the marker at the item level. Returns whether a
+ * marker was applied.
  */
 function tryApplyPromptCacheBreakpoint(item: OpenAI.Responses.ResponseInputItem): boolean {
 	const content = (item as { content?: unknown }).content;
-	if (!Array.isArray(content)) {
-		return false;
+	if (Array.isArray(content)) {
+		const lastContentBlock = content.at(-1) as { prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint } | undefined;
+		if (!lastContentBlock) {
+			return false;
+		}
+
+		lastContentBlock.prompt_cache_breakpoint = promptCacheBreakpoint;
+		return true;
 	}
 
-	for (let contentIndex = content.length - 1; contentIndex >= 0; contentIndex--) {
-		const block = content[contentIndex] as { type?: string; prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint };
-		if (block.type === 'input_text' || block.type === 'input_image' || block.type === 'input_file') {
-			block.prompt_cache_breakpoint = promptCacheBreakpoint;
-			return true;
-		}
+	const itemType = (item as { type?: string }).type;
+	if (
+		itemType === 'function_call'
+		|| itemType === 'function_call_output'
+		|| itemType === 'tool_search_call'
+		|| itemType === 'tool_search_output'
+	) {
+		(item as { prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint }).prompt_cache_breakpoint = promptCacheBreakpoint;
+		return true;
 	}
 
 	return false;

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -604,32 +604,21 @@ function hasCacheBreakpoint(message: Raw.ChatMessage): boolean {
  * Attaches a prompt-cache marker (`prompt_cache_breakpoint: { mode: 'explicit' }`) to a single
  * Responses API input item.
  *
- * Items that carry a non-empty `content` array (user/system/assistant messages) receive the marker
- * on their last content block. Items without a content array (`function_call`,
- * `function_call_output`, `tool_search_*`) receive the marker at the item level. Returns whether a
- * marker was applied.
+ * The Responses API supports cache breakpoints only on `input_text`, `input_image`, and
+ * `input_file` content blocks. Returns whether a marker was applied.
  */
 function tryApplyPromptCacheBreakpoint(item: OpenAI.Responses.ResponseInputItem): boolean {
 	const content = (item as { content?: unknown }).content;
-	if (Array.isArray(content)) {
-		const lastContentBlock = content.at(-1) as { prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint } | undefined;
-		if (!lastContentBlock) {
-			return false;
-		}
-
-		lastContentBlock.prompt_cache_breakpoint = promptCacheBreakpoint;
-		return true;
+	if (!Array.isArray(content)) {
+		return false;
 	}
 
-	const itemType = (item as { type?: string }).type;
-	if (
-		itemType === 'function_call'
-		|| itemType === 'function_call_output'
-		|| itemType === 'tool_search_call'
-		|| itemType === 'tool_search_output'
-	) {
-		(item as { prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint }).prompt_cache_breakpoint = promptCacheBreakpoint;
-		return true;
+	for (let contentIndex = content.length - 1; contentIndex >= 0; contentIndex--) {
+		const block = content[contentIndex] as { type?: string; prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint };
+		if (block.type === 'input_text' || block.type === 'input_image' || block.type === 'input_file') {
+			block.prompt_cache_breakpoint = promptCacheBreakpoint;
+			return true;
+		}
 	}
 
 	return false;

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -128,14 +128,15 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 		: undefined;
 	const shouldLoadToolFromToolSearch = shouldDeferTools ? (name: string) => !toolDeferralService!.isNonDeferredTool(name) : undefined;
 	const promptCacheBreakpointsEnabled = configService.getExperimentBasedConfig(ConfigKey.ResponsesApiPromptCacheBreakpointEnabled, expService);
-
+	const modelSupportsCacheBreakpoints = modelSupportCacheBreakPoints(endpoint);
+	const supportsCacheBreakpoints = promptCacheBreakpointsEnabled && modelSupportsCacheBreakpoints;
 	const body: IEndpointBody = {
 		model,
 		...rawMessagesToResponseAPI(model, options.messages, ignoreStatefulMarker, webSocketStatefulMarker, {
 			toolsMap,
 			shouldLoadToolFromToolSearch,
 			modeChanged,
-			supportsCacheBreakpoints: promptCacheBreakpointsEnabled && modelSupportCacheBreakPoints(endpoint),
+			supportsCacheBreakpoints,
 		}),
 		stream: true,
 		tools: finalTools.length > 0 ? finalTools : undefined,
@@ -148,7 +149,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 		top_logprobs: options.postOptions.logprobs ? 3 : undefined,
 		store: false,
 		text: verbosity ? { verbosity } : undefined,
-		prompt_cache_options: { mode: promptCacheBreakpointsEnabled ? 'explicit' : 'implicit' },
+		prompt_cache_options: modelSupportsCacheBreakpoints ? { mode: supportsCacheBreakpoints ? 'explicit' : 'implicit' } : undefined,
 	};
 
 	if (compactThreshold !== undefined) {

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -148,6 +148,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 		top_logprobs: options.postOptions.logprobs ? 3 : undefined,
 		store: false,
 		text: verbosity ? { verbosity } : undefined,
+		prompt_cache_options: { mode: promptCacheBreakpointsEnabled ? 'explicit' : 'implicit' },
 	};
 
 	if (compactThreshold !== undefined) {

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -382,7 +382,6 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 
 	const input: OpenAI.Responses.ResponseInputItem[] = [];
 	for (const message of messages) {
-		const inputStartIndex = input.length;
 		switch (message.role) {
 			case Raw.ChatRole.Assistant:
 				if (message.content.length) {
@@ -458,6 +457,7 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 							.filter((c): c is RawDocumentContentPart => c.type === Raw.ChatCompletionContentPartKind.Document)
 							.map(rawDocumentToResponsesInputFile)
 							.filter(isDefined);
+						applyPromptCacheBreakpointsToToolMedia(message.content, asImages, asFiles, supportsCacheBreakpoints);
 
 						// todod@connor4312: hack while responses API only supports text output from tools
 						input.push({ type: 'function_call_output', call_id: message.toolCallId, output: asText });
@@ -471,21 +471,11 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 				}
 				break;
 			case Raw.ChatRole.User:
-				input.push({ type: 'message', role: 'user', content: message.content.map(rawContentToResponsesContent).filter(isDefined) });
+				input.push({ type: 'message', role: 'user', content: rawContentToResponsesContentList(message.content, supportsCacheBreakpoints) });
 				break;
 			case Raw.ChatRole.System:
-				input.push({ type: 'message', role: 'system', content: message.content.map(rawContentToResponsesContent).filter(isDefined) });
+				input.push({ type: 'message', role: 'system', content: rawContentToResponsesContentList(message.content, supportsCacheBreakpoints) });
 				break;
-		}
-
-		if (supportsCacheBreakpoints && input.length > inputStartIndex && hasCacheBreakpoint(message)) {
-			// Attach the prompt-cache marker to the last item this message produced, scanning back past
-			// reasoning/compaction items that cannot carry it.
-			for (let inputIndex = input.length - 1; inputIndex >= inputStartIndex; inputIndex--) {
-				if (tryApplyPromptCacheBreakpoint(input[inputIndex])) {
-					break;
-				}
-			}
 		}
 	}
 
@@ -589,52 +579,65 @@ interface ResponsesPromptCacheBreakpoint {
 	readonly mode: 'explicit';
 }
 
+type ResponsesCacheableContent = OpenAI.Responses.ResponseInputContent & {
+	prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint;
+};
+
 const promptCacheBreakpoint: ResponsesPromptCacheBreakpoint = { mode: 'explicit' };
 
-/**
- * Whether a raw message carries one or more prompt-cache breakpoints. The Responses content
- * converters drop `CacheBreakpoint` parts, so we detect them at the message level and later attach
- * `prompt_cache_breakpoint` to the appropriate Responses input item/content block.
- */
-function hasCacheBreakpoint(message: Raw.ChatMessage): boolean {
-	return message.content.some(part => part.type === Raw.ChatCompletionContentPartKind.CacheBreakpoint);
-}
-
-/**
- * Attaches a prompt-cache marker (`prompt_cache_breakpoint: { mode: 'explicit' }`) to a single
- * Responses API input item.
- *
- * Items that carry a non-empty `content` array (user/system/assistant messages) receive the marker
- * on their last content block. Items without a content array (`function_call`,
- * `function_call_output`, `tool_search_*`) receive the marker at the item level. Returns whether a
- * marker was applied.
- */
-function tryApplyPromptCacheBreakpoint(item: OpenAI.Responses.ResponseInputItem): boolean {
-	const content = (item as { content?: unknown }).content;
-	if (Array.isArray(content)) {
-		const lastContentBlock = content.at(-1) as { prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint } | undefined;
-		if (!lastContentBlock) {
-			return false;
+function rawContentToResponsesContentList(parts: readonly Raw.ChatCompletionContentPart[], supportsCacheBreakpoints: boolean): OpenAI.Responses.ResponseInputContent[] {
+	const content: ResponsesCacheableContent[] = [];
+	let target: ResponsesCacheableContent | undefined;
+	for (const part of parts) {
+		if (part.type === Raw.ChatCompletionContentPartKind.CacheBreakpoint) {
+			if (supportsCacheBreakpoints && target) {
+				target.prompt_cache_breakpoint = promptCacheBreakpoint;
+			}
+			continue;
 		}
 
-		lastContentBlock.prompt_cache_breakpoint = promptCacheBreakpoint;
-		return true;
+		const converted = rawContentToResponsesContent(part);
+		if (converted) {
+			target = converted;
+			content.push(target);
+		} else {
+			target = undefined;
+		}
 	}
-
-	const itemType = (item as { type?: string }).type;
-	if (
-		itemType === 'function_call'
-		|| itemType === 'function_call_output'
-		|| itemType === 'tool_search_call'
-		|| itemType === 'tool_search_output'
-	) {
-		(item as { prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint }).prompt_cache_breakpoint = promptCacheBreakpoint;
-		return true;
-	}
-
-	return false;
+	return content;
 }
 
+function applyPromptCacheBreakpointsToToolMedia(
+	parts: readonly Raw.ChatCompletionContentPart[],
+	images: OpenAI.Responses.ResponseInputImage[],
+	files: OpenAI.Responses.ResponseInputFile[],
+	supportsCacheBreakpoints: boolean,
+): void {
+	if (!supportsCacheBreakpoints) {
+		return;
+	}
+
+	let imageIndex = 0;
+	let fileIndex = 0;
+	let target: ResponsesCacheableContent | undefined;
+	for (const part of parts) {
+		switch (part.type) {
+			case Raw.ChatCompletionContentPartKind.Image:
+				target = images[imageIndex++];
+				break;
+			case Raw.ChatCompletionContentPartKind.Document:
+				target = part.documentData.mediaType === 'application/pdf' ? files[fileIndex++] : undefined;
+				break;
+			case Raw.ChatCompletionContentPartKind.CacheBreakpoint:
+				if (target) {
+					target.prompt_cache_breakpoint = promptCacheBreakpoint;
+				}
+				break;
+			default:
+				target = undefined;
+		}
+	}
+}
 /**
  * The Responses API rejects the entire request with
  * `400 invalid_request_body: Invalid 'input[N].id': '...'. Expected an ID that begins with 'rs'.`

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -1012,7 +1012,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		});
 	});
 
-	it('does not attach prompt_cache_breakpoint to output_text', () => {
+	it('attaches prompt_cache_breakpoint to a message when its content is not supported', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1023,11 +1023,12 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages);
 
-		expect(body.input?.[0]).toEqual(expect.objectContaining({
+		expect(body.input?.[0]).toMatchObject({
 			role: 'assistant',
 			type: 'message',
 			content: [{ type: 'output_text', text: 'final answer' }],
-		}));
+			prompt_cache_breakpoint: expectedPromptCacheBreakpoint,
+		});
 		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
@@ -1058,7 +1059,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		expect(body.input?.[1]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
-	it('does not attach prompt_cache_breakpoint to function_call or output_text', () => {
+	it('skips function_call inputs and attaches prompt_cache_breakpoint to the preceding message', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1081,6 +1082,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		expect(firstCall).not.toHaveProperty('prompt_cache_breakpoint');
 
 		const messageItem = input.find(item => (item as { type?: string }).type === 'message');
+		expect(messageItem).toMatchObject({ prompt_cache_breakpoint: expectedPromptCacheBreakpoint });
 		expect((messageItem as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
@@ -1115,7 +1117,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		expect(body.input?.[1]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
-	it('attaches prompt_cache_breakpoint to input_file', () => {
+	it('attaches prompt_cache_breakpoint to the message instead of input_file', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.User,
 			content: [
@@ -1132,8 +1134,10 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		expect(body.input?.[0]).toMatchObject({
 			type: 'message',
 			role: 'user',
-			content: [{ type: 'input_file', prompt_cache_breakpoint: expectedPromptCacheBreakpoint }],
+			content: [{ type: 'input_file' }],
+			prompt_cache_breakpoint: expectedPromptCacheBreakpoint,
 		});
+		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
 	it('does not synthesize a whitespace text block when the marked message has no other content', () => {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -970,13 +970,13 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
-	it('attaches prompt_cache_breakpoint to the last content block of a user message', () => {
+	it('attaches prompt_cache_breakpoint only to the content block immediately before the marker', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.User,
 			content: [
 				{ type: Raw.ChatCompletionContentPartKind.Text, text: 'first' },
-				{ type: Raw.ChatCompletionContentPartKind.Text, text: 'second' },
 				cacheBreakpoint(),
+				{ type: Raw.ChatCompletionContentPartKind.Text, text: 'second' },
 			],
 		}];
 
@@ -987,11 +987,11 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 			type: 'message',
 			role: 'user',
 			content: [
-				{ type: 'input_text', text: 'first' },
-				{ type: 'input_text', text: 'second', prompt_cache_breakpoint: expectedPromptCacheBreakpoint },
+				{ type: 'input_text', text: 'first', prompt_cache_breakpoint: expectedPromptCacheBreakpoint },
+				{ type: 'input_text', text: 'second' },
 			],
 		});
-		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
+		expect((body.input?.[0] as { content: unknown[] }).content[1]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
 	it('attaches prompt_cache_breakpoint to the last content block of a system message', () => {
@@ -1012,7 +1012,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		});
 	});
 
-	it('attaches prompt_cache_breakpoint to the last output_text of a terminal assistant message', () => {
+	it('does not attach prompt_cache_breakpoint to assistant output_text', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1023,14 +1023,10 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages);
 
-		expect(body.input?.[0]).toMatchObject({
-			role: 'assistant',
-			type: 'message',
-			content: [{ type: 'output_text', text: 'final answer', prompt_cache_breakpoint: expectedPromptCacheBreakpoint }],
-		});
+		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
-	it('attaches prompt_cache_breakpoint at item level to a tool result (function_call_output)', () => {
+	it('does not attach prompt_cache_breakpoint to function_call_output', () => {
 		const messages: Raw.ChatMessage[] = [
 			{
 				role: Raw.ChatRole.Assistant,
@@ -1053,11 +1049,11 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 			type: 'function_call_output',
 			call_id: 'call_1',
 			output: 'result',
-			prompt_cache_breakpoint: expectedPromptCacheBreakpoint,
 		});
+		expect(body.input?.[1]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
-	it('attaches prompt_cache_breakpoint at item level to the last function_call when the assistant has tool calls', () => {
+	it('does not attach prompt_cache_breakpoint to assistant messages or function calls', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1074,7 +1070,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		const input = body.input as OpenAI.Responses.ResponseInputItem[];
 
 		const lastCall = input.find(item => isFunctionCallInputItem(item, 'tool_b'));
-		expect(lastCall).toMatchObject({ prompt_cache_breakpoint: expectedPromptCacheBreakpoint });
+		expect(lastCall).not.toHaveProperty('prompt_cache_breakpoint');
 
 		const firstCall = input.find(item => isFunctionCallInputItem(item, 'tool_a'));
 		expect(firstCall).not.toHaveProperty('prompt_cache_breakpoint');

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -947,9 +947,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 	const buildBody = (messages: Raw.ChatMessage[], endpoint = cacheBreakpointEndpoint, enablePromptCacheBreakpoint = true) => {
 		const services = createPlatformServices();
 		const accessor = services.createTestingAccessor();
-		if (enablePromptCacheBreakpoint) {
-			accessor.get(IConfigurationService).setConfig(ConfigKey.ResponsesApiPromptCacheBreakpointEnabled, true);
-		}
+		accessor.get(IConfigurationService).setConfig(ConfigKey.ResponsesApiPromptCacheBreakpointEnabled, enablePromptCacheBreakpoint);
 		const instantiationService = accessor.get(IInstantiationService);
 		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, createRequestOptions(messages, false), endpoint.model, endpoint));
 		accessor.dispose();
@@ -1014,7 +1012,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		});
 	});
 
-	it('attaches prompt_cache_breakpoint to the last output_text of a terminal assistant message', () => {
+	it('does not attach prompt_cache_breakpoint to output_text', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1025,14 +1023,15 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages);
 
-		expect(body.input?.[0]).toMatchObject({
+		expect(body.input?.[0]).toEqual(expect.objectContaining({
 			role: 'assistant',
 			type: 'message',
-			content: [{ type: 'output_text', text: 'final answer', prompt_cache_breakpoint: expectedPromptCacheBreakpoint }],
-		});
+			content: [{ type: 'output_text', text: 'final answer' }],
+		}));
+		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
-	it('attaches prompt_cache_breakpoint at item level to a tool result (function_call_output)', () => {
+	it('does not attach prompt_cache_breakpoint to function_call_output', () => {
 		const messages: Raw.ChatMessage[] = [
 			{
 				role: Raw.ChatRole.Assistant,
@@ -1051,15 +1050,15 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages);
 
-		expect(body.input?.[1]).toMatchObject({
+		expect(body.input?.[1]).toEqual(expect.objectContaining({
 			type: 'function_call_output',
 			call_id: 'call_1',
 			output: 'result',
-			prompt_cache_breakpoint: expectedPromptCacheBreakpoint,
-		});
+		}));
+		expect(body.input?.[1]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
-	it('attaches prompt_cache_breakpoint at item level to the last function_call when the assistant has tool calls', () => {
+	it('does not attach prompt_cache_breakpoint to function_call or output_text', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1076,7 +1075,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		const input = body.input as OpenAI.Responses.ResponseInputItem[];
 
 		const lastCall = input.find(item => isFunctionCallInputItem(item, 'tool_b'));
-		expect(lastCall).toMatchObject({ prompt_cache_breakpoint: expectedPromptCacheBreakpoint });
+		expect(lastCall).not.toHaveProperty('prompt_cache_breakpoint');
 
 		const firstCall = input.find(item => isFunctionCallInputItem(item, 'tool_a'));
 		expect(firstCall).not.toHaveProperty('prompt_cache_breakpoint');
@@ -1114,6 +1113,27 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 			],
 		});
 		expect(body.input?.[1]).not.toHaveProperty('prompt_cache_breakpoint');
+	});
+
+	it('attaches prompt_cache_breakpoint to input_file', () => {
+		const messages: Raw.ChatMessage[] = [{
+			role: Raw.ChatRole.User,
+			content: [
+				{
+					type: Raw.ChatCompletionContentPartKind.Document,
+					documentData: { data: 'cGRm', mediaType: 'application/pdf' },
+				},
+				cacheBreakpoint(),
+			],
+		}];
+
+		const body = buildBody(messages);
+
+		expect(body.input?.[0]).toMatchObject({
+			type: 'message',
+			role: 'user',
+			content: [{ type: 'input_file', prompt_cache_breakpoint: expectedPromptCacheBreakpoint }],
+		});
 	});
 
 	it('does not synthesize a whitespace text block when the marked message has no other content', () => {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -1012,7 +1012,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		});
 	});
 
-	it('does not attach prompt_cache_breakpoint to output_text', () => {
+	it('attaches prompt_cache_breakpoint to the last output_text of a terminal assistant message', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1023,15 +1023,14 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages);
 
-		expect(body.input?.[0]).toEqual(expect.objectContaining({
+		expect(body.input?.[0]).toMatchObject({
 			role: 'assistant',
 			type: 'message',
-			content: [{ type: 'output_text', text: 'final answer' }],
-		}));
-		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
+			content: [{ type: 'output_text', text: 'final answer', prompt_cache_breakpoint: expectedPromptCacheBreakpoint }],
+		});
 	});
 
-	it('does not attach prompt_cache_breakpoint to function_call_output', () => {
+	it('attaches prompt_cache_breakpoint at item level to a tool result (function_call_output)', () => {
 		const messages: Raw.ChatMessage[] = [
 			{
 				role: Raw.ChatRole.Assistant,
@@ -1050,15 +1049,15 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages);
 
-		expect(body.input?.[1]).toEqual(expect.objectContaining({
+		expect(body.input?.[1]).toMatchObject({
 			type: 'function_call_output',
 			call_id: 'call_1',
 			output: 'result',
-		}));
-		expect(body.input?.[1]).not.toHaveProperty('prompt_cache_breakpoint');
+			prompt_cache_breakpoint: expectedPromptCacheBreakpoint,
+		});
 	});
 
-	it('does not attach prompt_cache_breakpoint to function_call or output_text', () => {
+	it('attaches prompt_cache_breakpoint at item level to the last function_call when the assistant has tool calls', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1075,13 +1074,12 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		const input = body.input as OpenAI.Responses.ResponseInputItem[];
 
 		const lastCall = input.find(item => isFunctionCallInputItem(item, 'tool_b'));
-		expect(lastCall).not.toHaveProperty('prompt_cache_breakpoint');
+		expect(lastCall).toMatchObject({ prompt_cache_breakpoint: expectedPromptCacheBreakpoint });
 
 		const firstCall = input.find(item => isFunctionCallInputItem(item, 'tool_a'));
 		expect(firstCall).not.toHaveProperty('prompt_cache_breakpoint');
 
 		const messageItem = input.find(item => (item as { type?: string }).type === 'message');
-		expect(messageItem).not.toHaveProperty('prompt_cache_breakpoint');
 		expect((messageItem as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
@@ -1114,27 +1112,6 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 			],
 		});
 		expect(body.input?.[1]).not.toHaveProperty('prompt_cache_breakpoint');
-	});
-
-	it('attaches prompt_cache_breakpoint to input_file', () => {
-		const messages: Raw.ChatMessage[] = [{
-			role: Raw.ChatRole.User,
-			content: [
-				{
-					type: Raw.ChatCompletionContentPartKind.Document,
-					documentData: { data: 'cGRm', mediaType: 'application/pdf' },
-				},
-				cacheBreakpoint(),
-			],
-		}];
-
-		const body = buildBody(messages);
-
-		expect(body.input?.[0]).toMatchObject({
-			type: 'message',
-			role: 'user',
-			content: [{ type: 'input_file', prompt_cache_breakpoint: expectedPromptCacheBreakpoint }],
-		});
 	});
 
 	it('does not synthesize a whitespace text block when the marked message has no other content', () => {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -1152,6 +1152,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages, testEndpoint);
 
+		expect(body.prompt_cache_options).toBeUndefined();
 		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 });

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -1012,7 +1012,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		});
 	});
 
-	it('attaches prompt_cache_breakpoint to a message when its content is not supported', () => {
+	it('does not attach prompt_cache_breakpoint to output_text', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1023,12 +1023,11 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages);
 
-		expect(body.input?.[0]).toMatchObject({
+		expect(body.input?.[0]).toEqual(expect.objectContaining({
 			role: 'assistant',
 			type: 'message',
 			content: [{ type: 'output_text', text: 'final answer' }],
-			prompt_cache_breakpoint: expectedPromptCacheBreakpoint,
-		});
+		}));
 		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
@@ -1059,7 +1058,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		expect(body.input?.[1]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
-	it('skips function_call inputs and attaches prompt_cache_breakpoint to the preceding message', () => {
+	it('does not attach prompt_cache_breakpoint to function_call or output_text', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.Assistant,
 			content: [
@@ -1082,7 +1081,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		expect(firstCall).not.toHaveProperty('prompt_cache_breakpoint');
 
 		const messageItem = input.find(item => (item as { type?: string }).type === 'message');
-		expect(messageItem).toMatchObject({ prompt_cache_breakpoint: expectedPromptCacheBreakpoint });
+		expect(messageItem).not.toHaveProperty('prompt_cache_breakpoint');
 		expect((messageItem as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
@@ -1117,7 +1116,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		expect(body.input?.[1]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
-	it('attaches prompt_cache_breakpoint to the message instead of input_file', () => {
+	it('attaches prompt_cache_breakpoint to input_file', () => {
 		const messages: Raw.ChatMessage[] = [{
 			role: Raw.ChatRole.User,
 			content: [
@@ -1134,10 +1133,8 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		expect(body.input?.[0]).toMatchObject({
 			type: 'message',
 			role: 'user',
-			content: [{ type: 'input_file' }],
-			prompt_cache_breakpoint: expectedPromptCacheBreakpoint,
+			content: [{ type: 'input_file', prompt_cache_breakpoint: expectedPromptCacheBreakpoint }],
 		});
-		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
 	it('does not synthesize a whitespace text block when the marked message has no other content', () => {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -968,6 +968,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages, cacheBreakpointEndpoint, false);
 
+		expect(body.prompt_cache_options).toEqual({ mode: 'implicit' });
 		expect((body.input?.[0] as { content: unknown[] }).content[0]).not.toHaveProperty('prompt_cache_breakpoint');
 	});
 
@@ -983,6 +984,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 
 		const body = buildBody(messages);
 
+		expect(body.prompt_cache_options).toEqual(expectedPromptCacheBreakpoint);
 		expect(body.input?.[0]).toMatchObject({
 			type: 'message',
 			role: 'user',

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -107,6 +107,7 @@ export interface IEndpointBody {
 	input?: readonly any[];
 	truncation?: 'auto' | 'disabled';
 	prompt_cache_key?: string;
+	prompt_cache_options?: { mode: 'implicit' | 'explicit' };
 	include?: ['reasoning.encrypted_content'];
 	store?: boolean;
 	text?: {


### PR DESCRIPTION
## Summary

- set the request-wide Responses API `prompt_cache_options.mode` to `explicit` when prompt cache breakpoints are enabled
- default the request-wide cache mode to `implicit` otherwise
- add coverage for both request-wide cache policy modes

## Testing

- `npm run test:unit -- src/platform/endpoint/node/test/responsesApi.spec.ts`
- `npm run typecheck`