### PR TITLE
Validate workspace trust for notebook links

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1125,11 +1125,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		const resource = extractedSelection.uri;
 
 		if (!this.fileService.hasProvider(resource) || this.workspaceContextService.isInsideWorkspace(resource)) {
-			await this.openerService.open(uri, {
-				fromUserGesture: true,
-				fromWorkspace: true,
-				editorOptions: selection ? { selection } : undefined
-			});
+			await this.openerService.open(uri, { fromUserGesture: true, fromWorkspace: true });
 			return;
 		}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -32,13 +32,14 @@ import { IContextMenuService } from '../../../../../../platform/contextview/brow
 import { IFileDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { EditorOpenSource, ITextEditorOptions } from '../../../../../../platform/editor/common/editor.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
-import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
+import { extractSelection, IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { editorFindMatch, editorFindMatchHighlight } from '../../../../../../platform/theme/common/colorRegistry.js';
 import { IThemeService, Themable } from '../../../../../../platform/theme/common/themeService.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
+import { EditorInput } from '../../../../../common/editor/editorInput.js';
 import { CellEditState, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IDisplayOutputViewModel, IFocusNotebookCellOptions, IGenericCellViewModel, IInsetRenderOutput, INotebookEditorCreationOptions, INotebookWebviewMessage, RenderOutputType } from '../../notebookBrowser.js';
 import { NOTEBOOK_WEBVIEW_BOUNDARY } from '../notebookCellList.js';
 import { preloadsScriptStr } from './webviewPreloads.js';
@@ -1100,7 +1101,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 				fragment: `L${lineCol[0].slice(1)}`
 			});
 			lineNumber = parseInt(lineCol[1], 10);
-			column = parseInt(lineCol[2], 10);
+			column = lineCol[2] ? parseInt(lineCol[2], 10) : 1;
 		}
 
 		//#region error renderer migration, remove once done
@@ -1119,25 +1120,45 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		});
 		//#endregion
 
-		let targetGroup: IEditorGroup | undefined = undefined;
+		const extractedSelection = extractSelection(uri);
+		const selection = lineNumber !== undefined && column !== undefined ? { startLineNumber: lineNumber, startColumn: column } : extractedSelection.selection;
+		const resource = extractedSelection.uri;
+
+		if (!this.fileService.hasProvider(resource) || this.workspaceContextService.isInsideWorkspace(resource)) {
+			await this.openerService.open(uri, {
+				fromUserGesture: true,
+				fromWorkspace: true,
+				editorOptions: selection ? { selection } : undefined
+			});
+			return;
+		}
+
+		let match: { group: IEditorGroup; editor: EditorInput } | undefined = undefined;
 
 		for (const group of this.editorGroupService.groups) {
-			const editorInput = group.editors.find(editor => editor.resource && isEqual(editor.resource, uri, true));
+			const editorInput = group.editors.find(editor => editor.resource && isEqual(editor.resource, resource, true));
 			if (editorInput) {
-				targetGroup = group;
+				match = { group, editor: editorInput };
 				break;
 			}
 		}
 
-		const selection = lineNumber !== undefined && column !== undefined ? { startLineNumber: lineNumber, startColumn: column } : undefined;
-		const resource = selection ? uri.with({ fragment: null }) : uri;
-		await this.editorService.openEditors([{
-			resource,
-			options: {
-				selection,
-				source: EditorOpenSource.USER
-			}
-		}], targetGroup, { validateTrust: true });
+		const options = {
+			selection,
+			source: EditorOpenSource.USER
+		};
+
+		if (match) {
+			await this.editorService.openEditors([{
+				editor: match.editor,
+				options
+			}], match.group, { validateTrust: true });
+		} else {
+			await this.editorService.openEditors([{
+				resource,
+				options
+			}], undefined, { validateTrust: true });
+		}
 	}
 
 	private _handleHighlightCodeBlock(codeBlocks: ReadonlyArray<ICodeBlockHighlightRequest>) {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -30,7 +30,7 @@ import { IConfigurationService } from '../../../../../../platform/configuration/
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../../../platform/contextview/browser/contextView.js';
 import { IFileDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
-import { ITextEditorOptions, ITextEditorSelection } from '../../../../../../platform/editor/common/editor.js';
+import { EditorOpenSource, ITextEditorOptions } from '../../../../../../platform/editor/common/editor.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
@@ -39,7 +39,6 @@ import { editorFindMatch, editorFindMatchHighlight } from '../../../../../../pla
 import { IThemeService, Themable } from '../../../../../../platform/theme/common/themeService.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
-import { EditorInput } from '../../../../../common/editor/editorInput.js';
 import { CellEditState, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IDisplayOutputViewModel, IFocusNotebookCellOptions, IGenericCellViewModel, IInsetRenderOutput, INotebookEditorCreationOptions, INotebookWebviewMessage, RenderOutputType } from '../../notebookBrowser.js';
 import { NOTEBOOK_WEBVIEW_BOUNDARY } from '../notebookCellList.js';
 import { preloadsScriptStr } from './webviewPreloads.js';
@@ -54,6 +53,7 @@ import { IWebviewElement, IWebviewService, WebviewContentPurpose, WebviewOriginS
 import { WebviewWindowDragMonitor } from '../../../../webview/browser/webviewWindowDragMonitor.js';
 import { asWebviewUri, webviewGenericCspSource } from '../../../../webview/common/webview.js';
 import { IEditorGroup, IEditorGroupsService } from '../../../../../services/editor/common/editorGroupsService.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { IPathService } from '../../../../../services/path/common/pathService.js';
 import { FromWebviewMessage, IAckOutputHeight, IClickedDataUrlMessage, ICodeBlockHighlightRequest, IContentWidgetTopRequest, IControllerPreload, ICreationContent, ICreationRequestMessage, IFindMatch, IMarkupCellInitialization, RendererMetadata, StaticPreloadMetadata, ToWebviewMessage } from './webviewMessages.js';
@@ -178,6 +178,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		@ILanguageService private readonly languageService: ILanguageService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
+		@IEditorService private readonly editorService: IEditorService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IPathService private readonly pathService: IPathService,
 		@INotebookLoggingService private readonly notebookLogService: INotebookLoggingService,
@@ -813,9 +814,9 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 					} else {
 						// uri with scheme
 						if (osPath.isAbsolute(data.href)) {
-							this._openUri(URI.file(data.href));
+							await this._openUri(URI.file(data.href));
 						} else {
-							this._openUri(URI.parse(data.href));
+							await this._openUri(URI.parse(data.href));
 						}
 					}
 					break;
@@ -1085,11 +1086,11 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 			if (fragment) {
 				linkToOpen = linkToOpen.with({ fragment });
 			}
-			this._openUri(linkToOpen);
+			await this._openUri(linkToOpen);
 		}
 	}
 
-	private _openUri(uri: URI) {
+	private async _openUri(uri: URI): Promise<void> {
 		let lineNumber: number | undefined = undefined;
 		let column: number | undefined = undefined;
 		const lineCol = LINE_COLUMN_REGEX.exec(uri.path);
@@ -1118,23 +1119,25 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		});
 		//#endregion
 
-		let match: { group: IEditorGroup; editor: EditorInput } | undefined = undefined;
+		let targetGroup: IEditorGroup | undefined = undefined;
 
 		for (const group of this.editorGroupService.groups) {
 			const editorInput = group.editors.find(editor => editor.resource && isEqual(editor.resource, uri, true));
 			if (editorInput) {
-				match = { group, editor: editorInput };
+				targetGroup = group;
 				break;
 			}
 		}
 
-		if (match) {
-			const selection: ITextEditorSelection | undefined = lineNumber !== undefined && column !== undefined ? { startLineNumber: lineNumber, startColumn: column } : undefined;
-			const textEditorOptions: ITextEditorOptions = { selection: selection };
-			match.group.openEditor(match.editor, selection ? textEditorOptions : undefined);
-		} else {
-			this.openerService.open(uri, { fromUserGesture: true, fromWorkspace: true });
-		}
+		const selection = lineNumber !== undefined && column !== undefined ? { startLineNumber: lineNumber, startColumn: column } : undefined;
+		const resource = selection ? uri.with({ fragment: null }) : uri;
+		await this.editorService.openEditors([{
+			resource,
+			options: {
+				selection,
+				source: EditorOpenSource.USER
+			}
+		}], targetGroup, { validateTrust: true });
 	}
 
 	private _handleHighlightCodeBlock(codeBlocks: ReadonlyArray<ICodeBlockHighlightRequest>) {

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -5,7 +5,7 @@
 
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IResourceEditorInput, IEditorOptions, IResourceEditorInputIdentifier, ITextResourceEditorInput } from '../../../../platform/editor/common/editor.js';
-import { IEditorPane, GroupIdentifier, IUntitledTextResourceEditorInput, IResourceDiffEditorInput, ITextDiffEditorPane, IEditorIdentifier, ISaveOptions, IRevertOptions, EditorsOrder, IVisibleEditorPane, IEditorCloseEvent, IUntypedEditorInput, IFindEditorOptions, IEditorWillOpenEvent, ITextResourceDiffEditorInput } from '../../../common/editor.js';
+import { IEditorPane, GroupIdentifier, IUntitledTextResourceEditorInput, IResourceDiffEditorInput, ITextDiffEditorPane, IEditorIdentifier, ISaveOptions, IRevertOptions, EditorsOrder, IVisibleEditorPane, IEditorCloseEvent, IUntypedEditorInput, IFindEditorOptions, IEditorWillOpenEvent, ITextResourceDiffEditorInput, EditorInputWithOptions } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { Event } from '../../../../base/common/event.js';
 import { IEditor, IDiffEditor } from '../../../../editor/common/editorCommon.js';
@@ -317,6 +317,7 @@ export interface IEditorService {
 	 * @returns the editors that opened. The array can be empty or have less elements for editors
 	 * that failed to open or were instructed to open as inactive.
 	 */
+	openEditors(editors: EditorInputWithOptions[], group?: PreferredGroup, options?: IOpenEditorsOptions): Promise<readonly IEditorPane[]>;
 	openEditors(editors: IUntypedEditorInput[], group?: PreferredGroup, options?: IOpenEditorsOptions): Promise<readonly IEditorPane[]>;
 
 	/**


### PR DESCRIPTION
Route notebook webview resource links through the editor service trust gate while preserving selections and editor group targeting.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
