### PR TITLE
report edit arc in Agent host

### DIFF
--- a/src/vs/base/common/editArcTracker.ts
+++ b/src/vs/base/common/editArcTracker.ts
@@ -1,0 +1,365 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BugIndicatingError } from './errors.js';
+import { commonPrefixLength, commonSuffixLength, splitLines } from './strings.js';
+
+export interface IArcTextReplacement {
+	readonly start: number;
+	readonly endExclusive: number;
+	readonly text: string;
+}
+
+export interface IArcTextEdit {
+	readonly replacements: readonly IArcTextReplacement[];
+}
+
+export interface IEditArcLineCountInfo {
+	readonly deletedLineCounts: number;
+	readonly insertedLineCounts: number;
+}
+
+export interface IEditArcValues extends IEditArcLineCountInfo {
+	readonly arc: number;
+}
+
+interface ITrackedReplacement extends IArcTextReplacement {
+	readonly isTracked: boolean;
+}
+
+/**
+ * Tracks how many characters from an initial edit survive later edits.
+ */
+export class EditArcTracker {
+	private readonly _trackedEdit: readonly ITrackedReplacement[];
+	private _updatedTrackedEdit: readonly ITrackedReplacement[];
+
+	constructor(
+		private readonly _valueBeforeTrackedEdit: string,
+		trackedEdit: IArcTextEdit,
+	) {
+		this._trackedEdit = normalizeReplacements(removeCommonText(trackedEdit.replacements, _valueBeforeTrackedEdit, true));
+		this._updatedTrackedEdit = this._trackedEdit;
+	}
+
+	getOriginalCharacterCount(): number {
+		let result = 0;
+		for (const replacement of this._trackedEdit) {
+			result += replacement.text.length;
+		}
+		return result;
+	}
+
+	handleEdits(edit: IArcTextEdit): void {
+		const untrackedEdit = normalizeReplacements(edit.replacements.map(replacement => ({
+			...replacement,
+			isTracked: false,
+		})));
+		this._updatedTrackedEdit = compose(this._updatedTrackedEdit, untrackedEdit);
+	}
+
+	getAcceptedRestrainedCharactersCount(): number {
+		let result = 0;
+		for (const replacement of this._updatedTrackedEdit) {
+			if (replacement.isTracked) {
+				result += replacement.text.length;
+			}
+		}
+		return result;
+	}
+
+	getLineCountInfo(): IEditArcLineCountInfo {
+		return getLineCountInfo(
+			this._updatedTrackedEdit.filter(replacement => replacement.isTracked),
+			this._valueBeforeTrackedEdit
+		);
+	}
+
+	getValues(): IEditArcValues {
+		return {
+			arc: this.getAcceptedRestrainedCharactersCount(),
+			...this.getLineCountInfo(),
+		};
+	}
+}
+
+function removeCommonText(replacements: readonly IArcTextReplacement[], originalText: string, isTracked: boolean): ITrackedReplacement[] {
+	return replacements.map(replacement => {
+		const oldText = originalText.substring(replacement.start, replacement.endExclusive);
+		const prefixLength = commonPrefixLength(oldText, replacement.text);
+		const suffixLength = Math.min(
+			oldText.length - prefixLength,
+			replacement.text.length - prefixLength,
+			commonSuffixLength(oldText, replacement.text)
+		);
+		return {
+			start: replacement.start + prefixLength,
+			endExclusive: replacement.endExclusive - suffixLength,
+			text: replacement.text.substring(prefixLength, replacement.text.length - suffixLength),
+			isTracked,
+		};
+	});
+}
+
+function normalizeReplacements(replacements: readonly ITrackedReplacement[]): ITrackedReplacement[] {
+	const result: ITrackedReplacement[] = [];
+	let previous: ITrackedReplacement | undefined;
+
+	for (const replacement of replacements) {
+		if (replacement.start > replacement.endExclusive) {
+			throw new BugIndicatingError('Edit replacement start must not be after its end');
+		}
+		if (previous && replacement.start < previous.endExclusive) {
+			throw new BugIndicatingError('Edit replacements must be sorted and disjoint');
+		}
+		if (replacement.start === replacement.endExclusive && replacement.text.length === 0) {
+			continue;
+		}
+		if (previous && previous.endExclusive === replacement.start && previous.isTracked === replacement.isTracked) {
+			previous = {
+				start: previous.start,
+				endExclusive: replacement.endExclusive,
+				text: previous.text + replacement.text,
+				isTracked: previous.isTracked,
+			};
+			continue;
+		}
+		if (previous) {
+			result.push(previous);
+		}
+		previous = replacement;
+	}
+
+	if (previous) {
+		result.push(previous);
+	}
+	return result;
+}
+
+function compose(first: readonly ITrackedReplacement[], second: readonly ITrackedReplacement[]): ITrackedReplacement[] {
+	if (first.length === 0) {
+		return second.slice();
+	}
+	if (second.length === 0) {
+		return first.slice();
+	}
+
+	const firstQueue = first.slice();
+	const result: ITrackedReplacement[] = [];
+	let firstToSecondOffset = 0;
+
+	for (const secondReplacement of second) {
+		while (true) {
+			const firstReplacement = firstQueue[0];
+			if (!firstReplacement || firstReplacement.start + firstToSecondOffset + firstReplacement.text.length >= secondReplacement.start) {
+				break;
+			}
+			firstQueue.shift();
+			result.push(firstReplacement);
+			firstToSecondOffset += firstReplacement.text.length - (firstReplacement.endExclusive - firstReplacement.start);
+		}
+
+		const offsetBeforeIntersections = firstToSecondOffset;
+		let firstIntersecting: ITrackedReplacement | undefined;
+		let lastIntersecting: ITrackedReplacement | undefined;
+
+		while (true) {
+			const firstReplacement = firstQueue[0];
+			if (!firstReplacement || firstReplacement.start + firstToSecondOffset > secondReplacement.endExclusive) {
+				break;
+			}
+			firstIntersecting ??= firstReplacement;
+			lastIntersecting = firstReplacement;
+			firstQueue.shift();
+			firstToSecondOffset += firstReplacement.text.length - (firstReplacement.endExclusive - firstReplacement.start);
+		}
+
+		if (!firstIntersecting) {
+			result.push(deltaReplacement(secondReplacement, -firstToSecondOffset));
+			continue;
+		}
+
+		const replaceStart = Math.min(firstIntersecting.start, secondReplacement.start - offsetBeforeIntersections);
+		const prefixLength = secondReplacement.start - (firstIntersecting.start + offsetBeforeIntersections);
+		if (prefixLength > 0) {
+			result.push(sliceReplacement(firstIntersecting, replaceStart, replaceStart, 0, prefixLength));
+		}
+
+		if (!lastIntersecting) {
+			throw new BugIndicatingError('Missing intersecting ARC edit');
+		}
+		const suffixLength = lastIntersecting.endExclusive + firstToSecondOffset - secondReplacement.endExclusive;
+		if (suffixLength > 0) {
+			const suffix = sliceReplacement(
+				lastIntersecting,
+				lastIntersecting.endExclusive,
+				lastIntersecting.endExclusive,
+				lastIntersecting.text.length - suffixLength,
+				lastIntersecting.text.length
+			);
+			firstQueue.unshift(suffix);
+			firstToSecondOffset -= suffix.text.length - (suffix.endExclusive - suffix.start);
+		}
+
+		result.push(sliceReplacement(
+			secondReplacement,
+			replaceStart,
+			secondReplacement.endExclusive - firstToSecondOffset,
+			0,
+			secondReplacement.text.length
+		));
+	}
+
+	result.push(...firstQueue);
+	return normalizeReplacements(result);
+}
+
+function deltaReplacement(replacement: ITrackedReplacement, offset: number): ITrackedReplacement {
+	return {
+		...replacement,
+		start: replacement.start + offset,
+		endExclusive: replacement.endExclusive + offset,
+	};
+}
+
+function sliceReplacement(
+	replacement: ITrackedReplacement,
+	start: number,
+	endExclusive: number,
+	textStart: number,
+	textEndExclusive: number,
+): ITrackedReplacement {
+	return {
+		start,
+		endExclusive,
+		text: replacement.text.substring(textStart, textEndExclusive),
+		isTracked: replacement.isTracked,
+	};
+}
+
+interface IPosition {
+	readonly lineNumber: number;
+	readonly column: number;
+}
+
+interface ITextReplacement {
+	readonly start: IPosition;
+	readonly end: IPosition;
+	readonly startOffset: number;
+	readonly endOffset: number;
+	readonly text: string;
+}
+
+function getLineCountInfo(replacements: readonly ITrackedReplacement[], initialText: string): IEditArcLineCountInfo {
+	if (replacements.length === 0) {
+		return { deletedLineCounts: 0, insertedLineCounts: 0 };
+	}
+
+	const lineOffsets = new LineOffsets(initialText);
+	const textReplacements = replacements.map(replacement => ({
+		start: lineOffsets.getPosition(replacement.start),
+		end: lineOffsets.getPosition(replacement.endExclusive),
+		startOffset: replacement.start,
+		endOffset: replacement.endExclusive,
+		text: replacement.text,
+	}));
+
+	let deletedLineCounts = 0;
+	let insertedLineCounts = 0;
+	let current: ITextReplacement[] = [];
+	for (let i = 0; i < textReplacements.length; i++) {
+		const replacement = textReplacements[i];
+		const next = textReplacements[i + 1];
+		current.push(replacement);
+		if (next && next.start.lineNumber === replacement.end.lineNumber) {
+			continue;
+		}
+
+		const joined = joinTextReplacements(current, initialText);
+		current = [];
+		const newLines = splitLines(joined.text);
+		let startLineNumber = joined.start.lineNumber;
+		let endLineNumberExclusive = joined.end.lineNumber + 1;
+
+		const firstLinePrefix = initialText.substring(lineOffsets.getLineStart(joined.start.lineNumber), joined.startOffset);
+		newLines[0] = firstLinePrefix + newLines[0];
+		const lastLineSuffix = initialText.substring(joined.endOffset, lineOffsets.getLineEnd(joined.end.lineNumber));
+		newLines[newLines.length - 1] += lastLineSuffix;
+
+		const startsAtLineEnd = joined.start.column === lineOffsets.getLineLength(joined.start.lineNumber) + 1;
+		const endsAtLineStart = joined.end.column === 1;
+		if (startsAtLineEnd && newLines[0].length === firstLinePrefix.length) {
+			startLineNumber++;
+			newLines.shift();
+		}
+		if (newLines.length > 0 && startLineNumber < endLineNumberExclusive && endsAtLineStart && newLines[newLines.length - 1].length === lastLineSuffix.length) {
+			endLineNumberExclusive--;
+			newLines.pop();
+		}
+
+		deletedLineCounts += endLineNumberExclusive - startLineNumber;
+		insertedLineCounts += newLines.length;
+	}
+
+	return { deletedLineCounts, insertedLineCounts };
+}
+
+function joinTextReplacements(replacements: readonly ITextReplacement[], initialText: string): ITextReplacement {
+	const first = replacements[0];
+	const last = replacements[replacements.length - 1];
+	let text = first.text;
+	for (let i = 1; i < replacements.length; i++) {
+		text += initialText.substring(replacements[i - 1].endOffset, replacements[i].startOffset);
+		text += replacements[i].text;
+	}
+	return {
+		start: first.start,
+		end: last.end,
+		startOffset: first.startOffset,
+		endOffset: last.endOffset,
+		text,
+	};
+}
+
+class LineOffsets {
+	private readonly _lineStarts = [0];
+	private readonly _lineEnds: number[] = [];
+
+	constructor(text: string) {
+		for (let i = 0; i < text.length; i++) {
+			if (text.charCodeAt(i) === 10) {
+				this._lineStarts.push(i + 1);
+				this._lineEnds.push(i > 0 && text.charCodeAt(i - 1) === 13 ? i - 1 : i);
+			}
+		}
+		this._lineEnds.push(text.length);
+	}
+
+	getPosition(offset: number): IPosition {
+		let low = 0;
+		let high = this._lineStarts.length - 1;
+		while (low < high) {
+			const middle = Math.ceil((low + high) / 2);
+			if (this._lineStarts[middle] <= offset) {
+				low = middle;
+			} else {
+				high = middle - 1;
+			}
+		}
+		return { lineNumber: low + 1, column: offset - this._lineStarts[low] + 1 };
+	}
+
+	getLineStart(lineNumber: number): number {
+		return this._lineStarts[lineNumber - 1];
+	}
+
+	getLineEnd(lineNumber: number): number {
+		return this._lineEnds[lineNumber - 1];
+	}
+
+	getLineLength(lineNumber: number): number {
+		return this.getLineEnd(lineNumber) - this.getLineStart(lineNumber);
+	}
+}

--- a/src/vs/platform/agentHost/common/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitService.ts
@@ -150,6 +150,7 @@ export interface IWorktreeFileProgress {
 export interface IAgentHostGitService {
 	readonly _serviceBrand: undefined;
 	getCurrentBranch(workingDirectory: URI): Promise<string | undefined>;
+	getCurrentBranchName?(workingDirectory: URI): Promise<string | undefined>;
 	getDefaultBranch(workingDirectory: URI): Promise<IDefaultBranch | undefined>;
 	getRefs(workingDirectory: URI, query?: IRefQuery): Promise<GitRef[]>;
 	getBranches(workingDirectory: URI, query?: IRefQuery): Promise<Branch[]>;

--- a/src/vs/platform/agentHost/common/diffComputeService.ts
+++ b/src/vs/platform/agentHost/common/diffComputeService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { IArcTextReplacement } from '../../../base/common/editArcTracker.js';
 
 export interface IDiffCountResult {
 	added: number;
@@ -15,6 +16,13 @@ export interface IOffsetEdit {
 	startOffset: number;
 	endOffsetExclusive: number;
 	newText: string;
+}
+
+export interface IDetailedDiffResult {
+	added: number;
+	removed: number;
+	replacements: readonly IArcTextReplacement[];
+	hitTimeout: boolean;
 }
 
 export const IDiffComputeService = createDecorator<IDiffComputeService>('diffComputeService');
@@ -37,4 +45,9 @@ export interface IDiffComputeService {
 	 * @param timeoutMs - Maximum time in milliseconds before aborting. Defaults to {@link DEFAULT_DIFF_TIMEOUT_MS}.
 	 */
 	computeDiffCounts(original: string, modified: string, timeoutMs?: number): Promise<IDiffCountResult>;
+
+	/**
+	 * Computes whitespace-sensitive offset replacements between two text strings.
+	 */
+	computeDetailedDiff(original: string, modified: string, timeoutMs?: number): Promise<IDetailedDiffResult>;
 }

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -41,6 +41,10 @@ export class AgentHostGitService implements IAgentHostGitService {
 			|| undefined;
 	}
 
+	async getCurrentBranchName(workingDirectory: URI): Promise<string | undefined> {
+		return (await this._runGit(workingDirectory, ['branch', '--show-current']))?.trim() || undefined;
+	}
+
 	async getDefaultBranch(workingDirectory: URI): Promise<IDefaultBranch | undefined> {
 		// Try to read the default branch from the remote HEAD reference
 		const remoteRef = (await this._runGit(workingDirectory, ['symbolic-ref', 'refs/remotes/origin/HEAD']))?.trim();

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -77,6 +77,7 @@ import { IAgentEditAttributionService } from '../common/fileEditAttribution.js';
 import { NodeWorkerDiffComputeService } from './diffComputeService.js';
 import { AgentEditAttributionService } from './shared/agentEditAttributionService.js';
 import { IEditSurvivalReporterFactory, EditSurvivalReporterFactory } from './shared/editSurvivalReporter.js';
+import { EditArcReporterService, IEditArcReporterService } from './shared/editArcReporter.js';
 import { AgentHostClientFileSystemProvider } from '../common/agentHostClientFileSystemProvider.js';
 import { AGENT_CLIENT_SCHEME } from '../common/agentClientUri.js';
 import { AGENT_HOST_CLIENT_BYOK_LM_CHANNEL, createAgentHostClientByokLmConnection } from '../common/agentHostClientByokLmChannel.js';
@@ -226,6 +227,8 @@ async function startAgentHost(): Promise<void> {
 
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
 		diServices.set(IAgentConfigurationService, agentService.configurationService);
+		const editArcReporterService = disposables.add(instantiationService.createInstance(EditArcReporterService, undefined));
+		diServices.set(IEditArcReporterService, editArcReporterService);
 		diServices.set(IAgentHostGitHubEndpointService, agentService.gitHubEndpointService);
 		diServices.set(IAgentHostCompletions, agentService.completionsService);
 

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -70,6 +70,7 @@ import { IAgentEditAttributionService } from '../common/fileEditAttribution.js';
 import { NodeWorkerDiffComputeService } from './diffComputeService.js';
 import { AgentEditAttributionService } from './shared/agentEditAttributionService.js';
 import { IEditSurvivalReporterFactory, EditSurvivalReporterFactory } from './shared/editSurvivalReporter.js';
+import { EditArcReporterService, IEditArcReporterService } from './shared/editArcReporter.js';
 import { SessionDataService } from './sessionDataService.js';
 import { IWindowsMxcTerminalSandboxRuntime, WindowsMxcTerminalSandboxRuntime } from '../../sandbox/common/terminalSandboxMxcRuntime.js';
 import { ISandboxHelperService } from '../../sandbox/common/sandboxHelperService.js';
@@ -278,6 +279,8 @@ async function main(): Promise<void> {
 		diServices.set(IEditSurvivalReporterFactory, instantiationService.createInstance(EditSurvivalReporterFactory));
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
 		diServices.set(IAgentConfigurationService, agentService.configurationService);
+		const editArcReporterService = disposables.add(instantiationService.createInstance(EditArcReporterService, undefined));
+		diServices.set(IEditArcReporterService, editArcReporterService);
 		diServices.set(IAgentHostGitHubEndpointService, agentService.gitHubEndpointService);
 		diServices.set(IAgentHostCompletions, agentService.completionsService);
 		diServices.set(IAgentHostGitService, gitService);

--- a/src/vs/platform/agentHost/node/diffComputeService.ts
+++ b/src/vs/platform/agentHost/node/diffComputeService.ts
@@ -7,7 +7,7 @@ import { Worker } from 'worker_threads';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { FileAccess } from '../../../base/common/network.js';
 import { ILogService } from '../../log/common/log.js';
-import { DEFAULT_DIFF_TIMEOUT_MS, IDiffComputeService, type IDiffCountResult } from '../common/diffComputeService.js';
+import { DEFAULT_DIFF_TIMEOUT_MS, IDiffComputeService, type IDetailedDiffResult, type IDiffCountResult } from '../common/diffComputeService.js';
 
 /**
  * Node.js implementation of {@link IDiffComputeService} that runs
@@ -21,7 +21,7 @@ export class NodeWorkerDiffComputeService extends Disposable implements IDiffCom
 	private _worker: Worker | undefined;
 	private _workerFailures = 0;
 	private _nextId = 1;
-	private readonly _pending = new Map<number, { resolve: (value: IDiffCountResult) => void; reject: (err: Error) => void }>();
+	private readonly _pending = new Map<number, { resolve: (value: IDiffCountResult | IDetailedDiffResult) => void; reject: (err: Error) => void }>();
 
 	constructor(
 		@ILogService private readonly _logService: ILogService,
@@ -30,12 +30,20 @@ export class NodeWorkerDiffComputeService extends Disposable implements IDiffCom
 	}
 
 	async computeDiffCounts(original: string, modified: string, timeoutMs: number = DEFAULT_DIFF_TIMEOUT_MS): Promise<IDiffCountResult> {
+		return this._callWorker('computeDiffCounts', original, modified, timeoutMs);
+	}
+
+	async computeDetailedDiff(original: string, modified: string, timeoutMs: number = DEFAULT_DIFF_TIMEOUT_MS): Promise<IDetailedDiffResult> {
+		return this._callWorker('computeDetailedDiff', original, modified, timeoutMs);
+	}
+
+	private async _callWorker<T extends IDiffCountResult | IDetailedDiffResult>(functionName: string, original: string, modified: string, timeoutMs: number): Promise<T> {
 		const worker = this._ensureWorker();
 		const id = this._nextId++;
-		return new Promise<IDiffCountResult>((resolve, reject) => {
-			this._pending.set(id, { resolve, reject });
+		return new Promise<T>((resolve, reject) => {
+			this._pending.set(id, { resolve: value => resolve(value as T), reject });
 			try {
-				worker.postMessage({ id, fn: 'computeDiffCounts', args: [original, modified, timeoutMs] });
+				worker.postMessage({ id, fn: functionName, args: [original, modified, timeoutMs] });
 			} catch (err) {
 				this._pending.delete(id);
 				reject(err instanceof Error ? err : new Error(String(err)));
@@ -50,7 +58,7 @@ export class NodeWorkerDiffComputeService extends Disposable implements IDiffCom
 		if (!this._worker) {
 			const workerPath = FileAccess.asFileUri('vs/platform/agentHost/node/diffWorkerMain.js').fsPath;
 			const w = new Worker(workerPath, { name: 'Diff compute worker' });
-			w.on('message', (msg: { id: number; res?: IDiffCountResult; err?: { message: string; stack?: string } }) => {
+			w.on('message', (msg: { id: number; res?: IDiffCountResult | IDetailedDiffResult; err?: { message: string; stack?: string } }) => {
 				const handler = this._pending.get(msg.id);
 				if (!handler) {
 					return;

--- a/src/vs/platform/agentHost/node/diffWorkerMain.ts
+++ b/src/vs/platform/agentHost/node/diffWorkerMain.ts
@@ -6,7 +6,8 @@
 import { parentPort } from 'worker_threads';
 import { DefaultLinesDiffComputer } from '../../../editor/common/diff/defaultLinesDiffComputer/defaultLinesDiffComputer.js';
 import type { ILinesDiffComputerOptions } from '../../../editor/common/diff/linesDiffComputer.js';
-import type { IDiffCountResult } from '../common/diffComputeService.js';
+import type { RangeMapping } from '../../../editor/common/diff/rangeMapping.js';
+import type { IDetailedDiffResult, IDiffCountResult } from '../common/diffComputeService.js';
 
 export function computeDiffCounts(originalText: string, modifiedText: string, timeoutMs: number): IDiffCountResult {
 	const originalLines = originalText.split(/\r\n|\r|\n/);
@@ -65,6 +66,68 @@ function getOffset(range: { readonly startLineNumber: number; readonly startColu
 	return lineStart + column - 1;
 }
 
+export function computeDetailedDiff(originalText: string, modifiedText: string, timeoutMs: number): IDetailedDiffResult {
+	const originalLines = originalText.split(/\r\n|\r|\n/);
+	const modifiedLines = modifiedText.split(/\r\n|\r|\n/);
+	const diffComputer = new DefaultLinesDiffComputer();
+	const result = diffComputer.computeDiff(originalLines, modifiedLines, {
+		ignoreTrimWhitespace: false,
+		maxComputationTimeMs: timeoutMs,
+		computeMoves: false,
+	});
+
+	let added = 0;
+	let removed = 0;
+	const replacements = [];
+	const originalOffsets = new LineOffsetConverter(originalText);
+	const modifiedOffsets = new LineOffsetConverter(modifiedText);
+	for (const change of result.changes) {
+		removed += change.original.length;
+		added += change.modified.length;
+		const mappings = change.innerChanges ?? [change.toRangeMapping2(originalLines, modifiedLines)];
+		for (const mapping of mappings) {
+			replacements.push(toReplacement(mapping, originalText, modifiedText, originalOffsets, modifiedOffsets));
+		}
+	}
+
+	return { added, removed, replacements, hitTimeout: result.hitTimeout };
+}
+
+function toReplacement(
+	mapping: RangeMapping,
+	_originalText: string,
+	modifiedText: string,
+	originalOffsets: LineOffsetConverter,
+	modifiedOffsets: LineOffsetConverter,
+) {
+	const start = originalOffsets.getOffset(mapping.originalRange.startLineNumber, mapping.originalRange.startColumn);
+	const endExclusive = originalOffsets.getOffset(mapping.originalRange.endLineNumber, mapping.originalRange.endColumn);
+	const modifiedStart = modifiedOffsets.getOffset(mapping.modifiedRange.startLineNumber, mapping.modifiedRange.startColumn);
+	const modifiedEndExclusive = modifiedOffsets.getOffset(mapping.modifiedRange.endLineNumber, mapping.modifiedRange.endColumn);
+	return {
+		start,
+		endExclusive,
+		text: modifiedText.substring(modifiedStart, modifiedEndExclusive),
+	};
+}
+
+class LineOffsetConverter {
+	private readonly _lineStarts = [0];
+
+	constructor(private readonly _text: string) {
+		const lineBreak = /\r\n|\r|\n/g;
+		let match: RegExpExecArray | null;
+		while ((match = lineBreak.exec(_text))) {
+			this._lineStarts.push(match.index + match[0].length);
+		}
+	}
+
+	getOffset(lineNumber: number, column: number): number {
+		const lineStart = this._lineStarts[Math.min(Math.max(lineNumber - 1, 0), this._lineStarts.length - 1)];
+		return Math.min(lineStart + Math.max(column - 1, 0), this._text.length);
+	}
+}
+
 function main() {
 	const port = parentPort;
 	if (!port) {
@@ -75,6 +138,9 @@ function main() {
 		try {
 			if (fn === 'computeDiffCounts') {
 				const res = computeDiffCounts(args[0] as string, args[1] as string, args[2] as number);
+				port.postMessage({ id, res });
+			} else if (fn === 'computeDetailedDiff') {
+				const res = computeDetailedDiff(args[0] as string, args[1] as string, args[2] as number);
 				port.postMessage({ id, res });
 			} else {
 				port.postMessage({ id, err: { message: `Unknown function: ${fn}` } });

--- a/src/vs/platform/agentHost/node/diffWorkerMain.ts
+++ b/src/vs/platform/agentHost/node/diffWorkerMain.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { parentPort } from 'worker_threads';
+import { IArcTextReplacement } from '../../../base/common/editArcTracker.js';
 import { DefaultLinesDiffComputer } from '../../../editor/common/diff/defaultLinesDiffComputer/defaultLinesDiffComputer.js';
 import type { ILinesDiffComputerOptions } from '../../../editor/common/diff/linesDiffComputer.js';
 import type { RangeMapping } from '../../../editor/common/diff/rangeMapping.js';
@@ -78,7 +79,7 @@ export function computeDetailedDiff(originalText: string, modifiedText: string, 
 
 	let added = 0;
 	let removed = 0;
-	const replacements = [];
+	let replacements: IArcTextReplacement[] = [];
 	const originalOffsets = new LineOffsetConverter(originalText);
 	const modifiedOffsets = new LineOffsetConverter(modifiedText);
 	for (const change of result.changes) {
@@ -88,6 +89,10 @@ export function computeDetailedDiff(originalText: string, modifiedText: string, 
 		for (const mapping of mappings) {
 			replacements.push(toReplacement(mapping, originalText, modifiedText, originalOffsets, modifiedOffsets));
 		}
+	}
+
+	if (applyReplacements(originalText, replacements) !== modifiedText) {
+		replacements = [{ start: 0, endExclusive: originalText.length, text: modifiedText }];
 	}
 
 	return { added, removed, replacements, hitTimeout: result.hitTimeout };
@@ -109,6 +114,17 @@ function toReplacement(
 		endExclusive,
 		text: modifiedText.substring(modifiedStart, modifiedEndExclusive),
 	};
+}
+
+function applyReplacements(value: string, replacements: readonly IArcTextReplacement[]): string {
+	let result = '';
+	let offset = 0;
+	for (const replacement of replacements) {
+		result += value.substring(offset, replacement.start);
+		result += replacement.text;
+		offset = replacement.endExclusive;
+	}
+	return result + value.substring(offset);
 }
 
 class LineOffsetConverter {

--- a/src/vs/platform/agentHost/node/shared/arcToolEdit.ts
+++ b/src/vs/platform/agentHost/node/shared/arcToolEdit.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IArcTextEdit, IArcTextReplacement } from '../../../../base/common/editArcTracker.js';
+import { IOffsetEdit } from '../../common/diffComputeService.js';
 
 export function extractArcTextEdit(toolName: string, input: unknown, beforeText: string, afterText: string): IArcTextEdit | undefined {
 	const object = asObject(input);
@@ -33,6 +34,19 @@ export function extractArcTextEdit(toolName: string, input: unknown, beforeText:
 	}
 
 	return edit && applyEdit(beforeText, edit) === afterText ? edit : undefined;
+}
+
+export function createArcTextEditFromDiff(changes: readonly IOffsetEdit[], beforeText: string, afterText: string): IArcTextEdit {
+	const edit: IArcTextEdit = {
+		replacements: changes.map(change => ({
+			start: change.startOffset,
+			endExclusive: change.endOffsetExclusive,
+			text: change.newText,
+		}))
+	};
+	return applyEdit(beforeText, edit) === afterText ? edit : {
+		replacements: [{ start: 0, endExclusive: beforeText.length, text: afterText }]
+	};
 }
 
 function fullReplacement(beforeText: string, text: string | undefined): IArcTextEdit | undefined {

--- a/src/vs/platform/agentHost/node/shared/arcToolEdit.ts
+++ b/src/vs/platform/agentHost/node/shared/arcToolEdit.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IArcTextEdit, IArcTextReplacement } from '../../../../base/common/editArcTracker.js';
+
+export function extractArcTextEdit(toolName: string, input: unknown, beforeText: string, afterText: string): IArcTextEdit | undefined {
+	const object = asObject(input);
+	let edit: IArcTextEdit | undefined;
+
+	switch (toolName) {
+		case 'Write':
+			edit = fullReplacement(beforeText, readString(object, 'content'));
+			break;
+		case 'create':
+			edit = fullReplacement(beforeText, readString(object, 'file_text'));
+			break;
+		case 'Edit':
+			edit = stringReplacement(beforeText, readString(object, 'old_string'), readString(object, 'new_string'), object?.replace_all === true);
+			break;
+		case 'edit':
+		case 'str_replace':
+			edit = stringReplacement(beforeText, readString(object, 'old_str'), readString(object, 'new_str'), false);
+			break;
+		case 'str_replace_editor':
+			if (object?.command === 'create') {
+				edit = fullReplacement(beforeText, readString(object, 'file_text'));
+			} else if (object?.command === 'str_replace') {
+				edit = stringReplacement(beforeText, readString(object, 'old_str'), readString(object, 'new_str'), false);
+			}
+			break;
+	}
+
+	return edit && applyEdit(beforeText, edit) === afterText ? edit : undefined;
+}
+
+function fullReplacement(beforeText: string, text: string | undefined): IArcTextEdit | undefined {
+	return text === undefined ? undefined : {
+		replacements: [{ start: 0, endExclusive: beforeText.length, text }]
+	};
+}
+
+function stringReplacement(beforeText: string, oldText: string | undefined, newText: string | undefined, replaceAll: boolean): IArcTextEdit | undefined {
+	if (oldText === undefined || newText === undefined || oldText.length === 0) {
+		return undefined;
+	}
+
+	const replacements: IArcTextReplacement[] = [];
+	let offset = 0;
+	while (offset <= beforeText.length) {
+		const start = beforeText.indexOf(oldText, offset);
+		if (start === -1) {
+			break;
+		}
+		replacements.push({ start, endExclusive: start + oldText.length, text: newText });
+		if (!replaceAll) {
+			break;
+		}
+		offset = start + oldText.length;
+	}
+	return replacements.length > 0 ? { replacements } : undefined;
+}
+
+function applyEdit(value: string, edit: IArcTextEdit): string {
+	let result = '';
+	let offset = 0;
+	for (const replacement of edit.replacements) {
+		result += value.substring(offset, replacement.start);
+		result += replacement.text;
+		offset = replacement.endExclusive;
+	}
+	return result + value.substring(offset);
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === 'object' && value !== null ? value as Record<string, unknown> : undefined;
+}
+
+function readString(object: Record<string, unknown> | undefined, key: string): string | undefined {
+	const value = object?.[key];
+	return typeof value === 'string' ? value : undefined;
+}

--- a/src/vs/platform/agentHost/node/shared/editArcReporter.ts
+++ b/src/vs/platform/agentHost/node/shared/editArcReporter.ts
@@ -1,0 +1,364 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SequencerByKey, TimeoutTimer } from '../../../../base/common/async.js';
+import { EditArcTracker, IArcTextEdit } from '../../../../base/common/editArcTracker.js';
+import { Disposable, DisposableMap, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
+import { dirname, extname } from '../../../../base/common/path.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { URI } from '../../../../base/common/uri.js';
+import { FileChangeType, FileOperationResult, IFileService, toFileOperationResult } from '../../../files/common/files.js';
+import { createDecorator } from '../../../instantiation/common/instantiation.js';
+import { ILogService } from '../../../log/common/log.js';
+import { IEditArcTelemetryClassification, IEditArcTelemetryEvent } from '../../../telemetry/common/editArcTelemetry.js';
+import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { AgentSession } from '../../common/agentService.js';
+import { IAgentHostGitService } from '../../common/agentHostGitService.js';
+import { AgentHostEditTelemetryEnabledConfigKey, platformRootSchema } from '../../common/agentHostSchema.js';
+import { IDiffComputeService } from '../../common/diffComputeService.js';
+import { isAhpChatChannel, isSubagentSession, parseRequiredSessionUriFromChatUri } from '../../common/state/sessionState.js';
+import { IAgentConfigurationService } from '../agentConfigurationService.js';
+import { IAgentHostTelemetryService, isAgentHostTelemetryService } from '../agentHostTelemetryService.js';
+
+export interface IEditArcReporterLaunchParams {
+	readonly sessionUri: string;
+	readonly turnId: string;
+	readonly toolCallId: string;
+	readonly filePath: string;
+	readonly beforeText: string;
+	readonly afterText: string;
+	readonly initialEdit: IArcTextEdit;
+	readonly modelId?: string;
+	readonly toolName?: string;
+	readonly mode?: string;
+	readonly completionTime: number;
+}
+
+export const IEditArcReporterService = createDecorator<IEditArcReporterService>('editArcReporterService');
+
+export interface IEditArcReporterService {
+	readonly _serviceBrand: undefined;
+	reportEdit(params: IEditArcReporterLaunchParams): Promise<void>;
+}
+
+export class NullEditArcReporterService implements IEditArcReporterService {
+	readonly _serviceBrand: undefined;
+	async reportEdit(_params: IEditArcReporterLaunchParams): Promise<void> { }
+}
+
+interface IResourceState extends IDisposable {
+	readonly resource: URI;
+	readonly reporters: Set<EditArcReporter>;
+	logicalText: string;
+	isDisposing: boolean;
+}
+
+const SAMPLE_SCHEDULE_MS = [0, 60_000, 300_000];
+const MAX_TRACKED_FILE_SIZE_CHARS = 5 * 1024 * 1024;
+const MAX_REPORTERS_PER_RESOURCE = 20;
+const MAX_REPORTERS_HOST_WIDE = 200;
+const MAX_RETAINED_CHARACTERS_HOST_WIDE = 100 * 1024 * 1024;
+
+export class EditArcReporterService extends Disposable implements IEditArcReporterService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _resourceSequencer = new SequencerByKey<string>();
+	private readonly _resources = this._register(new DisposableMap<string, IResourceState>());
+	private _reporterCount = 0;
+	private _retainedCharacters = 0;
+
+	constructor(
+		private readonly _sampleScheduleMs: readonly number[] = SAMPLE_SCHEDULE_MS,
+		@IFileService private readonly _fileService: IFileService,
+		@IDiffComputeService private readonly _diffComputeService: IDiffComputeService,
+		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
+		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@ILogService private readonly _logService: ILogService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+	) {
+		super();
+		this._register(this._configurationService.onDidRootConfigChange(() => {
+			if (!this._isEnabled()) {
+				this._disposeAllReporters('configuration disabled');
+			}
+		}));
+	}
+
+	async reportEdit(params: IEditArcReporterLaunchParams): Promise<void> {
+		const resource = URI.file(params.filePath);
+		const key = extUriBiasedIgnorePathCase.getComparisonKey(resource);
+		await this._resourceSequencer.queue(key, async () => {
+			if (!this._isEnabled()) {
+				this._logService.trace(`[EditArcReporter] Skipping ${params.filePath}: telemetry is disabled`);
+				return;
+			}
+			if (extname(params.filePath).toLowerCase() === '.ipynb') {
+				this._logService.trace(`[EditArcReporter] Skipping notebook: ${params.filePath}`);
+				return;
+			}
+			const retainedCharacters = params.beforeText.length + params.afterText.length;
+			if (Math.max(params.beforeText.length, params.afterText.length) > MAX_TRACKED_FILE_SIZE_CHARS) {
+				this._logService.warn(`[EditArcReporter] Skipping oversized file: ${params.filePath}`);
+				return;
+			}
+
+			let state = this._resources.get(key);
+			if (state) {
+				if (!await this._applyCompletedEdit(state, params)) {
+					return;
+				}
+			} else {
+				state = this._createResourceState(key, resource, params.afterText);
+			}
+
+			if (state.reporters.size >= MAX_REPORTERS_PER_RESOURCE) {
+				this._logService.warn(`[EditArcReporter] Skipping edit: per-resource reporter limit reached for ${params.filePath}`);
+				return;
+			}
+			if (this._reporterCount >= MAX_REPORTERS_HOST_WIDE || this._retainedCharacters + retainedCharacters > MAX_RETAINED_CHARACTERS_HOST_WIDE) {
+				this._logService.warn(`[EditArcReporter] Skipping edit: host reporter memory limit reached`);
+				return;
+			}
+
+			const reporter = new EditArcReporter(params, this._sampleScheduleMs, this._gitService, this._telemetryService, timeDelayMs => this.reconcileAndSample(state!, reporter, timeDelayMs), () => {
+				state!.reporters.delete(reporter);
+				this._reporterCount--;
+				this._retainedCharacters -= retainedCharacters;
+				if (!state!.isDisposing && state!.reporters.size === 0) {
+					this._resources.deleteAndDispose(key);
+				}
+			});
+			state.reporters.add(reporter);
+			this._reporterCount++;
+			this._retainedCharacters += retainedCharacters;
+		});
+	}
+
+	private _createResourceState(key: string, resource: URI, logicalText: string): IResourceState {
+		const store = new DisposableStore();
+		const state: IResourceState = {
+			resource,
+			logicalText,
+			reporters: new Set(),
+			isDisposing: false,
+			dispose: () => {
+				state.isDisposing = true;
+				store.dispose();
+			},
+		};
+		store.add(toDisposable(() => {
+			for (const reporter of [...state.reporters]) {
+				reporter.dispose();
+			}
+		}));
+		try {
+			const watcher = store.add(this._fileService.createWatcher(URI.file(dirname(resource.fsPath)), { recursive: false, excludes: [] }));
+			store.add(watcher.onDidChange(event => {
+				if (event.contains(resource, FileChangeType.ADDED, FileChangeType.UPDATED, FileChangeType.DELETED)) {
+					this._resourceSequencer.queue(key, async () => {
+						try {
+							await this._reconcileFromDisk(state, false);
+						} catch (error) {
+							this._logService.warn(`[EditArcReporter] Watcher reconciliation failed for ${resource.fsPath}`, error);
+						}
+					});
+				}
+			}));
+		} catch (error) {
+			this._logService.warn(`[EditArcReporter] Failed to watch ${resource.fsPath}; delayed samples will use forced reconciliation`, error);
+		}
+		this._resources.set(key, state);
+		return state;
+	}
+
+	private async _applyCompletedEdit(state: IResourceState, params: IEditArcReporterLaunchParams): Promise<boolean> {
+		if (state.logicalText === params.afterText) {
+			return true;
+		}
+		if (state.logicalText === params.beforeText) {
+			await this._applyEdit(state, params.initialEdit, params.afterText);
+			return true;
+		}
+
+		const detailed = await this._diffComputeService.computeDetailedDiff(state.logicalText, params.afterText);
+		if (detailed.hitTimeout) {
+			this._logService.warn(`[EditArcReporter] Could not update older reporters before ${params.toolCallId}: detailed diff timed out`);
+			return false;
+		}
+		await this._applyEdit(state, { replacements: detailed.replacements }, params.afterText);
+		return true;
+	}
+
+	private async _reconcileFromDisk(state: IResourceState, sample: boolean): Promise<boolean> {
+		let currentText: string;
+		try {
+			currentText = (await this._fileService.readFile(state.resource)).value.toString();
+		} catch (error) {
+			if (toFileOperationResult(error) === FileOperationResult.FILE_NOT_FOUND) {
+				currentText = '';
+			} else {
+				this._logService.warn(`[EditArcReporter] Failed to read ${state.resource.fsPath}${sample ? ' before sample' : ''}`, error);
+				return false;
+			}
+		}
+		if (currentText === state.logicalText) {
+			return true;
+		}
+
+		const detailed = await this._diffComputeService.computeDetailedDiff(state.logicalText, currentText);
+		if (detailed.hitTimeout) {
+			this._logService.warn(`[EditArcReporter] Detailed diff timed out for ${state.resource.fsPath}`);
+			return false;
+		}
+		await this._applyEdit(state, { replacements: detailed.replacements }, currentText);
+		return true;
+	}
+
+	private async _applyEdit(state: IResourceState, edit: IArcTextEdit, afterText: string): Promise<void> {
+		for (const reporter of state.reporters) {
+			reporter.handleEdit(edit);
+		}
+		state.logicalText = afterText;
+	}
+
+	private _isEnabled(): boolean {
+		return this._telemetryService.telemetryLevel >= TelemetryLevel.USAGE
+			&& this._configurationService.getRootValue(platformRootSchema, AgentHostEditTelemetryEnabledConfigKey) !== false;
+	}
+
+	private _disposeAllReporters(reason: string): void {
+		if (this._reporterCount > 0) {
+			this._logService.info(`[EditArcReporter] Disposing ${this._reporterCount} active reporters: ${reason}`);
+		}
+		this._resources.clearAndDisposeAll();
+		this._reporterCount = 0;
+		this._retainedCharacters = 0;
+	}
+
+	async reconcileAndSample(state: IResourceState, reporter: EditArcReporter, timeDelayMs: number): Promise<void> {
+		const key = extUriBiasedIgnorePathCase.getComparisonKey(state.resource);
+		await this._resourceSequencer.queue(key, async () => {
+			if (!this._isEnabled()) {
+				reporter.dispose();
+				return;
+			}
+			if (timeDelayMs !== 0 && !await this._reconcileFromDisk(state, true)) {
+				return;
+			}
+			await reporter.emit(timeDelayMs);
+		});
+	}
+}
+
+class EditArcReporter extends Disposable {
+	private readonly _tracker: EditArcTracker;
+	private readonly _uniqueEditId = generateUuid();
+	private readonly _workingDirectory: URI;
+	private readonly _initialBranch: Promise<string | undefined>;
+	private _sampleIndex = 0;
+
+	constructor(
+		private readonly _params: IEditArcReporterLaunchParams,
+		private readonly _sampleScheduleMs: readonly number[],
+		private readonly _gitService: IAgentHostGitService,
+		private readonly _telemetryService: ITelemetryService,
+		private readonly _sample: (timeDelayMs: number) => Promise<void>,
+		onDispose: () => void,
+	) {
+		super();
+		this._tracker = new EditArcTracker(_params.beforeText, _params.initialEdit);
+		this._workingDirectory = URI.file(dirname(_params.filePath));
+		this._initialBranch = this._getCurrentBranchName();
+		this._register(toDisposable(onDispose));
+		this._scheduleNext();
+	}
+
+	handleEdit(edit: IArcTextEdit): void {
+		this._tracker.handleEdits(edit);
+	}
+
+	private _scheduleNext(): void {
+		if (this._store.isDisposed) {
+			return;
+		}
+		if (this._sampleIndex >= this._sampleScheduleMs.length) {
+			this.dispose();
+			return;
+		}
+		const delay = Math.max(0, this._params.completionTime + this._sampleScheduleMs[this._sampleIndex] - Date.now());
+		const timer = this._register(new TimeoutTimer());
+		timer.setIfNotSet(async () => {
+			const timeDelayMs = this._sampleScheduleMs[this._sampleIndex++];
+			try {
+				await this._sample(timeDelayMs);
+			} finally {
+				this._scheduleNext();
+			}
+		}, delay);
+	}
+
+	async emit(timeDelayMs: number): Promise<void> {
+		const sessionUri = isAhpChatChannel(this._params.sessionUri) ? parseRequiredSessionUriFromChatUri(this._params.sessionUri) : this._params.sessionUri;
+		const provider = AgentSession.provider(sessionUri) ?? 'unknown';
+		const originalLineCounts = new EditArcTracker(this._params.beforeText, this._params.initialEdit).getLineCountInfo();
+		const currentLineCounts = this._tracker.getLineCountInfo();
+		const event: IEditArcTelemetryEvent = {
+			sourceKeyCleaned: 'source:Chat.applyEdits',
+			extensionId: undefined,
+			extensionVersion: undefined,
+			opportunityId: undefined,
+			editSessionId: AgentSession.id(sessionUri),
+			requestId: this._params.turnId,
+			modelId: this._params.modelId,
+			languageId: undefined,
+			mode: this._params.mode,
+			uniqueEditId: this._uniqueEditId,
+			provider,
+			agentSessionId: AgentSession.id(sessionUri),
+			isSubagentSession: isSubagentSession(sessionUri) ? 'true' : 'false',
+			didBranchChange: await this._initialBranch === await this._getCurrentBranchName() ? 0 : 1,
+			timeDelayMs,
+			originalCharCount: this._tracker.getOriginalCharacterCount(),
+			originalLineCount: originalLineCounts.insertedLineCounts,
+			originalDeletedLineCount: originalLineCounts.deletedLineCounts,
+			arc: this._tracker.getAcceptedRestrainedCharactersCount(),
+			currentLineCount: currentLineCounts.insertedLineCounts,
+			currentDeletedLineCount: currentLineCounts.deletedLineCounts,
+		};
+		this._telemetryService.publicLog2<IEditArcTelemetryEvent, IEditArcTelemetryClassification>('editTelemetry.reportEditArc', event);
+		if (provider === 'copilotcli' && isAgentHostTelemetryService(this._telemetryService)) {
+			const { didBranchChange, timeDelayMs: delay, originalCharCount, originalLineCount, originalDeletedLineCount, arc, currentLineCount, currentDeletedLineCount, ...properties } = event;
+			const telemetry = this._telemetryService as IAgentHostTelemetryService;
+			telemetry.sendGHTelemetryEvent('vscode.editTelemetry.reportEditArc', withoutUndefined(properties), {
+				didBranchChange,
+				timeDelayMs: delay,
+				originalCharCount,
+				originalLineCount,
+				originalDeletedLineCount,
+				arc,
+				currentLineCount,
+				currentDeletedLineCount,
+			});
+		}
+		if (timeDelayMs === this._sampleScheduleMs.at(-1)) {
+			this.dispose();
+		}
+	}
+
+	private _getCurrentBranchName(): Promise<string | undefined> {
+		return this._gitService.getCurrentBranchName?.(this._workingDirectory) ?? this._gitService.getCurrentBranch(this._workingDirectory);
+	}
+}
+
+function withoutUndefined(values: Record<string, string | undefined>): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const [key, value] of Object.entries(values)) {
+		if (value !== undefined) {
+			result[key] = value;
+		}
+	}
+	return result;
+}

--- a/src/vs/platform/agentHost/node/shared/editArcReporter.ts
+++ b/src/vs/platform/agentHost/node/shared/editArcReporter.ts
@@ -111,11 +111,12 @@ export class EditArcReporterService extends Disposable implements IEditArcReport
 				if (!await this._applyCompletedEdit(state, params)) {
 					return;
 				}
-			} else {
-				state = this._createResourceState(key, resource, params.afterText);
+				if (!this._isEnabled() || this._resources.get(key) !== state) {
+					return;
+				}
 			}
 
-			if (state.reporters.size >= MAX_REPORTERS_PER_RESOURCE) {
+			if (state && state.reporters.size >= MAX_REPORTERS_PER_RESOURCE) {
 				this._logService.warn(`[EditArcReporter] Skipping edit: per-resource reporter limit reached for ${params.filePath}`);
 				return;
 			}
@@ -124,15 +125,17 @@ export class EditArcReporterService extends Disposable implements IEditArcReport
 				return;
 			}
 
-			const reporter = new EditArcReporter(params, this._sampleScheduleMs, state.gitWorkingDirectory, this._gitService, this._telemetryService, this._logService, timeDelayMs => this.reconcileAndSample(state!, reporter, timeDelayMs), () => {
-				state!.reporters.delete(reporter);
+			state ??= this._createResourceState(key, resource, params.afterText);
+			const resourceState = state;
+			const reporter: EditArcReporter = new EditArcReporter(params, this._sampleScheduleMs, resourceState.gitWorkingDirectory, this._gitService, this._telemetryService, this._logService, (timeDelayMs): Promise<void> => this.reconcileAndSample(resourceState, reporter, timeDelayMs), () => {
+				resourceState.reporters.delete(reporter);
 				this._reporterCount--;
 				this._retainedCharacters -= retainedCharacters;
-				if (!state!.isDisposing && state!.reporters.size === 0) {
+				if (!resourceState.isDisposing && resourceState.reporters.size === 0) {
 					this._resources.deleteAndDispose(key);
 				}
 			});
-			state.reporters.add(reporter);
+			resourceState.reporters.add(reporter);
 			this._reporterCount++;
 			this._retainedCharacters += retainedCharacters;
 		});

--- a/src/vs/platform/agentHost/node/shared/editArcReporter.ts
+++ b/src/vs/platform/agentHost/node/shared/editArcReporter.ts
@@ -19,7 +19,7 @@ import { AgentSession } from '../../common/agentService.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { AgentHostEditTelemetryEnabledConfigKey, platformRootSchema } from '../../common/agentHostSchema.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
-import { isAhpChatChannel, isSubagentSession, parseRequiredSessionUriFromChatUri } from '../../common/state/sessionState.js';
+import { isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseRequiredSessionUriFromChatUri } from '../../common/state/sessionState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IAgentHostTelemetryService, isAgentHostTelemetryService } from '../agentHostTelemetryService.js';
 
@@ -51,6 +51,7 @@ export class NullEditArcReporterService implements IEditArcReporterService {
 
 interface IResourceState extends IDisposable {
 	readonly resource: URI;
+	readonly gitWorkingDirectory: Promise<URI>;
 	readonly reporters: Set<EditArcReporter>;
 	logicalText: string;
 	isDisposing: boolean;
@@ -123,7 +124,7 @@ export class EditArcReporterService extends Disposable implements IEditArcReport
 				return;
 			}
 
-			const reporter = new EditArcReporter(params, this._sampleScheduleMs, this._gitService, this._telemetryService, timeDelayMs => this.reconcileAndSample(state!, reporter, timeDelayMs), () => {
+			const reporter = new EditArcReporter(params, this._sampleScheduleMs, state.gitWorkingDirectory, this._gitService, this._telemetryService, this._logService, timeDelayMs => this.reconcileAndSample(state!, reporter, timeDelayMs), () => {
 				state!.reporters.delete(reporter);
 				this._reporterCount--;
 				this._retainedCharacters -= retainedCharacters;
@@ -139,8 +140,10 @@ export class EditArcReporterService extends Disposable implements IEditArcReport
 
 	private _createResourceState(key: string, resource: URI, logicalText: string): IResourceState {
 		const store = new DisposableStore();
+		const fileDirectory = URI.file(dirname(resource.fsPath));
 		const state: IResourceState = {
 			resource,
+			gitWorkingDirectory: this._gitService.getRepositoryRoot(fileDirectory).then(repositoryRoot => repositoryRoot ?? fileDirectory),
 			logicalText,
 			reporters: new Set(),
 			isDisposing: false,
@@ -256,21 +259,21 @@ export class EditArcReporterService extends Disposable implements IEditArcReport
 class EditArcReporter extends Disposable {
 	private readonly _tracker: EditArcTracker;
 	private readonly _uniqueEditId = generateUuid();
-	private readonly _workingDirectory: URI;
 	private readonly _initialBranch: Promise<string | undefined>;
 	private _sampleIndex = 0;
 
 	constructor(
 		private readonly _params: IEditArcReporterLaunchParams,
 		private readonly _sampleScheduleMs: readonly number[],
+		private readonly _gitWorkingDirectory: Promise<URI>,
 		private readonly _gitService: IAgentHostGitService,
 		private readonly _telemetryService: ITelemetryService,
+		private readonly _logService: ILogService,
 		private readonly _sample: (timeDelayMs: number) => Promise<void>,
 		onDispose: () => void,
 	) {
 		super();
 		this._tracker = new EditArcTracker(_params.beforeText, _params.initialEdit);
-		this._workingDirectory = URI.file(dirname(_params.filePath));
 		this._initialBranch = this._getCurrentBranchName();
 		this._register(toDisposable(onDispose));
 		this._scheduleNext();
@@ -294,6 +297,8 @@ class EditArcReporter extends Disposable {
 			const timeDelayMs = this._sampleScheduleMs[this._sampleIndex++];
 			try {
 				await this._sample(timeDelayMs);
+			} catch (error) {
+				this._logService.warn(`[EditArcReporter] Failed to sample ${this._params.filePath} after ${timeDelayMs}ms`, error);
 			} finally {
 				this._scheduleNext();
 			}
@@ -318,7 +323,7 @@ class EditArcReporter extends Disposable {
 			uniqueEditId: this._uniqueEditId,
 			provider,
 			agentSessionId: AgentSession.id(sessionUri),
-			isSubagentSession: isSubagentSession(sessionUri) ? 'true' : 'false',
+			isSubagentSession: isSubagentChatUri(this._params.sessionUri) || isSubagentSession(sessionUri) ? 'true' : 'false',
 			didBranchChange: await this._initialBranch === await this._getCurrentBranchName() ? 0 : 1,
 			timeDelayMs,
 			originalCharCount: this._tracker.getOriginalCharacterCount(),
@@ -348,8 +353,9 @@ class EditArcReporter extends Disposable {
 		}
 	}
 
-	private _getCurrentBranchName(): Promise<string | undefined> {
-		return this._gitService.getCurrentBranchName?.(this._workingDirectory) ?? this._gitService.getCurrentBranch(this._workingDirectory);
+	private async _getCurrentBranchName(): Promise<string | undefined> {
+		const workingDirectory = await this._gitWorkingDirectory;
+		return this._gitService.getCurrentBranchName?.(workingDirectory) ?? this._gitService.getCurrentBranch(workingDirectory);
 	}
 }
 

--- a/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
+++ b/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
@@ -14,6 +14,8 @@ import { buildSessionDbUri } from '../../common/sessionDbUri.js';
 import { FileEditKind, ToolResultContentType, type ToolResultFileEditContent } from '../../common/state/sessionState.js';
 import { extractAiChunks } from './editChunkExtractor.js';
 import { IEditSurvivalReporterFactory } from './editSurvivalReporter.js';
+import { IEditArcReporterService } from './editArcReporter.js';
+import { extractArcTextEdit } from './arcToolEdit.js';
 
 /**
  * Tracks file edits made by tools in a session by snapshotting file content
@@ -44,6 +46,7 @@ export class FileEditTracker {
 		@IDiffComputeService private readonly _diffComputeService: IDiffComputeService,
 		@IEditSurvivalReporterFactory private readonly _editSurvivalReporterFactory: IEditSurvivalReporterFactory,
 		@IAgentEditAttributionService private readonly _editAttributionService: IAgentEditAttributionService,
+		@IEditArcReporterService private readonly _editArcReporterService: IEditArcReporterService,
 	) { }
 
 	/**
@@ -117,6 +120,7 @@ export class FileEditTracker {
 		const afterBytes = edit.afterContent.buffer;
 		const beforeText = edit.beforeContent.toString();
 		const afterText = edit.afterContent.toString();
+		const completionTime = Date.now();
 
 		const isCreate = !edit.beforeExisted && afterBytes.length > 0;
 
@@ -188,6 +192,35 @@ export class FileEditTracker {
 		} catch (error) {
 			this._logService.warn(`[FileEditTracker] Failed to record edit attribution for ${filePath}: ${error}`);
 		}
+
+		try {
+			let initialEdit = extractArcTextEdit(toolName, toolInput, beforeText, afterText);
+			if (!initialEdit) {
+				const detailed = await this._diffComputeService.computeDetailedDiff(beforeText, afterText);
+				if (detailed.hitTimeout) {
+					this._logService.warn(`[FileEditTracker] Detailed diff timed out; ARC telemetry will not start: ${filePath}`);
+				} else {
+					initialEdit = { replacements: detailed.replacements };
+				}
+			}
+			if (initialEdit) {
+				await this._editArcReporterService.reportEdit({
+					sessionUri: this._sessionUri,
+					turnId,
+					toolCallId,
+					filePath,
+					beforeText,
+					afterText,
+					initialEdit,
+					modelId,
+					toolName,
+					completionTime,
+				});
+			}
+		} catch (error) {
+			this._logService.warn(`[FileEditTracker] Failed to start ARC telemetry: ${filePath}`, error);
+		}
+
 		if (!marker) {
 			return content;
 		}

--- a/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
+++ b/src/vs/platform/agentHost/node/shared/fileEditTracker.ts
@@ -15,7 +15,7 @@ import { FileEditKind, ToolResultContentType, type ToolResultFileEditContent } f
 import { extractAiChunks } from './editChunkExtractor.js';
 import { IEditSurvivalReporterFactory } from './editSurvivalReporter.js';
 import { IEditArcReporterService } from './editArcReporter.js';
-import { extractArcTextEdit } from './arcToolEdit.js';
+import { createArcTextEditFromDiff, extractArcTextEdit } from './arcToolEdit.js';
 
 /**
  * Tracks file edits made by tools in a session by snapshotting file content
@@ -193,33 +193,22 @@ export class FileEditTracker {
 			this._logService.warn(`[FileEditTracker] Failed to record edit attribution for ${filePath}: ${error}`);
 		}
 
-		try {
-			let initialEdit = extractArcTextEdit(toolName, toolInput, beforeText, afterText);
-			if (!initialEdit) {
-				const detailed = await this._diffComputeService.computeDetailedDiff(beforeText, afterText);
-				if (detailed.hitTimeout) {
-					this._logService.warn(`[FileEditTracker] Detailed diff timed out; ARC telemetry will not start: ${filePath}`);
-				} else {
-					initialEdit = { replacements: detailed.replacements };
-				}
-			}
-			if (initialEdit) {
-				await this._editArcReporterService.reportEdit({
-					sessionUri: this._sessionUri,
-					turnId,
-					toolCallId,
-					filePath,
-					beforeText,
-					afterText,
-					initialEdit,
-					modelId,
-					toolName,
-					completionTime,
-				});
-			}
-		} catch (error) {
+		const initialEdit = extractArcTextEdit(toolName, toolInput, beforeText, afterText)
+			?? createArcTextEditFromDiff(changes, beforeText, afterText);
+		this._editArcReporterService.reportEdit({
+			sessionUri: this._sessionUri,
+			turnId,
+			toolCallId,
+			filePath,
+			beforeText,
+			afterText,
+			initialEdit,
+			modelId,
+			toolName,
+			completionTime,
+		}).catch(error => {
 			this._logService.warn(`[FileEditTracker] Failed to start ARC telemetry: ${filePath}`, error);
-		}
+		});
 
 		if (!marker) {
 			return content;

--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -7,7 +7,7 @@ import type { IReference } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Event } from '../../../../base/common/event.js';
-import type { IDiffComputeService, IDiffCountResult } from '../../common/diffComputeService.js';
+import type { IDetailedDiffResult, IDiffComputeService, IDiffCountResult } from '../../common/diffComputeService.js';
 import type { IFileEditContent, IFileEditRecord, ILocalTurnRecord, IReviewedFileRecord, ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import type { Message } from '../../common/state/sessionState.js';
 
@@ -189,6 +189,20 @@ export class TestDiffComputeService implements IDiffComputeService {
 
 	async computeDiffCounts(original: string, modified: string): Promise<IDiffCountResult> {
 		this.callCount++;
+		return this._computeDiffCounts(original, modified);
+	}
+
+	async computeDetailedDiff(original: string, modified: string): Promise<IDetailedDiffResult> {
+		const counts = this._computeDiffCounts(original, modified);
+		return {
+			added: counts.added,
+			removed: counts.removed,
+			replacements: original === modified ? [] : [{ start: 0, endExclusive: original.length, text: modified }],
+			hitTimeout: false,
+		};
+	}
+
+	private _computeDiffCounts(original: string, modified: string): IDiffCountResult {
 		if (this._result) {
 			return this._result;
 		}

--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -184,6 +184,7 @@ export class TestDiffComputeService implements IDiffComputeService {
 	declare readonly _serviceBrand: undefined;
 
 	callCount = 0;
+	detailedCallCount = 0;
 
 	constructor(private readonly _result?: IDiffCountResult) { }
 
@@ -193,6 +194,7 @@ export class TestDiffComputeService implements IDiffComputeService {
 	}
 
 	async computeDetailedDiff(original: string, modified: string): Promise<IDetailedDiffResult> {
+		this.detailedCallCount++;
 		const counts = this._computeDiffCounts(original, modified);
 		return {
 			added: counts.added,

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -30,7 +30,7 @@ import type { IClientTransport, IProtocolTransport } from '../../common/state/se
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { AgentHostCodexAgentEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostClaudeMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId } from '../../common/agentService.js';
-import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, EDIT_TELEMETRY_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
 import type { Implementation } from '../../common/state/protocol/common/commands.js';
 import { agentsWindowAgentHostClientInfo } from '../../common/agentHostClientInfo.js';
 
@@ -991,6 +991,23 @@ suite('RemoteAgentHostProtocolClient', () => {
 
 		const enabled = findLastRootConfigNotification(transport.sentMessages, AgentHostDisableRepoInfoTelemetryConfigKey);
 		assert.deepStrictEqual(getRootConfig(enabled), { [AgentHostDisableRepoInfoTelemetryConfigKey]: false });
+	});
+
+	test('forwards edit telemetry on connect and change', async () => {
+		const configurationService = new TestConfigurationService({ [EDIT_TELEMETRY_ENABLED_SETTING_ID]: false });
+		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
+
+		await connectClient(client, transport);
+
+		const disabled = findRootConfigNotification(transport.sentMessages, AgentHostEditTelemetryEnabledConfigKey);
+		assert.deepStrictEqual(getRootConfig(disabled), { [AgentHostEditTelemetryEnabledConfigKey]: false });
+
+		transport.sentMessages.length = 0;
+		await configurationService.setUserConfiguration(EDIT_TELEMETRY_ENABLED_SETTING_ID, true);
+		fireConfigurationChange(configurationService, EDIT_TELEMETRY_ENABLED_SETTING_ID);
+
+		const enabled = findLastRootConfigNotification(transport.sentMessages, AgentHostEditTelemetryEnabledConfigKey);
+		assert.deepStrictEqual(getRootConfig(enabled), { [AgentHostEditTelemetryEnabledConfigKey]: true });
 	});
 
 	test('forwards terminal auto-approve rules on connect', async () => {

--- a/src/vs/platform/agentHost/test/node/claudeFileEditObserver.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeFileEditObserver.test.ts
@@ -24,6 +24,7 @@ import { ToolResultContentType } from '../../common/state/sessionState.js';
 import { ClaudeFileEditObserver } from '../../node/claude/claudeFileEditObserver.js';
 import { ClaudeMapperState } from '../../node/claude/claudeMapSessionEvents.js';
 import { IEditSurvivalReporterFactory, NullEditSurvivalReporterFactory } from '../../node/shared/editSurvivalReporter.js';
+import { IEditArcReporterService, NullEditArcReporterService } from '../../node/shared/editArcReporter.js';
 import { createZeroDiffComputeService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 
 interface IObserverHarness {
@@ -47,6 +48,7 @@ function createObserver(disposables: Pick<import('../../../../base/common/lifecy
 		[IDiffComputeService, createZeroDiffComputeService()],
 		[IAgentEditAttributionService, new NullAgentEditAttributionService()],
 		[IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory()],
+		[IEditArcReporterService, new NullEditArcReporterService()],
 	);
 	const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 	const observer = disposables.add(instantiationService.createInstance(

--- a/src/vs/platform/agentHost/test/node/diffWorkerMain.test.ts
+++ b/src/vs/platform/agentHost/test/node/diffWorkerMain.test.ts
@@ -5,7 +5,8 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { computeDiffCounts } from '../../node/diffWorkerMain.js';
+import { IArcTextReplacement } from '../../../../base/common/editArcTracker.js';
+import { computeDetailedDiff, computeDiffCounts } from '../../node/diffWorkerMain.js';
 
 suite('Agent Host Diff Worker', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -25,6 +26,32 @@ suite('Agent Host Diff Worker', () => {
 			changeCount: 2,
 		});
 	});
+
+	test('detailed diff preserves line endings and whitespace changes', () => {
+		const original = 'first  \r\nsecond\r\n';
+		const modified = 'first \r\nsecond changed\r\n';
+		const result = computeDetailedDiff(original, modified, 5000);
+
+		assert.deepStrictEqual({
+			content: applyReplacements(original, result.replacements),
+			added: result.added,
+			removed: result.removed,
+			hitTimeout: result.hitTimeout,
+		}, {
+			content: modified,
+			added: 2,
+			removed: 2,
+			hitTimeout: false,
+		});
+	});
+
+	test('line counts retain whitespace-insensitive behavior', () => {
+		assert.deepStrictEqual(computeDiffCounts('first  \n', 'first \n', 5000), {
+			added: 0,
+			removed: 0,
+			changes: [],
+		});
+	});
 });
 
 function applyChanges(content: string, changes: readonly { startOffset: number; endOffsetExclusive: number; newText: string }[]): string {
@@ -36,4 +63,15 @@ function applyChanges(content: string, changes: readonly { startOffset: number; 
 		lastOffset = change.endOffsetExclusive;
 	}
 	return result + content.substring(lastOffset);
+}
+
+function applyReplacements(value: string, replacements: readonly IArcTextReplacement[]): string {
+	let result = '';
+	let offset = 0;
+	for (const replacement of replacements) {
+		result += value.substring(offset, replacement.start);
+		result += replacement.text;
+		offset = replacement.endExclusive;
+	}
+	return result + value.substring(offset);
 }

--- a/src/vs/platform/agentHost/test/node/diffWorkerMain.test.ts
+++ b/src/vs/platform/agentHost/test/node/diffWorkerMain.test.ts
@@ -45,6 +45,34 @@ suite('Agent Host Diff Worker', () => {
 		});
 	});
 
+	test('detailed diff reconstructs line-ending-only changes', () => {
+		const original = 'first\r\nsecond\r\n';
+		const modified = 'first\nsecond\n';
+		const result = computeDetailedDiff(original, modified, 5000);
+
+		assert.deepStrictEqual({
+			content: applyReplacements(original, result.replacements),
+			hitTimeout: result.hitTimeout,
+		}, {
+			content: modified,
+			hitTimeout: false,
+		});
+	});
+
+	test('detailed diff reconstructs mixed content and line-ending changes', () => {
+		const original = 'first\r\nsecond\r\nthird\r\n';
+		const modified = 'first\nchanged\nthird\n';
+		const result = computeDetailedDiff(original, modified, 5000);
+
+		assert.deepStrictEqual({
+			content: applyReplacements(original, result.replacements),
+			hitTimeout: result.hitTimeout,
+		}, {
+			content: modified,
+			hitTimeout: false,
+		});
+	});
+
 	test('line counts retain whitespace-insensitive behavior', () => {
 		assert.deepStrictEqual(computeDiffCounts('first  \n', 'first \n', 5000), {
 			added: 0,

--- a/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
@@ -22,7 +22,8 @@ import { ToolResultContentType } from '../../common/state/sessionState.js';
 import { TestDiffComputeService } from '../common/sessionTestHelpers.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { IEditSurvivalReporterFactory, NullEditSurvivalReporterFactory } from '../../node/shared/editSurvivalReporter.js';
-import { FileEditTracker } from '../../node/shared/fileEditTracker.js';
+import { FileEditTracker, buildSessionDbUri, parseSessionDbUri } from '../../node/shared/fileEditTracker.js';
+import { IEditArcReporterService, NullEditArcReporterService } from '../../node/shared/editArcReporter.js';
 
 suite('FileEditTracker', () => {
 
@@ -47,6 +48,7 @@ suite('FileEditTracker', () => {
 		services.set(IDiffComputeService, diffComputeService);
 		services.set(IAgentEditAttributionService, new NullAgentEditAttributionService());
 		services.set(IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory());
+		services.set(IEditArcReporterService, new NullEditArcReporterService());
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		tracker = instantiationService.createInstance(FileEditTracker, 'copilot:/test-session', db);
 	});
@@ -114,6 +116,7 @@ suite('FileEditTracker', () => {
 
 	test('attaches Agent attribution marker to the file edit result', async () => {
 		const services = new ServiceCollection();
+		let arcReportCount = 0;
 		services.set(ILogService, new NullLogService());
 		services.set(IFileService, fileService);
 		services.set(IDiffComputeService, new TestDiffComputeService());
@@ -133,6 +136,10 @@ suite('FileEditTracker', () => {
 			cancelFlush: async () => ({ outcome: 'missing', agentModifiedCount: 0 }),
 		});
 		services.set(IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory());
+		services.set(IEditArcReporterService, {
+			_serviceBrand: undefined,
+			reportEdit: async () => { arcReportCount++; },
+		});
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const localTracker = instantiationService.createInstance(FileEditTracker, 'copilot:/test-session', db);
 		await fileService.writeFile(URI.file('/workspace/marker.txt'), VSBuffer.fromString('before'));
@@ -149,6 +156,7 @@ suite('FileEditTracker', () => {
 			beforeDigest: createFileEditContentDigest('before'),
 			afterDigest: createFileEditContentDigest('after'),
 		});
+		assert.strictEqual(arcReportCount, 1);
 	});
 
 	test('returns the file edit result when attribution fails', async () => {
@@ -168,6 +176,7 @@ suite('FileEditTracker', () => {
 			cancelFlush: async () => ({ outcome: 'missing', agentModifiedCount: 0 }),
 		});
 		services.set(IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory());
+		services.set(IEditArcReporterService, new NullEditArcReporterService());
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const localTracker = instantiationService.createInstance(FileEditTracker, 'copilot:/test-session', db);
 		await fileService.writeFile(URI.file('/workspace/fallback.txt'), VSBuffer.fromString('before'));
@@ -198,6 +207,7 @@ suite('FileEditTracker', () => {
 		services.set(IDiffComputeService, new TestDiffComputeService({ added: 1, removed: 1, changes: [] }));
 		services.set(IAgentEditAttributionService, new NullAgentEditAttributionService());
 		services.set(IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory());
+		services.set(IEditArcReporterService, new NullEditArcReporterService());
 		const inst: IInstantiationService = disposables.add(new InstantiationService(services));
 		const localTracker = inst.createInstance(FileEditTracker, 'copilot:/test-session', db);
 

--- a/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DeferredPromise } from '../../../../base/common/async.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -22,8 +23,8 @@ import { ToolResultContentType } from '../../common/state/sessionState.js';
 import { TestDiffComputeService } from '../common/sessionTestHelpers.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { IEditSurvivalReporterFactory, NullEditSurvivalReporterFactory } from '../../node/shared/editSurvivalReporter.js';
-import { FileEditTracker, buildSessionDbUri, parseSessionDbUri } from '../../node/shared/fileEditTracker.js';
-import { IEditArcReporterService, NullEditArcReporterService } from '../../node/shared/editArcReporter.js';
+import { FileEditTracker } from '../../node/shared/fileEditTracker.js';
+import { IEditArcReporterLaunchParams, IEditArcReporterService, NullEditArcReporterService } from '../../node/shared/editArcReporter.js';
 
 suite('FileEditTracker', () => {
 
@@ -192,6 +193,62 @@ suite('FileEditTracker', () => {
 		}, {
 			type: ToolResultContentType.FileEdit,
 			marker: undefined,
+		});
+	});
+
+	test('reuses the existing diff and does not wait for ARC reporting', async () => {
+		const reportStarted = new DeferredPromise<IEditArcReporterLaunchParams>();
+		const releaseReport = new DeferredPromise<void>();
+		const services = new ServiceCollection();
+		const localDiffComputeService = new TestDiffComputeService();
+		services.set(ILogService, new NullLogService());
+		services.set(IFileService, fileService);
+		services.set(IDiffComputeService, localDiffComputeService);
+		services.set(IAgentEditAttributionService, new NullAgentEditAttributionService());
+		services.set(IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory());
+		services.set(IEditArcReporterService, {
+			_serviceBrand: undefined,
+			reportEdit: async params => {
+				reportStarted.complete(params);
+				await releaseReport.p;
+			},
+		});
+		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
+		const localTracker = instantiationService.createInstance(FileEditTracker, 'copilot:/test-session', db);
+		await fileService.writeFile(URI.file('/workspace/non-blocking.txt'), VSBuffer.fromString('before'));
+
+		await localTracker.trackEditStart('/workspace/non-blocking.txt');
+		await fileService.writeFile(URI.file('/workspace/non-blocking.txt'), VSBuffer.fromString('after'));
+		await localTracker.completeEdit('/workspace/non-blocking.txt');
+		const resultPromise = localTracker.takeCompletedEdit('turn-1', 'tc-non-blocking', '/workspace/non-blocking.txt', 'apply_patch', undefined, 'model');
+		const report = await reportStarted.p;
+		let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+		const completion = await Promise.race([
+			resultPromise.then(() => 'complete' as const),
+			new Promise<'timeout'>(resolve => {
+				timeoutHandle = setTimeout(() => resolve('timeout'), 100);
+			}),
+		]);
+		if (timeoutHandle) {
+			clearTimeout(timeoutHandle);
+		}
+		releaseReport.complete();
+		const result = await resultPromise;
+
+		assert.deepStrictEqual({
+			completion,
+			resultType: result?.type,
+			diffCallCount: localDiffComputeService.callCount,
+			detailedDiffCallCount: localDiffComputeService.detailedCallCount,
+			initialEdit: report.initialEdit,
+		}, {
+			completion: 'complete',
+			resultType: ToolResultContentType.FileEdit,
+			diffCallCount: 1,
+			detailedDiffCallCount: 0,
+			initialEdit: {
+				replacements: [{ start: 0, endExclusive: 6, text: 'after' }]
+			},
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/shared/arcToolEdit.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/arcToolEdit.test.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { extractArcTextEdit } from '../../../node/shared/arcToolEdit.js';
+
+suite('Agent Host ARC Tool Edit', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('extracts verified single replacements', () => {
+		assert.deepStrictEqual(extractArcTextEdit('Edit', {
+			old_string: 'before',
+			new_string: 'after',
+		}, 'const value = before;', 'const value = after;'), {
+			replacements: [{ start: 14, endExclusive: 20, text: 'after' }]
+		});
+	});
+
+	test('extracts verified full-file writes', () => {
+		assert.deepStrictEqual(extractArcTextEdit('Write', {
+			content: 'new content',
+		}, 'old content', 'new content'), {
+			replacements: [{ start: 0, endExclusive: 11, text: 'new content' }]
+		});
+	});
+
+	test('rejects tool edits that do not reproduce the captured result', () => {
+		assert.strictEqual(extractArcTextEdit('Edit', {
+			old_string: 'before',
+			new_string: 'after',
+		}, 'const value = before;', 'formatter changed this'), undefined);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/shared/arcToolEdit.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/arcToolEdit.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { extractArcTextEdit } from '../../../node/shared/arcToolEdit.js';
+import { createArcTextEditFromDiff, extractArcTextEdit } from '../../../node/shared/arcToolEdit.js';
 
 suite('Agent Host ARC Tool Edit', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -32,5 +32,21 @@ suite('Agent Host ARC Tool Edit', () => {
 			old_string: 'before',
 			new_string: 'after',
 		}, 'const value = before;', 'formatter changed this'), undefined);
+	});
+
+	test('creates verified ARC edits from existing diff changes', () => {
+		assert.deepStrictEqual(createArcTextEditFromDiff([{
+			startOffset: 6,
+			endOffsetExclusive: 12,
+			newText: 'after',
+		}], 'value=before', 'value=after'), {
+			replacements: [{ start: 6, endExclusive: 12, text: 'after' }]
+		});
+	});
+
+	test('falls back to a full replacement when diff changes do not reconstruct the result', () => {
+		assert.deepStrictEqual(createArcTextEditFromDiff([], 'first\r\nsecond', 'first\nsecond'), {
+			replacements: [{ start: 0, endExclusive: 13, text: 'first\nsecond' }]
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/shared/editArcReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/editArcReporter.test.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { timeout } from '../../../../../base/common/async.js';
+import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { FileService } from '../../../../files/common/fileService.js';
+import { IFileSystemWatcher, IWatchOptionsWithoutCorrelation } from '../../../../files/common/files.js';
 import { InMemoryFileSystemProvider } from '../../../../files/common/inMemoryFilesystemProvider.js';
 import { NullLogService } from '../../../../log/common/log.js';
 import { TelemetryMeasurements, TelemetryProps } from '../../../node/agentHostRestrictedTelemetry.js';
@@ -21,6 +22,16 @@ import { TestDiffComputeService, createNoopGitService } from '../../common/sessi
 import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
 import { IAgentHostGitService } from '../../../common/agentHostGitService.js';
 import { buildSubagentChatUri } from '../../../common/state/sessionState.js';
+import { IDetailedDiffResult, IDiffComputeService } from '../../../common/diffComputeService.js';
+
+class CountingFileService extends FileService {
+	watcherCount = 0;
+
+	override createWatcher(resource: URI, options: IWatchOptionsWithoutCorrelation & { recursive: false }): IFileSystemWatcher {
+		this.watcherCount++;
+		return super.createWatcher(resource, options);
+	}
+}
 
 class RecordingTelemetryService extends NullTelemetryServiceShape {
 	readonly events: Array<{ name: string; data: Record<string, unknown> }> = [];
@@ -44,12 +55,12 @@ class RecordingTelemetryService extends NullTelemetryServiceShape {
 
 suite('Agent Host Edit ARC Reporter', () => {
 	const disposables = new DisposableStore();
-	let fileService: FileService;
+	let fileService: CountingFileService;
 	let telemetry: RecordingTelemetryService;
 	let config: TestAgentConfigurationService;
 
 	setup(() => {
-		fileService = disposables.add(new FileService(new NullLogService()));
+		fileService = disposables.add(new CountingFileService(new NullLogService()));
 		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
 		telemetry = new RecordingTelemetryService();
 		config = createConfigurationService(true);
@@ -179,6 +190,76 @@ suite('Agent Host Edit ARC Reporter', () => {
 			{ timeDelayMs: 60, arc: 1 },
 		]);
 		assert.deepStrictEqual(telemetry.githubEvents, []);
+	});
+
+	test('does not create a reporter after reconciliation state is disposed', async () => {
+		const detailedStarted = new DeferredPromise<void>();
+		const detailedResult = new DeferredPromise<IDetailedDiffResult>();
+		const diffComputeService: IDiffComputeService = {
+			_serviceBrand: undefined,
+			computeDiffCounts: async () => ({ added: 0, removed: 0, changes: [] }),
+			computeDetailedDiff: async () => {
+				detailedStarted.complete();
+				return detailedResult.p;
+			},
+		};
+		const resource = URI.file('/workspace/stale.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('AIbase'));
+		const service = disposables.add(new EditArcReporterService([0, 60_000], fileService, diffComputeService, createNoopGitService(), config, new NullLogService(), telemetry));
+		await service.reportEdit({
+			sessionUri: 'claude:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'base',
+			afterText: 'AIbase',
+			initialEdit: { replacements: [{ start: 0, endExclusive: 0, text: 'AI' }] },
+			completionTime: Date.now(),
+		});
+		await timeout(10);
+
+		const secondReport = service.reportEdit({
+			sessionUri: 'claude:/session-1',
+			turnId: 'turn-2',
+			toolCallId: 'tool-2',
+			filePath: resource.fsPath,
+			beforeText: 'unrelated',
+			afterText: 'newbase',
+			initialEdit: { replacements: [{ start: 0, endExclusive: 9, text: 'newbase' }] },
+			completionTime: Date.now(),
+		});
+		await detailedStarted.p;
+		config.setEnabled(false);
+		config.setEnabled(true);
+		detailedResult.complete({
+			added: 1,
+			removed: 1,
+			replacements: [{ start: 0, endExclusive: 6, text: 'newbase' }],
+			hitTimeout: false,
+		});
+		await secondReport;
+		await timeout(10);
+
+		assert.deepStrictEqual(telemetry.events.map(event => event.data.requestId), ['turn-1']);
+	});
+
+	test('does not create resource watchers after the host reporter limit is reached', async () => {
+		const service = disposables.add(new EditArcReporterService([60_000], fileService, new TestDiffComputeService(), createNoopGitService(), config, new NullLogService(), telemetry));
+
+		for (let index = 0; index <= 200; index++) {
+			await service.reportEdit({
+				sessionUri: 'claude:/session-1',
+				turnId: `turn-${index}`,
+				toolCallId: `tool-${index}`,
+				filePath: `/workspace/file-${index}.ts`,
+				beforeText: '',
+				afterText: 'AI',
+				initialEdit: { replacements: [{ start: 0, endExclusive: 0, text: 'AI' }] },
+				completionTime: Date.now(),
+			});
+		}
+
+		assert.strictEqual(fileService.watcherCount, 200);
 	});
 
 	test('disposes active reporters when edit telemetry is disabled', async () => {

--- a/src/vs/platform/agentHost/test/node/shared/editArcReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/editArcReporter.test.ts
@@ -1,0 +1,265 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { FileService } from '../../../../files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../../files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../../log/common/log.js';
+import { TelemetryMeasurements, TelemetryProps } from '../../../node/agentHostRestrictedTelemetry.js';
+import { NullTelemetryServiceShape } from '../../../../telemetry/common/telemetryUtils.js';
+import { TelemetryLevel } from '../../../../telemetry/common/telemetry.js';
+import { EditArcReporterService } from '../../../node/shared/editArcReporter.js';
+import { TestDiffComputeService, createNoopGitService } from '../../common/sessionTestHelpers.js';
+import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
+import { IAgentHostGitService } from '../../../common/agentHostGitService.js';
+
+class RecordingTelemetryService extends NullTelemetryServiceShape {
+	readonly events: Array<{ name: string; data: Record<string, unknown> }> = [];
+	readonly githubEvents: Array<{ name: string; properties: TelemetryProps | undefined; measurements: TelemetryMeasurements | undefined }> = [];
+
+	constructor() {
+		super();
+		Object.defineProperty(this, 'telemetryLevel', { value: TelemetryLevel.USAGE });
+	}
+
+	override publicLog2(eventName?: string, data?: Record<string, unknown>): void {
+		this.events.push({ name: eventName ?? '', data: data ?? {} });
+	}
+
+	updateTelemetryLevel(): void { }
+
+	sendGHTelemetryEvent(name: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		this.githubEvents.push({ name, properties, measurements });
+	}
+}
+
+suite('Agent Host Edit ARC Reporter', () => {
+	const disposables = new DisposableStore();
+	let fileService: FileService;
+	let telemetry: RecordingTelemetryService;
+	let config: TestAgentConfigurationService;
+
+	setup(() => {
+		fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		telemetry = new RecordingTelemetryService();
+		config = createConfigurationService(true);
+	});
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('emits the locked Microsoft and GitHub event shape', async () => {
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('hello AI'));
+		const service = disposables.add(new EditArcReporterService([0, 30, 60], fileService, new TestDiffComputeService(), createNoopGitService(), config, new NullLogService(), telemetry));
+
+		await service.reportEdit({
+			sessionUri: 'copilotcli:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'hello',
+			afterText: 'hello AI',
+			initialEdit: { replacements: [{ start: 5, endExclusive: 5, text: ' AI' }] },
+			modelId: 'gpt-5',
+			toolName: 'edit',
+			completionTime: Date.now(),
+		});
+		await timeout(10);
+
+		const event = telemetry.events[0];
+		assert.deepStrictEqual({
+			name: event.name,
+			data: { ...event.data, uniqueEditId: '<uuid>' },
+			githubName: telemetry.githubEvents[0]?.name,
+		}, {
+			name: 'editTelemetry.reportEditArc',
+			data: {
+				sourceKeyCleaned: 'source:Chat.applyEdits',
+				extensionId: undefined,
+				extensionVersion: undefined,
+				opportunityId: undefined,
+				editSessionId: 'session-1',
+				requestId: 'turn-1',
+				modelId: 'gpt-5',
+				languageId: undefined,
+				mode: undefined,
+				uniqueEditId: '<uuid>',
+				provider: 'copilotcli',
+				agentSessionId: 'session-1',
+				isSubagentSession: 'false',
+				didBranchChange: 0,
+				timeDelayMs: 0,
+				originalCharCount: 3,
+				originalLineCount: 1,
+				originalDeletedLineCount: 1,
+				arc: 3,
+				currentLineCount: 1,
+				currentDeletedLineCount: 1,
+			},
+			githubName: 'vscode.editTelemetry.reportEditArc',
+		});
+	});
+
+	test('updates older reporters before starting the next reporter', async () => {
+		const resource = URI.file('/workspace/order.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('AIbase'));
+		const service = disposables.add(new EditArcReporterService([0, 30, 60], fileService, new TestDiffComputeService(), createNoopGitService(), config, new NullLogService(), telemetry));
+		const completionTime = Date.now();
+
+		await service.reportEdit({
+			sessionUri: 'claude:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'base',
+			afterText: 'AIbase',
+			initialEdit: { replacements: [{ start: 0, endExclusive: 0, text: 'AI' }] },
+			completionTime,
+		});
+		await timeout(10);
+		const firstEditId = telemetry.events[0].data.uniqueEditId;
+
+		await fileService.writeFile(resource, VSBuffer.fromString('Abase'));
+		await service.reportEdit({
+			sessionUri: 'claude:/session-1',
+			turnId: 'turn-2',
+			toolCallId: 'tool-2',
+			filePath: resource.fsPath,
+			beforeText: 'AIbase',
+			afterText: 'Abase',
+			initialEdit: { replacements: [{ start: 1, endExclusive: 2, text: '' }] },
+			completionTime: Date.now(),
+		});
+		await timeout(70);
+
+		assert.deepStrictEqual(telemetry.events
+			.filter(event => event.data.uniqueEditId === firstEditId)
+			.map(event => ({ timeDelayMs: event.data.timeDelayMs, arc: event.data.arc })), [
+			{ timeDelayMs: 0, arc: 2 },
+			{ timeDelayMs: 30, arc: 1 },
+			{ timeDelayMs: 60, arc: 1 },
+		]);
+		assert.deepStrictEqual(telemetry.githubEvents, []);
+	});
+
+	test('disposes active reporters when edit telemetry is disabled', async () => {
+		const resource = URI.file('/workspace/disabled.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('hello AI'));
+		const service = disposables.add(new EditArcReporterService([0, 30, 60], fileService, new TestDiffComputeService(), createNoopGitService(), config, new NullLogService(), telemetry));
+
+		await service.reportEdit({
+			sessionUri: 'claude:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'hello',
+			afterText: 'hello AI',
+			initialEdit: { replacements: [{ start: 5, endExclusive: 5, text: ' AI' }] },
+			completionTime: Date.now(),
+		});
+		await timeout(10);
+		config.setEnabled(false);
+		await timeout(70);
+
+		assert.deepStrictEqual(telemetry.events.map(event => event.data.timeDelayMs), [0]);
+	});
+
+	test('reports symbolic branch changes', async () => {
+		const resource = URI.file('/workspace/branch.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('hello AI'));
+		let branch = 'main';
+		const gitService: IAgentHostGitService = {
+			...createNoopGitService(),
+			getCurrentBranchName: async () => branch,
+		};
+		const service = disposables.add(new EditArcReporterService([0, 30], fileService, new TestDiffComputeService(), gitService, config, new NullLogService(), telemetry));
+
+		await service.reportEdit({
+			sessionUri: 'claude:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'hello',
+			afterText: 'hello AI',
+			initialEdit: { replacements: [{ start: 5, endExclusive: 5, text: ' AI' }] },
+			completionTime: Date.now(),
+		});
+		await timeout(10);
+		branch = 'feature';
+		await timeout(40);
+
+		assert.deepStrictEqual(telemetry.events.map(event => ({
+			timeDelayMs: event.data.timeDelayMs,
+			didBranchChange: event.data.didBranchChange,
+		})), [
+			{ timeDelayMs: 0, didBranchChange: 0 },
+			{ timeDelayMs: 30, didBranchChange: 1 },
+		]);
+	});
+
+	test('treats deletion as removal of the tracked edit', async () => {
+		const resource = URI.file('/workspace/deleted.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('hello AI'));
+		const service = disposables.add(new EditArcReporterService([0, 30], fileService, new TestDiffComputeService(), createNoopGitService(), config, new NullLogService(), telemetry));
+
+		await service.reportEdit({
+			sessionUri: 'claude:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'hello',
+			afterText: 'hello AI',
+			initialEdit: { replacements: [{ start: 5, endExclusive: 5, text: ' AI' }] },
+			completionTime: Date.now(),
+		});
+		await timeout(10);
+		await fileService.del(resource);
+		await timeout(40);
+
+		assert.deepStrictEqual(telemetry.events.map(event => ({
+			timeDelayMs: event.data.timeDelayMs,
+			arc: event.data.arc,
+		})), [
+			{ timeDelayMs: 0, arc: 3 },
+			{ timeDelayMs: 30, arc: 0 },
+		]);
+	});
+});
+
+interface TestAgentConfigurationService extends IAgentConfigurationService {
+	setEnabled(enabled: boolean): void;
+}
+
+function createConfigurationService(enabled: boolean): TestAgentConfigurationService {
+	const rootConfigChange = new Emitter<void>();
+	return {
+		_serviceBrand: undefined,
+		onDidRootConfigChange: rootConfigChange.event,
+		onDidSessionConfigChange: Event.None,
+		getEffectiveValue: () => undefined,
+		getEffectiveWorkingDirectory: () => undefined,
+		getEffectiveWorkingDirectories: () => undefined,
+		isWorkingDirectoryPending: () => false,
+		resolveWorkingDirectoryForResume: async (_session, workingDirectory) => workingDirectory,
+		updateSessionConfig: () => { },
+		getSessionConfigValues: () => undefined,
+		getRootValue: (schema, key) => schema.validate(key, enabled) ? enabled : undefined,
+		updateRootConfig: () => { },
+		persistRootConfig: () => { },
+		whenIdle: async () => { },
+		setEnabled(value) {
+			enabled = value;
+			rootConfigChange.fire();
+		},
+	};
+}

--- a/src/vs/platform/agentHost/test/node/shared/editArcReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/editArcReporter.test.ts
@@ -20,6 +20,7 @@ import { EditArcReporterService } from '../../../node/shared/editArcReporter.js'
 import { TestDiffComputeService, createNoopGitService } from '../../common/sessionTestHelpers.js';
 import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
 import { IAgentHostGitService } from '../../../common/agentHostGitService.js';
+import { buildSubagentChatUri } from '../../../common/state/sessionState.js';
 
 class RecordingTelemetryService extends NullTelemetryServiceShape {
 	readonly events: Array<{ name: string; data: Record<string, unknown> }> = [];
@@ -110,6 +111,34 @@ suite('Agent Host Edit ARC Reporter', () => {
 		});
 	});
 
+	test('reports edits from subagent chat channels', async () => {
+		const resource = URI.file('/workspace/subagent.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('hello AI'));
+		const service = disposables.add(new EditArcReporterService([0], fileService, new TestDiffComputeService(), createNoopGitService(), config, new NullLogService(), telemetry));
+
+		await service.reportEdit({
+			sessionUri: buildSubagentChatUri('copilotcli:/session-1', 'parent-tool'),
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'hello',
+			afterText: 'hello AI',
+			initialEdit: { replacements: [{ start: 5, endExclusive: 5, text: ' AI' }] },
+			completionTime: Date.now(),
+		});
+		await timeout(10);
+
+		assert.deepStrictEqual({
+			editSessionId: telemetry.events[0].data.editSessionId,
+			agentSessionId: telemetry.events[0].data.agentSessionId,
+			isSubagentSession: telemetry.events[0].data.isSubagentSession,
+		}, {
+			editSessionId: 'session-1',
+			agentSessionId: 'session-1',
+			isSubagentSession: 'true',
+		});
+	});
+
 	test('updates older reporters before starting the next reporter', async () => {
 		const resource = URI.file('/workspace/order.ts');
 		await fileService.writeFile(resource, VSBuffer.fromString('AIbase'));
@@ -174,6 +203,37 @@ suite('Agent Host Edit ARC Reporter', () => {
 		assert.deepStrictEqual(telemetry.events.map(event => event.data.timeDelayMs), [0]);
 	});
 
+	test('continues sampling after a sample fails', async () => {
+		const resource = URI.file('/workspace/failure.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('hello AI'));
+		let branchLookupCount = 0;
+		const gitService: IAgentHostGitService = {
+			...createNoopGitService(),
+			getCurrentBranchName: async () => {
+				branchLookupCount++;
+				if (branchLookupCount === 3) {
+					throw new Error('branch lookup failed');
+				}
+				return 'main';
+			},
+		};
+		const service = disposables.add(new EditArcReporterService([0, 30, 60], fileService, new TestDiffComputeService(), gitService, config, new NullLogService(), telemetry));
+
+		await service.reportEdit({
+			sessionUri: 'claude:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'hello',
+			afterText: 'hello AI',
+			initialEdit: { replacements: [{ start: 5, endExclusive: 5, text: ' AI' }] },
+			completionTime: Date.now(),
+		});
+		await timeout(80);
+
+		assert.deepStrictEqual(telemetry.events.map(event => event.data.timeDelayMs), [0, 60]);
+	});
+
 	test('reports symbolic branch changes', async () => {
 		const resource = URI.file('/workspace/branch.ts');
 		await fileService.writeFile(resource, VSBuffer.fromString('hello AI'));
@@ -204,6 +264,47 @@ suite('Agent Host Edit ARC Reporter', () => {
 		})), [
 			{ timeDelayMs: 0, didBranchChange: 0 },
 			{ timeDelayMs: 30, didBranchChange: 1 },
+		]);
+	});
+
+	test('retains the repository root when the edited parent directory is deleted', async () => {
+		const resource = URI.file('/workspace/removed/branch.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('hello AI'));
+		const repositoryRoot = URI.file('/workspace');
+		const fileDirectory = URI.file('/workspace/removed');
+		let fileDirectoryExists = true;
+		const gitService: IAgentHostGitService = {
+			...createNoopGitService(),
+			getRepositoryRoot: async () => repositoryRoot,
+			getCurrentBranchName: async workingDirectory => {
+				if (workingDirectory.toString() === repositoryRoot.toString()) {
+					return 'main';
+				}
+				return fileDirectoryExists && workingDirectory.toString() === fileDirectory.toString() ? 'main' : undefined;
+			},
+		};
+		const service = disposables.add(new EditArcReporterService([0, 30], fileService, new TestDiffComputeService(), gitService, config, new NullLogService(), telemetry));
+
+		await service.reportEdit({
+			sessionUri: 'claude:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'hello',
+			afterText: 'hello AI',
+			initialEdit: { replacements: [{ start: 5, endExclusive: 5, text: ' AI' }] },
+			completionTime: Date.now(),
+		});
+		await timeout(10);
+		fileDirectoryExists = false;
+		await timeout(40);
+
+		assert.deepStrictEqual(telemetry.events.map(event => ({
+			timeDelayMs: event.data.timeDelayMs,
+			didBranchChange: event.data.didBranchChange,
+		})), [
+			{ timeDelayMs: 0, didBranchChange: 0 },
+			{ timeDelayMs: 30, didBranchChange: 0 },
 		]);
 	});
 

--- a/src/vs/platform/telemetry/common/editArcTelemetry.ts
+++ b/src/vs/platform/telemetry/common/editArcTelemetry.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const EDIT_TELEMETRY_SETTING_ID = 'telemetry.editStats.enabled';
+
+export interface IEditArcTelemetryEvent {
+	sourceKeyCleaned: string;
+	extensionId: string | undefined;
+	extensionVersion: string | undefined;
+	opportunityId: string | undefined;
+	editSessionId: string | undefined;
+	requestId: string | undefined;
+	modelId: string | undefined;
+	languageId: string | undefined;
+	mode: string | undefined;
+	uniqueEditId: string | undefined;
+	provider: string | undefined;
+	agentSessionId: string | undefined;
+	isSubagentSession: string | undefined;
+
+	didBranchChange: number;
+	timeDelayMs: number;
+	originalCharCount: number;
+	originalLineCount: number;
+	originalDeletedLineCount: number;
+	arc: number;
+	currentLineCount: number;
+	currentDeletedLineCount: number;
+}
+
+export type IEditArcTelemetryClassification = {
+	owner: 'hediet';
+	comment: 'Reports the accepted and retained character count for an inline completion/edit. @sentToGitHub';
+
+	sourceKeyCleaned: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The key of the edit source.' };
+	extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension id (copilot or copilot-chat); which provided this inline completion.' };
+	extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension.' };
+	opportunityId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Unique identifier for an opportunity to show an inline completion or NES.' };
+	editSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session id.' };
+	requestId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The request id.' };
+	modelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The model id.' };
+	languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language id of the document.' };
+	mode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The mode chat was in.' };
+	uniqueEditId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The unique identifier for the edit.' };
+	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The Agent Host provider that produced the edit.' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The Agent Host session identifier.' };
+	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the edit was produced in an Agent Host subagent session.' };
+
+	didBranchChange: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Indicates if the branch changed in the meantime. If the branch changed (value is 1); this event should probably be ignored.' };
+	timeDelayMs: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The time delay between the user accepting the edit and measuring the survival rate.' };
+	originalCharCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The original character count before any edits.' };
+	originalLineCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The original line count before any edits.' };
+	originalDeletedLineCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The original deleted line count before any edits.' };
+	arc: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The accepted and restrained character count.' };
+	currentLineCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The current line count after edits.' };
+	currentDeletedLineCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The current deleted line count after edits.' };
+};

--- a/src/vs/workbench/contrib/editTelemetry/browser/settingIds.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/settingIds.ts
@@ -3,5 +3,5 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export const EDIT_TELEMETRY_SETTING_ID = 'telemetry.editStats.enabled';
+export { EDIT_TELEMETRY_SETTING_ID } from '../../../../platform/telemetry/common/editArcTelemetry.js';
 export const AI_STATS_SETTING_ID = 'editor.aiStats.enabled';

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/arcTelemetrySender.ts
@@ -16,6 +16,7 @@ import { forwardToChannelIf, isCopilotLikeExtension } from '../../../../../platf
 import { ProviderId } from '../../../../../editor/common/languages.js';
 import { ArcTelemetryReporter } from './arcTelemetryReporter.js';
 import { IRandomService } from '../randomService.js';
+import { IEditArcTelemetryClassification, IEditArcTelemetryEvent } from '../../../../../platform/telemetry/common/editArcTelemetry.js';
 
 export class EditTelemetryReportInlineEditArcSender extends Disposable {
 	constructor(
@@ -178,52 +179,7 @@ export class EditTelemetryReportEditArcForChatOrInlineChatSender extends Disposa
 
 			const docWithJustReason = createDocWithJustReason(docWithAnnotatedEdits, this._store);
 			const reporter = this._store.add(this._instantiationService.createInstance(ArcTelemetryReporter, [0, 60, 300].map(s => s * 1000), _prev, docWithJustReason, scmRepoBridge, edit, res => {
-				res.telemetryService.publicLog2<{
-					sourceKeyCleaned: string;
-					extensionId: string | undefined;
-					extensionVersion: string | undefined;
-					opportunityId: string | undefined;
-					editSessionId: string | undefined;
-					requestId: string | undefined;
-					modelId: string | undefined;
-					languageId: string | undefined;
-					mode: string | undefined;
-					uniqueEditId: string | undefined;
-
-					didBranchChange: number;
-					timeDelayMs: number;
-
-					originalCharCount: number;
-					originalLineCount: number;
-					originalDeletedLineCount: number;
-					arc: number;
-					currentLineCount: number;
-					currentDeletedLineCount: number;
-				}, {
-					owner: 'hediet';
-					comment: 'Reports the accepted and retained character count for an inline completion/edit. @sentToGitHub';
-
-					sourceKeyCleaned: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The key of the edit source.' };
-					extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The extension id (copilot or copilot-chat); which provided this inline completion.' };
-					extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension.' };
-					opportunityId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Unique identifier for an opportunity to show an inline completion or NES.' };
-					editSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session id.' };
-					requestId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The request id.' };
-					modelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The model id.' };
-					languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language id of the document.' };
-					mode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The mode chat was in.' };
-					uniqueEditId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The unique identifier for the edit.' };
-
-					didBranchChange: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Indicates if the branch changed in the meantime. If the branch changed (value is 1); this event should probably be ignored.' };
-					timeDelayMs: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The time delay between the user accepting the edit and measuring the survival rate.' };
-
-					originalCharCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The original character count before any edits.' };
-					originalLineCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The original line count before any edits.' };
-					originalDeletedLineCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The original deleted line count before any edits.' };
-					arc: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The accepted and restrained character count.' };
-					currentLineCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The current line count after edits.' };
-					currentDeletedLineCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The current deleted line count after edits.' };
-				}>('editTelemetry.reportEditArc', {
+				res.telemetryService.publicLog2<IEditArcTelemetryEvent, IEditArcTelemetryClassification>('editTelemetry.reportEditArc', {
 					sourceKeyCleaned: data.toKey(Number.MAX_SAFE_INTEGER, {
 						$extensionId: false,
 						$extensionVersion: false,
@@ -242,6 +198,9 @@ export class EditTelemetryReportEditArcForChatOrInlineChatSender extends Disposa
 					languageId: data.props.$$languageId,
 					mode: data.props.$$mode,
 					uniqueEditId,
+					provider: undefined,
+					agentSessionId: undefined,
+					isSubagentSession: undefined,
 
 					didBranchChange: res.didBranchChange ? 1 : 0,
 					timeDelayMs: res.timeDelayMs,

--- a/src/vs/workbench/contrib/editTelemetry/common/arcTracker.ts
+++ b/src/vs/workbench/contrib/editTelemetry/common/arcTracker.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { sumBy } from '../../../../base/common/arrays.js';
-import { LineEdit } from '../../../../editor/common/core/edits/lineEdit.js';
-import { AnnotatedStringEdit, BaseStringEdit, IEditData } from '../../../../editor/common/core/edits/stringEdit.js';
+import { EditArcTracker, IArcTextEdit } from '../../../../base/common/editArcTracker.js';
+import { BaseStringEdit } from '../../../../editor/common/core/edits/stringEdit.js';
 import { AbstractText } from '../../../../editor/common/core/text/abstractText.js';
 
 /**
@@ -13,77 +12,45 @@ import { AbstractText } from '../../../../editor/common/core/text/abstractText.j
  * stay unmodified after a certain amount of time after acceptance.
 */
 export class ArcTracker {
-	private _updatedTrackedEdit: AnnotatedStringEdit<IsTrackedEditData>;
-	private _trackedEdit: BaseStringEdit;
+	private readonly _tracker: EditArcTracker;
 
 	constructor(
-		private readonly _valueBeforeTrackedEdit: AbstractText,
+		valueBeforeTrackedEdit: AbstractText,
 		trackedEdit: BaseStringEdit,
 	) {
-		this._trackedEdit = trackedEdit.removeCommonSuffixPrefix(_valueBeforeTrackedEdit.getValue());
-		this._updatedTrackedEdit = this._trackedEdit.mapData(() => new IsTrackedEditData(true));
+		this._tracker = new EditArcTracker(valueBeforeTrackedEdit.getValue(), toArcTextEdit(trackedEdit));
 	}
 
 	getOriginalCharacterCount(): number {
-		return sumBy(this._trackedEdit.replacements, e => e.getNewLength());
+		return this._tracker.getOriginalCharacterCount();
 	}
 
 	/**
 	 * edit must apply to _updatedTrackedEdit.apply(_valueBeforeTrackedEdit)
 	*/
 	handleEdits(edit: BaseStringEdit): void {
-		const e = edit.mapData(_d => new IsTrackedEditData(false));
-		const composedEdit = this._updatedTrackedEdit.compose(e); // (still) applies to _valueBeforeTrackedEdit
-
-		// TODO@hediet improve memory by using:
-		// composedEdit = const onlyTrackedEdit = composedEdit.decomposeSplit(e => !e.data.isTrackedEdit).e2;
-
-		this._updatedTrackedEdit = composedEdit;
+		this._tracker.handleEdits(toArcTextEdit(edit));
 	}
 
 	getAcceptedRestrainedCharactersCount(): number {
-		const s = sumBy(this._updatedTrackedEdit.replacements, e => e.data.isTrackedEdit ? e.getNewLength() : 0);
-		return s;
-	}
-
-	getDebugState(): unknown {
-		return {
-			edits: this._updatedTrackedEdit.replacements.map(e => ({
-				range: e.replaceRange.toString(),
-				newText: e.newText,
-				isTrackedEdit: e.data.isTrackedEdit,
-			}))
-		};
+		return this._tracker.getAcceptedRestrainedCharactersCount();
 	}
 
 	public getLineCountInfo(): { deletedLineCounts: number; insertedLineCounts: number } {
-		const e = this._updatedTrackedEdit.toStringEdit(r => r.data.isTrackedEdit);
-		const le = LineEdit.fromStringEdit(e, this._valueBeforeTrackedEdit);
-		const deletedLineCount = sumBy(le.replacements, r => r.lineRange.length);
-		const insertedLineCount = sumBy(le.getNewLineRanges(), r => r.length);
-		return {
-			deletedLineCounts: deletedLineCount,
-			insertedLineCounts: insertedLineCount,
-		};
+		return this._tracker.getLineCountInfo();
 	}
 
 	public getValues(): unknown {
-		return {
-			arc: this.getAcceptedRestrainedCharactersCount(),
-			...this.getLineCountInfo(),
-		};
+		return this._tracker.getValues();
 	}
 }
 
-export class IsTrackedEditData implements IEditData<IsTrackedEditData> {
-	constructor(
-		public readonly isTrackedEdit: boolean
-	) { }
-
-	join(data: IsTrackedEditData): IsTrackedEditData | undefined {
-		if (this.isTrackedEdit !== data.isTrackedEdit) {
-			return undefined;
-		}
-		return this;
-	}
+function toArcTextEdit(edit: BaseStringEdit): IArcTextEdit {
+	return {
+		replacements: edit.replacements.map(replacement => ({
+			start: replacement.replaceRange.start,
+			endExclusive: replacement.replaceRange.endExclusive,
+			text: replacement.newText,
+		}))
+	};
 }

--- a/src/vs/workbench/contrib/editTelemetry/test/node/arcTracker.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/node/arcTracker.test.ts
@@ -13,6 +13,7 @@ import { join, resolve } from '../../../../../base/common/path.js';
 import { StringEdit, StringReplacement } from '../../../../../editor/common/core/edits/stringEdit.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { ensureDependenciesAreSet } from '../../../../../editor/common/core/text/positionToOffset.js';
+import { EditArcTracker, IArcTextEdit } from '../../../../../base/common/editArcTracker.js';
 
 suite('ArcTracker', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -123,22 +124,37 @@ function createStringEditFromJson(editData: IEdits['edits'][0]): StringEdit {
 	return new StringEdit(replacements);
 }
 
+function createArcTextEditFromJson(editData: IEdits['edits'][0]): IArcTextEdit {
+	return {
+		replacements: editData.replacements.map(replacement => ({
+			start: replacement.start,
+			endExclusive: replacement.endEx,
+			text: replacement.text,
+		}))
+	};
+}
+
 function runTestWithData(data: IEdits): unknown {
 	const edits = data.edits.map(editData => createStringEditFromJson(editData));
+	const coreEdits = data.edits.map(editData => createArcTextEditFromJson(editData));
 
 	const t = new ArcTracker(
 		new StringText(data.initialText),
 		edits[0]
 	);
+	const coreTracker = new EditArcTracker(data.initialText, coreEdits[0]);
 
 	const stats: unknown[] = [];
 	stats.push(t.getValues());
+	assert.deepStrictEqual(coreTracker.getValues(), t.getValues());
 	let lastLineNumbers = t.getLineCountInfo().insertedLineCounts;
 	let lastArc = t.getAcceptedRestrainedCharactersCount();
 
 	for (let i = 1; i < edits.length; i++) {
 		t.handleEdits(edits[i]);
+		coreTracker.handleEdits(coreEdits[i]);
 		stats.push(t.getValues());
+		assert.deepStrictEqual(coreTracker.getValues(), t.getValues());
 
 		const newLineNumbers = t.getLineCountInfo().insertedLineCounts;
 		assert.ok(newLineNumbers <= lastLineNumbers, `Line numbers must not increase. Last: ${lastLineNumbers}, new: ${newLineNumbers}`);


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-internalbacklog/issues/8425


## Summary

Emit ARC telemetry for Agent Host file edits using the same tracking logic already used for local workbench Chat and Inline Chat edits.

The existing workbench ARC implementation is moved into a shared `EditArcTracker`. The workbench adapter now delegates to it, while Agent Host feeds tool edits and subsequent file changes into the same tracker.

## Local behavior

No intended workbench behavior change:

- ARC calculation is unchanged.
- Sampling remains at 0, 60, and 300 seconds.
- The existing `editTelemetry.reportEditArc` event name and payload remain unchanged.
- Inline completion telemetry (`editTelemetry.reportInlineEditArc`) is unaffected.

## Parity

Local and Agent Host reporting share:

- The same ARC character calculation.
- The same inserted/deleted line calculations.
- The same 0/60/300-second sampling schedule.
- The same branch-change measurement.
- The same Microsoft telemetry contract and event name: `editTelemetry.reportEditArc`.

The input pipelines differ:

- Local tracking observes in-memory editor edits.
- Agent Host tracking reconciles tool edits with subsequent on-disk changes.

Agent Host additionally populates `provider`, `agentSessionId`, and `isSubagentSession`. For Copilot CLI sessions it also emits `vscode.editTelemetry.reportEditArc` to GitHub telemetry.

## Validation

- Existing local ARC fixture expectations remain unchanged.
- Parity tests compare the shared tracker and workbench adapter after each edit.
- Agent Host tests cover reconciliation, file deletion, branch changes, configuration changes, limits, and EOL changes.
- Manual Code OSS testing verified immediate and 60-second Agent Host ARC samples.
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
