### PR TITLE
NES: add ARIA menu semantics and keyboard nav to gutter indicator menu

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
@@ -197,6 +197,8 @@ export class GutterIndicatorMenuContent {
 function hoverContent(content: ChildNode) {
 	return n.div({
 		class: 'content',
+		role: 'menu',
+		ariaLabel: localize('inlineEditGutterMenu', "Inline Edit"),
 		style: {
 			margin: 4,
 			minWidth: 180,
@@ -227,13 +229,44 @@ function option(props: {
 }) {
 	return derived({ name: 'inlineEdits.option' }, (_reader) => n.div({
 		class: ['monaco-menu-option', props.isActive?.map(v => v && 'active')],
+		role: 'menuitem',
+		ariaLabel: props.title,
 		onmouseenter: () => props.onHoverChange?.(true),
 		onmouseleave: () => props.onHoverChange?.(false),
+		onfocus: () => props.onHoverChange?.(true),
+		onblur: () => props.onHoverChange?.(false),
 		onclick: props.onAction,
 		onkeydown: e => {
-			if (e.key === 'Enter') {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
 				props.onAction?.();
+				return;
 			}
+
+			const options = Array.from(
+				(e.currentTarget as HTMLElement).closest('[role="menu"]')
+					?.querySelectorAll<HTMLElement>('.monaco-menu-option') ?? []
+			);
+			const idx = options.indexOf(e.currentTarget as HTMLElement);
+			if (idx < 0 || options.length === 0) {
+				return;
+			}
+
+			let next = -1;
+			if (e.key === 'ArrowDown') {
+				next = (idx + 1) % options.length;
+			} else if (e.key === 'ArrowUp') {
+				next = (idx - 1 + options.length) % options.length;
+			} else if (e.key === 'Home') {
+				next = 0;
+			} else if (e.key === 'End') {
+				next = options.length - 1;
+			} else {
+				return;
+			}
+
+			e.preventDefault();
+			options[next].focus();
 		},
 		tabIndex: 0,
 		style: {
@@ -288,6 +321,7 @@ function separator() {
 	return n.div({
 		id: 'inline-edit-gutter-indicator-menu-separator',
 		class: 'menu-separator',
+		role: 'separator',
 		style: {
 			color: asCssVariable(editorActionListForeground),
 			padding: '2px 0',

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorMenu.ts
@@ -2,25 +2,18 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
 
 import { ChildNode, LiveElement, n } from '../../../../../../../base/browser/dom.js';
-import { ActionBar, IActionBarOptions } from '../../../../../../../base/browser/ui/actionbar/actionbar.js';
 import { renderIcon } from '../../../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { KeybindingLabel } from '../../../../../../../base/browser/ui/keybindingLabel/keybindingLabel.js';
-import { IAction } from '../../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../../base/common/codicons.js';
 import { ResolvedKeybinding } from '../../../../../../../base/common/keybindings.js';
-import { IObservable, autorun, constObservable, derived, observableFromEvent, observableValue } from '../../../../../../../base/common/observable.js';
+import { IObservable, ISettableObservable, autorun, constObservable, derived, observableFromEvent, observableValue } from '../../../../../../../base/common/observable.js';
 import { OS } from '../../../../../../../base/common/platform.js';
 import { ThemeIcon } from '../../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../../nls.js';
 import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
 import { IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
-import { nativeHoverDelegate } from '../../../../../../../platform/hover/browser/hover.js';
 import { IKeybindingService } from '../../../../../../../platform/keybinding/common/keybinding.js';
 import { defaultKeybindingLabelStyles } from '../../../../../../../platform/theme/browser/defaultStyles.js';
 import { asCssVariable, descriptionForeground, editorActionListForeground, editorHoverBorder } from '../../../../../../../platform/theme/common/colorRegistry.js';
@@ -49,15 +42,19 @@ export class GutterIndicatorMenuContent {
 	}
 
 	private _createHoverContent() {
-		const activeElement = observableValue<string | undefined>('active', undefined);
+		const hoveredId = observableValue<string | undefined>('hovered', undefined);
+		const focusedId = observableValue<string | undefined>('focused', undefined);
+		const tabStopId = observableValue<string | undefined>('tabStop', undefined);
 
-		const createOptionArgs = (options: { id: string; title: string; icon: IObservable<ThemeIcon> | ThemeIcon; commandId: string | IObservable<string>; commandArgs?: unknown[] }): FirstFnArg<typeof option> => {
+		const createOptionArgs = (options: { id: string; title: string; icon: IObservable<ThemeIcon> | ThemeIcon; commandId: string | IObservable<string>; commandArgs?: unknown[]; isFirstTabStop?: boolean }): FirstFnArg<typeof option> => {
 			return {
 				title: options.title,
 				icon: options.icon,
 				keybinding: typeof options.commandId === 'string' ? this._getKeybinding(options.commandArgs ? undefined : options.commandId) : derived(this, reader => typeof options.commandId === 'string' ? undefined : this._getKeybinding(options.commandArgs ? undefined : options.commandId.read(reader)).read(reader)),
-				isActive: activeElement.map(v => v === options.id),
-				onHoverChange: v => activeElement.set(v ? options.id : undefined, undefined),
+				isActive: getOptionActive(options.id, hoveredId, focusedId),
+				tabIndex: getOptionTabIndex(options.id, !!options.isFirstTabStop, tabStopId),
+				onHoverChange: makeHoverChangeHandler(options.id, hoveredId),
+				onFocusChange: makeFocusChangeHandler(options.id, focusedId, tabStopId),
 				onAction: () => {
 					const commandId = typeof options.commandId === 'string' ? options.commandId : options.commandId.get();
 					this._close(true, commandId);
@@ -66,13 +63,14 @@ export class GutterIndicatorMenuContent {
 			};
 		};
 
-		const extensionCommandGroups = this._data.extensionCommands.map(group =>
+		const extensionCommandGroups = this._data.extensionCommands.map((group, groupIdx) =>
 			group.map((c, idx) => option(createOptionArgs({
 				id: c.command.id + '_' + idx,
 				title: c.command.title,
 				icon: c.icon ?? Codicon.symbolEvent,
 				commandId: c.command.id,
-				commandArgs: c.command.arguments
+				commandArgs: c.command.arguments,
+				isFirstTabStop: this._data.extensionCommandsOnly && groupIdx === 0 && idx === 0,
 			})))
 		);
 
@@ -96,6 +94,7 @@ export class GutterIndicatorMenuContent {
 			title: localize('gotoAndAccept', "Go To / Accept"),
 			icon: Codicon.check,
 			commandId: inlineSuggestCommitId,
+			isFirstTabStop: true,
 		}));
 
 		const reject = option(createOptionArgs({
@@ -117,8 +116,10 @@ export class GutterIndicatorMenuContent {
 			title: m.name,
 			icon: m.id === this._data.modelInfo?.currentModelId ? Codicon.check : Codicon.circle,
 			keybinding: constObservable(undefined),
-			isActive: activeElement.map(v => v === 'model_' + m.id),
-			onHoverChange: v => activeElement.set(v ? 'model_' + m.id : undefined, undefined),
+			isActive: getOptionActive('model_' + m.id, hoveredId, focusedId),
+			tabIndex: getOptionTabIndex('model_' + m.id, false, tabStopId),
+			onHoverChange: makeHoverChangeHandler('model_' + m.id, hoveredId),
+			onFocusChange: makeFocusChangeHandler('model_' + m.id, focusedId, tabStopId),
 			onAction: () => {
 				this._close(true);
 				this._data.setModelId?.(m.id);
@@ -155,18 +156,13 @@ export class GutterIndicatorMenuContent {
 			commandArgs: ['@tag:nextEditSuggestions']
 		}));
 
-		const actions = this._data.action ? [this._data.action] : [];
-		const actionBarFooter = actions.length > 0 ? actionBar(
-			actions.map(action => ({
-				id: action.id,
-				label: action.title + '...',
-				enabled: true,
-				run: () => this._commandService.executeCommand(action.id, ...(action.arguments ?? [])),
-				class: undefined,
-				tooltip: action.tooltip ?? action.title
-			})),
-			{ hoverDelegate: nativeHoverDelegate /* unable to show hover inside another hover */ }
-		) : undefined;
+		const footerAction = this._data.action ? option(createOptionArgs({
+			id: 'footerAction',
+			title: this._data.action.title + '...',
+			icon: Codicon.feedback,
+			commandId: this._data.action.id,
+			commandArgs: this._data.action.arguments,
+		})) : undefined;
 
 		return hoverContent([
 			title,
@@ -181,8 +177,8 @@ export class GutterIndicatorMenuContent {
 
 			...extensionCommandNodes,
 
-			actionBarFooter ? separator() : undefined,
-			actionBarFooter
+			footerAction ? separator() : undefined,
+			footerAction
 		]);
 	}
 
@@ -192,6 +188,47 @@ export class GutterIndicatorMenuContent {
 		}
 		return observableFromEvent(this._contextKeyService.onDidChangeContext, () => this._keybindingService.lookupKeybinding(commandId)); // TODO: use contextkeyservice to use different renderings
 	}
+}
+
+function getOptionActive(id: string, hoveredId: IObservable<string | undefined>, focusedId: IObservable<string | undefined>): IObservable<boolean> {
+	return derived({ name: 'inlineEdits.optionActive' }, reader => {
+		const hovered = hoveredId.read(reader);
+		if (hovered !== undefined) {
+			return hovered === id;
+		}
+		return focusedId.read(reader) === id;
+	});
+}
+
+function getOptionTabIndex(id: string, isFirstTabStop: boolean, tabStopId: IObservable<string | undefined>): IObservable<number> {
+	return derived({ name: 'inlineEdits.optionTabIndex' }, reader => {
+		const stop = tabStopId.read(reader);
+		if (stop === undefined) {
+			return isFirstTabStop ? 0 : -1;
+		}
+		return stop === id ? 0 : -1;
+	});
+}
+
+function makeHoverChangeHandler(id: string, hoveredId: ISettableObservable<string | undefined>): (isHovered: boolean) => void {
+	return (isHovered: boolean) => {
+		if (isHovered) {
+			hoveredId.set(id, undefined);
+		} else if (hoveredId.get() === id) {
+			hoveredId.set(undefined, undefined);
+		}
+	};
+}
+
+function makeFocusChangeHandler(id: string, focusedId: ISettableObservable<string | undefined>, tabStopId: ISettableObservable<string | undefined>): (isFocused: boolean) => void {
+	return (isFocused: boolean) => {
+		if (isFocused) {
+			focusedId.set(id, undefined);
+			tabStopId.set(id, undefined);
+		} else if (focusedId.get() === id) {
+			focusedId.set(undefined, undefined);
+		}
+	};
 }
 
 function hoverContent(content: ChildNode) {
@@ -224,7 +261,9 @@ function option(props: {
 	icon: IObservable<ThemeIcon> | ThemeIcon;
 	keybinding: IObservable<ResolvedKeybinding | undefined>;
 	isActive?: IObservable<boolean>;
+	tabIndex?: IObservable<number>;
 	onHoverChange?: (isHovered: boolean) => void;
+	onFocusChange?: (isFocused: boolean) => void;
 	onAction?: () => void;
 }) {
 	return derived({ name: 'inlineEdits.option' }, (_reader) => n.div({
@@ -233,8 +272,8 @@ function option(props: {
 		ariaLabel: props.title,
 		onmouseenter: () => props.onHoverChange?.(true),
 		onmouseleave: () => props.onHoverChange?.(false),
-		onfocus: () => props.onHoverChange?.(true),
-		onblur: () => props.onHoverChange?.(false),
+		onfocus: () => props.onFocusChange?.(true),
+		onblur: () => props.onFocusChange?.(false),
 		onclick: props.onAction,
 		onkeydown: e => {
 			if (e.key === 'Enter' || e.key === ' ') {
@@ -268,7 +307,7 @@ function option(props: {
 			e.preventDefault();
 			options[next].focus();
 		},
-		tabIndex: 0,
+		tabIndex: props.tabIndex ?? 0,
 		style: {
 			borderRadius: 3, // same as hover widget border radius
 		}
@@ -295,23 +334,6 @@ function option(props: {
 				_reader.store.add(autorun(reader => {
 					keybindingLabel.set(props.keybinding.read(reader));
 				}));
-			}
-		})
-	]));
-}
-
-// TODO: make this observable
-function actionBar(actions: IAction[], options: IActionBarOptions) {
-	return derived({ name: 'inlineEdits.actionBar' }, (_reader) => n.div({
-		class: ['action-widget-action-bar'],
-		style: {
-			padding: '3px 24px',
-		}
-	}, [
-		n.div({
-			ref: elem => {
-				const actionBar = _reader.store.add(new ActionBar(elem, options));
-				actionBar.push(actions, { icon: false, label: true });
 			}
 		})
 	]));


### PR DESCRIPTION
## Summary
- Fixes [#327617](https://github.com/microsoft/vscode/issues/327617) by giving the NES gutter indicator menu `role="menu"`, menuitem/`separator` roles, and proper `aria-label`s
- Adds Enter/Space activation plus ArrowUp/Down (wrapping) and Home/End navigation between menu options
- Syncs the visual active highlight with keyboard focus via focus/blur handlers

## Test plan
- [ ] Trigger a next edit suggestion and open the gutter indicator menu
- [ ] Tab into a menu item; confirm ArrowUp/Down wrap between options and Home/End jump to ends
- [ ] Confirm Enter and Space activate the focused item
- [ ] With a screen reader, confirm the menu is announced as a menu and items use the action title (not icon+keybinding soup)
- [ ] Confirm mouse hover highlight still works


Made with [Cursor](https://cursor.com)