### PR TITLE
telemetry: report ResizeObserver delivery context

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -2058,16 +2058,18 @@ export class DragAndDropObserver extends Disposable {
  * 1. Lifetime management: `dispose()` disconnects the underlying observer.
  * 2. Auxiliary-window support: pass `targetWindow` so the observer is
  *    constructed in the realm of the element being observed.
- * 3. Attribution for the
+ * 3. Context for the
  *    `ResizeObserver loop completed with undelivered notifications` warning:
- *    each instance carries a stable `name`, and just before invoking the
- *    user callback we publish that name to a module-level slot. The warning
- *    is delivered as a stackless `ErrorEvent` on `window` after callbacks
- *    run, so error telemetry can swap in the most-recently-invoked
- *    observer's name to pinpoint the offending consumer (see
- *    {@link getRecentDisposableResizeObserverAttributionForLoopError}).
+ *    each instance carries a stable `name`, and just before invoking the user
+ *    callback we add that name to a bounded, per-window set that is cleared
+ *    at the next animation frame. The warning is delivered as a stackless
+ *    `ErrorEvent` on `window` after callbacks run, so error telemetry can
+ *    include the wrapped observers that recently ran in that window (see
+ *    {@link getRecentDisposableResizeObserverContextForLoopError}). This is
+ *    delivery context, not causal attribution: the browser does not expose
+ *    which observer or skipped target caused the warning.
  *
- * @param name Stable identifier used in attribution. Prefer something that
+ * @param name Stable identifier used in loop-warning context. Prefer one that
  * survives minification and refactors (e.g. the consumer class + purpose)
  * since callstacks change across releases.
  * @param callback Invoked synchronously when the browser delivers resize
@@ -2094,24 +2096,7 @@ export class DisposableResizeObserver extends Disposable {
 		this.name = name;
 		const ctor = options?.resizeObserverCtor ?? targetWindow.ResizeObserver;
 		this.observer = new ctor((entries: ResizeObserverEntry[], observer) => {
-			_lastInvokedDisposableResizeObserver = this;
-			// Clear via a 0-ms timer (a new macrotask) rather than a
-			// microtask: microtask checkpoints run at the end of every
-			// script, i.e. after each ResizeObserver callback returns, but
-			// Chromium dispatches the synthetic `ResizeObserver loop
-			// completed with undelivered notifications` error *after* all
-			// callbacks in the observation phase finish. A microtask would
-			// clear the slot before the warning fires; a setTimeout(0)
-			// runs after the entire current task completes (callbacks +
-			// loop-error dispatch), so attribution survives long enough to
-			// be picked up by `window.onerror` while still being scoped to
-			// the same task that produced it. The equality check ensures
-			// only the *last* writer in a phase actually clears the slot.
-			setTimeout(() => {
-				if (_lastInvokedDisposableResizeObserver === this) {
-					_lastInvokedDisposableResizeObserver = undefined;
-				}
-			}, 0);
+			recordDisposableResizeObserverInvocation(targetWindow, this.name);
 			try {
 				callback(entries, observer);
 			} catch (e) {
@@ -2128,32 +2113,75 @@ export class DisposableResizeObserver extends Disposable {
 }
 
 /**
- * The most recently invoked `DisposableResizeObserver`. Set just before each
- * user callback runs and cleared by a 0-ms timer scheduled in the same step,
- * so the slot only carries an attribution within the same task as the
- * `ResizeObserver loop completed with undelivered notifications` warning
- * (which fires synchronously at the end of the resize-observation phase).
- * A microtask would be too eager — microtask checkpoints run between each
- * callback, before the loop-error dispatch.
+ * Keep the context bounded so a large delivery phase cannot create an
+ * unbounded telemetry value. Names are static component identifiers, and are
+ * sorted when read so equivalent phases share a stable bucket.
  */
-let _lastInvokedDisposableResizeObserver: DisposableResizeObserver | undefined;
+const maxRecentDisposableResizeObservers = 8;
 
 /**
- * If `message` looks like the ResizeObserver loop warning, return an
- * attribution string built from the most recently invoked
- * `DisposableResizeObserver` so error telemetry can replace its synthetic,
- * stackless callstack with the offending observer's `name`. Returns
- * `undefined` for unrelated messages or when no observer has fired yet.
+ * Wrapped observers that ran recently in one window. This is deliberately
+ * scoped by window because auxiliary windows have independent documents and
+ * resize-observation delivery loops.
  */
-export function getRecentDisposableResizeObserverAttributionForLoopError(message: string | undefined | null): string | undefined {
+interface IRecentDisposableResizeObserverContext {
+	readonly names: Set<string>;
+	overflow: boolean;
+}
+
+const recentDisposableResizeObserverContexts = new WeakMap<CodeWindow, IRecentDisposableResizeObserverContext>();
+
+function recordDisposableResizeObserverInvocation(targetWindow: CodeWindow, name: string): void {
+	let context = recentDisposableResizeObserverContexts.get(targetWindow);
+	if (!context) {
+		context = { names: new Set(), overflow: false };
+		recentDisposableResizeObserverContexts.set(targetWindow, context);
+
+		// ResizeObserver callbacks and the synthetic loop error are delivered
+		// after requestAnimationFrame callbacks in the rendering update. A
+		// request made here therefore clears this context at the next frame,
+		// after telemetry has observed any warning from the current update.
+		targetWindow.requestAnimationFrame(() => recentDisposableResizeObserverContexts.delete(targetWindow));
+	}
+
+	if (context.names.has(name)) {
+		return;
+	}
+	if (context.names.size < maxRecentDisposableResizeObservers) {
+		context.names.add(name);
+	} else {
+		context.overflow = true;
+		const largestName = Array.from(context.names).sort().at(-1)!;
+		if (name < largestName) {
+			context.names.delete(largestName);
+			context.names.add(name);
+		}
+	}
+}
+
+/**
+ * If `message` looks like the ResizeObserver loop warning, return a stable
+ * context string containing the wrapped observers that ran recently in
+ * `targetWindow`. The names are delivery context only; the browser does not
+ * expose the observer or skipped target that caused the warning. Returns
+ * `undefined` for unrelated messages or when no wrapped observer has fired.
+ */
+export function getRecentDisposableResizeObserverContextForLoopError(
+	message: string | undefined | null,
+	targetWindow: CodeWindow = mainWindow,
+): string | undefined {
 	if (typeof message !== 'string' || !message.includes('ResizeObserver loop')) {
 		return undefined;
 	}
-	const observer = _lastInvokedDisposableResizeObserver;
-	if (!observer) {
+	const context = recentDisposableResizeObserverContexts.get(targetWindow);
+	if (!context) {
 		return undefined;
 	}
-	return `[DisposableResizeObserver(${observer.name})] ${message}`;
+	const names = Array.from(context.names).sort();
+	if (context.overflow) {
+		names.push('<overflow>');
+	}
+	return `[ResizeObserverLoopContext(recentWrappedObservers=${names.join(',')})] ${message}`;
 }
 
 type HTMLElementAttributeKeys<T> = Partial<{ [K in keyof T]: T[K] extends Function ? never : T[K] extends object ? HTMLElementAttributeKeys<T[K]> : T[K] }>;

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -2181,7 +2181,7 @@ export function getRecentDisposableResizeObserverContextForLoopError(
 	if (context.overflow) {
 		names.push('<overflow>');
 	}
-	return `[ResizeObserverLoopContext(recentWrappedObservers=${names.join(',')})] ${message}`;
+	return `[ResizeObserverLoopContext(${names.join(',')})] ${message}`;
 }
 
 type HTMLElementAttributeKeys<T> = Partial<{ [K in keyof T]: T[K] extends Function ? never : T[K] extends object ? HTMLElementAttributeKeys<T[K]> : T[K] }>;

--- a/src/vs/base/test/browser/dom.test.ts
+++ b/src/vs/base/test/browser/dom.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { $, h, trackAttributes, copyAttributes, disposableWindowInterval, getWindows, getWindowsCount, getWindowId, getWindowById, hasWindow, getWindow, getDocument, isHTMLElement, SafeTriangle, AnimationFrameScheduler, DisposableResizeObserver, getRecentDisposableResizeObserverAttributionForLoopError, findParentWithClass, hasParentWithClass } from '../../browser/dom.js';
+import { $, h, trackAttributes, copyAttributes, disposableWindowInterval, getWindows, getWindowsCount, getWindowId, getWindowById, hasWindow, getWindow, getDocument, isHTMLElement, SafeTriangle, AnimationFrameScheduler, DisposableResizeObserver, getRecentDisposableResizeObserverContextForLoopError, findParentWithClass, hasParentWithClass } from '../../browser/dom.js';
 import { asCssValueWithDefault } from '../../../base/browser/cssValue.js';
 import { ensureCodeWindow, isAuxiliaryWindow, mainWindow } from '../../browser/window.js';
 import { DeferredPromise, timeout } from '../../common/async.js';
@@ -553,6 +553,8 @@ suite('dom', () => {
 	});
 
 	suite('DisposableResizeObserver', () => {
+		teardown(() => new Promise<void>(resolve => mainWindow.requestAnimationFrame(() => resolve())));
+
 		// Captures the callback handed to a `ResizeObserver` so tests can fire
 		// deliveries synthetically. Returned via dependency injection — no
 		// global mutation, no `any` casts.
@@ -642,7 +644,7 @@ suite('dom', () => {
 			observer.dispose();
 		});
 
-		test('exposes the configured name for attribution', () => {
+		test('exposes the configured name for loop-warning context', () => {
 			const fake = createFakeResizeObserverCtor();
 			const observer = new DisposableResizeObserver(
 				'my-observer',
@@ -654,42 +656,82 @@ suite('dom', () => {
 			observer.dispose();
 		});
 
-		test('getRecentDisposableResizeObserverAttributionForLoopError returns undefined for unrelated messages', () => {
-			assert.strictEqual(getRecentDisposableResizeObserverAttributionForLoopError(undefined), undefined);
-			assert.strictEqual(getRecentDisposableResizeObserverAttributionForLoopError('Uncaught TypeError: foo'), undefined);
+		test('getRecentDisposableResizeObserverContextForLoopError returns undefined for unrelated messages', () => {
+			assert.strictEqual(getRecentDisposableResizeObserverContextForLoopError(undefined), undefined);
+			assert.strictEqual(getRecentDisposableResizeObserverContextForLoopError('Uncaught TypeError: foo'), undefined);
 		});
 
-		test('getRecentDisposableResizeObserverAttributionForLoopError returns last invoked observer name for the loop warning', () => {
+		test('getRecentDisposableResizeObserverContextForLoopError returns sorted unique wrapped observers from the current frame', () => {
 			const fake = createFakeResizeObserverCtor();
 			const a = new DisposableResizeObserver('a', () => { /* noop */ }, mainWindow, { resizeObserverCtor: fake.ctor });
 			fake.fire([fakeEntry()]);
 			const fakeB = createFakeResizeObserverCtor();
 			const b = new DisposableResizeObserver('b', () => { /* noop */ }, mainWindow, { resizeObserverCtor: fakeB.ctor });
 			fakeB.fire([fakeEntry()]);
-			const attribution = getRecentDisposableResizeObserverAttributionForLoopError(
+			fake.fire([fakeEntry()]);
+			const context = getRecentDisposableResizeObserverContextForLoopError(
 				'ResizeObserver loop completed with undelivered notifications.',
 			);
-			assert.ok(attribution, 'attribution string must be produced for the loop warning');
-			assert.ok(attribution!.startsWith('[DisposableResizeObserver(b)] '), 'attribution prefixes the message with the most recently invoked observer name');
+			assert.strictEqual(
+				context,
+				'[ResizeObserverLoopContext(recentWrappedObservers=a,b)] ResizeObserver loop completed with undelivered notifications.',
+			);
 			a.dispose();
 			b.dispose();
 		});
 
-		test('getRecentDisposableResizeObserverAttributionForLoopError clears after the current task so unrelated later errors are not mis-attributed', async () => {
+		test('getRecentDisposableResizeObserverContextForLoopError marks bounded participant overflow', () => {
+			const observers: DisposableResizeObserver[] = [];
+			for (let i = 8; i >= 0; i--) {
+				const fake = createFakeResizeObserverCtor();
+				observers.push(new DisposableResizeObserver(`observer-${i}`, () => { /* noop */ }, mainWindow, { resizeObserverCtor: fake.ctor }));
+				fake.fire([fakeEntry()]);
+			}
+			assert.strictEqual(
+				getRecentDisposableResizeObserverContextForLoopError('ResizeObserver loop completed with undelivered notifications.'),
+				'[ResizeObserverLoopContext(recentWrappedObservers=observer-0,observer-1,observer-2,observer-3,observer-4,observer-5,observer-6,observer-7,<overflow>)] ResizeObserver loop completed with undelivered notifications.',
+			);
+			observers.forEach(observer => observer.dispose());
+		});
+
+		test('getRecentDisposableResizeObserverContextForLoopError is scoped to the observer window', async () => {
+			const iframe = document.createElement('iframe');
+			document.body.appendChild(iframe);
+			const auxiliaryWindow = iframe.contentWindow!;
+			ensureCodeWindow(auxiliaryWindow, 999);
+
+			const fake = createFakeResizeObserverCtor();
+			const observer = new DisposableResizeObserver('auxiliary', () => { /* noop */ }, auxiliaryWindow, { resizeObserverCtor: fake.ctor });
+			fake.fire([fakeEntry()]);
+
+			assert.strictEqual(
+				getRecentDisposableResizeObserverContextForLoopError('ResizeObserver loop completed with undelivered notifications.', mainWindow),
+				undefined,
+			);
+			assert.strictEqual(
+				getRecentDisposableResizeObserverContextForLoopError('ResizeObserver loop completed with undelivered notifications.', auxiliaryWindow),
+				'[ResizeObserverLoopContext(recentWrappedObservers=auxiliary)] ResizeObserver loop completed with undelivered notifications.',
+			);
+
+			observer.dispose();
+			await new Promise<void>(resolve => auxiliaryWindow.requestAnimationFrame(() => resolve()));
+			iframe.remove();
+		});
+
+		test('getRecentDisposableResizeObserverContextForLoopError clears at the next animation frame', async () => {
 			const fake = createFakeResizeObserverCtor();
 			const observer = new DisposableResizeObserver('scoped', () => { /* noop */ }, mainWindow, { resizeObserverCtor: fake.ctor });
 			fake.fire([fakeEntry()]);
-			// Slot is set synchronously and survives microtasks (so it is
+			// Context is recorded synchronously and survives microtasks (so it is
 			// still set when Chromium dispatches the loop warning at the end
 			// of the resize-observation phase).
 			await Promise.resolve();
-			assert.ok(getRecentDisposableResizeObserverAttributionForLoopError('ResizeObserver loop completed with undelivered notifications.'));
-			// A 0-ms timer (next macrotask) clears the slot.
-			await new Promise(resolve => setTimeout(resolve, 0));
+			assert.ok(getRecentDisposableResizeObserverContextForLoopError('ResizeObserver loop completed with undelivered notifications.'));
+			await new Promise<void>(resolve => mainWindow.requestAnimationFrame(() => resolve()));
 			assert.strictEqual(
-				getRecentDisposableResizeObserverAttributionForLoopError('ResizeObserver loop completed with undelivered notifications.'),
+				getRecentDisposableResizeObserverContextForLoopError('ResizeObserver loop completed with undelivered notifications.'),
 				undefined,
-				'slot must be cleared by the next task so an unrelated later error does not inherit a stale observer name',
+				'context must be cleared at the next frame so a later rendering update does not inherit stale observers',
 			);
 			observer.dispose();
 		});

--- a/src/vs/base/test/browser/dom.test.ts
+++ b/src/vs/base/test/browser/dom.test.ts
@@ -674,7 +674,7 @@ suite('dom', () => {
 			);
 			assert.strictEqual(
 				context,
-				'[ResizeObserverLoopContext(recentWrappedObservers=a,b)] ResizeObserver loop completed with undelivered notifications.',
+				'[ResizeObserverLoopContext(a,b)] ResizeObserver loop completed with undelivered notifications.',
 			);
 			a.dispose();
 			b.dispose();
@@ -689,7 +689,7 @@ suite('dom', () => {
 			}
 			assert.strictEqual(
 				getRecentDisposableResizeObserverContextForLoopError('ResizeObserver loop completed with undelivered notifications.'),
-				'[ResizeObserverLoopContext(recentWrappedObservers=observer-0,observer-1,observer-2,observer-3,observer-4,observer-5,observer-6,observer-7,<overflow>)] ResizeObserver loop completed with undelivered notifications.',
+				'[ResizeObserverLoopContext(observer-0,observer-1,observer-2,observer-3,observer-4,observer-5,observer-6,observer-7,<overflow>)] ResizeObserver loop completed with undelivered notifications.',
 			);
 			observers.forEach(observer => observer.dispose());
 		});
@@ -710,7 +710,7 @@ suite('dom', () => {
 			);
 			assert.strictEqual(
 				getRecentDisposableResizeObserverContextForLoopError('ResizeObserver loop completed with undelivered notifications.', auxiliaryWindow),
-				'[ResizeObserverLoopContext(recentWrappedObservers=auxiliary)] ResizeObserver loop completed with undelivered notifications.',
+				'[ResizeObserverLoopContext(auxiliary)] ResizeObserver loop completed with undelivered notifications.',
 			);
 
 			observer.dispose();

--- a/src/vs/platform/telemetry/browser/errorTelemetry.ts
+++ b/src/vs/platform/telemetry/browser/errorTelemetry.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { mainWindow } from '../../../base/browser/window.js';
-import { getRecentDisposableResizeObserverAttributionForLoopError } from '../../../base/browser/dom.js';
+import { getRecentDisposableResizeObserverContextForLoopError } from '../../../base/browser/dom.js';
 import { ErrorNoTelemetry } from '../../../base/common/errors.js';
 import { toDisposable } from '../../../base/common/lifecycle.js';
 import BaseErrorTelemetry, { ErrorEvent } from '../common/errorTelemetry.js';
@@ -54,14 +54,14 @@ export default class ErrorTelemetry extends BaseErrorTelemetry {
 			}
 		}
 
-		// Attribute the stackless `ResizeObserver loop completed with
-		// undelivered notifications` warning to the most recently invoked
-		// `DisposableResizeObserver`, so the bucket points at the offending
-		// consumer instead of just the message.
-		const resizeObserverAttribution = getRecentDisposableResizeObserverAttributionForLoopError(msg);
-		if (resizeObserverAttribution) {
-			data.msg = resizeObserverAttribution;
-			data.callstack = resizeObserverAttribution;
+		// The browser does not expose which observer or skipped target caused a
+		// ResizeObserver loop warning. Include the wrapped observers that ran
+		// recently as delivery context instead of falsely attributing the loop
+		// to whichever callback happened to run last.
+		const resizeObserverContext = getRecentDisposableResizeObserverContextForLoopError(msg);
+		if (resizeObserverContext) {
+			data.msg = resizeObserverContext;
+			data.callstack = resizeObserverContext;
 		}
 
 		this._enqueue(data);

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
@@ -619,10 +619,7 @@ const CODE_BLOCK_IN_LIST: IFixtureMessage[] = [
 ];
 
 async function renderResizeObserverLoopHarness(context: ComponentFixtureContext, hostLayoutMode: IChatWidgetFixtureOptions['hostLayoutMode']): Promise<void> {
-	const targetWindow = context.container.ownerDocument.defaultView;
-	if (!targetWindow) {
-		throw new Error('ResizeObserver harness requires a window');
-	}
+	const targetWindow = dom.getWindow(context.container);
 
 	let handle: IChatWidgetFixtureHandle | undefined;
 	await renderChatWidget(context, {
@@ -676,7 +673,7 @@ async function renderResizeObserverLoopHarness(context: ComponentFixtureContext,
 		if (event instanceof ErrorEvent && event.message.includes('ResizeObserver loop')) {
 			warningCount++;
 			warnings.textContent = `Warnings: ${warningCount}`;
-			warnings.dataset['lastAttribution'] = dom.getRecentDisposableResizeObserverAttributionForLoopError(event.message) ?? event.message;
+			warnings.dataset['observerContext'] = dom.getRecentDisposableResizeObserverContextForLoopError(event.message, targetWindow) ?? event.message;
 			status.textContent = 'Captured ResizeObserver warning';
 		}
 	}));

--- a/src/vs/workbench/test/browser/componentFixtures/resizeObserver.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/resizeObserver.fixture.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { ComponentFixtureContext, defineComponentFixture, defineThemedFixtureGroup } from './fixtureUtils.js';
+
+function renderLoopContextProbe(context: ComponentFixtureContext): void {
+	const targetWindow = dom.getWindow(context.container);
+	const target = dom.append(context.container, dom.$('.resize-observer-context-target'));
+	target.style.width = '100px';
+	target.style.height = '10px';
+
+	const status = dom.append(context.container, dom.$('.resize-observer-context-status'));
+	status.textContent = 'Waiting for ResizeObserver loop warning';
+	status.dataset['warningCount'] = '0';
+
+	const observation = context.disposableStore.add(new MutableDisposable<IDisposable>());
+	context.disposableStore.add(dom.addDisposableListener(targetWindow, dom.EventType.ERROR, event => {
+		if (!(event instanceof ErrorEvent) || !event.message.includes('ResizeObserver loop')) {
+			return;
+		}
+
+		status.dataset['warningCount'] = '1';
+		status.dataset['observerContext'] = dom.getRecentDisposableResizeObserverContextForLoopError(event.message, targetWindow) ?? '';
+		status.textContent = 'Captured ResizeObserver loop warning';
+		observation.clear();
+	}));
+
+	const observer = context.disposableStore.add(new dom.DisposableResizeObserver(
+		'ResizeObserverContextFixture.selfResizer',
+		() => target.style.width = `${target.getBoundingClientRect().width + 1}px`,
+		targetWindow,
+	));
+	observation.value = observer.observe(target);
+}
+
+export default defineThemedFixtureGroup({ path: 'base/resizeObserver/' }, {
+	LoopContext: defineComponentFixture({
+		labels: { kind: 'animated' },
+		virtualTime: { enabled: false },
+		render: renderLoopContextProbe,
+	}),
+});

--- a/test/componentFixtures/playwright/tests/chatResizeObserver.spec.ts
+++ b/test/componentFixtures/playwright/tests/chatResizeObserver.spec.ts
@@ -26,8 +26,8 @@ for (const scenario of scenarios) {
 		await page.getByRole('button', { name: 'Run 20-turn burst' }).click();
 		await expect(page.getByRole('status')).toContainText(/Completed/, { timeout: 30_000 });
 		const warningText = await page.locator('.resize-observer-loop-warnings').textContent();
-		const lastAttribution = await page.locator('.resize-observer-loop-warnings').getAttribute('data-last-attribution');
-		console.log(`[chat-resize-harness:${scenario.name}] ${warningText}; page errors: ${resizeObserverErrors.length}; last attribution: ${lastAttribution}`);
+		const observerContext = await page.locator('.resize-observer-loop-warnings').getAttribute('data-observer-context');
+		console.log(`[chat-resize-harness:${scenario.name}] ${warningText}; page errors: ${resizeObserverErrors.length}; observer context: ${observerContext}`);
 		const warningCount = Number(warningText?.replace('Warnings: ', ''));
 		expect(warningCount).toBe(scenario.expectedWarnings);
 		if (scenario.name === 'stacked targeted layout') {

--- a/test/componentFixtures/playwright/tests/resizeObserverContext.spec.ts
+++ b/test/componentFixtures/playwright/tests/resizeObserverContext.spec.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, test } from '@playwright/test';
+import { openFixture } from './utils.js';
+
+test('retains wrapped observer context until the browser dispatches the loop warning', async ({ page }) => {
+	await openFixture(page, 'base/resizeObserver/resizeObserver/LoopContext/Dark', '.resize-observer-context-status');
+
+	const status = page.locator('.resize-observer-context-status');
+	await expect(status).toHaveAttribute('data-warning-count', '1');
+	await expect(status).toHaveAttribute(
+		'data-observer-context',
+		'[ResizeObserverLoopContext(recentWrappedObservers=ResizeObserverContextFixture.selfResizer)] ResizeObserver loop completed with undelivered notifications.',
+	);
+});

--- a/test/componentFixtures/playwright/tests/resizeObserverContext.spec.ts
+++ b/test/componentFixtures/playwright/tests/resizeObserverContext.spec.ts
@@ -13,6 +13,6 @@ test('retains wrapped observer context until the browser dispatches the loop war
 	await expect(status).toHaveAttribute('data-warning-count', '1');
 	await expect(status).toHaveAttribute(
 		'data-observer-context',
-		'[ResizeObserverLoopContext(recentWrappedObservers=ResizeObserverContextFixture.selfResizer)] ResizeObserver loop completed with undelivered notifications.',
+		'[ResizeObserverLoopContext(ResizeObserverContextFixture.selfResizer)] ResizeObserver loop completed with undelivered notifications.',
 	);
 });


### PR DESCRIPTION
## Problem

VS Code currently rewrites Chromium's stackless `ResizeObserver loop completed with undelivered notifications` warning with the name of the **most recently invoked** `DisposableResizeObserver`:

```ts
_lastInvokedDisposableResizeObserver = this;
```

The telemetry comments call that observer the "offending consumer," but callback order is not causality. A callback can mutate a different observed target, and an unrelated observer can run last before the browser dispatches the warning. This is how a real cross-observer virtualized-row lifecycle bug was attributed to both `ChatInputPart.containerHeight` and `ChatListItemRenderer.itemHeight`.

The browser cannot provide the missing answer after the fact. Per the ResizeObserver processing model, skipped targets stay in internal `[[skippedTargets]]`; `Deliver Resize Loop Error` creates an `ErrorEvent` with only the generic message. No observer, target, or causative callback is exposed to JavaScript.

## Change

Replace false causal attribution with honest delivery context:

```text
[ResizeObserverLoopContext(A,B)]
```

- records every distinct wrapped observer that ran in the current rendering frame;
- scopes state per `CodeWindow`, because auxiliary windows have independent documents and delivery loops;
- sorts names so callback order does not fragment equivalent buckets;
- bounds context to the lexicographically smallest 8 names plus `<overflow>` so output is deterministic and finite;
- clears at the next animation frame, after Blink has dispatched any loop warning from the current rendering update;
- keeps the `ResizeObserverLoopContext` wrapper as the explicit non-causal label.

Only `DisposableResizeObserver` consumers are included; raw `ResizeObserver` consumers remain outside this context.

This changes the bucket shape on purpose. Existing per-last-callback buckets should not be interpreted as component failure rates.

## Verification

- `npm run typecheck-client` — passes.
- `scripts/test.bat --grep "DisposableResizeObserver"` — 10 passing:
  - synchronous delivery remains unchanged;
  - names are sorted and deduplicated;
  - overflow is canonical even when callbacks arrive in reverse order;
  - state is isolated per window;
  - state clears at the next animation frame.
- New real Chromium component fixture deliberately resizes its own observed target. Playwright asserts the browser-generated loop warning still sees:

```text
[ResizeObserverLoopContext(ResizeObserverContextFixture.selfResizer)]
```

The fixture stops observation on the first warning so it cannot leak or spin.
- Independent code review: no significant issues.

## Follow-up

This PR makes the cheap signal truthful; it does **not** claim to recover exact causality. A separate sampled diagnostic can trace callback → changed observed-target geometry/connectivity edges after the first warning. That work needs coverage/confidence gates and should not be mixed into the stable error bucket change.

Related: #293359, #316509, #316501, #327933.


