### PR TITLE
Enabling experiments for dictation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -295,7 +295,8 @@ configurationRegistry.registerConfiguration({
 			],
 			markdownDescription: nls.localize('dictation.model', "The model used for dictation. On-device models download on first use and run locally through Microsoft Foundry Local; the cloud option streams audio to the Microsoft AI voice service."),
 			default: 'nemotron-speech-streaming-en-0.6b',
-			tags: ['experimental']
+			tags: ['experimental'],
+			experiment: { mode: 'auto' }
 		},
 		[DictationSettingId.ShowTranscript]: {
 			type: 'boolean',


### PR DESCRIPTION
This pull request makes a small change to the dictation model configuration. It adds an `experiment` property with `mode: 'auto'` to the configuration options for the dictation model.

- Added `experiment: { mode: 'auto' }` to the dictation model configuration in `chat.shared.contribution.ts` to enable experimental handling.