### PR TITLE
Add 1px margin-bottom to workspace picker container

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -45,7 +45,7 @@
 	max-width: 800px;
 	padding: 0;
 	box-sizing: border-box;
-	margin-bottom: 1px;
+	margin-bottom: var(--vscode-spacing-size20);
 }
 
 .new-chat-widget-container.revealed .new-session-workspace-picker-container {

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -45,6 +45,7 @@
 	max-width: 800px;
 	padding: 0;
 	box-sizing: border-box;
+	margin-bottom: 1px;
 }
 
 .new-chat-widget-container.revealed .new-session-workspace-picker-container {


### PR DESCRIPTION
The new-session-workspace-picker-container should have a 1px bottom margin to provide proper spacing between the workspace picker and the chat input.