### PR TITLE
Fix Agents composer CSS specificity

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatView.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatView.css
@@ -98,11 +98,14 @@
 	border-color: color-mix(in srgb, var(--vscode-agentsChatInput-focusBorder, var(--vscode-focusBorder)) 40%, transparent) !important;
 }
 
-.agent-sessions-workbench .interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor {
+/* Outrank the generic `.interactive-session .interactive-input-part
+ * .chat-input-container .chat-editor-container .interactive-input-editor
+ * .monaco-editor` background rules in chat.css. */
+.agent-sessions-workbench .interactive-session .interactive-input-part .chat-input-container .chat-editor-container .interactive-input-editor .monaco-editor {
 	background-color: transparent;
 }
 
-.agent-sessions-workbench .interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
+.agent-sessions-workbench .interactive-session .interactive-input-part .chat-input-container .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
 	background-color: var(--vscode-agentsChatInput-background);
 }
 

--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -23,8 +23,11 @@
 	padding: 4px 10px !important;
 	box-sizing: border-box;
 }
+
+/* Include the widget owner to outrank the max-width from
+ * `.new-chat-widget-container .new-chat-bottom-container` in chatWidget.css. */
 .new-chat-in-session .new-chat-input-container,
-.new-chat-in-session .new-chat-bottom-container,
+.new-chat-in-session .new-chat-widget-container .new-chat-bottom-container,
 .new-chat-in-session .new-chat-input-area {
 	max-width: 950px;
 }
@@ -52,7 +55,9 @@
 }
 
 /* Bottom container: match VS Code secondary toolbar */
-.new-chat-in-session .new-chat-bottom-container {
+/* Outrank `.new-chat-widget-container .new-chat-bottom-container`, which sets
+ * generic padding, min-height, and gap values in chatWidget.css. */
+.new-chat-in-session .new-chat-widget-container .new-chat-bottom-container {
 	padding: 0 4px 0 5px;
 	margin-top: 4px;
 	min-height: auto;
@@ -76,7 +81,9 @@
 }
 
 /* Picker labels: match VS Code chat-secondary-toolbar sizing for all pickers */
-.new-chat-in-session .new-chat-bottom-container .action-label,
+/* Outrank the generic `.new-chat-widget-container .new-chat-bottom-container
+ * .action-label` sizing in chatWidget.css. */
+.new-chat-in-session .new-chat-widget-container .new-chat-bottom-container .action-label,
 .new-chat-in-session .sessions-chat-toolbar .action-label {
 	height: 16px;
 	padding: 3px 6px;

--- a/src/vs/sessions/contrib/chat/browser/media/sessionBackgroundActivitiesControl.css
+++ b/src/vs/sessions/contrib/chat/browser/media/sessionBackgroundActivitiesControl.css
@@ -30,7 +30,9 @@
 	text-overflow: ellipsis;
 }
 
-.session-background-activities .session-background-activities-button .codicon {
+/* Outrank `.monaco-workbench .codicon[class*='codicon-']`, which otherwise
+ * resets compact activity icons to the workbench codicon font size. */
+.session-background-activities .session-background-activities-button .codicon[class*='codicon-'] {
 	font-size: var(--vscode-codiconFontSize-compact);
 	flex-shrink: 0;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1830,8 +1830,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	font-size: 12px;
 }
 
-.interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor,
-.interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
+/* Outrank `.monaco-workbench .part.auxiliarybar > .content .monaco-editor` so
+ * embedded chat inputs use the input background instead of the sidebar one. */
+.interactive-session .interactive-input-part .chat-input-container .chat-editor-container .interactive-input-editor .monaco-editor,
+.interactive-session .interactive-input-part .chat-input-container .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
 	background-color: var(--vscode-input-background);
 }
 


### PR DESCRIPTION
## Summary

Make Agents composer styling independent of stylesheet order by giving contextual owners enough specificity to beat generic workbench and chat rules.

The native new-session composer now consistently uses its explicit in-session toolbar overrides. This intentionally collapses the generic empty 28px bottom toolbar; the same appearance previously occurred only when stylesheets were reversed. The other composer fixtures preserve their normal-order appearance.

## Cascade conflicts

| Intended rule | Competing rule | Affected declarations |
| --- | --- | --- |
| `.new-chat-in-session .new-chat-widget-container .new-chat-bottom-container` | `.new-chat-widget-container .new-chat-bottom-container` | `max-width`, `padding`, `min-height`, `gap` |
| `.new-chat-in-session .new-chat-widget-container .new-chat-bottom-container .action-label` | `.new-chat-widget-container .new-chat-bottom-container .action-label` | `height`, `padding`, `font-size` |
| `.session-background-activities .session-background-activities-button .codicon[class*='codicon-']` | `.monaco-workbench .codicon[class*='codicon-']` | `font-size` |
| `.interactive-session .interactive-input-part .chat-input-container … .monaco-editor` | `.monaco-workbench .part.auxiliarybar > .content .monaco-editor` | `background-color` |
| `.agent-sessions-workbench .interactive-session .interactive-input-part .chat-input-container … .monaco-editor` | the generic chat-input background rule above | `background-color` |

Inline comments record each non-obvious specificity relationship next to the affected rule.

## Validation

- Rendered 56 composer fixtures in product and fully reversed stylesheet order: 0 exact image mismatches, 0 errors (32 mismatches before the fix).
- Verified all 48 non-new-session product-order fixtures retain their previous hashes; the 8 native new-session fixtures consistently select their intended contextual overrides.
- Focused stylelint passed for all four changed stylesheets.