### PR TITLE
agents: restore message timestamps from persisted agent transcripts

### DIFF
--- a/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
@@ -142,10 +142,34 @@ function replayTurnToTurn(codexTurn: CodexTurn): Turn | undefined {
 	}
 	return {
 		id: codexTurn.id,
+		...codexTurnTiming(codexTurn),
 		message: { text: userText, origin: { kind: MessageKind.User } },
 		responseParts: parts,
 		usage: undefined,
 		state: turnStateFromStatus(codexTurn.status),
+	};
+}
+
+/**
+ * Restores wall-clock turn timing from codex's persisted thread. Codex stores
+ * Unix seconds, which we widen to the protocol's ISO 8601 `startedAt` plus a
+ * millisecond `duration`, preferring its own `durationMs` when present.
+ * Mirrors the live mapper (`mapTurnStarted` / `mapTurnCompleted`) so restored
+ * turns display the same time as they did while streaming.
+ */
+function codexTurnTiming(codexTurn: CodexTurn): { startedAt?: string; duration?: number } {
+	const startedAtSeconds = codexTurn.startedAt;
+	if (typeof startedAtSeconds !== 'number' || !Number.isFinite(startedAtSeconds)) {
+		return {};
+	}
+	const duration = typeof codexTurn.durationMs === 'number' && Number.isFinite(codexTurn.durationMs) && codexTurn.durationMs >= 0
+		? codexTurn.durationMs
+		: typeof codexTurn.completedAt === 'number' && Number.isFinite(codexTurn.completedAt)
+			? Math.max(0, (codexTurn.completedAt - startedAtSeconds) * 1000)
+			: undefined;
+	return {
+		startedAt: new Date(startedAtSeconds * 1000).toISOString(),
+		...(duration !== undefined ? { duration } : {}),
 	};
 }
 

--- a/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
@@ -150,13 +150,7 @@ function replayTurnToTurn(codexTurn: CodexTurn): Turn | undefined {
 	};
 }
 
-/**
- * Restores wall-clock turn timing from codex's persisted thread. Codex stores
- * Unix seconds, which we widen to the protocol's ISO 8601 `startedAt` plus a
- * millisecond `duration`, preferring its own `durationMs` when present.
- * Mirrors the live mapper (`mapTurnStarted` / `mapTurnCompleted`) so restored
- * turns display the same time as they did while streaming.
- */
+/** Restores turn timing from codex's persisted thread: Unix-second stamps widen to ISO 8601 `startedAt` plus a millisecond `duration`. */
 function codexTurnTiming(codexTurn: CodexTurn): { startedAt?: string; duration?: number } {
 	const startedAtSeconds = codexTurn.startedAt;
 	if (typeof startedAtSeconds !== 'number' || !Number.isFinite(startedAtSeconds)) {

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -132,6 +132,8 @@ interface ITurnBuilder {
 	message: Message;
 	/** ISO 8601 timestamp of the SDK event that opened this turn, when known. */
 	startedAt: string | undefined;
+	/** ISO 8601 timestamp of the most recent SDK event that belonged to this turn. */
+	lastEventAt: string | undefined;
 	readonly responseParts: ResponsePart[];
 	usage: UsageInfo | undefined;
 	/** Tool starts seen but not yet completed in this turn, keyed by toolCallId. */
@@ -152,15 +154,10 @@ function newTurnBuilder(id: string, text: string, options?: { attachments?: Mess
 		...(options?.model ? { model: options.model } : {}),
 		...(options?.agent ? { agent: options.agent } : {}),
 	};
-	return { id, message, startedAt: options?.startedAt, responseParts: [], usage: undefined, pendingTools: new Map() };
+	return { id, message, startedAt: options?.startedAt, lastEventAt: options?.startedAt, responseParts: [], usage: undefined, pendingTools: new Map() };
 }
 
-/**
- * Reads the SDK envelope's ISO 8601 `timestamp`, which every session event
- * carries. Returns `undefined` when it is missing or unparseable, so a
- * malformed (or older, timestamp-less) event log degrades to "no known time"
- * rather than producing a bogus one.
- */
+/** Reads the SDK envelope's ISO 8601 `timestamp`, or `undefined` when missing or unparseable. */
 function readEventTimestamp(event: SessionEvent): string | undefined {
 	const timestamp: unknown = event.timestamp;
 	return isString(timestamp) && Number.isFinite(Date.parse(timestamp)) ? timestamp : undefined;
@@ -228,15 +225,10 @@ function makeToolStartInfo(toolName: string, rawArguments: unknown, parentToolCa
 	};
 }
 
-/**
- * Seals a turn builder into a {@link Turn}, restoring its wall-clock timing
- * from the SDK event envelopes. `endedAt` is the timestamp of the last event
- * that belonged to this turn; the duration is only emitted when both ends are
- * known and consistent, so consumers never render a negative elapsed time.
- */
-function finalizeTurn(builder: ITurnBuilder, state: TurnState, endedAt: string | undefined): Turn {
+/** Seals a turn builder into a {@link Turn}, deriving `duration` from its first and last event timestamps. */
+function finalizeTurn(builder: ITurnBuilder, state: TurnState): Turn {
 	const startedAtMs = builder.startedAt === undefined ? undefined : Date.parse(builder.startedAt);
-	const endedAtMs = endedAt === undefined ? undefined : Date.parse(endedAt);
+	const endedAtMs = builder.lastEventAt === undefined ? undefined : Date.parse(builder.lastEventAt);
 	const duration = startedAtMs !== undefined && endedAtMs !== undefined && Number.isFinite(startedAtMs) && Number.isFinite(endedAtMs)
 		? Math.max(0, endedAtMs - startedAtMs)
 		: undefined;
@@ -361,19 +353,19 @@ export async function mapSessionEvents(
 
 	/** Envelope timestamp of the event currently being processed. */
 	let currentEventTimestamp: string | undefined;
-	/**
-	 * Envelope timestamp of the previously processed event. A parent turn is
-	 * flushed while handling the event that *starts* the next turn, so this is
-	 * its end time — using the current event's timestamp instead would fold the
-	 * user's idle time between turns into the previous turn's duration.
-	 */
-	let previousEventTimestamp: string | undefined;
 
-	const flushParent = (endedAt: string | undefined): void => {
+	/** Records the current event as belonging to `builder`, so it bounds that turn's duration. */
+	const touch = (builder: ITurnBuilder | undefined): void => {
+		if (builder && currentEventTimestamp !== undefined) {
+			builder.lastEventAt = currentEventTimestamp;
+		}
+	};
+
+	const flushParent = (): void => {
 		if (!parentBuilder) {
 			return;
 		}
-		turns.push(finalizeTurn(parentBuilder, parentTurnState, endedAt));
+		turns.push(finalizeTurn(parentBuilder, parentTurnState));
 		parentBuilder = undefined;
 		parentTurnState = TurnState.Cancelled;
 		parentTurnAborted = false;
@@ -392,9 +384,7 @@ export async function mapSessionEvents(
 			return;
 		}
 		const list = subagentTurns.get(parentToolCallId) ?? [];
-		// A subagent turn is flushed by the event that completes its spawning
-		// tool call, so the current event's timestamp is its end time.
-		list.push(finalizeTurn(builder, state, currentEventTimestamp));
+		list.push(finalizeTurn(builder, state));
 		subagentTurns.set(parentToolCallId, list);
 	};
 
@@ -407,6 +397,7 @@ export async function mapSessionEvents(
 				subagentTurnStates.set(parentToolCallId, TurnState.Complete);
 			}
 		}
+		touch(builder);
 		return builder;
 	};
 
@@ -414,21 +405,23 @@ export async function mapSessionEvents(
 		if (parentToolCallId) {
 			return ensureSubagentBuilder(parentToolCallId);
 		}
+		touch(parentBuilder);
 		return parentBuilder;
 	};
 
 	for (const e of events) {
-		previousEventTimestamp = currentEventTimestamp;
 		currentEventTimestamp = readEventTimestamp(e);
 		switch (e.type) {
 			case 'assistant.turn_start':
 				if (!e.agentId) {
 					rootAssistantTurnActive = true;
+					touch(parentBuilder);
 				}
 				break;
 			case 'assistant.turn_end':
 				if (!e.agentId) {
 					rootAssistantTurnActive = false;
+					touch(parentBuilder);
 				}
 				break;
 			case 'session.model_change': {
@@ -474,7 +467,7 @@ export async function mapSessionEvents(
 					// `setTurnEventId` records as `event_id`) so the restored
 					// turn id round-trips back to the SDK boundary id that
 					// fork / truncate RPCs operate on.
-					flushParent(previousEventTimestamp);
+					flushParent();
 					const turnId = e.id ?? messageId;
 					parentBuilder = newTurnBuilder(turnId, content, { attachments, model: currentModel, agent: currentAgent, startedAt: currentEventTimestamp });
 					if (pendingAutoModeResolved) {
@@ -497,6 +490,7 @@ export async function mapSessionEvents(
 				if (!content && !reasoningText && !hasToolRequests) {
 					if (!parentToolCallId && parentBuilder && !parentTurnAborted) {
 						parentTurnState = TurnState.Complete;
+						touch(parentBuilder);
 					}
 					break;
 				}
@@ -540,8 +534,9 @@ export async function mapSessionEvents(
 						kind: ResponsePartKind.SystemNotification,
 						content: notification.messageText,
 					});
+					touch(parentBuilder);
 				} else if (notification.startsTurn) {
-					flushParent(previousEventTimestamp);
+					flushParent();
 					parentBuilder = newTurnBuilder(e.id, notification.messageText, { origin: MessageKind.SystemNotification, startedAt: currentEventTimestamp });
 				}
 				break;
@@ -559,6 +554,7 @@ export async function mapSessionEvents(
 				const parentToolCallId = resolveParentToolCallId(e.agentId, e.data.parentToolCallId);
 				if (!parentToolCallId && parentBuilder) {
 					parentTurnState = TurnState.Cancelled;
+					touch(parentBuilder);
 				}
 				break;
 			}
@@ -635,6 +631,7 @@ export async function mapSessionEvents(
 					if (parentBuilder) {
 						parentTurnState = TurnState.Cancelled;
 						parentTurnAborted = true;
+						touch(parentBuilder);
 					}
 				}
 				break;
@@ -644,7 +641,7 @@ export async function mapSessionEvents(
 		}
 	}
 
-	flushParent(currentEventTimestamp);
+	flushParent();
 	for (const parentToolCallId of [...subagentBuilders.keys()]) {
 		flushSubagent(parentToolCallId);
 	}

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -130,6 +130,8 @@ interface ISubagentInfo {
 interface ITurnBuilder {
 	id: string;
 	message: Message;
+	/** ISO 8601 timestamp of the SDK event that opened this turn, when known. */
+	startedAt: string | undefined;
 	readonly responseParts: ResponsePart[];
 	usage: UsageInfo | undefined;
 	/** Tool starts seen but not yet completed in this turn, keyed by toolCallId. */
@@ -142,7 +144,7 @@ export interface IMapSessionEventsOptions {
 	readonly agent?: AgentSelection;
 }
 
-function newTurnBuilder(id: string, text: string, options?: { attachments?: MessageAttachment[]; model?: ModelSelection; agent?: AgentSelection; origin?: MessageKind }): ITurnBuilder {
+function newTurnBuilder(id: string, text: string, options?: { attachments?: MessageAttachment[]; model?: ModelSelection; agent?: AgentSelection; origin?: MessageKind; startedAt?: string }): ITurnBuilder {
 	const message: Message = {
 		text,
 		origin: { kind: options?.origin ?? MessageKind.User },
@@ -150,7 +152,18 @@ function newTurnBuilder(id: string, text: string, options?: { attachments?: Mess
 		...(options?.model ? { model: options.model } : {}),
 		...(options?.agent ? { agent: options.agent } : {}),
 	};
-	return { id, message, responseParts: [], usage: undefined, pendingTools: new Map() };
+	return { id, message, startedAt: options?.startedAt, responseParts: [], usage: undefined, pendingTools: new Map() };
+}
+
+/**
+ * Reads the SDK envelope's ISO 8601 `timestamp`, which every session event
+ * carries. Returns `undefined` when it is missing or unparseable, so a
+ * malformed (or older, timestamp-less) event log degrades to "no known time"
+ * rather than producing a bogus one.
+ */
+function readEventTimestamp(event: SessionEvent): string | undefined {
+	const timestamp: unknown = event.timestamp;
+	return isString(timestamp) && Number.isFinite(Date.parse(timestamp)) ? timestamp : undefined;
 }
 
 function readStringProperty(source: unknown, key: string): string | undefined {
@@ -215,9 +228,22 @@ function makeToolStartInfo(toolName: string, rawArguments: unknown, parentToolCa
 	};
 }
 
-function finalizeTurn(builder: ITurnBuilder, state: TurnState): Turn {
+/**
+ * Seals a turn builder into a {@link Turn}, restoring its wall-clock timing
+ * from the SDK event envelopes. `endedAt` is the timestamp of the last event
+ * that belonged to this turn; the duration is only emitted when both ends are
+ * known and consistent, so consumers never render a negative elapsed time.
+ */
+function finalizeTurn(builder: ITurnBuilder, state: TurnState, endedAt: string | undefined): Turn {
+	const startedAtMs = builder.startedAt === undefined ? undefined : Date.parse(builder.startedAt);
+	const endedAtMs = endedAt === undefined ? undefined : Date.parse(endedAt);
+	const duration = startedAtMs !== undefined && endedAtMs !== undefined && Number.isFinite(startedAtMs) && Number.isFinite(endedAtMs)
+		? Math.max(0, endedAtMs - startedAtMs)
+		: undefined;
 	return {
 		id: builder.id,
+		...(builder.startedAt !== undefined ? { startedAt: builder.startedAt } : {}),
+		...(duration !== undefined ? { duration } : {}),
 		message: builder.message,
 		responseParts: builder.responseParts,
 		usage: builder.usage,
@@ -333,11 +359,21 @@ export async function mapSessionEvents(
 	let rootAssistantTurnActive = false;
 	let pendingAutoModeResolved: Extract<SessionEvent, { type: 'session.auto_mode_resolved' }>['data'] | undefined;
 
-	const flushParent = (): void => {
+	/** Envelope timestamp of the event currently being processed. */
+	let currentEventTimestamp: string | undefined;
+	/**
+	 * Envelope timestamp of the previously processed event. A parent turn is
+	 * flushed while handling the event that *starts* the next turn, so this is
+	 * its end time — using the current event's timestamp instead would fold the
+	 * user's idle time between turns into the previous turn's duration.
+	 */
+	let previousEventTimestamp: string | undefined;
+
+	const flushParent = (endedAt: string | undefined): void => {
 		if (!parentBuilder) {
 			return;
 		}
-		turns.push(finalizeTurn(parentBuilder, parentTurnState));
+		turns.push(finalizeTurn(parentBuilder, parentTurnState, endedAt));
 		parentBuilder = undefined;
 		parentTurnState = TurnState.Cancelled;
 		parentTurnAborted = false;
@@ -356,14 +392,16 @@ export async function mapSessionEvents(
 			return;
 		}
 		const list = subagentTurns.get(parentToolCallId) ?? [];
-		list.push(finalizeTurn(builder, state));
+		// A subagent turn is flushed by the event that completes its spawning
+		// tool call, so the current event's timestamp is its end time.
+		list.push(finalizeTurn(builder, state, currentEventTimestamp));
 		subagentTurns.set(parentToolCallId, list);
 	};
 
 	const ensureSubagentBuilder = (parentToolCallId: string): ITurnBuilder => {
 		let builder = subagentBuilders.get(parentToolCallId);
 		if (!builder) {
-			builder = newTurnBuilder(generateUuid(), '');
+			builder = newTurnBuilder(generateUuid(), '', { startedAt: currentEventTimestamp });
 			subagentBuilders.set(parentToolCallId, builder);
 			if (!subagentTurnStates.has(parentToolCallId)) {
 				subagentTurnStates.set(parentToolCallId, TurnState.Complete);
@@ -380,6 +418,8 @@ export async function mapSessionEvents(
 	};
 
 	for (const e of events) {
+		previousEventTimestamp = currentEventTimestamp;
+		currentEventTimestamp = readEventTimestamp(e);
 		switch (e.type) {
 			case 'assistant.turn_start':
 				if (!e.agentId) {
@@ -434,9 +474,9 @@ export async function mapSessionEvents(
 					// `setTurnEventId` records as `event_id`) so the restored
 					// turn id round-trips back to the SDK boundary id that
 					// fork / truncate RPCs operate on.
-					flushParent();
+					flushParent(previousEventTimestamp);
 					const turnId = e.id ?? messageId;
-					parentBuilder = newTurnBuilder(turnId, content, { attachments, model: currentModel, agent: currentAgent });
+					parentBuilder = newTurnBuilder(turnId, content, { attachments, model: currentModel, agent: currentAgent, startedAt: currentEventTimestamp });
 					if (pendingAutoModeResolved) {
 						parentBuilder.usage = {
 							model: pendingAutoModeResolved.chosenModel,
@@ -467,7 +507,7 @@ export async function mapSessionEvents(
 				// branch above.
 				const fallbackTurnId = e.id ?? messageId;
 				const builder = targetBuilderFor(parentToolCallId)
-					?? (parentBuilder = newTurnBuilder(fallbackTurnId, ''));
+					?? (parentBuilder = newTurnBuilder(fallbackTurnId, '', { startedAt: currentEventTimestamp }));
 				if (reasoningText) {
 					builder.responseParts.push({
 						kind: ResponsePartKind.Reasoning,
@@ -501,8 +541,8 @@ export async function mapSessionEvents(
 						content: notification.messageText,
 					});
 				} else if (notification.startsTurn) {
-					flushParent();
-					parentBuilder = newTurnBuilder(e.id, notification.messageText, { origin: MessageKind.SystemNotification });
+					flushParent(previousEventTimestamp);
+					parentBuilder = newTurnBuilder(e.id, notification.messageText, { origin: MessageKind.SystemNotification, startedAt: currentEventTimestamp });
 				}
 				break;
 			}
@@ -567,7 +607,7 @@ export async function mapSessionEvents(
 				const synth = synthesizeSkillToolCall(e.data, e.id);
 				const parentToolCallId = resolveParentToolCallId(e.agentId, undefined);
 				const builder = targetBuilderFor(parentToolCallId)
-					?? (parentBuilder = newTurnBuilder(generateUuid(), ''));
+					?? (parentBuilder = newTurnBuilder(generateUuid(), '', { startedAt: currentEventTimestamp }));
 				if (!parentToolCallId && builder === parentBuilder) {
 					parentTurnState = TurnState.Cancelled;
 				}
@@ -604,7 +644,7 @@ export async function mapSessionEvents(
 		}
 	}
 
-	flushParent();
+	flushParent(currentEventTimestamp);
 	for (const parentToolCallId of [...subagentBuilders.keys()]) {
 		flushSubagent(parentToolCallId);
 	}

--- a/src/vs/platform/agentHost/test/node/codex/codexReplayMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexReplayMapper.test.ts
@@ -42,6 +42,40 @@ suite('codexReplayMapper', () => {
 		assert.strictEqual((part as { content: string }).content, 'hello back');
 	});
 
+	test('restores turn timing from the persisted codex thread', () => {
+		const turns = replayThreadToTurns({
+			id: 'thr',
+			turns: [{
+				id: 'turn_a',
+				items: [{ type: 'userMessage', id: 'u1', content: [{ type: 'text', text: 'hi', text_elements: [] }] }],
+				itemsView: { type: 'full' } as never,
+				status: 'completed' as never,
+				error: null,
+				startedAt: 1785060000, completedAt: null, durationMs: 4200,
+			}, {
+				id: 'turn_b',
+				items: [{ type: 'userMessage', id: 'u2', content: [{ type: 'text', text: 'again', text_elements: [] }] }],
+				itemsView: { type: 'full' } as never,
+				status: 'completed' as never,
+				error: null,
+				startedAt: 1785060100, completedAt: 1785060103, durationMs: null,
+			}, {
+				id: 'turn_c',
+				items: [{ type: 'userMessage', id: 'u3', content: [{ type: 'text', text: 'legacy', text_elements: [] }] }],
+				itemsView: { type: 'full' } as never,
+				status: 'completed' as never,
+				error: null,
+				startedAt: null, completedAt: null, durationMs: null,
+			}],
+		} as never);
+
+		assert.deepStrictEqual(turns.map(turn => ({ id: turn.id, startedAt: turn.startedAt, duration: turn.duration })), [
+			{ id: 'turn_a', startedAt: '2026-07-26T10:00:00.000Z', duration: 4200 },
+			{ id: 'turn_b', startedAt: '2026-07-26T10:01:40.000Z', duration: 3000 },
+			{ id: 'turn_c', startedAt: undefined, duration: undefined },
+		]);
+	});
+
 	test('failed turn maps to TurnState.Error', () => {
 		const turns = replayThreadToTurns({
 			id: 'thr',

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -900,7 +900,7 @@ suite('CopilotAgentSession', () => {
 			type: 'user.message',
 			id: 'event-1',
 			parentId: null,
-			timestamp: new Date().toISOString(),
+			timestamp: '2026-07-29T10:00:00.000Z',
 			data: {
 				interactionId: 'message-1',
 				content: '/act-on-feedback',
@@ -915,6 +915,8 @@ suite('CopilotAgentSession', () => {
 
 		assert.deepStrictEqual(await session.getMessages(), [{
 			id: 'event-1',
+			startedAt: '2026-07-29T10:00:00.000Z',
+			duration: 0,
 			message: {
 				text: '/act-on-feedback',
 				origin: { kind: MessageKind.User },

--- a/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
+++ b/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
@@ -119,6 +119,8 @@ export interface ISessionEventAbort {
 export interface ISessionEventAssistantTurn {
 	type: 'assistant.turn_start' | 'assistant.turn_end';
 	agentId?: string;
+	/** ISO 8601 envelope timestamp; the mapper uses it to restore turn timing. */
+	timestamp?: string;
 	data: {
 		turnId: string;
 		interactionId?: string;
@@ -143,7 +145,7 @@ export type ISessionEvent =
 	| ISessionEventAbort
 	| ISessionEventAssistantTurn
 	| ISessionEventSystemNotification
-	| { type: string; data?: unknown };
+	| { type: string; timestamp?: string; data?: unknown };
 
 /**
  * Widens ergonomic {@link ISessionEvent} test fixtures to the real SDK

--- a/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
+++ b/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
@@ -19,6 +19,8 @@ export interface ISessionEventToolStart {
 	type: 'tool.execution_start';
 	/** Envelope-level sub-agent instance id; resolved to the parent tool call id via `subagent.started`. */
 	agentId?: string;
+	/** ISO 8601 envelope timestamp; the mapper uses it to restore turn timing. */
+	timestamp?: string;
 	data: {
 		toolCallId: string;
 		toolName: string;
@@ -35,6 +37,8 @@ export interface ISessionEventToolComplete {
 	type: 'tool.execution_complete';
 	/** Envelope-level sub-agent instance id. See {@link ISessionEventToolStart.agentId}. */
 	agentId?: string;
+	/** ISO 8601 envelope timestamp; the mapper uses it to restore turn timing. */
+	timestamp?: string;
 	data: {
 		toolCallId: string;
 		success: boolean;
@@ -60,6 +64,8 @@ export interface ISessionEventMessage {
 	id?: string;
 	/** Envelope-level sub-agent instance id. See {@link ISessionEventToolStart.agentId}. */
 	agentId?: string;
+	/** ISO 8601 envelope timestamp; the mapper uses it to restore turn timing. */
+	timestamp?: string;
 	data: {
 		messageId?: string;
 		interactionId?: string;
@@ -122,6 +128,8 @@ export interface ISessionEventAssistantTurn {
 export interface ISessionEventSystemNotification {
 	type: 'system.notification';
 	id?: string;
+	/** ISO 8601 envelope timestamp; the mapper uses it to restore turn timing. */
+	timestamp?: string;
 	data: SessionEventPayload<'system.notification'>['data'];
 }
 
@@ -141,8 +149,8 @@ export type ISessionEvent =
  * Widens ergonomic {@link ISessionEvent} test fixtures to the real SDK
  * {@link SessionEvent} union so they can be fed to the production
  * `mapSessionEvents`. The test shapes deliberately omit envelope fields the
- * mapper ignores (`parentId`, `timestamp`, …), so this is a safe deliberate
- * widening rather than a representation of real SDK events.
+ * mapper ignores (`parentId`, …), so this is a safe deliberate widening
+ * rather than a representation of real SDK events.
  */
 export function toSessionEvents(events: readonly ISessionEvent[]): SessionEvent[] {
 	return events as unknown as SessionEvent[];

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -569,6 +569,35 @@ suite('mapSessionEvents — history replay', () => {
 			],
 		}]);
 	});
+
+	test('restores turn timing from the SDK event envelopes', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', id: 'turn-1', timestamp: '2026-07-29T10:00:00.000Z', data: { interactionId: 'm1', content: 'first' } },
+			{ type: 'assistant.message', timestamp: '2026-07-29T10:00:03.500Z', data: { messageId: 'm2', content: 'First answer.' } },
+			{ type: 'user.message', id: 'turn-2', timestamp: '2026-07-29T10:05:00.000Z', data: { interactionId: 'm3', content: 'second' } },
+			{ type: 'assistant.message', timestamp: '2026-07-29T10:05:01.000Z', data: { messageId: 'm4', content: 'Second answer.' } },
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual(turns.map(turn => ({ id: turn.id, startedAt: turn.startedAt, duration: turn.duration })), [
+			{ id: 'turn-1', startedAt: '2026-07-29T10:00:00.000Z', duration: 3500 },
+			{ id: 'turn-2', startedAt: '2026-07-29T10:05:00.000Z', duration: 1000 },
+		]);
+	});
+
+	test('leaves turn timing undefined when envelopes carry no usable timestamp', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', id: 'turn-1', data: { interactionId: 'm1', content: 'first' } },
+			{ type: 'assistant.message', timestamp: 'not-a-date', data: { messageId: 'm2', content: 'First answer.' } },
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual(turns.map(turn => ({ id: turn.id, startedAt: turn.startedAt, duration: turn.duration })), [
+			{ id: 'turn-1', startedAt: undefined, duration: undefined },
+		]);
+	});
 });
 
 suite('mapSessionEvents — subagent routing', () => {

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -586,6 +586,23 @@ suite('mapSessionEvents — history replay', () => {
 		]);
 	});
 
+	test('bounds turn duration by the last event belonging to the turn', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', id: 'turn-1', timestamp: '2026-07-29T10:00:00.000Z', data: { interactionId: 'm1', content: 'first' } },
+			{ type: 'assistant.turn_start', timestamp: '2026-07-29T10:00:00.500Z', data: { turnId: 't1' } },
+			{ type: 'assistant.message', timestamp: '2026-07-29T10:00:03.500Z', data: { messageId: 'm2', content: 'First answer.' } },
+			{ type: 'assistant.turn_end', timestamp: '2026-07-29T10:00:04.000Z', data: { turnId: 't1' } },
+			// Ignored by the mapper an hour later: it must not extend the turn.
+			{ type: 'session.unrelated_event', timestamp: '2026-07-29T11:00:00.000Z' },
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual(turns.map(turn => ({ id: turn.id, startedAt: turn.startedAt, duration: turn.duration })), [
+			{ id: 'turn-1', startedAt: '2026-07-29T10:00:00.000Z', duration: 4000 },
+		]);
+	});
+
 	test('leaves turn timing undefined when envelopes carry no usable timestamp', async () => {
 		const events: ISessionEvent[] = [
 			{ type: 'user.message', id: 'turn-1', data: { interactionId: 'm1', content: 'first' } },


### PR DESCRIPTION
Chat messages show the time they were sent, but the time disappeared after restarting the client.

## Root cause

The timestamp already flows correctly on the client: `Turn.startedAt` / `Turn.duration` → `stateToProgressAdapter` → `IChatSessionHistoryItem.timestamp` → `ChatRequestModel.requestTimestamp` → renderer. While a session is live, `ChatTurnStarted` actions carry `startedAt`, so times render fine.

The problem is on the agent host: when a session is restored from a persisted transcript, the history **replay mappers** rebuild the turns and dropped the timing entirely. `chatServiceImpl` then passes `message.timestamp ?? null`, and `null` means "unknown, render nothing".

`claudeReplayMapper` already mapped its message timestamps; the Copilot and Codex mappers did not.

## Fix

- **Copilot** (`mapSessionEvents.ts`): read the ISO 8601 `timestamp` off the SDK `SessionEvent` envelope and use it to set `startedAt` and compute `duration`. A parent turn is flushed while handling the event that *starts the next* turn, so the previous event's timestamp is used as its end time — otherwise user idle time between turns would be folded into the previous turn's duration. Malformed/absent timestamps degrade to `undefined` rather than a fabricated time.
- **Codex** (`codexReplayMapper.ts`): derive timing from the persisted thread turn (`startedAt`/`completedAt` are Unix seconds, `durationMs` is preferred when present, mirroring the live `mapTurnCompleted`).

No client change was needed — the client already synthesizes a provisional `Date.now()` timestamp for new requests and renders the host-provided one when available.

## Testing

- New unit tests in `mapSessionEvents.test.ts` and `codexReplayMapper.test.ts`, including a case where envelopes carry no usable timestamp.
- Updated one existing `copilotAgentSession.test.ts` assertion, since replayed turns now carry timing.
- Full `agentHost` suite passes apart from 4 `SessionPermissionManager` failures that are pre-existing on the base commit (verified by stashing) and unrelated to this change.