### PR TITLE
Fix Agents Changes CSS specificity

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -305,7 +305,10 @@
 	color: var(--vscode-descriptionForeground);
 }
 
-.changes-file-list .changes-review-comments-badge .codicon {
+/* Include the view owner to outrank
+ * `.monaco-workbench .codicon[class*='codicon-']` and keep both badge icons at
+ * the compact 12px size instead of the workbench default 16px. */
+.changes-view-body .changes-file-list .changes-review-comments-badge .codicon {
 	font-size: var(--vscode-codiconFontSize-compact);
 }
 
@@ -318,7 +321,7 @@
 	color: var(--vscode-descriptionForeground);
 }
 
-.changes-file-list .changes-agent-feedback-badge .codicon {
+.changes-view-body .changes-file-list .changes-agent-feedback-badge .codicon {
 	font-size: var(--vscode-codiconFontSize-compact);
 }
 

--- a/src/vs/sessions/contrib/changes/browser/media/multiFileDiffEditor.css
+++ b/src/vs/sessions/contrib/changes/browser/media/multiFileDiffEditor.css
@@ -29,7 +29,10 @@
 	pointer-events: none;
 }
 
-.agent-sessions-workbench .part.editor .multiDiffEntry .header-content {
+/* Include the multi-diff owner to outrank the equally specific core
+ * `.monaco-component.multiDiffEditor .multiDiffEntry .header .header-content`
+ * rule for the Agents header margin, padding, border, and background. */
+.agent-sessions-workbench .part.editor .multiDiffEditor .multiDiffEntry .header-content {
 	border-radius: var(--vscode-cornerRadius-medium);
 	border: none;
 	background: var(--vscode-sideBarSectionHeader-background);
@@ -42,7 +45,9 @@
 	border-bottom: none;
 }
 
-.agent-sessions-workbench .part.editor .multiDiffEntry .header-content .file-path .title {
+/* The same owner keeps the Agents body font size from tying the core
+ * `.header-content .file-path .title` 14px rule. */
+.agent-sessions-workbench .part.editor .multiDiffEditor .multiDiffEntry .header-content .file-path .title {
 	font-size: var(--vscode-agents-fontSize-body1);
 	line-height: 22px;
 }


### PR DESCRIPTION
## Problem

Two Agents Changes surfaces tied shared/core rules on specificity, leaving stylesheet order to choose their rendered values.

| Surface | Agents rule | Equal-specificity competitor | Order-dependent properties |
| --- | --- | --- | --- |
| Review-comment and agent-feedback badges | `.changes-file-list … .codicon` | `.monaco-workbench .codicon[class*='codicon-']` | compact `font-size: 12px` versus `16px` |
| Embedded multi-diff header | `.agent-sessions-workbench .part.editor .multiDiffEntry .header-content` | `.monaco-component.multiDiffEditor .multiDiffEntry .header .header-content` | margin, padding, border, and background |
| Embedded multi-diff title | Agents `.header-content .file-path .title` | core `.header-content .file-path .title` | Agents body font size versus core `14px` |

## Change

Adds the smallest owning surface to each selector: `.changes-view-body` for badge icons and `.multiDiffEditor` for embedded diff headers. Inline comments identify the competing selectors and affected declarations.

## Validation

- `npm run stylelint -- src/vs/sessions/contrib/changes/browser/media/changesView.css src/vs/sessions/contrib/changes/browser/media/multiFileDiffEditor.css`
- `npm run precommit`
- Rendered all 12 `sessions/changes` fixtures in product and reversed stylesheet order: exact image hashes match with no render errors