### PR TITLE
Fix duplicate symlink decorations in the explorer

### DIFF
--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -26,6 +26,8 @@ import { IHostService } from '../../../services/host/browser/host.js';
 import { IExpression } from '../../../../base/common/glob.js';
 import { ResourceGlobMatcher } from '../../../common/resources.js';
 import { IFilesConfigurationService } from '../../../services/filesConfiguration/common/filesConfigurationService.js';
+import { IDecorationsService } from '../../../services/decorations/common/decorations.js';
+import { ExplorerDecorationsProvider } from './views/explorerDecorationsProvider.js';
 
 export const UNDO_REDO_SOURCE = new UndoRedoSource();
 
@@ -39,6 +41,7 @@ export class ExplorerService implements IExplorerService {
 	private config: IFilesConfiguration['explorer'];
 	private cutItems: ExplorerItem[] | undefined;
 	private view: IExplorerView | undefined;
+	private decorationsProviderRegistered = false;
 	private model: ExplorerModel;
 	private onFileChangesScheduler: RunOnceScheduler;
 	private fileChangeEvents: FileChangesEvent[] = [];
@@ -54,7 +57,8 @@ export class ExplorerService implements IExplorerService {
 		@IBulkEditService private readonly bulkEditService: IBulkEditService,
 		@IProgressService private readonly progressService: IProgressService,
 		@IHostService hostService: IHostService,
-		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService
+		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService,
+		@IDecorationsService private readonly decorationsService: IDecorationsService
 	) {
 		this.config = this.configurationService.getValue('explorer');
 
@@ -156,6 +160,16 @@ export class ExplorerService implements IExplorerService {
 
 	registerView(contextProvider: IExplorerView): void {
 		this.view = contextProvider;
+
+		// The explorer decorations are computed from this (window wide) model and
+		// are therefore shared by all explorer views. Register the provider only
+		// once, otherwise each view contributes its own badge and decorations
+		// render multiple times per resource.
+		if (!this.decorationsProviderRegistered) {
+			this.decorationsProviderRegistered = true;
+			const provider = this.disposables.add(new ExplorerDecorationsProvider(this, this.contextService));
+			this.disposables.add(this.decorationsService.registerDecorationsProvider(provider));
+		}
 	}
 
 	getViewId(): string | undefined {

--- a/src/vs/workbench/contrib/files/browser/views/explorerDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerDecorationsProvider.ts
@@ -44,13 +44,21 @@ export function provideDecorations(fileStat: ExplorerItem): IDecorationData | un
 	return undefined;
 }
 
+/**
+ * Provides the explorer specific file decorations (symbolic link, unknown file
+ * type, excluded, unresolvable root). The decorations are computed from the
+ * explorer model and therefore apply to the whole window: register this provider
+ * only once per window, otherwise every registration contributes its own badge
+ * and decorations render multiple times.
+ */
 export class ExplorerDecorationsProvider implements IDecorationsProvider {
+
 	readonly label: string = localize('label', "Explorer");
 	private readonly _onDidChange = new Emitter<URI[]>();
 	private readonly toDispose = new DisposableStore();
 
 	constructor(
-		@IExplorerService private explorerService: IExplorerService,
+		private readonly explorerService: IExplorerService,
 		@IWorkspaceContextService contextService: IWorkspaceContextService
 	) {
 		this.toDispose.add(this._onDidChange);

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -12,7 +12,6 @@ import { IFilesConfiguration, ExplorerFolderContext, FilesExplorerFocusedContext
 import { FileCopiedContext, NEW_FILE_COMMAND_ID, NEW_FOLDER_COMMAND_ID } from '../fileActions.js';
 import * as DOM from '../../../../../base/browser/dom.js';
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
-import { ExplorerDecorationsProvider } from './explorerDecorationsProvider.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../../platform/workspace/common/workspace.js';
 import { IConfigurationService, IConfigurationChangeEvent } from '../../../../../platform/configuration/common/configuration.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
@@ -21,7 +20,6 @@ import { IProgressService, ProgressLocation } from '../../../../../platform/prog
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IContextKeyService, IContextKey, ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ResourceContextKey } from '../../../../common/contextkeys.js';
-import { IDecorationsService } from '../../../../services/decorations/common/decorations.js';
 import { WorkbenchCompressibleAsyncDataTree } from '../../../../../platform/list/browser/listService.js';
 import { DelayedDragHandler } from '../../../../../base/browser/dnd.js';
 import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from '../../../../services/editor/common/editorService.js';
@@ -183,7 +181,6 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 
 	private dragHandler!: DelayedDragHandler;
 	private _autoReveal: boolean | 'force' | 'focusNoScroll' = false;
-	private decorationsProvider: ExplorerDecorationsProvider | undefined;
 	private readonly delegate: IExplorerViewContainerDelegate | undefined;
 
 	override get singleViewPaneContainerTitle(): string {
@@ -203,7 +200,6 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IConfigurationService configurationService: IConfigurationService,
-		@IDecorationsService private readonly decorationService: IDecorationsService,
 		@ILabelService private readonly labelService: ILabelService,
 		@IThemeService themeService: IWorkbenchThemeService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
@@ -836,10 +832,6 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 		}, _progress => promise);
 
 		await promise;
-		if (!this.decorationsProvider) {
-			this.decorationsProvider = new ExplorerDecorationsProvider(this.explorerService, this.contextService);
-			this._register(this.decorationService.registerDecorationsProvider(this.decorationsProvider));
-		}
 	}
 
 	public async selectResource(resource: URI | undefined, reveal = this._autoReveal, retry = 0): Promise<void> {


### PR DESCRIPTION
Fixes #324389

The symlink `↷` decoration rendered multiple times next to each other on entries in the Files (explorer) view in the Agents window.

### Root cause

`ExplorerDecorationsProvider` was constructed and registered **per `ExplorerView` instance**, in `ExplorerView.setTreeInput`, guarded only by a field on that view.

`DecorationsService` keys its cached data per *provider instance* and merges every provider's letter into a single badge (`letters.join('', '')`). So each extra registration contributed another arrow — matching the issue screenshot showing `↷, ↷, ↷, ↷, ↷`.

In the classic workbench there is only ever one `ExplorerView`, so this never surfaced. In the Agents window the Files view is gated on `SessionHasWorkspaceContext` / `WorkspaceFolderCountContext`, so its view descriptor is removed and re-added as sessions are switched — every additional live `SessionsExplorerView` added another provider, and another arrow.

### Fix

The decorations are derived from the explorer *model*, not from a view, so the provider should be window-scoped rather than view-scoped:

- `ExplorerService.registerView` now registers the decorations provider exactly once (idempotent), owned by the service''s `DisposableStore`, so any number of explorer views share a single registration.
- `ExplorerDecorationsProvider` takes the explorer service as a plain constructor argument (before the service params) instead of via DI, so the service can construct it directly. Added a doc comment recording the single-registration requirement.
- `ExplorerView` no longer creates or registers a provider; the now-unused `IDecorationsService` dependency and field were removed.

The badge now renders exactly once regardless of how many explorer views a window has, and decorations stay correct as views come and go on session switches.

### Validation

- `tsc --project ./src/tsconfig.json --noEmit` — no errors in the touched areas.
- Hygiene passes (pre-commit hook).
