### PR TITLE
Fix Agents window shell CSS specificity

### DIFF
--- a/src/vs/sessions/browser/media/sidebarActionButton.css
+++ b/src/vs/sessions/browser/media/sidebarActionButton.css
@@ -3,8 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.sidebar-action > .action-label {
-	/* Hide the default action-label rendered by ActionViewItem */
+/* The label also carries a codicon class, so include the list owner to outrank
+ * `.codicon[class*='codicon-']` and keep its `display: inline-block` from
+ * revealing the default ActionViewItem glyph when stylesheet order changes. */
+.sidebar-action-list .sidebar-action > .action-label {
 	display: none;
 }
 

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -276,7 +276,9 @@
 	display: none;
 }
 
-.chat-composite-bar-new-chat .action-item .action-label {
+/* Include the tab-row owner to outrank `.monaco-action-bar .action-item .codicon`,
+ * which otherwise resets this button's width and height from 26px to 16px. */
+.chat-composite-bar-tabs-row > .chat-composite-bar-new-chat .action-item .action-label {
 	box-sizing: border-box;
 	width: 26px;
 	height: 26px;
@@ -356,11 +358,10 @@
 }
 
 /* Lock icon for read-only (non-interactive) chats, shown before the label.
-	The element carries the `codicon` class, whose base rule
-	`.codicon[class*='codicon-'] { display: inline-block }` has specificity (0,2,0),
-	so these hide/show rules are scoped to the tab to win on specificity —
-	otherwise the lock would show on every tab regardless of read-only state. */
-.chat-composite-bar-tab .chat-composite-bar-tab-lock.codicon {
+	Include the tab-strip owner to outrank
+	`.monaco-workbench .codicon[class*='codicon-']`, which otherwise resets the
+	compact 12px lock to 16px when the workbench stylesheet loads later. */
+.session-chat-tabs-bar .chat-composite-bar-tab .chat-composite-bar-tab-lock.codicon {
 	display: none;
 	flex-shrink: 0;
 	align-items: center;
@@ -404,7 +405,9 @@
 	height: 22px;
 }
 
-.chat-composite-bar-tab-input.monaco-inputbox .input {
+/* Include the tab owner to outrank `.monaco-inputbox > .ibwrapper > .input`,
+ * which otherwise restores the base 4px 6px padding around the rename input. */
+.chat-composite-bar-tab .chat-composite-bar-tab-input.monaco-inputbox .input {
 	font-family: inherit;
 	font-weight: inherit;
 	font-size: inherit;
@@ -473,7 +476,10 @@
 	background-color: var(--vscode-list-warningForeground);
 }
 
-.chat-composite-bar-tab.in-progress .chat-composite-bar-tab-indicator-icon {
+/* Include the tab-strip owner to outrank
+ * `.monaco-workbench .codicon[class*='codicon-']` and keep the in-progress
+ * indicator at the compact 12px size. */
+.session-chat-tabs-bar .chat-composite-bar-tab.in-progress .chat-composite-bar-tab-indicator-icon {
 	font-size: var(--vscode-codiconFontSize-compact, 12px);
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -74,11 +74,12 @@
 	cursor: pointer;
 	overflow: hidden;
 }
+/* Codicons use the base 16px token rather than an unsupported intermediate size. */
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-icon {
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize);
 }
 
 /* Session title - primary label in the command center box. */


### PR DESCRIPTION
## Problem

Several Agents window shell rules tied shared base/workbench selectors on specificity, so stylesheet concatenation order decided the rendered result.

| Surface | Intended rule | Equal-specificity competitor | Order-dependent property |
| --- | --- | --- | --- |
| Sidebar action placeholder | `.sidebar-action > .action-label` | `.codicon[class*='codicon-']` | `display: none` versus `inline-block` |
| New Chat tab button | `.chat-composite-bar-new-chat .action-item .action-label` | `.monaco-action-bar .action-item .codicon` | `width`/`height: 26px` versus `16px` |
| Read-only lock and in-progress indicator | tab-local codicon selectors | `.monaco-workbench .codicon[class*='codicon-']` | compact `font-size: 12px` versus `16px` |
| Rename input | `.chat-composite-bar-tab-input.monaco-inputbox .input` | `.monaco-inputbox > .ibwrapper > .input` | `padding: 0 4px` versus `4px 6px` |
| Command-center title icon | title-icon selector | `.monaco-workbench .codicon[class*='codicon-']` | unsupported `font-size: 14px` versus `16px` |

## Change

The first four cases add the smallest semantic owner needed to break the tie. Each non-obvious selector has an inline comment naming the competing selector and affected property.

The title icon is handled differently: codicons support only base 16px and compact 12px sizes, so it now uses `var(--vscode-codiconFontSize)`. Because that agrees with the shared workbench rule, no extra selector specificity is needed. This intentional 14px → 16px correction accounts for the two titlebar screenshot changes reported by CI.

## Validation

- `npm run stylelint -- src/vs/sessions/browser/media/sidebarActionButton.css src/vs/sessions/browser/parts/media/chatCompositeBar.css src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css`
- `npm run precommit`
- Rendered 54 chat composite bar, session header, titlebar, pull-request, and changes fixtures in product and reversed stylesheet order: exact image hashes match with no render errors