### PR TITLE
Fix tool risk badge compact icons

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/media/toolRiskBadge.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/media/toolRiskBadge.css
@@ -26,9 +26,15 @@
 	align-items: center;
 	justify-content: center;
 	min-width: 12px;
-	font-size: 12px;
 	line-height: 1;
 	color: var(--tool-risk-accent, var(--vscode-descriptionForeground));
+}
+
+/* Outrank `.monaco-workbench .codicon[class*='codicon-']` so these compact
+ * badge icons are not promoted to the workbench's base codicon size. */
+.chat-confirmation-widget2 > .tool-risk-badge .tool-risk-icon.codicon,
+.chat-confirmation-widget2 > .tool-risk-badge .tool-risk-details-icon.codicon {
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .chat-confirmation-widget2 > .tool-risk-badge .tool-risk-text {
@@ -44,7 +50,6 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 12px;
 	line-height: 1;
 	color: var(--vscode-descriptionForeground);
 	cursor: pointer;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/toolRiskBadgeWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/toolRiskBadgeWidget.ts
@@ -71,7 +71,7 @@ export class ToolRiskBadgeWidget extends Disposable {
 
 	setLoading(): void {
 		this._setVariant('loading');
-		this._setIcon(ThemeIcon.modify(Codicon.loading, 'spin'));
+		this._setIcon(ThemeIcon.modify(Codicon.loadingCompact, 'spin'));
 		const text = localize('toolRisk.assessing', "Assessing risk\u2026");
 		this._textEl.textContent = text;
 		this._setHover(localize('toolRisk.assessingHover', "Generating a risk assessment for this tool call."));
@@ -86,15 +86,15 @@ export class ToolRiskBadgeWidget extends Disposable {
 		switch (assessment.risk) {
 			case ToolRiskLevel.Green:
 				this._setVariant('green');
-				this._setIcon(Codicon.pass);
+				this._setIcon(Codicon.passCompact);
 				break;
 			case ToolRiskLevel.Orange:
 				this._setVariant('orange');
-				this._setIcon(Codicon.warning);
+				this._setIcon(Codicon.warningCompact);
 				break;
 			case ToolRiskLevel.Red:
 				this._setVariant('red');
-				this._setIcon(Codicon.error);
+				this._setIcon(Codicon.errorCompact);
 				break;
 		}
 		this.domNode.style.display = '';

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/toolInvocationParts/toolRiskBadgeWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/toolInvocationParts/toolRiskBadgeWidget.test.ts
@@ -12,22 +12,26 @@ import { ToolRiskLevel } from '../../../../../browser/tools/chatToolRiskAssessme
 suite('ToolRiskBadgeWidget', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('renders red risk with error codicon', () => {
+	test('renders compact risk codicons', () => {
 		const widget = store.add(new ToolRiskBadgeWidget(NullHoverService));
-		widget.setAssessment({
-			risk: ToolRiskLevel.Red,
-			explanation: 'High risk',
-		});
-
 		const icon = widget.domNode.querySelector('.tool-risk-icon');
+		const classNames = [icon?.className];
+		for (const risk of [ToolRiskLevel.Green, ToolRiskLevel.Orange, ToolRiskLevel.Red]) {
+			widget.setAssessment({ risk, explanation: 'Risk assessment' });
+			classNames.push(icon?.className);
+		}
+
 		assert.deepStrictEqual({
 			ariaHidden: icon?.getAttribute('aria-hidden'),
-			className: icon?.className,
-			textContent: icon?.textContent,
+			classNames,
 		}, {
 			ariaHidden: 'true',
-			className: 'tool-risk-icon codicon codicon-error',
-			textContent: '',
+			classNames: [
+				'tool-risk-icon codicon codicon-loading-compact codicon-modifier-spin',
+				'tool-risk-icon codicon codicon-pass-compact',
+				'tool-risk-icon codicon codicon-warning-compact',
+				'tool-risk-icon codicon codicon-error-compact',
+			],
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Keep tool-risk badge icons at the compact icon role regardless of stylesheet order, and use the compact glyph variants available for loading, green, orange, and red states.

This follows the existing badge design: the status and details icons remain visually secondary to the risk explanation. The trailing info icon stays `Codicon.info` because no compact variant exists, but it is rendered at the compact size.

## Cascade conflict

| Intended rule | Competing rule | Affected declaration |
| --- | --- | --- |
| `.chat-confirmation-widget2 > .tool-risk-badge .tool-risk-icon.codicon` | `.monaco-workbench .codicon[class*='codicon-']` | compact `font-size` vs. base `16px` |
| `.chat-confirmation-widget2 > .tool-risk-badge .tool-risk-details-icon.codicon` | `.monaco-workbench .codicon[class*='codicon-']` | compact `font-size` vs. base `16px` |

An inline comment records the specificity relationship beside the override.

## Validation

- Focused `ToolRiskBadgeWidget` unit test passed for loading, green, orange, and red compact glyph classes.
- Rendered 16 isolated risk-badge and hover-preview fixtures in product and fully reversed stylesheet order: 0 exact image mismatches, 0 errors (16 mismatches before the fix).
- Verified the risk confirmation region is pixel-identical across orders in full-chat fixtures; those fixtures retain a separate composer background dependency addressed by #328016.
- Focused stylelint passed with one pre-existing radius token suggestion.

---

Check vscode\.github\instructions\design-tokens.instructions.md for codicon font size usage.