### PR TITLE
agentHost: refresh subscriptions after session recreation

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -884,7 +884,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		}
 		// Use `.then` (not `async`) so the tracked promise and the returned promise are the same object — callers
 		// awaiting via `getInflightSessionCreate` resume on the same microtask queue as direct `createSession()` awaiters.
-		const promise = this._sendRequest('createSession', {
+		const createRequest = this._sendRequest('createSession', {
 			channel: session.toString(),
 			provider,
 			workingDirectories: config?.workingDirectories?.map(d => fromAgentHostUri(d).toString()),
@@ -892,8 +892,12 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			config: config?.config,
 			activeClient: config?.activeClient,
 			progressToken: config?.progressToken,
-		}).then(() => session);
-		this._subscriptionManager.trackSessionCreate(session, promise);
+		});
+		const promise = createRequest.then(async () => {
+			await this._subscriptionManager.refreshSubscription(session, createRequest);
+			return session;
+		});
+		this._subscriptionManager.trackSessionCreate(session, promise, createRequest);
 		return promise;
 	}
 

--- a/src/vs/platform/agentHost/common/state/agentSubscription.ts
+++ b/src/vs/platform/agentHost/common/state/agentSubscription.ts
@@ -985,15 +985,26 @@ export class AgentSubscriptionManager extends Disposable {
 	private async _refreshSubscription(resource: URI, triggeringCreate?: object): Promise<void> {
 		const entry = this._subscriptions.get(resource);
 		if (!entry) {
+			// No component currently holds this resource, so there is no client
+			// subscription whose pre-create state needs to be replaced.
 			return;
 		}
 
 		if (entry.sub.value === undefined) {
 			if (triggeringCreate && entry.initialSubscribeAfterCreate === triggeringCreate) {
+				// This initial subscribe already waits for the same raw create
+				// request that triggered this refresh. Its first snapshot is
+				// therefore post-create; another subscribe would be redundant.
 				return;
 			}
+			// The pending initial subscribe started before this create (or was
+			// not gated by one). Let it settle before fetching a post-create
+			// snapshot so the two snapshot requests cannot race each other.
 			await entry.initialSubscribePromise;
 			if (this._subscriptions.get(resource) !== entry) {
+				// The last holder may have disposed this entry while we waited,
+				// and another holder may now own a different entry for the same
+				// URI. Never apply this refresh operation to that replacement.
 				return;
 			}
 		}
@@ -1004,6 +1015,8 @@ export class AgentSubscriptionManager extends Disposable {
 			snapshot = await this._subscribe(resource);
 		} catch (error) {
 			if (this._subscriptions.get(resource) === entry) {
+				// Only cancel buffering on the entry that began this refresh.
+				// A replacement entry for the same URI has its own lifecycle.
 				entry.sub.cancelSnapshotRefresh();
 				const message = error instanceof Error ? error.message : String(error);
 				this._log(`Failed to refresh subscription ${resource.toString()}: ${message}`);
@@ -1012,6 +1025,8 @@ export class AgentSubscriptionManager extends Disposable {
 		}
 
 		if (this._subscriptions.get(resource) === entry) {
+			// As above, the entry could have been disposed or replaced while the
+			// subscribe request was in flight.
 			this._replaceSubscriptionSnapshot(entry, snapshot.state, snapshot.fromSeq);
 		}
 	}

--- a/src/vs/platform/agentHost/common/state/agentSubscription.ts
+++ b/src/vs/platform/agentHost/common/state/agentSubscription.ts
@@ -917,6 +917,11 @@ export class AgentSubscriptionManager extends Disposable {
 	/**
 	 * Refetch the snapshot for an existing managed non-root subscription.
 	 *
+	 * Call this only after an operation that can replace the authoritative
+	 * state for the same URI. Applying the replacement snapshot clears pending
+	 * optimistic Session and Chat actions because they were based on the
+	 * previous authoritative state.
+	 *
 	 * A pending subscription already gated by `triggeringCreate` is left to its
 	 * initial subscribe. An earlier pending subscribe is allowed to settle, then
 	 * refreshed so its result cannot predate the triggering create. Refreshes

--- a/src/vs/platform/agentHost/common/state/agentSubscription.ts
+++ b/src/vs/platform/agentHost/common/state/agentSubscription.ts
@@ -156,13 +156,18 @@ abstract class BaseAgentSubscription<T> extends Disposable implements IAgentSubs
 	}
 
 	/**
-	 * Abandon a replacement snapshot and discard envelopes received during it.
-	 * They may belong to the replacement resource and cannot be safely reduced
-	 * onto the retained pre-refresh state.
+	 * Abandon a replacement snapshot. Buffered actions are not reduced onto the
+	 * retained pre-refresh state because they may belong to the replacement
+	 * resource. Subclasses can still consume acknowledgements for their pending
+	 * optimistic actions via {@link _onSnapshotRefreshCancelled}.
 	 */
 	cancelSnapshotRefresh(): void {
+		const bufferedEnvelopes = this._bufferedEnvelopes;
 		this._isRefreshingSnapshot = false;
 		this._bufferedEnvelopes = undefined;
+		if (bufferedEnvelopes) {
+			this._onSnapshotRefreshCancelled(bufferedEnvelopes);
+		}
 	}
 
 	/**
@@ -211,6 +216,13 @@ abstract class BaseAgentSubscription<T> extends Disposable implements IAgentSubs
 		return undefined; // No write-ahead by default
 	}
 
+	/**
+	 * Called when a replacement snapshot fails. Buffered actions must not update
+	 * the retained confirmed state, but optimistic subscriptions can retire
+	 * pending entries that the server already acknowledged.
+	 */
+	protected _onSnapshotRefreshCancelled(_bufferedEnvelopes: readonly ActionEnvelope[]): void { }
+
 	/** Hook called after a snapshot is applied. Replays buffered actions. */
 	protected _onSnapshotApplied(_fromSeq: number): void {
 		// Replay any actions that arrived before the snapshot
@@ -235,6 +247,20 @@ abstract class BaseAgentSubscription<T> extends Disposable implements IAgentSubs
 		this._confirmedState = this._applyReducer(this._confirmedState!, envelope.action);
 		this._onDidChange.fire(this.value as T);
 	}
+}
+
+function dropBufferedAcknowledgedPendingActions(
+	bufferedEnvelopes: readonly ActionEnvelope[],
+	clientId: string,
+	dropPendingByClientSeq: (clientSeq: number) => boolean,
+): boolean {
+	let didDropPending = false;
+	for (const envelope of bufferedEnvelopes) {
+		if (envelope.origin?.clientId === clientId && envelope.origin.clientSeq !== undefined) {
+			didDropPending = dropPendingByClientSeq(envelope.origin.clientSeq) || didDropPending;
+		}
+	}
+	return didDropPending;
 }
 
 // --- Root State Subscription -------------------------------------------------
@@ -330,6 +356,12 @@ export class SessionStateSubscription extends BaseAgentSubscription<SessionState
 		super._onSnapshotApplied(fromSeq);
 		// Re-apply pending actions on top of new confirmed state
 		this._recomputeOptimistic();
+	}
+
+	protected override _onSnapshotRefreshCancelled(bufferedEnvelopes: readonly ActionEnvelope[]): void {
+		if (dropBufferedAcknowledgedPendingActions(bufferedEnvelopes, this._clientId, clientSeq => this.dropPendingByClientSeq(clientSeq))) {
+			this._recomputeOptimistic();
+		}
 	}
 
 	protected override _reconcile(envelope: ActionEnvelope, isOwnAction: boolean): void {
@@ -476,6 +508,12 @@ export class ChatStateSubscription extends BaseAgentSubscription<ChatState> {
 	protected override _onSnapshotApplied(fromSeq: number): void {
 		super._onSnapshotApplied(fromSeq);
 		this._recomputeOptimistic();
+	}
+
+	protected override _onSnapshotRefreshCancelled(bufferedEnvelopes: readonly ActionEnvelope[]): void {
+		if (dropBufferedAcknowledgedPendingActions(bufferedEnvelopes, this._clientId, clientSeq => this.dropPendingByClientSeq(clientSeq))) {
+			this._recomputeOptimistic();
+		}
 	}
 
 	protected override _reconcile(envelope: ActionEnvelope, isOwnAction: boolean): void {

--- a/src/vs/platform/agentHost/common/state/agentSubscription.ts
+++ b/src/vs/platform/agentHost/common/state/agentSubscription.ts
@@ -102,6 +102,7 @@ abstract class BaseAgentSubscription<T> extends Disposable implements IAgentSubs
 	protected _confirmedState: T | undefined;
 	private _error: Error | undefined;
 	private _bufferedEnvelopes: ActionEnvelope[] | undefined;
+	private _isRefreshingSnapshot = false;
 
 	protected readonly _onDidChange = this._register(new Emitter<T>());
 	readonly onDidChange: Event<T> = this._onDidChange.event;
@@ -141,8 +142,27 @@ abstract class BaseAgentSubscription<T> extends Disposable implements IAgentSubs
 	handleSnapshot(state: T, fromSeq: number): void {
 		this._confirmedState = state;
 		this._error = undefined;
+		this._isRefreshingSnapshot = false;
 		this._onSnapshotApplied(fromSeq);
 		this._onDidChange.fire(this.value as T);
+	}
+
+	/**
+	 * Buffer incoming envelopes until a replacement snapshot is applied.
+	 */
+	beginSnapshotRefresh(): void {
+		this._isRefreshingSnapshot = true;
+		this._bufferedEnvelopes ??= [];
+	}
+
+	/**
+	 * Abandon a replacement snapshot and discard envelopes received during it.
+	 * They may belong to the replacement resource and cannot be safely reduced
+	 * onto the retained pre-refresh state.
+	 */
+	cancelSnapshotRefresh(): void {
+		this._isRefreshingSnapshot = false;
+		this._bufferedEnvelopes = undefined;
 	}
 
 	/**
@@ -164,7 +184,7 @@ abstract class BaseAgentSubscription<T> extends Disposable implements IAgentSubs
 
 		// Buffer actions that arrive before the snapshot has been applied.
 		// They're replayed in _onSnapshotApplied().
-		if (this._confirmedState === undefined) {
+		if (this._confirmedState === undefined || this._isRefreshingSnapshot) {
 			if (!this._bufferedEnvelopes) {
 				this._bufferedEnvelopes = [];
 			}
@@ -777,7 +797,16 @@ export class AnnotationsStateSubscription extends BaseAgentSubscription<Annotati
 	}
 }
 
-type ManagedSubscriptionEntry = { sub: ManagedSubscription; kind: StateComponents; refCount: number; holders: Map<number, string> };
+type ManagedSubscriptionEntry = {
+	sub: ManagedSubscription;
+	kind: StateComponents;
+	refCount: number;
+	holders: Map<number, string>;
+	initialSubscribePromise?: Promise<void>;
+	initialSubscribeAfterCreate?: object;
+};
+
+type InflightSessionCreate = { promise: Promise<unknown>; subscribeGate: Promise<unknown>; marker: object };
 
 // --- Subscription Manager ----------------------------------------------------
 
@@ -795,7 +824,8 @@ type ManagedSubscriptionEntry = { sub: ManagedSubscription; kind: StateComponent
 export class AgentSubscriptionManager extends Disposable {
 
 	private readonly _subscriptions = new ResourceMap<ManagedSubscriptionEntry>();
-	private readonly _inflightCreates = new ResourceMap<Promise<unknown>>();
+	private readonly _inflightCreates = new ResourceMap<InflightSessionCreate[]>();
+	private readonly _subscriptionRefreshes = new ResourceMap<Promise<void>>();
 	private _referenceOwnerIds = 0;
 	private readonly _rootState: RootStateSubscription;
 	private readonly _clientId: string;
@@ -848,26 +878,105 @@ export class AgentSubscriptionManager extends Disposable {
 	 * this before deciding whether the sessions provider's eager-create raced first send).
 	 */
 	getInflightSessionCreate(resource: URI): Promise<unknown> | undefined {
-		return this._inflightCreates.get(resource);
+		return this._getLatestInflightSessionCreate(resource)?.promise;
 	}
 
 	/**
-	 * Register an in-flight `createSession` Promise for a session URI. Any
-	 * subscribe issued for this resource while the create is pending waits
-	 * for the Promise before issuing the wire-level subscribe.
+	 * Register an in-flight `createSession` Promise for a session URI.
+	 * `subscribeGate` can settle before the public Promise's post-create work,
+	 * allowing an initial subscribe to proceed without depending on a refresh
+	 * that may itself be waiting for that subscribe.
 	 */
-	trackSessionCreate(resource: URI, promise: Promise<unknown>): void {
-		this._inflightCreates.set(resource, promise);
+	trackSessionCreate(resource: URI, promise: Promise<unknown>, subscribeGate: Promise<unknown> = promise, marker: object = subscribeGate): void {
+		const inflight = this._inflightCreates.get(resource) ?? [];
+		const entry = { promise, subscribeGate, marker };
+		inflight.push(entry);
+		this._inflightCreates.set(resource, inflight);
 		// This branch only observes settlement to evict the inflight entry; the
 		// `createSession` caller (and the server, via logService.error) owns the
 		// result. `finally` re-raises a rejection, so without this trailing
 		// `catch` an expected create failure (e.g. AHP_AUTH_REQUIRED) would be
 		// reported a second time as an unhandled rejection.
 		void promise.finally(() => {
-			if (this._inflightCreates.get(resource) === promise) {
+			const current = this._inflightCreates.get(resource);
+			const index = current?.indexOf(entry) ?? -1;
+			if (current && index !== -1) {
+				current.splice(index, 1);
+			}
+			if (current?.length === 0) {
 				this._inflightCreates.delete(resource);
 			}
 		}).catch(() => { });
+	}
+
+	private _getLatestInflightSessionCreate(resource: URI): InflightSessionCreate | undefined {
+		const inflight = this._inflightCreates.get(resource);
+		return inflight?.[inflight.length - 1];
+	}
+
+	/**
+	 * Refetch the snapshot for an existing managed non-root subscription.
+	 *
+	 * A pending subscription already gated by `triggeringCreate` is left to its
+	 * initial subscribe. An earlier pending subscribe is allowed to settle, then
+	 * refreshed so its result cannot predate the triggering create. Refreshes
+	 * for the same resource are serialized so each caller observes a snapshot
+	 * fetched after its triggering operation.
+	 */
+	refreshSubscription(resource: URI, triggeringCreate?: object): Promise<void> {
+		const previous = this._subscriptionRefreshes.get(resource);
+		const promise = (async () => {
+			if (previous) {
+				await previous;
+			}
+			await this._refreshSubscription(resource, triggeringCreate);
+		})();
+		this._subscriptionRefreshes.set(resource, promise);
+		void promise.then(
+			() => this._deleteSubscriptionRefresh(resource, promise),
+			() => this._deleteSubscriptionRefresh(resource, promise),
+		);
+		return promise;
+	}
+
+	private async _refreshSubscription(resource: URI, triggeringCreate?: object): Promise<void> {
+		const entry = this._subscriptions.get(resource);
+		if (!entry) {
+			return;
+		}
+
+		if (entry.sub.value === undefined) {
+			if (triggeringCreate && entry.initialSubscribeAfterCreate === triggeringCreate) {
+				return;
+			}
+			await entry.initialSubscribePromise;
+			if (this._subscriptions.get(resource) !== entry) {
+				return;
+			}
+		}
+
+		entry.sub.beginSnapshotRefresh();
+		let snapshot: IStateSnapshot;
+		try {
+			snapshot = await this._subscribe(resource);
+		} catch (error) {
+			if (this._subscriptions.get(resource) === entry) {
+				entry.sub.cancelSnapshotRefresh();
+				const message = error instanceof Error ? error.message : String(error);
+				this._log(`Failed to refresh subscription ${resource.toString()}: ${message}`);
+			}
+			return;
+		}
+
+		if (this._subscriptions.get(resource) === entry) {
+			this._replaceSubscriptionSnapshot(entry, snapshot.state, snapshot.fromSeq);
+		}
+	}
+
+	private _deleteSubscriptionRefresh(resource: URI, promise: Promise<void>): void {
+		if (this._subscriptionRefreshes.get(resource) === promise) {
+			this._subscriptionRefreshes.delete(resource);
+		}
 	}
 
 	/**
@@ -903,11 +1012,12 @@ export class AgentSubscriptionManager extends Disposable {
 		// Kick off server subscription asynchronously.
 		// Capture the entry reference so we can validate it hasn't been
 		// replaced by a new subscription for the same key (race guard).
-		void (async () => {
-			const inflight = this._inflightCreates.get(resource);
+		const inflight = this._getLatestInflightSessionCreate(resource);
+		entry.initialSubscribeAfterCreate = inflight?.marker;
+		entry.initialSubscribePromise = (async () => {
 			if (inflight) {
 				try {
-					await inflight;
+					await inflight.subscribeGate;
 				} catch {
 					// Swallow — fall through to subscribe so the error
 					// surfaces consistently via setError() on the
@@ -1097,6 +1207,10 @@ export class AgentSubscriptionManager extends Disposable {
 		if (!entry) {
 			return;
 		}
+		this._replaceSubscriptionSnapshot(entry, state, fromSeq);
+	}
+
+	private _replaceSubscriptionSnapshot(entry: ManagedSubscriptionEntry, state: unknown, fromSeq: number): void {
 		// Clear any pending optimistic actions before reseating confirmed
 		// state \u2014 they were predicated on the pre-disconnect confirmed
 		// state and won't reconcile correctly against a fresh snapshot.
@@ -1163,6 +1277,7 @@ export class AgentSubscriptionManager extends Disposable {
 			entry.sub.dispose();
 		}
 		this._subscriptions.clear();
+		this._subscriptionRefreshes.clear();
 		super.dispose();
 	}
 }

--- a/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DeferredPromise } from '../../../../base/common/async.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -626,18 +627,21 @@ suite('AgentSubscriptionManager', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createManager(subscribe: (resource: URI) => Promise<{ resource: string; state: SessionState | TerminalState | ChangesetState; fromSeq: number }> = async (resource) => {
-		subscribedResources.push(resource.toString());
-		const key = resource.toString();
-		if (key.startsWith('copilot:')) {
-			return { resource: key, state: makeSessionState(key), fromSeq: 0 };
-		}
-		return { resource: key, state: makeTerminalState(), fromSeq: 0 };
-	}): AgentSubscriptionManager {
+	function createManager(
+		subscribe: (resource: URI) => Promise<{ resource: string; state: SessionState | ChatState | TerminalState | ChangesetState; fromSeq: number }> = async resource => {
+			subscribedResources.push(resource.toString());
+			const key = resource.toString();
+			if (key.startsWith('copilot:')) {
+				return { resource: key, state: makeSessionState(key), fromSeq: 0 };
+			}
+			return { resource: key, state: makeTerminalState(), fromSeq: 0 };
+		},
+		log: (message: string) => void = noop,
+	): AgentSubscriptionManager {
 		return disposables.add(new AgentSubscriptionManager(
 			'c1',
 			() => ++seq,
-			noop,
+			log,
 			subscribe,
 			(resource) => {
 				unsubscribedResources.push(resource.toString());
@@ -909,6 +913,292 @@ suite('AgentSubscriptionManager', () => {
 
 		retryRef.dispose();
 		assert.strictEqual(mgr.getSubscriptionUnmanaged<SessionState>(uri), undefined);
+	});
+
+	test('refreshSubscription waits for a pending initial subscribe before refetching', async () => {
+		const initialSnapshot = new DeferredPromise<{ resource: string; state: SessionState; fromSeq: number }>();
+		let subscribeCalls = 0;
+		const mgr = createManager(resource => {
+			subscribeCalls++;
+			if (subscribeCalls === 1) {
+				return initialSnapshot.p;
+			}
+			return Promise.resolve({ resource: resource.toString(), state: makeSessionState(resource.toString(), { title: 'Refreshed' }), fromSeq: 1 });
+		});
+		const uri = URI.parse(sessionUri);
+
+		await mgr.refreshSubscription(uri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
+		const refresh = mgr.refreshSubscription(uri);
+
+		assert.strictEqual(subscribeCalls, 1);
+
+		initialSnapshot.complete({ resource: sessionUri, state: makeSessionState(sessionUri, { title: 'Initial' }), fromSeq: 0 });
+		await refresh;
+
+		assert.deepStrictEqual({
+			subscribeCalls,
+			value: ref.object.value,
+		}, {
+			subscribeCalls: 2,
+			value: makeSessionState(sessionUri, { title: 'Refreshed' }),
+		});
+		ref.dispose();
+	});
+
+	test('refreshSubscription leaves a pending subscribe gated by the same create', async () => {
+		const creation = new DeferredPromise<void>();
+		let subscribeCalls = 0;
+		const mgr = createManager(async resource => {
+			subscribeCalls++;
+			return { resource: resource.toString(), state: makeSessionState(resource.toString()), fromSeq: 0 };
+		});
+		const uri = URI.parse(sessionUri);
+		mgr.trackSessionCreate(uri, creation.p);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
+
+		await mgr.refreshSubscription(uri, creation.p);
+		assert.strictEqual(subscribeCalls, 0);
+
+		creation.complete();
+		await new Promise(r => setTimeout(r, 0));
+		assert.strictEqual(subscribeCalls, 1);
+		ref.dispose();
+	});
+
+	test('trackSessionCreate preserves older overlapping creates', async () => {
+		const first = new DeferredPromise<void>();
+		const second = new DeferredPromise<void>();
+		const mgr = createManager();
+		const uri = URI.parse(sessionUri);
+		mgr.trackSessionCreate(uri, first.p);
+		mgr.trackSessionCreate(uri, second.p);
+
+		assert.strictEqual(mgr.getInflightSessionCreate(uri), second.p);
+
+		second.complete();
+		await new Promise(r => setTimeout(r, 0));
+		assert.strictEqual(mgr.getInflightSessionCreate(uri), first.p);
+
+		first.complete();
+		await new Promise(r => setTimeout(r, 0));
+		assert.strictEqual(mgr.getInflightSessionCreate(uri), undefined);
+	});
+
+	test('refreshSubscription reseats shared state and fences buffered envelopes', async () => {
+		const refreshSnapshot = new DeferredPromise<{ resource: string; state: SessionState; fromSeq: number }>();
+		let subscribeCalls = 0;
+		const mgr = createManager(async resource => {
+			subscribeCalls++;
+			if (subscribeCalls === 1) {
+				return { resource: resource.toString(), state: makeSessionState(resource.toString(), { title: 'Snapshot A' }), fromSeq: 5 };
+			}
+			return refreshSnapshot.p;
+		});
+		const uri = URI.parse(sessionUri);
+		const ref1 = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'HolderA');
+		const ref2 = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'HolderB');
+		await new Promise(r => setTimeout(r, 0));
+
+		mgr.dispatchOptimistic(sessionUri, { type: ActionType.SessionTitleChanged, title: 'Stale optimistic title' });
+		const changedTitles: string[] = [];
+		disposables.add(ref1.object.onDidChange(state => changedTitles.push(state.title)));
+
+		const refresh = mgr.refreshSubscription(uri);
+		mgr.receiveEnvelope(makeEnvelope({ type: ActionType.SessionTitleChanged, title: 'Fenced envelope' }, 10));
+		mgr.receiveEnvelope(makeEnvelope({ type: ActionType.SessionTitleChanged, title: 'Newer envelope' }, 11));
+		refreshSnapshot.complete({
+			resource: sessionUri,
+			state: makeSessionState(sessionUri, { title: 'Snapshot B', workingDirectories: ['file:///new'] }),
+			fromSeq: 10,
+		});
+		await refresh;
+
+		assert.deepStrictEqual({
+			sameObject: ref1.object === ref2.object,
+			value: ref1.object.value,
+			verifiedValue: ref1.object.verifiedValue,
+			pending: mgr.getPendingSessionActions(),
+			subscribeCalls,
+			holders: mgr.getActiveSubscriptions()[0].holders,
+			changedTitles,
+		}, {
+			sameObject: true,
+			value: makeSessionState(sessionUri, { title: 'Newer envelope', workingDirectories: ['file:///new'] }),
+			verifiedValue: makeSessionState(sessionUri, { title: 'Newer envelope', workingDirectories: ['file:///new'] }),
+			pending: [],
+			subscribeCalls: 2,
+			holders: [{ owner: 'HolderA', count: 1 }, { owner: 'HolderB', count: 1 }],
+			changedTitles: ['Newer envelope', 'Newer envelope', 'Newer envelope'],
+		});
+
+		ref1.dispose();
+		ref2.dispose();
+	});
+
+	test('refreshSubscription failure preserves old state and drops buffered envelopes', async () => {
+		const refreshSnapshot = new DeferredPromise<{ resource: string; state: SessionState; fromSeq: number }>();
+		const logs: string[] = [];
+		let subscribeCalls = 0;
+		const mgr = createManager(async resource => {
+			subscribeCalls++;
+			if (subscribeCalls === 1) {
+				return { resource: resource.toString(), state: makeSessionState(resource.toString(), { title: 'Snapshot A' }), fromSeq: 5 };
+			}
+			return refreshSnapshot.p;
+		}, message => logs.push(message));
+		const uri = URI.parse(sessionUri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
+		await new Promise(r => setTimeout(r, 0));
+		mgr.dispatchOptimistic(sessionUri, { type: ActionType.SessionTitleChanged, title: 'Pending title' });
+
+		const refresh = mgr.refreshSubscription(uri);
+		mgr.receiveEnvelope(makeEnvelope({ type: ActionType.SessionTitleChanged, title: 'New-session envelope' }, 6));
+		refreshSnapshot.error(new Error('refresh failed'));
+		await refresh;
+
+		assert.deepStrictEqual({
+			value: ref.object.value,
+			verifiedValue: ref.object.verifiedValue,
+			pending: mgr.getPendingSessionActions().map(p => p.action),
+			logs,
+		}, {
+			value: makeSessionState(sessionUri, { title: 'Pending title' }),
+			verifiedValue: makeSessionState(sessionUri, { title: 'Snapshot A' }),
+			pending: [{ type: ActionType.SessionTitleChanged, title: 'Pending title' }],
+			logs: [`Failed to refresh subscription ${sessionUri}: refresh failed`],
+		});
+
+		ref.dispose();
+	});
+
+	test('refreshSubscription recovers an errored subscription', async () => {
+		let subscribeCalls = 0;
+		const mgr = createManager(async resource => {
+			subscribeCalls++;
+			if (subscribeCalls === 1) {
+				throw new Error('not created');
+			}
+			return { resource: resource.toString(), state: makeSessionState(resource.toString(), { title: 'Recovered' }), fromSeq: 1 };
+		});
+		const uri = URI.parse(sessionUri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
+		await new Promise(r => setTimeout(r, 0));
+		assert.ok(ref.object.value instanceof Error);
+
+		await mgr.refreshSubscription(uri);
+
+		assert.deepStrictEqual({
+			subscribeCalls,
+			value: ref.object.value,
+		}, {
+			subscribeCalls: 2,
+			value: makeSessionState(sessionUri, { title: 'Recovered' }),
+		});
+		ref.dispose();
+	});
+
+	test('refreshSubscription serializes refreshes for the same resource', async () => {
+		const firstRefresh = new DeferredPromise<{ resource: string; state: SessionState; fromSeq: number }>();
+		const secondRefresh = new DeferredPromise<{ resource: string; state: SessionState; fromSeq: number }>();
+		let subscribeCalls = 0;
+		const mgr = createManager(async resource => {
+			subscribeCalls++;
+			switch (subscribeCalls) {
+				case 1:
+					return { resource: resource.toString(), state: makeSessionState(resource.toString(), { title: 'Initial' }), fromSeq: 0 };
+				case 2:
+					return firstRefresh.p;
+				default:
+					return secondRefresh.p;
+			}
+		});
+		const uri = URI.parse(sessionUri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
+		await new Promise(r => setTimeout(r, 0));
+
+		const refresh1 = mgr.refreshSubscription(uri);
+		const refresh2 = mgr.refreshSubscription(uri);
+		assert.strictEqual(subscribeCalls, 2);
+
+		firstRefresh.complete({ resource: sessionUri, state: makeSessionState(sessionUri, { title: 'First refresh' }), fromSeq: 1 });
+		await refresh1;
+		await Promise.resolve();
+		assert.strictEqual(subscribeCalls, 3);
+
+		secondRefresh.complete({ resource: sessionUri, state: makeSessionState(sessionUri, { title: 'Second refresh' }), fromSeq: 2 });
+		await refresh2;
+
+		assert.strictEqual((ref.object.value as SessionState).title, 'Second refresh');
+		ref.dispose();
+	});
+
+	test('refreshSubscription does not mutate a replacement entry', async () => {
+		const oldRefresh = new DeferredPromise<{ resource: string; state: SessionState; fromSeq: number }>();
+		let subscribeCalls = 0;
+		const mgr = createManager(async resource => {
+			subscribeCalls++;
+			if (subscribeCalls === 1) {
+				return { resource: resource.toString(), state: makeSessionState(resource.toString(), { title: 'Old entry' }), fromSeq: 0 };
+			}
+			if (subscribeCalls === 2) {
+				return oldRefresh.p;
+			}
+			return { resource: resource.toString(), state: makeSessionState(resource.toString(), { title: 'Replacement entry' }), fromSeq: 2 };
+		});
+		const uri = URI.parse(sessionUri);
+		const oldRef = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'old');
+		await new Promise(r => setTimeout(r, 0));
+
+		const refresh = mgr.refreshSubscription(uri);
+		oldRef.dispose();
+		const replacementRef = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'replacement');
+		await new Promise(r => setTimeout(r, 0));
+		oldRefresh.complete({ resource: sessionUri, state: makeSessionState(sessionUri, { title: 'Stale refresh' }), fromSeq: 1 });
+		await refresh;
+
+		assert.deepStrictEqual({
+			subscribeCalls,
+			value: replacementRef.object.value,
+		}, {
+			subscribeCalls: 3,
+			value: makeSessionState(sessionUri, { title: 'Replacement entry' }),
+		});
+		replacementRef.dispose();
+	});
+
+	test('refreshSubscription only refreshes the requested resource', async () => {
+		let sessionSubscribeCalls = 0;
+		const chatState = makeChatState(chatUri, makeSessionSummary(sessionUri), { title: 'Chat state' });
+		const mgr = createManager(async resource => {
+			if (resource.toString() === sessionUri) {
+				sessionSubscribeCalls++;
+				return {
+					resource: sessionUri,
+					state: makeSessionState(sessionUri, { title: sessionSubscribeCalls === 1 ? 'Session A' : 'Session B' }),
+					fromSeq: sessionSubscribeCalls,
+				};
+			}
+			return { resource: chatUri, state: chatState, fromSeq: 1 };
+		});
+		const sessionRef = mgr.getSubscription<SessionState>(StateComponents.Session, URI.parse(sessionUri), 'session');
+		const chatRef = mgr.getSubscription<ChatState>(StateComponents.Chat, URI.parse(chatUri), 'chat');
+		await new Promise(r => setTimeout(r, 0));
+		const originalChatObject = chatRef.object;
+
+		await mgr.refreshSubscription(URI.parse(sessionUri));
+
+		assert.deepStrictEqual({
+			sessionTitle: (sessionRef.object.value as SessionState).title,
+			chatObjectUnchanged: chatRef.object === originalChatObject,
+			chatValue: chatRef.object.value,
+		}, {
+			sessionTitle: 'Session B',
+			chatObjectUnchanged: true,
+			chatValue: chatState,
+		});
+		sessionRef.dispose();
+		chatRef.dispose();
 	});
 
 	test('getActiveSubscriptions reports kind, refCount, holders and status per active subscription', async () => {

--- a/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
@@ -1036,6 +1036,71 @@ suite('AgentSubscriptionManager', () => {
 		ref2.dispose();
 	});
 
+	test('reconnect snapshot does not override an in-flight refresh', async () => {
+		const refreshSnapshot = new DeferredPromise<{ resource: string; state: SessionState; fromSeq: number }>();
+		let subscribeCalls = 0;
+		const mgr = createManager(async resource => {
+			subscribeCalls++;
+			if (subscribeCalls === 1) {
+				return { resource: resource.toString(), state: makeSessionState(resource.toString(), { title: 'Snapshot A' }), fromSeq: 1 };
+			}
+			return refreshSnapshot.p;
+		});
+		const uri = URI.parse(sessionUri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
+		await new Promise(r => setTimeout(r, 0));
+
+		const refresh = mgr.refreshSubscription(uri);
+		mgr.applyReconnectSnapshot(sessionUri, makeSessionState(sessionUri, { title: 'Reconnect snapshot' }), 2);
+		const reconnectValue = ref.object.value;
+		refreshSnapshot.complete({ resource: sessionUri, state: makeSessionState(sessionUri, { title: 'Snapshot B' }), fromSeq: 3 });
+		await refresh;
+
+		assert.deepStrictEqual({
+			subscribeCalls,
+			reconnectValue,
+			value: ref.object.value,
+		}, {
+			subscribeCalls: 2,
+			reconnectValue: makeSessionState(sessionUri, { title: 'Reconnect snapshot' }),
+			value: makeSessionState(sessionUri, { title: 'Snapshot B' }),
+		});
+		ref.dispose();
+	});
+
+	test('reconnect missing does not prevent an in-flight refresh from recovering', async () => {
+		const refreshSnapshot = new DeferredPromise<{ resource: string; state: SessionState; fromSeq: number }>();
+		let subscribeCalls = 0;
+		const mgr = createManager(async resource => {
+			subscribeCalls++;
+			if (subscribeCalls === 1) {
+				return { resource: resource.toString(), state: makeSessionState(resource.toString(), { title: 'Snapshot A' }), fromSeq: 1 };
+			}
+			return refreshSnapshot.p;
+		});
+		const uri = URI.parse(sessionUri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
+		await new Promise(r => setTimeout(r, 0));
+
+		const refresh = mgr.refreshSubscription(uri);
+		mgr.markSubscriptionsMissing([uri]);
+		const wasMissing = ref.object.value instanceof Error;
+
+		refreshSnapshot.complete({ resource: sessionUri, state: makeSessionState(sessionUri, { title: 'Snapshot B' }), fromSeq: 3 });
+		await refresh;
+
+		assert.deepStrictEqual({
+			subscribeCalls,
+			wasMissing,
+			value: ref.object.value,
+		}, {
+			subscribeCalls: 2,
+			wasMissing: true,
+			value: makeSessionState(sessionUri, { title: 'Snapshot B' }),
+		});
+		ref.dispose();
+	});
+
 	test('refreshSubscription failure preserves old state and drops buffered envelopes', async () => {
 		const refreshSnapshot = new DeferredPromise<{ resource: string; state: SessionState; fromSeq: number }>();
 		const logs: string[] = [];

--- a/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
@@ -505,6 +505,33 @@ suite('ChatStateSubscription', () => {
 			turns: [{ id: 'turn-1', state: TurnState.Complete }],
 		});
 	});
+
+	test('cancelSnapshotRefresh retires a buffered own acknowledgement without applying it', () => {
+		const sub = createSub();
+		const confirmed = makeChatState(chatUri);
+		sub.handleSnapshot(confirmed, 0);
+		const action = {
+			type: ActionType.ChatTurnStarted,
+			turnId: 'turn-1',
+			startedAt: '2025-01-01T00:00:00.000Z',
+			message: { text: 'hello', origin: { kind: MessageKind.User } },
+		} as const;
+		const clientSeq = sub.applyOptimistic(action);
+
+		sub.beginSnapshotRefresh();
+		sub.receiveEnvelope(makeEnvelope(action, 1, { clientId: 'c1', clientSeq }));
+		sub.cancelSnapshotRefresh();
+
+		assert.deepStrictEqual({
+			pending: sub.getPendingActions(),
+			value: sub.value,
+			verifiedValue: sub.verifiedValue,
+		}, {
+			pending: [],
+			value: confirmed,
+			verifiedValue: confirmed,
+		});
+	});
 });
 
 // TerminalStateSubscription
@@ -1118,7 +1145,10 @@ suite('AgentSubscriptionManager', () => {
 		mgr.dispatchOptimistic(sessionUri, { type: ActionType.SessionTitleChanged, title: 'Pending title' });
 
 		const refresh = mgr.refreshSubscription(uri);
-		mgr.receiveEnvelope(makeEnvelope({ type: ActionType.SessionTitleChanged, title: 'New-session envelope' }, 6));
+		const acknowledgedAction = { type: ActionType.SessionTitleChanged, title: 'Acknowledged during refresh' } as const;
+		const acknowledgedClientSeq = mgr.dispatchOptimistic(sessionUri, acknowledgedAction);
+		mgr.receiveEnvelope(makeEnvelope(acknowledgedAction, 6, { clientId: 'c1', clientSeq: acknowledgedClientSeq }));
+		mgr.receiveEnvelope(makeEnvelope({ type: ActionType.SessionTitleChanged, title: 'New-session envelope' }, 7));
 		refreshSnapshot.error(new Error('refresh failed'));
 		await refresh;
 

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -25,7 +25,7 @@ import { ActionType, type ChatTurnStartedAction, type SessionActiveClientSetActi
 import { ProtocolError, type AhpServerNotification, type JsonRpcNotification, type JsonRpcRequest, type JsonRpcResponse, type ProtocolMessage } from '../../common/state/sessionProtocol.js';
 import { hasKey } from '../../../../base/common/types.js';
 import { mainWindow } from '../../../../base/browser/window.js';
-import { CustomizationType, MessageAttachmentKind, MessageKind, PendingMessageKind, readSessionWorkspaceless, ROOT_STATE_URI, SessionStatus, StateComponents, customizationId, withSessionWorkspaceless } from '../../common/state/sessionState.js';
+import { CustomizationType, MessageAttachmentKind, MessageKind, PendingMessageKind, readSessionWorkspaceless, ROOT_STATE_URI, SessionLifecycle, SessionStatus, StateComponents, customizationId, withSessionWorkspaceless } from '../../common/state/sessionState.js';
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
@@ -33,6 +33,7 @@ import { AgentHostCodexAgentEnabledSettingId, AgentHostCopilotMultiRootEnabledSe
 import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
 import type { Implementation } from '../../common/state/protocol/common/commands.js';
 import { agentsWindowAgentHostClientInfo } from '../../common/agentHostClientInfo.js';
+import type { SessionState } from '../../common/state/protocol/state.js';
 
 type ProtocolTransportMessage = ProtocolMessage | AhpServerNotification | JsonRpcNotification | JsonRpcResponse | JsonRpcRequest;
 type RootConfigValue = boolean | string | AgentHostTerminalAutoApproveRules | undefined;
@@ -115,9 +116,11 @@ class CloseOnDisposeProtocolTransport extends TestProtocolTransport {
 
 class CountingLogService extends NullLogService {
 	warnCount = 0;
+	readonly warnings: string[] = [];
 
-	override warn(_message: string, ..._args: unknown[]): void {
+	override warn(message: string, ..._args: unknown[]): void {
 		this.warnCount++;
+		this.warnings.push(message);
 	}
 }
 
@@ -225,6 +228,18 @@ suite('RemoteAgentHostProtocolClient', () => {
 		for (let i = 0; i < 10; i++) {
 			await Promise.resolve();
 		}
+	}
+
+	function requestsFor(transport: TestProtocolTransport, method: string): JsonRpcRequest[] {
+		return transport.sentMessages.filter((message): message is JsonRpcRequest =>
+			hasKey(message, { method: true, id: true }) && message.method === method);
+	}
+
+	async function waitForRequestCount(transport: TestProtocolTransport, method: string, count: number): Promise<JsonRpcRequest[]> {
+		while (requestsFor(transport, method).length < count) {
+			await Promise.resolve();
+		}
+		return requestsFor(transport, method);
 	}
 
 	function fireConfigurationChange(configurationService: TestConfigurationService, settingId: string): void {
@@ -444,6 +459,269 @@ suite('RemoteAgentHostProtocolClient', () => {
 		assert.ok(request);
 		transport.fireMessage({ jsonrpc: '2.0', id: request.id, result: null });
 		assert.strictEqual(await creation, session);
+	});
+
+	suite('createSession subscription refresh', () => {
+		const session = URI.parse('copilot:/provisional');
+
+		function sessionState(title: string, folder: string, plugin: string): SessionState {
+			return {
+				provider: 'copilot',
+				title,
+				status: SessionStatus.Idle,
+				lifecycle: SessionLifecycle.Ready,
+				activeClients: [],
+				chats: [],
+				workingDirectories: [folder],
+				customizations: [
+					{ type: CustomizationType.Plugin, id: customizationId(plugin), uri: plugin, name: plugin, enabled: true },
+				],
+			};
+		}
+
+		test('refreshes an existing subscription before createSession settles', async () => {
+			const { client, transport } = createClient();
+			await connectClient(client, transport);
+			const ref = client.getSubscription<SessionState>(StateComponents.Session, session, 'test');
+			const initialSubscribe = (await waitForRequestCount(transport, 'subscribe', 1))[0];
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: initialSubscribe.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Snapshot A', 'file:///old', 'file:///plugins/old'), fromSeq: 1 } },
+			});
+			await flushMicrotasks();
+
+			const creation = client.createSession({ provider: 'copilot', session });
+			assert.strictEqual(client.getInflightSessionCreate(session), creation);
+			const create = (await waitForRequestCount(transport, 'createSession', 1))[0];
+			transport.fireMessage({ jsonrpc: '2.0', id: create.id, result: null });
+			const refreshSubscribe = (await waitForRequestCount(transport, 'subscribe', 2))[1];
+			let settled = false;
+			void creation.then(() => settled = true);
+			await flushMicrotasks();
+			assert.strictEqual(settled, false);
+
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: refreshSubscribe.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Snapshot B', 'file:///new', 'file:///plugins/new'), fromSeq: 2 } },
+			});
+
+			assert.strictEqual(await creation, session);
+			assert.deepStrictEqual(ref.object.value, sessionState('Snapshot B', 'file:///new', 'file:///plugins/new'));
+			ref.dispose();
+		});
+
+		test('does not duplicate subscribe for a subscription acquired during creation', async () => {
+			const { client, transport } = createClient();
+			await connectClient(client, transport);
+
+			const creation = client.createSession({ provider: 'copilot', session });
+			const ref = client.getSubscription<SessionState>(StateComponents.Session, session, 'test');
+			const create = (await waitForRequestCount(transport, 'createSession', 1))[0];
+			transport.fireMessage({ jsonrpc: '2.0', id: create.id, result: null });
+			const subscribe = (await waitForRequestCount(transport, 'subscribe', 1))[0];
+			assert.strictEqual(requestsFor(transport, 'subscribe').length, 1);
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: subscribe.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Initial', 'file:///new', 'file:///plugins/new'), fromSeq: 1 } },
+			});
+
+			assert.strictEqual(await creation, session);
+			await flushMicrotasks();
+			assert.strictEqual(requestsFor(transport, 'subscribe').length, 1);
+			assert.deepStrictEqual(ref.object.value, sessionState('Initial', 'file:///new', 'file:///plugins/new'));
+			ref.dispose();
+		});
+
+		test('refetches when the initial subscribe started before creation', async () => {
+			const { client, transport } = createClient();
+			await connectClient(client, transport);
+			const ref = client.getSubscription<SessionState>(StateComponents.Session, session, 'test');
+			const initialSubscribe = (await waitForRequestCount(transport, 'subscribe', 1))[0];
+
+			const creation = client.createSession({ provider: 'copilot', session });
+			const create = (await waitForRequestCount(transport, 'createSession', 1))[0];
+			transport.fireMessage({ jsonrpc: '2.0', id: create.id, result: null });
+			await flushMicrotasks();
+			assert.strictEqual(requestsFor(transport, 'subscribe').length, 1);
+
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: initialSubscribe.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Snapshot A', 'file:///old', 'file:///plugins/old'), fromSeq: 1 } },
+			});
+			const refreshSubscribe = (await waitForRequestCount(transport, 'subscribe', 2))[1];
+			let settled = false;
+			void creation.then(() => settled = true);
+			await flushMicrotasks();
+			assert.strictEqual(settled, false);
+
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: refreshSubscribe.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Snapshot B', 'file:///new', 'file:///plugins/new'), fromSeq: 2 } },
+			});
+
+			assert.strictEqual(await creation, session);
+			assert.deepStrictEqual(ref.object.value, sessionState('Snapshot B', 'file:///new', 'file:///plugins/new'));
+			ref.dispose();
+		});
+
+		test('refresh failure warns without rejecting successful creation', async () => {
+			const logService = new CountingLogService();
+			const { client, transport } = createClient(undefined, undefined, undefined, logService);
+			await connectClient(client, transport);
+			const ref = client.getSubscription<SessionState>(StateComponents.Session, session, 'test');
+			const initialSubscribe = (await waitForRequestCount(transport, 'subscribe', 1))[0];
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: initialSubscribe.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Snapshot A', 'file:///old', 'file:///plugins/old'), fromSeq: 1 } },
+			});
+			await flushMicrotasks();
+
+			const creation = client.createSession({ provider: 'copilot', session });
+			const create = (await waitForRequestCount(transport, 'createSession', 1))[0];
+			transport.fireMessage({ jsonrpc: '2.0', id: create.id, result: null });
+			const refreshSubscribe = (await waitForRequestCount(transport, 'subscribe', 2))[1];
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: refreshSubscribe.id,
+				error: { code: AhpErrorCodes.NotFound, message: 'refresh failed' },
+			});
+
+			assert.strictEqual(await creation, session);
+			assert.ok(logService.warnings.some(message => message.includes(`Failed to refresh subscription ${session.toString()}: refresh failed`)));
+			assert.deepStrictEqual(ref.object.value, sessionState('Snapshot A', 'file:///old', 'file:///plugins/old'));
+			ref.dispose();
+		});
+
+		test('serializes refreshes for overlapping creates', async () => {
+			const { client, transport } = createClient();
+			await connectClient(client, transport);
+			const ref = client.getSubscription<SessionState>(StateComponents.Session, session, 'test');
+			const initialSubscribe = (await waitForRequestCount(transport, 'subscribe', 1))[0];
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: initialSubscribe.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Initial', 'file:///old', 'file:///plugins/old'), fromSeq: 1 } },
+			});
+			await flushMicrotasks();
+
+			const creation1 = client.createSession({ provider: 'copilot', session });
+			const creation2 = client.createSession({ provider: 'copilot', session });
+			assert.strictEqual(client.getInflightSessionCreate(session), creation2);
+			const creates = await waitForRequestCount(transport, 'createSession', 2);
+			transport.fireMessage({ jsonrpc: '2.0', id: creates[0].id, result: null });
+			const refresh1 = (await waitForRequestCount(transport, 'subscribe', 2))[1];
+			transport.fireMessage({ jsonrpc: '2.0', id: creates[1].id, result: null });
+			await flushMicrotasks();
+			assert.strictEqual(requestsFor(transport, 'subscribe').length, 2);
+
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: refresh1.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('First', 'file:///one', 'file:///plugins/one'), fromSeq: 2 } },
+			});
+			assert.strictEqual(await creation1, session);
+			const refresh2 = (await waitForRequestCount(transport, 'subscribe', 3))[2];
+			let secondSettled = false;
+			void creation2.then(() => secondSettled = true);
+			await flushMicrotasks();
+			assert.strictEqual(secondSettled, false);
+
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: refresh2.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Second', 'file:///two', 'file:///plugins/two'), fromSeq: 3 } },
+			});
+			assert.strictEqual(await creation2, session);
+			assert.deepStrictEqual(ref.object.value, sessionState('Second', 'file:///two', 'file:///plugins/two'));
+			ref.dispose();
+		});
+
+		test('does not deadlock a pending subscription during overlapping creates', async () => {
+			const { client, transport } = createClient();
+			await connectClient(client, transport);
+
+			const creation1 = client.createSession({ provider: 'copilot', session });
+			const creation2 = client.createSession({ provider: 'copilot', session });
+			const ref = client.getSubscription<SessionState>(StateComponents.Session, session, 'test');
+			const creates = await waitForRequestCount(transport, 'createSession', 2);
+
+			transport.fireMessage({ jsonrpc: '2.0', id: creates[0].id, result: null });
+			transport.fireMessage({ jsonrpc: '2.0', id: creates[1].id, result: null });
+			const initialSubscribe = (await waitForRequestCount(transport, 'subscribe', 1))[0];
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: initialSubscribe.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Initial', 'file:///initial', 'file:///plugins/initial'), fromSeq: 1 } },
+			});
+
+			const refresh1 = (await waitForRequestCount(transport, 'subscribe', 2))[1];
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: refresh1.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('First', 'file:///one', 'file:///plugins/one'), fromSeq: 2 } },
+			});
+			const refresh2 = (await waitForRequestCount(transport, 'subscribe', 3))[2];
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: refresh2.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Second', 'file:///two', 'file:///plugins/two'), fromSeq: 3 } },
+			});
+
+			assert.deepStrictEqual({
+				creation1: await creation1,
+				creation2: await creation2,
+				value: ref.object.value,
+			}, {
+				creation1: session,
+				creation2: session,
+				value: sessionState('Second', 'file:///two', 'file:///plugins/two'),
+			});
+			ref.dispose();
+		});
+
+		test('refreshes a pending subscription after out-of-order creates', async () => {
+			const { client, transport } = createClient();
+			await connectClient(client, transport);
+
+			const creation1 = client.createSession({ provider: 'copilot', session });
+			const creation2 = client.createSession({ provider: 'copilot', session });
+			const ref = client.getSubscription<SessionState>(StateComponents.Session, session, 'test');
+			const creates = await waitForRequestCount(transport, 'createSession', 2);
+
+			transport.fireMessage({ jsonrpc: '2.0', id: creates[1].id, result: null });
+			const initialSubscribe = (await waitForRequestCount(transport, 'subscribe', 1))[0];
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: initialSubscribe.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('Second', 'file:///two', 'file:///plugins/two'), fromSeq: 2 } },
+			});
+			assert.strictEqual(await creation2, session);
+
+			transport.fireMessage({ jsonrpc: '2.0', id: creates[0].id, result: null });
+			const refresh = (await waitForRequestCount(transport, 'subscribe', 2))[1];
+			transport.fireMessage({
+				jsonrpc: '2.0',
+				id: refresh.id,
+				result: { snapshot: { resource: session.toString(), state: sessionState('First', 'file:///one', 'file:///plugins/one'), fromSeq: 3 } },
+			});
+
+			assert.deepStrictEqual({
+				creation1: await creation1,
+				value: ref.object.value,
+				subscribeCalls: requestsFor(transport, 'subscribe').length,
+			}, {
+				creation1: session,
+				value: sessionState('First', 'file:///one', 'file:///plugins/one'),
+				subscribeCalls: 2,
+			});
+			ref.dispose();
+		});
 	});
 
 	suite('createChat', () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/327804

## Summary

- refresh an existing managed session subscription after `createSession` so same-URI provisional session recreation publishes the new working directory and customizations
- preserve the shared subscription object while fencing concurrent envelopes and replacing its authoritative snapshot
- handle pending, overlapping, out-of-order, and reconnect-interleaved creates without duplicate subscribes or deadlocks
- document that managed refresh is reserved for authoritative same-URI replacement operations

## Validation

- `npm run compile`
- `npm run precommit`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/common/agentSubscription.test.ts --run src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts` (135 passing)
