### PR TITLE
chat: keep leading whitespace in a response selection snippet

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/responseSelectionResolver.ts
+++ b/src/vs/sessions/contrib/chat/browser/responseSelectionResolver.ts
@@ -99,7 +99,8 @@ export function resolveResponseSelection(widget: IChatWidget): IResolvedResponse
 		return undefined;
 	}
 
-	// Trailing newlines are an artifact of how browsers extend line selections
-	// past the block they belong to; they add nothing to the quoted snippet.
-	return { response: firstItem, text: nativeSelection.toString().trim(), range: range.cloneRange() };
+	// Browsers extend a line selection past the block it belongs to, leaving a
+	// trailing newline that adds nothing to the quoted snippet. Only the end is
+	// trimmed: leading whitespace is part of what the user actually selected.
+	return { response: firstItem, text: nativeSelection.toString().trimEnd(), range: range.cloneRange() };
 }

--- a/src/vs/sessions/contrib/chat/test/browser/responseSelectionResolver.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/responseSelectionResolver.test.ts
@@ -69,6 +69,27 @@ suite('resolveResponseSelection', () => {
 		assert.strictEqual(resolved!.text, 'hello world');
 	});
 
+	test('preserves leading whitespace while dropping the trailing newline artifact', () => {
+		// Leading whitespace is part of what the user selected (e.g. starting
+		// mid-indentation); only the newline browsers append when a line
+		// selection spills into the next block should be dropped.
+		const { store, doc, widgetDomNode } = setup();
+		const markdown = doc.createElement('div');
+		markdown.classList.add('chat-markdown-part');
+		const textNode = doc.createTextNode('    indented text');
+		markdown.appendChild(textNode);
+		widgetDomNode.appendChild(markdown);
+
+		stubSelection(store, textNode, textNode, '    indented text\n');
+		const response = makeResponse('turn-1');
+		const widget = upcastPartial<IChatWidget>({
+			domNode: widgetDomNode,
+			getElementFromNode: () => response,
+		});
+
+		assert.strictEqual(resolveResponseSelection(widget)?.text, '    indented text');
+	});
+
 	test('resolves a line selection that ends at the start of the element after the markdown', () => {
 		// A triple-click selects the whole line and parks the selection's focus
 		// at offset 0 of the *next* block, which for the last line of a


### PR DESCRIPTION
- Trims only the end of the selected text when building the side-chat
  snippet. The trailing newline browsers append when a line selection
  spills into the next block is still dropped, but a selection that
  starts mid-indentation (a nested list item, a quoted line) no longer
  silently loses the whitespace the user actually selected.

Follow-up to #327931, addressing Copilot review feedback.
