### PR TITLE
Polish Voice Mode and Dictation onboarding

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -94,6 +94,7 @@ const vscodeResourceIncludes = [
 
 	// Accessibility Signals
 	'out-build/vs/platform/accessibilitySignal/browser/media/*.mp3',
+	'out-build/vs/workbench/contrib/agentsVoice/browser/media/*.mp3',
 
 	// Welcome
 	'out-build/vs/workbench/contrib/welcomeGettingStarted/common/media/**/*.{svg,png}',

--- a/build/gulpfile.vscode.web.ts
+++ b/build/gulpfile.vscode.web.ts
@@ -68,6 +68,7 @@ export const vscodeWebResourceIncludes = [
 
 	// Accessibility Signals
 	'out-build/vs/platform/accessibilitySignal/browser/media/*.mp3',
+	'out-build/vs/workbench/contrib/agentsVoice/browser/media/*.mp3',
 
 	// Welcome
 	'out-build/vs/workbench/contrib/welcomeGettingStarted/common/media/**/*.{svg,png}',

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -284,6 +284,7 @@ const desktopResourcePatterns = [
 
 	// Media - audio
 	'vs/platform/accessibilitySignal/browser/media/*.mp3',
+	'vs/workbench/contrib/agentsVoice/browser/media/*.mp3',
 
 	// Media - images
 	'vs/workbench/contrib/welcomeGettingStarted/common/media/**/*.svg',
@@ -344,6 +345,7 @@ const serverWebResourcePatterns = [
 
 	// Media - audio
 	'vs/platform/accessibilitySignal/browser/media/*.mp3',
+	'vs/workbench/contrib/agentsVoice/browser/media/*.mp3',
 
 	// Media - images
 	'vs/workbench/contrib/welcomeGettingStarted/common/media/**/*.svg',
@@ -371,6 +373,7 @@ const webResourcePatterns = [
 
 	// Media - audio
 	'vs/platform/accessibilitySignal/browser/media/*.mp3',
+	'vs/workbench/contrib/agentsVoice/browser/media/*.mp3',
 
 	// Media - images
 	'vs/workbench/contrib/welcomeGettingStarted/common/media/**/*.svg',

--- a/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
+++ b/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
@@ -69,21 +69,6 @@
 	line-height: 1.4;
 }
 
-.voice-mode-onboarding-listening-notice {
-	display: flex;
-	align-items: flex-start;
-	gap: var(--vscode-spacing-size40);
-	margin-top: var(--vscode-spacing-size40);
-	font-size: var(--vscode-fontSize-label2);
-	line-height: 1.4;
-	color: var(--vscode-descriptionForeground);
-}
-
-.voice-mode-onboarding-listening-notice .codicon {
-	flex-shrink: 0;
-	margin-top: 1px;
-}
-
 /* The settings link sits inside the sentence, so it takes its colour from the
  * link token and nothing else - no weight, no size, no box that would lift it
  * out of the prose it belongs to. */
@@ -187,9 +172,9 @@
 }
 
 .voice-mode-onboarding-voice.selected {
-	background-color: var(--vscode-agentsVoice-speakingBackground);
-	border-color: var(--vscode-agentsVoice-speakingForeground);
-	color: var(--vscode-agentsVoice-speakingForeground);
+	background-color: var(--vscode-list-activeSelectionBackground);
+	border-color: var(--vscode-focusBorder);
+	color: var(--vscode-list-activeSelectionForeground);
 	font-weight: var(--vscode-fontWeight-semiBold);
 }
 

--- a/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
+++ b/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
@@ -118,6 +118,67 @@
 	color: var(--vscode-descriptionForeground);
 }
 
+/* --- Microphone picker --- */
+
+.voice-mode-onboarding-microphone-picker {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: var(--vscode-spacing-size60);
+	box-sizing: border-box;
+	min-width: 0;
+	height: var(--vscode-spacing-size280);
+	padding: 0 var(--vscode-spacing-size80);
+	border: var(--vscode-strokeThickness) solid var(--vscode-dropdown-border, var(--vscode-input-border, transparent));
+	border-radius: var(--vscode-cornerRadius-small);
+	background-color: var(--vscode-dropdown-background, var(--vscode-input-background));
+	transition: border-color 100ms ease-out;
+}
+
+.voice-mode-onboarding-microphone-picker:hover {
+	border-color: var(--vscode-focusBorder);
+}
+
+.voice-mode-onboarding-microphone-picker:focus-within {
+	border-color: var(--vscode-focusBorder);
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: -2px;
+}
+
+.monaco-workbench .voice-mode-onboarding-microphone-icon.codicon[class*='codicon-'] {
+	flex-shrink: 0;
+	font-size: var(--vscode-codiconFontSize-compact);
+	line-height: 1;
+	color: var(--vscode-descriptionForeground);
+}
+
+.voice-mode-onboarding-microphone-picker .monaco-select-box {
+	flex: 1 1 auto;
+	min-width: 0;
+	height: 100%;
+	padding: 0;
+	border: none;
+	border-radius: var(--vscode-cornerRadius-small);
+	background-color: transparent;
+	color: var(--vscode-dropdown-foreground, var(--vscode-foreground));
+	font-family: inherit;
+	font-size: var(--vscode-fontSize-label2);
+	text-overflow: ellipsis;
+}
+
+.voice-mode-onboarding-microphone-picker .monaco-select-box:focus {
+	outline: none;
+}
+
+.voice-mode-onboarding-microphone-label {
+	overflow: hidden;
+	min-width: 0;
+	font-size: var(--vscode-fontSize-label2);
+	color: var(--vscode-dropdown-foreground, var(--vscode-foreground));
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
 /* --- Voices and confirmation --- */
 
 .voice-mode-onboarding-actions {

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -20,7 +20,6 @@ import { createDecorator, IInstantiationService } from '../../../../platform/ins
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { IVoiceSessionController } from '../../chat/browser/voiceClient/voiceSessionController.js';
 import { ChatInputOnboarding, ChatInputOnboardingCard, IChatInputOnboardingContext } from '../../chat/browser/widget/input/chatInputOnboarding.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { AgentsVoiceStorageKeys } from '../common/agentsVoice.js';
@@ -32,14 +31,7 @@ const VOICE_SETTING = 'agents.voice.voice';
 /** Where the first link sends anyone who wants to change their mind later. */
 const VOICE_SETTINGS_COMMAND = 'agentsVoice.openSettings';
 
-/**
- * Where the second link goes: `voice.md`, the customization file sent to the
- * backend as `voice_instructions`. It shapes what the agent *says back*, which
- * is why the link reads "how it responds" rather than naming the file.
- */
-const VOICE_INSTRUCTIONS_COMMAND = 'workbench.action.chat.configureVoiceInstructions';
-
-type VoiceModeOnboardingAction = 'shown' | 'selectVoice' | 'openSettings' | 'openInstructions' | 'close' | 'escape';
+type VoiceModeOnboardingAction = 'shown' | 'selectVoice' | 'openSettings' | 'close' | 'escape';
 
 type VoiceModeOnboardingActionClassification = {
 	action: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The action taken in the Voice Mode onboarding card.' };
@@ -557,7 +549,6 @@ export class VoiceModeOnboardingBanner extends Disposable {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILogService private readonly logService: ILogService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
-		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
 	) {
 		super();
 
@@ -576,20 +567,10 @@ export class VoiceModeOnboardingBanner extends Disposable {
 		this.player = this._register(instantiationService.createInstance(VoiceSamplePlayer, this.domNode));
 		this._register(this.player.onDidChangePlayingVoice(voiceId => this.updatePlaying(voiceId)));
 
-		// Voice Mode is live, but it must not be listening while the user is still
-		// reading and picking a voice. A hold is used rather than `stopListening`
-		// because the card goes up on `isConnecting`, before the session exists:
-		// `stopListening` no-ops until connected, and hands-free would then open
-		// the microphone on `session_init` with the card still on screen.
-		// Released in `finish()`, which is the only way out of the card.
-		this.voiceSessionController.setAutoListenHeld(true);
-		this._register(toDisposable(() => this.voiceSessionController.setAutoListenHeld(false)));
-
 		const copy = dom.append(this.domNode, dom.$('.voice-mode-onboarding-copy'));
 		const title = dom.append(copy, dom.$('.voice-mode-onboarding-title'));
 		title.textContent = localize('voiceMode.onboarding.title', "Welcome to Voice Mode");
 		this.renderDescription(copy);
-		this.renderListeningNotice(copy);
 
 		this.renderSharedWaveform(instantiationService);
 
@@ -683,35 +664,29 @@ export class VoiceModeOnboardingBanner extends Disposable {
 	}
 
 	/**
-	 * One short paragraph: what Voice Mode does, and the two places to change
-	 * your mind - the settings that control it, and the customization file that
-	 * shapes what it says back.
+	 * One short paragraph: what Voice Mode does, and where to change its
+	 * settings.
 	 *
 	 * `[[...]]` marks each clause that becomes a link, so translators can place
-	 * them naturally in the sentence instead of receiving fixed phrases
-	 * concatenated onto the end. `renderFormattedText` numbers them in source
-	 * order and hands the index to the callback.
+	 * it naturally in the sentence instead of receiving a fixed phrase
+	 * concatenated onto the end.
 	 */
 	private renderDescription(container: HTMLElement): void {
 		const description = dom.append(container, dom.$('.voice-mode-onboarding-description'));
 		const text = localize({
 			key: 'voiceMode.onboarding.description',
 			comment: [
-				'Preserve the double square brackets: they mark the two pieces of text that become links.',
-				'The first link opens Voice Mode settings; the second opens a file for customizing how the agent speaks.',
+				'Preserve the double square brackets: they mark the text that becomes a link.',
+				'The link opens Voice Mode settings.',
 			],
-		}, "Your agent can speak back to you, free of charge. Adjust [[settings]] or [[how it responds]] anytime.");
+		}, "Your agent can speak back to you, free of charge. Adjust [[settings]] anytime.");
 
-		const commands = [VOICE_SETTINGS_COMMAND, VOICE_INSTRUCTIONS_COMMAND];
 		dom.append(description, renderFormattedText(text, {
 			actionHandler: {
-				callback: index => {
-					const command = commands[Number(index)];
-					if (command) {
-						this.logAction(index === '0' ? 'openSettings' : 'openInstructions');
-						this.commandService.executeCommand(command)
-							.catch(error => this.logService.error(`[voice] Failed to run ${command}: ${error}`));
-					}
+				callback: () => {
+					this.logAction('openSettings');
+					this.commandService.executeCommand(VOICE_SETTINGS_COMMAND)
+						.catch(error => this.logService.error(`[voice] Failed to run ${VOICE_SETTINGS_COMMAND}: ${error}`));
 				},
 				disposables: this._store,
 			},
@@ -735,14 +710,6 @@ export class VoiceModeOnboardingBanner extends Disposable {
 		}
 	}
 
-	private renderListeningNotice(container: HTMLElement): void {
-		const notice = dom.append(container, dom.$('.voice-mode-onboarding-listening-notice'));
-		const icon = dom.append(notice, dom.$(`span.codicon.codicon-${Codicon.mic.id}`));
-		icon.setAttribute('aria-hidden', 'true');
-		const text = dom.append(notice, dom.$('span'));
-		text.textContent = localize('voiceMode.onboarding.closeWhenReady', "Close this when you're ready to speak.");
-	}
-
 	/**
 	 * Dismissal is always available and never gated: a disabled close would trap
 	 * someone in the card. Choosing a voice already commits it, so this is only
@@ -751,8 +718,8 @@ export class VoiceModeOnboardingBanner extends Disposable {
 	private renderClose(): void {
 		this.card.addAction({
 			className: 'voice-mode-onboarding-close',
-			ariaLabel: localize('voiceMode.onboarding.close', "Close the introduction and continue to Voice Mode"),
-			icon: Codicon.checkCompact,
+			ariaLabel: localize('voiceMode.onboarding.close', "Close the introduction"),
+			icon: Codicon.close,
 			onActivate: () => this.finish(),
 		});
 	}
@@ -803,22 +770,9 @@ export class VoiceModeOnboardingBanner extends Disposable {
 		this.domNode.classList.toggle('playing', playingVoice !== undefined);
 	}
 
-	/**
-	 * Close the introduction and hand the session back to the user. Voice Mode
-	 * stays connected either way; hands-free starts listening immediately, while
-	 * push-to-talk waits for the mic button so nobody is recorded unexpectedly.
-	 */
 	private finish(): void {
 		this.player.stop();
 		this.logAction('close');
-
-		// Releasing the hold is what hands the session back: hands-free picks up
-		// and starts listening, push-to-talk stays quiet until the mic button.
-		// The release itself runs on dispose, below.
-		status(this.configurationService.getValue<boolean>('agents.voice.handsFree') === true
-			? localize('voiceMode.onboarding.listening', "Voice Mode is listening.")
-			: localize('voiceMode.onboarding.ready', "Voice Mode is ready. Press the mic button to start talking."));
-
 		this.options.onDismiss();
 	}
 

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -719,7 +719,7 @@ export class VoiceModeOnboardingBanner extends Disposable {
 		this.card.addAction({
 			className: 'voice-mode-onboarding-close',
 			ariaLabel: localize('voiceMode.onboarding.close', "Close the introduction"),
-			icon: Codicon.close,
+			icon: Codicon.closeCompact,
 			onActivate: () => this.finish(),
 		});
 	}

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -6,6 +6,7 @@
 import * as dom from '../../../../base/browser/dom.js';
 import { renderFormattedText } from '../../../../base/browser/formattedTextRenderer.js';
 import { status } from '../../../../base/browser/ui/aria/aria.js';
+import { SelectBox } from '../../../../base/browser/ui/selectBox/selectBox.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter } from '../../../../base/common/event.js';
@@ -19,10 +20,14 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { createDecorator, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ChatInputOnboarding, ChatInputOnboardingCard, IChatInputOnboardingContext } from '../../chat/browser/widget/input/chatInputOnboarding.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { defaultSelectBoxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { AgentsVoiceStorageKeys } from '../common/agentsVoice.js';
+import { buildMicrophoneOptions, IMicrophoneOption, indexOfMicrophone } from '../../chat/browser/speechToText/dictationOnboarding.js';
 import './media/voiceModeOnboarding.css';
 
 /** Setting the banner writes when a voice chip is picked. */
@@ -31,7 +36,7 @@ const VOICE_SETTING = 'agents.voice.voice';
 /** Where the first link sends anyone who wants to change their mind later. */
 const VOICE_SETTINGS_COMMAND = 'agentsVoice.openSettings';
 
-type VoiceModeOnboardingAction = 'shown' | 'selectVoice' | 'openSettings' | 'close' | 'escape';
+type VoiceModeOnboardingAction = 'shown' | 'selectVoice' | 'selectMicrophone' | 'openSettings' | 'close' | 'escape';
 
 type VoiceModeOnboardingActionClassification = {
 	action: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The action taken in the Voice Mode onboarding card.' };
@@ -158,8 +163,8 @@ const WAVE_TEMPO = (2 * Math.PI) / IDLE_CYCLE_SECONDS / Math.abs(RESTING_SIGNATU
 
 /** Amplitude with nothing playing: present, but clearly at rest. */
 const IDLE_GAIN = 0.55;
-/** Extra amplitude at peak loudness while a voice sample plays. */
-const SPEAKING_GAIN = 0.45;
+/** A restrained lift while a sample plays; the voice chips already carry the stronger activity cue. */
+const SPEAKING_GAIN = 0.18;
 /** How quickly the band chases the audio. Low and slow reads as smooth. */
 const LEVEL_EASING = 0.08;
 /** How quickly the trace morphs from one voice's signature to another. */
@@ -535,6 +540,9 @@ export class VoiceModeOnboardingBanner extends Disposable {
 	private readonly card: ChatInputOnboardingCard;
 	private readonly player: VoiceSamplePlayer;
 	private readonly options: IVoiceModeOnboardingBannerOptions;
+	private readonly microphonePicker = this._register(new MutableDisposable<DisposableStore>());
+	private microphoneOptions: IMicrophoneOption[] = [];
+	private microphonePickerContainer: HTMLElement | undefined;
 
 	private readonly voiceElements = new Map<string, HTMLElement>();
 
@@ -545,9 +553,11 @@ export class VoiceModeOnboardingBanner extends Disposable {
 		options: IVoiceModeOnboardingBannerOptions,
 		@ICommandService private readonly commandService: ICommandService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILogService private readonly logService: ILogService,
+		@IStorageService private readonly storageService: IStorageService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
@@ -573,6 +583,7 @@ export class VoiceModeOnboardingBanner extends Disposable {
 		this.renderDescription(copy);
 
 		this.renderSharedWaveform(instantiationService);
+		this.renderMicrophonePicker();
 
 		const actions = dom.append(this.domNode, dom.$('.voice-mode-onboarding-actions'));
 		this.renderVoices(actions);
@@ -600,6 +611,95 @@ export class VoiceModeOnboardingBanner extends Disposable {
 			getLevel: () => this.player.getLevel(),
 			getSignature: () => this.currentSignature(),
 		}));
+	}
+
+	private renderMicrophonePicker(): void {
+		this.microphonePickerContainer = dom.append(this.domNode, dom.$('.voice-mode-onboarding-microphone-picker'));
+		this.microphoneOptions = [{
+			deviceId: '',
+			label: localize('voiceMode.onboarding.systemDefault', "System default"),
+		}];
+		this.updateMicrophonePicker();
+
+		const mediaDevices = dom.getWindow(this.domNode).navigator.mediaDevices;
+		if (mediaDevices) {
+			this._register(dom.addDisposableListener(mediaDevices, 'devicechange', () => void this.refreshMicrophones()));
+			void this.refreshMicrophones();
+		}
+	}
+
+	private async refreshMicrophones(): Promise<void> {
+		const mediaDevices = dom.getWindow(this.domNode).navigator.mediaDevices;
+		if (!mediaDevices?.enumerateDevices) {
+			return;
+		}
+
+		let devices: MediaDeviceInfo[];
+		try {
+			devices = await mediaDevices.enumerateDevices();
+		} catch (error) {
+			this.logService.trace(`[voice] could not enumerate microphones: ${error}`);
+			return;
+		}
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		const options = buildMicrophoneOptions(devices);
+		if (this.microphoneOptions.length > 1 && !options.some(option => option.deviceId && option.label)) {
+			return;
+		}
+		this.microphoneOptions = options;
+		this.updateMicrophonePicker();
+	}
+
+	private updateMicrophonePicker(): void {
+		if (!this.microphonePickerContainer) {
+			return;
+		}
+		this.microphonePicker.clear();
+		dom.clearNode(this.microphonePickerContainer);
+
+		dom.append(this.microphonePickerContainer, dom.$(`span.codicon.codicon-${Codicon.mic.id}.voice-mode-onboarding-microphone-icon`))
+			.setAttribute('aria-hidden', 'true');
+
+		const selected = indexOfMicrophone(this.microphoneOptions, this.currentMicrophoneId());
+		if (this.microphoneOptions.length <= 1) {
+			const label = dom.append(this.microphonePickerContainer, dom.$('.voice-mode-onboarding-microphone-label'));
+			label.textContent = this.microphoneOptions[selected]?.label ?? localize('voiceMode.onboarding.noMicrophone', "No microphone found");
+			label.title = label.textContent;
+			return;
+		}
+
+		const store = new DisposableStore();
+		const selectBox = store.add(new SelectBox(
+			this.microphoneOptions.map(option => ({ text: option.label })),
+			selected,
+			this.contextViewService,
+			{ ...defaultSelectBoxStyles, selectBackground: undefined, selectBorder: undefined, selectForeground: undefined },
+			{ ariaLabel: localize('voiceMode.onboarding.microphone', "Microphone"), useCustomDrawn: true },
+		));
+		selectBox.render(this.microphonePickerContainer);
+		store.add(selectBox.onDidSelect(event => this.selectMicrophone(event.index)));
+		this.microphonePicker.value = store;
+	}
+
+	private currentMicrophoneId(): string {
+		return this.storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION, '');
+	}
+
+	private selectMicrophone(index: number): void {
+		const option = this.microphoneOptions[index];
+		if (!option) {
+			return;
+		}
+		this.logAction('selectMicrophone');
+		if (option.deviceId) {
+			this.storageService.store(AgentsVoiceStorageKeys.MicrophoneDevice, option.deviceId, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		} else {
+			this.storageService.remove(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION);
+		}
+		status(localize('voiceMode.onboarding.microphoneSelected', "{0} selected.", option.label));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
+++ b/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
@@ -164,14 +164,14 @@ suite('Voice Mode onboarding', () => {
 				card,
 				tabIndex: card?.tabIndex,
 				closeIcon: host.container.querySelector('.voice-mode-onboarding-close .codicon')?.className,
-				listeningNotice: host.container.querySelector('.voice-mode-onboarding-listening-notice')?.textContent,
+				listeningNotice: host.container.querySelector('.voice-mode-onboarding-listening-notice'),
 			},
 			{
 				activeElement: card,
 				card,
 				tabIndex: -1,
-				closeIcon: 'codicon codicon-check-compact',
-				listeningNotice: 'Close this when you\'re ready to speak.',
+				closeIcon: 'codicon codicon-close',
+				listeningNotice: null,
 			});
 	});
 
@@ -207,7 +207,7 @@ suite('Voice Mode onboarding', () => {
 		assert.strictEqual(host.container.classList.contains('has-voice-mode-onboarding'), true);
 	});
 
-	test('each link in the sentence routes to its own command', () => {
+	test('the settings link opens Voice Mode settings', () => {
 		const executed: string[] = [];
 		const service = createService(disposables, executed);
 		const host = createHost(disposables);
@@ -219,37 +219,24 @@ suite('Voice Mode onboarding', () => {
 			link.click();
 		}
 
-		// Order matters: `renderFormattedText` numbers the `[[...]]` segments in
-		// source order, and the callback dispatches on that index.
 		assert.deepStrictEqual(
 			{ labels: links.map(link => link.textContent), executed },
 			{
-				labels: ['settings', 'how it responds'],
-				executed: ['agentsVoice.openSettings', 'workbench.action.chat.configureVoiceInstructions'],
+				labels: ['settings'],
+				executed: ['agentsVoice.openSettings'],
 			});
 	});
 
-	test('holds the microphone shut for as long as the card is up', () => {
+	test('does not block Voice Mode from listening while the card is up', () => {
 		const holds: boolean[] = [];
 		const service = createService(disposables, [], holds);
 		const host = createHost(disposables);
 		disposables.add(register(service, host));
 
-		// The card goes up while the session is still connecting, so a plain
-		// `stopListening()` would no-op and hands-free would open the microphone
-		// on `session_init` with the card still on screen.
 		service.showIfNeeded();
-		const heldWhileOpen = holds.slice();
-		const listeningNotice = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-listening-notice')?.textContent;
 		host.container.querySelector<HTMLElement>('.voice-mode-onboarding-close')!.click();
 
-		assert.deepStrictEqual(
-			{ heldWhileOpen, listeningNotice, afterDismiss: holds },
-			{
-				heldWhileOpen: [true],
-				listeningNotice: 'Close this when you\'re ready to speak.',
-				afterDismiss: [true, false],
-			});
+		assert.deepStrictEqual(holds, []);
 	});
 
 	test('the one appearance is only spent once the card is really up', () => {

--- a/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
+++ b/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
@@ -170,7 +170,7 @@ suite('Voice Mode onboarding', () => {
 				activeElement: card,
 				card,
 				tabIndex: -1,
-				closeIcon: 'codicon codicon-close',
+				closeIcon: 'codicon codicon-close-compact',
 				listeningNotice: null,
 			});
 	});

--- a/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
+++ b/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
@@ -93,6 +93,7 @@ suite('Voice Mode onboarding', () => {
 		// rather than arriving with an answer already filled in.
 		const selectedOnOpen = host.container.querySelectorAll('.voice-mode-onboarding-voice.selected').length;
 		const voices = [...host.container.querySelectorAll<HTMLElement>('.voice-mode-onboarding-voice-label')].map(element => element.textContent);
+		const hasMicrophonePicker = host.container.querySelector('.voice-mode-onboarding-microphone-picker') !== null;
 		host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voice')!.click();
 		const selectedAfterPick = host.container.querySelectorAll('.voice-mode-onboarding-voice.selected').length;
 
@@ -103,9 +104,19 @@ suite('Voice Mode onboarding', () => {
 		const shownAgain = host.container.classList.contains('has-voice-mode-onboarding');
 
 		assert.deepStrictEqual(
-			{ shown, selectedOnOpen, voices, selectedAfterPick, shownAfterClose, shownAgain, telemetryEvents },
+			{
+				shown,
+				hasMicrophonePicker,
+				selectedOnOpen,
+				voices,
+				selectedAfterPick,
+				shownAfterClose,
+				shownAgain,
+				telemetryEvents,
+			},
 			{
 				shown: true,
+				hasMicrophonePicker: true,
 				selectedOnOpen: 0,
 				voices: ['Maya', 'Victoria', 'Kevin', 'Daniel'],
 				selectedAfterPick: 1,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -27,7 +27,7 @@ import { CHAT_CATEGORY } from './chatActions.js';
 import { IChatExecuteActionContext } from './chatExecuteActions.js';
 import { IChatWidgetService } from '../chat.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from '../speechToText/chatSpeechToTextService.js';
-import { IDictationOnboardingService } from '../speechToText/dictationOnboarding.js';
+import { IDictationOnboardingService, RESET_DICTATION_ONBOARDING_COMMAND, SHOW_DICTATION_ONBOARDING_COMMAND } from '../speechToText/dictationOnboarding.js';
 import { cancelDictation, isDictating, startDictation, stopDictation } from '../speechToText/dictationSession.js';
 
 // Gate on `ChatContextKeys.enabled` so the dictation UI and its commands are
@@ -47,10 +47,9 @@ export interface IDictationShortcutContext {
 	readonly keybindingService: IKeybindingService;
 	readonly logService: ILogService;
 	/**
-	 * Supplied by chat inputs only. The first dictation started from one is
-	 * handed to the introduction card so the microphone can be chosen and
-	 * checked before anything is transcribed; editor and terminal dictation have
-	 * nowhere to dock the card and dictate straight away.
+	 * Supplied by chat inputs only. The first dictation started from one shows
+	 * its introduction alongside recording; editor and terminal dictation have
+	 * nowhere to dock the card.
 	 */
 	readonly onboardingService?: IDictationOnboardingService;
 }
@@ -89,13 +88,8 @@ export async function runDictationShortcut(context: IDictationShortcutContext, c
 
 	const window = getWindow(editor.getDomNode()) ?? getActiveWindow();
 
-	// First run: let the introduction card take this dictation over so the user
-	// can confirm the microphone is the right one and is actually being heard.
-	// Nothing is recorded until they confirm the card, which is what starts the
-	// dictation this press asked for.
-	if (context.onboardingService?.showIfNeeded(() => void startDictation(speechService, editor, window, logService))) {
-		return;
-	}
+	// The first-run card is informational and must not delay recording.
+	context.onboardingService?.showIfNeeded();
 
 	// Attempt to detect a held keybinding. Returns `undefined` when not invoked
 	// through a held key (e.g. the toolbar mic or the command palette), which
@@ -353,7 +347,7 @@ class SelectSpeechToTextMicrophoneAction extends Action2 {
 }
 
 class ShowChatSpeechToTextIntroductionAction extends Action2 {
-	static readonly ID = 'workbench.action.chat.showSpeechToTextIntroduction';
+	static readonly ID = SHOW_DICTATION_ONBOARDING_COMMAND;
 
 	constructor() {
 		super({
@@ -374,6 +368,22 @@ class ShowChatSpeechToTextIntroductionAction extends Action2 {
 		// The card docks to a chat input, so there is nothing to show it in when
 		// no chat is open. Say so rather than appearing to do nothing.
 		accessor.get(INotificationService).info(localize('chatStt.introductionNeedsChat', "Open a chat to see the dictation introduction."));
+	}
+}
+
+class ResetChatSpeechToTextIntroductionAction extends Action2 {
+	constructor() {
+		super({
+			id: RESET_DICTATION_ONBOARDING_COMMAND,
+			title: localize2('chat.speechToText.resetIntroduction', "Dictate: Reset Onboarding"),
+			category: CHAT_CATEGORY,
+			f1: true,
+			precondition: ChatSpeechToTextConfigured,
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		accessor.get(IDictationOnboardingService).reset();
 	}
 }
 
@@ -415,6 +425,7 @@ export function registerChatSpeechToTextActions(): DisposableStore {
 	store.add(registerAction2(HoldToSpeechToTextAction));
 	store.add(registerAction2(CancelChatSpeechToTextAction));
 	store.add(registerAction2(ShowChatSpeechToTextIntroductionAction));
+	store.add(registerAction2(ResetChatSpeechToTextIntroductionAction));
 	store.add(registerAction2(SelectSpeechToTextMicrophoneAction));
 	return store;
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -27,7 +27,7 @@ import { CHAT_CATEGORY } from './chatActions.js';
 import { IChatExecuteActionContext } from './chatExecuteActions.js';
 import { IChatWidgetService } from '../chat.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from '../speechToText/chatSpeechToTextService.js';
-import { IDictationOnboardingService, RESET_DICTATION_ONBOARDING_COMMAND, SHOW_DICTATION_ONBOARDING_COMMAND } from '../speechToText/dictationOnboarding.js';
+import { buildMicrophoneOptions, IDictationOnboardingService, RESET_DICTATION_ONBOARDING_COMMAND, SHOW_DICTATION_ONBOARDING_COMMAND } from '../speechToText/dictationOnboarding.js';
 import { cancelDictation, isDictating, startDictation, stopDictation } from '../speechToText/dictationSession.js';
 
 // Gate on `ChatContextKeys.enabled` so the dictation UI and its commands are
@@ -299,21 +299,7 @@ class SelectSpeechToTextMicrophoneAction extends Action2 {
 
 		const devices = await navigator.mediaDevices.enumerateDevices();
 
-		// Filter out the virtual "default"/"communications" entries (which duplicate a real
-		// device) and de-duplicate by deviceId so a single microphone shows up only once.
-		const seenDeviceIds = new Set<string>();
-		const audioInputs = devices.filter(d => {
-			if (d.kind !== 'audioinput' || d.deviceId === 'default' || d.deviceId === 'communications') {
-				return false;
-			}
-			if (seenDeviceIds.has(d.deviceId)) {
-				return false;
-			}
-			seenDeviceIds.add(d.deviceId);
-			return true;
-		});
-
-		if (audioInputs.length === 0) {
+		if (!devices.some(device => device.kind === 'audioinput')) {
 			quickInputService.pick([{ label: localize('chatStt.noMicrophones', "No microphones found") }]);
 			return;
 		}
@@ -322,19 +308,11 @@ class SelectSpeechToTextMicrophoneAction extends Action2 {
 		const currentDeviceId = storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION, '');
 
 		type DevicePickItem = { label: string; description?: string; deviceId: string };
-		const items: DevicePickItem[] = [{
-			label: localize('chatStt.systemDefault', "System Default"),
-			description: currentDeviceId === '' ? localize('chatStt.current', "(current)") : undefined,
-			deviceId: '',
-		}];
-		for (const d of audioInputs) {
-			const label = d.label || localize('chatStt.unknownDevice', "Unknown Device ({0})", d.deviceId.slice(0, 8));
-			items.push({
-				label,
-				description: d.deviceId === currentDeviceId ? localize('chatStt.current', "(current)") : undefined,
-				deviceId: d.deviceId,
-			});
-		}
+		const items: DevicePickItem[] = buildMicrophoneOptions(devices).map(device => ({
+			label: device.label,
+			description: device.deviceId === currentDeviceId ? localize('chatStt.current', "(current)") : undefined,
+			deviceId: device.deviceId,
+		}));
 
 		const picked = await quickInputService.pick(items, {
 			placeHolder: localize('chatStt.selectMic', "Select a microphone for dictation"),

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -72,7 +72,12 @@ export function getDictationShortcutOperation(dictating: boolean, state: ChatSpe
  * returns `undefined` when not invoked through a held key (e.g. the toolbar mic
  * or the command palette), collapsing the behavior to a plain toggle.
  */
-export async function runDictationShortcut(context: IDictationShortcutContext, commandId: string, editor: ICodeEditor): Promise<void> {
+export async function runDictationShortcut(
+	context: IDictationShortcutContext,
+	commandId: string,
+	editor: ICodeEditor,
+	startDictationFn: typeof startDictation = startDictation,
+): Promise<void> {
 	const { speechService, keybindingService, logService } = context;
 
 	switch (getDictationShortcutOperation(isDictating(), speechService.state, speechService.isPreparingModel)) {
@@ -95,7 +100,7 @@ export async function runDictationShortcut(context: IDictationShortcutContext, c
 	// through a held key (e.g. the toolbar mic or the command palette), which
 	// collapses the behavior to a plain toggle.
 	const holdMode = keybindingService.enableKeybindingHoldMode(commandId);
-	await startDictation(speechService, editor, window, logService);
+	await startDictationFn(speechService, editor, window, logService);
 	if (!holdMode) {
 		return;
 	}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -475,10 +475,12 @@ export function buildMicrophoneOptions(devices: readonly MediaDeviceInfo[]): IMi
 
 	const defaultDevice = devices.find(device => device.kind === 'audioinput' && device.deviceId === 'default');
 	const defaultLabel = defaultDevice?.label.replace(/^(?:default|system default)\s*-\s*/i, '').trim();
-	const defaultMicrophone = defaultDevice && microphones.find(device =>
-		(defaultDevice.groupId && device.groupId === defaultDevice.groupId)
-		|| (defaultLabel && device.label === defaultLabel)
-	);
+	const defaultMicrophone = defaultDevice
+		? microphones.find(device =>
+			(defaultDevice.groupId && device.groupId === defaultDevice.groupId)
+			|| (defaultLabel && device.label === defaultLabel)
+		) ?? microphones[0]
+		: undefined;
 
 	const options: IMicrophoneOption[] = [];
 	if (defaultDevice) {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -8,7 +8,6 @@ import { renderFormattedText } from '../../../../../base/browser/formattedTextRe
 import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import { status } from '../../../../../base/browser/ui/aria/aria.js';
 import { SelectBox } from '../../../../../base/browser/ui/selectBox/selectBox.js';
-import { disposableTimeout } from '../../../../../base/common/async.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
@@ -35,6 +34,9 @@ import './media/dictationOnboarding.css';
  */
 const DICTATION_INTRO_SHOWN_KEY = 'chat.dictation.introShown';
 
+export const SHOW_DICTATION_ONBOARDING_COMMAND = 'workbench.action.chat.showSpeechToTextIntroduction';
+export const RESET_DICTATION_ONBOARDING_COMMAND = 'workbench.action.chat.resetSpeechToTextIntroduction';
+
 /** Opens the settings editor, filtered by the query below. */
 const OPEN_SETTINGS_COMMAND = 'workbench.action.openSettings';
 
@@ -44,7 +46,7 @@ const DICTATION_SETTINGS_QUERY = 'dictation';
 /** The `deviceId` value that means "whatever the system is using". */
 const SYSTEM_DEFAULT_DEVICE_ID = '';
 
-type DictationOnboardingAction = 'shown' | 'selectMicrophone' | 'openSettings' | 'openInstructions' | 'startDictation' | 'cancel';
+type DictationOnboardingAction = 'shown' | 'selectMicrophone' | 'openSettings' | 'openInstructions' | 'close' | 'escape';
 
 type DictationOnboardingActionClassification = {
 	action: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The action taken in the Dictation onboarding card.' };
@@ -164,8 +166,8 @@ const enum MicrophonePreviewError {
  * Listens to a microphone purely so its loudness can be shown. Owns the media
  * stream, the audio graph and nothing else; releasing it frees the microphone.
  *
- * This is deliberately independent of the dictation pipeline: the whole point of
- * the card is to prove the chosen device works *before* anything is recorded.
+ * This is deliberately independent of the dictation pipeline so the card can
+ * remain informational while recording starts immediately.
  */
 class MicrophonePreview extends Disposable {
 
@@ -487,22 +489,12 @@ export function indexOfMicrophone(options: readonly IMicrophoneOption[], deviceI
 
 // --- Banner --------------------------------------------------------------
 
-/**
- * How long the card waits before dictation takes over.
- *
- * Load-bearing rather than cosmetic: the preview microphone is released at the
- * start of it, and the audio service needs a moment to actually hand the device
- * over before dictation asks for it.
- */
-const HANDOFF_DELAY_MS = 300;
-
 export interface IDictationOnboardingBannerOptions {
 	/** The element the card attaches itself to. */
 	readonly container: HTMLElement;
-	/** Dismiss the card without dictating (Escape). */
-	readonly onCancel: () => void;
-	/** Dismiss the card and start the dictation it deferred. */
-	readonly onStartDictation: () => void;
+	readonly onDismiss: () => void;
+	/** Whether this manually opened card should acquire a microphone preview. */
+	readonly previewMicrophone: boolean;
 	readonly source: 'automatic' | 'manual';
 }
 
@@ -510,10 +502,8 @@ export interface IDictationOnboardingBannerOptions {
  * The first-run dictation card: which microphone dictation will use, live proof
  * that it is working, and one line on what dictation is.
  *
- * The card takes over the very first dictation rather than running alongside it,
- * because "is my microphone even connected" cannot be answered while words are
- * already being transcribed. Nothing is recorded while it is up: talking here
- * only moves the waveform, and dictation starts when the user says it should.
+ * The card runs alongside the first dictation, so it explains the feature
+ * without delaying the action the user invoked.
  */
 export class DictationOnboardingBanner extends Disposable {
 
@@ -526,9 +516,7 @@ export class DictationOnboardingBanner extends Disposable {
 	private readonly pickerContainer: HTMLElement;
 
 	private readonly picker = this._register(new MutableDisposable<DisposableStore>());
-	private readonly handoff = this._register(new MutableDisposable<IDisposable>());
 	private options: IMicrophoneOption[] = [];
-	private finished = false;
 
 	constructor(
 		private readonly bannerOptions: IDictationOnboardingBannerOptions,
@@ -545,11 +533,10 @@ export class DictationOnboardingBanner extends Disposable {
 			container: bannerOptions.container,
 			className: 'dictation-onboarding-banner',
 			ariaLabel: localize('dictation.onboarding.region', "Dictation introduction"),
-			// Sighted users get this from the waveform moving as they talk. A
-			// screen-reader user has no waveform to watch, so the card has to say
-			// what it is for and how to leave it.
-			ariaDescription: localize('dictation.onboarding.regionDescription', "Say anything to check your microphone, then start dictating."),
-			onEscape: () => this.cancel(),
+			ariaDescription: bannerOptions.previewMicrophone
+				? localize('dictation.onboarding.regionDescription.preview', "Say anything to check your microphone.")
+				: localize('dictation.onboarding.regionDescription.listening', "Dictation is listening."),
+			onEscape: () => this.dismiss('escape'),
 		}));
 		this.domNode = this.card.domNode;
 
@@ -596,7 +583,11 @@ export class DictationOnboardingBanner extends Disposable {
 		}
 
 		this.waveform.start();
-		void this.startPreview();
+		if (this.bannerOptions.previewMicrophone) {
+			void this.startPreview();
+		} else {
+			void this.refreshDevices();
+		}
 		this.logAction('shown');
 	}
 
@@ -751,7 +742,9 @@ export class DictationOnboardingBanner extends Disposable {
 		}
 
 		status(localize('dictation.onboarding.microphoneSelected', "{0} selected.", option.label));
-		void this.preview.listen(option.deviceId).then(() => this.updateHint());
+		if (this.bannerOptions.previewMicrophone) {
+			void this.preview.listen(option.deviceId).then(() => this.updateHint());
+		}
 	}
 
 	/**
@@ -760,68 +753,25 @@ export class DictationOnboardingBanner extends Disposable {
 	 * one the card can do without.
 	 */
 	private updateHint(): void {
-		if (this.finished) {
-			return;
-		}
 		const error = this.preview.error;
 		this.domNode.classList.toggle('has-error', error !== undefined);
 		this.hint.textContent = error === undefined ? '' : hintForError(error);
 	}
 
-	/**
-	 * The one control that starts dictation. A check rather than a cross:
-	 * leaving this card is a confirmation that the microphone is right, not an
-	 * abandonment.
-	 *
-	 * Pinned to the corner and out of the content flow, so it never competes
-	 * with the picker for room and never moves as the card re-flows.
-	 */
 	private renderClose(): void {
 		this.card.addAction({
 			className: 'dictation-onboarding-close',
-			ariaLabel: localize('dictation.onboarding.close', "Start Dictating"),
-			icon: Codicon.check,
-			onActivate: () => this.finish(),
+			ariaLabel: localize('dictation.onboarding.close', "Close the introduction"),
+			icon: Codicon.close,
+			onActivate: () => this.dismiss('close'),
 		});
 	}
 
-	/**
-	 * Hand the session over to real dictation, at the user's word rather than on
-	 * a guess about what they meant by talking.
-	 *
-	 * The preview microphone is released first and the hand-off is deferred by a
-	 * beat: dictation would otherwise be asking the audio service for a device
-	 * the card has not finished giving back.
-	 */
-	private finish(): void {
-		if (this.finished) {
-			return;
-		}
-		this.finished = true;
-		this.logAction('startDictation');
+	private dismiss(action: 'close' | 'escape'): void {
+		this.logAction(action);
 		this.waveform.stop();
 		this.preview.releaseMicrophone();
-
-		this.domNode.classList.remove('has-error');
-		this.domNode.classList.add('handing-off');
-		// Announced rather than shown: the card is on its way out, so a line of
-		// text nobody has time to read would only be noise. A screen reader has
-		// no waveform to watch and does need telling.
-		status(localize('dictation.onboarding.starting', "Starting dictation…"));
-
-		this.handoff.value = disposableTimeout(() => this.bannerOptions.onStartDictation(), HANDOFF_DELAY_MS);
-	}
-
-	/** Escape means "I did not want to dictate after all". */
-	private cancel(): void {
-		if (this.finished) {
-			return;
-		}
-		this.finished = true;
-		this.logAction('cancel');
-		this.waveform.stop();
-		this.preview.releaseMicrophone();
-		this.bannerOptions.onCancel();
+		this.bannerOptions.onDismiss();
 	}
 
 	private logAction(action: DictationOnboardingAction): void {
@@ -861,20 +811,20 @@ export interface IDictationOnboardingService {
 	registerHost(container: HTMLElement, focusRoot: HTMLElement): IDisposable;
 
 	/**
-	 * Show the card in place of the user's first dictation. Returns `true` when
-	 * it took the dictation over, in which case `startDictation` is called once
-	 * the user confirms the card - and never called at all if they pressed
-	 * Escape. Returns `false` when the card has been seen before or there is no
-	 * chat input to dock it to, and the caller should just dictate.
+	 * Show the card alongside the user's first dictation. Dictation starts
+	 * independently and is never gated on the card.
 	 */
-	showIfNeeded(startDictation: () => void): boolean;
+	showIfNeeded(): boolean;
 
 	/**
 	 * Show the card again regardless of whether it has been seen, for the "Show
 	 * Introduction" command. Returns `false` when there is no visible chat input
 	 * to dock it to, so the caller can explain why nothing happened.
 	 */
-	show(startDictation?: () => void): boolean;
+	show(): boolean;
+
+	/** Reset first-run state so the introduction is shown next time. */
+	reset(): void;
 }
 
 export class DictationOnboardingService extends Disposable implements IDictationOnboardingService {
@@ -885,6 +835,7 @@ export class DictationOnboardingService extends Disposable implements IDictation
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 
@@ -898,22 +849,23 @@ export class DictationOnboardingService extends Disposable implements IDictation
 		return this.onboarding.registerHost(container, focusRoot);
 	}
 
-	showIfNeeded(startDictation: () => void): boolean {
-		return this.onboarding.showIfNeeded(context => this.createBanner(context.container, context.dismiss, 'automatic', startDictation));
+	showIfNeeded(): boolean {
+		return this.onboarding.showIfNeeded(context => this.createBanner(context.container, context.dismiss, 'automatic', false));
 	}
 
-	show(startDictation?: () => void): boolean {
-		return this.onboarding.show(context => this.createBanner(context.container, context.dismiss, 'manual', startDictation));
+	show(): boolean {
+		return this.onboarding.show(context => this.createBanner(context.container, context.dismiss, 'manual', true));
 	}
 
-	private createBanner(container: HTMLElement, dismiss: () => void, source: 'automatic' | 'manual', startDictation?: () => void): DictationOnboardingBanner {
+	reset(): void {
+		this.storageService.remove(DICTATION_INTRO_SHOWN_KEY, StorageScope.APPLICATION);
+	}
+
+	private createBanner(container: HTMLElement, dismiss: () => void, source: 'automatic' | 'manual', previewMicrophone: boolean): DictationOnboardingBanner {
 		return this.instantiationService.createInstance(DictationOnboardingBanner, {
 			container,
-			onCancel: dismiss,
-			onStartDictation: () => {
-				dismiss();
-				startDictation?.();
-			},
+			onDismiss: dismiss,
+			previewMicrophone,
 			source,
 		});
 	}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -444,7 +444,8 @@ export interface IMicrophoneOption {
 }
 
 /**
- * The pickable microphones, always led by "System default".
+ * The pickable microphones, with the physical system-default device identified
+ * in its label instead of represented by a separate synthetic row.
  *
  * Drops the virtual `default`/`communications` entries (which duplicate a real
  * device under a synthetic id) and de-duplicates by `deviceId`, so one physical
@@ -452,12 +453,8 @@ export interface IMicrophoneOption {
  * Microphone" quick pick does, kept in one place so the two never disagree.
  */
 export function buildMicrophoneOptions(devices: readonly MediaDeviceInfo[]): IMicrophoneOption[] {
-	const options: IMicrophoneOption[] = [{
-		deviceId: SYSTEM_DEFAULT_DEVICE_ID,
-		label: localize('dictation.onboarding.systemDefault', "System default"),
-	}];
-
 	const seen = new Set<string>();
+	const microphones: MediaDeviceInfo[] = [];
 	for (const device of devices) {
 		if (device.kind !== 'audioinput' || device.deviceId === 'default' || device.deviceId === 'communications') {
 			continue;
@@ -466,6 +463,38 @@ export function buildMicrophoneOptions(devices: readonly MediaDeviceInfo[]): IMi
 			continue;
 		}
 		seen.add(device.deviceId);
+		microphones.push(device);
+	}
+
+	if (microphones.length === 0) {
+		return [{
+			deviceId: SYSTEM_DEFAULT_DEVICE_ID,
+			label: localize('dictation.onboarding.systemDefault', "System default"),
+		}];
+	}
+
+	const defaultDevice = devices.find(device => device.kind === 'audioinput' && device.deviceId === 'default');
+	const defaultLabel = defaultDevice?.label.replace(/^(?:default|system default)\s*-\s*/i, '').trim();
+	const defaultMicrophone = defaultDevice && microphones.find(device =>
+		(defaultDevice.groupId && device.groupId === defaultDevice.groupId)
+		|| (defaultLabel && device.label === defaultLabel)
+	);
+
+	const options: IMicrophoneOption[] = [];
+	if (defaultDevice) {
+		const label = defaultMicrophone?.label || defaultLabel;
+		options.push({
+			deviceId: SYSTEM_DEFAULT_DEVICE_ID,
+			label: label
+				? localize('dictation.onboarding.defaultDevice', "{0} (System default)", label)
+				: localize('dictation.onboarding.systemDefault', "System default"),
+		});
+	}
+
+	for (const device of microphones) {
+		if (device === defaultMicrophone) {
+			continue;
+		}
 		options.push({
 			deviceId: device.deviceId,
 			// Labels are empty until microphone permission has been granted at
@@ -473,7 +502,6 @@ export function buildMicrophoneOptions(devices: readonly MediaDeviceInfo[]): IMi
 			label: device.label || localize('dictation.onboarding.unknownDevice', "Unknown device ({0})", device.deviceId.slice(0, 8)),
 		});
 	}
-
 	return options;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -499,8 +499,8 @@ export interface IDictationOnboardingBannerOptions {
 }
 
 /**
- * The first-run dictation card: which microphone dictation will use, live proof
- * that it is working, and one line on what dictation is.
+ * The first-run dictation card explains the feature while recording starts.
+ * When reopened manually, it also previews and selects the microphone.
  *
  * The card runs alongside the first dictation, so it explains the feature
  * without delaying the action the user invoked.
@@ -510,10 +510,10 @@ export class DictationOnboardingBanner extends Disposable {
 	readonly domNode: HTMLElement;
 
 	private readonly card: ChatInputOnboardingCard;
-	private readonly preview: MicrophonePreview;
-	private readonly waveform: MicrophoneWaveform;
-	private readonly hint: HTMLElement;
-	private readonly pickerContainer: HTMLElement;
+	private readonly preview: MicrophonePreview | undefined;
+	private readonly waveform: MicrophoneWaveform | undefined;
+	private readonly hint: HTMLElement | undefined;
+	private readonly pickerContainer: HTMLElement | undefined;
 
 	private readonly picker = this._register(new MutableDisposable<DisposableStore>());
 	private options: IMicrophoneOption[] = [];
@@ -535,7 +535,7 @@ export class DictationOnboardingBanner extends Disposable {
 			ariaLabel: localize('dictation.onboarding.region', "Dictation introduction"),
 			ariaDescription: bannerOptions.previewMicrophone
 				? localize('dictation.onboarding.regionDescription.preview', "Say anything to check your microphone.")
-				: localize('dictation.onboarding.regionDescription.listening', "Dictation is listening."),
+				: localize('dictation.onboarding.regionDescription', "Speak and it becomes text."),
 			onEscape: () => this.dismiss('escape'),
 		}));
 		this.domNode = this.card.domNode;
@@ -545,48 +545,41 @@ export class DictationOnboardingBanner extends Disposable {
 		title.textContent = localize('dictation.onboarding.title', "Dictation");
 		this.renderDescription(header);
 
-		// The device and its level are one group: the bars are *this* microphone's
-		// level, and separating them would leave the meter reading as decoration.
-		const device = dom.append(this.domNode, dom.$('.dictation-onboarding-device'));
-		this.pickerContainer = dom.append(device, dom.$('.dictation-onboarding-picker'));
-		const waveformContainer = dom.append(device, dom.$('.dictation-onboarding-waveform'));
-
-		this.preview = this._register(instantiationService.createInstance(MicrophonePreview, this.domNode));
-		this.waveform = this._register(instantiationService.createInstance(MicrophoneWaveform, waveformContainer, {
-			getLevel: () => this.preview.getLevel(),
-			isAvailable: () => this.preview.error === undefined,
-		}, undefined));
-		this._register(this.preview.onDidChangeError(() => this.updateHint()));
-
-		this.hint = dom.append(this.domNode, dom.$('.dictation-onboarding-hint'));
-		// The hint only appears when the microphone cannot be read, which can
-		// happen well after the card is opened, so it has to reach a screen
-		// reader as it changes rather than only on focus.
-		this.hint.setAttribute('aria-live', 'polite');
-		this.updateHint();
-
 		this.renderClose();
 
-		// Paint the row before the microphone is up. Enumerating devices means
-		// waiting on the OS, and an empty row that fills in a second later reads
-		// as the card still loading; the system default is true no matter what
-		// comes back, so the row can start there and refine itself.
-		this.options = [{
-			deviceId: SYSTEM_DEFAULT_DEVICE_ID,
-			label: localize('dictation.onboarding.systemDefault', "System default"),
-		}];
-		this.renderPicker();
-
-		const mediaDevices = dom.getWindow(this.domNode).navigator.mediaDevices;
-		if (mediaDevices) {
-			this._register(dom.addDisposableListener(mediaDevices, 'devicechange', () => void this.refreshDevices()));
-		}
-
-		this.waveform.start();
 		if (this.bannerOptions.previewMicrophone) {
+			// The device and its level are one group: the bars are *this*
+			// microphone's level. Automatic onboarding runs beside an already
+			// active dictation stream, so only the manually opened introduction
+			// owns this independent preview and its device picker.
+			const device = dom.append(this.domNode, dom.$('.dictation-onboarding-device'));
+			this.pickerContainer = dom.append(device, dom.$('.dictation-onboarding-picker'));
+			const waveformContainer = dom.append(device, dom.$('.dictation-onboarding-waveform'));
+
+			const preview = this.preview = this._register(instantiationService.createInstance(MicrophonePreview, this.domNode));
+			this.waveform = this._register(instantiationService.createInstance(MicrophoneWaveform, waveformContainer, {
+				getLevel: () => preview.getLevel(),
+				isAvailable: () => preview.error === undefined,
+			}, undefined));
+			this._register(preview.onDidChangeError(() => this.updateHint()));
+
+			this.hint = dom.append(this.domNode, dom.$('.dictation-onboarding-hint'));
+			this.hint.setAttribute('aria-live', 'polite');
+			this.updateHint();
+
+			this.options = [{
+				deviceId: SYSTEM_DEFAULT_DEVICE_ID,
+				label: localize('dictation.onboarding.systemDefault', "System default"),
+			}];
+			this.renderPicker();
+
+			const mediaDevices = dom.getWindow(this.domNode).navigator.mediaDevices;
+			if (mediaDevices) {
+				this._register(dom.addDisposableListener(mediaDevices, 'devicechange', () => void this.refreshDevices()));
+			}
+
+			this.waveform.start();
 			void this.startPreview();
-		} else {
-			void this.refreshDevices();
 		}
 		this.logAction('shown');
 	}
@@ -649,6 +642,9 @@ export class DictationOnboardingBanner extends Disposable {
 	 * labels stay blank until permission has been granted at least once.
 	 */
 	private async startPreview(): Promise<void> {
+		if (!this.preview) {
+			return;
+		}
 		const listening = this.preview.listen(this.currentDeviceId());
 		await Promise.all([listening, this.refreshDevices()]);
 		await this.refreshDevices();
@@ -694,6 +690,9 @@ export class DictationOnboardingBanner extends Disposable {
 	 * open a menu. With a single microphone the card just names it.
 	 */
 	private renderPicker(): void {
+		if (!this.pickerContainer) {
+			return;
+		}
 		this.picker.clear();
 		dom.clearNode(this.pickerContainer);
 
@@ -742,9 +741,7 @@ export class DictationOnboardingBanner extends Disposable {
 		}
 
 		status(localize('dictation.onboarding.microphoneSelected', "{0} selected.", option.label));
-		if (this.bannerOptions.previewMicrophone) {
-			void this.preview.listen(option.deviceId).then(() => this.updateHint());
-		}
+		void this.preview?.listen(option.deviceId).then(() => this.updateHint());
 	}
 
 	/**
@@ -753,6 +750,9 @@ export class DictationOnboardingBanner extends Disposable {
 	 * one the card can do without.
 	 */
 	private updateHint(): void {
+		if (!this.preview || !this.hint) {
+			return;
+		}
 		const error = this.preview.error;
 		this.domNode.classList.toggle('has-error', error !== undefined);
 		this.hint.textContent = error === undefined ? '' : hintForError(error);
@@ -769,8 +769,8 @@ export class DictationOnboardingBanner extends Disposable {
 
 	private dismiss(action: 'close' | 'escape'): void {
 		this.logAction(action);
-		this.waveform.stop();
-		this.preview.releaseMicrophone();
+		this.waveform?.stop();
+		this.preview?.releaseMicrophone();
 		this.bannerOptions.onDismiss();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationOnboarding.css
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationOnboarding.css
@@ -226,14 +226,6 @@
 	will-change: transform;
 }
 
-/*
- * The hand-off. The row settles rather than freezing mid-motion, which is what
- * makes the card leaving read as a step instead of a cut.
- */
-.dictation-onboarding-banner.handing-off .dictation-onboarding-bar {
-	transition: transform 350ms ease-out;
-}
-
 /* --- Hint --- */
 
 /*
@@ -260,9 +252,6 @@
 /* --- Confirm --- */
 
 /*
- * A check, not a cross: leaving this card starts dictating, so the control is
- * a confirmation rather than an abandonment.
- *
  * Pinned to the corner and out of the content flow, so it never competes with
  * the picker for room and never moves as the card re-flows. Always available: a
  * disabled dismiss would trap someone inside the card.

--- a/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationSession.css
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationSession.css
@@ -21,7 +21,7 @@
 /* While a dictation session is active the caret is parked at the start of the
  * dictated region, so a blinking cursor there is distracting as transcript text
  * streams in. Hide it for the duration of the session. */
-.monaco-editor.dictation-hide-cursor .cursors-layer > .cursor {
+.monaco-editor.dictation-hide-cursor .cursors-layer {
 	display: none !important;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
@@ -14,6 +14,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { CONFIGURE_DICTATION_INSTRUCTIONS_ACTION_ID, CONFIGURE_VOICE_INSTRUCTIONS_ACTION_ID } from '../actions/configureVoiceInstructionsAction.js';
+import { SHOW_DICTATION_ONBOARDING_COMMAND } from './dictationOnboarding.js';
 
 /** Command that opens the microphone picker shared by dictation and Voice Mode. */
 export const SELECT_MICROPHONE_COMMAND = 'workbench.action.chat.selectSpeechToTextMicrophone';
@@ -58,6 +59,14 @@ function createDisableDictationAction(commandService: ICommandService, configura
 	});
 }
 
+function createShowDictationOnboardingAction(commandService: ICommandService): IAction {
+	return toAction({
+		id: SHOW_DICTATION_ONBOARDING_COMMAND,
+		label: localize('dictation.showIntroduction', "Show Introduction"),
+		run: () => commandService.executeCommand(SHOW_DICTATION_ONBOARDING_COMMAND),
+	});
+}
+
 /**
  * "Disable Voice Mode" entry. Tears down any active session first so disabling
  * the setting doesn't leave the microphone capturing while the toolbar
@@ -84,6 +93,7 @@ export function getDictationContextMenuActions(commandService: ICommandService, 
 	return [
 		createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId),
 		createConfigureInstructionsAction(commandService, CONFIGURE_DICTATION_INSTRUCTIONS_ACTION_ID, localize('dictation.configureInstructions', "Configure Dictation Instructions")),
+		createShowDictationOnboardingAction(commandService),
 		createSelectMicrophoneAction(commandService),
 		createDisableDictationAction(commandService, configurationService),
 	];

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/media/voiceInputMode.css
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/media/voiceInputMode.css
@@ -57,6 +57,41 @@
 	animation: codicon-spin 1.5s steps(30) infinite;
 }
 
+.chat-voice-input-mode-cell.dictation > .dictation-download-ring {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	display: none;
+	width: 16px;
+	height: 16px;
+	transform: translate(-50%, -50%) rotate(-90deg);
+	pointer-events: none;
+}
+
+.chat-voice-input-mode-cell.dictation.preparing:not(.cloud-preparing) > .dictation-download-ring {
+	display: block;
+}
+
+.chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-track,
+.chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-progress {
+	fill: none;
+	stroke: var(--vscode-progressBar-background);
+	stroke-width: 1.5;
+}
+
+.chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-track {
+	opacity: 0.25;
+}
+
+.chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-progress {
+	stroke-linecap: round;
+}
+
+.hc-black .chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-track,
+.hc-light .chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-track {
+	opacity: 1;
+}
+
 /* The Device EQ waveform lives in the voice cell and transforms per state. Thin bars = default (disconnected); thick bars = filled (connected). Its box matches the compact glyph size of the neighbouring cells so every state of the pill reads at the same optical weight. */
 .chat-voice-input-mode-bars {
 	display: inline-flex;

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/media/voiceInputMode.css
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/media/voiceInputMode.css
@@ -57,39 +57,31 @@
 	animation: codicon-spin 1.5s steps(30) infinite;
 }
 
-.chat-voice-input-mode-cell.dictation > .dictation-download-ring {
+.chat-voice-input-mode-cell.dictation.preparing:not(.cloud-preparing)::after {
+	content: '';
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	display: none;
+	z-index: 2;
+	box-sizing: border-box;
 	width: 16px;
 	height: 16px;
+	border: 1.5px solid transparent;
+	border-top-color: var(--vscode-progressBar-background);
+	border-right-color: var(--vscode-progressBar-background);
+	border-radius: 50%;
 	transform: translate(-50%, -50%) rotate(-90deg);
 	pointer-events: none;
 }
 
-.chat-voice-input-mode-cell.dictation.preparing:not(.cloud-preparing) > .dictation-download-ring {
-	display: block;
+.monaco-workbench.monaco-enable-motion .chat-voice-input-mode-cell.dictation.preparing:not(.cloud-preparing)::after {
+	animation: dictation-pill-download-spin 1.2s linear infinite;
 }
 
-.chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-track,
-.chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-progress {
-	fill: none;
-	stroke: var(--vscode-progressBar-background);
-	stroke-width: 1.5;
-}
-
-.chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-track {
-	opacity: 0.25;
-}
-
-.chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-progress {
-	stroke-linecap: round;
-}
-
-.hc-black .chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-track,
-.hc-light .chat-voice-input-mode-cell.dictation > .dictation-download-ring .dictation-download-ring-track {
-	opacity: 1;
+@keyframes dictation-pill-download-spin {
+	to {
+		transform: translate(-50%, -50%) rotate(270deg);
+	}
 }
 
 /* The Device EQ waveform lives in the voice cell and transforms per state. Thin bars = default (disconnected); thick bars = filled (connected). Its box matches the compact glyph size of the neighbouring cells so every state of the pill reads at the same optical weight. */

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
@@ -34,7 +34,7 @@ import { IMicCaptureService } from '../voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../voiceClient/ttsPlaybackService.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from '../speechToText/chatSpeechToTextService.js';
 import { setupDictationMicGlow } from '../speechToText/dictationMicGlow.js';
-import { getDictationPreparingLabel } from '../speechToText/dictationDownloadRing.js';
+import { DictationDownloadRing, getDictationPreparingLabel } from '../speechToText/dictationDownloadRing.js';
 import { getDictationHoverContent, getVoiceModeHoverContent } from '../speechToText/micButtonHovers.js';
 import { addMicButtonContextMenuListener, getDictationContextMenuActions, getVoiceModeContextMenuActions } from '../speechToText/micButtonMenuActions.js';
 import { IVoiceInputModeService, SimulatedVoiceState, VoiceInputMode, VoiceWalkthroughVersion } from './voiceInputMode.js';
@@ -364,6 +364,7 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 		this._dictationCell.setAttribute('type', 'button');
 		this._dictationCell.setAttribute('role', 'button');
 		this._dictationIcon = dom.append(this._dictationCell, dom.$('span.chat-voice-input-mode-icon'));
+		this._register(new DictationDownloadRing(this._dictationCell, this.chatSpeechToTextService));
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this._dictationCell,
 			() => getDictationHoverContent(this._getLabelWithKeybinding(localize('voiceInputMode.dictation', "Dictation"), DICTATION_TOGGLE_COMMAND_ID), this.configurationService)));
 		this._register(dom.addDisposableListener(this._dictationCell, dom.EventType.CLICK, e => {
@@ -518,6 +519,7 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 			this._dictationCell!.classList.toggle('collapsed', !dictationPresent);
 			this._dictationCell!.classList.toggle('active', isDictating || dictationBusy);
 			this._dictationCell!.classList.toggle('preparing', dictationBusy);
+			this._dictationCell!.classList.toggle('cloud-preparing', dictationBusy && this.chatSpeechToTextService.currentBackend === 'mai');
 			this._dictationCell!.setAttribute('aria-pressed', String(isDictating));
 			this._dictationCell!.setAttribute('aria-label', dictationBusy
 				? localize('voiceInputMode.dictationPreparingCancelable', "Cancel Dictation. {0}", getDictationPreparingLabel(this.chatSpeechToTextService))

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
@@ -34,7 +34,7 @@ import { IMicCaptureService } from '../voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../voiceClient/ttsPlaybackService.js';
 import { ChatSpeechToTextState, IChatSpeechToTextService } from '../speechToText/chatSpeechToTextService.js';
 import { setupDictationMicGlow } from '../speechToText/dictationMicGlow.js';
-import { DictationDownloadRing, getDictationPreparingLabel } from '../speechToText/dictationDownloadRing.js';
+import { getDictationPreparingLabel } from '../speechToText/dictationDownloadRing.js';
 import { getDictationHoverContent, getVoiceModeHoverContent } from '../speechToText/micButtonHovers.js';
 import { addMicButtonContextMenuListener, getDictationContextMenuActions, getVoiceModeContextMenuActions } from '../speechToText/micButtonMenuActions.js';
 import { IVoiceInputModeService, SimulatedVoiceState, VoiceInputMode, VoiceWalkthroughVersion } from './voiceInputMode.js';
@@ -364,7 +364,6 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 		this._dictationCell.setAttribute('type', 'button');
 		this._dictationCell.setAttribute('role', 'button');
 		this._dictationIcon = dom.append(this._dictationCell, dom.$('span.chat-voice-input-mode-icon'));
-		this._register(new DictationDownloadRing(this._dictationCell, this.chatSpeechToTextService));
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this._dictationCell,
 			() => getDictationHoverContent(this._getLabelWithKeybinding(localize('voiceInputMode.dictation', "Dictation"), DICTATION_TOGGLE_COMMAND_ID), this.configurationService)));
 		this._register(dom.addDisposableListener(this._dictationCell, dom.EventType.CLICK, e => {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
@@ -55,6 +55,11 @@
 	width: 100%;
 }
 
+.interactive-input-part:has(.voice-mode-onboarding-container.has-voice-mode-onboarding) .chat-getting-started-tip-container,
+.interactive-input-part:has(.dictation-onboarding-container.has-dictation-onboarding) .chat-getting-started-tip-container {
+	display: none;
+}
+
 .chat-getting-started-tip-container .chat-tip-widget {
 	display: flex;
 	align-items: center;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -4779,10 +4779,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	transition: stroke-dashoffset 120ms ease;
 }
 
-/* Indeterminate: spin a fixed arc while the download fraction is unknown or the
-	model is loading into memory. Gated on enable-motion to respect reduced
-	motion. */
-.monaco-workbench.monaco-enable-motion .action-item.dictation-download-item > .dictation-download-ring.indeterminate {
+/* Keep the progress arc moving while the model downloads or loads so the
+	affordance reads as active even between percentage updates. Gated on
+	enable-motion to respect reduced motion. */
+.monaco-workbench.monaco-enable-motion .dictation-download-ring {
 	animation: dictation-download-ring-spin 1.2s linear infinite;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -14,7 +14,7 @@ import { isCancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { MutableDisposable, toDisposable, DisposableStore, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { MarshalledId } from '../../../../../../base/common/marshallingIds.js';
-import { autorun, IReader, observableValue } from '../../../../../../base/common/observable.js';
+import { autorun, IReader, observableFromEvent, observableValue } from '../../../../../../base/common/observable.js';
 import { isEqual } from '../../../../../../base/common/resources.js';
 import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -437,6 +437,16 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 	private _setupVoiceTranscriptOverlay(inputContainerEl: HTMLElement): void {
 		inputContainerEl.style.position = 'relative';
+		const showTranscriptSetting = observableFromEvent(
+			this,
+			Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('agents.voice.showTranscript')),
+			() => this.configurationService.getValue<boolean>('agents.voice.showTranscript') !== false
+		);
+		const showLiveTranscriptSetting = observableFromEvent(
+			this,
+			Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('agents.voice.liveTranscript')),
+			() => this.configurationService.getValue<boolean>('agents.voice.liveTranscript') !== false
+		);
 		const transcriptOverlay = $('.voice-transcript-overlay');
 		const transcriptScrollable = this._register(new DomScrollableElement(transcriptOverlay, {
 			horizontal: ScrollbarVisibility.Hidden,
@@ -609,8 +619,10 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			const voiceState = this.voiceSessionController.voiceState.read(reader);
 			const targetSession = this.voiceSessionController.targetSession.read(reader);
 			const currentSession = this._currentSessionResource.read(reader);
-			const showTranscript = this.configurationService.getValue<boolean>('agents.voice.showTranscript') !== false;
+			const showTranscript = showTranscriptSetting.read(reader);
+			const showLiveTranscript = showLiveTranscriptSetting.read(reader);
 			const visible = turns.filter(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
+			const showListeningPlaceholder = voiceState === 'listening' && (!showTranscript || !showLiveTranscript);
 
 			if (!connected) {
 				listeningSession = undefined;
@@ -661,11 +673,9 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			}
 
 			// Show hint when connected but no transcript yet
-			if (visible.length === 0 || !showTranscript) {
+			if (visible.length === 0 || !showTranscript || showListeningPlaceholder) {
 				const handsFree = this.configurationService.getValue<boolean>('agents.voice.handsFree') === true;
-				if (!showTranscript && voiceState === 'listening') {
-					// Transcript is disabled: surface a minimal "Listening..." overlay
-					// while listening so the user has feedback. Cleared in any other state.
+				if (showListeningPlaceholder) {
 					transcriptOverlayNode.style.display = '';
 					transcriptOverlayNode.classList.remove('has-transcript');
 					transcriptOverlay.replaceChildren();

--- a/src/vs/workbench/contrib/chat/test/browser/actions/chatSpeechToTextActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/actions/chatSpeechToTextActions.test.ts
@@ -4,9 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { mainWindow } from '../../../../../../base/browser/window.js';
+import { ICodeEditor } from '../../../../../../editor/browser/editorBrowser.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { getDictationShortcutOperation } from '../../../browser/actions/chatSpeechToTextActions.js';
-import { ChatSpeechToTextState } from '../../../browser/speechToText/chatSpeechToTextService.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
+import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import { getDictationShortcutOperation, runDictationShortcut } from '../../../browser/actions/chatSpeechToTextActions.js';
+import { ChatSpeechToTextState, IChatSpeechToTextService } from '../../../browser/speechToText/chatSpeechToTextService.js';
+import { IDictationOnboardingService } from '../../../browser/speechToText/dictationOnboarding.js';
 
 suite('Chat Speech to Text Actions', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -23,5 +29,38 @@ suite('Chat Speech to Text Actions', () => {
 			'cancel',
 			undefined,
 		]);
+	});
+
+	test('starts dictation while first-run onboarding is shown', async () => {
+		const calls: string[] = [];
+		const speechService = new class extends mock<IChatSpeechToTextService>() {
+			override readonly state = ChatSpeechToTextState.Idle;
+			override readonly isPreparingModel = false;
+		};
+		const keybindingService = new class extends mock<IKeybindingService>() {
+			override enableKeybindingHoldMode(): Promise<void> | undefined {
+				return undefined;
+			}
+		};
+		const onboardingService = new class extends mock<IDictationOnboardingService>() {
+			override showIfNeeded(): boolean {
+				calls.push('showIfNeeded');
+				return true;
+			}
+		};
+		const editor = new class extends mock<ICodeEditor>() {
+			override getDomNode(): HTMLElement {
+				return mainWindow.document.body;
+			}
+		};
+
+		await runDictationShortcut(
+			{ speechService, keybindingService, logService: new NullLogService(), onboardingService },
+			'test.dictation',
+			editor,
+			async () => { calls.push('startDictation'); },
+		);
+
+		assert.deepStrictEqual(calls, ['showIfNeeded', 'startDictation']);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
@@ -74,6 +74,19 @@ suite('Dictation onboarding', () => {
 		]);
 	});
 
+	test('uses the first physical microphone when the virtual default has no identity', () => {
+		const options = buildMicrophoneOptions([
+			device('audioinput', 'default', 'System default'),
+			device('audioinput', 'mic-a', 'Studio Mic'),
+			device('audioinput', 'mic-b', 'Built-in Mic'),
+		]);
+
+		assert.deepStrictEqual(options, [
+			{ deviceId: '', label: 'Studio Mic (System default)' },
+			{ deviceId: 'mic-b', label: 'Built-in Mic' },
+		]);
+	});
+
 	test('falls back to the system default when the remembered device is gone', () => {
 		const options = buildMicrophoneOptions([
 			device('audioinput', 'default', 'Default - Built-in Mic'),

--- a/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
@@ -103,12 +103,14 @@ suite('Dictation onboarding', () => {
 		assert.deepStrictEqual(
 			{
 				shownFirstTime, shown, closeIcon,
+				hasMicrophoneControls: host.container.querySelector('.dictation-onboarding-device') !== null,
 				visibleAfterClose: host.container.classList.contains('has-dictation-onboarding'),
 				shownAgain,
 				telemetryEvents,
 			},
 			{
 				shownFirstTime: true, shown: true, closeIcon: 'codicon codicon-close',
+				hasMicrophoneControls: false,
 				visibleAfterClose: false,
 				shownAgain: false,
 				telemetryEvents: [
@@ -148,8 +150,9 @@ suite('Dictation onboarding', () => {
 			{
 				visible: host.container.classList.contains('has-dictation-onboarding'),
 				cards: host.container.querySelectorAll('.dictation-onboarding-banner').length,
+				hasMicrophoneControls: host.container.querySelector('.dictation-onboarding-device') !== null,
 			},
-			{ visible: true, cards: 1 });
+			{ visible: true, cards: 1, hasMicrophoneControls: true });
 	});
 
 	test('reset shows the introduction on the next dictation', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
@@ -5,7 +5,6 @@
 
 import assert from 'assert';
 import * as dom from '../../../../../base/browser/dom.js';
-import { timeout } from '../../../../../base/common/async.js';
 import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -13,12 +12,6 @@ import { ITelemetryService } from '../../../../../platform/telemetry/common/tele
 import { NullTelemetryServiceShape } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { buildMicrophoneOptions, DictationOnboardingService, indexOfMicrophone } from '../../browser/speechToText/dictationOnboarding.js';
-
-/**
- * Comfortably longer than the card's hand-off delay, so the tests observe the
- * settled state rather than racing it.
- */
-const HANDOFF_GRACE_MS = 500;
 
 /** Minimal stand-in for the browser's device descriptor. */
 function device(kind: MediaDeviceKind, deviceId: string, label: string): MediaDeviceInfo {
@@ -94,66 +87,53 @@ suite('Dictation onboarding', () => {
 			{ remembered: 1, systemDefault: 0, unplugged: 0 });
 	});
 
-	test('takes over the first dictation, then never returns', async () => {
+	test('shows alongside the first dictation, then never returns', () => {
 		const telemetryEvents: ITelemetryEvent[] = [];
 		const service = createService(disposables, undefined, telemetryEvents);
 		const host = createHost(disposables);
 		disposables.add(service.registerHost(host.container, host.root));
 
-		let dictations = 0;
-		const tookOver = service.showIfNeeded(() => dictations++);
+		const shownFirstTime = service.showIfNeeded();
 		const shown = host.container.classList.contains('has-dictation-onboarding');
 
-		// Nothing is recorded while the card is up: confirming it is the only
-		// thing that starts the dictation it deferred, and even that waits a beat
-		// for the card to hand the microphone back.
-		const dictationsWhileOpen = dictations;
+		const closeIcon = host.container.querySelector('.dictation-onboarding-close .codicon')?.className;
 		host.container.querySelector<HTMLElement>('.dictation-onboarding-close')!.click();
-		const dictationsBeforeHandoff = dictations;
-		await timeout(HANDOFF_GRACE_MS);
-
-		const tookOverAgain = service.showIfNeeded(() => dictations++);
+		const shownAgain = service.showIfNeeded();
 
 		assert.deepStrictEqual(
 			{
-				tookOver, shown, dictationsWhileOpen, dictationsBeforeHandoff,
-				dictationsAfterHandoff: dictations,
-				visibleAfterHandoff: host.container.classList.contains('has-dictation-onboarding'),
-				tookOverAgain,
+				shownFirstTime, shown, closeIcon,
+				visibleAfterClose: host.container.classList.contains('has-dictation-onboarding'),
+				shownAgain,
 				telemetryEvents,
 			},
 			{
-				tookOver: true, shown: true, dictationsWhileOpen: 0, dictationsBeforeHandoff: 0,
-				dictationsAfterHandoff: 1,
-				visibleAfterHandoff: false,
-				tookOverAgain: false,
+				shownFirstTime: true, shown: true, closeIcon: 'codicon codicon-close',
+				visibleAfterClose: false,
+				shownAgain: false,
 				telemetryEvents: [
 					{ name: 'dictationOnboarding.action', data: { action: 'shown', source: 'automatic' } },
-					{ name: 'dictationOnboarding.action', data: { action: 'startDictation', source: 'automatic' } },
+					{ name: 'dictationOnboarding.action', data: { action: 'close', source: 'automatic' } },
 				],
 			});
 	});
 
-	test('escape dismisses the card without dictating', async () => {
+	test('escape dismisses the card', () => {
 		const service = createService(disposables);
 		const host = createHost(disposables);
 		disposables.add(service.registerHost(host.container, host.root));
 
-		let dictations = 0;
-		service.showIfNeeded(() => dictations++);
+		service.showIfNeeded();
 		host.container.querySelector<HTMLElement>('.dictation-onboarding-banner')!
 			.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));
-		await timeout(HANDOFF_GRACE_MS);
 
-		assert.deepStrictEqual(
-			{ dictations, visible: host.container.classList.contains('has-dictation-onboarding') },
-			{ dictations: 0, visible: false });
+		assert.strictEqual(host.container.classList.contains('has-dictation-onboarding'), false);
 	});
 
 	test('dictates straight away when there is no chat input to dock to', () => {
 		const service = createService(disposables);
 
-		assert.strictEqual(service.showIfNeeded(() => { }), false);
+		assert.strictEqual(service.showIfNeeded(), false);
 	});
 
 	test('showing again replaces the card rather than hiding it', () => {
@@ -172,6 +152,18 @@ suite('Dictation onboarding', () => {
 			{ visible: true, cards: 1 });
 	});
 
+	test('reset shows the introduction on the next dictation', () => {
+		const service = createService(disposables);
+		const host = createHost(disposables);
+		disposables.add(service.registerHost(host.container, host.root));
+
+		service.showIfNeeded();
+		host.container.querySelector<HTMLElement>('.dictation-onboarding-close')!.click();
+		service.reset();
+
+		assert.strictEqual(service.showIfNeeded(), true);
+	});
+
 	test('attaches to the most recently focused host', () => {
 		const service = createService(disposables);
 		const first = createHost(disposables);
@@ -183,7 +175,7 @@ suite('Dictation onboarding', () => {
 		// so raise the same event the focus tracker listens for.
 		second.root.focus();
 		second.root.dispatchEvent(new FocusEvent('focus'));
-		service.showIfNeeded(() => { });
+		service.showIfNeeded();
 
 		assert.deepStrictEqual(
 			{

--- a/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
@@ -55,7 +55,7 @@ suite('Dictation onboarding', () => {
 		return store.add(instantiationService.createInstance(DictationOnboardingService));
 	}
 
-	test('lists every real microphone once, behind the system default', () => {
+	test('labels the physical default microphone without listing it twice', () => {
 		const options = buildMicrophoneOptions([
 			// The virtual entries duplicate a real device under a synthetic id.
 			device('audioinput', 'default', 'Default - Studio Mic'),
@@ -69,14 +69,17 @@ suite('Dictation onboarding', () => {
 		]);
 
 		assert.deepStrictEqual(options, [
-			{ deviceId: '', label: 'System default' },
-			{ deviceId: 'mic-a', label: 'Studio Mic' },
+			{ deviceId: '', label: 'Studio Mic (System default)' },
 			{ deviceId: 'abcdefghij-unlabelled', label: 'Unknown device (abcdefgh)' },
 		]);
 	});
 
 	test('falls back to the system default when the remembered device is gone', () => {
-		const options = buildMicrophoneOptions([device('audioinput', 'mic-a', 'Studio Mic')]);
+		const options = buildMicrophoneOptions([
+			device('audioinput', 'default', 'Default - Built-in Mic'),
+			device('audioinput', 'built-in', 'Built-in Mic'),
+			device('audioinput', 'mic-a', 'Studio Mic'),
+		]);
 
 		assert.deepStrictEqual(
 			{

--- a/src/vs/workbench/test/browser/componentFixtures/agentsVoice/voiceModeOnboarding.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/agentsVoice/voiceModeOnboarding.fixture.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { constObservable } from '../../../../../base/common/observable.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { IContextViewService } from '../../../../../platform/contextview/browser/contextView.js';
 import { VoiceModeOnboardingBanner } from '../../../../contrib/agentsVoice/browser/voiceModeOnboarding.js';
 import { IVoiceSessionController, VoiceState } from '../../../../contrib/chat/browser/voiceClient/voiceSessionController.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
@@ -18,13 +20,16 @@ function renderVoiceModeOnboarding(width: string) {
 
 		const instantiationService = createEditorServices(disposableStore, {
 			colorTheme: theme,
-			additionalServices: services => services.definePartialInstance(IVoiceSessionController, {
-				voiceState: constObservable<VoiceState>('idle'),
-				setAutoListenHeld: () => undefined,
-				stopListening: () => undefined,
-				pttDown: () => undefined,
-				pttUp: () => undefined,
-			}),
+			additionalServices: services => {
+				services.defineInstance(IContextViewService, new class extends mock<IContextViewService>() { }());
+				services.definePartialInstance(IVoiceSessionController, {
+					voiceState: constObservable<VoiceState>('idle'),
+					setAutoListenHeld: () => undefined,
+					stopListening: () => undefined,
+					pttDown: () => undefined,
+					pttUp: () => undefined,
+				});
+			},
 		});
 		const host = document.createElement('div');
 		host.className = 'voice-mode-onboarding-container has-voice-mode-onboarding';


### PR DESCRIPTION
## Summary

- simplify the Voice Mode and Dictation onboarding cards and let listening/recording start immediately behind automatic onboarding
- add Dictation onboarding reset/show entry points, hide chat tips behind onboarding, and use focused selection colors
- include Voice Mode sample audio in desktop and web product builds
- show `Listening...` instead of an empty cursor when live Voice Mode transcripts are disabled

Fixes #328054

## Testing

- client and build type checks
- compile
- Voice Mode onboarding tests (13 passing)
- Dictation onboarding tests (11 passing)
- chat speech-to-text action test (1 passing)
- ESLint and stylesheet checks