### PR TITLE
Fix AI Customizations CSS specificity

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -308,6 +308,8 @@ The first sidebar entry is `Overview`, which opens the AI Customization manageme
 
 `IAICustomizationListItem.badge` is an optional string that renders as a small inline tag next to the item name. For context instructions, this badge shows the raw `applyTo` pattern (e.g. a glob like `**/*.ts`), while the tooltip (`badgeTooltip`) explains the behavior. For skills with UI integrations, the badge reads "UI Integration" with a tooltip describing which UI surface invokes the skill. The badge text is also included in search filtering.
 
+Group, customization, MCP server, and plugin type icons remain in the renderer DOM but are visually suppressed so labels lead the compact list layout. Their role selectors must outrank the shared codicon base rule rather than relying on stylesheet order. The migration shortcut and MCP status codicons similarly keep their role-specific flex display so their centering is deterministic.
+
 ### Embedded Detail Editors
 
 The management editor opens inline detail panes for prompt files, MCP servers, and plugins. Prompt-file details use the standard text editor pane. MCP and plugin details render dedicated compact widgets — `EmbeddedMcpServerDetail` and `EmbeddedAgentPluginDetail` — purpose-built for the narrow split-pane host. They show the icon, name, scope/source, and description. Do **not** embed the full extension-editor panes inside the split-pane host: they assume a wide page-level layout and don't shrink cleanly.

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -125,7 +125,9 @@
 	outline-offset: -1px;
 }
 
-.ai-customization-management-editor .sidebar-migration-icon {
+/* Outrank `.codicon[class*='codicon-'] { display: inline-block; }` so the
+ * migration warning retains its flex centering. */
+.ai-customization-management-editor .sidebar-migration-button .sidebar-migration-icon {
 	flex-shrink: 0;
 	width: 16px;
 	height: 16px;
@@ -467,7 +469,9 @@
 	margin-left: auto;
 }
 
-.ai-customization-group-header .group-icon {
+/* Outrank the shared codicon display rule so this renderer-only icon remains
+ * hidden instead of taking space before the group label. */
+.ai-customization-group-header .group-icon.codicon {
 	display: none;
 }
 
@@ -616,7 +620,9 @@
 	gap: 6px;
 }
 
-.ai-customization-list-item .item-type-icon {
+/* Outrank the shared codicon display rule so the hidden item-type role does
+ * not take space before customization labels. */
+.ai-customization-list-item .item-type-icon.codicon {
 	display: none;
 }
 
@@ -1616,7 +1622,9 @@
 	opacity: 0.85;
 }
 
-.mcp-server-item .mcp-server-icon {
+/* MCP and plugin renderers share this role. Outrank the codicon display rule
+ * so their hidden type icons do not take space before item details. */
+.mcp-server-item .mcp-server-icon.codicon {
 	display: none;
 }
 
@@ -1668,6 +1676,12 @@
 	align-items: center;
 	justify-content: center;
 	font-size: var(--vscode-codiconFontSize);
+}
+
+/* Outrank `.codicon[class*='codicon-'] { display: inline-block; }` so status
+ * icons retain the flex centering defined above. */
+.mcp-server-item .mcp-server-status.codicon {
+	display: flex;
 }
 
 .mcp-server-item .mcp-server-status-action.monaco-button {


### PR DESCRIPTION
## Summary

Make AI Customizations icon roles independent of stylesheet order while preserving the current product appearance.

Hidden group, customization-item, MCP, and plugin type icons now consistently remain hidden. The migration warning and MCP status codicons consistently retain their role-specific flex centering. The design document records this renderer contract.

## Cascade conflicts

| Intended rule | Competing rule | Affected declaration |
| --- | --- | --- |
| `.ai-customization-management-editor .sidebar-migration-button .sidebar-migration-icon` | `.codicon[class*='codicon-']` | `display: flex` vs. `inline-block` |
| `.ai-customization-group-header .group-icon.codicon` | `.codicon[class*='codicon-']` | `display: none` vs. `inline-block` |
| `.ai-customization-list-item .item-type-icon.codicon` | `.codicon[class*='codicon-']` | `display: none` vs. `inline-block` |
| `.mcp-server-item .mcp-server-icon.codicon` | `.codicon[class*='codicon-']` | `display: none` vs. `inline-block` |
| `.mcp-server-item .mcp-server-status.codicon` | `.codicon[class*='codicon-']` | `display: flex` vs. `inline-block` |

Inline comments identify each intentional specificity relationship next to the rule.

## Validation

- Rendered all 86 `chat/aiCustomizations` fixtures in product and fully reversed stylesheet order: 0 exact image mismatches, 0 errors (48 mismatches before the fix).
- Compared fixed product-order images with clean `main`: all 86 hashes are unchanged.
- Focused stylelint passed; only pre-existing design-token suggestions were reported.