### PR TITLE
Fix agent host diff file paths

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostFileSystemService.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemService.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
+import { OS } from '../../../base/common/platform.js';
 import { IFileService } from '../../files/common/files.js';
 import { InMemoryFileSystemProvider } from '../../files/common/inMemoryFilesystemProvider.js';
 import { InstantiationType, registerSingleton } from '../../instantiation/common/extensions.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ILabelService } from '../../label/common/label.js';
 import { AgentHostFileSystemProvider, type IRemoteFilesystemConnection } from './agentHostFileSystemProvider.js';
-import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME } from './agentHostUri.js';
+import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostLabelFormatter, LOCAL_AGENT_HOST_AUTHORITY } from './agentHostUri.js';
 
 export type { IRemoteFilesystemConnection } from './agentHostFileSystemProvider.js';
 
@@ -55,7 +56,11 @@ class AgentHostFileSystemService extends Disposable implements IAgentHostFileSys
 
 		this._fsProvider = this._register(new AgentHostFileSystemProvider());
 		this._register(_fileService.registerProvider(AGENT_HOST_SCHEME, this._fsProvider));
+
+		// Two formatters: the scheme-wide fallback for hosts whose operating
+		// system is unknown, and a more specific one for the in-process host.
 		this._register(labelService.registerFormatter(AGENT_HOST_LABEL_FORMATTER));
+		this._register(labelService.registerFormatter(agentHostLabelFormatter(LOCAL_AGENT_HOST_AUTHORITY, OS)));
 	}
 
 	registerAuthority(authority: string, connection: IRemoteFilesystemConnection): IDisposable {

--- a/src/vs/platform/agentHost/common/agentHostUri.ts
+++ b/src/vs/platform/agentHost/common/agentHostUri.ts
@@ -160,17 +160,19 @@ export const LOCAL_AGENT_HOST_AUTHORITY = 'local';
 /**
  * Fallback label formatter for {@link AGENT_HOST_SCHEME} URIs of hosts
  * whose operating system is unknown. The URI path is already the original
- * resource path, so the label is the path verbatim, except that a Windows
- * drive letter is normalized (`/c:/a` renders as `C:/a`). The separator is
- * left as `/` because a POSIX host may well be reached from a Windows
- * client, where `\` would corrupt its paths.
+ * resource path, so the label is the path verbatim.
+ *
+ * Deliberately lossless: without knowing the host's operating system,
+ * neither `\` separators nor drive letter normalization can be applied
+ * safely, since `/c:/repo/a.ts` is a valid POSIX path too and rendering it
+ * as `C:/repo/a.ts` would name a different resource. Hosts whose operating
+ * system is known get {@link agentHostLabelFormatter} instead.
  */
 export const AGENT_HOST_LABEL_FORMATTER: ResourceLabelFormatter = {
 	scheme: AGENT_HOST_SCHEME,
 	formatting: {
 		label: '${path}',
 		separator: '/',
-		normalizeDriveLetter: true,
 	},
 };
 

--- a/src/vs/platform/agentHost/common/agentHostUri.ts
+++ b/src/vs/platform/agentHost/common/agentHostUri.ts
@@ -5,6 +5,7 @@
 
 import { decodeBase64, encodeBase64, VSBuffer } from '../../../base/common/buffer.js';
 import { Schemas } from '../../../base/common/network.js';
+import { OperatingSystem } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import type { ResourceLabelFormatter } from '../../label/common/label.js';
 
@@ -151,13 +152,47 @@ export function agentHostAuthority(address: string): string {
 }
 
 /**
- * Label formatter for {@link AGENT_HOST_SCHEME} URIs. The URI path is
- * already the original resource path, so the label is the path verbatim.
+ * Authority of the in-process agent host. It always runs on the same
+ * machine — and therefore the same operating system — as the client.
+ */
+export const LOCAL_AGENT_HOST_AUTHORITY = 'local';
+
+/**
+ * Fallback label formatter for {@link AGENT_HOST_SCHEME} URIs of hosts
+ * whose operating system is unknown. The URI path is already the original
+ * resource path, so the label is the path verbatim, except that a Windows
+ * drive letter is normalized (`/c:/a` renders as `C:/a`). The separator is
+ * left as `/` because a POSIX host may well be reached from a Windows
+ * client, where `\` would corrupt its paths.
  */
 export const AGENT_HOST_LABEL_FORMATTER: ResourceLabelFormatter = {
 	scheme: AGENT_HOST_SCHEME,
 	formatting: {
 		label: '${path}',
 		separator: '/',
+		normalizeDriveLetter: true,
 	},
 };
+
+/**
+ * Label formatter for {@link AGENT_HOST_SCHEME} URIs of an agent host whose
+ * operating system is known, so its paths render the way they do natively
+ * on that host (`C:\a\b` instead of `/c:/a/b`). This matters because such
+ * URIs are shown side by side with plain `file:` URIs — for example as the
+ * original side of a diff — which are always rendered natively.
+ *
+ * Registered per authority since the operating system cannot be derived
+ * from the client: a Windows client may be connected to a POSIX host.
+ */
+export function agentHostLabelFormatter(authority: string, os: OperatingSystem): ResourceLabelFormatter {
+	const isWindows = os === OperatingSystem.Windows;
+	return {
+		scheme: AGENT_HOST_SCHEME,
+		authority,
+		formatting: {
+			label: '${path}',
+			separator: isWindows ? '\\' : '/',
+			normalizeDriveLetter: isWindows,
+		},
+	};
+}

--- a/src/vs/platform/agentHost/common/fileEditDiff.ts
+++ b/src/vs/platform/agentHost/common/fileEditDiff.ts
@@ -5,6 +5,7 @@
 
 import { URI } from '../../../base/common/uri.js';
 import { isEqual } from '../../../base/common/resources.js';
+import { canonicalizeSessionDbUri } from './sessionDbUri.js';
 import type { FileEdit } from './state/protocol/state.js';
 import { FileEditKind } from './state/sessionState.js';
 
@@ -36,6 +37,11 @@ export interface INormalizedFileEdit {
  * Decodes a protocol {@link FileEdit} into parsed URIs and a resolved
  * {@link FileEditKind}. Returns `undefined` when the edit carries no usable
  * file URI (neither `before` nor `after`).
+ *
+ * Content URIs are canonicalized so their path is the edited file's path,
+ * which keeps resource labels readable and stops diff editors from reporting
+ * an edit as a rename because the content snapshot's path differs from the
+ * file's.
  */
 export function normalizeFileEdit(edit: FileEdit): INormalizedFileEdit | undefined {
 	const beforeUri = edit.before ? URI.parse(edit.before.uri) : undefined;
@@ -62,7 +68,7 @@ export function normalizeFileEdit(edit: FileEdit): INormalizedFileEdit | undefin
 		resource,
 		beforeUri,
 		afterUri,
-		beforeContentUri: edit.before?.content.uri ? URI.parse(edit.before.content.uri) : undefined,
-		afterContentUri: edit.after?.content.uri ? URI.parse(edit.after.content.uri) : undefined,
+		beforeContentUri: edit.before?.content.uri ? canonicalizeSessionDbUri(URI.parse(edit.before.content.uri)) : undefined,
+		afterContentUri: edit.after?.content.uri ? canonicalizeSessionDbUri(URI.parse(edit.after.content.uri)) : undefined,
 	};
 }

--- a/src/vs/platform/agentHost/common/fileEditDiff.ts
+++ b/src/vs/platform/agentHost/common/fileEditDiff.ts
@@ -68,7 +68,7 @@ export function normalizeFileEdit(edit: FileEdit): INormalizedFileEdit | undefin
 		resource,
 		beforeUri,
 		afterUri,
-		beforeContentUri: edit.before?.content.uri ? canonicalizeSessionDbUri(URI.parse(edit.before.content.uri)) : undefined,
-		afterContentUri: edit.after?.content.uri ? canonicalizeSessionDbUri(URI.parse(edit.after.content.uri)) : undefined,
+		beforeContentUri: edit.before?.content.uri && beforeUri ? canonicalizeSessionDbUri(URI.parse(edit.before.content.uri), beforeUri) : undefined,
+		afterContentUri: edit.after?.content.uri && afterUri ? canonicalizeSessionDbUri(URI.parse(edit.after.content.uri), afterUri) : undefined,
 	};
 }

--- a/src/vs/platform/agentHost/common/sessionDbUri.ts
+++ b/src/vs/platform/agentHost/common/sessionDbUri.ts
@@ -13,13 +13,18 @@ const SESSION_DB_SCHEME = 'session-db';
  * session database. The path is the edited file's path so resource labels
  * show a real path; the lookup fields live in the query, where `filePath` is
  * kept verbatim because it is part of the database key.
+ *
+ * Only safe to call on the agent host, since `URI.file` interprets `\` per
+ * the operating system it runs on. Clients must use
+ * {@link canonicalizeSessionDbUri}, which takes the path from the file URI
+ * the host already resolved.
  */
 export function buildSessionDbUri(sessionUri: string, toolCallId: string, filePath: string, part: 'before' | 'after'): string {
-	return URI.from({
-		scheme: SESSION_DB_SCHEME,
-		path: URI.file(filePath).path,
-		query: JSON.stringify({ sessionUri, toolCallId, filePath, part } satisfies ISessionDbUriFields),
-	}).toString();
+	return sessionDbUri(URI.file(filePath).path, { sessionUri, toolCallId, filePath, part }).toString();
+}
+
+function sessionDbUri(path: string, fields: ISessionDbUriFields): URI {
+	return URI.from({ scheme: SESSION_DB_SCHEME, path, query: JSON.stringify(fields) });
 }
 
 /** Parsed fields from a `session-db:` content URI. */
@@ -48,15 +53,19 @@ export function parseSessionDbUri(raw: string): ISessionDbUriFields | undefined 
 }
 
 /**
- * Rewrites a legacy `session-db:` URI into the current layout, whose path is
- * the edited file's path. Snapshots recorded by earlier builds encode the
- * blob's location in the path (`/<toolCallId>/<hexFilePath>/<part>/<name>`),
+ * Rewrites a legacy `session-db:` URI so its path is `fileUri`'s, the path of
+ * the file the content belongs to. Snapshots recorded by earlier builds encode
+ * the blob's location in the path (`/<toolCallId>/<hexFilePath>/<part>/<name>`),
  * which surfaces in resource labels and makes diff editors report the file as
  * renamed because the original side's path differs from the modified side's.
  * Any other URI (already-canonical, unparseable, or a different scheme) is
  * returned unchanged.
+ *
+ * The path is taken from `fileUri` rather than re-derived from the recorded
+ * file system path, so a session recorded on a Windows host canonicalizes the
+ * same way on a POSIX client.
  */
-export function canonicalizeSessionDbUri(uri: URI): URI {
+export function canonicalizeSessionDbUri(uri: URI, fileUri: URI): URI {
 	if (uri.scheme !== SESSION_DB_SCHEME || uri.query) {
 		return uri;
 	}
@@ -64,7 +73,7 @@ export function canonicalizeSessionDbUri(uri: URI): URI {
 	if (!fields) {
 		return uri;
 	}
-	return URI.parse(buildSessionDbUri(fields.sessionUri, fields.toolCallId, fields.filePath, fields.part));
+	return sessionDbUri(fileUri.path, fields);
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/src/vs/platform/agentHost/common/sessionDbUri.ts
+++ b/src/vs/platform/agentHost/common/sessionDbUri.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { decodeHex } from '../../../base/common/buffer.js';
+import { URI } from '../../../base/common/uri.js';
+
+const SESSION_DB_SCHEME = 'session-db';
+
+/**
+ * Builds a `session-db:` URI referencing a file-edit content blob in the
+ * session database. The path is the edited file's path so resource labels
+ * show a real path; the lookup fields live in the query, where `filePath` is
+ * kept verbatim because it is part of the database key.
+ */
+export function buildSessionDbUri(sessionUri: string, toolCallId: string, filePath: string, part: 'before' | 'after'): string {
+	return URI.from({
+		scheme: SESSION_DB_SCHEME,
+		path: URI.file(filePath).path,
+		query: JSON.stringify({ sessionUri, toolCallId, filePath, part } satisfies ISessionDbUriFields),
+	}).toString();
+}
+
+/** Parsed fields from a `session-db:` content URI. */
+export interface ISessionDbUriFields {
+	sessionUri: string;
+	toolCallId: string;
+	filePath: string;
+	part: 'before' | 'after';
+}
+
+/**
+ * Parses a `session-db:` URI produced by {@link buildSessionDbUri}.
+ * Returns `undefined` if the URI is not a valid `session-db:` URI.
+ */
+export function parseSessionDbUri(raw: string): ISessionDbUriFields | undefined {
+	let parsed: URI;
+	try {
+		parsed = URI.parse(raw);
+	} catch {
+		return undefined;
+	}
+	if (parsed.scheme !== SESSION_DB_SCHEME) {
+		return undefined;
+	}
+	return parsed.query ? parseSessionDbUriQuery(parsed.query) : parseLegacySessionDbUri(parsed);
+}
+
+/**
+ * Rewrites a legacy `session-db:` URI into the current layout, whose path is
+ * the edited file's path. Snapshots recorded by earlier builds encode the
+ * blob's location in the path (`/<toolCallId>/<hexFilePath>/<part>/<name>`),
+ * which surfaces in resource labels and makes diff editors report the file as
+ * renamed because the original side's path differs from the modified side's.
+ * Any other URI (already-canonical, unparseable, or a different scheme) is
+ * returned unchanged.
+ */
+export function canonicalizeSessionDbUri(uri: URI): URI {
+	if (uri.scheme !== SESSION_DB_SCHEME || uri.query) {
+		return uri;
+	}
+	const fields = parseLegacySessionDbUri(uri);
+	if (!fields) {
+		return uri;
+	}
+	return URI.parse(buildSessionDbUri(fields.sessionUri, fields.toolCallId, fields.filePath, fields.part));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === 'string' && value.length > 0;
+}
+
+function parseSessionDbUriQuery(query: string): ISessionDbUriFields | undefined {
+	let fields: Partial<ISessionDbUriFields>;
+	try {
+		fields = JSON.parse(query) as Partial<ISessionDbUriFields>;
+	} catch {
+		return undefined;
+	}
+	if (typeof fields !== 'object' || fields === null) {
+		return undefined;
+	}
+	const { sessionUri, toolCallId, filePath, part } = fields;
+	if (!isNonEmptyString(sessionUri) || !isNonEmptyString(toolCallId) || !isNonEmptyString(filePath) || (part !== 'before' && part !== 'after')) {
+		return undefined;
+	}
+	return { sessionUri, toolCallId, filePath, part };
+}
+
+/**
+ * Parses the query-less layout used before the fields moved into the query
+ * (`session-db://<hexSessionUri>/<toolCallId>/<hexFilePath>/<part>/<basename>`),
+ * so snapshots recorded by earlier builds still resolve.
+ */
+function parseLegacySessionDbUri(uri: URI): ISessionDbUriFields | undefined {
+	const [, toolCallId, filePath, part] = uri.path.split('/');
+	if (!toolCallId || !filePath || (part !== 'before' && part !== 'after')) {
+		return undefined;
+	}
+	try {
+		return {
+			sessionUri: decodeHex(uri.authority).toString(),
+			toolCallId: decodeURIComponent(toolCallId),
+			filePath: decodeHex(filePath).toString(),
+			part
+		};
+	} catch {
+		return undefined;
+	}
+}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -40,7 +40,7 @@ import { IProductService } from '../../product/common/productService.js';
 import { buildBoundedSideChatSourceContext, getSideChatPartialResponse } from './agentPeerChats.js';
 import { AgentConfigurationService, IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostTerminalManager, IAgentHostTerminalManager } from './agentHostTerminalManager.js';
-import { ISessionDbUriFields, parseSessionDbUri } from './shared/fileEditTracker.js';
+import { ISessionDbUriFields, parseSessionDbUri } from '../common/sessionDbUri.js';
 import { IGitBlobUriFields, parseGitBlobUri } from './gitDiffContent.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
 import { IAgentHostGitService } from '../common/agentHostGitService.js';

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -17,7 +17,7 @@ import { MessageAttachmentKind, type MessageAttachment } from '../../common/stat
 import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type AgentSelection, type Message, type ModelSelection, type ResponsePart, type StringOrMarkdown, type TerminalCommandResult, type ToolCallCompletedState, type ToolResultContent, type ToolResultTerminalContent, type Turn, type UsageInfo } from '../../common/state/sessionState.js';
 import { buildNonPtyShellTerminalUri } from './copilotNonPtyShellTerminals.js';
 import { getInvocationMessage, getPastTenseMessage, getShellIntention, getShellLanguage, getSubagentMetadata, getTaskCompleteMarkdown, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isTaskCompleteTool, synthesizeSkillToolCall } from './copilotToolDisplay.js';
-import { buildSessionDbUri } from '../shared/fileEditTracker.js';
+import { buildSessionDbUri } from '../../common/sessionDbUri.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
 import { buildMcpChannel, buildMcpTopLevelCustomizationId } from '../shared/mcpCustomizationController.js';

--- a/src/vs/platform/agentHost/node/sessionDiffAggregator.ts
+++ b/src/vs/platform/agentHost/node/sessionDiffAggregator.ts
@@ -7,7 +7,7 @@ import { URI } from '../../../base/common/uri.js';
 import type { IFileEditRecord, ISessionDatabase } from '../common/sessionDataService.js';
 import type { IDiffComputeService } from '../common/diffComputeService.js';
 import { FileEditKind, type ISessionFileDiff } from '../common/state/sessionState.js';
-import { buildSessionDbUri } from './shared/fileEditTracker.js';
+import { buildSessionDbUri } from '../common/sessionDbUri.js';
 
 function getFileEditUri(diff: ISessionFileDiff): string | undefined {
 	return diff.after?.uri ?? diff.before?.uri;

--- a/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
+++ b/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
@@ -3,100 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { decodeHex, VSBuffer } from '../../../../base/common/buffer.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IFileService } from '../../../files/common/files.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IDiffComputeService, IOffsetEdit } from '../../common/diffComputeService.js';
 import { AttributedToolResultFileEditContent, FILE_EDIT_ATTRIBUTION_PROPERTY, IAgentEditAttributionService, IFileEditAttributionMarker } from '../../common/fileEditAttribution.js';
 import { ISessionDatabase } from '../../common/sessionDataService.js';
+import { buildSessionDbUri } from '../../common/sessionDbUri.js';
 import { FileEditKind, ToolResultContentType, type ToolResultFileEditContent } from '../../common/state/sessionState.js';
 import { extractAiChunks } from './editChunkExtractor.js';
 import { IEditSurvivalReporterFactory } from './editSurvivalReporter.js';
-
-const SESSION_DB_SCHEME = 'session-db';
-
-/**
- * Builds a `session-db:` URI referencing a file-edit content blob in the
- * session database. The path is the edited file's path so resource labels
- * show a real path; the lookup fields live in the query, where `filePath` is
- * kept verbatim because it is part of the database key.
- */
-export function buildSessionDbUri(sessionUri: string, toolCallId: string, filePath: string, part: 'before' | 'after'): string {
-	return URI.from({
-		scheme: SESSION_DB_SCHEME,
-		path: URI.file(filePath).path,
-		query: JSON.stringify({ sessionUri, toolCallId, filePath, part } satisfies ISessionDbUriFields),
-	}).toString();
-}
-
-/** Parsed fields from a `session-db:` content URI. */
-export interface ISessionDbUriFields {
-	sessionUri: string;
-	toolCallId: string;
-	filePath: string;
-	part: 'before' | 'after';
-}
-
-/**
- * Parses a `session-db:` URI produced by {@link buildSessionDbUri}.
- * Returns `undefined` if the URI is not a valid `session-db:` URI.
- */
-export function parseSessionDbUri(raw: string): ISessionDbUriFields | undefined {
-	let parsed: URI;
-	try {
-		parsed = URI.parse(raw);
-	} catch {
-		return undefined;
-	}
-	if (parsed.scheme !== SESSION_DB_SCHEME) {
-		return undefined;
-	}
-	return parsed.query ? parseSessionDbUriQuery(parsed.query) : parseLegacySessionDbUri(parsed);
-}
-
-function isNonEmptyString(value: unknown): value is string {
-	return typeof value === 'string' && value.length > 0;
-}
-
-function parseSessionDbUriQuery(query: string): ISessionDbUriFields | undefined {
-	let fields: Partial<ISessionDbUriFields>;
-	try {
-		fields = JSON.parse(query) as Partial<ISessionDbUriFields>;
-	} catch {
-		return undefined;
-	}
-	if (typeof fields !== 'object' || fields === null) {
-		return undefined;
-	}
-	const { sessionUri, toolCallId, filePath, part } = fields;
-	if (!isNonEmptyString(sessionUri) || !isNonEmptyString(toolCallId) || !isNonEmptyString(filePath) || (part !== 'before' && part !== 'after')) {
-		return undefined;
-	}
-	return { sessionUri, toolCallId, filePath, part };
-}
-
-/**
- * Parses the query-less layout used before the fields moved into the query
- * (`session-db://<hexSessionUri>/<toolCallId>/<hexFilePath>/<part>/<basename>`),
- * so snapshots recorded by earlier builds still resolve.
- */
-function parseLegacySessionDbUri(uri: URI): ISessionDbUriFields | undefined {
-	const [, toolCallId, filePath, part] = uri.path.split('/');
-	if (!toolCallId || !filePath || (part !== 'before' && part !== 'after')) {
-		return undefined;
-	}
-	try {
-		return {
-			sessionUri: decodeHex(uri.authority).toString(),
-			toolCallId: decodeURIComponent(toolCallId),
-			filePath: decodeHex(filePath).toString(),
-			part
-		};
-	} catch {
-		return undefined;
-	}
-}
 
 /**
  * Tracks file edits made by tools in a session by snapshotting file content

--- a/src/vs/platform/agentHost/test/common/fileEditDiff.test.ts
+++ b/src/vs/platform/agentHost/test/common/fileEditDiff.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { URI } from '../../../../base/common/uri.js';
 import type { FileEdit } from '../../common/state/protocol/state.js';
@@ -50,5 +51,24 @@ suite('fileEditDiff', () => {
 
 	test('returns undefined when no usable URI is present', () => {
 		assert.strictEqual(normalizeFileEdit({}), undefined);
+	});
+
+	test('canonicalizes legacy session-db content URIs so their path is the edited file', () => {
+		const hex = (value: string) => encodeHex(VSBuffer.fromString(value)).toString();
+		const legacy = (part: string) => URI.from({
+			scheme: 'session-db',
+			authority: hex('copilot:/s1'),
+			path: `/call_1/${hex('/repo/a.ts')}/${part}/a.ts`,
+		}).toString();
+
+		const normalized = normalizeFileEdit({
+			before: { uri: fileA, content: { uri: legacy('before') } },
+			after: { uri: fileA, content: { uri: legacy('after') } },
+		});
+
+		assert.deepStrictEqual(
+			[normalized?.beforeContentUri?.path, normalized?.afterContentUri?.path],
+			['/repo/a.ts', '/repo/a.ts'],
+		);
 	});
 });

--- a/src/vs/platform/agentHost/test/common/sessionDbUri.test.ts
+++ b/src/vs/platform/agentHost/test/common/sessionDbUri.test.ts
@@ -115,7 +115,7 @@ suite('canonicalizeSessionDbUri', () => {
 
 	test('rewrites a legacy URI into the current layout', () => {
 		const legacy = legacyUri('copilot:/abc-123', 'call_1', '/workspace/file.ts', 'before', 'file.ts');
-		const canonical = canonicalizeSessionDbUri(legacy);
+		const canonical = canonicalizeSessionDbUri(legacy, URI.file('/workspace/file.ts'));
 
 		assert.deepStrictEqual(
 			[canonical.path, parseSessionDbUri(canonical.toString())],
@@ -123,13 +123,24 @@ suite('canonicalizeSessionDbUri', () => {
 		);
 	});
 
+	test('takes the path from the file URI, so a Windows session canonicalizes the same way on any client', () => {
+		const legacy = legacyUri('copilot:/abc-123', 'call_1', 'C:\\Code\\repo\\file.ts', 'before', 'file.ts');
+		const canonical = canonicalizeSessionDbUri(legacy, URI.parse('file:///c%3A/Code/repo/file.ts'));
+
+		assert.deepStrictEqual(
+			[canonical.path, parseSessionDbUri(canonical.toString())?.filePath],
+			['/c:/Code/repo/file.ts', 'C:\\Code\\repo\\file.ts'],
+		);
+	});
+
 	test('leaves canonical, unparseable and foreign URIs untouched', () => {
 		const canonical = URI.parse(buildSessionDbUri('copilot:/s1', 'tc-1', '/workspace/file.ts', 'before'));
 		const unparseable = URI.from({ scheme: 'session-db', path: '/nonsense' });
 		const foreign = URI.file('/workspace/file.ts');
+		const fileUri = URI.file('/workspace/file.ts');
 
 		assert.deepStrictEqual(
-			[canonical, unparseable, foreign].map(uri => canonicalizeSessionDbUri(uri).toString()),
+			[canonical, unparseable, foreign].map(uri => canonicalizeSessionDbUri(uri, fileUri).toString()),
 			[canonical.toString(), unparseable.toString(), foreign.toString()],
 		);
 	});

--- a/src/vs/platform/agentHost/test/common/sessionDbUri.test.ts
+++ b/src/vs/platform/agentHost/test/common/sessionDbUri.test.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { buildSessionDbUri, canonicalizeSessionDbUri, parseSessionDbUri } from '../../common/sessionDbUri.js';
+
+const hex = (value: string) => encodeHex(VSBuffer.fromString(value)).toString();
+
+function legacyUri(sessionUri: string, toolCallId: string, filePath: string, part: string, name: string): URI {
+	return URI.from({
+		scheme: 'session-db',
+		authority: hex(sessionUri),
+		path: `/${toolCallId}/${hex(filePath)}/${part}/${name}`,
+	});
+}
+
+suite('buildSessionDbUri / parseSessionDbUri', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('round-trips a simple URI', () => {
+		const uri = buildSessionDbUri('copilot:/abc-123', 'tc-1', '/workspace/file.ts', 'before');
+		const parsed = parseSessionDbUri(uri);
+		assert.ok(parsed);
+		assert.deepStrictEqual(parsed, {
+			sessionUri: 'copilot:/abc-123',
+			toolCallId: 'tc-1',
+			filePath: '/workspace/file.ts',
+			part: 'before',
+		});
+	});
+
+	test('round-trips with special characters in filePath', () => {
+		const uri = buildSessionDbUri('copilot:/s1', 'tc-2', '/work space/file (1).ts', 'after');
+		const parsed = parseSessionDbUri(uri);
+		assert.ok(parsed);
+		assert.strictEqual(parsed.filePath, '/work space/file (1).ts');
+		assert.strictEqual(parsed.part, 'after');
+	});
+
+	test('round-trips with special characters in toolCallId', () => {
+		const uri = buildSessionDbUri('copilot:/s1', 'call_abc=123&x', '/file.ts', 'before');
+		const parsed = parseSessionDbUri(uri);
+		assert.ok(parsed);
+		assert.strictEqual(parsed.toolCallId, 'call_abc=123&x');
+	});
+
+	test('round-trips a backslashed Windows filePath, which the database lookup needs verbatim', () => {
+		const filePath = 'C:\\Code\\vscode\\src\\vs\\file.ts';
+		const parsed = parseSessionDbUri(buildSessionDbUri('copilot:/s1', 'tc-1', filePath, 'before'));
+		assert.ok(parsed);
+		assert.strictEqual(parsed.filePath, filePath);
+	});
+
+	test('parseSessionDbUri returns undefined for non-session-db URIs', () => {
+		assert.strictEqual(parseSessionDbUri('file:///foo/bar'), undefined);
+		assert.strictEqual(parseSessionDbUri('https://example.com'), undefined);
+	});
+
+	test('parseSessionDbUri returns undefined for malformed session-db URIs', () => {
+		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1'), undefined);
+		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1?toolCallId=tc-1'), undefined);
+		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1?toolCallId=tc-1&filePath=/f&part=middle'), undefined);
+	});
+
+	test('parseSessionDbUri returns undefined for JSON queries that are not objects', () => {
+		const queries = ['null', '123', '"a string"', 'true', '[]'];
+		assert.deepStrictEqual(
+			queries.map(query => parseSessionDbUri(`session-db:/f.ts?${encodeURIComponent(query)}`)),
+			queries.map(() => undefined),
+		);
+	});
+
+	test('parseSessionDbUri rejects empty lookup keys, which would hit the database', () => {
+		const withField = (field: Partial<Record<'sessionUri' | 'toolCallId' | 'filePath', string>>) =>
+			`session-db:/f.ts?${encodeURIComponent(JSON.stringify({ sessionUri: 's', toolCallId: 't', filePath: '/f.ts', part: 'before', ...field }))}`;
+
+		assert.deepStrictEqual([
+			parseSessionDbUri(withField({ sessionUri: '' })),
+			parseSessionDbUri(withField({ toolCallId: '' })),
+			parseSessionDbUri(withField({ filePath: '' })),
+		], [undefined, undefined, undefined]);
+	});
+
+	test('URI path is the file path, so labels show a real path', () => {
+		const uri = buildSessionDbUri('copilot:/s1', 'tc-1', '/workspace/src/index.ts', 'before');
+		assert.strictEqual(URI.parse(uri).path, '/workspace/src/index.ts');
+	});
+
+	test('URI path is the file path for files with spaces and special chars', () => {
+		const uri = buildSessionDbUri('copilot:/s1', 'tc-1', '/work space/file (1).ts', 'after');
+		assert.strictEqual(URI.parse(uri).path, '/work space/file (1).ts');
+	});
+
+	test('parses the legacy hex-encoded layout', () => {
+		const legacy = legacyUri('copilot:/abc-123', 'tc-1', '/workspace/file.ts', 'before', 'file.ts').toString();
+
+		assert.deepStrictEqual(parseSessionDbUri(legacy), {
+			sessionUri: 'copilot:/abc-123',
+			toolCallId: 'tc-1',
+			filePath: '/workspace/file.ts',
+			part: 'before',
+		});
+	});
+});
+
+suite('canonicalizeSessionDbUri', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('rewrites a legacy URI into the current layout', () => {
+		const legacy = legacyUri('copilot:/abc-123', 'call_1', '/workspace/file.ts', 'before', 'file.ts');
+		const canonical = canonicalizeSessionDbUri(legacy);
+
+		assert.deepStrictEqual(
+			[canonical.path, parseSessionDbUri(canonical.toString())],
+			['/workspace/file.ts', { sessionUri: 'copilot:/abc-123', toolCallId: 'call_1', filePath: '/workspace/file.ts', part: 'before' }],
+		);
+	});
+
+	test('leaves canonical, unparseable and foreign URIs untouched', () => {
+		const canonical = URI.parse(buildSessionDbUri('copilot:/s1', 'tc-1', '/workspace/file.ts', 'before'));
+		const unparseable = URI.from({ scheme: 'session-db', path: '/nonsense' });
+		const foreign = URI.file('/workspace/file.ts');
+
+		assert.deepStrictEqual(
+			[canonical, unparseable, foreign].map(uri => canonicalizeSessionDbUri(uri).toString()),
+			[canonical.toString(), unparseable.toString(), foreign.toString()],
+		);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -17,11 +17,12 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { createFileEditContentDigest, getFileEditAttributionMarker, IAgentEditAttributionService, NullAgentEditAttributionService } from '../../common/fileEditAttribution.js';
+import { parseSessionDbUri } from '../../common/sessionDbUri.js';
 import { ToolResultContentType } from '../../common/state/sessionState.js';
 import { TestDiffComputeService } from '../common/sessionTestHelpers.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { IEditSurvivalReporterFactory, NullEditSurvivalReporterFactory } from '../../node/shared/editSurvivalReporter.js';
-import { FileEditTracker, buildSessionDbUri, parseSessionDbUri } from '../../node/shared/fileEditTracker.js';
+import { FileEditTracker } from '../../node/shared/fileEditTracker.js';
 
 suite('FileEditTracker', () => {
 
@@ -235,100 +236,5 @@ suite('FileEditTracker', () => {
 		assert.ok(content);
 		assert.strictEqual(new TextDecoder().decode(content.beforeContent), 'original');
 		assert.strictEqual(new TextDecoder().decode(content.afterContent), 'modified');
-	});
-});
-
-suite('buildSessionDbUri / parseSessionDbUri', () => {
-
-	ensureNoDisposablesAreLeakedInTestSuite();
-
-	test('round-trips a simple URI', () => {
-		const uri = buildSessionDbUri('copilot:/abc-123', 'tc-1', '/workspace/file.ts', 'before');
-		const parsed = parseSessionDbUri(uri);
-		assert.ok(parsed);
-		assert.deepStrictEqual(parsed, {
-			sessionUri: 'copilot:/abc-123',
-			toolCallId: 'tc-1',
-			filePath: '/workspace/file.ts',
-			part: 'before',
-		});
-	});
-
-	test('round-trips with special characters in filePath', () => {
-		const uri = buildSessionDbUri('copilot:/s1', 'tc-2', '/work space/file (1).ts', 'after');
-		const parsed = parseSessionDbUri(uri);
-		assert.ok(parsed);
-		assert.strictEqual(parsed.filePath, '/work space/file (1).ts');
-		assert.strictEqual(parsed.part, 'after');
-	});
-
-	test('round-trips with special characters in toolCallId', () => {
-		const uri = buildSessionDbUri('copilot:/s1', 'call_abc=123&x', '/file.ts', 'before');
-		const parsed = parseSessionDbUri(uri);
-		assert.ok(parsed);
-		assert.strictEqual(parsed.toolCallId, 'call_abc=123&x');
-	});
-
-	test('round-trips a backslashed Windows filePath, which the database lookup needs verbatim', () => {
-		const filePath = 'C:\\Code\\vscode\\src\\vs\\file.ts';
-		const parsed = parseSessionDbUri(buildSessionDbUri('copilot:/s1', 'tc-1', filePath, 'before'));
-		assert.ok(parsed);
-		assert.strictEqual(parsed.filePath, filePath);
-	});
-
-	test('parseSessionDbUri returns undefined for non-session-db URIs', () => {
-		assert.strictEqual(parseSessionDbUri('file:///foo/bar'), undefined);
-		assert.strictEqual(parseSessionDbUri('https://example.com'), undefined);
-	});
-
-	test('parseSessionDbUri returns undefined for malformed session-db URIs', () => {
-		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1'), undefined);
-		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1?toolCallId=tc-1'), undefined);
-		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1?toolCallId=tc-1&filePath=/f&part=middle'), undefined);
-	});
-
-	test('parseSessionDbUri returns undefined for JSON queries that are not objects', () => {
-		const queries = ['null', '123', '"a string"', 'true', '[]'];
-		assert.deepStrictEqual(
-			queries.map(query => parseSessionDbUri(`session-db:/f.ts?${encodeURIComponent(query)}`)),
-			queries.map(() => undefined),
-		);
-	});
-
-	test('parseSessionDbUri rejects empty lookup keys, which would hit the database', () => {
-		const withField = (field: Partial<Record<'sessionUri' | 'toolCallId' | 'filePath', string>>) =>
-			`session-db:/f.ts?${encodeURIComponent(JSON.stringify({ sessionUri: 's', toolCallId: 't', filePath: '/f.ts', part: 'before', ...field }))}`;
-
-		assert.deepStrictEqual([
-			parseSessionDbUri(withField({ sessionUri: '' })),
-			parseSessionDbUri(withField({ toolCallId: '' })),
-			parseSessionDbUri(withField({ filePath: '' })),
-		], [undefined, undefined, undefined]);
-	});
-
-	test('URI path is the file path, so labels show a real path', () => {
-		const uri = buildSessionDbUri('copilot:/s1', 'tc-1', '/workspace/src/index.ts', 'before');
-		assert.strictEqual(URI.parse(uri).path, '/workspace/src/index.ts');
-	});
-
-	test('URI path is the file path for files with spaces and special chars', () => {
-		const uri = buildSessionDbUri('copilot:/s1', 'tc-1', '/work space/file (1).ts', 'after');
-		assert.strictEqual(URI.parse(uri).path, '/work space/file (1).ts');
-	});
-
-	test('parses the legacy hex-encoded layout', () => {
-		const hex = (value: string) => encodeHex(VSBuffer.fromString(value)).toString();
-		const legacy = URI.from({
-			scheme: 'session-db',
-			authority: hex('copilot:/abc-123'),
-			path: `/tc-1/${hex('/workspace/file.ts')}/before/file.ts`,
-		}).toString();
-
-		assert.deepStrictEqual(parseSessionDbUri(legacy), {
-			sessionUri: 'copilot:/abc-123',
-			toolCallId: 'tc-1',
-			filePath: '/workspace/file.ts',
-			part: 'before',
-		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/historyRecordFixtures.test.ts
+++ b/src/vs/platform/agentHost/test/node/historyRecordFixtures.test.ts
@@ -10,7 +10,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { AgentSession } from '../../common/agentService.js';
 import { FileEditKind, MessageKind, ResponsePartKind, ToolResultContentType } from '../../common/state/sessionState.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
-import { parseSessionDbUri } from '../../node/shared/fileEditTracker.js';
+import { parseSessionDbUri } from '../../common/sessionDbUri.js';
 import { mapSessionEventsToHistoryRecords } from './historyRecordFixtures.js';
 import { mapSessionEvents } from '../../node/copilot/mapSessionEvents.js';
 import { toSessionEvents, type ISessionEvent } from './copilotTestEvents.js';

--- a/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
+++ b/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
@@ -10,7 +10,7 @@ import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { IFileEditRecord, ISessionDatabase } from '../../common/sessionDataService.js';
 import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type Message, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolResultContent, type Turn } from '../../common/state/sessionState.js';
 import { getInvocationMessage, getPastTenseMessage, getShellLanguage, getSubagentMetadata, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, synthesizeSkillToolCall } from '../../node/copilot/copilotToolDisplay.js';
-import { buildSessionDbUri } from '../../node/shared/fileEditTracker.js';
+import { buildSessionDbUri } from '../../common/sessionDbUri.js';
 import type { ISessionEvent, ISessionEventMessage, ISessionEventSkillInvoked, ISessionEventSubagentStarted, ISessionEventToolComplete, ISessionEventToolStart } from './copilotTestEvents.js';
 
 // =============================================================================

--- a/src/vs/platform/agentHost/test/node/sessionDiffAggregator.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionDiffAggregator.test.ts
@@ -9,7 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { FileEditKind, type ISessionFileDiff } from '../../common/state/sessionState.js';
 import { encodeString, TestDiffComputeService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { computeSessionDiffs, computeUnionedDiffs } from '../../node/sessionDiffAggregator.js';
-import { parseSessionDbUri } from '../../node/shared/fileEditTracker.js';
+import { parseSessionDbUri } from '../../common/sessionDbUri.js';
 
 const TEST_SESSION_URI = 'session://test-session';
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiffs.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiffs.ts
@@ -126,9 +126,10 @@ export function diffsEqual(current: readonly ISessionFileChange[], diffs: readon
 		}
 
 		const beforeContentUri = d.before?.content?.uri;
+		const beforeUri = d.before?.uri;
 		const currentOriginal = c.originalUri?.toString();
-		if (beforeContentUri) {
-			const parsedBefore = canonicalizeSessionDbUri(URI.parse(beforeContentUri));
+		if (beforeContentUri && beforeUri) {
+			const parsedBefore = canonicalizeSessionDbUri(URI.parse(beforeContentUri), URI.parse(beforeUri));
 			const mappedBefore = mapUri ? mapUri(parsedBefore) : parsedBefore;
 			if (currentOriginal !== mappedBefore.toString()) {
 				return false;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiffs.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiffs.ts
@@ -8,6 +8,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { SessionStatus as ProtocolSessionStatus, type ChangesetFile } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ISessionFileDiff } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { normalizeFileEdit } from '../../../../../platform/agentHost/common/fileEditDiff.js';
+import { canonicalizeSessionDbUri } from '../../../../../platform/agentHost/common/sessionDbUri.js';
 import { IChatSessionFileChange2, isIChatSessionFileChange2 } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISessionFileChange, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { readChangesetFileMeta } from '../../../../../platform/agentHost/common/meta/agentChangesetFileMeta.js';
@@ -127,7 +128,7 @@ export function diffsEqual(current: readonly ISessionFileChange[], diffs: readon
 		const beforeContentUri = d.before?.content?.uri;
 		const currentOriginal = c.originalUri?.toString();
 		if (beforeContentUri) {
-			const parsedBefore = URI.parse(beforeContentUri);
+			const parsedBefore = canonicalizeSessionDbUri(URI.parse(beforeContentUri));
 			const mappedBefore = mapUri ? mapUri(parsedBefore) : parsedBefore;
 			if (currentOriginal !== mappedBefore.toString()) {
 				return false;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -10,7 +10,7 @@ import { basename, dirname } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
-import { toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { LOCAL_AGENT_HOST_AUTHORITY, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { affectsAgentHostProviderPreference, IAgentConnection, IAgentHostService, shouldSurfaceLocalAgentHostProvider, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
 import type { ISessionGitState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -200,7 +200,7 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 	}
 
 	protected override _diffUriMapper(): (uri: URI) => URI {
-		return uri => toAgentHostUri(uri, 'local');
+		return uri => toAgentHostUri(uri, LOCAL_AGENT_HOST_AUTHORITY);
 	}
 
 	// -- Workspaces ----------------------------------------------------------

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -12,6 +12,7 @@ import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
 import { affectsAgentHostProviderPreference, IAgentHostService, shouldSurfaceLocalAgentHostProvider, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
 import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { LOCAL_AGENT_HOST_AUTHORITY } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { NotificationType } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { type AgentInfo, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
@@ -142,7 +143,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		}
 		this._initialized = true;
 		this._promptCacheNotification = this._register(this._instantiationService.createInstance(AgentHostPromptCacheNotification));
-		this._register(this._agentHostFileSystemService.registerAuthority('local', this._agentHostService));
+		this._register(this._agentHostFileSystemService.registerAuthority(LOCAL_AGENT_HOST_AUTHORITY, this._agentHostService));
 
 		// React to root state changes (agent discovery / removal)
 		this._register(this._agentHostService.rootState.onDidChange(rootState => {
@@ -281,7 +282,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			fullName: agent.displayName,
 			description: agent.description,
 			connection: this._agentHostService,
-			connectionAuthority: 'local',
+			connectionAuthority: LOCAL_AGENT_HOST_AUTHORITY,
 			resolveAuthentication: (resources) => this._resolveAuthenticationInteractively(resources),
 			promptCacheNotification: this._promptCacheNotification,
 		}));

--- a/src/vs/workbench/services/agentHost/common/agentHostFileSystemService.ts
+++ b/src/vs/workbench/services/agentHost/common/agentHostFileSystemService.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
+import { OS } from '../../../../base/common/platform.js';
 import { AgentHostFileSystemProvider, type IRemoteFilesystemConnection } from '../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../../../platform/agentHost/common/agentHostFileSystemService.js';
-import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME } from '../../../../platform/agentHost/common/agentHostUri.js';
+import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostLabelFormatter, LOCAL_AGENT_HOST_AUTHORITY } from '../../../../platform/agentHost/common/agentHostUri.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { InMemoryFileSystemProvider } from '../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
@@ -48,7 +49,11 @@ class AgentHostFileSystemService extends Disposable implements IAgentHostFileSys
 
 		this._fsProvider = this._register(new AgentHostFileSystemProvider());
 		this._register(_fileService.registerProvider(AGENT_HOST_SCHEME, this._fsProvider));
+
+		// Two formatters: the scheme-wide fallback for hosts whose operating
+		// system is unknown, and a more specific one for the in-process host.
 		this._register(labelService.registerFormatter(AGENT_HOST_LABEL_FORMATTER));
+		this._register(labelService.registerFormatter(agentHostLabelFormatter(LOCAL_AGENT_HOST_AUTHORITY, OS)));
 	}
 
 	registerAuthority(authority: string, connection: IRemoteFilesystemConnection): IDisposable {

--- a/src/vs/workbench/services/agentHost/test/browser/agentHostLabelFormatter.test.ts
+++ b/src/vs/workbench/services/agentHost/test/browser/agentHostLabelFormatter.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { OperatingSystem } from '../../../../../base/common/platform.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { AGENT_HOST_LABEL_FORMATTER, agentHostLabelFormatter, LOCAL_AGENT_HOST_AUTHORITY, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { LabelService } from '../../../label/common/labelService.js';
+import { TestEnvironmentService, TestLifecycleService, TestPathService, TestRemoteAgentService } from '../../../../test/browser/workbenchTestServices.js';
+import { TestContextService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+
+suite('AgentHost label formatter', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createLabelService(): LabelService {
+		const labelService = disposables.add(new LabelService(
+			TestEnvironmentService,
+			new TestContextService(),
+			new TestPathService(URI.file('/Users/test')),
+			new TestRemoteAgentService(),
+			disposables.add(new TestStorageService()),
+			disposables.add(new TestLifecycleService())
+		));
+		disposables.add(labelService.registerFormatter(AGENT_HOST_LABEL_FORMATTER));
+		return labelService;
+	}
+
+	test('a Windows host renders paths natively, so they match the `file:` side of a diff', () => {
+		const labelService = createLabelService();
+		disposables.add(labelService.registerFormatter(agentHostLabelFormatter(LOCAL_AGENT_HOST_AUTHORITY, OperatingSystem.Windows)));
+
+		// Agent host URIs carry a lower-cased drive letter because they
+		// round-trip through `URI.toString()` on the way to the client
+		const wrapped = toAgentHostUri(URI.from({ scheme: 'session-db', path: '/c:/Code/repo/src/app.ts' }), LOCAL_AGENT_HOST_AUTHORITY);
+
+		assert.strictEqual(labelService.getUriLabel(wrapped), 'C:\\Code\\repo\\src\\app.ts');
+	});
+
+	test('a POSIX host renders paths natively', () => {
+		const labelService = createLabelService();
+		disposables.add(labelService.registerFormatter(agentHostLabelFormatter(LOCAL_AGENT_HOST_AUTHORITY, OperatingSystem.Linux)));
+
+		const wrapped = toAgentHostUri(URI.from({ scheme: 'session-db', path: '/home/user/repo/src/app.ts' }), LOCAL_AGENT_HOST_AUTHORITY);
+
+		assert.strictEqual(labelService.getUriLabel(wrapped), '/home/user/repo/src/app.ts');
+	});
+
+	test('a host of unknown operating system keeps POSIX separators but normalizes the drive letter', () => {
+		const labelService = createLabelService();
+
+		const windowsUri = toAgentHostUri(URI.from({ scheme: 'session-db', path: '/c:/Code/repo/src/app.ts' }), 'remotehost');
+		const posixUri = toAgentHostUri(URI.from({ scheme: 'session-db', path: '/home/user/repo/src/app.ts' }), 'remotehost');
+
+		assert.deepStrictEqual({
+			windows: labelService.getUriLabel(windowsUri),
+			posix: labelService.getUriLabel(posixUri),
+		}, {
+			windows: 'C:/Code/repo/src/app.ts',
+			posix: '/home/user/repo/src/app.ts',
+		});
+	});
+});

--- a/src/vs/workbench/services/agentHost/test/browser/agentHostLabelFormatter.test.ts
+++ b/src/vs/workbench/services/agentHost/test/browser/agentHostLabelFormatter.test.ts
@@ -49,9 +49,11 @@ suite('AgentHost label formatter', () => {
 		assert.strictEqual(labelService.getUriLabel(wrapped), '/home/user/repo/src/app.ts');
 	});
 
-	test('a host of unknown operating system keeps POSIX separators but normalizes the drive letter', () => {
+	test('a host of unknown operating system renders the path losslessly', () => {
 		const labelService = createLabelService();
 
+		// `/c:/…` is a valid POSIX path too, so without knowing the host's
+		// operating system neither form may be rewritten
 		const windowsUri = toAgentHostUri(URI.from({ scheme: 'session-db', path: '/c:/Code/repo/src/app.ts' }), 'remotehost');
 		const posixUri = toAgentHostUri(URI.from({ scheme: 'session-db', path: '/home/user/repo/src/app.ts' }), 'remotehost');
 
@@ -59,7 +61,7 @@ suite('AgentHost label formatter', () => {
 			windows: labelService.getUriLabel(windowsUri),
 			posix: labelService.getUriLabel(posixUri),
 		}, {
-			windows: 'C:/Code/repo/src/app.ts',
+			windows: '/c:/Code/repo/src/app.ts',
 			posix: '/home/user/repo/src/app.ts',
 		});
 	});


### PR DESCRIPTION
Fixes two problems with the file paths shown when diffing agent host changes (e.g. from the changes pill in the Session chat input toolbar).

### 1. `.../<toolCallId>/.../before/<file>` on the original side

`session-db:` content URIs have two layouts. The legacy one encoded everything in the URI path:

```
session-db://<hexSessionUri>/<toolCallId>/<hexFilePath>/before/<basename>
```

The current layout puts the real file path in the path and the lookup fields in the query, but legacy URIs are still parsed for backwards compatibility, so old sessions leak that shape into the UI. It also made the multi diff row render as a rename (`R` badge plus a struck through path), because a row is flagged as renamed whenever `modifiedUri.path !== originalUri.path`.

New `canonicalizeSessionDbUri` rewrites legacy URIs into the current layout, applied at the single consuming choke point `normalizeFileEdit` so the changes view, chat response file changes and the pill diff all benefit. The URI helpers moved from `node/shared/fileEditTracker.ts` into a new common module so browser code can use them.

### 2. `/c:/Code/...` next to `C:\Code\...` for the same file

The paths were already identical; only the labels differed. The `file:` side renders via `fsPath` plus drive letter normalization, while the wrapped `vscode-agent-host:` side went through a formatter of `{ label: '${path}', separator: '/' }` with no drive letter normalization. (The lower cased drive comes from `URI.toString()`, which always lower cases it.)

- New `agentHostLabelFormatter(authority, os)` produces OS native formatting and is registered for the `local` authority with the client OS, since the in-process host always runs on this machine.
- The scheme wide fallback, used by remote hosts whose OS the protocol does not report, gains `normalizeDriveLetter: true`. That is safe cross platform because it only fires when `label[2] === ':'`. It deliberately keeps `/`, as hardcoding `\` would corrupt a Linux or WSL host's paths when viewed from a Windows client.

| URI | label |
| --- | --- |
| local (Windows) | `C:\Code\repo\src\app.ts` |
| remote, OS unknown, Windows path | `C:/Code/repo/src/app.ts` |
| remote, OS unknown, posix path | `/home/user/repo/src/app.ts` |

### Testing

New unit tests for `canonicalizeSessionDbUri` and for all three label cases above. The existing agent host URI, filesystem provider and file edit diff suites still pass.
