### PR TITLE
agentHost: Emit initiator client type in CTS telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostRepoInfoTelemetry.ts
+++ b/src/vs/platform/agentHost/node/agentHostRepoInfoTelemetry.ts
@@ -114,7 +114,7 @@ export function measureRepoInfoDiffsJSON(diffsJSON: string): { readonly diffSize
 }
 
 export class AgentHostRepoInfoTelemetry extends Disposable {
-	private readonly _beginResults = new Map<string, Promise<AgentHostRepoInfoResult | undefined>>();
+	private readonly _beginResults = new Map<string, { readonly clientType: AgentHostClientType; readonly result: Promise<AgentHostRepoInfoResult | undefined> }>();
 	private _isDisposed = false;
 
 	constructor(
@@ -127,23 +127,26 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 	}
 
 	async reportBegin(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<void> {
-		let result = this._beginResults.get(telemetryMessageId);
-		if (!result) {
-			result = this._captureSafely(context, sessionUri, telemetryMessageId, clientType, 'begin', workingDirectory, baseBranch, isContextCurrent);
-			this._beginResults.set(telemetryMessageId, result);
+		let begin = this._beginResults.get(telemetryMessageId);
+		if (!begin) {
+			begin = {
+				clientType,
+				result: this._captureSafely(context, sessionUri, telemetryMessageId, clientType, 'begin', workingDirectory, baseBranch, isContextCurrent),
+			};
+			this._beginResults.set(telemetryMessageId, begin);
 		}
-		await result;
+		await begin.result;
 	}
 
-	async reportEnd(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<void> {
+	async reportEnd(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<void> {
 		const begin = this._beginResults.get(telemetryMessageId);
 		if (!begin) {
 			return;
 		}
 		try {
-			const beginResult = await begin;
+			const beginResult = await begin.result;
 			if (beginResult === 'success' || beginResult === 'noChanges') {
-				await this._captureSafely(context, sessionUri, telemetryMessageId, clientType, 'end', workingDirectory, baseBranch, isContextCurrent);
+				await this._captureSafely(context, sessionUri, telemetryMessageId, begin.clientType, 'end', workingDirectory, baseBranch, isContextCurrent);
 			}
 		} finally {
 			this._beginResults.delete(telemetryMessageId);

--- a/src/vs/platform/agentHost/node/agentHostRepoInfoTelemetry.ts
+++ b/src/vs/platform/agentHost/node/agentHostRepoInfoTelemetry.ts
@@ -8,6 +8,7 @@ import { Disposable } from '../../../base/common/lifecycle.js';
 import { relativePath } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
+import type { AgentHostClientType } from '../common/agentHostClientInfo.js';
 import { IAgentHostGitService } from '../common/agentHostGitService.js';
 import type { ISessionFileDiff } from '../common/state/sessionState.js';
 import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
@@ -125,16 +126,16 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		super();
 	}
 
-	async reportBegin(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<void> {
+	async reportBegin(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<void> {
 		let result = this._beginResults.get(telemetryMessageId);
 		if (!result) {
-			result = this._captureSafely(context, sessionUri, telemetryMessageId, 'begin', workingDirectory, baseBranch, isContextCurrent);
+			result = this._captureSafely(context, sessionUri, telemetryMessageId, clientType, 'begin', workingDirectory, baseBranch, isContextCurrent);
 			this._beginResults.set(telemetryMessageId, result);
 		}
 		await result;
 	}
 
-	async reportEnd(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<void> {
+	async reportEnd(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<void> {
 		const begin = this._beginResults.get(telemetryMessageId);
 		if (!begin) {
 			return;
@@ -142,7 +143,7 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		try {
 			const beginResult = await begin;
 			if (beginResult === 'success' || beginResult === 'noChanges') {
-				await this._captureSafely(context, sessionUri, telemetryMessageId, 'end', workingDirectory, baseBranch, isContextCurrent);
+				await this._captureSafely(context, sessionUri, telemetryMessageId, clientType, 'end', workingDirectory, baseBranch, isContextCurrent);
 			}
 		} finally {
 			this._beginResults.delete(telemetryMessageId);
@@ -159,16 +160,16 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		super.dispose();
 	}
 
-	private async _captureSafely(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, location: 'begin' | 'end', workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<AgentHostRepoInfoResult | undefined> {
+	private async _captureSafely(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, location: 'begin' | 'end', workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<AgentHostRepoInfoResult | undefined> {
 		try {
-			return await this._capture(context, sessionUri, telemetryMessageId, location, workingDirectory, baseBranch, isContextCurrent);
+			return await this._capture(context, sessionUri, telemetryMessageId, clientType, location, workingDirectory, baseBranch, isContextCurrent);
 		} catch (error) {
 			this._logService.warn(`[AgentHostRepoInfoTelemetry] Failed to capture ${location} repo info: ${error instanceof Error ? error.message : String(error)}`);
 			return undefined;
 		}
 	}
 
-	private async _capture(telemetryContext: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, location: 'begin' | 'end', workingDirectory: URI | undefined, persistedBaseBranch: string | undefined, isContextCurrent: () => boolean): Promise<AgentHostRepoInfoResult | undefined> {
+	private async _capture(telemetryContext: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, location: 'begin' | 'end', workingDirectory: URI | undefined, persistedBaseBranch: string | undefined, isContextCurrent: () => boolean): Promise<AgentHostRepoInfoResult | undefined> {
 		if (!workingDirectory || !isContextCurrent() || (!telemetryContext.restrictedTelemetryEnabled && !telemetryContext.isInternal)) {
 			return undefined;
 		}
@@ -200,13 +201,13 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 			return undefined;
 		}
 		if (safety.hasVirtualFileSystem) {
-			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, 'virtualFileSystem', 0, 0, 0);
+			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, 'virtualFileSystem', 0, 0, 0);
 		}
 		if (safety.baselineCommitTimestamp === undefined || Date.now() - safety.baselineCommitTimestamp > MAX_MERGE_BASE_AGE_MS) {
-			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, 'mergeBaseTooOld', 0, 0, 0);
+			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, 'mergeBaseTooOld', 0, 0, 0);
 		}
 		if (safety.commitCount === undefined || safety.commitCount >= MAX_DIFF_COMMITS) {
-			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, 'tooManyCommits', 0, 0, 0);
+			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, 'tooManyCommits', 0, 0, 0);
 		}
 		const tree = await this._gitService.captureWorkingTreeAsTree(workingDirectory);
 		if (!tree) {
@@ -222,10 +223,10 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 			return undefined;
 		}
 		if (fileDiffs.length === 0) {
-			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, workingDirectory, tree, 'noChanges', safety.workspaceFileCount, 0, 0);
+			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'noChanges', safety.workspaceFileCount, 0, 0);
 		}
 		if (fileDiffs.length > MAX_CHANGES) {
-			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, 'tooManyChanges', safety.workspaceFileCount, fileDiffs.length, 0);
+			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, 'tooManyChanges', safety.workspaceFileCount, fileDiffs.length, 0);
 		}
 
 		const repositoryRoot = await this._gitService.getRepositoryRoot(workingDirectory);
@@ -241,7 +242,7 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		const fileRelativePaths = JSON.stringify([...new Set(resolvedDescriptors.map(descriptor => descriptor.newPath ?? descriptor.oldPath).filter((path): path is string => path !== undefined))]);
 		// The SDK does not expose per-path exclusion decisions yet, so withhold patch content unless exclusion is explicitly disabled.
 		if (telemetryContext.copilotIgnoreEnabled !== false) {
-			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, workingDirectory, tree, 'success', safety.workspaceFileCount, fileDiffs.length, 0, fileRelativePaths);
+			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'success', safety.workspaceFileCount, fileDiffs.length, 0, fileRelativePaths);
 		}
 		let patchTooLarge = false;
 		const limiter = new Limiter<{ readonly uri: string; readonly originalUri: string; readonly renameUri: string | undefined; readonly status: string; readonly diff: string }>(DIFF_PATCH_CONCURRENCY);
@@ -263,22 +264,22 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 			};
 		})));
 		if (patchTooLarge) {
-			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, workingDirectory, tree, 'diffTooLarge', safety.workspaceFileCount, fileDiffs.length, MAX_DIFFS_JSON_BYTES + 1, fileRelativePaths);
+			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'diffTooLarge', safety.workspaceFileCount, fileDiffs.length, MAX_DIFFS_JSON_BYTES + 1, fileRelativePaths);
 		}
 		const diffsJSON = JSON.stringify(diffs);
 		const measurement = measureRepoInfoDiffsJSON(diffsJSON);
 		if (measurement.tooLarge) {
-			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, workingDirectory, tree, 'diffTooLarge', safety.workspaceFileCount, fileDiffs.length, measurement.diffSizeBytes, fileRelativePaths);
+			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'diffTooLarge', safety.workspaceFileCount, fileDiffs.length, measurement.diffSizeBytes, fileRelativePaths);
 		}
-		return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, workingDirectory, tree, 'success', safety.workspaceFileCount, fileDiffs.length, measurement.diffSizeBytes, fileRelativePaths, diffsJSON);
+		return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'success', safety.workspaceFileCount, fileDiffs.length, measurement.diffSizeBytes, fileRelativePaths, diffsJSON);
 	}
 
-	private async _reportIfTreeUnchanged(telemetryContext: IAgentHostRestrictedTelemetryContext, isContextCurrent: () => boolean, telemetryMessageId: string, location: 'begin' | 'end', repoInfo: IRepoInfoContext, workingDirectory: URI, capturedTree: string, stableResult: 'success' | 'noChanges' | 'diffTooLarge', workspaceFileCount: number, changedFileCount: number, diffSizeBytes: number, fileRelativePaths?: string, diffsJSON?: string): Promise<AgentHostRepoInfoResult> {
+	private async _reportIfTreeUnchanged(telemetryContext: IAgentHostRestrictedTelemetryContext, isContextCurrent: () => boolean, telemetryMessageId: string, clientType: AgentHostClientType, location: 'begin' | 'end', repoInfo: IRepoInfoContext, workingDirectory: URI, capturedTree: string, stableResult: 'success' | 'noChanges' | 'diffTooLarge', workspaceFileCount: number, changedFileCount: number, diffSizeBytes: number, fileRelativePaths?: string, diffsJSON?: string): Promise<AgentHostRepoInfoResult> {
 		const currentTree = await this._gitService.captureWorkingTreeAsTree(workingDirectory);
 		if (!currentTree || currentTree !== capturedTree) {
-			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, 'filesChanged', workspaceFileCount, changedFileCount, 0);
+			return this._report(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, 'filesChanged', workspaceFileCount, changedFileCount, 0);
 		}
-		return this._report(telemetryContext, isContextCurrent, telemetryMessageId, location, repoInfo, stableResult, workspaceFileCount, changedFileCount, diffSizeBytes, fileRelativePaths, diffsJSON);
+		return this._report(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, stableResult, workspaceFileCount, changedFileCount, diffSizeBytes, fileRelativePaths, diffsJSON);
 	}
 
 	private _describeFileDiff(repositoryRoot: URI, diff: ISessionFileDiff, untrackedPaths: ReadonlySet<string>): IRepoInfoFileDescriptor | undefined {
@@ -310,12 +311,13 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		};
 	}
 
-	private _report(telemetryContext: IAgentHostRestrictedTelemetryContext, isContextCurrent: () => boolean, telemetryMessageId: string, location: 'begin' | 'end', repoInfo: IRepoInfoContext, result: AgentHostRepoInfoResult, workspaceFileCount: number, changedFileCount: number, diffSizeBytes: number, fileRelativePaths?: string, diffsJSON?: string): AgentHostRepoInfoResult {
+	private _report(telemetryContext: IAgentHostRestrictedTelemetryContext, isContextCurrent: () => boolean, telemetryMessageId: string, clientType: AgentHostClientType, location: 'begin' | 'end', repoInfo: IRepoInfoContext, result: AgentHostRepoInfoResult, workspaceFileCount: number, changedFileCount: number, diffSizeBytes: number, fileRelativePaths?: string, diffsJSON?: string): AgentHostRepoInfoResult {
 		if (this._isDisposed || !isContextCurrent()) {
 			return result;
 		}
 		void this._reporter.reportRepoInfo(telemetryContext, {
 			telemetryMessageId,
+			clientType,
 			location,
 			remoteUrl: repoInfo.remoteUrl,
 			repoId: repoInfo.repoId,

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -201,6 +201,7 @@ export interface IAgentHostToolCallDetailsReport {
 export interface IAgentHostAutoModeRouterDecisionReport {
 	session: string;
 	turnId: string;
+	clientType: AgentHostClientType;
 	chosenModel: string;
 	predictedLabel: string | undefined;
 	confidence: number | undefined;
@@ -209,6 +210,7 @@ export interface IAgentHostAutoModeRouterDecisionReport {
 }
 
 export interface IAgentHostSkillContentReadReport {
+	clientType: AgentHostClientType;
 	/** The skill name. */
 	name: string;
 	/** Path to the SKILL.md file. */
@@ -227,6 +229,7 @@ export type AgentHostRepoInfoResult = 'success' | 'filesChanged' | 'diffTooLarge
 
 export interface IAgentHostRepoInfoReport {
 	telemetryMessageId: string;
+	clientType: AgentHostClientType;
 	location: 'begin' | 'end';
 	remoteUrl: string;
 	repoId: string;
@@ -499,6 +502,7 @@ export class AgentHostTelemetryReporter {
 		const properties = {
 			conversationId: AgentSession.id(report.session),
 			vscodeRequestId: report.turnId,
+			initiatorClientType: report.clientType,
 			...(report.predictedLabel !== undefined ? { predictedLabel: report.predictedLabel } : {}),
 			candidateModel: candidateModels[0] ?? '',
 			chosenModel: report.chosenModel,
@@ -538,6 +542,7 @@ export class AgentHostTelemetryReporter {
 		// never emit a `skillExtensionVersion` without a corresponding `skillExtensionId`.
 		const skillExtensionVersion = report.pluginName ? (report.pluginVersion ?? '') : '';
 		const plaintextProps = {
+			initiatorClientType: report.clientType,
 			skillName: report.name,
 			skillPath: report.path,
 			skillExtensionId: report.pluginName ?? '',
@@ -546,6 +551,7 @@ export class AgentHostTelemetryReporter {
 			skillContentHash: contentHash,
 		};
 		restricted.sendGHTelemetryEvent('skillContentRead', {
+			initiatorClientType: report.clientType,
 			skillNameHash: String(hash(report.name)),
 			skillExtensionIdHash: report.pluginName ? String(hash(report.pluginName)) : '',
 			skillExtensionVersion,
@@ -562,6 +568,7 @@ export class AgentHostTelemetryReporter {
 			return;
 		}
 		const properties = {
+			initiatorClientType: report.clientType,
 			remoteUrl: report.remoteUrl,
 			repoId: report.repoId,
 			repoType: report.repoType,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -746,7 +746,6 @@ export class CopilotAgentSession extends Disposable {
 	private readonly _repoInfoTelemetry: AgentHostRepoInfoTelemetry;
 	private _activeRepoInfoTurn: {
 		readonly telemetryMessageId: string;
-		readonly clientType: AgentHostClientType;
 		cancelled: boolean;
 		begin: Promise<{ readonly context: IAgentHostRestrictedTelemetryContext; readonly baseBranch: string | undefined } | undefined>;
 	} | undefined;
@@ -3121,11 +3120,11 @@ export class CopilotAgentSession extends Disposable {
 		return resolved;
 	}
 
-	private async _endRepoInfoTelemetry(telemetryMessageId: string, clientType: AgentHostClientType, resolved: { readonly context: IAgentHostRestrictedTelemetryContext; readonly baseBranch: string | undefined } | undefined, isCurrent: () => boolean): Promise<void> {
+	private async _endRepoInfoTelemetry(telemetryMessageId: string, resolved: { readonly context: IAgentHostRestrictedTelemetryContext; readonly baseBranch: string | undefined } | undefined, isCurrent: () => boolean): Promise<void> {
 		if (!resolved || this._store.isDisposed || !isCurrent()) {
 			return;
 		}
-		await this._repoInfoTelemetry.reportEnd(resolved.context, this.sessionUri.toString(), telemetryMessageId, clientType, this._workingDirectory, resolved.baseBranch, isCurrent);
+		await this._repoInfoTelemetry.reportEnd(resolved.context, this.sessionUri.toString(), telemetryMessageId, this._workingDirectory, resolved.baseBranch, isCurrent);
 	}
 
 	private _completeActiveRepoInfoTelemetry(): void {
@@ -3135,7 +3134,7 @@ export class CopilotAgentSession extends Disposable {
 		}
 		this._activeRepoInfoTurn = undefined;
 		const isCurrent = () => !turn.cancelled && this._isLaunchTokenCurrent();
-		void turn.begin.then(resolved => this._endRepoInfoTelemetry(turn.telemetryMessageId, turn.clientType, resolved, isCurrent));
+		void turn.begin.then(resolved => this._endRepoInfoTelemetry(turn.telemetryMessageId, resolved, isCurrent));
 	}
 
 	private _cancelActiveRepoInfoTelemetry(): void {
@@ -4525,12 +4524,11 @@ export class CopilotAgentSession extends Disposable {
 				this._cancelActiveRepoInfoTelemetry();
 				const turn: NonNullable<CopilotAgentSession['_activeRepoInfoTurn']> = {
 					telemetryMessageId,
-					clientType: this._currentTurn?.clientType ?? AgentHostClientType.Unknown,
 					cancelled: false,
 					begin: Promise.resolve(undefined),
 				};
 				const isCurrent = () => !turn.cancelled && this._isLaunchTokenCurrent();
-				turn.begin = this._beginRepoInfoTelemetry(telemetryMessageId, turn.clientType, isCurrent);
+				turn.begin = this._beginRepoInfoTelemetry(telemetryMessageId, this._currentTurn?.clientType ?? AgentHostClientType.Unknown, isCurrent);
 				this._activeRepoInfoTurn = turn;
 			}
 		}));

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -746,6 +746,7 @@ export class CopilotAgentSession extends Disposable {
 	private readonly _repoInfoTelemetry: AgentHostRepoInfoTelemetry;
 	private _activeRepoInfoTurn: {
 		readonly telemetryMessageId: string;
+		readonly clientType: AgentHostClientType;
 		cancelled: boolean;
 		begin: Promise<{ readonly context: IAgentHostRestrictedTelemetryContext; readonly baseBranch: string | undefined } | undefined>;
 	} | undefined;
@@ -3105,7 +3106,7 @@ export class CopilotAgentSession extends Disposable {
 		}
 	}
 
-	private async _beginRepoInfoTelemetry(telemetryMessageId: string, isCurrent: () => boolean): Promise<{ readonly context: IAgentHostRestrictedTelemetryContext; readonly baseBranch: string | undefined } | undefined> {
+	private async _beginRepoInfoTelemetry(telemetryMessageId: string, clientType: AgentHostClientType, isCurrent: () => boolean): Promise<{ readonly context: IAgentHostRestrictedTelemetryContext; readonly baseBranch: string | undefined } | undefined> {
 		let resolved: { readonly context: IAgentHostRestrictedTelemetryContext; readonly baseBranch: string | undefined } | undefined;
 		try {
 			resolved = await this._resolveRepoInfoTelemetryContext();
@@ -3116,15 +3117,15 @@ export class CopilotAgentSession extends Disposable {
 		if (!resolved || this._store.isDisposed || !isCurrent()) {
 			return undefined;
 		}
-		await this._repoInfoTelemetry.reportBegin(resolved.context, this.sessionUri.toString(), telemetryMessageId, this._workingDirectory, resolved.baseBranch, isCurrent);
+		await this._repoInfoTelemetry.reportBegin(resolved.context, this.sessionUri.toString(), telemetryMessageId, clientType, this._workingDirectory, resolved.baseBranch, isCurrent);
 		return resolved;
 	}
 
-	private async _endRepoInfoTelemetry(telemetryMessageId: string, resolved: { readonly context: IAgentHostRestrictedTelemetryContext; readonly baseBranch: string | undefined } | undefined, isCurrent: () => boolean): Promise<void> {
+	private async _endRepoInfoTelemetry(telemetryMessageId: string, clientType: AgentHostClientType, resolved: { readonly context: IAgentHostRestrictedTelemetryContext; readonly baseBranch: string | undefined } | undefined, isCurrent: () => boolean): Promise<void> {
 		if (!resolved || this._store.isDisposed || !isCurrent()) {
 			return;
 		}
-		await this._repoInfoTelemetry.reportEnd(resolved.context, this.sessionUri.toString(), telemetryMessageId, this._workingDirectory, resolved.baseBranch, isCurrent);
+		await this._repoInfoTelemetry.reportEnd(resolved.context, this.sessionUri.toString(), telemetryMessageId, clientType, this._workingDirectory, resolved.baseBranch, isCurrent);
 	}
 
 	private _completeActiveRepoInfoTelemetry(): void {
@@ -3134,7 +3135,7 @@ export class CopilotAgentSession extends Disposable {
 		}
 		this._activeRepoInfoTurn = undefined;
 		const isCurrent = () => !turn.cancelled && this._isLaunchTokenCurrent();
-		void turn.begin.then(resolved => this._endRepoInfoTelemetry(turn.telemetryMessageId, resolved, isCurrent));
+		void turn.begin.then(resolved => this._endRepoInfoTelemetry(turn.telemetryMessageId, turn.clientType, resolved, isCurrent));
 	}
 
 	private _cancelActiveRepoInfoTelemetry(): void {
@@ -3657,6 +3658,7 @@ export class CopilotAgentSession extends Disposable {
 			// Restricted `skillContentRead`: which skill file was loaded. Main-agent only, like the other restricted events.
 			if (!e.agentId) {
 				this._telemetryReporter.skillContentRead({
+					clientType: this._currentTurn?.clientType ?? AgentHostClientType.Unknown,
 					name: e.data.name,
 					path: e.data.path,
 					content: e.data.content,
@@ -3761,6 +3763,7 @@ export class CopilotAgentSession extends Disposable {
 				this._telemetryReporter.autoModeRouterDecision({
 					session: this.sessionUri.toString(),
 					turnId,
+					clientType: this._currentTurn?.clientType ?? AgentHostClientType.Unknown,
 					chosenModel: e.data.chosenModel,
 					predictedLabel: e.data.predictedLabel,
 					confidence: e.data.confidence,
@@ -4522,11 +4525,12 @@ export class CopilotAgentSession extends Disposable {
 				this._cancelActiveRepoInfoTelemetry();
 				const turn: NonNullable<CopilotAgentSession['_activeRepoInfoTurn']> = {
 					telemetryMessageId,
+					clientType: this._currentTurn?.clientType ?? AgentHostClientType.Unknown,
 					cancelled: false,
 					begin: Promise.resolve(undefined),
 				};
 				const isCurrent = () => !turn.cancelled && this._isLaunchTokenCurrent();
-				turn.begin = this._beginRepoInfoTelemetry(telemetryMessageId, isCurrent);
+				turn.begin = this._beginRepoInfoTelemetry(telemetryMessageId, turn.clientType, isCurrent);
 				this._activeRepoInfoTurn = turn;
 			}
 		}));

--- a/src/vs/platform/agentHost/test/node/agentHostRepoInfoTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRepoInfoTelemetry.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
+import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
 import type { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import type { ISessionFileDiff } from '../../common/state/sessionState.js';
 import { AgentHostRepoInfoTelemetry, measureRepoInfoDiffsJSON, resolveRepoInfoRemote } from '../../node/agentHostRepoInfoTelemetry.js';
@@ -87,13 +88,14 @@ suite('AgentHostRepoInfoTelemetry', () => {
 			reportRepoInfo: async (_context, report) => { reports.push(report); },
 		}, gitService, createTestGitHubEndpointService(), new NullLogService()));
 
-		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', root, undefined, () => true);
-		await collector.reportEnd(restrictedContext, 'agent-session://copilot/s1', 'turn-1', root, undefined, () => true);
+		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.EditorWindow, root, undefined, () => true);
+		await collector.reportEnd(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.EditorWindow, root, undefined, () => true);
 
 		assert.deepStrictEqual({
 			patches,
 			reports: reports.map(report => ({
 				telemetryMessageId: report.telemetryMessageId,
+				clientType: report.clientType,
 				location: report.location,
 				result: report.result,
 				remoteUrl: report.remoteUrl,
@@ -109,6 +111,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 			patches: ['tree-begin', 'tree-end'],
 			reports: [{
 				telemetryMessageId: 'turn-1',
+				clientType: AgentHostClientType.EditorWindow,
 				location: 'begin',
 				result: 'success',
 				remoteUrl: 'https://github.com/microsoft/vscode.git',
@@ -126,6 +129,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 				changedFileCount: 1,
 			}, {
 				telemetryMessageId: 'turn-1',
+				clientType: AgentHostClientType.EditorWindow,
 				location: 'end',
 				result: 'success',
 				remoteUrl: 'https://github.com/microsoft/vscode.git',
@@ -153,7 +157,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 		};
 		const collector = disposables.add(new AgentHostRepoInfoTelemetry({ reportRepoInfo: async () => { } }, gitService, createTestGitHubEndpointService(), new NullLogService()));
 
-		await collector.reportBegin({ ...restrictedContext, restrictedTelemetryEnabled: false, isInternal: false }, 'agent-session://copilot/s1', 'turn-1', URI.file('/repo'), undefined, () => true);
+		await collector.reportBegin({ ...restrictedContext, restrictedTelemetryEnabled: false, isInternal: false }, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.Unknown, URI.file('/repo'), undefined, () => true);
 
 		assert.strictEqual(gitCalls, 0);
 	});
@@ -178,8 +182,8 @@ suite('AgentHostRepoInfoTelemetry', () => {
 		const reports: IAgentHostRepoInfoReport[] = [];
 		const collector = disposables.add(new AgentHostRepoInfoTelemetry({ reportRepoInfo: async (_context, report) => { reports.push(report); } }, gitService, createTestGitHubEndpointService(), new NullLogService()));
 
-		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', root, undefined, () => true);
-		await collector.reportEnd(restrictedContext, 'agent-session://copilot/s1', 'turn-1', root, undefined, () => true);
+		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.AgentsWindow, root, undefined, () => true);
+		await collector.reportEnd(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.AgentsWindow, root, undefined, () => true);
 
 		assert.deepStrictEqual({ snapshots, results: reports.map(report => report.result) }, { snapshots: 1, results: ['tooManyChanges'] });
 	});
@@ -206,7 +210,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 		const collector = disposables.add(new AgentHostRepoInfoTelemetry({ reportRepoInfo: async (_context, report) => { reports.push(report); } }, gitService, createTestGitHubEndpointService(), new NullLogService()));
 
 		for (const [index, copilotIgnoreEnabled] of [true, undefined].entries()) {
-			await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled }, 'agent-session://copilot/s1', `turn-${index}`, root, undefined, () => true);
+			await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled }, 'agent-session://copilot/s1', `turn-${index}`, AgentHostClientType.Unknown, root, undefined, () => true);
 		}
 
 		assert.deepStrictEqual({
@@ -254,7 +258,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 		};
 		const collector = disposables.add(new AgentHostRepoInfoTelemetry({ reportRepoInfo: async (_context, report) => { reports.push(report); } }, gitService, createTestGitHubEndpointService(), new NullLogService()));
 
-		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', root, undefined, () => true);
+		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.EditorWindow, root, undefined, () => true);
 
 		assert.deepStrictEqual(reports.map(report => ({ result: report.result, diffsJSON: report.diffsJSON, fileRelativePaths: report.fileRelativePaths })), [{
 			result: 'filesChanged',
@@ -283,7 +287,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 		};
 		const collector = disposables.add(new AgentHostRepoInfoTelemetry({ reportRepoInfo: async (_context, report) => { reports.push(report); } }, gitService, createTestGitHubEndpointService(), new NullLogService()));
 
-		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', root, undefined, () => true);
+		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.EditorWindow, root, undefined, () => true);
 
 		const diffs = JSON.parse(reports[0].diffsJSON ?? '[]');
 		assert.deepStrictEqual({

--- a/src/vs/platform/agentHost/test/node/agentHostRepoInfoTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRepoInfoTelemetry.test.ts
@@ -89,7 +89,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 		}, gitService, createTestGitHubEndpointService(), new NullLogService()));
 
 		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.EditorWindow, root, undefined, () => true);
-		await collector.reportEnd(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.EditorWindow, root, undefined, () => true);
+		await collector.reportEnd(restrictedContext, 'agent-session://copilot/s1', 'turn-1', root, undefined, () => true);
 
 		assert.deepStrictEqual({
 			patches,
@@ -183,7 +183,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 		const collector = disposables.add(new AgentHostRepoInfoTelemetry({ reportRepoInfo: async (_context, report) => { reports.push(report); } }, gitService, createTestGitHubEndpointService(), new NullLogService()));
 
 		await collector.reportBegin(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.AgentsWindow, root, undefined, () => true);
-		await collector.reportEnd(restrictedContext, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.AgentsWindow, root, undefined, () => true);
+		await collector.reportEnd(restrictedContext, 'agent-session://copilot/s1', 'turn-1', root, undefined, () => true);
 
 		assert.deepStrictEqual({ snapshots, results: reports.map(report => report.result) }, { snapshots: 1, results: ['tooManyChanges'] });
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -33,6 +33,7 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 	readonly enhancedEvents: IRestrictedCall[] = [];
 	readonly enhancedMeasurements: Array<TelemetryMeasurements | undefined> = [];
 	readonly internalEvents: IRestrictedCall[] = [];
+	readonly githubStandardEvents: IRestrictedCall[] = [];
 	readonly standardEvents: Array<{ eventName: string; data: ITelemetryData | undefined }> = [];
 
 	publicLog(): void { }
@@ -44,7 +45,9 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 	setExperimentProperty(): void { }
 	setCommonProperty(): void { }
 
-	sendGHTelemetryEvent(): void { }
+	sendGHTelemetryEvent(eventName: string, properties?: TelemetryProps): void {
+		this.githubStandardEvents.push({ eventName, properties });
+	}
 	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
 		this.enhancedEvents.push({ eventName, properties });
 		this.enhancedMeasurements.push(measurements);
@@ -235,6 +238,7 @@ suite('AgentHostTelemetryReporter', () => {
 		reporter.autoModeRouterDecision({
 			session,
 			turnId: 'turn-hydra',
+			clientType: AgentHostClientType.EditorWindow,
 			chosenModel: 'gpt-5',
 			predictedLabel: 'high',
 			confidence: 0.9,
@@ -244,6 +248,7 @@ suite('AgentHostTelemetryReporter', () => {
 		reporter.autoModeRouterDecision({
 			session,
 			turnId: 'turn-binary',
+			clientType: AgentHostClientType.AgentsWindow,
 			chosenModel: 'gpt-4.1',
 			predictedLabel: 'no_reasoning',
 			confidence: undefined,
@@ -257,6 +262,7 @@ suite('AgentHostTelemetryReporter', () => {
 				properties: {
 					conversationId: AgentSession.id(session),
 					vscodeRequestId: 'turn-hydra',
+					initiatorClientType: 'editor_window',
 					predictedLabel: 'high',
 					candidateModel: 'gpt-5',
 					chosenModel: 'gpt-5',
@@ -268,6 +274,7 @@ suite('AgentHostTelemetryReporter', () => {
 				properties: {
 					conversationId: AgentSession.id(session),
 					vscodeRequestId: 'turn-binary',
+					initiatorClientType: 'agents_window',
 					predictedLabel: 'no_reasoning',
 					candidateModel: '',
 					chosenModel: 'gpt-4.1',
@@ -283,8 +290,9 @@ suite('AgentHostTelemetryReporter', () => {
 		const service = new TestRestrictedTelemetryService();
 		const reporter = new AgentHostTelemetryReporter(service);
 
-		reporter.skillContentRead({ name: '', path: '/skills/x/SKILL.md', content: 'body', source: 'project', pluginName: undefined, pluginVersion: undefined }); // dropped: no name
+		reporter.skillContentRead({ clientType: AgentHostClientType.Unknown, name: '', path: '/skills/x/SKILL.md', content: 'body', source: 'project', pluginName: undefined, pluginVersion: undefined }); // dropped: no name
 		reporter.skillContentRead({
+			clientType: AgentHostClientType.AgentsWindow,
 			name: 'pdf', path: '/plugins/pdf/SKILL.md', content: 'skill body',
 			source: 'plugin', pluginName: 'pdf-plugin', pluginVersion: '1.2.3',
 		}); // emitted
@@ -292,6 +300,7 @@ suite('AgentHostTelemetryReporter', () => {
 		const expected: IRestrictedCall = {
 			eventName: 'skillContentRead',
 			properties: {
+				initiatorClientType: 'agents_window',
 				skillName: 'pdf',
 				skillPath: '/plugins/pdf/SKILL.md',
 				skillExtensionId: 'pdf-plugin',
@@ -300,8 +309,25 @@ suite('AgentHostTelemetryReporter', () => {
 				skillContentHash: String(hash('skill body')),
 			},
 		};
-		assert.deepStrictEqual(service.enhancedEvents, [expected]);
-		assert.deepStrictEqual(service.internalEvents, [expected]);
+		assert.deepStrictEqual({
+			standard: service.githubStandardEvents,
+			enhanced: service.enhancedEvents,
+			internal: service.internalEvents,
+		}, {
+			standard: [{
+				eventName: 'skillContentRead',
+				properties: {
+					initiatorClientType: 'agents_window',
+					skillNameHash: String(hash('pdf')),
+					skillExtensionIdHash: String(hash('pdf-plugin')),
+					skillExtensionVersion: '1.2.3',
+					skillStorage: 'plugin',
+					skillContentHash: String(hash('skill body')),
+				},
+			}],
+			enhanced: [expected],
+			internal: [expected],
+		});
 	});
 
 	test('repoInfo gates collection and multiplexes sink-specific properties', async () => {
@@ -317,6 +343,7 @@ suite('AgentHostTelemetryReporter', () => {
 			isVscodeTeamMember: true,
 		}, {
 			telemetryMessageId: 'turn-1',
+			clientType: AgentHostClientType.EditorWindow,
 			location: 'begin',
 			remoteUrl: 'https://github.com/microsoft/vscode',
 			repoId: 'microsoft/vscode',
@@ -339,6 +366,7 @@ suite('AgentHostTelemetryReporter', () => {
 			enhanced: {
 				eventName: 'request.repoInfo',
 				properties: {
+					initiatorClientType: 'editor_window',
 					remoteUrl: 'https://github.com/microsoft/vscode',
 					repoId: 'microsoft/vscode',
 					repoType: 'github',
@@ -356,6 +384,7 @@ suite('AgentHostTelemetryReporter', () => {
 			internal: {
 				eventName: 'request.repoInfo',
 				properties: {
+					initiatorClientType: 'editor_window',
 					remoteUrl: 'https://github.com/microsoft/vscode',
 					repoId: 'microsoft/vscode',
 					repoType: 'github',
@@ -375,7 +404,7 @@ suite('AgentHostTelemetryReporter', () => {
 		const service = new TestRestrictedTelemetryService();
 		const reporter = new AgentHostTelemetryReporter(service);
 
-		reporter.skillContentRead({ name: 'local', path: '/skills/local/SKILL.md', content: 'c', source: 'project', pluginName: undefined, pluginVersion: '9.9.9' });
+		reporter.skillContentRead({ clientType: AgentHostClientType.EditorWindow, name: 'local', path: '/skills/local/SKILL.md', content: 'c', source: 'project', pluginName: undefined, pluginVersion: '9.9.9' });
 
 		assert.strictEqual(service.enhancedEvents.length, 1);
 		assert.strictEqual(service.enhancedEvents[0].properties?.skillExtensionId, '');

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -23,6 +23,7 @@ import type { ClassifiedEvent, IGDPRProperty, OmitMetadata, StrictPropertyCheck 
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryServiceShape } from '../../../telemetry/common/telemetryUtils.js';
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
+import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
 import type { ChatInputRequestWithPlanReview } from '../../common/agentHostPlanReview.js';
 import { AgentFeedbackAttachmentDisplayKind } from '../../common/meta/agentFeedbackAttachments.js';
 import { readToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
@@ -7484,7 +7485,7 @@ suite('CopilotAgentSession', () => {
 					telemetryEndpoint: 'https://telemetry.example',
 				},
 			});
-			session.resetTurnState('turn-auto');
+			session.resetTurnState('turn-auto', undefined, AgentHostClientType.AgentsWindow);
 
 			mockSession.fire('session.auto_mode_resolved', {
 				chosenModel: 'subagent-model',
@@ -7504,6 +7505,7 @@ suite('CopilotAgentSession', () => {
 					properties: {
 						conversationId: 'test-session-1',
 						vscodeRequestId: 'turn-auto',
+						initiatorClientType: 'agents_window',
 						predictedLabel: 'needs_reasoning',
 						candidateModel: 'gpt-5',
 						chosenModel: 'gpt-5',
@@ -7546,7 +7548,7 @@ suite('CopilotAgentSession', () => {
 
 			mockSession.fire('assistant.turn_start', { turnId: 'subagent-turn' }, { agentId: 'subagent-1' });
 			mockSession.fire('assistant.turn_end', { turnId: 'subagent-turn' }, { agentId: 'subagent-1' });
-			session.resetTurnState('request-1');
+			session.resetTurnState('request-1', undefined, AgentHostClientType.EditorWindow);
 			mockSession.fire('assistant.turn_start', { turnId: 'root-round-1' });
 			await timeout(0);
 			mockSession.fire('assistant.turn_end', { turnId: 'root-round-1' });
@@ -7557,11 +7559,11 @@ suite('CopilotAgentSession', () => {
 
 			assert.deepStrictEqual(telemetryService.events
 				.filter(event => event.eventName === 'request.repoInfo')
-				.map(event => ({ destination: event.destination, location: event.properties?.location, telemetryMessageId: event.properties?.telemetryMessageId, result: event.properties?.result })), [
-				{ destination: 'enhanced', location: 'begin', telemetryMessageId: 'request-1', result: 'noChanges' },
-				{ destination: 'internal', location: 'begin', telemetryMessageId: 'request-1', result: 'noChanges' },
-				{ destination: 'enhanced', location: 'end', telemetryMessageId: 'request-1', result: 'noChanges' },
-				{ destination: 'internal', location: 'end', telemetryMessageId: 'request-1', result: 'noChanges' },
+				.map(event => ({ destination: event.destination, initiatorClientType: event.properties?.initiatorClientType, location: event.properties?.location, telemetryMessageId: event.properties?.telemetryMessageId, result: event.properties?.result })), [
+				{ destination: 'enhanced', initiatorClientType: 'editor_window', location: 'begin', telemetryMessageId: 'request-1', result: 'noChanges' },
+				{ destination: 'internal', initiatorClientType: 'editor_window', location: 'begin', telemetryMessageId: 'request-1', result: 'noChanges' },
+				{ destination: 'enhanced', initiatorClientType: 'editor_window', location: 'end', telemetryMessageId: 'request-1', result: 'noChanges' },
+				{ destination: 'internal', initiatorClientType: 'editor_window', location: 'end', telemetryMessageId: 'request-1', result: 'noChanges' },
 			]);
 		});
 


### PR DESCRIPTION
## Summary

- include `initiatorClientType` on the existing standard CTS `skillContentRead` event
- add the same attribution to enhanced/internal skill, auto-mode, and repository-info telemetry
- preserve the initiating client across asynchronous repository-info begin/end capture

## Validation

- `npm run compile-client`
- focused Agent Host telemetry unit tests
- `npm run precommit`

Follow-up to #327417.

(Written by Copilot)