### PR TITLE
webview: consume Ctrl/Cmd+W and Ctrl/Cmd+N on desktop too

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
@@ -127,11 +127,7 @@ suite('vscode API - webview', () => {
 	test('consumes Ctrl/Cmd+W and Ctrl/Cmd+N so the platform cannot act on them too', async () => {
 		const timeout = 20_000;
 
-		// Keys the workbench binds itself. If the webview leaves one un-prevented the
-		// platform acts on it as well: a PWA closes its window, and on desktop the
-		// native menu accelerator dispatches the bound command a second time after
-		// the forwarded keydown already ran it. A key the workbench does not claim
-		// has to stay un-prevented so webview content keeps receiving it.
+		// 'plain a' must stay un-prevented so webview content keeps receiving keys.
 		const cases = [
 			{ name: 'ctrl+w', keyCode: 87, ctrlKey: true, metaKey: false },
 			{ name: 'meta+w', keyCode: 87, ctrlKey: false, metaKey: true },
@@ -180,13 +176,11 @@ suite('vscode API - webview', () => {
 						bubbles: true,
 						cancelable: true,
 					});
-					// Not every engine honors keyCode from the init dictionary, and the
-					// handler under test matches on it.
+					// The handler matches on keyCode, which not every engine takes from init.
 					if (event.keyCode !== testCase.keyCode) {
 						Object.defineProperty(event, 'keyCode', { get: () => testCase.keyCode });
 					}
-					// Untrusted events are never forwarded to the workbench, so this
-					// exercises the webview's own handling without closing this panel.
+					// Untrusted events are not forwarded, so this cannot close the panel.
 					window.dispatchEvent(event);
 					return { name: testCase.name, keyCode: event.keyCode, defaultPrevented: event.defaultPrevented };
 				});
@@ -195,8 +189,7 @@ suite('vscode API - webview', () => {
 				vscode.postMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
 			}
 		};
-		// The host installs its keydown listener on this window, so yield once to be
-		// sure it is attached before probing.
+		// Yield so the host's keydown listener on this window is certainly attached.
 		setTimeout(run, 0);
 	</script>
 </body>

--- a/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
@@ -127,13 +127,16 @@ suite('vscode API - webview', () => {
 	test('consumes Ctrl/Cmd+W and Ctrl/Cmd+N so the platform cannot act on them too', async () => {
 		const timeout = 20_000;
 
-		// 'plain a' must stay un-prevented so webview content keeps receiving keys.
+		// The altGr cases report as Ctrl+Alt and type a character on some layouts, so
+		// they and 'plain a' must stay un-prevented for webview content to receive them.
 		const cases = [
-			{ name: 'ctrl+w', keyCode: 87, ctrlKey: true, metaKey: false },
-			{ name: 'meta+w', keyCode: 87, ctrlKey: false, metaKey: true },
-			{ name: 'ctrl+n', keyCode: 78, ctrlKey: true, metaKey: false },
-			{ name: 'meta+n', keyCode: 78, ctrlKey: false, metaKey: true },
-			{ name: 'plain a', keyCode: 65, ctrlKey: false, metaKey: false },
+			{ name: 'ctrl+w', keyCode: 87, ctrlKey: true, metaKey: false, altKey: false },
+			{ name: 'meta+w', keyCode: 87, ctrlKey: false, metaKey: true, altKey: false },
+			{ name: 'ctrl+n', keyCode: 78, ctrlKey: true, metaKey: false, altKey: false },
+			{ name: 'meta+n', keyCode: 78, ctrlKey: false, metaKey: true, altKey: false },
+			{ name: 'altgr+w', keyCode: 87, ctrlKey: true, metaKey: false, altKey: true },
+			{ name: 'altgr+n', keyCode: 78, ctrlKey: true, metaKey: false, altKey: true },
+			{ name: 'plain a', keyCode: 65, ctrlKey: false, metaKey: false, altKey: false },
 		];
 
 		const panel = vscode.window.createWebviewPanel(webviewViewType, 'Webview Keydown Test', vscode.ViewColumn.Active, {
@@ -173,6 +176,7 @@ suite('vscode API - webview', () => {
 						keyCode: testCase.keyCode,
 						ctrlKey: testCase.ctrlKey,
 						metaKey: testCase.metaKey,
+						altKey: testCase.altKey,
 						bubbles: true,
 						cancelable: true,
 					});
@@ -205,6 +209,8 @@ suite('vscode API - webview', () => {
 			{ name: 'meta+w', keyCode: 87, defaultPrevented: true },
 			{ name: 'ctrl+n', keyCode: 78, defaultPrevented: true },
 			{ name: 'meta+n', keyCode: 78, defaultPrevented: true },
+			{ name: 'altgr+w', keyCode: 87, defaultPrevented: false },
+			{ name: 'altgr+n', keyCode: 78, defaultPrevented: false },
 			{ name: 'plain a', keyCode: 65, defaultPrevented: false },
 		]);
 	});

--- a/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
@@ -123,4 +123,96 @@ suite('vscode API - webview', () => {
 			await rm(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	test('consumes Ctrl/Cmd+W and Ctrl/Cmd+N so the platform cannot act on them too', async () => {
+		const timeout = 20_000;
+
+		// Keys the workbench binds itself. If the webview leaves one un-prevented the
+		// platform acts on it as well: a PWA closes its window, and on desktop the
+		// native menu accelerator dispatches the bound command a second time after
+		// the forwarded keydown already ran it. A key the workbench does not claim
+		// has to stay un-prevented so webview content keeps receiving it.
+		const cases = [
+			{ name: 'ctrl+w', keyCode: 87, ctrlKey: true, metaKey: false },
+			{ name: 'meta+w', keyCode: 87, ctrlKey: false, metaKey: true },
+			{ name: 'ctrl+n', keyCode: 78, ctrlKey: true, metaKey: false },
+			{ name: 'meta+n', keyCode: 78, ctrlKey: false, metaKey: true },
+			{ name: 'plain a', keyCode: 65, ctrlKey: false, metaKey: false },
+		];
+
+		const panel = vscode.window.createWebviewPanel(webviewViewType, 'Webview Keydown Test', vscode.ViewColumn.Active, {
+			enableScripts: true,
+		});
+		disposables.push(panel);
+
+		const didDispose = asPromise(panel.onDidDispose, timeout);
+		const didReceiveMessage = new Promise<{
+			readonly type: 'done';
+			readonly results: readonly { readonly name: string; readonly keyCode: number; readonly defaultPrevented: boolean }[];
+		}>((resolve, reject) => {
+			disposables.push(panel.webview.onDidReceiveMessage(message => {
+				if (message?.type === 'done') {
+					resolve(message);
+				} else if (message?.type === 'error') {
+					reject(new Error(message.message));
+				}
+			}));
+		});
+
+		const nonce = String(Date.now());
+		panel.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}';">
+</head>
+<body>
+	<script nonce="${nonce}">
+		const vscode = acquireVsCodeApi();
+		const cases = ${JSON.stringify(cases)};
+		const run = () => {
+			try {
+				const results = cases.map(testCase => {
+					const event = new KeyboardEvent('keydown', {
+						keyCode: testCase.keyCode,
+						ctrlKey: testCase.ctrlKey,
+						metaKey: testCase.metaKey,
+						bubbles: true,
+						cancelable: true,
+					});
+					// Not every engine honors keyCode from the init dictionary, and the
+					// handler under test matches on it.
+					if (event.keyCode !== testCase.keyCode) {
+						Object.defineProperty(event, 'keyCode', { get: () => testCase.keyCode });
+					}
+					// Untrusted events are never forwarded to the workbench, so this
+					// exercises the webview's own handling without closing this panel.
+					window.dispatchEvent(event);
+					return { name: testCase.name, keyCode: event.keyCode, defaultPrevented: event.defaultPrevented };
+				});
+				vscode.postMessage({ type: 'done', results });
+			} catch (error) {
+				vscode.postMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
+			}
+		};
+		// The host installs its keydown listener on this window, so yield once to be
+		// sure it is attached before probing.
+		setTimeout(run, 0);
+	</script>
+</body>
+</html>`;
+
+		const result = await Promise.race([
+			didReceiveMessage,
+			didDispose.then(() => Promise.reject(new Error('Webview disposed before the keydown probe reported'))),
+		]);
+
+		assert.deepStrictEqual(result.results, [
+			{ name: 'ctrl+w', keyCode: 87, defaultPrevented: true },
+			{ name: 'meta+w', keyCode: 87, defaultPrevented: true },
+			{ name: 'ctrl+n', keyCode: 78, defaultPrevented: true },
+			{ name: 'meta+n', keyCode: 78, defaultPrevented: true },
+			{ name: 'plain a', keyCode: 65, defaultPrevented: false },
+		]);
+	});
 });

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-nwlicgcSw6Z8ipNjNsUx5rOAD+Ua8UrTuM5dfV8OCIE=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-IsHVcRjd+MiEm0tHYrcvKUS8oPCVnVaPERo8BOxeu0I=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -601,12 +601,8 @@
 					return; // let the browser handle this
 				}
 			} else if (isCloseTab(e) || isNewWindow(e)) {
-				// Prevent the platform from acting on a key the host already handles.
-				// In a PWA that is Ctrl+W closing the window and Ctrl+N opening a new
-				// one. On desktop the real event has to be consumed too: an unhandled
-				// key reaches the native menu, whose accelerator dispatches the same
-				// command a second time after the forwarded keydown already ran it.
-				// (No effect in a regular browser tab.)
+				// The host handles these, so the real event must not reach the platform:
+				// a PWA acts on it, and on desktop the menu accelerator dispatches again.
 				e.preventDefault();
 			} else if (!onElectron && (isHelp(e) || isRefresh(e))) {
 				// Prevent F1 opening browser help / F5 reloading the PWA.

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-IsHVcRjd+MiEm0tHYrcvKUS8oPCVnVaPERo8BOxeu0I=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-M6pdmP3iARx8MZG9opsw69xUdqV6xq/fl0YUcd78/2o=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -600,9 +600,8 @@
 				} else {
 					return; // let the browser handle this
 				}
-			} else if (isCloseTab(e) || isNewWindow(e)) {
-				// The host handles these, so the real event must not reach the platform:
-				// a PWA acts on it, and on desktop the menu accelerator dispatches again.
+			} else if (isHostBoundShortcut(e)) {
+				// The host handles these, so the platform must not act on them as well.
 				e.preventDefault();
 			} else if (!onElectron && (isHelp(e) || isRefresh(e))) {
 				// Prevent F1 opening browser help / F5 reloading the PWA.
@@ -712,6 +711,24 @@
 			const hasMeta = e.ctrlKey || e.metaKey;
 			// 78: keyCode of "N"
 			return hasMeta && e.keyCode === 78;
+		}
+
+		/**
+		 * Shortcuts the workbench binds itself, so the webview has to consume the real
+		 * event: in a PWA the browser acts on it, and on desktop it reaches the native
+		 * menu whose accelerator dispatches the command a second time.
+		 *
+		 * AltGr is excluded because it reports as Ctrl+Alt, so layouts that type a
+		 * character with AltGr+W or AltGr+N would otherwise lose that input.
+		 *
+		 * @param {KeyboardEvent} e
+		 * @return {boolean}
+		 */
+		function isHostBoundShortcut(e) {
+			if (e.altKey || e.getModifierState('AltGraph')) {
+				return false;
+			}
+			return isCloseTab(e) || isNewWindow(e);
 		}
 
 		/**

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-FFQoOVVa2tOE3uqUvirwaMNT20TZmrHcL2aaOjJ8BUo=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-nwlicgcSw6Z8ipNjNsUx5rOAD+Ua8UrTuM5dfV8OCIE=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -600,9 +600,16 @@
 				} else {
 					return; // let the browser handle this
 				}
-			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e) || isRefresh(e))) {
-				// Prevent Ctrl+W closing window / Ctrl+N opening new window in PWA.
+			} else if (isCloseTab(e) || isNewWindow(e)) {
+				// Prevent the platform from acting on a key the host already handles.
+				// In a PWA that is Ctrl+W closing the window and Ctrl+N opening a new
+				// one. On desktop the real event has to be consumed too: an unhandled
+				// key reaches the native menu, whose accelerator dispatches the same
+				// command a second time after the forwarded keydown already ran it.
 				// (No effect in a regular browser tab.)
+				e.preventDefault();
+			} else if (!onElectron && (isHelp(e) || isRefresh(e))) {
+				// Prevent F1 opening browser help / F5 reloading the PWA.
 				e.preventDefault();
 			}
 


### PR DESCRIPTION
# webview: consume Ctrl/Cmd+W and Ctrl/Cmd+N on desktop too

## What is broken

With a webview editor focused (Markdown preview, Release Notes, Simple Browser, any extension webview), a single <kbd>Cmd+W</kbd> closes **two** editor tabs. <kbd>Cmd+N</kbd> likewise opens **two** new tabs. Regular file tabs behave correctly, which is what makes this look like an extension bug rather than a core one.

It is intermittent in practice, because it depends on what has focus when the second dispatch lands.

## Root cause

A webview cannot let the workbench handle a key by itself. `handleInnerKeydown` in `pre/index.html` forwards the keydown to the host, and `webviewElement.handleKeyEvent` replays it:

```ts
// src/vs/workbench/contrib/webview/browser/webviewElement.ts
const emulatedKeyboardEvent = new KeyboardEvent(type, event);
Object.defineProperty(emulatedKeyboardEvent, 'target', { get: () => this.element });
this.window?.dispatchEvent(emulatedKeyboardEvent);
```

That is a **synthetic copy**. Whatever happens to it, the *real* event in the webview frame is untouched, so the real key stays unhandled and reaches the native menu. The menu has an accelerator for it, because `withKeybinding` in the main process looks up an accelerator per command id:

```ts
// src/vs/platform/menubar/electron-main/menubar.ts
withKeybinding(commandId, options) {
    const binding = typeof commandId === 'string' ? this.keybindings[commandId] : undefined;
    if (binding?.label) { if (binding.isNative !== false) { options.accelerator = binding.label; ... } }
    else { options.accelerator = undefined; }
}
```

`Cmd+W` is bound to `workbench.action.closeActiveEditor`, so *File > Close Editor* carries a `Cmd+W` accelerator. Triggering it sends `vscode:runKeybinding` back to the renderer, which dispatches the command a **second** time:

```ts
// src/vs/platform/keybinding/common/abstractKeybindingService.ts
public dispatchByUserSettingsLabel(userSettingsLabel: string, target: IContextKeyServiceTarget): void {
    this._log(`/ Dispatching keybinding triggered via menu entry accelerator - ${userSettingsLabel}`);
    ...
    this._doDispatch(keybindings[0], target, false);
}
```

By then the first dispatch has already closed the active tab and moved focus to the next one, so the second dispatch closes **that** tab.

```mermaid
sequenceDiagram
    participant U as User
    participant WV as Webview frame
    participant WB as Workbench renderer
    participant M as Native menu (main)

    U->>WV: Cmd+W (real event)
    WV->>WB: postMessage 'did-keydown'
    WB->>WB: replay synthetic KeyboardEvent
    WB->>WB: closeActiveEditor -> closes tab A, focus moves to B
    Note over WV: real event was never preventDefault'd
    WV-->>M: unhandled key reaches the native menu
    M->>WB: vscode:runKeybinding 'cmd+w'
    WB->>WB: dispatchByUserSettingsLabel -> closeActiveEditor -> closes tab B
```

**Why a regular editor is fine.** The keybinding service consumes the real event when a binding matches, so the key never reaches the menu:

```ts
// src/vs/workbench/services/keybinding/browser/keybindingService.ts
const shouldPreventDefault = this._dispatch(keyEvent, keyEvent.target);
if (shouldPreventDefault) {
    keyEvent.preventDefault();
}
```

## The fix

These two keys were already consumed for the PWA case in #164981 (for #150735), just gated behind `!onElectron`. The desktop failure mode is different but the remedy is the same, so the gate is dropped for the two keys the workbench binds itself. `F1` and `F5` stay web-only, since those are browser actions rather than menu accelerators.

```diff
-			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e) || isRefresh(e))) {
-				// Prevent Ctrl+W closing window / Ctrl+N opening new window in PWA.
+			} else if (isCloseTab(e) || isNewWindow(e)) {
+				// Prevent the platform from acting on a key the host already handles.
+				// ...
 				e.preventDefault();
+			} else if (!onElectron && (isHelp(e) || isRefresh(e))) {
+				// Prevent F1 opening browser help / F5 reloading the PWA.
+				e.preventDefault();
 			}
```

### AltGr is excluded

`isCloseTab` and `isNewWindow` test `e.ctrlKey || e.metaKey`, and AltGr reports as Ctrl+Alt on Windows and Linux. Consuming those keys on desktop without a guard would therefore swallow AltGr+W and AltGr+N, so a layout that types a character there (n-acute on Polish, for instance) would lose that input in every desktop webview. The condition moved into a named predicate that ignores Alt and the AltGraph modifier:

```js
function isHostBoundShortcut(e) {
	if (e.altKey || e.getModifierState('AltGraph')) {
		return false;
	}
	return isCloseTab(e) || isNewWindow(e);
}
```

The web path had this hazard already, so the guard fixes that case too. Both combinations are covered as negative test cases.

### The CSP hash had to be updated

`pre/index.html` pins a `sha256` of its own inline script in its CSP, and that hash is maintained by hand rather than generated by the build. Editing the script without updating the hash makes the CSP block it, and then **no webview loads at all**. The hash in this PR is recomputed accordingly:

```
script bytes : 39448
old hash     : sha256-FFQoOVVa2tOE3uqUvirwaMNT20TZmrHcL2aaOjJ8BUo=
new hash     : sha256-nwlicgcSw6Z8ipNjNsUx5rOAD+Ua8UrTuM5dfV8OCIE=
```

Worth knowing for reviewers: the added test also guards this, since a blocked script prevents nothing and the test fails.

## Test

`extensions/vscode-api-tests` gains a case that dispatches keydowns inside a real webview and asserts which ones the webview consumes. It is safe to run because untrusted (script dispatched) events are never forwarded to the workbench (`shouldForwardKeyEvent` requires `isTrusted`), so it exercises `handleInnerKeydown` without actually closing the panel under test.

It includes a **negative case** (`plain a`) so an over-broad fix that prevents everything cannot pass.

## Before and after

Verified against a shipped **1.130.0** desktop build, patching only the webview bootstrap, using a standalone copy of the same assertion as the committed test so it could run without a source build. Same binary, same isolated profile, same harness. Only the change differs.

Three states were measured, so the AltGr guard is shown to be load-bearing rather than assumed.

**1. Unpatched, the reported bug**

```text
VS Code 1.130.0 (Desktop)
FAIL  ctrl+w   defaultPrevented=false  expected=true
FAIL  meta+w   defaultPrevented=false  expected=true
FAIL  ctrl+n   defaultPrevented=false  expected=true
FAIL  meta+n   defaultPrevented=false  expected=true
PASS  altgr+w  defaultPrevented=false  expected=false
PASS  altgr+n  defaultPrevented=false  expected=false
PASS  plain a  defaultPrevented=false  expected=false
failures: 4          exit code: 1
```

**2. Consuming the keys without the AltGr guard, to confirm the hazard is real**

```text
PASS  ctrl+w   defaultPrevented=true   expected=true
PASS  meta+w   defaultPrevented=true   expected=true
PASS  ctrl+n   defaultPrevented=true   expected=true
PASS  meta+n   defaultPrevented=true   expected=true
FAIL  altgr+w  defaultPrevented=true   expected=false
FAIL  altgr+n  defaultPrevented=true   expected=false
PASS  plain a  defaultPrevented=false  expected=false
failures: 2          exit code: 1
```

**3. This PR**

```text
PASS  ctrl+w   defaultPrevented=true   expected=true
PASS  meta+w   defaultPrevented=true   expected=true
PASS  ctrl+n   defaultPrevented=true   expected=true
PASS  meta+n   defaultPrevented=true   expected=true
PASS  altgr+w  defaultPrevented=false  expected=false
PASS  altgr+n  defaultPrevented=false  expected=false
PASS  plain a  defaultPrevented=false  expected=false
failures: 0          exit code: 0
```

State 1 reproduced identically on three consecutive runs. State 2 is what the added AltGr cases exist to catch.

### Independent confirmation that the accelerator path is real

While automating this, a launched window that was frontmost but not the key window still closed a tab on `Cmd+W`, even though the renderer received no keydown at all. That isolates the second dispatch: with the renderer path inert, the native menu accelerator alone still closes an editor.

The keybinding troubleshooting log shows both dispatches for one keypress, ~8 ms apart (`Developer: Toggle Keyboard Shortcuts Troubleshooting`):

```
14:58:19.814 [KeybindingService]: + Invoking command workbench.action.nextEditor.
14:58:19.821 [KeybindingService]: / Dispatching keybinding triggered via menu entry accelerator - alt+cmd+right
14:58:19.822 [KeybindingService]: + Invoking command workbench.action.nextEditor.
```

## Manual repro

1. Open four files so there are several tabs.
2. Open a webview editor, for example *Markdown: Open Preview*.
3. Focus the webview tab.
4. Press <kbd>Cmd+W</kbd> once.

Before: two tabs close. After: one tab closes.

## Scope note

The same double dispatch applies to any shortcut whose command is also a menu item. `Cmd+Alt+Left/Right` skipping two tabs is the same root cause. This PR deliberately covers only the two keys that already had `isCloseTab` and `isNewWindow` helpers, to keep the change small. A general fix would need the webview to know which keys the workbench has bound.

## Downstream reports

Users hit this through extension webviews, where it reads as an extension bug. anthropics/claude-code#29631 collects several independent reports with the same trace.


## Verification against the linked issues

@dmitrivMS asked whether the two issues I listed are actually fixed. Here is what I can and cannot show.

### What is verified

The change consumes the real event on desktop. Running this PR's integration test with `main`'s `pre/index.html` in place, the four combos come back un-consumed, and with this branch they are consumed:

```
      -    "defaultPrevented": false      +    "defaultPrevented": true    ctrl+w
      -    "defaultPrevented": false      +    "defaultPrevented": true    meta+w
      -    "defaultPrevented": false      +    "defaultPrevented": true    ctrl+n
      -    "defaultPrevented": false      +    "defaultPrevented": true    meta+n
```

Full matrix on desktop (`onElectron = true`):

| key combo | before | after |
|---|---|---|
| `Cmd+W`, `Ctrl+W` | passes to platform | **consumed** |
| `Cmd+N`, `Ctrl+N` | passes to platform | **consumed** |
| `Ctrl+Tab`, `Ctrl+Shift+Tab` | passes to platform | passes to platform |
| `Cmd+Alt+Right` (default mac `nextEditor`) | passes to platform | passes to platform |
| `AltGr+W`, `AltGr+N` | passes to platform | passes to platform |
| `Cmd+C`, `Cmd+S` | consumed | consumed |
| `F1`, `F5` | passes to platform | passes to platform |
| plain `a` | passes to platform | passes to platform |

On web the matrix is unchanged except `AltGr+W` and `AltGr+N`, which go from consumed to passed. That is the intended AltGr guard so layouts that type a character with those combos keep the input, but it is a change on the web path rather than a no-op, so I would rather call it out than bury it.

### What is not verified

I could not reproduce #270722 against `main`, so I cannot claim this PR fixes it.

I built `main` and drove a real <kbd>Cmd+W</kbd> at a focused extension webview panel with two other editors open. The webview received a trusted `keydown` (`isTrusted: true`, `keyCode: 87`, `metaKey: true`) and did not consume it, and File > Close Editor does carry a `Cmd+W` accelerator in that build (`AXMenuItemCmdChar=W`, no extra modifiers). Every precondition in my root-cause description above was satisfied. Exactly one tab closed.

A likely explanation is that the re-dispatch path is already guarded on `main`:

```ts
// webviewElement.ts
private shouldForwardKeyEvent(event: KeyEvent): boolean {
    return event.isTrusted || !!this._content.options.forwardUntrustedKeypressEvents;
}
private handleKeyEvent(type: 'keydown' | 'keyup', event: KeyEvent) {
    if (!this.shouldForwardKeyEvent(event) || !this.isActiveElement()) {
        return;
    }
```

Those guards landed in c74dbf449ec (2026-06-03) and 0a43759b446 (2026-06-05), both well after #241801 (Feb 2025) and #270722 (Jul 2025) were filed. So the double dispatch those issues describe may already be mitigated on `main` and only reproduce on released builds.

That does not make this change wrong. Consuming a key the workbench binds itself is still the correct behavior for the webview, and it is what keeps the platform from acting on it in a PWA. But I do not want to attach a fixes claim I cannot demonstrate, so I would treat this as hardening unless someone can reproduce the double close on current `main`.

One note for triage on #270722 regardless: it is currently assigned to the notebook team on the basis that notebook support would implement the fix. A saved figure opens as a `.png` through `imagePreview.previewEditor`, which is a `WebviewPanel` custom editor, so the surface is core webview rather than Jupyter.

### #241801 WebView editor can dispatch keybinding when workbench does already

Not fixed by this PR, and I verified that rather than assuming it. I temporarily added `ctrl+tab`, `ctrl+shift+tab`, and `meta+alt+right` probes to the test and they report `defaultPrevented: false` on this branch, identical to `main`, because `isHostBoundShortcut` covers only `isCloseTab` and `isNewWindow`.

Happy to drop both issue links and land this purely on its own merits if you prefer.
